### PR TITLE
refactor(cli): finish runtime plumbing centralization and consolidate dialog scaffolding

### DIFF
--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Agent/PermissionCommand+Requests.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Agent/PermissionCommand+Requests.swift
@@ -5,7 +5,7 @@ import PeekabooCore
 import PeekabooFoundation
 
 extension PermissionCommand {
-    struct RequestScreenRecordingSubcommand: OutputFormattable {
+    struct RequestScreenRecordingSubcommand: OutputFormattable, InjectedRuntimeBackedCommand {
         nonisolated(unsafe) static var commandDescription: CommandDescription {
             MainActorCommandDescription.describe {
                 CommandDescription(
@@ -15,30 +15,7 @@ extension PermissionCommand {
             }
         }
 
-        @RuntimeStorage private var runtime: CommandRuntime?
-
-        private var resolvedRuntime: CommandRuntime {
-            guard let runtime else {
-                preconditionFailure("CommandRuntime must be configured before accessing runtime resources")
-            }
-            return runtime
-        }
-
-        private var services: any PeekabooServiceProviding {
-            self.resolvedRuntime.services
-        }
-
-        private var logger: Logger {
-            self.resolvedRuntime.logger
-        }
-
-        var outputLogger: Logger {
-            self.logger
-        }
-
-        var jsonOutput: Bool {
-            self.resolvedRuntime.configuration.jsonOutput
-        }
+        @RuntimeStorage var runtime: CommandRuntime?
 
         /// Trigger the screen recording permission prompt using the best available mechanism.
         @MainActor
@@ -125,7 +102,7 @@ extension PermissionCommand {
         }
     }
 
-    struct RequestAccessibilitySubcommand: OutputFormattable {
+    struct RequestAccessibilitySubcommand: OutputFormattable, InjectedRuntimeBackedCommand {
         nonisolated(unsafe) static var commandDescription: CommandDescription {
             MainActorCommandDescription.describe {
                 CommandDescription(
@@ -135,30 +112,7 @@ extension PermissionCommand {
             }
         }
 
-        @RuntimeStorage private var runtime: CommandRuntime?
-
-        private var resolvedRuntime: CommandRuntime {
-            guard let runtime else {
-                preconditionFailure("CommandRuntime must be configured before accessing runtime resources")
-            }
-            return runtime
-        }
-
-        private var services: any PeekabooServiceProviding {
-            self.resolvedRuntime.services
-        }
-
-        private var logger: Logger {
-            self.resolvedRuntime.logger
-        }
-
-        var outputLogger: Logger {
-            self.logger
-        }
-
-        var jsonOutput: Bool {
-            self.resolvedRuntime.configuration.jsonOutput
-        }
+        @RuntimeStorage var runtime: CommandRuntime?
 
         /// Prompt the user to grant accessibility permission and open the relevant System Settings pane.
         @MainActor
@@ -234,7 +188,8 @@ extension PermissionCommand {
         }
     }
 
-    struct RequestEventSynthesizingSubcommand: ErrorHandlingCommand, OutputFormattable {
+    struct RequestEventSynthesizingSubcommand: ErrorHandlingCommand, OutputFormattable,
+    InjectedRuntimeBackedCommand {
         nonisolated(unsafe) static var commandDescription: CommandDescription {
             MainActorCommandDescription.describe {
                 CommandDescription(
@@ -244,30 +199,7 @@ extension PermissionCommand {
             }
         }
 
-        @RuntimeStorage private var runtime: CommandRuntime?
-
-        private var resolvedRuntime: CommandRuntime {
-            guard let runtime else {
-                preconditionFailure("CommandRuntime must be configured before accessing runtime resources")
-            }
-            return runtime
-        }
-
-        private var services: any PeekabooServiceProviding {
-            self.resolvedRuntime.services
-        }
-
-        private var logger: Logger {
-            self.resolvedRuntime.logger
-        }
-
-        var outputLogger: Logger {
-            self.logger
-        }
-
-        var jsonOutput: Bool {
-            self.resolvedRuntime.configuration.jsonOutput
-        }
+        @RuntimeStorage var runtime: CommandRuntime?
 
         /// Prompt macOS for event-posting access used by process-targeted hotkeys.
         @MainActor

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Agent/PermissionCommand+Status.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Agent/PermissionCommand+Status.swift
@@ -4,7 +4,7 @@ import PeekabooCore
 import PeekabooFoundation
 
 extension PermissionCommand {
-    struct StatusSubcommand: OutputFormattable {
+    struct StatusSubcommand: OutputFormattable, InjectedRuntimeBackedCommand {
         nonisolated(unsafe) static var commandDescription: CommandDescription {
             MainActorCommandDescription.describe {
                 CommandDescription(
@@ -14,30 +14,7 @@ extension PermissionCommand {
             }
         }
 
-        @RuntimeStorage private var runtime: CommandRuntime?
-
-        private var resolvedRuntime: CommandRuntime {
-            guard let runtime else {
-                preconditionFailure("CommandRuntime must be configured before accessing runtime resources")
-            }
-            return runtime
-        }
-
-        private var services: any PeekabooServiceProviding {
-            self.resolvedRuntime.services
-        }
-
-        private var logger: Logger {
-            self.resolvedRuntime.logger
-        }
-
-        var outputLogger: Logger {
-            self.logger
-        }
-
-        var jsonOutput: Bool {
-            self.resolvedRuntime.configuration.jsonOutput
-        }
+        @RuntimeStorage var runtime: CommandRuntime?
 
         /// Summarize the current permission state for the agent-centric workflow.
         @MainActor

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/RuntimeBackedCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/RuntimeBackedCommand.swift
@@ -2,11 +2,11 @@ import PeekabooCore
 import PeekabooFoundation
 
 @MainActor
-protocol RuntimeBackedCommand: RuntimeOptionsConfigurable {
+protocol InjectedRuntimeBackedCommand {
     var runtime: CommandRuntime? { get set }
 }
 
-extension RuntimeBackedCommand {
+extension InjectedRuntimeBackedCommand {
     var resolvedRuntime: CommandRuntime {
         guard let runtime else {
             preconditionFailure("CommandRuntime must be configured before accessing runtime resources")
@@ -26,6 +26,15 @@ extension RuntimeBackedCommand {
         self.logger
     }
 
+    var jsonOutput: Bool {
+        self.resolvedRuntime.configuration.jsonOutput
+    }
+}
+
+@MainActor
+protocol RuntimeBackedCommand: InjectedRuntimeBackedCommand, RuntimeOptionsConfigurable {}
+
+extension RuntimeBackedCommand {
     var jsonOutput: Bool {
         self.runtime?.configuration.jsonOutput ?? self.runtimeOptions.jsonOutput
     }

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Core/BridgeCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Core/BridgeCommand.swift
@@ -29,7 +29,7 @@ struct BridgeCommand: ParsableCommand {
 
 extension BridgeCommand {
     @MainActor
-    struct StatusSubcommand: OutputFormattable, RuntimeOptionsConfigurable {
+    struct StatusSubcommand: OutputFormattable, RuntimeBackedCommand {
         nonisolated(unsafe) static var commandDescription: CommandDescription {
             MainActorCommandDescription.describe {
                 CommandDescription(
@@ -39,33 +39,14 @@ extension BridgeCommand {
             }
         }
 
-        @RuntimeStorage private var runtime: CommandRuntime?
+        @RuntimeStorage var runtime: CommandRuntime?
         var runtimeOptions = CommandRuntimeOptions()
-
-        private var resolvedRuntime: CommandRuntime {
-            guard let runtime else {
-                preconditionFailure("CommandRuntime must be configured before accessing runtime resources")
-            }
-            return runtime
-        }
 
         private var configuration: CommandRuntime.Configuration {
             if let runtime {
                 return runtime.configuration
             }
             return self.runtimeOptions.makeConfiguration()
-        }
-
-        private var logger: Logger {
-            self.resolvedRuntime.logger
-        }
-
-        var outputLogger: Logger {
-            self.logger
-        }
-
-        var jsonOutput: Bool {
-            self.configuration.jsonOutput
         }
 
         private var verbose: Bool {

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Core/CaptureCommand+Action.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Core/CaptureCommand+Action.swift
@@ -6,7 +6,7 @@ import PeekabooFoundation
 
 @MainActor
 struct CaptureActionCommand: ApplicationResolvable, ErrorHandlingCommand, OutputFormattable,
-RuntimeOptionsConfigurable {
+RuntimeOptionsConfigurable, InjectedRuntimeBackedCommand {
     var app: String?
     var pid: Int32?
     var mode: String?
@@ -38,7 +38,7 @@ RuntimeOptionsConfigurable {
     var videoOut: String?
     var command: [String] = []
 
-    @RuntimeStorage private var runtime: CommandRuntime?
+    @RuntimeStorage var runtime: CommandRuntime?
     var runtimeOptions = CommandRuntimeOptions()
 
     nonisolated(unsafe) static var commandDescription: CommandDescription {
@@ -59,31 +59,8 @@ RuntimeOptionsConfigurable {
         }
     }
 
-    private var resolvedRuntime: CommandRuntime {
-        guard let runtime else {
-            preconditionFailure("CommandRuntime must be configured before accessing runtime resources")
-        }
-        return runtime
-    }
-
-    private var logger: Logger {
-        self.resolvedRuntime.logger
-    }
-
-    var services: any PeekabooServiceProviding {
-        self.resolvedRuntime.services
-    }
-
     func withCaptureFocusMutation(_ operation: () async throws -> Void) async rethrows {
         try await self.resolvedRuntime.withCaptureFocusMutation(operation)
-    }
-
-    var jsonOutput: Bool {
-        self.resolvedRuntime.configuration.jsonOutput
-    }
-
-    var outputLogger: Logger {
-        self.logger
     }
 
     mutating func run(using runtime: CommandRuntime) async throws {

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Core/CaptureCommand+Live.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Core/CaptureCommand+Live.swift
@@ -4,7 +4,8 @@ import PeekabooCore
 import PeekabooFoundation
 
 @MainActor
-struct CaptureLiveCommand: ApplicationResolvable, ErrorHandlingCommand, OutputFormattable, RuntimeOptionsConfigurable {
+struct CaptureLiveCommand: ApplicationResolvable, ErrorHandlingCommand, OutputFormattable, RuntimeOptionsConfigurable,
+InjectedRuntimeBackedCommand {
     // Targeting
     @Option(name: .long, help: "Target application name, bundle ID, or 'PID:12345'") var app: String?
     @Option(name: .long, help: "Target application by process ID") var pid: Int32?
@@ -55,34 +56,11 @@ struct CaptureLiveCommand: ApplicationResolvable, ErrorHandlingCommand, OutputFo
     @Option(name: .long, help: "Minutes before temp sessions auto-clean (default 120)") var autocleanMinutes: Int?
     @Option(name: .long, help: "Optional MP4 output path (built from kept frames)") var videoOut: String?
 
-    @RuntimeStorage private var runtime: CommandRuntime?
+    @RuntimeStorage var runtime: CommandRuntime?
     var runtimeOptions = CommandRuntimeOptions()
-
-    private var resolvedRuntime: CommandRuntime {
-        guard let runtime else {
-            preconditionFailure("CommandRuntime must be configured before accessing runtime resources")
-        }
-        return runtime
-    }
-
-    private var logger: Logger {
-        self.resolvedRuntime.logger
-    }
-
-    var services: any PeekabooServiceProviding {
-        self.resolvedRuntime.services
-    }
 
     func withCaptureFocusMutation(_ operation: () async throws -> Void) async rethrows {
         try await self.resolvedRuntime.withCaptureFocusMutation(operation)
-    }
-
-    var jsonOutput: Bool {
-        self.resolvedRuntime.configuration.jsonOutput
-    }
-
-    var outputLogger: Logger {
-        self.logger
     }
 
     mutating func run(using runtime: CommandRuntime) async throws {

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Core/CaptureCommand+Video.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Core/CaptureCommand+Video.swift
@@ -8,7 +8,8 @@ import PeekabooFoundation
 // MARK: Video capture
 
 @MainActor
-struct CaptureVideoCommand: ErrorHandlingCommand, OutputFormattable, RuntimeOptionsConfigurable {
+struct CaptureVideoCommand: ErrorHandlingCommand, OutputFormattable, RuntimeOptionsConfigurable,
+InjectedRuntimeBackedCommand {
     @Argument(help: "Input video file") var input: String
     @Option(name: .long, help: "Sample FPS (default 2). Mutually exclusive with --every-ms") var sampleFps: Double?
     @Option(name: .long, help: "Sample every N milliseconds (mutually exclusive with --sample-fps)") var everyMs: Int?
@@ -24,31 +25,8 @@ struct CaptureVideoCommand: ErrorHandlingCommand, OutputFormattable, RuntimeOpti
     @Option(name: .long, help: "Minutes before temp sessions auto-clean (default 120)") var autocleanMinutes: Int?
     @Option(name: .long, help: "Optional MP4 output path (built from kept frames)") var videoOut: String?
 
-    @RuntimeStorage private var runtime: CommandRuntime?
+    @RuntimeStorage var runtime: CommandRuntime?
     var runtimeOptions = CommandRuntimeOptions()
-
-    private var resolvedRuntime: CommandRuntime {
-        guard let runtime else {
-            preconditionFailure("CommandRuntime must be configured before accessing runtime resources")
-        }
-        return runtime
-    }
-
-    private var logger: Logger {
-        self.resolvedRuntime.logger
-    }
-
-    private var services: any PeekabooServiceProviding {
-        self.resolvedRuntime.services
-    }
-
-    var jsonOutput: Bool {
-        self.resolvedRuntime.configuration.jsonOutput
-    }
-
-    var outputLogger: Logger {
-        self.logger
-    }
 
     mutating func run(using runtime: CommandRuntime) async throws {
         self.runtime = runtime

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Core/ConfigCommand+Shared.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Core/ConfigCommand+Shared.swift
@@ -9,29 +9,11 @@ import PeekabooCore
 import PeekabooFoundation
 
 @MainActor
-protocol ConfigRuntimeCommand {
-    var runtime: CommandRuntime? { get set }
-
+protocol ConfigRuntimeCommand: InjectedRuntimeBackedCommand {
     mutating func prepare(using runtime: CommandRuntime)
 }
 
 extension ConfigRuntimeCommand {
-    /// Lazily unwrap the command runtime or crash fast during development.
-    var resolvedRuntime: CommandRuntime {
-        guard let runtime else {
-            preconditionFailure("CommandRuntime must be configured before accessing runtime resources")
-        }
-        return runtime
-    }
-
-    var logger: Logger {
-        self.resolvedRuntime.logger
-    }
-
-    var jsonOutput: Bool {
-        self.resolvedRuntime.configuration.jsonOutput
-    }
-
     mutating func prepare(using runtime: CommandRuntime) {
         self.runtime = runtime
         self.logger.setJsonOutputMode(self.jsonOutput)

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/DragCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/DragCommand.swift
@@ -7,7 +7,7 @@ import PeekabooFoundation
 /// Perform drag and drop operations using intelligent element finding
 @available(macOS 14.0, *)
 @MainActor
-struct DragCommand: ErrorHandlingCommand, OutputFormattable {
+struct DragCommand: ErrorHandlingCommand, OutputFormattable, InjectedRuntimeBackedCommand {
     @OptionGroup var target: InteractionTargetOptions
 
     @Option(help: "Starting element ID from snapshot")
@@ -43,30 +43,7 @@ struct DragCommand: ErrorHandlingCommand, OutputFormattable {
 
     @Flag(help: "Confirm foreground pointer movement and focus the target when specified")
     var foreground = false
-    @RuntimeStorage private var runtime: CommandRuntime?
-
-    private var resolvedRuntime: CommandRuntime {
-        guard let runtime else {
-            preconditionFailure("CommandRuntime must be configured before accessing runtime resources")
-        }
-        return runtime
-    }
-
-    var services: any PeekabooServiceProviding {
-        self.resolvedRuntime.services
-    }
-
-    private var logger: Logger {
-        self.resolvedRuntime.logger
-    }
-
-    var outputLogger: Logger {
-        self.logger
-    }
-
-    var jsonOutput: Bool {
-        self.resolvedRuntime.configuration.jsonOutput
-    }
+    @RuntimeStorage var runtime: CommandRuntime?
 
     @MainActor
     mutating func run(using runtime: CommandRuntime) async throws {

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/HotkeyCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/HotkeyCommand.swift
@@ -6,7 +6,7 @@ import PeekabooFoundation
 /// Presses key combinations like Cmd+C, Ctrl+A, etc. using the UIAutomationService.
 @available(macOS 14.0, *)
 @MainActor
-struct HotkeyCommand: ErrorHandlingCommand, OutputFormattable {
+struct HotkeyCommand: ErrorHandlingCommand, OutputFormattable, InjectedRuntimeBackedCommand {
     @Argument(help: "Keys to press (comma-, plus-, or space-separated)")
     var keysArgument: String?
 
@@ -28,30 +28,7 @@ struct HotkeyCommand: ErrorHandlingCommand, OutputFormattable {
     var foreground = false
 
     @OptionGroup var focusOptions: FocusCommandOptions
-    @RuntimeStorage private var runtime: CommandRuntime?
-
-    private var resolvedRuntime: CommandRuntime {
-        guard let runtime else {
-            preconditionFailure("CommandRuntime must be configured before accessing runtime resources")
-        }
-        return runtime
-    }
-
-    private var services: any PeekabooServiceProviding {
-        self.resolvedRuntime.services
-    }
-
-    private var logger: Logger {
-        self.resolvedRuntime.logger
-    }
-
-    var outputLogger: Logger {
-        self.logger
-    }
-
-    var jsonOutput: Bool {
-        self.resolvedRuntime.configuration.jsonOutput
-    }
+    @RuntimeStorage var runtime: CommandRuntime?
 
     /// Keys after resolving positional/option input and trimming whitespace. Nil when missing/empty.
     var resolvedKeys: String? {

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/MoveCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/MoveCommand.swift
@@ -7,7 +7,7 @@ import PeekabooFoundation
 /// Moves the mouse cursor to specific coordinates or UI elements.
 @available(macOS 14.0, *)
 @MainActor
-struct MoveCommand: ErrorHandlingCommand, OutputFormattable {
+struct MoveCommand: ErrorHandlingCommand, OutputFormattable, InjectedRuntimeBackedCommand {
     @Argument(help: "Coordinates as x,y (e.g., 100,200)")
     var coordinates: String?
 
@@ -46,30 +46,7 @@ struct MoveCommand: ErrorHandlingCommand, OutputFormattable {
 
     @Option(help: "Snapshot ID for element resolution, or 'latest'")
     var snapshot: String?
-    @RuntimeStorage private var runtime: CommandRuntime?
-
-    private var resolvedRuntime: CommandRuntime {
-        guard let runtime else {
-            preconditionFailure("CommandRuntime must be configured before accessing runtime resources")
-        }
-        return runtime
-    }
-
-    private var services: any PeekabooServiceProviding {
-        self.resolvedRuntime.services
-    }
-
-    private var logger: Logger {
-        self.resolvedRuntime.logger
-    }
-
-    var outputLogger: Logger {
-        self.logger
-    }
-
-    var jsonOutput: Bool {
-        self.resolvedRuntime.configuration.jsonOutput
-    }
+    @RuntimeStorage var runtime: CommandRuntime?
 
     private var resolvedCoordinates: String? {
         self.coordinates ?? self.coords

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/PerformActionCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/PerformActionCommand.swift
@@ -21,43 +21,28 @@ struct PerformActionCommand: ErrorHandlingCommand, OutputFormattable, RuntimeBac
     @MainActor
     mutating func run(using runtime: CommandRuntime) async throws {
         self.runtime = runtime
-        self.logger.setJsonOutputMode(self.jsonOutput)
-
-        do {
-            let target = try self.requireTarget()
-            let actionName = try self.requireAction()
-            let observation = await self.resolveObservationContext()
-            try await observation.validateIfExplicit(using: self.services.snapshots)
-            let startTime = Date()
-            self.resolvedRuntime.beginInteractionMutation()
-            let result = try await AutomationServiceBridge.performAction(
-                automation: self.services.automation,
-                target: target,
-                actionName: actionName,
-                snapshotId: observation.snapshotId
-            )
-            await InteractionObservationInvalidator.invalidateAfterMutation(
-                targets: self.resolvedRuntime.interactionMutationTargets,
-                logger: self.logger,
-                reason: "perform-action"
-            )
-
-            let outputPayload = ElementActionCommandResult(
-                success: true,
-                target: result.target,
-                actionName: result.actionName,
-                oldValue: result.oldValue,
-                newValue: result.newValue,
-                executionTime: Date().timeIntervalSince(startTime)
-            )
-
-            self.output(outputPayload) {
-                print("✅ Performed \(result.actionName ?? actionName) on \(result.target)")
-            }
-        } catch {
-            self.handleError(error)
-            throw ExitCode.failure
-        }
+        try await ElementActionCommandExecutor.execute(
+            runtime: runtime,
+            snapshot: self.snapshot,
+            invalidationReason: "perform-action",
+            prepare: {
+                try (self.requireTarget(), self.requireAction())
+            },
+            operation: { automation, target, actionName, snapshotId in
+                try await AutomationServiceBridge.performAction(
+                    automation: automation,
+                    target: target,
+                    actionName: actionName,
+                    snapshotId: snapshotId
+                )
+            },
+            render: { result, outputPayload, actionName in
+                self.output(outputPayload) {
+                    print("✅ Performed \(result.actionName ?? actionName) on \(result.target)")
+                }
+            },
+            handleError: { self.handleError($0) }
+        )
     }
 
     private func requireTarget() throws -> String {
@@ -72,14 +57,6 @@ struct PerformActionCommand: ErrorHandlingCommand, OutputFormattable, RuntimeBac
             throw ValidationError("--action is required")
         }
         return action
-    }
-
-    private func resolveObservationContext() async -> InteractionObservationContext {
-        await InteractionObservationContext.resolve(
-            explicitSnapshot: self.snapshot,
-            fallbackToLatest: true,
-            snapshots: self.services.snapshots
-        )
     }
 }
 

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/PerformActionCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/PerformActionCommand.swift
@@ -22,9 +22,11 @@ struct PerformActionCommand: ErrorHandlingCommand, OutputFormattable, RuntimeBac
     mutating func run(using runtime: CommandRuntime) async throws {
         self.runtime = runtime
         try await ElementActionCommandExecutor.execute(
-            runtime: runtime,
-            snapshot: self.snapshot,
-            invalidationReason: "perform-action",
+            context: ElementActionCommandContext(
+                runtime: runtime,
+                snapshot: self.snapshot,
+                invalidationReason: "perform-action"
+            ),
             prepare: {
                 try (self.requireTarget(), self.requireAction())
             },

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/SetValueCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/SetValueCommand.swift
@@ -21,46 +21,31 @@ struct SetValueCommand: ErrorHandlingCommand, OutputFormattable, RuntimeBackedCo
     @MainActor
     mutating func run(using runtime: CommandRuntime) async throws {
         self.runtime = runtime
-        self.logger.setJsonOutputMode(self.jsonOutput)
-
-        do {
-            let target = try self.requireTarget()
-            let value = try self.requireValue()
-            let observation = await self.resolveObservationContext()
-            try await observation.validateIfExplicit(using: self.services.snapshots)
-            let startTime = Date()
-            self.resolvedRuntime.beginInteractionMutation()
-            let result = try await AutomationServiceBridge.setValue(
-                automation: self.services.automation,
-                target: target,
-                value: .string(value),
-                snapshotId: observation.snapshotId
-            )
-            await InteractionObservationInvalidator.invalidateAfterMutation(
-                targets: self.resolvedRuntime.interactionMutationTargets,
-                logger: self.logger,
-                reason: "set-value"
-            )
-
-            let outputPayload = ElementActionCommandResult(
-                success: true,
-                target: result.target,
-                actionName: result.actionName,
-                oldValue: result.oldValue,
-                newValue: result.newValue,
-                executionTime: Date().timeIntervalSince(startTime)
-            )
-
-            self.output(outputPayload) {
-                print("✅ Set value on \(result.target)")
-                if let newValue = result.newValue {
-                    print("📝 New value: \(newValue)")
+        try await ElementActionCommandExecutor.execute(
+            runtime: runtime,
+            snapshot: self.snapshot,
+            invalidationReason: "set-value",
+            prepare: {
+                try (self.requireTarget(), self.requireValue())
+            },
+            operation: { automation, target, value, snapshotId in
+                try await AutomationServiceBridge.setValue(
+                    automation: automation,
+                    target: target,
+                    value: .string(value),
+                    snapshotId: snapshotId
+                )
+            },
+            render: { result, outputPayload, _ in
+                self.output(outputPayload) {
+                    print("✅ Set value on \(result.target)")
+                    if let newValue = result.newValue {
+                        print("📝 New value: \(newValue)")
+                    }
                 }
-            }
-        } catch {
-            self.handleError(error)
-            throw ExitCode.failure
-        }
+            },
+            handleError: { self.handleError($0) }
+        )
     }
 
     private func requireTarget() throws -> String {
@@ -75,14 +60,6 @@ struct SetValueCommand: ErrorHandlingCommand, OutputFormattable, RuntimeBackedCo
             throw ValidationError("Value is required")
         }
         return value
-    }
-
-    private func resolveObservationContext() async -> InteractionObservationContext {
-        await InteractionObservationContext.resolve(
-            explicitSnapshot: self.snapshot,
-            fallbackToLatest: true,
-            snapshots: self.services.snapshots
-        )
     }
 }
 
@@ -141,4 +118,62 @@ struct ElementActionCommandResult: Codable {
     let oldValue: String?
     let newValue: String?
     let executionTime: TimeInterval
+}
+
+@MainActor
+enum ElementActionCommandExecutor {
+    static func execute<Prepared>(
+        runtime: CommandRuntime,
+        snapshot: String?,
+        invalidationReason: String,
+        prepare: () throws -> (target: String, value: Prepared),
+        operation: (
+            _ automation: any UIAutomationServiceProtocol,
+            _ target: String,
+            _ value: Prepared,
+            _ snapshotId: String?
+        ) async throws -> ElementActionResult,
+        render: (_ result: ElementActionResult, _ output: ElementActionCommandResult, _ value: Prepared) -> Void,
+        handleError: (any Error) -> Void
+    ) async throws {
+        let services = runtime.services
+        let logger = runtime.logger
+        logger.setJsonOutputMode(runtime.configuration.jsonOutput)
+
+        do {
+            let prepared = try prepare()
+            let observation = await InteractionObservationContext.resolve(
+                explicitSnapshot: snapshot,
+                fallbackToLatest: true,
+                snapshots: services.snapshots
+            )
+            try await observation.validateIfExplicit(using: services.snapshots)
+            let startTime = Date()
+            runtime.beginInteractionMutation()
+            let result = try await operation(
+                services.automation,
+                prepared.target,
+                prepared.value,
+                observation.snapshotId
+            )
+            await InteractionObservationInvalidator.invalidateAfterMutation(
+                targets: runtime.interactionMutationTargets,
+                logger: logger,
+                reason: invalidationReason
+            )
+
+            let output = ElementActionCommandResult(
+                success: true,
+                target: result.target,
+                actionName: result.actionName,
+                oldValue: result.oldValue,
+                newValue: result.newValue,
+                executionTime: Date().timeIntervalSince(startTime)
+            )
+            render(result, output, prepared.value)
+        } catch {
+            handleError(error)
+            throw ExitCode.failure
+        }
+    }
 }

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/SetValueCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/SetValueCommand.swift
@@ -22,9 +22,11 @@ struct SetValueCommand: ErrorHandlingCommand, OutputFormattable, RuntimeBackedCo
     mutating func run(using runtime: CommandRuntime) async throws {
         self.runtime = runtime
         try await ElementActionCommandExecutor.execute(
-            runtime: runtime,
-            snapshot: self.snapshot,
-            invalidationReason: "set-value",
+            context: ElementActionCommandContext(
+                runtime: runtime,
+                snapshot: self.snapshot,
+                invalidationReason: "set-value"
+            ),
             prepare: {
                 try (self.requireTarget(), self.requireValue())
             },
@@ -120,12 +122,16 @@ struct ElementActionCommandResult: Codable {
     let executionTime: TimeInterval
 }
 
+struct ElementActionCommandContext {
+    let runtime: CommandRuntime
+    let snapshot: String?
+    let invalidationReason: String
+}
+
 @MainActor
 enum ElementActionCommandExecutor {
     static func execute<Prepared>(
-        runtime: CommandRuntime,
-        snapshot: String?,
-        invalidationReason: String,
+        context: ElementActionCommandContext,
         prepare: () throws -> (target: String, value: Prepared),
         operation: (
             _ automation: any UIAutomationServiceProtocol,
@@ -136,6 +142,7 @@ enum ElementActionCommandExecutor {
         render: (_ result: ElementActionResult, _ output: ElementActionCommandResult, _ value: Prepared) -> Void,
         handleError: (any Error) -> Void
     ) async throws {
+        let runtime = context.runtime
         let services = runtime.services
         let logger = runtime.logger
         logger.setJsonOutputMode(runtime.configuration.jsonOutput)
@@ -143,7 +150,7 @@ enum ElementActionCommandExecutor {
         do {
             let prepared = try prepare()
             let observation = await InteractionObservationContext.resolve(
-                explicitSnapshot: snapshot,
+                explicitSnapshot: context.snapshot,
                 fallbackToLatest: true,
                 snapshots: services.snapshots
             )
@@ -159,7 +166,7 @@ enum ElementActionCommandExecutor {
             await InteractionObservationInvalidator.invalidateAfterMutation(
                 targets: runtime.interactionMutationTargets,
                 logger: logger,
-                reason: invalidationReason
+                reason: context.invalidationReason
             )
 
             let output = ElementActionCommandResult(

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/MCP/BrowserCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/MCP/BrowserCommand.swift
@@ -4,7 +4,8 @@ import PeekabooCore
 import TachikomaMCP
 
 @MainActor
-struct BrowserCommand: ErrorHandlingCommand, OutputFormattable, RuntimeOptionsConfigurable {
+struct BrowserCommand: ErrorHandlingCommand, OutputFormattable, RuntimeOptionsConfigurable,
+InjectedRuntimeBackedCommand {
     var action = "status"
     var channel: String?
     var pageId: Int?
@@ -49,7 +50,7 @@ struct BrowserCommand: ErrorHandlingCommand, OutputFormattable, RuntimeOptionsCo
         return options
     }()
 
-    @RuntimeStorage private var runtime: CommandRuntime?
+    @RuntimeStorage var runtime: CommandRuntime?
 
     static let commandDescription = CommandDescription(
         commandName: "browser",
@@ -66,29 +67,6 @@ struct BrowserCommand: ErrorHandlingCommand, OutputFormattable, RuntimeOptionsCo
           peekaboo browser snapshot --path /tmp/page.txt
         """
     )
-
-    private var resolvedRuntime: CommandRuntime {
-        guard let runtime else {
-            preconditionFailure("CommandRuntime must be configured before accessing runtime resources")
-        }
-        return runtime
-    }
-
-    private var services: any PeekabooServiceProviding {
-        self.resolvedRuntime.services
-    }
-
-    private var logger: Logger {
-        self.resolvedRuntime.logger
-    }
-
-    var jsonOutput: Bool {
-        self.resolvedRuntime.configuration.jsonOutput
-    }
-
-    var outputLogger: Logger {
-        self.logger
-    }
 
     mutating func setRuntimeOptions(_ options: CommandRuntimeOptions) {
         var options = options

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/MCP/InspectUICommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/MCP/InspectUICommand.swift
@@ -4,7 +4,8 @@ import PeekabooCore
 import TachikomaMCP
 
 @MainActor
-struct InspectUICommand: ErrorHandlingCommand, OutputFormattable, RuntimeOptionsConfigurable {
+struct InspectUICommand: ErrorHandlingCommand, OutputFormattable, RuntimeOptionsConfigurable,
+InjectedRuntimeBackedCommand {
     var appTarget: String?
     var snapshot: String?
     var maxDepth: Int?
@@ -18,7 +19,7 @@ struct InspectUICommand: ErrorHandlingCommand, OutputFormattable, RuntimeOptions
         return options
     }()
 
-    @RuntimeStorage private var runtime: CommandRuntime?
+    @RuntimeStorage var runtime: CommandRuntime?
 
     static let commandDescription = CommandDescription(
         commandName: "inspect-ui",
@@ -32,29 +33,6 @@ struct InspectUICommand: ErrorHandlingCommand, OutputFormattable, RuntimeOptions
           peekaboo inspect-ui --snapshot 1234 --max-elements 200 --json
         """
     )
-
-    private var resolvedRuntime: CommandRuntime {
-        guard let runtime else {
-            preconditionFailure("CommandRuntime must be configured before accessing runtime resources")
-        }
-        return runtime
-    }
-
-    private var services: any PeekabooServiceProviding {
-        self.resolvedRuntime.services
-    }
-
-    private var logger: Logger {
-        self.resolvedRuntime.logger
-    }
-
-    var jsonOutput: Bool {
-        self.resolvedRuntime.configuration.jsonOutput
-    }
-
-    var outputLogger: Logger {
-        self.logger
-    }
 
     mutating func setRuntimeOptions(_ options: CommandRuntimeOptions) {
         var options = options

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/AppCommand+Launch.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/AppCommand+Launch.swift
@@ -8,7 +8,7 @@ extension AppCommand {
     // MARK: - Launch Application
 
     @MainActor
-    struct LaunchSubcommand {
+    struct LaunchSubcommand: InjectedRuntimeBackedCommand {
         static let commandDescription = CommandDescription(
             commandName: "launch",
             abstract: "Launch an application",
@@ -52,30 +52,7 @@ extension AppCommand {
             parsing: .upToNextOption
         )
         var openTargets: [String] = []
-        @RuntimeStorage private var runtime: CommandRuntime?
-
-        private var resolvedRuntime: CommandRuntime {
-            guard let runtime else {
-                preconditionFailure("CommandRuntime must be configured before accessing runtime resources")
-            }
-            return runtime
-        }
-
-        @MainActor private var logger: Logger {
-            self.resolvedRuntime.logger
-        }
-
-        @MainActor private var services: any PeekabooServiceProviding {
-            self.resolvedRuntime.services
-        }
-
-        var outputLogger: Logger {
-            self.logger
-        }
-
-        var jsonOutput: Bool {
-            self.resolvedRuntime.configuration.jsonOutput
-        }
+        @RuntimeStorage var runtime: CommandRuntime?
 
         var shouldFocusAfterLaunch: Bool {
             self.foreground

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/AppCommand+List.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/AppCommand+List.swift
@@ -9,7 +9,7 @@ extension AppCommand {
 
     @MainActor
 
-    struct ListSubcommand {
+    struct ListSubcommand: InjectedRuntimeBackedCommand {
         static let commandDescription = CommandDescription(
             commandName: "list",
             abstract: "List running applications",
@@ -27,30 +27,7 @@ extension AppCommand {
 
         @Flag(help: "Include background apps")
         var includeBackground = false
-        @RuntimeStorage private var runtime: CommandRuntime?
-
-        private var resolvedRuntime: CommandRuntime {
-            guard let runtime else {
-                preconditionFailure("CommandRuntime must be configured before accessing runtime resources")
-            }
-            return runtime
-        }
-
-        private var logger: Logger {
-            self.resolvedRuntime.logger
-        }
-
-        @MainActor private var services: any PeekabooServiceProviding {
-            self.resolvedRuntime.services
-        }
-
-        var outputLogger: Logger {
-            self.logger
-        }
-
-        var jsonOutput: Bool {
-            self.resolvedRuntime.configuration.jsonOutput
-        }
+        @RuntimeStorage var runtime: CommandRuntime?
 
         static func filteredApplications(
             _ applications: [ServiceApplicationInfo],

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/AppCommand+Quit.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/AppCommand+Quit.swift
@@ -8,7 +8,7 @@ extension AppCommand {
     // MARK: - Quit Application
 
     @MainActor
-    struct QuitSubcommand {
+    struct QuitSubcommand: InjectedRuntimeBackedCommand {
         static let commandDescription = CommandDescription(
             commandName: "quit",
             abstract: "Quit one or more applications"
@@ -28,30 +28,7 @@ extension AppCommand {
 
         @Flag(help: "Force quit (doesn't save changes)")
         var force = false
-        @RuntimeStorage private var runtime: CommandRuntime?
-
-        private var resolvedRuntime: CommandRuntime {
-            guard let runtime else {
-                preconditionFailure("CommandRuntime must be configured before accessing runtime resources")
-            }
-            return runtime
-        }
-
-        private var logger: Logger {
-            self.resolvedRuntime.logger
-        }
-
-        @MainActor private var services: any PeekabooServiceProviding {
-            self.resolvedRuntime.services
-        }
-
-        var outputLogger: Logger {
-            self.logger
-        }
-
-        var jsonOutput: Bool {
-            self.resolvedRuntime.configuration.jsonOutput
-        }
+        @RuntimeStorage var runtime: CommandRuntime?
 
         /// Resolve the targeted applications, issue quit or force-quit requests, and report results per app.
         @MainActor

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/AppCommand+Relaunch.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/AppCommand+Relaunch.swift
@@ -8,7 +8,7 @@ extension AppCommand {
     // MARK: - Relaunch Application
 
     @MainActor
-    struct RelaunchSubcommand {
+    struct RelaunchSubcommand: InjectedRuntimeBackedCommand {
         static let commandDescription = CommandDescription(
             commandName: "relaunch",
             abstract: "Quit and relaunch an application"
@@ -31,30 +31,7 @@ extension AppCommand {
 
         @Flag(help: "Bring the app to the foreground after relaunching")
         var foreground = false
-        @RuntimeStorage private var runtime: CommandRuntime?
-
-        private var resolvedRuntime: CommandRuntime {
-            guard let runtime else {
-                preconditionFailure("CommandRuntime must be configured before accessing runtime resources")
-            }
-            return runtime
-        }
-
-        private var logger: Logger {
-            self.resolvedRuntime.logger
-        }
-
-        @MainActor private var services: any PeekabooServiceProviding {
-            self.resolvedRuntime.services
-        }
-
-        var outputLogger: Logger {
-            self.logger
-        }
-
-        var jsonOutput: Bool {
-            self.resolvedRuntime.configuration.jsonOutput
-        }
+        @RuntimeStorage var runtime: CommandRuntime?
 
         /// Quit the target app, wait if requested, relaunch it, and report success metrics.
         @MainActor

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/AppCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/AppCommand.swift
@@ -49,7 +49,7 @@ struct AppCommand: ParsableCommand {
 
     @MainActor
 
-    struct HideSubcommand {
+    struct HideSubcommand: InjectedRuntimeBackedCommand {
         static let commandDescription = CommandDescription(
             commandName: "hide",
             abstract: "Hide an application"
@@ -60,30 +60,7 @@ struct AppCommand: ParsableCommand {
 
         @Option(name: .long, help: "Target application by process ID")
         var pid: Int32?
-        @RuntimeStorage private var runtime: CommandRuntime?
-
-        private var resolvedRuntime: CommandRuntime {
-            guard let runtime else {
-                preconditionFailure("CommandRuntime must be configured before accessing runtime resources")
-            }
-            return runtime
-        }
-
-        private var logger: Logger {
-            self.resolvedRuntime.logger
-        }
-
-        var outputLogger: Logger {
-            self.logger
-        }
-
-        @MainActor private var services: any PeekabooServiceProviding {
-            self.resolvedRuntime.services
-        }
-
-        var jsonOutput: Bool {
-            self.resolvedRuntime.configuration.jsonOutput
-        }
+        @RuntimeStorage var runtime: CommandRuntime?
 
         /// Hide the specified application and emit confirmation in either text or JSON form.
         @MainActor
@@ -123,7 +100,7 @@ struct AppCommand: ParsableCommand {
 
     @MainActor
 
-    struct UnhideSubcommand {
+    struct UnhideSubcommand: InjectedRuntimeBackedCommand {
         static let commandDescription = CommandDescription(
             commandName: "unhide",
             abstract: "Show a hidden application"
@@ -137,30 +114,7 @@ struct AppCommand: ParsableCommand {
 
         @Flag(help: "Bring to front after unhiding")
         var activate = false
-        @RuntimeStorage private var runtime: CommandRuntime?
-
-        private var resolvedRuntime: CommandRuntime {
-            guard let runtime else {
-                preconditionFailure("CommandRuntime must be configured before accessing runtime resources")
-            }
-            return runtime
-        }
-
-        private var logger: Logger {
-            self.resolvedRuntime.logger
-        }
-
-        var outputLogger: Logger {
-            self.logger
-        }
-
-        @MainActor private var services: any PeekabooServiceProviding {
-            self.resolvedRuntime.services
-        }
-
-        var jsonOutput: Bool {
-            self.resolvedRuntime.configuration.jsonOutput
-        }
+        @RuntimeStorage var runtime: CommandRuntime?
 
         /// Unhide the target application and optionally re-activate its main window.
         @MainActor
@@ -216,7 +170,7 @@ struct AppCommand: ParsableCommand {
 
     @MainActor
 
-    struct SwitchSubcommand {
+    struct SwitchSubcommand: InjectedRuntimeBackedCommand {
         static let commandDescription = CommandDescription(
             commandName: "switch",
             abstract: "Switch to another application"
@@ -230,30 +184,7 @@ struct AppCommand: ParsableCommand {
 
         @Flag(help: "Verify the target app becomes frontmost")
         var verify = false
-        @RuntimeStorage private var runtime: CommandRuntime?
-
-        private var resolvedRuntime: CommandRuntime {
-            guard let runtime else {
-                preconditionFailure("CommandRuntime must be configured before accessing runtime resources")
-            }
-            return runtime
-        }
-
-        private var logger: Logger {
-            self.resolvedRuntime.logger
-        }
-
-        var outputLogger: Logger {
-            self.logger
-        }
-
-        @MainActor private var services: any PeekabooServiceProviding {
-            self.resolvedRuntime.services
-        }
-
-        var jsonOutput: Bool {
-            self.resolvedRuntime.configuration.jsonOutput
-        }
+        @RuntimeStorage var runtime: CommandRuntime?
 
         /// Switch focus either by cycling (Cmd+Tab) or by activating a specific application.
         @MainActor

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/CleanCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/CleanCommand.swift
@@ -5,7 +5,7 @@ import PeekabooCore
 /// Clean up snapshot cache and temporary files
 @available(macOS 14.0, *)
 @MainActor
-struct CleanCommand: OutputFormattable, RuntimeOptionsConfigurable {
+struct CleanCommand: OutputFormattable, RuntimeBackedCommand {
     static let commandDescription = CommandDescription(
         commandName: "clean",
         abstract: "Clean up snapshot cache and temporary files",
@@ -40,40 +40,8 @@ struct CleanCommand: OutputFormattable, RuntimeOptionsConfigurable {
 
     @Flag(help: "Show what would be deleted without actually deleting")
     var dryRun = false
-    @RuntimeStorage private var runtime: CommandRuntime?
+    @RuntimeStorage var runtime: CommandRuntime?
     var runtimeOptions = CommandRuntimeOptions()
-
-    private var resolvedRuntime: CommandRuntime {
-        guard let runtime else {
-            preconditionFailure("CommandRuntime must be configured before accessing runtime resources")
-        }
-        return runtime
-    }
-
-    private var services: any PeekabooServiceProviding {
-        self.resolvedRuntime.services
-    }
-
-    private var logger: Logger {
-        self.resolvedRuntime.logger
-    }
-
-    var outputLogger: Logger {
-        self.logger
-    }
-
-    private var configuration: CommandRuntime.Configuration {
-        if let runtime {
-            return runtime.configuration
-        }
-        // During bare parsing in unit tests no runtime is injected; fall back
-        // to the parsed runtime options so flags like --json are visible.
-        return self.runtimeOptions.makeConfiguration()
-    }
-
-    var jsonOutput: Bool {
-        self.configuration.jsonOutput
-    }
 
     var effectiveOlderThan: Int? {
         if let olderThan {

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/DaemonCommand+Start.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/DaemonCommand+Start.swift
@@ -5,7 +5,7 @@ import PeekabooFoundation
 
 extension DaemonCommand {
     @MainActor
-    struct Start: OutputFormattable, RuntimeOptionsConfigurable {
+    struct Start: OutputFormattable, RuntimeOptionsConfigurable, InjectedRuntimeBackedCommand {
         nonisolated(unsafe) static var commandDescription: CommandDescription {
             MainActorCommandDescription.describe {
                 CommandDescription(
@@ -24,27 +24,8 @@ extension DaemonCommand {
         @Option(name: .long, help: "Seconds to wait for daemon startup (default 3)")
         var waitSeconds: Int = 3
 
-        @RuntimeStorage private var runtime: CommandRuntime?
+        @RuntimeStorage var runtime: CommandRuntime?
         var runtimeOptions = CommandRuntimeOptions()
-
-        private var resolvedRuntime: CommandRuntime {
-            guard let runtime else {
-                preconditionFailure("CommandRuntime must be configured before accessing runtime resources")
-            }
-            return runtime
-        }
-
-        private var logger: Logger {
-            self.resolvedRuntime.logger
-        }
-
-        var outputLogger: Logger {
-            self.logger
-        }
-
-        var jsonOutput: Bool {
-            self.resolvedRuntime.configuration.jsonOutput
-        }
 
         mutating func run(using runtime: CommandRuntime) async throws {
             self.runtime = runtime

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/DaemonCommand+Status.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/DaemonCommand+Status.swift
@@ -3,7 +3,7 @@ import PeekabooBridge
 
 extension DaemonCommand {
     @MainActor
-    struct Status: OutputFormattable, RuntimeOptionsConfigurable {
+    struct Status: OutputFormattable, RuntimeOptionsConfigurable, InjectedRuntimeBackedCommand {
         nonisolated(unsafe) static var commandDescription: CommandDescription {
             MainActorCommandDescription.describe {
                 CommandDescription(
@@ -16,27 +16,8 @@ extension DaemonCommand {
         @Option(name: .long, help: "Override bridge socket path")
         var bridgeSocket: String?
 
-        @RuntimeStorage private var runtime: CommandRuntime?
+        @RuntimeStorage var runtime: CommandRuntime?
         var runtimeOptions = CommandRuntimeOptions()
-
-        private var resolvedRuntime: CommandRuntime {
-            guard let runtime else {
-                preconditionFailure("CommandRuntime must be configured before accessing runtime resources")
-            }
-            return runtime
-        }
-
-        private var logger: Logger {
-            self.resolvedRuntime.logger
-        }
-
-        var outputLogger: Logger {
-            self.logger
-        }
-
-        var jsonOutput: Bool {
-            self.resolvedRuntime.configuration.jsonOutput
-        }
 
         mutating func run(using runtime: CommandRuntime) async throws {
             self.runtime = runtime

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/DaemonCommand+Stop.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/DaemonCommand+Stop.swift
@@ -5,7 +5,7 @@ import PeekabooFoundation
 
 extension DaemonCommand {
     @MainActor
-    struct Stop: OutputFormattable, RuntimeOptionsConfigurable {
+    struct Stop: OutputFormattable, RuntimeOptionsConfigurable, InjectedRuntimeBackedCommand {
         nonisolated(unsafe) static var commandDescription: CommandDescription {
             MainActorCommandDescription.describe {
                 CommandDescription(
@@ -21,27 +21,8 @@ extension DaemonCommand {
         @Option(name: .long, help: "Seconds to wait for daemon shutdown (default 12)")
         var waitSeconds: Int = DaemonControlClient.defaultShutdownWaitSeconds
 
-        @RuntimeStorage private var runtime: CommandRuntime?
+        @RuntimeStorage var runtime: CommandRuntime?
         var runtimeOptions = CommandRuntimeOptions()
-
-        private var resolvedRuntime: CommandRuntime {
-            guard let runtime else {
-                preconditionFailure("CommandRuntime must be configured before accessing runtime resources")
-            }
-            return runtime
-        }
-
-        private var logger: Logger {
-            self.resolvedRuntime.logger
-        }
-
-        var outputLogger: Logger {
-            self.logger
-        }
-
-        var jsonOutput: Bool {
-            self.resolvedRuntime.configuration.jsonOutput
-        }
 
         mutating func run(using runtime: CommandRuntime) async throws {
             self.runtime = runtime

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/DialogCommand+Click.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/DialogCommand+Click.swift
@@ -6,7 +6,7 @@ extension DialogCommand {
     // MARK: - Click Dialog Button
 
     @MainActor
-    struct ClickSubcommand {
+    struct ClickSubcommand: InjectedRuntimeBackedCommand {
         @Option(help: "Button text to click (e.g., 'OK', 'Cancel', 'Save')")
         var button: String
 
@@ -15,92 +15,47 @@ extension DialogCommand {
 
         @OptionGroup var target: InteractionTargetOptions
         @OptionGroup var focusOptions: FocusCommandOptions
-        @RuntimeStorage private var runtime: CommandRuntime?
-
-        private var resolvedRuntime: CommandRuntime {
-            guard let runtime else {
-                preconditionFailure("CommandRuntime must be configured before accessing runtime resources")
-            }
-            return runtime
-        }
-
-        private var services: any PeekabooServiceProviding {
-            self.resolvedRuntime.services
-        }
-
-        private var logger: Logger {
-            self.resolvedRuntime.logger
-        }
-
-        var outputLogger: Logger {
-            self.logger
-        }
-
-        var jsonOutput: Bool {
-            self.resolvedRuntime.configuration.jsonOutput
-        }
+        @RuntimeStorage var runtime: CommandRuntime?
 
         @MainActor
         mutating func run(using runtime: CommandRuntime) async throws {
             self.runtime = runtime
-            self.logger.setJsonOutputMode(self.jsonOutput)
-
-            do {
-                try self.target.validate()
-                guard self.foreground || !self.focusOptions.hasForegroundFocusOverrides else {
-                    throw ValidationError("Dialog focus options require --foreground")
-                }
-                if self.foreground {
-                    if self.focusOptions.autoFocus {
-                        self.resolvedRuntime.beginInteractionMutation()
+            try await DialogCommand.execute(
+                runtime: runtime,
+                target: self.target,
+                focus: .whenRequested(self.foreground, self.focusOptions),
+                validate: {
+                    guard self.foreground || !self.focusOptions.hasForegroundFocusOverrides else {
+                        throw ValidationError("Dialog focus options require --foreground")
                     }
-                    try await ensureFocused(
-                        snapshotId: nil,
-                        target: self.target,
-                        options: self.focusOptions,
-                        services: self.services
+                },
+                operation: { context in
+                    let result = try await context.services.dialogs.clickButton(
+                        buttonText: self.button,
+                        windowTitle: context.windowTitle,
+                        appName: context.appHint,
+                        allowGlobalFallback: self.foreground
+                    )
+
+                    if self.jsonOutput {
+                        let outputData = DialogClickResult(
+                            action: "dialog_click",
+                            button: result.details["button"] ?? self.button,
+                            buttonIdentifier: result.details["button_identifier"],
+                            window: result.details["window"] ?? "Dialog"
+                        )
+                        outputSuccessCodable(data: outputData, logger: self.outputLogger)
+                    } else {
+                        print("✓ Clicked '\(result.details["button"] ?? self.button)' button")
+                    }
+                    AutomationEventLogger.log(
+                        .dialog,
+                        "action=click button='\(result.details["button"] ?? self.button)' "
+                            + "window='\(result.details["window"] ?? context.windowTitle ?? "unknown")' "
+                            + "app='\(context.appHint ?? "unknown")'"
                     )
                 }
-
-                let resolvedWindowTitle = try await self.target.resolveWindowTitleOptional(services: self.services)
-                let appHint = try await DialogCommand.resolveDialogAppHint(target: self.target, services: self.services)
-
-                self.resolvedRuntime.beginInteractionMutation()
-                let result = try await self.services.dialogs.clickButton(
-                    buttonText: self.button,
-                    windowTitle: resolvedWindowTitle,
-                    appName: appHint,
-                    allowGlobalFallback: self.foreground
-                )
-
-                if self.jsonOutput {
-                    let outputData = DialogClickResult(
-                        action: "dialog_click",
-                        button: result.details["button"] ?? self.button,
-                        buttonIdentifier: result.details["button_identifier"],
-                        window: result.details["window"] ?? "Dialog"
-                    )
-                    outputSuccessCodable(data: outputData, logger: self.outputLogger)
-                } else {
-                    print("✓ Clicked '\(result.details["button"] ?? self.button)' button")
-                }
-                AutomationEventLogger.log(
-                    .dialog,
-                    "action=click button='\(result.details["button"] ?? self.button)' "
-                        + "window='\(result.details["window"] ?? resolvedWindowTitle ?? "unknown")' "
-                        + "app='\(appHint ?? "unknown")'"
-                )
-
-            } catch let error as Commander.ValidationError {
-                handleDialogValidationError(error, jsonOutput: self.jsonOutput, logger: self.outputLogger)
-                throw ExitCode(1)
-            } catch let error as DialogError {
-                handleDialogServiceError(error, jsonOutput: self.jsonOutput, logger: self.outputLogger)
-                throw ExitCode(1)
-            } catch {
-                handleGenericError(error, jsonOutput: self.jsonOutput, logger: self.outputLogger)
-                throw ExitCode(1)
-            }
+            )
         }
     }
 }

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/DialogCommand+DismissList.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/DialogCommand+DismissList.swift
@@ -6,7 +6,7 @@ extension DialogCommand {
     // MARK: - Dismiss Dialog
 
     @MainActor
-    struct DismissSubcommand {
+    struct DismissSubcommand: InjectedRuntimeBackedCommand {
         static let commandDescription = CommandDescription(
             commandName: "dismiss",
             abstract: "Dismiss a dialog using DialogService"
@@ -20,104 +20,60 @@ extension DialogCommand {
 
         @OptionGroup var target: InteractionTargetOptions
         @OptionGroup var focusOptions: FocusCommandOptions
-        @RuntimeStorage private var runtime: CommandRuntime?
-
-        private var resolvedRuntime: CommandRuntime {
-            guard let runtime else {
-                preconditionFailure("CommandRuntime must be configured before accessing runtime resources")
-            }
-            return runtime
-        }
-
-        private var services: any PeekabooServiceProviding {
-            self.resolvedRuntime.services
-        }
-
-        private var logger: Logger {
-            self.resolvedRuntime.logger
-        }
-
-        var outputLogger: Logger {
-            self.logger
-        }
-
-        var jsonOutput: Bool {
-            self.resolvedRuntime.configuration.jsonOutput
-        }
+        @RuntimeStorage var runtime: CommandRuntime?
 
         @MainActor
         mutating func run(using runtime: CommandRuntime) async throws {
             self.runtime = runtime
-            self.logger.setJsonOutputMode(self.jsonOutput)
-
-            do {
-                try self.target.validate()
-                guard !self.force || self.foreground else {
-                    throw ValidationError("dialog dismiss --force sends global Escape and requires --foreground")
-                }
-                guard self.foreground || !self.focusOptions.hasForegroundFocusOverrides else {
-                    throw ValidationError("Dialog focus options require --foreground")
-                }
-                if self.foreground {
-                    if self.focusOptions.autoFocus {
-                        self.resolvedRuntime.beginInteractionMutation()
+            try await DialogCommand.execute(
+                runtime: runtime,
+                target: self.target,
+                focus: .whenRequested(self.foreground, self.focusOptions),
+                validate: {
+                    guard !self.force || self.foreground else {
+                        throw ValidationError("dialog dismiss --force sends global Escape and requires --foreground")
                     }
-                    try await ensureFocused(
-                        snapshotId: nil,
-                        target: self.target,
-                        options: self.focusOptions,
-                        services: self.services
+                    guard self.foreground || !self.focusOptions.hasForegroundFocusOverrides else {
+                        throw ValidationError("Dialog focus options require --foreground")
+                    }
+                },
+                operation: { context in
+                    let result = try await context.services.dialogs.dismissDialog(
+                        force: self.force,
+                        windowTitle: context.windowTitle,
+                        appName: context.appHint
+                    )
+
+                    if self.jsonOutput {
+                        let outputData = DialogDismissResult(
+                            action: "dialog_dismiss",
+                            method: result.details["method"] ?? "unknown",
+                            button: result.details["button"]
+                        )
+                        outputSuccessCodable(data: outputData, logger: self.outputLogger)
+                    } else if result.details["method"] == "escape" {
+                        print("✓ Dismissed dialog with Escape")
+                    } else if let button = result.details["button"] {
+                        print("✓ Dismissed dialog by clicking '\(button)'")
+                    } else {
+                        print("✓ Dismissed dialog")
+                    }
+                    let method = result.details["method"] ?? (self.force ? "escape" : "button")
+                    let dismissedButton = result.details["button"] ?? "none"
+                    AutomationEventLogger.log(
+                        .dialog,
+                        "action=dismiss method=\(method) button='\(dismissedButton)' "
+                            + "app='\(context.appHint ?? "unknown")'"
                     )
                 }
-
-                let resolvedWindowTitle = try await target.resolveWindowTitleOptional(services: self.services)
-                let appHint = try await DialogCommand.resolveDialogAppHint(target: self.target, services: self.services)
-                self.resolvedRuntime.beginInteractionMutation()
-                let result = try await services.dialogs.dismissDialog(
-                    force: self.force,
-                    windowTitle: resolvedWindowTitle,
-                    appName: appHint
-                )
-
-                if self.jsonOutput {
-                    let outputData = DialogDismissResult(
-                        action: "dialog_dismiss",
-                        method: result.details["method"] ?? "unknown",
-                        button: result.details["button"]
-                    )
-                    outputSuccessCodable(data: outputData, logger: self.outputLogger)
-                } else if result.details["method"] == "escape" {
-                    print("✓ Dismissed dialog with Escape")
-                } else if let button = result.details["button"] {
-                    print("✓ Dismissed dialog by clicking '\(button)'")
-                } else {
-                    print("✓ Dismissed dialog")
-                }
-                let method = result.details["method"] ?? (self.force ? "escape" : "button")
-                let dismissedButton = result.details["button"] ?? "none"
-                AutomationEventLogger.log(
-                    .dialog,
-                    "action=dismiss method=\(method) button='\(dismissedButton)' "
-                        + "app='\(appHint ?? "unknown")'"
-                )
-
-            } catch let error as Commander.ValidationError {
-                handleDialogValidationError(error, jsonOutput: self.jsonOutput, logger: self.outputLogger)
-                throw ExitCode(1)
-            } catch let error as DialogError {
-                handleDialogServiceError(error, jsonOutput: self.jsonOutput, logger: self.outputLogger)
-                throw ExitCode(1)
-            } catch {
-                handleGenericError(error, jsonOutput: self.jsonOutput, logger: self.outputLogger)
-                throw ExitCode(1)
-            }
+            )
         }
     }
 
     // MARK: - List Dialog Elements
 
     @MainActor
-    struct ListSubcommand {
+    struct ListSubcommand: InjectedRuntimeBackedCommand {
         static let commandDescription = CommandDescription(
             commandName: "list",
             abstract: "List elements in current dialog using DialogService"
@@ -127,103 +83,74 @@ extension DialogCommand {
         var timeoutSeconds: TimeInterval = 5
 
         @OptionGroup var target: InteractionTargetOptions
-        @RuntimeStorage private var runtime: CommandRuntime?
-
-        private var resolvedRuntime: CommandRuntime {
-            guard let runtime else {
-                preconditionFailure("CommandRuntime must be configured before accessing runtime resources")
-            }
-            return runtime
-        }
-
-        private var services: any PeekabooServiceProviding {
-            self.resolvedRuntime.services
-        }
-
-        private var logger: Logger {
-            self.resolvedRuntime.logger
-        }
-
-        var outputLogger: Logger {
-            self.logger
-        }
-
-        var jsonOutput: Bool {
-            self.resolvedRuntime.configuration.jsonOutput
-        }
+        @RuntimeStorage var runtime: CommandRuntime?
 
         @MainActor
         mutating func run(using runtime: CommandRuntime) async throws {
             self.runtime = runtime
-            self.logger.setJsonOutputMode(self.jsonOutput)
-
-            do {
-                try self.target.validate()
-                let resolvedWindowTitle = try await target.resolveWindowTitleOptional(services: self.services)
-                let appHint = try await DialogCommand.resolveDialogAppHint(target: self.target, services: self.services)
-                let dialogService = self.services.dialogs
-                let timeoutSeconds = timeoutSeconds
-                let elements = try await withMainActorCommandTimeout(
-                    seconds: timeoutSeconds,
-                    operationName: "dialog list"
-                ) {
-                    try await dialogService.listDialogElements(
-                        windowTitle: resolvedWindowTitle,
-                        appName: appHint
-                    )
-                }
-
-                if self.jsonOutput {
-                    let textFields = elements.textFields.map { field in
-                        DialogListResult.TextField(
-                            title: field.title ?? "",
-                            value: field.value ?? "",
-                            placeholder: field.placeholder ?? ""
+            let timeoutSeconds = self.timeoutSeconds
+            try await DialogCommand.execute(
+                runtime: runtime,
+                target: self.target,
+                focus: .none,
+                beginsInteractionMutation: false,
+                handlesValidationError: false,
+                operation: { context in
+                    let elements = try await withMainActorCommandTimeout(
+                        seconds: timeoutSeconds,
+                        operationName: "dialog list"
+                    ) {
+                        try await context.services.dialogs.listDialogElements(
+                            windowTitle: context.windowTitle,
+                            appName: context.appHint
                         )
                     }
-                    let outputData = DialogListResult(
-                        title: elements.dialogInfo.title,
-                        role: elements.dialogInfo.role,
-                        buttons: elements.buttons.map(\.title),
-                        textFields: textFields,
-                        textElements: elements.staticTexts
-                    )
-                    outputSuccessCodable(data: outputData, logger: self.outputLogger)
-                } else {
-                    print("Dialog: \(elements.dialogInfo.title)")
 
-                    if !elements.buttons.isEmpty {
-                        print("\nButtons:")
-                        elements.buttons.forEach { print("  • \($0.title)") }
-                    }
+                    if self.jsonOutput {
+                        let textFields = elements.textFields.map { field in
+                            DialogListResult.TextField(
+                                title: field.title ?? "",
+                                value: field.value ?? "",
+                                placeholder: field.placeholder ?? ""
+                            )
+                        }
+                        let outputData = DialogListResult(
+                            title: elements.dialogInfo.title,
+                            role: elements.dialogInfo.role,
+                            buttons: elements.buttons.map(\.title),
+                            textFields: textFields,
+                            textElements: elements.staticTexts
+                        )
+                        outputSuccessCodable(data: outputData, logger: self.outputLogger)
+                    } else {
+                        print("Dialog: \(elements.dialogInfo.title)")
 
-                    if !elements.textFields.isEmpty {
-                        print("\nText Fields:")
-                        for field in elements.textFields {
-                            let title = field.title ?? "Untitled"
-                            let placeholder = field.placeholder ?? ""
-                            print("  • \(title) [\(placeholder)]")
+                        if !elements.buttons.isEmpty {
+                            print("\nButtons:")
+                            elements.buttons.forEach { print("  • \($0.title)") }
+                        }
+
+                        if !elements.textFields.isEmpty {
+                            print("\nText Fields:")
+                            for field in elements.textFields {
+                                let title = field.title ?? "Untitled"
+                                let placeholder = field.placeholder ?? ""
+                                print("  • \(title) [\(placeholder)]")
+                            }
+                        }
+
+                        if !elements.staticTexts.isEmpty {
+                            print("\nText:")
+                            elements.staticTexts.forEach { print("  \($0)") }
                         }
                     }
-
-                    if !elements.staticTexts.isEmpty {
-                        print("\nText:")
-                        elements.staticTexts.forEach { print("  \($0)") }
-                    }
+                    AutomationEventLogger.log(
+                        .dialog,
+                        "action=list title='\(elements.dialogInfo.title)' buttons=\(elements.buttons.count) "
+                            + "text_fields=\(elements.textFields.count) app='\(context.appHint ?? "unknown")'"
+                    )
                 }
-                AutomationEventLogger.log(
-                    .dialog,
-                    "action=list title='\(elements.dialogInfo.title)' buttons=\(elements.buttons.count) "
-                        + "text_fields=\(elements.textFields.count) app='\(appHint ?? "unknown")'"
-                )
-
-            } catch let error as DialogError {
-                handleDialogServiceError(error, jsonOutput: self.jsonOutput, logger: self.outputLogger)
-                throw ExitCode(1)
-            } catch {
-                handleGenericError(error, jsonOutput: self.jsonOutput, logger: self.outputLogger)
-                throw ExitCode(1)
-            }
+            )
         }
     }
 }

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/DialogCommand+File.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/DialogCommand+File.swift
@@ -7,7 +7,7 @@ extension DialogCommand {
     // MARK: - Handle File Dialog
 
     @MainActor
-    struct FileSubcommand {
+    struct FileSubcommand: InjectedRuntimeBackedCommand {
         static let commandDescription = CommandDescription(
             commandName: "file",
             abstract: "Handle file save/open dialogs using DialogService"
@@ -33,125 +33,71 @@ extension DialogCommand {
 
         @OptionGroup var target: InteractionTargetOptions
         @OptionGroup var focusOptions: FocusCommandOptions
-        @RuntimeStorage private var runtime: CommandRuntime?
-
-        private var resolvedRuntime: CommandRuntime {
-            guard let runtime else {
-                preconditionFailure("CommandRuntime must be configured before accessing runtime resources")
-            }
-            return runtime
-        }
-
-        private var services: any PeekabooServiceProviding {
-            self.resolvedRuntime.services
-        }
-
-        private var logger: Logger {
-            self.resolvedRuntime.logger
-        }
-
-        var outputLogger: Logger {
-            self.logger
-        }
-
-        var jsonOutput: Bool {
-            self.resolvedRuntime.configuration.jsonOutput
-        }
+        @RuntimeStorage var runtime: CommandRuntime?
 
         @MainActor
         mutating func run(using runtime: CommandRuntime) async throws {
             self.runtime = runtime
-            self.logger.setJsonOutputMode(self.jsonOutput)
+            let path = self.path
+            let name = self.name
+            let select = self.select
+            let ensureExpanded = self.ensureExpanded
+            try await DialogCommand.execute(
+                runtime: runtime,
+                target: self.target,
+                focus: .required(self.focusOptions),
+                resolveWindowTitle: false,
+                handlesPeekabooError: true,
+                validate: {
+                    guard self.foreground else {
+                        throw ValidationError(
+                            "dialog file uses keyboard/coordinate interaction and requires --foreground"
+                        )
+                    }
+                },
+                operation: { context in
+                    let result = try await withMainActorCommandTimeout(
+                        seconds: self.timeoutSeconds,
+                        operationName: "dialog file",
+                        desktopMutationWatermarkStore: DesktopMutationWatermarkStore()
+                    ) {
+                        try await context.services.dialogs.handleFileDialog(
+                            path: path,
+                            filename: name,
+                            actionButton: select,
+                            ensureExpanded: ensureExpanded,
+                            appName: context.appHint
+                        )
+                    }
 
-            do {
-                try self.target.validate()
-                guard self.foreground else {
-                    throw ValidationError("dialog file uses keyboard/coordinate interaction and requires --foreground")
-                }
-                if self.focusOptions.autoFocus {
-                    self.resolvedRuntime.beginInteractionMutation()
-                }
-                try await ensureFocused(
-                    snapshotId: nil,
-                    target: self.target,
-                    options: self.focusOptions,
-                    services: self.services
-                )
-
-                let appHint = try await DialogCommand.resolveDialogAppHint(target: self.target, services: self.services)
-                let dialogs = self.services.dialogs
-                let path = self.path
-                let name = self.name
-                let select = self.select
-                let ensureExpanded = self.ensureExpanded
-
-                self.resolvedRuntime.beginInteractionMutation()
-                let result = try await withMainActorCommandTimeout(
-                    seconds: self.timeoutSeconds,
-                    operationName: "dialog file",
-                    desktopMutationWatermarkStore: DesktopMutationWatermarkStore()
-                ) {
-                    try await dialogs.handleFileDialog(
-                        path: path,
-                        filename: name,
-                        actionButton: select,
-                        ensureExpanded: ensureExpanded,
-                        appName: appHint
+                    if self.jsonOutput {
+                        outputSuccessCodable(data: self.makeOutput(from: result), logger: self.outputLogger)
+                    } else {
+                        print("✓ Handled file dialog")
+                        if let path = result.details["path"] {
+                            print("  Path: \(path)")
+                        }
+                        if let name = result.details["filename"] {
+                            print("  Name: \(name)")
+                        }
+                        print("  Action: \(result.details["button_clicked"] ?? self.select ?? "default")")
+                        if let savedPath = result.details["saved_path"], result.details["saved_path_exists"] == "true" {
+                            print("  Saved: \(savedPath)")
+                        }
+                    }
+                    let resolvedPath = result.details["path"] ?? self.path ?? "unknown"
+                    let resolvedName = result.details["filename"] ?? self.name ?? "unknown"
+                    let buttonClicked = result.details["button_clicked"] ?? self.select ?? "default"
+                    let savedPath = result.details["saved_path"] ?? "unknown"
+                    let savedPathVerified = result.details["saved_path_exists"] ?? "unknown"
+                    AutomationEventLogger.log(
+                        .dialog,
+                        "action=file path='\(resolvedPath)' name='\(resolvedName)' "
+                            + "button='\(buttonClicked)' saved_path='\(savedPath)' "
+                            + "saved_path_verified=\(savedPathVerified) app='\(context.appHint ?? "unknown")'"
                     )
                 }
-
-                if self.jsonOutput {
-                    outputSuccessCodable(data: self.makeOutput(from: result), logger: self.outputLogger)
-                } else {
-                    print("✓ Handled file dialog")
-                    if let path = result.details["path"] {
-                        print("  Path: \(path)")
-                    }
-                    if let name = result.details["filename"] {
-                        print("  Name: \(name)")
-                    }
-                    print("  Action: \(result.details["button_clicked"] ?? self.select ?? "default")")
-                    if let savedPath = result.details["saved_path"], result.details["saved_path_exists"] == "true" {
-                        print("  Saved: \(savedPath)")
-                    }
-                }
-                let resolvedPath = result.details["path"] ?? self.path ?? "unknown"
-                let resolvedName = result.details["filename"] ?? self.name ?? "unknown"
-                let buttonClicked = result.details["button_clicked"] ?? self.select ?? "default"
-                let savedPath = result.details["saved_path"] ?? "unknown"
-                let savedPathVerified = result.details["saved_path_exists"] ?? "unknown"
-                AutomationEventLogger.log(
-                    .dialog,
-                    "action=file path='\(resolvedPath)' name='\(resolvedName)' "
-                        + "button='\(buttonClicked)' saved_path='\(savedPath)' "
-                        + "saved_path_verified=\(savedPathVerified) app='\(appHint ?? "unknown")'"
-                )
-
-            } catch let error as Commander.ValidationError {
-                handleDialogValidationError(error, jsonOutput: self.jsonOutput, logger: self.outputLogger)
-                throw ExitCode(1)
-            } catch let error as DialogError {
-                handleDialogServiceError(error, jsonOutput: self.jsonOutput, logger: self.outputLogger)
-                throw ExitCode(1)
-            } catch let error as PeekabooError {
-                let code: ErrorCode = switch error {
-                case .timeout:
-                    .TIMEOUT
-                case .invalidInput:
-                    .INVALID_INPUT
-                default:
-                    .UNKNOWN_ERROR
-                }
-                if self.jsonOutput {
-                    outputError(message: error.localizedDescription, code: code, logger: self.outputLogger)
-                } else {
-                    fputs("❌ \(error.localizedDescription)\n", stderr)
-                }
-                throw ExitCode(1)
-            } catch {
-                handleGenericError(error, jsonOutput: self.jsonOutput, logger: self.outputLogger)
-                throw ExitCode(1)
-            }
+            )
         }
 
         private func makeOutput(from result: DialogActionResult) -> FileDialogResult {

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/DialogCommand+Input.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/DialogCommand+Input.swift
@@ -6,7 +6,7 @@ extension DialogCommand {
     // MARK: - Input Text in Dialog
 
     @MainActor
-    struct InputSubcommand {
+    struct InputSubcommand: InjectedRuntimeBackedCommand {
         static let commandDescription = CommandDescription(
             commandName: "input",
             abstract: "Enter text in a dialog field using DialogService"
@@ -29,97 +29,54 @@ extension DialogCommand {
 
         @OptionGroup var target: InteractionTargetOptions
         @OptionGroup var focusOptions: FocusCommandOptions
-        @RuntimeStorage private var runtime: CommandRuntime?
-
-        private var resolvedRuntime: CommandRuntime {
-            guard let runtime else {
-                preconditionFailure("CommandRuntime must be configured before accessing runtime resources")
-            }
-            return runtime
-        }
-
-        private var services: any PeekabooServiceProviding {
-            self.resolvedRuntime.services
-        }
-
-        private var logger: Logger {
-            self.resolvedRuntime.logger
-        }
-
-        var outputLogger: Logger {
-            self.logger
-        }
-
-        var jsonOutput: Bool {
-            self.resolvedRuntime.configuration.jsonOutput
-        }
+        @RuntimeStorage var runtime: CommandRuntime?
 
         @MainActor
         mutating func run(using runtime: CommandRuntime) async throws {
             self.runtime = runtime
-            self.logger.setJsonOutputMode(self.jsonOutput)
-
-            do {
-                try self.target.validate()
-                guard self.foreground else {
-                    throw ValidationError("dialog input sends keyboard input and requires --foreground")
-                }
-                if self.focusOptions.autoFocus {
-                    self.resolvedRuntime.beginInteractionMutation()
-                }
-                try await ensureFocused(
-                    snapshotId: nil,
-                    target: self.target,
-                    options: self.focusOptions,
-                    services: self.services
-                )
-
-                let resolvedWindowTitle = try await self.target.resolveWindowTitleOptional(services: self.services)
-                let appHint = try await DialogCommand.resolveDialogAppHint(target: self.target, services: self.services)
-
-                let fieldIdentifier = self.field ?? self.index.map { String($0) }
-                self.resolvedRuntime.beginInteractionMutation()
-                let result = try await self.services.dialogs.enterText(
-                    text: self.text,
-                    fieldIdentifier: fieldIdentifier,
-                    clearExisting: self.clear,
-                    windowTitle: resolvedWindowTitle,
-                    appName: appHint
-                )
-
-                if self.jsonOutput {
-                    let outputData = DialogInputResult(
-                        action: "dialog_input",
-                        field: result.details["field"] ?? "Text Field",
-                        textLength: result.details["text_length"] ?? String(self.text.count),
-                        cleared: result.details["cleared"] ?? String(self.clear)
+            try await DialogCommand.execute(
+                runtime: runtime,
+                target: self.target,
+                focus: .required(self.focusOptions),
+                validate: {
+                    guard self.foreground else {
+                        throw ValidationError("dialog input sends keyboard input and requires --foreground")
+                    }
+                },
+                operation: { context in
+                    let fieldIdentifier = self.field ?? self.index.map { String($0) }
+                    let result = try await context.services.dialogs.enterText(
+                        text: self.text,
+                        fieldIdentifier: fieldIdentifier,
+                        clearExisting: self.clear,
+                        windowTitle: context.windowTitle,
+                        appName: context.appHint
                     )
-                    outputSuccessCodable(data: outputData, logger: self.outputLogger)
-                } else {
-                    print("✓ Entered text in '\(result.details["field"] ?? "field")'")
-                }
-                let fieldDescription = result.details["field"]
-                    ?? self.field
-                    ?? self.index.map { "index \($0)" }
-                    ?? "field"
-                let textLength = result.details["text_length"] ?? String(self.text.count)
-                let clearedValue = result.details["cleared"] ?? String(self.clear)
-                AutomationEventLogger.log(
-                    .dialog,
-                    "action=input field='\(fieldDescription)' chars=\(textLength) "
-                        + "cleared=\(clearedValue) app='\(appHint ?? "unknown")'"
-                )
 
-            } catch let error as Commander.ValidationError {
-                handleDialogValidationError(error, jsonOutput: self.jsonOutput, logger: self.outputLogger)
-                throw ExitCode(1)
-            } catch let error as DialogError {
-                handleDialogServiceError(error, jsonOutput: self.jsonOutput, logger: self.outputLogger)
-                throw ExitCode(1)
-            } catch {
-                handleGenericError(error, jsonOutput: self.jsonOutput, logger: self.outputLogger)
-                throw ExitCode(1)
-            }
+                    if self.jsonOutput {
+                        let outputData = DialogInputResult(
+                            action: "dialog_input",
+                            field: result.details["field"] ?? "Text Field",
+                            textLength: result.details["text_length"] ?? String(self.text.count),
+                            cleared: result.details["cleared"] ?? String(self.clear)
+                        )
+                        outputSuccessCodable(data: outputData, logger: self.outputLogger)
+                    } else {
+                        print("✓ Entered text in '\(result.details["field"] ?? "field")'")
+                    }
+                    let fieldDescription = result.details["field"]
+                        ?? self.field
+                        ?? self.index.map { "index \($0)" }
+                        ?? "field"
+                    let textLength = result.details["text_length"] ?? String(self.text.count)
+                    let clearedValue = result.details["cleared"] ?? String(self.clear)
+                    AutomationEventLogger.log(
+                        .dialog,
+                        "action=input field='\(fieldDescription)' chars=\(textLength) "
+                            + "cleared=\(clearedValue) app='\(context.appHint ?? "unknown")'"
+                    )
+                }
+            )
         }
     }
 }

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/DialogCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/DialogCommand.swift
@@ -6,6 +6,18 @@ import PeekabooFoundation
 /// Interact with system dialogs and alerts
 @MainActor
 struct DialogCommand: ParsableCommand {
+    enum ExecutionFocus {
+        case none
+        case whenRequested(Bool, FocusCommandOptions)
+        case required(FocusCommandOptions)
+    }
+
+    struct ExecutionContext {
+        let services: any PeekabooServiceProviding
+        let windowTitle: String?
+        let appHint: String?
+    }
+
     static let commandDescription = CommandDescription(
         commandName: "dialog",
         abstract: "Interact with system dialogs and alerts",
@@ -56,6 +68,105 @@ struct DialogCommand: ParsableCommand {
         }
 
         return match.bundleIdentifier ?? match.name
+    }
+
+    static func execute(
+        runtime: CommandRuntime,
+        target: InteractionTargetOptions,
+        focus: ExecutionFocus,
+        resolveWindowTitle: Bool = true,
+        beginsInteractionMutation: Bool = true,
+        handlesValidationError: Bool = true,
+        handlesPeekabooError: Bool = false,
+        validate: () throws -> Void = {},
+        operation: (ExecutionContext) async throws -> Void
+    ) async throws {
+        var target = target
+        let logger = runtime.logger
+        let jsonOutput = runtime.configuration.jsonOutput
+        logger.setJsonOutputMode(jsonOutput)
+
+        do {
+            try target.validate()
+            try validate()
+
+            switch focus {
+            case .none:
+                break
+            case let .whenRequested(foreground, options):
+                if foreground {
+                    if options.autoFocus {
+                        runtime.beginInteractionMutation()
+                    }
+                    try await ensureFocused(
+                        snapshotId: nil,
+                        target: target,
+                        options: options,
+                        services: runtime.services
+                    )
+                }
+            case let .required(options):
+                if options.autoFocus {
+                    runtime.beginInteractionMutation()
+                }
+                try await ensureFocused(
+                    snapshotId: nil,
+                    target: target,
+                    options: options,
+                    services: runtime.services
+                )
+            }
+
+            let windowTitle: String? = if resolveWindowTitle {
+                try await target.resolveWindowTitleOptional(services: runtime.services)
+            } else {
+                nil
+            }
+            let appHint = try await self.resolveDialogAppHint(target: target, services: runtime.services)
+
+            if beginsInteractionMutation {
+                runtime.beginInteractionMutation()
+            }
+            try await operation(
+                ExecutionContext(
+                    services: runtime.services,
+                    windowTitle: windowTitle,
+                    appHint: appHint
+                )
+            )
+        } catch let error as Commander.ValidationError {
+            if handlesValidationError {
+                handleDialogValidationError(error, jsonOutput: jsonOutput, logger: logger)
+            } else {
+                handleGenericError(error, jsonOutput: jsonOutput, logger: logger)
+            }
+            throw ExitCode(1)
+        } catch let error as DialogError {
+            handleDialogServiceError(error, jsonOutput: jsonOutput, logger: logger)
+            throw ExitCode(1)
+        } catch let error as PeekabooError {
+            guard handlesPeekabooError else {
+                handleGenericError(error, jsonOutput: jsonOutput, logger: logger)
+                throw ExitCode(1)
+            }
+            let code: ErrorCode = switch error {
+            case .timeout:
+                .TIMEOUT
+            case .invalidInput:
+                .INVALID_INPUT
+            default:
+                .UNKNOWN_ERROR
+            }
+            if jsonOutput {
+                outputError(message: error.localizedDescription, code: code, logger: logger)
+            } else {
+                fputs("❌ \(error.localizedDescription)\n", stderr)
+            }
+            throw ExitCode(1)
+        } catch {
+            handleGenericError(error, jsonOutput: jsonOutput, logger: logger)
+            throw ExitCode(1)
+        }
     }
 }
 

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/DockCommand+Launch.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/DockCommand+Launch.swift
@@ -7,36 +7,13 @@ extension DockCommand {
     // MARK: - Launch from Dock
 
     @MainActor
-    struct LaunchSubcommand: OutputFormattable {
+    struct LaunchSubcommand: OutputFormattable, InjectedRuntimeBackedCommand {
         @Argument(help: "Application name in the Dock")
         var app: String
 
         @Flag(help: "Verify the app is running after launch")
         var verify = false
-        @RuntimeStorage private var runtime: CommandRuntime?
-
-        private var resolvedRuntime: CommandRuntime {
-            guard let runtime else {
-                preconditionFailure("CommandRuntime must be configured before accessing runtime resources")
-            }
-            return runtime
-        }
-
-        private var services: any PeekabooServiceProviding {
-            self.resolvedRuntime.services
-        }
-
-        private var logger: Logger {
-            self.resolvedRuntime.logger
-        }
-
-        var outputLogger: Logger {
-            self.logger
-        }
-
-        var jsonOutput: Bool {
-            self.resolvedRuntime.configuration.jsonOutput
-        }
+        @RuntimeStorage var runtime: CommandRuntime?
 
         @MainActor
         mutating func run(using runtime: CommandRuntime) async throws {

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/DockCommand+List.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/DockCommand+List.swift
@@ -5,33 +5,10 @@ extension DockCommand {
     // MARK: - List Dock Items
 
     @MainActor
-    struct ListSubcommand: ErrorHandlingCommand, OutputFormattable {
+    struct ListSubcommand: ErrorHandlingCommand, OutputFormattable, InjectedRuntimeBackedCommand {
         @Flag(help: "Include separators and spacers")
         var includeAll = false
-        @RuntimeStorage private var runtime: CommandRuntime?
-
-        private var resolvedRuntime: CommandRuntime {
-            guard let runtime else {
-                preconditionFailure("CommandRuntime must be configured before accessing runtime resources")
-            }
-            return runtime
-        }
-
-        private var services: any PeekabooServiceProviding {
-            self.resolvedRuntime.services
-        }
-
-        private var logger: Logger {
-            self.resolvedRuntime.logger
-        }
-
-        var outputLogger: Logger {
-            self.logger
-        }
-
-        var jsonOutput: Bool {
-            self.resolvedRuntime.configuration.jsonOutput
-        }
+        @RuntimeStorage var runtime: CommandRuntime?
 
         @MainActor
         mutating func run(using runtime: CommandRuntime) async throws {

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/DockCommand+RightClick.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/DockCommand+RightClick.swift
@@ -5,36 +5,13 @@ extension DockCommand {
     // MARK: - Right-Click Dock Item
 
     @MainActor
-    struct RightClickSubcommand: OutputFormattable {
+    struct RightClickSubcommand: OutputFormattable, InjectedRuntimeBackedCommand {
         @Option(help: "Application name in the Dock")
         var app: String
 
         @Option(help: "Menu item to select after right-clicking")
         var select: String?
-        @RuntimeStorage private var runtime: CommandRuntime?
-
-        private var resolvedRuntime: CommandRuntime {
-            guard let runtime else {
-                preconditionFailure("CommandRuntime must be configured before accessing runtime resources")
-            }
-            return runtime
-        }
-
-        private var services: any PeekabooServiceProviding {
-            self.resolvedRuntime.services
-        }
-
-        private var logger: Logger {
-            self.resolvedRuntime.logger
-        }
-
-        var outputLogger: Logger {
-            self.logger
-        }
-
-        var jsonOutput: Bool {
-            self.resolvedRuntime.configuration.jsonOutput
-        }
+        @RuntimeStorage var runtime: CommandRuntime?
 
         @MainActor
         mutating func run(using runtime: CommandRuntime) async throws {

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/DockCommand+Visibility.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/DockCommand+Visibility.swift
@@ -5,31 +5,8 @@ extension DockCommand {
     // MARK: - Hide Dock
 
     @MainActor
-    struct HideSubcommand: ErrorHandlingCommand, OutputFormattable {
-        @RuntimeStorage private var runtime: CommandRuntime?
-
-        private var resolvedRuntime: CommandRuntime {
-            guard let runtime else {
-                preconditionFailure("CommandRuntime must be configured before accessing runtime resources")
-            }
-            return runtime
-        }
-
-        private var services: any PeekabooServiceProviding {
-            self.resolvedRuntime.services
-        }
-
-        private var logger: Logger {
-            self.resolvedRuntime.logger
-        }
-
-        var outputLogger: Logger {
-            self.logger
-        }
-
-        var jsonOutput: Bool {
-            self.resolvedRuntime.configuration.jsonOutput
-        }
+    struct HideSubcommand: ErrorHandlingCommand, OutputFormattable, InjectedRuntimeBackedCommand {
+        @RuntimeStorage var runtime: CommandRuntime?
 
         @MainActor
         mutating func run(using runtime: CommandRuntime) async throws {
@@ -60,31 +37,8 @@ extension DockCommand {
     // MARK: - Show Dock
 
     @MainActor
-    struct ShowSubcommand: ErrorHandlingCommand, OutputFormattable {
-        @RuntimeStorage private var runtime: CommandRuntime?
-
-        private var resolvedRuntime: CommandRuntime {
-            guard let runtime else {
-                preconditionFailure("CommandRuntime must be configured before accessing runtime resources")
-            }
-            return runtime
-        }
-
-        private var services: any PeekabooServiceProviding {
-            self.resolvedRuntime.services
-        }
-
-        private var logger: Logger {
-            self.resolvedRuntime.logger
-        }
-
-        var outputLogger: Logger {
-            self.logger
-        }
-
-        var jsonOutput: Bool {
-            self.resolvedRuntime.configuration.jsonOutput
-        }
+    struct ShowSubcommand: ErrorHandlingCommand, OutputFormattable, InjectedRuntimeBackedCommand {
+        @RuntimeStorage var runtime: CommandRuntime?
 
         @MainActor
         mutating func run(using runtime: CommandRuntime) async throws {

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/MenuBarCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/MenuBarCommand.swift
@@ -6,7 +6,7 @@ import PeekabooFoundation
 
 /// Command for interacting with macOS menu bar items (status items).
 @MainActor
-struct MenuBarCommand: ParsableCommand, ErrorHandlingCommand, OutputFormattable {
+struct MenuBarCommand: ParsableCommand, ErrorHandlingCommand, OutputFormattable, InjectedRuntimeBackedCommand {
     nonisolated(unsafe) static var commandDescription: CommandDescription {
         MainActorCommandDescription.describe {
             CommandDescription(
@@ -58,33 +58,10 @@ struct MenuBarCommand: ParsableCommand, ErrorHandlingCommand, OutputFormattable 
 
     @Flag(help: "Verify the click by checking for a matching popover window")
     var verify: Bool = false
-    @RuntimeStorage private var runtime: CommandRuntime?
-
-    private var resolvedRuntime: CommandRuntime {
-        guard let runtime else {
-            preconditionFailure("CommandRuntime must be configured before accessing runtime resources")
-        }
-        return runtime
-    }
-
-    private var services: any PeekabooServiceProviding {
-        self.resolvedRuntime.services
-    }
-
-    private var logger: Logger {
-        self.resolvedRuntime.logger
-    }
-
-    var outputLogger: Logger {
-        self.logger
-    }
+    @RuntimeStorage var runtime: CommandRuntime?
 
     private var configuration: CommandRuntime.Configuration {
         self.resolvedRuntime.configuration
-    }
-
-    var jsonOutput: Bool {
-        self.configuration.jsonOutput
     }
 
     private var isVerbose: Bool {

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/MenuCommand+Click.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/MenuCommand+Click.swift
@@ -7,7 +7,7 @@ extension MenuCommand {
     // MARK: - Click Menu Item
 
     @MainActor
-    struct ClickSubcommand: OutputFormattable {
+    struct ClickSubcommand: OutputFormattable, InjectedRuntimeBackedCommand {
         @OptionGroup var target: InteractionTargetOptions
 
         @Option(help: "Menu item to click (for simple, non-nested items)")
@@ -20,30 +20,7 @@ extension MenuCommand {
         var foreground = false
 
         @OptionGroup var focusOptions: FocusCommandOptions
-        @RuntimeStorage private var runtime: CommandRuntime?
-
-        private var resolvedRuntime: CommandRuntime {
-            guard let runtime else {
-                preconditionFailure("CommandRuntime must be configured before accessing runtime resources")
-            }
-            return runtime
-        }
-
-        private var services: any PeekabooServiceProviding {
-            self.resolvedRuntime.services
-        }
-
-        private var logger: Logger {
-            self.resolvedRuntime.logger
-        }
-
-        var outputLogger: Logger {
-            self.logger
-        }
-
-        var jsonOutput: Bool {
-            self.resolvedRuntime.configuration.jsonOutput
-        }
+        @RuntimeStorage var runtime: CommandRuntime?
 
         @MainActor
         mutating func run(using runtime: CommandRuntime) async throws {

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/MenuCommand+ClickExtra.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/MenuCommand+ClickExtra.swift
@@ -7,7 +7,7 @@ extension MenuCommand {
     // MARK: - Click System Menu Extra
 
     @MainActor
-    struct ClickExtraSubcommand: OutputFormattable {
+    struct ClickExtraSubcommand: OutputFormattable, InjectedRuntimeBackedCommand {
         @Option(help: "Title of the menu extra (e.g., 'WiFi', 'Bluetooth')")
         var title: String
 
@@ -16,30 +16,7 @@ extension MenuCommand {
 
         @Flag(help: "Verify the menu extra popover opens after clicking")
         var verify: Bool = false
-        @RuntimeStorage private var runtime: CommandRuntime?
-
-        private var resolvedRuntime: CommandRuntime {
-            guard let runtime else {
-                preconditionFailure("CommandRuntime must be configured before accessing runtime resources")
-            }
-            return runtime
-        }
-
-        private var services: any PeekabooServiceProviding {
-            self.resolvedRuntime.services
-        }
-
-        private var logger: Logger {
-            self.resolvedRuntime.logger
-        }
-
-        var outputLogger: Logger {
-            self.logger
-        }
-
-        var jsonOutput: Bool {
-            self.resolvedRuntime.configuration.jsonOutput
-        }
+        @RuntimeStorage var runtime: CommandRuntime?
 
         @MainActor
         mutating func run(using runtime: CommandRuntime) async throws {

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/MenuCommand+List.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/MenuCommand+List.swift
@@ -7,7 +7,7 @@ extension MenuCommand {
     // MARK: - List Menu Items
 
     @MainActor
-    struct ListSubcommand: OutputFormattable {
+    struct ListSubcommand: OutputFormattable, InjectedRuntimeBackedCommand {
         @OptionGroup var target: InteractionTargetOptions
 
         @Flag(help: "Include disabled menu items")
@@ -17,30 +17,7 @@ extension MenuCommand {
         var foreground = false
 
         @OptionGroup var focusOptions: FocusCommandOptions
-        @RuntimeStorage private var runtime: CommandRuntime?
-
-        private var resolvedRuntime: CommandRuntime {
-            guard let runtime else {
-                preconditionFailure("CommandRuntime must be configured before accessing runtime resources")
-            }
-            return runtime
-        }
-
-        private var services: any PeekabooServiceProviding {
-            self.resolvedRuntime.services
-        }
-
-        private var logger: Logger {
-            self.resolvedRuntime.logger
-        }
-
-        var outputLogger: Logger {
-            self.logger
-        }
-
-        var jsonOutput: Bool {
-            self.resolvedRuntime.configuration.jsonOutput
-        }
+        @RuntimeStorage var runtime: CommandRuntime?
 
         @MainActor
         mutating func run(using runtime: CommandRuntime) async throws {
@@ -141,36 +118,13 @@ extension MenuCommand {
     // MARK: - List All Menu Bar Items
 
     @MainActor
-    struct ListAllSubcommand: OutputFormattable {
+    struct ListAllSubcommand: OutputFormattable, InjectedRuntimeBackedCommand {
         @Flag(help: "Include disabled menu items")
         var includeDisabled = false
 
         @Flag(help: "Include item frames (pixel positions)")
         var includeFrames = false
-        @RuntimeStorage private var runtime: CommandRuntime?
-
-        private var resolvedRuntime: CommandRuntime {
-            guard let runtime else {
-                preconditionFailure("CommandRuntime must be configured before accessing runtime resources")
-            }
-            return runtime
-        }
-
-        private var services: any PeekabooServiceProviding {
-            self.resolvedRuntime.services
-        }
-
-        private var logger: Logger {
-            self.resolvedRuntime.logger
-        }
-
-        var outputLogger: Logger {
-            self.logger
-        }
-
-        var jsonOutput: Bool {
-            self.resolvedRuntime.configuration.jsonOutput
-        }
+        @RuntimeStorage var runtime: CommandRuntime?
 
         @MainActor
         mutating func run(using runtime: CommandRuntime) async throws {

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/RunCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/RunCommand.swift
@@ -4,7 +4,7 @@ import PeekabooCore
 
 @available(macOS 14.0, *)
 @MainActor
-struct RunCommand: OutputFormattable {
+struct RunCommand: OutputFormattable, InjectedRuntimeBackedCommand {
     nonisolated(unsafe) static var commandDescription: CommandDescription {
         MainActorCommandDescription.describe {
             CommandDescription(
@@ -23,33 +23,10 @@ struct RunCommand: OutputFormattable {
 
     @Flag(help: "Continue execution even if a step fails")
     var noFailFast = false
-    @RuntimeStorage private var runtime: CommandRuntime?
-
-    private var resolvedRuntime: CommandRuntime {
-        guard let runtime else {
-            preconditionFailure("CommandRuntime must be configured before accessing runtime resources")
-        }
-        return runtime
-    }
-
-    private var services: any PeekabooServiceProviding {
-        self.resolvedRuntime.services
-    }
-
-    private var logger: Logger {
-        self.resolvedRuntime.logger
-    }
-
-    var outputLogger: Logger {
-        self.logger
-    }
+    @RuntimeStorage var runtime: CommandRuntime?
 
     private var configuration: CommandRuntime.Configuration {
         self.resolvedRuntime.configuration
-    }
-
-    var jsonOutput: Bool {
-        self.configuration.jsonOutput
     }
 
     private var isVerbose: Bool {

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/SleepCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/SleepCommand.swift
@@ -3,7 +3,7 @@ import Foundation
 
 @available(macOS 14.0, *)
 @MainActor
-struct SleepCommand: OutputFormattable, RuntimeOptionsConfigurable {
+struct SleepCommand: OutputFormattable, RuntimeBackedCommand {
     nonisolated(unsafe) static var commandDescription: CommandDescription {
         MainActorCommandDescription.describe {
             CommandDescription(
@@ -16,35 +16,8 @@ struct SleepCommand: OutputFormattable, RuntimeOptionsConfigurable {
 
     @Argument(help: "Duration to sleep in milliseconds")
     var duration: Int
-    @RuntimeStorage private var runtime: CommandRuntime?
+    @RuntimeStorage var runtime: CommandRuntime?
     var runtimeOptions = CommandRuntimeOptions()
-
-    private var resolvedRuntime: CommandRuntime {
-        guard let runtime else {
-            preconditionFailure("CommandRuntime must be configured before accessing runtime resources")
-        }
-        return runtime
-    }
-
-    private var configuration: CommandRuntime.Configuration {
-        if let runtime {
-            return runtime.configuration
-        }
-        // Unit tests exercise parsing without injecting a runtime; fall back to parsed flags.
-        return self.runtimeOptions.makeConfiguration()
-    }
-
-    private var logger: Logger {
-        self.resolvedRuntime.logger
-    }
-
-    var outputLogger: Logger {
-        self.logger
-    }
-
-    var jsonOutput: Bool {
-        self.configuration.jsonOutput
-    }
 
     @MainActor
     mutating func run(using runtime: CommandRuntime) async throws {

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/SpaceCommand+List.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/SpaceCommand+List.swift
@@ -5,33 +5,10 @@ import PeekabooCore
 // MARK: - List Spaces
 
 @MainActor
-struct ListSubcommand: ErrorHandlingCommand, OutputFormattable {
+struct ListSubcommand: ErrorHandlingCommand, OutputFormattable, InjectedRuntimeBackedCommand {
     @Flag(name: .long, help: "Include detailed window information")
     var detailed = false
-    @RuntimeStorage private var runtime: CommandRuntime?
-
-    private var resolvedRuntime: CommandRuntime {
-        guard let runtime else {
-            preconditionFailure("CommandRuntime must be configured before accessing runtime resources")
-        }
-        return runtime
-    }
-
-    private var services: any PeekabooServiceProviding {
-        self.resolvedRuntime.services
-    }
-
-    private var logger: Logger {
-        self.resolvedRuntime.logger
-    }
-
-    var outputLogger: Logger {
-        self.logger
-    }
-
-    var jsonOutput: Bool {
-        self.resolvedRuntime.configuration.jsonOutput
-    }
+    @RuntimeStorage var runtime: CommandRuntime?
 
     @MainActor
     mutating func run(using runtime: CommandRuntime) async throws {

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/SpaceCommand+MoveWindow.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/SpaceCommand+MoveWindow.swift
@@ -5,7 +5,8 @@ import PeekabooCore
 // MARK: - Move Window to Space
 
 @MainActor
-struct MoveWindowSubcommand: ApplicationResolvable, ErrorHandlingCommand, OutputFormattable {
+struct MoveWindowSubcommand: ApplicationResolvable, ErrorHandlingCommand, OutputFormattable,
+InjectedRuntimeBackedCommand {
     @Option(name: .long, help: "Target application name, bundle ID, or 'PID:12345'")
     var app: String?
 
@@ -26,30 +27,7 @@ struct MoveWindowSubcommand: ApplicationResolvable, ErrorHandlingCommand, Output
 
     @Flag(name: .long, help: "Switch to the target Space after moving")
     var follow = false
-    @RuntimeStorage private var runtime: CommandRuntime?
-
-    private var resolvedRuntime: CommandRuntime {
-        guard let runtime else {
-            preconditionFailure("CommandRuntime must be configured before accessing runtime resources")
-        }
-        return runtime
-    }
-
-    private var services: any PeekabooServiceProviding {
-        self.resolvedRuntime.services
-    }
-
-    private var logger: Logger {
-        self.resolvedRuntime.logger
-    }
-
-    var outputLogger: Logger {
-        self.logger
-    }
-
-    var jsonOutput: Bool {
-        self.resolvedRuntime.configuration.jsonOutput
-    }
+    @RuntimeStorage var runtime: CommandRuntime?
 
     mutating func validate() throws {
         _ = try self.resolveApplicationIdentifier()

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/SpaceCommand+Switch.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/SpaceCommand+Switch.swift
@@ -4,29 +4,10 @@ import PeekabooCore
 // MARK: - Switch Space
 
 @MainActor
-struct SwitchSubcommand: ErrorHandlingCommand, OutputFormattable {
+struct SwitchSubcommand: ErrorHandlingCommand, OutputFormattable, InjectedRuntimeBackedCommand {
     @Option(name: .long, help: "Space number to switch to (1-based)")
     var to: Int
-    @RuntimeStorage private var runtime: CommandRuntime?
-
-    private var resolvedRuntime: CommandRuntime {
-        guard let runtime else {
-            preconditionFailure("CommandRuntime must be configured before accessing runtime resources")
-        }
-        return runtime
-    }
-
-    private var logger: Logger {
-        self.resolvedRuntime.logger
-    }
-
-    var outputLogger: Logger {
-        self.logger
-    }
-
-    var jsonOutput: Bool {
-        self.resolvedRuntime.configuration.jsonOutput
-    }
+    @RuntimeStorage var runtime: CommandRuntime?
 
     /// Validate the requested Space index, switch to it, and report the outcome.
     @MainActor

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/VisualizerCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/VisualizerCommand.swift
@@ -7,7 +7,7 @@ import PeekabooFoundation
 import PeekabooVisualizer
 
 @MainActor
-struct VisualizerCommand: RuntimeOptionsConfigurable, OutputFormattable, ErrorHandlingCommand {
+struct VisualizerCommand: RuntimeBackedCommand, OutputFormattable, ErrorHandlingCommand {
     nonisolated(unsafe) static var commandDescription: CommandDescription {
         MainActorCommandDescription.describe {
             CommandDescription(
@@ -22,34 +22,8 @@ struct VisualizerCommand: RuntimeOptionsConfigurable, OutputFormattable, ErrorHa
         }
     }
 
-    @RuntimeStorage private var runtime: CommandRuntime?
+    @RuntimeStorage var runtime: CommandRuntime?
     var runtimeOptions = CommandRuntimeOptions()
-
-    private var resolvedRuntime: CommandRuntime {
-        guard let runtime else {
-            preconditionFailure("CommandRuntime must be configured before accessing runtime resources")
-        }
-        return runtime
-    }
-
-    private var configuration: CommandRuntime.Configuration {
-        if let runtime {
-            return runtime.configuration
-        }
-        return self.runtimeOptions.makeConfiguration()
-    }
-
-    private var logger: Logger {
-        self.resolvedRuntime.logger
-    }
-
-    var outputLogger: Logger {
-        self.logger
-    }
-
-    var jsonOutput: Bool {
-        self.configuration.jsonOutput
-    }
 
     mutating func run(using runtime: CommandRuntime) async throws {
         self.runtime = runtime

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/WindowCommand+Focus.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/WindowCommand+Focus.swift
@@ -6,7 +6,7 @@ import PeekabooFoundation
 
 extension WindowCommand {
     @MainActor
-    struct FocusSubcommand: ErrorHandlingCommand, OutputFormattable {
+    struct FocusSubcommand: ErrorHandlingCommand, OutputFormattable, InjectedRuntimeBackedCommand {
         @OptionGroup var windowOptions: WindowIdentificationOptions
 
         @OptionGroup var focusOptions: FocusCommandOptions
@@ -16,30 +16,7 @@ extension WindowCommand {
 
         @Flag(help: "Verify the window is focused after the action")
         var verify = false
-        @RuntimeStorage private var runtime: CommandRuntime?
-
-        private var resolvedRuntime: CommandRuntime {
-            guard let runtime else {
-                preconditionFailure("CommandRuntime must be configured before accessing runtime resources")
-            }
-            return runtime
-        }
-
-        private var services: any PeekabooServiceProviding {
-            self.resolvedRuntime.services
-        }
-
-        private var logger: Logger {
-            self.resolvedRuntime.logger
-        }
-
-        var outputLogger: Logger {
-            self.logger
-        }
-
-        var jsonOutput: Bool {
-            self.resolvedRuntime.configuration.jsonOutput
-        }
+        @RuntimeStorage var runtime: CommandRuntime?
 
         /// Focus the targeted window, handling Space switches or relocation according to the provided options.
         @MainActor

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/WindowCommand+Geometry.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/WindowCommand+Geometry.swift
@@ -8,7 +8,7 @@ extension WindowCommand {
     // MARK: - Move Command
 
     @MainActor
-    struct MoveSubcommand: ErrorHandlingCommand, OutputFormattable {
+    struct MoveSubcommand: ErrorHandlingCommand, OutputFormattable, InjectedRuntimeBackedCommand {
         @OptionGroup var windowOptions: WindowIdentificationOptions
 
         @Option(name: .customShort("x", allowingJoined: false), help: "New X coordinate")
@@ -16,30 +16,7 @@ extension WindowCommand {
 
         @Option(name: .customShort("y", allowingJoined: false), help: "New Y coordinate")
         var y: Int
-        @RuntimeStorage private var runtime: CommandRuntime?
-
-        private var resolvedRuntime: CommandRuntime {
-            guard let runtime else {
-                preconditionFailure("CommandRuntime must be configured before accessing runtime resources")
-            }
-            return runtime
-        }
-
-        private var services: any PeekabooServiceProviding {
-            self.resolvedRuntime.services
-        }
-
-        private var logger: Logger {
-            self.resolvedRuntime.logger
-        }
-
-        var outputLogger: Logger {
-            self.logger
-        }
-
-        var jsonOutput: Bool {
-            self.resolvedRuntime.configuration.jsonOutput
-        }
+        @RuntimeStorage var runtime: CommandRuntime?
 
         /// Move the window to the absolute screen coordinates provided by the user.
         @MainActor
@@ -117,7 +94,7 @@ extension WindowCommand {
     // MARK: - Resize Command
 
     @MainActor
-    struct ResizeSubcommand: ErrorHandlingCommand, OutputFormattable {
+    struct ResizeSubcommand: ErrorHandlingCommand, OutputFormattable, InjectedRuntimeBackedCommand {
         @OptionGroup var windowOptions: WindowIdentificationOptions
 
         @Option(name: .customShort("w", allowingJoined: false), help: "New width")
@@ -125,30 +102,7 @@ extension WindowCommand {
 
         @Option(name: .long, help: "New height")
         var height: Int
-        @RuntimeStorage private var runtime: CommandRuntime?
-
-        private var resolvedRuntime: CommandRuntime {
-            guard let runtime else {
-                preconditionFailure("CommandRuntime must be configured before accessing runtime resources")
-            }
-            return runtime
-        }
-
-        private var services: any PeekabooServiceProviding {
-            self.resolvedRuntime.services
-        }
-
-        private var logger: Logger {
-            self.resolvedRuntime.logger
-        }
-
-        var outputLogger: Logger {
-            self.logger
-        }
-
-        var jsonOutput: Bool {
-            self.resolvedRuntime.configuration.jsonOutput
-        }
+        @RuntimeStorage var runtime: CommandRuntime?
 
         /// Resize the window to the supplied dimensions, preserving its origin.
         @MainActor
@@ -226,7 +180,7 @@ extension WindowCommand {
     // MARK: - Set Bounds Command
 
     @MainActor
-    struct SetBoundsSubcommand: ErrorHandlingCommand, OutputFormattable {
+    struct SetBoundsSubcommand: ErrorHandlingCommand, OutputFormattable, InjectedRuntimeBackedCommand {
         @OptionGroup var windowOptions: WindowIdentificationOptions
 
         @Option(name: .customShort("x", allowingJoined: false), help: "New X coordinate")
@@ -240,30 +194,7 @@ extension WindowCommand {
 
         @Option(name: .long, help: "New height")
         var height: Int
-        @RuntimeStorage private var runtime: CommandRuntime?
-
-        private var resolvedRuntime: CommandRuntime {
-            guard let runtime else {
-                preconditionFailure("CommandRuntime must be configured before accessing runtime resources")
-            }
-            return runtime
-        }
-
-        private var services: any PeekabooServiceProviding {
-            self.resolvedRuntime.services
-        }
-
-        private var logger: Logger {
-            self.resolvedRuntime.logger
-        }
-
-        var outputLogger: Logger {
-            self.logger
-        }
-
-        var jsonOutput: Bool {
-            self.resolvedRuntime.configuration.jsonOutput
-        }
+        @RuntimeStorage var runtime: CommandRuntime?
 
         /// Set both position and size for the window in a single operation, then confirm the new bounds.
         @MainActor

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/WindowCommand+List.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/WindowCommand+List.swift
@@ -7,36 +7,14 @@ extension WindowCommand {
     // MARK: - List Command
 
     @MainActor
-    struct WindowListSubcommand: ErrorHandlingCommand, OutputFormattable, ApplicationResolvable {
+    struct WindowListSubcommand: ErrorHandlingCommand, OutputFormattable, ApplicationResolvable,
+    InjectedRuntimeBackedCommand {
         @Option(name: .long, help: "Target application name, bundle ID, or 'PID:12345'")
         var app: String?
 
         @Option(name: .long, help: "Target application by process ID")
         var pid: Int32?
-        @RuntimeStorage private var runtime: CommandRuntime?
-
-        private var resolvedRuntime: CommandRuntime {
-            guard let runtime else {
-                preconditionFailure("CommandRuntime must be configured before accessing runtime resources")
-            }
-            return runtime
-        }
-
-        private var services: any PeekabooServiceProviding {
-            self.resolvedRuntime.services
-        }
-
-        private var logger: Logger {
-            self.resolvedRuntime.logger
-        }
-
-        var outputLogger: Logger {
-            self.logger
-        }
-
-        var jsonOutput: Bool {
-            self.resolvedRuntime.configuration.jsonOutput
-        }
+        @RuntimeStorage var runtime: CommandRuntime?
 
         @Flag(name: .long, help: "Group windows by Space (virtual desktop)")
         var groupBySpace = false

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/WindowCommand+State.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/WindowCommand+State.swift
@@ -6,35 +6,12 @@ import PeekabooFoundation
 
 extension WindowCommand {
     @MainActor
-    struct CloseSubcommand: ErrorHandlingCommand, OutputFormattable {
+    struct CloseSubcommand: ErrorHandlingCommand, OutputFormattable, InjectedRuntimeBackedCommand {
         @OptionGroup var windowOptions: WindowIdentificationOptions
 
         @Flag(help: "Allow focused/global fallback if AX close does not dismiss the window")
         var foreground = false
-        @RuntimeStorage private var runtime: CommandRuntime?
-
-        private var resolvedRuntime: CommandRuntime {
-            guard let runtime else {
-                preconditionFailure("CommandRuntime must be configured before accessing runtime resources")
-            }
-            return runtime
-        }
-
-        private var services: any PeekabooServiceProviding {
-            self.resolvedRuntime.services
-        }
-
-        private var logger: Logger {
-            self.resolvedRuntime.logger
-        }
-
-        var outputLogger: Logger {
-            self.logger
-        }
-
-        var jsonOutput: Bool {
-            self.resolvedRuntime.configuration.jsonOutput
-        }
+        @RuntimeStorage var runtime: CommandRuntime?
 
         /// Resolve the target window, close it, and surface the outcome in JSON or text form.
         @MainActor
@@ -95,32 +72,9 @@ extension WindowCommand {
     }
 
     @MainActor
-    struct MinimizeSubcommand: ErrorHandlingCommand, OutputFormattable {
+    struct MinimizeSubcommand: ErrorHandlingCommand, OutputFormattable, InjectedRuntimeBackedCommand {
         @OptionGroup var windowOptions: WindowIdentificationOptions
-        @RuntimeStorage private var runtime: CommandRuntime?
-
-        private var resolvedRuntime: CommandRuntime {
-            guard let runtime else {
-                preconditionFailure("CommandRuntime must be configured before accessing runtime resources")
-            }
-            return runtime
-        }
-
-        private var services: any PeekabooServiceProviding {
-            self.resolvedRuntime.services
-        }
-
-        private var logger: Logger {
-            self.resolvedRuntime.logger
-        }
-
-        var outputLogger: Logger {
-            self.logger
-        }
-
-        var jsonOutput: Bool {
-            self.resolvedRuntime.configuration.jsonOutput
-        }
+        @RuntimeStorage var runtime: CommandRuntime?
 
         /// Resolve the target window, minimize it to the Dock, and report the action.
         @MainActor
@@ -176,32 +130,9 @@ extension WindowCommand {
     }
 
     @MainActor
-    struct MaximizeSubcommand: ErrorHandlingCommand, OutputFormattable {
+    struct MaximizeSubcommand: ErrorHandlingCommand, OutputFormattable, InjectedRuntimeBackedCommand {
         @OptionGroup var windowOptions: WindowIdentificationOptions
-        @RuntimeStorage private var runtime: CommandRuntime?
-
-        private var resolvedRuntime: CommandRuntime {
-            guard let runtime else {
-                preconditionFailure("CommandRuntime must be configured before accessing runtime resources")
-            }
-            return runtime
-        }
-
-        private var services: any PeekabooServiceProviding {
-            self.resolvedRuntime.services
-        }
-
-        private var logger: Logger {
-            self.resolvedRuntime.logger
-        }
-
-        var outputLogger: Logger {
-            self.logger
-        }
-
-        var jsonOutput: Bool {
-            self.resolvedRuntime.configuration.jsonOutput
-        }
+        @RuntimeStorage var runtime: CommandRuntime?
 
         /// Expand the resolved window to fill the available screen real estate and share the updated frame.
         @MainActor


### PR DESCRIPTION
## Summary

Follow-up to #317: finishes the CLI runtime-plumbing centralization and consolidates duplicated command execution scaffolding. Net −1,185 LOC, no behavior change.

- **Plumbing, part 2.** #317 migrated the 22 commands whose accessor block matched the canonical fallback shape. This PR adds a second protocol, `InjectedRuntimeBackedCommand`, for the larger family whose `jsonOutput` reads the injected runtime's configuration directly; `RuntimeBackedCommand` now refines it, keeping the fallback chain override. 37 injected-runtime command files plus 6 configuration-backed files migrate onto the shared shapes. Two files stay custom for cause: `PressCommand` (constructs a default runtime for parsing-only access) and `ClipboardCommand` (intentionally distinct precondition message).
- **Dialog scaffolding.** `DialogCommand+Click/Input/File/DismissList` shared ~45 identical lines of validation/focus/mutation-barrier/error sequencing per subcommand; that now lives in one `DialogCommand.execute` helper, with each subcommand supplying only its unique operation. Output and error strings unchanged (covered by DialogCommand test suites).
- **Element-action skeleton.** `PerformActionCommand` and `SetValueCommand` shared a 37-line execution skeleton, now one `ElementActionCommandExecutor` with a grouped context struct.

## Testing

- pnpm run build:cli, ./scripts/build-mac-debug.sh — green
- pnpm run lint — 21 pre-existing warnings, 0 serious, no new violations
- pnpm run format — clean
- pnpm run test:safe — 710 + 73 tests green
- autoreview (branch vs origin/main) — clean, no accepted findings
