### PR TITLE
fix(build): centralize AX window symbol declaration

### DIFF
--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/AXWindowIDResolver.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/AXWindowIDResolver.swift
@@ -1,0 +1,16 @@
+import ApplicationServices
+import CoreGraphics
+
+@_silgen_name("_AXUIElementGetWindow")
+private func copyAXWindowID(_ element: AXUIElement, _ windowID: inout CGWindowID) -> AXError
+
+enum AXWindowIDResolver {
+    static func copyWindowID(_ element: AXUIElement, into windowID: inout CGWindowID) -> AXError {
+        copyAXWindowID(element, &windowID)
+    }
+
+    static func windowID(of element: AXUIElement) -> CGWindowID? {
+        var windowID: CGWindowID = 0
+        return self.copyWindowID(element, into: &windowID) == .success ? windowID : nil
+    }
+}

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/DetachedAXObservationWorker.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/DetachedAXObservationWorker.swift
@@ -116,9 +116,6 @@ enum DetachedAXObservationWorker {
         self.childAttributeNames.count
     }
 
-    @_silgen_name("_AXUIElementGetWindow")
-    private static func copyWindowID(_ element: AXUIElement, _ windowID: inout CGWindowID) -> AXError
-
     static func descriptorReadDisposition(error: AXError, values: [Any]?)
         -> DetachedAXMultiAttributeReadDisposition
     {
@@ -223,7 +220,7 @@ enum DetachedAXObservationWorker {
 
         let result = DetachedAXObservationResult(
             elements: state.elements,
-            windowID: self.windowID(of: window).map(Int.init) ?? request.windowID,
+            windowID: AXWindowIDResolver.windowID(of: window).map(Int.init) ?? request.windowID,
             windowTitle: title,
             windowBounds: bounds,
             isDialog: ["AXDialog", "AXSystemDialog", "AXSheet"].contains(subrole) || self.isFileDialogTitle(title),
@@ -312,7 +309,7 @@ enum DetachedAXObservationWorker {
                 windows: windows,
                 remainingTimeout: { self.remainingMessagingTimeout(until: deadline) },
                 applyTimeout: { AXUIElementSetMessagingTimeout($0, $1) },
-                windowID: { self.windowID(of: $0).map(Int.init) })
+                windowID: { AXWindowIDResolver.windowID(of: $0).map(Int.init) })
             if let exactIndex = DetachedAXExactWindowSelectionPolicy.uniqueExactIndex(
                 windowID: Int(cgWindowID),
                 candidates: candidates)
@@ -640,11 +637,6 @@ enum DetachedAXObservationWorker {
             return nil
         }
         return CGRect(origin: position, size: size)
-    }
-
-    private static func windowID(of element: AXUIElement) -> CGWindowID? {
-        var windowID: CGWindowID = 0
-        return self.copyWindowID(element, &windowID) == .success ? windowID : nil
     }
 
     private static func stringValue(_ value: Any?) -> String? {

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/DetachedExactWindowFocusReader.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/DetachedExactWindowFocusReader.swift
@@ -36,9 +36,6 @@ struct ExactKeyWindowSnapshot: Sendable, Equatable {
 enum DetachedExactWindowFocusReader {
     private static let messagingTimeout: Float = 0.05
 
-    @_silgen_name("_AXUIElementGetWindow")
-    private static func copyWindowID(_ element: AXUIElement, _ windowID: inout CGWindowID) -> AXError
-
     static func read(processIdentifier: pid_t) -> ExactWindowFocusSnapshot? {
         guard processIdentifier > 0 else { return nil }
         let application = AXUIElementCreateApplication(processIdentifier)
@@ -62,7 +59,7 @@ enum DetachedExactWindowFocusReader {
         }
         return ExactWindowFocusSnapshot(
             processIdentifier: focusedProcessIdentifier,
-            windowID: window.flatMap(self.windowID(of:)).map(Int.init),
+            windowID: window.flatMap(AXWindowIDResolver.windowID(of:)).map(Int.init),
             frame: frame,
             role: self.stringAttribute(kAXRoleAttribute as String, of: focusedElement),
             title: self.stringAttribute(kAXTitleAttribute as String, of: focusedElement),
@@ -90,7 +87,7 @@ enum DetachedExactWindowFocusReader {
             !self.elementArrayAttribute("AXSheets", of: focusedWindow).isEmpty
         return ExactKeyWindowSnapshot(
             processIdentifier: focusedProcessIdentifier,
-            windowID: self.windowID(of: focusedWindow).map(Int.init),
+            windowID: AXWindowIDResolver.windowID(of: focusedWindow).map(Int.init),
             hasSheet: hasSheet)
     }
 
@@ -138,11 +135,6 @@ enum DetachedExactWindowFocusReader {
             return nil
         }
         return CGRect(origin: position, size: size)
-    }
-
-    private static func windowID(of element: AXUIElement) -> CGWindowID? {
-        var windowID: CGWindowID = 0
-        return self.copyWindowID(element, &windowID) == .success ? windowID : nil
     }
 
     private static func pointValue(_ value: CFTypeRef?) -> CGPoint? {

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/WindowManagementService+Resolution.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/WindowManagementService+Resolution.swift
@@ -364,9 +364,6 @@ struct BoundedAXWindowScanReceipt: Sendable, Equatable {
 }
 
 enum BoundedAXWindowIdentityScanner {
-    @_silgen_name("_AXUIElementGetWindow")
-    private static func copyWindowID(_ element: AXUIElement, _ windowID: inout CGWindowID) -> AXError
-
     static func find(
         windowID: Int,
         processIdentifiers: [pid_t],
@@ -465,7 +462,7 @@ enum BoundedAXWindowIdentityScanner {
         ownerProcessStartIdentity: UInt64) -> BoundedAXWindowIdentitySnapshot?
     {
         var candidateID: CGWindowID = 0
-        guard self.copyWindowID(window, &candidateID) == .success,
+        guard AXWindowIDResolver.copyWindowID(window, into: &candidateID) == .success,
               candidateID == requestedID
         else {
             return nil

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/WindowManagementService+StateOperations.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/WindowManagementService+StateOperations.swift
@@ -952,9 +952,6 @@ extension CGPoint {
 private enum BoundedBackgroundWindowAX {
     private static let messagingTimeout: Float = 0.75
 
-    @_silgen_name("_AXUIElementGetWindow")
-    private static func copyWindowID(_ element: AXUIElement, _ windowID: inout CGWindowID) -> AXError
-
     static func windowPresence(expectedIdentity: WindowMutationIdentity) async -> PinnedMinimizedWindowAXPresence {
         await Task.detached(priority: .userInitiated) {
             let processStartIdentityBeforeScan = SystemIdentityResolver.processStartIdentity(
@@ -997,7 +994,7 @@ private enum BoundedBackgroundWindowAX {
                 timeout: self.messagingTimeout)
             { childWindow in
                 var candidateID: CGWindowID = 0
-                guard self.copyWindowID(childWindow, &candidateID) == .success,
+                guard AXWindowIDResolver.copyWindowID(childWindow, into: &candidateID) == .success,
                       exactMinimizedRestoreCandidateIsValid(
                           expectedIdentity: expectedIdentity,
                           liveProcessStartIdentity: SystemIdentityResolver.processStartIdentity(
@@ -1016,7 +1013,7 @@ private enum BoundedBackgroundWindowAX {
                     kCFBooleanFalse) == .success,
                     SystemIdentityResolver.processStartIdentity(expectedIdentity.ownerProcessIdentifier) ==
                     expectedIdentity.ownerProcessStartIdentity,
-                    self.copyWindowID(childWindow, &candidateID) == .success,
+                    AXWindowIDResolver.copyWindowID(childWindow, into: &candidateID) == .success,
                     candidateID == windowID,
                     self.bounds(of: childWindow) == capturedBounds,
                     self.boolAttribute(kAXMinimizedAttribute as String, of: childWindow) == false
@@ -1156,7 +1153,8 @@ private enum BoundedBackgroundWindowAX {
                 timeout: self.messagingTimeout)
             { childWindow in
                 var candidateID: CGWindowID = 0
-                return self.copyWindowID(childWindow, &candidateID) == .success && candidateID == windowID
+                return AXWindowIDResolver.copyWindowID(childWindow, into: &candidateID) == .success &&
+                    candidateID == windowID
             }
             if matches {
                 return window
@@ -1199,7 +1197,7 @@ private enum BoundedBackgroundWindowAX {
                 timeout: self.messagingTimeout)
             { childWindow -> (windowID: CGWindowID?, bounds: CGRect?) in
                 var candidateID: CGWindowID = 0
-                guard self.copyWindowID(childWindow, &candidateID) == .success else {
+                guard AXWindowIDResolver.copyWindowID(childWindow, into: &candidateID) == .success else {
                     return (nil, nil)
                 }
                 return (candidateID, candidateID == windowID ? self.bounds(of: childWindow) : nil)


### PR DESCRIPTION
## Summary

- declare `_AXUIElementGetWindow` once at file scope behind a shared resolver
- remove the duplicate type-scoped declarations that Swift 6.4 treats as conflicting owners of one ABI symbol
- preserve the existing exact-window ID resolution and error handling at every call site

## Proof

- `swift test --package-path Core/PeekabooAutomationKit --no-parallel` — 156 XCTest and 474 Swift Testing tests passed; one live-context test skipped
- `MAC_RELEASE_CODESIGN_IDENTITY='Developer ID Application: OpenClaw Foundation (FWJYW4S8P8)' pnpm run build:swift:all` — passed on Apple Swift 6.4 for arm64 and x86_64 at rebased exact head `cbefe251`
- exact-head universal binary SHA-256: `6ada85a3a995c0c022207f598f809d74608aa23015317e00a47c72e499071fed`
- code signature verified with identifier `boo.peekaboo.peekaboo` and Team ID `FWJYW4S8P8`
- `pnpm run build:cli`
- `pnpm run format`
- `pnpm run lint` — no serious violations; existing warnings only
- strict SwiftLint on all five touched files
- `git diff --check`

## Notes

This is an internal build-compatibility fix with no user-facing behavior change, so no changelog entry is needed.
