### PR TITLE
feat(mac): show automated app icons in the menu bar

### DIFF
--- a/Apps/Mac/Peekaboo/Core/Settings.swift
+++ b/Apps/Mac/Peekaboo/Core/Settings.swift
@@ -196,6 +196,10 @@ final class PeekabooSettings {
         didSet { self.save() }
     }
 
+    var showAutomationTargetIcons: Bool = true {
+        didSet { self.save() }
+    }
+
     // MARK: - Visualizer Settings
 
     var visualizerEnabled: Bool = true {
@@ -518,6 +522,9 @@ extension PeekabooSettings {
         self.agentModeEnabled = self.valueOrDefault(key: "agentModeEnabled", defaultValue: false)
         self.hapticFeedbackEnabled = self.userDefaults.bool(forKey: self.namespaced("hapticFeedbackEnabled"))
         self.soundEffectsEnabled = self.userDefaults.bool(forKey: self.namespaced("soundEffectsEnabled"))
+        self.showAutomationTargetIcons = self.valueOrDefault(
+            key: "showAutomationTargetIcons",
+            defaultValue: true)
 
         self.ensureTrueFlag(markerKey: "hapticFeedbackEnabledSet", value: &self.hapticFeedbackEnabled)
         self.ensureTrueFlag(markerKey: "soundEffectsEnabledSet", value: &self.soundEffectsEnabled)
@@ -593,6 +600,9 @@ extension PeekabooSettings {
         self.userDefaults.set(self.agentModeEnabled, forKey: "\(self.keyPrefix)agentModeEnabled")
         self.userDefaults.set(self.hapticFeedbackEnabled, forKey: "\(self.keyPrefix)hapticFeedbackEnabled")
         self.userDefaults.set(self.soundEffectsEnabled, forKey: "\(self.keyPrefix)soundEffectsEnabled")
+        self.userDefaults.set(
+            self.showAutomationTargetIcons,
+            forKey: "\(self.keyPrefix)showAutomationTargetIcons")
 
         // Save visualizer settings
         self.userDefaults.set(self.visualizerEnabled, forKey: "\(self.keyPrefix)visualizerEnabled")

--- a/Apps/Mac/Peekaboo/Features/Settings/VisualizerSettingsView.swift
+++ b/Apps/Mac/Peekaboo/Features/Settings/VisualizerSettingsView.swift
@@ -10,6 +10,14 @@ struct VisualizerSettingsView: View {
 
     var body: some View {
         Form {
+            Section("Menu Bar") {
+                SettingsToggleRow(
+                    title: "Show automated app icons in the menu bar",
+                    subtitle: "Show recently automated apps next to Peekaboo's menu bar icon.",
+                    systemImage: "app.badge",
+                    isOn: self.$settings.showAutomationTargetIcons)
+            }
+
             Section {
                 SettingsToggleRow(
                     title: "Enable visualizer",

--- a/Apps/Mac/Peekaboo/Features/StatusBar/AutomationTargetTracker.swift
+++ b/Apps/Mac/Peekaboo/Features/StatusBar/AutomationTargetTracker.swift
@@ -1,0 +1,142 @@
+import AppKit
+import Observation
+import os
+
+struct AutomationTarget: Equatable, Identifiable {
+    var id: pid_t {
+        self.processIdentifier
+    }
+
+    let processIdentifier: pid_t
+    let bundleIdentifier: String?
+    let name: String
+    let lastActivity: Date
+}
+
+struct AutomationTargetActivityStore {
+    private(set) var activeTargets: [AutomationTarget] = []
+    private var targetsByProcessIdentifier: [pid_t: AutomationTarget] = [:]
+    private let maximumDisplayedTargets: Int
+    private let idleTimeout: TimeInterval
+    private(set) var isEnabled: Bool
+
+    init(
+        isEnabled: Bool = true,
+        maximumDisplayedTargets: Int = 3,
+        idleTimeout: TimeInterval)
+    {
+        self.isEnabled = isEnabled
+        self.maximumDisplayedTargets = maximumDisplayedTargets
+        self.idleTimeout = idleTimeout
+    }
+
+    mutating func recordActivity(
+        processIdentifier: pid_t,
+        bundleIdentifier: String?,
+        name: String,
+        at date: Date)
+    {
+        guard self.isEnabled else { return }
+
+        self.targetsByProcessIdentifier[processIdentifier] = AutomationTarget(
+            processIdentifier: processIdentifier,
+            bundleIdentifier: bundleIdentifier,
+            name: name,
+            lastActivity: date)
+        self.expireTargets(at: date)
+    }
+
+    mutating func expireTargets(at date: Date) {
+        self.targetsByProcessIdentifier = self.targetsByProcessIdentifier.filter {
+            date.timeIntervalSince($0.value.lastActivity) < self.idleTimeout
+        }
+        self.refreshActiveTargets()
+    }
+
+    mutating func setEnabled(_ isEnabled: Bool) {
+        self.isEnabled = isEnabled
+        if !isEnabled {
+            self.targetsByProcessIdentifier.removeAll()
+        }
+        self.refreshActiveTargets()
+    }
+
+    private mutating func refreshActiveTargets() {
+        self.activeTargets = self.targetsByProcessIdentifier.values
+            .sorted {
+                if $0.lastActivity == $1.lastActivity {
+                    return $0.processIdentifier < $1.processIdentifier
+                }
+                return $0.lastActivity > $1.lastActivity
+            }
+            .prefix(self.maximumDisplayedTargets)
+            .map(\.self)
+    }
+}
+
+@Observable
+@MainActor
+final class AutomationTargetTracker {
+    static let idleTimeout: TimeInterval = 10
+
+    @ObservationIgnored private let logger = Logger(subsystem: "boo.peekaboo.app", category: "AutomationTargets")
+
+    private(set) var activeTargets: [AutomationTarget] = []
+    private var store: AutomationTargetActivityStore
+    private var expiryTask: Task<Void, Never>?
+
+    init(isEnabled: Bool = true) {
+        self.store = AutomationTargetActivityStore(
+            isEnabled: isEnabled,
+            idleTimeout: Self.idleTimeout)
+        self.startExpiryTask()
+    }
+
+    isolated deinit {
+        self.expiryTask?.cancel()
+    }
+
+    func recordActivity(pid: pid_t) {
+        guard pid > 0 else { return }
+
+        let application = NSRunningApplication(processIdentifier: pid)
+        let bundleIdentifier = application?.bundleIdentifier
+        let name = application?.localizedName ?? bundleIdentifier ?? "Application"
+        self.store.recordActivity(
+            processIdentifier: pid,
+            bundleIdentifier: bundleIdentifier,
+            name: name,
+            at: Date())
+        self.publishActiveTargets()
+        self.logger.debug(
+            "Recorded activity for \(name, privacy: .public) (pid \(pid)); \(self.activeTargets.count) active")
+    }
+
+    func setEnabled(_ isEnabled: Bool) {
+        self.store.setEnabled(isEnabled)
+        self.publishActiveTargets()
+    }
+
+    private func startExpiryTask() {
+        self.expiryTask = Task { @MainActor [weak self] in
+            while !Task.isCancelled {
+                do {
+                    try await Task.sleep(for: .seconds(1))
+                } catch {
+                    return
+                }
+                self?.expireTargets()
+            }
+        }
+    }
+
+    private func expireTargets() {
+        self.store.expireTargets(at: Date())
+        self.publishActiveTargets()
+    }
+
+    private func publishActiveTargets() {
+        guard self.activeTargets != self.store.activeTargets else { return }
+        self.activeTargets = self.store.activeTargets
+    }
+}

--- a/Apps/Mac/Peekaboo/Features/StatusBar/StatusBarController.swift
+++ b/Apps/Mac/Peekaboo/Features/StatusBar/StatusBarController.swift
@@ -45,8 +45,15 @@ enum StatusMenuAppearance {
 /// Manages the macOS status bar integration with animated icon states and popover UI.
 @MainActor
 final class StatusBarController: NSObject, NSMenuDelegate {
+    private struct ResolvedAutomationTarget {
+        let target: AutomationTarget
+        let icon: NSImage
+    }
+
     private static let permissionsStatusItemIdentifier = NSUserInterfaceItemIdentifier(
         "boo.peekaboo.statusMenu.permissionsStatus")
+    private static let statusIconSize = NSSize(width: 18, height: 18)
+    private static let statusIconSpacing: CGFloat = 3
 
     private let logger = Logger(subsystem: "boo.peekaboo.app", category: "StatusBar")
     private let statusItem: NSStatusItem
@@ -58,6 +65,10 @@ final class StatusBarController: NSObject, NSMenuDelegate {
     private let permissions: Permissions
     private let settings: PeekabooSettings
     private let updater: any UpdaterProviding
+    private let automationTargetTracker: AutomationTargetTracker
+    private var latestGhostIcon: NSImage?
+    private var resolvedAutomationTargets: [ResolvedAutomationTarget] = []
+    private var appearanceObservation: NSKeyValueObservation?
 
     /// Icon animation
     private let animationController = MenuBarAnimationController()
@@ -71,12 +82,14 @@ final class StatusBarController: NSObject, NSMenuDelegate {
         sessionStore: SessionStore,
         permissions: Permissions,
         settings: PeekabooSettings,
+        automationTargetTracker: AutomationTargetTracker = AutomationTargetTracker(),
         updater: any UpdaterProviding)
     {
         self.agent = agent
         self.sessionStore = sessionStore
         self.permissions = permissions
         self.settings = settings
+        self.automationTargetTracker = automationTargetTracker
         self.updater = updater
 
         // Create status item
@@ -87,7 +100,12 @@ final class StatusBarController: NSObject, NSMenuDelegate {
         self.setupStatusItem()
         self.setupPopover()
         self.setupAnimationController()
+        self.observeEffectiveAppearance()
         self.observeAgentState()
+        self.automationTargetTracker.setEnabled(self.settings.showAutomationTargetIcons)
+        self.updateAutomationTargets(self.automationTargetTracker.activeTargets)
+        self.observeAutomationTargetIcons()
+        self.observeAutomationTargetIconSetting()
     }
 
     // MARK: - Setup
@@ -110,6 +128,7 @@ final class StatusBarController: NSObject, NSMenuDelegate {
             self.logger.info("MenuIcon loaded successfully: \(menuIcon.size.width)x\(menuIcon.size.height)")
             button.image = menuIcon
             button.image?.isTemplate = true
+            self.latestGhostIcon = menuIcon
         } else {
             self.logger.error("Failed to load MenuIcon - using fallback")
             // Create a simple fallback icon
@@ -121,6 +140,7 @@ final class StatusBarController: NSObject, NSMenuDelegate {
             }
             fallbackIcon.isTemplate = true
             button.image = fallbackIcon
+            self.latestGhostIcon = fallbackIcon
         }
 
         button.action = #selector(self.statusItemClicked)
@@ -136,11 +156,132 @@ final class StatusBarController: NSObject, NSMenuDelegate {
 
         // Set up callback to update icon when animation renders new frame
         self.animationController.onIconUpdateNeeded = { [weak self] icon in
-            self?.statusItem.button?.image = icon
+            guard let self else { return }
+            self.latestGhostIcon = icon
+            self.renderStatusItem()
         }
 
         // Force initial render
         self.animationController.forceRender()
+    }
+
+    private func observeAutomationTargetIcons() {
+        withObservationTracking {
+            _ = self.automationTargetTracker.activeTargets
+        } onChange: { [weak self] in
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                self.updateAutomationTargets(self.automationTargetTracker.activeTargets)
+                self.observeAutomationTargetIcons()
+            }
+        }
+    }
+
+    private func observeAutomationTargetIconSetting() {
+        withObservationTracking {
+            _ = self.settings.showAutomationTargetIcons
+        } onChange: { [weak self] in
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                self.automationTargetTracker.setEnabled(self.settings.showAutomationTargetIcons)
+                self.updateAutomationTargets(self.automationTargetTracker.activeTargets)
+                self.observeAutomationTargetIconSetting()
+            }
+        }
+    }
+
+    private func observeEffectiveAppearance() {
+        let application = NSApplication.shared
+        self.appearanceObservation = application.observe(\.effectiveAppearance, options: [.new]) { [weak self] _, _ in
+            Task { @MainActor [weak self] in
+                self?.renderStatusItem()
+            }
+        }
+    }
+
+    private func updateAutomationTargets(_ targets: [AutomationTarget]) {
+        self.resolvedAutomationTargets = targets.compactMap { target -> ResolvedAutomationTarget? in
+            guard let icon = self.automationTargetIcon(for: target) else { return nil }
+            return ResolvedAutomationTarget(target: target, icon: icon)
+        }
+        let resolvedTargetCount = self.resolvedAutomationTargets.count
+        self.logger.debug("Rendering status item with \(resolvedTargetCount) target icons (\(targets.count) tracked)")
+        self.renderStatusItem()
+    }
+
+    private func renderStatusItem() {
+        guard let button = self.statusItem.button, let ghostIcon = self.latestGhostIcon else { return }
+
+        guard !self.resolvedAutomationTargets.isEmpty else {
+            ghostIcon.isTemplate = true
+            button.image = ghostIcon
+            button.toolTip = "Peekaboo"
+            button.setAccessibilityLabel("Peekaboo")
+            return
+        }
+
+        let appearance = button.effectiveAppearance
+        let targetCount = self.resolvedAutomationTargets.count
+        let imageWidth = Self.statusIconSize.width * CGFloat(targetCount + 1) +
+            Self.statusIconSpacing * CGFloat(targetCount)
+        let compositeIcon = NSImage(
+            size: NSSize(width: imageWidth, height: Self.statusIconSize.height),
+            flipped: false)
+        { [resolvedAutomationTargets = self.resolvedAutomationTargets] _ in
+            let ghostRect = NSRect(origin: .zero, size: Self.statusIconSize)
+            ghostIcon.draw(in: ghostRect)
+
+            let context = NSGraphicsContext.current!.cgContext
+            context.saveGState()
+            context.setBlendMode(.sourceIn)
+            appearance.performAsCurrentDrawingAppearance {
+                context.setFillColor(NSColor.labelColor.cgColor)
+                context.fill(ghostRect)
+            }
+            context.restoreGState()
+
+            for (index, resolvedTarget) in resolvedAutomationTargets.enumerated() {
+                let x = Self.statusIconSize.width + Self.statusIconSpacing +
+                    CGFloat(index) * (Self.statusIconSize.width + Self.statusIconSpacing)
+                let iconRect = NSRect(
+                    x: x,
+                    y: 0,
+                    width: Self.statusIconSize.width,
+                    height: Self.statusIconSize.height)
+                resolvedTarget.icon.draw(in: iconRect)
+            }
+            return true
+        }
+        compositeIcon.isTemplate = false
+        button.image = compositeIcon
+
+        let names = self.resolvedAutomationTargets.map(\.target.name).joined(separator: ", ")
+        let description = "Peekaboo is automating \(names)"
+        button.toolTip = description
+        button.setAccessibilityLabel(description)
+
+        let frame = button.window?.frame ?? .zero
+        self.logger.debug(
+            "Status item visible=\(self.statusItem.isVisible) frame=\(String(describing: frame), privacy: .public)")
+    }
+
+    private func automationTargetIcon(for target: AutomationTarget) -> NSImage? {
+        let sourceIcon: NSImage? = if let runningIcon = NSRunningApplication(processIdentifier: target
+            .processIdentifier)?.icon
+        {
+            runningIcon
+        } else if let bundleIdentifier = target.bundleIdentifier,
+                  let applicationURL = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleIdentifier)
+        {
+            NSWorkspace.shared.icon(forFile: applicationURL.path)
+        } else {
+            nil
+        }
+
+        guard let icon = sourceIcon?.copy() as? NSImage else { return nil }
+        icon.size = Self.statusIconSize
+        icon.isTemplate = false
+        return icon
     }
 
     private func setupPopover() {

--- a/Apps/Mac/Peekaboo/PeekabooApp.swift
+++ b/Apps/Mac/Peekaboo/PeekabooApp.swift
@@ -222,6 +222,7 @@ private struct AppStateConnectionContext {
 final class AppDelegate: NSObject, NSApplicationDelegate {
     private let logger = Logger(subsystem: "boo.peekaboo.app", category: "App")
     private var statusBarController: StatusBarController?
+    private let automationTargetTracker = AutomationTargetTracker()
     let updaterController: any UpdaterProviding = makeUpdaterController()
     var windowOpener: ((String) -> Void)?
     private var bridgeHost: PeekabooBridgeHost?
@@ -270,6 +271,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 sessionStore: context.sessionStore,
                 permissions: context.permissions,
                 settings: context.settings,
+                automationTargetTracker: self.automationTargetTracker,
                 updater: self.updaterController)
         }
 
@@ -555,6 +557,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             "boo.peekaboo.mac", // GUI
         ]
         let allowlistedTeams = PeekabooBridgeConstants.trustedReleaseTeamIDs
+        let automationActivityObserver = self.makeAutomationActivityObserver()
 
         self.logger.info("Starting Peekaboo Bridge at \(PeekabooBridgeConstants.peekabooSocketPath, privacy: .public)")
         self.bridgeStartTask = Task { @MainActor [weak self] in
@@ -569,6 +572,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                         socketPath: PeekabooBridgeConstants.peekabooSocketPath,
                         allowlistedTeams: allowlistedTeams,
                         allowlistedBundles: allowlistedBundles,
+                        automationActivityObserver: automationActivityObserver,
                         allowedOperations: PeekabooBridgeOperation.remoteDefaultAllowlist)
                     return
                 } catch PeekabooBridgeHostError.socketAlreadyOwned {
@@ -585,6 +589,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                         .error("Failed to start Peekaboo Bridge: \(error.localizedDescription, privacy: .public)")
                     return
                 }
+            }
+        }
+    }
+
+    private func makeAutomationActivityObserver() -> @Sendable (pid_t) -> Void {
+        let tracker = self.automationTargetTracker
+        return { [weak tracker] processIdentifier in
+            Task { @MainActor in
+                tracker?.recordActivity(pid: processIdentifier)
             }
         }
     }

--- a/Apps/Mac/PeekabooTests/Controllers/AutomationTargetTrackerTests.swift
+++ b/Apps/Mac/PeekabooTests/Controllers/AutomationTargetTrackerTests.swift
@@ -1,0 +1,89 @@
+import Foundation
+import Testing
+@testable import Peekaboo
+
+@Suite(.tags(.unit))
+@MainActor
+struct AutomationTargetTrackerTests {
+    private let start = Date(timeIntervalSince1970: 1000)
+
+    @Test
+    func `Display is capped at three targets`() {
+        var store = AutomationTargetActivityStore(idleTimeout: 10)
+
+        for processIdentifier in 1...4 {
+            store.recordActivity(
+                processIdentifier: pid_t(processIdentifier),
+                bundleIdentifier: nil,
+                name: "App \(processIdentifier)",
+                at: self.start.addingTimeInterval(TimeInterval(processIdentifier)))
+        }
+
+        #expect(store.activeTargets.map(\.processIdentifier) == [4, 3, 2])
+    }
+
+    @Test
+    func `Most recently active targets win`() {
+        var store = AutomationTargetActivityStore(idleTimeout: 10)
+        for processIdentifier in 1...3 {
+            store.recordActivity(
+                processIdentifier: pid_t(processIdentifier),
+                bundleIdentifier: nil,
+                name: "App \(processIdentifier)",
+                at: self.start.addingTimeInterval(TimeInterval(processIdentifier)))
+        }
+
+        store.recordActivity(
+            processIdentifier: 1,
+            bundleIdentifier: nil,
+            name: "App 1",
+            at: self.start.addingTimeInterval(4))
+
+        #expect(store.activeTargets.map(\.processIdentifier) == [1, 3, 2])
+    }
+
+    @Test
+    func `Expired targets are removed and recent overflow returns`() {
+        var store = AutomationTargetActivityStore(idleTimeout: 10)
+        for processIdentifier in 1...4 {
+            store.recordActivity(
+                processIdentifier: pid_t(processIdentifier),
+                bundleIdentifier: nil,
+                name: "App \(processIdentifier)",
+                at: self.start.addingTimeInterval(TimeInterval(processIdentifier * 2)))
+        }
+
+        store.expireTargets(at: self.start.addingTimeInterval(13))
+
+        #expect(store.activeTargets.map(\.processIdentifier) == [4, 3, 2])
+        store.expireTargets(at: self.start.addingTimeInterval(17))
+        #expect(store.activeTargets.map(\.processIdentifier) == [4])
+    }
+
+    @Test
+    func `Disabling clears and blocks activity until reenabled`() {
+        var store = AutomationTargetActivityStore(idleTimeout: 10)
+        store.recordActivity(
+            processIdentifier: 1,
+            bundleIdentifier: nil,
+            name: "App 1",
+            at: self.start)
+
+        store.setEnabled(false)
+        #expect(store.activeTargets.isEmpty)
+        store.recordActivity(
+            processIdentifier: 2,
+            bundleIdentifier: nil,
+            name: "App 2",
+            at: self.start.addingTimeInterval(1))
+        #expect(store.activeTargets.isEmpty)
+
+        store.setEnabled(true)
+        store.recordActivity(
+            processIdentifier: 3,
+            bundleIdentifier: nil,
+            name: "App 3",
+            at: self.start.addingTimeInterval(2))
+        #expect(store.activeTargets.map(\.processIdentifier) == [3])
+    }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - Add a Developer-ID-signed Playground validation harness that continuously detects focus, window, cursor, clipboard, and visualizer leakage during background automation.
+- Show recently automated app icons beside Peekaboo in the menu bar, with a settings toggle.
 
 ### Changed
 - Remove the obsolete scoped-commit helper now that agent work uses isolated worktrees.

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeBootstrap.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeBootstrap.swift
@@ -11,6 +11,7 @@ public enum PeekabooBridgeBootstrap {
         allowlistedTeams: Set<String>,
         allowlistedBundles: Set<String>,
         daemonControl: (any PeekabooDaemonControlProviding)? = nil,
+        automationActivityObserver: (@Sendable (pid_t) -> Void)? = nil,
         allowedOperations: Set<PeekabooBridgeOperation> = PeekabooBridgeOperation.remoteDefaultAllowlist,
         maxMessageBytes: Int = 64 * 1024 * 1024,
         requestTimeoutSec: TimeInterval = 10) -> PeekabooBridgeHost
@@ -22,7 +23,8 @@ public enum PeekabooBridgeBootstrap {
             allowlistedBundles: allowlistedBundles,
             allowedOperations: allowedOperations,
             daemonControl: daemonControl,
-            desktopMutationWatermarkStore: DesktopMutationWatermarkStore())
+            desktopMutationWatermarkStore: DesktopMutationWatermarkStore(),
+            automationActivityObserver: automationActivityObserver)
         let host = PeekabooBridgeHost(
             socketPath: socketPath,
             server: server,
@@ -43,6 +45,7 @@ public enum PeekabooBridgeBootstrap {
         allowlistedTeams: Set<String>,
         allowlistedBundles: Set<String>,
         daemonControl: (any PeekabooDaemonControlProviding)? = nil,
+        automationActivityObserver: (@Sendable (pid_t) -> Void)? = nil,
         allowedOperations: Set<PeekabooBridgeOperation> = PeekabooBridgeOperation.remoteDefaultAllowlist,
         maxMessageBytes: Int = 64 * 1024 * 1024,
         requestTimeoutSec: TimeInterval = 10) async throws -> PeekabooBridgeHost
@@ -54,7 +57,8 @@ public enum PeekabooBridgeBootstrap {
             allowlistedBundles: allowlistedBundles,
             allowedOperations: allowedOperations,
             daemonControl: daemonControl,
-            desktopMutationWatermarkStore: DesktopMutationWatermarkStore())
+            desktopMutationWatermarkStore: DesktopMutationWatermarkStore(),
+            automationActivityObserver: automationActivityObserver)
         let host = PeekabooBridgeHost(
             socketPath: socketPath,
             server: server,

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer+Handlers.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer+Handlers.swift
@@ -277,6 +277,7 @@ extension PeekabooBridgeServer {
                     message: "Background typing is not supported by this bridge host")
             }
 
+            self.automationActivityObserver?(pid_t(payload.targetProcessIdentifier))
             let result = try await targetedTypeService.typeActions(
                 payload.actions,
                 cadence: payload.cadence,
@@ -293,6 +294,7 @@ extension PeekabooBridgeServer {
                     message: "Background hotkeys are not supported by this bridge host")
             }
 
+            self.automationActivityObserver?(pid_t(payload.targetProcessIdentifier))
             try await targetedHotkeyService.hotkey(
                 keys: payload.keys,
                 holdDuration: payload.holdDuration,
@@ -315,6 +317,7 @@ extension PeekabooBridgeServer {
                         code: .operationNotSupported,
                         message: "Exact-window background clicks are not supported by this bridge host")
                 }
+                self.automationActivityObserver?(pid_t(payload.targetProcessIdentifier))
                 try await exactWindowService.click(
                     target: payload.target,
                     clickType: payload.clickType,
@@ -322,6 +325,7 @@ extension PeekabooBridgeServer {
                     targetProcessIdentifier: pid_t(payload.targetProcessIdentifier),
                     targetWindowID: targetWindowID)
             } else {
+                self.automationActivityObserver?(pid_t(payload.targetProcessIdentifier))
                 try await targetedClickService.click(
                     target: payload.target,
                     clickType: payload.clickType,

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer+ServiceHandlers.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer+ServiceHandlers.swift
@@ -20,15 +20,19 @@ extension PeekabooBridgeServer {
             return .bool(running)
         case let .launchApplication(payload):
             let app = try await self.services.applications.launchApplication(identifier: payload.identifier)
+            self.automationActivityObserver?(pid_t(app.processIdentifier))
             return .application(app)
         case let .launchApplicationWithOptions(payload):
             let app = try await self.services.applications.launchApplication(request: payload)
+            self.automationActivityObserver?(pid_t(app.processIdentifier))
             return .application(app)
         case let .relaunchApplicationWithOptions(payload):
             let app = try await self.services.applications.relaunchApplication(request: payload)
+            self.automationActivityObserver?(pid_t(app.processIdentifier))
             return .application(app)
         case let .activateApplication(payload):
             try await self.services.applications.activateApplication(identifier: payload.identifier)
+            await self.reportAutomationActivity(appIdentifier: payload.identifier)
             return .ok
         case let .quitApplication(payload):
             let success = try await self.services.applications.quitApplication(
@@ -37,6 +41,7 @@ extension PeekabooBridgeServer {
             return .bool(success)
         case let .hideApplication(payload):
             try await self.services.applications.hideApplication(identifier: payload.identifier)
+            await self.reportAutomationActivity(appIdentifier: payload.identifier)
             return .ok
         case let .unhideApplication(payload):
             try await self.services.applications.unhideApplication(identifier: payload.identifier)
@@ -50,6 +55,15 @@ extension PeekabooBridgeServer {
         default:
             throw Self.invalidRequest(for: request)
         }
+    }
+
+    /// Reports app-identifier operations to the automation activity observer once the target resolves to a pid.
+    private func reportAutomationActivity(appIdentifier: String) async {
+        guard let observer = self.automationActivityObserver else { return }
+        guard let app = try? await self.services.applications.findApplication(identifier: appIdentifier) else {
+            return
+        }
+        observer(pid_t(app.processIdentifier))
     }
 
     func handleMenuRequest(_ request: PeekabooBridgeRequest) async throws -> PeekabooBridgeResponse {

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer.swift
@@ -36,6 +36,7 @@ public final class PeekabooBridgeServer {
     let postEventAccessRequester: @MainActor @Sendable () -> Bool
     let permissionStatusEvaluator: @MainActor @Sendable (_ allowAppleScriptLaunch: Bool) -> PermissionsStatus
     let desktopMutationWatermarkStore: DesktopMutationWatermarkStore?
+    let automationActivityObserver: (@Sendable (pid_t) -> Void)?
     private let desktopMutationGate = PeekabooBridgeMutationGate()
     private let encoder: JSONEncoder
     private let decoder: JSONDecoder
@@ -53,6 +54,7 @@ public final class PeekabooBridgeServer {
         postEventAccessEvaluator: (@MainActor @Sendable () -> Bool)? = nil,
         postEventAccessRequester: (@MainActor @Sendable () -> Bool)? = nil,
         permissionStatusEvaluator: (@MainActor @Sendable (_ allowAppleScriptLaunch: Bool) -> PermissionsStatus)? = nil,
+        automationActivityObserver: (@Sendable (pid_t) -> Void)? = nil,
         encoder: JSONEncoder = .peekabooBridgeEncoder(),
         decoder: JSONDecoder = .peekabooBridgeDecoder())
     {
@@ -64,6 +66,7 @@ public final class PeekabooBridgeServer {
         self.allowedOperations = allowedOperations
         self.daemonControl = daemonControl
         self.desktopMutationWatermarkStore = desktopMutationWatermarkStore
+        self.automationActivityObserver = automationActivityObserver
         self.postEventAccessEvaluator = postEventAccessEvaluator ?? { [services] in
             services.permissions.checkPostEventPermission()
         }


### PR DESCRIPTION
## Summary

While Peekaboo automates an app, its menu bar item now shows which app is being driven — Codex-computer-use style. The ghost icon leads, followed by up to three full-color icons of the most recently automated apps, grouped tightly (3pt gaps) inside the single status item. Icons disappear 10 seconds after the last automation activity; if more than three apps are active, the three most recent win.

Gated by a new default-on toggle in Settings → Visualizer → Menu Bar ("Show automated app icons in the menu bar"). Turning it off clears the icons immediately.

## Implementation

- `AutomationTargetTracker` (new): pure bookkeeping store (cap 3, most-recent-wins, 10s idle expiry, disable-clears) driven by a 1s sweep; `@Observable` for UI.
- `PeekabooBridgeServer` gains an optional `automationActivityObserver: (@Sendable (pid_t) -> Void)?`, reported from targeted click/type/hotkey handlers and app-identifier ops (activate, launch, relaunch, hide). Wired to the tracker in `AppDelegate.startBridgeHost` with a MainActor hop; no AppKit in the bridge module.
- `StatusBarController` composes one `NSImage` per render: template ghost (hand-tinted via `labelColor` against the button's effective appearance when composited with color icons, KVO re-render on appearance change), then target app icons from `NSRunningApplication`. Wobble animation frames flow through the same path. Tooltip/accessibility become "Peekaboo is automating <names>".

## Testing

- `swift test --package-path Apps/Mac --filter AutomationTargetTrackerTests` — 4/4 (cap, recency, expiry, disable).
- `./scripts/build-mac-debug.sh` (Debug + Release) — green.
- Live-verified on macOS 27 by driving Calculator/TextEdit/Finder through the bridge; screenshots in comment below.
- `pnpm run lint` / `pnpm run format` clean for touched files; autoreview (Codex) clean.

Changelog updated under 3.10.1 Unreleased.
