### PR TITLE
fix(window): reject transient restore thumbnail bounds

### DIFF
--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -43,7 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bind destructive window mutations to immutable capture-time bounds, reject owner-generation or bounds drift, repin intended geometry transitions, and refuse Bridge hosts that would ignore the stronger receipt.
 - Fail closed when exact window selection or capture receipts drift, remove bounds-only minimized-window fallbacks, quarantine timed-out OCR until native work exits, and keep transient agent images correlated and execution-owned.
 - Keep minimized exact PID/window-ID targets addressable through bounded AX inventory, add native background `window restore` to CLI/MCP/Bridge, and make default minimized close return restore-or-`--foreground` guidance.
-- Let background `window restore` accept a successful native unminimize once the same exact window ID, owner process generation, and original bounds reappear, instead of failing on transient AX readback.
+- Let background `window restore` accept a successful native unminimize once the same exact window ID, owner process generation, and original bounds reappear, and keep its output pinned to those verified bounds while public inventory settles.
 - Treat WindowServer disappearance as valid after AX-verified minimize and close minimized exact windows through a bounded non-activating AX restore/close path.
 - Re-minimize a temporarily restored exact window before returning any failed or indeterminate minimized-close result.
 - Make background screenshot, observation, and live-capture paths visualizer-silent, including multi-display and menu-bar OCR fallbacks, while preserving explicit foreground feedback.

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/WindowCommand+State.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/WindowCommand+State.swift
@@ -197,7 +197,11 @@ extension WindowCommand {
                         target: exactTarget
                     ).first
                 }
