### PR TITLE
fix(input): pin press sequences to process generation

### DIFF
--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add actionable text and JSON migration hints for removed v4 commands and flags, reject ambiguous press input shapes, and align `see`/`type`/`press` help with the accepted grammar.
 - Reject conflicting app/PID and window selectors across interaction CLI and MCP entry points before focus, observation, or mutation.
 - Require explicit `--foreground` for long-press clicks so the shared physical cursor cannot be used through an implicit delivery-mode promotion.
+- Pin background `press` sequences to one process generation, stop before a recycled PID can receive later chords, and report partial delivery as retry-unsafe.
 - Preserve stable `verify_state` proof for a directly matched exact AX identifier/value when only unrelated accessibility siblings are unreadable, while keeping absence, mismatch, ambiguity, and target drift fail-closed.
 - Wait for WindowServer to settle after an exact background maximize dispatch before repinning its final bounds, avoiding false failures without relaxing owner-generation checks.
 - Preserve OpenAI Responses tool-error payloads without sending unsupported `failed` statuses that abort the next agent turn.

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommandRuntime.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommandRuntime.swift
@@ -33,6 +33,8 @@ struct CommandRuntimeOptions {
     var requiresSurvivingApplicationHost = false
     /// Protocol 1.16 carries a process-generation receipt with application quit requests.
     var requiresProcessGenerationPinnedApplicationQuit = false
+    /// Protocol 1.19 carries a process-generation receipt with targeted hotkey requests.
+    var requiresProcessGenerationPinnedHotkeys = false
     var requiresHostApplicationInventory = false
     var requiresImplicitSnapshotInvalidation = false
     var requiresCallerDesktopMutationBarrier = false

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommandServiceBridges.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommandServiceBridges.swift
@@ -205,6 +205,31 @@ enum AutomationServiceBridge {
         }.value
     }
 
