### PR TITLE
feat(formatting): restore tool-summary detail lost in the formatter unification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Show recently automated app icons beside Peekaboo in the menu bar, with a settings toggle.
 
 ### Changed
+- Enrich shared tool summaries with menu counts, clicked menu paths, screenshot dimensions, app lifecycle names, screen resolutions, and clipboard actions so the agent chat and Mac activity feed regain the detail lost in the formatter unification.
 - Remove the obsolete scoped-commit helper now that agent work uses isolated worktrees.
 - Make app launch, open, relaunch, observation, capture, targeted keyboard input, and action-backed scrolling background by default; focus, global keys, synthetic scrolling, and physical pointer gestures now require explicit foreground consent.
 - Route `peekaboo run` through the canonical targeted interaction services with flat agent-friendly JSON parameters while retaining legacy script decoding.

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/ToolFormatting/Formatters/ApplicationToolFormatter.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/ToolFormatting/Formatters/ApplicationToolFormatter.swift
@@ -13,6 +13,16 @@ public class ApplicationToolFormatter: BaseToolFormatter {
             self.formatListAppsResult(result)
         case .launchApp:
             self.formatLaunchAppResult(result)
+        case .quitApp:
+            self.formatLifecycleResult(result, verb: "Quit")
+        case .focusApp:
+            self.formatLifecycleResult(result, verb: "Focused")
+        case .hideApp:
+            self.formatLifecycleResult(result, verb: "Hid")
+        case .unhideApp:
+            self.formatLifecycleResult(result, verb: "Showed")
+        case .switchApp:
+            self.formatLifecycleResult(result, verb: "Switched to")
         case .focusWindow:
             self.formatFocusWindowResult(result)
         case .listWindows:
@@ -22,6 +32,16 @@ public class ApplicationToolFormatter: BaseToolFormatter {
         default:
             super.formatResultSummary(result: result)
         }
+    }
+
+    private func formatLifecycleResult(_ result: [String: Any], verb: String) -> String {
+        guard let app = ToolResultExtractor.string("app", from: result) ??
+            ToolResultExtractor.string("appName", from: result) ??
+            ToolResultExtractor.string("application", from: result)
+        else {
+            return ""
+        }
+        return "→ \(verb) \(app)"
     }
 
     private func formatListAppsResult(_ result: [String: Any]) -> String {

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/ToolFormatting/Formatters/ElementToolFormatter.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/ToolFormatting/Formatters/ElementToolFormatter.swift
@@ -28,9 +28,19 @@ public class ElementToolFormatter: BaseToolFormatter {
             self.formatListElementsResult(result)
         case .focused:
             self.formatFocusedElementResult(result)
+        case .inspectUI:
+            self.formatInspectUIResult(result)
         default:
             super.formatResultSummary(result: result)
         }
+    }
+
+    private func formatInspectUIResult(_ result: [String: Any]) -> String {
+        let count = ToolResultExtractor.int("count", from: result) ??
+            ToolResultExtractor.int("elementCount", from: result) ??
+            (ToolResultExtractor.array("elements", from: result) as [[String: Any]]?)?.count
+        guard let count else { return "" }
+        return "→ \(count) element\(count == 1 ? "" : "s")"
     }
 
     // MARK: - Find Element Formatting

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/ToolFormatting/Formatters/MenuSystemToolFormatter+Menu.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/ToolFormatting/Formatters/MenuSystemToolFormatter+Menu.swift
@@ -19,6 +19,10 @@ extension MenuSystemToolFormatter {
             parts.append("\"\(path)\"")
         } else if let item = ToolResultExtractor.string("menuItem", from: result) {
             parts.append("\"\(item)\"")
+        } else if let clicked = ToolResultExtractor.string("clicked", from: result) {
+            parts.append("\"\(clicked)\"")
+        } else if let path = ToolResultExtractor.string("path", from: result) {
+            parts.append("\"\(self.normalizedMenuPath(path))\"")
         }
 
         if let app = ToolResultExtractor.string("app", from: result) {
@@ -52,9 +56,31 @@ extension MenuSystemToolFormatter {
     }
 
     func formatListMenuItemsResult(_ result: [String: Any]) -> String {
+        let items: [[String: Any]]? = ToolResultExtractor.array("items", from: result)
+        if items == nil, ToolResultExtractor.int("count", from: result) == nil {
+            let menuCount: Int? = if let menus: [[String: Any]] = ToolResultExtractor.array("menus", from: result) {
+                menus.count
+            } else {
+                ToolResultExtractor.int("menuCount", from: result)
+            }
+
+            guard let menuCount else { return "" }
+
+            var summary = "→ \(menuCount) menu\(menuCount == 1 ? "" : "s")"
+            if let app = ToolResultExtractor.string("app", from: result) ??
+                ToolResultExtractor.string("appName", from: result)
+            {
+                summary += " for \(app)"
+            }
+            if let totalItems = ToolResultExtractor.int("totalItems", from: result) {
+                summary += " (\(totalItems) item\(totalItems == 1 ? "" : "s"))"
+            }
+            return summary
+        }
+
         var parts: [String] = []
 
-        if let items: [[String: Any]] = ToolResultExtractor.array("items", from: result) {
+        if let items {
             let count = items.count
             parts.append("→ \(count) menu item\(count == 1 ? "" : "s")")
         } else if let count = ToolResultExtractor.int("count", from: result) {
@@ -65,11 +91,13 @@ extension MenuSystemToolFormatter {
             parts.append("in \(menu) menu")
         }
 
-        if let app = ToolResultExtractor.string("app", from: result) {
+        if let app = ToolResultExtractor.string("app", from: result) ??
+            ToolResultExtractor.string("appName", from: result)
+        {
             parts.append("for \(app)")
         }
 
-        if let items: [[String: Any]] = ToolResultExtractor.array("items", from: result) {
+        if let items {
             let details = self.menuItemDetails(items)
             if !details.isEmpty {
                 parts.append("[\(details.joined(separator: ", "))]")

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/ToolFormatting/Formatters/MenuSystemToolFormatter.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/ToolFormatting/Formatters/MenuSystemToolFormatter.swift
@@ -8,8 +8,33 @@ import PeekabooAutomation
 
 /// Formatter for menu and dialog tools with comprehensive result formatting.
 public class MenuSystemToolFormatter: BaseToolFormatter {
+    override public func formatCompactSummary(arguments: [String: Any]) -> String {
+        switch self.toolType {
+        case .menuClick:
+            if let path = arguments["path"] as? String {
+                return self.normalizedMenuPath(path)
+            }
+            if let menu = arguments["menu"] as? String {
+                if let item = arguments["item"] as? String {
+                    return "\(menu) → \(item)"
+                }
+                return menu
+            }
+            return ""
+
+        case .listMenus:
+            if let app = arguments["app"] as? String ?? arguments["appName"] as? String {
+                return "for \(app)"
+            }
+            return ""
+
+        default:
+            return super.formatCompactSummary(arguments: arguments)
+        }
+    }
+
     override public func formatResultSummary(result: [String: Any]) -> String {
-        switch toolType {
+        switch self.toolType {
         case .menuClick:
             self.formatMenuClickResult(result)
 
@@ -25,5 +50,12 @@ public class MenuSystemToolFormatter: BaseToolFormatter {
         default:
             super.formatResultSummary(result: result)
         }
+    }
+
+    func normalizedMenuPath(_ path: String) -> String {
+        path.components(separatedBy: ">")
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+            .joined(separator: " → ")
     }
 }

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/ToolFormatting/Formatters/SystemToolFormatter.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/ToolFormatting/Formatters/SystemToolFormatter.swift
@@ -76,6 +76,8 @@ public class SystemToolFormatter: BaseToolFormatter {
             self.formatCopyResult(result)
         case .pasteFromClipboard:
             self.formatPasteResult(result)
+        case .clipboard:
+            self.formatClipboardResult(result)
         default:
             super.formatResultSummary(result: result)
         }
@@ -204,6 +206,37 @@ public class SystemToolFormatter: BaseToolFormatter {
     }
 
     // MARK: - Clipboard Formatting
+
+    private func formatClipboardResult(_ result: [String: Any]) -> String {
+        let action = ToolResultExtractor.string("action", from: result)?.lowercased()
+        switch action {
+        case "set", "write", "load":
+            return "→ Copied to clipboard"
+        case "clear":
+            return "→ Clipboard cleared"
+        case "get", "read":
+            guard let content = self.clipboardContent(from: result) else { return "" }
+            return "→ \"\(self.truncate(content, maxLength: 40))\""
+        default:
+            break
+        }
+
+        guard let response = ToolResultExtractor.string("result", from: result) else { return "" }
+        if response.hasPrefix("Set clipboard") {
+            return "→ Copied to clipboard"
+        }
+        if response.hasPrefix("Cleared clipboard") {
+            return "→ Clipboard cleared"
+        }
+        return "→ \"\(self.truncate(response, maxLength: 40))\""
+    }
+
+    private func clipboardContent(from result: [String: Any]) -> String? {
+        ToolResultExtractor.string("content", from: result) ??
+            ToolResultExtractor.string("text", from: result) ??
+            ToolResultExtractor.string("textPreview", from: result) ??
+            ToolResultExtractor.string("result", from: result)
+    }
 
     private func formatCopyResult(_ result: [String: Any]) -> String {
         var parts: [String] = []

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/ToolFormatting/Formatters/VisionToolFormatter.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/ToolFormatting/Formatters/VisionToolFormatter.swift
@@ -16,6 +16,8 @@ public class VisionToolFormatter: BaseToolFormatter {
             self.formatScreenshotResult(result)
         case .windowCapture:
             self.formatWindowCaptureResult(result)
+        case .analyze:
+            self.formatAnalyzeResult(result)
         default:
             super.formatResultSummary(result: result)
         }
@@ -92,8 +94,14 @@ public class VisionToolFormatter: BaseToolFormatter {
         var details: [String] = []
 
         // Dimensions
+        let size = ToolResultExtractor.dictionary("size", from: result)
         if let width = ToolResultExtractor.int("width", from: result),
            let height = ToolResultExtractor.int("height", from: result)
+        {
+            details.append("\(width)×\(height)px")
+        } else if let size,
+                  let width = ToolResultExtractor.int("width", from: size),
+                  let height = ToolResultExtractor.int("height", from: size)
         {
             details.append("\(width)×\(height)px")
         }
@@ -101,7 +109,7 @@ public class VisionToolFormatter: BaseToolFormatter {
         // File size
         if let size = ToolResultExtractor.int("fileSize", from: result) {
             details.append(self.formatFileSize(size))
-        } else if let sizeStr = ToolResultExtractor.string("size", from: result) {
+        } else if size == nil, let sizeStr = ToolResultExtractor.string("size", from: result) {
             details.append(sizeStr)
         }
 
@@ -125,6 +133,16 @@ public class VisionToolFormatter: BaseToolFormatter {
         }
 
         return parts.joined(separator: " ")
+    }
+
+    private func formatAnalyzeResult(_ result: [String: Any]) -> String {
+        guard let analysis = ToolResultExtractor.string("analysis", from: result) ??
+            ToolResultExtractor.string("text", from: result) ??
+            ToolResultExtractor.string("result", from: result)
+        else {
+            return ""
+        }
+        return "→ \"\(self.truncate(analysis, maxLength: 60))\""
     }
 
     private func formatWindowCaptureResult(_ result: [String: Any]) -> String {
@@ -221,7 +239,9 @@ public class VisionToolFormatter: BaseToolFormatter {
     }
 
     private func extractCaptureContext(from result: [String: Any]) -> String {
-        if let app = ToolResultExtractor.string("app", from: result), app != "entire screen" {
+        if let description = ToolResultExtractor.string("description", from: result) {
+            return self.truncate(description, maxLength: 60)
+        } else if let app = ToolResultExtractor.string("app", from: result), app != "entire screen" {
             return app
         } else if let mode = ToolResultExtractor.string("mode", from: result) {
             if mode == "window" {
@@ -246,7 +266,13 @@ public class VisionToolFormatter: BaseToolFormatter {
         // Element breakdown
         if let elements: [[String: Any]] = ToolResultExtractor.array("elements", from: result) {
             let typeCount = Dictionary(grouping: elements) { element in
-                (element["type"] as? String) ?? "unknown"
+                guard let type = (element["type"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines),
+                      !type.isEmpty,
+                      type.lowercased() != "unknown"
+                else {
+                    return "element"
+                }
+                return type
             }.mapValues { $0.count }
 
             // Sort by count and take top 3
@@ -283,7 +309,13 @@ public class VisionToolFormatter: BaseToolFormatter {
         guard !counts.isEmpty else { return nil }
 
         let formatted = counts.map { type, count in
-            type == "total" ? "\(count) elements" : "\(count) \(type)"
+            if type == "total" {
+                return "\(count) element\(count == 1 ? "" : "s")"
+            }
+            if type == "element" {
+                return "\(count) element\(count == 1 ? "" : "s")"
+            }
+            return "\(count) \(type)"
         }.joined(separator: ", ")
 
         return "[\(formatted)]"

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/ToolFormatting/Formatters/WindowToolFormatter+SpaceResults.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/ToolFormatting/Formatters/WindowToolFormatter+SpaceResults.swift
@@ -12,6 +12,11 @@ extension WindowToolFormatter {
             let count = spaces.count
             parts.append("→ \(count) space\(count == 1 ? "" : "s")")
 
+            let spacesWithWindows = spaces.count(where: { ($0["hasWindows"] as? Bool) == true })
+            if spacesWithWindows > 0 {
+                parts.append("(\(spacesWithWindows) with windows)")
+            }
+
             // Current space
             if let currentSpace = spaces.first(where: { ($0["isCurrent"] as? Bool) == true }) {
                 if let index = currentSpace["index"] as? Int {

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/ToolFormatting/Formatters/WindowToolFormatter+WindowResults.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/ToolFormatting/Formatters/WindowToolFormatter+WindowResults.swift
@@ -142,35 +142,68 @@ extension WindowToolFormatter {
             parts.append("→ \(count) screen\(count == 1 ? "" : "s")")
 
             // Main screen
-            if let mainScreen = screens.first(where: { ($0["isMain"] as? Bool) == true }) {
+            if let mainScreen = screens.first(where: {
+                ($0["isMain"] as? Bool) == true || ($0["isPrimary"] as? Bool) == true
+            }) {
                 if let name = mainScreen["name"] as? String {
                     parts.append("Main: \(name)")
                 }
 
-                if let width = mainScreen["width"] as? Int,
-                   let height = mainScreen["height"] as? Int
-                {
-                    parts.append("(\(width)×\(height))")
+                if let resolution = self.screenResolution(mainScreen) {
+                    parts.append("(\(resolution))")
                 }
+            } else if screens.count == 1, let screen = screens.first,
+                      let resolution = self.screenResolution(screen)
+            {
+                parts.append("(\(resolution))")
             }
 
             // External screens
-            let externalCount = screens.count(where: { ($0["isBuiltin"] as? Bool) != true })
+            let externalCount = screens.count(where: { ($0["isBuiltin"] as? Bool) == false })
             if externalCount > 0 {
                 parts.append("• \(externalCount) external")
             }
 
             // Total resolution
-            if screens.count > 1 {
-                let totalWidth = screens.compactMap { $0["width"] as? Int }.reduce(0, +)
-                let totalHeight = screens.compactMap { $0["height"] as? Int }.max() ?? 0
-                parts.append("• Total: \(totalWidth)×\(totalHeight)")
+            let resolutions = screens.compactMap(self.screenDimensions)
+            if screens.count > 1, resolutions.count == screens.count {
+                let totalWidth = resolutions.map(\.width).reduce(0, +)
+                let totalHeight = resolutions.map(\.height).max() ?? 0
+                if totalWidth > 0, totalHeight > 0 {
+                    parts.append("• Total: \(totalWidth)×\(totalHeight)")
+                }
             }
         } else if let count = ToolResultExtractor.int("count", from: result) {
             parts.append("→ \(count) screen\(count == 1 ? "" : "s")")
         }
 
         return parts.isEmpty ? "→ listed" : parts.joined(separator: " ")
+    }
+
+    private func screenResolution(_ screen: [String: Any]) -> String? {
+        if let dimensions = self.screenDimensions(screen) {
+            return "\(dimensions.width)×\(dimensions.height)"
+        }
+        guard let resolution = screen["resolution"] as? String else { return nil }
+        let normalized = resolution.replacingOccurrences(of: " ", with: "")
+            .replacingOccurrences(of: "x", with: "×")
+            .replacingOccurrences(of: "X", with: "×")
+        return normalized.isEmpty ? nil : normalized
+    }
+
+    private func screenDimensions(_ screen: [String: Any]) -> (width: Int, height: Int)? {
+        if let width = ToolResultExtractor.int("width", from: screen),
+           let height = ToolResultExtractor.int("height", from: screen)
+        {
+            return (width, height)
+        }
+        guard let resolution = ToolResultExtractor.dictionary("resolution", from: screen),
+              let width = ToolResultExtractor.int("width", from: resolution),
+              let height = ToolResultExtractor.int("height", from: resolution)
+        else {
+            return nil
+        }
+        return (width, height)
     }
 
     private func appendWindowCountDescription(
@@ -198,7 +231,10 @@ extension WindowToolFormatter {
                 .prefix(3)
                 .joined(separator: ", ")
             parts.append("[\(appSummary)]")
-        } else if let app = appGroups.keys.first {
+        } else if let app = appGroups.keys.first,
+                  !app.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+                  app.caseInsensitiveCompare("Unknown") != .orderedSame
+        {
             parts.append("for \(app)")
         }
     }
@@ -265,7 +301,9 @@ extension WindowToolFormatter {
         into parts: inout [String])
     {
         if let app = ToolResultExtractor.string("app", from: result) ??
-            ToolResultExtractor.string("appName", from: result)
+            ToolResultExtractor.string("appName", from: result),
+            !app.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+            app.caseInsensitiveCompare("Unknown") != .orderedSame
         {
             if !parts.joined(separator: " ").contains(app) {
                 parts.append("for \(app)")

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/ToolFormatting/ToolFormatter.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/ToolFormatting/ToolFormatter.swift
@@ -81,7 +81,7 @@ open class BaseToolFormatter: ToolFormatter {
     open func formatResultSummary(result: [String: Any]) -> String {
         // Default: check for common patterns
         if let count = ToolResultExtractor.int("count", from: result) {
-            return "→ \(count) items"
+            return "→ \(count) item\(count == 1 ? "" : "s")"
         }
         return ""
     }

--- a/Core/PeekabooCore/Tests/PeekabooTests/ToolFormatterEnrichmentTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/ToolFormatterEnrichmentTests.swift
@@ -1,0 +1,203 @@
+import Testing
+@testable import PeekabooAgentRuntime
+
+@Suite("Tool formatter enrichment")
+struct ToolFormatterEnrichmentTests {
+    private let registry = ToolFormatterRegistry()
+
+    @Test
+    func `list menus supports item and menu structure results`() {
+        let formatter = self.registry.formatter(for: .listMenus)
+
+        #expect(formatter.formatResultSummary(result: [
+            "items": [["enabled": true]],
+            "menu": "File",
+            "app": "Safari",
+        ]) == "→ 1 menu item in File menu for Safari [1 enabled]")
+        #expect(formatter.formatResultSummary(result: [
+            "menus": [[:], [:], [:], [:]],
+            "app": "Safari",
+            "totalItems": 28,
+        ]) == "→ 4 menus for Safari (28 items)")
+        #expect(formatter.formatResultSummary(result: [
+            "menuCount": 1,
+            "appName": "Finder",
+        ]) == "→ 1 menu for Finder")
+        #expect(formatter.formatResultSummary(result: [
+            "menus": [[:], [:], [:], [:]],
+            "totalItems": 28,
+        ]) == "→ 4 menus (28 items)")
+        #expect(formatter.formatResultSummary(result: [:]).isEmpty)
+    }
+
+    @Test
+    func `menu click supports alternate results and compact arguments`() {
+        let formatter = self.registry.formatter(for: .menuClick)
+
+        #expect(formatter.formatResultSummary(result: ["clicked": "PDF"]) == "→ Clicked menu \"PDF\"")
+        #expect(formatter.formatResultSummary(result: ["path": "Edit > Copy"]) ==
+            "→ Clicked menu \"Edit → Copy\"")
+        #expect(formatter.formatResultSummary(result: [
+            "menuPath": ["File", "Export", "PDF"],
+            "clicked": "ignored",
+            "app": "Preview",
+            "shortcut": "cmd+shift+p",
+        ]) == "→ Clicked menu \"File → Export → PDF\" in Preview [shortcut: ⌘⇧p]")
+        #expect(formatter.formatCompactSummary(arguments: ["path": " File > Export > PDF "]) ==
+            "File → Export → PDF")
+        #expect(formatter.formatCompactSummary(arguments: ["menu": "Edit", "item": "Copy"]) == "Edit → Copy")
+        #expect(formatter.formatCompactSummary(arguments: ["menu": "Edit"]) == "Edit")
+        #expect(formatter.formatCompactSummary(arguments: [:]).isEmpty)
+        #expect(self.registry.formatter(for: .listMenus).formatCompactSummary(arguments: ["appName": "Safari"]) ==
+            "for Safari")
+    }
+
+    @Test
+    func `screenshot supports nested size dimensions`() {
+        let formatter = self.registry.formatter(for: .screenshot)
+
+        #expect(formatter.formatResultSummary(result: [
+            "size": ["width": 1440, "height": 900],
+        ]) == "→ Screenshot saved (1440×900px)")
+        #expect(formatter.formatResultSummary(result: [
+            "path": "/tmp/shot.png",
+            "size": ["width": 1440.0, "height": 900.0],
+        ]) == "→ shot.png (1440×900px)")
+        #expect(formatter.formatResultSummary(result: ["size": "2 MB"]) == "→ Screenshot saved (2 MB)")
+    }
+
+    @Test
+    func `see prefers description and labels unknown element types`() {
+        let formatter = self.registry.formatter(for: .see)
+
+        #expect(formatter.formatResultSummary(result: [
+            "description": "Login dialog",
+            "elements": [[:], ["type": "unknown"]],
+        ]) == "→ Login dialog • [2 elements]")
+        #expect(formatter.formatResultSummary(result: [
+            "description": "Toolbar",
+            "elements": [["type": "button"], ["type": "button"], ["type": "button"]],
+        ]) == "→ Toolbar • [3 button]")
+    }
+
+    @Test
+    func `analyze summarizes text without generic fallback`() {
+        let formatter = self.registry.formatter(for: .analyze)
+
+        #expect(formatter.formatResultSummary(result: ["text": "A login form with two fields"]) ==
+            "→ \"A login form with two fields\"")
+        #expect(formatter.formatResultSummary(result: ["count": 2]).isEmpty)
+    }
+
+    @Test
+    func `application lifecycle uses app name and suppresses generic fallback`() {
+        #expect(self.registry.formatter(for: .quitApp).formatResultSummary(result: ["app": "Safari"]) ==
+            "→ Quit Safari")
+        #expect(self.registry.formatter(for: .focusApp).formatResultSummary(result: ["appName": "Safari"]) ==
+            "→ Focused Safari")
+        #expect(self.registry.formatter(for: .hideApp).formatResultSummary(result: ["application": "Safari"]) ==
+            "→ Hid Safari")
+        #expect(self.registry.formatter(for: .unhideApp).formatResultSummary(result: ["app": "Safari"]) ==
+            "→ Showed Safari")
+        #expect(self.registry.formatter(for: .switchApp).formatResultSummary(result: ["app": "Safari"]) ==
+            "→ Switched to Safari")
+        #expect(self.registry.formatter(for: .quitApp).formatResultSummary(result: ["count": 1]).isEmpty)
+    }
+
+    @Test
+    func `list windows suppresses unknown app and preserves real app detail`() {
+        let formatter = self.registry.formatter(for: .listWindows)
+
+        #expect(formatter.formatResultSummary(result: ["windows": [[:]]]) == "→ 1 window")
+        #expect(formatter.formatResultSummary(result: [
+            "windows": [
+                ["app": "Safari", "title": "Docs"],
+                ["app": "Safari", "title": "Settings"],
+            ],
+        ]) == "→ 2 windows for Safari • \"Docs\", \"Settings\"")
+        #expect(formatter.formatResultSummary(result: ["count": 2, "app": "Unknown"]) == "→ 2 windows")
+    }
+
+    @Test
+    func `list screens shows single resolution and suppresses missing total`() {
+        let formatter = self.registry.formatter(for: .listScreens)
+
+        #expect(formatter.formatResultSummary(result: [
+            "screens": [["resolution": ["width": 1440, "height": 900]]],
+        ]) == "→ 1 screen (1440×900)")
+        #expect(formatter.formatResultSummary(result: [
+            "screens": [["resolution": "1440 x 900"]],
+        ]) == "→ 1 screen (1440×900)")
+        #expect(formatter.formatResultSummary(result: [
+            "screens": [
+                ["width": 0, "height": 0],
+                ["width": 0, "height": 0],
+            ],
+        ]) == "→ 2 screens")
+        #expect(formatter.formatResultSummary(result: ["screens": [["name": "One"], ["name": "Two"]]]) ==
+            "→ 2 screens")
+    }
+
+    @Test
+    func `list spaces reports spaces containing windows`() {
+        let formatter = self.registry.formatter(for: .listSpaces)
+
+        #expect(formatter.formatResultSummary(result: [
+            "spaces": [
+                ["hasWindows": true],
+                ["hasWindows": false],
+                ["hasWindows": true],
+            ],
+        ]) == "→ 3 spaces (2 with windows)")
+        #expect(formatter.formatResultSummary(result: [
+            "spaces": [["hasWindows": false]],
+        ]) == "→ 1 space")
+    }
+
+    @Test
+    func `inspect ui reports element counts only`() {
+        let formatter = self.registry.formatter(for: .inspectUI)
+
+        #expect(formatter.formatResultSummary(result: ["count": 42]) == "→ 42 elements")
+        #expect(formatter.formatResultSummary(result: ["elementCount": 1]) == "→ 1 element")
+        #expect(formatter.formatResultSummary(result: ["elements": [[:], [:]]]) == "→ 2 elements")
+        #expect(formatter.formatResultSummary(result: [:]).isEmpty)
+    }
+
+    @Test
+    func `base formatter pluralizes generic item count`() {
+        let formatter = BaseToolFormatter(toolType: .wait)
+
+        #expect(formatter.formatResultSummary(result: ["count": 1]) == "→ 1 item")
+        #expect(formatter.formatResultSummary(result: ["count": 2]) == "→ 2 items")
+    }
+
+    @Test
+    func `clipboard summarizes reads writes and clears`() {
+        let formatter = self.registry.formatter(for: .clipboard)
+
+        #expect(formatter.formatResultSummary(result: ["result": "hello from clipboard"]) ==
+            "→ \"hello from clipboard\"")
+        #expect(formatter.formatResultSummary(result: ["result": "Set clipboard (public.utf8-plain-text, 5 bytes)"]) ==
+            "→ Copied to clipboard")
+        #expect(formatter.formatResultSummary(result: ["result": "Cleared clipboard."]) ==
+            "→ Clipboard cleared")
+        #expect(formatter.formatResultSummary(result: ["action": "get", "content": "read value"]) ==
+            "→ \"read value\"")
+        #expect(formatter.formatResultSummary(result: [:]).isEmpty)
+    }
+
+    @Test
+    func `untouched formatter outputs remain stable`() {
+        #expect(self.registry.formatter(for: .windowCapture).formatResultSummary(result: [
+            "app": "Safari",
+            "windowTitle": "Docs",
+        ]) == "→ Safari \"Docs\"")
+        #expect(self.registry.formatter(for: .dockLaunch).formatResultSummary(result: ["app": "Preview"]) ==
+            "→ launched Preview from dock")
+        #expect(self.registry.formatter(for: .shell).formatResultSummary(result: [
+            "exitCode": 0,
+            "command": "pwd",
+        ]) == "→ Success \"pwd\"")
+    }
+}


### PR DESCRIPTION
## Summary

PR #320 unified Mac summaries on the shared registry and documented the detail lost in its parity table.

This PR enriches the shared formatters to cover the result-key shapes the deleted Mac stack understood and suppresses noisy fallbacks, benefiting both agent chat and the Mac activity feed.

## Before / after

- `list_menus`: "for Safari" -> "-> 4 menus for Safari (28 items)"
- `menu_click`: "-> Clicked menu" -> "-> Clicked menu \"Edit -> Copy\""
- `screenshot`: "-> Screenshot saved" -> "-> shot.png (1440x900px)"
- lifecycle: "-> 1 items" -> "-> Quit Safari"
- `list_windows`: "-> 2 windows for Unknown" -> "-> 2 windows"
- `list_screens`: drops bogus "Total: 0x0"

## Testing

- `pnpm run lint` (21 pre-existing, 0 serious)
- `pnpm run format` clean
- `pnpm run test:safe` green (710 + 73)
- 13 new exact-output regression tests
- Autoreview clean

`CHANGELOG.md` is updated.
