### PR TITLE
fix(agent): fail structured terminal errors

### DIFF
--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove the MCP `list`, `hotkey`, and `swipe` tools plus legacy agent shims; rename MCP `perform_action` to `action`.
 
 ### Fixed
+- Normalize agent failures and `see` success JSON under the shared result envelope, with nonzero terminal failures, specific validation/credential/session/runtime codes, and no duplicate inner `success` field.
 - Add actionable migration hints for removed v4 commands and flags, reject ambiguous press input shapes, and align `see`/`type`/`press` help with the accepted grammar.
 - Stop cancelled on-demand daemon idle timers from rescheduling one another after repeated Bridge activity.
 - Reject conflicting app/PID and window selectors before focus, observation, or mutation.

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/AI/AgentCommand+Audio.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/AI/AgentCommand+Audio.swift
@@ -10,19 +10,18 @@ import PeekabooCore
 
 @available(macOS 14.0, *)
 extension AgentCommand {
-    func buildExecutionTask() async throws -> String? {
+    func buildExecutionTask() async throws -> String {
         if self.audio || self.audioFile != nil {
             return try await self.processAudioInput()
         }
 
         guard let providedTask = self.task else {
-            self.printMissingTaskError(message: "Task argument is required", usage: "")
-            return nil
+            try self.failAgentCommand(message: "Task argument is required", code: .VALIDATION_ERROR)
         }
         return providedTask
     }
 
-    private func processAudioInput() async throws -> String? {
+    private func processAudioInput() async throws -> String {
         self.logAudioStartMessage()
         let audioService = self.services.audioInput
 
@@ -30,20 +29,23 @@ extension AgentCommand {
             let transcript = try await self.transcribeAudio(using: audioService)
             self.logTranscriptionSuccess(transcript)
             return self.composeExecutionTask(with: transcript)
+        } catch let error as CancellationError {
+            throw error
         } catch {
-            self.logAudioError(error)
-            return nil
+            try self.failAgentCommand(
+                message: AgentMessages.Audio.processingError(error),
+                code: .AGENT_ERROR)
         }
     }
 
     private func logAudioStartMessage() {
-        guard !self.jsonOutput && !self.quiet else { return }
+        guard !self.jsonOutput, !self.quiet else { return }
         if let audioPath = self.audioFile {
             print("\(TerminalColor.cyan)🎙️ Processing audio file: \(audioPath)\(TerminalColor.reset)")
         } else {
             let recordingMessage = [
                 "\(TerminalColor.cyan)🎙️ Starting audio recording...",
-                " (Press Ctrl+C to stop)\(TerminalColor.reset)"
+                " (Press Ctrl+C to stop)\(TerminalColor.reset)",
             ].joined()
             print(recordingMessage)
         }
@@ -84,10 +86,10 @@ extension AgentCommand {
     }
 
     private func logTranscriptionSuccess(_ transcript: String) {
-        guard !self.jsonOutput && !self.quiet else { return }
+        guard !self.jsonOutput, !self.quiet else { return }
         let message = [
             "\(TerminalColor.green)\(AgentDisplayTokens.Status.success) Transcription complete",
-            "\(TerminalColor.reset)"
+            "\(TerminalColor.reset)",
         ].joined()
         print(message)
         print("\(TerminalColor.gray)Transcript: \(transcript.prefix(100))...\(TerminalColor.reset)")
@@ -102,22 +104,5 @@ extension AgentCommand {
             return transcript
         }
         return "\(providedTask)\n\nAudio transcript:\n\(transcript)"
-    }
-
-    private func logAudioError(_ error: any Error) {
-        let message = AgentMessages.Audio.processingError(error)
-        if self.jsonOutput {
-            let logger = Logger.shared
-            logger.setJsonOutputMode(true)
-            outputError(message: message, code: .AGENT_ERROR, logger: logger)
-        } else {
-            let failurePrefix = [
-                "\(TerminalColor.red)\(AgentDisplayTokens.Status.failure)",
-                " ",
-                message
-            ].joined()
-            let audioErrorMessage = [failurePrefix, "\(TerminalColor.reset)"].joined()
-            print(audioErrorMessage)
-        }
     }
 }

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/AI/AgentCommand+Chat.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/AI/AgentCommand+Chat.swift
@@ -17,28 +17,24 @@ extension AgentCommand {
         let underlyingError: any Error
     }
 
-    private func ensureChatModePreconditions() -> Bool {
+    private func validateChatModePreconditions() throws {
         let flags = AgentChatPreconditions.Flags(
             jsonOutput: self.jsonOutput,
             quiet: self.quiet,
             dryRun: self.dryRun,
             noCache: self.noCache,
             audio: self.audio,
-            audioFileProvided: self.audioFile != nil
-        )
+            audioFileProvided: self.audioFile != nil)
         if let violation = AgentChatPreconditions.firstViolation(for: flags) {
-            self.printAgentExecutionError(violation)
-            return false
+            try self.failAgentCommand(message: violation, code: .VALIDATION_ERROR)
         }
-        return true
     }
 
     func printNonInteractiveChatHelp() {
         if self.jsonOutput {
             self
                 .printAgentExecutionError(
-                    AgentMessages.Chat.nonInteractiveHelp
-                )
+                    AgentMessages.Chat.nonInteractiveHelp)
             return
         }
 
@@ -58,11 +54,9 @@ extension AgentCommand {
         requestedModel: LanguageModel?,
         initialPrompt: String?,
         capabilities: TerminalCapabilities,
-        queueMode: QueueMode
-    ) async throws {
-        guard self.ensureChatModePreconditions() else {
-            throw ExitCode.failure
-        }
+        queueMode: QueueMode) async throws
+    {
+        try self.validateChatModePreconditions()
 
         if self.shouldUseTauTUIChat(capabilities: capabilities) {
             do {
@@ -71,15 +65,13 @@ extension AgentCommand {
                     requestedModel: requestedModel,
                     initialPrompt: initialPrompt,
                     capabilities: capabilities,
-                    queueMode: queueMode
-                )
+                    queueMode: queueMode)
                 return
             } catch is ExitCode {
                 throw ExitCode.failure
             } catch {
                 self.printAgentExecutionError(
-                    "Failed to launch TauTUI chat: \(error.localizedDescription). Falling back to basic chat."
-                )
+                    "Failed to launch TauTUI chat: \(error.localizedDescription). Falling back to basic chat.")
             }
         }
 
@@ -88,8 +80,7 @@ extension AgentCommand {
             requestedModel: requestedModel,
             initialPrompt: initialPrompt,
             capabilities: capabilities,
-            queueMode: queueMode
-        )
+            queueMode: queueMode)
     }
 
     @MainActor
