### PR TITLE
fix(capture): return exact ScreenCaptureKit window pixels

### DIFF
--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Add actionable text and JSON migration hints for removed v4 commands and flags, reject ambiguous press input shapes, and align `see`/`type`/`press` help with the accepted grammar.
 - Stop cancelled on-demand daemon idle timers from rescheduling one another, preventing runaway CPU and memory use after repeated Bridge activity.
+- Return exact window-sized pixels from automatic and modern ScreenCaptureKit capture instead of accepting a display-sized transparent canvas, and avoid SDK continuation-leak diagnostics when a quarantined screenshot callback never arrives.
 - Reject conflicting app/PID and window selectors across interaction CLI and MCP entry points before focus, observation, or mutation.
 - Require explicit `--foreground` for long-press clicks so the shared physical cursor cannot be used through an implicit delivery-mode promotion.
 - Preserve stable `verify_state` proof for a directly matched exact AX identifier/value when only unrelated accessibility siblings are unreadable, while keeping absence, mismatch, ambiguity, and target drift fail-closed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 ### Fixed
 - Add actionable text and JSON migration hints for removed v4 commands and flags, reject ambiguous press input shapes, and align `see`/`type`/`press` help with the accepted grammar.
 - Stop cancelled on-demand daemon idle timers from rescheduling one another, preventing runaway CPU and memory use after repeated Bridge activity.