+    static func hotkey(
+        automation: any UIAutomationServiceProtocol,
+        keys: String,
+        holdDuration: Int,
+        expectedProcessIdentity: ApplicationProcessIdentity
+    ) async throws {
+        try await Task { @MainActor in
+            try BackgroundHotkeyPolicy.validate(keys: keys)
+
+            guard let targetedHotkeyService = automation as? any TargetedHotkeyServiceProtocol,
+                  targetedHotkeyService.supportsProcessGenerationPinnedHotkeys
+            else {
+                throw PeekabooError.serviceUnavailable(
+                    "Background hotkeys require process-generation-pinned delivery; update the runtime host"
+                )
+            }
+
+            try await targetedHotkeyService.hotkey(
+                keys: keys,
+                holdDuration: holdDuration,
+                expectedProcessIdentity: expectedProcessIdentity
+            )
+        }.value
+    }
+
     private static func targetedHotkeyUnavailableError(service: any TargetedHotkeyServiceProtocol) -> PeekabooError {
         if service.targetedHotkeyRequiresEventSynthesizingPermission {
             return .permissionDeniedEventSynthesizing

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommanderBinder.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommanderBinder.swift
@@ -53,6 +53,8 @@ enum CommanderCLIBinder {
         options.requiresApplicationRelaunch = commandType == AppCommand.RelaunchSubcommand.self
         options.requiresSurvivingApplicationHost = commandType == AppCommand.QuitSubcommand.self
         options.requiresProcessGenerationPinnedApplicationQuit = commandType == AppCommand.QuitSubcommand.self
+        options.requiresProcessGenerationPinnedHotkeys = commandType == PressCommand.self &&
+            !CommanderBindableValues(parsedValues: parsedValues).flag("foreground")
         options.requiresHostApplicationInventory = Self.requiresHostApplicationInventory(commandType)
         options.requiresImplicitSnapshotInvalidation = Self.requiresImplicitSnapshotInvalidation(
             commandType,

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/BridgeCapabilityPolicy.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/BridgeCapabilityPolicy.swift
@@ -70,6 +70,11 @@ enum BridgeCapabilityPolicy {
             return false
         }
 
+        if options.requiresProcessGenerationPinnedHotkeys,
+           !self.supportsProcessGenerationPinnedHotkeys(for: handshake) {
+            return false
+        }
+
         if options.requiresHostApplicationInventory, !self.supportsHostApplicationInventory(for: handshake) {
             return false
         }
@@ -305,6 +310,13 @@ enum BridgeCapabilityPolicy {
     ) -> Bool {
         handshake.negotiatedVersion >= PeekabooBridgeConstants.processGenerationPinnedApplicationQuitVersion &&
             self.supportsOperation(.quitApplication, for: handshake)
+    }
+
+    static func supportsProcessGenerationPinnedHotkeys(
+        for handshake: PeekabooBridgeHandshakeResponse
+    ) -> Bool {
+        handshake.negotiatedVersion >= PeekabooBridgeConstants.processGenerationPinnedHotkeyVersion &&
+            self.supportsOperation(.targetedHotkey, for: handshake)
     }
 
     static func supportsInspectAccessibilityTree(for handshake: PeekabooBridgeHandshakeResponse) -> Bool {

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/RuntimeHostResolver.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/RuntimeHostResolver.swift
@@ -506,6 +506,8 @@ enum RuntimeHostResolver {
                     services: RemotePeekabooServices(
                         client: client,
                         supportsTargetedHotkeys: targetedHotkeyAvailability.isEnabled,
+                        supportsProcessGenerationPinnedHotkeys:
+                        BridgeCapabilityPolicy.supportsProcessGenerationPinnedHotkeys(for: handshake),
                         targetedHotkeyUnavailableReason: targetedHotkeyAvailability.unavailableReason,
                         targetedHotkeyRequiresEventSynthesizingPermission:
                         targetedHotkeyAvailability.missingPermissions.contains(.postEvent),

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/KeyboardDeliverySupport.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/KeyboardDeliverySupport.swift
@@ -9,11 +9,50 @@ enum KeyboardDeliveryMode: String {
 }
 
 enum KeyboardDeliverySupport {
+    static func requireBackgroundProcessIdentity(
+        target: InteractionTargetOptions,
+        snapshotId: String?,
+        services: any PeekabooServiceProviding
+    ) async throws -> ApplicationProcessIdentity {
+        switch try await self.resolveBackgroundProcess(
+            target: target,
+            snapshotId: snapshotId,
+            services: services
+        ) {
+        case let .pid(processIdentifier):
+            try await self.requireCurrentProcessIdentity(
+                processIdentifier: processIdentifier,
+                services: services
+            )
+        case let .application(app, description):
+            try self.requireProcessIdentity(app, targetDescription: description)
+        case let .snapshot(processIdentifier, capturedWindowIdentity, snapshotId):
+            try await self.requireSnapshotProcessIdentity(
+                processIdentifier: processIdentifier,
+                capturedWindowIdentity: capturedWindowIdentity,
+                snapshotId: snapshotId,
+                services: services
+            )
+        }
+    }
+
     static func requireBackgroundProcessIdentifier(
         target: InteractionTargetOptions,
         snapshotId: String?,
         services: any PeekabooServiceProviding
     ) async throws -> pid_t {
+        try await pid_t(self.resolveBackgroundProcess(
+            target: target,
+            snapshotId: snapshotId,
+            services: services
+        ).processIdentifier)
+    }
+
+    private static func resolveBackgroundProcess(
+        target: InteractionTargetOptions,
+        snapshotId: String?,
+        services: any PeekabooServiceProviding
+    ) async throws -> ResolvedBackgroundProcess {
         if target.windowTitle != nil || target.windowIndex != nil || target.windowId != nil {
             throw ValidationError(
                 "Background keyboard delivery cannot safely target a specific window. " +
@@ -25,7 +64,7 @@ enum KeyboardDeliverySupport {
             guard pid > 0 else {
                 throw ValidationError("--pid must be greater than 0")
             }
-            return pid_t(pid)
+            return .pid(pid)
         }
 
         if let appIdentifier = target.app?.trimmingCharacters(in: .whitespacesAndNewlines),
@@ -34,21 +73,29 @@ enum KeyboardDeliverySupport {
             guard app.processIdentifier > 0 else {
                 throw ValidationError("Could not resolve a running process for --app '\(appIdentifier)'.")
             }
-            return pid_t(app.processIdentifier)
+            return .application(app, description: "--app '\(appIdentifier)'")
         }
 
         if let snapshotId,
            let snapshot = try await services.snapshots.getUIAutomationSnapshot(snapshotId: snapshotId),
-           let processId = snapshot.applicationProcessId,
-           processId > 0 {
-            return pid_t(processId)
+           let processIdentifier = snapshot.applicationProcessId,
+           processIdentifier > 0 {
+            return .snapshot(
+                processIdentifier,
+                capturedWindowIdentity: snapshot.windowMutationIdentity,
+                snapshotId: snapshotId
+            )
         }
 
         if let snapshotId,
            let detectionResult = try await services.snapshots.getDetectionResult(snapshotId: snapshotId),
-           let processId = detectionResult.metadata.windowContext?.applicationProcessId,
-           processId > 0 {
-            return pid_t(processId)
+           let processIdentifier = detectionResult.metadata.windowContext?.applicationProcessId,
+           processIdentifier > 0 {
+            return .snapshot(
+                processIdentifier,
+                capturedWindowIdentity: detectionResult.metadata.windowContext?.windowMutationIdentity,
+                snapshotId: snapshotId
+            )
         }
 
         if snapshotId != nil {
@@ -64,6 +111,21 @@ enum KeyboardDeliverySupport {
         )
     }
 
+    private enum ResolvedBackgroundProcess {
+        case pid(Int32)
+        case application(ServiceApplicationInfo, description: String)
+        case snapshot(Int32, capturedWindowIdentity: WindowMutationIdentity?, snapshotId: String)
+
+        var processIdentifier: Int32 {
+            switch self {
+            case let .pid(processIdentifier), let .snapshot(processIdentifier, _, _):
+                processIdentifier
+            case let .application(app, _):
+                app.processIdentifier
+            }
+        }
+    }
+
     static func validateForegroundFlags(
         foreground: Bool,
         focusOptions: FocusCommandOptions,
@@ -76,5 +138,57 @@ enum KeyboardDeliverySupport {
         if focusOptions.backgroundDeliveryExplicitlyRequested, focusOptions.hasForegroundFocusOverrides {
             throw ValidationError("\(backgroundFlagName ?? "--focus-background") cannot be combined with focus options")
         }
+    }
+
+    private static func requireSnapshotProcessIdentity(
+        processIdentifier: Int32,
+        capturedWindowIdentity: WindowMutationIdentity?,
+        snapshotId: String,
+        services: any PeekabooServiceProviding
+    ) async throws -> ApplicationProcessIdentity {
+        let currentIdentity = try await self.requireCurrentProcessIdentity(
+            processIdentifier: processIdentifier,
+            services: services
+        )
+        guard let capturedWindowIdentity else { return currentIdentity }
+
+        let capturedIdentity = ApplicationProcessIdentity(
+            processIdentifier: capturedWindowIdentity.ownerProcessIdentifier,
+            processStartIdentity: capturedWindowIdentity.ownerProcessStartIdentity
+        )
+        guard capturedIdentity.processIdentifier == processIdentifier,
+              capturedIdentity == currentIdentity
+        else {
+            throw ValidationError(
+                "Snapshot '\(snapshotId)' is stale: its target application exited or changed process generation."
+            )
+        }
+        return capturedIdentity
+    }
+
+    private static func requireCurrentProcessIdentity(
+        processIdentifier: Int32,
+        services: any PeekabooServiceProviding
+    ) async throws -> ApplicationProcessIdentity {
+        let app = try await services.applications.findApplication(identifier: "PID:\(processIdentifier)")
+        guard app.processIdentifier == processIdentifier else {
+            throw ValidationError("Could not resolve running process PID:\(processIdentifier).")
+        }
+        return try self.requireProcessIdentity(app, targetDescription: "PID:\(processIdentifier)")
+    }
+
+    private static func requireProcessIdentity(
+        _ app: ServiceApplicationInfo,
+        targetDescription: String
+    ) throws -> ApplicationProcessIdentity {
+        guard app.processIdentifier > 0 else {
+            throw ValidationError("Could not resolve a running process for \(targetDescription).")
+        }
+        guard let processIdentity = app.processIdentity else {
+            throw ValidationError(
+                "The runtime host could not pin \(targetDescription) to a process generation; update the host."
+            )
+        }
+        return processIdentity
     }
 }

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/PressCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/PressCommand.swift
@@ -76,7 +76,8 @@ struct PressCommand: ActionOutputFormattable, ErrorHandlingCommand, OutputFormat
             )
             try await observation.validateIfExplicit(using: self.services.snapshots)
 
-            let targetPID = try await self.backgroundProcessIdentifier(snapshotId: observation.snapshotId)
+            let targetIdentity = try await self.backgroundProcessIdentity(snapshotId: observation.snapshotId)
+            let targetPID = targetIdentity?.processIdentifier
             self.resolvedRuntime.beginInteractionMutation()
             if targetPID == nil {
                 try await ensureFocused(
@@ -90,30 +91,43 @@ struct PressCommand: ActionOutputFormattable, ErrorHandlingCommand, OutputFormat
             let parsedChords = try self.parsedChords()
             var completedPresses = 0
 
-            for repetition in 0..<self.count {
-                for (index, chord) in parsedChords.indexed() {
-                    if let targetPID {
-                        try await AutomationServiceBridge.hotkey(
-                            automation: self.services.automation,
-                            keys: chord.serviceKeys,
-                            holdDuration: self.hold.roundedMilliseconds,
-                            targetProcessIdentifier: targetPID
-                        )
-                    } else {
-                        try await AutomationServiceBridge.hotkey(
-                            automation: self.services.automation,
-                            keys: chord.serviceKeys,
-                            holdDuration: self.hold.roundedMilliseconds
-                        )
-                    }
-                    completedPresses += 1
+            do {
+                for repetition in 0..<self.count {
+                    for (index, chord) in parsedChords.indexed() {
+                        try Task.checkCancellation()
+                        if let targetIdentity {
+                            try await AutomationServiceBridge.hotkey(
+                                automation: self.services.automation,
+                                keys: chord.serviceKeys,
+                                holdDuration: self.hold.roundedMilliseconds,
+                                expectedProcessIdentity: targetIdentity
+                            )
+                        } else {
+                            try await AutomationServiceBridge.hotkey(
+                                automation: self.services.automation,
+                                keys: chord.serviceKeys,
+                                holdDuration: self.hold.roundedMilliseconds
+                            )
+                        }
+                        completedPresses += 1
+                        try Task.checkCancellation()
 
-                    let isLastKey = index == parsedChords.count - 1
-                    let isLastRepetition = repetition == self.count - 1
-                    if self.delay.milliseconds > 0, !(isLastKey && isLastRepetition) {
-                        try await Task.sleep(for: .seconds(self.delay.seconds))
+                        let isLastKey = index == parsedChords.count - 1
+                        let isLastRepetition = repetition == self.count - 1
+                        if self.delay.milliseconds > 0, !(isLastKey && isLastRepetition) {
+                            try await Task.sleep(for: .seconds(self.delay.seconds))
+                        }
                     }
                 }
+            } catch let error as InputDeliveryIndeterminateError {
+                throw error
+            } catch {
+                guard completedPresses > 0 else { throw error }
+                throw InputDeliveryIndeterminateError(
+                    operation: .hotkey,
+                    emittedUnitCount: completedPresses,
+                    causeDescription: error.localizedDescription
+                )
             }
 
             await InteractionObservationInvalidator.invalidateAfterMutation(
@@ -176,12 +190,12 @@ struct PressCommand: ActionOutputFormattable, ErrorHandlingCommand, OutputFormat
         }
     }
 
-    private func backgroundProcessIdentifier(snapshotId: String?) async throws -> pid_t? {
+    private func backgroundProcessIdentity(snapshotId: String?) async throws -> ApplicationProcessIdentity? {
         guard !self.focusOptions.foreground else {
             return nil
         }
 
-        return try await KeyboardDeliverySupport.requireBackgroundProcessIdentifier(
+        return try await KeyboardDeliverySupport.requireBackgroundProcessIdentity(
             target: self.target,
             snapshotId: snapshotId,
             services: self.services

--- a/Apps/CLI/Tests/CLIAutomationTests/PressCommandTests.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/PressCommandTests.swift
@@ -90,6 +90,156 @@ struct PressCommandTests {
     }
 
     @Test
+    func `Background sequence pins one unchanged process generation`() async throws {
+        let identity = ApplicationProcessIdentity(processIdentifier: 4201, processStartIdentity: 71)
+        let applications = await self.makeApplicationService(identity: identity)
+        let context = await self.makeContext(applications: applications) { automation, _ in
+            automation.currentHotkeyProcessIdentity = { processIdentifier in
+                applications.applications.first {
+                    $0.processIdentifier == processIdentifier
+                }?.processIdentity
+            }
+        }
+
+        let result = try await self.runPress(
+            arguments: ["a", "b", "--pid", "4201", "--delay", "0", "--json"],
+            context: context
+        )
+
+        #expect(result.exitStatus == 0)
+        let calls = await self.automationState(context) { $0.targetedHotkeyCalls }
+        #expect(calls.map(\.keys) == ["a", "b"])
+        #expect(calls.map(\.expectedProcessIdentity) == [identity, identity])
+    }
+
+    @Test
+    func `Background sequence stops indeterminate after PID is reused`() async throws {
+        let identity = ApplicationProcessIdentity(processIdentifier: 4202, processStartIdentity: 72)
+        let replacement = ApplicationProcessIdentity(processIdentifier: 4202, processStartIdentity: 73)
+        let applications = await self.makeApplicationService(identity: identity)
+        let context = await self.makeContext(applications: applications) { automation, _ in
+            automation.currentHotkeyProcessIdentity = { processIdentifier in
+                applications.applications.first {
+                    $0.processIdentifier == processIdentifier
+                }?.processIdentity
+            }
+            automation.afterPinnedHotkey = {
+                applications.applications = [Self.application(identity: replacement)]
+            }
+        }
+
+        let result = try await self.runPress(
+            arguments: ["a", "b", "--pid", "4202", "--delay", "0"],
+            context: context
+        )
+
+        #expect(result.exitStatus != 0)
+        #expect(result.combinedOutput.contains("outcome is indeterminate"))
+        #expect(result.combinedOutput.contains("do not retry blindly"))
+        let calls = await self.automationState(context) { $0.targetedHotkeyCalls }
+        #expect(calls.map(\.keys) == ["a"])
+        #expect(calls.first?.expectedProcessIdentity == identity)
+    }
+
+    @Test
+    func `Background sequence stops indeterminate after target exits`() async throws {
+        let identity = ApplicationProcessIdentity(processIdentifier: 4203, processStartIdentity: 74)
+        let applications = await self.makeApplicationService(identity: identity)
+        let context = await self.makeContext(applications: applications) { automation, _ in
+            automation.currentHotkeyProcessIdentity = { processIdentifier in
+                applications.applications.first {
+                    $0.processIdentifier == processIdentifier
+                }?.processIdentity
+            }
+            automation.afterPinnedHotkey = {
+                applications.applications = []
+            }
+        }
+
+        let result = try await self.runPress(
+            arguments: ["a", "b", "--pid", "4203", "--delay", "0"],
+            context: context
+        )
+
+        #expect(result.exitStatus != 0)
+        #expect(result.combinedOutput.contains("outcome is indeterminate"))
+        let calls = await self.automationState(context) { $0.targetedHotkeyCalls }
+        #expect(calls.map(\.keys) == ["a"])
+    }
+
+    @Test
+    func `Snapshot window receipt rejects a replaced process before first chord`() async throws {
+        let captured = ApplicationProcessIdentity(processIdentifier: 4205, processStartIdentity: 76)
+        let replacement = ApplicationProcessIdentity(processIdentifier: 4205, processStartIdentity: 77)
+        let applications = await self.makeApplicationService(identity: replacement)
+        let context = await self.makeContext(applications: applications)
+        let snapshotId = "press-stale-process"
+        let detection = ElementDetectionResult(
+            snapshotId: snapshotId,
+            screenshotPath: "/tmp/press-stale-process.png",
+            elements: DetectedElements(),
+            metadata: DetectionMetadata(
+                detectionTime: 0,
+                elementCount: 0,
+                method: "stub",
+                windowContext: WindowContext(
+                    applicationName: "PressTarget",
+                    applicationBundleId: "com.example.press-target",
+                    applicationProcessId: captured.processIdentifier,
+                    windowID: 905,
+                    windowBounds: CGRect(x: 0, y: 0, width: 800, height: 600),
+                    windowMutationIdentity: WindowMutationIdentity(
+                        windowID: 905,
+                        ownerProcessIdentifier: captured.processIdentifier,
+                        ownerProcessStartIdentity: captured.processStartIdentity
+                    )
+                )
+            )
+        )
+        try await context.snapshots.storeDetectionResult(snapshotId: snapshotId, result: detection)
+
+        let result = try await self.runPress(
+            arguments: ["a", "--snapshot", snapshotId],
+            context: context
+        )
+
+        #expect(result.exitStatus != 0)
+        #expect(result.combinedOutput.contains("changed process generation"))
+        let calls = await self.automationState(context) { $0.targetedHotkeyCalls }
+        #expect(calls.isEmpty)
+    }
+
+    @Test
+    func `Cancellation during sequence delay never delivers a later chord`() async throws {
+        let identity = ApplicationProcessIdentity(processIdentifier: 4204, processStartIdentity: 75)
+        let applications = await self.makeApplicationService(identity: identity)
+        let context = await self.makeContext(applications: applications) { automation, _ in
+            automation.currentHotkeyProcessIdentity = { _ in identity }
+        }
+        let command = Task {
+            try await self.runPress(
+                arguments: ["a", "b", "--pid", "4204", "--delay", "5s"],
+                context: context
+            )
+        }
+
+        for _ in 0..<100 {
+            let count = await self.automationState(context) { $0.targetedHotkeyCalls.count }
+            if count == 1 {
+                break
+            }
+            try await Task.sleep(for: .milliseconds(2))
+        }
+        command.cancel()
+        let result = try await command.value
+
+        #expect(result.exitStatus != 0)
+        #expect(result.combinedOutput.contains("outcome is indeterminate"))
+        let calls = await self.automationState(context) { $0.targetedHotkeyCalls }
+        #expect(calls.map(\.keys) == ["a"])
+    }
+
+    @Test
     func `Snapshot argument is forwarded`() async throws {
         let snapshotId = "snapshot-42"
         let context = await self.makeContext()
@@ -136,13 +286,31 @@ struct PressCommandTests {
     }
 
     private func makeContext(
+        applications: any ApplicationServiceProtocol = StubApplicationService(applications: []),
         configure: (@MainActor (StubAutomationService, StubSnapshotManager) -> Void)? = nil
     ) async -> TestServicesFactory.AutomationTestContext {
         await MainActor.run {
-            let context = TestServicesFactory.makeAutomationTestContext()
+            let context = TestServicesFactory.makeAutomationTestContext(applications: applications)
             configure?(context.automation, context.snapshots)
             return context
         }
+    }
+
+    private func makeApplicationService(
+        identity: ApplicationProcessIdentity
+    ) async -> StubApplicationService {
+        await MainActor.run {
+            StubApplicationService(applications: [Self.application(identity: identity)])
+        }
+    }
+
+    private nonisolated static func application(identity: ApplicationProcessIdentity) -> ServiceApplicationInfo {
+        ServiceApplicationInfo(
+            processIdentifier: identity.processIdentifier,
+            processStartIdentity: identity.processStartIdentity,
+            bundleIdentifier: "com.example.press-target",
+            name: "PressTarget"
+        )
     }
 
     private func automationState<T: Sendable>(

--- a/Apps/CLI/Tests/CLIAutomationTests/Support/TestServices.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/Support/TestServices.swift
@@ -169,6 +169,7 @@ ExactWindowTargetedClickServiceProtocol {
         let keys: String
         let holdDuration: Int
         let targetProcessIdentifier: pid_t
+        let expectedProcessIdentity: ApplicationProcessIdentity?
     }
 
     struct TargetedTypeActionsCall {
@@ -212,10 +213,13 @@ ExactWindowTargetedClickServiceProtocol {
     var waitForElementCalls: [WaitForElementCall] = []
     var detectElementsCalls: [(imageData: Data, snapshotId: String?, windowContext: WindowContext?)] = []
     var supportsTargetedHotkeys = true
+    var supportsProcessGenerationPinnedHotkeys = true
     var targetedHotkeyUnavailableReason: String?
     var targetedHotkeyRequiresEventSynthesizingPermission = false
     var hotkeyError: (any Error)?
     var targetedHotkeyError: (any Error)?
+    var currentHotkeyProcessIdentity: ((pid_t) -> ApplicationProcessIdentity?)?
+    var afterPinnedHotkey: (() -> Void)?
     var supportsTargetedTypeActions = true
     var targetedTypeUnavailableReason: String?
     var targetedTypeRequiresEventSynthesizingPermission = false
@@ -401,11 +405,35 @@ ExactWindowTargetedClickServiceProtocol {
         self.targetedHotkeyCalls.append(TargetedHotkeyCall(
             keys: keys,
             holdDuration: holdDuration,
-            targetProcessIdentifier: targetProcessIdentifier
+            targetProcessIdentifier: targetProcessIdentifier,
+            expectedProcessIdentity: nil
         ))
         if let targetedHotkeyError {
             throw targetedHotkeyError
         }
+    }
+
+    func hotkey(
+        keys: String,
+        holdDuration: Int,
+        expectedProcessIdentity: ApplicationProcessIdentity
+    ) async throws {
+        if let currentHotkeyProcessIdentity,
+           currentHotkeyProcessIdentity(expectedProcessIdentity.processIdentifier) != expectedProcessIdentity {
+            throw PeekabooError.invalidInput(
+                "Background hotkey target process exited or changed process generation"
+            )
+        }
+        self.targetedHotkeyCalls.append(TargetedHotkeyCall(
+            keys: keys,
+            holdDuration: holdDuration,
+            targetProcessIdentifier: expectedProcessIdentity.processIdentifier,
+            expectedProcessIdentity: expectedProcessIdentity
+        ))
+        if let targetedHotkeyError {
+            throw targetedHotkeyError
+        }
+        self.afterPinnedHotkey?()
     }
 
     func swipe(from: CGPoint, to: CGPoint, duration: Int, steps: Int, profile: MouseMovementProfile) async throws {

--- a/Apps/CLI/Tests/CoreCLITests/CommanderBinderTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/CommanderBinderTests.swift
@@ -560,6 +560,42 @@ struct CommanderBinderTests {
     }
 
     @Test
+    func `Background press requires process-generation-pinned Bridge hotkeys`() throws {
+        let background = try CommanderCLIBinder.makeRuntimeOptions(
+            from: ParsedValues(positional: ["a"], options: ["pid": ["42"]], flags: []),
+            commandType: PressCommand.self
+        )
+        let foreground = try CommanderCLIBinder.makeRuntimeOptions(
+            from: ParsedValues(positional: ["a"], options: [:], flags: ["foreground"]),
+            commandType: PressCommand.self
+        )
+        let operations: [PeekabooBridgeOperation] = [
+            .targetedHotkey,
+            .invalidateImplicitLatestSnapshot,
+        ]
+        let legacy = PeekabooBridgeHandshakeResponse(
+            negotiatedVersion: .init(major: 1, minor: 18),
+            hostKind: .onDemand,
+            build: nil,
+            supportedOperations: operations,
+            enabledOperations: operations
+        )
+        let current = PeekabooBridgeHandshakeResponse(
+            negotiatedVersion: PeekabooBridgeConstants.processGenerationPinnedHotkeyVersion,
+            hostKind: .onDemand,
+            build: nil,
+            supportedOperations: operations,
+            enabledOperations: operations
+        )
+
+        #expect(background.requiresProcessGenerationPinnedHotkeys)
+        #expect(!foreground.requiresProcessGenerationPinnedHotkeys)
+        #expect(!CommandRuntime.supportsRemoteRequirements(for: legacy, options: background))
+        #expect(CommandRuntime.supportsRemoteRequirements(for: current, options: background))
+        #expect(CommandRuntime.supportsRemoteRequirements(for: legacy, options: foreground))
+    }
+
+    @Test
     func `Click delivery selects the permission required by its actual path`() throws {
         let coordinate = try CommanderCLIBinder.makeRuntimeOptions(
             from: ParsedValues(

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 - Add actionable text and JSON migration hints for removed v4 commands and flags, reject ambiguous press input shapes, and align `see`/`type`/`press` help with the accepted grammar.
 - Reject conflicting app/PID and window selectors across interaction CLI and MCP entry points before focus, observation, or mutation.
 - Require explicit `--foreground` for long-press clicks so the shared physical cursor cannot be used through an implicit delivery-mode promotion.
+- Pin background `press` sequences to one process generation, stop before a recycled PID can receive later chords, and report partial delivery as retry-unsafe.
 - Preserve stable `verify_state` proof for a directly matched exact AX identifier/value when only unrelated accessibility siblings are unreadable, while keeping absence, mismatch, ambiguity, and target drift fail-closed.
 - Preserve the requested characters during background typing on non-US keyboard layouts instead of interpreting fixed US key positions through the active layout. Thanks @canvascoding for #330.
 - Wait for WindowServer to settle after an exact background maximize dispatch before repinning its final bounds, avoiding false failures without relaxing owner-generation checks.

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Core/Protocols/UIAutomationServiceProtocol.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Core/Protocols/UIAutomationServiceProtocol.swift
@@ -241,15 +241,25 @@ public protocol DetectElementsRequestTimeoutAdjusting: UIAutomationServiceProtoc
 @MainActor
 public protocol TargetedHotkeyServiceProtocol: UIAutomationServiceProtocol {
     var supportsTargetedHotkeys: Bool { get }
+    var supportsProcessGenerationPinnedHotkeys: Bool { get }
     var targetedHotkeyUnavailableReason: String? { get }
     var targetedHotkeyRequiresEventSynthesizingPermission: Bool { get }
 
     func hotkey(keys: String, holdDuration: Int, targetProcessIdentifier: pid_t) async throws
+
+    func hotkey(
+        keys: String,
+        holdDuration: Int,
+        expectedProcessIdentity: ApplicationProcessIdentity) async throws
 }
 
 extension TargetedHotkeyServiceProtocol {
     public var supportsTargetedHotkeys: Bool {
         true
+    }
+
+    public var supportsProcessGenerationPinnedHotkeys: Bool {
+        false
     }
 
     public var targetedHotkeyUnavailableReason: String? {
@@ -258,6 +268,15 @@ extension TargetedHotkeyServiceProtocol {
 
     public var targetedHotkeyRequiresEventSynthesizingPermission: Bool {
         false
+    }
+
+    public func hotkey(
+        keys _: String,
+        holdDuration _: Int,
+        expectedProcessIdentity _: ApplicationProcessIdentity) async throws
+    {
+        throw PeekabooError.serviceUnavailable(
+            "This automation service does not support process-generation-pinned hotkeys")
     }
 }
 

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/UIAutomationService+PointerKeyboardOperations.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/UIAutomationService+PointerKeyboardOperations.swift
@@ -109,6 +109,29 @@ extension UIAutomationService {
     public func hotkey(
         keys: String,
         holdDuration: Int,
+        expectedProcessIdentity: ApplicationProcessIdentity) async throws
+    {
+        try await self.operationLaneCoordinator.run(scope: .process(expectedProcessIdentity), access: .write) {
+            let validator: @MainActor @Sendable () async throws -> Void = {
+                guard self.processStartIdentityProvider(expectedProcessIdentity.processIdentifier) ==
+                    expectedProcessIdentity.processStartIdentity
+                else {
+                    throw PeekabooError.invalidInput(
+                        "Background hotkey target process exited or changed process generation")
+                }
+            }
+            defer { self.elementDetectionService.invalidateCache() }
+            _ = try await self.hotkeyService.hotkey(
+                keys: keys,
+                holdDuration: holdDuration,
+                targetProcessIdentifier: expectedProcessIdentity.processIdentifier,
+                deliveryValidator: validator)
+        }
+    }
+
+    public func hotkey(
+        keys: String,
+        holdDuration: Int,
         expectedWindowIdentity: WindowMutationIdentity,
         expectedWindowBounds: CGRect) async throws
     {

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/UIAutomationService.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/UIAutomationService.swift
@@ -42,6 +42,7 @@ public final class UIAutomationService: TargetedHotkeyServiceProtocol, TargetedT
     ExactWindowTargetedClickServiceProtocol, TargetedFocusedElementServiceProtocol,
     ExactWindowTargetedKeyboardServiceProtocol
 {
+    public let supportsProcessGenerationPinnedHotkeys = true
     public let supportsExactWindowTargetedKeyboard = true
     public let exactWindowTargetedKeyboardUnavailableReason: String? = nil
     let logger = Logger(subsystem: "boo.peekaboo.core", category: "UIAutomationService")
@@ -63,6 +64,7 @@ public final class UIAutomationService: TargetedHotkeyServiceProtocol, TargetedT
     let automationElementResolver: any AutomationElementResolving
     let exactWindowFocusReader: @Sendable (pid_t) -> ExactWindowFocusSnapshot?
     let exactWindowIdentityValidator: @Sendable (WindowMutationIdentity, CGRect) -> Bool
+    let processStartIdentityProvider: @Sendable (pid_t) -> UInt64?
     let operationLaneCoordinator: DesktopOperationLaneCoordinator
 
     // Search constraints to prevent unbounded AX traversals
@@ -135,11 +137,14 @@ public final class UIAutomationService: TargetedHotkeyServiceProtocol, TargetedT
         actionInputDriver: any ActionInputDriving,
         syntheticInputDriver: any SyntheticInputDriving = SyntheticInputDriver(),
         automationElementResolver: any AutomationElementResolving,
+        hotkeyService: HotkeyService? = nil,
         feedbackClient: any AutomationFeedbackClient = NoopAutomationFeedbackClient(),
         exactWindowFocusReader: @escaping @Sendable (pid_t) -> ExactWindowFocusSnapshot? =
             DetachedExactWindowFocusReader.read,
         exactWindowIdentityValidator: @escaping @Sendable (WindowMutationIdentity, CGRect) -> Bool =
             SystemIdentityResolver.validateWindowMutationIdentity,
+        processStartIdentityProvider: @escaping @Sendable (pid_t) -> UInt64? =
+            SystemIdentityResolver.processStartIdentity,
         operationLaneCoordinator: DesktopOperationLaneCoordinator = .shared)
     {
         let manager = snapshotManager ?? SnapshotManager()
@@ -156,6 +161,7 @@ public final class UIAutomationService: TargetedHotkeyServiceProtocol, TargetedT
         self.feedbackClient = feedbackClient
         self.exactWindowFocusReader = exactWindowFocusReader
         self.exactWindowIdentityValidator = exactWindowIdentityValidator
+        self.processStartIdentityProvider = processStartIdentityProvider
         self.operationLaneCoordinator = operationLaneCoordinator
 
         // Initialize specialized services
@@ -181,7 +187,7 @@ public final class UIAutomationService: TargetedHotkeyServiceProtocol, TargetedT
             actionInputDriver: actionInputDriver,
             syntheticInputDriver: syntheticInputDriver,
             automationElementResolver: automationElementResolver)
-        self.hotkeyService = HotkeyService(
+        self.hotkeyService = hotkeyService ?? HotkeyService(
             inputPolicy: inputPolicy,
             actionInputDriver: actionInputDriver)
         self.gestureService = GestureService()

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ProcessGenerationPinnedHotkeyTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ProcessGenerationPinnedHotkeyTests.swift
@@ -1,0 +1,114 @@
+import CoreGraphics
+import Foundation
+import PeekabooFoundation
+import Testing
+@testable import PeekabooAutomationKit
+
+@Suite(.serialized)
+@MainActor
+struct ProcessGenerationPinnedHotkeyTests {
+    @Test
+    func `Unchanged process generation completes targeted hotkey`() async throws {
+        var postedEvents: [CGEventType] = []
+        let identity = self.identity(generation: 91)
+        let service = self.makeService(
+            currentGeneration: { 91 },
+            eventPoster: { event, _ in postedEvents.append(event.type) })
+
+        try await service.hotkey(
+            keys: "cmd,shift,l",
+            holdDuration: 0,
+            expectedProcessIdentity: identity)
+
+        #expect(postedEvents == [
+            .flagsChanged,
+            .flagsChanged,
+            .keyDown,
+            .keyUp,
+            .flagsChanged,
+            .flagsChanged,
+        ])
+    }
+
+    @Test
+    func `Changed process generation before dispatch emits nothing`() async throws {
+        var postedEventCount = 0
+        let service = self.makeService(
+            currentGeneration: { 93 },
+            eventPoster: { _, _ in postedEventCount += 1 })
+
+        await #expect(throws: PeekabooError.self) {
+            try await service.hotkey(
+                keys: "cmd,shift,l",
+                holdDuration: 0,
+                expectedProcessIdentity: self.identity(generation: 92))
+        }
+        #expect(postedEventCount == 0)
+    }
+
+    @Test
+    func `Process generation drift after dispatch is retry unsafe`() async throws {
+        let generation = LockedProcessGeneration(94)
+        var postedEventCount = 0
+        let service = self.makeService(
+            currentGeneration: { generation.value },
+            eventPoster: { _, _ in
+                postedEventCount += 1
+                if postedEventCount == 6 {
+                    generation.value = 95
+                }
+            })
+
+        do {
+            try await service.hotkey(
+                keys: "cmd,shift,l",
+                holdDuration: 0,
+                expectedProcessIdentity: self.identity(generation: 94))
+            Issue.record("Expected process-generation drift to fail closed")
+        } catch let error as InputDeliveryIndeterminateError {
+            #expect(error.operation == .hotkey)
+            #expect(error.emittedUnitCount == 6)
+            #expect(error.operationMayHaveCompleted)
+            #expect(!error.retrySafe)
+            #expect(error.causeDescription?.contains("process generation") == true)
+        }
+
+        #expect(postedEventCount == 6)
+    }
+
+    private func makeService(
+        currentGeneration: @escaping @Sendable () -> UInt64?,
+        eventPoster: @escaping @MainActor @Sendable (CGEvent, pid_t) -> Void) -> UIAutomationService
+    {
+        let hotkeyService = HotkeyService(
+            inputPolicy: UIInputPolicy(defaultStrategy: .synthOnly),
+            postEventAccessEvaluator: { true },
+            eventPoster: eventPoster)
+        return UIAutomationService(
+            inputPolicy: UIInputPolicy(defaultStrategy: .synthOnly),
+            actionInputDriver: ActionInputDriver(),
+            automationElementResolver: AutomationElementResolver(),
+            hotkeyService: hotkeyService,
+            processStartIdentityProvider: { _ in currentGeneration() })
+    }
+
+    private func identity(generation: UInt64) -> ApplicationProcessIdentity {
+        ApplicationProcessIdentity(
+            processIdentifier: getpid(),
+            processStartIdentity: generation)
+    }
+}
+
+private final class LockedProcessGeneration: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storedValue: UInt64?
+
+    init(_ value: UInt64?) {
+        self.storedValue = value
+    }
+
+    var value: UInt64? {
+        get { self.lock.withLock { self.storedValue } }
+        set { self.lock.withLock { self.storedValue = newValue } }
+    }
+}

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeClient+Interaction.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeClient+Interaction.swift
@@ -189,6 +189,19 @@ extension PeekabooBridgeClient {
     public func hotkey(
         keys: String,
         holdDuration: Int,
+        expectedProcessIdentity: ApplicationProcessIdentity) async throws
+    {
+        try await self.sendExpectOK(
+            .targetedHotkey(PeekabooBridgeTargetedHotkeyRequest(
+                keys: keys,
+                holdDuration: holdDuration,
+                targetProcessIdentifier: expectedProcessIdentity.processIdentifier,
+                expectedProcessIdentity: expectedProcessIdentity)))
+    }
+
+    public func hotkey(
+        keys: String,
+        holdDuration: Int,
         expectedWindowIdentity: WindowMutationIdentity,
         expectedWindowBounds: CGRect) async throws
     {

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeConstants.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeConstants.swift
@@ -28,11 +28,15 @@ public enum PeekabooBridgeConstants {
     }
 
     /// Current protocol version supported by this build.
-    public static let protocolVersion = PeekabooBridgeProtocolVersion(major: 1, minor: 18)
+    public static let protocolVersion = PeekabooBridgeProtocolVersion(major: 1, minor: 19)
 
     /// First protocol that carries an application process-generation receipt with quit requests.
     public static let processGenerationPinnedApplicationQuitVersion =
         PeekabooBridgeProtocolVersion(major: 1, minor: 16)
+
+    /// First protocol that carries a process-generation receipt with targeted hotkey requests.
+    public static let processGenerationPinnedHotkeyVersion =
+        PeekabooBridgeProtocolVersion(major: 1, minor: 19)
 
     /// Oldest protocol version this build can serve without changing request semantics.
     public static let minimumProtocolVersion = PeekabooBridgeProtocolVersion(major: 1, minor: 0)

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgePayloads.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgePayloads.swift
@@ -182,11 +182,18 @@ public struct PeekabooBridgeTargetedHotkeyRequest: Codable, Sendable {
     public let keys: String
     public let holdDuration: Int
     public let targetProcessIdentifier: Int32
+    public let expectedProcessIdentity: ApplicationProcessIdentity?
 
-    public init(keys: String, holdDuration: Int, targetProcessIdentifier: Int32) {
+    public init(
+        keys: String,
+        holdDuration: Int,
+        targetProcessIdentifier: Int32,
+        expectedProcessIdentity: ApplicationProcessIdentity? = nil)
+    {
         self.keys = keys
         self.holdDuration = holdDuration
         self.targetProcessIdentifier = targetProcessIdentifier
+        self.expectedProcessIdentity = expectedProcessIdentity
     }
 }
 

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeRequest+DesktopMutation.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeRequest+DesktopMutation.swift
@@ -84,6 +84,8 @@ extension PeekabooBridgeRequest {
             .process(ApplicationProcessIdentity(
                 processIdentifier: payload.expectedWindowIdentity.ownerProcessIdentifier,
                 processStartIdentity: payload.expectedWindowIdentity.ownerProcessStartIdentity))
+        case let .targetedHotkey(payload):
+            payload.expectedProcessIdentity.map(DesktopOperationScope.process) ?? .global
         case let .targetedClick(payload):
             if let targetWindowID = payload.targetWindowID,
                let identity = payload.expectedWindowIdentity,

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer+Handlers.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer+Handlers.swift
@@ -324,21 +324,7 @@ extension PeekabooBridgeServer {
             }
             return .typeResult(result)
         case let .targetedHotkey(payload):
-            guard
-                let targetedHotkeyService = self.services.automation as? any TargetedHotkeyServiceProtocol,
-                targetedHotkeyService.supportsTargetedHotkeys
-            else {
-                throw PeekabooBridgeErrorEnvelope(
-                    code: .operationNotSupported,
-                    message: "Background hotkeys are not supported by this bridge host")
-            }
-
-            self.automationActivityObserver?(pid_t(payload.targetProcessIdentifier))
-            try await targetedHotkeyService.hotkey(
-                keys: payload.keys,
-                holdDuration: payload.holdDuration,
-                targetProcessIdentifier: pid_t(payload.targetProcessIdentifier))
-            return .ok
+            return try await self.handleTargetedHotkey(payload)
         case let .exactWindowTargetedHotkey(payload):
             guard let service = self.services.automation as? any ExactWindowTargetedKeyboardServiceProtocol,
                   service.supportsExactWindowTargetedKeyboard
@@ -416,6 +402,43 @@ extension PeekabooBridgeServer {
         default:
             throw Self.invalidRequest(for: request)
         }
+    }
+
+    private func handleTargetedHotkey(
+        _ payload: PeekabooBridgeTargetedHotkeyRequest) async throws -> PeekabooBridgeResponse
+    {
+        guard
+            let service = self.services.automation as? any TargetedHotkeyServiceProtocol,
+            service.supportsTargetedHotkeys
+        else {
+            throw PeekabooBridgeErrorEnvelope(
+                code: .operationNotSupported,
+                message: "Background hotkeys are not supported by this bridge host")
+        }
+
+        self.automationActivityObserver?(pid_t(payload.targetProcessIdentifier))
+        if let expectedIdentity = payload.expectedProcessIdentity {
+            guard expectedIdentity.processIdentifier == payload.targetProcessIdentifier else {
+                throw PeekabooBridgeErrorEnvelope(
+                    code: .invalidRequest,
+                    message: "Targeted hotkey PID does not match its process-generation receipt")
+            }
+            guard service.supportsProcessGenerationPinnedHotkeys else {
+                throw PeekabooBridgeErrorEnvelope(
+                    code: .operationNotSupported,
+                    message: "Process-generation-pinned background hotkeys are not supported by this bridge host")
+            }
+            try await service.hotkey(
+                keys: payload.keys,
+                holdDuration: payload.holdDuration,
+                expectedProcessIdentity: expectedIdentity)
+        } else {
+            try await service.hotkey(
+                keys: payload.keys,
+                holdDuration: payload.holdDuration,
+                targetProcessIdentifier: pid_t(payload.targetProcessIdentifier))
+        }
+        return .ok
     }
 
     private func handleWindowRequest(_ request: PeekabooBridgeRequest) async throws -> PeekabooBridgeResponse {

--- a/Core/PeekabooCore/Sources/PeekabooCore/Support/RemotePeekabooServices.swift
+++ b/Core/PeekabooCore/Sources/PeekabooCore/Support/RemotePeekabooServices.swift
@@ -33,6 +33,7 @@ public final class RemotePeekabooServices: PeekabooServiceProviding {
     public init(
         client: PeekabooBridgeClient,
         supportsTargetedHotkeys: Bool = false,
+        supportsProcessGenerationPinnedHotkeys: Bool = false,
         targetedHotkeyUnavailableReason: String? = nil,
         targetedHotkeyRequiresEventSynthesizingPermission: Bool = false,
         supportsTargetedTypeActions: Bool = false,
@@ -80,6 +81,7 @@ public final class RemotePeekabooServices: PeekabooServiceProviding {
             RemoteElementActionUIAutomationService(
                 client: client,
                 supportsTargetedHotkeys: supportsTargetedHotkeys,
+                supportsProcessGenerationPinnedHotkeys: supportsProcessGenerationPinnedHotkeys,
                 targetedHotkeyUnavailableReason: targetedHotkeyUnavailableReason,
                 targetedHotkeyRequiresEventSynthesizingPermission: targetedHotkeyRequiresEventSynthesizingPermission,
                 supportsTargetedTypeActions: supportsTargetedTypeActions,
@@ -98,6 +100,7 @@ public final class RemotePeekabooServices: PeekabooServiceProviding {
             RemoteUIAutomationService(
                 client: client,
                 supportsTargetedHotkeys: supportsTargetedHotkeys,
+                supportsProcessGenerationPinnedHotkeys: supportsProcessGenerationPinnedHotkeys,
                 targetedHotkeyUnavailableReason: targetedHotkeyUnavailableReason,
                 targetedHotkeyRequiresEventSynthesizingPermission: targetedHotkeyRequiresEventSynthesizingPermission,
                 supportsTargetedTypeActions: supportsTargetedTypeActions,

--- a/Core/PeekabooCore/Sources/PeekabooCore/Support/RemoteUIAutomationService.swift
+++ b/Core/PeekabooCore/Sources/PeekabooCore/Support/RemoteUIAutomationService.swift
@@ -14,6 +14,7 @@ public class RemoteUIAutomationService: DetectElementsRequestTimeoutAdjusting, T
 {
     let client: PeekabooBridgeClient
     public let supportsTargetedHotkeys: Bool
+    public let supportsProcessGenerationPinnedHotkeys: Bool
     public let targetedHotkeyUnavailableReason: String?
     public let targetedHotkeyRequiresEventSynthesizingPermission: Bool
     public let supportsTargetedTypeActions: Bool
@@ -32,6 +33,7 @@ public class RemoteUIAutomationService: DetectElementsRequestTimeoutAdjusting, T
     public init(
         client: PeekabooBridgeClient,
         supportsTargetedHotkeys: Bool = false,
+        supportsProcessGenerationPinnedHotkeys: Bool = false,
         targetedHotkeyUnavailableReason: String? = nil,
         targetedHotkeyRequiresEventSynthesizingPermission: Bool = false,
         supportsTargetedTypeActions: Bool = false,
@@ -49,6 +51,7 @@ public class RemoteUIAutomationService: DetectElementsRequestTimeoutAdjusting, T
     {
         self.client = client
         self.supportsTargetedHotkeys = supportsTargetedHotkeys
+        self.supportsProcessGenerationPinnedHotkeys = supportsProcessGenerationPinnedHotkeys
         self.targetedHotkeyUnavailableReason = targetedHotkeyUnavailableReason
         self.targetedHotkeyRequiresEventSynthesizingPermission = targetedHotkeyRequiresEventSynthesizingPermission
         self.supportsTargetedTypeActions = supportsTargetedTypeActions
@@ -254,6 +257,39 @@ public class RemoteUIAutomationService: DetectElementsRequestTimeoutAdjusting, T
                 keys: keys,
                 holdDuration: holdDuration,
                 targetProcessIdentifier: targetProcessIdentifier)
+        } catch let envelope as PeekabooBridgeErrorEnvelope {
+            if envelope.operationMayHaveCompleted {
+                throw Self.inputDeliveryIndeterminateError(for: envelope, operation: .hotkey)
+            }
+            switch envelope.code {
+            case .permissionDenied:
+                throw Self.permissionDeniedError(for: envelope)
+            case .invalidRequest:
+                throw PeekabooError.invalidInput(envelope.message)
+            case .operationNotSupported:
+                throw PeekabooError.serviceUnavailable(envelope.message)
+            default:
+                throw envelope
+            }
+        }
+    }
+
+    public func hotkey(
+        keys: String,
+        holdDuration: Int,
+        expectedProcessIdentity: ApplicationProcessIdentity) async throws
+    {
+        guard self.supportsProcessGenerationPinnedHotkeys else {
+            throw PeekabooError.serviceUnavailable(
+                "Remote bridge host does not support process-generation-pinned background hotkeys; " +
+                    "use --no-remote or update the host")
+        }
+
+        do {
+            try await self.client.hotkey(
+                keys: keys,
+                holdDuration: holdDuration,
+                expectedProcessIdentity: expectedProcessIdentity)
         } catch let envelope as PeekabooBridgeErrorEnvelope {
             if envelope.operationMayHaveCompleted {
                 throw Self.inputDeliveryIndeterminateError(for: envelope, operation: .hotkey)

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeOperationScopeTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeOperationScopeTests.swift
@@ -56,6 +56,18 @@ struct PeekabooBridgeOperationScopeTests {
     }
 
     @Test
+    func `Generation-pinned hotkeys publish their application process scope`() {
+        let targeted = PeekabooBridgeRequest.targetedHotkey(.init(
+            keys: "cmd,a",
+            holdDuration: 10,
+            targetProcessIdentifier: self.process.processIdentifier,
+            expectedProcessIdentity: self.process))
+
+        #expect(targeted.desktopOperationScope == .process(self.process))
+        #expect(targeted.nativeLeafOwnsDesktopOperationLane)
+    }
+
+    @Test
     func `Background close and quit preserve generation-pinned scope`() {
         let identity = self.window(windowID: 73)
         let close = PeekabooBridgeRequest.backgroundCloseWindow(.init(

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeTests.swift
@@ -885,6 +885,50 @@ struct PeekabooBridgeTests {
         #expect(lastHotkey?.keys == "cmd,l")
         #expect(lastHotkey?.holdDuration == 50)
         #expect(lastHotkey?.targetProcessIdentifier == 9001)
+        #expect(lastHotkey?.expectedProcessIdentity == nil)
+    }
+
+    @Test
+    func `automation targeted hotkey forwards process-generation receipt`() async throws {
+        let stub = await MainActor.run { StubServices() }
+        let server = await MainActor.run {
+            PeekabooBridgeServer(
+                services: stub,
+                hostKind: .gui,
+                allowlistedTeams: [],
+                allowlistedBundles: [],
+                postEventAccessEvaluator: { true })
+        }
+        let identity = ApplicationProcessIdentity(processIdentifier: 9001, processStartIdentity: 1234)
+        let request = PeekabooBridgeRequest.targetedHotkey(.init(
+            keys: "cmd,l",
+            holdDuration: 50,
+            targetProcessIdentifier: identity.processIdentifier,
+            expectedProcessIdentity: identity))
+
+        let response = try await self.decode(server.decodeAndHandle(
+            JSONEncoder.peekabooBridgeEncoder().encode(request),
+            peer: nil))
+
+        guard case .ok = response else {
+            Issue.record("Expected ok response, got \(response)")
+            return
+        }
+        let lastHotkey = await stub.automationStub.lastProcessTargetedHotkey
+        #expect(lastHotkey?.expectedProcessIdentity == identity)
+    }
+
+    @Test
+    func `legacy targeted hotkey payload decodes without process receipt`() throws {
+        let data = Data(
+            #"{"keys":"cmd,l","holdDuration":50,"targetProcessIdentifier":9001}"#.utf8)
+
+        let payload = try JSONDecoder.peekabooBridgeDecoder().decode(
+            PeekabooBridgeTargetedHotkeyRequest.self,
+            from: data)
+
+        #expect(payload.targetProcessIdentifier == 9001)
+        #expect(payload.expectedProcessIdentity == nil)
     }
 
     @Test
@@ -1886,6 +1930,7 @@ final class StubAutomationService: TargetedHotkeyServiceProtocol, TargetedTypeSe
     ElementActionAutomationServiceProtocol, TargetedFocusedElementServiceProtocol,
     ExactWindowTargetedKeyboardServiceProtocol
 {
+    let supportsProcessGenerationPinnedHotkeys = true
     let supportsExactWindowTargetedKeyboard = true
     let exactWindowTargetedKeyboardUnavailableReason: String? = nil
     struct Click { let target: ClickTarget; let type: ClickType }
@@ -1893,6 +1938,7 @@ final class StubAutomationService: TargetedHotkeyServiceProtocol, TargetedTypeSe
         let keys: String
         let holdDuration: Int
         let targetProcessIdentifier: pid_t?
+        let expectedProcessIdentity: ApplicationProcessIdentity?
     }
 
     struct TargetedClick {
@@ -2128,7 +2174,24 @@ final class StubAutomationService: TargetedHotkeyServiceProtocol, TargetedTypeSe
         self.lastProcessTargetedHotkey = TargetedHotkey(
             keys: keys,
             holdDuration: holdDuration,
-            targetProcessIdentifier: targetProcessIdentifier)
+            targetProcessIdentifier: targetProcessIdentifier,
+            expectedProcessIdentity: nil)
+    }
+
+    func hotkey(
+        keys: String,
+        holdDuration: Int,
+        expectedProcessIdentity: ApplicationProcessIdentity) async throws
+    {
+        if let targetedHotkeyError {
+            throw targetedHotkeyError
+        }
+
+        self.lastProcessTargetedHotkey = TargetedHotkey(
+            keys: keys,
+            holdDuration: holdDuration,
+            targetProcessIdentifier: expectedProcessIdentity.processIdentifier,
+            expectedProcessIdentity: expectedProcessIdentity)
     }
 
     func swipe(from _: CGPoint, to _: CGPoint, duration _: Int, steps _: Int, profile _: MouseMovementProfile) async


### PR DESCRIPTION
## Summary

- pin background `press` sequences to one `ApplicationProcessIdentity` instead of a reusable numeric PID
- revalidate the process generation before and after every chord, stop later chords after target drift, and report partial sequences as retry-unsafe
- carry the optional generation receipt over Bridge protocol 1.19 while preserving legacy targeted-hotkey payload decoding
- keep foreground and exact-window keyboard behavior unchanged

## Tests

- `pnpm run format`
- `pnpm run lint`
- `pnpm run test:safe`
- `swift test --package-path Core/PeekabooAutomationKit --no-parallel` (478 passed, one environment-dependent AX case skipped)
- `RUN_AUTOMATION_READ=true PEEKABOO_INCLUDE_AUTOMATION_TESTS=true swift test --package-path Apps/CLI --filter PressCommandTests --no-parallel`
- `swift test --package-path Apps/CLI --filter CommanderBinderTests --no-parallel`
- `swift test --package-path Core/PeekabooCore --filter 'PeekabooBridgeOperationScopeTests|PeekabooBridgeTests' --no-parallel`
- source-blind signed-fixture validation: stable two-chord background delivery passed; terminating the target after chord one produced retry-unsafe guidance and no chord-two event; dead-PID reuse failed without claiming delivery
- autoreview clean after rebase onto current `origin/main`

## Documentation

- updated root and CLI changelogs
