### PR TITLE
feat(cli): v4 phase 5a — verify command + tools describe

### DIFF
--- a/Apps/CLI/Sources/PeekabooCLI/CLI/Configuration/CommandRegistry.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/CLI/Configuration/CommandRegistry.swift
@@ -42,6 +42,7 @@ enum CommandRegistry {
         .init(type: PermissionsCommand.self, category: .core),
         .init(type: LearnCommand.self, category: .core),
         .init(type: SeeCommand.self, category: .vision),
+        .init(type: VerifyCommand.self, category: .vision),
         .init(type: ClickCommand.self, category: .interaction),
         .init(type: TypeCommand.self, category: .interaction),
         .init(type: SetValueCommand.self, category: .interaction),

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/AI/VerifyCommand+CommanderMetadata.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/AI/VerifyCommand+CommanderMetadata.swift
@@ -1,0 +1,39 @@
+import Commander
+
+extension VerifyCommand: CommanderSignatureProviding {
+    static func commanderSignature() -> CommandSignature {
+        CommandSignature(
+            options: [
+                .commandOption("windowBounds", help: "Required x,y,width,height[,tolerance]", long: "window-bounds"),
+                .commandOption("on", help: "Element ID or role:label query", long: "on"),
+                .commandOption("valueEquals", help: "Required element value", long: "value-equals"),
+                .commandOption("timeout", help: "Polling timeout in milliseconds (default: 5000)", long: "timeout"),
+                .commandOption("stableSamples", help: "Required stable samples (default: 2)", long: "stable-samples"),
+                .commandOption("screenshot", help: "Save the final exact-window screenshot", long: "screenshot"),
+            ],
+            flags: [
+                .commandFlag("windowExists", help: "Require the target window to exist", long: "window-exists"),
+                .commandFlag("exists", help: "Require the selected element to exist", long: "exists"),
+                .commandFlag("enabled", help: "Require the selected element to be enabled", long: "enabled"),
+                .commandFlag("selected", help: "Require the selected element to be selected", long: "selected"),
+            ],
+            optionGroups: [InteractionTargetOptions.commanderSignature()]
+        )
+    }
+}
+
+extension VerifyCommand: CommanderBindableCommand {
+    mutating func applyCommanderValues(_ values: CommanderBindableValues) throws {
+        self.target = try values.makeInteractionTargetOptions()
+        self.windowExists = values.flag("windowExists")
+        self.windowBounds = values.singleOption("windowBounds")
+        self.on = values.singleOption("on")
+        self.exists = values.flag("exists")
+        self.valueEquals = values.singleOption("valueEquals")
+        self.enabled = values.flag("enabled")
+        self.selected = values.flag("selected")
+        self.timeout = try values.decodeOption("timeout", as: Int.self) ?? 5000
+        self.stableSamples = try values.decodeOption("stableSamples", as: Int.self) ?? 2
+        self.screenshot = values.singleOption("screenshot")
+    }
+}

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/AI/VerifyCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/AI/VerifyCommand.swift
@@ -1,0 +1,226 @@
+import Commander
+import Foundation
+import MCP
+import PeekabooCore
+import TachikomaMCP
+
+@MainActor
+struct VerifyCommand: ErrorHandlingCommand, OutputFormattable, RuntimeBackedCommand {
+    @OptionGroup var target: InteractionTargetOptions
+    @Flag(help: "Require the target window to exist") var windowExists = false
+    @Option(help: "Require window bounds x,y,width,height[,tolerance]") var windowBounds: String?
+    @Option(help: "Element ID or role:label query") var on: String?
+    @Flag(help: "Require the selected element to exist") var exists = false
+    @Option(help: "Require the selected element value to equal this text") var valueEquals: String?
+    @Flag(help: "Require the selected element to be enabled") var enabled = false
+    @Flag(help: "Require the selected element to be selected") var selected = false
+    @Option(help: "Polling timeout in milliseconds (maximum 10000)") var timeout = 5000
+    @Option(help: "Consecutive identical satisfied samples required") var stableSamples = 2
+    @Option(help: "Save the final exact-window screenshot") var screenshot: String?
+    @RuntimeStorage var runtime: CommandRuntime?
+    var runtimeOptions = CommandRuntimeOptions()
+
+    static let commandDescription = CommandDescription(
+        commandName: "verify",
+        abstract: "Verify window and element state without UI interaction",
+        discussion: """
+        Poll fresh native state until every predicate is stable. This replaces sleep-based polling.
+        Results are satisfied, unsatisfied, or unknown; unknown never implies success.
+
+        Examples:
+          peekaboo verify --app Safari --window-exists
+          peekaboo verify --app Safari --on button:Reload --exists --enabled --json
+        """
+    )
+
+    mutating func run(using runtime: CommandRuntime) async throws {
+        self.runtime = runtime
+        self.logger.setJsonOutputMode(self.jsonOutput)
+
+        do {
+            let arguments = try await self.makeArguments()
+            let context = MCPToolContext(
+                services: self.services,
+                snapshotMutationCoordinator: runtime.toolSnapshotMutationCoordinator
+            )
+            let tool = VerifyStateTool(context: context)
+            let response = try await context.execute(tool: tool, arguments: ToolArguments(raw: arguments))
+            guard !response.isError else {
+                try MCPToolCommandOutput.output(
+                    tool: tool.name,
+                    response: response,
+                    jsonOutput: self.jsonOutput,
+                    logger: self.outputLogger
+                )
+                return
+            }
+
+            let screenshotPath = try self.saveScreenshot(from: response)
+            let result = try Self.resultMetadata(response: response, screenshotPath: screenshotPath)
+            if self.jsonOutput {
+                outputSuccessCodable(data: result.payload, logger: self.outputLogger)
+            } else {
+                for content in response.content {
+                    if case let .text(text, _, _) = content {
+                        print(text)
+                    }
+                }
+                if let screenshotPath {
+                    print("Screenshot: \(screenshotPath)")
+                }
+                if let screenshotError = result.screenshotError {
+                    print("Screenshot error: \(screenshotError)")
+                }
+            }
+
+            switch result.status {
+            case "satisfied": return
+            case "unsatisfied": throw ExitCode(1)
+            default: throw ExitCode(2)
+            }
+        } catch let exit as ExitCode {
+            throw exit
+        } catch {
+            self.handleError(error)
+            throw ExitCode(2)
+        }
+    }
+
+    private func makeArguments() async throws -> [String: Any] {
+        var target = self.target
+        try target.validate()
+
+        var arguments: [String: Any] = try [
+            "predicates": self.predicates(),
+            "timeout_ms": self.timeout,
+            "stable_samples": self.stableSamples,
+            "final_screenshot": self.screenshot != nil,
+        ]
+
+        if let explicitPID = try target.resolveExplicitPIDObservationTarget() ?? target.pid {
+            arguments["pid"] = Int(explicitPID)
+        } else if let app = target.app?.trimmingCharacters(in: .whitespacesAndNewlines), !app.isEmpty {
+            arguments["app"] = app
+        } else if let windowID = target.windowId {
+            let windows = try await self.services.windows.listWindows(target: .windowId(windowID))
+            guard let pid = windows.first?.mutationIdentity?.ownerProcessIdentifier else {
+                throw ValidationError("--window-id alone must resolve a live owner; add --app or --pid")
+            }
+            arguments["pid"] = Int(pid)
+        } else {
+            throw ValidationError("Provide --app, --pid, or a live --window-id")
+        }
+
+        if let windowID = target.windowId {
+            arguments["window_id"] = windowID
+        }
+        if let windowTitle = target.windowTitle {
+            arguments["window_title"] = windowTitle
+        }
+        if let windowIndex = target.windowIndex {
+            arguments["window_index"] = windowIndex
+        }
+        return arguments
+    }
+
+    private func predicates() throws -> [[String: Any]] {
+        var predicates: [[String: Any]] = []
+        if self.windowExists {
+            predicates.append(["kind": "window_exists", "expected": true])
+        }
+        if let windowBounds {
+            try predicates.append(Self.boundsPredicate(windowBounds))
+        }
+
+        let hasElementPredicate = self.exists || self.valueEquals != nil || self.enabled || self.selected
+        if hasElementPredicate {
+            guard let on else { throw ValidationError("Element predicates require --on") }
+            let selector = try Self.elementSelector(on)
+            if self.exists {
+                predicates.append(["kind": "element_exists", "selector": selector, "expected": true])
+            }
+            if let valueEquals {
+                predicates.append(["kind": "element_value", "selector": selector, "expected_value": valueEquals])
+            }
+            if self.enabled {
+                predicates.append(["kind": "element_enabled", "selector": selector, "expected": true])
+            }
+            if self.selected {
+                predicates.append(["kind": "element_selected", "selector": selector, "expected": true])
+            }
+        } else if self.on != nil {
+            throw ValidationError("--on requires --exists, --value-equals, --enabled, or --selected")
+        }
+
+        guard !predicates.isEmpty else { throw ValidationError("Specify at least one verification predicate") }
+        return predicates
+    }
+
+    static func elementSelector(_ raw: String) throws -> [String: String] {
+        let query = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !query.isEmpty else { throw ValidationError("--on must not be empty") }
+        guard let separator = query.firstIndex(of: ":") else { return ["identifier": query] }
+        let role = query[..<separator].trimmingCharacters(in: .whitespacesAndNewlines)
+        let label = query[query.index(after: separator)...].trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !role.isEmpty, !label.isEmpty else {
+            throw ValidationError("Role queries use role:label, for example button:Save")
+        }
+        return ["role": role, "label": label]
+    }
+
+    static func boundsPredicate(_ raw: String) throws -> [String: Any] {
+        let values = raw.split(separator: ",", omittingEmptySubsequences: false).map {
+            Double($0.trimmingCharacters(in: .whitespacesAndNewlines))
+        }
+        guard (4...5).contains(values.count), values.allSatisfy({ $0 != nil }) else {
+            throw ValidationError("--window-bounds requires x,y,width,height[,tolerance]")
+        }
+        let numbers = values.compactMap(\.self)
+        var predicate: [String: Any] = [
+            "kind": "window_bounds",
+            "bounds": ["x": numbers[0], "y": numbers[1], "width": numbers[2], "height": numbers[3]],
+        ]
+        if numbers.count == 5 {
+            predicate["tolerance"] = numbers[4]
+        }
+        return predicate
+    }
+
+    private func saveScreenshot(from response: ToolResponse) throws -> String? {
+        guard let screenshot else { return nil }
+        for content in response.content {
+            guard case let .image(base64, mimeType, _, _) = content, mimeType == "image/png",
+                  let data = Data(base64Encoded: base64)
+            else { continue }
+            let expanded = (screenshot as NSString).expandingTildeInPath
+            let url = URL(fileURLWithPath: expanded).standardizedFileURL
+            try FileManager.default.createDirectory(
+                at: url.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try data.write(to: url, options: .atomic)
+            return url.path
+        }
+        return nil
+    }
+
+    private static func resultMetadata(
+        response: ToolResponse,
+        screenshotPath: String?
+    ) throws -> (status: String, payload: Value, screenshotError: String?) {
+        guard case let .object(meta)? = response.meta,
+              case let .string(status)? = meta["status"],
+              case .array? = meta["predicates"]
+        else { throw ValidationError("verify_state returned incomplete result metadata") }
+        var payload = meta
+        payload["unknown_reason"] = status == "unknown" ? meta["reason"] ?? .null : .null
+        payload.removeValue(forKey: "reason")
+        if let screenshotPath {
+            payload["screenshot_path"] = .string(screenshotPath)
+        }
+        return (status, .object(payload), meta["screenshot_error"]?.stringValue)
+    }
+}
+
+extension VerifyCommand: ParsableCommand {}
+extension VerifyCommand: AsyncRuntimeCommand {}

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommanderBinder.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommanderBinder.swift
@@ -91,7 +91,8 @@ enum CommanderCLIBinder {
         options.requestsHostPermissionGrant = Self.isInteractivePermissionRequest(commandType)
         options.usesPerToolSnapshotInvalidation = Self.isAgentExecutionCommand(commandType) ||
             commandType == MCPCommand.Serve.self ||
-            commandType == InspectUICommand.self
+            commandType == InspectUICommand.self ||
+            commandType == VerifyCommand.self
         options.verbose = parsedValues.flags.contains("verbose")
         options.jsonOutput = parsedValues.flags.contains("jsonOutput")
         let values = CommanderBindableValues(parsedValues: parsedValues)
@@ -469,6 +470,9 @@ enum CommanderCLIBinder {
     private static func prefersLocalRuntime(_ commandType: (any ParsableCommand.Type)?) -> Bool {
         commandType == MCPCommand.Serve.self ||
             commandType == ToolsCommand.self ||
+            commandType == ToolsListSubcommand.self ||
+            commandType == ToolsCommand.DescribeSubcommand.self ||
+            commandType == VerifyCommand.self ||
             commandType == LearnCommand.self ||
             commandType == CleanCommand.self ||
             commandType == ConfigCommand.InitCommand.self ||

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Core/ToolsCommand+CommanderMetadata.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Core/ToolsCommand+CommanderMetadata.swift
@@ -1,6 +1,6 @@
 import Commander
 
-extension ToolsCommand: CommanderSignatureProviding {
+extension ToolsListSubcommand: CommanderSignatureProviding {
     static func commanderSignature() -> CommandSignature {
         CommandSignature(
             flags: [
@@ -11,5 +11,13 @@ extension ToolsCommand: CommanderSignatureProviding {
                 ),
             ]
         )
+    }
+}
+
+extension ToolsCommand.DescribeSubcommand: CommanderSignatureProviding {
+    static func commanderSignature() -> CommandSignature {
+        CommandSignature(arguments: [
+            .make(label: "tool-name", help: "MCP tool name"),
+        ])
     }
 }

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Core/ToolsCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Core/ToolsCommand.swift
@@ -1,17 +1,15 @@
 import Commander
 import Foundation
+import MCP
 import PeekabooAutomation
 import PeekabooCore
 import TachikomaMCP
 
 @MainActor
-struct ToolsCommand: OutputFormattable, RuntimeBackedCommand {
-    private static let abstractText = "List the MCP/agent tool catalog"
-    private static let descriptionText = "Tools command for listing the MCP/agent tool catalog"
-
+struct ToolsCommand: ParsableCommand {
     static let commandDescription = CommandDescription(
         commandName: "tools",
-        abstract: Self.abstractText,
+        abstract: "List the MCP/agent tool catalog",
         discussion: """
         Display the Peekaboo MCP/agent tool catalog. These tools are exposed to agents
         and `peekaboo mcp` clients (e.g. Codex, Claude Code, Cursor). Some tools also
@@ -22,7 +20,20 @@ struct ToolsCommand: OutputFormattable, RuntimeBackedCommand {
           peekaboo tools                    # Show all tools
           peekaboo tools --verbose          # Show detailed information
           peekaboo tools --json             # Output in JSON format
-        """
+          peekaboo tools describe click     # Show one tool's full input schema
+        """,
+        subcommands: [ToolsListSubcommand.self, DescribeSubcommand.self],
+        defaultSubcommand: ToolsListSubcommand.self
+    )
+
+    func run() async throws {}
+}
+
+@MainActor
+struct ToolsListSubcommand: OutputFormattable, RuntimeBackedCommand {
+    static let commandDescription = CommandDescription(
+        commandName: "list",
+        abstract: "List the MCP/agent tool catalog"
     )
 
     @Flag(name: .customLong("no-sort"), help: "Disable alphabetical sorting")
@@ -31,31 +42,20 @@ struct ToolsCommand: OutputFormattable, RuntimeBackedCommand {
     var runtimeOptions = CommandRuntimeOptions()
     @RuntimeStorage var runtime: CommandRuntime?
 
-    var description: String {
-        Self.descriptionText
-    }
-
     var verbose: Bool {
         self.runtime?.configuration.verbose ?? self.runtimeOptions.verbose
-    }
-
-    private var showDetailedInfo: Bool {
-        self.verbose
     }
 
     mutating func run(using runtime: CommandRuntime) async throws {
         self.runtime = runtime
 
-        let toolContext = MCPToolContext(services: self.services)
-
-        let filters = ToolFiltering.currentFilters()
         let filteredTools = MCPToolCatalog.tools(
-            context: toolContext,
-            inputPolicy: self.inputPolicy(),
-            filters: filters,
-            log: { [logger] message in
-                logger.debug(message)
-            }
+            context: MCPToolContext(services: self.services),
+            inputPolicy: self.services.configuration.getUIInputPolicy(
+                cliStrategy: runtime.configuration.inputStrategy
+            ),
+            filters: ToolFiltering.currentFilters(),
+            log: { [logger] message in logger.debug(message) }
         )
         let sortedTools = self.noSort
             ? filteredTools
@@ -64,46 +64,30 @@ struct ToolsCommand: OutputFormattable, RuntimeBackedCommand {
         if self.jsonOutput {
             try self.outputJSON(tools: sortedTools)
         } else {
-            self.outputFormatted(tools: sortedTools, showDescription: self.showDetailedInfo)
+            self.outputFormatted(tools: sortedTools, showDescription: self.verbose)
         }
-    }
-
-    private func inputPolicy() -> UIInputPolicy {
-        self.services.configuration.getUIInputPolicy(
-            cliStrategy: self.resolvedRuntime.configuration.inputStrategy
-        )
     }
 
     // MARK: - JSON Output
 
     @MainActor
     private func outputJSON(tools: [any MCPTool]) throws {
-        struct ToolInfo: Codable {
-            let name: String
-            let description: String
+        let items = tools.map { tool in
+            Value.object(["name": .string(tool.name), "description": .string(tool.description)])
         }
-
-        struct Payload: Codable {
-            let tools: [ToolInfo]
-            let count: Int
-        }
-
-        let payload = Payload(
-            tools: tools.map { ToolInfo(name: $0.name, description: $0.description) },
-            count: tools.count
+        outputSuccessCodable(
+            data: Value.object(["tools": .array(items), "count": .int(tools.count)]),
+            logger: self.outputLogger
         )
-
-        outputSuccessCodable(data: payload, logger: self.outputLogger)
     }
 
     // MARK: - Formatted Output
 
     private func outputFormatted(tools: [any MCPTool], showDescription: Bool) {
-        if !tools.isEmpty {
-            print("Available Tools")
-            print("===============")
-            print()
-        }
+        guard !tools.isEmpty else { return }
+        print("Available Tools")
+        print("===============")
+        print()
 
         for tool in tools {
             print("• \(tool.name)")
@@ -112,19 +96,95 @@ struct ToolsCommand: OutputFormattable, RuntimeBackedCommand {
             }
         }
 
-        if !tools.isEmpty {
-            print()
-            print("Total tools: \(tools.count)")
+        print()
+        print("Total tools: \(tools.count)")
+    }
+}
+
+extension ToolsCommand {
+    struct ToolDescription: Codable {
+        let name: String
+        let description: String
+        let inputSchema: Value
+
+        enum CodingKeys: String, CodingKey {
+            case name, description
+            case inputSchema = "input_schema"
+        }
+    }
+
+    @MainActor
+    struct DescribeSubcommand: OutputFormattable, RuntimeBackedCommand {
+        @Argument(help: "MCP tool name")
+        var toolName: String = ""
+
+        @RuntimeStorage var runtime: CommandRuntime?
+        var runtimeOptions = CommandRuntimeOptions()
+
+        mutating func run(using runtime: CommandRuntime) async throws {
+            self.runtime = runtime
+            let tools = MCPToolCatalog.tools(
+                context: MCPToolContext(services: self.services),
+                inputPolicy: self.services.configuration.getUIInputPolicy(
+                    cliStrategy: runtime.configuration.inputStrategy
+                ),
+                filters: ToolFiltering.currentFilters()
+            )
+            guard let payload = Self.payload(named: self.toolName, tools: tools) else {
+                let names = tools.map(\.name).sorted().joined(separator: ", ")
+                throw ValidationError("Unknown tool '\(self.toolName)'. Valid names: \(names)")
+            }
+
+            if self.jsonOutput {
+                outputSuccessCodable(data: payload, logger: self.outputLogger)
+                return
+            }
+
+            print("Name: \(payload.name)")
+            print("Abstract: \(payload.description)")
+            print("Input schema:")
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+            let data = try encoder.encode(payload.inputSchema)
+            guard let schema = String(data: data, encoding: .utf8) else {
+                throw ValidationError("Could not render input schema for '\(payload.name)'")
+            }
+            print(schema)
+        }
+
+        static func payload(named name: String, tools: [any MCPTool]) -> ToolDescription? {
+            guard let tool = tools.first(where: { $0.name == name }) else { return nil }
+            return ToolDescription(name: tool.name, description: tool.description, inputSchema: tool.inputSchema)
         }
     }
 }
 
-@MainActor
-extension ToolsCommand: ParsableCommand {}
-extension ToolsCommand: AsyncRuntimeCommand {}
+extension ToolsListSubcommand: ParsableCommand {}
+extension ToolsListSubcommand: AsyncRuntimeCommand {}
 
 @MainActor
-extension ToolsCommand: CommanderBindableCommand {
+extension ToolsCommand.DescribeSubcommand: ParsableCommand {
+    nonisolated(unsafe) static var commandDescription: CommandDescription {
+        MainActorCommandDescription.describe {
+            CommandDescription(
+                commandName: "describe",
+                abstract: "Describe one MCP tool and print its full input schema"
+            )
+        }
+    }
+}
+
+extension ToolsCommand.DescribeSubcommand: AsyncRuntimeCommand {}
+
+@MainActor
+extension ToolsCommand.DescribeSubcommand: CommanderBindableCommand {
+    mutating func applyCommanderValues(_ values: CommanderBindableValues) throws {
+        self.toolName = try values.requiredPositional(0, label: "tool-name")
+    }
+}
+
+@MainActor
+extension ToolsListSubcommand: CommanderBindableCommand {
     mutating func applyCommanderValues(_ values: CommanderBindableValues) throws {
         self.noSort = values.flag("noSort")
     }

--- a/Apps/CLI/Tests/CLIRuntimeTests/CLIRuntimeSmokeTests.swift
+++ b/Apps/CLI/Tests/CLIRuntimeTests/CLIRuntimeSmokeTests.swift
@@ -117,7 +117,7 @@ struct CLIRuntimeSmokeTests {
     }
 
     @Test
-    func `peekaboo tools rejects unexpected positional arguments in JSON mode`() async throws {
+    func `peekaboo tools rejects unknown subcommands in JSON mode`() async throws {
         guard Self.ensureLocalRuntimeAvailable() else { return }
         let result = try await TestChildProcess.runPeekaboo(["tools", "extra", "--json", "--no-remote"])
         #expect(result.status == .exited(1))
@@ -133,7 +133,7 @@ struct CLIRuntimeSmokeTests {
 
         #expect(json["success"] as? Bool == false)
         #expect(error["code"] as? String == "INVALID_ARGUMENT")
-        #expect((error["message"] as? String)?.contains("Unexpected argument: extra") == true)
+        #expect((error["message"] as? String)?.contains("Unknown subcommand 'extra'") == true)
     }
 
     @Test

--- a/Apps/CLI/Tests/CoreCLITests/CommanderBinderCommandBindingTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/CommanderBinderCommandBindingTests.swift
@@ -190,7 +190,7 @@ struct CommanderBinderCommandBindingTests {
             options: [:],
             flags: ["noSort"]
         )
-        let command = try CommanderCLIBinder.instantiateCommand(ofType: ToolsCommand.self, parsedValues: parsed)
+        let command = try CommanderCLIBinder.instantiateCommand(ofType: ToolsListSubcommand.self, parsedValues: parsed)
         #expect(command.noSort == true)
     }
 

--- a/Apps/CLI/Tests/CoreCLITests/ToolsCommandTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/ToolsCommandTests.swift
@@ -1,4 +1,6 @@
 import Foundation
+import PeekabooAgentRuntime
+import PeekabooCore
 import Testing
 @testable import PeekabooCLI
 
@@ -21,7 +23,7 @@ struct ToolsCommandTests {
 
     @Test
     func `ToolsCommand default values`() throws {
-        let command = try ToolsCommand.parse([])
+        let command = try ToolsListSubcommand.parse([])
 
         #expect(command.verbose == false)
         #expect(command.jsonOutput == false)
@@ -31,7 +33,7 @@ struct ToolsCommandTests {
     @Test
     func `ToolsCommand argument parsing - verbose`() throws {
         let args = ["--verbose"]
-        let command = try ToolsCommand.parse(args)
+        let command = try ToolsListSubcommand.parse(args)
 
         #expect(command.verbose == true)
     }
@@ -39,7 +41,7 @@ struct ToolsCommandTests {
     @Test
     func `ToolsCommand argument parsing - json output`() throws {
         let args = ["--json"]
-        let command = try ToolsCommand.parse(args)
+        let command = try ToolsListSubcommand.parse(args)
 
         #expect(command.jsonOutput == true)
     }
@@ -47,15 +49,33 @@ struct ToolsCommandTests {
     @Test
     func `ToolsCommand argument parsing - no sort`() throws {
         let args = ["--no-sort"]
-        let command = try ToolsCommand.parse(args)
+        let command = try ToolsListSubcommand.parse(args)
 
         #expect(command.noSort == true)
     }
 
     @Test
-    func `ToolsCommand description property`() throws {
-        let command = try ToolsCommand.parse([])
-        #expect(command.description == "Tools command for listing the MCP/agent tool catalog")
+    @MainActor
+    func `describe subcommand exposes a catalog schema`() throws {
+        let command = try ToolsCommand.DescribeSubcommand.parse(["click"])
+        #expect(command.toolName == "click")
+
+        var foundDescribe = false
+        for subcommand in ToolsCommand.commandDescription.subcommands
+            where subcommand.commandDescription.commandName == "describe" {
+            foundDescribe = true
+        }
+        #expect(foundDescribe)
+
+        let services = PeekabooServices()
+        let tools = MCPToolCatalog.unfilteredTools(context: MCPToolContext(services: services))
+        let payload = try #require(ToolsCommand.DescribeSubcommand.payload(named: "click", tools: tools))
+        #expect(payload.name == "click")
+        #expect(!payload.description.isEmpty)
+        let json = try #require(String(data: JSONEncoder().encode(payload), encoding: .utf8))
+        #expect(json.contains("\"input_schema\""))
+        #expect(json.contains("\"properties\""))
+        #expect(ToolsCommand.DescribeSubcommand.payload(named: "nonexistent", tools: tools) == nil)
     }
 }
 
@@ -64,9 +84,9 @@ struct ToolsCommandTests {
 struct ToolsCommandStructureTests {
     @Test
     func `Command has required AsyncParsableCommand conformance`() throws {
-        let command = try ToolsCommand.parse([])
+        let command = try ToolsListSubcommand.parse([])
 
-        #expect(type(of: command) == ToolsCommand.self)
+        #expect(type(of: command) == ToolsListSubcommand.self)
     }
 
     @Test
@@ -86,7 +106,7 @@ struct ToolsCommandStructureTests {
 
     @Test
     func `Command properties have correct types and attributes`() throws {
-        let command = try ToolsCommand.parse([])
+        let command = try ToolsListSubcommand.parse([])
 
         #expect(type(of: command.verbose) == Bool.self)
         #expect(type(of: command.jsonOutput) == Bool.self)

--- a/Apps/CLI/Tests/CoreCLITests/VerifyCommandTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/VerifyCommandTests.swift
@@ -1,0 +1,50 @@
+import Testing
+@testable import PeekabooCLI
+
+@Suite(.tags(.safe))
+@MainActor
+struct VerifyCommandTests {
+    @Test
+    func `window predicate parses with defaults`() throws {
+        let command = try VerifyCommand.parse(["--app", "Finder", "--window-exists"])
+        #expect(command.target.app == "Finder")
+        #expect(command.windowExists)
+        #expect(command.timeout == 5000)
+        #expect(command.stableSamples == 2)
+    }
+
+    @Test
+    func `element predicates and timing parse`() throws {
+        let command = try VerifyCommand.parse([
+            "--pid", "123", "--on", "button:Save", "--exists", "--value-equals", "Ready",
+            "--enabled", "--selected", "--timeout", "9000", "--stable-samples", "3",
+        ])
+        #expect(command.target.pid == 123)
+        #expect(command.on == "button:Save")
+        #expect(command.exists && command.enabled && command.selected)
+        #expect(command.valueEquals == "Ready")
+        #expect(command.timeout == 9000)
+        #expect(command.stableSamples == 3)
+        #expect(try VerifyCommand.elementSelector("button:Save") == ["role": "button", "label": "Save"])
+        #expect(try VerifyCommand.elementSelector("B7") == ["identifier": "B7"])
+    }
+
+    @Test
+    func `window bounds accepts optional tolerance`() throws {
+        let predicate = try VerifyCommand.boundsPredicate("10,20,800,600,2.5")
+        #expect(predicate["kind"] as? String == "window_bounds")
+        #expect(predicate["tolerance"] as? Double == 2.5)
+        let bounds = try #require(predicate["bounds"] as? [String: Double])
+        #expect(bounds["width"] == 800)
+        #expect(bounds["height"] == 600)
+    }
+
+    @Test
+    func `verify is registered under vision`() {
+        var category: CommandRegistryEntry.Category?
+        for entry in CommandRegistry.entries where entry.type.commandDescription.commandName == "verify" {
+            category = entry.category
+        }
+        #expect(category == .vision)
+    }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [3.10.1] - Unreleased
 
 ### Added
+- Add `verify` for stable window and element assertions and `tools describe` for on-demand MCP input schemas.
 - Add a Developer-ID-signed Playground validation harness that continuously detects focus, window, cursor, clipboard, and visualizer leakage during background automation.
 - Show recently automated app icons beside Peekaboo in the menu bar, with a settings toggle.
 - Add distinct background app instances and exact WindowServer readiness/ID receipts to app launch and open workflows.

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/VerifyStateTool+Execution.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/VerifyStateTool+Execution.swift
@@ -303,8 +303,8 @@ extension VerifyStateTool {
             if let reason = await identityTracker.validate(application) {
                 return .unknown(reason)
             }
-            guard let window = Self.selectWindow(output.data.windows, exactID: nil) else {
-                return .missing("The application has no window")
+            guard let window = Self.selectWindow(output.data.windows, request: request) else {
+                return .missing(Self.missingWindowReason(request))
             }
             guard let selectedWindowID = CGWindowID(exactly: window.windowID) else {
                 return .unknown("Window enumeration returned invalid window ID \(window.windowID)")
@@ -467,13 +467,29 @@ extension VerifyStateTool {
         return "Application enumeration was incomplete: \(detail)"
     }
 
-    private static func selectWindow(_ windows: [ServiceWindowInfo], exactID: Int?) -> ServiceWindowInfo? {
-        if let exactID {
-            return windows.first(where: { $0.windowID == exactID })
+    private static func selectWindow(
+        _ windows: [ServiceWindowInfo],
+        request: VerifyStateRequest) -> ServiceWindowInfo?
+    {
+        if let title = request.windowTitle {
+            return windows.first(where: { $0.title.localizedCaseInsensitiveContains(title) })
+        }
+        if let index = request.windowIndex {
+            return windows.first(where: { $0.index == index })
         }
         return windows.first(where: { $0.isKeyWindow == true })
             ?? windows.first(where: \.isMainWindow)
             ?? windows.min(by: { $0.index < $1.index })
+    }
+
+    private static func missingWindowReason(_ request: VerifyStateRequest) -> String {
+        if let title = request.windowTitle {
+            return "No window title contains '\(title)'"
+        }
+        if let index = request.windowIndex {
+            return "Window index \(index) does not exist"
+        }
+        return "The application has no window"
     }
 
     private static func accessibilityTrustFailure(

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/VerifyStateTool+Types.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/VerifyStateTool+Types.swift
@@ -43,6 +43,8 @@ struct VerifyStateRequest: Sendable {
 
     let target: Target
     let windowID: CGWindowID?
+    let windowTitle: String?
+    let windowIndex: Int?
     let predicates: [VerifyStatePredicate]
     let timeoutMilliseconds: Int
     let stableSamples: Int
@@ -51,6 +53,8 @@ struct VerifyStateRequest: Sendable {
     init(
         target: Target,
         windowID: CGWindowID?,
+        windowTitle: String? = nil,
+        windowIndex: Int? = nil,
         predicates: [VerifyStatePredicate],
         timeoutMilliseconds: Int,
         stableSamples: Int,
@@ -58,6 +62,8 @@ struct VerifyStateRequest: Sendable {
     {
         self.target = target
         self.windowID = windowID
+        self.windowTitle = windowTitle
+        self.windowIndex = windowIndex
         self.predicates = predicates
         self.timeoutMilliseconds = timeoutMilliseconds
         self.stableSamples = stableSamples
@@ -103,6 +109,16 @@ struct VerifyStateRequest: Sendable {
         } else {
             self.windowID = nil
         }
+        self.windowTitle = input.windowTitle?.trimmingCharacters(in: .whitespacesAndNewlines)
+        self.windowIndex = input.windowIndex
+        let selectors = [self.windowID != nil, self.windowTitle?.isEmpty == false, self.windowIndex != nil]
+        guard selectors.count(where: { $0 }) <= 1 else {
+            throw VerifyStateInputError("window_id, window_title, and window_index are mutually exclusive")
+        }
+        guard self.windowTitle?.isEmpty != true else { throw VerifyStateInputError("window_title must not be empty") }
+        guard self.windowIndex.map({ $0 >= 0 }) ?? true else {
+            throw VerifyStateInputError("window_index must be 0 or greater")
+        }
 
         guard (1...8).contains(input.predicates.count) else {
             throw VerifyStateInputError("predicates must contain between 1 and 8 AND predicates")
@@ -144,6 +160,12 @@ struct VerifyStateRequest: Sendable {
         if let windowID {
             target["window_id"] = .int(Int(windowID))
         }
+        if let windowTitle {
+            target["window_title"] = .string(windowTitle)
+        }
+        if let windowIndex {
+            target["window_index"] = .int(windowIndex)
+        }
         return .object(target)
     }
 }
@@ -152,6 +174,8 @@ private struct VerifyStateInput: Decodable {
     let app: String?
     let pid: Int?
     let windowID: Int?
+    let windowTitle: String?
+    let windowIndex: Int?
     let predicates: [VerifyStatePredicateInput]
     let timeoutMilliseconds: Int?
     let stableSamples: Int?
@@ -160,6 +184,8 @@ private struct VerifyStateInput: Decodable {
     enum CodingKeys: String, CodingKey {
         case app, pid, predicates
         case windowID = "window_id"
+        case windowTitle = "window_title"
+        case windowIndex = "window_index"
         case timeoutMilliseconds = "timeout_ms"
         case stableSamples = "stable_samples"
         case finalScreenshot = "final_screenshot"

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/VerifyStateTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/VerifyStateTool.swift
@@ -39,6 +39,12 @@ public struct VerifyStateTool: MCPTool {
                     description: "Optional exact CoreGraphics window ID. Its live PID/process ownership is verified.",
                     minimum: 1,
                     maximum: Int(UInt32.max)),
+                "window_title": SchemaBuilder.string(
+                    description: "Optional window-title substring resolved on every poll. " +
+                        "Exclusive with other window selectors."),
+                "window_index": SchemaBuilder.integer(
+                    description: "Optional window index resolved on every poll. Exclusive with other window selectors.",
+                    minimum: 0),
                 "predicates": SchemaBuilder.array(
                     items: Self.predicateSchema,
                     description: "One to eight structured predicate objects. Every predicate must be satisfied.",

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/VerifyStateToolTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/VerifyStateToolTests.swift
@@ -107,6 +107,32 @@ struct VerifyStateToolTests {
     }
 
     @Test
+    func `Window title and index selectors participate in polling`() async throws {
+        let fixture = VerifyStateFixture()
+        let context = await fixture.context(results: [])
+        let tool = fixture.tool(context: context)
+        for selector in [["window_title": "rifi"], ["window_index": 0]] {
+            var arguments: [String: Any] = selector
+            arguments["pid"] = Int(fixture.application.processIdentifier)
+            arguments["predicates"] = [["kind": "window_exists", "expected": true]]
+            arguments["timeout_ms"] = 100
+            arguments["stable_samples"] = 1
+            let response = try await tool.execute(arguments: ToolArguments(raw: arguments))
+            #expect(Self.stringMeta("status", response) == "satisfied")
+        }
+
+        let missing = try await tool.execute(arguments: ToolArguments(raw: [
+            "pid": Int(fixture.application.processIdentifier),
+            "window_title": "Not Created Yet",
+            "predicates": [["kind": "window_exists", "expected": true]],
+            "timeout_ms": 100,
+            "stable_samples": 1,
+        ]))
+        #expect(Self.stringMeta("status", missing) == "unsatisfied")
+        #expect(Self.stringMeta("reason", missing)?.contains("Not Created Yet") == true)
+    }
+
+    @Test
     func `Truncated accessibility cannot satisfy even a positive match`() async throws {
         let fixture = await MainActor.run { VerifyStateFixture() }
         let truncated = fixture.result(truncated: true)
@@ -1173,6 +1199,14 @@ extension VerifyStateToolTests {
             "predicates": [["kind": "window_exists", "expected": true]],
         ]))
         #expect(oversizedWindowID.isError)
+
+        let conflictingWindows = try await tool.execute(arguments: ToolArguments(raw: [
+            "pid": 42,
+            "window_id": 1,
+            "window_title": "Dialog",
+            "predicates": [["kind": "window_exists", "expected": true]],
+        ]))
+        #expect(conflictingWindows.isError)
     }
 
     private static func stringMeta(_ key: String, _ response: ToolResponse) -> String? {

--- a/docs/cli-command-reference.md
+++ b/docs/cli-command-reference.md
@@ -14,9 +14,10 @@ Use `peekaboo <command> --help` for inline flag descriptions; this page links to
 ## Vision & Capture
 
 - [`see`](commands/see.md) – Capture annotated UI maps, produce snapshot IDs, and optionally run AI analysis.
+- [`verify`](commands/verify.md) – Poll stable window and element predicates with satisfied, unsatisfied, or unknown results.
 - [`image`](commands/image.md) – Save raw PNG/JPG captures of screens, windows, or menu bar regions; supports `--analyze` prompts.
 - `capture` – Long-running capture. `capture live` (adaptive PNG frames) replaces watch; `capture action` records around a child command; `capture video` ingests a video and samples frames. Outputs frames, contact sheet, metadata, optional MP4.
-- [`tools`](commands/tools.md) – List the MCP/agent tool catalog; supports `--verbose` and `--json`.
+- [`tools`](commands/tools.md) – List the MCP/agent tool catalog, or use `tools describe <name>` for one full input schema.
 - [`completions`](commands/completions.md) – Generate shell-native completions for zsh, bash, and fish from Commander metadata.
 - [`clean`](commands/clean.md) – Remove snapshot caches by ID, age, or all at once (`--dry-run` supported).
 - [`config`](commands/config.md) – `init`, `show`, `edit`, `validate`, `status`, `login`, plus `provider add|remove|list|test|models` and `credential set`.

--- a/docs/commands/tools.md
+++ b/docs/commands/tools.md
@@ -7,7 +7,7 @@ read_when:
 
 # `peekaboo tools`
 
-`peekaboo tools` prints the MCP/agent tool catalog that `peekaboo mcp` exposes (Image, See, Click, Window, Browser, Inspect UI, etc.). These names are the tools available to agents and MCP clients. Some tools also have dedicated top-level CLI wrappers, including `peekaboo browser` and `peekaboo inspect-ui`; run `peekaboo --help` for the full CLI command list.
+`peekaboo tools` prints the MCP/agent tool catalog that `peekaboo mcp` exposes (Image, See, Click, Window, Browser, Inspect UI, etc.). `peekaboo tools describe <name>` prints one tool's complete JSON input schema for token-cheap, on-demand discovery. Some tools also have dedicated top-level CLI wrappers, including `peekaboo browser` and `peekaboo inspect-ui`; run `peekaboo --help` for the full CLI command list.
 
 ## Key options
 | Flag | Description |
@@ -15,6 +15,12 @@ read_when:
 | `--no-sort` | Preserve registration order instead of alphabetizing every tool. |
 | `--verbose` | Include each tool's description alongside its name. |
 | `--json` | Emit `{tools:[…], count:n}` for machine parsing. |
+
+## Subcommands
+
+| Name | Purpose |
+| --- | --- |
+| `describe <tool-name>` | Print the tool name, abstract, and pretty JSON input schema. With `--json`, emit `{name, description, input_schema}`. Unknown names fail and list every valid name. |
 
 ## Implementation notes
 - The command and MCP server both use `MCPToolCatalog`, so tool additions only need to be registered once.
@@ -27,6 +33,10 @@ read_when:
 ```bash
 # Produce a JSON blob for an agent integration test
 peekaboo tools --json > /tmp/tools.json
+
+# Fetch only the click tool's schema
+peekaboo tools describe click
+peekaboo tools describe verify_state --json
 ```
 
 ## Troubleshooting

--- a/docs/commands/verify.md
+++ b/docs/commands/verify.md
@@ -1,0 +1,38 @@
+---
+summary: 'Poll window and element predicates via peekaboo verify'
+read_when:
+  - 'replacing sleep-based polling in UI automation'
+  - 'checking window or accessibility state without interaction'
+---
+
+# `peekaboo verify`
+
+`peekaboo verify` polls fresh native window and accessibility state until every requested predicate is stable or the timeout expires. It is the deterministic replacement for sleep-based polling: the command never focuses, clicks, types, or treats an incomplete observation as success.
+
+Results are ternary. `satisfied` exits 0, `unsatisfied` exits 1, and `unknown` exits 2. JSON output includes every predicate result and an `unknown_reason` field; it is `null` when the result is not unknown.
+
+## Key options
+
+| Flag | Description |
+| --- | --- |
+| Target flags | `--app`, `--pid`, `--window-id`, `--window-title`, and `--window-index` use the shared target grammar. |
+| `--window-exists` | Require the resolved target window to exist. |
+| `--window-bounds x,y,w,h[,tolerance]` | Require exact logical-point bounds, with an optional per-component tolerance (default 1). |
+| `--on <id-or-role:label>` | Select an element by opaque ID (for example `B7`) or exact role and label (for example `button:Reload`). |
+| `--exists` | Require the selected element to exist. |
+| `--value-equals <value>` | Require its accessibility value to match exactly. |
+| `--enabled` / `--selected` | Require the corresponding accessibility state. |
+| `--timeout <ms>` | Polling timeout in milliseconds (default 5000, maximum 10000). |
+| `--stable-samples <n>` | Consecutive identical satisfied samples required (default 2). |
+| `--screenshot <path>` | Save one final exact-window PNG when capture is available. |
+| `--json` | Emit structured status, predicate results, timing, and the unknown reason. |
+
+## Examples
+
+```bash
+peekaboo verify --app Safari --window-exists
+peekaboo verify --app Safari --on button:Reload --exists --enabled --json
+peekaboo verify --pid 1234 --window-bounds 40,80,1200,800,2 --timeout 10000
+```
+
+The command executes the same `verify_state` MCP tool used by agents, including its 100 ms fresh-observation polling, stability sampling, exact process/window identity checks, and hard ten-second deadline.


### PR DESCRIPTION
Phase 5a of the v4 CLI redesign (docs/v4-cli-plan.md §2): the two new capabilities.

## `peekaboo verify` (new)
Exposes the existing `verify_state` MCP tool as a CLI command - assert window/element predicates with timeout + stability sampling, ternary result (satisfied / unsatisfied / unknown; unknown never implies success). Exit codes 0/1/2. This is the principled replacement for sleep-based polling that got removed with `sleep` in Phase 1.

## `peekaboo tools describe <name>` (new)
Prints one tool's description + full JSON input schema on demand (cua-driver's `describe` pattern) - token-cheap schema discovery for agents; unknown names list all valid tools.

## Proof
+386 net production lines (under the +400 budget for this additive phase; running v4 total stays approx -7.2k). All gates green: build, lint, format, test:safe (798), automation target compile + 14 focused tests + 40 VerifyStateTool tests. Live-tested: Finder window-exists satisfied/exit 0, nonexistent app unsatisfied/exit 1, describe for real and unknown tools. Worker autoreview: one accepted finding fixed in the canonical tool; three rejected with runtime proof.
