### PR TITLE
fix(agent): stop learn from documenting a nonexistent shell command

### DIFF
--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -130,6 +130,16 @@ jobs:
           swift test --no-parallel --filter PeekabooAgentSessionSafetyTests
           swift test --no-parallel --filter PeekabooAgentStreamTerminalIntegrityTests
 
+      - name: Run agent-surface contract tests
+        working-directory: Core/PeekabooCore
+        # These guard the tables that silently rot: the curated `learn` copy, the
+        # MCP snapshot-effect classification, and the agent tool descriptions.
+        # The full Core suite is too slow for CI, so name the guards explicitly.
+        run: |
+          swift test --no-parallel --filter ToolRegistryContractTests
+          swift test --no-parallel --filter MCPToolSnapshotMutationTests
+          swift test --no-parallel --filter AgentToolDescriptionTests
+
   peekaboo-cli:
     name: Peekaboo CLI build & tests
     runs-on: macos-26

--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -8,8 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [4.0.1] - Unreleased
 
 ### Fixed
-- Remove the stale `shell` entry from the curated `learn` copy so agents are no longer taught a
-  command that does not exist.
+- Stop the curated `learn` copy from presenting `shell` as a CLI command: it remains a built-in Agent capability but is not in the MCP catalog and has no `peekaboo shell` CLI root.
 - Ensure action-command JSON validation failures before dispatch report `effect: refused`, including parser and binding errors.
 - Verify app focus against the exact active Workspace PID and visible frontmost-window PID, retry through native AX activation, and report the verified effect as confirmed instead of claiming success for an unfulfilled request.
 

--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [4.0.1] - Unreleased
 
 ### Fixed