-                logWindowAction(action: "restore", appName: appName, windowInfo: refreshedWindow)
+                logWindowAction(
+                    action: "restore",
+                    appName: appName,
+                    windowInfo: refreshedWindow
+                )
                 let data = createWindowActionResult(
                     action: "restore",
                     success: true,
@@ -205,7 +209,7 @@ extension WindowCommand {
                     appName: appName
                 )
                 output(data) {
-                    print("Successfully restored window '\(refreshedWindow.title)' of \(appName)")
+                    print("Successfully restored window '\(refreshedWindow?.title ?? windowInfo.title)' of \(appName)")
                 }
             } catch {
                 handleError(error)
@@ -333,9 +337,34 @@ extension WindowCommand {
 @MainActor
 func restoredWindowOutputInfo(
     original: ServiceWindowInfo,
+    tolerance: CGFloat = 1,
     refresh: @MainActor () async throws -> ServiceWindowInfo?
-) async -> ServiceWindowInfo {
+) async -> ServiceWindowInfo? {
+    guard let expectedIdentity = original.mutationIdentity,
+          expectedIdentity.windowID == original.windowID,
+          expectedIdentity.isMinimized == original.isMinimized,
+          let expectedBounds = expectedIdentity.capturedBounds,
+          windowFramesMatch(original.bounds, expectedBounds, tolerance: tolerance)
+    else {
+        return nil
+    }
+
     // The service has already repinned the exact restored window. Public/AX inventory can
-    // still omit it briefly, so a display-only refresh must not turn success into failure.
-    await (try? refresh()) ?? original
+    // still omit it briefly or expose its Dock thumbnail, so accept refresh metadata only
+    // when its complete identity receipt matches the verified restore receipt.
+    guard let refreshed = try? await refresh(),
+          let refreshedIdentity = refreshed.mutationIdentity,
+          refreshed.windowID == expectedIdentity.windowID,
+          refreshedIdentity.windowID == expectedIdentity.windowID,
+          refreshedIdentity.ownerProcessIdentifier == expectedIdentity.ownerProcessIdentifier,
+          refreshedIdentity.ownerProcessStartIdentity == expectedIdentity.ownerProcessStartIdentity,
+          refreshed.isMinimized == false,
+          refreshedIdentity.isMinimized == false,
+          let refreshedBounds = refreshedIdentity.capturedBounds,
+          windowFramesMatch(refreshed.bounds, expectedBounds, tolerance: tolerance),
+          windowFramesMatch(refreshedBounds, expectedBounds, tolerance: tolerance)
+    else {
+        return original
+    }
+    return refreshed
 }

--- a/Apps/CLI/Tests/CoreCLITests/WindowRestoreOutputTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/WindowRestoreOutputTests.swift
@@ -6,12 +6,22 @@ import Testing
 
 @MainActor
 struct WindowRestoreOutputTests {
-    private let original = ServiceWindowInfo(
-        windowID: 101,
-        title: "Fixture",
-        bounds: CGRect(x: 10, y: 20, width: 640, height: 480),
-        isMinimized: true
-    )
+    private var original: ServiceWindowInfo {
+        let bounds = CGRect(x: 10, y: 20, width: 640, height: 480)
+        return ServiceWindowInfo(
+            windowID: 101,
+            title: "Fixture",
+            bounds: bounds,
+            isMinimized: true,
+            mutationIdentity: WindowMutationIdentity(
+                windowID: 101,
+                ownerProcessIdentifier: 42,
+                ownerProcessStartIdentity: 7,
+                capturedBounds: bounds,
+                isMinimized: true
+            )
+        )
+    }
 
     @Test
     func `transient post-restore inventory failure preserves successful output`() async {
@@ -23,16 +33,102 @@ struct WindowRestoreOutputTests {
     }
 
     @Test
-    func `available post-restore inventory replaces stale display metadata`() async {
+    func `matching post-restore identity replaces stale display metadata within tolerance`() async {
+        let restoredBounds = CGRect(x: 10.5, y: 19.5, width: 640.5, height: 479.5)
         let refreshed = ServiceWindowInfo(
             windowID: 101,
             title: "Restored Fixture",
-            bounds: self.original.bounds,
-            isMinimized: false
+            bounds: restoredBounds,
+            isMinimized: false,
+            mutationIdentity: WindowMutationIdentity(
+                windowID: 101,
+                ownerProcessIdentifier: 42,
+                ownerProcessStartIdentity: 7,
+                capturedBounds: restoredBounds,
+                isMinimized: false
+            )
         )
 
         let selected = await restoredWindowOutputInfo(original: self.original) { refreshed }
 
         #expect(selected == refreshed)
+    }
+
+    @Test
+    func `Dock thumbnail refresh never replaces verified restored bounds`() async {
+        let thumbnailBounds = CGRect(x: 1694, y: 1039, width: 40, height: 81)
+        let thumbnail = ServiceWindowInfo(
+            windowID: 101,
+            title: "Fixture",
+            bounds: thumbnailBounds,
+            isMinimized: false,
+            mutationIdentity: WindowMutationIdentity(
+                windowID: 101,
+                ownerProcessIdentifier: 42,
+                ownerProcessStartIdentity: 7,
+                capturedBounds: thumbnailBounds,
+                isMinimized: false
+            )
+        )
+
+        let selected = await restoredWindowOutputInfo(original: self.original) { thumbnail }
+
+        #expect(selected == self.original)
+    }
+
+    @Test
+    func `changed owner generation never replaces verified restored identity`() async {
+        let replacement = ServiceWindowInfo(
+            windowID: 101,
+            title: "Replacement",
+            bounds: self.original.bounds,
+            isMinimized: false,
+            mutationIdentity: WindowMutationIdentity(
+                windowID: 101,
+                ownerProcessIdentifier: 42,
+                ownerProcessStartIdentity: 8,
+                capturedBounds: self.original.bounds,
+                isMinimized: false
+            )
+        )
+
+        let selected = await restoredWindowOutputInfo(original: self.original) { replacement }
+
+        #expect(selected == self.original)
+    }
+
+    @Test
+    func `unverified original receipt omits restore bounds honestly`() async {
+        let unverified = ServiceWindowInfo(
+            windowID: 101,
+            title: "Fixture",
+            bounds: self.original.bounds,
+            isMinimized: true
+        )
+
+        let selected = await restoredWindowOutputInfo(original: unverified) { self.original }
+
+        #expect(selected == nil)
+    }
+
+    @Test
+    func `idempotent visible restore retains its verified original receipt`() async {
+        let visible = ServiceWindowInfo(
+            windowID: 101,
+            title: "Fixture",
+            bounds: self.original.bounds,
+            isMinimized: false,
+            mutationIdentity: WindowMutationIdentity(
+                windowID: 101,
+                ownerProcessIdentifier: 42,
+                ownerProcessStartIdentity: 7,
+                capturedBounds: self.original.bounds,
+                isMinimized: false
+            )
+        )
+
+        let selected = await restoredWindowOutputInfo(original: visible) { nil }
+
+        #expect(selected == visible)
     }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@
 - Reject queued window mutations when the selected CGWindowID or owner PID generation has disappeared or been recycled, and report minimized windows from live AX state.
 - Bind destructive window mutations to immutable capture-time bounds, reject same-process CGWindowID reuse, repin intended geometry transitions, and refuse Bridge hosts that would ignore the stronger receipt.
 - Keep minimized exact PID/window-ID targets addressable through bounded AX inventory, add native background `window restore` to CLI/MCP/Bridge, and make default minimized close return restore-or-`--foreground` guidance.
-- Let background `window restore` accept a successful native unminimize once the same exact window ID, owner process generation, and original bounds reappear, instead of failing on transient AX readback.
+- Let background `window restore` accept a successful native unminimize once the same exact window ID, owner process generation, and original bounds reappear, and keep its output pinned to those verified bounds while public inventory settles.
 - Verify minimize from the original AX window when WindowServer hides it, and close minimized exact windows without activating their app.
 - Restore minimized privacy state before returning when a background close cannot be verified.
 - Keep agent JSON output machine-readable and refuse terminal text that impersonates an unexecuted tool call.


### PR DESCRIPTION
## Summary

- reject post-restore refresh metadata unless its exact window ID, owner process generation, restored state, and bounds match the verified restore receipt within one point
- retain the verified original receipt while public inventory is missing or exposes a Dock-animation thumbnail; omit bounds only when the original receipt itself is unverifiable
- cover the observed `40x81` Dock-thumbnail frame, identity drift, bounded rounding tolerance, inventory misses, and idempotent visible restore
- clarify the restore-output guarantee in both changelogs

## Root cause

After a verified background restore, public window inventory can briefly expose the exact CG window ID at its animated Dock-thumbnail frame. The CLI's best-effort display refresh accepted that same-ID descriptor without checking its owner-generation and bounds receipt, so a successful restore could report a tiny Dock-positioned `new_bounds` value.

## Proof

- `swift test --package-path Apps/CLI --filter WindowRestoreOutputTests --no-parallel` — 6/6
- `pnpm run test:safe` — 718 unit tests and 72 runtime tests passed
- strict SwiftLint and SwiftFormat on changed Swift files
- signed CLI through the explicit GUI Bridge with a distinct signed Playground fixture: 10/10 restore receipts retained the verified `1200x852` frame while 4 immediate public listings were transient
- source-blind GUI-Bridge validation: 6/6 restores, including 2 immediate inventory misses; every receipt retained verified bounds and the target stayed inactive
- missing exact-ID probe failed without changing the controlled target
- final autoreview clean with no accepted/actionable findings

No AppleScript path is involved.
