### PR TITLE
fix(window): accept verified background restore completion

### DIFF
--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bind destructive window mutations to immutable capture-time bounds, reject owner-generation or bounds drift, repin intended geometry transitions, and refuse Bridge hosts that would ignore the stronger receipt.
 - Fail closed when exact window selection or capture receipts drift, remove bounds-only minimized-window fallbacks, quarantine timed-out OCR until native work exits, and keep transient agent images correlated and execution-owned.
 - Keep minimized exact PID/window-ID targets addressable through bounded AX inventory, add native background `window restore` to CLI/MCP/Bridge, and make default minimized close return restore-or-`--foreground` guidance.
+- Let background `window restore` accept a successful native unminimize once the same exact window ID, owner process generation, and original bounds reappear, instead of failing on transient AX readback.
 - Treat WindowServer disappearance as valid after AX-verified minimize and close minimized exact windows through a bounded non-activating AX restore/close path.
 - Re-minimize a temporarily restored exact window before returning any failed or indeterminate minimized-close result.
 - Make background screenshot, observation, and live-capture paths visualizer-silent, including multi-display and menu-bar OCR fallbacks, while preserving explicit foreground feedback.

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/WindowCommand+State.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/WindowCommand+State.swift
@@ -191,10 +191,12 @@ extension WindowCommand {
                     reason: "window restore"
                 )
 
-                let refreshedWindow = try await WindowServiceBridge.listWindows(
-                    windows: self.services.windows,
-                    target: exactTarget
-                ).first ?? windowInfo
+                let refreshedWindow = await restoredWindowOutputInfo(original: windowInfo) {
+                    try await WindowServiceBridge.listWindows(
+                        windows: self.services.windows,
+                        target: exactTarget
+                    ).first
+                }
                 logWindowAction(action: "restore", appName: appName, windowInfo: refreshedWindow)
                 let data = createWindowActionResult(
                     action: "restore",
@@ -326,4 +328,14 @@ extension WindowCommand {
             }
         }
     }
+}
+
+@MainActor
+func restoredWindowOutputInfo(
+    original: ServiceWindowInfo,
+    refresh: @MainActor () async throws -> ServiceWindowInfo?
+) async -> ServiceWindowInfo {
+    // The service has already repinned the exact restored window. Public/AX inventory can
+    // still omit it briefly, so a display-only refresh must not turn success into failure.
+    await (try? refresh()) ?? original
 }

--- a/Apps/CLI/Tests/CoreCLITests/WindowRestoreOutputTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/WindowRestoreOutputTests.swift
@@ -1,0 +1,38 @@
+import CoreGraphics
+import PeekabooCore
+import PeekabooFoundation
+import Testing
+@testable import PeekabooCLI
+
+@MainActor
+struct WindowRestoreOutputTests {
+    private let original = ServiceWindowInfo(
+        windowID: 101,
+        title: "Fixture",
+        bounds: CGRect(x: 10, y: 20, width: 640, height: 480),
+        isMinimized: true
+    )
+
+    @Test
+    func `transient post-restore inventory failure preserves successful output`() async {
+        let selected = await restoredWindowOutputInfo(original: self.original) {
+            throw PeekabooError.windowNotFound(criteria: "windowId 101")
+        }
+
+        #expect(selected == self.original)
+    }
+
+    @Test
+    func `available post-restore inventory replaces stale display metadata`() async {
+        let refreshed = ServiceWindowInfo(
+            windowID: 101,
+            title: "Restored Fixture",
+            bounds: self.original.bounds,
+            isMinimized: false
+        )
+
+        let selected = await restoredWindowOutputInfo(original: self.original) { refreshed }
+
+        #expect(selected == refreshed)
+    }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 - Reject queued window mutations when the selected CGWindowID or owner PID generation has disappeared or been recycled, and report minimized windows from live AX state.
 - Bind destructive window mutations to immutable capture-time bounds, reject same-process CGWindowID reuse, repin intended geometry transitions, and refuse Bridge hosts that would ignore the stronger receipt.
 - Keep minimized exact PID/window-ID targets addressable through bounded AX inventory, add native background `window restore` to CLI/MCP/Bridge, and make default minimized close return restore-or-`--foreground` guidance.
+- Let background `window restore` accept a successful native unminimize once the same exact window ID, owner process generation, and original bounds reappear, instead of failing on transient AX readback.
 - Verify minimize from the original AX window when WindowServer hides it, and close minimized exact windows without activating their app.
 - Restore minimized privacy state before returning when a background close cannot be verified.
 - Keep agent JSON output machine-readable and refuse terminal text that impersonates an unexecuted tool call.

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/WindowManagementService+StateOperations.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/WindowManagementService+StateOperations.swift
@@ -69,7 +69,7 @@ extension WindowManagementService {
                         wasMinimized: expectedIdentity.isMinimized == true,
                         closeCompleted: false)
                     {
-                        _ = await BoundedBackgroundWindowAX.restoreMinimizedState(expectedIdentity: expectedIdentity)
+                        _ = try? await self.restorePinnedMinimizedWindow(expectedIdentity)
                     }
                     throw error
                 }