+- Return exact window-sized pixels from automatic and modern ScreenCaptureKit capture instead of accepting a display-sized transparent canvas, and avoid SDK continuation-leak diagnostics when a quarantined screenshot callback never arrives.
 - Reject conflicting app/PID and window selectors across interaction CLI and MCP entry points before focus, observation, or mutation.
 - Require explicit `--foreground` for long-press clicks so the shared physical cursor cannot be used through an implicit delivery-mode promotion.
 - Preserve stable `verify_state` proof for a directly matched exact AX identifier/value when only unrelated accessibility siblings are unreadable, while keeping absence, mismatch, ambiguity, and target drift fail-closed.

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/LegacyScreenCaptureOperator+PrivateScreenCaptureKit.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/LegacyScreenCaptureOperator+PrivateScreenCaptureKit.swift
@@ -42,7 +42,8 @@ extension LegacyScreenCaptureOperator {
 
     func captureWindowWithPrivateScreenCaptureKit(
         windowID: CGWindowID,
-        correlationId: String) async throws -> CGImage
+        correlationId: String,
+        scale: CaptureScalePreference) async throws -> CGImage
     {
         #if PEEKABOO_DISABLE_PRIVATE_SCK_WINDOW_LOOKUP
         throw OperationError.captureFailed(
@@ -53,9 +54,18 @@ extension LegacyScreenCaptureOperator {
         let config = self.makeScreenshotConfiguration()
         config.captureResolution = .best
         config.ignoreShadowsSingleWindow = true
+        config.scalesToFit = true
         if #available(macOS 14.2, *) {
             config.includeChildWindows = false
         }
+        let pixelSize = ScreenCapturePlanner.desktopIndependentWindowPixelSize(
+            filterContentRect: filter.contentRect,
+            fallbackWindowFrame: scWindow.frame,
+            pointPixelScale: CGFloat(filter.pointPixelScale),
+            fallbackNativeScale: 1,
+            useNativeScale: scale == .native)
+        config.width = pixelSize.width
+        config.height = pixelSize.height
 
         self.logger.debug(
             "Capturing window via private ScreenCaptureKit window-id lookup",
@@ -65,9 +75,19 @@ extension LegacyScreenCaptureOperator {
             ],
             correlationId: correlationId)
 
-        return try await ScreenCaptureKitCaptureGate.captureImage(
+        let image = try await ScreenCaptureKitCaptureGate.captureImage(
             contentFilter: filter,
             configuration: config)
+        guard ScreenCapturePlanner.matchesExpectedWindowPixelSize(
+            imageWidth: image.width,
+            imageHeight: image.height,
+            expected: pixelSize)
+        else {
+            throw OperationError.captureFailed(
+                reason: "Private ScreenCaptureKit returned \(image.width)x\(image.height) for a " +
+                    "\(pixelSize.width)x\(pixelSize.height) window capture")
+        }
+        return image
         #endif
     }
 

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/LegacyScreenCaptureOperator+Support.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/LegacyScreenCaptureOperator+Support.swift
@@ -8,14 +8,16 @@ extension LegacyScreenCaptureOperator {
     @MainActor
     func captureWindowWithCGWindowList(
         windowID: CGWindowID,
-        correlationId: String) async throws -> CGImage
+        correlationId: String,
+        scale: CaptureScalePreference) async throws -> CGImage
     {
         let allowsPrivateSCKLookup = ScreenCaptureService.captureEnginePreference != .legacy
         if Self.privateScreenCaptureKitWindowLookupEnabled(), allowsPrivateSCKLookup {
             do {
                 return try await self.captureWindowWithPrivateScreenCaptureKit(
                     windowID: windowID,
-                    correlationId: correlationId)
+                    correlationId: correlationId,
+                    scale: scale)
             } catch {
                 self.logger.warning(
                     "Private ScreenCaptureKit window capture failed, falling back to system screencapture",

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/LegacyScreenCaptureOperator+Window.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/LegacyScreenCaptureOperator+Window.swift
@@ -73,7 +73,10 @@ extension LegacyScreenCaptureOperator {
             ],
             correlationId: correlationId)
 
-        let image = try await self.captureWindowImage(windowID: windowID, correlationId: correlationId)
+        let image = try await self.captureWindowImage(
+            windowID: windowID,
+            correlationId: correlationId,
+            scale: scale)
         let mutationIdentity: WindowMutationIdentity? = mutationSnapshot.flatMap { snapshot in
             guard snapshot.ownerProcessStartIdentity == app.processStartIdentity else { return nil }
             return Self.validatedMutationIdentity(snapshot)
@@ -178,7 +181,10 @@ extension LegacyScreenCaptureOperator {
             ],
             correlationId: correlationId)
 
-        let image = try await self.captureWindowImage(windowID: windowID, correlationId: correlationId)
+        let image = try await self.captureWindowImage(
+            windowID: windowID,
+            correlationId: correlationId,
+            scale: scale)
         let mutationIdentity = mutationSnapshot.flatMap(Self.validatedMutationIdentity)
 
         let bounds = Self.windowBounds(from: targetWindow, fallbackImage: image)
@@ -276,11 +282,13 @@ extension LegacyScreenCaptureOperator {
 
     private func captureWindowImage(
         windowID: CGWindowID,
-        correlationId: String) async throws -> CGImage
+        correlationId: String,
+        scale: CaptureScalePreference) async throws -> CGImage
     {
         let image = try await self.captureWindowWithCGWindowList(
             windowID: windowID,
-            correlationId: correlationId)
+            correlationId: correlationId,
+            scale: scale)
         self.logger.debug(
             "Captured window via isolated legacy path",
             metadata: ["windowID": String(windowID)],

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/ScreenCaptureKitCaptureGate.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/ScreenCaptureKitCaptureGate.swift
@@ -62,9 +62,19 @@ enum ScreenCaptureKitCaptureGate {
             seconds: 3.0,
             operationName: "SCScreenshotManager.captureImage")
         {
-            try await SCScreenshotManager.captureImage(
-                contentFilter: contentFilter,
-                configuration: configuration)
+            try await ScreenCaptureKitCallbackBridge<CGImage>.wait { completion in
+                SCScreenshotManager.captureImage(
+                    contentFilter: contentFilter,
+                    configuration: configuration)
+                { image, error in
+                    if let image {
+                        completion(.success(image))
+                    } else {
+                        completion(.failure(error ?? OperationError.captureFailed(
+                            reason: "SCScreenshotManager returned neither an image nor an error")))
+                    }
+                }
+            }
         }
     }
 
@@ -90,6 +100,23 @@ enum ScreenCaptureKitCaptureGate {
             try await SCShareableContent.excludingDesktopWindows(
                 excludingDesktopWindows,
                 onScreenWindowsOnly: onScreenWindowsOnly)
+        }
+    }
+}
+
+/// ScreenCaptureKit has shipped completion paths that never call back. The outer operation coordinator owns
+/// that abandoned lifetime and quarantines the SCK lane until a late callback arrives. An unsafe continuation is
+/// intentional here: unlike the SDK-generated checked async overlay, process teardown cannot emit a misleading
+/// continuation-leak diagnostic for framework work that Peekaboo has already timed out and quarantined.
+enum ScreenCaptureKitCallbackBridge<Value: Sendable> {
+    static func wait(
+        _ start: @escaping @Sendable (@escaping @Sendable (Result<Value, any Error>) -> Void) -> Void) async throws
+        -> Value
+    {
+        try await withUnsafeThrowingContinuation { continuation in
+            start { result in
+                continuation.resume(with: result)
+            }
         }
     }
 }

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/ScreenCaptureKitOperator+Window.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/ScreenCaptureKitOperator+Window.swift
@@ -79,9 +79,7 @@ extension ScreenCaptureKitOperator {
         let image = try await self.captureWindowImage(
             targetWindow,
             scale: scale,
-            scalePlan: scalePlan,
-            display: targetDisplay,
-            useDisplayBoundFilter: resolution.isMapped)
+            scalePlan: scalePlan)
         let imageData = try image.pngData()
         let mutationIdentity: WindowMutationIdentity? = mutationSnapshot.flatMap { snapshot in
             guard snapshot.ownerProcessStartIdentity == app.processStartIdentity else { return nil }
@@ -167,9 +165,7 @@ extension ScreenCaptureKitOperator {
         let image = try await self.captureWindowImage(
             targetWindow,
             scale: scale,
-            scalePlan: scalePlan,
-            display: targetDisplay,
-            useDisplayBoundFilter: resolution.isMapped)
+            scalePlan: scalePlan)
         let imageData = try image.pngData()
         let mutationIdentity = mutationSnapshot.flatMap(Self.validatedMutationIdentity)
 
@@ -229,68 +225,59 @@ extension ScreenCaptureKitOperator {
     func captureWindowImage(
         _ window: SCWindow,
         scale: CaptureScalePreference,
-        scalePlan: ScreenCaptureScaleResolver.Plan,
-        display: SCDisplay,
-        useDisplayBoundFilter: Bool = true) async throws -> CGImage
+        scalePlan: ScreenCaptureScaleResolver.Plan) async throws -> CGImage
     {
         try await RetryHandler.withRetry(policy: .standard) {
             try await self.createScreenshot(
                 of: window,
                 scale: scale,
-                targetScale: scalePlan.nativeScale,
-                display: display,
-                useDisplayBoundFilter: useDisplayBoundFilter)
+                targetScale: scalePlan.nativeScale)
         }
     }
 
     /// Capture a window screenshot.
     ///
-    /// When `useDisplayBoundFilter` is `true` (the default), uses `SCContentFilter(display:including:)`
-    /// which stays reliable for GPU-rendered windows such as the iOS Simulator. When `false`, falls
-    /// back to `SCContentFilter(desktopIndependentWindow:)` — the ScreenCaptureKit API designed to
-    /// capture a window without needing to identify which display it lives on. The fallback path is
-    /// used when display resolution failed (multi-display setups with partial enumeration), keeping
-    /// the iOS Simulator behavior intact for the common case.
+    /// Window capture uses ScreenCaptureKit's desktop-independent filter. A display-bound filter describes a
+    /// display canvas with selected windows composited into it; on macOS 27 that path can return a display-sized
+    /// transparent surface or fail to invoke the screenshot callback. The desktop-independent contract instead
+    /// returns only the requested window while display resolution remains available for scale and metadata.
     func createScreenshot(
         of window: SCWindow,
         scale: CaptureScalePreference,
-        targetScale: CGFloat,
-        display: SCDisplay,
-        useDisplayBoundFilter: Bool = true) async throws -> CGImage
+        targetScale: CGFloat) async throws -> CGImage
     {
-        let scaleValue = scale == .native ? targetScale : 1.0
-
         let config = SCStreamConfiguration()
         config.captureResolution = .best
         config.showsCursor = false
-
-        let filter: SCContentFilter
-        let pixelSize: (width: Int, height: Int)
-        if useDisplayBoundFilter {
-            filter = SCContentFilter(display: display, including: [window])
-            pixelSize = ScreenCapturePlanner.capturePixelSize(for: window.frame, scale: scaleValue)
-            // `window.frame` is global desktop coordinates; display-bound filters require display-local `sourceRect`.
-            config.sourceRect = ScreenCapturePlanner.displayLocalSourceRect(
-                globalRect: window.frame,
-                displayFrame: display.frame)
-        } else {
-            // `desktopIndependentWindow` captures the window's full content without referencing any
-            // display, so no `sourceRect` is needed. This rescues capture on multi-display Macs where
-            // `SCShareableContent.displays` enumeration misses the display the window actually lives on.
-            filter = SCContentFilter(desktopIndependentWindow: window)
-            let filterScale = CGFloat(filter.pointPixelScale)
-            let outputScale = scale == .native && filterScale.isFinite && filterScale > 0 ? filterScale : scaleValue
-            pixelSize = ScreenCapturePlanner.capturePixelSize(
-                for: filter.contentRect,
-                fallbackFrame: window.frame,
-                scale: outputScale)
+        config.ignoreShadowsSingleWindow = true
+        config.scalesToFit = true
+        if #available(macOS 14.2, *) {
+            config.includeChildWindows = false
         }
+
+        let filter = SCContentFilter(desktopIndependentWindow: window)
+        let pixelSize = ScreenCapturePlanner.desktopIndependentWindowPixelSize(
+            filterContentRect: filter.contentRect,
+            fallbackWindowFrame: window.frame,
+            pointPixelScale: CGFloat(filter.pointPixelScale),
+            fallbackNativeScale: targetScale,
+            useNativeScale: scale == .native)
         config.width = pixelSize.width
         config.height = pixelSize.height
 
-        return try await ScreenCaptureKitCaptureGate.captureImage(
+        let image = try await ScreenCaptureKitCaptureGate.captureImage(
             contentFilter: filter,
             configuration: config)
+        guard ScreenCapturePlanner.matchesExpectedWindowPixelSize(
+            imageWidth: image.width,
+            imageHeight: image.height,
+            expected: pixelSize)
+        else {
+            throw OperationError.captureFailed(
+                reason: "ScreenCaptureKit returned \(image.width)x\(image.height) for a " +
+                    "\(pixelSize.width)x\(pixelSize.height) window capture")
+        }
+        return image
     }
 
     func windowMetadata(

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/ScreenCapturePlanner.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/ScreenCapturePlanner.swift
@@ -42,6 +42,38 @@ import Foundation
             height: self.capturePixelDimension(sourceFrame.height, scale: scale))
     }
 
+    /// Resolve the exact output size for a desktop-independent window filter.
+    ///
+    /// The filter's content rect is authoritative because ScreenCaptureKit may report a capture extent
+    /// that differs from the global WindowServer frame. The window frame remains a defensive fallback for
+    /// older/buggy framework results. Logical captures are always 1x; native captures prefer the filter's
+    /// point-to-pixel scale and fall back to the display-derived scale.
+    public static func desktopIndependentWindowPixelSize(
+        filterContentRect: CGRect,
+        fallbackWindowFrame: CGRect,
+        pointPixelScale: CGFloat,
+        fallbackNativeScale: CGFloat,
+        useNativeScale: Bool) -> (width: Int, height: Int)
+    {
+        let nativeScale = if pointPixelScale.isFinite, pointPixelScale > 0 {
+            pointPixelScale
+        } else {
+            fallbackNativeScale
+        }
+        return self.capturePixelSize(
+            for: filterContentRect,
+            fallbackFrame: fallbackWindowFrame,
+            scale: useNativeScale ? nativeScale : 1)
+    }
+
+    public static func matchesExpectedWindowPixelSize(
+        imageWidth: Int,
+        imageHeight: Int,
+        expected: (width: Int, height: Int)) -> Bool
+    {
+        imageWidth == expected.width && imageHeight == expected.height
+    }
+
     private static func captureSizeSourceFrame(_ frame: CGRect, fallbackFrame: CGRect?) -> CGRect {
         if self.isUsableCaptureSizeFrame(frame) {
             return frame

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ScreenCaptureKitTimeoutRaceTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ScreenCaptureKitTimeoutRaceTests.swift
@@ -6,6 +6,21 @@ import Testing
 
 struct ScreenCaptureKitTimeoutRaceTests {
     @Test
+    func `callback bridge returns success and failure without the SDK async overlay`() async throws {
+        let value = try await ScreenCaptureKitCallbackBridge<Int>.wait { completion in
+            completion(.success(42))
+        }
+        #expect(value == 42)
+
+        struct ExpectedError: Error {}
+        await #expect(throws: ExpectedError.self) {
+            try await ScreenCaptureKitCallbackBridge<Int>.wait { completion in
+                completion(.failure(ExpectedError()))
+            }
+        }
+    }
+
+    @Test
     func `cancellation before continuation installation still resumes the caller`() async {
         let race = ScreenCaptureKitTimeoutRace<Int>()
         race.cancel()

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ScreenCapturePlannerTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ScreenCapturePlannerTests.swift
@@ -1,0 +1,52 @@
+import CoreGraphics
+import Testing
+@testable @_spi(Testing) import PeekabooAutomationKit
+
+struct ScreenCapturePlannerTests {
+    @Test
+    func `desktop independent logical window capture cannot become a display canvas`() {
+        let size = ScreenCapturePlanner.desktopIndependentWindowPixelSize(
+            filterContentRect: CGRect(x: 420, y: 180, width: 935, height: 598),
+            fallbackWindowFrame: CGRect(x: 0, y: 0, width: 1920, height: 1080),
+            pointPixelScale: 2,
+            fallbackNativeScale: 2,
+            useNativeScale: false)
+
+        #expect(size.width == 935)
+        #expect(size.height == 598)
+        #expect(ScreenCapturePlanner.matchesExpectedWindowPixelSize(
+            imageWidth: 935,
+            imageHeight: 598,
+            expected: size))
+        #expect(!ScreenCapturePlanner.matchesExpectedWindowPixelSize(
+            imageWidth: 1920,
+            imageHeight: 1080,
+            expected: size))
+    }
+
+    @Test
+    func `desktop independent native capture uses filter scale`() {
+        let size = ScreenCapturePlanner.desktopIndependentWindowPixelSize(
+            filterContentRect: CGRect(x: -900, y: 80, width: 935, height: 598),
+            fallbackWindowFrame: CGRect(x: -900, y: 80, width: 1920, height: 1080),
+            pointPixelScale: 2,
+            fallbackNativeScale: 1,
+            useNativeScale: true)
+
+        #expect(size.width == 1870)
+        #expect(size.height == 1196)
+    }
+
+    @Test
+    func `desktop independent capture falls back from unusable filter geometry and scale`() {
+        let size = ScreenCapturePlanner.desktopIndependentWindowPixelSize(
+            filterContentRect: .zero,
+            fallbackWindowFrame: CGRect(x: 400, y: 200, width: 935, height: 598),
+            pointPixelScale: .nan,
+            fallbackNativeScale: 2,
+            useNativeScale: true)
+
+        #expect(size.width == 1870)
+        #expect(size.height == 1196)
+    }
+}


