### PR TITLE
docs(cli): align release tooling with v4 commands

### DIFF
--- a/Apps/CLI/Sources/PeekabooCLI/Commands/AI/AgentCommand+ModelParsing.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/AI/AgentCommand+ModelParsing.swift
@@ -143,7 +143,7 @@ extension AgentCommand {
             if let known = LanguageModel.parse(from: modelString), !known.supportsTools {
                 throw PeekabooError.invalidInput(
                     "Model '\(modelString)' does not support tool calling, which `peekaboo agent` requires. " +
-                        "Use it for vision instead (`peekaboo image --analyze` / `see --analyze`), " +
+                        "Use it for vision instead (`peekaboo see --analyze`), " +
                         "or pick a tool-capable model."
                 )
             }

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Core/LearnCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Core/LearnCommand.swift
@@ -52,9 +52,8 @@ struct LearnCommand {
 
         ## Available Tools
 
-        Peekaboo provides 30+ tools for macOS automation.
-        Each tool is designed for a specific purpose and can be combined
-        to create powerful workflows.
+        Peekaboo's registry-driven agent and MCP tools cover macOS observation,
+        interaction, app/window management, and workflow completion.
         """, to: &output)
     }
 
@@ -120,12 +119,14 @@ struct LearnCommand {
         ## Usage Best Practices
 
         1. Always start with `see` to understand the UI before interacting.
-        2. Click in the center of elements for reliable interactions.
+        2. Prefer opaque element IDs from the current snapshot over guessed coordinates.
         3. Verify each action before proceeding; use `see` again if needed.
-        4. Manage windows with the `window` tool's `list` and `focus` actions before automation.
+        4. Inventory targets with `app list`, `window list`, and `screen list`;
+           focus only when foreground delivery is required.
         5. Recover from errors by trying alternative interactions (menus, keyboard chords).
         6. Common workflows:
-           - Screenshot: `see --no-elements` with `--app` or `--mode screen`.
+           - Screenshot: `see --no-elements` with `--app`, `--window-id`, or `--mode screen`.
+           - AX tree: `see --tree --no-screenshot` with an exact app/window target.
            - Typing: `click` the field, then `type --app ...` the text; add `--foreground` only if needed.
            - Menus: `menu click --path ...`.
            - Keyboard shortcuts: `press cmd+shift+t` style chords.
@@ -135,13 +136,13 @@ struct LearnCommand {
     private func appendQuickReference(to output: inout String) {
         print("""
         ## Quick Reference
-        - **Vision**: see, image, capture
+        - **Observe**: see (`--no-elements` for screenshots, `--tree --no-screenshot` for AX), capture
         - **UI Automation**: click, type, press, scroll, drag
+        - **Inventory**: app list, window list, screen list
         - **Window Management**: window, space
-        - **Applications**: app
-        - **Elements**: inspect_ui, verify_state, set_value, action
+        - **Elements**: verify, set-value, action
         - **Menu/Dialog**: menu, dialog
-        - **System**: shell, done, need_info
+        - **System and integration**: clipboard, permissions, tools, mcp
 
         Remember: You are Peekaboo, an AI-powered screen automation assistant.
         Be confident, be helpful, and get things done!

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/DragCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/DragCommand.swift
@@ -272,7 +272,7 @@ extension DragCommand: ParsableCommand {
                   peekaboo drag --from "$SOURCE_ID" --to "$TARGET_ID" --foreground
                   peekaboo drag --from "100,200" --to "400,300" --foreground
                   peekaboo drag --from "$SOURCE_ID" --to-app Trash --foreground
-                  peekaboo drag --from "$SOURCE_ID" --to "500,250" --duration 2000 --foreground
+                  peekaboo drag --from "$SOURCE_ID" --to "500,250" --duration 2s --foreground
                   peekaboo drag --from "$SOURCE_ID" --to "$TARGET_ID" --modifiers shift --foreground
                   peekaboo drag --from "100,200" --to "400,300" --button right --foreground
 

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/TypeCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/TypeCommand.swift
@@ -289,8 +289,8 @@ extension TypeCommand: ParsableCommand {
                     EXAMPLES:
                       peekaboo type "Hello World" --app TextEdit # Background-target TextEdit
                       peekaboo type "user@example.com" --foreground
-                      peekaboo type "text" --app TextEdit --delay 0
-                      peekaboo type "text" --app TextEdit --delay 50
+                      peekaboo type "text" --app TextEdit --delay 0ms
+                      peekaboo type "text" --app TextEdit --delay 50ms
                       peekaboo type "text" --app TextEdit --wpm 150
                       peekaboo type "text" --app TextEdit --clear
                       peekaboo type "Line 1\nLine 2" --app TextEdit

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/AppCommand+List.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/AppCommand+List.swift
@@ -15,10 +15,8 @@ extension AppCommand {
             abstract: "List running applications",
             discussion: """
             App-management view of running applications. Hidden and background apps are
-            filtered unless --include-hidden or --include-background is passed.
-
-            For a broader inventory payload, use `peekaboo list apps`; it accepts the same
-            visibility flags for parity and emits both `applications` and preferred `apps`.
+            filtered unless --include-hidden or --include-background is passed. This is the
+            canonical v4 process inventory command; JSON emits `count` and `apps`.
             """
         )
 

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/AppCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/AppCommand.swift
@@ -31,7 +31,7 @@ struct AppCommand: ParsableCommand {
 
           # Relaunch applications
           peekaboo app relaunch Safari --foreground
-          peekaboo app relaunch "Visual Studio Code" --wait 3 --wait-until-ready
+          peekaboo app relaunch "Visual Studio Code" --wait 3s --wait-until-ready
         """,
         subcommands: [
             LaunchSubcommand.self,

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/MenuBarCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/MenuBarCommand.swift
@@ -12,7 +12,7 @@ struct MenuBarActionCommand: ErrorHandlingCommand, OutputFormattable, InjectedRu
     @Argument(help: "Name of the menu bar item to click (for click action)")
     var itemName: String?
 
-    @Option(help: "0-based index shown by 'peekaboo menubar list' or 'peekaboo list menubar'")
+    @Option(help: "0-based index shown by 'peekaboo menubar list'")
     var index: Int?
 
     @Flag(help: "Include raw debug fields (window owner/layer) in JSON output")

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/WindowCommand+Bindings.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/WindowCommand+Bindings.swift
@@ -57,11 +57,10 @@ extension WindowCommand.WindowListSubcommand: ParsableCommand {
                 commandName: "list",
                 abstract: "List renderable windows for an application",
                 discussion: """
-                Lists windows suitable for interaction targeting. It uses the same window IDs
-                and indexes as `peekaboo list windows`, but filters out non-renderable entries
-                such as non-zero layer, tiny, transparent, or Windows-menu-excluded windows.
-
-                Use `peekaboo list windows --app <app>` when you need the full enumeration.
+                Lists renderable windows suitable for interaction targeting. This is the canonical
+                v4 window inventory command and returns the IDs/indexes used by `--window-id` and
+                `--window-index`. Non-zero layer, tiny, transparent, and Windows-menu-excluded
+                entries are omitted.
                 """
             )
         }

--- a/Apps/CLI/Tests/CLIAutomationTests/HelpCommandTests.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/HelpCommandTests.swift
@@ -14,11 +14,16 @@ struct HelpCommandTests {
         #expect(output.contains("Usage"))
         #expect(output.contains("peekaboo <command>"))
         #expect(output.contains("Core Commands"))
-        #expect(output.contains("image"))
+        #expect(output.contains("see"))
         #expect(output.contains("screen"))
+        #expect(output.contains("press"))
+        #expect(output.contains("action"))
         #expect(output.contains("agent"))
         #expect(output.contains("Global Runtime Flags"))
         #expect(output.contains("--json/-j"))
+        #expect(!output.contains("\n  image "))
+        #expect(!output.contains("\n  hotkey "))
+        #expect(!output.contains("\n  perform-action "))
     }
 
     @Test
@@ -33,7 +38,6 @@ struct HelpCommandTests {
     @Test
     func `help subcommand for each tool`() async throws {
         let subcommands = [
-            "image",
             "screen",
             "config",
             "permissions",
@@ -41,6 +45,8 @@ struct HelpCommandTests {
             "click",
             "type",
             "scroll",
+            "press",
+            "action",
             "drag",
             "move",
             "clean",
@@ -100,7 +106,7 @@ struct HelpCommandTests {
     @Test
     func `Subcommand --help flag`() async throws {
         // Test that each subcommand's --help flag works
-        let subcommands = ["image", "screen", "config", "agent", "see", "click"]
+        let subcommands = ["screen", "config", "agent", "see", "click", "press", "action"]
 
         for subcommand in subcommands {
             let output = try await runPeekaboo([subcommand, "--help"]).stdout
@@ -120,6 +126,37 @@ struct HelpCommandTests {
         let maximizeHelp = try await runPeekaboo(["window", "maximize", "--help"]).stdout
         #expect(maximizeHelp.contains("without entering full screen"))
         #expect(!maximizeHelp.contains("Maximize a window (full screen)"))
+    }
+
+    @Test
+    func `V4 inventory and interaction help omit removed CLI forms`() async throws {
+        let helpPaths = [
+            ["app", "list", "--help"],
+            ["window", "list", "--help"],
+            ["screen", "list", "--help"],
+            ["see", "--help"],
+            ["click", "--help"],
+            ["drag", "--help"],
+        ]
+        let removedForms = [
+            "peekaboo image",
+            "peekaboo list apps",
+            "peekaboo list windows",
+            "peekaboo hotkey",
+            "peekaboo inspect-ui",
+            "peekaboo perform-action",
+            "peekaboo swipe",
+            "--coords",
+            "--from-coords",
+            "--to-coords",
+        ]
+
+        for path in helpPaths {
+            let output = try await runPeekaboo(path).stdout
+            for removed in removedForms {
+                #expect(!output.contains(removed), "\(path.joined(separator: " ")) help contains \(removed)")
+            }
+        }
     }
 
     // MARK: - Helper Methods

--- a/Apps/CLI/Tests/CLIAutomationTests/WindowCommandCLITests.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/WindowCommandCLITests.swift
@@ -61,7 +61,7 @@ struct WindowCommandCLITests {
     }
 
     @Test
-    func `Window list delegates to list windows`() async throws {
+    func `Window list returns a structured error for a missing app`() async throws {
         let result = try await runCommand(["window", "list", "--app", "NonExistentApp", "--json"])
         #expect(result.status != 0)
 

--- a/Apps/CLI/Tests/CoreCLITests/CommandHelpRendererTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/CommandHelpRendererTests.swift
@@ -29,6 +29,33 @@ struct CommandHelpRendererTests {
             #expect(help.range(of: #"\b[BTMS]\d+\b"#, options: .regularExpression) == nil)
         }
     }
+
+    @Test
+    func `V4 generated help uses canonical commands and explicit duration units`() {
+        let help = [
+            AppCommand.helpMessage(),
+            AppCommand.ListSubcommand.helpMessage(),
+            WindowCommand.WindowListSubcommand.helpMessage(),
+            ClickCommand.helpMessage(),
+            DragCommand.helpMessage(),
+            TypeCommand.helpMessage(),
+        ].joined(separator: "\n")
+
+        for removed in [
+            "peekaboo image",
+            "peekaboo list apps",
+            "peekaboo list windows",
+            "peekaboo hotkey",
+            "peekaboo inspect-ui",
+            "peekaboo perform-action",
+            "peekaboo swipe",
+        ] {
+            #expect(!help.contains(removed), "Generated help contains removed CLI form: \(removed)")
+        }
+        #expect(help.contains("--wait 3s"))
+        #expect(help.contains("--duration 2s"))
+        #expect(help.contains("--delay 50ms"))
+    }
 }
 
 private struct SampleHelpCommand: ParsableCommand {

--- a/Apps/Mac/PeekabooTests/Services/PeekabooToolExecutorTests.swift
+++ b/Apps/Mac/PeekabooTests/Services/PeekabooToolExecutorTests.swift
@@ -19,10 +19,12 @@ struct ToolRegistryTests {
             "click",
             "type",
             "scroll",
-            "hotkey",
-            "launch_app",
+            "press",
+            "action",
+            "drag",
+            "move",
             "app",
-            "list",
+            "window",
             "menu",
             "dialog",
             "dock",
@@ -32,6 +34,7 @@ struct ToolRegistryTests {
         ]
 
         #expect(toolNames.isSuperset(of: expectedTools))
+        #expect(toolNames.isDisjoint(with: ["hotkey", "launch_app", "list"]))
     }
 
     @Test

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/ToolRegistry/ToolDefinitions.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/ToolRegistry/ToolDefinitions.swift
@@ -62,7 +62,7 @@ public enum UIAutomationToolDefinitions {
         abstract: "Click on UI elements or coordinates",
         discussion: """
         Clicks on UI elements or coordinates. Supports element queries,
-        specific IDs from `see` or `inspect_ui`, or coordinates. CLI coordinate
+        specific IDs from `see`, or coordinates. CLI coordinate
         clicks are target-window-relative when app/window target flags are supplied.
         Background delivery is the default; pass `--foreground` for focused foreground clicks.
         """,
@@ -76,12 +76,12 @@ public enum UIAutomationToolDefinitions {
             ParameterDefinition(
                 name: "on",
                 type: .string,
-                description: "Opaque element ID copied exactly from current `see` or `inspect_ui` output",
+                description: "Opaque element ID copied exactly from current `see` output",
                 required: false),
             ParameterDefinition(
-                name: "coords",
+                name: "at",
                 type: .string,
-                description: "Click at coordinates in format 'x,y'",
+                description: "Click at coordinates in format 'x,y'; target-relative with window flags",
                 required: false),
             ParameterDefinition(
                 name: "double",

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/ToolRegistry/ToolRegistry.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/ToolRegistry/ToolRegistry.swift
@@ -47,7 +47,8 @@ public enum ToolRegistry {
             category: .automation,
             abstract: "High-precision UI clicking with fuzzy matching and snapshot-aware targeting.",
             discussion: """
-            Clicks on UI elements or coordinates. Supports IDs from `see` or `inspect_ui`,
+            Clicks on UI elements or coordinates. CLI interactions use IDs from `see`;
+            agent/MCP interactions may also use IDs from `inspect_ui`,
             fuzzy text queries, or raw coordinates. Clicks use background delivery by default;
             pass `--foreground` only when the target must receive a foreground mouse event.
 
@@ -57,16 +58,17 @@ public enum ToolRegistry {
             - Snapshot-aware IDs avoid ambiguity when multiple matches exist
 
             EXAMPLE
-            peekaboo click --foreground --wait-for 1500 --double \"Submit\"
-            peekaboo click --on "$ELEMENT_ID" --foreground --space-switch
+            peekaboo see --app Safari --json
+            peekaboo click \"Submit\" --app Safari --snapshot "$SNAPSHOT_ID" --wait-for 1500ms
+            peekaboo click --on "$ELEMENT_ID" --snapshot "$SNAPSHOT_ID"
 
             TROUBLESHOOTING
             If the element isn't found, refresh the snapshot with a fresh observation (`peekaboo see`
             in CLI, or `see`/`inspect_ui` in MCP), or provide a more precise query.
             """,
             examples: [
-                "peekaboo click \"Submit\"",
-                "peekaboo click --foreground --wait-for 2000 --double \"Save\"",
+                "peekaboo click \"Submit\" --app Safari --snapshot \"$SNAPSHOT_ID\" --wait-for 1500ms",
+                "peekaboo click --on \"$ELEMENT_ID\" --snapshot \"$SNAPSHOT_ID\"",
             ],
             agentGuidance: "Prefer ID-based clicks when possible. Use default background delivery, and add " +
                 "`--foreground` only when the app requires focused input. If fuzzy text fails, capture again and " +
@@ -81,16 +83,16 @@ public enum ToolRegistry {
             - Use "\\\\" or the word "escape" to send a literal backslash
 
             EXAMPLE
-            peekaboo type \"Hello\\nWorld\"
-            peekaboo type --text \"Press\\tescape\" --delay 50
+            peekaboo type \"Hello\\nWorld\" --app TextEdit
+            peekaboo type --text \"Press\\tescape\" --app TextEdit --delay 50ms
 
             TROUBLESHOOTING
             If the text appears in the wrong place, pass `--app`, `--pid`, `--window-id`, or `--snapshot` so
             Peekaboo can resolve a background target process. Use `--foreground` for apps that require focused input.
             """,
             examples: [
-                "peekaboo type \"Hello\\nWorld\"",
-                "peekaboo type --text \"Name:\\tJohn\" --delay 25",
+                "peekaboo type \"Hello\\nWorld\" --app TextEdit",
+                "peekaboo type --text \"Name:\\tJohn\" --app TextEdit --delay 25ms",
             ],
             agentGuidance: "Remember to escape newline/tab characters when providing prompts; " +
                 "literal newlines may be interpreted by the shell."),

--- a/Core/PeekabooCore/Tests/PeekabooAgentRuntimeTests/ToolRegistryContractTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooAgentRuntimeTests/ToolRegistryContractTests.swift
@@ -12,6 +12,21 @@ struct ToolRegistryContractTests {
 
         let tools = ToolRegistry.allTools(using: services)
         #expect(!tools.isEmpty)
+
+        let names = Set(tools.map(\.name))
+        #expect(names.isSuperset(of: [
+            "see",
+            "click",
+            "type",
+            "scroll",
+            "press",
+            "action",
+            "drag",
+            "move",
+            "app",
+            "window",
+        ]))
+        #expect(names.isDisjoint(with: ["hotkey", "launch_app", "list"]))
     }
 
     @Test

--- a/README.md
+++ b/README.md
@@ -76,10 +76,10 @@ Agent runs need a configured model provider. See [agent setup](docs/commands/age
 
 | Goal | Commands | Guide |
 | --- | --- | --- |
-| Observe the desktop | `image`, `see`, `list`, `screen` | [Capture and inspection](docs/quickstart.md) |
-| Interact with UI | `click`, `type`, `press`, `scroll`, `drag`, `set-value`, `perform-action` | [Automation](docs/automation.md) |
+| Observe the desktop | `see`, `capture`, `app list`, `window list`, `screen list` | [Capture and inspection](docs/quickstart.md) |
+| Interact with UI | `click`, `type`, `press`, `scroll`, `drag`, `move`, `set-value`, `action` | [Automation](docs/automation.md) |
 | Control macOS | `app`, `window`, `menu`, `menubar`, `dock`, `dialog`, `space` | [Command reference](docs/commands/README.md) |
-| Run workflows | `agent`, `run` | [Agent](docs/commands/agent.md) · [Scripts](docs/commands/run.md) |
+| Run workflows | `agent`, `capture action` | [Agent](docs/commands/agent.md) · [Action capture](docs/commands/capture.md) |
 | Integrate with clients | `mcp`, `browser`, `tools` | [MCP](docs/MCP.md) |
 
 Run `peekaboo help <command>` for live CLI help. The [complete command index](docs/commands/README.md) links to flags, examples, and troubleshooting for every command.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -32,6 +32,18 @@ pnpm run test:safe
 pnpm run prepare-release
 ```
 
+While the version/changelog decision is still in progress, run the deterministic subset without registry, git-fetch,
+or artifact work:
+
+```bash
+pnpm run build:cli
+pnpm run prepare-release -- --dry-run --bin Apps/CLI/.build/debug/peekaboo
+```
+
+The dry run validates metadata consistency, docs/links, generated v4 help, retired-command rejection, and the
+`app list`/`window list`/`screen list` JSON contracts. It is intentionally not release-readiness proof; the full
+preflight remains required after the version is final and the tree is clean.
+
 Run `pnpm run test:automation` and live provider tests when the release changes those surfaces. Before committing,
 run the repository autoreview workflow until no accepted actionable findings remain.
 

--- a/docs/building.md
+++ b/docs/building.md
@@ -49,6 +49,9 @@ For full release automation (tarballs, npm package, checksums), follow [RELEASIN
 # Validate + prep
 pnpm run prepare-release
 
+# Deterministic metadata/docs/CLI contract only (no registry or artifact checks)
+pnpm run prepare-release -- --dry-run --bin Apps/CLI/.build/debug/peekaboo
+
 # Generate artifacts / publish
 ./scripts/release-binaries.sh --create-github-release --publish-npm
 ```

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -9,14 +9,14 @@ read_when:
 
 Core automation
 - `agent.md` — run the autonomous agent loop.
-- `app.md` — launch/quit/focus apps.
-- `window.md` — move/resize/focus windows.
+- `app.md` — launch/quit/focus apps and list running processes with `app list`.
+- `window.md` — list/move/resize/focus windows with `window list` and its sibling actions.
 - `menu.md`, `menubar.md` — drive app menus and status items.
 - `click.md`, `move.md`, `scroll.md`, `drag.md`, `press.md`, `type.md`, `set-value.md`, `action.md` — input primitives.
-- `see.md`, `capture.md` — screenshots, annotated UI maps, AX trees, and capture sessions.
+- `see.md`, `capture.md` — screenshot-only `see --no-elements`, AX-only `see --tree --no-screenshot`, annotated UI maps, and capture sessions.
 
 System & config
-- `config.md`, `permissions.md`, `bridge.md`, `daemon.md`, `tools.md`, `clean.md`, `learn.md`, `screen.md`.
+- `config.md`, `permissions.md`, `bridge.md`, `daemon.md`, `tools.md`, `clean.md`, `learn.md`, `screen.md` (`screen list`).
 - `completions.md` — install shell-native completions for zsh, bash, and fish.
 - MCP helpers: `mcp.md`.
 - Clipboard: `clipboard.md`.
@@ -26,6 +26,6 @@ Reference tips
 
 ## Common troubleshooting
 - **Background/foreground issues** — input commands use background delivery when they can resolve a target process. Element/query clicks can use Accessibility actions; grant Event Synthesizing for keyboard input, coordinates, and click fallback, or pass `--foreground` and ensure the target app/window is focused.
-- **Element not found** — run `peekaboo see --annotate` to verify AX labels/roles; fall back to coordinates with `--at` when needed.
+- **Element not found** — run `peekaboo see --annotate` to verify AX labels/roles. Background coordinate clicks require a fresh exact-window snapshot plus `--window-id`; use `--foreground` only for intentional shared-pointer fallback.
 - **Permission errors** — re-run `peekaboo permissions grant` and restart affected apps if dialogs persist.
 - **Slow or flaky automation** — tune `--quiet`/`--heartbeat` for capture/live commands; for input commands use `--delay` where available or `/bin/sleep` between shell invocations.

--- a/docs/commands/action.md
+++ b/docs/commands/action.md
@@ -14,4 +14,6 @@ peekaboo action AXIncrement --on Stepper --app Calculator
 peekaboo action --action AXShowMenu --on "$ELEMENT_ID" --pid 1234
 ```
 
-Use `--app`, `--pid`, `--window-id`, `--window-title`, or `--window-index` to focus the intended target before the action. Window title/index selectors require an app or PID. The equivalent MCP tool is `action`.
+Use `--app`, `--pid`, `--window-id`, `--window-title`, or `--window-index` to resolve the intended target without
+activating it. Window title/index selectors require an app or PID. Add `--foreground` only when the action depends on
+focused-window state. The equivalent MCP tool is `action`.

--- a/docs/commands/agent.md
+++ b/docs/commands/agent.md
@@ -101,5 +101,5 @@ peekaboo agent sessions --json
 
 ## Troubleshooting
 - Verify Screen Recording + Accessibility permissions (`peekaboo permissions status`).
-- Confirm your target (app/window/selector) with `peekaboo list`/`peekaboo see` before rerunning.
+- Confirm your process with `peekaboo app list`, its exact window with `peekaboo window list`, and current UI with `peekaboo see` before rerunning.
 - Re-run with `--json` or `--verbose` to surface detailed errors.

--- a/docs/commands/capture.md
+++ b/docs/commands/capture.md
@@ -85,5 +85,5 @@ peekaboo capture video /path/to/demo.mov --every 500ms --no-diff
 - In SSH, LaunchAgent, Codex, and other background launchd sessions, prefer a Bridge host with Screen Recording.
   Legacy screen/area capture now rejects wallpaper-only or redacted false-success frames instead of writing them as
   valid output. Use `--no-remote --capture-engine cg` only when the caller is in the active Aqua session and has TCC.
-- Confirm your target (app/window/selector) with `peekaboo list`/`peekaboo see` before rerunning.
+- Confirm your process with `peekaboo app list`, its exact window with `peekaboo window list`, and current UI with `peekaboo see` before rerunning.
 - Re-run with `--json` or `--verbose` to surface detailed errors.

--- a/docs/commands/clean.md
+++ b/docs/commands/clean.md
@@ -38,5 +38,5 @@ peekaboo clean --snapshot "$SNAPSHOT"
 
 ## Troubleshooting
 - Verify Screen Recording + Accessibility permissions (`peekaboo permissions status`).
-- Confirm your target (app/window/selector) with `peekaboo list`/`peekaboo see` before rerunning.
+- Confirm your process with `peekaboo app list`, its exact window with `peekaboo window list`, and current UI with `peekaboo see` before rerunning.
 - Re-run with `--json` or `--verbose` to surface detailed errors.

--- a/docs/commands/click.md
+++ b/docs/commands/click.md
@@ -53,31 +53,37 @@ peekaboo click --on "$ELEMENT_ID"
 # Fuzzy search + extra wait for a slow dialog using foreground delivery
 peekaboo click "Allow" --foreground --wait-for 8s --space-switch
 
-# Issue a background right-click in an exact window without moving the cursor
-peekaboo click --window-id 59620 --at 420,180 --right
+# Resolve one exact window and capture a fresh coordinate reference
+peekaboo window list --app Safari --json
+peekaboo see --window-id "$WINDOW_ID" --no-elements --json
+
+# Issue a background right-click in that exact window without moving the cursor
+peekaboo click --window-id "$WINDOW_ID" --snapshot "$SNAPSHOT_ID" --at 420,180 --right
 
 # Trigger a SwiftUI long-press gesture
-peekaboo click --at 640,420 --long-press
+peekaboo click --window-id "$WINDOW_ID" --snapshot "$SNAPSHOT_ID" --at 640,420 --long-press
 
-# Click 20,40 inside a resolved app window
-peekaboo click --app Safari --at 20,40
+# Click 20,40 inside the freshly captured window
+peekaboo click --window-id "$WINDOW_ID" --snapshot "$SNAPSHOT_ID" --at 20,40
 
 # Force global screen coordinates while still focusing a target first
-peekaboo click --window-id 59620 --at 1024,88 --global --foreground
+peekaboo click --window-id "$WINDOW_ID" --snapshot "$SNAPSHOT_ID" --at 1024,88 --global --foreground
 
 # Click captured Safari coordinates without activating Safari
-peekaboo see --app Safari --json
-peekaboo click --at 420,180 --app Safari --global --snapshot "$SNAPSHOT_ID"
+peekaboo see --window-id "$WINDOW_ID" --no-elements --json
+peekaboo click --window-id "$WINDOW_ID" --snapshot "$SNAPSHOT_ID" --at 420,180
 
 # Browser fallback when web content has no actionable accessibility descendants
 peekaboo screen list --json
 peekaboo window list --app "Google Chrome" --json
-peekaboo click --window-id 59620 --at 420,180 --foreground --input-strategy synthOnly
+peekaboo see --window-id "$WINDOW_ID" --no-elements --json
+peekaboo click --window-id "$WINDOW_ID" --snapshot "$SNAPSHOT_ID" --at 420,180 \
+  --foreground --input-strategy synthOnly
 ```
 
 ## Troubleshooting
 - Verify Screen Recording + Accessibility permissions (`peekaboo permissions status`).
-- Confirm your target (app/window/selector) with `peekaboo list`/`peekaboo see` before rerunning.
+- Confirm your process with `peekaboo app list`, its exact window with `peekaboo window list`, and current UI with `peekaboo see` before rerunning.
 - If you see `SNAPSHOT_NOT_FOUND`, regenerate the snapshot with `peekaboo see` (or omit `--snapshot` to use the most recent one). Cleaned/expired snapshots cannot be reused.
 - Re-run with `--json` or `--verbose` to surface detailed errors.
 - Chromium browsers can expose menus plus generic web-area/layout containers while omitting actionable web-content descendants from `see --annotate`. This is a browser accessibility limitation, not proof that the page is empty. Use `screen list` and `window list` to map the intended display/window, then use `--foreground --input-strategy synthOnly` with window-relative coordinates. For already-focused browser automation, targetless `--global` is also valid.

--- a/docs/commands/config.md
+++ b/docs/commands/config.md
@@ -69,5 +69,5 @@ peekaboo config provider remove local-ollama --force
 
 ## Troubleshooting
 - Verify Screen Recording + Accessibility permissions (`peekaboo permissions status`).
-- Confirm your target (app/window/selector) with `peekaboo list`/`peekaboo see` before rerunning.
+- Confirm your process with `peekaboo app list`, its exact window with `peekaboo window list`, and current UI with `peekaboo see` before rerunning.
 - Re-run with `--json` or `--verbose` to surface detailed errors.

--- a/docs/commands/dialog.md
+++ b/docs/commands/dialog.md
@@ -51,5 +51,5 @@ peekaboo dialog file --path ~/Downloads --name report.pdf --ensure-expanded --ap
 
 ## Troubleshooting
 - Verify Screen Recording + Accessibility permissions (`peekaboo permissions status`).
-- Confirm your target (app/window/selector) with `peekaboo list`/`peekaboo see` before rerunning.
+- Confirm your process with `peekaboo app list`, its exact window with `peekaboo window list`, and current UI with `peekaboo see` before rerunning.
 - Re-run with `--json` or `--verbose` to surface detailed errors.

--- a/docs/commands/dock.md
+++ b/docs/commands/dock.md
@@ -42,5 +42,5 @@ peekaboo dock hide
 
 ## Troubleshooting
 - Verify Screen Recording + Accessibility permissions (`peekaboo permissions status`).
-- Confirm your target (app/window/selector) with `peekaboo list`/`peekaboo see` before rerunning.
+- Confirm your process with `peekaboo app list`, its exact window with `peekaboo window list`, and current UI with `peekaboo see` before rerunning.
 - Re-run with `--json` or `--verbose` to surface detailed errors.

--- a/docs/commands/drag.md
+++ b/docs/commands/drag.md
@@ -49,6 +49,6 @@ peekaboo drag --from row_1 --to row_5 --modifiers shift --foreground
 
 ## Troubleshooting
 - Verify Event Synthesizing permission (`peekaboo permissions status`).
-- Confirm your target (app/window/selector) with `peekaboo list`/`peekaboo see` before rerunning.
+- Confirm your process with `peekaboo app list`, its exact window with `peekaboo window list`, and current UI with `peekaboo see` before rerunning.
 - If you see `SNAPSHOT_NOT_FOUND`, regenerate the snapshot with `peekaboo see` (or omit `--snapshot` to use the most recent one).
 - Re-run with `--json` or `--verbose` to surface detailed errors.

--- a/docs/commands/learn.md
+++ b/docs/commands/learn.md
@@ -32,5 +32,5 @@ peekaboo learn | awk '/^## Commander/,0'
 
 ## Troubleshooting
 - Verify Screen Recording + Accessibility permissions (`peekaboo permissions status`).
-- Confirm your target (app/window/selector) with `peekaboo list`/`peekaboo see` before rerunning.
+- Confirm your process with `peekaboo app list`, its exact window with `peekaboo window list`, and current UI with `peekaboo see` before rerunning.
 - Re-run with `--json` or `--verbose` to surface detailed errors.

--- a/docs/commands/mcp.md
+++ b/docs/commands/mcp.md
@@ -56,5 +56,5 @@ An MCP client can wait for stable native state without interrupting the user:
 
 ## Troubleshooting
 - Verify Screen Recording + Accessibility permissions (`peekaboo permissions status`).
-- Confirm your target (app/window/selector) with `peekaboo list`/`peekaboo see` before rerunning.
+- Confirm your process with `peekaboo app list`, its exact window with `peekaboo window list`, and current UI with `peekaboo see` before rerunning.
 - Re-run with `--json` or `--verbose` to surface detailed errors.

--- a/docs/commands/menubar.md
+++ b/docs/commands/menubar.md
@@ -47,5 +47,5 @@ peekaboo menubar click --index 3 --json
 
 ## Troubleshooting
 - Verify Screen Recording + Accessibility permissions (`peekaboo permissions status`).
-- Confirm your target (app/window/selector) with `peekaboo list`/`peekaboo see` before rerunning.
+- Confirm your process with `peekaboo app list`, its exact window with `peekaboo window list`, and current UI with `peekaboo see` before rerunning.
 - Re-run with `--json` or `--verbose` to surface detailed errors.

--- a/docs/commands/move.md
+++ b/docs/commands/move.md
@@ -44,5 +44,5 @@ peekaboo move --on menu_gear --smooth --foreground
 
 ## Troubleshooting
 - Verify Event Synthesizing permission (`peekaboo permissions status`).
-- Confirm your target (app/window/selector) with `peekaboo list`/`peekaboo see` before rerunning.
+- Confirm your process with `peekaboo app list`, its exact window with `peekaboo window list`, and current UI with `peekaboo see` before rerunning.
 - Re-run with `--json` or `--verbose` to surface detailed errors.

--- a/docs/commands/press.md
+++ b/docs/commands/press.md
@@ -53,6 +53,6 @@ peekaboo press cmd+shift+t --app Safari
 
 ## Troubleshooting
 - Verify Screen Recording + Accessibility permissions (`peekaboo permissions status`). Background key presses also require Event Synthesizing access for the sending process; request it with `peekaboo permissions request event-synthesizing`.
-- Confirm your target (app/window/selector) with `peekaboo list`/`peekaboo see` before rerunning.
+- Confirm your process with `peekaboo app list`, its exact window with `peekaboo window list`, and current UI with `peekaboo see` before rerunning.
 - If you see `SNAPSHOT_NOT_FOUND`, regenerate the snapshot with `peekaboo see`.
 - Re-run with `--json` or `--verbose` to surface detailed errors.

--- a/docs/commands/screen.md
+++ b/docs/commands/screen.md
@@ -22,4 +22,11 @@ peekaboo screen list --json \
 
 `bounds` and `position` use the same upper-left-origin global logical coordinate space as `click --global`. Multiply dimensions by `scaleFactor` when comparing them with physical-pixel captures. A Retina display can therefore report logical bounds of 1944×1274, scale 2, and a 3888×2548 pixel capture.
 
-For browser pages whose accessibility tree contains no actionable web descendants, pair this inventory with `peekaboo window list --app <browser> --json`, then use `peekaboo click --window-id <id> --foreground --input-strategy synthOnly --at x,y`.
+For browser pages whose accessibility tree contains no actionable web descendants, pair this inventory with
+`peekaboo window list --app <browser> --json`, capture the selected exact window with
+`peekaboo see --window-id <id> --no-elements --json`, then use the fresh receipt:
+
+```bash
+peekaboo click --window-id "$WINDOW_ID" --snapshot "$SNAPSHOT_ID" --at x,y \
+  --foreground --input-strategy synthOnly
+```

--- a/docs/commands/scroll.md
+++ b/docs/commands/scroll.md
@@ -43,5 +43,5 @@ peekaboo scroll --direction right --smooth --app Keynote --foreground --space-sw
 
 ## Troubleshooting
 - Background element scroll needs Accessibility; foreground wheel input needs Event Synthesizing (`peekaboo permissions status`).
-- Confirm your target (app/window/selector) with `peekaboo list`/`peekaboo see` before rerunning.
+- Confirm your process with `peekaboo app list`, its exact window with `peekaboo window list`, and current UI with `peekaboo see` before rerunning.
 - Re-run with `--json` or `--verbose` to surface detailed errors.

--- a/docs/commands/space.md
+++ b/docs/commands/space.md
@@ -36,5 +36,5 @@ peekaboo space switch --to 1
 
 ## Troubleshooting
 - Verify Screen Recording + Accessibility permissions (`peekaboo permissions status`).
-- Confirm your target (app/window/selector) with `peekaboo list`/`peekaboo see` before rerunning.
+- Confirm your process with `peekaboo app list`, its exact window with `peekaboo window list`, and current UI with `peekaboo see` before rerunning.
 - Re-run with `--json` or `--verbose` to surface detailed errors.

--- a/docs/commands/tools.md
+++ b/docs/commands/tools.md
@@ -41,5 +41,5 @@ peekaboo tools describe verify_state --json
 
 ## Troubleshooting
 - Verify Screen Recording + Accessibility permissions (`peekaboo permissions status`).
-- Confirm your target (app/window/selector) with `peekaboo list`/`peekaboo see` before rerunning.
+- Confirm your process with `peekaboo app list`, its exact window with `peekaboo window list`, and current UI with `peekaboo see` before rerunning.
 - Re-run with `--json` or `--verbose` to surface detailed errors.

--- a/docs/commands/type.md
+++ b/docs/commands/type.md
@@ -56,6 +56,6 @@ peekaboo type "fast" --app TextEdit --profile linear --delay 10ms
 
 ## Troubleshooting
 - Verify Screen Recording + Accessibility permissions (`peekaboo permissions status`). Background typing also requires Event Synthesizing access for the sending process; request it with `peekaboo permissions request event-synthesizing`.
-- Confirm your target (app/window/selector) with `peekaboo list`/`peekaboo see` before rerunning.
+- Confirm your process with `peekaboo app list`, its exact window with `peekaboo window list`, and current UI with `peekaboo see` before rerunning.
 - If you see `SNAPSHOT_NOT_FOUND`, regenerate the snapshot with `peekaboo see`.
 - Re-run with `--json` or `--verbose` to surface detailed errors.

--- a/docs/commands/window.md
+++ b/docs/commands/window.md
@@ -17,7 +17,7 @@ read_when:
 | `move` | Move the window to new coordinates. | `-x <int>` / `-y <int>` specify the new origin. |
 | `resize` | Adjust width/height while keeping the origin. | `-w <int>` / `--height <int>`. |
 | `set-bounds` | Set both origin and size in one go. | `--x`, `--y`, `--width`, `--height`. |
-| `list` | Lists an app's renderable windows (filtered view of `list windows`). | Same targeting flags; adds `--group-by-space`. |
+| `list` | Lists an app's renderable windows with canonical IDs and indexes for interaction targeting. | `--app` or `--pid`; adds `--group-by-space`. |
 
 ## Implementation notes
 - Every action validates that at least an app, PID, or window ID is supplied; optional `--window-title` and `--window-index` disambiguate when multiple windows exist.
@@ -65,5 +65,5 @@ peekaboo window focus --app Terminal --verify
 
 ## Troubleshooting
 - Verify Screen Recording + Accessibility permissions (`peekaboo permissions status`).
-- Confirm your target (app/window/selector) with `peekaboo list`/`peekaboo see` before rerunning.
+- Confirm your process with `peekaboo app list`, its exact window with `peekaboo window list`, and current UI with `peekaboo see` before rerunning.
 - Re-run with `--json` or `--verbose` to surface detailed errors.

--- a/docs/focus.md
+++ b/docs/focus.md
@@ -53,7 +53,7 @@ When you execute a foreground interaction command (`type`, `click --foreground`,
 1. **Retrieves window info** from the current snapshot
 2. **Checks if window still exists** (handles closed windows gracefully)
 3. **Detects which Space** contains the window
-4. **Switches to that Space** if different from current
+4. **Switches or moves Spaces** only when `--space-switch` or `--bring-to-current-space` is explicit
 5. **Brings app to front** and focuses the specific window
 6. **Verifies focus succeeded** before proceeding
 7. **Executes your command** on the correctly focused window
@@ -64,11 +64,11 @@ Foreground interaction commands automatically handle focus:
 
 ```bash
 # These commands all include automatic focus management:
-peekaboo click "Submit" --foreground
-peekaboo type "Hello world"
+peekaboo click "Submit" --app Safari --foreground
+peekaboo type "Hello world" --app TextEdit --foreground
 peekaboo scroll --direction down --foreground
 peekaboo menu click --app Safari --item "New Tab"
-peekaboo press cmd+s
+peekaboo press cmd+s --app TextEdit --foreground
 peekaboo drag --from "$SOURCE_ID" --to "$TARGET_ID" --foreground
 ```
 
@@ -76,7 +76,7 @@ peekaboo drag --from "$SOURCE_ID" --to "$TARGET_ID" --foreground
 
 By default, Peekaboo will:
 - ✅ Focus the target window before interaction
-- ✅ Switch Spaces if the window is on a different desktop
+- ✅ Refuse an unintended Space switch unless `--space-switch` or `--bring-to-current-space` is explicit
 - ✅ Wait up to 5 seconds for focus to complete
 - ✅ Retry up to 3 times if focus fails
 - ✅ Verify focus before proceeding
@@ -102,7 +102,9 @@ Uses command-supported background delivery instead of activating the target app.
 
 ```bash
 peekaboo press cmd+l --app Safari
-peekaboo click --at 420,180 --app Safari
+peekaboo window list --app Safari --json
+peekaboo see --window-id "$WINDOW_ID" --no-elements --json
+peekaboo click --window-id "$WINDOW_ID" --snapshot "$SNAPSHOT_ID" --at 420,180
 peekaboo type "hello" --app TextEdit
 ```
 
@@ -169,21 +171,20 @@ Use cases:
 For explicit window management, use the `window focus` command:
 
 ```bash
-# Basic usage - focus window and switch Space if needed
+# Basic usage on the current Space
 peekaboo window focus --app Safari
 
 # Focus specific window by title
 peekaboo window focus --app Chrome --window-title "Gmail"
 
-# Control Space behavior
-peekaboo window focus --app Terminal --space-switch never
-peekaboo window focus --app "VS Code" --space-switch always
+# Switch to the target window's Space
+peekaboo window focus --app Terminal --space-switch
 
 # Move window to current Space
-peekaboo window focus --app TextEdit --move-here
+peekaboo window focus --app TextEdit --bring-to-current-space
 
-# Skip focus verification for speed
-peekaboo window focus --app Finder --no-verify
+# Request an explicit post-focus verification
+peekaboo window focus --app Finder --verify
 ```
 
 ### Options
@@ -191,9 +192,9 @@ peekaboo window focus --app Finder --no-verify
 - `--app <name>` - Application name, bundle ID, or PID
 - `--window-title <title>` - Specific window title (partial match)
 - `--window-index <number>` - Window index (0-based)
-- `--space-switch [auto|always|never]` - Space switching behavior
-- `--move-here` - Move window to current Space
-- `--no-verify` - Skip focus verification
+- `--space-switch` - Switch to the target window's Space
+- `--bring-to-current-space` - Move the target window to the current Space
+- `--verify` - Verify the exact window is focused after the action
 
 ## Space Management
 
@@ -205,19 +206,14 @@ Peekaboo provides comprehensive Space (virtual desktop) management:
 # List all user Spaces
 peekaboo space list
 
-# Include system and fullscreen Spaces
-peekaboo space list --all
+# Include detailed window assignments
+peekaboo space list --detailed
 
 # JSON output
 peekaboo space list --json
 ```
 
-### Current Space Info
-
-```bash
-# Show current Space details
-peekaboo space current
-```
+The list marks the active Space for each display; add `--json` when a script needs the active ID.
 
 ### Switch Spaces
 
@@ -225,8 +221,6 @@ peekaboo space current
 # Switch to Space 2 (1-based numbering)
 peekaboo space switch --to 2
 
-# Switch without waiting for animation
-peekaboo space switch --to 3 --no-wait
 ```
 
 ### Move Windows Between Spaces
@@ -242,11 +236,8 @@ peekaboo space move-window --app Chrome --window-title "Gmail" --to 2
 ### Find Windows
 
 ```bash
-# Find which Space contains a window
-peekaboo space where-is --app "Visual Studio Code"
-
-# Find specific window
-peekaboo space where-is --app Chrome --window-title "GitHub"
+# Include each Space's windows, then match the app or title in the result
+peekaboo space list --detailed --json
 ```
 
 ## Best Practices
@@ -256,13 +247,11 @@ peekaboo space where-is --app Chrome --window-title "GitHub"
 Always start with `see` to establish a snapshot:
 
 ```bash
-# Good: Establishes snapshot with window tracking
-peekaboo see --app Safari
+# Good: Establish an exact-window snapshot before acting
+peekaboo window list --app Safari --json
+peekaboo see --window-id "$WINDOW_ID" --json
 peekaboo click "Login" --foreground
-peekaboo type "username"
-
-# Less reliable: No window tracking
-peekaboo click "Login" --at 100,200 --foreground
+peekaboo type "username" --app Safari
 ```
 
 ### 2. Let Peekaboo Handle Focus
@@ -287,7 +276,7 @@ Be aware that Space switching takes time:
 peekaboo click "Save" --foreground --focus-timeout 10s
 
 # Or move windows to avoid switching
-peekaboo type "Important data" --bring-to-current-space
+peekaboo type "Important data" --app TextEdit --foreground --bring-to-current-space
 ```
 
 ### 4. Test Cross-Space Workflows
@@ -297,8 +286,8 @@ Test your automation across different Space configurations:
 ```bash
 # Test with window on different Space
 peekaboo space move-window --app YourApp --to 2
-peekaboo see --app YourApp  # Should auto-switch
-peekaboo click "Test Button" --foreground
+peekaboo see --app YourApp  # Read-only observation does not switch Spaces
+peekaboo click "Test Button" --app YourApp --foreground --space-switch
 ```
 
 ## Troubleshooting
@@ -308,15 +297,15 @@ peekaboo click "Test Button" --foreground
 This occurs when Space switching is disabled:
 
 ```bash
-# Solution 1: Allow Space switching (default)
-peekaboo click "Button" --foreground  # Will auto-switch
+# Solution 1: Explicitly allow Space switching
+peekaboo click "Button" --app YourApp --foreground --space-switch
 
 # Solution 2: Move window to current Space
-peekaboo click "Button" --foreground --bring-to-current-space
+peekaboo click "Button" --app YourApp --foreground --bring-to-current-space
 
 # Solution 3: Manually switch first
 peekaboo space switch --to 2
-peekaboo click "Button" --foreground
+peekaboo click "Button" --app YourApp --foreground
 ```
 
 ### "Window not found" Error
@@ -329,7 +318,7 @@ peekaboo window list --app YourApp
 
 # For minimized windows, restore first
 peekaboo window restore --app YourApp
-peekaboo click "Button" --foreground
+peekaboo click "Button" --app YourApp --foreground
 ```
 
 ### "Focus timeout" Error
@@ -338,10 +327,10 @@ The window is taking too long to focus:
 
 ```bash
 # Increase timeout
-peekaboo click "Button" --foreground --focus-timeout 10s
+peekaboo click "Button" --app YourApp --foreground --focus-timeout 10s
 
 # Or increase retry count
-peekaboo click "Button" --foreground --focus-retry-count 5
+peekaboo click "Button" --app YourApp --foreground --focus-retry-count 5
 ```
 
 ### Focus Not Working
@@ -356,13 +345,13 @@ peekaboo window focus --app YourApp --verbose
 peekaboo permissions status
 
 # Try without focus (for testing)
-peekaboo click "Button" --foreground --no-auto-focus
+peekaboo click "Button" --app YourApp --foreground --no-auto-focus
 ```
 
 ## Implementation notes (internal)
 - Window identity prefers `CGWindowID`, with `AXIdentifier`/title/index as fallbacks; sessions persist the ID for follow-up commands.
 - Space management uses CGS APIs (`CGSCopySpaces`, `CGSManagedDisplaySetCurrentSpace`, add/remove windows to spaces) via `SpaceUtilities`.
-- Focus pipeline: resolve window → ensure it exists → detect space → switch or move → bring app frontmost → focus window → verify → run command. Flags map to helpers (`--space-switch`, `--move-here`, retries/timeouts).
+- Focus pipeline: resolve window → ensure it exists → detect space → switch or move → bring app frontmost → focus window → verify → run command. Flags map to helpers (`--space-switch`, `--bring-to-current-space`, `--verify`, retries/timeouts).
 - Tests live in CLI/Core; keep them in sync when changing SpaceUtilities or focus options.
 
 ## Technical Details

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -66,7 +66,16 @@ peekaboo click "Address and search bar" --app Safari
 peekaboo type "github.com/openclaw/Peekaboo" --app Safari && peekaboo press Return --app Safari
 ```
 
-Coordinates also work: `peekaboo click --at 480,120 --app Safari`. With app/window target flags, click coordinates are target-window-relative; add `--global` for screen coordinates. Add `--foreground` only when the target app requires focused input. See [automation.md](automation.md) for the full input vocabulary.
+Coordinate clicks need a fresh capture receipt and an exact target in the default background mode. First run
+`peekaboo window list --app Safari --json`, copy the intended `window_id`, and capture that exact window:
+
+```bash
+peekaboo see --window-id "$WINDOW_ID" --no-elements --json
+peekaboo click --window-id "$WINDOW_ID" --snapshot "$SNAPSHOT_ID" --at 480,120
+```
+
+The point is relative to the captured window. Add `--global` for screen coordinates, or add `--foreground` only when
+the target app requires focused synthetic input. See [automation.md](automation.md) for the full input vocabulary.
 
 By default these targeted commands use background delivery: Safari can receive the click and text without becoming frontmost. If the target field ignores background input, rerun the same command with `--foreground` to focus the target first.
 

--- a/docs/testing/tools.md
+++ b/docs/testing/tools.md
@@ -82,12 +82,12 @@ physical-pointer phase), use [Background computer-use validation](background-com
 | `press` | Keyboard Fixture window and menu shortcuts | `Keyboard` & `Menu` | `peekaboo press cmd+1` | Covers bare keys, repeats, and xdotool-style chords | Historical keypress/hotkey logs remain valid evidence. |
 | `scroll` | Scroll Fixture window | `Scroll` | `peekaboo scroll --direction down --amount 8 --on vertical-scroll --snapshot <id>` | Verified – scroll offsets logged (2025-12-18) | `.artifacts/playground-tools/20251218-012323-scroll.log` |
 | `drag` | Drag Fixture and gesture area | `Drag` / `Gesture` | `peekaboo drag --from <id-or-x,y> --to <id-or-x,y> --snapshot <id>` | Covers element/coordinate endpoints and left/right buttons | Historical drag/swipe logs remain valid evidence. |
-| `move` | Click Fixture mouse probe | `Control` | `peekaboo move --on <elem> --snapshot <id> --smooth` | Verified – cursor movement emits deterministic probe logs (2025-12-17) | `.artifacts/playground-tools/20251217-153107-control.log` |
+| `move` | Click Fixture mouse probe | `Control` | `peekaboo move --on <elem> --snapshot <id> --smooth --foreground` | Verified – cursor movement emits deterministic probe logs (2025-12-17) | `.artifacts/playground-tools/20251217-153107-control.log` |
 
 ### Windows, Menus, Apps
 | Tool | Playground validation target | Log category | Sample CLI | Status | Latest log |
 | --- | --- | --- | --- | --- | --- |
-| `window` | Window Fixture window + `list windows` bounds | `Window` | `peekaboo window move --app boo.peekaboo.playground.debug --window-title "Window Fixture"` | Verified – focus/move/resize + minimize/maximize covered (2025-12-17) | `.artifacts/playground-tools/20251217-183242-window.log` |
+| `window` | Window Fixture window + `window list` bounds | `Window` | `peekaboo window move --app boo.peekaboo.playground.debug --window-title "Window Fixture"` | Verified – focus/move/resize + minimize/maximize covered (2025-12-17) | `.artifacts/playground-tools/20251217-183242-window.log` |
 | `space` | macOS Spaces while Playground anchored on Space 1 | `Space` | `peekaboo space list --detailed` | Verified – list/switch/move now emit `[Space]` logs (instr. added 2025-11-16) | `.artifacts/playground-tools/20251116-205548-space.log` |
 | `menu` | Playground “Test Menu” | `Menu` | `peekaboo menu click --app boo.peekaboo.playground.debug --path "Test Menu>Submenu>Nested Action A"` | Verified – nested menu click logged (2025-12-18) | `.artifacts/playground-tools/20251218-002308-menu.log` |
 | `menubar` | macOS menu extras (Wi-Fi, Clock) plus Playground status icons | `Menu` (system) | `peekaboo menubar list --json-output` | Verified – list + click captured; logs via Control Center predicate | `.artifacts/playground-tools/20251116-053932-menubar.log` |
@@ -114,17 +114,17 @@ The following subsections spell out the concrete steps, required Playground surf
 - **View**: Any (start with ClickTestingView to guarantee clear elements).
 - **Steps**:
   1. Bring Playground to front (`peekaboo app switch --to Playground`).
-  2. `peekaboo see --app Playground --output "$LOG_ROOT/see-playground.png"`.
-  3. Record snapshot ID printed to stdout, verify `~/.peekaboo/snapshots/<id>/map.json` references Playground elements (`single-click-button`, etc.).
+  2. `peekaboo see --app Playground --path "$LOG_ROOT/see-playground.png"`.
+  3. Record the snapshot ID printed to stdout, then verify `~/.peekaboo/snapshots/<id>/snapshot.json` references Playground elements (`single-click-button`, etc.).
 - **Log capture**: Optional `Click` capture if you immediately chain interactions with the new snapshot; otherwise store the PNG + snapshot metadata path.
 - **Pass criteria**: Snapshot folder exists, UI map contains Playground identifiers, CLI exits 0.
 - **2025-11-16 verification**: Re-enabled the ScreenCaptureKit path inside `Core/PeekabooCore/Sources/PeekabooAutomation/Services/Capture/ScreenCaptureService.swift` so the modern API runs before falling back to CGWindowList. `peekaboo see --app Playground --json-output --path .artifacts/playground-tools/20251116-082056-see-playground.png` now succeeds (snapshot `5B5A2C09-4F4C-4893-B096-C7B4EB38E614`) and drops `.artifacts/playground-tools/20251116-082056-see-playground.{json,png}`.
-- **2025-12-17 rerun**: `pnpm run peekaboo -- see --app Playground --path .artifacts/playground-tools/20251217-132837-see-playground.png --json-output > .artifacts/playground-tools/20251217-132837-see-playground.json` succeeded (Peekaboo `main/842434be-dirty`).
-#### `image`
+- **2025-12-17 rerun**: `Apps/CLI/.build/debug/peekaboo see --app Playground --path .artifacts/playground-tools/20251217-132837-see-playground.png --json > .artifacts/playground-tools/20251217-132837-see-playground.json` succeeded (Peekaboo `main/842434be-dirty`).
+#### Screenshot-only `see`
 - **View**: Keep Playground on ScrollTestingView to capture dynamic content.
 - **Steps**:
-  1. `peekaboo image window --app Playground --output "$LOG_ROOT/image-playground.png"`.
-  2. Repeat with `--screen main --bounds 100,100,800,600` to cover coordinate cropping.
+  1. `peekaboo see --no-elements --app Playground --mode window --path "$LOG_ROOT/screenshot-playground.png"`.
+  2. Repeat with `--mode area --region 100,100,800,600 --path "$LOG_ROOT/screenshot-area.png"` to cover coordinate cropping.
 - **2025-11-16 verification**: After restoring the ScreenCaptureKit → CGWindowList fallback order, both window and screen captures succeed. Saved `.artifacts/playground-tools/20251116-082109-image-window-playground.{json,png}` and `.artifacts/playground-tools/20251116-082125-image-screen0.{json,png}`; CLI debug logs still note tiny background windows but the primary Playground window captures at 1200×852.
 
 #### `capture`
@@ -146,12 +146,12 @@ The following subsections spell out the concrete steps, required Playground surf
   - Live window capture (Playground) completed successfully and respects short durations again (no longer stalls ~10s on the ScreenCaptureKit→CG fallback path): `.artifacts/playground-tools/20251218-024517-capture-live-window-fast.json` and `.artifacts/playground-tools/20251218-024517-capture-live-window-fast/`.
   - Video ingest (synthetic `ffmpeg testsrc2`, `--sample-fps 4 --no-diff`) produced 9 kept frames + contact sheet: `.artifacts/playground-tools/20251218-022826-capture-video.json` and `.artifacts/playground-tools/20251218-022826-capture-video/`.
 
-#### `list`
-- **Scenarios**: `list apps`, `list windows --app Playground`, `list screens`, `list menubar`, `list permissions`.
+#### Noun-based inventories
+- **Scenarios**: `app list`, `window list --app Playground`, `screen list`, `menubar list`, `permissions status`.
 - **Steps**:
   1. With Playground running, execute each subcommand and ensure Playground appears with expected bundle ID/window title.
-  2. For `list windows`, compare returned bounds vs. WindowTestingView readout.
-  3. For `list menubar`, capture the result and cross-check with actual status items.
+  2. For `window list`, compare returned bounds vs. WindowTestingView readout.
+  3. For `menubar list`, capture the result and cross-check with actual status items.
 - **Logs**: Use `playground-log` `Window` category when forcing focus changes to validate `app switch` interplay.
 #### `tools`
 - **Steps**:
@@ -173,9 +173,7 @@ The following subsections spell out the concrete steps, required Playground surf
     - `.artifacts/playground-tools/20251217-201134-move-snapshot-missing.json`
     - `.artifacts/playground-tools/20251217-201134-scroll-snapshot-missing.json`
     - `.artifacts/playground-tools/20251217-202239-snapshot-missing-drag.json`
-    - `.artifacts/playground-tools/20251217-202239-snapshot-missing-swipe.json`
     - `.artifacts/playground-tools/20251217-202239-snapshot-missing-type.json`
-    - `.artifacts/playground-tools/20251217-202239-snapshot-missing-hotkey.json`
     - `.artifacts/playground-tools/20251217-202239-snapshot-missing-press.json`
 
 #### `clipboard`
@@ -228,8 +226,8 @@ The following subsections spell out the concrete steps, required Playground surf
 - **Test cases**:
   1. Query-based click: `peekaboo click "Single Click"` (expect `Click` log + counter increment).
   2. ID-based click: copy the opaque ID from current `see` output, then run `peekaboo click --on "$ELEMENT_ID" --snapshot <id>` targeting `single-click-button`.
-  3. Coordinate click: `peekaboo click --at 400,400 --foreground` hitting the nested area.
-  4. Coordinate validation: `peekaboo click --at , --json-output` should fail with `VALIDATION_ERROR` (no crash).
+  3. Coordinate click: run an exact-window `see`, then use its receipts with `peekaboo click --window-id "$WINDOW_ID" --snapshot "$SNAPSHOT_ID" --at 400,400` to hit the nested area without moving focus.
+  4. Coordinate validation: `peekaboo click --window-id "$WINDOW_ID" --snapshot "$SNAPSHOT_ID" --at , --json` should fail with `VALIDATION_ERROR` (no crash).
   5. Error path: attempt to click disabled button and confirm descriptive `elementNotFound` guidance.
 - **Verification**: Playground counter increments, log file shows `[Click] Single click...` entries.
 - **2025-11-16 run**:
@@ -237,7 +235,7 @@ The following subsections spell out the concrete steps, required Playground surf
   - Generated fresh snapshot `263F8CD6-E809-4AC6-A7B3-604704095011` via `see` (`.artifacts/playground-tools/20251116-051120-click-see.{json,png}`).
   - `peekaboo click "Single Click" --snapshot <legacy snapshot>` succeeded but targeted Ghostty (click hit terminal input); highlighting importance of focusing Playground first.
   - `peekaboo app switch --to Playground` followed by `peekaboo click --on elem_6 --snapshot 263F8CD6-...` successfully hit the “View Logs” button (Playground log recorded the click).
-  - Coordinate click `--at 600,500` succeeded (see log); attempting `--on elem_disabled` produced expected `elementNotFound` error.
+  - Coordinate click `--window-id "$WINDOW_ID" --snapshot "$SNAPSHOT_ID" --at 600,500` succeeded (see log); attempting the disabled element ID produced the expected `elementNotFound` error.
   - Element IDs are opaque and unstable; always copy the exact ID from current `see` output.
 - **2025-12-17 Controls Fixture add-on**:
   - Open “Controls Fixture” via `⌘⌃3`, then drive checkboxes + segmented control by clicking snapshot IDs (`--on elem_…`) captured from `see`.
@@ -248,16 +246,16 @@ The following subsections spell out the concrete steps, required Playground surf
 - **View**: TextInputView.
 - **Log capture**: `Text` + `Focus` categories.
 - **Test cases**:
-  1. `peekaboo type "Hello Playground" --query "Basic"` to fill the basic field.
-  2. Use `--clear` then `--append` flows to verify editing.
-  3. Tab-step typing with `--tabs 2` into the secure field.
+  1. Use a fresh `see`, then `click --on "$FIELD_ID" --snapshot "$SNAPSHOT_ID"` to select the basic field.
+  2. Run `peekaboo type "Hello Playground" --clear --pid "$PLAYGROUND_PID"`, then type more text to verify appending.
+  3. Run `peekaboo press Tab --count 2 --pid "$PLAYGROUND_PID"` to reach the secure field.
   4. Unicode input (emoji) to ensure no crash.
 - **Verification**: Field contents update, log shows `[Text] Basic field changed` entries.
 - **2025-11-16 run**:
   - Logged `.artifacts/playground-tools/20251116-051202-text.log`.
   - Focused field via `peekaboo click "Focus Basic Field" --snapshot 263F8CD6-…` (snapshot from `.artifacts/playground-tools/20251116-051120-click-see.json`).
   - `peekaboo type "Hello Playground" --clear --snapshot 263F8CD6-…` updated the Basic Text Field (log shows “Basic text changed …”).
-  - `peekaboo type --tab 1 --snapshot 263F8CD6-…` advanced focus to the Number field, followed by `peekaboo type "42" --snapshot 263F8CD6-…`.
+  - `peekaboo press Tab --snapshot 263F8CD6-…` advanced focus to the Number field, followed by `peekaboo type "42" --snapshot 263F8CD6-…`.
   - Validation error confirmed via `peekaboo type "bad" --profile warp` (proper error message).
   - Note: prefer `--app`, `--pid`, `--window-id`, or `--snapshot` so `type` can use background delivery; use helper buttons and `click` to set field focus when a view requires it. Legacy `--on` / `--query` flags no longer exist.
 
@@ -268,25 +266,25 @@ The following subsections spell out the concrete steps, required Playground surf
   2. `peekaboo press up --count 3 --snapshot <id>` to ensure repeated presses log individually.
   3. Invalid key handling (`peekaboo press foo`) should error.
 - **2025-11-16 verification**:
-  - Switched to the Keyboard tab via `peekaboo press cmd+option+7 --foreground`, captured `.artifacts/playground-tools/20251116-090141-see-keyboardtab.{json,png}` (snapshot `C106D508-930C-4996-A4F4-A50E2E0BA91A`), and focused the “Press keys here…” field with a coordinate click (`--at 760,300`).
+  - Switched to the Keyboard tab via `peekaboo press cmd+option+7 --foreground`, captured `.artifacts/playground-tools/20251116-090141-see-keyboardtab.{json,png}` (snapshot `C106D508-930C-4996-A4F4-A50E2E0BA91A`), and focused the “Press keys here…” field with the exact capture receipt (`click --window-id "$WINDOW_ID" --snapshot "$SNAPSHOT_ID" --at 760,300`).
   - `peekaboo press return --snapshot C106D508-…` and `peekaboo press up --count 3 --snapshot C106D508-…` produced `[boo.peekaboo.playground:Keyboard] Key pressed: …` entries in `.artifacts/playground-tools/20251116-090455-keyboard.log`.
   - `peekaboo press foo` reports `Unknown key: 'foo'. Run 'peekaboo press --help' for available keys.` confirming validation and documenting the negative path.
 
-#### `hotkey`
-- **View**: KeyboardView hotkey demo or main window (use `cmd+shift+l` to open log viewer).
+#### `press` chord sequences
+- **View**: KeyboardView chord demo or main window (use `cmd+shift+l` to open the log viewer).
 - **Test cases**:
-  1. `peekaboo hotkey cmd,shift,l` should toggle the “Clear All Logs” command (log viewer clears entries).
-  2. `peekaboo hotkey cmd,1` to trigger Test Menu action; watch `Menu` logs.
+  1. `peekaboo press cmd+shift+l --pid "$PLAYGROUND_PID"` should toggle the “Clear All Logs” command (log viewer clears entries).
+  2. `peekaboo press cmd+1 --pid "$PLAYGROUND_PID"` triggers the Test Menu action; watch `Menu` logs.
   3. Negative test: provide invalid chord order to ensure validation message.
 - **Verification**: Playground `Keyboard` log file shows the keystrokes fired.
 - **2025-11-16 run**:
-  - Logs stored at `.artifacts/playground-tools/20251116-051654-keyboard-hotkey.log` (contains entries for `L` and `1` corresponding to the combos).
-  - `peekaboo hotkey --keys "cmd,shift,l" --snapshot 11227301-05DE-4540-8BE7-617F99A74156` (clears logs via shortcut).
-  - `peekaboo hotkey --keys "cmd,1" --snapshot …` switches Playground tabs.
-  - `peekaboo hotkey --keys "foo,bar"` correctly fails with `Unknown key: 'foo'`.
+  - The archived keyboard chord log contains entries for `L` and `1` corresponding to both combinations.
+  - `peekaboo press --key cmd+shift+l --snapshot 11227301-05DE-4540-8BE7-617F99A74156` clears logs via the shortcut.
+  - `peekaboo press --key cmd+1 --snapshot "$SNAPSHOT_ID"` switches Playground tabs.
+  - `peekaboo press foo+bar --pid "$PLAYGROUND_PID"` correctly fails with an unknown-key error.
 
 #### `scroll`
-- **View**: ScrollTestingView vertical/horizontal sections (switch using `peekaboo hotkey --keys "cmd,option,4"` to trigger the new Test Menu shortcut).
+- **View**: ScrollTestingView vertical/horizontal sections (switch using `peekaboo press cmd+option+4 --pid "$PLAYGROUND_PID"` to trigger the Test Menu shortcut).
 - **Test cases**:
   1. `peekaboo scroll --direction down --amount 6 --snapshot <id>` for vertical movement.
   2. `peekaboo scroll --direction right --amount 4 --smooth --snapshot <id>` for horizontal smooth scrolling.
@@ -304,12 +302,12 @@ The following subsections spell out the concrete steps, required Playground surf
     - `.artifacts/playground-tools/20251218-012323-click-scroll-{top,middle,bottom}.json` (Clicking fixture buttons via snapshot IDs).
     - `.artifacts/playground-tools/20251218-012323-scroll-{vertical-down,vertical-up,horizontal-right,horizontal-left,nested-outer-down,nested-inner-down}.json` (CLI evidence per scroll variant).
 
-#### `swipe`
+#### `drag` gesture coverage
 - **View**: Gesture Testing area.
 - **Test cases**:
   1. `peekaboo drag --from 1100,520 --to 700,520 --duration 600ms --foreground`.
   2. `peekaboo drag --from 850,600 --to 850,350 --duration 800ms --profile human --foreground`.
-  3. Negative test: `peekaboo swipe … --right-button` should error.
+  3. Negative test: `peekaboo drag --from 900,520 --to 700,520 --button middle --foreground` should error.
 - **2025-11-16 verification**:
   - Used snapshot `DBFDD053-4513-4603-B7C3-9170E7386BA7` (see `.artifacts/playground-tools/20251116-085714-see-scrolltab.{json,png}`) to keep the tab selection stable.
   - Horizontal and vertical commands above completed successfully; Playground log `.artifacts/playground-tools/20251116-090041-gesture.log` shows `[boo.peekaboo.playground:Gesture]` entries with exact coordinates, profiles, and step counts.

--- a/scripts/docs-lint.mjs
+++ b/scripts/docs-lint.mjs
@@ -10,6 +10,8 @@ const docsRoot = path.resolve('docs');
 const failures = [];
 const extraMarkdownFiles = [path.resolve('README.md')];
 const skillMarkdownFiles = [path.resolve('skills/peekaboo/SKILL.md')];
+const sourceContractFiles = [path.resolve('scripts/test-background-computer-use.sh')];
+const sourceCliDocsFiles = [path.resolve('scripts/release-binaries.sh')];
 const staleCliPatterns = [
   [/peekaboo capture --output\b/, 'use `peekaboo see --no-elements --path` or `peekaboo capture live --path`'],
   [/peekaboo capture --window-focused\b/, 'use `peekaboo see --no-elements --mode frontmost`'],
@@ -19,6 +21,7 @@ const staleCliPatterns = [
   [/peekaboo swipe\b/, 'use `peekaboo drag`'],
   [/peekaboo inspect-ui\b/, 'use `peekaboo see --tree --no-screenshot`'],
   [/peekaboo perform-action\b/, 'use `peekaboo action`'],
+  [/peekaboo list\b/, 'use noun-based `app list`, `window list`, or `screen list`'],
   [/--(?:from|to)-coords\b/, 'pass coordinates directly to `--from` or `--to`'],
   [/--max-depth\b/, 'use `--depth`'],
   [/peekaboo type[^\n]*--(?:return|escape|delete|tab)\b/, 'chain `peekaboo press` for key input'],
@@ -44,8 +47,29 @@ const staleCliPatterns = [
   [/--repeat\b/, 'use `--count`'],
   [/--label\b/, 'use positional query text or `--on`'],
   [/--ticks\b/, 'use `--amount`'],
+  [/docs\/commands\/run\.md/, 'link to the current command that owns the workflow'],
+  [/peekaboo space (?:current|where-is)\b/, 'use `peekaboo space list --detailed`'],
+  [/--space-switch\s+(?:always|never)\b/, 'use boolean `--space-switch`'],
+  [/--(?:move-here|no-verify)\b/, 'use `--bring-to-current-space` or `--verify`'],
+  [/peekaboo space list --all\b/, 'use `peekaboo space list --detailed`'],
+  [/peekaboo space switch[^\n]*--no-wait\b/, 'remove the retired `--no-wait` flag'],
+  [/peekaboo (?:capture|drag|move)[^\n]*--duration\s+\d+(?:\.\d+)?(?:\s|$)/,
+    'add an explicit `ms` or `s` duration suffix'],
+  [/peekaboo (?:click|press|type)[^\n]*--(?:delay|hold|wait-for)\s+\d+(?:\.\d+)?(?:\s|$)/,
+    'add an explicit `ms` or `s` timing suffix'],
   [/--(?:on|from|to)\s+[`"']?[BTMS]\d+\b/, 'use an opaque element ID copied from current output'],
-  [/element IDs?[^\n]*[`"']?[BTMS]\d+\b/i, 'describe element IDs as opaque'],
+  [/element IDs?\s+(?:(?:such as|like|for example)\s+)?[`"']?[BTMS]\d+\b/i,
+    'describe element IDs as opaque'],
+];
+const staleHarnessPatterns = [
+  [/^\s*hotkey\s/m, 'use `press`'],
+  [/^\s*inspect-ui\s/m, 'use `see --tree --no-screenshot`'],
+  [/^\s*image\s/m, 'use `see --no-elements`'],
+  [/^\s*perform-action\s/m, 'use `action`'],
+  [/^\s*list\s+(?:apps|windows|screens)\b/m, 'use noun-based inventory commands'],
+  [/\bapp launch[^\n]*--wait-until-ready\b/, 'use `app launch --wait-ready`'],
+  [/--coords\b/, 'use `--at`'],
+  [/--duration\s+\d+(?:\.\d+)?(?:\s|\\|$)/, 'add an explicit `ms` or `s` duration suffix'],
 ];
 const staleDocsPatterns = [
   [/mcp-capture-meta/i, 'remove stale native MCP capture metadata references'],
@@ -104,6 +128,14 @@ async function checkFile(file) {
         failures.push(`${file}: stale CLI example ${pattern}; ${replacement}`);
       }
     }
+    await checkLocalLinks(file, text);
+
+    for (const line of text.split('\n')) {
+      if (/peekaboo click\b.*--at\b/.test(line) &&
+          (!/--window-id\b/.test(line) || !/--snapshot\b/.test(line))) {
+        failures.push(`${file}: coordinate click must include a fresh snapshot and exact --window-id target`);
+      }
+    }
   }
 
   if (shouldCheckCurrentDocsDrift(file)) {
@@ -115,13 +147,54 @@ async function checkFile(file) {
   }
 }
 
+async function checkLocalLinks(file, text) {
+  const links = text.matchAll(/!?\[[^\]]*\]\(([^)\s]+)(?:\s+['"][^)]*)?\)/g);
+  for (const match of links) {
+    const rawTarget = match[1];
+    if (/^(?:https?:|mailto:|#)/.test(rawTarget)) continue;
+    const target = rawTarget.split('#', 1)[0].split('?', 1)[0];
+    if (!target) continue;
+    const resolved = path.resolve(path.dirname(file), decodeURIComponent(target));
+    try {
+      await fs.access(resolved);
+    } catch {
+      failures.push(`${file}: broken local link ${rawTarget}`);
+    }
+  }
+}
+
 function shouldCheckCurrentCliExamples(file) {
   const relative = path.relative(process.cwd(), file);
   if (relative === 'README.md') return true;
-  if (relative === 'docs/quickstart.md' || relative === 'docs/automation.md') return true;
+  if ([
+    'docs/quickstart.md',
+    'docs/automation.md',
+    'docs/cli-command-reference.md',
+    'docs/focus.md',
+    'docs/testing/background-computer-use.md',
+    'docs/testing/tools.md',
+  ].includes(relative)) return true;
   if (relative === 'docs/commands/README.md') return true;
   if (relative.startsWith('docs/commands/') && relative.endsWith('.md')) return true;
   return false;
+}
+
+async function checkSourceContractFile(file) {
+  const text = await fs.readFile(file, 'utf8');
+  for (const [pattern, replacement] of staleHarnessPatterns) {
+    if (pattern.test(text)) {
+      failures.push(`${file}: stale v4 harness form ${pattern}; ${replacement}`);
+    }
+  }
+}
+
+async function checkSourceCliDocsFile(file) {
+  const text = await fs.readFile(file, 'utf8');
+  for (const [pattern, replacement] of staleCliPatterns) {
+    if (pattern.test(text)) {
+      failures.push(`${file}: stale generated CLI docs ${pattern}; ${replacement}`);
+    }
+  }
 }
 
 function shouldCheckCurrentDocsDrift(file) {
@@ -166,6 +239,12 @@ for (const file of extraMarkdownFiles) {
 }
 for (const file of skillMarkdownFiles) {
   await checkSkillFile(file);
+}
+for (const file of sourceContractFiles) {
+  await checkSourceContractFile(file);
+}
+for (const file of sourceCliDocsFiles) {
+  await checkSourceCliDocsFile(file);
 }
 
 if (failures.length) {

--- a/scripts/prepare-release.js
+++ b/scripts/prepare-release.js
@@ -5,20 +5,61 @@
  * 
  * This script performs comprehensive checks before release:
  * 1. Git status checks (branch, uncommitted files, sync with origin)
- * 2. TypeScript/Node.js checks (lint, type check, tests)
+ * 2. Metadata and documentation contract checks
  * 3. Swift checks (format, lint, tests)
- * 4. Build and package verification
+ * 4. Build, CLI contract, and package verification
  */
 
-import { execSync } from 'child_process';
-import { readFileSync, existsSync, rmSync } from 'fs';
-import { join } from 'path';
+import { execSync, spawnSync } from 'child_process';
+import { readFileSync, existsSync } from 'fs';
+import { dirname, isAbsolute, join, resolve } from 'path';
 import { fileURLToPath } from 'url';
-import { dirname } from 'path';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const projectRoot = join(__dirname, '..');
+const cliArguments = process.argv.slice(2);
+let dryRun = false;
+let force = false;
+let binaryOverride = null;
+
+for (let index = 0; index < cliArguments.length; index += 1) {
+  const argument = cliArguments[index];
+  switch (argument) {
+    case '--':
+      break;
+    case '--dry-run':
+      dryRun = true;
+      break;
+    case '--force':
+      force = true;
+      break;
+    case '--bin': {
+      const value = cliArguments[index + 1];
+      if (!value) {
+        console.error('--bin requires a path');
+        process.exit(2);
+      }
+      binaryOverride = isAbsolute(value) ? value : resolve(projectRoot, value);
+      index += 1;
+      break;
+    }
+    case '-h':
+    case '--help':
+      console.log(`Usage: node scripts/prepare-release.js [options]
+
+Options:
+  --dry-run   Run deterministic metadata, docs, and CLI-contract checks only
+  --bin PATH  CLI binary for --dry-run (default: repo debug binary, then ./peekaboo)
+  --force     Allow a non-main branch during the full release preflight
+  -h, --help  Show this help`);
+      process.exit(0);
+      break;
+    default:
+      console.error(`Unknown option: ${argument}`);
+      process.exit(2);
+  }
+}
 
 // ANSI color codes
 const colors = {
@@ -105,8 +146,7 @@ function checkGitStatus() {
   const currentBranch = exec('git branch --show-current');
   if (currentBranch !== 'main') {
     logWarning(`Currently on branch '${currentBranch}', not 'main'`);
-    const proceed = process.argv.includes('--force');
-    if (!proceed) {
+    if (!force) {
       logError('Switch to main branch before releasing (use --force to override)');
       return false;
     }
@@ -157,34 +197,13 @@ function checkDependencies() {
   return true;
 }
 
-function checkTypeScript() {
-  logStep('TypeScript Checks');
-
-  // Clean build directory
-  log('Cleaning build directory...', colors.cyan);
-  rmSync(join(projectRoot, 'dist'), { recursive: true, force: true });
-
-  // Run ESLint
-  if (!execWithOutput('pnpm run lint', 'ESLint')) {
-    logError('ESLint found violations');
+function checkDocs() {
+  logStep('Documentation Contract Checks');
+  if (!execWithOutput('node scripts/docs-lint.mjs', 'documentation lint')) {
+    logError('Documentation contract checks failed');
     return false;
   }
-  logSuccess('ESLint passed');
-
-  // Type check
-  if (!execWithOutput('pnpm run build', 'TypeScript compilation')) {
-    logError('TypeScript compilation failed');
-    return false;
-  }
-  logSuccess('TypeScript compilation successful');
-
-  // Run TypeScript tests
-  if (!execWithOutput('pnpm test', 'TypeScript tests')) {
-    logError('TypeScript tests failed');
-    return false;
-  }
-  logSuccess('TypeScript tests passed');
-
+  logSuccess('Documentation contract checks passed');
   return true;
 }
 
@@ -317,45 +336,6 @@ function checkChangelog() {
   return true;
 }
 
-function checkSecurityAudit() {
-  logStep('Security Audit');
-
-  log('Running npm audit...', colors.cyan);
-  
-  const auditResult = exec('npm audit --json', { allowFailure: true });
-  
-  if (auditResult) {
-    try {
-      const audit = JSON.parse(auditResult);
-      const vulnCount = audit.metadata?.vulnerabilities || {};
-      const total = Object.values(vulnCount).reduce((sum, count) => sum + count, 0);
-      
-      if (total > 0) {
-        logWarning(`Found ${total} vulnerabilities:`);
-        if (vulnCount.critical > 0) logError(`  Critical: ${vulnCount.critical}`);
-        if (vulnCount.high > 0) logError(`  High: ${vulnCount.high}`);
-        if (vulnCount.moderate > 0) logWarning(`  Moderate: ${vulnCount.moderate}`);
-        if (vulnCount.low > 0) log(`  Low: ${vulnCount.low}`, colors.yellow);
-        
-        if (vulnCount.critical > 0 || vulnCount.high > 0) {
-          logError('Critical or high severity vulnerabilities found. Please fix before releasing.');
-          return false;
-        }
-        
-        logWarning('Non-critical vulnerabilities found. Consider fixing before release.');
-      } else {
-        logSuccess('No security vulnerabilities found');
-      }
-    } catch (e) {
-      logWarning('Could not parse npm audit results');
-    }
-  } else {
-    logSuccess('No security vulnerabilities found');
-  }
-  
-  return true;
-}
-
 function checkPackageSize() {
   logStep('Package Size Check');
 
@@ -394,227 +374,93 @@ function checkPackageSize() {
   return true;
 }
 
-function checkTypeScriptDeclarations() {
-  logStep('TypeScript Declarations Check');
+function checkSwiftCLIIntegration(binaryPath) {
+  logStep('Swift CLI Contract Tests');
 
-  // Check if .d.ts files are generated
-  const distPath = join(projectRoot, 'dist');
-  
-  if (!existsSync(distPath)) {
-    logError('dist/ directory not found. Please build the project first.');
+  if (!existsSync(binaryPath)) {
+    logError(`Peekaboo binary not found: ${binaryPath}`);
     return false;
   }
-  
-  // Look for .d.ts files
-  const dtsFiles = exec(`find "${distPath}" -name "*.d.ts" -type f`, { allowFailure: true });
-  
-  if (!dtsFiles || dtsFiles.trim() === '') {
-    logError('No TypeScript declaration files (.d.ts) found in dist/');
-    logError('Ensure TypeScript is configured to generate declarations');
-    return false;
-  }
-  
-  const declarationFiles = dtsFiles.split('\n').filter(f => f.trim());
-  log(`Found ${declarationFiles.length} TypeScript declaration files`, colors.cyan);
-  
-  // Check for main declaration file
-  const mainDtsPath = join(distPath, 'index.d.ts');
-  if (!existsSync(mainDtsPath)) {
-    logError('Missing main declaration file: dist/index.d.ts');
-    return false;
-  }
-  
-  logSuccess('TypeScript declarations are properly generated');
-  return true;
-}
 
-function checkMCPServerSmoke() {
-  logStep('MCP Server Smoke Test');
+  const run = (args) => spawnSync(binaryPath, args, {
+    cwd: projectRoot,
+    encoding: 'utf8',
+    stdio: 'pipe'
+  });
+  const combinedOutput = (result) => `${result.stdout || ''}\n${result.stderr || ''}`;
 
-  const serverPath = join(projectRoot, 'dist', 'index.js');
-  
-  if (!existsSync(serverPath)) {
-    logError('Server not built. Please run build first.');
+  const invalid = run(['invalid-command']);
+  if (invalid.status === 0 || !combinedOutput(invalid).includes("Unknown command 'invalid-command'")) {
+    logError('Unknown commands must fail with the Commander unknown-command diagnostic');
     return false;
   }
-  
-  log('Testing MCP server with simple JSON-RPC request...', colors.cyan);
-  
-  try {
-    // Test with a simple tools/list request
-    const testRequest = '{"jsonrpc": "2.0", "id": 1, "method": "tools/list"}';
-    const result = exec(`echo '${testRequest}' | node "${serverPath}"`, { allowFailure: true });
-    
-    if (!result) {
-      logError('MCP server failed to respond');
-      return false;
-    }
-    
-    // Parse and validate response
-    const lines = result.split('\n').filter(line => line.trim());
-    const response = lines[lines.length - 1]; // Get last line (the actual response)
-    
-    try {
-      const parsed = JSON.parse(response);
-      
-      if (parsed.error) {
-        logError(`MCP server returned error: ${parsed.error.message}`);
-        return false;
-      }
-      
-      if (!parsed.result || !parsed.result.tools) {
-        logError('MCP server response missing expected tools array');
-        return false;
-      }
-      
-      const toolCount = parsed.result.tools.length;
-      log(`MCP server responded successfully with ${toolCount} tools`, colors.cyan);
-      
-    } catch (e) {
-      logError('Failed to parse MCP server response');
-      logError(`Response: ${response}`);
-      return false;
-    }
-    
-  } catch (error) {
-    logError(`MCP server smoke test failed: ${error.message}`);
-    return false;
-  }
-  
-  logSuccess('MCP server smoke test passed');
-  return true;
-}
 
-function checkSwiftCLIIntegration() {
-  logStep('Swift CLI Integration Tests');
-  
-  log('Testing Swift CLI error handling and edge cases...', colors.cyan);
-  
-  // Test 1: Invalid command (since image is default, this gets interpreted as image subcommand argument)
-  let invalidOutput;
-  try {
-    execSync('./peekaboo invalid-command 2>&1', { 
-      cwd: projectRoot,
-      encoding: 'utf8',
-      stdio: 'pipe'
-    });
-    logError('Swift CLI should fail for invalid command');
-    return false;
-  } catch (error) {
-    invalidOutput = error.stdout || error.stderr || error.toString();
-  }
-  
-  if (!invalidOutput.includes('Unexpected argument')) {
-    logError('Swift CLI should show proper error for invalid command');
-    return false;
-  }
-  
-  // Test 2: Missing required arguments for window mode
-  let missingArgsOutput;
-  try {
-    missingArgsOutput = execSync('./peekaboo image --mode window --json 2>&1', { 
-      cwd: projectRoot,
-      encoding: 'utf8',
-      stdio: 'pipe'
-    });
-  } catch (error) {
-    // Command fails with non-zero exit code, but we want the output
-    missingArgsOutput = error.stdout || error.stderr || '';
-  }
-  
-  if (!missingArgsOutput) {
-    logError('Swift CLI should produce output for missing --app with window mode');
-    return false;
-  }
-  
-  try {
-    const errorData = JSON.parse(missingArgsOutput);
-    if (!errorData.error || errorData.success !== false) {
-      logError('Swift CLI should return error JSON for missing --app with window mode');
-      return false;
-    }
-  } catch (e) {
-    logError('Swift CLI should return valid JSON for missing --app error');
-    return false;
-  }
-  
-  // Test 3: Invalid window index
-  let invalidWindowOutput;
-  try {
-    execSync('./peekaboo image --mode window --app Finder --window-index abc --json 2>&1', { 
-      cwd: projectRoot,
-      encoding: 'utf8',
-      stdio: 'pipe'
-    });
-    logError('Swift CLI should fail for invalid window index');
-    return false;
-  } catch (error) {
-    invalidWindowOutput = error.stdout || error.stderr || error.toString();
-  }
-  
-  if (!invalidWindowOutput.includes('invalid for') || !invalidWindowOutput.includes('window-index')) {
-    logError('Swift CLI should show error for invalid window index');
-    return false;
-  }
-  
-  // Test 4: Test all subcommands are available
-  const subcommands = ['list', 'image'];
-  for (const cmd of subcommands) {
-    const helpOutput = exec(`./peekaboo ${cmd} --help`, { allowFailure: true });
-    if (!helpOutput || !helpOutput.includes('USAGE')) {
-      logError(`Swift CLI ${cmd} command help not available`);
+  const removedCommands = ['image', 'list', 'hotkey', 'inspect-ui', 'perform-action', 'swipe'];
+  for (const command of removedCommands) {
+    const result = run([command, '--help']);
+    if (result.status === 0 || !combinedOutput(result).includes(`Unknown command '${command}'`)) {
+      logError(`Removed command unexpectedly resolved: peekaboo ${command}`);
       return false;
     }
   }
-  
-  // Test 5: JSON output format validation
-  const formats = [
-    { cmd: './peekaboo list apps --json', required: ['success', 'data'] }
+
+  const helpContracts = [
+    { args: ['see', '--help'], required: ['--no-elements', '--tree', '--no-screenshot'] },
+    { args: ['click', '--help'], required: ['--at', '--wait-for', '--long-press'] },
+    { args: ['press', '--help'], required: ['--delay', '--hold', 'cmd+shift+t'] },
+    { args: ['action', '--help'], required: ['AXPress', '--on'] },
+    { args: ['drag', '--help'], required: ['--from', '--to', '--button', '--duration'] },
+    { args: ['move', '--help'], required: ['--at', '--on', '--foreground'] },
+    { args: ['app', 'list', '--help'], required: ['peekaboo app list', '--include-hidden'] },
+    { args: ['window', 'list', '--help'], required: ['peekaboo window list', '--group-by-space'] },
+    { args: ['screen', 'list', '--help'], required: ['peekaboo screen list'] }
   ];
-  
-  for (const { cmd, required } of formats) {
-    const output = exec(cmd, { allowFailure: true });
-    if (!output) {
-      logError(`Command failed: ${cmd}`);
+  const staleHelp = [
+    'peekaboo image',
+    'peekaboo list apps',
+    'peekaboo list windows',
+    'peekaboo hotkey',
+    'peekaboo inspect-ui',
+    'peekaboo perform-action',
+    'peekaboo swipe',
+    '--coords',
+    '--from-coords',
+    '--to-coords'
+  ];
+
+  for (const contract of helpContracts) {
+    const result = run(contract.args);
+    const output = combinedOutput(result);
+    if (result.status !== 0 || !contract.required.every((token) => output.includes(token))) {
+      logError(`CLI help contract failed: peekaboo ${contract.args.join(' ')}`);
       return false;
     }
-    
-    try {
-      const response = JSON.parse(output);
-      for (const field of required) {
-        if (!(field in response)) {
-          logError(`Missing required field '${field}' in: ${cmd}`);
-          return false;
-        }
-      }
-      // For list apps, also check data.applications exists
-      if (cmd.includes('list apps') && (!response.data || !response.data.applications)) {
-        logError(`Missing data.applications in: ${cmd}`);
-        return false;
-      }
-    } catch (e) {
-      logError(`Invalid JSON from: ${cmd}`);
+    const stale = staleHelp.find((token) => output.includes(token));
+    if (stale) {
+      logError(`CLI help contains removed form '${stale}': peekaboo ${contract.args.join(' ')}`);
       return false;
     }
   }
-  
-  // Test 6: Permission info in error messages
-  // Try to capture without permissions (this is just a smoke test, actual permission errors depend on system state)
-  const captureTest = exec('./peekaboo image --mode screen --json', { allowFailure: true });
-  if (captureTest) {
+
+  const jsonContracts = [
+    { args: ['app', 'list', '--json', '--no-remote'], field: 'apps' },
+    { args: ['window', 'list', '--app', 'Finder', '--json', '--no-remote'], field: 'windows' },
+    { args: ['screen', 'list', '--json', '--no-remote'], field: 'screens' }
+  ];
+  for (const contract of jsonContracts) {
+    const result = run(contract.args);
     try {
-      const result = JSON.parse(captureTest);
-      if (result.success) {
-        log('Screen capture succeeded (permissions granted)', colors.cyan);
-      } else if (result.error && result.error.code === 'PERMISSION_DENIED_SCREEN_RECORDING') {
-        log('Screen recording permission correctly detected as missing', colors.cyan);
+      const payload = JSON.parse(result.stdout);
+      if (result.status !== 0 || payload.success !== true || !(contract.field in payload.data)) {
+        throw new Error(`missing data.${contract.field}`);
       }
-    } catch (e) {
-      // Not JSON, might be a different error
+    } catch (error) {
+      logError(`CLI JSON contract failed for '${contract.args.join(' ')}': ${error.message}`);
+      return false;
     }
   }
-  
-  logSuccess('Swift CLI integration tests passed');
+
+  logSuccess('Swift CLI v4 command, help, and inventory contracts passed');
   return true;
 }
 
@@ -827,7 +673,31 @@ function buildAndVerifyPackage() {
 
 // Main execution
 async function main() {
-  console.log(`\n${colors.bright}🚀 Peekaboo MCP Release Preparation${colors.reset}\n`);
+  console.log(`\n${colors.bright}🚀 Peekaboo Release Preparation${colors.reset}\n`);
+
+  if (dryRun) {
+    const debugBinary = join(projectRoot, 'Apps', 'CLI', '.build', 'debug', 'peekaboo');
+    const packagedBinary = join(projectRoot, 'peekaboo');
+    const binaryPath = binaryOverride ?? (existsSync(debugBinary) ? debugBinary : packagedBinary);
+    const checks = [
+      checkRequiredFields,
+      checkVersionConsistency,
+      checkChangelog,
+      checkDocs,
+      () => checkSwiftCLIIntegration(binaryPath)
+    ];
+
+    for (const check of checks) {
+      if (!check()) {
+        console.log(`\n${colors.red}${colors.bright}❌ Release dry-run checks failed!${colors.reset}\n`);
+        process.exit(1);
+      }
+    }
+
+    console.log(`\n${colors.green}${colors.bright}✅ Deterministic release dry-run checks passed.${colors.reset}`);
+    console.log(`${colors.yellow}This mode does not prove git cleanliness, registry availability, tests, or release artifacts.${colors.reset}\n`);
+    return;
+  }
 
   const checks = [
     checkGitStatus,
@@ -836,8 +706,10 @@ async function main() {
     checkVersionAvailability,
     checkVersionConsistency,
     checkChangelog,
+    checkDocs,
     checkSwift,
     buildAndVerifyPackage,
+    () => checkSwiftCLIIntegration(binaryOverride ?? join(projectRoot, 'peekaboo')),
     checkPackageSize
   ];
 
@@ -848,17 +720,9 @@ async function main() {
     }
   }
 
-  console.log(`\n${colors.green}${colors.bright}✅ All checks passed! Ready to release! 🎉${colors.reset}\n`);
-  
-  const packageJson = JSON.parse(readFileSync(join(projectRoot, 'package.json'), 'utf8'));
-  console.log(`${colors.cyan}Next steps:${colors.reset}`);
-  console.log(`1. Update version in package.json (current: ${packageJson.version})`);
-  console.log(`2. Update CHANGELOG.md`);
-  console.log(`3. Commit version bump: git commit -am "Release v<version>"`);
-  console.log(`4. Create tag: git tag v<version>`);
-  console.log(`5. Push changes: git push origin main --tags`);
-  console.log(`6. Publish to npm: npm publish [--tag beta]`);
-  console.log(`7. Create GitHub release\n`);
+  console.log(`\n${colors.green}${colors.bright}✅ All checks passed! Ready for the release workflow. 🎉${colors.reset}\n`);
+  console.log(`Follow docs/RELEASING.md and run scripts/release-binaries.sh with the intended publish flags.`);
+  console.log(`This preflight does not tag, publish, notarize, or create a GitHub release.\n`);
 }
 
 // Run the script

--- a/scripts/release-binaries.sh
+++ b/scripts/release-binaries.sh
@@ -507,13 +507,13 @@ peekaboo --version
 
 \`\`\`bash
 # Capture screenshot
-peekaboo image --app Safari --path screenshot.png
+peekaboo see --no-elements --app Safari --path screenshot.png
 
 # List applications
-peekaboo list apps
+peekaboo app list
 
 # Capture and analyze a window with AI
-peekaboo image --app Safari --analyze "What is shown?"
+peekaboo see --app Safari --analyze "What is shown?"
 \`\`\`
 
 ## Documentation

--- a/scripts/test-background-computer-use.sh
+++ b/scripts/test-background-computer-use.sh
@@ -381,7 +381,7 @@ if "$PROBE_BIN" find-app --bundle-id "$PLAYGROUND_BUNDLE_ID" >/dev/null 2>&1; th
         > "$ARTIFACT_ROOT/playground-quit-existing.json" || true
 fi
 
-pb app launch "$PLAYGROUND_APP" --wait-until-ready --json \
+pb app launch "$PLAYGROUND_APP" --wait-ready --json \
     > "$ARTIFACT_ROOT/playground-launch.json"
 if ! read_launch_process_receipt "$ARTIFACT_ROOT/playground-launch.json" || \
    ! refresh_playground_process_receipt \
@@ -394,7 +394,7 @@ if ! kill -0 "$PLAYGROUND_PID" 2>/dev/null; then
     exit 1
 fi
 
-pb app launch --bundle-id "$SENTINEL_BUNDLE_ID" --wait-until-ready --foreground --json \
+pb app launch --bundle-id "$SENTINEL_BUNDLE_ID" --wait-ready --foreground --json \
     > "$ARTIFACT_ROOT/sentinel-launch.json"
 sleep 0.2
 "$PROBE_BIN" sample --output "$ARTIFACT_ROOT/sentinel.json"
@@ -612,7 +612,6 @@ LIFECYCLE_PROCESS_START_IDENTITY=""
 run_checked_case lifecycle-launch-maximize-close unchanged success \
     app launch TextEdit --new-instance --wait-for-window || true
 if read_lifecycle_launch_receipt lifecycle-launch-maximize-close "$LAST_RESULT"; then
-    MAXIMIZE_TEXTEDIT_PID="$LIFECYCLE_PID"
     MAXIMIZE_TEXTEDIT_WINDOW_ID="$LIFECYCLE_WINDOW_ID"
     run_checked_case lifecycle-maximize unchanged success \
         window maximize --window-id "$MAXIMIZE_TEXTEDIT_WINDOW_ID" || true
@@ -644,11 +643,11 @@ open_fixture() {
     local key="$1"
     local title="$2"
     local slug="$3"
-    run_checked_case "hotkey-open-$slug" unchanged success \
-        hotkey "cmd,ctrl,$key" --pid "$PLAYGROUND_PID" || true
-    assert_background_delivery "hotkey-open-$slug" "$LAST_RESULT" || true
+    run_checked_case "press-open-$slug" unchanged success \
+        press "cmd+ctrl+$key" --pid "$PLAYGROUND_PID" || true
+    assert_background_delivery "press-open-$slug" "$LAST_RESULT" || true
     run_checked_case "list-window-$slug" unchanged success \
-        list windows --pid "$PLAYGROUND_PID" --include-details bounds,ids || true
+        window list --pid "$PLAYGROUND_PID" || true
     OPENED_WINDOW_ID="$(window_id_from_result "$LAST_RESULT" "$title")"
     if [[ -z "$OPENED_WINDOW_ID" ]]; then
         record_failure "$slug fixture did not open in the background"
@@ -677,16 +676,17 @@ if [[ -z "$TEXT_SNAPSHOT" || -z "$BASIC_FIELD_ID" || -z "$FOCUS_BUTTON_ID" ]]; t
 fi
 
 run_checked_case inspect-text unchanged success \
-    inspect-ui --app "PID:$PLAYGROUND_PID" --max-elements 300 || true
+    see --tree --no-screenshot --pid "$PLAYGROUND_PID" --window-id "$TEXT_WINDOW_ID" \
+    --max-elements 300 || true
 assert_result_contains inspect-text "$LAST_RESULT" "Basic Text Field" || true
 
-run_checked_case image-text unchanged success \
-    image --pid "$PLAYGROUND_PID" --window-id "$TEXT_WINDOW_ID" \
-    --path "$ARTIFACT_ROOT/text-image.png" || true
+run_checked_case screenshot-text unchanged success \
+    see --no-elements --pid "$PLAYGROUND_PID" --window-id "$TEXT_WINDOW_ID" \
+    --path "$ARTIFACT_ROOT/text-screenshot.png" || true
 
 run_checked_case capture-text unchanged success \
     capture live --pid "$PLAYGROUND_PID" --window-title "Text Fixture" --mode window \
-    --duration 1 --idle-fps 2 --active-fps 2 --path "$ARTIFACT_ROOT/text-capture" || true
+    --duration 1s --idle-fps 2 --active-fps 2 --path "$ARTIFACT_ROOT/text-capture" || true
 
 run_checked_case focus-basic-field unchanged success \
     click --on "$FOCUS_BUTTON_ID" --snapshot "$TEXT_SNAPSHOT" \
@@ -770,17 +770,17 @@ run_checked_case see-click-for-action unchanged success \
 CLICK_SNAPSHOT="$(snapshot_id_from_result "$LAST_RESULT")"
 SINGLE_CLICK_ID="$(element_id_from_result "$LAST_RESULT" single-click-button)"
 
-run_checked_case perform-action unchanged success \
-    perform-action --on "$SINGLE_CLICK_ID" --action AXPress --snapshot "$CLICK_SNAPSHOT" || true
+run_checked_case action unchanged success \
+    action AXPress --on "$SINGLE_CLICK_ID" --snapshot "$CLICK_SNAPSHOT" || true
 run_checked_case see-click-after-action unchanged success \
     see --pid "$PLAYGROUND_PID" --window-id "$CLICK_WINDOW_ID" \
     --path "$ARTIFACT_ROOT/click-after-action.png" || true
-assert_result_contains perform-action-state "$LAST_RESULT" "2 total clicks" || true
+assert_result_contains action-state "$LAST_RESULT" "2 total clicks" || true
 
 CLICK_SNAPSHOT="$(snapshot_id_from_result "$LAST_RESULT")"
 SINGLE_CLICK_ID="$(element_id_from_result "$LAST_RESULT" single-click-button)"
 run_checked_case unsupported-action unchanged failure \
-    perform-action --on "$SINGLE_CLICK_ID" --action AXDefinitelyUnsupported --snapshot "$CLICK_SNAPSHOT" || true
+    action AXDefinitelyUnsupported --on "$SINGLE_CLICK_ID" --snapshot "$CLICK_SNAPSHOT" || true
 
 run_checked_case see-scroll unchanged success \
     see --pid "$PLAYGROUND_PID" --window-id "$SCROLL_WINDOW_ID" \
@@ -791,7 +791,7 @@ if [[ -z "$SCROLL_SNAPSHOT" || -z "$VERTICAL_SCROLL_ID" ]]; then
     record_failure "scroll fixture snapshot was missing the vertical scroll target"
 else
     run_checked_case scroll-action-unsupported unchanged failure \
-        scroll --direction down --amount 1 --delay 0 --on "$VERTICAL_SCROLL_ID" \
+        scroll --direction down --amount 1 --delay 0ms --on "$VERTICAL_SCROLL_ID" \
         --snapshot "$SCROLL_SNAPSHOT" --pid "$PLAYGROUND_PID" --window-id "$SCROLL_WINDOW_ID" || true
     assert_result_contains scroll-action-unsupported "$LAST_RESULT" "Accessibility-only" || true
 fi
@@ -819,7 +819,7 @@ if $RUN_FOREGROUND_PHASE; then
         > "$FOREGROUND_DIR/scroll-down.json"
     pb scroll --direction up --amount 1 --foreground --json \
         > "$FOREGROUND_DIR/scroll-up.json"
-    pb move --coords "$ORIGINAL_CURSOR" --foreground --json \
+    pb move --at "$ORIGINAL_CURSOR" --foreground --json \
         > "$FOREGROUND_DIR/restore-cursor.json"
 
     # Relaunching the controlled fixture resets any visual/scroll state from this explicit phase.


### PR DESCRIPTION
## Summary

- align public docs, generated help, and `peekaboo learn` with the v4 command surface
- migrate the release preflight, binary-release README, and background-computer-use harness off removed commands
- add a deterministic release dry run plus docs/link and generated-command drift guards
- require fresh exact-window receipts in background coordinate-click examples

## Proof

- `pnpm run build:cli`
- `pnpm run format`
- `pnpm run lint` (passes with existing non-serious repository warnings)
- `pnpm run lint:docs`
- `pnpm run prepare-release -- --dry-run --bin Apps/CLI/.build/debug/peekaboo`
- `bash -n scripts/test-background-computer-use.sh`
- `shellcheck scripts/test-background-computer-use.sh`
- `scripts/test-background-computer-use.sh --self-test --artifacts /tmp/peekaboo-phase34-background-self-test`
- `PEEKABOO_INCLUDE_AUTOMATION_TESTS=true RUN_AUTOMATION_READ=true swift test --package-path Apps/CLI --filter HelpCommandTests --no-parallel` (8 tests)
- `swift test --package-path Apps/CLI --filter CommandHelpRendererTests --no-parallel` (3 tests)
- `swift test --package-path Core/PeekabooCore --filter ToolRegistryContractTests --no-parallel` (2 tests)
- `pnpm run test:safe`: 734 main tests passed; the sole runtime failure was the process-global clipboard contract colliding with two concurrent test-suite processes
- isolated retry: `swift test --package-path Apps/CLI -Xswiftc -DPEEKABOO_SKIP_AUTOMATION --filter 'CLIRuntimeSmokeTests.*clipboard get JSON includes exact text' --no-parallel` (passed)
- autoreview clean against current `origin/main`

## Notes

No product input-safety behavior or changelog entries are changed. The release version decision remains separate.
