### PR TITLE
fix: verify application focus completion

### DIFF
--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Ensure action-command JSON validation failures before dispatch report `effect: refused`, including parser and binding errors.
+- Verify app focus against the exact active Workspace PID and visible frontmost-window PID, retry through native AX activation, and report the verified effect as confirmed instead of claiming success for an unfulfilled request.
 
 ## [4.0.0] - 2026-08-10
 

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/AppCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/AppCommand.swift
@@ -404,7 +404,7 @@ extension AppCommand.SwitchSubcommand: CommanderBindableCommand {
     }
 }
 
-extension AppCommand.FocusSubcommand: ActionOutputFormattable, AsyncRuntimeCommand, ErrorHandlingCommand,
+extension AppCommand.FocusSubcommand: ConfirmedActionOutputFormattable, AsyncRuntimeCommand, ErrorHandlingCommand,
     OutputFormattable,
     ApplicationResolvable, ApplicationResolver {}
 @MainActor

--- a/Apps/CLI/Tests/CLIAutomationTests/AppCommandTests.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/AppCommandTests.swift
@@ -103,9 +103,11 @@ struct AppCommandTests {
 
     @Test
     func `App focus preserves an exact PID target`() async throws {
-        let (_, service) = try await runAppCommandWithService([
+        let (output, service) = try await runAppCommandWithService([
             "app", "focus", "--pid", "202", "--json",
         ])
+        let object = try #require(JSONSerialization.jsonObject(with: Data(output.utf8)) as? [String: Any])
+        #expect(object["effect"] as? String == "confirmed")
         #expect(await appServiceState(service) { $0.activateCalls } == ["PID:202"])
     }
 

--- a/Apps/CLI/Tests/CLIAutomationTests/AppCommandTests.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/AppCommandTests.swift
@@ -110,6 +110,31 @@ struct AppCommandTests {
     }
 
     @Test
+    func `App focus exits nonzero when activation verification fails`() async throws {
+        let context = await MainActor.run { makeAppCommandContext() }
+        await MainActor.run {
+            context.applicationService.activateApplicationHandler = { _ in
+                throw NSError(
+                    domain: "AppFocusActivationVerification",
+                    code: 1,
+                    userInfo: [NSLocalizedDescriptionKey: "Application did not become active and frontmost"]
+                )
+            }
+        }
+
+        let result = try await InProcessCommandRunner.run(
+            ["app", "focus", "TextEdit", "--json"],
+            services: context.services
+        )
+
+        #expect(result.exitStatus != 0)
+        let object = try #require(
+            JSONSerialization.jsonObject(with: Data(result.stdout.utf8)) as? [String: Any]
+        )
+        #expect(object["success"] as? Bool == false)
+    }
+
+    @Test
     func `App quit exits nonzero when the application refuses to quit`() async throws {
         let context = await MainActor.run { makeAppCommandContext() }
         await MainActor.run {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 - Ensure action-command JSON validation failures before dispatch report
   `effect: refused`, including parser and binding errors.
+- Verify app focus against the exact active Workspace PID and visible frontmost-window PID, retry through native AX activation, and report the verified effect as confirmed instead of claiming success for an unfulfilled request.
 - Pin the OpenClaw Foundation identity for the release preflight so a bare `SIGN_IDENTITY`
   exported by the operator's login shell can no longer substitute for the release certificate,
   and surface any inherited identity instead of signing with it silently.

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/System/ApplicationService+Lifecycle.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/System/ApplicationService+Lifecycle.swift
@@ -1,4 +1,5 @@
 import AppKit
+import ApplicationServices
 import AXorcist
 import Foundation
 import os.log
@@ -365,17 +366,124 @@ extension ApplicationService {
                     message: "Failed to activate application: Could not find running application process")
             }
 
-            let activated = runningApp.activate(options: [])
+            try await self.requestVerifiedActivation(runningApp, applicationName: app.name)
+            self.logger.info("Successfully activated and verified frontmost: \(app.name)")
+        }
+    }
 
-            if !activated {
-                self.logger.error("Failed to activate application: \(app.name). Continuing without activation.")
+    private func requestVerifiedActivation(
+        _ application: NSRunningApplication,
+        applicationName: String) async throws
+    {
+        let processIdentifier = application.processIdentifier
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: self.applicationActivationTimeout)
+        var shouldUseAccessibilityFallback = false
+        var nativeRequestAccepted = false
+        var accessibilityRequestAccepted = false
+
+        repeat {
+            try Task.checkCancellation()
+            guard !application.isTerminated else {
+                throw PeekabooError.operationError(
+                    message: "Failed to activate \(applicationName): application terminated during activation")
+            }
+            if self.isVerifiedActive(application, processIdentifier: processIdentifier) {
                 return
             }
 
-            self.logger.info("Successfully activated: \(app.name)")
-            // Wait for activation to complete
-            try await Task.sleep(nanoseconds: 100_000_000) // 0.1 seconds
+            let accepted = self.applicationActivationHandler(application)
+            nativeRequestAccepted = nativeRequestAccepted || accepted
+            if shouldUseAccessibilityFallback || !accepted {
+                accessibilityRequestAccepted = self.applicationAccessibilityActivationHandler(processIdentifier) ||
+                    accessibilityRequestAccepted
+            }
+
+            if self.isVerifiedActive(application, processIdentifier: processIdentifier) {
+                return
+            }
+
+            let now = clock.now
+            guard now < deadline else { break }
+            try await self.applicationActivationSleepHandler(min(.milliseconds(100), now.duration(to: deadline)))
+            shouldUseAccessibilityFallback = true
+        } while true
+
+        let frontmostDescription = NSWorkspace.shared.frontmostApplication.map {
+            "\($0.localizedName ?? "unknown") (PID: \($0.processIdentifier))"
+        } ?? "none"
+        let windowServerState = self.windowServerActivationStateProvider(processIdentifier)
+        let frontmostWindowDescription = windowServerState.frontmostWindowProcessIdentifier
+            .map(String.init) ?? "none"
+        let diagnostic = "Activation verification failed for \(applicationName) " +
+            "(native accepted: \(nativeRequestAccepted), AX accepted: \(accessibilityRequestAccepted), " +
+            "frontmost: \(frontmostDescription), frontmost window PID: \(frontmostWindowDescription))"
+        self.logger.error("\(diagnostic, privacy: .public)")
+        throw PeekabooError.timeout(
+            "Application did not become active and frontmost: \(applicationName). " +
+                "Frontmost application: \(frontmostDescription). " +
+                "Frontmost window PID: \(frontmostWindowDescription)")
+    }
+
+    private func isVerifiedActive(
+        _ application: NSRunningApplication,
+        processIdentifier: pid_t) -> Bool
+    {
+        let windowServerState = self.windowServerActivationStateProvider(processIdentifier)
+        return Self.isVerifiedApplicationActivation(
+            processIdentifier: processIdentifier,
+            isActive: self.applicationActiveProvider(application),
+            frontmostProcessIdentifier: self.frontmostProcessIdentifierProvider(),
+            targetHasVisibleWindow: windowServerState.targetHasVisibleWindow,
+            frontmostWindowProcessIdentifier: windowServerState.frontmostWindowProcessIdentifier)
+    }
+
+    static func isVerifiedApplicationActivation(
+        processIdentifier: pid_t,
+        isActive: Bool,
+        frontmostProcessIdentifier: pid_t?,
+        targetHasVisibleWindow: Bool,
+        frontmostWindowProcessIdentifier: pid_t?) -> Bool
+    {
+        guard isActive, frontmostProcessIdentifier == processIdentifier else {
+            return false
         }
+        return !targetHasVisibleWindow || frontmostWindowProcessIdentifier == processIdentifier
+    }
+
+    static func windowServerActivationState(processIdentifier: pid_t) -> WindowServerActivationState {
+        let options: CGWindowListOption = [.optionOnScreenOnly, .excludeDesktopElements]
+        let windows = CGWindowListCopyWindowInfo(options, kCGNullWindowID) as? [[String: Any]] ?? []
+        var frontmostWindowProcessIdentifier: pid_t?
+        var targetHasVisibleWindow = false
+
+        for window in windows {
+            guard let ownerProcessIdentifier =
+                (window[kCGWindowOwnerPID as String] as? NSNumber)?.int32Value,
+                (window[kCGWindowLayer as String] as? NSNumber)?.intValue == 0,
+                ((window[kCGWindowAlpha as String] as? NSNumber)?.doubleValue ?? 1) > 0
+            else {
+                continue
+            }
+            if frontmostWindowProcessIdentifier == nil {
+                frontmostWindowProcessIdentifier = ownerProcessIdentifier
+            }
+            if ownerProcessIdentifier == processIdentifier {
+                targetHasVisibleWindow = true
+            }
+        }
+
+        return WindowServerActivationState(
+            targetHasVisibleWindow: targetHasVisibleWindow,
+            frontmostWindowProcessIdentifier: frontmostWindowProcessIdentifier)
+    }
+
+    static func requestAccessibilityActivation(processIdentifier: pid_t) -> Bool {
+        let applicationElement = AXUIElementCreateApplication(processIdentifier)
+        return AXUIElementSetAttributeValue(
+            applicationElement,
+            kAXFrontmostAttribute as CFString,
+            kCFBooleanTrue) == .success
     }
 
     public func quitApplication(identifier: String, force: Bool = false) async throws -> Bool {

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/System/ApplicationService.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/System/ApplicationService.swift
@@ -49,6 +49,11 @@ public final class ApplicationService: ApplicationServiceProtocol {
     public let supportsApplicationRelaunch = true
     public let supportsProcessGenerationPinnedApplicationQuit = true
 
+    struct WindowServerActivationState: Equatable, Sendable {
+        let targetHasVisibleWindow: Bool
+        let frontmostWindowProcessIdentifier: pid_t?
+    }
+
     typealias ApplicationOpenHandler = @MainActor (
         _ applicationURL: URL,
         _ openURLs: [URL],
@@ -60,6 +65,13 @@ public final class ApplicationService: ApplicationServiceProtocol {
     typealias RelaunchQuitHandler = @MainActor (_ request: ApplicationQuitRequest) async throws -> Bool
     typealias RelaunchRunningHandler = @MainActor (_ identifier: String) async throws -> Bool
     typealias ApplicationReadinessHandler = @MainActor (_ application: NSRunningApplication) -> Bool
+    typealias ApplicationActivationHandler = @MainActor (_ application: NSRunningApplication) -> Bool
+    typealias ApplicationAccessibilityActivationHandler = @MainActor (_ processIdentifier: pid_t) -> Bool
+    typealias ApplicationActiveProvider = @MainActor (_ application: NSRunningApplication) -> Bool
+    typealias FrontmostProcessIdentifierProvider = @MainActor () -> pid_t?
+    typealias WindowServerActivationStateProvider = @MainActor (_ processIdentifier: pid_t)
+        -> WindowServerActivationState
+    typealias ApplicationActivationSleepHandler = @MainActor (_ duration: Duration) async throws -> Void
     typealias ProcessStartIdentityProvider = @MainActor (_ processIdentifier: pid_t) -> UInt64?
     typealias ApplicationQuitHandler = @MainActor (_ application: NSRunningApplication, _ force: Bool) -> Bool
 
@@ -73,9 +85,16 @@ public final class ApplicationService: ApplicationServiceProtocol {
     let relaunchQuitHandler: RelaunchQuitHandler?
     let relaunchRunningHandler: RelaunchRunningHandler?
     let applicationReadinessHandler: ApplicationReadinessHandler
+    let applicationActivationHandler: ApplicationActivationHandler
+    let applicationAccessibilityActivationHandler: ApplicationAccessibilityActivationHandler
+    let applicationActiveProvider: ApplicationActiveProvider
+    let frontmostProcessIdentifierProvider: FrontmostProcessIdentifierProvider
+    let windowServerActivationStateProvider: WindowServerActivationStateProvider
+    let applicationActivationSleepHandler: ApplicationActivationSleepHandler
     let processStartIdentityProvider: ProcessStartIdentityProvider
     let applicationQuitHandler: ApplicationQuitHandler
     let applicationReadinessTimeout: TimeInterval
+    let applicationActivationTimeout: Duration
     let backgroundLaunchActivationGraceDuration: Duration
     let backgroundOpenActivationGraceDuration: Duration
     let operationLaneCoordinator: DesktopOperationLaneCoordinator
@@ -118,12 +137,27 @@ public final class ApplicationService: ApplicationServiceProtocol {
         relaunchQuitHandler: RelaunchQuitHandler? = nil,
         relaunchRunningHandler: RelaunchRunningHandler? = nil,
         applicationReadinessHandler: @escaping ApplicationReadinessHandler = ApplicationService.isReadyForAutomation,
+        applicationActivationHandler: @escaping ApplicationActivationHandler = { application in
+            application.activate(options: [.activateAllWindows])
+        },
+        applicationAccessibilityActivationHandler: @escaping ApplicationAccessibilityActivationHandler =
+            ApplicationService.requestAccessibilityActivation,
+        applicationActiveProvider: @escaping ApplicationActiveProvider = { $0.isActive },
+        frontmostProcessIdentifierProvider: @escaping FrontmostProcessIdentifierProvider = {
+            NSWorkspace.shared.frontmostApplication?.processIdentifier
+        },
+        windowServerActivationStateProvider: @escaping WindowServerActivationStateProvider =
+            ApplicationService.windowServerActivationState,
+        applicationActivationSleepHandler: @escaping ApplicationActivationSleepHandler = { duration in
+            try await Task.sleep(for: duration)
+        },
         processStartIdentityProvider: @escaping ProcessStartIdentityProvider = SystemIdentityResolver
             .processStartIdentity,
         applicationQuitHandler: @escaping ApplicationQuitHandler = { application, force in
             force ? application.forceTerminate() : application.terminate()
         },
         applicationReadinessTimeout: TimeInterval = 10,
+        applicationActivationTimeout: Duration = .seconds(2),
         backgroundLaunchActivationGraceDuration: Duration = .milliseconds(500),
         backgroundOpenActivationGraceDuration: Duration = .seconds(2))
     {
@@ -138,9 +172,16 @@ public final class ApplicationService: ApplicationServiceProtocol {
         self.relaunchQuitHandler = relaunchQuitHandler
         self.relaunchRunningHandler = relaunchRunningHandler
         self.applicationReadinessHandler = applicationReadinessHandler
+        self.applicationActivationHandler = applicationActivationHandler
+        self.applicationAccessibilityActivationHandler = applicationAccessibilityActivationHandler
+        self.applicationActiveProvider = applicationActiveProvider
+        self.frontmostProcessIdentifierProvider = frontmostProcessIdentifierProvider
+        self.windowServerActivationStateProvider = windowServerActivationStateProvider
+        self.applicationActivationSleepHandler = applicationActivationSleepHandler
         self.processStartIdentityProvider = processStartIdentityProvider
         self.applicationQuitHandler = applicationQuitHandler
         self.applicationReadinessTimeout = applicationReadinessTimeout
+        self.applicationActivationTimeout = applicationActivationTimeout
         self.backgroundLaunchActivationGraceDuration = backgroundLaunchActivationGraceDuration
         self.backgroundOpenActivationGraceDuration = backgroundOpenActivationGraceDuration
 

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ApplicationServiceLifecycleTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ApplicationServiceLifecycleTests.swift
@@ -7,6 +7,109 @@ import Testing
 struct ApplicationServiceLifecycleTests {
     @Test
     @MainActor
+    func `application activation retries until exact PID owns Workspace and frontmost window`() async throws {
+        let runningApplication = try #require(NSWorkspace.shared.runningApplications.first {
+            $0.activationPolicy == .regular && !$0.isTerminated
+        })
+        let targetProcessIdentifier = runningApplication.processIdentifier
+        var nativeActivationCount = 0
+        var accessibilityActivationCount = 0
+        var sleepCount = 0
+        var isActive = false
+        var frontmostProcessIdentifier: pid_t?
+        var windowServerState = ApplicationService.WindowServerActivationState(
+            targetHasVisibleWindow: true,
+            frontmostWindowProcessIdentifier: nil)
+        let service = ApplicationService(
+            applicationOpenHandler: { _, _, _ in runningApplication },
+            applicationActivationHandler: { _ in
+                nativeActivationCount += 1
+                return true
+            },
+            applicationAccessibilityActivationHandler: { processIdentifier in
+                accessibilityActivationCount += 1
+                #expect(processIdentifier == targetProcessIdentifier)
+                isActive = true
+                frontmostProcessIdentifier = processIdentifier
+                windowServerState = ApplicationService.WindowServerActivationState(
+                    targetHasVisibleWindow: true,
+                    frontmostWindowProcessIdentifier: processIdentifier)
+                return true
+            },
+            applicationActiveProvider: { _ in isActive },
+            frontmostProcessIdentifierProvider: { frontmostProcessIdentifier },
+            windowServerActivationStateProvider: { _ in windowServerState },
+            applicationActivationSleepHandler: { _ in sleepCount += 1 },
+            applicationActivationTimeout: .seconds(1))
+
+        try await service.activateApplication(identifier: "PID:\(targetProcessIdentifier)")
+
+        #expect(nativeActivationCount == 2)
+        #expect(accessibilityActivationCount == 1)
+        #expect(sleepCount == 1)
+    }
+
+    @Test
+    @MainActor
+    func `application activation verification requires exact Workspace and visible window owners`() {
+        #expect(ApplicationService.isVerifiedApplicationActivation(
+            processIdentifier: 42,
+            isActive: true,
+            frontmostProcessIdentifier: 42,
+            targetHasVisibleWindow: true,
+            frontmostWindowProcessIdentifier: 42))
+        #expect(!ApplicationService.isVerifiedApplicationActivation(
+            processIdentifier: 42,
+            isActive: false,
+            frontmostProcessIdentifier: 42,
+            targetHasVisibleWindow: true,
+            frontmostWindowProcessIdentifier: 42))
+        #expect(!ApplicationService.isVerifiedApplicationActivation(
+            processIdentifier: 42,
+            isActive: true,
+            frontmostProcessIdentifier: 43,
+            targetHasVisibleWindow: true,
+            frontmostWindowProcessIdentifier: 42))
+        #expect(!ApplicationService.isVerifiedApplicationActivation(
+            processIdentifier: 42,
+            isActive: true,
+            frontmostProcessIdentifier: 42,
+            targetHasVisibleWindow: true,
+            frontmostWindowProcessIdentifier: 43))
+        #expect(ApplicationService.isVerifiedApplicationActivation(
+            processIdentifier: 42,
+            isActive: true,
+            frontmostProcessIdentifier: 42,
+            targetHasVisibleWindow: false,
+            frontmostWindowProcessIdentifier: 43))
+    }
+
+    @Test
+    @MainActor
+    func `application activation rejects an accepted request that never becomes frontmost`() async throws {
+        let runningApplication = try #require(NSWorkspace.shared.runningApplications.first {
+            $0.activationPolicy == .regular && !$0.isTerminated
+        })
+        let service = ApplicationService(
+            applicationOpenHandler: { _, _, _ in runningApplication },
+            applicationActivationHandler: { _ in true },
+            applicationAccessibilityActivationHandler: { _ in true },
+            applicationActiveProvider: { _ in true },
+            frontmostProcessIdentifierProvider: { runningApplication.processIdentifier + 1 },
+            windowServerActivationStateProvider: { _ in
+                ApplicationService.WindowServerActivationState(
+                    targetHasVisibleWindow: true,
+                    frontmostWindowProcessIdentifier: runningApplication.processIdentifier + 1)
+            },
+            applicationActivationTimeout: .zero)
+
+        await #expect(throws: PeekabooError.self) {
+            try await service.activateApplication(identifier: "PID:\(runningApplication.processIdentifier)")
+        }
+    }
+
+    @Test
+    @MainActor
     func `quit verification waits until the process is actually terminated`() async throws {
         var checks = 0
         let terminated = try await waitForApplicationTermination(

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/AppTool+Responses.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/AppTool+Responses.swift
@@ -75,12 +75,6 @@ extension AppToolActions {
     }
 
     func identifier(for app: ServiceApplicationInfo) -> String {
-        if let bundleId = app.bundleIdentifier, !bundleId.isEmpty {
-            return bundleId
-        }
-        if !app.name.isEmpty {
-            return app.name
-        }
-        return "PID:\(app.processIdentifier)"
+        "PID:\(app.processIdentifier)"
     }
 }

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/AppToolLifecyclePinningTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/AppToolLifecyclePinningTests.swift
@@ -8,6 +8,33 @@ import Testing
 struct AppToolLifecyclePinningTests {
     @Test
     @MainActor
+    func `focus activates the exact process selected before mutation`() async throws {
+        let service = LifecyclePinningApplicationService(applications: [
+            ServiceApplicationInfo(
+                processIdentifier: 4070,
+                processStartIdentity: 70,
+                bundleIdentifier: "com.apple.TextEdit",
+                name: "TextEdit"),
+            ServiceApplicationInfo(
+                processIdentifier: 4071,
+                processStartIdentity: 71,
+                bundleIdentifier: "com.apple.TextEdit",
+                name: "TextEdit"),
+        ])
+        let actions = AppToolActions(
+            service: service,
+            automation: MockAutomationService(accessibilityGranted: true),
+            logger: Logger(subsystem: "boo.peekaboo.tests", category: "AppToolLifecyclePinning"))
+
+        _ = try await actions.perform(
+            action: "focus",
+            request: Self.request(name: "PID:4071"))
+
+        #expect(service.activationCalls == ["PID:4071"])
+    }
+
+    @Test
+    @MainActor
     func `single quit pins the process resolved before mutation`() async throws {
         let service = LifecyclePinningApplicationService(applications: [
             ServiceApplicationInfo(
@@ -112,6 +139,7 @@ private final class LifecyclePinningApplicationService: ApplicationServiceProtoc
     let applications: [ServiceApplicationInfo]
     private var currentProcessGenerations: [Int32: UInt64]
     private(set) var quitCalls: [ApplicationQuitRequest] = []
+    private(set) var activationCalls: [String] = []
     private(set) var terminationCount = 0
 
     init(applications: [ServiceApplicationInfo]) {
@@ -177,8 +205,8 @@ private final class LifecyclePinningApplicationService: ApplicationServiceProtoc
         throw UnexpectedLifecycleCall()
     }
 
-    func activateApplication(identifier _: String) async throws {
-        throw UnexpectedLifecycleCall()
+    func activateApplication(identifier: String) async throws {
+        self.activationCalls.append(identifier)
     }
 
     func hideApplication(identifier _: String) async throws {

--- a/docs/commands/app.md
+++ b/docs/commands/app.md
@@ -28,7 +28,13 @@ read_when:
 - Quit mode supports `--all` plus `--except`, automatically ignoring core system processes (`Finder`, `Dock`, `SystemUIServer`, `WindowServer`). Controlled cleanup can pair `--pid` with `--expected-process-start-identity`; Peekaboo atomically rejects a recycled PID instead of terminating its replacement. When quits fail, the command prints hints about unsaved changes and suggests `--force`.
 - Hide/unhide uses `NSRunningApplication.hide()` / `.unhide()` and surfaces JSON output with per-app success data.
 - `switch --cycle` synthesizes Cmd+Tab events using `CGEvent` so it behaves like the real keyboard shortcut; `switch --to` activates the exact PID resolved via AX.
-- `switch --verify` confirms the requested app is frontmost after activation (not supported with `--cycle`).
+- App activation is successful only after the exact resolved PID reports active and Workspace-frontmost. When the
+  target owns visible ordinary windows, the frontmost WindowServer window must also belong to that PID. Peekaboo
+  first uses native application activation, then falls back to the application's AX frontmost attribute when macOS
+  accepts the request without completing it. Multi-window apps activate all of their windows; use `window focus`
+  when one specific window must become key.
+- `switch --verify` performs an additional command-level confirmation after the shared verified activation path (not
+  supported with `--cycle`).
 - Supplying both the positional app and its named flag is accepted only when the values match; conflicting values fail before dispatch.
 - `relaunch` sends the initially selected PID/process-generation receipt, quit, termination polling (up to 5 s), the requested delay, and launch as one daemon-held transaction, so even a short daemon idle timeout cannot strand the app closed. The host rejects PID reuse before quit. It refuses to relaunch its own daemon, launches via bundle ID or bundle path, stays backgrounded unless `--foreground` is set, can wait for `isFinishedLaunching`, and returns the new process generation for race-free follow-up cleanup.
 - `app list` filters hidden/background apps unless `--include-hidden` or `--include-background` is passed and emits its established `data.apps` payload.


### PR DESCRIPTION
## Summary

- require the exact resolved PID to be active, Workspace-frontmost, and—when it owns visible windows—the frontmost WindowServer owner before returning success
- retry asynchronous activation and use native AX frontmost activation when AppKit accepts a request without completing it
- activate all windows for app-level focus while preserving `window focus` for exact-window selection
- keep MCP focus pinned to the already-resolved PID, including same-bundle multi-instance apps
- report successful CLI focus as `effect: confirmed` and fail nonzero when verification does not complete

## Root cause

`NSRunningApplication.activate` reports whether macOS accepted the request, not whether activation completed. Workspace activation can also become visible before WindowServer has actually moved the target window to the top. The service treated rejected, unfulfilled, and not-yet-visible requests as success after a fixed 100 ms sleep.

## Proof

- `swift test --package-path Core/PeekabooAutomationKit --filter ApplicationServiceLifecycleTests` (41 passed)
- `RUN_AUTOMATION_READ=true PEEKABOO_INCLUDE_AUTOMATION_TESTS=true swift test --package-path Apps/CLI --filter AppCommandTests --no-parallel` (19 passed)
- `swift test --package-path Core/PeekabooCore --filter AppToolLifecyclePinningTests` (4 passed)
- `pnpm run test:safe` (733 Core CLI tests and 72 runtime tests passed)
- `pnpm run format`
- `pnpm run lint` (0 serious violations; existing advisory warnings only)
- `pnpm run lint:docs`
- final AutoReview clean on exact base `68b83b8a`

Signed live validation used the Foundation-signed exact head `d68f67f5` and two simultaneously running Playground instances with the same bundle identifier. Four alternating exact-PID focus operations each returned `effect: confirmed`; fresh app inventory and an independent WindowServer probe immediately agreed on the requested PID/window. OpenClaw PID 1192/window 2292 was restored before exact-generation cleanup. Clipboard digest/change count and Peekaboo overlay IDs stayed unchanged, both owned PIDs were gone, and no branch daemon remained. Evidence: `/tmp/peekaboo-app-focus-windowserver-final.48mJgN`. No AppleScript was used.
