### PR TITLE
fix(cli): reject ambiguous interaction selectors

### DIFF
--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Keep agent screenshot grounding transient so session checkpoints retain text and tool state without persisting image bytes or local image paths.
 
 ### Fixed
+- Reject conflicting app/PID and window selectors across interaction CLI and MCP entry points before focus, observation, or mutation.
 - Preserve stable `verify_state` proof for a directly matched exact AX identifier/value when only unrelated accessibility siblings are unreadable, while keeping absence, mismatch, ambiguity, and target drift fail-closed.
 - Wait for WindowServer to settle after an exact background maximize dispatch before repinning its final bounds, avoiding false failures without relaxing owner-generation checks.
 - Preserve OpenAI Responses tool-error payloads without sending unsupported `failed` statuses that abort the next agent turn.

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/AI/SeeCommand+ObservationRequest.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/AI/SeeCommand+ObservationRequest.swift
@@ -3,6 +3,7 @@ import CoreGraphics
 import Foundation
 import PeekabooAutomationKit
 import PeekabooCore
+import PeekabooFoundation
 
 @available(macOS 14.0, *)
 @MainActor
@@ -23,6 +24,7 @@ extension SeeCommand {
     }
 
     func observationTargetForCaptureWithDetectionIfPossible() throws -> DesktopObservationTargetRequest? {
+        try self.validateInteractionTargetSelectors()
         if self.menubar {
             let hint = self.menuBarAppHint()
             return .menubarPopover(

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/AI/SeeCommand+PixelObservationRequest.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/AI/SeeCommand+PixelObservationRequest.swift
@@ -11,7 +11,8 @@ struct ImageWindowObservationTarget {
 
 @MainActor
 extension SeeCommand {
-    var observationWindowSelection: WindowSelection {
+    func observationWindowSelection() throws -> WindowSelection {
+        try self.validateInteractionTargetSelectors()
         if let windowTitle {
             return .title(windowTitle)
         }
@@ -24,7 +25,8 @@ extension SeeCommand {
     func observationApplicationTargetForWindowCapture(
         selection: WindowSelection? = nil
     ) throws -> ImageWindowObservationTarget {
-        let resolvedSelection = selection ?? self.observationWindowSelection
+        try self.validateInteractionTargetSelectors()
+        let resolvedSelection = try selection ?? self.observationWindowSelection()
         if let pid = try self.resolveExplicitPIDObservationTarget() {
             let identifier = "PID:\(pid)"
             return ImageWindowObservationTarget(
@@ -43,9 +45,7 @@ extension SeeCommand {
     }
 
     func observationTargetForExactWindowCapture(_ windowID: Int) throws -> DesktopObservationTargetRequest {
-        guard self.windowTitle == nil, self.windowIndex == nil else {
-            throw ValidationError("--window-id cannot be combined with --window-title or --window-index")
-        }
+        try self.validateInteractionTargetSelectors()
         let selection = WindowSelection.id(CGWindowID(windowID))
         if self.app != nil || self.pid != nil {
             return try self.observationApplicationTargetForWindowCapture(selection: selection).target

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/AI/SeeCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/AI/SeeCommand.swift
@@ -299,14 +299,9 @@ struct SeeCommand: ApplicationResolvable, ErrorHandlingCommand, RuntimeBackedCom
         if self.region != nil, self.mode != nil, self.mode != .area {
             throw ValidationError("--region can only be combined with --mode area")
         }
-        if self.app != nil, self.pid != nil {
-            throw ValidationError("Use either --app or --pid, not both")
-        }
+        try self.validateInteractionTargetSelectors()
         let windowSelectorCount = [self.windowTitle != nil, self.windowIndex != nil, self.windowId != nil]
             .count(where: { $0 })
-        if windowSelectorCount > 1 {
-            throw ValidationError("Use only one of --window-title, --window-index, or --window-id")
-        }
         if let appAlias = self.app?.lowercased(), appAlias == "frontmost" || appAlias == "menubar" {
             let allowedModes: Set<PeekabooCore.CaptureMode> = appAlias == "frontmost"
                 ? [.window, .frontmost]
@@ -355,6 +350,16 @@ struct SeeCommand: ApplicationResolvable, ErrorHandlingCommand, RuntimeBackedCom
                 )
             }
         }
+    }
+
+    func validateInteractionTargetSelectors() throws {
+        try InteractionTargetSelectorValidator.validateCLI(
+            hasApplication: self.app != nil,
+            hasProcessIdentifier: self.pid != nil,
+            hasWindowID: self.windowId != nil,
+            hasWindowTitle: self.windowTitle != nil,
+            hasWindowIndex: self.windowIndex != nil
+        )
     }
 
     private func runPixelOnlyCapture() async throws {

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/AI/VerifyCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/AI/VerifyCommand.swift
@@ -88,7 +88,7 @@ struct VerifyCommand: ErrorHandlingCommand, OutputFormattable, RuntimeBackedComm
     }
 
     private func makeArguments() async throws -> [String: Any] {
-        var target = self.target
+        let target = self.target
         try target.validate()
 
         var arguments: [String: Any] = try [

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommanderBinder.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommanderBinder.swift
@@ -620,6 +620,7 @@ extension CommanderBindableValues {
         if let index: Int = try decodeOption("windowIndex", as: Int.self) {
             options.windowIndex = index
         }
+        try options.validate()
     }
 
     func makeFocusOptions(includeBackgroundDelivery: Bool = false) throws -> FocusCommandOptions {

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/SetValueCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/SetValueCommand.swift
@@ -161,7 +161,7 @@ enum ElementActionCommandExecutor {
         logger.setJsonOutputMode(runtime.configuration.jsonOutput)
 
         do {
-            var target = context.target
+            let target = context.target
             try target.validate()
             let prepared = try prepare()
             var observation = await InteractionObservationContext.resolve(

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Shared/InteractionCoordinateResolver.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Shared/InteractionCoordinateResolver.swift
@@ -12,6 +12,7 @@ enum InteractionCoordinateResolver {
         services: any PeekabooServiceProviding,
         forceGlobal: Bool = false
     ) async throws -> InteractionCoordinateResolution {
+        try target.validate()
         guard target.hasAnyTarget else {
             return InteractionCoordinateResolution(
                 inputPoint: inputPoint,

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Shared/InteractionObservationContext.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Shared/InteractionObservationContext.swift
@@ -456,6 +456,7 @@ enum InteractionObservationRefresher {
 
 extension InteractionTargetOptions {
     func observationTargetRequest() throws -> DesktopObservationTargetRequest {
+        try self.validate()
         if let windowId {
             return .windowID(CGWindowID(windowId))
         }

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Shared/InteractionTargetOptions+CommanderMetadata.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Shared/InteractionTargetOptions+CommanderMetadata.swift
@@ -6,27 +6,27 @@ extension InteractionTargetOptions {
             options: [
                 .commandOption(
                     "app",
-                    help: "Target application name, bundle ID, or 'PID:12345'",
+                    help: "Target application name, bundle ID, or 'PID:12345' (alternative to --pid)",
                     long: "app"
                 ),
                 .commandOption(
                     "pid",
-                    help: "Target application by process ID",
+                    help: "Target application by process ID (alternative to --app)",
                     long: "pid"
                 ),
                 .commandOption(
                     "windowId",
-                    help: "Target window by CoreGraphics window id (window_id)",
+                    help: "Target by window id; cannot be combined with another window selector",
                     long: "window-id"
                 ),
                 .commandOption(
                     "windowTitle",
-                    help: "Target window by title (partial match supported)",
+                    help: "Target by title; requires --app/--pid and excludes other window selectors",
                     long: "window-title"
                 ),
                 .commandOption(
                     "windowIndex",
-                    help: "Target window by index (0-based, frontmost is 0)",
+                    help: "Target by index; requires --app/--pid and excludes other window selectors",
                     long: "window-index"
                 ),
             ]

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Shared/InteractionTargetOptions.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Shared/InteractionTargetOptions.swift
@@ -32,21 +32,30 @@ struct InteractionTargetOptions: CommanderParsable, ApplicationResolvable {
         self.app != nil || self.pid != nil || self.windowTitle != nil || self.windowIndex != nil || self.windowId != nil
     }
 
-    mutating func validate() throws {
+    func validateSelectorCombination() throws {
+        try InteractionTargetSelectorValidator.validateCLI(
+            hasApplication: self.app != nil,
+            hasProcessIdentifier: self.pid != nil,
+            hasWindowID: self.windowId != nil,
+            hasWindowTitle: self.windowTitle != nil,
+            hasWindowIndex: self.windowIndex != nil
+        )
+    }
+
+    func validate() throws {
+        try self.validateSelectorCombination()
+
         if let windowIndex = self.windowIndex, windowIndex < 0 {
             throw ValidationError("--window-index must be 0 or greater")
         }
 
-        if let windowId = self.windowId, windowId <= 0 {
-            throw ValidationError("--window-id must be greater than 0")
-        }
-
-        if self.windowTitle != nil || self.windowIndex != nil, self.app == nil, self.pid == nil, self.windowId == nil {
-            throw ValidationError("When using --window-title/--window-index, also provide --app or --pid.")
+        if let windowId = self.windowId, windowId <= 0 || UInt32(exactly: windowId) == nil {
+            throw ValidationError("--window-id must be between 1 and \(UInt32.max)")
         }
     }
 
     func resolveApplicationIdentifierOptional() throws -> String? {
+        try self.validate()
         guard self.app != nil || self.pid != nil else {
             return nil
         }
@@ -54,6 +63,7 @@ struct InteractionTargetOptions: CommanderParsable, ApplicationResolvable {
     }
 
     func resolveWindowID(services: any PeekabooServiceProviding) async throws -> CGWindowID? {
+        try self.validate()
         if let windowId = self.windowId {
             return CGWindowID(windowId)
         }
@@ -75,6 +85,7 @@ struct InteractionTargetOptions: CommanderParsable, ApplicationResolvable {
     }
 
     func resolveWindowTitleOptional(services: any PeekabooServiceProviding) async throws -> String? {
+        try self.validate()
         if let windowTitle {
             return windowTitle
         }
@@ -97,6 +108,7 @@ struct InteractionTargetOptions: CommanderParsable, ApplicationResolvable {
     }
 
     func toWindowTarget() throws -> WindowTarget? {
+        try self.validate()
         if let windowId {
             return .windowId(windowId)
         }
@@ -115,5 +127,35 @@ struct InteractionTargetOptions: CommanderParsable, ApplicationResolvable {
         }
 
         return .application(appIdentifier)
+    }
+}
+
+extension InteractionTargetSelectorValidator {
+    static func validateCLI(
+        hasApplication: Bool,
+        hasProcessIdentifier: Bool,
+        hasWindowID: Bool,
+        hasWindowTitle: Bool,
+        hasWindowIndex: Bool
+    ) throws {
+        do {
+            try self.validate(
+                hasApplication: hasApplication,
+                hasProcessIdentifier: hasProcessIdentifier,
+                hasWindowID: hasWindowID,
+                hasWindowTitle: hasWindowTitle,
+                hasWindowIndex: hasWindowIndex
+            )
+        } catch let error as InteractionTargetSelectorValidationError {
+            let message = switch error {
+            case .applicationAndProcessIdentifier:
+                "Use either --app or --pid, not both."
+            case .multipleWindowSelectors:
+                "Use only one of --window-id, --window-title, or --window-index."
+            case .windowSelectorRequiresApplication:
+                "--window-title and --window-index require --app or --pid."
+            }
+            throw ValidationError(message)
+        }
     }
 }

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/DialogCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/DialogCommand.swift
@@ -81,7 +81,7 @@ struct DialogCommand: ParsableCommand {
         validate: () throws -> Void = {},
         operation: (ExecutionContext) async throws -> Void
     ) async throws {
-        var target = target
+        let target = target
         let logger = runtime.logger
         let jsonOutput = runtime.configuration.jsonOutput
         logger.setJsonOutputMode(jsonOutput)

--- a/Apps/CLI/Tests/CoreCLITests/ImageObservationTargetParityTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/ImageObservationTargetParityTests.swift
@@ -1,3 +1,4 @@
+import Commander
 import PeekabooCore
 import Testing
 @testable import PeekabooAgentRuntime
@@ -7,7 +8,7 @@ import Testing
 @MainActor
 struct ImageObservationTargetParityTests {
     @Test(.tags(.fast))
-    func `image window selection prefers title over index`() throws {
+    func `image window selection rejects title and index`() throws {
         let command = try SeeCommand.parse([
             "--mode", "window",
             "--app", "Safari",
@@ -15,7 +16,9 @@ struct ImageObservationTargetParityTests {
             "--window-index", "2",
         ])
 
-        #expect(command.observationWindowSelection == .title("Inbox"))
+        #expect(throws: ValidationError.self) {
+            try command.observationWindowSelection()
+        }
     }
 
     @Test(.tags(.fast))

--- a/Apps/CLI/Tests/CoreCLITests/InteractionObservationContextTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/InteractionObservationContextTests.swift
@@ -1,3 +1,4 @@
+import Commander
 import CoreGraphics
 import Foundation
 import PeekabooAutomationKit
@@ -104,23 +105,14 @@ struct InteractionObservationContextTests {
     }
 
     @Test
-    func `Interaction observation target prefers title over index`() throws {
+    func `Interaction observation target rejects title and index`() throws {
         var target = InteractionTargetOptions()
         target.app = "Preview"
         target.windowTitle = "Main"
         target.windowIndex = 2
 
-        switch try target.observationTargetRequest() {
-        case let .app(identifier, window):
-            #expect(identifier == "Preview")
-            switch window {
-            case let .some(.title(title)):
-                #expect(title == "Main")
-            default:
-                Issue.record("Expected title window selection")
-            }
-        default:
-            Issue.record("Expected app observation target")
+        #expect(throws: ValidationError.self) {
+            try target.observationTargetRequest()
         }
     }
 

--- a/Apps/CLI/Tests/CoreCLITests/InteractionTargetSelectorValidationTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/InteractionTargetSelectorValidationTests.swift
@@ -1,0 +1,166 @@
+import Commander
+import Testing
+@testable import PeekabooCLI
+
+@MainActor
+struct InteractionTargetSelectorValidationTests {
+    struct Selectors: Sendable {
+        let app: String?
+        let pid: Int32?
+        let windowTitle: String?
+        let windowIndex: Int?
+        let windowID: Int?
+    }
+
+    @Test(arguments: [
+        Selectors(app: nil, pid: nil, windowTitle: nil, windowIndex: nil, windowID: nil),
+        Selectors(app: "TextEdit", pid: nil, windowTitle: nil, windowIndex: nil, windowID: nil),
+        Selectors(app: nil, pid: 42, windowTitle: nil, windowIndex: nil, windowID: nil),
+        Selectors(app: nil, pid: nil, windowTitle: nil, windowIndex: nil, windowID: 7),
+        Selectors(app: "TextEdit", pid: nil, windowTitle: "Document", windowIndex: nil, windowID: nil),
+        Selectors(app: nil, pid: 42, windowTitle: "Document", windowIndex: nil, windowID: nil),
+        Selectors(app: "TextEdit", pid: nil, windowTitle: nil, windowIndex: 2, windowID: nil),
+        Selectors(app: nil, pid: 42, windowTitle: nil, windowIndex: 2, windowID: nil),
+    ])
+    func `valid shared interaction selector combinations pass`(_ selectors: Selectors) throws {
+        let target = Self.makeTarget(selectors)
+        try target.validate()
+    }
+
+    @Test(arguments: [
+        Selectors(app: "TextEdit", pid: 42, windowTitle: nil, windowIndex: nil, windowID: nil),
+        Selectors(app: "PID:42", pid: 42, windowTitle: nil, windowIndex: nil, windowID: nil),
+        Selectors(app: "TextEdit", pid: 42, windowTitle: nil, windowIndex: nil, windowID: 7),
+    ])
+    func `app and pid fail closed`(_ selectors: Selectors) {
+        let target = Self.makeTarget(selectors)
+        #expect(throws: ValidationError.self) {
+            try target.validate()
+        }
+    }
+
+    @Test(arguments: [
+        Selectors(app: "TextEdit", pid: nil, windowTitle: "Document", windowIndex: nil, windowID: 7),
+        Selectors(app: "TextEdit", pid: nil, windowTitle: nil, windowIndex: 2, windowID: 7),
+        Selectors(app: "TextEdit", pid: nil, windowTitle: "Document", windowIndex: 2, windowID: nil),
+        Selectors(app: "TextEdit", pid: nil, windowTitle: "Document", windowIndex: 2, windowID: 7),
+    ])
+    func `multiple window selectors fail closed`(_ selectors: Selectors) {
+        let target = Self.makeTarget(selectors)
+        #expect(throws: ValidationError.self) {
+            try target.validate()
+        }
+    }
+
+    @Test(arguments: [
+        Selectors(app: nil, pid: nil, windowTitle: "Document", windowIndex: nil, windowID: nil),
+        Selectors(app: nil, pid: nil, windowTitle: nil, windowIndex: 2, windowID: nil),
+    ])
+    func `relative window selectors require an owner`(_ selectors: Selectors) {
+        let target = Self.makeTarget(selectors)
+        #expect(throws: ValidationError.self) {
+            try target.validate()
+        }
+    }
+
+    @Test
+    func `every phase 3 interaction surface rejects app and pid while binding`() {
+        let targetOptions = ["app": ["TextEdit"], "pid": ["42"]]
+
+        #expect(throws: (any Error).self) {
+            _ = try CommanderCLIBinder.instantiateCommand(
+                ofType: ActionCommand.self,
+                parsedValues: ParsedValues(
+                    positional: ["AXPress"],
+                    options: targetOptions.merging(["on": ["B1"]]) { current, _ in current },
+                    flags: []
+                )
+            )
+        }
+        #expect(throws: (any Error).self) {
+            _ = try CommanderCLIBinder.instantiateCommand(
+                ofType: SetValueCommand.self,
+                parsedValues: ParsedValues(
+                    positional: ["hello"],
+                    options: targetOptions.merging(["on": ["T1"]]) { current, _ in current },
+                    flags: []
+                )
+            )
+        }
+        #expect(throws: (any Error).self) {
+            _ = try CommanderCLIBinder.instantiateCommand(
+                ofType: PressCommand.self,
+                parsedValues: ParsedValues(positional: ["cmd+c"], options: targetOptions, flags: [])
+            )
+        }
+        #expect(throws: (any Error).self) {
+            _ = try CommanderCLIBinder.instantiateCommand(
+                ofType: ClickCommand.self,
+                parsedValues: ParsedValues(positional: ["Save"], options: targetOptions, flags: [])
+            )
+        }
+        #expect(throws: (any Error).self) {
+            _ = try CommanderCLIBinder.instantiateCommand(
+                ofType: DragCommand.self,
+                parsedValues: ParsedValues(
+                    positional: [],
+                    options: targetOptions.merging(["from": ["0,0"], "to": ["10,10"]]) { current, _ in current },
+                    flags: []
+                )
+            )
+        }
+    }
+
+    @Test
+    func `see rejects the same ambiguous selector matrix before observation`() throws {
+        let invalidArguments = [
+            ["--app", "TextEdit", "--pid", "42"],
+            ["--app", "TextEdit", "--window-id", "7", "--window-title", "Document"],
+            ["--app", "TextEdit", "--window-id", "7", "--window-index", "2"],
+            ["--app", "TextEdit", "--window-title", "Document", "--window-index", "2"],
+            ["--window-title", "Document"],
+            ["--window-index", "2"],
+        ]
+
+        for arguments in invalidArguments {
+            let command = try SeeCommand.parse(arguments)
+            #expect(throws: ValidationError.self) {
+                try command.validateMergedOptions()
+            }
+            #expect(throws: ValidationError.self) {
+                try command.observationTargetForCaptureWithDetectionIfPossible()
+            }
+        }
+    }
+
+    @Test
+    func `target resolution APIs cannot bypass selector validation`() {
+        let target = Self.makeTarget(Selectors(
+            app: "TextEdit",
+            pid: 42,
+            windowTitle: nil,
+            windowIndex: nil,
+            windowID: nil
+        ))
+
+        #expect(throws: ValidationError.self) {
+            try target.resolveApplicationIdentifierOptional()
+        }
+        #expect(throws: ValidationError.self) {
+            try target.toWindowTarget()
+        }
+        #expect(throws: ValidationError.self) {
+            try target.observationTargetRequest()
+        }
+    }
+
+    private static func makeTarget(_ selectors: Selectors) -> InteractionTargetOptions {
+        var target = InteractionTargetOptions()
+        target.app = selectors.app
+        target.pid = selectors.pid
+        target.windowTitle = selectors.windowTitle
+        target.windowIndex = selectors.windowIndex
+        target.windowId = selectors.windowID
+        return target
+    }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 - Remove the MCP `list` tool, MenuTool’s status-item actions, and agent shims `list_apps`, `list_screens`, and `launch_app`; add `window` action `list` (v4 breaking change).
 
 ### Fixed
+- Reject conflicting app/PID and window selectors across interaction CLI and MCP entry points before focus, observation, or mutation.
 - Preserve stable `verify_state` proof for a directly matched exact AX identifier/value when only unrelated accessibility siblings are unreadable, while keeping absence, mismatch, ambiguity, and target drift fail-closed.
 - Preserve the requested characters during background typing on non-US keyboard layouts instead of interpreting fixed US key positions through the active layout. Thanks @canvascoding for #330.
 - Wait for WindowServer to settle after an exact background maximize dispatch before repinning its final bounds, avoiding false failures without relaxing owner-generation checks.

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/DialogTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/DialogTool.swift
@@ -24,6 +24,7 @@ public struct DialogTool: MCPTool {
 
         Targeting (recommended for determinism):
         - Provide app/pid and optionally window_id/window_title/window_index to resolve the dialog in the background.
+        - app and pid are alternatives. Provide at most one window selector; title/index require app or pid.
         - Set foreground=true only for keyboard/file interaction or an explicit global fallback.
 
         Examples:
@@ -101,7 +102,7 @@ public struct DialogTool: MCPTool {
                 throw DialogToolInputError.foregroundRequired(action)
             }
 
-            let target = MCPInteractionTarget(
+            let target = try MCPInteractionTarget(
                 app: inputs.app,
                 pid: inputs.pid,
                 windowTitle: inputs.windowTitle,

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/MCPInteractionTarget.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/MCPInteractionTarget.swift
@@ -1,10 +1,14 @@
 import CoreGraphics
 import Foundation
 import PeekabooAutomation
+import PeekabooFoundation
 
-enum MCPInteractionTargetError: LocalizedError {
-    case windowIndexRequiresApp
+enum MCPInteractionTargetError: LocalizedError, Equatable {
+    case applicationAndProcessIdentifier
+    case multipleWindowSelectors
+    case windowSelectorRequiresApp
     case invalidWindowId
+    case invalidWindowIndex
     case invalidProcessIdentifier
     case backgroundTargetRequired
     case backgroundWindowTargetUnsupported
@@ -12,10 +16,16 @@ enum MCPInteractionTargetError: LocalizedError {
 
     var errorDescription: String? {
         switch self {
-        case .windowIndexRequiresApp:
-            "window_index requires app (or pid) so the index can be resolved deterministically."
+        case .applicationAndProcessIdentifier:
+            "app and pid are mutually exclusive; provide exactly one process selector."
+        case .multipleWindowSelectors:
+            "window_id, window_title, and window_index are mutually exclusive; provide at most one."
+        case .windowSelectorRequiresApp:
+            "window_title and window_index require app or pid so the window can be resolved deterministically."
         case .invalidWindowId:
-            "window_id must be a positive integer."
+            "window_id must be between 1 and \(UInt32.max)."
+        case .invalidWindowIndex:
+            "window_index must be 0 or greater."
         case .invalidProcessIdentifier:
             "pid must be a positive 32-bit integer."
         case .backgroundTargetRequired:
@@ -38,6 +48,21 @@ struct MCPInteractionTarget {
     let windowIndex: Int?
     let windowId: Int?
 
+    init(
+        app: String?,
+        pid: Int?,
+        windowTitle: String?,
+        windowIndex: Int?,
+        windowId: Int?) throws
+    {
+        self.app = app
+        self.pid = pid
+        self.windowTitle = windowTitle
+        self.windowIndex = windowIndex
+        self.windowId = windowId
+        try self.validate()
+    }
+
     var appIdentifier: String? {
         if let pid {
             return "PID:\(pid)"
@@ -46,17 +71,34 @@ struct MCPInteractionTarget {
     }
 
     func validate() throws {
-        if let pid, pid <= 0 {
+        do {
+            try InteractionTargetSelectorValidator.validate(
+                hasApplication: self.app != nil,
+                hasProcessIdentifier: self.pid != nil,
+                hasWindowID: self.windowId != nil,
+                hasWindowTitle: self.windowTitle != nil,
+                hasWindowIndex: self.windowIndex != nil)
+        } catch let error as InteractionTargetSelectorValidationError {
+            switch error {
+            case .applicationAndProcessIdentifier:
+                throw MCPInteractionTargetError.applicationAndProcessIdentifier
+            case .multipleWindowSelectors:
+                throw MCPInteractionTargetError.multipleWindowSelectors
+            case .windowSelectorRequiresApplication:
+                throw MCPInteractionTargetError.windowSelectorRequiresApp
+            }
+        }
+
+        if let pid, pid <= 0 || Int32(exactly: pid) == nil {
             throw MCPInteractionTargetError.invalidProcessIdentifier
         }
 
-        if let windowId, windowId <= 0 {
+        if let windowId, windowId <= 0 || CGWindowID(exactly: windowId) == nil {
             throw MCPInteractionTargetError.invalidWindowId
         }
 
-        let hasTitle = !(self.windowTitle?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ?? true)
-        if self.windowIndex != nil, !hasTitle, self.appIdentifier?.isEmpty ?? true {
-            throw MCPInteractionTargetError.windowIndexRequiresApp
+        if let windowIndex, windowIndex < 0 {
+            throw MCPInteractionTargetError.invalidWindowIndex
         }
     }
 

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/PasteTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/PasteTool.swift
@@ -26,6 +26,7 @@ public struct PasteTool: MCPTool {
 
         Targeting:
         - Provide app/pid for process-targeted background paste.
+        - app and pid are alternatives. Provide at most one window selector; title/index require app or pid.
         - Add window_id, window_title, or window_index for atomic exact-window background delivery. Peekaboo pins the
           selected window ID, owner PID, and bounds through dispatch instead of falling back to a sibling window.
         - Set foreground=true only for intentional focus-changing/global paste.
@@ -107,7 +108,7 @@ public struct PasteTool: MCPTool {
         let startTime = Date()
 
         do {
-            let target = MCPInteractionTarget(
+            let target = try MCPInteractionTarget(
                 app: arguments.getString("app"),
                 pid: arguments.getInt("pid"),
                 windowTitle: arguments.getString("window_title"),

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/PressTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/PressTool.swift
@@ -17,7 +17,8 @@ public struct PressTool: MCPTool {
         Presses one or more keyboard chords. Use `keys` for an xdotool-style chord sequence such as
         ["cmd+c", "Return"], or use `key` plus `modifiers` for a single chord. The two input shapes are
         mutually exclusive. Background delivery requires app/pid targeting; set foreground=true for intentional
-        OS-global shortcuts or to focus a specific window first.
+        OS-global shortcuts or to focus a specific window first. app and pid are alternatives; provide at most one of
+        window_id, window_title, or window_index, and pair title/index with app or pid.
         \(PeekabooMCPVersion.banner) using openai/gpt-5.5, anthropic/claude-opus-4-8
         """
     }
@@ -96,7 +97,7 @@ public struct PressTool: MCPTool {
             }
 
             let foreground = arguments.getBool("foreground") == true
-            let target = MCPInteractionTarget(
+            let target = try MCPInteractionTarget(
                 app: arguments.getString("app"),
                 pid: arguments.getInt("pid"),
                 windowTitle: arguments.getString("window_title"),

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/TypeTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/TypeTool.swift
@@ -17,7 +17,8 @@ public struct TypeTool: MCPTool {
         Types text into UI elements or a targeted app process.
         Supports human typing (--wpm) or fixed-delay (--delay) pacing. Use `press` for key presses and chords.
         Background delivery requires an element/snapshot/app/pid target. Set `foreground=true` for intentional input
-        at the current keyboard focus or when the app must be focused first.
+        at the current keyboard focus or when the app must be focused first. app and pid are alternatives; provide at
+        most one window selector, and pair window_title/window_index with app or pid.
         \(PeekabooMCPVersion.banner) using openai/gpt-5.5
         and anthropic/claude-opus-4-8
         """
@@ -87,7 +88,7 @@ public struct TypeTool: MCPTool {
     private func parseRequest(arguments: ToolArguments) throws -> TypeRequest {
         let wordsPerMinute = arguments.getNumber("wpm").map { Int($0) }
         let profile = try self.parseProfile(arguments.getString("profile"), wordsPerMinute: wordsPerMinute)
-        let target = MCPInteractionTarget(
+        let target = try MCPInteractionTarget(
             app: arguments.getString("app"),
             pid: arguments.getInt("pid"),
             windowTitle: arguments.getString("window_title"),

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPInteractionTargetTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPInteractionTargetTests.swift
@@ -1,16 +1,136 @@
 import PeekabooAutomation
+import TachikomaMCP
 import Testing
 @testable import PeekabooAgentRuntime
+@testable import PeekabooCore
 
 struct MCPInteractionTargetTests {
+    enum InvalidConsumerFixture: CaseIterable, Sendable {
+        case applicationAndPID
+        case windowIDAndTitle
+        case titleWithoutOwner
+        case indexWithoutOwner
+
+        var arguments: [String: Any] {
+            switch self {
+            case .applicationAndPID:
+                ["app": "Preview", "pid": 42]
+            case .windowIDAndTitle:
+                ["app": "Preview", "window_id": 7, "window_title": "Main"]
+            case .titleWithoutOwner:
+                ["window_title": "Main"]
+            case .indexWithoutOwner:
+                ["window_index": 2]
+            }
+        }
+
+        var message: String {
+            switch self {
+            case .applicationAndPID:
+                "app and pid are mutually exclusive"
+            case .windowIDAndTitle:
+                "window_id, window_title, and window_index are mutually exclusive"
+            case .titleWithoutOwner, .indexWithoutOwner:
+                "require app or pid"
+            }
+        }
+    }
+
+    struct Selectors: Sendable {
+        let app: String?
+        let pid: Int?
+        let windowTitle: String?
+        let windowIndex: Int?
+        let windowID: Int?
+    }
+
+    @Test(arguments: [
+        Selectors(app: nil, pid: nil, windowTitle: nil, windowIndex: nil, windowID: nil),
+        Selectors(app: "Preview", pid: nil, windowTitle: nil, windowIndex: nil, windowID: nil),
+        Selectors(app: nil, pid: 42, windowTitle: nil, windowIndex: nil, windowID: nil),
+        Selectors(app: nil, pid: nil, windowTitle: nil, windowIndex: nil, windowID: 7),
+        Selectors(app: "Preview", pid: nil, windowTitle: "Main", windowIndex: nil, windowID: nil),
+        Selectors(app: nil, pid: 42, windowTitle: "Main", windowIndex: nil, windowID: nil),
+        Selectors(app: "Preview", pid: nil, windowTitle: nil, windowIndex: 2, windowID: nil),
+        Selectors(app: nil, pid: 42, windowTitle: nil, windowIndex: 2, windowID: nil),
+    ])
+    func `valid selector combinations construct`(_ selectors: Selectors) throws {
+        _ = try Self.makeTarget(selectors)
+    }
+
+    @Test(arguments: [
+        Selectors(app: "Preview", pid: 42, windowTitle: nil, windowIndex: nil, windowID: nil),
+        Selectors(app: "PID:42", pid: 42, windowTitle: nil, windowIndex: nil, windowID: nil),
+        Selectors(app: "Preview", pid: 42, windowTitle: nil, windowIndex: nil, windowID: 7),
+    ])
+    func `app and pid fail closed during construction`(_ selectors: Selectors) {
+        #expect(throws: MCPInteractionTargetError.applicationAndProcessIdentifier) {
+            _ = try Self.makeTarget(selectors)
+        }
+    }
+
+    @Test(arguments: [
+        Selectors(app: "Preview", pid: nil, windowTitle: "Main", windowIndex: nil, windowID: 7),
+        Selectors(app: "Preview", pid: nil, windowTitle: nil, windowIndex: 2, windowID: 7),
+        Selectors(app: "Preview", pid: nil, windowTitle: "Main", windowIndex: 2, windowID: nil),
+        Selectors(app: "Preview", pid: nil, windowTitle: "Main", windowIndex: 2, windowID: 7),
+    ])
+    func `multiple window selectors fail closed during construction`(_ selectors: Selectors) {
+        #expect(throws: MCPInteractionTargetError.multipleWindowSelectors) {
+            _ = try Self.makeTarget(selectors)
+        }
+    }
+
+    @Test(arguments: [
+        Selectors(app: nil, pid: nil, windowTitle: "Main", windowIndex: nil, windowID: nil),
+        Selectors(app: nil, pid: nil, windowTitle: nil, windowIndex: 2, windowID: nil),
+    ])
+    func `relative window selectors require an owner during construction`(_ selectors: Selectors) {
+        #expect(throws: MCPInteractionTargetError.windowSelectorRequiresApp) {
+            _ = try Self.makeTarget(selectors)
+        }
+    }
+
+    @Test(arguments: [
+        Selectors(app: nil, pid: 0, windowTitle: nil, windowIndex: nil, windowID: nil),
+        Selectors(app: nil, pid: Int(Int32.max) + 1, windowTitle: nil, windowIndex: nil, windowID: nil),
+    ])
+    func `invalid process identifiers fail during construction`(_ selectors: Selectors) {
+        #expect(throws: MCPInteractionTargetError.invalidProcessIdentifier) {
+            _ = try Self.makeTarget(selectors)
+        }
+    }
+
+    @Test(arguments: [
+        Selectors(app: nil, pid: nil, windowTitle: nil, windowIndex: nil, windowID: 0),
+        Selectors(app: nil, pid: nil, windowTitle: nil, windowIndex: nil, windowID: Int(UInt32.max) + 1),
+    ])
+    func `invalid window identifiers fail during construction`(_ selectors: Selectors) {
+        #expect(throws: MCPInteractionTargetError.invalidWindowId) {
+            _ = try Self.makeTarget(selectors)
+        }
+    }
+
     @Test
-    func `window target prefers title over index`() throws {
-        let target = MCPInteractionTarget(
+    func `negative window index fails during construction`() {
+        #expect(throws: MCPInteractionTargetError.invalidWindowIndex) {
+            _ = try Self.makeTarget(Selectors(
+                app: "Preview",
+                pid: nil,
+                windowTitle: nil,
+                windowIndex: -1,
+                windowID: nil))
+        }
+    }
+
+    @Test
+    func `valid title target retains its owner`() throws {
+        let target = try Self.makeTarget(Selectors(
             app: "Preview",
             pid: nil,
             windowTitle: "Main",
-            windowIndex: 2,
-            windowId: nil)
+            windowIndex: nil,
+            windowID: nil))
 
         switch try target.toWindowTarget() {
         case let .applicationAndTitle(app, title):
@@ -21,20 +141,44 @@ struct MCPInteractionTargetTests {
         }
     }
 
-    @Test
-    func `title only target ignores ambiguous index`() throws {
-        let target = MCPInteractionTarget(
-            app: nil,
-            pid: nil,
-            windowTitle: "Main",
-            windowIndex: 2,
-            windowId: nil)
+    @MainActor
+    @Test(arguments: InvalidConsumerFixture.allCases)
+    func `all MCP interaction consumers reject invalid selectors before execution`(
+        fixture: InvalidConsumerFixture) async throws
+    {
+        let context = await MCPToolTestHelpers.makeContext()
+        let arguments = fixture.arguments
+        let responses = try await [
+            TypeTool(context: context).execute(arguments: ToolArguments(raw: arguments.merging([
+                "text": "hello",
+            ]) { current, _ in current })),
+            PressTool(context: context).execute(arguments: ToolArguments(raw: arguments.merging([
+                "keys": ["cmd+c"],
+            ]) { current, _ in current })),
+            PasteTool(context: context).execute(arguments: ToolArguments(raw: arguments.merging([
+                "text": "hello",
+            ]) { current, _ in current })),
+            DialogTool(context: context).execute(arguments: ToolArguments(raw: arguments.merging([
+                "action": "list",
+            ]) { current, _ in current })),
+        ]
 
-        switch try target.toWindowTarget() {
-        case let .title(title):
-            #expect(title == "Main")
-        default:
-            Issue.record("Expected title target")
+        for response in responses {
+            #expect(response.isError)
+            guard case let .text(text, _, _)? = response.content.first else {
+                Issue.record("Expected selector validation error")
+                continue
+            }
+            #expect(text.contains(fixture.message))
         }
+    }
+
+    private static func makeTarget(_ selectors: Selectors) throws -> MCPInteractionTarget {
+        try MCPInteractionTarget(
+            app: selectors.app,
+            pid: selectors.pid,
+            windowTitle: selectors.windowTitle,
+            windowIndex: selectors.windowIndex,
+            windowId: selectors.windowID)
     }
 }

--- a/Core/PeekabooFoundation/Sources/PeekabooFoundation/InteractionTargetSelectorValidation.swift
+++ b/Core/PeekabooFoundation/Sources/PeekabooFoundation/InteractionTargetSelectorValidation.swift
@@ -1,0 +1,28 @@
+public enum InteractionTargetSelectorValidationError: Error, Equatable, Sendable {
+    case applicationAndProcessIdentifier
+    case multipleWindowSelectors
+    case windowSelectorRequiresApplication
+}
+
+public enum InteractionTargetSelectorValidator {
+    public static func validate(
+        hasApplication: Bool,
+        hasProcessIdentifier: Bool,
+        hasWindowID: Bool,
+        hasWindowTitle: Bool,
+        hasWindowIndex: Bool) throws
+    {
+        if hasApplication, hasProcessIdentifier {
+            throw InteractionTargetSelectorValidationError.applicationAndProcessIdentifier
+        }
+
+        let windowSelectorCount = [hasWindowID, hasWindowTitle, hasWindowIndex].count(where: { $0 })
+        if windowSelectorCount > 1 {
+            throw InteractionTargetSelectorValidationError.multipleWindowSelectors
+        }
+
+        if hasWindowTitle || hasWindowIndex, !hasApplication, !hasProcessIdentifier {
+            throw InteractionTargetSelectorValidationError.windowSelectorRequiresApplication
+        }
+    }
+}

--- a/Core/PeekabooFoundation/Tests/PeekabooFoundationTests/InteractionTargetSelectorValidationTests.swift
+++ b/Core/PeekabooFoundation/Tests/PeekabooFoundationTests/InteractionTargetSelectorValidationTests.swift
@@ -1,0 +1,71 @@
+import Testing
+@testable import PeekabooFoundation
+
+struct InteractionTargetSelectorValidationTests {
+    struct Selectors: Sendable {
+        let app: Bool
+        let pid: Bool
+        let windowID: Bool
+        let windowTitle: Bool
+        let windowIndex: Bool
+    }
+
+    @Test(arguments: [
+        Selectors(app: false, pid: false, windowID: false, windowTitle: false, windowIndex: false),
+        Selectors(app: true, pid: false, windowID: false, windowTitle: false, windowIndex: false),
+        Selectors(app: false, pid: true, windowID: false, windowTitle: false, windowIndex: false),
+        Selectors(app: false, pid: false, windowID: true, windowTitle: false, windowIndex: false),
+        Selectors(app: true, pid: false, windowID: true, windowTitle: false, windowIndex: false),
+        Selectors(app: false, pid: true, windowID: true, windowTitle: false, windowIndex: false),
+        Selectors(app: true, pid: false, windowID: false, windowTitle: true, windowIndex: false),
+        Selectors(app: false, pid: true, windowID: false, windowTitle: true, windowIndex: false),
+        Selectors(app: true, pid: false, windowID: false, windowTitle: false, windowIndex: true),
+        Selectors(app: false, pid: true, windowID: false, windowTitle: false, windowIndex: true),
+    ])
+    func `valid selector combinations pass`(_ selectors: Selectors) throws {
+        try Self.validate(selectors)
+    }
+
+    @Test(arguments: [
+        Selectors(app: true, pid: true, windowID: false, windowTitle: false, windowIndex: false),
+        Selectors(app: true, pid: true, windowID: true, windowTitle: false, windowIndex: false),
+        Selectors(app: true, pid: true, windowID: false, windowTitle: true, windowIndex: false),
+        Selectors(app: true, pid: true, windowID: false, windowTitle: false, windowIndex: true),
+    ])
+    func `app and pid combinations fail closed`(_ selectors: Selectors) {
+        #expect(throws: InteractionTargetSelectorValidationError.applicationAndProcessIdentifier) {
+            try Self.validate(selectors)
+        }
+    }
+
+    @Test(arguments: [
+        Selectors(app: true, pid: false, windowID: true, windowTitle: true, windowIndex: false),
+        Selectors(app: true, pid: false, windowID: true, windowTitle: false, windowIndex: true),
+        Selectors(app: true, pid: false, windowID: false, windowTitle: true, windowIndex: true),
+        Selectors(app: true, pid: false, windowID: true, windowTitle: true, windowIndex: true),
+    ])
+    func `multiple window selectors fail closed`(_ selectors: Selectors) {
+        #expect(throws: InteractionTargetSelectorValidationError.multipleWindowSelectors) {
+            try Self.validate(selectors)
+        }
+    }
+
+    @Test(arguments: [
+        Selectors(app: false, pid: false, windowID: false, windowTitle: true, windowIndex: false),
+        Selectors(app: false, pid: false, windowID: false, windowTitle: false, windowIndex: true),
+    ])
+    func `relative window selectors require an application owner`(_ selectors: Selectors) {
+        #expect(throws: InteractionTargetSelectorValidationError.windowSelectorRequiresApplication) {
+            try Self.validate(selectors)
+        }
+    }
+
+    private static func validate(_ selectors: Selectors) throws {
+        try InteractionTargetSelectorValidator.validate(
+            hasApplication: selectors.app,
+            hasProcessIdentifier: selectors.pid,
+            hasWindowID: selectors.windowID,
+            hasWindowTitle: selectors.windowTitle,
+            hasWindowIndex: selectors.windowIndex)
+    }
+}

--- a/docs/application-resolving.md
+++ b/docs/application-resolving.md
@@ -7,7 +7,7 @@ read_when:
 
 # Application Resolution in Peekaboo
 
-This document explains how Peekaboo resolves applications across all commands that accept an application parameter.
+This document explains how Peekaboo resolves applications across commands that accept an application parameter.
 
 ## Overview
 
@@ -38,7 +38,7 @@ peekaboo menu list --app "PID:12345"
 # By PID using --pid parameter
 peekaboo app quit --pid 12345
 
-# Both parameters (when they refer to the same app)
+# Both parameters on a legacy window command (when they refer to the same app)
 peekaboo window focus --app Safari --pid 12345
 ```
 
@@ -112,37 +112,39 @@ peekaboo window list --app chrome
 3. Prioritizes running applications
 4. Falls back to installed applications
 
-## Lenient Parameter Handling
+## Selector safety and legacy leniency
 
-Peekaboo is designed to be forgiving with parameters, especially for AI agents that might provide redundant information.
+V4 interaction and observation commands fail closed: use either `--app` or `--pid`, never both. This rule covers `see` and commands that use the shared interaction target such as `action`, `click`, `drag`, `press`, `set-value`, and `type`. These commands may observe, focus, and mutate through different services, so a redundant-looking pair is unsafe when those services resolve it differently.
+
+Some legacy app/window management commands retain lenient parameter handling as a compatibility contract. For those commands, redundant app/PID information is accepted; a textual app selector remains authoritative because the synchronous resolver cannot reliably cross-check it against the PID.
 
 ### Allowed Redundancy
 
-These are all valid and equivalent:
+These legacy management forms are valid and equivalent:
 ```bash
 # Redundant PID specifications
 peekaboo window close --app "PID:12345" --pid 12345
 
-# Name and PID for same app
-peekaboo see --no-elements --app Safari --pid 67890  # If PID 67890 is Safari
+# Legacy compatibility: the textual app selector is authoritative
+peekaboo window focus --app Safari --pid 67890
 ```
 
 ### Conflict Detection
 
-These will produce errors:
+This produces an error:
 ```bash
 # Different PIDs
 peekaboo window close --app "PID:12345" --pid 67890
 
-# Name doesn't match PID
-peekaboo see --no-elements --app Safari --pid 12345  # If PID 12345 is Chrome
 ```
+
+A textual app/PID mismatch is not synchronously detectable in the legacy resolver. This is why interaction and observation commands reject the pair instead of choosing one.
 
 ## Implementation Details
 
 ### ApplicationResolvable Protocol
 
-All commands with application parameters conform to the `ApplicationResolvable` protocol:
+Commands with application parameters can conform to the `ApplicationResolvable` protocol:
 
 ```swift
 protocol ApplicationResolvable {
@@ -151,14 +153,14 @@ protocol ApplicationResolvable {
 }
 ```
 
-This ensures consistent behavior across all commands.
+Safety-sensitive interaction call sites add stricter selector validation before invoking this resolver.
 
 ### Resolution Priority
 
-When both `--app` and `--pid` are provided:
-1. Validate they refer to the same application
-2. Prefer the more readable format (name/bundle) for operations
-3. Use PID for precise targeting when needed
+When a legacy-compatible command accepts both `--app` and `--pid`:
+1. If `--app` uses `PID:<pid>`, validate that it matches `--pid`
+2. Otherwise, prefer the textual app or bundle identifier for the operation
+3. Do not infer that an accompanying PID proves the textual app's identity
 
 ### Error Messages
 
@@ -189,12 +191,7 @@ peekaboo app launch --app com.apple.Safari
 
 ### For AI Agents
 
-AI agents can safely:
-- Provide both `--app` and `--pid` if unsure
-- Use PID format in either parameter
-- Mix formats as needed
-
-The lenient validation ensures the command works if the parameters are consistent.
+AI agents should provide exactly one of `--app` or `--pid`. Use `PID:<pid>` in `--app` only when a schema lacks a separate PID field. Do not send both unless the specific legacy command documents that compatibility form.
 
 ## Common Patterns
 

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -21,6 +21,8 @@ Every input command accepts one of three target shapes:
 
 Prefer IDs when you can capture them, labels when you can't, and coordinates only as a last resort. The agent and MCP tooling default to the first two.
 
+Process and window selectors are fail-closed. Choose either `--app` or `--pid`, never both. Choose at most one of `--window-id`, `--window-title`, or `--window-index`; title and index require an app or PID owner. The same rules apply to MCP's `app`, `pid`, `window_id`, `window_title`, and `window_index` fields.
+
 ## Delivery modes
 
 Peekaboo has two input delivery modes:

--- a/docs/commands/see.md
+++ b/docs/commands/see.md
@@ -29,8 +29,8 @@ peekaboo see --app "Google Chrome" --window-title "Login" --json --path /tmp/chr
 
 | Flag | Description |
 | --- | --- |
-| `--app`, `--window-title`, `--pid` | Limit capture to a known app/window/process. |
-| `--window-id <id>` | Observe one exact WindowServer window. Pair it with `--app` or `--pid` to require that owner. It cannot be combined with `--window-title`. |
+| `--app`, `--window-title`, `--pid` | Limit capture to a known app/window/process. Use either `--app` or `--pid`; title requires one of them. |
+| `--window-id <id>` | Observe one exact WindowServer window. Pair it with `--app` or `--pid` to require that owner. Use at most one of `--window-id`, `--window-title`, or `--window-index`. |
 | `--mode screen|window|frontmost|multi|area` | Override the target picker. `multi` captures every screen; `area` uses `--region`. |
 | `--region x,y,width,height` | Capture a rectangular region (`area` mode is inferred). |
 | `--format png|jpg` / `--retina` | Select the image encoding and native display scale. |


### PR DESCRIPTION
## Summary

- centralize process/window selector combination validation in `PeekabooFoundation`
- make v4 CLI interaction/observation entry points reject ambiguous app/PID and window selectors before target resolution
- validate MCP interaction targets during construction so type, press, paste, and dialog consumers cannot silently choose different selectors
- preserve the documented lenient app/window-management compatibility path outside the v4 interaction surface
- clarify CLI help, MCP descriptions, and application-resolution guidance

## Safety contract

- `app` and `pid` are mutually exclusive
- `window_id`, `window_title`, and `window_index` are mutually exclusive
- title/index selectors require an app or PID owner
- invalid PID/window-ID ranges and negative indexes fail before focus, observation, or mutation

## Proof

- `pnpm run test:safe`
- `swift test --package-path Core/PeekabooCore --no-parallel`
- `swift test --package-path Core/PeekabooFoundation`
- `pnpm run lint` (repository warning baseline only; no changed-file violations)
- `pnpm run lint:docs`
- `pnpm run format`
- source-blind behavior contract against a Foundation-signed isolated CLI binary: all selector-conflict and boundary probes passed
- autoreview: clean, no accepted/actionable findings

## Notes

This intentionally removes title-over-index and PID-over-app precedence from v4 interaction targets. Legacy app/window management commands retain their documented redundant-selector compatibility behavior.
