### PR TITLE
chore(deps): update subprocess and pnpm

### DIFF
--- a/Apps/CLI/Package.swift
+++ b/Apps/CLI/Package.swift
@@ -115,7 +115,7 @@ let package = Package(
         .package(path: "../../Commander"),
         .package(url: "https://github.com/modelcontextprotocol/swift-sdk.git", "0.12.1" ..< "0.13.0"),
         .package(url: "https://github.com/dominicegginton/Spinner", from: "2.2.0"),
-        .package(url: "https://github.com/swiftlang/swift-subprocess.git", from: "0.5.0"),
+        .package(url: "https://github.com/swiftlang/swift-subprocess.git", from: "1.0.0"),
         .package(path: "../../TauTUI"),
         .package(path: "../../Core/PeekabooFoundation"),
         .package(path: "../../Core/PeekabooVisualizer"),

--- a/Apps/CLI/Tests/CLIRuntimeTests/Support/TestChildProcess.swift
+++ b/Apps/CLI/Tests/CLIRuntimeTests/Support/TestChildProcess.swift
@@ -51,8 +51,8 @@ enum TestChildProcess {
                 error: .string(limit: .max)
             )
             return Result(
-                standardOutput: collected.standardOutput ?? "",
-                standardError: collected.standardError ?? "",
+                standardOutput: collected.standardOutput,
+                standardError: collected.standardError,
                 status: collected.terminationStatus
             )
         }
@@ -69,8 +69,8 @@ enum TestChildProcess {
             error: .string(limit: .max)
         )
         return Result(
-            standardOutput: collected.standardOutput ?? "",
-            standardError: collected.standardError ?? "",
+            standardOutput: collected.standardOutput,
+            standardError: collected.standardError,
             status: collected.terminationStatus
         )
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Add `app focus` and positional app targets across quit, relaunch, hide, unhide, and switch while rejecting conflicting positional/flag targets (v4 breaking change).
 
 ### Changed
+- Update Swift Subprocess to 1.0.0 and pnpm to 11.21.0.
 - Convert clipboard and menubar actions, agent modes, permission requests, and flat config provider/credential operations into real nested subcommands (v4 breaking change).
 - Add `app launch --wait-ready` and repeatable `--open` targets as the surviving launch/open surface (v4 breaking change).
 - Redesign automation feedback around a natural agent cursor, a quiet target-window input HUD, and capture borders, suppressing window feedback whenever its target is not visibly active.

--- a/package.json
+++ b/package.json
@@ -82,5 +82,5 @@
   "devDependencies": {
     "chrome-devtools-mcp": "1.6.0"
   },
-  "packageManager": "pnpm@11.18.0"
+  "packageManager": "pnpm@11.21.0+sha512.521705bce689924eac72f5a3587122f362689ef6571e55ba80076fd637c11132ecffada26fad4ea79c485bfddbfd3d5a2a5b05805a77e893de71ec8a6cca3bb1"
 }


### PR DESCRIPTION
## Summary

- Update the CLI test harness from Swift Subprocess 0.5.0 to the source-stable 1.0.0 release.
- Adopt the 1.0 non-optional collected string-output contract.
- Refresh the Corepack package-manager declaration from pnpm 11.18.0 to 11.21.0 with its integrity hash.

All other direct and resolved dependencies were checked and are already current: `chrome-devtools-mcp` 1.6.0, Sparkle 2.9.5, KeyboardShortcuts 3.0.1, MCP Swift SDK 0.12.1, swift-log 1.15.0, swift-system 1.8.0, swift-collections 1.6.0, swift-configuration 1.2.0, swift-async-algorithms 1.1.5, swift-algorithms 1.2.1, and Spinner 2.2.0.

## Live proof

The dependency is used by the test harness to spawn the real Peekaboo executable. This command compiled Swift Subprocess 1.0.0, launched the built CLI through it, and verified the live tool catalog JSON:

```text
$ RUN_LOCAL_TESTS=1 swift test --package-path Apps/CLI --filter 'peekaboo tools emits standard JSON envelope'
✔ Test "peekaboo tools emits standard JSON envelope" passed after 0.121 seconds.
✔ Test run with 1 test in 1 suite passed after 0.121 seconds.
```

## Verification

- `pnpm run build:cli` — passed against Swift Subprocess 1.0.0
- `pnpm run test:safe` — 794 tests in 92 suites passed; signing/runtime/DMG/appcast/browser-contract checks passed
- `pnpm run format` — clean
- `pnpm run lint` — exit 0; 20 existing warnings, 0 serious
- all tracked Swift package lockfiles refreshed and unchanged because their graphs were already current
- `pnpm outdated --format json` — `{}`
- structured autoreview of the four-file diff — clean, no actionable findings
