### PR TITLE
fix(input): preserve text across keyboard layouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Remove the MCP `list` tool, MenuTool’s status-item actions, and agent shims `list_apps`, `list_screens`, and `launch_app`; add `window` action `list` (v4 breaking change).
 
 ### Fixed
+- Preserve the requested characters during background typing on non-US keyboard layouts instead of interpreting fixed US key positions through the active layout. Thanks @canvascoding for #330.
 - Wait for WindowServer to settle after an exact background maximize dispatch before repinning its final bounds, avoiding false failures without relaxing owner-generation checks.
 - Preserve OpenAI Responses tool-error payloads without sending unsupported `failed` statuses that abort the next agent turn.
 - Coordinate concurrent CLI, agent, GUI-bridge, and daemon desktop reads and mutations with generation-scoped cross-process lanes, preserving parallel work across unrelated exact targets while preventing conflicting background operations from overlapping.

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/BackgroundInputDriver.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/BackgroundInputDriver.swift
@@ -229,12 +229,6 @@ enum BackgroundInputDriver {
 
     static func typeCharacter(_ character: Character, targetProcessIdentifier: pid_t) throws {
         try self.validateTarget(targetProcessIdentifier)
-
-        if let stroke = self.keyboardStroke(for: character) {
-            try self.postKeyboardStroke(stroke, targetProcessIdentifier: targetProcessIdentifier)
-            return
-        }
-
         try self.postUnicodeCharacter(character, targetProcessIdentifier: targetProcessIdentifier)
     }
 
@@ -504,6 +498,18 @@ enum BackgroundInputDriver {
     }
 
     private static func postUnicodeCharacter(_ character: Character, targetProcessIdentifier: pid_t) throws {
+        let events = try self.unicodeKeyboardEvents(
+            for: character,
+            targetProcessIdentifier: targetProcessIdentifier)
+        self.post(events.keyDown, to: targetProcessIdentifier)
+        usleep(1000)
+        self.post(events.keyUp, to: targetProcessIdentifier)
+    }
+
+    static func unicodeKeyboardEvents(
+        for character: Character,
+        targetProcessIdentifier: pid_t) throws -> (keyDown: CGEvent, keyUp: CGEvent)
+    {
         let string = String(character)
         let source = CGEventSource(stateID: .hidSystemState)
 
@@ -521,38 +527,7 @@ enum BackgroundInputDriver {
 
         self.stampKeyboardRoutingFields(on: keyDown, targetProcessIdentifier: targetProcessIdentifier)
         self.stampKeyboardRoutingFields(on: keyUp, targetProcessIdentifier: targetProcessIdentifier)
-        self.post(keyDown, to: targetProcessIdentifier)
-        usleep(1000)
-        self.post(keyUp, to: targetProcessIdentifier)
-    }
-
-    private static func keyboardStroke(for character: Character) -> (keyCode: CGKeyCode, flags: CGEventFlags)? {
-        let string = String(character)
-        guard string.count == 1 else { return nil }
-
-        if let scalar = string.unicodeScalars.first,
-           CharacterSet.lowercaseLetters.contains(scalar),
-           let keyCode = self.keyCodes[string]
-        {
-            return (keyCode, [])
-        }
-
-        if let scalar = string.unicodeScalars.first,
-           CharacterSet.uppercaseLetters.contains(scalar),
-           let keyCode = self.keyCodes[string.lowercased()]
-        {
-            return (keyCode, .maskShift)
-        }
-
-        if let keyCode = self.keyCodes[string] {
-            return (keyCode, [])
-        }
-
-        if let shifted = self.shiftedKeyCodes[character] {
-            return (shifted, .maskShift)
-        }
-
-        return nil
+        return (keyDown, keyUp)
     }
 
     static func stampKeyboardRoutingFields(on event: CGEvent, targetProcessIdentifier: pid_t) {
@@ -885,21 +860,6 @@ enum BackgroundInputDriver {
         }
         return errno == EPERM
     }
-
-    private static let keyCodes: [String: CGKeyCode] = [
-        "a": 0x00, "s": 0x01, "d": 0x02, "f": 0x03, "h": 0x04, "g": 0x05, "z": 0x06, "x": 0x07,
-        "c": 0x08, "v": 0x09, "b": 0x0B, "q": 0x0C, "w": 0x0D, "e": 0x0E, "r": 0x0F, "y": 0x10,
-        "t": 0x11, "1": 0x12, "2": 0x13, "3": 0x14, "4": 0x15, "6": 0x16, "5": 0x17, "=": 0x18,
-        "9": 0x19, "7": 0x1A, "-": 0x1B, "8": 0x1C, "0": 0x1D, "]": 0x1E, "o": 0x1F, "u": 0x20,
-        "[": 0x21, "i": 0x22, "p": 0x23, "l": 0x25, "j": 0x26, "'": 0x27, "k": 0x28, ";": 0x29,
-        "\\": 0x2A, ",": 0x2B, "/": 0x2C, "n": 0x2D, "m": 0x2E, ".": 0x2F, "`": 0x32, " ": 0x31,
-    ]
-
-    private static let shiftedKeyCodes: [Character: CGKeyCode] = [
-        "!": 0x12, "@": 0x13, "#": 0x14, "$": 0x15, "%": 0x17, "^": 0x16, "&": 0x1A, "*": 0x1C,
-        "(": 0x19, ")": 0x1D, "_": 0x1B, "+": 0x18, "{": 0x21, "}": 0x1E, "|": 0x2A, ":": 0x29,
-        "\"": 0x27, "<": 0x2B, ">": 0x2F, "?": 0x2C, "~": 0x32,
-    ]
 }
 
 extension BackgroundInputDriver {

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/TypeServiceTargetResolutionTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/TypeServiceTargetResolutionTests.swift
@@ -6,6 +6,23 @@ import Testing
 
 struct TypeServiceTargetResolutionTests {
     @Test
+    func `targeted printable characters preserve their exact Unicode payload`() throws {
+        let targetPID: pid_t = 4242
+        let characters: [Character] = ["y", "z", "&", "|", "-", "\"", "ä"]
+
+        for character in characters {
+            let events = try BackgroundInputDriver.unicodeKeyboardEvents(
+                for: character,
+                targetProcessIdentifier: targetPID)
+
+            #expect(Self.unicodeString(from: events.keyDown) == String(character))
+            #expect(Self.unicodeString(from: events.keyUp) == String(character))
+            #expect(events.keyDown.getIntegerValueField(.eventTargetUnixProcessID) == Int64(targetPID))
+            #expect(events.keyUp.getIntegerValueField(.eventTargetUnixProcessID) == Int64(targetPID))
+        }
+    }
+
+    @Test
     @MainActor
     func `exact window delivery revalidates before every targeted character`() async throws {
         var typed: [Character] = []
@@ -165,6 +182,20 @@ struct TypeServiceTargetResolutionTests {
         #expect(TypeServiceSpecialKeyMapping.keyCode(for: .capsLock) == 0x39)
         #expect(TypeServiceSpecialKeyMapping.keyCode(for: .clear) == 0x47)
         #expect(TypeServiceSpecialKeyMapping.keyCode(for: .help) == 0x72)
+    }
+
+    private static func unicodeString(from event: CGEvent) -> String {
+        var length = 0
+        event.keyboardGetUnicodeString(
+            maxStringLength: 0,
+            actualStringLength: &length,
+            unicodeString: nil)
+        var buffer = [UniChar](repeating: 0, count: length)
+        event.keyboardGetUnicodeString(
+            maxStringLength: buffer.count,
+            actualStringLength: &length,
+            unicodeString: &buffer)
+        return String(utf16CodeUnits: buffer, count: length)
     }
 
     @Test

--- a/docs/commands/type.md
+++ b/docs/commands/type.md
@@ -34,6 +34,7 @@ read_when:
 - Window selectors are rejected in background mode because process-targeted events cannot prove which window owns the process's focused element. Use `--foreground` to focus that window first.
 - Default profile is `linear`, using no inter-key delay for fast deterministic input. Passing `--wpm` opts into human cadence; `--profile human` uses 140 WPM when `--wpm` is omitted.
 - Background delivery uses process-targeted CoreGraphics keyboard events and requires Event Synthesizing access. Apps that only accept typing in a focused key window may still need `--foreground`.
+- Printable background text is carried as Unicode instead of physical US key positions, so the requested characters remain stable across active keyboard layouts.
 - JSON output reports `totalCharacters`, `keyPresses`, delivery mode, optional target PID, and elapsed time; this matches what the agent logs when executing scripted steps.
 
 ## Examples


### PR DESCRIPTION
## Summary

- Send printable PID-targeted text as Unicode keyboard-event payloads instead of mapping it through fixed U.S. physical keycodes.
- Keep special keys and hotkeys on their existing virtual-key paths.
- Add focused Unicode payload coverage and document the keyboard-layout-independent contract.

Fixes #330.

## Root cause

Background typing already had a Unicode event fallback, but letters, digits, spaces, and U.S. punctuation took a hard-coded keycode map first. macOS interpreted those physical positions through the active layout, corrupting text on German QWERTZ and other non-U.S. sources.

## Live proof

Built the worktree CLI and forced local execution with `--no-remote` so the installed GUI bridge could not shadow the patched code. Both runs selected `com.apple.keylayout.German`, targeted a controlled Terminal PID, omitted Return, inspected the Terminal AX text, restored the original U.S. source, and closed the test process.

Before on current main:

```text
requested: PEEKABOO_LAYOUT yYzZ &|-"
received:  PEEKABOO?LAZOUT zZyY \/'ßÄ
```

After this change:

```text
requested: PEEKABOO_LAYOUT yYzZ &|-"
received:  PEEKABOO_LAYOUT yYzZ &|-"
```

Source-blind anti-cheat validation also delivered these exact payloads under German:

```text
BV_ONE yYzZ &|-" ä
BV_TWO zZyY _?+/ ö
```

The harness ended with `contract_clauses=4/4 anti_cheat=pass restored_source=com.apple.keylayout.US`.

## Verification

- `swift test --package-path Core/PeekabooAutomationKit --filter TypeServiceTargetResolutionTests` — 11 passed
- `pnpm run test:safe` — 794 tests in 92 suites passed; signing/runtime/DMG/appcast/browser-contract checks passed
- `pnpm run build:cli` — passed
- `pnpm run format` — clean after formatting one changed test file
- `pnpm run lint` — exit 0; 20 existing warnings, 0 serious
- `pnpm run lint:docs` — passed
- structured autoreview of the four-file diff — clean, no actionable findings
