### PR TITLE
feat(cli)!: v4 phase 6 — uniform JSON result envelope with effect vocabulary

### DIFF
--- a/Apps/CLI/Sources/PeekabooCLI/CLI/CommanderRuntimeExecutor.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/CLI/CommanderRuntimeExecutor.swift
@@ -37,6 +37,16 @@ enum CommanderRuntimeExecutor {
             parsedValues: resolved.parsedValues
         )
 
+        let isActionCommand = (command as? any ActionOutputFormattable)?.defaultEffect != nil
+        try await ResultEnvelopeContext.$isActionCommand.withValue(isActionCommand) {
+            try await self.runCommand(command, resolved: resolved)
+        }
+    }
+
+    private static func runCommand(
+        _ command: any ParsableCommand,
+        resolved: CommanderResolvedCommand
+    ) async throws {
         if var runtimeCommand = command as? any AsyncRuntimeCommand {
             let runtimeOptions = try CommanderCLIBinder.makeRuntimeOptions(
                 from: resolved.parsedValues,

--- a/Apps/CLI/Sources/PeekabooCLI/CLI/Output/JSONOutput.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/CLI/Output/JSONOutput.swift
@@ -1,170 +1,196 @@
 import Foundation
-import PeekabooFoundation
 
-/// Standard JSON response format for Peekaboo API output.
-///
-/// This is now deprecated - use CodableJSONResponse with specific types instead
-struct JSONResponse: Codable {
-    let success: Bool
-    let data: Empty? // Added for test compatibility
-    let messages: [String]?
-    let debug_logs: [String]
-    let error: ErrorInfo?
+nonisolated enum ActionEffect: String, Codable, Sendable {
+    case confirmed
+    case partial
+    case unverifiable
+    case suspectedNoop = "suspected_noop"
+    case refused
+}
 
-    init(
-        success: Bool,
-        data: Empty? = nil, // Added for test compatibility
-        messages: [String]? = nil,
-        debugLogs: [String] = [],
-        error: ErrorInfo? = nil
-    ) {
-        self.success = success
-        self.data = data
-        self.messages = messages
-        self.debug_logs = debugLogs
-        self.error = error
+protocol ActionOutputFormattable {
+    var defaultEffect: ActionEffect? { get }
+}
+
+extension ActionOutputFormattable {
+    var defaultEffect: ActionEffect? {
+        .unverifiable
     }
 }
 
-/// Error information structure for JSON responses.
-///
-/// Contains error details including message, standardized error code,
-/// and optional additional context.
-struct ErrorInfo: Codable {
+protocol ConfirmedActionOutputFormattable: ActionOutputFormattable {}
+extension ConfirmedActionOutputFormattable { var defaultEffect: ActionEffect? {
+    .confirmed
+} }
+
+nonisolated protocol ResultEnvelopeError: Error, Sendable {
+    var envelopeEffect: ActionEffect? { get }
+    var envelopeHint: String? { get }
+}
+
+struct ActionRefusalError: LocalizedError, ResultEnvelopeError {
     let message: String
+    let hint: String?
+
+    nonisolated var errorDescription: String? {
+        self.message
+    }
+
+    nonisolated var envelopeEffect: ActionEffect? {
+        .refused
+    }
+
+    nonisolated var envelopeHint: String? {
+        self.hint
+    }
+}
+
+enum ResultEnvelopeContext {
+    @TaskLocal static var isActionCommand = false
+}
+
+let jsonEncodingFailureEnvelope =
+    #"{"success":false,"data":null,"error":{"code":"INTERNAL_SWIFT_ERROR","# +
+    #""message":"Failed to encode JSON response"},"debug_logs":[]}"#
+
+struct ResultEnvelope<Payload> {
+    let success: Bool
+    var effect: ActionEffect?
+    let data: Payload
+    var messages: [String]?
+    var debug_logs: [String] = []
+    var error: ErrorInfo?
+}
+
+extension ResultEnvelope: Encodable where Payload: Encodable {}
+extension ResultEnvelope: Decodable where Payload: Decodable {}
+
+typealias JSONResponse = ResultEnvelope<Empty?>
+typealias CodableJSONResponse<Payload: Codable> = ResultEnvelope<Payload>
+
+struct ErrorInfo: Codable {
     let code: String
+    let message: String
+    let hint: String?
     let details: String?
 
-    init(message: String, code: ErrorCode, details: String? = nil) {
-        self.message = message
-        self.code = code.rawValue
+    init(message: String, code: ErrorCode, hint: String? = nil, details: String? = nil) {
+        self.init(message: message, code: code.rawValue, hint: hint, details: details)
+    }
+
+    init(message: String, code: String, hint: String? = nil, details: String? = nil) {
+        let presentation = splitErrorHint(from: message)
+        self.code = code
+        self.message = presentation.message
+        self.hint = hint ?? presentation.hint
         self.details = details
     }
 }
 
-/// Standardized error codes for Peekaboo operations.
-///
-/// Provides consistent error identification across the API for proper
-/// error handling by clients and automation tools.
+func splitErrorHint(from text: String) -> (message: String, hint: String?) {
+    let markers = [
+        (". Use ", "Use "), ("; use ", "Use "),
+        (". Try ", "Try "), ("; try ", "Try "),
+        (". Run ", "Run "), ("; run ", "Run "),
+        (". Add ", "Add "), ("; add ", "Add "),
+    ]
+    for (marker, prefix) in markers {
+        guard let range = text.range(of: marker) else { continue }
+        let message = text[..<range.lowerBound].trimmingCharacters(in: .whitespacesAndNewlines)
+        let suffix = text[range.upperBound...].trimmingCharacters(in: .whitespacesAndNewlines)
+        return (message.hasSuffix(".") ? message : message + ".", prefix + suffix)
+    }
+    return (text, nil)
+}
+
 enum ErrorCode: String, Codable {
-    case PERMISSION_ERROR_SCREEN_RECORDING
-    case PERMISSION_ERROR_ACCESSIBILITY
-    case PERMISSION_ERROR_EVENT_SYNTHESIZING
-    case PERMISSION_ERROR_APPLESCRIPT
-    case PERMISSION_DENIED
-    case APP_NOT_FOUND
-    case AMBIGUOUS_APP_IDENTIFIER
-    case WINDOW_NOT_FOUND
-    case CAPTURE_FAILED
-    case FILE_IO_ERROR
-    case INVALID_ARGUMENT
-    case SIPS_ERROR
-    case INTERNAL_SWIFT_ERROR
-    case UNKNOWN_ERROR
-    case WINDOW_MANIPULATION_ERROR
-    case VALIDATION_ERROR
-    case MENU_BAR_NOT_FOUND
-    case MENU_ITEM_NOT_FOUND
-    case DOCK_NOT_FOUND
-    case NO_ACTIVE_DIALOG
-    case ELEMENT_NOT_FOUND
-    case SESSION_NOT_FOUND
-    case SNAPSHOT_NOT_FOUND
-    case SNAPSHOT_STALE
-    case APPLICATION_NOT_FOUND
-    case NO_POINT_SPECIFIED
-    case INVALID_COORDINATES
-    case DOCK_LIST_NOT_FOUND
-    case DOCK_ITEM_NOT_FOUND
-    case POSITION_NOT_FOUND
-    case SCRIPT_ERROR
-    case MISSING_API_KEY
-    case AGENT_ERROR
-    case INTERACTION_FAILED
-    case TIMEOUT
+    case PERMISSION_ERROR_SCREEN_RECORDING, PERMISSION_ERROR_ACCESSIBILITY
+    case PERMISSION_ERROR_EVENT_SYNTHESIZING, PERMISSION_ERROR_APPLESCRIPT, PERMISSION_DENIED
+    case APP_NOT_FOUND, AMBIGUOUS_APP_IDENTIFIER, WINDOW_NOT_FOUND, CAPTURE_FAILED, FILE_IO_ERROR
+    case INVALID_ARGUMENT, SIPS_ERROR, INTERNAL_SWIFT_ERROR, UNKNOWN_ERROR, WINDOW_MANIPULATION_ERROR
+    case VALIDATION_ERROR, MENU_BAR_NOT_FOUND, MENU_ITEM_NOT_FOUND, DOCK_NOT_FOUND, NO_ACTIVE_DIALOG
+    case ELEMENT_NOT_FOUND, SESSION_NOT_FOUND, SNAPSHOT_NOT_FOUND, SNAPSHOT_STALE, APPLICATION_NOT_FOUND
+    case NO_POINT_SPECIFIED, INVALID_COORDINATES, DOCK_LIST_NOT_FOUND, DOCK_ITEM_NOT_FOUND
+    case POSITION_NOT_FOUND, SCRIPT_ERROR, MISSING_API_KEY, AGENT_ERROR, INTERACTION_FAILED, TIMEOUT
     case INVALID_INPUT
 }
 
-func outputJSON(_ response: JSONResponse, logger: Logger) {
-    do {
-        let encoder = JSONEncoder()
-        encoder.outputFormatting = .prettyPrinted
-        let data = try encoder.encode(response)
-        if let jsonString = String(data: data, encoding: .utf8) {
-            print(jsonString)
-        }
-    } catch {
-        logger.error("Failed to encode JSON response: \(error)")
-        // Fallback to simple error JSON
-        print("""
-        {
-          "success": false,
-          "error": {
-            "message": "Failed to encode JSON response",
-            "code": "INTERNAL_SWIFT_ERROR"
-          },
-          "debug_logs": []
-        }
-        """)
-    }
-}
-
-func outputSuccessCodable(data: some Codable, messages: [String]? = nil, logger: Logger) {
-    let debugLogs = logger.getDebugLogs()
-    let response = CodableJSONResponse(
-        success: true, data: data, messages: messages, debug_logs: debugLogs
+func outputSuccessCodable(
+    data: some Codable,
+    messages: [String]? = nil,
+    effect: ActionEffect? = nil,
+    logger: Logger
+) {
+    let response = ResultEnvelope(
+        success: true,
+        effect: effect,
+        data: data,
+        messages: messages,
+        debug_logs: logger.getDebugLogs()
     )
     outputJSONCodable(response, logger: logger)
 }
 
-func outputJSONCodable(_ response: some Encodable, logger: Logger) {
+func outputJSONCodable(_ response: ResultEnvelope<some Encodable>, logger: Logger) {
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = .prettyPrinted
     do {
-        let encoder = JSONEncoder()
-        encoder.outputFormatting = .prettyPrinted
-        // Note: JSONEncoder by default omits nil values from optionals
-        // This is standard behavior and generally desirable for cleaner output
         let data = try encoder.encode(response)
         if let jsonString = String(data: data, encoding: .utf8) {
             print(jsonString)
         }
     } catch {
         logger.error("Failed to encode JSON response: \(error)")
-        // Fallback to simple error JSON
-        print("""
-        {
-          "success": false,
-          "error": {
-            "message": "Failed to encode JSON response",
-            "code": "INTERNAL_SWIFT_ERROR"
-          },
-          "debug_logs": []
+        let fallback = makeJSONEncodingFailureEnvelope(effect: response.effect)
+        if let data = try? encoder.encode(fallback), let jsonString = String(data: data, encoding: .utf8) {
+            print(jsonString)
+        } else {
+            print(jsonEncodingFailureEnvelope)
         }
-        """)
     }
 }
 
-/// Generic JSON response wrapper for strongly-typed data.
-///
-/// Provides type-safe JSON responses when the data payload type
-/// is known at compile time.
-struct CodableJSONResponse<T: Codable>: Codable {
-    let success: Bool
-    let data: T
-    let messages: [String]?
-    let debug_logs: [String]
+func makeJSONEncodingFailureEnvelope(effect: ActionEffect?) -> ResultEnvelope<Empty?> {
+    ResultEnvelope(
+        success: false,
+        effect: effect == nil ? nil : .unverifiable,
+        data: nil,
+        error: ErrorInfo(message: "Failed to encode JSON response", code: .INTERNAL_SWIFT_ERROR)
+    )
 }
 
-func outputError(message: String, code: ErrorCode, details: String? = nil, logger: Logger) {
-    let error = ErrorInfo(message: message, code: code, details: details)
-    let debugLogs = logger.getDebugLogs()
-    outputJSON(JSONResponse(success: false, messages: nil, debugLogs: debugLogs, error: error), logger: logger)
+func outputError(
+    message: String,
+    code: ErrorCode,
+    hint: String? = nil,
+    details: String? = nil,
+    effect: ActionEffect? = nil,
+    logger: Logger
+) {
+    let response = ResultEnvelope<Empty?>(
+        success: false,
+        effect: effect ?? (ResultEnvelopeContext.isActionCommand ? defaultActionErrorEffect(code) : nil),
+        data: nil,
+        debug_logs: logger.getDebugLogs(),
+        error: ErrorInfo(message: message, code: code, hint: hint, details: details)
+    )
+    outputJSONCodable(response, logger: logger)
 }
 
-/// Empty type for successful responses with no data
+func defaultActionErrorEffect(_ code: ErrorCode) -> ActionEffect {
+    switch code {
+    case .INVALID_ARGUMENT, .VALIDATION_ERROR, .INVALID_INPUT,
+         .PERMISSION_DENIED, .PERMISSION_ERROR_SCREEN_RECORDING, .PERMISSION_ERROR_ACCESSIBILITY,
+         .PERMISSION_ERROR_EVENT_SYNTHESIZING, .PERMISSION_ERROR_APPLESCRIPT,
+         .APP_NOT_FOUND, .AMBIGUOUS_APP_IDENTIFIER, .WINDOW_NOT_FOUND, .ELEMENT_NOT_FOUND,
+         .APPLICATION_NOT_FOUND, .SESSION_NOT_FOUND, .SNAPSHOT_NOT_FOUND, .SNAPSHOT_STALE,
+         .NO_POINT_SPECIFIED, .INVALID_COORDINATES, .NO_ACTIVE_DIALOG,
+         .MENU_BAR_NOT_FOUND, .MENU_ITEM_NOT_FOUND, .DOCK_NOT_FOUND, .DOCK_LIST_NOT_FOUND,
+         .DOCK_ITEM_NOT_FOUND, .POSITION_NOT_FOUND:
+        .refused
+    default:
+        .unverifiable
+    }
+}
+
 struct Empty: Codable {}
-
-extension Empty: ExpressibleByNilLiteral {
-    init(nilLiteral: ()) {
-        self.init()
-    }
-}

--- a/Apps/CLI/Sources/PeekabooCLI/CLI/Utilities/ErrorHandling.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/CLI/Utilities/ErrorHandling.swift
@@ -13,14 +13,7 @@ private func emitError(
     prefix: String = "❌"
 ) {
     if jsonOutput {
-        let response = JSONResponse(
-            success: false,
-            error: ErrorInfo(
-                message: message,
-                code: code
-            )
-        )
-        outputJSON(response, logger: logger)
+        outputError(message: message, code: code, logger: logger)
     } else {
         print("\(prefix) \(message)")
     }

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommandErrorHandling.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommandErrorHandling.swift
@@ -25,7 +25,12 @@ extension ErrorHandlingCommand {
             outputError(
                 message: errorMessage(for: error),
                 code: errorCode,
+                hint: (error as? any ResultEnvelopeError)?.envelopeHint,
                 details: errorDetails(for: error),
+                effect: (error as? any ResultEnvelopeError)?.envelopeEffect ??
+                    ((self as? any ActionOutputFormattable)?.defaultEffect == nil
+                        ? nil
+                        : defaultActionErrorEffect(errorCode)),
                 logger: logger
             )
         } else {
@@ -40,7 +45,8 @@ extension ErrorHandlingCommand {
             } else {
                 error.localizedDescription
             }
-            fputs("Error: \(errorMessage)\n", stderr)
+            let hint = (error as? any ResultEnvelopeError)?.envelopeHint.map { " Hint: \($0)" } ?? ""
+            fputs("Error: \(errorMessage)\(hint)\n", stderr)
         }
     }
 
@@ -59,6 +65,8 @@ extension ErrorHandlingCommand {
             errorCode(for: bridgeError)
         case let posixError as POSIXError:
             errorCode(for: posixError)
+        case is ActionRefusalError:
+            .VALIDATION_ERROR
         case is Commander.ValidationError:
             .VALIDATION_ERROR
         default:

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommandOutputFormatting.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommandOutputFormatting.swift
@@ -1,9 +1,6 @@
 import Foundation
 import PeekabooCore
 
-// MARK: - Output Formatting Protocol
-
-/// Protocol for commands that support both JSON and human-readable output
 @MainActor
 protocol OutputFormattable {
     var jsonOutput: Bool { get }
@@ -11,30 +8,19 @@ protocol OutputFormattable {
 }
 
 extension OutputFormattable {
-    /// Output data in appropriate format
-    func output(_ data: some Codable, humanReadable: () -> Void) {
+    func output(_ data: some Codable, effect: ActionEffect? = nil, humanReadable: () -> Void) {
         if jsonOutput {
-            outputSuccessCodable(data: data, logger: self.outputLogger)
+            outputSuccessCodable(
+                data: data,
+                effect: effect ?? (self as? any ActionOutputFormattable)?.defaultEffect,
+                logger: self.outputLogger
+            )
         } else {
             humanReadable()
         }
     }
-
-    /// Output success with optional data
-    func outputSuccess(data: (some Codable)? = nil as Empty?) {
-        if jsonOutput {
-            if let data {
-                outputSuccessCodable(data: data, logger: self.outputLogger)
-            } else {
-                outputJSON(JSONResponse(success: true), logger: self.outputLogger)
-            }
-        }
-    }
 }
 
-// MARK: - Permission Checking
-
-/// Check and require screen recording permission
 @MainActor
 func requireScreenRecordingPermission(services: any PeekabooServiceProviding) async throws {
     let hasPermission = await Task { @MainActor in
@@ -46,7 +32,6 @@ func requireScreenRecordingPermission(services: any PeekabooServiceProviding) as
     }
 }
 
-/// Check and require accessibility permission
 @MainActor
 func requireAccessibilityPermission(services: any PeekabooServiceProviding) throws {
     if !services.permissions.checkAccessibilityPermission() {

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Core/CaptureCommand+Action.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Core/CaptureCommand+Action.swift
@@ -175,7 +175,7 @@ RuntimeOptionsConfigurable, InjectedRuntimeBackedCommand {
             let error = result.success
                 ? nil
                 : ErrorInfo(message: result.failureMessage, code: .VALIDATION_ERROR)
-            let envelope = CaptureActionJSONEnvelope(
+            let envelope = ResultEnvelope(
                 success: result.success,
                 data: result,
                 messages: nil,
@@ -320,14 +320,6 @@ struct CaptureActionCommandResult: Codable {
         }
         return "Capture artifact validation failed"
     }
-}
-
-struct CaptureActionJSONEnvelope: Codable {
-    let success: Bool
-    let data: CaptureActionCommandResult
-    let messages: [String]?
-    let debug_logs: [String]
-    let error: ErrorInfo?
 }
 
 struct CaptureActionArtifactValidation: Codable {

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Core/ConfigCommand+InitShowEdit.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Core/ConfigCommand+InitShowEdit.swift
@@ -240,12 +240,12 @@ extension ConfigCommand {
             let reporter = ProviderStatusReporter(timeoutSeconds: self.timeout.seconds)
             if self.jsonOutput {
                 let summary = await reporter.summary()
-                let response = ProviderStatusResponse(
+                let response = ResultEnvelope(
                     success: true,
                     data: summary,
-                    debugLogs: self.logger.getDebugLogs()
+                    debug_logs: self.logger.getDebugLogs()
                 )
-                outputJSON(response, logger: self.logger)
+                outputJSONCodable(response, logger: self.logger)
             } else {
                 await reporter.printSummary()
             }
@@ -347,16 +347,5 @@ extension ConfigCommand {
                 throw ExitCode.failure
             }
         }
-    }
-}
-
-private struct ProviderStatusResponse: Encodable {
-    let success: Bool
-    let data: ProviderStatusSummary
-    let debugLogs: [String]
-
-    enum CodingKeys: String, CodingKey {
-        case success, data
-        case debugLogs = "debug_logs"
     }
 }

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Core/ConfigCommand+Shared.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Core/ConfigCommand+Shared.swift
@@ -1,8 +1,3 @@
-//
-//  ConfigCommand+Shared.swift
-//  PeekabooCLI
-//
-
 import Commander
 import Foundation
 import PeekabooCore
@@ -17,7 +12,6 @@ extension ConfigRuntimeCommand {
     mutating func prepare(using runtime: CommandRuntime) {
         self.runtime = runtime
         self.logger.setJsonOutputMode(self.jsonOutput)
-        // Align Tachikoma profile dir with Peekaboo storage
         PeekabooCore.ConfigurationManager.configureTachikomaProfileDirectory()
     }
 
@@ -93,63 +87,27 @@ struct ConfigCommandOutput {
     }
 }
 
-struct SuccessOutput: Encodable {
-    let success: Bool
-    let data: [String: Any]
-    let debugLogs: [String]
-
-    init(success: Bool, data: [String: Any], debugLogs: [String] = []) {
-        self.success = success
-        self.data = data
-        self.debugLogs = debugLogs
-    }
-
-    func withDebugLogs(_ debugLogs: [String]) -> Self {
-        Self(success: self.success, data: self.data, debugLogs: debugLogs)
-    }
-
-    enum CodingKeys: String, CodingKey {
-        case success, data
-        case debugLogs = "debug_logs"
-    }
-
-    func encode(to encoder: any Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(self.success, forKey: .success)
-        try container.encode(JSONValue(self.data), forKey: .data)
-        try container.encode(self.debugLogs, forKey: .debugLogs)
-    }
+func SuccessOutput(
+    success: Bool,
+    data: [String: Any],
+    debugLogs: [String] = []
+) -> ResultEnvelope<JSONValue> {
+    ResultEnvelope(success: success, data: JSONValue(data), debug_logs: debugLogs)
 }
 
-struct ErrorOutput: Encodable {
-    let success = false
-    let error: ConfigErrorInfo
-    let debugLogs: [String]
-
-    init(error _: Bool = true, code: String, message: String, details: String?, debugLogs: [String] = []) {
-        self.error = ConfigErrorInfo(code: code, message: message, details: details)
-        self.debugLogs = debugLogs
-    }
-
-    enum CodingKeys: String, CodingKey {
-        case success, error
-        case debugLogs = "debug_logs"
-    }
-
-    func withDebugLogs(_ debugLogs: [String]) -> Self {
-        Self(
-            code: self.error.code,
-            message: self.error.message,
-            details: self.error.details,
-            debugLogs: debugLogs
-        )
-    }
-}
-
-struct ConfigErrorInfo: Encodable {
-    let code: String
-    let message: String
-    let details: String?
+func ErrorOutput(
+    error _: Bool = true,
+    code: String,
+    message: String,
+    details: String?,
+    debugLogs: [String] = []
+) -> ResultEnvelope<Empty?> {
+    ResultEnvelope(
+        success: false,
+        data: nil,
+        debug_logs: debugLogs,
+        error: ErrorInfo(message: message, code: code, details: details)
+    )
 }
 
 struct JSONValue: Encodable {
@@ -192,28 +150,30 @@ struct JSONValue: Encodable {
     }
 }
 
-func outputJSON(_ value: SuccessOutput, logger: Logger) {
-    writeConfigJSON(value.withDebugLogs(logger.getDebugLogs()), logger: logger)
+func outputJSON(_ value: ResultEnvelope<JSONValue>, logger: Logger) {
+    outputJSONCodable(
+        ResultEnvelope(
+            success: value.success,
+            effect: value.effect,
+            data: value.data,
+            messages: value.messages,
+            debug_logs: logger.getDebugLogs(),
+            error: value.error
+        ),
+        logger: logger
+    )
 }
 
-func outputJSON(_ value: ErrorOutput, logger: Logger) {
-    writeConfigJSON(value.withDebugLogs(logger.getDebugLogs()), logger: logger)
-}
-
-func outputJSON(_ value: some Encodable, logger: Logger) {
-    writeConfigJSON(value, logger: logger)
-}
-
-private func writeConfigJSON(_ value: some Encodable, logger: Logger) {
-    let encoder = JSONEncoder()
-    encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-    do {
-        let data = try encoder.encode(value)
-        if let json = String(data: data, encoding: .utf8) {
-            print(json)
-        }
-    } catch {
-        logger.error("Failed to encode config JSON output: \(error.localizedDescription)")
-        print("{\n  \"success\": false,\n  \"error\": {\n    \"message\": \"Failed to encode JSON response\"\n  }\n}")
-    }
+func outputJSON(_ value: ResultEnvelope<Empty?>, logger: Logger) {
+    outputJSONCodable(
+        ResultEnvelope<Empty?>(
+            success: value.success,
+            effect: value.effect,
+            data: value.data,
+            messages: value.messages,
+            debug_logs: logger.getDebugLogs(),
+            error: value.error
+        ),
+        logger: logger
+    )
 }

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/ActionCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/ActionCommand.swift
@@ -5,7 +5,7 @@ import PeekabooCore
 
 @available(macOS 14.0, *)
 @MainActor
-struct ActionCommand: ErrorHandlingCommand, OutputFormattable, RuntimeBackedCommand {
+struct ActionCommand: ConfirmedActionOutputFormattable, ErrorHandlingCommand, OutputFormattable, RuntimeBackedCommand {
     @Argument(help: "Accessibility action name, e.g. AXPress, AXShowMenu, AXIncrement")
     var actionName: String?
 

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/ClickCommand+Output.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/ClickCommand+Output.swift
@@ -2,7 +2,6 @@ import CoreGraphics
 import Foundation
 
 struct ClickResult: Codable {
-    let success: Bool
     let clickedElement: String?
     let clickLocation: [String: Double]
     let waitTime: Double
@@ -15,11 +14,8 @@ struct ClickResult: Codable {
     let screenCoordinates: [String: Double]?
     let targetPoint: InteractionTargetPointDiagnostics?
     let deliveryMode: String?
-    let verified: Bool?
-    let effect: String?
 
     init(
-        success: Bool,
         clickedElement: String?,
         clickLocation: CGPoint,
         waitTime: Double,
@@ -31,11 +27,8 @@ struct ClickResult: Codable {
         inputCoordinates: CGPoint? = nil,
         screenCoordinates: CGPoint? = nil,
         targetPoint: InteractionTargetPointDiagnostics? = nil,
-        deliveryMode: String? = nil,
-        verified: Bool? = nil,
-        effect: String? = nil
+        deliveryMode: String? = nil
     ) {
-        self.success = success
         self.clickedElement = clickedElement
         self.clickLocation = ["x": clickLocation.x, "y": clickLocation.y]
         self.waitTime = waitTime
@@ -48,7 +41,5 @@ struct ClickResult: Codable {
         self.screenCoordinates = screenCoordinates.map { ["x": $0.x, "y": $0.y] }
         self.targetPoint = targetPoint
         self.deliveryMode = deliveryMode
-        self.verified = verified
-        self.effect = effect
     }
 }

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/ClickCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/ClickCommand.swift
@@ -7,7 +7,7 @@ import PeekabooFoundation
 /// Click on UI elements identified in the current snapshot using intelligent element finding and smart waiting.
 @available(macOS 14.0, *)
 @MainActor
-struct ClickCommand: ErrorHandlingCommand, OutputFormattable, RuntimeBackedCommand {
+struct ClickCommand: ActionOutputFormattable, ErrorHandlingCommand, OutputFormattable, RuntimeBackedCommand {
     @Argument(help: "Element text or query to click")
     var query: String?
 
@@ -67,12 +67,11 @@ struct ClickCommand: ErrorHandlingCommand, OutputFormattable, RuntimeBackedComma
         do {
             try validate()
 
-            // Determine click target first to check if we need a snapshot
             let clickTarget: ClickTarget
             let waitResult: WaitForElementResult
             var activeSnapshotId: String
-            var coordinateResolution: InteractionCoordinateResolution?
-            var explicitWindowResolution: InteractionWindowResolution?
+            var coordinateResolution: InteractionCoordinateResolution?,
+                explicitWindowResolution: InteractionWindowResolution?
 
             // Foreground coordinates may be global. Background coordinates must remain bound to
             // one capture-owned exact-window receipt from a named snapshot.
@@ -84,7 +83,7 @@ struct ClickCommand: ErrorHandlingCommand, OutputFormattable, RuntimeBackedComma
                 let resolvedCoordinates: InteractionCoordinateResolution
                 if self.usesBackgroundDelivery {
                     guard let coordinateSnapshotId, !coordinateSnapshotId.isEmpty else {
-                        throw ValidationError(Self.backgroundCoordinateReferenceMessage)
+                        throw Self.backgroundCoordinateRefusal
                     }
                     resolvedCoordinates = try await self.resolveBackgroundCoordinateReference(
                         point,
@@ -267,7 +266,6 @@ struct ClickCommand: ErrorHandlingCommand, OutputFormattable, RuntimeBackedComma
             coordinateResolution: coordinateResolution
         )
         let result = ClickResult(
-            success: true,
             clickedElement: details.clickedElement,
             clickLocation: details.location,
             waitTime: waitResult.waitTime,
@@ -279,11 +277,14 @@ struct ClickCommand: ErrorHandlingCommand, OutputFormattable, RuntimeBackedComma
             inputCoordinates: coordinateResolution?.inputPoint,
             screenCoordinates: coordinateResolution?.screenPoint,
             targetPoint: details.targetPointDiagnostics,
-            deliveryMode: self.deliveryMode.rawValue,
-            verified: self.routedPointerEffectIsUnverifiable ? false : nil,
-            effect: self.routedPointerEffectIsUnverifiable ? "unverifiable" : nil
+            deliveryMode: self.deliveryMode.rawValue
         )
-        self.outputSuccess(result)
+        self.output(result, effect: self.clickEffect(for: clickTarget)) {
+            print(self.clickEffect(for: clickTarget) == .confirmed
+                ? "✅ Click confirmed by Accessibility"
+                : "⚠️ Click dispatched; application effect is unverifiable")
+            self.printClickDetails(result)
+        }
     }
 
     private func clickOutputDetails(
@@ -429,47 +430,41 @@ struct ClickCommand: ErrorHandlingCommand, OutputFormattable, RuntimeBackedComma
         return output.data.applications.first { $0.processIdentifier == processIdentifier }?.name
     }
 
-    private func outputSuccess(_ result: ClickResult) {
-        output(result) {
-            if result.verified == false {
-                print("⚠️ Click dispatched; application effect is unverifiable")
-            } else {
-                print("✅ Click successful")
-            }
-            print("🎯 App: \(result.targetApp)")
-            if let deliveryMode = result.deliveryMode {
-                print("🎯 Mode: \(deliveryMode)")
-            }
-            if let effect = result.effect {
-                print("🔎 Effect: \(effect)")
-            }
-            if let coordinateSpace = result.coordinateSpace {
-                print("🎯 Coordinate space: \(coordinateSpace)")
-            }
-            if let windowID = result.targetWindowId {
-                if let title = result.targetWindowTitle, !title.isEmpty {
-                    print("🪟 Window: \(windowID) (\(title))")
-                } else {
-                    print("🪟 Window: \(windowID)")
-                }
-            }
-            if let info = result.clickedElement {
-                print("📱 Clicked: \(info)")
-            }
-            let x = result.clickLocation["x"] ?? 0
-            let y = result.clickLocation["y"] ?? 0
-            print("📍 Location: (\(Int(x)), \(Int(y)))")
-            if result.waitTime > 0 {
-                print("⏳ Waited: \(String(format: "%.1f", result.waitTime))s")
-            }
-            print("⏱️  Completed in \(String(format: "%.2f", result.executionTime))s")
+    private func printClickDetails(_ result: ClickResult) {
+        print("🎯 App: \(result.targetApp)")
+        if let deliveryMode = result.deliveryMode {
+            print("🎯 Mode: \(deliveryMode)")
         }
+        if let coordinateSpace = result.coordinateSpace {
+            print("🎯 Coordinate space: \(coordinateSpace)")
+        }
+        if let windowID = result.targetWindowId {
+            if let title = result.targetWindowTitle, !title.isEmpty {
+                print("🪟 Window: \(windowID) (\(title))")
+            } else {
+                print("🪟 Window: \(windowID)")
+            }
+        }
+        if let info = result.clickedElement {
+            print("📱 Clicked: \(info)")
+        }
+        let x = result.clickLocation["x"] ?? 0
+        let y = result.clickLocation["y"] ?? 0
+        print("📍 Location: (\(Int(x)), \(Int(y)))")
+        if result.waitTime > 0 {
+            print("⏳ Waited: \(String(format: "%.1f", result.waitTime))s")
+        }
+        print("⏱️  Completed in \(String(format: "%.2f", result.executionTime))s")
     }
 
-    /// Routed pointer APIs acknowledge event queuing, not application-level handling. Report that
-    /// distinction for every background right/double click, including AX-to-pointer fallbacks.
-    private var routedPointerEffectIsUnverifiable: Bool {
-        self.usesBackgroundDelivery && (self.right || self.double)
+    private func clickEffect(for target: ClickTarget) -> ActionEffect {
+        guard self.usesBackgroundDelivery, !self.right, !self.double else { return .unverifiable }
+        switch target {
+        case .elementId, .query:
+            return .confirmed
+        case .coordinates:
+            return .unverifiable
+        }
     }
 
     private func refreshObservationIfQueryMissing(
@@ -913,9 +908,13 @@ struct ClickCommand: ErrorHandlingCommand, OutputFormattable, RuntimeBackedComma
 }
 
 extension ClickCommand {
+    private static let backgroundCoordinateRefusal = ActionRefusalError(
+        message: backgroundCoordinateReferenceMessage,
+        hint: "Use --foreground for explicit global input."
+    )
     private static let backgroundCoordinateReferenceMessage =
         "Background coordinate clicks require --snapshot from a fresh see capture of the exact target window. " +
-        "PID-only/app-only coordinates and empty snapshots are refused; use --foreground for explicit global input."
+        "PID-only/app-only coordinates and empty snapshots are refused."
 
     private func resolveBackgroundClickProcessIdentifier(
         snapshotId: String?,

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/DragCommand+Types.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/DragCommand+Types.swift
@@ -2,7 +2,6 @@ import Foundation
 import PeekabooCore
 
 struct DragResult: Codable {
-    let success: Bool
     let from: [String: Int]
     let to: [String: Int]
     let duration: Int

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/DragCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/DragCommand.swift
@@ -7,7 +7,7 @@ import PeekabooFoundation
 /// Perform drag and drop operations using intelligent element finding
 @available(macOS 14.0, *)
 @MainActor
-struct DragCommand: ErrorHandlingCommand, OutputFormattable, InjectedRuntimeBackedCommand {
+struct DragCommand: ActionOutputFormattable, ErrorHandlingCommand, OutputFormattable, InjectedRuntimeBackedCommand {
     @OptionGroup var target: InteractionTargetOptions
 
     @Option(help: "Starting element ID or coordinates as 'x,y'")
@@ -150,7 +150,6 @@ struct DragCommand: ErrorHandlingCommand, OutputFormattable, InjectedRuntimeBack
             try Task.checkCancellation()
 
             let result = DragResult(
-                success: true,
                 from: ["x": Int(startPoint.x), "y": Int(startPoint.y)],
                 to: ["x": Int(endPoint.x), "y": Int(endPoint.y)],
                 duration: movement.duration,
@@ -184,11 +183,6 @@ struct DragCommand: ErrorHandlingCommand, OutputFormattable, InjectedRuntimeBack
     /// Validate user input combinations
     private mutating func validateInputs() throws {
         try self.target.validate()
-        guard self.focusOptions.foreground else {
-            throw ValidationError(
-                "drag changes the physical cursor and requires explicit --foreground consent."
-            )
-        }
         guard self.from != nil else {
             throw ValidationError("Must specify --from as an element ID or x,y coordinates")
         }
@@ -199,6 +193,12 @@ struct DragCommand: ErrorHandlingCommand, OutputFormattable, InjectedRuntimeBack
 
         if self.to != nil, self.toApp != nil {
             throw ValidationError("Specify only one of --to or --to-app")
+        }
+        guard self.focusOptions.foreground else {
+            throw ActionRefusalError(
+                message: "drag changes the physical cursor and requires explicit consent.",
+                hint: "Use --foreground to provide explicit consent."
+            )
         }
         guard self.resolvedButton != nil else {
             throw ValidationError("--button must be either 'left' or 'right'")

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/MoveCommand+Types.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/MoveCommand+Types.swift
@@ -3,7 +3,6 @@ import Foundation
 import PeekabooCore
 
 struct MoveResult: Codable {
-    let success: Bool
     let targetLocation: [String: Double]
     let targetDescription: String
     let fromLocation: [String: Double]
@@ -15,7 +14,6 @@ struct MoveResult: Codable {
     let executionTime: TimeInterval
 
     init(
-        success: Bool,
         targetLocation: CGPoint,
         targetDescription: String,
         fromLocation: CGPoint,
@@ -26,7 +24,6 @@ struct MoveResult: Codable {
         targetPoint: InteractionTargetPointDiagnostics? = nil,
         executionTime: TimeInterval
     ) {
-        self.success = success
         self.targetLocation = ["x": targetLocation.x, "y": targetLocation.y]
         self.targetDescription = targetDescription
         self.fromLocation = ["x": fromLocation.x, "y": fromLocation.y]

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/MoveCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/MoveCommand.swift
@@ -7,7 +7,7 @@ import PeekabooFoundation
 /// Moves the mouse cursor to specific coordinates or UI elements.
 @available(macOS 14.0, *)
 @MainActor
-struct MoveCommand: ErrorHandlingCommand, OutputFormattable, InjectedRuntimeBackedCommand {
+struct MoveCommand: ActionOutputFormattable, ErrorHandlingCommand, OutputFormattable, InjectedRuntimeBackedCommand {
     @Option(
         help: "x,y — target-relative when --app/--window-* given; global otherwise (use --global for explicit global)"
     )
@@ -40,11 +40,6 @@ struct MoveCommand: ErrorHandlingCommand, OutputFormattable, InjectedRuntimeBack
 
     mutating func validate() throws {
         try self.target.validate()
-        guard self.focusOptions.foreground else {
-            throw ValidationError(
-                "move changes the physical cursor and requires explicit --foreground consent."
-            )
-        }
         let targetCount = [
             self.at == nil ? 0 : 1,
             self.on == nil ? 0 : 1,
@@ -56,6 +51,12 @@ struct MoveCommand: ErrorHandlingCommand, OutputFormattable, InjectedRuntimeBack
 
         guard targetCount == 1 else {
             throw ValidationError("Specify exactly one target: --at or --on")
+        }
+        guard self.focusOptions.foreground else {
+            throw ActionRefusalError(
+                message: "move changes the physical cursor and requires explicit consent.",
+                hint: "Use --foreground to provide explicit consent."
+            )
         }
 
         // Validate coordinates format if provided
@@ -118,7 +119,6 @@ struct MoveCommand: ErrorHandlingCommand, OutputFormattable, InjectedRuntimeBack
 
             // Output results
             let result = MoveResult(
-                success: true,
                 targetLocation: targetLocation,
                 targetDescription: targetDescription,
                 fromLocation: currentLocation,

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/PasteCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/PasteCommand.swift
@@ -7,7 +7,7 @@ import UniformTypeIdentifiers
 /// Pastes text through background typing when targeted, otherwise uses clipboard + Cmd+V.
 @available(macOS 14.0, *)
 @MainActor
-struct PasteCommand: ErrorHandlingCommand, OutputFormattable, RuntimeBackedCommand {
+struct PasteCommand: ActionOutputFormattable, ErrorHandlingCommand, OutputFormattable, RuntimeBackedCommand {
     @Argument(help: "Text to paste")
     var text: String?
 
@@ -121,7 +121,6 @@ struct PasteCommand: ErrorHandlingCommand, OutputFormattable, RuntimeBackedComma
             }
 
             let result = PasteResult(
-                success: true,
                 pastedUti: outcome.setResult.utiIdentifier,
                 pastedSize: outcome.setResult.data.count,
                 pastedTextPreview: outcome.setResult.textPreview,
@@ -136,7 +135,10 @@ struct PasteCommand: ErrorHandlingCommand, OutputFormattable, RuntimeBackedComma
                 targetPID: outcome.targetPID.map(Int.init)
             )
 
-            self.output(result) {
+            self.output(
+                result,
+                effect: outcome.restoreErrorDescription == nil ? .unverifiable : .partial
+            ) {
                 if outcome.restoreErrorDescription != nil {
                     print("⚠️  Pasted, but clipboard restoration failed. Do not retry the paste; " +
                         "the previous clipboard contents may be unavailable.")
@@ -310,7 +312,6 @@ struct PasteCommand: ErrorHandlingCommand, OutputFormattable, RuntimeBackedComma
         }
 
         let result = PasteResult(
-            success: true,
             pastedUti: setResult.utiIdentifier,
             pastedSize: setResult.data.count,
             pastedTextPreview: setResult.textPreview,
@@ -457,7 +458,6 @@ struct PasteCommand: ErrorHandlingCommand, OutputFormattable, RuntimeBackedComma
         }
 
         let result = PasteResult(
-            success: true,
             pastedUti: outcome.clipboard?.utiIdentifier ?? "current-clipboard",
             pastedSize: outcome.clipboard?.data.count ?? 0,
             // Never echo ambient clipboard content into structured output: the
@@ -613,7 +613,6 @@ private struct CurrentClipboardPasteOutcome: Sendable {
 }
 
 struct PasteResult: Codable {
-    let success: Bool
     let pastedUti: String
     let pastedSize: Int
     let pastedTextPreview: String?

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/PressCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/PressCommand.swift
@@ -6,7 +6,7 @@ import PeekabooFoundation
 /// Press keyboard chords or chord sequences.
 @available(macOS 14.0, *)
 @MainActor
-struct PressCommand: ErrorHandlingCommand, OutputFormattable, RuntimeOptionsConfigurable {
+struct PressCommand: ActionOutputFormattable, ErrorHandlingCommand, OutputFormattable, RuntimeOptionsConfigurable {
     @Argument(help: "Chord(s) to press. Chord syntax matches xdotool key (cmd+shift+t).")
     var chords: [String]
 
@@ -124,7 +124,6 @@ struct PressCommand: ErrorHandlingCommand, OutputFormattable, RuntimeOptionsConf
 
             // Output results
             let pressResult = PressResult(
-                success: true,
                 keys: parsedChords.map(\.displayValue),
                 totalPresses: completedPresses,
                 count: self.count,
@@ -190,10 +189,7 @@ struct PressCommand: ErrorHandlingCommand, OutputFormattable, RuntimeOptionsConf
     }
 }
 
-// MARK: - JSON Output Structure
-
 struct PressResult: Codable {
-    let success: Bool
     let keys: [String]
     let totalPresses: Int
     let count: Int

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/ScrollCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/ScrollCommand.swift
@@ -8,7 +8,7 @@ import PeekabooFoundation
 /// Supports scrolling on specific elements or at the current mouse position.
 @available(macOS 14.0, *)
 @MainActor
-struct ScrollCommand: ErrorHandlingCommand, OutputFormattable, RuntimeBackedCommand {
+struct ScrollCommand: ActionOutputFormattable, ErrorHandlingCommand, OutputFormattable, RuntimeBackedCommand {
     @Option(help: "Scroll direction: up, down, left, or right")
     var direction: String
 
@@ -132,7 +132,6 @@ struct ScrollCommand: ErrorHandlingCommand, OutputFormattable, RuntimeBackedComm
 
             // Output results
             let outputPayload = ScrollResult(
-                success: true,
                 direction: direction,
                 amount: amount,
                 location: ["x": scrollLocation.x, "y": scrollLocation.y],
@@ -140,7 +139,7 @@ struct ScrollCommand: ErrorHandlingCommand, OutputFormattable, RuntimeBackedComm
                 targetPoint: scrollResolution.diagnostics,
                 executionTime: Date().timeIntervalSince(startTime)
             )
-            output(outputPayload) {
+            output(outputPayload, effect: self.focusOptions.foreground ? .unverifiable : .confirmed) {
                 print("✅ Scroll completed")
                 print("🎯 Direction: \(self.direction)")
                 print("📊 Amount: \(self.amount) ticks")
@@ -159,9 +158,9 @@ struct ScrollCommand: ErrorHandlingCommand, OutputFormattable, RuntimeBackedComm
     private func validateDeliveryMode() throws {
         guard self.focusOptions.foreground else {
             if self.on == nil {
-                throw ValidationError(
-                    "Background scroll requires --on with an Accessibility-scrollable element; " +
-                        "add --foreground to scroll at the physical pointer."
+                throw ActionRefusalError(
+                    message: "Background scroll requires --on with an Accessibility-scrollable element.",
+                    hint: "Add --foreground to scroll at the physical pointer."
                 )
             }
             if self.smooth || self.delay.milliseconds > 0 {
@@ -179,10 +178,7 @@ struct ScrollCommand: ErrorHandlingCommand, OutputFormattable, RuntimeBackedComm
     // Error handling is provided by ErrorHandlingCommand protocol
 }
 
-// MARK: - JSON Output Structure
-
 struct ScrollResult: Codable {
-    let success: Bool
     let direction: String
     let amount: Int
     let location: [String: Double]
@@ -191,7 +187,6 @@ struct ScrollResult: Codable {
     let executionTime: TimeInterval
 
     init(
-        success: Bool,
         direction: String,
         amount: Int,
         location: [String: Double],
@@ -199,7 +194,6 @@ struct ScrollResult: Codable {
         targetPoint: InteractionTargetPointDiagnostics? = nil,
         executionTime: TimeInterval
     ) {
-        self.success = success
         self.direction = direction
         self.amount = amount
         self.location = location

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/SetValueCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/SetValueCommand.swift
@@ -5,7 +5,8 @@ import PeekabooCore
 
 @available(macOS 14.0, *)
 @MainActor
-struct SetValueCommand: ErrorHandlingCommand, OutputFormattable, RuntimeBackedCommand {
+struct SetValueCommand: ConfirmedActionOutputFormattable, ErrorHandlingCommand, OutputFormattable,
+RuntimeBackedCommand {
     @Argument(help: "Value to set")
     var value: String?
 
@@ -125,7 +126,6 @@ extension SetValueCommand: CommanderSignatureProviding {
 }
 
 struct ElementActionCommandResult: Codable {
-    let success: Bool
     let target: String
     let actionName: String?
     let oldValue: String?
@@ -204,7 +204,6 @@ enum ElementActionCommandExecutor {
             )
 
             let output = ElementActionCommandResult(
-                success: true,
                 target: result.target,
                 actionName: result.actionName,
                 oldValue: result.oldValue,

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/TypeCommand+Types.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/TypeCommand+Types.swift
@@ -1,7 +1,6 @@
 import Foundation
 
 struct TypeCommandResult: Codable {
-    let success: Bool
     let requestedText: String?
     let typedText: String?
     let keyPresses: Int

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/TypeCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/TypeCommand.swift
@@ -6,7 +6,7 @@ import PeekabooFoundation
 /// Types text into focused elements or sends keyboard input using the UIAutomationService.
 @available(macOS 14.0, *)
 @MainActor
-struct TypeCommand: ErrorHandlingCommand, OutputFormattable, RuntimeBackedCommand {
+struct TypeCommand: ActionOutputFormattable, ErrorHandlingCommand, OutputFormattable, RuntimeBackedCommand {
     @Argument(help: "Text to type")
     var text: String?
 
@@ -197,7 +197,6 @@ struct TypeCommand: ErrorHandlingCommand, OutputFormattable, RuntimeBackedComman
     ) {
         let specialKeys = max(typeResult.keyPresses - typeResult.totalCharacters, 0)
         let result = TypeCommandResult(
-            success: true,
             requestedText: self.resolvedText,
             typedText: self.resolvedText,
             keyPresses: typeResult.keyPresses,

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/MCP/MCPToolCommandOutput.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/MCP/MCPToolCommandOutput.swift
@@ -12,14 +12,6 @@ struct MCPToolCommandPayload: Codable {
     let meta: Value?
 }
 
-struct MCPToolCommandJSONEnvelope: Codable {
-    let success: Bool
-    let data: MCPToolCommandPayload
-    let messages: [String]?
-    let debug_logs: [String]
-    let error: ErrorInfo?
-}
-
 @MainActor
 enum MCPToolCommandOutput {
     static func payload(tool: String, response: ToolResponse) -> MCPToolCommandPayload {
@@ -43,7 +35,7 @@ enum MCPToolCommandOutput {
             let error = response.isError
                 ? ErrorInfo(message: payload.text, code: .VALIDATION_ERROR)
                 : nil
-            let envelope = MCPToolCommandJSONEnvelope(
+            let envelope = ResultEnvelope(
                 success: !response.isError,
                 data: payload,
                 messages: nil,

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/AppCommand+Launch.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/AppCommand+Launch.swift
@@ -195,7 +195,8 @@ extension AppCommand {
     }
 }
 
-extension AppCommand.LaunchSubcommand: AsyncRuntimeCommand, ErrorHandlingCommand, OutputFormattable {}
+extension AppCommand.LaunchSubcommand: AsyncRuntimeCommand, ConfirmedActionOutputFormattable, ErrorHandlingCommand,
+OutputFormattable {}
 
 @MainActor
 extension AppCommand.LaunchSubcommand: CommanderBindableCommand {

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/AppCommand+Quit.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/AppCommand+Quit.swift
@@ -111,11 +111,18 @@ extension AppCommand {
                 let allSucceeded = results.allSatisfy(\.success)
 
                 if self.jsonOutput {
-                    let response = CodableJSONResponse(
+                    let succeededCount = results.count(where: \.success)
+                    let response = ResultEnvelope(
                         success: allSucceeded,
+                        effect: allSucceeded ? .confirmed : (succeededCount > 0 ? .partial : .suspectedNoop),
                         data: data,
                         messages: nil,
-                        debug_logs: self.outputLogger.getDebugLogs()
+                        debug_logs: self.outputLogger.getDebugLogs(),
+                        error: allSucceeded ? nil : ErrorInfo(
+                            message: "Failed to quit \(results.count - succeededCount) application(s).",
+                            code: .INTERACTION_FAILED,
+                            hint: self.force ? nil : "Try --force to force quit."
+                        )
                     )
                     outputJSONCodable(response, logger: self.outputLogger)
                 } else {
@@ -239,7 +246,8 @@ private struct AppQuitTarget {
     }
 }
 
-extension AppCommand.QuitSubcommand: AsyncRuntimeCommand, ErrorHandlingCommand, OutputFormattable,
+extension AppCommand.QuitSubcommand: AsyncRuntimeCommand, ConfirmedActionOutputFormattable, ErrorHandlingCommand,
+    OutputFormattable,
     ApplicationResolvable,
     ApplicationResolver {}
 

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/AppCommand+Relaunch.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/AppCommand+Relaunch.swift
@@ -125,7 +125,8 @@ extension AppCommand {
     }
 }
 
-extension AppCommand.RelaunchSubcommand: AsyncRuntimeCommand, ErrorHandlingCommand, OutputFormattable,
+extension AppCommand.RelaunchSubcommand: AsyncRuntimeCommand, ConfirmedActionOutputFormattable, ErrorHandlingCommand,
+    OutputFormattable,
     ApplicationResolvable,
     ApplicationResolver {}
 

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/AppCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/AppCommand.swift
@@ -244,7 +244,7 @@ struct AppCommand: ParsableCommand {
                         success: true
                     )
 
-                    output(data) {
+                    output(data, effect: self.verify ? .confirmed : .unverifiable) {
                         print("✓ Switched to \(appInfo.name)")
                     }
                     AutomationEventLogger.log(
@@ -332,8 +332,9 @@ struct AppCommand: ParsableCommand {
     }
 }
 
-extension AppCommand.HideSubcommand: AsyncRuntimeCommand, ErrorHandlingCommand, OutputFormattable,
-ApplicationResolvable, ApplicationResolver {}
+extension AppCommand.HideSubcommand: AsyncRuntimeCommand, ConfirmedActionOutputFormattable, ErrorHandlingCommand,
+    OutputFormattable,
+    ApplicationResolvable, ApplicationResolver {}
 @MainActor
 extension AppCommand.HideSubcommand: CommanderBindableCommand {
     mutating func applyCommanderValues(_ values: CommanderBindableValues) throws {
@@ -345,8 +346,9 @@ extension AppCommand.HideSubcommand: CommanderBindableCommand {
     }
 }
 
-extension AppCommand.UnhideSubcommand: AsyncRuntimeCommand, ErrorHandlingCommand, OutputFormattable,
-ApplicationResolvable, ApplicationResolver {}
+extension AppCommand.UnhideSubcommand: AsyncRuntimeCommand, ConfirmedActionOutputFormattable, ErrorHandlingCommand,
+    OutputFormattable,
+    ApplicationResolvable, ApplicationResolver {}
 @MainActor
 extension AppCommand.UnhideSubcommand: CommanderBindableCommand {
     mutating func applyCommanderValues(_ values: CommanderBindableValues) throws {
@@ -390,8 +392,9 @@ extension AppCommand {
     }
 }
 
-extension AppCommand.SwitchSubcommand: AsyncRuntimeCommand, ErrorHandlingCommand, OutputFormattable,
-ApplicationResolver {}
+extension AppCommand.SwitchSubcommand: ActionOutputFormattable, AsyncRuntimeCommand, ErrorHandlingCommand,
+    OutputFormattable,
+    ApplicationResolver {}
 @MainActor
 extension AppCommand.SwitchSubcommand: CommanderBindableCommand {
     mutating func applyCommanderValues(_ values: CommanderBindableValues) throws {
@@ -401,8 +404,9 @@ extension AppCommand.SwitchSubcommand: CommanderBindableCommand {
     }
 }
 
-extension AppCommand.FocusSubcommand: AsyncRuntimeCommand, ErrorHandlingCommand, OutputFormattable,
-ApplicationResolvable, ApplicationResolver {}
+extension AppCommand.FocusSubcommand: ActionOutputFormattable, AsyncRuntimeCommand, ErrorHandlingCommand,
+    OutputFormattable,
+    ApplicationResolvable, ApplicationResolver {}
 @MainActor
 extension AppCommand.FocusSubcommand: CommanderBindableCommand {
     mutating func applyCommanderValues(_ values: CommanderBindableValues) throws {

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/ClipboardCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/ClipboardCommand.swift
@@ -5,7 +5,8 @@ import UniformTypeIdentifiers
 
 @available(macOS 14.0, *)
 @MainActor
-struct ClipboardActionCommand: OutputFormattable, RuntimeOptionsConfigurable {
+struct ClipboardActionCommand: ActionOutputFormattable, ErrorHandlingCommand, OutputFormattable,
+RuntimeOptionsConfigurable {
     var action: String?
     var actionOption: String?
 
@@ -71,28 +72,39 @@ struct ClipboardActionCommand: OutputFormattable, RuntimeOptionsConfigurable {
         self.configuration.jsonOutput
     }
 
+    var defaultEffect: ActionEffect? {
+        let action = (self.action ?? self.actionOption)?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard Self.actionMayMutate(action) else { return nil }
+        return .unverifiable
+    }
+
     @MainActor
     mutating func run(using runtime: CommandRuntime) async throws {
         self.runtime = runtime
         self.logger.setJsonOutputMode(self.jsonOutput)
 
-        let action = try self.resolvedAction()
-        if Self.actionMayMutate(action) {
-            self.resolvedRuntime.beginInteractionMutation()
-        }
-        switch action.lowercased() {
-        case "get":
-            try self.handleGet()
-        case "set":
-            try self.handleSet()
-        case "clear":
-            self.handleClear()
-        case "save":
-            try self.handleSave()
-        case "restore":
-            try self.handleRestore()
-        default:
-            throw ValidationError("Invalid action: \(action)")
+        do {
+            let action = try self.resolvedAction()
+            if Self.actionMayMutate(action) {
+                self.resolvedRuntime.beginInteractionMutation()
+            }
+            switch action.lowercased() {
+            case "get":
+                try self.handleGet()
+            case "set":
+                try self.handleSet()
+            case "clear":
+                self.handleClear()
+            case "save":
+                try self.handleSave()
+            case "restore":
+                try self.handleRestore()
+            default:
+                throw ValidationError("Invalid action: \(action)")
+            }
+        } catch {
+            self.handleError(error)
+            throw ExitCode.failure
         }
     }
 
@@ -184,7 +196,7 @@ struct ClipboardActionCommand: OutputFormattable, RuntimeOptionsConfigurable {
             verification: verification
         )
 
-        self.output(payload) {
+        self.output(payload, effect: verification == nil ? .unverifiable : .confirmed) {
             print("✅ Set clipboard (\(result.utiIdentifier), \(result.data.count) bytes)")
             self.printVerificationSummary(verification)
         }

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/DialogCommand+Click.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/DialogCommand+Click.swift
@@ -6,7 +6,7 @@ extension DialogCommand {
     // MARK: - Click Dialog Button
 
     @MainActor
-    struct ClickSubcommand: InjectedRuntimeBackedCommand {
+    struct ClickSubcommand: ConfirmedActionOutputFormattable, InjectedRuntimeBackedCommand {
         @Option(help: "Button text to click (e.g., 'OK', 'Cancel', 'Save')")
         var button: String
 
@@ -44,7 +44,7 @@ extension DialogCommand {
                             buttonIdentifier: result.details["button_identifier"],
                             window: result.details["window"] ?? "Dialog"
                         )
-                        outputSuccessCodable(data: outputData, logger: self.outputLogger)
+                        outputSuccessCodable(data: outputData, effect: .confirmed, logger: self.outputLogger)
                     } else {
                         print("✓ Clicked '\(result.details["button"] ?? self.button)' button")
                     }

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/DialogCommand+DismissList.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/DialogCommand+DismissList.swift
@@ -6,7 +6,7 @@ extension DialogCommand {
     // MARK: - Dismiss Dialog
 
     @MainActor
-    struct DismissSubcommand: InjectedRuntimeBackedCommand {
+    struct DismissSubcommand: ConfirmedActionOutputFormattable, InjectedRuntimeBackedCommand {
         static let commandDescription = CommandDescription(
             commandName: "dismiss",
             abstract: "Dismiss a dialog using DialogService"
@@ -50,7 +50,7 @@ extension DialogCommand {
                             method: result.details["method"] ?? "unknown",
                             button: result.details["button"]
                         )
-                        outputSuccessCodable(data: outputData, logger: self.outputLogger)
+                        outputSuccessCodable(data: outputData, effect: .confirmed, logger: self.outputLogger)
                     } else if result.details["method"] == "escape" {
                         print("✓ Dismissed dialog with Escape")
                     } else if let button = result.details["button"] {

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/DialogCommand+File.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/DialogCommand+File.swift
@@ -7,7 +7,7 @@ extension DialogCommand {
     // MARK: - Handle File Dialog
 
     @MainActor
-    struct FileSubcommand: InjectedRuntimeBackedCommand {
+    struct FileSubcommand: ConfirmedActionOutputFormattable, InjectedRuntimeBackedCommand {
         static let commandDescription = CommandDescription(
             commandName: "file",
             abstract: "Handle file save/open dialogs using DialogService"
@@ -71,7 +71,11 @@ extension DialogCommand {
                     }
 
                     if self.jsonOutput {
-                        outputSuccessCodable(data: self.makeOutput(from: result), logger: self.outputLogger)
+                        outputSuccessCodable(
+                            data: self.makeOutput(from: result),
+                            effect: .confirmed,
+                            logger: self.outputLogger
+                        )
                     } else {
                         print("✓ Handled file dialog")
                         if let path = result.details["path"] {

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/DialogCommand+Input.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/DialogCommand+Input.swift
@@ -6,7 +6,7 @@ extension DialogCommand {
     // MARK: - Input Text in Dialog
 
     @MainActor
-    struct InputSubcommand: InjectedRuntimeBackedCommand {
+    struct InputSubcommand: ConfirmedActionOutputFormattable, InjectedRuntimeBackedCommand {
         static let commandDescription = CommandDescription(
             commandName: "input",
             abstract: "Enter text in a dialog field using DialogService"
@@ -60,7 +60,7 @@ extension DialogCommand {
                             textLength: result.details["text_length"] ?? String(self.text.count),
                             cleared: result.details["cleared"] ?? String(self.clear)
                         )
-                        outputSuccessCodable(data: outputData, logger: self.outputLogger)
+                        outputSuccessCodable(data: outputData, effect: .confirmed, logger: self.outputLogger)
                     } else {
                         print("✓ Entered text in '\(result.details["field"] ?? "field")'")
                     }

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/DialogCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/DialogCommand.swift
@@ -298,15 +298,17 @@ func handleDialogServiceError(_ error: DialogError, jsonOutput: Bool, logger: Lo
         default:
             nil
         }
-        let response = JSONResponse(
+        let response = ResultEnvelope<Empty?>(
             success: false,
+            effect: ResultEnvelopeContext.isActionCommand ? defaultActionErrorEffect(errorCode) : nil,
+            data: nil,
             error: ErrorInfo(
                 message: error.localizedDescription,
                 code: errorCode,
                 details: details
             )
         )
-        outputJSON(response, logger: logger)
+        outputJSONCodable(response, logger: logger)
     } else {
         fputs("❌ \(error.localizedDescription)\n", stderr)
     }

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/DockCommand+Launch.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/DockCommand+Launch.swift
@@ -7,7 +7,7 @@ extension DockCommand {
     // MARK: - Launch from Dock
 
     @MainActor
-    struct LaunchSubcommand: OutputFormattable, InjectedRuntimeBackedCommand {
+    struct LaunchSubcommand: ConfirmedActionOutputFormattable, OutputFormattable, InjectedRuntimeBackedCommand {
         @Argument(help: "Application name in the Dock")
         var app: String
 
@@ -36,7 +36,7 @@ extension DockCommand {
                     }
 
                     let outputData = DockLaunchResult(action: "dock_launch", app: dockItem.title)
-                    outputSuccessCodable(data: outputData, logger: self.outputLogger)
+                    outputSuccessCodable(data: outputData, effect: .confirmed, logger: self.outputLogger)
                 } else {
                     print("✓ Launched \(dockItem.title) from Dock")
                 }

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/DockCommand+RightClick.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/DockCommand+RightClick.swift
@@ -5,7 +5,7 @@ extension DockCommand {
     // MARK: - Right-Click Dock Item
 
     @MainActor
-    struct RightClickSubcommand: OutputFormattable, InjectedRuntimeBackedCommand {
+    struct RightClickSubcommand: ConfirmedActionOutputFormattable, OutputFormattable, InjectedRuntimeBackedCommand {
         @Option(help: "Application name in the Dock")
         var app: String
 
@@ -41,7 +41,7 @@ extension DockCommand {
                         app: dockItem.title,
                         selectedItem: self.select ?? ""
                     )
-                    outputSuccessCodable(data: outputData, logger: self.outputLogger)
+                    outputSuccessCodable(data: outputData, effect: .confirmed, logger: self.outputLogger)
                 } else if let selected = self.select {
                     print("✓ Right-clicked \(dockItem.title) and selected '\(selected)'")
                 } else {

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/DockCommand+Visibility.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/DockCommand+Visibility.swift
@@ -5,7 +5,8 @@ extension DockCommand {
     // MARK: - Hide Dock
 
     @MainActor
-    struct HideSubcommand: ErrorHandlingCommand, OutputFormattable, InjectedRuntimeBackedCommand {
+    struct HideSubcommand: ConfirmedActionOutputFormattable, ErrorHandlingCommand, OutputFormattable,
+    InjectedRuntimeBackedCommand {
         @RuntimeStorage var runtime: CommandRuntime?
 
         @MainActor
@@ -20,7 +21,11 @@ extension DockCommand {
 
                 if self.jsonOutput {
                     struct DockHideResult: Codable { let action: String }
-                    outputSuccessCodable(data: DockHideResult(action: "dock_hide"), logger: self.outputLogger)
+                    outputSuccessCodable(
+                        data: DockHideResult(action: "dock_hide"),
+                        effect: .confirmed,
+                        logger: self.outputLogger
+                    )
                 } else {
                     print("✓ Dock hidden")
                 }
@@ -37,7 +42,8 @@ extension DockCommand {
     // MARK: - Show Dock
 
     @MainActor
-    struct ShowSubcommand: ErrorHandlingCommand, OutputFormattable, InjectedRuntimeBackedCommand {
+    struct ShowSubcommand: ConfirmedActionOutputFormattable, ErrorHandlingCommand, OutputFormattable,
+    InjectedRuntimeBackedCommand {
         @RuntimeStorage var runtime: CommandRuntime?
 
         @MainActor
@@ -52,7 +58,11 @@ extension DockCommand {
 
                 if self.jsonOutput {
                     struct DockShowResult: Codable { let action: String }
-                    outputSuccessCodable(data: DockShowResult(action: "dock_show"), logger: self.outputLogger)
+                    outputSuccessCodable(
+                        data: DockShowResult(action: "dock_show"),
+                        effect: .confirmed,
+                        logger: self.outputLogger
+                    )
                 } else {
                     print("✓ Dock shown")
                 }

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/DockCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/DockCommand.swift
@@ -166,14 +166,16 @@ func handleDockServiceError(_ error: DockError, jsonOutput: Bool, logger: Logger
     }
 
     if jsonOutput {
-        let response = JSONResponse(
+        let response = ResultEnvelope<Empty?>(
             success: false,
+            effect: ResultEnvelopeContext.isActionCommand ? defaultActionErrorEffect(errorCode) : nil,
+            data: nil,
             error: ErrorInfo(
                 message: error.localizedDescription,
                 code: errorCode
             )
         )
-        outputJSON(response, logger: logger)
+        outputJSONCodable(response, logger: logger)
     } else {
         fputs("❌ \(error.localizedDescription)\n", stderr)
     }

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/MenuBarCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/MenuBarCommand.swift
@@ -107,7 +107,11 @@ struct MenuBarActionCommand: ErrorHandlingCommand, OutputFormattable, InjectedRu
                     executionTime: Date().timeIntervalSince(startTime),
                     verified: verification?.verified
                 )
-                outputSuccessCodable(data: output, logger: self.outputLogger)
+                outputSuccessCodable(
+                    data: output,
+                    effect: verification?.verified == true ? .confirmed : .unverifiable,
+                    logger: self.outputLogger
+                )
             } else {
                 print("✅ Clicked menu bar item: \(result.elementDescription)")
                 if let verification {
@@ -177,8 +181,6 @@ struct MenuBarActionCommand: ErrorHandlingCommand, OutputFormattable, InjectedRu
     }
 }
 
-// MARK: - JSON Output Types
-
 private struct ClickJSONOutput: Codable {
     let success: Bool
     let clicked: String
@@ -222,7 +224,7 @@ struct MenuBarCommand: ParsableCommand {
         }
     }
 
-    struct ClickSubcommand: RuntimeBackedCommand {
+    struct ClickSubcommand: ActionOutputFormattable, RuntimeBackedCommand {
         static let commandDescription = CommandDescription(
             commandName: "click",
             abstract: "Click a menu bar status item"

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/MenuCommand+Click.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/MenuCommand+Click.swift
@@ -7,7 +7,7 @@ extension MenuCommand {
     // MARK: - Click Menu Item
 
     @MainActor
-    struct ClickSubcommand: OutputFormattable, InjectedRuntimeBackedCommand {
+    struct ClickSubcommand: ConfirmedActionOutputFormattable, OutputFormattable, InjectedRuntimeBackedCommand {
         @OptionGroup var target: InteractionTargetOptions
 
         @Option(help: "Menu item to click (for simple, non-nested items)")
@@ -103,7 +103,7 @@ extension MenuCommand {
                         menu_path: clickedPath,
                         clicked_item: clickedPath
                     )
-                    outputSuccessCodable(data: data, logger: self.outputLogger)
+                    outputSuccessCodable(data: data, effect: .confirmed, logger: self.outputLogger)
                 } else {
                     print("✓ Clicked menu item: \(clickedPath)")
                 }

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/SpaceCommand+MoveWindow.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/SpaceCommand+MoveWindow.swift
@@ -5,8 +5,9 @@ import PeekabooCore
 // MARK: - Move Window to Space
 
 @MainActor
-struct MoveWindowSubcommand: ApplicationResolvable, ErrorHandlingCommand, OutputFormattable,
-InjectedRuntimeBackedCommand {
+struct MoveWindowSubcommand: ActionOutputFormattable, ApplicationResolvable, ErrorHandlingCommand,
+    OutputFormattable,
+    InjectedRuntimeBackedCommand {
     @Option(name: .long, help: "Target application name, bundle ID, or 'PID:12345'")
     var app: String?
 
@@ -81,7 +82,7 @@ InjectedRuntimeBackedCommand {
                         moved_to_current: true,
                         followed: nil
                     )
-                    outputSuccessCodable(data: data, logger: self.logger)
+                    outputSuccessCodable(data: data, effect: .unverifiable, logger: self.logger)
                 } else {
                     print("✓ Moved window '\(windowInfo.title)' to current Space")
                 }
@@ -120,7 +121,7 @@ InjectedRuntimeBackedCommand {
                     moved_to_current: false,
                     followed: self.follow
                 )
-                outputSuccessCodable(data: data, logger: self.logger)
+                outputSuccessCodable(data: data, effect: .unverifiable, logger: self.logger)
             } else {
                 var message = "✓ Moved window '\(windowInfo.title)' to Space \(spaceNum)"
                 if self.follow {

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/SpaceCommand+Switch.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/SpaceCommand+Switch.swift
@@ -4,7 +4,8 @@ import PeekabooCore
 // MARK: - Switch Space
 
 @MainActor
-struct SwitchSubcommand: ErrorHandlingCommand, OutputFormattable, InjectedRuntimeBackedCommand {
+struct SwitchSubcommand: ActionOutputFormattable, ErrorHandlingCommand, OutputFormattable,
+InjectedRuntimeBackedCommand {
     @Option(name: .long, help: "Space number to switch to (1-based)")
     var to: Int
     @RuntimeStorage var runtime: CommandRuntime?
@@ -38,7 +39,7 @@ struct SwitchSubcommand: ErrorHandlingCommand, OutputFormattable, InjectedRuntim
                     space_id: targetSpace.id,
                     space_number: self.to
                 )
-                outputSuccessCodable(data: data, logger: self.logger)
+                outputSuccessCodable(data: data, effect: .unverifiable, logger: self.logger)
             } else {
                 print("✓ Switched to Space \(self.to)")
             }

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/WindowCommand+Bindings.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/WindowCommand+Bindings.swift
@@ -4,7 +4,6 @@ import PeekabooCore
 
 struct WindowActionResult: Codable {
     let action: String
-    let success: Bool
     let app_name: String
     let window_title: String?
     /// The frame the window actually has after the operation (read back from the OS).

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/WindowCommand+Focus.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/WindowCommand+Focus.swift
@@ -6,7 +6,8 @@ import PeekabooFoundation
 
 extension WindowCommand {
     @MainActor
-    struct FocusSubcommand: ErrorHandlingCommand, OutputFormattable, InjectedRuntimeBackedCommand {
+    struct FocusSubcommand: ActionOutputFormattable, ErrorHandlingCommand, OutputFormattable,
+    InjectedRuntimeBackedCommand {
         @OptionGroup var windowOptions: WindowIdentificationOptions
 
         @OptionGroup var focusOptions: FocusCommandOptions
@@ -132,12 +133,11 @@ extension WindowCommand {
 
                 let data = createWindowActionResult(
                     action: "focus",
-                    success: true,
                     windowInfo: finalWindowInfo,
                     appName: appName
                 )
 
-                output(data) {
+                output(data, effect: self.verify ? .confirmed : .unverifiable) {
                     var message = "Successfully focused window '\(finalWindowInfo?.title ?? "Untitled")' of \(appName)"
                     if self.focusOptions.bringToCurrentSpace {
                         message += " (moved to current Space)"

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/WindowCommand+Geometry.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/WindowCommand+Geometry.swift
@@ -8,7 +8,8 @@ extension WindowCommand {
     // MARK: - Move Command
 
     @MainActor
-    struct MoveSubcommand: ErrorHandlingCommand, OutputFormattable, InjectedRuntimeBackedCommand {
+    struct MoveSubcommand: ActionOutputFormattable, ErrorHandlingCommand, OutputFormattable,
+    InjectedRuntimeBackedCommand {
         @OptionGroup var windowOptions: WindowIdentificationOptions
 
         @Option(name: .customShort("x", allowingJoined: false), help: "New X coordinate")
@@ -80,7 +81,7 @@ extension WindowCommand {
                     windowInfo: verified.windowInfo
                 )
 
-                output(verified.result) {
+                output(verified.result, effect: verified.effect) {
                     let title = verified.windowInfo?.title ?? "Untitled"
                     let actualOrigin = verified.windowInfo?.bounds.origin ?? newOrigin
                     if let warning = verified.warning {
@@ -105,7 +106,8 @@ extension WindowCommand {
     // MARK: - Resize Command
 
     @MainActor
-    struct ResizeSubcommand: ErrorHandlingCommand, OutputFormattable, InjectedRuntimeBackedCommand {
+    struct ResizeSubcommand: ActionOutputFormattable, ErrorHandlingCommand, OutputFormattable,
+    InjectedRuntimeBackedCommand {
         @OptionGroup var windowOptions: WindowIdentificationOptions
 
         @Option(name: .customShort("w", allowingJoined: false), help: "New width")
@@ -177,7 +179,7 @@ extension WindowCommand {
                     windowInfo: verified.windowInfo
                 )
 
-                output(verified.result) {
+                output(verified.result, effect: verified.effect) {
                     let title = verified.windowInfo?.title ?? "Untitled"
                     let actualSize = verified.windowInfo?.bounds.size ?? newSize
                     if let warning = verified.warning {
@@ -202,7 +204,8 @@ extension WindowCommand {
     // MARK: - Set Bounds Command
 
     @MainActor
-    struct SetBoundsSubcommand: ErrorHandlingCommand, OutputFormattable, InjectedRuntimeBackedCommand {
+    struct SetBoundsSubcommand: ActionOutputFormattable, ErrorHandlingCommand, OutputFormattable,
+    InjectedRuntimeBackedCommand {
         @OptionGroup var windowOptions: WindowIdentificationOptions
 
         @Option(name: .customShort("x", allowingJoined: false), help: "New X coordinate")
@@ -280,7 +283,7 @@ extension WindowCommand {
                     windowInfo: verified.windowInfo
                 )
 
-                output(verified.result) {
+                output(verified.result, effect: verified.effect) {
                     let title = verified.windowInfo?.title ?? "Untitled"
                     let actualBounds = verified.windowInfo?.bounds ?? newBounds
                     let actualDescription =

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/WindowCommand+GeometryVerification.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/WindowCommand+GeometryVerification.swift
@@ -29,11 +29,19 @@ enum WindowGeometryOutcome: Equatable {
 }
 
 /// Thrown when a geometry mutation was accepted by AX but the window frame did not change at all.
-struct WindowGeometryIgnoredError: Error, LocalizedError {
+struct WindowGeometryIgnoredError: Error, LocalizedError, ResultEnvelopeError {
     let reason: String
 
-    var errorDescription: String? {
+    nonisolated var errorDescription: String? {
         self.reason
+    }
+
+    nonisolated var envelopeEffect: ActionEffect? {
+        .suspectedNoop
+    }
+
+    nonisolated var envelopeHint: String? {
+        nil
     }
 }
 
@@ -117,6 +125,7 @@ struct VerifiedWindowActionOutput {
     let windowInfo: ServiceWindowInfo?
     let result: WindowActionResult
     let warning: String?
+    let effect: ActionEffect
 }
 
 /// Build the action result from the read-back frame, surfacing clamped or unverifiable requests.
@@ -146,24 +155,29 @@ func verifiedWindowActionResult(
     }
 
     let warning: String?
+    let effect: ActionEffect
     switch outcome {
     case .applied:
         warning = nil
-    case let .constrained(text), let .unverified(text):
+        effect = .confirmed
+    case let .constrained(text):
         warning = text
+        effect = .partial
+    case let .unverified(text):
+        warning = text
+        effect = .unverifiable
     case let .ignored(reason):
         throw WindowGeometryIgnoredError(reason: reason)
     }
 
     let result = createWindowActionResult(
         action: action,
-        success: true,
         windowInfo: finalInfo,
         appName: appName,
         requestedBounds: requestedWindowBounds(requested: requested, original: originalInfo?.bounds),
         warning: warning
     )
-    return VerifiedWindowActionOutput(windowInfo: finalInfo, result: result, warning: warning)
+    return VerifiedWindowActionOutput(windowInfo: finalInfo, result: result, warning: warning, effect: effect)
 }
 
 /// Full requested rectangle for the JSON payload; components the command did not set fall back

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/WindowCommand+State.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/WindowCommand+State.swift
@@ -6,7 +6,8 @@ import PeekabooFoundation
 
 extension WindowCommand {
     @MainActor
-    struct CloseSubcommand: ErrorHandlingCommand, OutputFormattable, InjectedRuntimeBackedCommand {
+    struct CloseSubcommand: ConfirmedActionOutputFormattable, ErrorHandlingCommand, OutputFormattable,
+    InjectedRuntimeBackedCommand {
         @OptionGroup var windowOptions: WindowIdentificationOptions
 
         @Flag(help: "Allow focused/global fallback if AX close does not dismiss the window")
@@ -63,7 +64,6 @@ extension WindowCommand {
 
                 let data = createWindowActionResult(
                     action: "close",
-                    success: true,
                     windowInfo: windowInfo,
                     appName: appName
                 )
@@ -80,7 +80,8 @@ extension WindowCommand {
     }
 
     @MainActor
-    struct MinimizeSubcommand: ErrorHandlingCommand, OutputFormattable, InjectedRuntimeBackedCommand {
+    struct MinimizeSubcommand: ConfirmedActionOutputFormattable, ErrorHandlingCommand, OutputFormattable,
+    InjectedRuntimeBackedCommand {
         @OptionGroup var windowOptions: WindowIdentificationOptions
         @RuntimeStorage var runtime: CommandRuntime?
 
@@ -132,7 +133,6 @@ extension WindowCommand {
 
                 let data = createWindowActionResult(
                     action: "minimize",
-                    success: true,
                     windowInfo: windowInfo,
                     appName: appName
                 )
@@ -149,7 +149,8 @@ extension WindowCommand {
     }
 
     @MainActor
-    struct RestoreSubcommand: ErrorHandlingCommand, OutputFormattable, InjectedRuntimeBackedCommand {
+    struct RestoreSubcommand: ConfirmedActionOutputFormattable, ErrorHandlingCommand, OutputFormattable,
+    InjectedRuntimeBackedCommand {
         @OptionGroup var windowOptions: WindowIdentificationOptions
         @RuntimeStorage var runtime: CommandRuntime?
 
@@ -204,7 +205,6 @@ extension WindowCommand {
                 )
                 let data = createWindowActionResult(
                     action: "restore",
-                    success: true,
                     windowInfo: refreshedWindow,
                     appName: appName
                 )
@@ -219,7 +219,8 @@ extension WindowCommand {
     }
 
     @MainActor
-    struct MaximizeSubcommand: ErrorHandlingCommand, OutputFormattable, InjectedRuntimeBackedCommand {
+    struct MaximizeSubcommand: ActionOutputFormattable, ErrorHandlingCommand, OutputFormattable,
+    InjectedRuntimeBackedCommand {
         @OptionGroup var windowOptions: WindowIdentificationOptions
         @RuntimeStorage var runtime: CommandRuntime?
 
@@ -308,13 +309,21 @@ extension WindowCommand {
                 }
                 let data = createWindowActionResult(
                     action: "maximize",
-                    success: true,
                     windowInfo: finalWindowInfo,
                     appName: appName,
                     warning: warning
                 )
 
-                output(data) {
+                let effect: ActionEffect = if outcome.alreadyMaximized {
+                    .suspectedNoop
+                } else if outcome.info == nil {
+                    .unverifiable
+                } else if !outcome.stabilized {
+                    .partial
+                } else {
+                    .confirmed
+                }
+                output(data, effect: effect) {
                     let title = finalWindowInfo.title
                     if outcome.alreadyMaximized {
                         print("Window '\(title)' of \(appName) is already maximized")

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/WindowCommand+Support.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/WindowCommand+Support.swift
@@ -164,7 +164,6 @@ func windowDisplayName(from snapshot: UIAutomationSnapshot, snapshotId: String) 
 
 func createWindowActionResult(
     action: String,
-    success: Bool,
     windowInfo: ServiceWindowInfo?,
     appName: String? = nil,
     requestedBounds: WindowBounds? = nil,
@@ -183,7 +182,6 @@ func createWindowActionResult(
 
     return WindowActionResult(
         action: action,
-        success: success,
         app_name: appName ?? "Unknown",
         window_title: windowInfo?.title,
         new_bounds: bounds,

--- a/Apps/CLI/Tests/CLIAutomationTests/ClipboardCommandTests.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/ClipboardCommandTests.swift
@@ -16,7 +16,7 @@ struct ClipboardCommandTests {
         let data = try #require(result.stdout.data(using: .utf8))
         let payload = try JSONDecoder().decode(JSONResponse.self, from: data)
         #expect(payload.success == false)
-        #expect(payload.error?.code == ErrorCode.VALIDATION_ERROR.rawValue)
+        #expect(payload.error?.code == ErrorCode.INVALID_ARGUMENT.rawValue)
     }
 
     @Test

--- a/Apps/CLI/Tests/CLIAutomationTests/DragCommandTests.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/DragCommandTests.swift
@@ -137,7 +137,6 @@ struct DragCommandTests {
         let payloadData = Data(self.output(from: result).utf8)
         let payload = try JSONDecoder().decode(CodableJSONResponse<DragResult>.self, from: payloadData)
         #expect(payload.success)
-        #expect(payload.data.success)
         #expect(payload.data.profile == "linear")
         let dragCalls = await self.automationState(context) { $0.dragCalls }
         let call = try #require(dragCalls.first)

--- a/Apps/CLI/Tests/CLIAutomationTests/MoveCommandTests.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/MoveCommandTests.swift
@@ -126,7 +126,6 @@ struct MoveCommandTests {
         let data = try #require(self.output(from: result).data(using: .utf8))
         let payload = try JSONDecoder().decode(CodableJSONResponse<MoveResult>.self, from: data)
         #expect(payload.success)
-        #expect(payload.data.success)
         #expect(payload.data.targetDescription.contains("Coordinates"))
         #expect(payload.data.targetLocation["x"] == 150)
         #expect(payload.data.targetLocation["y"] == 250)

--- a/Apps/CLI/Tests/CLIAutomationTests/PasteCommandTests.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/PasteCommandTests.swift
@@ -356,7 +356,6 @@ struct PasteCommandTests {
             from: jsonResult,
             as: CodableJSONResponse<PasteResult>.self
         )
-        #expect(payload.data.success)
         #expect(!payload.data.restoreSucceeded)
         #expect(payload.data.restoreError == "Failed to write to clipboard: simulated restore failure")
 

--- a/Apps/CLI/Tests/CLIAutomationTests/PressCommandTests.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/PressCommandTests.swift
@@ -34,7 +34,6 @@ struct PressCommandTests {
         let payloadData = try #require(self.output(from: result).data(using: .utf8))
         let payload = try JSONDecoder().decode(CodableJSONResponse<PressResult>.self, from: payloadData)
         #expect(payload.success)
-        #expect(payload.data.success)
         #expect(payload.data.keys == ["return"])
         #expect(payload.data.totalPresses == 1)
     }

--- a/Apps/CLI/Tests/CLIAutomationTests/ScrollCommandTests.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/ScrollCommandTests.swift
@@ -72,7 +72,6 @@ struct ScrollCommandTests {
         let payloadData = try #require(self.output(from: result).data(using: .utf8))
         let payload = try JSONDecoder().decode(CodableJSONResponse<ScrollResult>.self, from: payloadData)
         #expect(payload.success)
-        #expect(payload.data.success)
         #expect(payload.data.direction == "down")
         #expect(payload.data.amount == 5)
     }
@@ -273,7 +272,6 @@ struct ScrollCommandResultStructTests {
     @Test
     func `Scroll result structure maintains fields`() {
         let result = ScrollResult(
-            success: true,
             direction: "down",
             amount: 5,
             location: ["x": 500.0, "y": 300.0],
@@ -281,7 +279,6 @@ struct ScrollCommandResultStructTests {
             executionTime: 0.15
         )
 
-        #expect(result.success == true)
         #expect(result.direction == "down")
         #expect(result.amount == 5)
         #expect(result.location["x"] == 500.0)

--- a/Apps/CLI/Tests/CLIAutomationTests/WindowCommandTests.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/WindowCommandTests.swift
@@ -62,7 +62,6 @@ struct WindowCommandTests {
         )
 
         #expect(response.data.action == "restore")
-        #expect(response.data.success)
         #expect(await MainActor.run {
             context.windowService.windowsByApp[appName]?.first?.isMinimized
         } == false)

--- a/Apps/CLI/Tests/CoreCLITests/ResultEnvelopeTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/ResultEnvelopeTests.swift
@@ -1,0 +1,74 @@
+import Foundation
+import Testing
+@testable import PeekabooCLI
+
+struct ResultEnvelopeTests {
+    private struct Payload: Codable { let value: Int }
+
+    @Test func `action envelope includes effect`() throws {
+        let envelope = ResultEnvelope(success: true, effect: .unverifiable, data: Payload(value: 1))
+        let object = try #require(
+            JSONSerialization.jsonObject(with: JSONEncoder().encode(envelope)) as? [String: Any]
+        )
+
+        #expect(object["success"] as? Bool == true)
+        #expect(object["effect"] as? String == "unverifiable")
+    }
+
+    @Test func `read envelope omits effect`() throws {
+        let envelope = ResultEnvelope(success: true, data: Payload(value: 1))
+        let object = try #require(
+            JSONSerialization.jsonObject(with: JSONEncoder().encode(envelope)) as? [String: Any]
+        )
+
+        #expect(object["effect"] == nil)
+    }
+
+    @Test func `existing next-step sentence becomes error hint`() {
+        let error = ErrorInfo(
+            message: "Invalid direction. Use up, down, left, or right.",
+            code: .INVALID_ARGUMENT
+        )
+
+        #expect(error.message == "Invalid direction.")
+        #expect(error.hint == "Use up, down, left, or right.")
+    }
+
+    @Test func `safety refusal carries refused effect and explicit hint`() {
+        let error = ActionRefusalError(
+            message: "Background coordinate clicks require a fresh snapshot.",
+            hint: "Use --foreground for explicit global input."
+        )
+
+        #expect(error.envelopeEffect == .refused)
+        #expect(error.envelopeHint == "Use --foreground for explicit global input.")
+    }
+
+    @Test func `encoding fallback remains valid JSON`() throws {
+        let fallback = makeJSONEncodingFailureEnvelope(effect: .confirmed)
+        let data = try JSONEncoder().encode(fallback)
+        let decoded = try JSONDecoder().decode(JSONResponse.self, from: data)
+        #expect(decoded.success == false)
+        #expect(decoded.effect == .unverifiable)
+        #expect(decoded.data == nil)
+
+        let emergencyObject = try #require(
+            JSONSerialization.jsonObject(with: Data(jsonEncodingFailureEnvelope.utf8)) as? [String: Any]
+        )
+        #expect(emergencyObject["success"] as? Bool == false)
+        #expect(emergencyObject["data"] is NSNull)
+    }
+
+    @Test func `pre-dispatch validation is refused`() {
+        #expect(defaultActionErrorEffect(.VALIDATION_ERROR) == .refused)
+        #expect(defaultActionErrorEffect(.INTERACTION_FAILED) == .unverifiable)
+    }
+
+    @Test @MainActor func `clipboard reads omit action effect`() {
+        var command = ClipboardActionCommand()
+        command.action = "get"
+        #expect(command.defaultEffect == nil)
+        command.action = "set"
+        #expect(command.defaultEffect == .unverifiable)
+    }
+}

--- a/Apps/CLI/Tests/CoreCLITests/WindowGeometryVerificationTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/WindowGeometryVerificationTests.swift
@@ -86,7 +86,7 @@ struct WindowGeometryVerificationTests {
         let warning = try #require(output.result.warning)
         #expect(warning.contains("requested size 900x700"))
         #expect(warning.contains("actual size 1200x800"))
-        #expect(output.result.success)
+        #expect(output.effect == .partial)
     }
 
     @Test func `fully ignored resize throws instead of claiming success`() async throws {
@@ -115,7 +115,7 @@ struct WindowGeometryVerificationTests {
         #expect(bounds.width == 900)
         #expect(bounds.height == 700)
         #expect(output.result.warning == nil)
-        #expect(output.result.success)
+        #expect(output.effect == .confirmed)
     }
 
     @Test func `set-bounds with clamped size keeps the applied position and warns`() async throws {
@@ -145,7 +145,6 @@ struct WindowGeometryVerificationTests {
 
         let warning = try #require(output.result.warning)
         #expect(warning.contains("requested size 900x700"))
-        #expect(output.result.success)
     }
 
     @Test func `move reports the achieved origin without warning`() async throws {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Add `app focus` and positional app targets across quit, relaunch, hide, unhide, and switch while rejecting conflicting positional/flag targets (v4 breaking change).
 
 ### Changed
+- Standardize CLI JSON on one result envelope with action-only effect vocabulary, actionable error hints, and nonzero exits for failed actions (v4 breaking change).
 - Standardize all CLI duration/timeout/delay flags on bare-millisecond plus `ms`/`s` parsing, coordinate input on `--at`/`--global`, modifiers on normalized comma-separated lists, and the input-command focus flag matrix (v4 breaking change).
 - Update Swift Subprocess to 1.0.0 and pnpm to 11.21.0.
 - Merge keyboard shortcuts into xdotool-style `press` chords, fold swipe gestures into dual-target `drag`, consolidate screenshot and AX-tree CLI reads under `see`, and rename CLI/MCP `perform-action`/`perform_action` to `action` (v4 breaking change).

--- a/docs/cli-command-reference.md
+++ b/docs/cli-command-reference.md
@@ -55,4 +55,8 @@ Timing flags share one grammar: bare numbers mean milliseconds, while `ms` and `
 - `see --tree --no-screenshot` – Accessibility-tree text/control inspection without pixel capture.
 - [`mcp`](commands/mcp.md) – Run Peekaboo's MCP server; `serve` is the only subcommand and stdio is the implemented transport.
 
-Need structured payloads? Pass `--json` (or the Commander-provided `--json-output` alias) where supported and compose commands with your shell.
+## JSON result envelope
+
+Pass `--json` (or the Commander-provided `--json-output` alias) for one stable result shape. Every response has `success`, `data` (null when unavailable), optional `error`, and `debug_logs`. Failed responses exit nonzero and include `error.code`, `error.message`, and an actionable `error.hint` when the command already knows the next step.
+
+Action commands also include a top-level `effect`: `confirmed` when existing AX/readback verification proves the result, `partial` for a partly completed multi-step action, `unverifiable` when input was dispatched without an application-level signal, `suspected_noop` when a post-check found no change, or `refused` when a safety gate prevented dispatch. Read-only commands omit `effect`. MCP tool result contracts are unchanged.


### PR DESCRIPTION
Phase 6 of the v4 CLI redesign (docs/v4-cli-plan.md §6) - the final code phase: one JSON result envelope, honest effects.

## Changes
- One generic `ResultEnvelope` encoder across all CLI JSON paths; eight bespoke response shells deleted (`JSONResponse`, `CodableJSONResponse`, `MCPToolCommandJSONEnvelope`, `CaptureActionJSONEnvelope`, `SuccessOutput`, `ErrorOutput`, `ConfigErrorInfo`, `ProviderStatusResponse`).
- Action commands report `effect: confirmed | partial | unverifiable | suspected_noop | refused`, derived strictly from EXISTING verification machinery (AX readbacks, process-generation receipts, window geometry verification, clipboard --verify); read commands omit the field. Where no verification signal exists the honest default is `unverifiable` - nothing was invented.
- Errors carry an actionable `hint` split from existing message text (e.g. the background-coordinate refusal now hints "Use --foreground for explicit global input").
- Failed results exit nonzero everywhere; duplicate inner `data.success` fields removed.
- MCP tool contracts unchanged (separate surface).

## Proof
Net -2 production lines (+472/-474). Gates: build, lint, format, test:safe (812), automation target build + 206 focused tests, docs-lint. Autoreview clean. Live-verified on desktop: refused click carries effect+hint, `screen list` omits effect, `app launch/quit` report confirmed via process receipts. Full per-command effect-source table in the PR discussion if wanted - it's also documented in docs/cli-command-reference.md.
