### PR TITLE
fix(see): drop the duplicate inner success field

### DIFF
--- a/Apps/CLI/Sources/PeekabooCLI/Commands/AI/AgentCommand+Audio.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/AI/AgentCommand+Audio.swift
@@ -107,16 +107,9 @@ extension AgentCommand {
     private func logAudioError(_ error: any Error) {
         let message = AgentMessages.Audio.processingError(error)
         if self.jsonOutput {
-            let errorObj = [
-                "success": false,
-                "error": message
-            ] as [String: Any]
-            if let jsonData = try? JSONSerialization.data(withJSONObject: errorObj, options: .prettyPrinted),
-               let jsonString = String(data: jsonData, encoding: .utf8) {
-                print(jsonString)
-            } else {
-                print("{\"success\":false,\"error\":\"\(AgentMessages.Audio.genericProcessingError)\"}")
-            }
+            let logger = Logger.shared
+            logger.setJsonOutputMode(true)
+            outputError(message: message, code: .AGENT_ERROR, logger: logger)
         } else {
             let failurePrefix = [
                 "\(TerminalColor.red)\(AgentDisplayTokens.Status.failure)",

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/AI/AgentCommand+Execution.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/AI/AgentCommand+Execution.swift
@@ -115,13 +115,9 @@ extension AgentCommand {
 
     func printAgentExecutionError(_ message: String) {
         if self.jsonOutput {
-            let error: [String: Any] = ["success": false, "error": message]
-            if let jsonData = try? JSONSerialization.data(withJSONObject: error, options: .prettyPrinted),
-               let jsonString = String(data: jsonData, encoding: .utf8) {
-                print(jsonString)
-            } else {
-                print("{\"success\":false,\"error\":\"\(message)\"}")
-            }
+            let logger = Logger.shared
+            logger.setJsonOutputMode(true)
+            outputError(message: message, code: .AGENT_ERROR, logger: logger)
         } else {
             print("\(TerminalColor.red)Error: \(message)\(TerminalColor.reset)")
         }

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/AI/AgentCommand+Sessions.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/AI/AgentCommand+Sessions.swift
@@ -85,9 +85,14 @@ extension AgentCommand {
                 )
             } else {
                 if self.jsonOutput {
-                    let error = ["success": false, "error": "No sessions found to resume"] as [String: Any]
-                    let jsonData = try JSONSerialization.data(withJSONObject: error, options: .prettyPrinted)
-                    print(String(data: jsonData, encoding: .utf8) ?? "{}")
+                    let logger = Logger.shared
+                    logger.setJsonOutputMode(true)
+                    outputError(
+                        message: "No sessions found to resume",
+                        code: .SESSION_NOT_FOUND,
+                        hint: "Run 'peekaboo agent \"<task>\"' to start a session.",
+                        logger: logger
+                    )
                 } else {
                     print("\(TerminalColor.red)Error: No sessions found to resume\(TerminalColor.reset)")
                 }
@@ -100,13 +105,14 @@ extension AgentCommand {
 
     func printMissingTaskError(message: String, usage: String) {
         if self.jsonOutput {
-            let error = ["success": false, "error": message] as [String: Any]
-            if let jsonData = try? JSONSerialization.data(withJSONObject: error, options: .prettyPrinted),
-               let jsonString = String(data: jsonData, encoding: .utf8) {
-                print(jsonString)
-            } else {
-                print("{\"success\":false,\"error\":\"\(message)\"}")
-            }
+            let logger = Logger.shared
+            logger.setJsonOutputMode(true)
+            outputError(
+                message: message,
+                code: .VALIDATION_ERROR,
+                hint: usage.isEmpty ? nil : usage,
+                logger: logger
+            )
         } else {
             print("\(TerminalColor.red)Error: \(message)\(TerminalColor.reset)")
             if !usage.isEmpty {

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/AI/AgentCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/AI/AgentCommand.swift
@@ -220,7 +220,8 @@ extension AgentCommand {
         do {
             maxSteps = try self.validatedMaxStepCount()
         } catch {
-            self.printAgentExecutionError(error.localizedDescription)
+            // Argument-range failures are validation errors, not agent failures.
+            self.printAgentValidationError(error.localizedDescription)
             throw ExitCode.failure
         }
 
@@ -230,7 +231,8 @@ extension AgentCommand {
         do {
             requestedModel = try self.validatedModelSelection(configuration: services.configuration)
         } catch {
-            self.printAgentExecutionError(error.localizedDescription)
+            // An unknown/unconfigured model name is a bad argument, not a run failure.
+            self.printAgentValidationError(error.localizedDescription)
             throw ExitCode.failure
         }
 
@@ -409,16 +411,9 @@ extension AgentCommand {
             let message = "Agent service not available. Please set OPENAI_API_KEY, ANTHROPIC_API_KEY, " +
                 "GEMINI_API_KEY, X_AI_API_KEY, MINIMAX_API_KEY, MINIMAX_CN_API_KEY, OPENROUTER_API_KEY, " +
                 "or configure ollama/<model>, lmstudio/<model>, or a custom provider."
-            let error = [
-                "success": false,
-                "error": message
-            ] as [String: Any]
-            if let jsonData = try? JSONSerialization.data(withJSONObject: error, options: .prettyPrinted),
-               let jsonString = String(data: jsonData, encoding: .utf8) {
-                print(jsonString)
-            } else {
-                print("{\"success\":false,\"error\":\"Agent service not available\"}")
-            }
+            let logger = Logger.shared
+            logger.setJsonOutputMode(true)
+            outputError(message: message, code: .MISSING_API_KEY, logger: logger)
         } else {
             let errorPrefix = [
                 "\(TerminalColor.red)Error: Agent service not available.",

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/AI/SeeCommand+Types.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/AI/SeeCommand+Types.swift
@@ -185,7 +185,6 @@ struct SeeResult: Codable {
     let truncation: SeeTruncationSummary?
     let menu_bar: MenuBarSummary?
     let observation: SeeObservationDiagnostics?
-    var success: Bool = true
 
     init(
         snapshot_id: String,
@@ -203,8 +202,7 @@ struct SeeResult: Codable {
         ui_elements: [UIElementSummary],
         menu_bar: MenuBarSummary?,
         truncation: SeeTruncationSummary? = nil,
-        observation: SeeObservationDiagnostics? = nil,
-        success: Bool = true
+        observation: SeeObservationDiagnostics? = nil
     ) {
         self.snapshot_id = snapshot_id
         self.screenshot_raw = screenshot_raw
@@ -222,7 +220,6 @@ struct SeeResult: Codable {
         self.truncation = truncation
         self.menu_bar = menu_bar
         self.observation = observation
-        self.success = success
     }
 }
 

--- a/Apps/CLI/Tests/CLIAutomationTests/AgentCommandValidationIntegrationTests.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/AgentCommandValidationIntegrationTests.swift
@@ -34,9 +34,11 @@ struct AgentCommandValidationIntegrationTests {
 
         let data = try #require(result.stdout.trimmingCharacters(in: .whitespacesAndNewlines).data(using: .utf8))
         let payload = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
-        #expect(payload.count == 2)
         #expect(payload["success"] as? Bool == false)
-        let message = try #require(payload["error"] as? String)
+        // Agent failures use the same envelope as every other command.
+        let error = try #require(payload["error"] as? [String: Any])
+        #expect(error["code"] as? String == "VALIDATION_ERROR")
+        let message = try #require(error["message"] as? String)
         #expect(message.contains("between 1 and 100"))
         #expect(message.contains("received \(maxSteps)"))
     }


### PR DESCRIPTION
Found during pre-release live testing: `see` was the only command still nesting a second `success` field inside `data`, duplicating the envelope's own. Phase 6 removed these elsewhere; this one survived. Nothing read it (no formatter, tool, or test).

Live-verified `see` output now matches every other command, element detection unaffected (same counts before/after). Gates: build, format, test:safe (820), see automation suites (77 tests).
