### PR TITLE
fix(cli): honor explicit bridge for app quit

### DIFF
--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommanderBinder.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommanderBinder.swift
@@ -128,6 +128,12 @@ enum CommanderCLIBinder {
             .trimmingCharacters(in: .whitespacesAndNewlines)
         let hasExplicitBridgeSocket = explicitBridgeSocket?.isEmpty == false ||
             environmentBridgeSocket?.isEmpty == false
+        if commandType == AppCommand.QuitSubcommand.self, hasExplicitBridgeSocket {
+            // Implicit quit routing needs a reusable daemon so the selected host cannot be one
+            // of the applications being quit. An explicit socket is the caller's selected host;
+            // the Bridge server rejects self-quit requests before service dispatch.
+            options.requiresSurvivingApplicationHost = false
+        }
         if commandType == AgentCommand.self,
            !values.flag("no-remote"),
            !hasExplicitBridgeSocket {

--- a/Apps/CLI/Tests/CoreCLITests/RuntimeHostApplicationSelectionTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/RuntimeHostApplicationSelectionTests.swift
@@ -160,6 +160,57 @@ struct RuntimeHostApplicationSelectionTests {
 
     @Test
     @MainActor
+    func `Explicit GUI host can execute pinned application quit`() async throws {
+        let socketPath = "/tmp/peekaboo-gui.sock"
+        let options = try CommanderCLIBinder.makeRuntimeOptions(
+            from: ParsedValues(
+                positional: [],
+                options: ["bridge-socket": [socketPath]],
+                flags: []
+            ),
+            commandType: AppCommand.QuitSubcommand.self
+        )
+        let environmentOptions = try CommanderCLIBinder.makeRuntimeOptions(
+            from: ParsedValues(positional: [], options: [:], flags: []),
+            commandType: AppCommand.QuitSubcommand.self,
+            environment: ["PEEKABOO_BRIDGE_SOCKET": socketPath]
+        )
+        let candidate = RuntimeHostResolver.ImplicitRemoteCandidate(
+            socketPath: socketPath,
+            requireReusableDaemon: false,
+            requiredHostKind: nil,
+            requiresValidatedHistoricalDaemon: false
+        )
+        let operations: [PeekabooBridgeOperation] = [
+            .quitApplication,
+            .invalidateImplicitLatestSnapshot,
+        ]
+        let guiHost = PeekabooBridgeHandshakeResponse(
+            negotiatedVersion: .init(major: 1, minor: 18),
+            hostKind: .gui,
+            build: nil,
+            supportedOperations: operations,
+            enabledOperations: operations
+        )
+
+        #expect(options.bridgeSocketPath == socketPath)
+        #expect(!options.requiresSurvivingApplicationHost)
+        #expect(options.requiresProcessGenerationPinnedApplicationQuit)
+        #expect(!environmentOptions.requiresSurvivingApplicationHost)
+        #expect(CommandRuntime.explicitBridgeSocket(
+            options: environmentOptions,
+            environment: ["PEEKABOO_BRIDGE_SOCKET": socketPath]
+        ) == socketPath)
+        #expect(CommandRuntime.supportsRemoteRequirements(for: guiHost, options: options))
+        #expect(await RuntimeHostResolver.validateRemoteCandidate(
+            candidate,
+            handshake: guiHost,
+            options: options
+        ) != nil)
+    }
+
+    @Test
+    @MainActor
     func `Application inventory prefers GUI host before reusable daemon`() {
         var options = CommandRuntimeOptions()
         options.requiresHostApplicationInventory = true

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer+ServiceHandlers.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer+ServiceHandlers.swift
@@ -1,3 +1,4 @@
+import Darwin
 import Foundation
 import PeekabooAutomationKit
 import PeekabooFoundation
@@ -39,6 +40,9 @@ extension PeekabooBridgeServer {
                 throw PeekabooError.invalidInput(
                     "Bridge application quit requires a process-generation identity " +
                         "(protocol 1.16 or newer); update the client")
+            }
+            guard expectedIdentity.processIdentifier != getpid() else {
+                throw PeekabooError.serviceUnavailable("A runtime host cannot quit itself")
             }
             let success = try await self.services.applications.quitApplication(request: ApplicationQuitRequest(
                 identifier: payload.identifier,

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeQuitIdentityTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeQuitIdentityTests.swift
@@ -151,6 +151,34 @@ struct PeekabooBridgeQuitIdentityTests {
         #expect(await MainActor.run { applications.quitRequests }.isEmpty)
     }
 
+    @Test
+    func `Bridge rejects host self quit before service dispatch`() async throws {
+        let applications = await MainActor.run { StubApplicationService() }
+        let server = await MainActor.run {
+            PeekabooBridgeServer(
+                services: StubServices(applications: applications),
+                hostKind: .gui,
+                allowlistedTeams: [],
+                allowlistedBundles: [])
+        }
+        let request = PeekabooBridgeRequest.quitApplication(PeekabooBridgeQuitAppRequest(
+            identifier: "PID:\(getpid())",
+            force: true,
+            expectedIdentity: .init(
+                processIdentifier: getpid(),
+                processStartIdentity: 456)))
+
+        let response = try await self.response(for: request, server: server)
+
+        guard case let .error(envelope) = response else {
+            Issue.record("Expected host self quit to fail, got \(response)")
+            return
+        }
+        #expect(envelope.code == .operationNotSupported)
+        #expect(envelope.message == "A runtime host cannot quit itself")
+        #expect(await MainActor.run { applications.quitRequests }.isEmpty)
+    }
+
     private func response(
         for request: PeekabooBridgeRequest,
         server: PeekabooBridgeServer) async throws -> PeekabooBridgeResponse


### PR DESCRIPTION
## Summary

- Honor an explicit `--bridge-socket` or `PEEKABOO_BRIDGE_SOCKET` for generation-pinned `app quit`, including capable GUI Bridge hosts.
- Keep implicit quit routing on reusable daemon hosts.
- Reject Bridge self-quit requests before application-service dispatch so an explicitly selected host cannot terminate itself.

## Root cause

Every quit command was marked as requiring a surviving on-demand host. That safety rule was also applied to an explicitly selected GUI socket, even when the GUI host advertised protocol 1.18 `quitApplication`. The resolver rejected the healthy host and silently used process-local services.

## Verification

- `pnpm run format`
- `pnpm run lint` (0 serious violations; existing warnings only)
- `swift test --package-path Apps/CLI -Xswiftc -DPEEKABOO_SKIP_AUTOMATION --filter RuntimeHostApplicationSelectionTests` (8 tests)
- `swift test --package-path Core/PeekabooCore --filter PeekabooBridgeQuitIdentityTests` (6 tests)
- `pnpm run build:cli`
- Structured autoreview: clean, no actionable findings
- Signed live CLI proof against Peekaboo.app protocol 1.18: launched a unique Foundation-signed background probe, quit its exact PID and process-start identity through the explicit GUI socket, observed `Runtime host: remote gui`, verified only the probe exited, and rechecked the GUI Bridge as healthy.
- Signed self-protection proof: an explicitly selected test daemon refused its own generation-pinned quit, remained alive, then stopped cleanly with its test socket removed.

No visible UI changes; screenshots are not meaningful for this routing fix.
