### PR TITLE
ci: upgrade macOS runners to macos-26 / Xcode 26.6

### DIFF
--- a/.github/workflows/commander-multiplatform.yml
+++ b/.github/workflows/commander-multiplatform.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   macos-host:
-    runs-on: macos-15
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@v7
         with:
@@ -26,7 +26,7 @@ jobs:
         run: swift test
 
   apple-simulators:
-    runs-on: macos-15
+    runs-on: macos-26
     needs: macos-host
     strategy:
       matrix:

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   peekaboo-core:
     name: PeekabooCore build & tests
-    runs-on: macos-15
+    runs-on: macos-26
     env:
       PEEKABOO_INCLUDE_AUTOMATION_TESTS: "false"
       RUN_AUTOMATION_TESTS: "false"
@@ -32,10 +32,10 @@ jobs:
       - name: Docs lint
         run: node scripts/docs-lint.mjs
 
-      - name: Select Xcode 26.2 (if present) or fallback to default
+      - name: Select Xcode 26.6 (if present) or fallback to default
         run: |
           set -euo pipefail
-          for candidate in /Applications/Xcode_26.2.app /Applications/Xcode_26.1.app /Applications/Xcode_26.0.app /Applications/Xcode_16.4.app /Applications/Xcode_16.3.app /Applications/Xcode.app; do
+          for candidate in /Applications/Xcode_26.6.app /Applications/Xcode_26.5.app /Applications/Xcode_26.4.1.app /Applications/Xcode_26.3.app /Applications/Xcode_26.2.app /Applications/Xcode.app; do
             if [[ -d "$candidate" ]]; then
               sudo xcode-select -s "$candidate"
               echo "DEVELOPER_DIR=${candidate}/Contents/Developer" >> "$GITHUB_ENV"
@@ -132,7 +132,7 @@ jobs:
 
   peekaboo-cli:
     name: Peekaboo CLI build & tests
-    runs-on: macos-15
+    runs-on: macos-26
     needs: peekaboo-core
     env:
       PEEKABOO_INCLUDE_AUTOMATION_TESTS: "false"
@@ -143,10 +143,10 @@ jobs:
           submodules: recursive
           fetch-depth: 1
 
-      - name: Select Xcode 26.2 (if present) or fallback to default
+      - name: Select Xcode 26.6 (if present) or fallback to default
         run: |
           set -euo pipefail
-          for candidate in /Applications/Xcode_26.2.app /Applications/Xcode_26.1.app /Applications/Xcode_26.0.app /Applications/Xcode_16.4.app /Applications/Xcode_16.3.app /Applications/Xcode.app; do
+          for candidate in /Applications/Xcode_26.6.app /Applications/Xcode_26.5.app /Applications/Xcode_26.4.1.app /Applications/Xcode_26.3.app /Applications/Xcode_26.2.app /Applications/Xcode.app; do
             if [[ -d "$candidate" ]]; then
               sudo xcode-select -s "$candidate"
               echo "DEVELOPER_DIR=${candidate}/Contents/Developer" >> "$GITHUB_ENV"
@@ -249,7 +249,7 @@ jobs:
 
   tachikoma:
     name: Tachikoma build & tests
-    runs-on: macos-15
+    runs-on: macos-26
     needs: peekaboo-cli
     env:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
@@ -260,10 +260,10 @@ jobs:
           submodules: recursive
           fetch-depth: 1
 
-      - name: Select Xcode 26.2 (if present) or fallback to default
+      - name: Select Xcode 26.6 (if present) or fallback to default
         run: |
           set -euo pipefail
-          for candidate in /Applications/Xcode_26.2.app /Applications/Xcode_26.1.app /Applications/Xcode_26.0.app /Applications/Xcode_16.4.app /Applications/Xcode_16.3.app /Applications/Xcode.app; do
+          for candidate in /Applications/Xcode_26.6.app /Applications/Xcode_26.5.app /Applications/Xcode_26.4.1.app /Applications/Xcode_26.3.app /Applications/Xcode_26.2.app /Applications/Xcode.app; do
             if [[ -d "$candidate" ]]; then
               sudo xcode-select -s "$candidate"
               echo "DEVELOPER_DIR=${candidate}/Contents/Developer" >> "$GITHUB_ENV"
