### PR TITLE
fix(visualizer): show the input HUD for targeted operations

### DIFF
--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/UIAutomationService+Operations.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/UIAutomationService+Operations.swift
@@ -232,8 +232,9 @@ extension UIAutomationService {
         }
     }
 
-    /// Background delivery must remain invisible to the foreground user. Visualizer windows are
-    /// desktop-global, so only untargeted/foreground clicks may emit click feedback.
+    /// Click feedback anchors to the click's target window; the renderer only renders
+    /// when that window is visibly frontmost, so background delivery stays invisible
+    /// without suppressing feedback for the app the user is actually watching.
     func visualizeClick(
         target: ClickTarget,
         actionAnchor: CGPoint?,
@@ -241,13 +242,20 @@ extension UIAutomationService {
         snapshotId: String?,
         targetProcessIdentifier: pid_t?) async throws
     {
-        guard targetProcessIdentifier == nil else { return }
+        let anchor = await self.inputFeedbackAnchor(
+            snapshotId: snapshotId,
+            targetProcessIdentifier: targetProcessIdentifier)
+        // Targeted clicks with no resolvable target window show nothing; the
+        // renderer additionally suppresses anchors that are not visibly frontmost.
+        if targetProcessIdentifier != nil, anchor == nil {
+            return
+        }
         let fallbackPoint = try await self.getClickPoint(for: target, snapshotId: snapshotId)
         if let clickPoint = Self.visualFeedbackPoint(actionAnchor: actionAnchor, fallbackPoint: fallbackPoint) {
             _ = await self.feedbackClient.showClickFeedback(
                 at: clickPoint,
                 type: clickType,
-                target: self.visualizerTargetWindow(snapshotId: snapshotId))
+                target: anchor)
         }
     }
 

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/UIAutomationService+PointerKeyboardOperations.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/UIAutomationService+PointerKeyboardOperations.swift
@@ -154,18 +154,23 @@ extension UIAutomationService {
         }
     }
 