@@ -98,32 +89,30 @@ extension AgentCommand {
         requestedModel: LanguageModel?,
         initialPrompt: String?,
         capabilities: TerminalCapabilities,
-        queueMode: QueueMode
-    ) async throws {
+        queueMode: QueueMode) async throws
+    {
         let failTasklessResumeTurn = self.shouldFailTasklessResumeTurn(capabilities: capabilities)
         var turnContext = ChatTurnContext(
             sessionId: nil,
             requestedModel: requestedModel,
             queueMode: queueMode,
-            queuedWhileRunning: []
-        )
+            queuedWhileRunning: [])
         do {
             turnContext.sessionId = try await self.initialChatSessionId(agentService)
-        } catch {
-            self.printAgentExecutionError(error.localizedDescription)
+        } catch is ExitCode {
             throw ExitCode.failure
+        } catch {
+            try self.failAgentCommand(message: error.localizedDescription, code: .AGENT_ERROR)
         }
 
         let modelDescription = await self.describeChatModel(
             requestedModel,
             sessionId: turnContext.sessionId,
-            agentService: agentService
-        )
+            agentService: agentService)
         self.printChatWelcome(
             sessionId: turnContext.sessionId,
             modelDescription: modelDescription,
-            queueMode: queueMode
-        )
+            queueMode: queueMode)
         self.printChatHelpIntro()
 
         if let seed = initialPrompt {
@@ -159,8 +148,7 @@ extension AgentCommand {
                     batchedPrompt,
                     agentService: agentService,
                     context: &turnContext,
-                    propagateTurnFailure: failTasklessResumeTurn
-                )
+                    propagateTurnFailure: failTasklessResumeTurn)
             } catch is ReportedChatTurnError {
                 if failTasklessResumeTurn {
                     throw ExitCode.failure
@@ -185,27 +173,26 @@ extension AgentCommand {
         requestedModel: LanguageModel?,
         initialPrompt: String?,
         capabilities: TerminalCapabilities,
-        queueMode: QueueMode
-    ) async throws {
+        queueMode: QueueMode) async throws
+    {
         var activeSessionId: String?
         do {
             activeSessionId = try await self.initialChatSessionId(agentService)
-        } catch {
-            self.printAgentExecutionError(error.localizedDescription)
+        } catch is ExitCode {
             throw ExitCode.failure
+        } catch {
+            try self.failAgentCommand(message: error.localizedDescription, code: .AGENT_ERROR)
         }
 
         let modelDescription = await self.describeChatModel(
             requestedModel,
             sessionId: activeSessionId,
-            agentService: agentService
-        )
+            agentService: agentService)
         let chatUI = AgentChatUI(
             modelDescription: modelDescription,
             sessionId: activeSessionId,
             queueMode: queueMode,
-            helpLines: self.chatHelpLines
-        )
+            helpLines: self.chatHelpLines)
 
         try chatUI.start()
         defer { chatUI.stop() }
@@ -256,14 +243,12 @@ extension AgentCommand {
                 sessionId: sessionForRun,
                 requestedModel: requestedModel,
                 queueMode: queueMode,
-                delegate: tuiDelegate
-            )
+                delegate: tuiDelegate)
             currentRun = Task { @MainActor in
                 try await self.runAgentTurnForTUI(
                     batchedPrompt,
                     agentService: agentService,
-                    context: tuiContext
-                )
+                    context: tuiContext)
             }
 
             do {
@@ -301,8 +286,8 @@ extension AgentCommand {
     private func runAgentTurnForTUI(
         _ input: String,
         agentService: PeekabooAgentService,
-        context: AgentRunContext
-    ) async throws -> AgentExecutionResult {
+        context: AgentRunContext) async throws -> AgentExecutionResult
+    {
         let sessionId = context.sessionId
         let requestedModel = context.requestedModel
         let queueMode = context.queueMode
@@ -316,8 +301,7 @@ extension AgentCommand {
                 dryRun: self.dryRun,
                 queueMode: queueMode,
                 eventDelegate: delegate,
-                verbose: self.verbose
-            )
+                verbose: self.verbose)
         }
 
         return try await agentService.executeTask(
@@ -329,16 +313,17 @@ extension AgentCommand {
             queueMode: queueMode,
             eventDelegate: delegate,
             verbose: self.verbose,
-            persistSession: !self.noCache
-        )
+            persistSession: !self.noCache)
     }
 
     private func initialChatSessionId(
-        _ agentService: PeekabooAgentService
-    ) async throws -> String? {
+        _ agentService: PeekabooAgentService) async throws -> String?
+    {
         if let sessionId = self.resumeSession {
             guard try await agentService.getSessionInfo(sessionId: sessionId) != nil else {
-                throw PeekabooError.sessionNotFound(sessionId)
+                try self.failAgentCommand(
+                    message: "Session not found or expired: \(sessionId)",
+                    code: .SESSION_NOT_FOUND)
             }
             return sessionId
         }
@@ -346,7 +331,10 @@ extension AgentCommand {
         if self.resume {
             let sessions = try await agentService.listSessions()
             guard let mostRecent = sessions.first else {
-                throw PeekabooError.commandFailed("No sessions available to resume.")
+                try self.failAgentCommand(
+                    message: "No sessions found to resume",
+                    code: .SESSION_NOT_FOUND,
+                    hint: "Run 'peekaboo agent run \"<task>\"' to start a session.")
             }
             return mostRecent.id
         }
@@ -373,8 +361,8 @@ extension AgentCommand {
         _ input: String,
         agentService: PeekabooAgentService,
         context: inout ChatTurnContext,
-        propagateTurnFailure: Bool = false
-    ) async throws {
+        propagateTurnFailure: Bool = false) async throws
+    {
         let startingSessionId = context.sessionId
         let queueMode = context.queueMode
         let requestedModel = context.requestedModel
@@ -398,8 +386,7 @@ extension AgentCommand {
                         dryRun: self.dryRun,
                         queueMode: queueMode,
                         eventDelegate: streamingDelegate,
-                        verbose: self.verbose
-                    )
+                        verbose: self.verbose)
                     self.displayResult(result, delegate: outputDelegate)
                     return result
                 } catch {
@@ -416,8 +403,7 @@ extension AgentCommand {
                     maxSteps: self.resolvedMaxSteps,
                     queueMode: queueMode,
                     preserveStepLimitError: true,
-                    wrapReportedFailure: true
-                )
+                    wrapReportedFailure: true)
             }
         }
 