+- Remove the stale `shell` entry from the curated `learn` copy so agents are no longer taught a
+  command that does not exist.
 - Ensure action-command JSON validation failures before dispatch report `effect: refused`, including parser and binding errors.
 - Verify app focus against the exact active Workspace PID and visible frontmost-window PID, retry through native AX activation, and report the verified effect as confirmed instead of claiming success for an unfulfilled request.
 

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Core/ToolsCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Core/ToolsCommand.swift
@@ -9,11 +9,12 @@ import TachikomaMCP
 struct ToolsCommand: ParsableCommand {
     static let commandDescription = CommandDescription(
         commandName: "tools",
-        abstract: "List the MCP/agent tool catalog",
+        abstract: "List the MCP tool catalog",
         discussion: """
-        Display the Peekaboo MCP/agent tool catalog. These tools are exposed to agents
-        and `peekaboo mcp` clients (e.g. Codex, Claude Code, Cursor). Some tools also
-        have dedicated CLI wrappers, such as `peekaboo browser`.
+        Display the native tools exposed to `peekaboo mcp` clients (e.g. Codex,
+        Claude Code, Cursor). The built-in Peekaboo Agent adds agent-only capabilities,
+        including `shell`; run `peekaboo learn` for the combined guidance. Some MCP
+        tools also have dedicated CLI wrappers, such as `peekaboo browser`.
         Run `peekaboo --help` for the CLI command list.
 
         Examples:
@@ -33,7 +34,7 @@ struct ToolsCommand: ParsableCommand {
 struct ToolsListSubcommand: OutputFormattable, RuntimeBackedCommand {
     static let commandDescription = CommandDescription(
         commandName: "list",
-        abstract: "List the MCP/agent tool catalog"
+        abstract: "List the MCP tool catalog"
     )
 
     @Flag(name: .customLong("no-sort"), help: "Disable alphabetical sorting")

--- a/Apps/CLI/Tests/CLIRuntimeTests/CLIRuntimeSmokeTests.swift
+++ b/Apps/CLI/Tests/CLIRuntimeTests/CLIRuntimeSmokeTests.swift
@@ -380,7 +380,8 @@ struct CLIRuntimeSmokeTests {
         """.write(
             to: tempDir.appendingPathComponent("config.json"),
             atomically: true,
-            encoding: .utf8)
+            encoding: .utf8
+        )
 
         let result = try await TestChildProcess.runPeekaboo([
             "agent",
@@ -459,7 +460,8 @@ struct CLIRuntimeSmokeTests {
         let startTime = Date()
         let result = try await TestChildProcess.runPeekaboo(
             ["visualizer", "--json", "--no-remote"],
-            environment: ["PEEKABOO_VISUAL_FEEDBACK": "false"])
+            environment: ["PEEKABOO_VISUAL_FEEDBACK": "false"]
+        )
         let duration = Date().timeIntervalSince(startTime)
 
         let payload = !result.standardOutput.isEmpty ? result.standardOutput : result.standardError

--- a/Apps/CLI/Tests/CLIRuntimeTests/CLIRuntimeSmokeTests.swift
+++ b/Apps/CLI/Tests/CLIRuntimeTests/CLIRuntimeSmokeTests.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Subprocess
 import Testing
+@testable import PeekabooCLI
 
 enum CLIRuntimeEnvironment {
     static var shouldRunSmokeTests: Bool {
@@ -44,7 +45,8 @@ struct CLIRuntimeSmokeTests {
               let success = json["success"] as? Bool,
               success == false,
               let error = json["error"] as? [String: Any],
-              let code = error["code"] as? String else {
+              let code = error["code"] as? String
+        else {
             Issue.record("Expected successful app list JSON or structured permission error JSON.")
             return
         }
@@ -60,7 +62,8 @@ struct CLIRuntimeSmokeTests {
         let data = Data(payload.utf8)
         let object = try JSONSerialization.jsonObject(with: data)
         guard let json = object as? [String: Any],
-              let error = json["error"] as? [String: Any] else {
+              let error = json["error"] as? [String: Any]
+        else {
             Issue.record("Expected JSON parse-error output from window list.")
             return
         }
@@ -79,7 +82,8 @@ struct CLIRuntimeSmokeTests {
         let data = Data(payload.utf8)
         let object = try JSONSerialization.jsonObject(with: data)
         guard let json = object as? [String: Any],
-              let error = json["error"] as? [String: Any] else {
+              let error = json["error"] as? [String: Any]
+        else {
             Issue.record("Expected JSON parse-error output.")
             return
         }
@@ -129,7 +133,8 @@ struct CLIRuntimeSmokeTests {
         let data = Data(result.standardOutput.utf8)
         let object = try JSONSerialization.jsonObject(with: data)
         guard let json = object as? [String: Any],
-              let error = json["error"] as? [String: Any] else {
+              let error = json["error"] as? [String: Any]
+        else {
             Issue.record("Expected JSON parse-error output from tools command.")
             return
         }
@@ -148,7 +153,8 @@ struct CLIRuntimeSmokeTests {
         let data = Data(result.standardOutput.utf8)
         let object = try JSONSerialization.jsonObject(with: data)
         guard let json = object as? [String: Any],
-              let payload = json["data"] as? [String: Any] else {
+              let payload = json["data"] as? [String: Any]
+        else {
             Issue.record("Expected JSON object output from browser status.")
             return
         }
@@ -208,7 +214,8 @@ struct CLIRuntimeSmokeTests {
         let data = Data(result.standardOutput.utf8)
         let object = try JSONSerialization.jsonObject(with: data)
         guard let json = object as? [String: Any],
-              let error = json["error"] as? [String: Any] else {
+              let error = json["error"] as? [String: Any]
+        else {
             Issue.record("Expected JSON object output from config error.")
             return
         }
@@ -268,7 +275,8 @@ struct CLIRuntimeSmokeTests {
         let data = Data(payload.utf8)
         let object = try JSONSerialization.jsonObject(with: data)
         guard let json = object as? [String: Any],
-              let success = json["success"] as? Bool else {
+              let success = json["success"] as? Bool
+        else {
             Issue.record("Expected JSON object output from dialog list command.")
             return
         }
@@ -295,7 +303,7 @@ struct CLIRuntimeSmokeTests {
                 "--text",
                 text,
                 "--json",
-                "--no-remote"
+                "--no-remote",
             ])
             #expect(setResult.status == .exited(0))
 
@@ -303,7 +311,7 @@ struct CLIRuntimeSmokeTests {
                 "clipboard",
                 "get",
                 "--json",
-                "--no-remote"
+                "--no-remote",
             ])
             #expect(getResult.status == .exited(0))
             let payload = try Self.jsonDataPayload(from: getResult.standardOutput)
@@ -316,7 +324,7 @@ struct CLIRuntimeSmokeTests {
                 "--output",
                 "-",
                 "--json",
-                "--no-remote"
+                "--no-remote",
             ])
             #expect(stdoutJSONResult.status == .exited(0))
             let stdoutJSONPayload = try Self.jsonDataPayload(from: stdoutJSONResult.standardOutput)
@@ -327,7 +335,7 @@ struct CLIRuntimeSmokeTests {
                 "get",
                 "--output",
                 "-",
-                "--no-remote"
+                "--no-remote",
             ])
             #expect(stdoutResult.status == .exited(0))
             #expect(stdoutResult.standardOutput == text)
@@ -348,7 +356,7 @@ struct CLIRuntimeSmokeTests {
         let result = try await TestChildProcess.runPeekaboo([
             "agent",
             "list files",
-            "--dry-run"
+            "--dry-run",
         ], environment: ["PEEKABOO_DISABLE_AGENT": "1", "PEEKABOO_NO_REMOTE": "1"])
         #expect(result.status == .exited(1))
         #expect(result.standardOutput.contains("Agent service not available"))
@@ -372,8 +380,7 @@ struct CLIRuntimeSmokeTests {
         """.write(
             to: tempDir.appendingPathComponent("config.json"),
             atomically: true,
-            encoding: .utf8
-        )
+            encoding: .utf8)
 
         let result = try await TestChildProcess.runPeekaboo([
             "agent",
@@ -399,12 +406,27 @@ struct CLIRuntimeSmokeTests {
     }
 
     @Test
+    @MainActor
     func `peekaboo learn prints comprehensive guide`() async throws {
         guard Self.ensureLocalRuntimeAvailable() else { return }
         let result = try await TestChildProcess.runPeekaboo(["learn", "--no-remote"])
         #expect(result.status == .exited(0))
         #expect(result.standardOutput.contains("# Peekaboo Comprehensive Guide"))
         #expect(result.standardOutput.contains("## Commander Command Signatures"))
+
+        let registeredRoots = Set(CommandRegistry.definitions().map(\.name))
+        let expression = try NSRegularExpression(pattern: #"\bpeekaboo ([a-z][a-z0-9-]*)"#)
+        let output = result.standardOutput
+        let range = NSRange(output.startIndex..<output.endIndex, in: output)
+        let documentedRoots: Set<String> = Set(expression.matches(in: output, range: range)
+            .compactMap { match -> String? in
+                guard let rootRange = Range(match.range(at: 1), in: output) else { return nil }
+                return String(output[rootRange])
+            })
+        let unavailableRoots = documentedRoots.subtracting(registeredRoots).sorted()
+
+        #expect(documentedRoots.contains("click"))
+        #expect(unavailableRoots.isEmpty, "Learn documents unavailable CLI roots: \(unavailableRoots)")
     }
 
     @Test
@@ -437,8 +459,7 @@ struct CLIRuntimeSmokeTests {
         let startTime = Date()
         let result = try await TestChildProcess.runPeekaboo(
             ["visualizer", "--json", "--no-remote"],
-            environment: ["PEEKABOO_VISUAL_FEEDBACK": "false"]
-        )
+            environment: ["PEEKABOO_VISUAL_FEEDBACK": "false"])
         let duration = Date().timeIntervalSince(startTime)
 
         let payload = !result.standardOutput.isEmpty ? result.standardOutput : result.standardError
@@ -462,7 +483,7 @@ struct CLIRuntimeSmokeTests {
             "--slot",
             slot,
             "--json",
-            "--no-remote"
+            "--no-remote",
         ])
 
         guard saveResult.status == .exited(0) else {
@@ -478,7 +499,7 @@ struct CLIRuntimeSmokeTests {
                 "--slot",
                 slot,
                 "--json",
-                "--no-remote"
+                "--no-remote",
             ])
         } catch {
             _ = try? await TestChildProcess.runPeekaboo([
@@ -487,7 +508,7 @@ struct CLIRuntimeSmokeTests {
                 "--slot",
                 slot,
                 "--json",
-                "--no-remote"
+                "--no-remote",
             ])
             throw error
         }
@@ -498,7 +519,8 @@ struct CLIRuntimeSmokeTests {
         let object = try JSONSerialization.jsonObject(with: data)
         guard let json = object as? [String: Any],
               json["success"] as? Bool == true,
-              let payload = json["data"] as? [String: Any] else {
+              let payload = json["data"] as? [String: Any]
+        else {
             Issue.record("Expected successful JSON envelope.")
             return [:]
         }

--- a/Apps/CLI/Tests/CoreCLITests/ToolsCommandTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/ToolsCommandTests.swift
@@ -12,9 +12,11 @@ struct ToolsCommandTests {
         let config = ToolsCommand.commandDescription
 
         #expect(config.commandName == "tools")
-        #expect(config.abstract == "List the MCP/agent tool catalog")
+        #expect(config.abstract == "List the MCP tool catalog")
         #expect(config.discussion != nil)
         let discussion = config.discussion ?? ""
+        #expect(discussion.contains("built-in Peekaboo Agent adds agent-only capabilities"))
+        #expect(discussion.contains("including `shell`"))
         #expect(discussion.contains("Examples:"))
         #expect(discussion.contains("peekaboo tools"))
         #expect(discussion.contains("--verbose"))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,7 @@
 ## [4.0.1] - Unreleased
 
 ### Fixed
-- Stop `peekaboo learn` from documenting a `shell` tool that no longer exists. The curated
-  agent copy kept its own name table, so agents were taught `peekaboo shell "..."`, which fails
-  with an unknown-command error and gets no migration hint. A contract test now fails if the
-  curated copy documents any tool the runtime does not expose.
+- Stop `peekaboo learn` from presenting `shell` as a CLI command: it remains a built-in Agent capability but is not in the MCP catalog and has no `peekaboo shell` CLI root; guard both curated Agent overrides and rendered CLI roots against future drift.
 - Ensure action-command JSON validation failures before dispatch report
   `effect: refused`, including parser and binding errors.
 - Verify app focus against the exact active Workspace PID and visible frontmost-window PID, retry through native AX activation, and report the verified effect as confirmed instead of claiming success for an unfulfilled request.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## [4.0.1] - Unreleased
 
 ### Fixed
+- Stop `peekaboo learn` from documenting a `shell` tool that no longer exists. The curated
+  agent copy kept its own name table, so agents were taught `peekaboo shell "..."`, which fails
+  with an unknown-command error and gets no migration hint. A contract test now fails if the
+  curated copy documents any tool the runtime does not expose.
 - Ensure action-command JSON validation failures before dispatch report
   `effect: refused`, including parser and binding errors.
 - Verify app focus against the exact active Workspace PID and visible frontmost-window PID, retry through native AX activation, and report the verified effect as confirmed instead of claiming success for an unfulfilled request.

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/ToolRegistry/ToolRegistry.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/ToolRegistry/ToolRegistry.swift
@@ -18,6 +18,12 @@ public enum ToolRegistry {
         let agentGuidance: String?
     }
 
+    /// Tool names carrying curated `learn` copy. Exposed so a contract test can
+    /// keep this table from documenting a tool the runtime no longer exposes.
+    static var overriddenToolNames: Set<String> {
+        Set(self.toolOverrides.keys)
+    }
+
     private static let toolOverrides: [String: ToolOverride] = [
         "see": ToolOverride(
             category: .vision,
@@ -57,10 +63,14 @@ public enum ToolRegistry {
             - Smart waiting keeps checking until the element is reachable
             - Snapshot-aware IDs avoid ambiguity when multiple matches exist
 
+            CLICK KIND
+            - `--double` for a double-click, `--right` for a secondary click
+            - `--long-press` presses and holds, and requires `--foreground`
+
             EXAMPLE
             peekaboo see --app Safari --json
             peekaboo click \"Submit\" --app Safari --snapshot "$SNAPSHOT_ID" --wait-for 1500ms
-            peekaboo click --on "$ELEMENT_ID" --snapshot "$SNAPSHOT_ID"
+            peekaboo click --on "$ELEMENT_ID" --snapshot "$SNAPSHOT_ID" --double
 
             TROUBLESHOOTING
             If the element isn't found, refresh the snapshot with a fresh observation (`peekaboo see`
@@ -96,24 +106,6 @@ public enum ToolRegistry {
             ],
             agentGuidance: "Remember to escape newline/tab characters when providing prompts; " +
                 "literal newlines may be interpreted by the shell."),
-        "shell": ToolOverride(
-            category: .system,
-            abstract: "Run shell commands with quoting guidance and examples.",
-            discussion: """
-            Runs shell commands directly from Peekaboo. Always quote your command when it contains spaces
-            or shell metacharacters.
-
-            EXAMPLE
-            peekaboo shell \"ls -la \\\"/Applications/Utilities\\\"\"
-            peekaboo shell --command 'bash -lc \"echo \\\"Hello\\\"\"'
-            """,
-            examples: [
-                "peekaboo shell \"open -a Safari\"",
-                "peekaboo shell --command 'bash -lc \"whoami\"'",
-            ],
-            agentGuidance: """
-            Use single quotes around the entire command and escape internal quotes when interacting via shells.
-            """),
         "clipboard": ToolOverride(
             category: .system,
             abstract: "Read/write the macOS clipboard (text, images, files) with save/restore slots.",

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/ToolRegistry/ToolRegistry.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/ToolRegistry/ToolRegistry.swift
@@ -18,8 +18,8 @@ public enum ToolRegistry {
         let agentGuidance: String?
     }
 
-    /// Tool names carrying curated `learn` copy. Exposed so a contract test can
-    /// keep this table from documenting a tool the runtime no longer exposes.
+    /// Runtime tool names carrying curated copy. Exposed so a contract test can
+    /// keep this table synchronized with the agent/MCP tool surface.
     static var overriddenToolNames: Set<String> {
         Set(self.toolOverrides.keys)
     }

--- a/Core/PeekabooCore/Tests/PeekabooAgentRuntimeTests/ToolRegistryContractTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooAgentRuntimeTests/ToolRegistryContractTests.swift
@@ -23,6 +23,7 @@ struct ToolRegistryContractTests {
             "action",
             "drag",
             "move",
+            "shell",
             "app",
             "window",
         ]))
@@ -30,7 +31,7 @@ struct ToolRegistryContractTests {
     }
 
     @Test
-    func `Curated learn copy only documents tools the runtime exposes`() {
+    func `Curated copy only overrides tools the runtime exposes`() {
         let services = PeekabooServices()
         services.installAgentRuntimeDefaults()
 
@@ -38,9 +39,7 @@ struct ToolRegistryContractTests {
         let documented = ToolRegistry.overriddenToolNames
         let orphaned = documented.subtracting(exposed).sorted()
 
-        // A stale entry here is not inert: `peekaboo learn` renders it, so agents
-        // are taught a tool that fails with an unknown-command error.
-        #expect(orphaned.isEmpty, "Curated copy documents unavailable tools: \(orphaned)")
+        #expect(orphaned.isEmpty, "Curated copy overrides unavailable runtime tools: \(orphaned)")
     }
 
     @Test

--- a/Core/PeekabooCore/Tests/PeekabooAgentRuntimeTests/ToolRegistryContractTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooAgentRuntimeTests/ToolRegistryContractTests.swift
@@ -1,7 +1,7 @@
-import PeekabooAgentRuntime
 import PeekabooAutomation
 import PeekabooCore
 import Testing
+@testable import PeekabooAgentRuntime
 
 @MainActor
 struct ToolRegistryContractTests {
@@ -27,6 +27,20 @@ struct ToolRegistryContractTests {
             "window",
         ]))
         #expect(names.isDisjoint(with: ["hotkey", "launch_app", "list"]))
+    }
+
+    @Test
+    func `Curated learn copy only documents tools the runtime exposes`() {
+        let services = PeekabooServices()
+        services.installAgentRuntimeDefaults()
+
+        let exposed = Set(ToolRegistry.allTools(using: services).map(\.name))
+        let documented = ToolRegistry.overriddenToolNames
+        let orphaned = documented.subtracting(exposed).sorted()
+
+        // A stale entry here is not inert: `peekaboo learn` renders it, so agents
+        // are taught a tool that fails with an unknown-command error.
+        #expect(orphaned.isEmpty, "Curated copy documents unavailable tools: \(orphaned)")
     }
 
     @Test

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPToolRegistryTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPToolRegistryTests.swift
@@ -194,6 +194,7 @@ struct MCPToolRegistryIntegrationTests {
         #expect(names.contains("inspect_ui"))
         #expect(names.contains("verify_state"))
         #expect(names.contains("capture"))
+        #expect(!names.contains("shell"))
     }
 
     @Test


### PR DESCRIPTION
## Summary

`peekaboo learn` was teaching agents invalid CLI syntax.

`shell` remains a built-in Agent capability, but it is not in the MCP catalog and has no `peekaboo shell` CLI root. The curated guide copy still included worked examples such as `peekaboo shell "open -a Safari"`, so agents following the generated CLI guide received `Unknown command 'shell'`.

The underlying mistake was treating the runtime-tool namespace and CLI-root namespace as interchangeable.

## Changes

- Remove the stale CLI-form `shell` override while retaining the real Agent `shell` tool.
- Keep curated runtime overrides constrained to tools the Agent runtime actually exposes.
- Clarify that `peekaboo tools` lists the MCP catalog while the built-in Agent adds Agent-only capabilities such as `shell`.
- Validate every rendered `peekaboo <root>` reference from the real `peekaboo learn` output against the authoritative CLI `CommandRegistry`.
- Assert a known valid `peekaboo click` reference so the rendered-guide test cannot pass vacuously.
- Restore the `--double`, `--right`, and `--long-press` click guidance that the v4 rewrite dropped even though those flags remain supported.
- Add the agent-surface contract suites to macOS CI.

## Why two guards are needed

The runtime membership guard prevents curated copy from drifting away from the built-in Agent tool catalog, where `shell` correctly exists. It cannot detect CLI-form examples for an Agent-only tool.

The rendered-guide guard closes that gap by running the real `peekaboo learn`, extracting every documented `peekaboo <root>` reference, and checking each root against `CommandRegistry`.

## Proof

- `swift test --package-path Core/PeekabooCore --filter ToolRegistryContractTests` — 3 passed
- `swift test --package-path Core/PeekabooCore --filter MCPToolRegistryIntegrationTests` — 3 passed, including the explicit Agent/MCP `shell` boundary
- `swift test --package-path Core/PeekabooCore --filter MCPToolSnapshotMutationTests` — 26 passed
- `swift test --package-path Core/PeekabooCore --filter AgentToolDescriptionTests` — 15 passed
- `swift test --package-path Apps/CLI --filter ToolsCommandTests` — 9 passed
- `swift test --package-path Apps/CLI --filter CLIRuntimeSmokeTests` — 18 passed, including the rendered-guide CLI-root validation
- Source-blind built-CLI behavior validation — 5/5 passed: Agent `shell` guidance retained, MCP catalog boundary clear, invalid CLI form absent, valid `click` control present, alternate-click help retained
- `pnpm run test:safe` — passed
- `pnpm run lint` — passed with existing non-serious warnings
- `pnpm run lint:docs` — passed
- SwiftFormat — clean
- Autoreview/TruffleHog — clean at 0.99 confidence after the final boundary clarification

## Context

Found by stress-testing the shipped 4.0.0 binary and cross-checking the commands generated by `learn` against the actual CLI surface. A follow-up review caught that the first regression guard checked only the runtime namespace; the final CLI runtime test exercises the rendered guide and authoritative root registry end to end.
