### PR TITLE
feat(formatting): cover the current tool surface and drop the dead --realtime flag

### DIFF
--- a/Apps/CLI/Sources/PeekabooCLI/Commands/AI/AgentCommand+Commander.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/AI/AgentCommand+Commander.swift
@@ -17,7 +17,6 @@ extension AgentCommand: CommanderBindableCommand {
         self.noCache = values.flag("noCache")
         self.audio = values.flag("audio")
         self.audioFile = values.singleOption("audioFile")
-        self.realtime = values.flag("realtime")
         self.simple = values.flag("simple")
         self.noColor = values.flag("noColor")
         self.chat = values.flag("chat")

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/AI/AgentCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/AI/AgentCommand.swift
@@ -116,9 +116,6 @@ struct AgentCommand: RuntimeBackedCommand {
     @Option(name: .long, help: "Audio input file path (instead of microphone)")
     var audioFile: String?
 
-    @Flag(name: .long, help: "Use real-time audio streaming (OpenAI only)")
-    var realtime = false
-
     @Flag(name: .long, help: "Force simple output mode (no colors or rich formatting)")
     var simple = false
 

--- a/Apps/CLI/Tests/CLIAutomationTests/AgentCommandBasicTests.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/AgentCommandBasicTests.swift
@@ -27,9 +27,9 @@ struct AgentCommandBasicTests {
 
     @Test
     func `Agent rejects the removed realtime flag`() async throws {
-        let result = try await InProcessCommandRunner.runShared(["agent", "--realtime"])
+        let result = try await InProcessCommandRunner.runShared(["agent", "--realtime"], allowedExitCodes: [1])
 
         #expect(result.exitStatus != 0)
-        #expect(result.combinedOutput.contains("Unknown option '--realtime'"))
+        #expect(result.combinedOutput.contains("Unknown option --realtime"))
     }
 }

--- a/Apps/CLI/Tests/CLIAutomationTests/AgentCommandBasicTests.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/AgentCommandBasicTests.swift
@@ -21,6 +21,15 @@ struct AgentCommandBasicTests {
         #expect(result.combinedOutput.contains("claude-sonnet-5"))
         #expect(result.combinedOutput.contains("Maximum model turns before failing (1-100, default 100)"))
         #expect(result.combinedOutput.contains("Resume the most recent session"))
+        #expect(!result.combinedOutput.contains("--realtime"))
         #expect(!result.combinedOutput.contains("use with task argument"))
+    }
+
+    @Test
+    func `Agent rejects the removed realtime flag`() async throws {
+        let result = try await InProcessCommandRunner.runShared(["agent", "--realtime"])
+
+        #expect(result.exitStatus != 0)
+        #expect(result.combinedOutput.contains("Unknown option '--realtime'"))
     }
 }

--- a/Apps/CLI/Tests/CoreCLITests/CommanderBinderCommandBindingAppTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/CommanderBinderCommandBindingAppTests.swift
@@ -375,7 +375,6 @@ struct CommanderBinderAppConfigTests {
                 "listSessions",
                 "noCache",
                 "audio",
-                "realtime",
                 "simple",
                 "noColor"
             ]
@@ -393,7 +392,6 @@ struct CommanderBinderAppConfigTests {
         #expect(command.noCache == true)
         #expect(command.audio == true)
         #expect(command.audioFile == "/tmp/input.wav")
-        #expect(command.realtime == true)
         #expect(command.simple == true)
         #expect(command.noColor == true)
     }

--- a/Apps/CLI/Tests/CoreCLITests/ToolFormatterCoverageTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/ToolFormatterCoverageTests.swift
@@ -1,0 +1,64 @@
+import PeekabooAgentRuntime
+import PeekabooCore
+import Testing
+@testable import PeekabooCLI
+
+@Suite("Current tool formatter coverage")
+@MainActor
+struct ToolFormatterCoverageTests {
+    @Test
+    func `current MCP and agent tools use specialized formatters`() throws {
+        let services = PeekabooServices()
+        let context = MCPToolContext(services: services)
+        let mcpNames = MCPToolCatalog.unfilteredTools(context: context).map(\.name)
+        let agentNames = try PeekabooAgentService(services: services).createAgentTools().map(\.name)
+        let currentToolNames = Set(mcpNames + agentNames)
+        let registry = ToolFormatterRegistry()
+
+        for name in currentToolNames.sorted() {
+            let toolType = try #require(ToolType(rawValue: name), "Missing ToolType case for \(name)")
+            let formatter = registry.formatter(for: toolType)
+            let isSpecialized = formatter is ApplicationToolFormatter ||
+                formatter is VisionToolFormatter ||
+                formatter is UIAutomationToolFormatter ||
+                formatter is MenuSystemToolFormatter ||
+                formatter is SystemToolFormatter ||
+                formatter is DockToolFormatter ||
+                formatter is WindowToolFormatter ||
+                formatter is ElementToolFormatter ||
+                formatter is CommunicationToolFormatter
+            #expect(isSpecialized, "\(name) uses the generic formatter fallback")
+        }
+    }
+
+    @Test
+    func `grouped tools include their action in compact summaries`() {
+        let registry = ToolFormatterRegistry()
+
+        #expect(registry.formatter(for: .app).formatCompactSummary(arguments: [
+            "action": "focus",
+            "name": "Safari",
+        ]) == "focus Safari")
+        #expect(registry.formatter(for: .window).formatCompactSummary(arguments: [
+            "action": "resize",
+            "app": "Preview",
+            "width": 800,
+            "height": 600,
+        ]) == "resize · Preview · 800×600")
+        #expect(registry.formatter(for: .menu).formatCompactSummary(arguments: [
+            "action": "click",
+            "path": "File > Export",
+        ]) == "click · File → Export")
+        #expect(registry.formatter(for: .space).formatCompactSummary(arguments: [
+            "action": "switch",
+            "to": 2,
+        ]) == "switch to 2")
+    }
+
+    @Test
+    func `agent rejects removed realtime option`() {
+        #expect(throws: (any Error).self) {
+            _ = try AgentCommand.parse(["--realtime"])
+        }
+    }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Show recently automated app icons beside Peekaboo in the menu bar, with a settings toggle.
 
 ### Changed