@@ -508,8 +494,8 @@ extension AgentCommand {
     func describeChatModel(
         _ requestedModel: LanguageModel?,
         sessionId: String?,
-        agentService: PeekabooAgentService
-    ) async -> String {
+        agentService: PeekabooAgentService) async -> String
+    {
         if let requestedModel {
             return agentService.safeModelDisplayName(for: requestedModel)
         }

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/AI/AgentCommand+Execution.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/AI/AgentCommand+Execution.swift
@@ -9,23 +9,22 @@ import TauTUI
 
 @available(macOS 14.0, *)
 extension AgentCommand {
-    func ensureAgentHasCredentials(
-        selectedModel: LanguageModel
-    ) -> Bool {
+    func requireAgentCredentials(
+        selectedModel: LanguageModel) throws
+    {
         if self.isLocalModel(selectedModel) {
-            return true
+            return
         }
 
         if self.hasCredentials(for: selectedModel) {
-            return true
+            return
         }
 
         let providerName = self.providerDisplayName(for: selectedModel)
         let envVar = self.providerEnvironmentVariable(for: selectedModel)
-        self.printAgentExecutionError(
-            "Missing API key for \(providerName). Set \(envVar) and retry."
-        )
-        return false
+        try self.failAgentCommand(
+            message: "Missing API key for \(providerName). Set \(envVar) and retry.",
+            code: .MISSING_API_KEY)
     }
 
     /// Render the agent execution result using either JSON output or a rich CLI transcript.
@@ -114,23 +113,34 @@ extension AgentCommand {
     }
 
     func printAgentExecutionError(_ message: String) {
-        if self.jsonOutput {
-            let logger = Logger.shared
-            logger.setJsonOutputMode(true)
-            outputError(message: message, code: .AGENT_ERROR, logger: logger)
-        } else {
-            print("\(TerminalColor.red)Error: \(message)\(TerminalColor.reset)")
-        }
+        self.emitAgentError(message: message, code: .AGENT_ERROR)
     }
 
     func printAgentValidationError(_ message: String) {
+        self.emitAgentError(message: message, code: .VALIDATION_ERROR)
+    }
+
+    func emitAgentError(message: String, code: ErrorCode, hint: String? = nil) {
         if self.jsonOutput {
             let logger = Logger.shared
             logger.setJsonOutputMode(true)
-            outputError(message: message, code: .VALIDATION_ERROR, logger: logger)
-        } else {
+            outputError(message: message, code: code, hint: hint, logger: logger)
+        } else if code == .VALIDATION_ERROR {
             fputs("Error: \(message)\n", stderr)
+            if let hint, !hint.isEmpty {
+                fputs("\(hint)\n", stderr)
+            }
+        } else {
+            print("\(TerminalColor.red)Error: \(message)\(TerminalColor.reset)")
+            if let hint, !hint.isEmpty {
+                print(hint)
+            }
         }
+    }
+
+    func failAgentCommand(message: String, code: ErrorCode, hint: String? = nil) throws -> Never {
+        self.emitAgentError(message: message, code: code, hint: hint)
+        throw ExitCode.failure
     }
 
     func executeAgentTask(
@@ -140,8 +150,8 @@ extension AgentCommand {
         maxSteps: Int,
         queueMode: QueueMode,
         preserveStepLimitError: Bool = false,
-        wrapReportedFailure: Bool = false
-    ) async throws -> AgentExecutionResult {
+        wrapReportedFailure: Bool = false) async throws -> AgentExecutionResult
+    {
         let outputDelegate = self.makeDisplayDelegate(for: task)
         let streamingDelegate = self.makeStreamingDelegate(using: outputDelegate)
         do {
@@ -154,8 +164,7 @@ extension AgentCommand {
                 queueMode: queueMode,
                 eventDelegate: streamingDelegate,
                 verbose: self.verbose,
-                persistSession: !self.noCache
-            )
+                persistSession: !self.noCache)
             self.displayResult(result, delegate: outputDelegate)
             let duration = String(format: "%.2f", result.metadata.executionTime)
             let sessionId = result.sessionId ?? "none"
@@ -165,8 +174,7 @@ extension AgentCommand {
                 .agent,
                 "result status=\(status) task='\(task)' model=\(result.metadata.modelName) duration=\(duration)s "
                     + "tools=\(result.metadata.toolCallCount) dry_run=\(self.dryRun) "
-                    + "session=\(sessionId) tokens=\(finalTokens)"
-            )
+                    + "session=\(sessionId) tokens=\(finalTokens)")
             return result
         } catch let error as PeekabooAgentService.AgentStepLimitExceededError where preserveStepLimitError {
             if outputDelegate?.hasReceivedError != true {

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/AI/AgentCommand+Sessions.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/AI/AgentCommand+Sessions.swift
@@ -29,8 +29,25 @@ extension AgentCommand {
         guard self.noCache else { return }
         guard !self.resume, self.resumeSession == nil, !self.listSessions else {
             throw PeekabooError.invalidInput(
-                "--no-cache cannot be combined with resume or sessions mode."
-            )
+                "--no-cache cannot be combined with resume or sessions mode.")
+        }
+    }
+
+    func requireRequestedSession(_ agentService: PeekabooAgentService) async throws {
+        if let sessionId = self.resumeSession {
+            guard try await agentService.getSessionInfo(sessionId: sessionId) != nil else {
+                try self.failAgentCommand(
+                    message: "Session not found or expired: \(sessionId)",
+                    code: .SESSION_NOT_FOUND)
+            }
+        } else if self.resume {
+            let sessions = try await agentService.listSessions()
+            guard sessions.first != nil else {
+                try self.failAgentCommand(
+                    message: "No sessions found to resume",
+                    code: .SESSION_NOT_FOUND,
+                    hint: "Run 'peekaboo agent run \"<task>\"' to start a session.")
+            }
         }
     }
 
@@ -38,15 +55,14 @@ extension AgentCommand {
         _ agentService: PeekabooAgentService,
         requestedModel: LanguageModel?,
         maxSteps: Int,
-        queueMode: QueueMode
-    ) async throws -> Bool {
+        queueMode: QueueMode) async throws -> Bool
+    {
         if let sessionId = self.resumeSession {
             guard let continuationTask = self.task else {
-                self.printMissingTaskError(
+                try self.failAgentCommand(
                     message: "Task argument required when resuming session",
-                    usage: "Usage: peekaboo agent resume <session-id>"
-                )
-                return true
+                    code: .VALIDATION_ERROR,
+                    hint: "Usage: peekaboo agent resume <session-id>")
             }
             try await self.resumeAgentSession(
                 agentService,
@@ -55,19 +71,16 @@ extension AgentCommand {
                     task: continuationTask,
                     requestedModel: requestedModel,
                     maxSteps: maxSteps,
-                    queueMode: queueMode
-                )
-            )
+                    queueMode: queueMode))
             return true
         }
 
         if self.resume {
             guard let continuationTask = self.task else {
-                self.printMissingTaskError(
+                try self.failAgentCommand(
                     message: "Task argument required when resuming",
-                    usage: "Usage: peekaboo agent resume"
-                )
-                return true
+                    code: .VALIDATION_ERROR,
+                    hint: "Usage: peekaboo agent resume")
             }
 
             let sessions = try await agentService.listSessions()
@@ -80,45 +93,17 @@ extension AgentCommand {
                         task: continuationTask,
                         requestedModel: requestedModel,
                         maxSteps: maxSteps,
-                        queueMode: queueMode
-                    )
-                )
+                        queueMode: queueMode))
             } else {
-                if self.jsonOutput {
-                    let logger = Logger.shared
-                    logger.setJsonOutputMode(true)
-                    outputError(
-                        message: "No sessions found to resume",
-                        code: .SESSION_NOT_FOUND,
-                        hint: "Run 'peekaboo agent \"<task>\"' to start a session.",
-                        logger: logger
-                    )
-                } else {
-                    print("\(TerminalColor.red)Error: No sessions found to resume\(TerminalColor.reset)")
-                }
+                try self.failAgentCommand(
+                    message: "No sessions found to resume",
+                    code: .SESSION_NOT_FOUND,
+                    hint: "Run 'peekaboo agent run \"<task>\"' to start a session.")
             }
             return true
         }
 
         return false