@@ -360,7 +360,7 @@ jobs:
 
   mac-apps:
     name: Build macOS apps (Peekaboo + Inspector)
-    runs-on: macos-15
+    runs-on: macos-26
     needs: [peekaboo-cli, tachikoma]
     steps:
       - uses: actions/checkout@v7
@@ -368,10 +368,10 @@ jobs:
           submodules: recursive
           fetch-depth: 1
 
-      - name: Select Xcode 26.2 (if present) or fallback to default
+      - name: Select Xcode 26.6 (if present) or fallback to default
         run: |
           set -euo pipefail
-          for candidate in /Applications/Xcode_26.2.app /Applications/Xcode_26.1.app /Applications/Xcode_26.0.app /Applications/Xcode_16.4.app /Applications/Xcode_16.3.app /Applications/Xcode.app; do
+          for candidate in /Applications/Xcode_26.6.app /Applications/Xcode_26.5.app /Applications/Xcode_26.4.1.app /Applications/Xcode_26.3.app /Applications/Xcode_26.2.app /Applications/Xcode.app; do
             if [[ -d "$candidate" ]]; then
               sudo xcode-select -s "$candidate"
               echo "DEVELOPER_DIR=${candidate}/Contents/Developer" >> "$GITHUB_ENV"
@@ -420,7 +420,7 @@ jobs:
 
   lint:
     name: SwiftLint (core + CLI)
-    runs-on: macos-15
+    runs-on: macos-26
     needs: [peekaboo-cli, tachikoma, mac-apps]
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/macos26-artifact-smoke.yml
+++ b/.github/workflows/macos26-artifact-smoke.yml
@@ -1,4 +1,4 @@
-name: macOS 15 extracted-artifact smoke
+name: macOS 26 extracted-artifact smoke
 
 on:
   workflow_dispatch:
@@ -8,17 +8,17 @@ permissions:
 
 jobs:
   extracted-artifact-smoke:
-    runs-on: macos-15
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@v7
         with:
           submodules: recursive
           fetch-depth: 1
 
-      - name: Select Xcode 26.2 (if present) or fallback to default
+      - name: Select Xcode 26.6 (if present) or fallback to default
         run: |
           set -euo pipefail
-          for candidate in /Applications/Xcode_26.2.app /Applications/Xcode_26.1.app /Applications/Xcode_26.0.app /Applications/Xcode_16.4.app /Applications/Xcode.app; do
+          for candidate in /Applications/Xcode_26.6.app /Applications/Xcode_26.5.app /Applications/Xcode_26.4.1.app /Applications/Xcode_26.3.app /Applications/Xcode_26.2.app /Applications/Xcode.app; do
             if [[ -d "$candidate" ]]; then
               sudo xcode-select -s "$candidate"
               break


### PR DESCRIPTION
Upgrades CI to the modern toolchain:

- `runs-on: macos-15` -> `macos-26` (macOS 26.6 image) for all macOS jobs in macos-ci, artifact smoke, and Commander multiplatform workflows
- Xcode selection cascade now prefers 26.6 -> 26.5 -> 26.4.1 -> 26.3 -> 26.2 -> default (the macos-26 image ships 26.6 as default; the old 16.x fallbacks no longer exist on the image)
- Renamed the dispatch-only artifact-smoke workflow to match (macos26-artifact-smoke)

Context: the macos-15 image tops out at Xcode 26.3 and defaults to 16.4; we were pinning 26.2. Local baseline is macOS 26.x/arm64, so this closes the CI/local gap. Also relevant: we just worked around a Swift 6.2.3 (Xcode 26.2) SILGen crash in CLIAutomationTests - a newer toolchain narrows exposure to that class of bug.

This PR's own CI run is the validation that main builds green on the new image.