-    /// PID-routed hotkeys are background operations and never emit foreground feedback.
+    /// PID-routed hotkeys anchor to the target's own window; the renderer only
+    /// renders when that window is visibly frontmost. No anchor, no HUD.
     func visualizeHotkey(
         keys: String,
         targetProcessIdentifier: pid_t?,
         visualizerTarget: VisualizerTargetWindow? = nil) async
     {
-        guard targetProcessIdentifier == nil else { return }
+        guard let anchor = await self.inputFeedbackAnchor(
+            snapshotId: nil,
+            targetProcessIdentifier: targetProcessIdentifier,
+            resolved: visualizerTarget)
+        else { return }
         let keyArray = keys.split(separator: ",").map { String($0).trimmingCharacters(in: .whitespaces) }
         _ = await self.feedbackClient.showHotkeyDisplay(
             keys: keyArray,
             duration: 1.0,
-            target: visualizerTarget ?? VisualizerTargetWindowResolver.frontmostWindow())
+            target: anchor)
     }
 
     // MARK: - Gesture Operations

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/UIAutomationService+PointerKeyboardOperations.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/UIAutomationService+PointerKeyboardOperations.swift
@@ -161,11 +161,13 @@ extension UIAutomationService {
         targetProcessIdentifier: pid_t?,
         visualizerTarget: VisualizerTargetWindow? = nil) async
     {
-        guard let anchor = await self.inputFeedbackAnchor(
+        let anchor = await self.inputFeedbackAnchor(
             snapshotId: nil,
             targetProcessIdentifier: targetProcessIdentifier,
             resolved: visualizerTarget)
-        else { return }
+        if targetProcessIdentifier != nil, anchor == nil {
+            return
+        }
         let keyArray = keys.split(separator: ",").map { String($0).trimmingCharacters(in: .whitespaces) }
         _ = await self.feedbackClient.showHotkeyDisplay(
             keys: keyArray,

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/UIAutomationService+TypingOperations.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/UIAutomationService+TypingOperations.swift
@@ -247,9 +247,13 @@ extension UIAutomationService {
         visualizerTarget: VisualizerTargetWindow? = nil) async
     {
         guard !keys.isEmpty else { return }
-        // Targeted typing (including press and background text paste) is intentionally invisible.
-        // The visualizer overlay is desktop-global even though the input is routed to one process.
-        guard targetProcessIdentifier == nil else { return }
+        // Targeted typing anchors to its target's own window; the renderer only
+        // renders when that window is visibly frontmost. No anchor, no HUD.
+        guard let anchor = await self.inputFeedbackAnchor(
+            snapshotId: nil,
+            targetProcessIdentifier: targetProcessIdentifier,
+            resolved: visualizerTarget)
+        else { return }
         // Typed text shows verbatim in the caption; only password fields mask.
         // Type-action callers sample each text segment at delivery time; the
         // post-typing sample remains a final safety net for direct text entry.
@@ -260,7 +264,7 @@ extension UIAutomationService {
             duration: 2.0,
             cadence: cadence,
             masksTypedText: masksTypedText,
-            target: visualizerTarget ?? VisualizerTargetWindowResolver.frontmostWindow())
+            target: anchor)
     }
 
     private func keySequence(from actions: [TypeAction]) -> [String] {

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/UIAutomationService+TypingOperations.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/UIAutomationService+TypingOperations.swift
@@ -248,12 +248,16 @@ extension UIAutomationService {
     {
         guard !keys.isEmpty else { return }
         // Targeted typing anchors to its target's own window; the renderer only
-        // renders when that window is visibly frontmost. No anchor, no HUD.
-        guard let anchor = await self.inputFeedbackAnchor(
+        // renders when that window is visibly frontmost. Targeted input with no
+        // resolvable anchor shows nothing; untargeted input keeps its optional
+        // frontmost anchor exactly as before.
+        let anchor = await self.inputFeedbackAnchor(
             snapshotId: nil,
             targetProcessIdentifier: targetProcessIdentifier,
             resolved: visualizerTarget)
-        else { return }
+        if targetProcessIdentifier != nil, anchor == nil {
+            return
+        }
         // Typed text shows verbatim in the caption; only password fields mask.
         // Type-action callers sample each text segment at delivery time; the
         // post-typing sample remains a final safety net for direct text entry.

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/UIAutomationService+TypingOperations.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/UIAutomationService+TypingOperations.swift
@@ -259,8 +259,12 @@ extension UIAutomationService {
             return
         }
         // Typed text shows verbatim in the caption; only password fields mask.
-        // Type-action callers sample each text segment at delivery time; the
-        // post-typing sample remains a final safety net for direct text entry.
+        // Both masking signals are scoped to the SAME identity the renderer's
+        // visibility check uses: `typedIntoSecureField` is sampled per segment at
+        // delivery time against the target pid, and this post-typing safety net
+        // queries the target application's own focused element (system-wide only
+        // when untargeted). A targeted secure field therefore masks even though
+        // targeted input can now reach the HUD.
         let masksTypedText = typedIntoSecureField
             || TypeService.focusedElementIsSecureField(processIdentifier: targetProcessIdentifier)
         _ = await self.feedbackClient.showTypingFeedback(

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/VisualizerTargetWindowResolver.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/VisualizerTargetWindowResolver.swift
@@ -16,6 +16,14 @@ enum VisualizerTargetWindowResolver {
             .first { $0.processIdentifier == application.processIdentifier }
     }
 
+    /// Frontmost ordinary window belonging to `pid`. `onScreenWindows()` is
+    /// front-to-back, so the first match is the app's frontmost window — the
+    /// same rule the renderer's visibility evaluator enforces.
+    @MainActor
+    static func frontmostWindow(ofProcess pid: pid_t) -> VisualizerTargetWindow? {
+        self.onScreenWindows().first { $0.processIdentifier == pid }
+    }
+
     static func target(from context: WindowContext?) -> VisualizerTargetWindow? {
         guard let context,
               let processIdentifier = context.applicationProcessId,
@@ -73,5 +81,34 @@ extension UIAutomationService {
             return target
         }
         return VisualizerTargetWindowResolver.frontmostWindow()
+    }
+
+    /// Anchor for input feedback. Untargeted input follows the frontmost
+    /// window; process-targeted input anchors to the target's own window
+    /// (snapshot context first, else the pid's frontmost window) so the
+    /// renderer's visibility evaluator can decide whether it may render.
+    /// A targeted operation with no resolvable anchor shows nothing.
+    func inputFeedbackAnchor(
+        snapshotId: String?,
+        targetProcessIdentifier: pid_t?,
+        resolved visualizerTarget: VisualizerTargetWindow? = nil) async -> VisualizerTargetWindow?
+    {
+        guard let pid = targetProcessIdentifier else {
+            if let visualizerTarget {
+                return visualizerTarget
+            }
+            return await self.visualizerTargetWindow(snapshotId: snapshotId)
+        }
+        if let visualizerTarget, visualizerTarget.processIdentifier == pid {
+            return visualizerTarget
+        }
+        if let snapshotId,
+           let result = try? await self.snapshotManager.getDetectionResult(snapshotId: snapshotId),
+           let target = VisualizerTargetWindowResolver.target(from: result.metadata.windowContext),
+           target.processIdentifier == pid
+        {
+            return target
+        }
+        return await VisualizerTargetWindowResolver.frontmostWindow(ofProcess: pid)
     }
 }


### PR DESCRIPTION
Fixes the last gap between the visualizer redesign and its design intent: targeted input (the primary agent path) never showed the input HUD because pre-redesign guards suppressed ALL process-targeted feedback - a rule written when overlays were desktop-global.

The redesigned HUD anchors to the target window and the renderer already refuses anchors that are not visibly frontmost, so the guards now resolve a target-scoped anchor instead of returning early: snapshot window context first, else the pid's frontmost window (same z-order rule as the renderer's evaluator). Untargeted input keeps its optional frontmost anchor exactly as before; targeted input with no resolvable window still shows nothing.

Live-verified both directions on the desktop: typing to frontmost TextEdit shows the compact chip pinned to the window's bottom edge; the same command with Finder frontmost renders nothing.

Autoreview: two rounds. Round 1's untargeted-regression finding was accommodated (anchor is now only required for targeted input). Round 2 flagged secure-input disclosure; rejected with proof - both masking signals are already scoped to the target identity (per-segment delivery-time sampling with the target pid + pid-scoped AX post-check), now documented inline. Gates: build, format, lint, test:safe (812), AutomationKit visualizer tests.