-    }
-
-    func printMissingTaskError(message: String, usage: String) {
-        if self.jsonOutput {
-            let logger = Logger.shared
-            logger.setJsonOutputMode(true)
-            outputError(
-                message: message,
-                code: .VALIDATION_ERROR,
-                hint: usage.isEmpty ? nil : usage,
-                logger: logger
-            )
-        } else {
-            print("\(TerminalColor.red)Error: \(message)\(TerminalColor.reset)")
-            if !usage.isEmpty {
-                print(usage)
-            }
-        }
     }
 
     @MainActor
@@ -134,8 +119,7 @@ extension AgentCommand {
                 task: summary.summary ?? "Unknown task",
                 created: summary.createdAt,
                 lastModified: summary.lastAccessedAt,
-                messageCount: summary.messageCount
-            )
+                messageCount: summary.messageCount)
         }
 
         guard !sessions.isEmpty else {
@@ -167,7 +151,7 @@ extension AgentCommand {
                 "task": session.task,
                 "createdAt": ISO8601DateFormatter().string(from: session.created),
                 "updatedAt": ISO8601DateFormatter().string(from: session.lastModified),
-                "messageCount": session.messageCount
+                "messageCount": session.messageCount,
             ]
         }
         let response = ["success": true, "sessions": sessionData] as [String: Any]