@@ -88,8 +88,13 @@ extension WindowManagementService {
             try await withMinimizedWindowFailureRecovery(
                 wasMinimized: expectedIdentity.isMinimized == true,
                 restore: {
-                    let restored = await BoundedBackgroundWindowAX.restoreMinimizedState(
-                        expectedIdentity: expectedIdentity)
+                    let restored: Bool
+                    do {
+                        try await self.restorePinnedMinimizedWindow(expectedIdentity)
+                        restored = true
+                    } catch {
+                        restored = false
+                    }
                     if !restored {
                         let message = "Could not restore minimized state after foreground close failure. " +
                             "windowID=\(trackedWindowID)"
@@ -167,18 +172,7 @@ extension WindowManagementService {
         try await self.operationLaneCoordinator.run(scope: .window(expectedIdentity), access: .write) {
             try self.validatePinnedWindowMutation(target: target, expectedIdentity: expectedIdentity)
             if expectedIdentity.isMinimized == true {
-                guard await BoundedBackgroundWindowAX.restoreMinimizedState(expectedIdentity: expectedIdentity) else {
-                    throw OperationError.interactionFailed(
-                        action: "restore window",
-                        reason: "Window restore operation failed or the exact minimized receipt became ambiguous")
-                }
-                guard let capturedBounds = expectedIdentity.capturedBounds else {
-                    throw PeekabooError.commandFailed(
-                        "Window \(expectedIdentity.windowID) restore receipt lacks capture-time bounds")
-                }
-                _ = try await self.waitForRepinnedWindowMutation(
-                    expectedIdentity,
-                    expectedBounds: capturedBounds)
+                try await self.restorePinnedMinimizedWindow(expectedIdentity)
                 return
             }
             let window = try await self.element(for: target)
@@ -203,6 +197,17 @@ extension WindowManagementService {
                     "Window \(expectedIdentity.windowID) did not reach verified restored state")
             }
         }
+    }
+
+    private func restorePinnedMinimizedWindow(_ expectedIdentity: WindowMutationIdentity) async throws {
+        _ = try await completePinnedMinimizedWindowRestore(
+            expectedIdentity: expectedIdentity,
+            dispatch: {
+                await BoundedBackgroundWindowAX.dispatchMinimizedRestore(expectedIdentity: expectedIdentity)
+            },
+            repin: { identity, expectedBounds in
+                try await self.waitForRepinnedWindowMutation(identity, expectedBounds: expectedBounds)
+            })
     }
 
     public func maximizeWindow(target: WindowTarget) async throws {
@@ -835,6 +840,38 @@ func pinnedWindowRestoreIdentityMatches(
         currentBounds == expectedIdentity.capturedBounds
 }
 
+@MainActor
+func completePinnedMinimizedWindowRestore(
+    expectedIdentity: WindowMutationIdentity,
+    dispatch: @MainActor () async -> Bool,
+    repin: @MainActor (WindowMutationIdentity, CGRect) async throws -> WindowMutationIdentity) async throws
+    -> WindowMutationIdentity
+{
+    guard expectedIdentity.isMinimized == true,
+          let capturedBounds = expectedIdentity.capturedBounds
+    else {
+        throw PeekabooError.commandFailed(
+            "Window \(expectedIdentity.windowID) restore receipt lacks minimized state or capture-time bounds")
+    }
+    guard await dispatch() else {
+        throw OperationError.interactionFailed(
+            action: "restore window",
+            reason: "Window restore operation failed or the exact minimized receipt became ambiguous")
+    }
+
+    let restoredIdentity = try await repin(expectedIdentity, capturedBounds)
+    guard restoredIdentity.windowID == expectedIdentity.windowID,
+          restoredIdentity.ownerProcessIdentifier == expectedIdentity.ownerProcessIdentifier,
+          restoredIdentity.ownerProcessStartIdentity == expectedIdentity.ownerProcessStartIdentity,
+          restoredIdentity.capturedBounds == capturedBounds,
+          restoredIdentity.isMinimized == false
+    else {
+        throw PeekabooError.commandFailed(
+            "Window \(expectedIdentity.windowID) became ambiguous after restore dispatch")
+    }
+    return restoredIdentity
+}
+
 func exactWindowIDForStateMutation(
     target: WindowTarget,
     resolvedWindows: [ServiceWindowInfo]) throws -> Int
@@ -958,10 +995,9 @@ private enum BoundedBackgroundWindowAX {
         }.value
     }
 
-    static func restoreMinimizedState(expectedIdentity: WindowMutationIdentity) async -> Bool {
+    static func dispatchMinimizedRestore(expectedIdentity: WindowMutationIdentity) async -> Bool {
         await Task.detached(priority: .userInitiated) {
             guard expectedIdentity.isMinimized == true,
-                  let capturedBounds = expectedIdentity.capturedBounds,
                   let windowID = CGWindowID(exactly: expectedIdentity.windowID),
                   SystemIdentityResolver.validateWindowMutationOwnerGeneration(expectedIdentity),
                   self.windowServerAllowsExactMinimizedRestore(
@@ -991,20 +1027,12 @@ private enum BoundedBackgroundWindowAX {
                 else {
                     return false
                 }
-                guard AXUIElementSetAttributeValue(
+                // AX state readback can lag a successful write. The caller verifies completion by
+                // repinning the exact WindowServer ID, owner generation, and captured bounds.
+                return AXUIElementSetAttributeValue(
                     childWindow,
                     kAXMinimizedAttribute as CFString,
-                    kCFBooleanFalse) == .success,
-                    SystemIdentityResolver.processStartIdentity(expectedIdentity.ownerProcessIdentifier) ==
-                    expectedIdentity.ownerProcessStartIdentity,
-                    AXWindowIDResolver.copyWindowID(childWindow, into: &candidateID) == .success,
-                    candidateID == windowID,
-                    self.bounds(of: childWindow) == capturedBounds,
-                    self.boolAttribute(kAXMinimizedAttribute as String, of: childWindow) == false
-                else {
-                    return false
-                }
-                return true
+                    kCFBooleanFalse) == .success
             }
         }.value
     }

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/WindowStateMutationPolicyTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/WindowStateMutationPolicyTests.swift
@@ -243,6 +243,70 @@ struct WindowStateMutationPolicyTests {
     }
 
     @Test
+    @MainActor
+    func `restore accepts exact same ID reappearance after asynchronous AX state reflection`() async throws {
+        let expected = self.identity.withMinimizedState(true)
+        let restored = self.identity.withMinimizedState(false)
+        let synchronousAXStillReportedMinimized = true
+
+        let result = try await completePinnedMinimizedWindowRestore(
+            expectedIdentity: expected,
+            dispatch: {
+                #expect(synchronousAXStillReportedMinimized)
+                return true
+            },
+            repin: { receipt, bounds in
+                #expect(receipt == expected)
+                #expect(bounds == expected.capturedBounds)
+                return restored
+            })
+
+        #expect(result == restored)
+    }
+
+    @Test
+    @MainActor
+    func `restore rejects ambiguous reappearance ownership generation and bounds`() async {
+        let expected = self.identity.withMinimizedState(true)
+        let ambiguousCandidates = [
+            WindowMutationIdentity(
+                windowID: 925,
+                ownerProcessIdentifier: 42,
+                ownerProcessStartIdentity: 7,
+                capturedBounds: expected.capturedBounds,
+                isMinimized: false),
+            WindowMutationIdentity(
+                windowID: 924,
+                ownerProcessIdentifier: 43,
+                ownerProcessStartIdentity: 7,
+                capturedBounds: expected.capturedBounds,
+                isMinimized: false),
+            WindowMutationIdentity(
+                windowID: 924,
+                ownerProcessIdentifier: 42,
+                ownerProcessStartIdentity: 8,
+                capturedBounds: expected.capturedBounds,
+                isMinimized: false),
+            WindowMutationIdentity(
+                windowID: 924,
+                ownerProcessIdentifier: 42,
+                ownerProcessStartIdentity: 7,
+                capturedBounds: CGRect(x: 50, y: 60, width: 700, height: 500),
+                isMinimized: false),
+            expected,
+        ]
+
+        for candidate in ambiguousCandidates {
+            await #expect(throws: PeekabooError.self) {
+                try await completePinnedMinimizedWindowRestore(
+                    expectedIdentity: expected,
+                    dispatch: { true },
+                    repin: { _, _ in candidate })
+            }
+        }
+    }
+
+    @Test
     func `minimized restoration rejects process generation change`() {
         #expect(!exactMinimizedRestoreCandidateIsValid(
             expectedIdentity: self.identity.withMinimizedState(true),


### PR DESCRIPTION
## Summary

- treat a successful exact-window AX unminimize as dispatch, then verify completion through the authoritative WindowServer repin path
- keep restore fail-closed on window ID, owner PID generation, original bounds, and final non-minimized state
- prevent a transient display-only inventory miss after verified restore from turning CLI success into `WINDOW_NOT_FOUND`
- document the user-visible restore reliability fix in both changelogs

## Root cause

macOS can apply `AXMinimized = false` before Accessibility readback and the public/AX window inventory settle. Peekaboo performed synchronous post-write reads and the CLI performed one mandatory display refresh, so either transient could report failure after the exact window had already reappeared at its original bounds.

## Proof

- `swift test --package-path Core/PeekabooAutomationKit --no-parallel`
- `swift test --package-path Apps/CLI --filter WindowRestoreOutputTests --no-parallel`
- SwiftFormat lint on all changed Swift files
- strict SwiftLint on all changed Swift files
- signed local CLI plus a distinct signed Playground fixture: 20/20 pre-rebase and 8/8 post-rebase exact background minimize/restore cycles, same window ID and bounds, unchanged frontmost app
- source-blind post-rebase validation: 6/6 cycles, including inventory-settle retries and a missing-ID no-mutation probe
- final autoreview clean with no accepted/actionable findings

No AppleScript path is involved.
