### PR TITLE
fix(agent): update Tachikoma tool error handling

### DIFF
--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Wait for WindowServer to settle after an exact background maximize dispatch before repinning its final bounds, avoiding false failures without relaxing owner-generation checks.
+- Preserve OpenAI Responses tool-error payloads without sending unsupported `failed` statuses that abort the next agent turn.
 - Refuse PID-only/app-only background coordinate clicks and require a fresh capture-owned exact-window receipt, with retry-safe pre-dispatch metadata and no mutation invalidation on validation failure.
 - Route automatic window capture around quarantined or contended in-process ScreenCaptureKit calls through a bounded isolated `screencapture` fallback, while explicit modern-only capture still fails honestly.
 - Require explicit `--foreground` before click focus flags can select the foreground path, instead of silently overriding the background default.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 
 ### Fixed
 - Wait for WindowServer to settle after an exact background maximize dispatch before repinning its final bounds, avoiding false failures without relaxing owner-generation checks.
+- Preserve OpenAI Responses tool-error payloads without sending unsupported `failed` statuses that abort the next agent turn.
 - Coordinate concurrent CLI, agent, GUI-bridge, and daemon desktop reads and mutations with generation-scoped cross-process lanes, preserving parallel work across unrelated exact targets while preventing conflicting background operations from overlapping.
 - Preserve tool response metadata for native agent tools so the Mac activity feed and CLI agent chat show their short summaries, matching external MCP tools.
 - Return all content items from multi-part native tool responses (e.g. `see` with annotation, `analyze`) instead of only the first.


### PR DESCRIPTION
## Summary

- advance Tachikoma from `2ba00c869abb195209bd2a6633b0df6612ba17ea` to `28869625b63dcfaf7dd82b24a3283eabfdd17c8d`
- consume upstream Tachikoma PR #48 so errored OpenAI Responses tool outputs retain their diagnostic payload without sending unsupported `status: "failed"`
- include the intervening optional-tool-parameter preservation fix from Tachikoma PR #47
- document the agent fix in both Peekaboo changelogs

## Reproduction

The installed agent reached an errored tool result and the next Responses request failed before further UI work with:

> Invalid value: 'failed'. Supported values are: 'in_progress', 'completed', and 'incomplete'.

Peekaboo `main` still pinned Tachikoma before the already-landed upstream fix.

## Proof

- `swift test --package-path Tachikoma --filter OpenAIResponsesProviderTests --no-parallel` — 36 passed
- `swift test --package-path Tachikoma --no-parallel` — 806 provider/core and 43 MCP tests passed
- `pnpm run build:cli`
- `swift test --package-path Core/PeekabooCore --filter AgentExecutionTraceTests --no-parallel` — 3 passed
- `pnpm run test:safe` — release-script checks plus 711 CLI and 72 runtime tests passed
- `pnpm run lint` — passed with existing warnings only
- `pnpm run lint:docs`
- scoped autoreview of Tachikoma `2ba00c8..2886962` and the Peekaboo changelog diff — no actionable findings