@@ -179,7 +163,7 @@ extension AgentCommand {
     private func printSessionsList(_ sessions: [AgentSessionInfo]) {
         let headerLine = [
             "\(TerminalColor.cyan)\(TerminalColor.bold)Agent Sessions:\(TerminalColor.reset)",
-            "\n"
+            "\n",
         ].joined()
         print(headerLine)
 
@@ -197,14 +181,14 @@ extension AgentCommand {
         if sessions.count > 10 {
             print([
                 "\n",
-                "\(TerminalColor.dim)... and \(sessions.count - 10) more sessions\(TerminalColor.reset)"
+                "\(TerminalColor.dim)... and \(sessions.count - 10) more sessions\(TerminalColor.reset)",
             ].joined())
         }
 
         let resumeHintLine = [
             "\n",
             "\(TerminalColor.dim)To resume: peekaboo agent resume <session-id>",
-            "\(TerminalColor.reset)"
+            "\(TerminalColor.reset)",
         ].joined()
         print(resumeHintLine)
     }
@@ -214,7 +198,7 @@ extension AgentCommand {
         let sessionLine = [
             "\(TerminalColor.blue)\(index + 1).\(TerminalColor.reset)",
             " ",
-            "\(TerminalColor.bold)\(session.id.prefix(8))\(TerminalColor.reset)"
+            "\(TerminalColor.bold)\(session.id.prefix(8))\(TerminalColor.reset)",
         ].joined()
         print(sessionLine)
         print("   Messages: \(session.messageCount)")
@@ -223,15 +207,15 @@ extension AgentCommand {
 
     private func resumeAgentSession(
         _ agentService: PeekabooAgentService,
-        request: ResumeAgentSessionRequest
-    ) async throws {
+        request: ResumeAgentSessionRequest) async throws
+    {
         if !self.jsonOutput {
             let resumingLine = [
                 "\(TerminalColor.cyan)\(TerminalColor.bold)",
                 "\(AgentDisplayTokens.Status.info)",
                 " Resuming session \(request.sessionId.prefix(8))...",
                 "\(TerminalColor.reset)",
-                "\n"
+                "\n",
             ].joined()
             print(resumingLine)
         }
@@ -246,9 +230,18 @@ extension AgentCommand {
                 maxSteps: request.maxSteps,
                 dryRun: self.dryRun,
                 queueMode: request.queueMode,
-                eventDelegate: streamingDelegate
-            )
+                eventDelegate: streamingDelegate)
             self.displayResult(result, delegate: outputDelegate)
+        } catch let error as PeekabooError {
+            if case let .sessionNotFound(sessionId) = error {
+                try self.failAgentCommand(
+                    message: "Session not found or expired: \(sessionId)",
+                    code: .SESSION_NOT_FOUND)
+            }
+            if outputDelegate?.hasReceivedError != true {
+                self.printAgentExecutionError("Failed to resume session: \(error.localizedDescription)")
+            }
+            throw ExitCode.failure
         } catch {
             if outputDelegate?.hasReceivedError != true {
                 self.printAgentExecutionError("Failed to resume session: \(error.localizedDescription)")

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/AI/AgentCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/AI/AgentCommand.swift
@@ -17,7 +17,8 @@ private var isDebugLoggingEnabled: Bool {
     }
     // Check if agent is in verbose mode
     if ProcessInfo.processInfo.arguments.contains("-v") ||
-        ProcessInfo.processInfo.arguments.contains("--verbose") {
+        ProcessInfo.processInfo.arguments.contains("--verbose")
+    {
         return true
     }
     return false
@@ -53,18 +54,14 @@ struct AgentCommand: RuntimeBackedCommand {
         usageExamples: [
             CommandUsageExample(
                 command: "peekaboo agent \"Prepare the TestFlight build for review\"",
-                description: "Start a brand-new session with a natural-language brief."
-            ),
+                description: "Start a brand-new session with a natural-language brief."),
             CommandUsageExample(
                 command: "peekaboo agent resume",
-                description: "Resume the most recent session without retyping the task."
-            ),
+                description: "Resume the most recent session without retyping the task."),
             CommandUsageExample(
                 command: "peekaboo agent resume SESSION_ID --max-steps 12",
-                description: "Resume a known session while capping the step budget."
-            )
-        ]
-    )
+                description: "Resume a known session while capping the step budget."),
+        ])
 
     @Argument(help: "Natural language description of the task to perform (optional when using --resume)")
     var task: String?
@@ -90,8 +87,7 @@ struct AgentCommand: RuntimeBackedCommand {
         AI model to use (for example: gpt-5.6, gpt-5.5, claude-fable-5, claude-sonnet-5, \
         gemini-3.5-flash, grok-4.3, minimax-m2.7, minimax-cn/m2.7, \
         ollama/<model>, lmstudio/<model>, or <custom-provider>/<model>)
-        """
-    )
+        """)
     var model: String?
     var resume = false
 
@@ -174,15 +170,13 @@ extension AgentCommand {
             aiDebugPrint(
                 "DEBUG: Caught DecodingError in run(): \(error)",
                 verbose: self.verbose,
-                jsonOutput: self.jsonOutput
-            )
+                jsonOutput: self.jsonOutput)
             throw error
         } catch let error as NSError {
             aiDebugPrint(
                 "DEBUG: Caught NSError in run(): \(error)",
                 verbose: self.verbose,
-                jsonOutput: self.jsonOutput
-            )
+                jsonOutput: self.jsonOutput)
             aiDebugPrint("DEBUG: Domain: \(error.domain)", verbose: self.verbose, jsonOutput: self.jsonOutput)
             aiDebugPrint("DEBUG: Code: \(error.code)", verbose: self.verbose, jsonOutput: self.jsonOutput)
             aiDebugPrint("DEBUG: UserInfo: \(error.userInfo)", verbose: self.verbose, jsonOutput: self.jsonOutput)
@@ -191,8 +185,7 @@ extension AgentCommand {
             aiDebugPrint(
                 "DEBUG: Caught unknown error in run(): \(error)",
                 verbose: self.verbose,
-                jsonOutput: self.jsonOutput
-            )
+                jsonOutput: self.jsonOutput)
             throw error
         }
     }
