### PR TITLE
fix(cli): keep direct actions in background

### DIFF
--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reject conflicting app/PID and window selectors across interaction CLI and MCP entry points before focus, observation, or mutation.
 - Require explicit `--foreground` for long-press clicks so the shared physical cursor cannot be used through an implicit delivery-mode promotion.
 - Pin background `press` sequences to one process generation, stop before a recycled PID can receive later chords, and report partial delivery as retry-unsafe.
+- Keep direct `action` and `set-value` app, PID, and exact-window targeting background-only by default, including web-content discovery, unless `--foreground` is explicit.
 - Preserve stable `verify_state` proof for a directly matched exact AX identifier/value when only unrelated accessibility siblings are unreadable, while keeping absence, mismatch, ambiguity, and target drift fail-closed.
 - Wait for WindowServer to settle after an exact background maximize dispatch before repinning its final bounds, avoiding false failures without relaxing owner-generation checks.
 - Preserve OpenAI Responses tool-error payloads without sending unsupported `failed` statuses that abort the next agent turn.

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/SetValueCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/SetValueCommand.swift
@@ -172,7 +172,12 @@ enum ElementActionCommandExecutor {
             let refreshRuntime = runtime
             observation = try await InteractionObservationRefresher.refreshForTargetIfNeeded(
                 observation,
-                elementTarget: prepared.target,
+                options: TargetedElementObservationRefreshOptions(
+                    elementTarget: prepared.target,
+                    allowWebFocusFallback: Self.shouldAllowWebFocusFallback(
+                        focusOptions: context.focusOptions
+                    )
+                ),
                 target: target,
                 services: services,
                 logger: logger,
@@ -183,7 +188,7 @@ enum ElementActionCommandExecutor {
             try await observation.validateIfExplicit(using: services.snapshots)
             let startTime = Date()
             runtime.beginInteractionMutation()
-            if target.hasAnyTarget {
+            if Self.shouldFocus(target: target, focusOptions: context.focusOptions) {
                 try await ensureFocused(
                     snapshotId: observation.focusSnapshotId(for: target),
                     target: target,
@@ -215,5 +220,16 @@ enum ElementActionCommandExecutor {
             handleError(error)
             throw ExitCode.failure
         }
+    }
+
+    static func shouldFocus(
+        target: InteractionTargetOptions,
+        focusOptions: FocusCommandOptions
+    ) -> Bool {
+        target.hasAnyTarget && focusOptions.foreground && focusOptions.autoFocus
+    }
+
+    static func shouldAllowWebFocusFallback(focusOptions: FocusCommandOptions) -> Bool {
+        focusOptions.foreground && focusOptions.autoFocus
     }
 }

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Shared/InteractionObservationContext.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Shared/InteractionObservationContext.swift
@@ -175,11 +175,16 @@ struct InteractionObservationRefreshDependencies {
     }
 }
 
+struct TargetedElementObservationRefreshOptions {
+    let elementTarget: String
+    let allowWebFocusFallback: Bool
+}
+
 @MainActor
 enum InteractionObservationRefresher {
     static func refreshForTargetIfNeeded(
         _ observation: InteractionObservationContext,
-        elementTarget: String,
+        options: TargetedElementObservationRefreshOptions,
         target: InteractionTargetOptions,
         services: any PeekabooServiceProviding,
         logger: Logger,
@@ -187,7 +192,7 @@ enum InteractionObservationRefresher {
     ) async throws -> InteractionObservationContext {
         try await self.refreshForTargetIfNeeded(
             observation,
-            elementTarget: elementTarget,
+            options: options,
             target: target,
             dependencies: InteractionObservationRefreshDependencies(
                 desktopObservation: services.desktopObservation,
@@ -200,7 +205,7 @@ enum InteractionObservationRefresher {
 
     static func refreshForTargetIfNeeded(
         _ observation: InteractionObservationContext,
-        elementTarget: String,
+        options: TargetedElementObservationRefreshOptions,
         target: InteractionTargetOptions,
         dependencies: InteractionObservationRefreshDependencies,
         logger: Logger
@@ -217,8 +222,9 @@ enum InteractionObservationRefresher {
 
         return try await self.refreshObservation(
             observation,
-            reason: "explicit target for element '\(elementTarget)'",
+            reason: "explicit target for element '\(options.elementTarget)'",
             target: target,
+            allowWebFocusFallback: options.allowWebFocusFallback,
             dependencies: dependencies,
             logger: logger
         )
@@ -344,6 +350,7 @@ enum InteractionObservationRefresher {
         _ observation: InteractionObservationContext,
         reason: String,
         target: InteractionTargetOptions,
+        allowWebFocusFallback: Bool = true,
         dependencies: InteractionObservationRefreshDependencies,
         logger: Logger
     ) async throws -> InteractionObservationContext {
@@ -360,7 +367,10 @@ enum InteractionObservationRefresher {
                     scale: .logical1x,
                     visualizerMode: .none
                 ),
-                detection: DesktopDetectionOptions(mode: .accessibility, allowWebFocusFallback: true),
+                detection: DesktopDetectionOptions(
+                    mode: .accessibility,
+                    allowWebFocusFallback: allowWebFocusFallback
+                ),
                 output: DesktopObservationOutputOptions(
                     saveSnapshot: true,
                     snapshotID: snapshotID

--- a/Apps/CLI/Tests/CoreCLITests/InteractionObservationContextTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/InteractionObservationContextTests.swift
@@ -704,7 +704,10 @@ struct InteractionObservationContextTests {
 
         let refreshed = try await InteractionObservationRefresher.refreshForTargetIfNeeded(
             observation,
-            elementTarget: "B1",
+            options: TargetedElementObservationRefreshOptions(
+                elementTarget: "B1",
+                allowWebFocusFallback: false
+            ),
             target: target,
             dependencies: InteractionObservationRefreshDependencies(
                 desktopObservation: desktopObservation,
@@ -720,6 +723,62 @@ struct InteractionObservationContextTests {
             #expect(identifier == "TargetApp")
         default:
             Issue.record("Expected targeted app observation")
+        }
+    }
+
+    @Test
+    func `Targeted element action refresh preserves scope and explicit web focus policy`() async throws {
+        var appTarget = InteractionTargetOptions()
+        appTarget.app = "TargetApp"
+        var pidTarget = InteractionTargetOptions()
+        pidTarget.pid = 4242
+        var windowTarget = InteractionTargetOptions()
+        windowTarget.windowId = 7373
+
+        let cases: [(InteractionTargetOptions, DesktopObservationTargetRequest)] = [
+            (appTarget, .app(identifier: "TargetApp", window: nil)),
+            (pidTarget, .pid(4242, window: nil)),
+            (windowTarget, .windowID(7373)),
+        ]
+
+        for (target, expectedTarget) in cases {
+            for allowWebFocusFallback in [false, true] {
+                let snapshots = CoreSnapshotManagerStub()
+                let observation = await InteractionObservationContext.resolve(
+                    explicitSnapshot: nil,
+                    fallbackToLatest: true,
+                    snapshots: snapshots
+                )
+                let freshDetection = Self.detectionResult(
+                    snapshotId: "fresh-snapshot",
+                    element: Self.buttonElement(id: "B1")
+                )
+                let desktopObservation = RecordingDesktopObservationService(
+                    elements: freshDetection,
+                    snapshots: snapshots
+                )
+
+                let refreshed = try await InteractionObservationRefresher.refreshForTargetIfNeeded(
+                    observation,
+                    options: TargetedElementObservationRefreshOptions(
+                        elementTarget: "B1",
+                        allowWebFocusFallback: allowWebFocusFallback
+                    ),
+                    target: target,
+                    dependencies: InteractionObservationRefreshDependencies(
+                        desktopObservation: desktopObservation,
+                        snapshots: snapshots
+                    ),
+                    logger: Logger.shared
+                )
+
+                let request = try #require(desktopObservation.requests.first)
+                let refreshedSnapshotID = try #require(refreshed.snapshotId)
+                #expect(request.target == expectedTarget)
+                #expect(request.detection.allowWebFocusFallback == allowWebFocusFallback)
+                #expect(request.output.snapshotID == refreshedSnapshotID)
+                #expect(try await snapshots.getDetectionResult(snapshotId: refreshedSnapshotID) != nil)
+            }
         }
     }
 
@@ -741,7 +800,10 @@ struct InteractionObservationContextTests {
         await #expect(throws: PeekabooError.self) {
             _ = try await InteractionObservationRefresher.refreshForTargetIfNeeded(
                 observation,
-                elementTarget: "B1",
+                options: TargetedElementObservationRefreshOptions(
+                    elementTarget: "B1",
+                    allowWebFocusFallback: false
+                ),
                 target: target,
                 dependencies: InteractionObservationRefreshDependencies(
                     desktopObservation: desktopObservation,

--- a/Apps/CLI/Tests/CoreCLITests/Phase3CommandParsingTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/Phase3CommandParsingTests.swift
@@ -130,6 +130,71 @@ struct Phase3CommandParsingTests {
     }
 
     @Test
+    func `Direct element actions focus and web press only with explicit foreground`() throws {
+        let targetArguments = [
+            ["--app", "TextEdit"],
+            ["--pid", "4242"],
+            ["--window-id", "7373"],
+        ]
+
+        for arguments in targetArguments {
+            let backgroundAction = try ActionCommand.parse(
+                ["AXPress", "--on", "B7"] + arguments
+            )
+            let foregroundAction = try ActionCommand.parse(
+                ["AXPress", "--on", "B7"] + arguments + ["--foreground"]
+            )
+            let backgroundSetValue = try SetValueCommand.parse(
+                ["hello", "--on", "T1"] + arguments
+            )
+            let foregroundSetValue = try SetValueCommand.parse(
+                ["hello", "--on", "T1"] + arguments + ["--foreground"]
+            )
+
+            for command in [
+                (backgroundAction.target, backgroundAction.focusOptions),
+                (backgroundSetValue.target, backgroundSetValue.focusOptions),
+            ] {
+                #expect(!ElementActionCommandExecutor.shouldFocus(
+                    target: command.0,
+                    focusOptions: command.1
+                ))
+                #expect(!ElementActionCommandExecutor.shouldAllowWebFocusFallback(
+                    focusOptions: command.1
+                ))
+            }
+
+            for command in [
+                (foregroundAction.target, foregroundAction.focusOptions),
+                (foregroundSetValue.target, foregroundSetValue.focusOptions),
+            ] {
+                #expect(ElementActionCommandExecutor.shouldFocus(
+                    target: command.0,
+                    focusOptions: command.1
+                ))
+                #expect(ElementActionCommandExecutor.shouldAllowWebFocusFallback(
+                    focusOptions: command.1
+                ))
+            }
+        }
+    }
+
+    @Test
+    func `Explicit foreground respects no auto focus for direct element actions`() throws {
+        let command = try ActionCommand.parse([
+            "AXPress", "--on", "B7", "--app", "TextEdit", "--foreground", "--no-auto-focus",
+        ])
+
+        #expect(!ElementActionCommandExecutor.shouldFocus(
+            target: command.target,
+            focusOptions: command.focusOptions
+        ))
+        #expect(!ElementActionCommandExecutor.shouldAllowWebFocusFallback(
+            focusOptions: command.focusOptions
+        ))
+    }
+
+    @Test
     func `Removed root commands are unknown`() throws {
         let descriptors = CommanderRegistryBuilder.buildDescriptors()
         let program = Program(descriptors: descriptors.map(\.metadata))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 - Reject conflicting app/PID and window selectors across interaction CLI and MCP entry points before focus, observation, or mutation.
 - Require explicit `--foreground` for long-press clicks so the shared physical cursor cannot be used through an implicit delivery-mode promotion.
 - Pin background `press` sequences to one process generation, stop before a recycled PID can receive later chords, and report partial delivery as retry-unsafe.
+- Keep direct `action` and `set-value` app, PID, and exact-window targeting background-only by default, including web-content discovery, unless `--foreground` is explicit.
 - Preserve stable `verify_state` proof for a directly matched exact AX identifier/value when only unrelated accessibility siblings are unreadable, while keeping absence, mismatch, ambiguity, and target drift fail-closed.
 - Preserve the requested characters during background typing on non-US keyboard layouts instead of interpreting fixed US key positions through the active layout. Thanks @canvascoding for #330.
 - Wait for WindowServer to settle after an exact background maximize dispatch before repinning its final bounds, avoiding false failures without relaxing owner-generation checks.

--- a/docs/commands/action.md
+++ b/docs/commands/action.md
@@ -16,4 +16,5 @@ peekaboo action --action AXShowMenu --on "$ELEMENT_ID" --pid 1234
 
 Use `--app`, `--pid`, `--window-id`, `--window-title`, or `--window-index` to resolve the intended target without
 activating it. Window title/index selectors require an app or PID. Add `--foreground` only when the action depends on
-focused-window state. The equivalent MCP tool is `action`.
+focused-window state; this also permits web-content discovery to focus the page when required. The equivalent MCP tool
+is `action`.

--- a/docs/commands/set-value.md
+++ b/docs/commands/set-value.md
@@ -16,7 +16,8 @@ read_when:
 | `<value>` | String value to write. |
 | `--on <id-or-query>` | Element ID from `peekaboo see`, or a query used by the automation service. Required. |
 | `--snapshot <id>` | Snapshot ID from `peekaboo see`; uses the latest action context when omitted. |
-| Target flags | `--app`, `--pid`, `--window-id`, `--window-title`, and `--window-index` focus the intended target before mutation. |
+| Target flags | `--app`, `--pid`, `--window-id`, `--window-title`, and `--window-index` scope the mutation without activating the app. |
+| `--foreground` | Explicitly focus the target before mutation and allow web-content discovery to focus the page when required. |
 
 ## Notes
 


### PR DESCRIPTION
## Summary

- require explicit `--foreground` consent before scoped direct AX actions focus an application or window
- disable web-focus fallback during background `action` and `set-value` target refreshes while preserving exact app, PID, and window observation scope
- document the background-first contract and cover both commands across all three target forms

## Proof

- `swift test --package-path Apps/CLI -Xswiftc -DPEEKABOO_SKIP_AUTOMATION --filter Phase3CommandParsingTests`
- `swift test --package-path Apps/CLI -Xswiftc -DPEEKABOO_SKIP_AUTOMATION --filter InteractionObservationContextTests`
- `pnpm run test:safe` — 751 Core CLI tests and 72 runtime tests passed; release/signing and Chrome MCP contract checks passed
- final restack on `main`: 44 focused direct-action/observation tests passed, docs lint passed, and AutoReview remained clean
- `pnpm run lint` — no serious violations; repository baseline warnings only
- `pnpm run lint:docs`
- `pnpm run format`
- AutoReview clean with no accepted/actionable findings

## Live validation

A Foundation-signed CLI and Playground instance were exercised through the GUI bridge. `set-value` and `action AXPress` each succeeded with app, PID, and exact-window targeting while the native frontmost application ASN stayed unchanged after every operation. The value mutations returned a verified old/new chain, including the exact-window result, and a fresh observation confirmed the final value. Cleanup terminated only the launch-owned Playground PID without changing foreground focus. An independent source-blind validator reproduced the same behavior.