+- Add rich formatter coverage for every current MCP and agent tool, and remove the non-functional agent `--realtime` flag.
 - Enrich shared tool summaries with menu counts, clicked menu paths, screenshot dimensions, app lifecycle names, screen resolutions, and clipboard actions so the agent chat and Mac activity feed regain the detail lost in the formatter unification.
 - Remove the obsolete scoped-commit helper now that agent work uses isolated worktrees.
 - Make app launch, open, relaunch, observation, capture, targeted keyboard input, and action-backed scrolling background by default; focus, global keys, synthetic scrolling, and physical pointer gestures now require explicit foreground consent.

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/ToolFormatting/Formatters/ApplicationToolFormatter.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/ToolFormatting/Formatters/ApplicationToolFormatter.swift
@@ -7,6 +7,37 @@ import Foundation
 
 /// Formatter for application tools with comprehensive result formatting
 public class ApplicationToolFormatter: BaseToolFormatter {
+    override public func formatCompactSummary(arguments: [String: Any]) -> String {
+        switch self.toolType {
+        case .app:
+            let action = (arguments["action"] as? String) ?? "manage"
+            let target = arguments["name"] as? String ?? arguments["bundleId"] as? String ??
+                arguments["to"] as? String
+            return [action.replacingOccurrences(of: "-", with: " "), target]
+                .compactMap(\.self)
+                .joined(separator: " ")
+        case .list:
+            switch arguments["item_type"] as? String {
+            case "application_windows":
+                if let app = arguments["app"] as? String {
+                    return "windows for \(app)"
+                }
+                return "application windows"
+            case "server_status":
+                return "server status"
+            case "running_applications":
+                return "running applications"
+            default:
+                if let app = arguments["app"] as? String {
+                    return "windows for \(app)"
+                }
+                return "running applications"
+            }
+        default:
+            return super.formatCompactSummary(arguments: arguments)
+        }
+    }
+
     override public func formatResultSummary(result: [String: Any]) -> String {
         switch toolType {
         case .listApps:

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/ToolFormatting/Formatters/CommunicationToolFormatter.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/ToolFormatting/Formatters/CommunicationToolFormatter.swift
@@ -20,7 +20,7 @@ public class CommunicationToolFormatter: BaseToolFormatter {
 
     override public func formatStarting(arguments: [String: Any]) -> String {
         switch toolType {
-        case .taskCompleted:
+        case .done, .taskCompleted:
             "Completing task..."
 
         case .needMoreInformation, .needInfo:

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/ToolFormatting/Formatters/ElementToolFormatter.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/ToolFormatting/Formatters/ElementToolFormatter.swift
@@ -9,19 +9,33 @@ import Foundation
 public class ElementToolFormatter: BaseToolFormatter {
     override public func formatCompactSummary(arguments: [String: Any]) -> String {
         switch toolType {
+        case .setValue:
+            let target = arguments["on"] as? String ?? "element"
+            if let value = arguments["value"] {
+                return "\(target) to \(self.truncate(String(describing: value), maxLength: 30))"
+            }
+            return target
+        case .performAction:
+            let action = arguments["action"] as? String ?? "action"
+            let target = arguments["on"] as? String ?? "element"
+            return "\(action) on \(target)"
         case .findElement:
-            self.compactSummaryForFind(arguments: arguments)
+            return self.compactSummaryForFind(arguments: arguments)
         case .listElements:
-            self.compactSummaryForList(arguments: arguments)
+            return self.compactSummaryForList(arguments: arguments)
         case .focused:
-            self.compactSummaryForFocused(arguments: arguments)
+            return self.compactSummaryForFocused(arguments: arguments)
         default:
-            super.formatCompactSummary(arguments: arguments)
+            return super.formatCompactSummary(arguments: arguments)
         }
     }
 
     override public func formatResultSummary(result: [String: Any]) -> String {
         switch toolType {
+        case .setValue:
+            self.formatSetValueResult(result)
+        case .performAction:
+            self.formatPerformActionResult(result)
         case .findElement:
             self.formatFindElementResult(result)
         case .listElements:
@@ -33,6 +47,24 @@ public class ElementToolFormatter: BaseToolFormatter {
         default:
             super.formatResultSummary(result: result)
         }
+    }
+
+    private func formatSetValueResult(_ result: [String: Any]) -> String {
+        guard let target = ToolResultExtractor.string("target", from: result) else { return "" }
+        if let value = ToolResultExtractor.string("new_value", from: result) ??
+            ToolResultExtractor.string("value", from: result)
+        {
+            return "→ Set \(target) to \"\(self.truncate(value, maxLength: 40))\""
+        }
+        return "→ Set value on \(target)"
+    }
+
+    private func formatPerformActionResult(_ result: [String: Any]) -> String {
+        guard let target = ToolResultExtractor.string("target", from: result) else { return "" }
+        if let action = ToolResultExtractor.string("action_name", from: result) {
+            return "→ Performed \(action) on \(target)"
+        }
+        return "→ Performed action on \(target)"
     }
 
     private func formatInspectUIResult(_ result: [String: Any]) -> String {

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/ToolFormatting/Formatters/MenuSystemToolFormatter.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/ToolFormatting/Formatters/MenuSystemToolFormatter.swift
@@ -10,6 +10,40 @@ import PeekabooAutomation
 public class MenuSystemToolFormatter: BaseToolFormatter {
     override public func formatCompactSummary(arguments: [String: Any]) -> String {
         switch self.toolType {
+        case .menu:
+            let action = arguments["action"] as? String ?? "menu"
+            var parts = [action.replacingOccurrences(of: "-", with: " ")]
+            if let path = arguments["path"] as? String {
+                parts.append(self.normalizedMenuPath(path))
+            } else if let app = arguments["app"] as? String {
+                parts.append("for \(app)")
+            }
+            return parts.joined(separator: " · ")
+
+        case .dialog:
+            let action = arguments["action"] as? String ?? "dialog"
+            var parts = [action]
+            if let button = arguments["button"] as? String {
+                parts.append("\"\(button)\"")
+            } else if let field = arguments["field"] as? String {
+                parts.append("\(field) field")
+            }
+            if let app = arguments["app"] as? String {
+                parts.append("in \(app)")
+            }
+            return parts.joined(separator: " ")
+
+        case .dock:
+            let action = arguments["action"] as? String ?? "dock"
+            var parts = [action.replacingOccurrences(of: "-", with: " ")]
+            if let app = arguments["app"] as? String {
+                parts.append(app)
+            }
+            if let selection = arguments["select"] as? String {
+                parts.append("→ \(selection)")
+            }
+            return parts.joined(separator: " ")
+
         case .menuClick:
             if let path = arguments["path"] as? String {
                 return self.normalizedMenuPath(path)

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/ToolFormatting/Formatters/SystemToolFormatter.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/ToolFormatting/Formatters/SystemToolFormatter.swift
@@ -9,6 +9,10 @@ import PeekabooAutomation
 /// Formatter for system tools with comprehensive result formatting
 public class SystemToolFormatter: BaseToolFormatter {
     override public func formatCompactSummary(arguments: [String: Any]) -> String {
+        if let currentToolSummary = self.formatCurrentToolCompactSummary(arguments: arguments) {
+            return currentToolSummary
+        }
+
         switch toolType {
         case .shell:
             var parts: [String] = []
@@ -64,6 +68,47 @@ public class SystemToolFormatter: BaseToolFormatter {
         default:
             return super.formatCompactSummary(arguments: arguments)
         }
+    }
+
+    private func formatCurrentToolCompactSummary(arguments: [String: Any]) -> String? {
+        switch self.toolType {
+        case .browser:
+            let action = arguments["action"] as? String ?? "browser"
+            if let url = arguments["url"] as? String {
+                return "\(action.replacingOccurrences(of: "_", with: " ")) \(self.truncate(url, maxLength: 50))"
+            }
+            if action == "call", let tool = arguments["mcp_tool"] as? String {
+                return "call \(tool)"
+            }
+            return action.replacingOccurrences(of: "_", with: " ")
+        case .permissions:
+            return "macOS automation access"
+        case .sleep:
+            if let duration = arguments["duration"] as? Double {
+                return self.formatMilliseconds(duration)
+            }
+            if let duration = arguments["duration"] as? Int {
+                return self.formatMilliseconds(Double(duration))
+            }
+            return ""
+        case .agent:
+            if arguments["listSessions"] as? Bool == true {
+                return "list sessions"
+            }
+            if let task = arguments["task"] as? String {
+                return self.truncate(task, maxLength: 60)
+            }
+            return ""
+        default:
+            return nil
+        }
+    }
+
+    private func formatMilliseconds(_ milliseconds: Double) -> String {
+        if milliseconds < 1000 {
+            return String(format: "%.0fms", milliseconds)
+        }
+        return String(format: "%.1fs", milliseconds / 1000)
     }
 
     override public func formatResultSummary(result: [String: Any]) -> String {

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/ToolFormatting/Formatters/UIAutomationToolFormatter.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/ToolFormatting/Formatters/UIAutomationToolFormatter.swift
@@ -7,6 +7,25 @@ import Foundation
 
 /// Formatter for UI automation tools with comprehensive result formatting
 public class UIAutomationToolFormatter: BaseToolFormatter {
+    override public func formatCompactSummary(arguments: [String: Any]) -> String {
+        guard self.toolType == .paste else {
+            return super.formatCompactSummary(arguments: arguments)
+        }
+
+        var parts: [String] = []
+        if let text = arguments["text"] as? String {
+            parts.append("\"\(self.truncate(text, maxLength: 30))\"")
+        } else if let path = arguments["filePath"] as? String ?? arguments["imagePath"] as? String {
+            parts.append(URL(fileURLWithPath: path).lastPathComponent)
+        } else {
+            parts.append("clipboard payload")
+        }
+        if let app = arguments["app"] as? String {
+            parts.append("to \(app)")
+        }
+        return parts.joined(separator: " ")
+    }
+
     override public func formatResultSummary(result: [String: Any]) -> String {
         switch toolType {
         case .click:
@@ -25,8 +44,20 @@ public class UIAutomationToolFormatter: BaseToolFormatter {
             self.formatSwipeResult(result)
         case .move:
             self.formatMoveResult(result)
+        case .paste:
+            self.formatPasteResult(result)
         default:
             super.formatResultSummary(result: result)
         }
+    }
+
+    private func formatPasteResult(_ result: [String: Any]) -> String {
+        guard let pasted = ToolResultExtractor.dictionary("pasted", from: result) else {
+            return ""
+        }
+        if let preview = ToolResultExtractor.string("textPreview", from: pasted), !preview.isEmpty {
+            return "→ Pasted \"\(self.truncate(preview, maxLength: 40))\""
+        }
+        return "→ Pasted"
     }
 }

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/ToolFormatting/Formatters/VisionToolFormatter.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/ToolFormatting/Formatters/VisionToolFormatter.swift
@@ -25,7 +25,7 @@ public class VisionToolFormatter: BaseToolFormatter {
 
     override public func formatCompactSummary(arguments: [String: Any]) -> String {
         switch self.toolType {
-        case .see, .screenshot, .windowCapture:
+        case .see, .image, .screenshot, .windowCapture:
             var parts: [String] = []
 
             if let target = self.describeCaptureTarget(arguments["app_target"] as? String) {
@@ -47,6 +47,24 @@ public class VisionToolFormatter: BaseToolFormatter {
                 parts.append(filename)
             }
 
+            return parts.joined(separator: " · ")
+
+        case .capture:
+            let source = arguments["source"] as? String ?? "live"
+            if source == "video" {
+                if let input = arguments["input"] as? String {
+                    return "video \(URL(fileURLWithPath: input).lastPathComponent)"
+                }
+                return "video"
+            }
+
+            var parts = [arguments["mode"] as? String ?? "frontmost"]
+            if let app = arguments["app"] as? String {
+                parts.append(app)
+            }
+            if let title = arguments["window_title"] as? String {
+                parts.append("\"\(self.truncate(title, maxLength: 30))\"")
+            }
             return parts.joined(separator: " · ")
 
         default:

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/ToolFormatting/Formatters/WindowToolFormatter.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/ToolFormatting/Formatters/WindowToolFormatter.swift
@@ -10,6 +10,32 @@ import PeekabooAutomation
 public class WindowToolFormatter: BaseToolFormatter {
     override public func formatCompactSummary(arguments: [String: Any]) -> String {
         switch toolType {
+        case .window:
+            var parts = [(arguments["action"] as? String ?? "window").replacingOccurrences(of: "-", with: " ")]
+            if let app = arguments["app"] as? String {
+                parts.append(app)
+            }
+            if let title = arguments["title"] as? String {
+                parts.append("\"\(self.truncate(title, maxLength: 30))\"")
+            }
+            if let width = arguments["width"], let height = arguments["height"] {
+                parts.append("\(width)×\(height)")
+            }
+            return parts.joined(separator: " · ")
+
+        case .space:
+            let action = arguments["action"] as? String ?? "space"
+            var parts = [action.replacingOccurrences(of: "-", with: " ")]
+            if let app = arguments["app"] as? String {
+                parts.append(app)
+            }
+            if let target = arguments["to"] {
+                parts.append("to \(target)")
+            } else if arguments["to_current"] as? Bool == true {
+                parts.append("to current space")
+            }
+            return parts.joined(separator: " ")
+
         case .focusWindow:
             if let app = arguments["appName"] as? String {
                 return app

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/ToolFormatting/ToolFormatterRegistry.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/ToolFormatting/ToolFormatterRegistry.swift
@@ -26,23 +26,27 @@ public final class ToolFormatterRegistry: @unchecked Sendable {
 
         // Application tools
         let appFormatter = ApplicationToolFormatter(toolType: .launchApp)
-        self.register(appFormatter, for: [.launchApp, .listApps, .quitApp, .focusApp, .hideApp, .unhideApp, .switchApp])
+        self.register(appFormatter, for: [
+            .app, .list,
+            .launchApp, .listApps, .quitApp, .focusApp, .hideApp, .unhideApp, .switchApp,
+        ])
 
         // Vision tools
         let visionFormatter = VisionToolFormatter(toolType: .see)
-        self.register(visionFormatter, for: [.see, .screenshot, .windowCapture, .analyze])
+        self.register(visionFormatter, for: [.see, .image, .capture, .screenshot, .windowCapture, .analyze])
 
         // UI Automation tools
         let uiFormatter = UIAutomationToolFormatter(toolType: .click)
         self.register(uiFormatter, for: [
             .click,
-            .type, .scroll, .hotkey, .press,
+            .type, .paste, .scroll, .hotkey, .press,
             .move,
         ])
 
         // Menu and dialog tools
         let menuSystemFormatter = MenuSystemToolFormatter(toolType: .menuClick)
         self.register(menuSystemFormatter, for: [
+            .menu, .dialog, .dock,
             .menuClick, .listMenus,
             .dialogInput, .dialogClick,
         ])
@@ -50,6 +54,7 @@ public final class ToolFormatterRegistry: @unchecked Sendable {
         // System tools
         let systemFormatter = SystemToolFormatter(toolType: .shell)
         self.register(systemFormatter, for: [
+            .browser, .permissions, .sleep, .agent,
             .shell, .wait, .clipboard, .copyToClipboard, .pasteFromClipboard,
         ])
 
@@ -62,6 +67,7 @@ public final class ToolFormatterRegistry: @unchecked Sendable {
         // Window management tools (use standard for now)
         let windowFormatter = WindowToolFormatter(toolType: .focusWindow)
         self.register(windowFormatter, for: [
+            .window, .space,
             .focusWindow, .resizeWindow, .listWindows,
             .minimizeWindow, .maximizeWindow, .listScreens,
             .listSpaces, .switchSpace, .moveWindowToSpace,
@@ -69,11 +75,13 @@ public final class ToolFormatterRegistry: @unchecked Sendable {
 
         // Element query tools (use standard for now)
         let elementFormatter = ElementToolFormatter(toolType: .findElement)
-        self.register(elementFormatter, for: [.findElement, .listElements, .focused])
+        self.register(
+            elementFormatter,
+            for: [.setValue, .performAction, .findElement, .listElements, .focused, .inspectUI])
 
         // Communication tools (use standard)
         let commFormatter = CommunicationToolFormatter(toolType: .taskCompleted)
-        self.register(commFormatter, for: [.taskCompleted, .needMoreInformation, .needInfo])
+        self.register(commFormatter, for: [.done, .taskCompleted, .needMoreInformation, .needInfo])
 
         // Additional tools that might not have specific formatters yet
         self.registerRemainingTools()

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/ToolFormatting/ToolType.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/ToolFormatting/ToolType.swift
@@ -11,23 +11,35 @@ public enum ToolType: String, CaseIterable, Sendable {
     // MARK: - Vision Tools
 
     case see
+    case image
+    case capture
+    case analyze
+
+    // Historical split-tool names retained so persisted sessions keep rich formatting.
     case screenshot
     case windowCapture = "window_capture"
-    case analyze
 
     // MARK: - UI Automation
 
     case click
     case type
+    case setValue = "set_value"
+    case performAction = "perform_action"
     case scroll
     case hotkey
     case drag
     case move
     case swipe
+    case paste
+
+    /// Historical split-tool name retained for persisted sessions.
     case press
 
     // MARK: - Application Management
 
+    case app
+
+    // Historical split-tool names retained for persisted sessions.
     case launchApp = "launch_app"
     case listApps = "list_apps"
     case quitApp = "quit_app"
@@ -38,6 +50,10 @@ public enum ToolType: String, CaseIterable, Sendable {
 
     // MARK: - Window Management
 
+    case window
+    case space
+
+    // Historical split-tool names retained for persisted sessions.
     case focusWindow = "focus_window"
     case resizeWindow = "resize_window"
     case listWindows = "list_windows"
@@ -47,6 +63,11 @@ public enum ToolType: String, CaseIterable, Sendable {
 
     // MARK: - Menu & Dialog
 
+    case menu
+    case dialog
+    case dock
+
+    // Historical split-tool names retained for persisted sessions.
     case menuClick = "menu_click"
     case listMenus = "list_menus"
     case dialogClick = "dialog_click"
@@ -54,12 +75,16 @@ public enum ToolType: String, CaseIterable, Sendable {
 
     // MARK: - Dock
 
+    // Historical split-tool names retained for persisted sessions.
     case listDock = "list_dock"
     case dockClick = "dock_click"
     case dockLaunch = "dock_launch"
 
     // MARK: - Element Query
 
+    case list
+
+    // Historical split-tool names retained for persisted sessions.
     case findElement = "find_element"
     case listElements = "list_elements"
     case focused
@@ -67,7 +92,13 @@ public enum ToolType: String, CaseIterable, Sendable {
 
     // MARK: - System
 
+    case browser
+    case permissions
+    case sleep
+    case agent
     case shell
+
+    // Historical split-tool names retained for persisted sessions.
     case wait
     case clipboard
     case copyToClipboard = "copy_to_clipboard"
@@ -78,6 +109,9 @@ public enum ToolType: String, CaseIterable, Sendable {
 
     // MARK: - Communication
 
+    case done
+
+    // Historical completion names retained for persisted sessions.
     case taskCompleted = "task_completed"
     case needMoreInformation = "need_more_information"
     case needInfo = "need_info"
@@ -87,24 +121,28 @@ public enum ToolType: String, CaseIterable, Sendable {
     /// The category this tool belongs to
     var category: ToolCategory {
         switch self {
-        case .see, .screenshot, .windowCapture, .analyze:
+        case .see, .image, .capture, .screenshot, .windowCapture, .analyze:
             .vision
-        case .click, .type, .scroll, .hotkey, .drag, .move, .swipe, .press:
+        case .click, .type, .setValue, .performAction, .scroll, .hotkey, .drag, .move, .swipe, .paste, .press:
             .ui
-        case .launchApp, .listApps, .quitApp, .focusApp, .hideApp, .unhideApp, .switchApp:
+        case .app, .launchApp, .listApps, .quitApp, .focusApp, .hideApp, .unhideApp, .switchApp:
             .app
-        case .focusWindow, .resizeWindow, .listWindows, .minimizeWindow, .maximizeWindow, .listScreens:
+        case .window, .space, .focusWindow, .resizeWindow, .listWindows, .minimizeWindow, .maximizeWindow, .listScreens:
             .window
-        case .menuClick, .listMenus, .dialogClick, .dialogInput:
+        case .menu, .dialog, .menuClick, .listMenus, .dialogClick, .dialogInput:
             .menu
-        case .listDock, .dockClick, .dockLaunch:
+        case .dock, .listDock, .dockClick, .dockLaunch:
             .dock
-        case .findElement, .listElements, .focused, .inspectUI:
+        case .list, .findElement, .listElements, .focused, .inspectUI:
             .element
-        case .shell, .wait, .clipboard, .copyToClipboard, .pasteFromClipboard, .listSpaces, .switchSpace,
+        case .browser:
+            .browser
+        case .permissions, .sleep, .agent, .shell, .wait, .clipboard, .copyToClipboard, .pasteFromClipboard,
+             .listSpaces,
+             .switchSpace,
              .moveWindowToSpace:
             .system
-        case .taskCompleted, .needMoreInformation, .needInfo:
+        case .done, .taskCompleted, .needMoreInformation, .needInfo:
             .completion
         }
     }
@@ -118,6 +156,8 @@ public enum ToolType: String, CaseIterable, Sendable {
         case .needMoreInformation, .needInfo:
             "\(AgentDisplayTokens.Status.info)"
         case .wait:
+            "\(AgentDisplayTokens.Status.time)"
+        case .sleep:
             "\(AgentDisplayTokens.Status.time)"
         case .shell:
             "[sh]"
@@ -136,6 +176,23 @@ public enum ToolType: String, CaseIterable, Sendable {
     /// Human-readable display name for the tool
     public var displayName: String {
         switch self {
+        case .image: "Capture Image"
+        case .capture: "Capture Activity"
+        case .setValue: "Set Value"
+        case .performAction: "Perform Action"
+        case .paste: "Paste"
+        case .app: "Application"
+        case .window: "Window"
+        case .space: "Space"
+        case .menu: "Menu"
+        case .dialog: "Dialog"
+        case .dock: "Dock"
+        case .list: "List System Items"
+        case .browser: "Browser"
+        case .permissions: "Check Permissions"
+        case .sleep: "Sleep"
+        case .agent: "Agent"
+        case .done: "Done"
         case .launchApp: "Launch Application"
         case .listApps: "List Applications"
         case .quitApp: "Quit Application"
@@ -181,7 +238,7 @@ public enum ToolType: String, CaseIterable, Sendable {
     /// Whether this is a communication tool that should be displayed differently
     var isCommunicationTool: Bool {
         switch self {
-        case .taskCompleted, .needMoreInformation, .needInfo:
+        case .done, .taskCompleted, .needMoreInformation, .needInfo:
             true
         default:
             false

--- a/docs/commands/agent.md
+++ b/docs/commands/agent.md
@@ -21,14 +21,14 @@ read_when:
 | `--list-sessions` | Print cached sessions (id, task, timestamps, message count) instead of running anything. |
 | `--no-cache` | Always create a fresh session even if one is already active. |
 | `--quiet` / `--simple` / `--no-color` / `--debug-terminal` | Control output mode; the command auto-detects terminal capabilities when you don’t override it. |
-| `--audio` / `--audio-file <path>` / `--realtime` | Use microphone input, pipe audio from disk, or enable OpenAI’s realtime audio mode. |
+| `--audio` / `--audio-file <path>` | Use microphone input or pipe audio from disk. |
 
 ## Implementation notes
 - The command resolves output “modes” (`minimal`, `compact`, `enhanced`, `quiet`, `verbose`) using terminal detection heuristics; `--simple` and `--no-color` force minimal mode, while `--quiet` suppresses progress output entirely.
 - Session metadata lives inside `agentService` (PeekabooCore). `--resume` grabs the most recent session, `--list-sessions` prints the cached list, and `--no-cache` disables reuse so each run starts clean.
 - All agent executions run under `CommandRuntime.makeDefault()`, so environment variables, credentials, and logging levels match the top-level CLI state.
 - When `--dry-run` is set the agent still reasons about the task, but tool invocations are skipped; this is useful for understanding plans without touching the UI.
-- Audio flags wire into Tachikoma’s audio stack: `--audio` opens the microphone, `--audio-file` loads a WAV/CAF file, and `--realtime` enables low-latency streaming (OpenAI-only).
+- Audio flags wire into Tachikoma’s audio stack: `--audio` opens the microphone and `--audio-file` loads a WAV/CAF file.
 - Generation uses `agent.temperature` and `agent.maxTokens` from the shared config written by the macOS Settings UI.
   Token requests are capped to model capability; unsupported temperature controls are omitted automatically.
 - A run saves its session and fails when its final permitted turn still requests tools and therefore needs another

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -56,7 +56,7 @@ Not in scope: backwards compatibility with pre-3.0 CLIs, legacy argument parser 
 ### 3.2 PeekabooAgentRuntime
 - `PeekabooAgentService`: orchestrates tools, system prompt, MCP tool registry.
 - `AgentDisplayTokens`: maps tool names to icons/text for progress output.
-- Tachikoma integrations for GPT‑5, Claude, Grok, and Ollama. `--audio` and `--audio-file` transcribe input before running the agent; `--realtime` is still accepted by the parser but currently has no execution path pending a product decision.
+- Tachikoma integrations for GPT‑5, Claude, Grok, and Ollama. `--audio` and `--audio-file` transcribe input before running the agent; the non-functional `--realtime` flag was removed.
 
 ### 3.3 PeekabooVisualizer
 - Animation + overlay payloads for CLI/app progress indicators.


### PR DESCRIPTION
## Summary

Resolves the two remaining formatter/CLI decision items from the cleanup audit.

**Formatter coverage for the current tool surface.** `ToolType` previously modeled the old split-tool names, so most current grouped tools (`app`, `window`, `menu`, `dialog`, `dock`, `image`, `capture`, `space`, `paste`, `set_value`, `perform_action`, `list`, `permissions`, `sleep`, `browser`, `agent`, `done`) fell through to generic formatting in agent chat and the Mac activity feed. All 17 now resolve to their appropriate existing formatter families, with grouped-tool action arguments reflected in summaries (e.g. `app` shows focus/quit/launch). Legacy split-tool names stay as marked historical-session compatibility cases. A new regression test derives the canonical name list from the live MCP catalog and agent tool definitions at runtime, so any future tool without formatter coverage fails CI.

**`agent --realtime` removed.** The realtime-voice feature was deleted earlier in the cleanup; the flag had become a silent no-op. It's now removed from the command, Commander signature, and docs — passing it fails with a normal unknown-option error. A regression test covers the rejection.

Changelog entry included (user-facing).

## Testing

- pnpm run build:cli, ./scripts/build-mac-debug.sh — green
- pnpm run lint — 21 pre-existing warnings, 0 serious; pnpm run format — clean
- pnpm run test:safe — 713 + 73 tests green (3 new tests)
- autoreview (branch vs origin/main) — clean, 0.99