### PR DESCRIPTION
## Summary

Fix exact-window capture so automatic and forced-modern ScreenCaptureKit paths return only the requested window,
never a display-sized transparent canvas. Keep the existing bounded capture gate, but call Apple's completion-handler
API directly so a framework callback that never arrives can be timed out and quarantined without the SDK async
overlay emitting a misleading checked-continuation leak diagnostic.

## Root cause

- Auto is legacy-first, but its private WindowServer-ID lookup re-entered ScreenCaptureKit with a
  desktop-independent filter and left `SCStreamConfiguration.width`/`height` at their 1920x1080 defaults.
- Forced modern used a display-bound including-window filter plus a display-local `sourceRect`. On macOS 27 that
  path could return a transparent display canvas or never invoke the screenshot callback.
- The SDK-generated async `SCScreenshotManager.captureImage` overlay owns a checked continuation, so an abandoned
  Apple callback printed a continuation-leak warning even though Peekaboo had already timed out and quarantined the
  operation.

## Changes

- Use the canonical desktop-independent window filter for both automatic private-SCK and modern window capture.
- Size output from the filter's content rect at the requested logical/native scale, with the WindowServer frame and
  display scale as defensive fallbacks.
- Require the returned `CGImage` to exactly match the planned window pixel size. A bad auto result now falls back
  instead of becoming a false success.