@@ -200,24 +193,22 @@ extension AgentCommand {
     @MainActor
     mutating func runInternal(runtime: CommandRuntime) async throws {
         if self.isAgentDisabled() {
-            self.emitAgentUnavailableMessage()
-            throw ExitCode.failure
+            try self.failAgentCommand(
+                message: "Agent service not available because PEEKABOO_DISABLE_AGENT is set.",
+                code: .AGENT_ERROR)
         }
 
         do {
             try self.validateSessionOptions()
         } catch {
-            self.printAgentValidationError(error.localizedDescription)
-            throw ExitCode.failure
+            try self.failAgentCommand(message: error.localizedDescription, code: .VALIDATION_ERROR)
         }
 
         let maxSteps: Int
         do {
             maxSteps = try self.validatedMaxStepCount()
         } catch {
-            // Argument-range failures are validation errors, not agent failures.
-            self.printAgentValidationError(error.localizedDescription)
-            throw ExitCode.failure
+            try self.failAgentCommand(message: error.localizedDescription, code: .VALIDATION_ERROR)
         }
 
         let services = runtime.services
@@ -226,9 +217,7 @@ extension AgentCommand {
         do {
             requestedModel = try self.validatedModelSelection(configuration: services.configuration)
         } catch {
-            // An unknown/unconfigured model name is a bad argument, not a run failure.
-            self.printAgentValidationError(error.localizedDescription)
-            throw ExitCode.failure
+            try self.failAgentCommand(message: error.localizedDescription, code: .VALIDATION_ERROR)
         }
 
         let configuredAIService = PeekabooAIService(configuration: services.configuration)
@@ -243,8 +232,7 @@ extension AgentCommand {
             self.implicitToolModel(
                 from: configuredAIService,
                 configuration: services.configuration,
-                existingAgentModel: existingAgentModel
-            )
+                existingAgentModel: existingAgentModel)
         let usesPersistedSessionModel = self.shouldUsePersistedSessionModel(requestedModel: requestedModel)
         if self.listSessions {
             let listingModel = selectedModel ?? existingAgentModel ?? .anthropic(.opus48)
@@ -254,8 +242,7 @@ extension AgentCommand {
                 try PeekabooAgentService(
                     services: services,
                     defaultModel: listingModel,
-                    snapshotMutationCoordinator: mutationCoordinator
-                )
+                    snapshotMutationCoordinator: mutationCoordinator)
             }
             try await self.showSessions(agentService)
             return
@@ -264,29 +251,29 @@ extension AgentCommand {
         if selectedModel == nil, !usesPersistedSessionModel {
             if let capabilityError = self.unavailableImplicitCustomModelToolCapabilityError(
                 from: configuredAIService,
-                configuration: services.configuration
-            ) {
-                self.printAgentExecutionError(capabilityError.localizedDescription)
-                throw ExitCode.failure
+                configuration: services.configuration)
+            {
+                try self.failAgentCommand(
+                    message: capabilityError.localizedDescription,
+                    code: .VALIDATION_ERROR)
             }
-            self.emitAgentUnavailableMessage()
-            throw ExitCode.failure
+            try self.failAgentUnavailable()
         }
 
         let serviceDefaultModel = selectedModel ?? existingAgentModel ?? .anthropic(.opus48)
         if !usesPersistedSessionModel,
            !self.hasCredentials(for: serviceDefaultModel),
-           !self.isLocalModel(serviceDefaultModel) {
+           !self.isLocalModel(serviceDefaultModel)
+        {
             if requestedModel != nil {
                 let providerName = self.providerDisplayName(for: serviceDefaultModel)
                 let envVar = self.providerEnvironmentVariable(for: serviceDefaultModel)
-                self.printAgentExecutionError(
-                    "Missing API key for \(providerName). Set \(envVar) and retry."
-                )
+                try self.failAgentCommand(
+                    message: "Missing API key for \(providerName). Set \(envVar) and retry.",
+                    code: .MISSING_API_KEY)
             } else {
-                self.emitAgentUnavailableMessage()
+                try self.failAgentUnavailable()
             }
-            throw ExitCode.failure
         }
 
         let agentService: any AgentServiceProtocol = if let existing = existingAgent {
@@ -295,8 +282,7 @@ extension AgentCommand {
             try PeekabooAgentService(
                 services: services,
                 defaultModel: serviceDefaultModel,
-                snapshotMutationCoordinator: mutationCoordinator
-            )
+                snapshotMutationCoordinator: mutationCoordinator)
         }
 
         let terminalCapabilities = TerminalDetector.detectCapabilities()
@@ -312,10 +298,10 @@ extension AgentCommand {
         }
 
         if !usesPersistedSessionModel {
-            guard self.ensureAgentHasCredentials(selectedModel: serviceDefaultModel) else {
-                throw ExitCode.failure
-            }
+            try self.requireAgentCredentials(selectedModel: serviceDefaultModel)
         }
+
+        try await self.requireRequestedSession(peekabooAgent)
 
         let chatPolicy = AgentChatLaunchPolicy()
         let chatContext = AgentChatLaunchContext(
@@ -324,19 +310,23 @@ extension AgentCommand {
             listSessions: self.listSessions,
             normalizedTaskInput: self.normalizedTaskInput,
             capabilities: terminalCapabilities,
-            hasSessionResumption: self.resume || self.resumeSession != nil
-        )
+            hasSessionResumption: self.resume || self.resumeSession != nil)
 
         let queueMode: QueueMode
         do {
             queueMode = try self.resolvedQueueMode()
         } catch {
-            self.printAgentExecutionError(error.localizedDescription)
-            throw ExitCode.failure
+            try self.failAgentCommand(message: error.localizedDescription, code: .VALIDATION_ERROR)
         }
 
         switch chatPolicy.strategy(for: chatContext) {
         case .helpOnly:
+            if self.jsonOutput {
+                try self.failAgentCommand(
+                    message: "Task argument is required",
+                    code: .VALIDATION_ERROR,
+                    hint: AgentMessages.Chat.nonInteractiveHelp)
+            }
             self.printNonInteractiveChatHelp()
             return
         case let .interactive(initialPrompt):
@@ -345,8 +335,7 @@ extension AgentCommand {
                 requestedModel: requestedModel,
                 initialPrompt: initialPrompt,
                 capabilities: terminalCapabilities,
-                queueMode: queueMode
-            )
+                queueMode: queueMode)
             return
         case .none:
             break
@@ -356,22 +345,19 @@ extension AgentCommand {
             peekabooAgent,
             requestedModel: requestedModel,
             maxSteps: maxSteps,
-            queueMode: queueMode
-        ) {
+            queueMode: queueMode)
+        {
             return
         }
 
-        guard let executionTask = try await self.buildExecutionTask() else {
-            return
-        }
+        let executionTask = try await self.buildExecutionTask()
 
         _ = try await self.executeAgentTask(
             peekabooAgent,
             task: executionTask,
             requestedModel: requestedModel,
             maxSteps: maxSteps,
-            queueMode: queueMode
-        )
+            queueMode: queueMode)
     }
 
     private func isAgentDisabled() -> Bool {
@@ -401,23 +387,10 @@ extension AgentCommand {
         }
     }
 
-    func emitAgentUnavailableMessage() {
-        if self.jsonOutput {
-            let message = "Agent service not available. Please set OPENAI_API_KEY, ANTHROPIC_API_KEY, " +
-                "GEMINI_API_KEY, X_AI_API_KEY, MINIMAX_API_KEY, MINIMAX_CN_API_KEY, OPENROUTER_API_KEY, " +
-                "or configure ollama/<model>, lmstudio/<model>, or a custom provider."
-            let logger = Logger.shared
-            logger.setJsonOutputMode(true)
-            outputError(message: message, code: .MISSING_API_KEY, logger: logger)
-        } else {
-            let errorPrefix = [
-                "\(TerminalColor.red)Error: Agent service not available.",
-                " Please set OPENAI_API_KEY, ANTHROPIC_API_KEY, GEMINI_API_KEY, X_AI_API_KEY,",
-                " MINIMAX_API_KEY, MINIMAX_CN_API_KEY, OPENROUTER_API_KEY,",
-                " or configure ollama/<model>, lmstudio/<model>, or a custom provider."
-            ].joined()
-            let errorMessageLine = [errorPrefix, "\(TerminalColor.reset)"].joined()
-            print(errorMessageLine)
-        }
+    func failAgentUnavailable() throws -> Never {
+        let message = "Agent service not available. Please set OPENAI_API_KEY, ANTHROPIC_API_KEY, " +
+            "GEMINI_API_KEY, X_AI_API_KEY, MINIMAX_API_KEY, MINIMAX_CN_API_KEY, OPENROUTER_API_KEY, " +
+            "or configure ollama/<model>, lmstudio/<model>, or a custom provider."
+        try self.failAgentCommand(message: message, code: .MISSING_API_KEY)
     }
 }

--- a/Apps/CLI/Tests/CLIAutomationTests/AgentCommandValidationIntegrationTests.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/AgentCommandValidationIntegrationTests.swift
@@ -8,6 +8,13 @@ import Testing
 
 @Suite(.serialized, .tags(.safe))
 struct AgentCommandValidationIntegrationTests {
+    private struct FailureCase {
+        let name: String
+        let arguments: [String]
+        let code: PeekabooCLI.ErrorCode
+        let message: String
+    }
+
     @Test
     func `No cache session conflicts return one validation JSON object`() async throws {
         let result = try await InProcessCommandRunner.runShared(
@@ -41,6 +48,82 @@ struct AgentCommandValidationIntegrationTests {
         let message = try #require(error["message"] as? String)
         #expect(message.contains("between 1 and 100"))
         #expect(message.contains("received \(maxSteps)"))
+    }
+
+    @Test
+    @MainActor
+    func `Terminal agent failures use raw envelopes and nonzero exits`() async throws {
+        try await self.withIsolatedAgentEnvironment { sessionDirectory in
+            let services = TestServicesFactory.makePeekabooServices()
+            let localModel = "ollama/llama3.3"
+            let parsedLocalModel = try #require(LanguageModel.parse(from: localModel))
+            let agentService = try PeekabooAgentService(
+                services: services,
+                defaultModel: parsedLocalModel,
+                sessionManager: AgentSessionManager(sessionDirectory: sessionDirectory)
+            )
+            services.agent = agentService
+            let cases: [FailureCase] = [
+                .init(
+                    name: "missing task",
+                    arguments: ["agent", "run", "--model", localModel, "--json"],
+                    code: .VALIDATION_ERROR,
+                    message: "Task argument is required"
+                ),
+                .init(
+                    name: "no resumable session",
+                    arguments: ["agent", "resume", "--model", localModel, "--json"],
+                    code: .SESSION_NOT_FOUND,
+                    message: "No sessions found to resume"
+                ),
+                .init(
+                    name: "invalid resume session",
+                    arguments: ["agent", "resume", "missing-\(UUID().uuidString)", "--model", localModel, "--json"],
+                    code: .SESSION_NOT_FOUND,
+                    message: "Session not found or expired"
+                ),
+                .init(
+                    name: "audio transcription failure",
+                    arguments: [
+                        "agent", "run", "--audio-file", "/tmp/peekaboo-missing-audio.wav",
+                        "--model", localModel, "--json",
+                    ],
+                    code: .AGENT_ERROR,
+                    message: "Audio processing failed"
+                ),
+                .init(
+                    name: "missing provider key",
+                    arguments: ["agent", "run", "task", "--model", "gemini-3.5-flash", "--json"],
+                    code: .MISSING_API_KEY,
+                    message: "Missing API key"
+                ),
+                .init(
+                    name: "unknown model",
+                    arguments: ["agent", "run", "task", "--model", "definitely-not-a-model", "--json"],
+                    code: .VALIDATION_ERROR,
+                    message: "Unsupported model"
+                ),
+                .init(
+                    name: "invalid queue mode",
+                    arguments: [
+                        "agent", "run", "task", "--model", localModel,
+                        "--queue-mode", "sideways", "--json",
+                    ],
+                    code: .VALIDATION_ERROR,
+                    message: "Invalid queue mode"
+                ),
+            ]
+
+            for testCase in cases {
+                let result = try await InProcessCommandRunner.run(testCase.arguments, services: services)
+                try self.requireFailureEnvelope(
+                    result,
+                    code: testCase.code,
+                    messageContains: testCase.message,
+                    context: testCase.name
+                )
+            }
+        }
     }
 
     @Test
@@ -398,6 +481,7 @@ struct AgentCommandValidationIntegrationTests {
             "PEEKABOO_CONFIG_DIR",
             "PEEKABOO_CONFIG_NONINTERACTIVE",
             "PEEKABOO_CONFIG_DISABLE_MIGRATION",
+            "GEMINI_API_KEY",
         ]
         let previous = Dictionary(uniqueKeysWithValues: environmentKeys.map { key in
             (key, getenv(key).map { String(cString: $0) })
@@ -406,6 +490,7 @@ struct AgentCommandValidationIntegrationTests {
         setenv("PEEKABOO_CONFIG_DIR", tempDirectory.path, 1)
         setenv("PEEKABOO_CONFIG_NONINTERACTIVE", "1", 1)
         setenv("PEEKABOO_CONFIG_DISABLE_MIGRATION", "1", 1)
+        unsetenv("GEMINI_API_KEY")
         ConfigurationManager.shared.resetForTesting()
 
         defer {
@@ -440,6 +525,27 @@ struct AgentCommandValidationIntegrationTests {
         return try await TerminalDetector.$standardOutputFileDescriptor.withValue(terminalFileDescriptor) {
             try await body()
         }
+    }
+
+    private func requireFailureEnvelope(
+        _ result: CommandRunResult,
+        code: PeekabooCLI.ErrorCode,
+        messageContains: String,
+        context: String = #function
+    ) throws {
+        #expect(result.exitStatus == 1, "Wrong exit status for \(context)")
+        #expect(result.stderr.isEmpty, "JSON error leaked to stderr for \(context)")
+
+        let data = Data(result.stdout.utf8)
+        let payload = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        #expect(payload["success"] as? Bool == false, "Missing failure status for \(context)")
+        #expect(payload["data"] is NSNull, "Failure data was not null for \(context)")
+        #expect(payload["effect"] == nil, "Agent failure unexpectedly gained an action effect for \(context)")
+
+        let error = try #require(payload["error"] as? [String: Any])
+        #expect(error["code"] as? String == code.rawValue, "Wrong error code for \(context)")
+        let message = try #require(error["message"] as? String)
+        #expect(message.contains(messageContains), "Wrong error message for \(context): \(message)")
     }
 }
 

--- a/Apps/CLI/Tests/CLIAutomationTests/SeeCommandTests.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/SeeCommandTests.swift
@@ -711,9 +711,13 @@ struct SeeCommandRuntimeTests {
                 CodableJSONResponse<SeeResult>.self,
                 from: data
             )
+            let rawResponse = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+            let rawData = try #require(rawResponse["data"] as? [String: Any])
             let element = try #require(response.data.ui_elements.first)
 
             #expect(response.success == true)
+            #expect(rawResponse["success"] as? Bool == true)
+            #expect(rawData["success"] == nil)
             #expect(element.description == "Wingman Grindr Session Helper")
             #expect(element.role_description == "Pop Up Button")
             #expect(element.help == "Pinned extension button")

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,9 @@ It is a breaking release — see `docs/v4-migration.md` for the complete old→n
 
 ### Fixed
 
+- Normalize agent failures and `see` success JSON under the shared result envelope,
+  with nonzero terminal failures, specific validation/credential/session/runtime codes,
+  and no duplicate inner `success` field.
 - Add actionable text and JSON migration hints for removed v4 commands and flags,
   reject ambiguous press input shapes, and align `see`/`type`/`press` help with the
   accepted grammar.


### PR DESCRIPTION
## Summary

Repairs the agent result-envelope exit and classification regression that landed through #366 and the no-op #365 merge.

- Make terminal agent error emission unconditionally throw a failure exit after writing the standard envelope.
- Preserve specific `VALIDATION_ERROR`, `MISSING_API_KEY`, `SESSION_NOT_FOUND`, and `AGENT_ERROR` ownership.
- Preflight requested sessions so JSON resume failures retain session-specific errors before chat validation.
- Keep cancellation propagation and nonterminal chat-turn reporting unchanged.
- Add raw JSON and exit-status coverage for missing task, missing/invalid sessions, audio failure, missing credentials, unknown models, invalid queue mode, and step ranges.
- Assert the #366 `see` contract directly: top-level `success: true`, with no nested `data.success`.

## Proof

- `swift build --package-path Apps/CLI`
- `PEEKABOO_INCLUDE_AUTOMATION_TESTS=true swift test --package-path Apps/CLI --filter 'AgentCommandValidationIntegrationTests|See command JSON includes accessibility metadata fields' --no-parallel` (12 tests)
- `pnpm run test:safe`
- `pnpm run lint`
- `pnpm run lint:docs`
- Autoreview clean on exact branch diff

## Context

#366 squash-landed the original structured-envelope change before its known exit-status blocker was repaired. #365 later merged with an identical tree, so this branch is based on that landed state and contains only the repair.
