### PR TITLE
fix(agent): preserve ToolResponse meta in native tool results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Add strict bridge 1.11 capabilities for background scrolling, dialog buttons, and window close so stale hosts fail before unsafe fallback dispatch.
 
 ### Fixed
+- Preserve tool response metadata for native agent tools so the Mac activity feed and CLI agent chat show their short summaries, matching external MCP tools.
 - Stop bridge hosts from requiring AppleScript permission for native application activate, hide, unhide, hide-others, and show-all operations.
 - Keep targeted UI observation in the background, exclude irrelevant application menu trees, and restore the documented `see` traversal flags and output-path aliases.
 - Reject phantom-success accessibility actions, support selectable sidebar rows, and verify typed `set-value` results against live AX state.

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/Agent/AgentToolMCPBridge.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/Agent/AgentToolMCPBridge.swift
@@ -1,5 +1,6 @@
 import Foundation
 import MCP
+import PeekabooAutomation
 import Tachikoma
 import TachikomaMCP
 
@@ -46,27 +47,44 @@ func convertToolResponseToAgentToolResult(_ response: ToolResponse) -> AnyAgentT
         return AnyAgentToolValue(string: "Error: \(errorMessage)")
     }
 
+    let contentValue: AnyAgentToolValue
+
     // Convert the first content item to a result
     if let firstContent = response.content.first {
         switch firstContent {
         case let .text(text, _, _):
-            return AnyAgentToolValue(string: text)
+            contentValue = AnyAgentToolValue(string: text)
         case let .image(data, mimeType, _, _):
             // For images, return a descriptive string
-            return AnyAgentToolValue(string: "[Image: \(mimeType), size: \(data.count) bytes]")
+            contentValue = AnyAgentToolValue(string: "[Image: \(mimeType), size: \(data.count) bytes]")
         case let .resource(resource, _, _):
             // For resources, return the text content if available
-            return AnyAgentToolValue(string: resource.text ?? "[Resource: \(resource.uri)]")
+            contentValue = AnyAgentToolValue(string: resource.text ?? "[Resource: \(resource.uri)]")
         case let .resourceLink(uri, name, _, _, mimeType, _):
             let mimeTypeDescription = mimeType.map { ", mimeType: \($0)" } ?? ""
-            return AnyAgentToolValue(string: "[Resource Link: \(name), uri: \(uri)\(mimeTypeDescription)]")
+            contentValue = AnyAgentToolValue(string: "[Resource Link: \(name), uri: \(uri)\(mimeTypeDescription)]")
         case let .audio(data, mimeType, _, _):
-            return AnyAgentToolValue(string: "[Audio: \(mimeType), size: \(data.count) bytes]")
+            contentValue = AnyAgentToolValue(string: "[Audio: \(mimeType), size: \(data.count) bytes]")
         }
+    } else {
+        // No content
+        contentValue = AnyAgentToolValue(string: "Success")
     }
 
-    // No content
-    return AnyAgentToolValue(string: "Success")
+    guard let meta = response.meta else {
+        return contentValue
+    }
+
+    var payload: [String: AnyAgentToolValue] = [
+        "result": contentValue,
+        "meta": TypedValueBridge.anyAgentValue(from: meta),
+    ]
+
+    if let text = contentValue.stringValue {
+        payload["text"] = AnyAgentToolValue(string: text)
+    }
+
+    return AnyAgentToolValue(object: payload)
 }
 
 @preconcurrency

--- a/Core/PeekabooCore/Sources/PeekabooAutomation/Utils/TypedValueBridge.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAutomation/Utils/TypedValueBridge.swift
@@ -2,7 +2,7 @@ import Foundation
 import MCP
 import Tachikoma
 
