### PR TITLE
fix(daemon): stop idle timer cancellation cascades

### DIFF
--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Add actionable text and JSON migration hints for removed v4 commands and flags, reject ambiguous press input shapes, and align `see`/`type`/`press` help with the accepted grammar.
+- Stop cancelled on-demand daemon idle timers from rescheduling one another, preventing runaway CPU and memory use after repeated Bridge activity.
 - Reject conflicting app/PID and window selectors across interaction CLI and MCP entry points before focus, observation, or mutation.
 - Require explicit `--foreground` for long-press clicks so the shared physical cursor cannot be used through an implicit delivery-mode promotion.
 - Preserve stable `verify_state` proof for a directly matched exact AX identifier/value when only unrelated accessibility siblings are unreadable, while keeping absence, mismatch, ambiguity, and target drift fail-closed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 
 ### Fixed
 - Add actionable text and JSON migration hints for removed v4 commands and flags, reject ambiguous press input shapes, and align `see`/`type`/`press` help with the accepted grammar.
+- Stop cancelled on-demand daemon idle timers from rescheduling one another, preventing runaway CPU and memory use after repeated Bridge activity.
 - Reject conflicting app/PID and window selectors across interaction CLI and MCP entry points before focus, observation, or mutation.
 - Require explicit `--foreground` for long-press clicks so the shared physical cursor cannot be used through an implicit delivery-mode promotion.
 - Preserve stable `verify_state` proof for a directly matched exact AX identifier/value when only unrelated accessibility siblings are unreadable, while keeping absence, mismatch, ambiguity, and target drift fail-closed.

--- a/Core/PeekabooCore/Sources/PeekabooCore/Daemon/PeekabooDaemon.swift
+++ b/Core/PeekabooCore/Sources/PeekabooCore/Daemon/PeekabooDaemon.swift
@@ -113,6 +113,7 @@ public final class PeekabooDaemon: PeekabooConditionalDaemonControlProviding {
     private var activeRequestCount = 0
     private var lastActivityAt: Date?
     private var idleShutdownTask: Task<Void, Never>?
+    private var idleShutdownGeneration: UInt64 = 0
     private var shutdownTask: Task<Void, Never>?
 
     public init(configuration: Configuration) {
@@ -350,14 +351,26 @@ public final class PeekabooDaemon: PeekabooConditionalDaemonControlProviding {
         self.idleShutdownTask?.cancel()
         let lastActivityAt = self.lastActivityAt ?? Date()
         let remaining = max(0.05, lastActivityAt.addingTimeInterval(idleTimeout).timeIntervalSinceNow)
+        self.idleShutdownGeneration &+= 1
+        let generation = self.idleShutdownGeneration
         self.idleShutdownTask = Task { [weak self] in
-            try? await Task.sleep(nanoseconds: UInt64(remaining * 1_000_000_000))
-            await self?.stopIfIdleTimedOut()
+            do {
+                try await Task.sleep(nanoseconds: UInt64(remaining * 1_000_000_000))
+            } catch {
+                return
+            }
+            guard !Task.isCancelled else { return }
+            await self?.stopIfIdleTimedOut(generation: generation)
         }
     }
 
-    private func stopIfIdleTimedOut() async {
-        guard !self.isStopping,
+    var idleShutdownGenerationForTesting: UInt64 {
+        self.idleShutdownGeneration
+    }
+
+    private func stopIfIdleTimedOut(generation: UInt64) async {
+        guard generation == self.idleShutdownGeneration,
+              !self.isStopping,
               self.activeRequestCount == 0,
               let idleTimeout = self.configuration.idleTimeout,
               let lastActivityAt = self.lastActivityAt,

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooDaemonTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooDaemonTests.swift
@@ -1,8 +1,8 @@
 import Foundation
 import PeekabooAutomationKit
 import PeekabooBridge
-import PeekabooCore
 import Testing
+@testable import PeekabooCore
 
 @Suite(.tags(.safe))
 @MainActor
@@ -39,6 +39,35 @@ struct PeekabooDaemonTests {
         #expect(status.activity?.idleExitAt != nil)
 
         _ = await daemon.requestStop()
+    }
+
+    @Test
+    func `cancelled idle timers cannot reschedule and cancel their successors`() async throws {
+        let daemon = PeekabooDaemon(configuration: .init(
+            mode: .auto,
+            bridgeSocketPath: "/tmp/peekaboo-test.sock",
+            allowlistedTeams: [],
+            windowTrackingEnabled: false,
+            hostKind: .onDemand,
+            idleTimeout: 0.25,
+            bridgeHostingEnabled: false))
+
+        for _ in 0..<50 {
+            #expect(await daemon.admitActivity(operation: .listApplications))
+            await daemon.recordActivityEnd(operation: .listApplications)
+        }
+
+        let expectedGeneration = daemon.idleShutdownGenerationForTesting
+        #expect(expectedGeneration == 50)
+
+        for _ in 0..<20 {
+            await Task.yield()
+        }
+        try await Task.sleep(for: .milliseconds(20))
+
+        #expect(daemon.idleShutdownGenerationForTesting == expectedGeneration)
+        #expect(await daemon.requestStop())
+        await daemon.waitUntilStopped()
     }
 
     @Test


### PR DESCRIPTION
## Summary

- make cancelled on-demand daemon idle timers return immediately instead of falling through into timeout evaluation
- generation-pin each scheduled timer so stale work cannot act on or reschedule a successor
- add a deterministic repeated-activity regression and document the resource-safety fix

## Root cause

`scheduleIdleShutdownIfNeeded` previously swallowed `Task.sleep` cancellation. A cancelled timer could therefore call `stopIfIdleTimedOut`, observe that the real deadline had not elapsed, schedule a replacement, and cancel the newer timer. Under repeated Bridge activity this became a self-sustaining task cascade. Live affected daemons reached 145–168% CPU and 2.4–4.4 GB RSS.

The regression demonstrates the failure deterministically: 50 legitimate schedules become 13,424 schedules in 39 ms with the old fallthrough. The fixed path remains at exactly 50.

## Proof

- `swift test --filter PeekabooDaemonTests` — 9/9 passed
- `pnpm run build:cli` — passed
- `pnpm run format` — clean
- `pnpm run lint` — exit 0, zero serious violations
- targeted strict SwiftLint — zero violations
- `pnpm run lint:docs` and `git diff --check` — clean
- final Autoreview — clean, no actionable findings
- Foundation-signed live proof: after 50 real Bridge `app list` requests, the isolated daemon held at 34 MB RSS and 0.6% settled CPU, exited on its 10-second idle deadline, and removed its socket

The broader serial Core suite on the pre-#361 base exposed one unrelated current-main help-description expectation for the removed `--double` flag; the daemon suite and adjacent Bridge suites were green. No UI was mutated during the live daemon proof.
