### PR TITLE
docs: add v4 plan front matter

### DIFF
--- a/docs/v4-cli-plan.md
+++ b/docs/v4-cli-plan.md
@@ -1,3 +1,10 @@
+---
+summary: 'Plan for redesigning the Peekaboo 4 CLI and aligning its CLI, MCP, and agent tool surfaces.'
+read_when:
+  - 'reviewing or implementing the Peekaboo 4 CLI redesign'
+  - 'changing command names, tool parity, result envelopes, or migration policy'
+---
+
 # Peekaboo 4 CLI Redesign Plan
 
 Status: draft for review · Branch: `steipete/peekaboo-v4-cli-cleanup-73955f` · 2026-08-09


### PR DESCRIPTION
## Summary

- add the required front matter to the Peekaboo 4 CLI redesign plan
- provide a concise summary and implementation-focused `read_when` entries

## Proof

- `pnpm run lint:docs`
- `git diff --check origin/main...HEAD`
- autoreview clean with no accepted or actionable findings

No changelog entry: this only repairs documentation metadata and unblocks the existing docs lint gate.