-enum TypedValueBridge {
+package enum TypedValueBridge {
     static func typedValue(from value: MCP.Value) -> Tachikoma.TypedValue {
         switch value {
         case .null:
@@ -67,7 +67,7 @@ enum TypedValueBridge {
         }
     }
 
-    static func anyAgentValue(from value: MCP.Value) -> AnyAgentToolValue {
+    package static func anyAgentValue(from value: MCP.Value) -> AnyAgentToolValue {
         self.anyAgentValue(from: self.typedValue(from: value))
     }
 

--- a/Core/PeekabooCore/Tests/PeekabooAgentRuntimeTests/AgentToolMCPBridgeMetaTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooAgentRuntimeTests/AgentToolMCPBridgeMetaTests.swift
@@ -1,0 +1,74 @@
+import MCP
+import TachikomaMCP
+import Testing
+@testable import PeekabooAgentRuntime
+
+struct AgentToolMCPBridgeMetaTests {
+    @Test
+    func `Text content preserves summary metadata`() throws {
+        let text = "native tool output"
+        let response = ToolResponse.text(
+            text,
+            meta: .object([
+                "summary": .object([
+                    "command": .string("echo hi"),
+                ]),
+            ]))
+
+        let converted = convertToolResponseToAgentToolResult(response)
+        guard let payload = try converted.toJSON() as? [String: Any] else {
+            Issue.record("Converted response is not an object")
+            return
+        }
+
+        #expect(payload["result"] as? String == text)
+        #expect(payload["text"] as? String == text)
+        guard let summary = ToolEventSummary.from(resultJSON: payload) else {
+            Issue.record("Converted response is missing summary metadata")
+            return
+        }
+        #expect(summary.shortDescription(toolName: "shell") != nil)
+    }
+
+    @Test
+    func `Text content without metadata keeps legacy string result`() throws {
+        let text = "legacy native tool output"
+        let converted = convertToolResponseToAgentToolResult(.text(text))
+
+        #expect(try converted.toJSON() as? String == text)
+    }
+
+    @Test
+    func `Error response ignores metadata`() throws {
+        let response = ToolResponse.error(
+            "native tool failed",
+            meta: .object([
+                "summary": .object([
+                    "command": .string("false"),
+                ]),
+            ]))
+        let converted = convertToolResponseToAgentToolResult(response)
+
+        #expect(try converted.toJSON() as? String == "Error: native tool failed")
+    }
+
+    @Test
+    func `Shell tool metadata survives native bridge`() async throws {
+        let command = "echo bridge-meta-test"
+        let tool = ShellTool()
+        let response = try await tool.execute(arguments: ToolArguments(raw: ["command": command]))
+        let converted = convertToolResponseToAgentToolResult(response)
+
+        guard let payload = try converted.toJSON() as? [String: Any] else {
+            Issue.record("Converted ShellTool response is not an object")
+            return
+        }
+        guard let summary = ToolEventSummary.from(resultJSON: payload) else {
+            Issue.record("Converted ShellTool response is missing summary metadata")
+            return
+        }
+
+        #expect(summary.command == command)
+        #expect(summary.shortDescription(toolName: tool.name)?.hasPrefix("Run `\(command)`") == true)
+    }
+}


### PR DESCRIPTION
## Summary
Native agent tools bridged through convertToolResponseToAgentToolResult dropped ToolResponse.meta, so ToolEventSummary short summaries (meta.summary) never reached the Mac activity feed or CLI agent chat - the meta.summary path was dead for all native tools and only external MCP tools (via Tachikoma's MCPToolAdapter.convertResponse) showed summaries.
This wraps metadata-bearing native results in the same {"result", "meta", "text"} shape MCPToolAdapter.convertResponse produces, reusing the existing TypedValueBridge (promoted to package visibility) for MCP.Value conversion. Error responses and metadata-free responses are byte-identical to before.
## Changes
- Core/PeekabooCore/Sources/PeekabooAgentRuntime/Agent/AgentToolMCPBridge.swift: wrap results with result/meta/text when response.meta is present
- Core/PeekabooCore/Sources/PeekabooAutomation/Utils/TypedValueBridge.swift: package visibility for the existing converter
- New regression tests in Core/PeekabooCore/Tests/PeekabooAgentRuntimeTests/AgentToolMCPBridgeMetaTests.swift (4 tests incl. end-to-end ShellTool -> ToolEventSummary.from(resultJSON:))
- CHANGELOG.md entry under 3.10.1 Unreleased
## Testing
- swift test --package-path Core/PeekabooCore --filter AgentToolMCPBridgeMetaTests (4/4 pass)
- pnpm run lint (0 serious), pnpm run format, pnpm run test:safe (all green)