- Preserve logical WindowServer bounds and coordinate metadata independently from image pixel dimensions.
- Bridge the completion-handler API with a lifetime intentionally owned by the existing timeout/quarantine
  coordinator; the SCK lane remains held until a late callback really arrives.

This matches Cua's current macOS window-capture design: desktop-independent filter, exact content-rect sizing,
bounded native worker, and compatibility fallback.

## Proof

- Focused capture planner/callback/gate suites: 11/11 passed.
- `swift build --package-path Apps/CLI` passed.
- SwiftFormat changed zero files; full SwiftLint exited 0 with zero serious findings; strict SwiftLint found zero
  violations in all changed Swift files.
- Docs lint and `git diff --check` passed.
- Structured Autoreview: clean, no accepted/actionable findings, correctness 0.98.

A full 480-test AutomationKit run passed 479 tests; one cancellation-latency assertion missed its one-second bound
while the concurrent suite was saturated, then passed in isolation at 0.019 seconds and in the complete affected
gate suite.

Foundation-signed live validation used an existing background Calendar window (PID 858, window ID 119,
WindowServer bounds 935x598):

| Capture | Pixels | Wall time |
| --- | ---: | ---: |
| modern logical | 935x598 | 0.49 s |
| modern native (1x display) | 935x598 | 0.43 s |
| auto logical | 935x598 | 0.41 s |
| explicit classic logical | 935x598 | 0.64 s |
| immediate modern repeat | 935x598 | 0.46 s |

All images were at least 99.9685% nontransparent. The 10 ms monitor recorded zero focus, top-window, cursor,
clipboard, overlay, or Calendar-geometry changes. An exact-build on-demand daemon also served a fully opaque 935x598
automatic capture in 0.56 seconds, then exited on its idle deadline and removed its socket with no leaked process.
