### PR TITLE
fix(agent): expose verify-state predicate schema

### DIFF
--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/Agent/PeekabooAgentService+ToolSchema.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/Agent/PeekabooAgentService+ToolSchema.swift
@@ -47,14 +47,7 @@ extension PeekabooAgentService {
 
         // MCP schemas can express unions with anyOf/oneOf and no top-level type.
         // Keep those properties visible so strict providers do not see orphan required entries.
-        let paramType: AgentToolParameterProperty.ParameterType = if case let .string(typeStr) = propDict["type"],
-                                                                     let resolved = AgentToolParameterProperty
-                                                                         .ParameterType(rawValue: typeStr)
-        {
-            resolved
-        } else {
-            .string
-        }
+        let paramType = self.parameterType(from: propDict)
 
         let description = self.descriptionValue(from: propDict["description"])
         let enumValues = self.enumValues(from: propDict["enum"])
@@ -95,17 +88,35 @@ extension PeekabooAgentService {
             return AgentToolParameterItems(type: AgentToolParameterProperty.ParameterType.string.rawValue)
         }
 
-        let itemType: AgentToolParameterProperty.ParameterType = if case let .string(typeString) = itemsDict["type"],
-                                                                    let resolved = AgentToolParameterProperty
-                                                                        .ParameterType(rawValue: typeString)
-        {
-            resolved
-        } else {
-            .string
-        }
+        let itemType = self.parameterType(from: itemsDict)
 
         return AgentToolParameterItems(
             type: itemType.rawValue,
             description: self.descriptionValue(from: itemsDict["description"]))
+    }
+
+    private func parameterType(
+        from schema: [String: Value],
+        fallback: AgentToolParameterProperty.ParameterType = .string)
+        -> AgentToolParameterProperty.ParameterType
+    {
+        if case let .string(typeString) = schema["type"],
+           let resolved = AgentToolParameterProperty.ParameterType(rawValue: typeString)
+        {
+            return resolved
+        }
+
+        for unionKey in ["oneOf", "anyOf"] {
+            guard case let .array(variants) = schema[unionKey] else { continue }
+            let types = Set(variants.compactMap { variant -> AgentToolParameterProperty.ParameterType? in
+                guard case let .object(variantSchema) = variant else { return nil }
+                return self.parameterType(from: variantSchema)
+            })
+            if types.count == 1, let type = types.first {
+                return type
+            }
+        }
+
+        return fallback
     }
 }

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/Agent/Tools/AgentSystemPrompt.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/Agent/Tools/AgentSystemPrompt.swift
@@ -85,6 +85,8 @@ public struct AgentSystemPrompt {
           observations, but send the next click, type, scroll, hotkey, or other desktop mutation in a later response.
         - Prefer `verify_state` over fixed sleeps when waiting for exact window bounds or native element
           existence/value/enabled/selected state. It is observation-only and requires stable fresh AX samples.
+          Its predicates are structured JSON objects, never prose strings or AX expressions; follow the tool's
+          predicate schema and examples exactly.
         - `see` accepts an `app_target` field to capture background apps; `inspect_ui` accepts the same field for
           AX-only inspection. Observation never focuses the target by default. Only set `web_focus: true` when a
           sparse Chromium/Tauri accessibility tree justifies an explicit AXPress retry.

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/VerifyStateTool+Types.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/VerifyStateTool+Types.swift
@@ -11,6 +11,26 @@ enum VerifyStateStatus: String, Sendable {
     case unknown
 }
 
+enum VerifyStatePredicateContract {
+    static let schemaDescription =
+        """
+        Each item must be a JSON object, never a prose string or AX expression. Supported shapes:
+        {"kind":"window_exists","expected":true}
+        {"kind":"window_bounds","bounds":{"x":0,"y":0,"width":800,"height":600},"tolerance":1}
+        {"kind":"element_exists","selector":{"identifier":"save-button"},"expected":true}
+        {"kind":"element_value","selector":{"identifier":"basic-text-field"},"expected_value":"Ready"}
+        {"kind":"element_enabled","selector":{"label":"Save"},"expected":true}
+        {"kind":"element_selected","selector":{"role":"AXCheckBox"},"expected":true}
+        Selectors accept one or more exact identifier, label, or role fields.
+        """
+
+    static let malformedInputMessage =
+        """
+        predicates must be an array of structured JSON objects, not prose strings or AX expressions. For example: \
+        {"kind":"element_value","selector":{"identifier":"basic-text-field"},"expected_value":"Ready"}
+        """
+}
+
 struct VerifyStateRequest: Sendable {
     static let defaultTimeoutMilliseconds = 5000
     static let maximumTimeoutMilliseconds = 10000
@@ -45,6 +65,20 @@ struct VerifyStateRequest: Sendable {
     }
 
     init(arguments: ToolArguments) throws {
+        if let predicatesValue = arguments.getValue(for: "predicates") {
+            guard case let .array(predicateValues) = predicatesValue,
+                  predicateValues.allSatisfy({ value in
+                      if case .object = value {
+                          true
+                      } else {
+                          false
+                      }
+                  })
+            else {
+                throw VerifyStateInputError(VerifyStatePredicateContract.malformedInputMessage)
+            }
+        }
+
         let input = try arguments.decode(VerifyStateInput.self)
         let normalizedApp = input.app?.trimmingCharacters(in: .whitespacesAndNewlines)
 

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/VerifyStateTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/VerifyStateTool.swift
@@ -22,6 +22,8 @@ public struct VerifyStateTool: MCPTool {
         satisfied samples by default, and never focuses, clicks, types, or replays an action.
         The hard timeout is 10 seconds. Results are `satisfied`, `unsatisfied`, or `unknown`;
         truncated, stale, ambiguous, process-generation-changed, or owner-mismatched observations are `unknown`.
+        Predicates are structured JSON objects, never prose strings or AX expressions. For example:
+        {"kind":"element_value","selector":{"identifier":"basic-text-field"},"expected_value":"Ready"}
         """
     }
 
@@ -39,7 +41,7 @@ public struct VerifyStateTool: MCPTool {
                     maximum: Int(UInt32.max)),
                 "predicates": SchemaBuilder.array(
                     items: Self.predicateSchema,
-                    description: "One to eight predicates. Every predicate must be satisfied.",
+                    description: "One to eight structured predicate objects. Every predicate must be satisfied.",
                     minItems: 1,
                     maxItems: 8),
                 "timeout_ms": SchemaBuilder.integer(
@@ -153,6 +155,6 @@ public struct VerifyStateTool: MCPTool {
                     "expected": SchemaBuilder.boolean(),
                 ],
                 required: ["kind", "selector", "expected"]),
-        ])
+        ], description: VerifyStatePredicateContract.schemaDescription)
     }
 }

--- a/Core/PeekabooCore/Tests/PeekabooAgentRuntimeTests/AgentSystemPromptTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooAgentRuntimeTests/AgentSystemPromptTests.swift
@@ -110,6 +110,16 @@ struct AgentSystemPromptTests {
     }
 
     @Test
+    func `generated prompt requires structured verify state predicates`() {
+        guard #available(macOS 14.0, *) else { return }
+        let prompt = AgentSystemPrompt.generate()
+
+        #expect(prompt.contains("predicates are structured JSON objects"))
+        #expect(prompt.contains("never prose strings or AX expressions"))
+        #expect(prompt.contains("predicate schema and examples exactly"))
+    }
+
+    @Test
     func `generated prompt limits each response to one desktop mutation`() {
         guard #available(macOS 14.0, *) else { return }
         let prompt = AgentSystemPrompt.generate()

--- a/Core/PeekabooCore/Tests/PeekabooTests/AgentToolDescriptionTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/AgentToolDescriptionTests.swift
@@ -215,6 +215,21 @@ struct AgentToolDescriptionTests {
 
     @Test
     @MainActor
+    func `Verify state agent schema exposes structured predicate objects and examples`() throws {
+        let service = try PeekabooAgentService(services: PeekabooServices())
+        let tool = service.createVerifyStateTool()
+        let predicates = try #require(tool.parameters.properties["predicates"])
+        let items = try #require(predicates.items)
+
+        #expect(predicates.type == .array)
+        #expect(items.type == "object")
+        #expect(items.description?.contains(#"{"kind":"window_exists","expected":true}"#) == true)
+        #expect(items.description?.contains(#"{"kind":"element_value""#) == true)
+        #expect(tool.description.contains("never prose strings or AX expressions"))
+    }
+
+    @Test
+    @MainActor
     func `Optional parameters have default values documented`() {
         let allTools = makeAgentTools()
 

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/VerifyStateToolTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/VerifyStateToolTests.swift
@@ -11,6 +11,61 @@ import Testing
 @MainActor
 struct VerifyStateToolTests {
     @Test
+    func `Public schema documents structured predicate object variants`() async {
+        let fixture = VerifyStateFixture()
+        let context = await fixture.context(results: [])
+
+        guard case let .object(schema) = fixture.tool(context: context).inputSchema,
+              case let .object(properties)? = schema["properties"],
+              case let .object(predicates)? = properties["predicates"],
+              case let .object(items)? = predicates["items"],
+              case let .array(variants)? = items["oneOf"],
+              case let .string(description)? = items["description"]
+        else {
+            Issue.record("verify_state predicate schema is missing")
+            return
+        }
+
+        #expect(variants.count == 6)
+        #expect(variants.allSatisfy { variant in
+            guard case let .object(variantSchema) = variant,
+                  case let .string(type)? = variantSchema["type"]
+            else { return false }
+            return type == "object"
+        })
+        #expect(description.contains(#"{"kind":"window_exists","expected":true}"#))
+        #expect(description.contains(#"{"kind":"element_value""#))
+    }
+
+    @Test
+    func `Prose predicate formats return the supported structured shape`() async throws {
+        let fixture = VerifyStateFixture()
+        let context = await fixture.context(results: [])
+        let malformedPredicates = [
+            ["window id is 2887", "element with identifier basic-text-field has value Ready"],
+            ["identifier=basic-text-field value=Ready"],
+            [#"AXIdentifier == "basic-text-field" AND AXValue == "Ready""#],
+        ]
+
+        for predicates in malformedPredicates {
+            let response = try await fixture.tool(context: context).execute(arguments: ToolArguments(raw: [
+                "pid": Int(fixture.application.processIdentifier),
+                "window_id": fixture.window.windowID,
+                "predicates": predicates,
+            ]))
+
+            #expect(response.isError)
+            guard case let .text(text, _, _)? = response.content.first else {
+                Issue.record("Expected verify_state error text")
+                continue
+            }
+            #expect(text.contains("array of structured JSON objects"))
+            #expect(text.contains(#"{"kind":"element_value""#))
+            #expect(!text.contains("isn’t in the correct format"))
+        }
+    }
+
+    @Test
     func `Verifier requires two fresh identical satisfied samples by default`() async throws {
         let fixture = await MainActor.run { VerifyStateFixture() }
         let context = await fixture.context(results: [fixture.satisfiedResult, fixture.satisfiedResult])


### PR DESCRIPTION
## Summary

- Preserve a structured object item type when an MCP array uses homogeneous `oneOf` or `anyOf` object variants.
- Document all canonical `verify_state` predicate object shapes in the public schema, agent tool description, and system prompt.
- Reject prose strings, key/value shorthand, and AX expressions before evaluation with an actionable structured-object example instead of a generic decode error.

The predicate decoder and supported semantics stay strict and unchanged; this fixes how the contract is presented to agents and how malformed calls recover.

## Proof

- `swift test --package-path Core/PeekabooCore --filter VerifyStateToolTests` — 39 passed
- `swift test --package-path Core/PeekabooCore --filter AgentToolDescriptionTests` — 15 passed
- focused agent-system-prompt regression — 1 passed
- source-blind built MCP stdio validation — 15/15 schema and malformed-input checks passed
- `pnpm run format` — clean
- `pnpm run lint` — exit 0; 20 existing warnings, 0 serious
- autoreview against `origin/main` — clean, no actionable findings

The broader core run passed all 1,263 `PeekabooTests`; a separate stale `AgentSystemPromptTests` expectation fails unchanged on `main` and is unrelated to this patch.

No changelog or submodule pointer changes.
