### PR TITLE
fix(window): wait for maximize geometry to settle

### DIFF
--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Keep agent screenshot grounding transient so session checkpoints retain text and tool state without persisting image bytes or local image paths.
 
 ### Fixed
+- Wait for WindowServer to settle after an exact background maximize dispatch before repinning its final bounds, avoiding false failures without relaxing owner-generation checks.
 - Refuse PID-only/app-only background coordinate clicks and require a fresh capture-owned exact-window receipt, with retry-safe pre-dispatch metadata and no mutation invalidation on validation failure.
 - Route automatic window capture around quarantined or contended in-process ScreenCaptureKit calls through a bounded isolated `screencapture` fallback, while explicit modern-only capture still fails honestly.
 - Require explicit `--foreground` before click focus flags can select the foreground path, instead of silently overriding the background default.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Remove the MCP `list` tool, MenuTool’s status-item actions, and agent shims `list_apps`, `list_screens`, and `launch_app`; add `window` action `list` (v4 breaking change).
 
 ### Fixed
+- Wait for WindowServer to settle after an exact background maximize dispatch before repinning its final bounds, avoiding false failures without relaxing owner-generation checks.
 - Coordinate concurrent CLI, agent, GUI-bridge, and daemon desktop reads and mutations with generation-scoped cross-process lanes, preserving parallel work across unrelated exact targets while preventing conflicting background operations from overlapping.
 - Preserve tool response metadata for native agent tools so the Mac activity feed and CLI agent chat show their short summaries, matching external MCP tools.
 - Return all content items from multi-part native tool responses (e.g. `see` with annotation, `analyze`) instead of only the first.

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/WindowManagementService+StateOperations.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/WindowManagementService+StateOperations.swift
@@ -927,6 +927,19 @@ func maximizedVisibleFrame(
     }
 }
 
+func backgroundGeometryDispatchRemainsPinned(
+    expectedIdentity: WindowMutationIdentity,
+    positionSetSucceeded: Bool,
+    sizeSetSucceeded: Bool,
+    liveProcessStartIdentity: UInt64?,
+    candidateWindowID: Int?) -> Bool
+{
+    positionSetSucceeded &&
+        sizeSetSucceeded &&
+        liveProcessStartIdentity == expectedIdentity.ownerProcessStartIdentity &&
+        candidateWindowID == expectedIdentity.windowID
+}
+
 extension CGRect {
     fileprivate var area: CGFloat {
         guard !self.isNull, !self.isInfinite else { return 0 }
@@ -1124,10 +1137,17 @@ private enum BoundedBackgroundWindowAX {
                     childWindow,
                     kAXSizeAttribute as CFString,
                     sizeValue)
-                return positionResult == .success && sizeResult == .success &&
-                    SystemIdentityResolver.repinWindowMutationIdentity(
-                        expectedIdentity,
-                        expectedBounds: bounds) != nil
+                var candidateWindowID: CGWindowID = 0
+                let windowIDResult = AXWindowIDResolver.copyWindowID(
+                    childWindow,
+                    into: &candidateWindowID)
+                return backgroundGeometryDispatchRemainsPinned(
+                    expectedIdentity: expectedIdentity,
+                    positionSetSucceeded: positionResult == .success,
+                    sizeSetSucceeded: sizeResult == .success,
+                    liveProcessStartIdentity: SystemIdentityResolver.processStartIdentity(
+                        expectedIdentity.ownerProcessIdentifier),
+                    candidateWindowID: windowIDResult == .success ? Int(candidateWindowID) : nil)
             }
         }.value
     }

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/WindowStateMutationPolicyTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/WindowStateMutationPolicyTests.swift
@@ -535,6 +535,44 @@ struct WindowStateMutationPolicyTests {
 
         #expect(selected == primary)
     }
+
+    @Test
+    func `maximize dispatch accepts asynchronous final geometry for the pinned window`() {
+        #expect(backgroundGeometryDispatchRemainsPinned(
+            expectedIdentity: self.identity,
+            positionSetSucceeded: true,
+            sizeSetSucceeded: true,
+            liveProcessStartIdentity: 7,
+            candidateWindowID: 924))
+    }
+
+    @Test
+    func `maximize dispatch rejects AX failure or identity replacement`() {
+        #expect(!backgroundGeometryDispatchRemainsPinned(
+            expectedIdentity: self.identity,
+            positionSetSucceeded: false,
+            sizeSetSucceeded: true,
+            liveProcessStartIdentity: 7,
+            candidateWindowID: 924))
+        #expect(!backgroundGeometryDispatchRemainsPinned(
+            expectedIdentity: self.identity,
+            positionSetSucceeded: true,
+            sizeSetSucceeded: false,
+            liveProcessStartIdentity: 7,
+            candidateWindowID: 924))
+        #expect(!backgroundGeometryDispatchRemainsPinned(
+            expectedIdentity: self.identity,
+            positionSetSucceeded: true,
+            sizeSetSucceeded: true,
+            liveProcessStartIdentity: 8,
+            candidateWindowID: 924))
+        #expect(!backgroundGeometryDispatchRemainsPinned(
+            expectedIdentity: self.identity,
+            positionSetSucceeded: true,
+            sizeSetSucceeded: true,
+            liveProcessStartIdentity: 7,
+            candidateWindowID: 925))
+    }
 }
 
 private enum ForegroundCloseTestError: Error {


### PR DESCRIPTION
## Summary

- separate bounded AX maximize dispatch proof from asynchronous WindowServer final-frame verification
- revalidate the exact AX window ID and owner process generation after both geometry setters
- keep the existing two-second exact final-bounds repin as the success gate and cover dispatch replacement failures

## Root cause

The AX position and size setters succeeded, but the immediate WindowServer repin sometimes observed an intermediate frame and returned failure even though the exact window reached the requested visible bounds moments later. The command therefore reported a false failure after successfully maximizing the window.

## Verification

- `swift test --package-path Core/PeekabooAutomationKit --filter WindowStateMutationPolicyTests` (43 tests)
- `pnpm run format`
- `pnpm run lint` (0 serious violations; existing warnings only)
- Foundation Developer-ID-signed arm64 release CLI build
- live signed Playground: reset to `550,132,1200x852`, exact background maximize returned success at `0,30,2300x1055`, and the frontmost application did not change
- autoreview clean
