### PR TITLE
test(cli): fix racy PID handshake in daemon launch policy tests

### DIFF
--- a/Apps/CLI/Tests/CLIRuntimeTests/DaemonLaunchPolicyTests.swift
+++ b/Apps/CLI/Tests/CLIRuntimeTests/DaemonLaunchPolicyTests.swift
@@ -4,6 +4,27 @@ import Testing
 @testable import PeekabooCLI
 
 struct DaemonLaunchPolicyTests {
+    /// Shell snippet that writes the child's PID via an atomic rename, so the PID file
+    /// never exists in a created-but-not-yet-written state.
+    private static func writePIDCommand(to pidURL: URL) -> String {
+        "echo $$ > \(pidURL.path).tmp; mv \(pidURL.path).tmp \(pidURL.path)"
+    }
+
+    /// Polls until the PID file contains a parsable positive PID; returns nil on deadline.
+    private static func waitForPID(at pidURL: URL, timeout: TimeInterval = 5) async throws -> pid_t? {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if let text = try? String(contentsOf: pidURL, encoding: .utf8) {
+                let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+                if let pid = pid_t(trimmed), pid > 0 {
+                    return pid
+                }
+            }
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        return nil
+    }
+
     @Test
     func `daemon executable resolution prefers the canonical bundle executable`() {
         let bundleExecutable = URL(fileURLWithPath: "/opt/peekaboo/bin/peekaboo")
@@ -121,6 +142,7 @@ struct DaemonLaunchPolicyTests {
                 kill(childPID, SIGKILL)
             }
             unlink(pidURL.path)
+            unlink(pidURL.path + ".tmp")
         }
 
         let clock = ContinuousClock()
@@ -128,7 +150,7 @@ struct DaemonLaunchPolicyTests {
         do {
             _ = try await DaemonLaunchPolicy.launchDaemon(
                 socketPath: "/tmp/peekaboo-daemon-term-\(UUID().uuidString).sock",
-                arguments: ["-c", "trap '' TERM; echo $$ > \(pidURL.path); exec /bin/sleep 30"],
+                arguments: ["-c", "trap '' TERM; \(Self.writePIDCommand(to: pidURL)); exec /bin/sleep 30"],
                 timeout: 0.05,
                 executableURL: URL(fileURLWithPath: "/bin/sh"),
                 logHandle: .nullDevice
@@ -144,9 +166,7 @@ struct DaemonLaunchPolicyTests {
         }
 
         #expect(clock.now - startedAt < .seconds(3))
-        let pidText = try String(contentsOf: pidURL, encoding: .utf8)
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-        childPID = pid_t(pidText)
+        childPID = try await Self.waitForPID(at: pidURL)
         let stoppedPID = try #require(childPID)
         #expect(kill(stoppedPID, 0) == -1)
         #expect(errno == ESRCH)
@@ -162,33 +182,25 @@ struct DaemonLaunchPolicyTests {
                 kill(childPID, SIGKILL)
             }
             unlink(pidURL.path)
+            unlink(pidURL.path + ".tmp")
         }
 
         let launchTask = Task {
             try await DaemonLaunchPolicy.launchDaemon(
                 socketPath: "/tmp/peekaboo-daemon-cancel-\(UUID().uuidString).sock",
-                arguments: ["-c", "echo $$ > \(pidURL.path); exec /bin/sleep 30"],
+                arguments: ["-c", "\(Self.writePIDCommand(to: pidURL)); exec /bin/sleep 30"],
                 timeout: 10,
                 executableURL: URL(fileURLWithPath: "/bin/sh"),
                 logHandle: .nullDevice
             )
         }
-        let pidDeadline = Date().addingTimeInterval(1)
-        while !FileManager.default.fileExists(atPath: pidURL.path), Date() < pidDeadline {
-            try await Task.sleep(nanoseconds: 10_000_000)
-        }
-        guard FileManager.default.fileExists(atPath: pidURL.path) else {
+        guard let stoppedPID = try await Self.waitForPID(at: pidURL) else {
             launchTask.cancel()
             _ = await launchTask.result
-            Issue.record("Daemon child did not write its PID")
+            Issue.record("Daemon child did not write a parsable PID")
             return
         }
-
-        let pidText = try String(contentsOf: pidURL, encoding: .utf8)
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-        let parsedPID = pid_t(pidText)
-        childPID = parsedPID
-        let stoppedPID = try #require(parsedPID)
+        childPID = stoppedPID
         launchTask.cancel()
 
         switch await launchTask.result {


### PR DESCRIPTION
## Summary

Fixes the flaky CLI test "canceling daemon launch terminates and reaps the child" (failed on PR #318, run 31293328001, with a nil parsedPID, then passed on rerun).

Root cause: the test polled for the PID file's *existence* and then read it immediately, but the shell's `>` redirection creates the empty file before `echo` writes the PID into it. Under CI load the test won that race, read an empty string, and failed `#require`. `DaemonLaunchPolicy.launchDaemon` never parses child output (readiness comes from the control socket), so this is purely a test-harness race — no product change.

## Fix

- The child shell now writes the PID to a `.tmp` file and atomically renames it into place, so the PID file never exists in a created-but-unwritten state.
- The test polls until the file content actually parses as a positive PID (shared `waitForPID` helper) instead of polling for bare existence, with the deadline raised from 1s to 5s.
- The sibling test "daemon timeout bounds termination for a TERM ignoring child" had the same read-before-write hazard (unconditional read, no wait) and now uses the same helpers.

## Proof

- `swift test --filter DaemonLaunchPolicyTests`: 20/20 consecutive passes.
- Another 10/10 passes with 8 concurrent CPU-burner processes simulating CI load (the condition that triggered the original failure).
- SwiftFormat and SwiftLint clean on the changed file.
