### PR TITLE
fix: make background automation honest and fast

### DIFF
--- a/Apps/CLI/Sources/PeekabooCLI/Commands/AI/SeeCommand+CommanderMetadata.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/AI/SeeCommand+CommanderMetadata.swift
@@ -27,13 +27,19 @@ extension SeeCommand: CommanderSignatureProviding {
                 ),
                 .commandOption(
                     "mode",
-                    help: "Capture mode (screen, window, frontmost)",
+                    help: "Capture mode (screen, window, frontmost, multi)",
                     long: "mode"
                 ),
-                .commandOption(
-                    "path",
-                    help: "Output path for screenshot",
-                    long: "path"
+                .make(
+                    label: "path",
+                    names: [
+                        .long("path"),
+                        .aliasLong("save"),
+                        .aliasLong("output"),
+                        .short("o"),
+                    ],
+                    help: "Output path for screenshot (aliases: --save, --output, -o)",
+                    parsing: .singleValue
                 ),
                 .commandOption(
                     "captureEngine",
@@ -54,6 +60,21 @@ extension SeeCommand: CommanderSignatureProviding {
                     "timeoutSeconds",
                     help: "Overall timeout in seconds (default: 20, or 60 when --analyze is set)",
                     long: "timeout-seconds"
+                ),
+                .commandOption(
+                    "maxDepth",
+                    help: "Maximum AX traversal depth (env: PEEKABOO_AX_MAX_DEPTH)",
+                    long: "max-depth"
+                ),
+                .commandOption(
+                    "maxElements",
+                    help: "Maximum AX elements to collect (env: PEEKABOO_AX_MAX_ELEMENTS)",
+                    long: "max-elements"
+                ),
+                .commandOption(
+                    "maxChildren",
+                    help: "Maximum AX children per node (env: PEEKABOO_AX_MAX_CHILDREN)",
+                    long: "max-children"
                 ),
             ],
             flags: [

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/AI/SeeCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/AI/SeeCommand.swift
@@ -420,6 +420,9 @@ extension SeeCommand: CommanderBindableCommand {
         self.annotate = values.flag("annotate")
         self.analyze = values.singleOption("analyze")
         self.timeoutSeconds = try values.decodeOption("timeoutSeconds", as: Int.self)
+        self.maxDepth = try values.decodeOption("maxDepth", as: Int.self)
+        self.maxElements = try values.decodeOption("maxElements", as: Int.self)
+        self.maxChildren = try values.decodeOption("maxChildren", as: Int.self)
         self.noWebFocus = values.flag("noWebFocus")
         self.menubar = values.flag("menubar")
     }

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/AppCommand+CommanderMetadata.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/AppCommand+CommanderMetadata.swift
@@ -7,7 +7,7 @@ extension AppCommand.LaunchSubcommand: CommanderSignatureProviding {
                 .make(
                     label: "app",
                     help: "Application name or path",
-                    isOptional: false
+                    isOptional: true
                 ),
             ],
             options: [
@@ -186,7 +186,7 @@ extension AppCommand.RelaunchSubcommand: CommanderSignatureProviding {
                 .make(
                     label: "app",
                     help: "Application name, bundle ID, or 'PID:12345'",
-                    isOptional: false
+                    isOptional: true
                 ),
             ],
             options: [

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/AppCommand+Quit.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/AppCommand+Quit.swift
@@ -165,8 +165,17 @@ extension AppCommand {
                     force: force,
                     results: results
                 )
+                let allSucceeded = results.allSatisfy(\.success)
 
-                output(data) {
+                if self.jsonOutput {
+                    let response = CodableJSONResponse(
+                        success: allSucceeded,
+                        data: data,
+                        messages: nil,
+                        debug_logs: self.outputLogger.getDebugLogs()
+                    )
+                    outputJSONCodable(response, logger: self.outputLogger)
+                } else {
                     for result in results {
                         if result.success {
                             print("✓ Quit \(result.app_name)")
@@ -187,7 +196,12 @@ extension AppCommand {
                         "quit app=\(result.app_name) pid=\(result.pid) success=\(result.success) force=\(self.force)"
                     )
                 }
+                if !allSucceeded {
+                    throw ExitCode.failure
+                }
 
+            } catch let exitCode as ExitCode {
+                throw exitCode
             } catch {
                 handleError(error)
                 throw ExitCode(1)

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/AppCommand+Relaunch.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/AppCommand+Relaunch.swift
@@ -15,11 +15,7 @@ extension AppCommand {
         )
 
         @Argument(help: "Application name, bundle ID, or 'PID:12345' for process ID")
-        var app: String
-
-        var positionalAppIdentifier: String {
-            self.app
-        }
+        var app: String?
 
         @Option(name: .long, help: "Target application by process ID")
         var pid: Int32?
@@ -142,14 +138,17 @@ extension AppCommand {
 }
 
 extension AppCommand.RelaunchSubcommand: AsyncRuntimeCommand, ErrorHandlingCommand, OutputFormattable,
-    ApplicationResolvablePositional,
+    ApplicationResolvable,
     ApplicationResolver {}
 
 @MainActor
 extension AppCommand.RelaunchSubcommand: CommanderBindableCommand {
     mutating func applyCommanderValues(_ values: CommanderBindableValues) throws {
-        app = try values.decodePositional(0, label: "app")
+        app = try values.decodeOptionalPositional(0, label: "app")
         pid = try values.decodeOption("pid", as: Int32.self)
+        guard app != nil || pid != nil else {
+            throw CommanderBindingError.missingArgument(label: "app or --pid")
+        }
         if let wait: TimeInterval = try values.decodeOption("wait", as: TimeInterval.self) {
             self.wait = wait
         }

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/AppCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/AppCommand.swift
@@ -55,11 +55,7 @@ struct AppCommand: ParsableCommand {
         )
 
         @Option(help: "Application to hide")
-        var app: String
-
-        var positionalAppIdentifier: String {
-            self.app
-        }
+        var app: String?
 
         @Option(name: .long, help: "Target application by process ID")
         var pid: Int32?
@@ -133,11 +129,7 @@ struct AppCommand: ParsableCommand {
         )
 
         @Option(help: "Application to unhide")
-        var app: String
-
-        var positionalAppIdentifier: String {
-            self.app
-        }
+        var app: String?
 
         @Option(name: .long, help: "Target application by process ID")
         var pid: Int32?
@@ -364,28 +356,34 @@ struct AppCommand: ParsableCommand {
 }
 
 extension AppCommand.HideSubcommand: AsyncRuntimeCommand, ErrorHandlingCommand, OutputFormattable,
-ApplicationResolvablePositional, ApplicationResolver {}
+ApplicationResolvable, ApplicationResolver {}
 @MainActor
 extension AppCommand.HideSubcommand: CommanderBindableCommand {
     mutating func applyCommanderValues(_ values: CommanderBindableValues) throws {
         self.app = try Self.resolveAppArgument(values, label: "app")
         self.pid = try values.decodeOption("pid", as: Int32.self)
+        guard self.app != nil || self.pid != nil else {
+            throw CommanderBindingError.missingArgument(label: "app or --pid")
+        }
     }
 }
 
 extension AppCommand.UnhideSubcommand: AsyncRuntimeCommand, ErrorHandlingCommand, OutputFormattable,
-ApplicationResolvablePositional, ApplicationResolver {}
+ApplicationResolvable, ApplicationResolver {}
 @MainActor
 extension AppCommand.UnhideSubcommand: CommanderBindableCommand {
     mutating func applyCommanderValues(_ values: CommanderBindableValues) throws {
         self.app = try AppCommand.HideSubcommand.resolveAppArgument(values, label: "app")
         self.pid = try values.decodeOption("pid", as: Int32.self)
+        guard self.app != nil || self.pid != nil else {
+            throw CommanderBindingError.missingArgument(label: "app or --pid")
+        }
         self.activate = values.flag("activate")
     }
 }
 
 extension AppCommand.HideSubcommand {
-    fileprivate static func resolveAppArgument(_ values: CommanderBindableValues, label: String) throws -> String {
+    fileprivate static func resolveAppArgument(_ values: CommanderBindableValues, label: String) throws -> String? {
         let positional = values.positionalValue(at: 0)
         let option = values.singleOption(label)
 
@@ -401,7 +399,7 @@ extension AppCommand.HideSubcommand {
         case let (_, option?):
             return option
         default:
-            throw CommanderBindingError.missingArgument(label: label)
+            return nil
         }
     }
 }

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/MenuCommand+ClickExtra.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/MenuCommand+ClickExtra.swift
@@ -11,7 +11,7 @@ extension MenuCommand {
         @Option(help: "Title of the menu extra (e.g., 'WiFi', 'Bluetooth')")
         var title: String
 
-        @Option(help: "Menu item to click after opening the extra")
+        @Option(help: "Reserved for future nested menu support; currently rejected")
         var item: String?
 
         @Flag(help: "Verify the menu extra popover opens after clicking")
@@ -47,6 +47,11 @@ extension MenuCommand {
             self.logger.setJsonOutputMode(self.jsonOutput)
 
             do {
+                guard self.item == nil else {
+                    throw ValidationError(
+                        "--item is not supported by menu click-extra; open the extra first, then use another interaction command"
+                    )
+                }
                 let verifier = MenuBarClickVerifier(services: self.services)
                 let verifyTarget = self.verify ? try await self.resolveVerificationTarget() : nil
                 let preFocus = self.verify ? try await verifier.captureFocusSnapshot() : nil
@@ -69,22 +74,15 @@ extension MenuCommand {
                     verification = nil
                 }
 
-                if self.item != nil {
-                    try await Task.sleep(nanoseconds: 200_000_000)
-                    fputs("Warning: Clicking menu items within menu extras is not yet implemented\n", stderr)
-                }
-
                 if self.jsonOutput {
                     let data = MenuExtraClickResult(
                         action: "menu_extra_click",
                         menu_extra: title,
-                        clicked_item: item ?? self.title,
+                        clicked_item: self.title,
                         location: clickResult.location.map { ["x": $0.x, "y": $0.y] },
                         verified: verification?.verified
                     )
                     outputSuccessCodable(data: data, logger: self.outputLogger)
-                } else if let clickedItem = item {
-                    print("✓ Clicked '\(clickedItem)' in \(self.title) menu")
                 } else {
                     if let location = clickResult.location {
                         print("✓ Clicked menu extra: \(self.title) at (\(Int(location.x)), \(Int(location.y)))")
@@ -96,6 +94,13 @@ extension MenuCommand {
                     }
                 }
 
+            } catch let error as Commander.ValidationError {
+                if self.jsonOutput {
+                    outputError(message: error.localizedDescription, code: .INVALID_INPUT, logger: self.outputLogger)
+                } else {
+                    fputs("Error: \(error.localizedDescription)\n", stderr)
+                }
+                throw ExitCode(1)
             } catch let error as MenuError {
                 MenuErrorOutputSupport.renderMenuError(
                     error,

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/MenuCommand+CommanderMetadata.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/MenuCommand+CommanderMetadata.swift
@@ -34,8 +34,15 @@ extension MenuCommand.ClickExtraSubcommand: CommanderSignatureProviding {
                 ),
                 .commandOption(
                     "item",
-                    help: "Menu item to click after opening the extra",
+                    help: "Reserved for future nested menu support; currently rejected",
                     long: "item"
+                ),
+            ],
+            flags: [
+                .commandFlag(
+                    "verify",
+                    help: "Verify the menu extra popover opens after clicking",
+                    long: "verify"
                 ),
             ]
         )

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/WindowCommand+Bindings.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/WindowCommand+Bindings.swift
@@ -198,5 +198,6 @@ extension WindowCommand.WindowListSubcommand: CommanderBindableCommand {
     mutating func applyCommanderValues(_ values: CommanderBindableValues) throws {
         self.app = values.singleOption("app")
         self.pid = try values.decodeOption("pid", as: Int32.self)
+        self.groupBySpace = values.flag("groupBySpace")
     }
 }

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/WindowCommand+CommanderMetadata.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/WindowCommand+CommanderMetadata.swift
@@ -40,7 +40,7 @@ extension WindowCommand.ResizeSubcommand: CommanderSignatureProviding {
     static func commanderSignature() -> CommandSignature {
         CommandSignature(
             options: [
-                .commandOption("width", help: "New width", long: "width"),
+                .commandOption("width", help: "New width", long: "width", short: "w"),
                 .commandOption("height", help: "New height", long: "height"),
             ],
             optionGroups: [WindowCommandSignatures.windowOptions]
@@ -54,7 +54,7 @@ extension WindowCommand.SetBoundsSubcommand: CommanderSignatureProviding {
             options: [
                 .commandOption("x", help: "New X coordinate", long: "x", short: "x"),
                 .commandOption("y", help: "New Y coordinate", long: "y", short: "y"),
-                .commandOption("width", help: "New width", long: "width"),
+                .commandOption("width", help: "New width", long: "width", short: "w"),
                 .commandOption("height", help: "New height", long: "height"),
             ],
             optionGroups: [WindowCommandSignatures.windowOptions]
@@ -86,6 +86,13 @@ extension WindowCommand.WindowListSubcommand: CommanderSignatureProviding {
             options: [
                 .commandOption("app", help: "Target application", long: "app"),
                 .commandOption("pid", help: "Target application by process ID", long: "pid"),
+            ],
+            flags: [
+                .commandFlag(
+                    "groupBySpace",
+                    help: "Group windows by Space (virtual desktop)",
+                    long: "group-by-space"
+                ),
             ]
         )
     }

--- a/Apps/CLI/Tests/CLIAutomationTests/AppCommandTests.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/AppCommandTests.swift
@@ -58,6 +58,23 @@ struct AppCommandTests {
     }
 
     @Test
+    func `App quit exits nonzero when the application refuses to quit`() async throws {
+        let context = await MainActor.run { makeAppCommandContext() }
+        await MainActor.run {
+            context.applicationService.quitShouldSucceed = false
+        }
+        let result = try await InProcessCommandRunner.run(
+            ["app", "quit", "--app", "Finder", "--json"],
+            services: context.services
+        )
+        #expect(result.exitStatus != 0)
+        let object = try #require(
+            JSONSerialization.jsonObject(with: Data(result.stdout.utf8)) as? [String: Any]
+        )
+        #expect(object["success"] as? Bool == false)
+    }
+
+    @Test
     func `App hide command validation`() async throws {
         // Normal hide should work
         let output = try await runAppCommand(["app", "hide", "--app", "Finder", "--help"])
@@ -83,7 +100,7 @@ struct AppCommandTests {
     @Test
     func `App lifecycle flow`() {
         // This tests the logical flow of app lifecycle commands
-        let launchCmd = ["app", "launch", "--app", "TextEdit", "--wait-until-ready"]
+        let launchCmd = ["app", "launch", "TextEdit", "--wait-until-ready"]
         let hideCmd = ["app", "hide", "--app", "TextEdit"]
         let showCmd = ["app", "unhide", "--app", "TextEdit"]
         let quitCmd = ["app", "quit", "--app", "TextEdit", "--json"]

--- a/Apps/CLI/Tests/CLIAutomationTests/MenuCommandTests.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/MenuCommandTests.swift
@@ -95,6 +95,18 @@ struct MenuCommandTests {
         #expect(output.contains("Click a system menu extra"))
         #expect(output.contains("--title"))
         #expect(output.contains("--item"))
+        #expect(output.contains("--verify"))
+    }
+
+    @Test
+    func `Menu click-extra rejects unsupported nested item without clicking`() async throws {
+        let (result, context) = try await self.runMenuCommandWithContext([
+            "menu", "click-extra", "--title", "WiFi", "--item", "Settings", "--json",
+        ])
+        #expect(result.exitStatus != 0)
+        #expect(self.output(from: result).contains("--item is not supported"))
+        let calls = await self.menuState(context.menuService) { $0.clickExtraCalls }
+        #expect(calls.isEmpty)
     }
 
     @Test

--- a/Apps/CLI/Tests/CoreCLITests/AppCommandBindingTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/AppCommandBindingTests.swift
@@ -24,4 +24,38 @@ struct AppCommandBindingTests {
         #expect(command.app == "Preview")
         #expect(command.activate == true)
     }
+
+    @Test
+    func `hide accepts pid without app`() throws {
+        let parsed = ParsedValues(positional: [], options: ["pid": ["123"]], flags: [])
+        let command = try CommanderCLIBinder.instantiateCommand(
+            ofType: AppCommand.HideSubcommand.self,
+            parsedValues: parsed
+        )
+        #expect(command.app == nil)
+        #expect(command.pid == 123)
+    }
+
+    @Test
+    func `unhide accepts pid without app`() throws {
+        let parsed = ParsedValues(positional: [], options: ["pid": ["123"]], flags: ["activate"])
+        let command = try CommanderCLIBinder.instantiateCommand(
+            ofType: AppCommand.UnhideSubcommand.self,
+            parsedValues: parsed
+        )
+        #expect(command.app == nil)
+        #expect(command.pid == 123)
+        #expect(command.activate == true)
+    }
+
+    @Test
+    func `relaunch accepts pid without app`() throws {
+        let parsed = ParsedValues(positional: [], options: ["pid": ["123"]], flags: [])
+        let command = try CommanderCLIBinder.instantiateCommand(
+            ofType: AppCommand.RelaunchSubcommand.self,
+            parsedValues: parsed
+        )
+        #expect(command.app == nil)
+        #expect(command.pid == 123)
+    }
 }

--- a/Apps/CLI/Tests/CoreCLITests/CommanderBinderCommandBindingTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/CommanderBinderCommandBindingTests.swift
@@ -156,7 +156,10 @@ struct CommanderBinderCommandBindingTests {
                 "mode": ["screen"],
                 "path": ["/tmp/see.png"],
                 "screenIndex": ["2"],
-                "analyze": ["describe"]
+                "analyze": ["describe"],
+                "maxDepth": ["8"],
+                "maxElements": ["500"],
+                "maxChildren": ["100"]
             ],
             flags: ["annotate"]
         )
@@ -169,6 +172,9 @@ struct CommanderBinderCommandBindingTests {
         #expect(command.screenIndex == 2)
         #expect(command.annotate == true)
         #expect(command.analyze == "describe")
+        #expect(command.maxDepth == 8)
+        #expect(command.maxElements == 500)
+        #expect(command.maxChildren == 100)
     }
 
     @Test
@@ -391,7 +397,7 @@ struct CommanderBinderCommandBindingTests {
                 "app": ["Finder"],
                 "pid": ["999"]
             ],
-            flags: []
+            flags: ["groupBySpace"]
         )
         let command = try CommanderCLIBinder.instantiateCommand(
             ofType: WindowCommand.WindowListSubcommand.self,
@@ -399,6 +405,7 @@ struct CommanderBinderCommandBindingTests {
         )
         #expect(command.app == "Finder")
         #expect(command.pid == 999)
+        #expect(command.groupBySpace == true)
     }
 
     @Test

--- a/Apps/CLI/Tests/CoreCLITests/CommanderBinderProgramResolutionTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/CommanderBinderProgramResolutionTests.swift
@@ -47,6 +47,73 @@ struct CommanderBinderProgramResolutionTests {
 
     @Test
     @MainActor
+    func `Commander program preserves see traversal and path aliases`() throws {
+        let descriptors = CommanderRegistryBuilder.buildDescriptors()
+        let program = Program(descriptors: descriptors.map(\.metadata))
+        for alias in ["--path", "--save", "--output", "-o"] {
+            let invocation = try program.resolve(argv: [
+                "peekaboo",
+                "see",
+                alias, "/tmp/see.png",
+                "--max-depth", "8",
+                "--max-elements", "500",
+                "--max-children", "100",
+            ])
+            let values = invocation.parsedValues
+            #expect(values.options["path"] == ["/tmp/see.png"])
+            #expect(values.options["maxDepth"] == ["8"])
+            #expect(values.options["maxElements"] == ["500"])
+            #expect(values.options["maxChildren"] == ["100"])
+        }
+        let modeHelp = SeeCommand.commanderSignature().options.first { $0.label == "mode" }?.help
+        #expect(modeHelp?.contains("multi") == true)
+    }
+
+    @Test
+    @MainActor
+    func `Commander program preserves window and menu documented options`() throws {
+        let descriptors = CommanderRegistryBuilder.buildDescriptors()
+        let program = Program(descriptors: descriptors.map(\.metadata))
+        let listInvocation = try program.resolve(argv: [
+            "peekaboo", "window", "list", "--app", "Finder", "--group-by-space",
+        ])
+        #expect(listInvocation.parsedValues.flags.contains("groupBySpace"))
+
+        let resizeInvocation = try program.resolve(argv: [
+            "peekaboo", "window", "resize", "--app", "Finder", "-w", "800", "--height", "600",
+        ])
+        #expect(resizeInvocation.parsedValues.options["width"] == ["800"])
+
+        let boundsInvocation = try program.resolve(argv: [
+            "peekaboo", "window", "set-bounds", "--app", "Finder",
+            "--x", "0", "--y", "0", "-w", "800", "--height", "600",
+        ])
+        #expect(boundsInvocation.parsedValues.options["width"] == ["800"])
+
+        let menuInvocation = try program.resolve(argv: [
+            "peekaboo", "menu", "click-extra", "--title", "WiFi", "--verify",
+        ])
+        #expect(menuInvocation.parsedValues.flags.contains("verify"))
+    }
+
+    @Test
+    @MainActor
+    func `App launch help treats app as optional with bundle identifier`() throws {
+        let argument = AppCommand.LaunchSubcommand.commanderSignature().arguments.first
+        #expect(argument?.label == "app")
+        #expect(argument?.isOptional == true)
+
+        let descriptors = CommanderRegistryBuilder.buildDescriptors()
+        let program = Program(descriptors: descriptors.map(\.metadata))
+        let invocation = try program.resolve(argv: [
+            "peekaboo", "app", "launch", "--bundle-id", "com.apple.TextEdit",
+        ])
+        #expect(invocation.parsedValues.positional.isEmpty)
+        #expect(invocation.parsedValues.options["bundleId"] == ["com.apple.TextEdit"])
+    }
+
+    @Test
+    @MainActor
     func `Commander program resolves list windows options`() throws {
         let descriptors = CommanderRegistryBuilder.buildDescriptors()
         let program = Program(descriptors: descriptors.map(\.metadata))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@
 ### Changed
 - Remove the obsolete scoped-commit helper now that agent work uses isolated worktrees.
 
+### Fixed
+- Stop bridge hosts from requiring AppleScript permission for native application activate, hide, unhide, hide-others, and show-all operations.
+- Keep targeted UI observation in the background, exclude irrelevant application menu trees, and restore the documented `see` traversal flags and output-path aliases.
+- Reject phantom-success accessibility actions, support selectable sidebar rows, and verify typed `set-value` results against live AX state.
+- Suppress desktop-global visualizer overlays for process-targeted background click, type, press, paste, and hotkey delivery.
+- Restore documented app, window, and menu CLI options; unsupported menu-extra item selection and failed app quits now exit nonzero instead of claiming success.
+- Remove the Dock-removal AppleScript path in favor of native accessibility actions.
+
 ## [3.10.0] - 2026-08-02
 
 ### Added

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Core/Protocols/ElementDetectionModels.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Core/Protocols/ElementDetectionModels.swift
@@ -148,6 +148,9 @@ public nonisolated struct WindowContext: Sendable, Codable {
     /// Whether element detection should attempt to focus embedded web content when inputs are missing
     public let shouldFocusWebContent: Bool?
 
+    /// Whether detection should append the application's menu-bar accessibility tree
+    public let includeMenuBarElements: Bool?
+
     /// Optional traversal budget to constrain AX tree collection
     public let traversalBudget: AXTraversalBudget?
 
@@ -159,6 +162,7 @@ public nonisolated struct WindowContext: Sendable, Codable {
         windowID: Int? = nil,
         windowBounds: CGRect? = nil,
         shouldFocusWebContent: Bool? = nil,
+        includeMenuBarElements: Bool? = nil,
         traversalBudget: AXTraversalBudget?)
     {
         self.applicationName = applicationName
@@ -168,6 +172,7 @@ public nonisolated struct WindowContext: Sendable, Codable {
         self.windowID = windowID
         self.windowBounds = windowBounds
         self.shouldFocusWebContent = shouldFocusWebContent
+        self.includeMenuBarElements = includeMenuBarElements
         self.traversalBudget = traversalBudget
     }
 
@@ -178,7 +183,8 @@ public nonisolated struct WindowContext: Sendable, Codable {
         windowTitle: String? = nil,
         windowID: Int? = nil,
         windowBounds: CGRect? = nil,
-        shouldFocusWebContent: Bool? = nil)
+        shouldFocusWebContent: Bool? = nil,
+        includeMenuBarElements: Bool? = nil)
     {
         self.init(
             applicationName: applicationName,
@@ -188,6 +194,7 @@ public nonisolated struct WindowContext: Sendable, Codable {
             windowID: windowID,
             windowBounds: windowBounds,
             shouldFocusWebContent: shouldFocusWebContent,
+            includeMenuBarElements: includeMenuBarElements,
             traversalBudget: nil)
     }
 }

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Observation/DesktopObservationRequestModels.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Observation/DesktopObservationRequestModels.swift
@@ -164,7 +164,7 @@ public struct DesktopDetectionOptions: Sendable, Codable, Equatable {
     public init(
         mode: DetectionMode = .accessibility,
         allowWebFocusFallback: Bool = true,
-        includeMenuBarElements: Bool = true,
+        includeMenuBarElements: Bool = false,
         preferOCR: Bool = false,
         traversalBudget: AXTraversalBudget = AXTraversalBudget.resolved())
     {
@@ -187,7 +187,7 @@ public struct DesktopDetectionOptions: Sendable, Codable, Equatable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.mode = try container.decode(DetectionMode.self, forKey: .mode)
         self.allowWebFocusFallback = try container.decode(Bool.self, forKey: .allowWebFocusFallback)
-        self.includeMenuBarElements = try container.decode(Bool.self, forKey: .includeMenuBarElements)
+        self.includeMenuBarElements = try container.decodeIfPresent(Bool.self, forKey: .includeMenuBarElements) ?? false
         self.preferOCR = try container.decode(Bool.self, forKey: .preferOCR)
         self.traversalBudget = try container.decodeIfPresent(AXTraversalBudget.self, forKey: .traversalBudget)
             ?? AXTraversalBudget.resolved()

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Observation/DesktopObservationService+Detection.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Observation/DesktopObservationService+Detection.swift
@@ -22,6 +22,7 @@ extension DesktopObservationService {
             windowID: context?.windowID,
             windowBounds: context?.windowBounds,
             shouldFocusWebContent: request.detection.allowWebFocusFallback,
+            includeMenuBarElements: request.detection.includeMenuBarElements,
             traversalBudget: request.detection.traversalBudget)
 
         return try await tracer.span("detection.ax") {

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/ActionInputDriver.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/ActionInputDriver.swift
@@ -63,7 +63,11 @@ struct ActionInputResult: Equatable {
     var anchorPoint: CGPoint?
     var elementRole: String?
 
-    init(actionName: String? = nil, anchorPoint: CGPoint? = nil, elementRole: String? = nil) {
+    init(
+        actionName: String? = nil,
+        anchorPoint: CGPoint? = nil,
+        elementRole: String? = nil)
+    {
         self.actionName = actionName
         self.anchorPoint = anchorPoint
         self.elementRole = elementRole
@@ -214,12 +218,13 @@ struct ActionInputDriver: ActionInputDriving {
     nonisolated static func setValueRejectionReason(
         role: String?,
         subrole: String?,
-        isValueSettable: Bool) -> ActionInputUnsupportedReason?
+        isValueSettable: Bool,
+        isSelectedSettable: Bool = false) -> ActionInputUnsupportedReason?
     {
         if role == "AXSecureTextField" || subrole == "AXSecureTextField" {
             return .secureValueNotAllowed
         }
-        if !isValueSettable {
+        if !isValueSettable, !isSelectedSettable {
             return .valueNotSettable
         }
         return nil
@@ -262,6 +267,10 @@ struct ActionInputDriver: ActionInputDriving {
     private func performAction(_ actionName: String, on element: any AutomationElementRepresenting)
         throws -> ActionInputResult
     {
+        guard element.supportsAction(actionName) else {
+            throw ActionInputError.unsupported(.actionUnsupported)
+        }
+
         do {
             try element.performAutomationAction(actionName)
             return ActionInputResult(
@@ -291,13 +300,36 @@ struct ActionInputDriver: ActionInputDriving {
         if let rejectionReason = Self.setValueRejectionReason(
             role: element.role,
             subrole: element.subrole,
-            isValueSettable: element.isValueSettable)
+            isValueSettable: element.isValueSettable,
+            isSelectedSettable: element.isSelectedSettable)
         {
             throw ActionInputError.unsupported(rejectionReason)
         }
 
         do {
-            try element.setAutomationValue(value)
+            if !element.isValueSettable, element.isSelectedSettable {
+                let requested = try Self.booleanValue(value, role: element.role)
+                if element.selectedValue != requested {
+                    try element.setAutomationSelected(requested)
+                }
+                guard element.selectedValue == requested else {
+                    throw ActionInputError.failed(
+                        "Accessibility selection did not change to the requested value")
+                }
+                return ActionInputResult(
+                    actionName: kAXSelectedAttribute as String,
+                    anchorPoint: element.anchorPoint,
+                    elementRole: element.role)
+            }
+
+            let requested = try Self.coerceValue(value, currentValue: element.value, role: element.role)
+            if !Self.value(element.value, matches: requested) {
+                try element.setAutomationValue(requested)
+            }
+            guard Self.value(element.value, matches: requested) else {
+                throw ActionInputError.failed(
+                    "Accessibility value did not change to the requested value")
+            }
             return ActionInputResult(
                 actionName: AXActionNames.kAXSetValueAction,
                 anchorPoint: element.anchorPoint,
@@ -305,6 +337,174 @@ struct ActionInputDriver: ActionInputDriving {
         } catch {
             throw Self.classify(error)
         }
+    }
+
+    private nonisolated static func coerceValue(
+        _ requested: UIElementValue,
+        currentValue: Any?,
+        role: String?) throws -> UIElementValue
+    {
+        if self.isTextRole(role) || currentValue is String {
+            return .string(requested.displayString)
+        }
+        if self.isBooleanRole(role) || self.valueKind(currentValue) == .bool {
+            return try .bool(self.booleanValue(requested, role: role))
+        }
+        if self.isNumericRole(role) {
+            return try .double(self.doubleValue(requested))
+        }
+
+        switch self.valueKind(currentValue) {
+        case .int:
+            return try .int(self.integerValue(requested))
+        case .double:
+            return try .double(self.doubleValue(requested))
+        case .bool, .string:
+            // Handled above.
+            return requested
+        case .unknown:
+            return requested
+        }
+    }
+
+    private nonisolated static func booleanValue(_ value: UIElementValue, role: String?) throws -> Bool {
+        switch value {
+        case let .bool(value):
+            return value
+        case let .int(value) where value == 0 || value == 1:
+            return value == 1
+        case let .double(value) where value == 0 || value == 1:
+            return value == 1
+        case let .string(value):
+            switch value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+            case "true", "1", "yes", "on":
+                return true
+            case "false", "0", "no", "off":
+                return false
+            default:
+                break
+            }
+        default:
+            break
+        }
+        let target = role.map { " for \($0)" } ?? ""
+        throw ActionInputError.failed("Expected a boolean value\(target)")
+    }
+
+    private nonisolated static func integerValue(_ value: UIElementValue) throws -> Int {
+        switch value {
+        case let .int(value):
+            return value
+        case let .double(value) where value.isFinite:
+            if let integer = Int(exactly: value) {
+                return integer
+            }
+        case let .string(value):
+            let value = value.trimmingCharacters(in: .whitespacesAndNewlines)
+            if let integer = Int(value) {
+                return integer
+            }
+            if let double = Double(value), double.isFinite, let integer = Int(exactly: double) {
+                return integer
+            }
+        case let .bool(value):
+            return value ? 1 : 0
+        default:
+            break
+        }
+        throw ActionInputError.failed("Expected an integer value")
+    }
+
+    private nonisolated static func doubleValue(_ value: UIElementValue) throws -> Double {
+        let result: Double? = switch value {
+        case let .double(value):
+            value
+        case let .int(value):
+            Double(value)
+        case let .string(value):
+            Double(value.trimmingCharacters(in: .whitespacesAndNewlines))
+        case let .bool(value):
+            value ? 1 : 0
+        }
+        guard let result, result.isFinite else {
+            throw ActionInputError.failed("Expected a finite numeric value")
+        }
+        return result
+    }
+
+    private nonisolated static func value(_ actual: Any?, matches expected: UIElementValue) -> Bool {
+        guard let actual else { return false }
+        switch expected {
+        case let .bool(expected):
+            if self.valueKind(actual) == .bool, let actual = actual as? Bool {
+                return actual == expected
+            }
+            if let number = actual as? NSNumber {
+                return number.intValue == (expected ? 1 : 0)
+            }
+            return false
+        case let .int(expected):
+            guard let number = actual as? NSNumber else { return false }
+            return !self.numberIsFloatingPoint(number) && number.intValue == expected
+        case let .double(expected):
+            guard let number = actual as? NSNumber else { return false }
+            let actual = number.doubleValue
+            let tolerance = max(1e-9, abs(expected) * 1e-9)
+            return actual.isFinite && abs(actual - expected) <= tolerance
+        case let .string(expected):
+            return (actual as? String) == expected
+        }
+    }
+
+    private enum ValueKind: Equatable {
+        case bool
+        case int
+        case double
+        case string
+        case unknown
+    }
+
+    private nonisolated static func valueKind(_ value: Any?) -> ValueKind {
+        guard let value else { return .unknown }
+        if value is String {
+            return .string
+        }
+        guard let number = value as? NSNumber else { return .unknown }
+        if CFGetTypeID(number) == CFBooleanGetTypeID() {
+            return .bool
+        }
+        return self.numberIsFloatingPoint(number) ? .double : .int
+    }
+
+    private nonisolated static func numberIsFloatingPoint(_ number: NSNumber) -> Bool {
+        switch String(cString: number.objCType) {
+        case "f", "d", "D":
+            true
+        default:
+            false
+        }
+    }
+
+    private nonisolated static func isTextRole(_ role: String?) -> Bool {
+        switch role {
+        case AXRoleNames.kAXTextFieldRole, AXRoleNames.kAXTextAreaRole, AXRoleNames.kAXComboBoxRole:
+            true
+        default:
+            false
+        }
+    }
+
+    private nonisolated static func isBooleanRole(_ role: String?) -> Bool {
+        switch role {
+        case AXRoleNames.kAXCheckBoxRole, AXRoleNames.kAXRadioButtonRole, "AXSwitch", "AXToggle":
+            true
+        default:
+            false
+        }
+    }
+
+    private nonisolated static func isNumericRole(_ role: String?) -> Bool {
+        role == "AXSlider"
     }
 
     private func scrollActionNames(for direction: PeekabooFoundation.ScrollDirection) -> [String] {

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/AutomationElement.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/AutomationElement.swift
@@ -23,6 +23,8 @@ protocol AutomationElementRepresenting: Sendable {
     var actionNames: [String] { get }
     var isValueSettable: Bool { get }
     var isFocusedSettable: Bool { get }
+    var isSelectedSettable: Bool { get }
+    var selectedValue: Bool? { get }
     var isEnabled: Bool { get }
     var isFocused: Bool { get }
     var isOffscreen: Bool { get }
@@ -44,6 +46,7 @@ protocol AutomationElementRepresenting: Sendable {
     func performAutomationAction(_ actionName: String) throws
     func setAutomationValue(_ value: UIElementValue) throws
     func setAutomationFocused(_ focused: Bool) throws
+    func setAutomationSelected(_ selected: Bool) throws
     func stringAttribute(_ name: String) -> String?
     func intAttribute(_ name: String) -> Int?
 }
@@ -55,6 +58,18 @@ extension AutomationElementRepresenting {
 
     func supportsAction(_ actionName: String) -> Bool {
         self.actionNames.contains(actionName)
+    }
+
+    var isSelectedSettable: Bool {
+        false
+    }
+
+    var selectedValue: Bool? {
+        nil
+    }
+
+    func setAutomationSelected(_: Bool) throws {
+        throw AccessibilitySystemError(.attributeUnsupported)
     }
 }
 
@@ -107,7 +122,12 @@ struct AutomationElement: AutomationElementRepresenting {
 
     @MainActor
     var value: Any? {
-        self.element.value()
+        var value: CFTypeRef?
+        let error = AXUIElementCopyAttributeValue(
+            self.element.underlyingElement,
+            AXAttributeNames.kAXValueAttribute as CFString,
+            &value)
+        return error == .success ? value : nil
     }
 
     @MainActor
@@ -128,6 +148,22 @@ struct AutomationElement: AutomationElementRepresenting {
     @MainActor
     var isFocusedSettable: Bool {
         self.element.isAttributeSettable(named: AXAttributeNames.kAXFocusedAttribute)
+    }
+
+    @MainActor
+    var isSelectedSettable: Bool {
+        self.element.isAttributeSettable(named: kAXSelectedAttribute as String)
+    }
+
+    @MainActor
+    var selectedValue: Bool? {
+        var value: CFTypeRef?
+        let error = AXUIElementCopyAttributeValue(
+            self.element.underlyingElement,
+            kAXSelectedAttribute as CFString,
+            &value)
+        guard error == .success, let value else { return nil }
+        return value as? Bool
     }
 
     @MainActor
@@ -216,6 +252,17 @@ struct AutomationElement: AutomationElementRepresenting {
             self.element.underlyingElement,
             AXAttributeNames.kAXFocusedAttribute as CFString,
             (focused ? kCFBooleanTrue : kCFBooleanFalse) as CFTypeRef)
+        guard error == .success else {
+            throw AccessibilitySystemError(error)
+        }
+    }
+
+    @MainActor
+    func setAutomationSelected(_ selected: Bool) throws {
+        let error = AXUIElementSetAttributeValue(
+            self.element.underlyingElement,
+            kAXSelectedAttribute as CFString,
+            (selected ? kCFBooleanTrue : kCFBooleanFalse) as CFTypeRef)
         guard error == .success else {
             throw AccessibilitySystemError(error)
         }

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/AutomationElementResolver.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/AutomationElementResolver.swift
@@ -70,6 +70,13 @@ protocol AutomationWindowRootResolving: Sendable {
 }
 
 @MainActor
+protocol AutomationElementTreeReading: Sendable {
+    func descriptor(for element: Element) -> AXDescriptorReader.Descriptor?
+    func children(of element: Element) -> [Element]?
+    func processIdentifier(of element: Element) -> pid_t?
+}
+
+@MainActor
 private struct SystemAutomationWindowRootResolver: AutomationWindowRootResolving {
     private let identityService = WindowIdentityService()
 
@@ -79,11 +86,35 @@ private struct SystemAutomationWindowRootResolver: AutomationWindowRootResolving
 }
 
 @MainActor
+private struct SystemAutomationElementTreeReader: AutomationElementTreeReading {
+    func descriptor(for element: Element) -> AXDescriptorReader.Descriptor? {
+        AXDescriptorReader.describe(element)
+    }
+
+    func children(of element: Element) -> [Element]? {
+        element.children()
+    }
+
+    func processIdentifier(of element: Element) -> pid_t? {
+        var processIdentifier: pid_t = 0
+        guard AXUIElementGetPid(element.underlyingElement, &processIdentifier) == .success else {
+            return nil
+        }
+        return processIdentifier
+    }
+}
+
+@MainActor
 struct AutomationElementResolver: AutomationElementResolving {
     private let windowRootResolver: any AutomationWindowRootResolving
+    private let treeReader: any AutomationElementTreeReading
 
-    init(windowRootResolver: any AutomationWindowRootResolving = SystemAutomationWindowRootResolver()) {
+    init(
+        windowRootResolver: any AutomationWindowRootResolving = SystemAutomationWindowRootResolver(),
+        treeReader: any AutomationElementTreeReading = SystemAutomationElementTreeReader())
+    {
         self.windowRootResolver = windowRootResolver
+        self.treeReader = treeReader
     }
 
     func resolve(
@@ -106,10 +137,12 @@ struct AutomationElementResolver: AutomationElementResolving {
                 windowContext: windowContext,
                 targetProcessIdentifier: targetProcessIdentifier,
                 detectedElement: detectedElement),
-            targetProcessIdentifier: targetProcessIdentifier)
-        { element in
-            guard let descriptor = AXDescriptorReader.describe(element) else { return nil }
-            return self.score(descriptor: descriptor, for: detectedElement)
+            targetProcessIdentifier: targetProcessIdentifier,
+            exactSnapshotElement: self.canUseExactSnapshotFastPath(
+                detectedElement: detectedElement,
+                windowContext: windowContext) ? detectedElement : nil)
+        { _, descriptor in
+            self.score(descriptor: descriptor, for: detectedElement)
         }
     }
 
@@ -139,8 +172,7 @@ struct AutomationElementResolver: AutomationElementResolving {
                 windowContext: windowContext,
                 targetProcessIdentifier: targetProcessIdentifier),
             targetProcessIdentifier: targetProcessIdentifier)
-        { element in
-            guard let descriptor = AXDescriptorReader.describe(element) else { return nil }
+        { _, descriptor in
             if requireTextInput, !self.isTextInput(role: descriptor.role) {
                 return nil
             }
@@ -230,7 +262,8 @@ struct AutomationElementResolver: AutomationElementResolving {
     private func bestElement(
         in roots: [Element],
         targetProcessIdentifier: pid_t? = nil,
-        scorer: (Element) -> Int?) -> AutomationElement?
+        exactSnapshotElement: DetectedElement? = nil,
+        scorer: (Element, AXDescriptorReader.Descriptor) -> Int?) -> AutomationElement?
     {
         var visited = 0
         var stack = roots
@@ -240,26 +273,68 @@ struct AutomationElementResolver: AutomationElementResolving {
         while let element = stack.popLast(), visited < 4000 {
             visited += 1
 
-            if let score = scorer(element), score > bestScore {
-                best = element
-                bestScore = score
+            if let descriptor = self.treeReader.descriptor(for: element) {
+                if let exactSnapshotElement,
+                   self.isExactSnapshotMatch(descriptor: descriptor, for: exactSnapshotElement),
+                   self.matchesProcessIdentifier(element, targetProcessIdentifier)
+                {
+                    return AutomationElement(element)
+                }
+
+                if let score = scorer(element, descriptor), score > bestScore {
+                    best = element
+                    bestScore = score
+                }
             }
 
-            if let children = element.children() {
+            if let children = self.treeReader.children(of: element) {
                 stack.append(contentsOf: children.reversed())
             }
         }
 
-        guard let best else { return nil }
-        if let targetProcessIdentifier {
-            var resolvedProcessIdentifier: pid_t = 0
-            guard AXUIElementGetPid(best.underlyingElement, &resolvedProcessIdentifier) == .success,
-                  resolvedProcessIdentifier == targetProcessIdentifier
-            else {
-                return nil
-            }
-        }
+        guard let best, self.matchesProcessIdentifier(best, targetProcessIdentifier) else { return nil }
         return AutomationElement(best)
+    }
+
+    private func canUseExactSnapshotFastPath(
+        detectedElement: DetectedElement,
+        windowContext: WindowContext?) -> Bool
+    {
+        windowContext?.windowID != nil || DetectedElementRootPolicy.requiresApplicationRoot(detectedElement)
+    }
+
+    private func isExactSnapshotMatch(
+        descriptor: AXDescriptorReader.Descriptor,
+        for element: DetectedElement) -> Bool
+    {
+        guard let expectedIdentifier = self.normalized(element.attributes["identifier"]),
+              let actualIdentifier = self.normalized(descriptor.identifier),
+              expectedIdentifier == actualIdentifier,
+              descriptor.frame.equalTo(element.bounds)
+        else {
+            return false
+        }
+
+        if let expectedRole = self.normalized(element.attributes["role"]) {
+            return self.normalized(descriptor.role) == expectedRole
+        }
+
+        // `.other` deliberately accepts any role in fuzzy scoring, so it cannot establish exact identity.
+        return element.type != .other && self.elementType(element.type, matchesRole: descriptor.role)
+    }
+
+    private func matchesProcessIdentifier(_ element: Element, _ expectedProcessIdentifier: pid_t?) -> Bool {
+        guard let expectedProcessIdentifier else { return true }
+        return self.treeReader.processIdentifier(of: element) == expectedProcessIdentifier
+    }
+
+    private func normalized(_ value: String?) -> String? {
+        guard let normalized = value?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased(),
+              !normalized.isEmpty
+        else {
+            return nil
+        }
+        return normalized
     }
 
     private func score(descriptor: AXDescriptorReader.Descriptor, for element: DetectedElement) -> Int? {

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/BackgroundInputDriver.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/BackgroundInputDriver.swift
@@ -34,6 +34,7 @@ enum BackgroundInputDriver {
     enum PositionalClickAction: Equatable {
         case press
         case showMenu
+        case select
         case focus
     }
 
@@ -88,20 +89,7 @@ enum BackgroundInputDriver {
             try self.assertBelongsToTargetWindow(resolved.element, targetWindowID: targetWindowID, at: point)
         }
 
-        switch resolved.action {
-        case .press:
-            try await self.performDetachedAction(
-                AXActionNames.kAXPressAction,
-                on: resolved.element,
-                gracePeriod: DetachedAXActionRunner.pressGracePeriod)
-        case .showMenu:
-            try await self.performDetachedAction(
-                AXActionNames.kAXShowMenuAction,
-                on: resolved.element,
-                gracePeriod: DetachedAXActionRunner.showMenuGracePeriod)
-        case .focus:
-            try resolved.element.setAutomationFocused(true)
-        }
+        try await self.performPositionalClickAction(resolved.action, on: resolved.element)
     }
 
     /// Picks the element that should receive a positional background click.
@@ -143,6 +131,10 @@ enum BackgroundInputDriver {
         }
 
         guard button == .left else { return nil }
+        if let selectableRow = self.selectableRow(in: spatiallyValid) {
+            return (selectableRow, .select)
+        }
+
         let focusable = spatiallyValid.first(where: self.canFocusForPositionalClick)
         if let focusable {
             let role = focusable.role ?? "<none>"
@@ -967,6 +959,44 @@ enum BackgroundInputDriver {
 }
 
 extension BackgroundInputDriver {
+    @MainActor
+    static func performPositionalClickAction(
+        _ action: PositionalClickAction,
+        on element: any AutomationElementRepresenting) async throws
+    {
+        switch action {
+        case .press:
+            try await self.performDetachedAction(
+                AXActionNames.kAXPressAction,
+                on: element,
+                gracePeriod: DetachedAXActionRunner.pressGracePeriod)
+        case .showMenu:
+            try await self.performDetachedAction(
+                AXActionNames.kAXShowMenuAction,
+                on: element,
+                gracePeriod: DetachedAXActionRunner.showMenuGracePeriod)
+        case .select:
+            try element.setAutomationSelected(true)
+        case .focus:
+            try element.setAutomationFocused(true)
+        }
+    }
+
+    @MainActor
+    private static func selectableRow(
+        in elements: [any AutomationElementRepresenting]) -> (any AutomationElementRepresenting)?
+    {
+        guard let row = elements.first(where: {
+            $0.isEnabled && $0.role == AXRoleNames.kAXRowRole && $0.isSelectedSettable
+        }) else {
+            return nil
+        }
+        let frame = String(describing: row.frame)
+        self.logger.debug(
+            "Resolved background positional click to role=AXRow action=select frame=\(frame, privacy: .public)")
+        return row
+    }
+
     static let doubleClickUnsupportedMessage = """
     Background double-click is not supported: macOS delivers pid-targeted mouse events at the \
     window origin instead of the requested point. Re-run with --foreground to focus the app and \

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/DockService+Actions.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/DockService+Actions.swift
@@ -137,42 +137,13 @@ extension DockService {
     }
 
     func removeFromDockImpl(appName: String) async throws {
-        let appleScript = """
-        on run argv
-        set targetName to item 1 of argv
-        tell application "System Events"
-            tell process "Dock"
-                set dockItems to every UI element of list 1
-                repeat with dockItem in dockItems
-                    if name of dockItem contains targetName then
-                        perform action "AXShowMenu" of dockItem
-                        delay 0.1
-                        click menu item "Remove from Dock" of menu 1 of dockItem
-                        return "Removed"
-                    end if
-                end repeat
-            end tell
-        end tell
-        return "Not found"
-        end run
-        """
-
-        let task = Process()
-        task.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
-        task.arguments = ["-e", appleScript, appName]
-
-        let pipe = Pipe()
-        task.standardOutput = pipe
-        task.standardError = Pipe()
-
-        try task.run()
-        try DockService.waitForProcessExit(task, timeoutSeconds: 30)
-
-        let data = pipe.fileHandleForReading.readDataToEndOfFile()
-        let result = String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-
-        if result == "Not found" {
-            throw PeekabooError.elementNotFound("App '\(appName)' not found in Dock")
+        let element = try self.findDockElement(appName: appName)
+        do {
+            _ = try await ActionInputDriver().tryRightClick(element: AutomationElement(element))
+            try await self.clickContextMenuItem("Remove from Dock", for: element)
+        } catch {
+            throw PeekabooError.operationError(
+                message: "Failed to remove '\(appName)' from Dock: \(error.localizedDescription)")
         }
     }
 

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/DockService+Process.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/DockService+Process.swift
@@ -5,7 +5,7 @@ extension DockService {
     /// Wait for a launched `Process` with a hard deadline.
     ///
     /// Foundation's `waitUntilExit()` can block forever if the child wedges. Dock
-    /// commands (`defaults`, `killall`, `osascript`) should never hang the CLI/MCP.
+    /// commands (`defaults`, `killall`) should never hang the CLI/MCP.
     nonisolated static func waitForProcessExit(
         _ process: Process,
         timeoutSeconds: TimeInterval = 15) throws

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/ElementDetectionCache.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/ElementDetectionCache.swift
@@ -11,11 +11,18 @@ import PeekabooFoundation
         public let windowID: Int
         public let processID: pid_t
         public let allowWebFocus: Bool
+        public let includeMenuBarElements: Bool
 
-        public init(windowID: Int, processID: pid_t, allowWebFocus: Bool) {
+        public init(
+            windowID: Int,
+            processID: pid_t,
+            allowWebFocus: Bool,
+            includeMenuBarElements: Bool)
+        {
             self.windowID = windowID
             self.processID = processID
             self.allowWebFocus = allowWebFocus
+            self.includeMenuBarElements = includeMenuBarElements
         }
     }
 
@@ -43,9 +50,18 @@ import PeekabooFoundation
         self.now = now
     }
 
-    public func key(windowID: Int?, processID: pid_t, allowWebFocus: Bool) -> Key? {
+    public func key(
+        windowID: Int?,
+        processID: pid_t,
+        allowWebFocus: Bool,
+        includeMenuBarElements: Bool) -> Key?
+    {
         guard let windowID else { return nil }
-        return Key(windowID: windowID, processID: processID, allowWebFocus: allowWebFocus)
+        return Key(
+            windowID: windowID,
+            processID: processID,
+            allowWebFocus: allowWebFocus,
+            includeMenuBarElements: includeMenuBarElements)
     }
 
     public func elements(for key: Key) -> [DetectedElement]? {

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/ElementDetectionCache.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/ElementDetectionCache.swift
@@ -17,7 +17,7 @@ import PeekabooFoundation
             windowID: Int,
             processID: pid_t,
             allowWebFocus: Bool,
-            includeMenuBarElements: Bool)
+            includeMenuBarElements: Bool = false)
         {
             self.windowID = windowID
             self.processID = processID
@@ -54,7 +54,7 @@ import PeekabooFoundation
         windowID: Int?,
         processID: pid_t,
         allowWebFocus: Bool,
-        includeMenuBarElements: Bool) -> Key?
+        includeMenuBarElements: Bool = false) -> Key?
     {
         guard let windowID else { return nil }
         return Key(

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/ElementDetectionService.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/ElementDetectionService.swift
@@ -83,6 +83,7 @@ public final class ElementDetectionService {
 
         var elementIdMap: [String: DetectedElement] = [:]
         let allowWebFocus = windowContext?.shouldFocusWebContent ?? true
+        let includeMenuBarElements = windowContext?.includeMenuBarElements ?? true
         let budget = AXTraversalBudget.normalizedForTraversal(windowContext?.traversalBudget)
         let usesDefaultBudget = budget == AXTraversalBudget()
         let resolvedWindowBounds = windowContext?.windowBounds ?? windowResolution.window.frame()
@@ -94,6 +95,7 @@ public final class ElementDetectionService {
             windowID: resolvedWindowID,
             windowBounds: resolvedWindowBounds,
             shouldFocusWebContent: windowContext?.shouldFocusWebContent,
+            includeMenuBarElements: windowContext?.includeMenuBarElements,
             traversalBudget: budget)
 
         // GameBridge: check if this is a known game-bridge app (SDL/GPU-rendered)
@@ -113,7 +115,8 @@ public final class ElementDetectionService {
             ? self.axTreeCache.key(
                 windowID: resolvedWindowID,
                 processID: targetApp.processIdentifier,
-                allowWebFocus: allowWebFocus)
+                allowWebFocus: allowWebFocus,
+                includeMenuBarElements: includeMenuBarElements)
             : nil
         if let cacheKey, let cached = self.axTreeCache.result(for: cacheKey) {
             self.logger.debug("Using cached AX tree for window \(cacheKey.windowID)")
@@ -127,6 +130,7 @@ public final class ElementDetectionService {
                     appElement: windowResolution.appElement,
                     appIsActive: targetApp.isActive,
                     allowWebFocus: allowWebFocus,
+                    includeMenuBarElements: includeMenuBarElements,
                     budget: budget),
                 elementIdMap: &elementIdMap)
             detectedElements = collection.elements
@@ -171,6 +175,7 @@ extension ElementDetectionService {
                 appElement: timeoutRequest.appElement,
                 appIsActive: timeoutRequest.appIsActive,
                 allowWebFocus: timeoutRequest.allowWebFocus,
+                includeMenuBarElements: timeoutRequest.includeMenuBarElements,
                 deadline: deadline,
                 budget: timeoutRequest.budget)
             let collection = await self.collectElements(
@@ -209,7 +214,10 @@ extension ElementDetectionService {
             elementIdMap = collection.elementIdMap
             truncationInfo = collection.truncationInfo
 
-            if request.appIsActive, let menuBar = request.appElement.menuBar() {
+            if Self.shouldCollectMenuBarElements(
+                requested: request.includeMenuBarElements,
+                appIsActive: request.appIsActive), let menuBar = request.appElement.menuBar()
+            {
                 let menuBarTruncation = self.menuBarElementCollector.appendMenuBar(
                     menuBar,
                     elements: &detectedElements,
@@ -242,6 +250,10 @@ extension ElementDetectionService {
             elements: detectedElements,
             truncationInfo: truncationInfo)
     }
+
+    static func shouldCollectMenuBarElements(requested: Bool, appIsActive: Bool) -> Bool {
+        requested && appIsActive
+    }
 }
 
 @_spi(Testing) public enum ElementDetectionWebFocusRetryDelay {
@@ -260,6 +272,7 @@ private struct ElementCollectionRequest {
     let appElement: Element
     let appIsActive: Bool
     let allowWebFocus: Bool
+    let includeMenuBarElements: Bool
     let deadline: Date
     let budget: AXTraversalBudget?
 }
@@ -269,6 +282,7 @@ private struct ElementCollectionTimeoutRequest {
     let appElement: Element
     let appIsActive: Bool
     let allowWebFocus: Bool
+    let includeMenuBarElements: Bool
     let budget: AXTraversalBudget?
     let timeoutSeconds = 20.0
 }

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/ElementDetectionWindowResolver.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/ElementDetectionWindowResolver.swift
@@ -77,15 +77,7 @@ struct ElementDetectionWindowResolver {
                 let identifier = app.localizedName ?? app.bundleIdentifier ?? "PID:\(app.processIdentifier)"
                 self.logger.notice("Resolved window via CGWindowID \(windowID): '\(title)' for \(identifier)")
 
-                let window: Element
-                if let focused = self.focusedWindowIfMatches(app: app),
-                   self.windowIdentityService.getWindowID(from: focused).map(Int.init) == windowID
-                {
-                    window = focused
-                } else {
-                    await self.focusWindow(withID: windowID, appName: identifier)
-                    window = self.focusedWindowIfMatches(app: app) ?? handle.element
-                }
+                let window = handle.element
 
                 let subrole = window.subrole() ?? ""
                 let isDialogRole = ["AXDialog", "AXSystemDialog", "AXSheet"].contains(subrole)
@@ -214,10 +206,6 @@ struct ElementDetectionWindowResolver {
                 let fallbackTarget = app.localizedName ?? "app"
                 let fallbackTitle = matching.title ?? "Untitled"
                 self.logger.info("Using CG fallback window '\(fallbackTitle)' for \(fallbackTarget)")
-                await self.focusWindow(withID: Int(matching.windowID), appName: app.localizedName ?? "app")
-                if let focused = self.focusedWindowIfMatches(app: app) {
-                    return focused
-                }
                 return element
             }
         }
@@ -227,10 +215,6 @@ struct ElementDetectionWindowResolver {
                 let fallbackTarget = app.localizedName ?? "app"
                 let fallbackTitle = info.title ?? "Untitled"
                 self.logger.info("Using CG fallback window '\(fallbackTitle)' for \(fallbackTarget)")
-                await self.focusWindow(withID: Int(info.windowID), appName: app.localizedName ?? "app")
-                if let focused = self.focusedWindowIfMatches(app: app) {
-                    return focused
-                }
                 return element
             }
         }
@@ -278,10 +262,6 @@ struct ElementDetectionWindowResolver {
             }
 
             self.logger.notice("Using window service fallback window '\(windowInfo.title)' for \(identifier)")
-            await self.focusWindow(withID: windowInfo.windowID, appName: identifier)
-            if let focused = self.focusedWindowIfMatches(app: app) {
-                return focused
-            }
             return element
         } catch {
             self.logger.error("Window service fallback failed: \(error.localizedDescription)")
@@ -308,14 +288,6 @@ struct ElementDetectionWindowResolver {
 
         self.logger.notice("Using focused window fallback for \(app.localizedName ?? "app")")
         return focusedWindow
-    }
-
-    private func focusWindow(withID windowID: Int, appName: String) async {
-        do {
-            try await self.windowManagementService.focusWindow(target: .windowId(windowID))
-        } catch {
-            self.logger.warning("Failed to focus window \(windowID) for \(appName): \(error.localizedDescription)")
-        }
     }
 }
 

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/UIAutomationService+ElementActions.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/UIAutomationService+ElementActions.swift
@@ -10,6 +10,7 @@ extension UIAutomationService: ElementActionAutomationServiceProtocol {
         self.logger.debug("Set value requested - target: \(target, privacy: .public)")
         let resolved = try await self.resolveActionTarget(target, snapshotId: snapshotId)
         let oldValue = self.safeValueDescription(resolved.element.value)
+            ?? resolved.element.selectedValue.map(String.init)
         let result = try await self.normalizingSnapshotErrors {
             try await UIInputDispatcher.run(
                 verb: .setValue,
@@ -30,7 +31,11 @@ extension UIAutomationService: ElementActionAutomationServiceProtocol {
                         reason: "Direct value setting is not supported for this element."))
                 })
         }
-        let newValue = self.safeValueDescription(resolved.element.value) ?? value.displayString
+        guard let newValue = self.safeValueDescription(resolved.element.value)
+            ?? resolved.element.selectedValue.map(String.init)
+        else {
+            throw PeekabooError.operationError(message: "Accessibility value could not be verified after setting")
+        }
 
         return ElementActionResult(
             target: resolved.description,

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/UIAutomationService+Operations.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/UIAutomationService+Operations.swift
@@ -157,11 +157,12 @@ extension UIAutomationService {
             try await self.clickService.click(target: target, clickType: clickType, snapshotId: snapshotId)
         }
 
-        // Show visual feedback if available
-        let fallbackPoint = try await self.getClickPoint(for: target, snapshotId: snapshotId)
-        if let clickPoint = Self.visualFeedbackPoint(actionAnchor: result.anchorPoint, fallbackPoint: fallbackPoint) {
-            _ = await self.feedbackClient.showClickFeedback(at: clickPoint, type: clickType)
-        }
+        try await self.visualizeClick(
+            target: target,
+            actionAnchor: result.anchorPoint,
+            clickType: clickType,
+            snapshotId: snapshotId,
+            targetProcessIdentifier: nil)
     }
 
     public func click(
@@ -179,10 +180,12 @@ extension UIAutomationService {
                 targetProcessIdentifier: targetProcessIdentifier)
         }
 
-        let fallbackPoint = try await self.getClickPoint(for: target, snapshotId: snapshotId)
-        if let clickPoint = Self.visualFeedbackPoint(actionAnchor: result.anchorPoint, fallbackPoint: fallbackPoint) {
-            _ = await self.feedbackClient.showClickFeedback(at: clickPoint, type: clickType)
-        }
+        try await self.visualizeClick(
+            target: target,
+            actionAnchor: result.anchorPoint,
+            clickType: clickType,
+            snapshotId: snapshotId,
+            targetProcessIdentifier: targetProcessIdentifier)
     }
 
     public func click(
@@ -202,8 +205,26 @@ extension UIAutomationService {
                 targetWindowID: targetWindowID)
         }
 
+        try await self.visualizeClick(
+            target: target,
+            actionAnchor: result.anchorPoint,
+            clickType: clickType,
+            snapshotId: snapshotId,
+            targetProcessIdentifier: targetProcessIdentifier)
+    }
+
+    /// Background delivery must remain invisible to the foreground user. Visualizer windows are
+    /// desktop-global, so only untargeted/foreground clicks may emit click feedback.
+    func visualizeClick(
+        target: ClickTarget,
+        actionAnchor: CGPoint?,
+        clickType: ClickType,
+        snapshotId: String?,
+        targetProcessIdentifier: pid_t?) async throws
+    {
+        guard targetProcessIdentifier == nil else { return }
         let fallbackPoint = try await self.getClickPoint(for: target, snapshotId: snapshotId)
-        if let clickPoint = Self.visualFeedbackPoint(actionAnchor: result.anchorPoint, fallbackPoint: fallbackPoint) {
+        if let clickPoint = Self.visualFeedbackPoint(actionAnchor: actionAnchor, fallbackPoint: fallbackPoint) {
             _ = await self.feedbackClient.showClickFeedback(at: clickPoint, type: clickType)
         }
     }

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/UIAutomationService+PointerKeyboardOperations.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/UIAutomationService+PointerKeyboardOperations.swift
@@ -65,8 +65,7 @@ extension UIAutomationService {
         self.logger.debug("Delegating hotkey to HotkeyService")
         _ = try await self.hotkeyService.hotkey(keys: keys, holdDuration: holdDuration)
 
-        let keyArray = keys.split(separator: ",").map { String($0).trimmingCharacters(in: .whitespaces) }
-        _ = await self.feedbackClient.showHotkeyDisplay(keys: keyArray, duration: 1.0)
+        await self.visualizeHotkey(keys: keys, targetProcessIdentifier: nil)
     }
 
     public func hotkey(keys: String, holdDuration: Int, targetProcessIdentifier: pid_t) async throws {
@@ -76,6 +75,13 @@ extension UIAutomationService {
             holdDuration: holdDuration,
             targetProcessIdentifier: targetProcessIdentifier)
 
+        await self.visualizeHotkey(keys: keys, targetProcessIdentifier: targetProcessIdentifier)
+    }
+
+    /// PID-routed hotkeys are background operations. Suppress the desktop-global overlay so they
+    /// do not cover or distract the foreground application.
+    func visualizeHotkey(keys: String, targetProcessIdentifier: pid_t?) async {
+        guard targetProcessIdentifier == nil else { return }
         let keyArray = keys.split(separator: ",").map { String($0).trimmingCharacters(in: .whitespaces) }
         _ = await self.feedbackClient.showHotkeyDisplay(keys: keyArray, duration: 1.0)
     }

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/UIAutomationService+TypingOperations.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/UIAutomationService+TypingOperations.swift
@@ -173,6 +173,9 @@ extension UIAutomationService {
         targetProcessIdentifier: pid_t? = nil) async
     {
         guard !keys.isEmpty else { return }
+        // Targeted typing (including press and background text paste) is intentionally invisible.
+        // The visualizer overlay is desktop-global even though the input is routed to one process.
+        guard targetProcessIdentifier == nil else { return }
         // Typed text shows verbatim in the caption; only password fields mask.
         // Type-action callers sample each text segment at delivery time; the
         // post-typing sample remains a final safety net for direct text entry.

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/AXTreeCollectorBudgetTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/AXTreeCollectorBudgetTests.swift
@@ -2,7 +2,7 @@
 import CoreGraphics
 import Foundation
 import XCTest
-@testable import PeekabooAutomationKit
+@testable @_spi(Testing) import PeekabooAutomationKit
 
 @MainActor
 final class AXTreeCollectorBudgetTests: XCTestCase {
@@ -136,6 +136,79 @@ final class AXTreeCollectorBudgetTests: XCTestCase {
 
         XCTAssertEqual(decoded.traversalBudget, AXTraversalBudget())
         XCTAssertEqual(decoded.allowWebFocusFallback, false)
+    }
+
+    func testDesktopDetectionDefaultsExcludeApplicationMenuBar() {
+        XCTAssertFalse(DesktopDetectionOptions().includeMenuBarElements)
+    }
+
+    func testMenuBarCollectionRequiresExplicitRequestAndActiveApplication() {
+        XCTAssertFalse(ElementDetectionService.shouldCollectMenuBarElements(requested: false, appIsActive: false))
+        XCTAssertFalse(ElementDetectionService.shouldCollectMenuBarElements(requested: false, appIsActive: true))
+        XCTAssertFalse(ElementDetectionService.shouldCollectMenuBarElements(requested: true, appIsActive: false))
+        XCTAssertTrue(ElementDetectionService.shouldCollectMenuBarElements(requested: true, appIsActive: true))
+    }
+
+    func testElementCacheSeparatesMenuBarPolicies() throws {
+        let cache = ElementDetectionCache()
+        let withoutMenuBar = try XCTUnwrap(cache.key(
+            windowID: 42,
+            processID: 123,
+            allowWebFocus: false,
+            includeMenuBarElements: false))
+        let withMenuBar = try XCTUnwrap(cache.key(
+            windowID: 42,
+            processID: 123,
+            allowWebFocus: false,
+            includeMenuBarElements: true))
+
+        XCTAssertNotEqual(withoutMenuBar, withMenuBar)
+    }
+
+    func testExactWindowResolutionDoesNotActivateBackgroundApplication() async throws {
+        guard let originalFrontmost = NSWorkspace.shared.frontmostApplication else {
+            throw XCTSkip("No frontmost application available")
+        }
+
+        let identity = WindowIdentityService()
+        var target: (app: NSRunningApplication, windowID: Int)?
+        for app in NSWorkspace.shared.runningApplications
+            where app.processIdentifier != originalFrontmost.processIdentifier && app.activationPolicy == .regular
+        {
+            let windows = AXApp(app).element.windowsWithTimeout() ?? []
+            if let windowID = windows.lazy.compactMap({ identity.getWindowID(from: $0).map(Int.init) }).first {
+                target = (app, windowID)
+                break
+            }
+        }
+
+        guard let target else {
+            throw XCTSkip("No accessible background application window available")
+        }
+
+        let resolver = ElementDetectionWindowResolver(applicationService: ApplicationService())
+        _ = try await resolver.resolveWindow(
+            for: target.app,
+            context: WindowContext(
+                applicationProcessId: target.app.processIdentifier,
+                windowID: target.windowID))
+
+        XCTAssertEqual(
+            NSWorkspace.shared.frontmostApplication?.processIdentifier,
+            originalFrontmost.processIdentifier,
+            "Resolving an AX window for observation must not activate its application")
+    }
+
+    func testDesktopDetectionOptionsDecodesPayloadWithoutMenuBarPolicy() throws {
+        let options = DesktopDetectionOptions(includeMenuBarElements: true)
+        let encoded = try JSONEncoder().encode(options)
+        var object = try XCTUnwrap(JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+        object.removeValue(forKey: "includeMenuBarElements")
+        let oldPayload = try JSONSerialization.data(withJSONObject: object)
+
+        let decoded = try JSONDecoder().decode(DesktopDetectionOptions.self, from: oldPayload)
+
+        XCTAssertFalse(decoded.includeMenuBarElements)
     }
 
     func testMissingBudgetNormalizationAppliesEnvironmentOverrides() {

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ActionInputDriverTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ActionInputDriverTests.swift
@@ -360,6 +360,109 @@ struct ActionInputDriverTests {
 
     @MainActor
     @Test
+    func `numeric slider coerces CLI text to a floating point AX value`() throws {
+        let element = MockAutomationElement(
+            role: AXRoleNames.kAXSliderRole,
+            value: 50.0,
+            isValueSettable: true)
+
+        let result = try ActionInputDriver().trySetValueForTesting(element: element, value: .string("0.75"))
+
+        #expect(element.setValues == [.double(0.75)])
+        #expect((element.value as? Double) == 0.75)
+        #expect(result.actionName == AXActionNames.kAXSetValueAction)
+    }
+
+    @MainActor
+    @Test
+    func `boolean selected attribute is set and verified`() throws {
+        let element = MockAutomationElement(
+            role: AXRoleNames.kAXRowRole,
+            isSelectedSettable: true,
+            selectedValue: false)
+
+        let result = try ActionInputDriver().trySetValueForTesting(element: element, value: .string("true"))
+
+        #expect(element.setSelectedValues == [true])
+        #expect(element.selectedValue == true)
+        #expect(result.actionName == kAXSelectedAttribute as String)
+    }
+
+    @MainActor
+    @Test
+    func `numeric-looking text field value remains a string`() throws {
+        let element = MockAutomationElement(
+            role: AXRoleNames.kAXTextFieldRole,
+            value: "123",
+            isValueSettable: true)
+
+        _ = try ActionInputDriver().trySetValueForTesting(element: element, value: .string("456"))
+
+        #expect(element.setValues == [.string("456")])
+        #expect((element.value as? String) == "456")
+    }
+
+    @MainActor
+    @Test
+    func `idempotent set succeeds without writing the attribute`() throws {
+        let element = MockAutomationElement(
+            role: AXRoleNames.kAXSliderRole,
+            value: 0.75,
+            isValueSettable: true)
+
+        let result = try ActionInputDriver().trySetValueForTesting(element: element, value: .string("0.75"))
+
+        #expect(element.setValues.isEmpty)
+        #expect(result.actionName == AXActionNames.kAXSetValueAction)
+    }
+
+    @MainActor
+    @Test
+    func `phantom-success setter fails when value does not change`() {
+        let element = MockAutomationElement(
+            role: AXRoleNames.kAXSliderRole,
+            value: 50.0,
+            isValueSettable: true,
+            valueSetterDoesNotChange: true)
+
+        do {
+            _ = try ActionInputDriver().trySetValueForTesting(element: element, value: .string("0.75"))
+            Issue.record("Expected unchanged value to fail verification")
+        } catch let error as ActionInputError {
+            guard case let .failed(message) = error else {
+                Issue.record("Unexpected action input error: \(error)")
+                return
+            }
+            #expect(message.contains("did not change"))
+            #expect(element.setValues == [.double(0.75)])
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+    }
+
+    @MainActor
+    @Test
+    func `unverifiable value setter fails instead of fabricating a result`() {
+        let element = MockAutomationElement(
+            role: AXRoleNames.kAXSliderRole,
+            isValueSettable: true,
+            valueSetterDoesNotChange: true)
+
+        do {
+            _ = try ActionInputDriver().trySetValueForTesting(element: element, value: .double(0.75))
+            Issue.record("Expected unverifiable value to fail")
+        } catch let error as ActionInputError {
+            guard case .failed = error else {
+                Issue.record("Unexpected action input error: \(error)")
+                return
+            }
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+    }
+
+    @MainActor
+    @Test
     func `mock menu tree can exercise hotkey menu resolution without live AX`() throws {
         let saveItem = MockAutomationElement(
             role: AXRoleNames.kAXMenuItemRole,
@@ -389,6 +492,66 @@ struct ActionInputDriverTests {
         } catch {
             Issue.record("Unexpected error: \(error)")
         }
+    }
+
+    @MainActor
+    @Test
+    func `non-advertised action is rejected before a phantom-success AX invocation`() {
+        let element = PhantomSuccessAutomationElement(role: AXRoleNames.kAXButtonRole)
+
+        do {
+            _ = try ActionInputDriver().tryPerformActionForTesting(
+                element: element,
+                actionName: AXActionNames.kAXPressAction)
+            Issue.record("Expected non-advertised action to be rejected")
+        } catch let error as ActionInputError {
+            #expect(error == .unsupported(.actionUnsupported))
+            #expect(element.performedActions.isEmpty)
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+    }
+}
+
+@MainActor
+private final class PhantomSuccessAutomationElement: AutomationElementRepresenting, @unchecked Sendable {
+    let name: String? = nil
+    let label: String? = nil
+    let roleDescription: String? = nil
+    let identifier: String? = nil
+    let role: String?
+    let subrole: String? = nil
+    let frame: CGRect? = nil
+    let value: Any? = nil
+    let stringValue: String? = nil
+    let actionNames: [String] = []
+    let isValueSettable = false
+    let isFocusedSettable = false
+    let isEnabled = true
+    let isFocused = false
+    let isOffscreen = false
+    let anchorPoint: CGPoint? = nil
+    let automationChildren: [any AutomationElementRepresenting] = []
+    var performedActions: [String] = []
+
+    init(role: String?) {
+        self.role = role
+    }
+
+    func performAutomationAction(_ actionName: String) throws {
+        self.performedActions.append(actionName)
+    }
+
+    func setAutomationValue(_: UIElementValue) throws {}
+
+    func setAutomationFocused(_: Bool) throws {}
+
+    func stringAttribute(_: String) -> String? {
+        nil
+    }
+
+    func intAttribute(_: String) -> Int? {
+        nil
     }
 }
 
@@ -493,6 +656,8 @@ private final class MockAutomationElement: AutomationElementRepresenting, @unche
     let actionNames: [String]
     let isValueSettable: Bool
     let isFocusedSettable: Bool
+    let isSelectedSettable: Bool
+    var selectedValue: Bool?
     let isEnabled: Bool
     let isFocused: Bool
     let isOffscreen: Bool
@@ -504,9 +669,11 @@ private final class MockAutomationElement: AutomationElementRepresenting, @unche
     private let stringAttributes: [String: String]
     private let intAttributes: [String: Int]
     private let actionErrors: [String: any Error]
+    private let valueSetterDoesNotChange: Bool
     var performedActions: [String] = []
     var setValues: [UIElementValue] = []
     var setFocusedValues: [Bool] = []
+    var setSelectedValues: [Bool] = []
 
     var automationChildren: [any AutomationElementRepresenting] {
         self.children
@@ -524,13 +691,16 @@ private final class MockAutomationElement: AutomationElementRepresenting, @unche
         actionNames: [String] = [],
         isValueSettable: Bool = false,
         isFocusedSettable: Bool = false,
+        isSelectedSettable: Bool = false,
+        selectedValue: Bool? = nil,
         isEnabled: Bool = true,
         isFocused: Bool = false,
         isOffscreen: Bool = false,
         children: [MockAutomationElement] = [],
         stringAttributes: [String: String] = [:],
         intAttributes: [String: Int] = [:],
-        actionErrors: [String: any Error] = [:])
+        actionErrors: [String: any Error] = [:],
+        valueSetterDoesNotChange: Bool = false)
     {
         self.name = name
         self.label = label
@@ -543,6 +713,8 @@ private final class MockAutomationElement: AutomationElementRepresenting, @unche
         self.actionNames = actionNames
         self.isValueSettable = isValueSettable
         self.isFocusedSettable = isFocusedSettable
+        self.isSelectedSettable = isSelectedSettable
+        self.selectedValue = selectedValue
         self.isEnabled = isEnabled
         self.isFocused = isFocused
         self.isOffscreen = isOffscreen
@@ -550,6 +722,7 @@ private final class MockAutomationElement: AutomationElementRepresenting, @unche
         self.stringAttributes = stringAttributes
         self.intAttributes = intAttributes
         self.actionErrors = actionErrors
+        self.valueSetterDoesNotChange = valueSetterDoesNotChange
     }
 
     func performAutomationAction(_ actionName: String) throws {
@@ -566,8 +739,18 @@ private final class MockAutomationElement: AutomationElementRepresenting, @unche
         guard self.isValueSettable else {
             throw AccessibilitySystemError(.attributeUnsupported)
         }
-        self.value = value.displayString
         self.setValues.append(value)
+        guard !self.valueSetterDoesNotChange else { return }
+        switch value {
+        case let .bool(value):
+            self.value = value
+        case let .int(value):
+            self.value = value
+        case let .double(value):
+            self.value = value
+        case let .string(value):
+            self.value = value
+        }
     }
 
     func setAutomationFocused(_ focused: Bool) throws {
@@ -575,6 +758,14 @@ private final class MockAutomationElement: AutomationElementRepresenting, @unche
             throw AccessibilitySystemError(.attributeUnsupported)
         }
         self.setFocusedValues.append(focused)
+    }
+
+    func setAutomationSelected(_ selected: Bool) throws {
+        guard self.isSelectedSettable else {
+            throw AccessibilitySystemError(.attributeUnsupported)
+        }
+        self.setSelectedValues.append(selected)
+        self.selectedValue = selected
     }
 
     func stringAttribute(_ name: String) -> String? {

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/AutomationElementResolverTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/AutomationElementResolverTests.swift
@@ -1,0 +1,135 @@
+import AppKit
+import ApplicationServices
+@preconcurrency import AXorcist
+import Testing
+@testable @_spi(Testing) import PeekabooAutomationKit
+
+@MainActor
+struct AutomationElementResolverTests {
+    @Test
+    func `exact snapshot match disambiguates duplicate identifiers and frames without scanning the tail`() throws {
+        let app = try #require(NSWorkspace.shared.runningApplications.first { !$0.isTerminated })
+        let root = self.makeElement(1)
+        let duplicateIdentifier = self.makeElement(2)
+        let duplicateFrame = self.makeElement(3)
+        let match = self.makeElement(4)
+        let unvisitedTail = self.makeElement(5)
+        let targetFrame = CGRect(x: 120, y: 240, width: 80, height: 32)
+        let reader = ResolverTreeReader(
+            descriptors: [
+                duplicateIdentifier: self.descriptor(
+                    identifier: "shared-id",
+                    frame: CGRect(x: 20, y: 40, width: 80, height: 32)),
+                duplicateFrame: self.descriptor(identifier: "different-id", frame: targetFrame),
+                match: self.descriptor(identifier: "shared-id", frame: targetFrame),
+                unvisitedTail: self.descriptor(identifier: "shared-id", frame: targetFrame),
+            ],
+            children: [root: [duplicateIdentifier, duplicateFrame, match, unvisitedTail]],
+            processIdentifiers: [match: app.processIdentifier])
+        let resolver = AutomationElementResolver(
+            windowRootResolver: ResolverWindowRootResolver(root: root),
+            treeReader: reader)
+
+        let resolved = resolver.resolve(
+            detectedElement: self.detectedElement(identifier: "shared-id", frame: targetFrame),
+            windowContext: WindowContext(applicationProcessId: app.processIdentifier, windowID: 42),
+            targetProcessIdentifier: app.processIdentifier)
+
+        #expect(resolved?.element == match)
+        #expect(reader.descriptorReads == [root, duplicateIdentifier, duplicateFrame, match])
+        #expect(!reader.descriptorReads.contains(unvisitedTail))
+    }
+
+    @Test
+    func `exact snapshot match rejects a candidate from another process`() throws {
+        let app = try #require(NSWorkspace.shared.runningApplications.first { !$0.isTerminated })
+        let root = self.makeElement(11)
+        let wrongProcess = self.makeElement(12)
+        let targetFrame = CGRect(x: 120, y: 240, width: 80, height: 32)
+        let reader = ResolverTreeReader(
+            descriptors: [wrongProcess: self.descriptor(identifier: "target-id", frame: targetFrame)],
+            children: [root: [wrongProcess]],
+            processIdentifiers: [wrongProcess: app.processIdentifier + 1])
+        let resolver = AutomationElementResolver(
+            windowRootResolver: ResolverWindowRootResolver(root: root),
+            treeReader: reader)
+
+        let resolved = resolver.resolve(
+            detectedElement: self.detectedElement(identifier: "target-id", frame: targetFrame),
+            windowContext: WindowContext(applicationProcessId: app.processIdentifier, windowID: 42),
+            targetProcessIdentifier: app.processIdentifier)
+
+        #expect(resolved == nil)
+        #expect(reader.processIdentifierReads == [wrongProcess, wrongProcess])
+    }
+
+    private func detectedElement(identifier: String, frame: CGRect) -> DetectedElement {
+        DetectedElement(
+            id: "B1",
+            type: .button,
+            label: "Target",
+            bounds: frame,
+            attributes: ["identifier": identifier, "role": "AXButton"])
+    }
+
+    private func descriptor(identifier: String, frame: CGRect) -> AXDescriptorReader.Descriptor {
+        AXDescriptorReader.Descriptor(
+            frame: frame,
+            role: "AXButton",
+            title: "Target",
+            label: nil,
+            value: nil,
+            description: nil,
+            help: nil,
+            roleDescription: nil,
+            identifier: identifier,
+            isEnabled: true,
+            placeholder: nil)
+    }
+
+    private func makeElement(_ offset: pid_t) -> Element {
+        Element(AXUIElementCreateApplication(getpid() + offset))
+    }
+}
+
+@MainActor
+private final class ResolverTreeReader: AutomationElementTreeReading {
+    private let descriptors: [Element: AXDescriptorReader.Descriptor]
+    private let childMap: [Element: [Element]]
+    private let processIdentifiers: [Element: pid_t]
+    private(set) var descriptorReads: [Element] = []
+    private(set) var processIdentifierReads: [Element] = []
+
+    init(
+        descriptors: [Element: AXDescriptorReader.Descriptor],
+        children: [Element: [Element]],
+        processIdentifiers: [Element: pid_t])
+    {
+        self.descriptors = descriptors
+        self.childMap = children
+        self.processIdentifiers = processIdentifiers
+    }
+
+    func descriptor(for element: Element) -> AXDescriptorReader.Descriptor? {
+        self.descriptorReads.append(element)
+        return self.descriptors[element]
+    }
+
+    func children(of element: Element) -> [Element]? {
+        self.childMap[element]
+    }
+
+    func processIdentifier(of element: Element) -> pid_t? {
+        self.processIdentifierReads.append(element)
+        return self.processIdentifiers[element]
+    }
+}
+
+@MainActor
+private struct ResolverWindowRootResolver: AutomationWindowRootResolving {
+    let root: Element
+
+    func root(for _: CGWindowID, in _: NSRunningApplication) -> Element? {
+        self.root
+    }
+}

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/BackgroundInputDriverPositionalTargetTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/BackgroundInputDriverPositionalTargetTests.swift
@@ -194,6 +194,32 @@ struct BackgroundInputDriverPositionalTargetTests {
 
     @Test
     @MainActor
+    func `left click selects a writable row ancestor when the hit label has no press action`() async throws {
+        let point = CGPoint(x: 1578, y: 609)
+        let label = PositionalMockElement(
+            role: AXRoleNames.kAXButtonRole,
+            frame: CGRect(x: 1524, y: 597, width: 108, height: 24))
+        let cell = PositionalMockElement(
+            role: "AXCell",
+            frame: CGRect(x: 1518, y: 593, width: 178, height: 32))
+        let row = PositionalMockElement(
+            role: AXRoleNames.kAXRowRole,
+            frame: CGRect(x: 1508, y: 593, width: 198, height: 32),
+            isSelectedSettable: true)
+
+        let resolved = BackgroundInputDriver.positionalClickTarget(
+            inCandidates: [label, cell, row],
+            at: point,
+            button: MouseButton.left)
+
+        #expect(resolved?.action == .select)
+        #expect((resolved?.element as? PositionalMockElement) === row)
+        try await BackgroundInputDriver.performPositionalClickAction(.select, on: row)
+        #expect(row.setSelectedValues == [true])
+    }
+
+    @Test
+    @MainActor
     func `value settable web group does not masquerade as a focused click`() {
         // Chromium exposes full-page AXGroup containers as value/focus-settable. Setting focus on
         // that container returns success but delivers no click.
@@ -238,6 +264,24 @@ struct BackgroundInputDriverPositionalTargetTests {
             button: MouseButton.right)
         #expect(withMenu?.action == .showMenu)
         #expect((withMenu?.element as? PositionalMockElement) === menuHost)
+    }
+
+    @Test
+    @MainActor
+    func `right click never selects a writable row`() {
+        let point = CGPoint(x: 50, y: 50)
+        let row = PositionalMockElement(
+            role: AXRoleNames.kAXRowRole,
+            frame: CGRect(x: 0, y: 0, width: 100, height: 100),
+            isSelectedSettable: true)
+
+        let resolved = BackgroundInputDriver.positionalClickTarget(
+            inCandidates: [row],
+            at: point,
+            button: MouseButton.right)
+
+        #expect(resolved == nil)
+        #expect(row.setSelectedValues.isEmpty)
     }
 
     @Test
@@ -311,6 +355,7 @@ private final class PositionalMockElement: AutomationElementRepresenting, @unche
     let actionNames: [String]
     let isValueSettable: Bool
     let isFocusedSettable: Bool
+    let isSelectedSettable: Bool
     let isEnabled: Bool
     let isFocused = false
     let isOffscreen = false
@@ -320,6 +365,7 @@ private final class PositionalMockElement: AutomationElementRepresenting, @unche
 
     let automationChildren: [any AutomationElementRepresenting] = []
     var setFocusedValues: [Bool] = []
+    var setSelectedValues: [Bool] = []
 
     /// Actions reported by the real `AXUIElementCopyActionNames` API in production. Kept separate
     /// from `actionNames` (the attribute read) so tests can model the SwiftUI case where the
@@ -334,6 +380,7 @@ private final class PositionalMockElement: AutomationElementRepresenting, @unche
         advertisedActionNames: [String]? = nil,
         isValueSettable: Bool = false,
         isFocusedSettable: Bool = false,
+        isSelectedSettable: Bool = false,
         isEnabled: Bool = true)
     {
         self.role = role
@@ -345,6 +392,7 @@ private final class PositionalMockElement: AutomationElementRepresenting, @unche
         self.actionNames = advertisedActionNames ?? Array(supportedActions)
         self.isValueSettable = isValueSettable
         self.isFocusedSettable = isFocusedSettable
+        self.isSelectedSettable = isSelectedSettable
         self.isEnabled = isEnabled
     }
 
@@ -364,6 +412,13 @@ private final class PositionalMockElement: AutomationElementRepresenting, @unche
 
     func setAutomationFocused(_ focused: Bool) throws {
         self.setFocusedValues.append(focused)
+    }
+
+    func setAutomationSelected(_ selected: Bool) throws {
+        guard self.isSelectedSettable else {
+            throw AccessibilitySystemError(.attributeUnsupported)
+        }
+        self.setSelectedValues.append(selected)
     }
 
     func stringAttribute(_ name: String) -> String? {

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/DesktopObservationServiceTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/DesktopObservationServiceTests.swift
@@ -129,7 +129,10 @@ final class DesktopObservationServiceTests: XCTestCase {
 
         let result = try await service.observe(DesktopObservationRequest(
             target: .app(identifier: "Fixture", window: .title("Edit")),
-            detection: DesktopDetectionOptions(mode: .accessibility, allowWebFocusFallback: false),
+            detection: DesktopDetectionOptions(
+                mode: .accessibility,
+                allowWebFocusFallback: false,
+                includeMenuBarElements: false),
             output: DesktopObservationOutputOptions(snapshotID: "snapshot-1")))
 
         XCTAssertNotNil(result.elements)
@@ -140,6 +143,7 @@ final class DesktopObservationServiceTests: XCTestCase {
         XCTAssertEqual(automation.lastWindowContext?.windowTitle, "Editor")
         XCTAssertEqual(automation.lastWindowContext?.windowID, 77)
         XCTAssertEqual(automation.lastWindowContext?.shouldFocusWebContent, false)
+        XCTAssertEqual(automation.lastWindowContext?.includeMenuBarElements, false)
         XCTAssertEqual(result.timings.spans.map(\.name), [
             "state.snapshot",
             "target.resolve",

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/UIAutomationServiceVisualizerTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/UIAutomationServiceVisualizerTests.swift
@@ -1,4 +1,6 @@
 import CoreGraphics
+import Foundation
+import PeekabooFoundation
 import Testing
 @testable import PeekabooAutomationKit
 
@@ -22,5 +24,80 @@ struct UIAutomationServiceVisualizerTests {
         let point = UIAutomationService.visualFeedbackPoint(actionAnchor: nil, fallbackPoint: fallback)
 
         #expect(point == fallback)
+    }
+
+    @Test
+    @MainActor
+    func `targeted background interactions suppress global visualizer feedback`() async throws {
+        let feedback = RecordingAutomationFeedbackClient()
+        let service = UIAutomationService(feedbackClient: feedback)
+
+        try await service.visualizeClick(
+            target: .coordinates(CGPoint(x: 10, y: 20)),
+            actionAnchor: CGPoint(x: 10, y: 20),
+            clickType: .single,
+            snapshotId: nil,
+            targetProcessIdentifier: 42)
+        await service.visualizeTypeActions(
+            [.text("background"), .key(.return)],
+            cadence: .fixed(milliseconds: 0),
+            typedIntoSecureField: true,
+            targetProcessIdentifier: 42)
+        await service.visualizeHotkey(keys: "cmd,shift,p", targetProcessIdentifier: 42)
+
+        #expect(feedback.clickCount == 0)
+        #expect(feedback.typingCount == 0)
+        #expect(feedback.hotkeyCount == 0)
+    }
+
+    @Test
+    @MainActor
+    func `untargeted foreground interactions preserve global visualizer feedback`() async throws {
+        let feedback = RecordingAutomationFeedbackClient()
+        let service = UIAutomationService(feedbackClient: feedback)
+
+        try await service.visualizeClick(
+            target: .coordinates(CGPoint(x: 10, y: 20)),
+            actionAnchor: CGPoint(x: 10, y: 20),
+            clickType: .single,
+            snapshotId: nil,
+            targetProcessIdentifier: nil)
+        await service.visualizeTypeActions(
+            [.text("foreground"), .key(.return)],
+            cadence: .fixed(milliseconds: 0),
+            typedIntoSecureField: true,
+            targetProcessIdentifier: nil)
+        await service.visualizeHotkey(keys: "cmd,shift,p", targetProcessIdentifier: nil)
+
+        #expect(feedback.clickCount == 1)
+        #expect(feedback.typingCount == 1)
+        #expect(feedback.hotkeyCount == 1)
+    }
+}
+
+@MainActor
+private final class RecordingAutomationFeedbackClient: AutomationFeedbackClient {
+    private(set) var clickCount = 0
+    private(set) var typingCount = 0
+    private(set) var hotkeyCount = 0
+
+    func showClickFeedback(at _: CGPoint, type _: ClickType) async -> Bool {
+        self.clickCount += 1
+        return true
+    }
+
+    func showTypingFeedback(
+        keys _: [String],
+        duration _: TimeInterval,
+        cadence _: TypingCadence,
+        masksTypedText _: Bool) async -> Bool
+    {
+        self.typingCount += 1
+        return true
+    }
+
+    func showHotkeyDisplay(keys _: [String], duration _: TimeInterval) async -> Bool {
+        self.hotkeyCount += 1
+        return true
     }
 }

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeOperation+Policy.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeOperation+Policy.swift
@@ -18,9 +18,6 @@ extension PeekabooBridgeOperation {
              .rightClickDockItem, .hideDock, .showDock, .isDockHidden, .findDockItem, .dialogFindActive,
              .dialogClickButton, .dialogEnterText, .dialogHandleFile, .dialogDismiss, .dialogListElements:
             [.accessibility]
-        case .activateApplication, .hideApplication, .unhideApplication,
-             .hideOtherApplications, .showAllApplications:
-            [.appleScript]
         case ._appleScriptProbe,
              .permissionsStatus,
              .requestPostEventPermission,
@@ -48,7 +45,12 @@ extension PeekabooBridgeOperation {
              .launchApplication,
              .launchApplicationWithOptions,
              .relaunchApplicationWithOptions,
+             .activateApplication,
              .quitApplication,
+             .hideApplication,
+             .unhideApplication,
+             .hideOtherApplications,
+             .showAllApplications,
              .targetedClick,
              .exactWindowTargetedClick:
             []

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeTargetedClickTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeTargetedClickTests.swift
@@ -344,7 +344,8 @@ struct PeekabooBridgeTargetedClickTests {
         #expect(handshake.supportedOperations.contains(.quitApplication))
         #expect(handshake.enabledOperations?.contains(.quitApplication) == true)
         #expect(handshake.permissionTags[PeekabooBridgeOperation.quitApplication.rawValue] == [])
-        #expect(handshake.enabledOperations?.contains(.hideApplication) == false)
+        #expect(handshake.enabledOperations?.contains(.hideApplication) == true)
+        #expect(handshake.permissionTags[PeekabooBridgeOperation.hideApplication.rawValue] == [])
     }
 
     @Test
@@ -718,8 +719,12 @@ struct PeekabooBridgeTargetedClickTests {
     }
 
     @Test
-    func `application quit does not require AppleScript permission`() {
+    func `native application lifecycle operations do not require AppleScript permission`() {
+        #expect(PeekabooBridgeOperation.activateApplication.requiredPermissions.isEmpty)
         #expect(PeekabooBridgeOperation.quitApplication.requiredPermissions.isEmpty)
-        #expect(PeekabooBridgeOperation.hideApplication.requiredPermissions == [.appleScript])
+        #expect(PeekabooBridgeOperation.hideApplication.requiredPermissions.isEmpty)
+        #expect(PeekabooBridgeOperation.unhideApplication.requiredPermissions.isEmpty)
+        #expect(PeekabooBridgeOperation.hideOtherApplications.requiredPermissions.isEmpty)
+        #expect(PeekabooBridgeOperation.showAllApplications.requiredPermissions.isEmpty)
     }
 }

--- a/Core/PeekabooCore/Tests/PeekabooTests/RemoteApplicationServiceTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/RemoteApplicationServiceTests.swift
@@ -51,11 +51,12 @@ struct RemoteApplicationServiceTests {
     }
 
     @Test
-    func `lifecycle falls back when on-demand bridge lacks AppleScript permission`() async throws {
+    func `native lifecycle uses bridge without AppleScript permission`() async throws {
         let socketPath = "/tmp/peekaboo-bridge-app-fallback-\(UUID().uuidString).sock"
+        let bridgedApplications = await MainActor.run { RecordingApplicationFallback() }
         let server = await MainActor.run {
             PeekabooBridgeServer(
-                services: PeekabooServices(),
+                services: StubServices(applications: bridgedApplications),
                 hostKind: .onDemand,
                 allowlistedTeams: [],
                 allowlistedBundles: [],
@@ -77,13 +78,7 @@ struct RemoteApplicationServiceTests {
         defer { Task { await host.stop() } }
 
         let directClient = PeekabooBridgeClient(socketPath: socketPath, requestTimeoutSec: 2)
-        do {
-            try await directClient.hideApplication(identifier: "Finder")
-            Issue.record("Expected bridge AppleScript permission denial")
-        } catch let envelope as PeekabooBridgeErrorEnvelope {
-            #expect(envelope.code == .permissionDenied)
-            #expect(envelope.permission == .appleScript)
-        }
+        try await directClient.hideApplication(identifier: "Finder")
 
         let fallback = await MainActor.run { RecordingApplicationFallback() }
         let remote = await MainActor.run {
@@ -93,8 +88,10 @@ struct RemoteApplicationServiceTests {
         }
 
         try await remote.hideApplication(identifier: "Finder")
+        let bridgedIdentifiers = await MainActor.run { bridgedApplications.hiddenIdentifiers }
         let hiddenIdentifiers = await MainActor.run { fallback.hiddenIdentifiers }
-        #expect(hiddenIdentifiers == ["Finder"])
+        #expect(bridgedIdentifiers == ["Finder", "Finder"])
+        #expect(hiddenIdentifiers.isEmpty)
     }
 
     @Test

--- a/docs/commands/app.md
+++ b/docs/commands/app.md
@@ -14,7 +14,7 @@ read_when:
 | --- | --- | --- |
 | `launch` | Start an app by name/path/bundle ID, optionally opening documents. | `--bundle-id`, `--open <path|url>` (repeatable), `--wait-until-ready`, `--no-focus`. |
 | `quit` | Quit one app or *all* regular apps (with optional exclusions). | `--app <name>`, `--pid`, `--all`, `--except "Finder,Terminal"`, `--force`. |
-| `relaunch` | Quit + relaunch the same app in one step. | Positional `<app>`, `--wait <seconds>` between quit/launch, `--force`, `--wait-until-ready`. |
+| `relaunch` | Quit + relaunch the same app in one step. | Positional `<app>` or `--pid`, `--wait <seconds>` between quit/launch, `--force`, `--wait-until-ready`. |
 | `hide` / `unhide` | Toggle app visibility. | Accept the same targeting flags as `launch`/`quit`. |
 | `switch` | Activate a specific app (`--to`) or cycle Cmd+Tab style (`--cycle`). | `--to <name|bundle|PID:1234>`, `--cycle`, `--verify` (only with `--to`). |
 | `list` | App-management view of running apps, filtering hidden/background apps by default. | `--include-hidden`, `--include-background`. |

--- a/docs/commands/menu.md
+++ b/docs/commands/menu.md
@@ -13,7 +13,7 @@ read_when:
 | Subcommand | Purpose | Key options |
 | --- | --- | --- |
 | `click` | Activate an application menu item via `--item` (single-level) or `--path "File > Export > PDF"`. | Target flags `--app <name|bundle|PID:1234>`, optional `--pid`, optional `--window-id`/`--window-title`/`--window-index`, plus all focus flags. Paths are normalized automatically if you accidentally pass a `'>'` string to `--item`. |
-| `click-extra` | Click status-bar menu extras (Wi-Fi, Bluetooth, custom icons). | `--title <menu-extra>` is required; `--verify` confirms the popover opened; `--item` is parsed but currently prints a warning because nested extra menus aren’t implemented yet. |
+| `click-extra` | Click status-bar menu extras (Wi-Fi, Bluetooth, custom icons). | `--title <menu-extra>` is required; `--verify` confirms the popover opened; `--item` fails with a nonzero exit because nested extra-menu selection is not implemented yet. |
 | `list` | Dump the menu tree for a specific app (optionally showing disabled items). | Same target flags as `click`, plus `--include-disabled`. |
 | `list-all` | Snapshot the frontmost app’s full menu tree *and* all system menu extras in one go. | `--include-disabled`, `--include-frames` (adds pixel coordinates for extras). |
 

--- a/docs/commands/see.md
+++ b/docs/commands/see.md
@@ -30,7 +30,7 @@ peekaboo see --app "Google Chrome" --window-title "Login" --json --path /tmp/chr
 | `--app`, `--window-title`, `--pid` | Limit capture to a known app/window/process. |
 | `--mode screen|window|frontmost|multi` | Override the auto target picker. `area` is intentionally rejected because `see` does not expose rectangle coordinates; use `peekaboo image --mode area --region x,y,width,height` for raw region screenshots. |
 | `--annotate` | Overlay element bounds/IDs on the output image. |
-| `--path <file>` | Save the screenshot/annotation to disk. |
+| `--path <file>` / `--save` / `--output` / `-o` | Save the screenshot/annotation to disk. |
 | `--json` | Emit structured metadata (recommended for scripting). |
 | `--menubar` | Capture menu bar popovers via window list + OCR (useful for status-item settings panels). When `--app` is set, the app name is used as an OCR hint for popover selection. |
 | `--timeout-seconds <seconds>` | Increase overall timeout for large/complex windows (defaults to 20s, or 60s with `--analyze`). |


### PR DESCRIPTION
## Summary

- keep targeted UI observation in the background and exclude irrelevant application menu trees
- reject phantom-success accessibility actions, support selectable rows, and verify typed value mutations against live AX state
- suppress desktop-global visualizer overlays for PID-targeted background input
- remove native lifecycle permission gating and Dock-removal AppleScript in favor of AppKit/AX paths
- restore documented CLI options and make unsupported or failed actions exit honestly
- add an exact snapshot identifier/frame/role/PID resolution fast path

## Live proof

- System Settings background navigation now succeeds while ChatGPT remains frontmost and the physical cursor stays fixed; exact resolution reduced action execution from 3.31s to 0.33s (0.57s wall).
- Playground numeric slider mutation reports and verifies 50 to 75 in app-owned state while ChatGPT and the cursor remain unchanged.
- Background Playground observation no longer activates the app or includes its menu bar; warm observation is 0.50s in-command (0.81s wall), with 102 relevant elements instead of 338.
- Native app switching succeeds without AppleScript-gated bridge permissions.

## Validation

- `pnpm run format`
- `xcrun swift test --package-path Core/PeekabooAutomationKit --no-parallel`
- focused PeekabooCore bridge and remote application tests
- focused CLI parser, binder, app, and menu tests
- full CLI safe Swift suite with automation disabled
- `pnpm run lint`
- `pnpm run lint:docs`
- `scripts/test-peekaboo-perf.sh`
- structured Autoreview: clean, no actionable findings

`pnpm run test:safe` reaches a pre-existing current-main release-policy mismatch before Swift tests: `.mac-release.env` uses `openclaw-release`, while `scripts/test-release-signing-policy.sh` still expects `openclaw-foundation-release-20260714`. The remaining safe components and full Swift suite pass independently; this PR does not change release credential policy.

## Scope

This PR fixes proven background observation/action, native lifecycle, performance, and CLI contract defects. Global pointer/scroll/gesture policy, targetless input behavior, launch/open defaults, dialog fallbacks, exact-window keyboard routing, clipboard leases, and script-engine migration remain a separate follow-up so those architectural changes can be reviewed and proven independently.
