### PR TITLE
fix(agent): return all multi-part native tool content items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Fixed
 - Preserve tool response metadata for native agent tools so the Mac activity feed and CLI agent chat show their short summaries, matching external MCP tools.
+- Return all content items from multi-part native tool responses (e.g. `see` with annotation, `analyze`) instead of only the first.
 - Stop bridge hosts from requiring AppleScript permission for native application activate, hide, unhide, hide-others, and show-all operations.
 - Keep targeted UI observation in the background, exclude irrelevant application menu trees, and restore the documented `see` traversal flags and output-path aliases.
 - Reject phantom-success accessibility actions, support selectable sidebar rows, and verify typed `set-value` results against live AX state.

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/Agent/AgentToolMCPBridge.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/Agent/AgentToolMCPBridge.swift
@@ -33,6 +33,24 @@ extension ToolArguments {
 
 // MARK: - Helper function to convert ToolResponse to AnyAgentToolValue
 
+private func convertToolResponseContent(_ content: MCP.Tool.Content) -> AnyAgentToolValue {
+    switch content {
+    case let .text(text, _, _):
+        return AnyAgentToolValue(string: text)
+    case let .image(data, mimeType, _, _):
+        // For images, return a descriptive string
+        return AnyAgentToolValue(string: "[Image: \(mimeType), size: \(data.count) bytes]")
+    case let .resource(resource, _, _):
+        // For resources, return the text content if available
+        return AnyAgentToolValue(string: resource.text ?? "[Resource: \(resource.uri)]")
+    case let .resourceLink(uri, name, _, _, mimeType, _):
+        let mimeTypeDescription = mimeType.map { ", mimeType: \($0)" } ?? ""
+        return AnyAgentToolValue(string: "[Resource Link: \(name), uri: \(uri)\(mimeTypeDescription)]")
+    case let .audio(data, mimeType, _, _):
+        return AnyAgentToolValue(string: "[Audio: \(mimeType), size: \(data.count) bytes]")
+    }
+}
+
 @preconcurrency
 func convertToolResponseToAgentToolResult(_ response: ToolResponse) -> AnyAgentToolValue {
     // If there's an error, return error message
@@ -47,28 +65,12 @@ func convertToolResponseToAgentToolResult(_ response: ToolResponse) -> AnyAgentT
         return AnyAgentToolValue(string: "Error: \(errorMessage)")
     }
 
-    let contentValue: AnyAgentToolValue
-
-    // Convert the first content item to a result
-    if let firstContent = response.content.first {
-        switch firstContent {
-        case let .text(text, _, _):
-            contentValue = AnyAgentToolValue(string: text)
-        case let .image(data, mimeType, _, _):
-            // For images, return a descriptive string
-            contentValue = AnyAgentToolValue(string: "[Image: \(mimeType), size: \(data.count) bytes]")
-        case let .resource(resource, _, _):
-            // For resources, return the text content if available
-            contentValue = AnyAgentToolValue(string: resource.text ?? "[Resource: \(resource.uri)]")
-        case let .resourceLink(uri, name, _, _, mimeType, _):
-            let mimeTypeDescription = mimeType.map { ", mimeType: \($0)" } ?? ""
-            contentValue = AnyAgentToolValue(string: "[Resource Link: \(name), uri: \(uri)\(mimeTypeDescription)]")
-        case let .audio(data, mimeType, _, _):
-            contentValue = AnyAgentToolValue(string: "[Audio: \(mimeType), size: \(data.count) bytes]")
-        }
+    let contentValue: AnyAgentToolValue = if response.content.isEmpty {
+        AnyAgentToolValue(string: "Success")
+    } else if response.content.count == 1 {
+        convertToolResponseContent(response.content[0])
     } else {
-        // No content
-        contentValue = AnyAgentToolValue(string: "Success")
+        AnyAgentToolValue(array: response.content.map { convertToolResponseContent($0) })
     }
 
     guard let meta = response.meta else {

--- a/Core/PeekabooCore/Tests/PeekabooAgentRuntimeTests/AgentToolMCPBridgeMetaTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooAgentRuntimeTests/AgentToolMCPBridgeMetaTests.swift
@@ -71,4 +71,51 @@ struct AgentToolMCPBridgeMetaTests {
         #expect(summary.command == command)
         #expect(summary.shortDescription(toolName: tool.name)?.hasPrefix("Run `\(command)`") == true)
     }
+
+    @Test
+    func `Multiple text content items preserve metadata and omit text wrapper`() throws {
+        let response = ToolResponse(
+            content: [
+                .text(text: "analysis", annotations: nil, _meta: nil),
+                .text(text: "completed in 1.00s", annotations: nil, _meta: nil),
+            ],
+            meta: .object([
+                "summary": .object([
+                    "command": .string("analyze image"),
+                ]),
+            ]))
+
+        let converted = convertToolResponseToAgentToolResult(response)
+        guard let payload = try converted.toJSON() as? [String: Any] else {
+            Issue.record("Converted response is not an object")
+            return
+        }
+
+        #expect(payload["result"] as? [String] == ["analysis", "completed in 1.00s"])
+        #expect(!payload.keys.contains("text"))
+        guard let summary = ToolEventSummary.from(resultJSON: payload) else {
+            Issue.record("Converted response is missing summary metadata")
+            return
+        }
+        #expect(summary.shortDescription(toolName: "analyze") != nil)
+    }
+
+    @Test
+    func `Text and image content items preserve both results without metadata`() throws {
+        let imageData = "AQID"
+        let response = ToolResponse(content: [
+            .text(text: "annotated screenshot", annotations: nil, _meta: nil),
+            .image(data: imageData, mimeType: "image/png", annotations: nil, _meta: nil),
+        ])
+
+        let converted = convertToolResponseToAgentToolResult(response)
+        guard let content = try converted.toJSON() as? [Any] else {
+            Issue.record("Converted response is not an array")
+            return
+        }
+
+        #expect(content.count == 2)
+        #expect(content[0] as? String == "annotated screenshot")
+        #expect(content[1] as? String == "[Image: image/png, size: 4 bytes]")
+    }
 }


### PR DESCRIPTION
## Summary
Follow-up to #326. convertToolResponseToAgentToolResult still collapsed multi-item ToolResponse.content to only the first item, so native tools lost data: see with annotation returned [text summary, annotated image] and analyze returned [analysis text, timing text], and everything after the first item was silently dropped.
Two or more content items now convert to an array of the same per-item values, matching Tachikoma's MCPToolAdapter.convertResponse (which also omits the "text" wrapper key for non-string results). Single-item, empty ("Success"), and error responses are byte-identical to before, as is the {"result", "meta", "text"} metadata wrapper from #326.
## Changes
- Core/PeekabooCore/Sources/PeekabooAgentRuntime/Agent/AgentToolMCPBridge.swift: extract per-item conversion helper; map 2+ content items to an array
- Two new regression tests in AgentToolMCPBridgeMetaTests.swift (multi-text with metadata; text+image without metadata)
- CHANGELOG.md entry under 3.10.1 Unreleased
## Testing
- swift test --package-path Core/PeekabooCore --filter AgentToolMCPBridgeMetaTests (6/6 pass)
- pnpm run lint (0 serious), pnpm run format, pnpm run test:safe (all green)
