### PR TITLE
feat(agent): default to the current model generation

### DIFF
--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [4.0.1] - Unreleased
 
+### Changed
+- Default new agent configurations to GPT-5.6 and Claude Opus 5 while keeping credential-only Anthropic discovery on Opus 4.8 for zero-retention compatibility and preserving explicit model selections.
+
 ### Fixed
 - Keep background app launch/open ownership through verified focus reconciliation, restoring only the exact prior process generation without overriding a later user foreground choice.
 - Stop the curated `learn` copy from presenting `shell` as a CLI command: it remains a built-in Agent capability but is not in the MCP catalog and has no `peekaboo shell` CLI root.

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/AI/AgentCommand+Commander.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/AI/AgentCommand+Commander.swift
@@ -20,7 +20,7 @@ struct AgentExecutionOptions: CommanderParsable {
     @Option(
         name: .long,
         help: """
-        AI model to use (for example: gpt-5.6, gpt-5.5, claude-fable-5, claude-sonnet-5, \
+        AI model to use (for example: gpt-5.6, claude-opus-5, claude-fable-5, claude-sonnet-5, \
         gemini-3.5-flash, grok-4.3, minimax-m2.7, minimax-cn/m2.7, \
         ollama/<model>, lmstudio/<model>, or <custom-provider>/<model>)
         """

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/AI/AgentCommand+ModelParsing.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/AI/AgentCommand+ModelParsing.swift
@@ -22,6 +22,10 @@ extension AgentCommand {
             .first
             .map { String($0).lowercased() }
 
+        if Self.genericOpenAIAliases.contains(trimmed.lowercased()) {
+            return .openai(.gpt56Sol)
+        }
+
         if trimmed.caseInsensitiveCompare("claude") == .orderedSame ||
             trimmed.caseInsensitiveCompare("anthropic") == .orderedSame {
             return .anthropic(.opus5)
@@ -56,12 +60,7 @@ extension AgentCommand {
         switch parsed {
         case let .openai(model):
             if Self.supportedOpenAIInputs.contains(model) {
-                // GPT-5.6 models route as themselves; older supported aliases
-                // collapse to the current flagship.
-                if Self.gpt56Models.contains(model) {
-                    return .openai(model)
-                }
-                return .openai(.gpt56Sol)
+                return .openai(model)
             }
         case let .anthropic(model):
             if Self.supportedAnthropicInputs.contains(model) {
@@ -248,10 +247,10 @@ extension AgentCommand {
         .gpt5Nano,
     ]
 
-    private static let gpt56Models: Set<LanguageModel.OpenAI> = [
-        .gpt56Sol,
-        .gpt56Terra,
-        .gpt56Luna,
+    private static let genericOpenAIAliases: Set<String> = [
+        "gpt",
+        "openai",
+        "openai/gpt",
     ]
 
     private static let supportedAnthropicInputs: Set<LanguageModel.Anthropic> = [

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/AI/AgentCommand+ModelParsing.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/AI/AgentCommand+ModelParsing.swift
@@ -24,7 +24,7 @@ extension AgentCommand {
 
         if trimmed.caseInsensitiveCompare("claude") == .orderedSame ||
             trimmed.caseInsensitiveCompare("anthropic") == .orderedSame {
-            return .anthropic(.opus48)
+            return .anthropic(.opus5)
         }
 
         if trimmed.caseInsensitiveCompare("sonnet") == .orderedSame {
@@ -57,11 +57,11 @@ extension AgentCommand {
         case let .openai(model):
             if Self.supportedOpenAIInputs.contains(model) {
                 // GPT-5.6 models route as themselves; older supported aliases
-                // collapse to the flagship.
+                // collapse to the current flagship.
                 if Self.gpt56Models.contains(model) {
                     return .openai(model)
                 }
-                return .openai(.gpt55)
+                return .openai(.gpt56Sol)
             }
         case let .anthropic(model):
             if Self.supportedAnthropicInputs.contains(model) {
@@ -255,6 +255,7 @@ extension AgentCommand {
     ]
 
     private static let supportedAnthropicInputs: Set<LanguageModel.Anthropic> = [
+        .opus5,
         .fable5,
         .sonnet5,
         .opus48,

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/AI/AgentCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/AI/AgentCommand.swift
@@ -87,7 +87,7 @@ struct AgentCommand: RuntimeBackedCommand {
     @Option(
         name: .long,
         help: """
-        AI model to use (for example: gpt-5.6, gpt-5.5, claude-fable-5, claude-sonnet-5, \
+        AI model to use (for example: gpt-5.6, claude-opus-5, claude-fable-5, claude-sonnet-5, \
         gemini-3.5-flash, grok-4.3, minimax-m2.7, minimax-cn/m2.7, \
         ollama/<model>, lmstudio/<model>, or <custom-provider>/<model>)
         """
@@ -244,7 +244,7 @@ extension AgentCommand {
             )
         let usesPersistedSessionModel = self.shouldUsePersistedSessionModel(requestedModel: requestedModel)
         if self.listSessions {
-            let listingModel = selectedModel ?? existingAgentModel ?? .anthropic(.opus48)
+            let listingModel = selectedModel ?? existingAgentModel ?? .anthropic(.opus5)
             let agentService: any AgentServiceProtocol = if let existing = existingAgent {
                 existing
             } else {
@@ -271,7 +271,7 @@ extension AgentCommand {
             try self.failAgentUnavailable()
         }
 
-        let serviceDefaultModel = selectedModel ?? existingAgentModel ?? .anthropic(.opus48)
+        let serviceDefaultModel = selectedModel ?? existingAgentModel ?? .anthropic(.opus5)
         if !usesPersistedSessionModel,
            !self.hasCredentials(for: serviceDefaultModel),
            !self.isLocalModel(serviceDefaultModel) {

--- a/Apps/CLI/Tests/CLIAutomationTests/AgentResumeCLITests.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/AgentResumeCLITests.swift
@@ -233,11 +233,11 @@ struct AgentResumeCLITests {
     @Test
     func `Resume respects configuration settings`() {
         // Test that resume functionality respects the same configuration as regular commands
-        let defaultModel = "gpt-5.5"
+        let defaultModel = "gpt-5.6"
         let defaultMaxSteps = 20
 
         // These would be the defaults used in resume
-        #expect(defaultModel == "gpt-5.5")
+        #expect(defaultModel == "gpt-5.6")
         #expect(defaultMaxSteps == 20)
 
         // Test that configuration override logic works

--- a/Apps/CLI/Tests/CoreCLITests/AgentCommandModelParsingTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/AgentCommandModelParsingTests.swift
@@ -35,17 +35,17 @@ struct AgentCommandTests {
     }
 
     @Test
-    func `Supported OpenAI aliases map to GPT-5.5`() throws {
+    func `Supported OpenAI aliases map to the current flagship`() throws {
         let command = try AgentCommand.parse([])
 
-        #expect(command.parseModelString("gpt-5.5") == .openai(.gpt55))
-        #expect(command.parseModelString("gpt-5.4") == .openai(.gpt55))
-        #expect(command.parseModelString("gpt-5.4-mini") == .openai(.gpt55))
-        #expect(command.parseModelString("gpt-5.4-nano") == .openai(.gpt55))
-        #expect(command.parseModelString("gpt-5") == .openai(.gpt55))
-        #expect(command.parseModelString("gpt-5-mini") == .openai(.gpt55))
-        #expect(command.parseModelString("gpt") == .openai(.gpt55))
-        #expect(command.parseModelString("gpt-5-nano") == .openai(.gpt55))
+        #expect(command.parseModelString("gpt-5.5") == .openai(.gpt56Sol))
+        #expect(command.parseModelString("gpt-5.4") == .openai(.gpt56Sol))
+        #expect(command.parseModelString("gpt-5.4-mini") == .openai(.gpt56Sol))
+        #expect(command.parseModelString("gpt-5.4-nano") == .openai(.gpt56Sol))
+        #expect(command.parseModelString("gpt-5") == .openai(.gpt56Sol))
+        #expect(command.parseModelString("gpt-5-mini") == .openai(.gpt56Sol))
+        #expect(command.parseModelString("gpt") == .openai(.gpt56Sol))
+        #expect(command.parseModelString("gpt-5-nano") == .openai(.gpt56Sol))
         #expect(command.parseModelString("gpt-5.1") == nil)
         #expect(command.parseModelString("gpt-5.2") == nil)
         #expect(command.parseModelString("gpt-4o") == nil)
@@ -68,6 +68,8 @@ struct AgentCommandTests {
     func `Supported Anthropic aliases parse current models`() throws {
         let command = try AgentCommand.parse([])
 
+        #expect(command.parseModelString("claude-opus-5") == .anthropic(.opus5))
+        #expect(command.parseModelString("opus") == .anthropic(.opus5))
         #expect(command.parseModelString("claude-fable-5") == .anthropic(.fable5))
         #expect(command.parseModelString("fable") == .anthropic(.fable5))
         #expect(command.parseModelString("claude-sonnet-5") == .anthropic(.sonnet5))
@@ -77,8 +79,8 @@ struct AgentCommandTests {
         #expect(command.parseModelString("claude-sonnet-4.6") == .anthropic(.sonnet46))
         #expect(command.parseModelString("claude-sonnet-4.5") == .anthropic(.sonnet45))
         #expect(command.parseModelString("Claude-Sonnet-4.5") == .anthropic(.sonnet45))
-        #expect(command.parseModelString("claude") == .anthropic(.opus48))
-        #expect(command.parseModelString("anthropic") == .anthropic(.opus48))
+        #expect(command.parseModelString("claude") == .anthropic(.opus5))
+        #expect(command.parseModelString("anthropic") == .anthropic(.opus5))
         #expect(command.parseModelString("claude-opus-4") == .anthropic(.opus4))
         #expect(command.parseModelString("claude-3-sonnet") == nil)
     }
@@ -234,8 +236,8 @@ struct AgentCommandTests {
     func `Model string normalization trims whitespace`() throws {
         let command = try AgentCommand.parse([])
 
-        #expect(command.parseModelString("  gpt-5  ") == .openai(.gpt55))
-        #expect(command.parseModelString("\tgpt-5\n") == .openai(.gpt55))
+        #expect(command.parseModelString("  gpt-5  ") == .openai(.gpt56Sol))
+        #expect(command.parseModelString("\tgpt-5\n") == .openai(.gpt56Sol))
         #expect(command.parseModelString(" claude-sonnet-4.5 ") == .anthropic(.sonnet45))
         #expect(command.parseModelString(" gemini-3-flash ") == .google(.gemini3Flash))
         #expect(command.parseModelString(" minimax-m2.7 ") == .minimax(.m27))
@@ -666,7 +668,7 @@ struct ModelSelectionIntegrationTests {
         command.model = "gpt-5"
 
         let parsedModel = command.model.flatMap { command.parseModelString($0) }
-        #expect(parsedModel == .openai(.gpt55))
+        #expect(parsedModel == .openai(.gpt56Sol))
 
         command.model = "claude-opus-4.7"
         let parsedClaude = command.model.flatMap { command.parseModelString($0) }
@@ -686,7 +688,8 @@ struct ModelSelectionIntegrationTests {
         let command = try AgentCommand.parse([])
 
         let testCases: [(String, LanguageModel)] = [
-            ("gpt-5.5", .openai(.gpt55)),
+            ("gpt-5.6", .openai(.gpt56Sol)),
+            ("claude-opus-5", .anthropic(.opus5)),
             ("claude-fable-5", .anthropic(.fable5)),
             ("claude-opus-4.8", .anthropic(.opus48)),
             ("gemini-3.5-flash", .google(.gemini35Flash)),
@@ -711,9 +714,23 @@ struct ModelSelectionIntegrationTests {
         var command = try AgentCommand.parse([])
         #expect(try command.validatedModelSelection() == nil)
 
-        command.model = "gpt-5.5"
+        command.model = "gpt-5.6"
         let parsed = try command.validatedModelSelection()
-        #expect(parsed == .openai(.gpt55))
+        #expect(parsed == .openai(.gpt56Sol))
+    }
+
+    @Test
+    func `Current generation CLI model selections validate`() throws {
+        let cases: [(input: String, expected: LanguageModel)] = [
+            ("claude-opus-5", .anthropic(.opus5)),
+            ("gpt-5.6", .openai(.gpt56Sol)),
+            ("opus", .anthropic(.opus5)),
+        ]
+
+        for testCase in cases {
+            let command = try AgentCommand.parse(["--model", testCase.input])
+            #expect(try command.validatedModelSelection() == testCase.expected)
+        }
     }
 
     @Test

--- a/Apps/CLI/Tests/CoreCLITests/AgentCommandModelParsingTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/AgentCommandModelParsingTests.swift
@@ -35,17 +35,37 @@ struct AgentCommandTests {
     }
 
     @Test
-    func `Supported OpenAI aliases map to the current flagship`() throws {
+    func `Explicit OpenAI selections preserve their parsed model`() throws {
         let command = try AgentCommand.parse([])
 
-        #expect(command.parseModelString("gpt-5.5") == .openai(.gpt56Sol))
-        #expect(command.parseModelString("gpt-5.4") == .openai(.gpt56Sol))
-        #expect(command.parseModelString("gpt-5.4-mini") == .openai(.gpt56Sol))
-        #expect(command.parseModelString("gpt-5.4-nano") == .openai(.gpt56Sol))
-        #expect(command.parseModelString("gpt-5") == .openai(.gpt56Sol))
-        #expect(command.parseModelString("gpt-5-mini") == .openai(.gpt56Sol))
-        #expect(command.parseModelString("gpt") == .openai(.gpt56Sol))
-        #expect(command.parseModelString("gpt-5-nano") == .openai(.gpt56Sol))
+        let selections: [(String, LanguageModel)] = [
+            ("gpt-5.5", .openai(.gpt55)),
+            ("gpt5.5", .openai(.gpt55)),
+            ("gpt55", .openai(.gpt55)),
+            ("gpt-5.5-mini", .openai(.gpt5Mini)),
+            ("gpt-5.5-nano", .openai(.gpt5Nano)),
+            ("gpt-5.4", .openai(.gpt54)),
+            ("gpt5.4", .openai(.gpt54)),
+            ("gpt54", .openai(.gpt54)),
+            ("gpt-5.4-mini", .openai(.gpt54Mini)),
+            ("gpt-5.4-nano", .openai(.gpt54Nano)),
+            ("gpt-5", .openai(.gpt5)),
+            ("gpt5", .openai(.gpt5)),
+            ("gpt-5-pro", .openai(.gpt5Pro)),
+            ("gpt-5-mini", .openai(.gpt5Mini)),
+            ("gpt-5-nano", .openai(.gpt5Nano)),
+            ("openai/gpt-5.5", .openai(.gpt55)),
+            ("openai/gpt-5.4-mini", .openai(.gpt54Mini)),
+            ("openai/gpt-5-pro", .openai(.gpt5Pro)),
+        ]
+        for (selection, expected) in selections {
+            #expect(command.parseModelString(selection) == expected)
+        }
+
+        for selection in ["gpt", "openai", "openai/gpt", " GPT "] {
+            #expect(command.parseModelString(selection) == .openai(.gpt56Sol))
+        }
+
         #expect(command.parseModelString("gpt-5.1") == nil)
         #expect(command.parseModelString("gpt-5.2") == nil)
         #expect(command.parseModelString("gpt-4o") == nil)
@@ -236,8 +256,8 @@ struct AgentCommandTests {
     func `Model string normalization trims whitespace`() throws {
         let command = try AgentCommand.parse([])
 
-        #expect(command.parseModelString("  gpt-5  ") == .openai(.gpt56Sol))
-        #expect(command.parseModelString("\tgpt-5\n") == .openai(.gpt56Sol))
+        #expect(command.parseModelString("  gpt-5  ") == .openai(.gpt5))
+        #expect(command.parseModelString("\tgpt-5\n") == .openai(.gpt5))
         #expect(command.parseModelString(" claude-sonnet-4.5 ") == .anthropic(.sonnet45))
         #expect(command.parseModelString(" gemini-3-flash ") == .google(.gemini3Flash))
         #expect(command.parseModelString(" minimax-m2.7 ") == .minimax(.m27))
@@ -668,7 +688,7 @@ struct ModelSelectionIntegrationTests {
         command.model = "gpt-5"
 
         let parsedModel = command.model.flatMap { command.parseModelString($0) }
-        #expect(parsedModel == .openai(.gpt56Sol))
+        #expect(parsedModel == .openai(.gpt5))
 
         command.model = "claude-opus-4.7"
         let parsedClaude = command.model.flatMap { command.parseModelString($0) }

--- a/Apps/Mac/Peekaboo/Core/Settings.swift
+++ b/Apps/Mac/Peekaboo/Core/Settings.swift
@@ -90,7 +90,7 @@ final class PeekabooSettings {
         didSet { self.save() }
     }
 
-    var selectedModel: String = "claude-opus-4-8" {
+    var selectedModel: String = "claude-opus-5" {
         didSet {
             self.save()
             self.updateConfigFile()
@@ -108,7 +108,7 @@ final class PeekabooSettings {
         }
     }
 
-    var customVisionModel: String = "gpt-5.5" {
+    var customVisionModel: String = "gpt-5.6" {
         didSet {
             self.save()
             self.updateConfigFile()
@@ -389,7 +389,7 @@ extension PeekabooSettings {
         let defaultModel = self.defaultModel(for: self.selectedProvider)
         self.selectedModel = self.userDefaults.string(forKey: self.namespaced("selectedModel")) ?? defaultModel
         self.useCustomVisionModel = self.userDefaults.bool(forKey: self.namespaced("useCustomVisionModel"))
-        self.customVisionModel = self.userDefaults.string(forKey: self.namespaced("customVisionModel")) ?? "gpt-5.5"
+        self.customVisionModel = self.userDefaults.string(forKey: self.namespaced("customVisionModel")) ?? "gpt-5.6"
 
         self.temperature = self.nonZeroDouble(forKey: "temperature", fallback: 0.7)
         self.maxTokens = self.nonZeroInt(forKey: "maxTokens", fallback: 16384)
@@ -591,7 +591,7 @@ extension PeekabooSettings {
                 case "openrouter":
                     "openrouter/\(self.selectedModel)"
                 default:
-                    "anthropic/claude-opus-4-8"
+                    "anthropic/claude-opus-5"
                 }
 
                 // Set providers string with fallbacks
@@ -707,7 +707,7 @@ extension PeekabooSettings {
             if self.customProviders[self.selectedProvider] != nil {
                 "\(self.selectedProvider)/\(self.selectedModel)"
             } else {
-                "anthropic/claude-opus-4-8"
+                "anthropic/claude-opus-5"
             }
         }
     }
@@ -939,9 +939,9 @@ extension PeekabooSettings {
 
         return switch provider {
         case "openai":
-            "gpt-5.5"
+            "gpt-5.6-sol"
         case "anthropic":
-            "claude-opus-4-8"
+            "claude-opus-5"
         case "grok":
             "grok-4.3"
         case "google":

--- a/Apps/Mac/Peekaboo/Features/Main/SessionHelpers.swift
+++ b/Apps/Mac/Peekaboo/Features/Main/SessionHelpers.swift
@@ -7,6 +7,7 @@ import SwiftUI
 func formatModelName(_ model: String) -> String {
     // Shorten common model names for display
     switch model {
+    case "gpt-5.6": "GPT-5.6"
     case "gpt-5.6-sol": "GPT-5.6 Sol"
     case "gpt-5.6-terra": "GPT-5.6 Terra"
     case "gpt-5.6-luna": "GPT-5.6 Luna"
@@ -18,6 +19,7 @@ func formatModelName(_ model: String) -> String {
     case "gpt-5-mini": "GPT-5 mini"
     case "claude-fable-5": "Claude Fable 5"
     case "claude-sonnet-5": "Claude Sonnet 5"
+    case "claude-opus-5": "Claude Opus 5"
     case "claude-opus-4-8": "Claude Opus 4.8"
     case "claude-opus-4-7": "Claude Opus 4.7"
     case "claude-sonnet-4-6": "Claude Sonnet 4.6"

--- a/Apps/Mac/Peekaboo/Features/Settings/SettingsWindow.swift
+++ b/Apps/Mac/Peekaboo/Features/Settings/SettingsWindow.swift
@@ -281,6 +281,7 @@ struct AgentSettingsView: View {
             ("gpt-5-mini", "GPT-5 mini"),
         ]),
         ("anthropic", [
+            ("claude-opus-5", "Claude Opus 5"),
             ("claude-fable-5", "Claude Fable 5"),
             ("claude-sonnet-5", "Claude Sonnet 5"),
             ("claude-opus-4-8", "Claude Opus 4.8"),
@@ -426,6 +427,8 @@ struct AgentSettingsView: View {
             "claude-fable-5": "Claude Fable 5 with 1M context for demanding " +
                 "reasoning and long-horizon agent tasks.",
             "claude-sonnet-5": "Claude Sonnet 5 with 1M context for fast, capable agent tasks.",
+            "claude-opus-5": "Claude Opus 5 with 1M context and up to 128K output for long-running " +
+                "automation and computer-use tasks.",
             "claude-opus-4-8": "Claude Opus 4.8 with 1M context for long-running " +
                 "automation and computer-use tasks.",
             "claude-sonnet-4-6": "Claude Sonnet 4.6 with new tools + computer use, " +

--- a/Apps/Mac/Peekaboo/Services/SessionTitleGenerator.swift
+++ b/Apps/Mac/Peekaboo/Services/SessionTitleGenerator.swift
@@ -85,19 +85,46 @@ final class SessionTitleGenerator {
         hasOpenAI: Bool,
         hasAnthropic: Bool) -> LanguageModel
     {
-        if providers.contains("anthropic/claude-fable-5"), hasAnthropic {
-            return .anthropic(.fable5)
+        if hasAnthropic,
+           let configuredAnthropic = self.configuredModel(for: "anthropic", in: providers)
+        {
+            return configuredAnthropic
         }
         if providers.contains(where: { $0 == "anthropic" || $0.hasPrefix("anthropic/") }), hasAnthropic {
-            return .anthropic(.opus48)
+            return .anthropic(.opus5)
+        }
+        if hasOpenAI,
+           let configuredOpenAI = self.configuredModel(for: "openai", in: providers)
+        {
+            return configuredOpenAI
         }
         if providers.contains(where: { $0 == "openai" || $0.hasPrefix("openai/") }), hasOpenAI {
-            return .openai(.gpt55)
+            return .openai(.gpt56Sol)
         }
         if providers.contains(where: { $0 == "ollama" || $0.hasPrefix("ollama/") }) {
             return .ollama(.llama33)
         }
-        return .anthropic(.opus48)
+        return .anthropic(.opus5)
+    }
+
+    private static func configuredModel(for provider: String, in selections: [String]) -> LanguageModel? {
+        for selection in selections {
+            let components = selection.split(separator: "/", maxSplits: 1).map(String.init)
+            guard components.count == 2,
+                  components[0].caseInsensitiveCompare(provider) == .orderedSame,
+                  let model = LanguageModel.parse(from: components[1])
+            else {
+                continue
+            }
+
+            switch (provider, model) {
+            case ("anthropic", .anthropic), ("openai", .openai):
+                return model
+            default:
+                continue
+            }
+        }
+        return nil
     }
 
     private func generationSettings(for model: LanguageModel) -> GenerationSettings {

--- a/Apps/Mac/Peekaboo/Services/SessionTitleGenerator.swift
+++ b/Apps/Mac/Peekaboo/Services/SessionTitleGenerator.swift
@@ -17,6 +17,9 @@ final class SessionTitleGenerator {
             .map { $0.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() }
         let hasOpenAI = self.configuration.hasOpenAIAuth()
         let hasAnthropic = self.configuration.hasAnthropicAuth()
+        let hasProviderSelection = self.configuration.hasConfiguredAIProviderList() ||
+            self.configuration.hasExplicitAIProviderList()
+        let configuredDefault = self.configuration.getAgentModel()
 
         return await withTaskGroup(of: String.self) { group in
             group.addTask { await Self.timeoutTitle() }
@@ -26,7 +29,9 @@ final class SessionTitleGenerator {
                     for: task,
                     providers: providerTokens,
                     hasOpenAI: hasOpenAI,
-                    hasAnthropic: hasAnthropic)
+                    hasAnthropic: hasAnthropic,
+                    hasProviderSelection: hasProviderSelection,
+                    configuredDefault: configuredDefault)
             }
 
             for await result in group {
@@ -60,13 +65,17 @@ final class SessionTitleGenerator {
         for task: String,
         providers: [String],
         hasOpenAI: Bool,
-        hasAnthropic: Bool) async -> String
+        hasAnthropic: Bool,
+        hasProviderSelection: Bool,
+        configuredDefault: String?) async -> String
     {
         do {
             let model = Self.selectModel(
                 providers: providers,
                 hasOpenAI: hasOpenAI,
-                hasAnthropic: hasAnthropic)
+                hasAnthropic: hasAnthropic,
+                hasProviderSelection: hasProviderSelection,
+                configuredDefault: configuredDefault)
             let prompt = self.buildPrompt(for: task)
 
             let result = try await generateText(
@@ -83,28 +92,57 @@ final class SessionTitleGenerator {
     static func selectModel(
         providers: [String],
         hasOpenAI: Bool,
-        hasAnthropic: Bool) -> LanguageModel
+        hasAnthropic: Bool,
+        hasProviderSelection: Bool = true,
+        configuredDefault: String? = nil) -> LanguageModel
     {
-        if hasAnthropic,
+        if let configuredDefault,
+           let configuredModel = LanguageModel.parse(from: configuredDefault)
+        {
+            switch configuredModel {
+            case .anthropic where hasAnthropic:
+                return configuredModel
+            case .openai where hasOpenAI:
+                return configuredModel
+            default:
+                break
+            }
+        }
+
+        if hasProviderSelection,
+           hasAnthropic,
            let configuredAnthropic = self.configuredModel(for: "anthropic", in: providers)
         {
             return configuredAnthropic
         }
-        if providers.contains(where: { $0 == "anthropic" || $0.hasPrefix("anthropic/") }), hasAnthropic {
+        if hasProviderSelection,
+           providers.contains(where: { $0 == "anthropic" || $0.hasPrefix("anthropic/") }),
+           hasAnthropic
+        {
             return .anthropic(.opus5)
         }
-        if hasOpenAI,
+        if hasProviderSelection,
+           hasOpenAI,
            let configuredOpenAI = self.configuredModel(for: "openai", in: providers)
         {
             return configuredOpenAI
         }
-        if providers.contains(where: { $0 == "openai" || $0.hasPrefix("openai/") }), hasOpenAI {
+        if hasProviderSelection,
+           providers.contains(where: { $0 == "openai" || $0.hasPrefix("openai/") }),
+           hasOpenAI
+        {
             return .openai(.gpt56Sol)
         }
-        if providers.contains(where: { $0 == "ollama" || $0.hasPrefix("ollama/") }) {
+        if hasProviderSelection, providers.contains(where: { $0 == "ollama" || $0.hasPrefix("ollama/") }) {
             return .ollama(.llama33)
         }
-        return .anthropic(.opus5)
+        if hasAnthropic {
+            return .anthropic(.opus48)
+        }
+        if hasOpenAI {
+            return .openai(.gpt56Sol)
+        }
+        return .anthropic(.opus48)
     }
 
     private static func configuredModel(for provider: String, in selections: [String]) -> LanguageModel? {

--- a/Apps/Mac/PeekabooTests/Services/SessionTitleGeneratorTests.swift
+++ b/Apps/Mac/PeekabooTests/Services/SessionTitleGeneratorTests.swift
@@ -26,6 +26,17 @@ struct SessionTitleGeneratorTests {
     }
 
     @Test
+    func `Auth-only Anthropic title generation keeps compatibility fallback`() {
+        let model = SessionTitleGenerator.selectModel(
+            providers: ["openai/gpt-5.6", "anthropic/claude-opus-5"],
+            hasOpenAI: false,
+            hasAnthropic: true,
+            hasProviderSelection: false)
+
+        #expect(model == .anthropic(.opus48))
+    }
+
+    @Test
     func `Explicit title provider model pins are preserved`() {
         let anthropic = SessionTitleGenerator.selectModel(
             providers: ["anthropic/claude-opus-4-8"],
@@ -38,5 +49,16 @@ struct SessionTitleGeneratorTests {
 
         #expect(anthropic == .anthropic(.opus48))
         #expect(openAI == .openai(.gpt55))
+    }
+
+    @Test
+    func `Configured agent default takes precedence over generated provider choices`() {
+        let model = SessionTitleGenerator.selectModel(
+            providers: ["openai/gpt-5.6", "anthropic/claude-opus-5"],
+            hasOpenAI: false,
+            hasAnthropic: true,
+            configuredDefault: "claude-opus-4-8")
+
+        #expect(model == .anthropic(.opus48))
     }
 }

--- a/Apps/Mac/PeekabooTests/Services/SessionTitleGeneratorTests.swift
+++ b/Apps/Mac/PeekabooTests/Services/SessionTitleGeneratorTests.swift
@@ -8,7 +8,7 @@ struct SessionTitleGeneratorTests {
     @Test
     func `Explicit Fable title provider selects Fable`() {
         let model = SessionTitleGenerator.selectModel(
-            providers: ["openai/gpt-5.5", "anthropic/claude-fable-5"],
+            providers: ["openai/gpt-5.6", "anthropic/claude-fable-5"],
             hasOpenAI: false,
             hasAnthropic: true)
 
@@ -22,6 +22,21 @@ struct SessionTitleGeneratorTests {
             hasOpenAI: false,
             hasAnthropic: true)
 
-        #expect(model == .anthropic(.opus48))
+        #expect(model == .anthropic(.opus5))
+    }
+
+    @Test
+    func `Explicit title provider model pins are preserved`() {
+        let anthropic = SessionTitleGenerator.selectModel(
+            providers: ["anthropic/claude-opus-4-8"],
+            hasOpenAI: false,
+            hasAnthropic: true)
+        let openAI = SessionTitleGenerator.selectModel(
+            providers: ["openai/gpt-5.5"],
+            hasOpenAI: true,
+            hasAnthropic: false)
+
+        #expect(anthropic == .anthropic(.opus48))
+        #expect(openAI == .openai(.gpt55))
     }
 }

--- a/Apps/Mac/PeekabooTests/Services/SettingsServiceTests.swift
+++ b/Apps/Mac/PeekabooTests/Services/SettingsServiceTests.swift
@@ -45,7 +45,7 @@ struct PeekabooSettingsTests {
             let settings = PeekabooSettings()
             #expect(settings.openAIAPIKey.isEmpty)
             #expect(settings.selectedProvider == "anthropic")
-            #expect(settings.selectedModel == "claude-opus-4-8")
+            #expect(settings.selectedModel == "claude-opus-5")
             #expect(settings.alwaysOnTop == false)
             #expect(settings.showInDock == true)
             #expect(settings.launchAtLogin == false)
@@ -79,7 +79,7 @@ struct PeekabooSettingsTests {
     func `Model selection updates correctly`() throws {
         try withIsolatedSettingsEnvironment { _ in
             let settings = PeekabooSettings()
-            let models = ["gpt-5.5", "gpt-5-mini", "gpt-5-nano"]
+            let models = ["gpt-5.6", "gpt-5-mini", "gpt-5-nano"]
 
             for model in models {
                 settings.selectedModel = model
@@ -850,6 +850,7 @@ struct PeekabooSettingsConfigHydrationTests {
         #expect(AgentSettingsView.builtinName(forModelId: "gpt-5.6-sol") == "GPT-5.6 Sol")
         #expect(AgentSettingsView.builtinName(forModelId: "gpt-5.6-terra") == "GPT-5.6 Terra")
         #expect(AgentSettingsView.builtinName(forModelId: "gpt-5.6-luna") == "GPT-5.6 Luna")
+        #expect(AgentSettingsView.builtinName(forModelId: "claude-opus-5") == "Claude Opus 5")
         #expect(AgentSettingsView.builtinName(forModelId: "claude-fable-5") == "Claude Fable 5")
         #expect(AgentSettingsView.builtinName(forModelId: "claude-sonnet-5") == "Claude Sonnet 5")
 
@@ -861,7 +862,8 @@ struct PeekabooSettingsConfigHydrationTests {
             "gpt-5.6-luna",
             "gpt-5.5",
         ])
-        #expect(anthropic.models.prefix(2).map(\.id) == [
+        #expect(anthropic.models.prefix(3).map(\.id) == [
+            "claude-opus-5",
             "claude-fable-5",
             "claude-sonnet-5",
         ])
@@ -1100,16 +1102,16 @@ extension PeekabooSettingsConfigHydrationTests {
             try settings.removeCustomProvider(id: "local-proxy")
 
             #expect(settings.selectedProvider == "anthropic")
-            #expect(settings.selectedModel == "claude-opus-4-8")
+            #expect(settings.selectedModel == "claude-opus-5")
 
             let persistedData = try Data(contentsOf: configPath)
             let persistedJSON = try #require(JSONSerialization.jsonObject(with: persistedData) as? [String: Any])
             let agent = try #require(persistedJSON["agent"] as? [String: Any])
             let aiProviders = try #require(persistedJSON["aiProviders"] as? [String: Any])
-            #expect(agent["defaultModel"] as? String == "claude-opus-4-8")
+            #expect(agent["defaultModel"] as? String == "claude-opus-5")
             #expect(
                 aiProviders["providers"] as? String ==
-                    "anthropic/claude-opus-4-8,ollama/llava:latest")
+                    "anthropic/claude-opus-5,ollama/llava:latest")
         }
     }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [4.0.1] - Unreleased
 
+### Changed
+- Default new agent configurations and generation fallbacks to GPT-5.6 and Claude Opus 5.
+
 ### Fixed
 - Keep background app launch/open ownership through verified focus reconciliation, restoring only the exact prior process generation while treating transient frontmost uncertainty and later user foreground choices conservatively.
 - Stop `peekaboo learn` from presenting `shell` as a CLI command: it remains a built-in Agent capability but is not in the MCP catalog and has no `peekaboo shell` CLI root; guard both curated Agent overrides and rendered CLI roots against future drift.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [4.0.1] - Unreleased
 
 ### Changed
-- Default new agent configurations and generation fallbacks to GPT-5.6 and Claude Opus 5.
+- Default new agent configurations to GPT-5.6 and Claude Opus 5 while keeping credential-only Anthropic discovery on Opus 4.8 for zero-retention compatibility and preserving explicit model selections.
 
 ### Fixed
 - Keep background app launch/open ownership through verified focus reconciliation, restoring only the exact prior process generation while treating transient frontmost uncertainty and later user foreground choices conservatively.

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/Agent/ActionVerifier.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/Agent/ActionVerifier.swift
@@ -27,7 +27,7 @@ public final class ActionVerifier {
 
     public init(
         smartCapture: SmartCaptureService,
-        verificationModel: LanguageModel = .openai(.gpt55))
+        verificationModel: LanguageModel = .openai(.gpt56Sol))
     {
         self.smartCapture = smartCapture
         self.verificationModel = verificationModel

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/Agent/PeekabooAgentService.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/Agent/PeekabooAgentService.swift
@@ -176,7 +176,7 @@ public final class PeekabooAgentService: AgentServiceProtocol {
 
     public init(
         services: any PeekabooServiceProviding,
-        defaultModel: LanguageModel = .anthropic(.opus48),
+        defaultModel: LanguageModel = .anthropic(.opus5),
         snapshotMutationCoordinator: (any MCPToolSnapshotMutationCoordinating)? = nil,
         snapshotExecutionGate: MCPToolSnapshotExecutionGate = MCPToolSnapshotExecutionGate(),
         sessionManager: AgentSessionManager? = nil)

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/ActionTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/ActionTool.swift
@@ -15,7 +15,7 @@ public struct ActionTool: MCPTool {
         """
         Invokes a named accessibility action on an element, such as AXPress or AXShowMenu.
         Use with element IDs from `see` or `inspect_ui` when a semantic action is available.
-        \(PeekabooMCPVersion.banner) using openai/gpt-5.5, anthropic/claude-opus-4-8
+        \(PeekabooMCPVersion.banner) using openai/gpt-5.6, anthropic/claude-opus-5
         """
     }
 

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/AnalyzeTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/AnalyzeTool.swift
@@ -32,7 +32,7 @@ public struct AnalyzeTool: MCPTool {
         { "image_path": "/tmp/chart.png", "question": "Which category has the highest value in this bar chart?" }
         The AI will analyze the image and attempt to answer your question based on its visual content.
 
-        \(PeekabooMCPVersion.banner) using openai/gpt-5.5, anthropic/claude-opus-4-8
+        \(PeekabooMCPVersion.banner) using openai/gpt-5.6, anthropic/claude-opus-5
         """
     }
 
@@ -176,7 +176,7 @@ public struct AnalyzeTool: MCPTool {
 
         switch provider {
         case "openai":
-            guard let model else { return .openai(.gpt55) }
+            guard let model else { return .openai(.gpt56Sol) }
             if Self.isUnsupportedLegacyModel(provider: provider, model: model) {
                 throw PeekabooError.invalidInput("Unsupported OpenAI model: \(model)")
             }
@@ -185,7 +185,7 @@ public struct AnalyzeTool: MCPTool {
             }
             return .openai(.custom(model))
         case "anthropic":
-            guard let model else { return .anthropic(.opus48) }
+            guard let model else { return .anthropic(.opus5) }
             if Self.isUnsupportedLegacyModel(provider: provider, model: model) {
                 throw PeekabooError.invalidInput("Unsupported Anthropic model: \(model)")
             }

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/ClickTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/ClickTool.swift
@@ -18,7 +18,7 @@ public struct ClickTool: MCPTool {
         Clicks on UI elements or coordinates.
         Supports element queries, specific IDs from `see` or `inspect_ui`, or raw coordinates.
         Background delivery is the default. Set `foreground` to true when the next step needs keyboard focus.
-        \(PeekabooMCPVersion.banner) using openai/gpt-5.5, anthropic/claude-opus-4-8
+        \(PeekabooMCPVersion.banner) using openai/gpt-5.6, anthropic/claude-opus-5
         """
     }
 

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/DockTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/DockTool.swift
@@ -17,8 +17,8 @@ public struct DockTool: MCPTool {
         Interact with the macOS Dock - launch apps, show context menus, hide/show dock.
         Actions: launch, right-click (with menu selection), hide, show, list
         Can list all dock items including persistent and running applications.
-        \(PeekabooMCPVersion.banner) using openai/gpt-5.5
-        and anthropic/claude-opus-4-8
+        \(PeekabooMCPVersion.banner) using openai/gpt-5.6
+        and anthropic/claude-opus-5
         """
     }
 

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/DragTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/DragTool.swift
@@ -16,7 +16,7 @@ public struct DragTool: MCPTool {
         Perform drag and drop operations between UI elements or coordinates.
         Supports element queries, specific IDs, or raw coordinates for both start and end points.
         This always changes the shared physical cursor and requires foreground=true.
-        \(PeekabooMCPVersion.banner) using openai/gpt-5.5, anthropic/claude-opus-4-8
+        \(PeekabooMCPVersion.banner) using openai/gpt-5.6, anthropic/claude-opus-5
         """
     }
 

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/MCPAgentTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/MCPAgentTool.swift
@@ -50,7 +50,7 @@ public struct MCPAgentTool: MCPTool {
                     description: "Task to perform in natural language (omit when only listing sessions)"),
                 "model": SchemaBuilder.string(
                     description: """
-                    OpenAI model to use (e.g., gpt-5.5, gpt-5-mini).
+                    OpenAI model to use (e.g., gpt-5.6, gpt-5-mini).
                     Call `list_models` first to see available presets and descriptions.
                     Choose 'FastChat' for quick responses, 'DeepAnalysis' for complex reasoning, etc.
                     If omitted, the tool auto-selects the first mode-compatible preset.

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/MenuTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/MenuTool.swift
@@ -24,8 +24,8 @@ public struct MenuTool: MCPTool {
         - List Chrome menus: { "action": "list", "app": "Google Chrome" }
         - Save document: { "action": "click", "app": "TextEdit", "path": "File > Save" }
         - Copy selection: { "action": "click", "app": "Safari", "path": "Edit > Copy" }
-        \(PeekabooMCPVersion.banner) using openai/gpt-5.5
-        and anthropic/claude-opus-4-8
+        \(PeekabooMCPVersion.banner) using openai/gpt-5.6
+        and anthropic/claude-opus-5
         """
     }
 

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/MoveTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/MoveTool.swift
@@ -16,7 +16,7 @@ public struct MoveTool: MCPTool {
         Move the mouse cursor to a specific position or UI element.
         Supports absolute coordinates, UI element targeting, or centering on screen.
         This always changes the shared physical cursor and requires foreground=true.
-        \(PeekabooMCPVersion.banner) using openai/gpt-5.5, anthropic/claude-opus-4-8
+        \(PeekabooMCPVersion.banner) using openai/gpt-5.6, anthropic/claude-opus-5
         """
     }
 

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/PermissionsTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/PermissionsTool.swift
@@ -12,7 +12,7 @@ public struct PermissionsTool: MCPTool {
     Check macOS system permissions required for automation.
     Verifies both Screen Recording and Accessibility permissions.
     Returns the current permission status for each required permission.
-    \(PeekabooMCPVersion.banner) using openai/gpt-5.5, anthropic/claude-opus-4-8
+    \(PeekabooMCPVersion.banner) using openai/gpt-5.6, anthropic/claude-opus-5
     """
 
     public var inputSchema: Value {

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/PressTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/PressTool.swift
@@ -19,7 +19,7 @@ public struct PressTool: MCPTool {
         mutually exclusive. Background delivery requires app/pid targeting; set foreground=true for intentional
         OS-global shortcuts or to focus a specific window first. app and pid are alternatives; provide at most one of
         window_id, window_title, or window_index, and pair title/index with app or pid.
-        \(PeekabooMCPVersion.banner) using openai/gpt-5.5, anthropic/claude-opus-4-8
+        \(PeekabooMCPVersion.banner) using openai/gpt-5.6, anthropic/claude-opus-5
         """
     }
 

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/ScrollTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/ScrollTool.swift
@@ -18,8 +18,8 @@ public struct ScrollTool: MCPTool {
         """
         Scrolls a UI target through Accessibility without interrupting the user by default.
         Set foreground=true to focus the target and allow synthetic wheel events at the pointer.
-        \(PeekabooMCPVersion.banner) using openai/gpt-5.5
-        and anthropic/claude-opus-4-8
+        \(PeekabooMCPVersion.banner) using openai/gpt-5.6
+        and anthropic/claude-opus-5
         """
     }
 

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/SetValueTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/SetValueTool.swift
@@ -15,7 +15,7 @@ public struct SetValueTool: MCPTool {
         """
         Sets an accessibility element value directly without synthesizing keystrokes.
         Use for forms and controls after `see` or `inspect_ui` returns an element ID. Requires a settable AX value.
-        \(PeekabooMCPVersion.banner) using openai/gpt-5.5, anthropic/claude-opus-4-8
+        \(PeekabooMCPVersion.banner) using openai/gpt-5.6, anthropic/claude-opus-5
         """
     }
 

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/SleepTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/SleepTool.swift
@@ -9,7 +9,7 @@ public struct SleepTool: MCPTool {
     public let description = """
     Pauses execution for a specified duration.
     Useful for waiting between UI actions or allowing animations to complete.
-    \(PeekabooMCPVersion.banner) using openai/gpt-5.5, anthropic/claude-opus-4-8
+    \(PeekabooMCPVersion.banner) using openai/gpt-5.6, anthropic/claude-opus-5
     """
 
     public var inputSchema: Value {

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/SpaceTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/SpaceTool.swift
@@ -49,7 +49,7 @@ public struct SpaceTool: MCPTool {
         - Move window to space 3: { "action": "move-window", "app": "Safari", "to": 3 }
         - Move window to current space: { "action": "move-window", "app": "TextEdit", "to_current": true }
         - Move and follow: { "action": "move-window", "app": "Terminal", "to": 2, "follow": true }
-        \(PeekabooMCPVersion.banner) using openai/gpt-5.5, anthropic/claude-opus-4-8
+        \(PeekabooMCPVersion.banner) using openai/gpt-5.6, anthropic/claude-opus-5
         """
     }
 

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/TypeTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/TypeTool.swift
@@ -19,8 +19,8 @@ public struct TypeTool: MCPTool {
         Background delivery requires an element/snapshot/app/pid target. Set `foreground=true` for intentional input
         at the current keyboard focus or when the app must be focused first. app and pid are alternatives; provide at
         most one window selector, and pair window_title/window_index with app or pid.
-        \(PeekabooMCPVersion.banner) using openai/gpt-5.5
-        and anthropic/claude-opus-4-8
+        \(PeekabooMCPVersion.banner) using openai/gpt-5.6
+        and anthropic/claude-opus-5
         """
     }
 

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/WindowTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/WindowTool.swift
@@ -38,7 +38,7 @@ public struct WindowTool: MCPTool {
         - { "action": "restore", "app": "PID:1234", "window_id": 5678 }
         - { "action": "set-bounds", "app": "Terminal", "x": 0, "y": 0, "width": 1280, "height": 720 }
         - { "action": "close", "app": "Safari", "title": "Grindr Web" }
-        \(PeekabooMCPVersion.banner) using openai/gpt-5.5, anthropic/claude-opus-4-8
+        \(PeekabooMCPVersion.banner) using openai/gpt-5.6, anthropic/claude-opus-5
         """
     }
 

--- a/Core/PeekabooCore/Sources/PeekabooAutomation/Configuration/ConfigurationManager+Accessors.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAutomation/Configuration/ConfigurationManager+Accessors.swift
@@ -34,7 +34,7 @@ extension ConfigurationManager {
             cliValue: cliValue,
             envVar: "PEEKABOO_AI_PROVIDERS",
             configValue: self.configuration?.aiProviders?.providers,
-            defaultValue: "openai/gpt-5.5,anthropic/claude-opus-4-8")
+            defaultValue: "openai/gpt-5.6,anthropic/claude-opus-5")
     }
 
     /// Whether the provider list came from an explicit user selection rather than an app-generated fallback list.
@@ -63,7 +63,8 @@ extension ConfigurationManager {
             .split(separator: ",")
             .map { $0.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() }
 
-        if entries == ["openai/gpt-5.5", "anthropic/claude-opus-4-7"] ||
+        if entries == ["openai/gpt-5.6", "anthropic/claude-opus-5"] ||
+            entries == ["openai/gpt-5.5", "anthropic/claude-opus-4-7"] ||
             entries == ["openai/gpt-5.5", "anthropic/claude-opus-4-8"]
         {
             return true

--- a/Core/PeekabooCore/Sources/PeekabooAutomation/Configuration/ConfigurationManager+Accessors.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAutomation/Configuration/ConfigurationManager+Accessors.swift
@@ -46,16 +46,29 @@ extension ConfigurationManager {
             return true
         }
 
-        guard let providers = self.configuration?.aiProviders?.providers?
-            .trimmingCharacters(in: .whitespacesAndNewlines),
-            !providers.isEmpty
-        else {
-            return false
-        }
+        guard let providers = self.configuredAIProviderList() else { return false }
 
         return !Self.isGeneratedAIProviderList(
             providers,
             configuredDefault: self.configuration?.agent?.defaultModel)
+    }
+
+    /// Whether a provider list is stored in the user's configuration file.
+    ///
+    /// This deliberately excludes built-in defaults and environment overrides so callers can distinguish a saved
+    /// model selection from credential-only discovery.
+    public func hasConfiguredAIProviderList() -> Bool {
+        self.configuredAIProviderList() != nil
+    }
+
+    private func configuredAIProviderList() -> String? {
+        guard let providers = self.configuration?.aiProviders?.providers?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+            !providers.isEmpty
+        else {
+            return nil
+        }
+        return providers
     }
 
     public static func isGeneratedAIProviderList(_ providers: String, configuredDefault: String?) -> Bool {

--- a/Core/PeekabooCore/Sources/PeekabooAutomation/Configuration/ConfigurationManager+CustomProviders.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAutomation/Configuration/ConfigurationManager+CustomProviders.swift
@@ -185,7 +185,7 @@ extension ConfigurationManager {
         }
 
         let testPayload: [String: Any] = [
-            "model": "claude-opus-4-8",
+            "model": Self.anthropicProbeModel(for: provider),
             "max_tokens": 10,
             "messages": [["role": "user", "content": "Hi"]],
         ]
@@ -202,6 +202,10 @@ extension ConfigurationManager {
 
         let errorMessage = String(data: data, encoding: .utf8) ?? "HTTP \(httpResponse.statusCode)"
         return (false, errorMessage)
+    }
+
+    static func anthropicProbeModel(for provider: Configuration.CustomProvider) -> String {
+        provider.models?.keys.min() ?? "claude-opus-5"
     }
 
     private func discoverOpenAICompatibleModels(

--- a/Core/PeekabooCore/Sources/PeekabooAutomation/Configuration/ConfigurationManager+Persistence.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAutomation/Configuration/ConfigurationManager+Persistence.swift
@@ -54,7 +54,7 @@ private enum ConfigurationDefaults {
     static let configurationTemplate = """
     {
       "aiProviders": {
-      "providers": "openai/gpt-5.5,anthropic/claude-opus-4-8"
+      "providers": "openai/gpt-5.6,anthropic/claude-opus-5"
       },
       "defaults": {
         "savePath": "~/Desktop/Screenshots",

--- a/Core/PeekabooCore/Sources/PeekabooAutomation/Services/AI/PeekabooAIService.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAutomation/Services/AI/PeekabooAIService.swift
@@ -193,7 +193,7 @@ public final class PeekabooAIService {
         _ = configuration.loadConfiguration()
         configuration.applyAIProviderKeys()
         self.resolvedModels = Self.resolveAvailableModels(configuration: configuration)
-        self.defaultModel = self.resolvedModels.first ?? .openai(.gpt55)
+        self.defaultModel = self.resolvedModels.first ?? .openai(.gpt56Sol)
         self.defaultVisionModel = self.resolvedModels.first { $0.supportsVision }
     }
 
@@ -492,7 +492,7 @@ public final class PeekabooAIService {
 
         // Fallback: prefer Anthropic if any auth (API key or OAuth) is present
         if configuration.hasAnthropicAuth() {
-            return self.appendingGeneratedVisionFallbacks(from: parsed, to: [.anthropic(.opus48)])
+            return self.appendingGeneratedVisionFallbacks(from: parsed, to: [.anthropic(.opus5)])
         }
         if let key = configuration.getGeminiAPIKey(), !key.isEmpty {
             return self.appendingGeneratedVisionFallbacks(from: parsed, to: [.google(.gemini35Flash)])
@@ -518,7 +518,7 @@ public final class PeekabooAIService {
         if !customModels.isEmpty {
             return self.appendingGeneratedVisionFallbacks(from: parsed, to: customModels)
         }
-        return [.openai(.gpt55), .anthropic(.opus48)]
+        return [.openai(.gpt56Sol), .anthropic(.opus5)]
     }
 
     private static func appendingGeneratedVisionFallbacks(
@@ -560,7 +560,8 @@ public final class PeekabooAIService {
             .split(separator: ",")
             .map { $0.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() }
 
-        if entries == ["openai/gpt-5.5", "anthropic/claude-opus-4-7"] ||
+        if entries == ["openai/gpt-5.6", "anthropic/claude-opus-5"] ||
+            entries == ["openai/gpt-5.5", "anthropic/claude-opus-4-7"] ||
             entries == ["openai/gpt-5.5", "anthropic/claude-opus-4-8"]
         {
             return true

--- a/Core/PeekabooCore/Sources/PeekabooAutomation/Services/AI/PeekabooAIService.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAutomation/Services/AI/PeekabooAIService.swift
@@ -475,7 +475,7 @@ public final class PeekabooAIService {
             return parsed
         }
 
-        if !parsed.isEmpty {
+        if configuration.hasConfiguredAIProviderList(), !parsed.isEmpty {
             let available = parsed.filter { self.hasCredentialsOrLocalRuntime(for: $0, configuration: configuration) }
             if !available.isEmpty {
                 return self.appendingGeneratedVisionFallbacks(from: parsed, to: available)
@@ -492,7 +492,7 @@ public final class PeekabooAIService {
 
         // Fallback: prefer Anthropic if any auth (API key or OAuth) is present
         if configuration.hasAnthropicAuth() {
-            return self.appendingGeneratedVisionFallbacks(from: parsed, to: [.anthropic(.opus5)])
+            return self.appendingGeneratedVisionFallbacks(from: parsed, to: [.anthropic(.opus48)])
         }
         if let key = configuration.getGeminiAPIKey(), !key.isEmpty {
             return self.appendingGeneratedVisionFallbacks(from: parsed, to: [.google(.gemini35Flash)])

--- a/Core/PeekabooCore/Sources/PeekabooAutomation/Utils/AIProviderParser.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAutomation/Utils/AIProviderParser.swift
@@ -101,11 +101,11 @@ public enum AIProviderParser {
             switch config.provider.lowercased() {
             case "openai":
                 if hasOpenAI {
-                    return "gpt-5.5"
+                    return "gpt-5.6"
                 }
             case "anthropic":
                 if hasAnthropic {
-                    return "claude-opus-4-8"
+                    return "claude-opus-5"
                 }
             case "google", "gemini":
                 if hasGemini {
@@ -130,9 +130,9 @@ public enum AIProviderParser {
 
         // Fall back to hardcoded defaults based on what's available
         if hasAnthropic {
-            return "claude-opus-4-8"
+            return "claude-opus-5"
         } else if hasOpenAI {
-            return "gpt-5.5"
+            return "gpt-5.6"
         } else if hasGemini {
             return "gemini-3.5-flash"
         } else if hasMiniMaxChina {
@@ -140,7 +140,7 @@ public enum AIProviderParser {
         } else if hasMiniMax {
             return "MiniMax-M2.7"
         } else {
-            return "gpt-5.5"
+            return "gpt-5.6"
         }
     }
 }

--- a/Core/PeekabooCore/Sources/PeekabooAutomation/Utils/AIProviderParser.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAutomation/Utils/AIProviderParser.swift
@@ -130,7 +130,7 @@ public enum AIProviderParser {
 
         // Fall back to hardcoded defaults based on what's available
         if hasAnthropic {
-            return "claude-opus-5"
+            return "claude-opus-4-8"
         } else if hasOpenAI {
             return "gpt-5.6"
         } else if hasGemini {

--- a/Core/PeekabooCore/Sources/PeekabooCore/Support/PeekabooServices+Agent.swift
+++ b/Core/PeekabooCore/Sources/PeekabooCore/Support/PeekabooServices+Agent.swift
@@ -198,7 +198,7 @@ extension PeekabooServices {
         if let configuredModel = PeekabooAIService(configuration: configuration).resolveConfiguredModel(modelString) {
             return configuredModel
         }
-        return LanguageModel.parse(from: modelString) ?? .openai(.gpt55)
+        return LanguageModel.parse(from: modelString) ?? .openai(.gpt56Sol)
     }
 
     private static func logModelConflict(_ determination: ModelDetermination, logger: SystemLogger) {
@@ -237,10 +237,10 @@ extension PeekabooServices {
             model = nil
             resolvedModel = nil
         } else if sources.hasAnthropic {
-            model = "claude-opus-4-8"
+            model = "claude-opus-5"
             resolvedModel = nil
         } else if sources.hasOpenAI {
-            model = "gpt-5.5"
+            model = "gpt-5.6"
             resolvedModel = nil
         } else if sources.hasGemini {
             model = "gemini-3.5-flash"
@@ -270,7 +270,7 @@ extension PeekabooServices {
             model = customDefaultModel.description
             resolvedModel = customDefaultModel
         } else {
-            model = "gpt-5.5"
+            model = "gpt-5.6"
             resolvedModel = nil
         }
 

--- a/Core/PeekabooCore/Sources/PeekabooCore/Support/PeekabooServices+Agent.swift
+++ b/Core/PeekabooCore/Sources/PeekabooCore/Support/PeekabooServices+Agent.swift
@@ -21,6 +21,7 @@ extension PeekabooServices {
         let environmentProviders = EnvironmentVariables.value(for: "PEEKABOO_AI_PROVIDERS")?
             .trimmingCharacters(in: .whitespacesAndNewlines)
         let hasEnvironmentProviders = environmentProviders?.isEmpty == false
+        let hasConfiguredProviderList = self.configuration.hasConfiguredAIProviderList()
         let configuredCustomDefaultResolution: ConfiguredCustomDefaultResolution = if hasEnvironmentProviders {
             .none
         } else {
@@ -92,9 +93,8 @@ extension PeekabooServices {
                     providers,
                     configuredDefault: configuredDefault,
                     isEnvironmentProvided: hasEnvironmentProviders,
-                    hasConfiguredProviderList: agentConfig?.aiProviders?.providers?
-                        .trimmingCharacters(in: .whitespacesAndNewlines)
-                        .isEmpty == false),
+                    hasConfiguredProviderList: hasConfiguredProviderList),
+                hasConfiguredProviderList: hasConfiguredProviderList,
                 isEnvironmentProvided: hasEnvironmentProviders)
 
             let determination = self.determineDefaultModelWithConflict(sources)
@@ -209,7 +209,11 @@ extension PeekabooServices {
     }
 
     private func determineDefaultModelWithConflict(_ sources: ModelSources) -> ModelDetermination {
-        let providerListModel = self.firstAvailableModel(in: sources)
+        let providerListModel: String? = if sources.isEnvironmentProvided || sources.hasConfiguredProviderList {
+            self.firstAvailableModel(in: sources)
+        } else {
+            nil
+        }
         let environmentModel = sources.isEnvironmentProvided ? providerListModel : nil
 
         let hasConflict = sources.isEnvironmentProvided
@@ -237,7 +241,7 @@ extension PeekabooServices {
             model = nil
             resolvedModel = nil
         } else if sources.hasAnthropic {
-            model = "claude-opus-5"
+            model = "claude-opus-4-8"
             resolvedModel = nil
         } else if sources.hasOpenAI {
             model = "gpt-5.6"
@@ -507,6 +511,7 @@ private struct ModelSources {
     let configuredDefault: String?
     let aiService: PeekabooAIService
     let isProviderListExplicit: Bool
+    let hasConfiguredProviderList: Bool
     let isEnvironmentProvided: Bool
 }
 

--- a/Core/PeekabooCore/Tests/PeekabooCoreTests/Services/AI/PeekabooAIServiceTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooCoreTests/Services/AI/PeekabooAIServiceTests.swift
@@ -26,7 +26,7 @@ struct PeekabooAIServiceTests {
         let models = service.availableModels()
 
         #expect(!models.isEmpty)
-        #expect(models == [.openai(.gpt55), .anthropic(.opus48)])
+        #expect(models == [.openai(.gpt56Sol), .anthropic(.opus5)])
     }
 
     @Test
@@ -187,8 +187,8 @@ struct PeekabooAIServiceTests {
         _ = ConfigurationManager.shared.loadConfiguration()
 
         let service = PeekabooAIService()
-        #expect(service.resolvedDefaultModel == .anthropic(.opus48))
-        #expect(service.availableModels() == [.anthropic(.opus48)])
+        #expect(service.resolvedDefaultModel == .anthropic(.opus5))
+        #expect(service.availableModels() == [.anthropic(.opus5)])
     }
 
     @Test
@@ -258,8 +258,8 @@ struct PeekabooAIServiceTests {
         _ = ConfigurationManager.shared.loadConfiguration()
 
         let service = PeekabooAIService()
-        #expect(service.resolvedDefaultModel == .openai(.gpt55))
-        #expect(service.availableModels().first == .openai(.gpt55))
+        #expect(service.resolvedDefaultModel == .openai(.gpt56Sol))
+        #expect(service.availableModels().first == .openai(.gpt56Sol))
     }
 
     @Test

--- a/Core/PeekabooCore/Tests/PeekabooCoreTests/Services/AI/PeekabooAIServiceTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooCoreTests/Services/AI/PeekabooAIServiceTests.swift
@@ -174,13 +174,56 @@ struct PeekabooAIServiceTests {
 
     @Test
     @MainActor
-    func `Falls back to Anthropic when only Anthropic key is present`() {
+    func `Auth-only Anthropic fallback remains zero-retention compatible`() throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("peekaboo-config-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+
+        setenv("PEEKABOO_CONFIG_DIR", tempDir.path, 1)
+        setenv("PEEKABOO_CONFIG_DISABLE_MIGRATION", "1", 1)
         setenv("ANTHROPIC_API_KEY", "key", 1)
         unsetenv("OPENAI_API_KEY")
-        unsetenv("PEEKABOO_CONFIG_DIR")
         defer {
+            unsetenv("PEEKABOO_CONFIG_DIR")
+            unsetenv("PEEKABOO_CONFIG_DISABLE_MIGRATION")
             unsetenv("ANTHROPIC_API_KEY")
             ConfigurationManager.shared.resetForTesting()
+            try? FileManager.default.removeItem(at: tempDir)
+        }
+
+        ConfigurationManager.shared.resetForTesting()
+        _ = ConfigurationManager.shared.loadConfiguration()
+
+        let service = PeekabooAIService()
+        #expect(service.resolvedDefaultModel == .anthropic(.opus48))
+        #expect(service.availableModels() == [.anthropic(.opus48)])
+    }
+
+    @Test
+    @MainActor
+    func `Saved current provider generation selects Opus 5`() throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("peekaboo-config-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        try """
+        {
+          "aiProviders": { "providers": "openai/gpt-5.6,anthropic/claude-opus-5" }
+        }
+        """.write(
+            to: tempDir.appendingPathComponent("config.json"),
+            atomically: true,
+            encoding: .utf8)
+
+        setenv("PEEKABOO_CONFIG_DIR", tempDir.path, 1)
+        setenv("PEEKABOO_CONFIG_DISABLE_MIGRATION", "1", 1)
+        setenv("ANTHROPIC_API_KEY", "key", 1)
+        unsetenv("OPENAI_API_KEY")
+        defer {
+            unsetenv("PEEKABOO_CONFIG_DIR")
+            unsetenv("PEEKABOO_CONFIG_DISABLE_MIGRATION")
+            unsetenv("ANTHROPIC_API_KEY")
+            ConfigurationManager.shared.resetForTesting()
+            try? FileManager.default.removeItem(at: tempDir)
         }
 
         ConfigurationManager.shared.resetForTesting()

--- a/Core/PeekabooCore/Tests/PeekabooTests/AIProviderParserTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/AIProviderParserTests.swift
@@ -7,9 +7,9 @@ import Testing
 struct AIProviderParserTests {
     @Test
     func `Parse single provider`() {
-        #expect(AIProviderParser.parse("openai/gpt-5.5") == AIProviderParser.ProviderConfig(
+        #expect(AIProviderParser.parse("openai/gpt-5.6") == AIProviderParser.ProviderConfig(
             provider: "openai",
-            model: "gpt-5.5"))
+            model: "gpt-5.6"))
         #expect(AIProviderParser.parse("anthropic/claude-opus-4-7") == AIProviderParser.ProviderConfig(
             provider: "anthropic",
             model: "claude-opus-4-7"))
@@ -32,9 +32,9 @@ struct AIProviderParserTests {
 
     @Test
     func `Parse with whitespace`() {
-        #expect(AIProviderParser.parse("  openai/gpt-5.5  ") == AIProviderParser.ProviderConfig(
+        #expect(AIProviderParser.parse("  openai/gpt-5.6  ") == AIProviderParser.ProviderConfig(
             provider: "openai",
-            model: "gpt-5.5"))
+            model: "gpt-5.6"))
         #expect(AIProviderParser.parse("\tanthropic/claude-opus-4-7\n") == AIProviderParser.ProviderConfig(
             provider: "anthropic",
             model: "claude-opus-4-7"))
@@ -53,25 +53,25 @@ struct AIProviderParserTests {
 
     @Test
     func `Parse provider list`() {
-        let providers = AIProviderParser.parseList("openai/gpt-5.5,anthropic/claude-opus-4-7,ollama/llava:latest")
+        let providers = AIProviderParser.parseList("openai/gpt-5.6,anthropic/claude-opus-5,ollama/llava:latest")
         #expect(providers.count == 3)
-        #expect(providers[0] == AIProviderParser.ProviderConfig(provider: "openai", model: "gpt-5.5"))
-        #expect(providers[1] == AIProviderParser.ProviderConfig(provider: "anthropic", model: "claude-opus-4-7"))
+        #expect(providers[0] == AIProviderParser.ProviderConfig(provider: "openai", model: "gpt-5.6"))
+        #expect(providers[1] == AIProviderParser.ProviderConfig(provider: "anthropic", model: "claude-opus-5"))
         #expect(providers[2] == AIProviderParser.ProviderConfig(provider: "ollama", model: "llava:latest"))
     }
 
     @Test
     func `Parse list with invalid entries`() {
         let providers = AIProviderParser.parseList(
-            "openai/gpt-4,invalid,anthropic/claude-3,/bad,ollama/,openai/gpt-5.5")
+            "openai/gpt-4,invalid,anthropic/claude-3,/bad,ollama/,openai/gpt-5.6")
         #expect(providers.count == 1)
-        #expect(providers[0] == AIProviderParser.ProviderConfig(provider: "openai", model: "gpt-5.5"))
+        #expect(providers[0] == AIProviderParser.ProviderConfig(provider: "openai", model: "gpt-5.6"))
     }
 
     @Test
     func `Parse first provider`() {
-        #expect(AIProviderParser.parseFirst("openai/gpt-5.5,anthropic/claude-opus-4-7")?.provider == "openai")
-        #expect(AIProviderParser.parseFirst("invalid,anthropic/claude-opus-4-7")?.provider == "anthropic")
+        #expect(AIProviderParser.parseFirst("openai/gpt-5.6,anthropic/claude-opus-5")?.provider == "openai")
+        #expect(AIProviderParser.parseFirst("invalid,anthropic/claude-opus-5")?.provider == "anthropic")
         #expect(AIProviderParser.parseFirst("invalid,bad,") == nil)
     }
 
@@ -79,39 +79,39 @@ struct AIProviderParserTests {
     func `Determine default model with all providers`() {
         // When all providers are available, should use first one
         let model = AIProviderParser.determineDefaultModel(
-            from: "ollama/llava:latest,openai/gpt-5.5,anthropic/claude-opus-4-7",
+            from: "ollama/llava:latest,openai/gpt-5.6,anthropic/claude-opus-5",
             hasOpenAI: true,
             hasAnthropic: true,
             hasOllama: false)
-        #expect(model == "gpt-5.5")
+        #expect(model == "gpt-5.6")
     }
 
     @Test
     func `Determine default model with limited providers`() {
         // When only some providers are available
         let model1 = AIProviderParser.determineDefaultModel(
-            from: "openai/gpt-5.5,ollama/llava:latest,anthropic/claude-opus-4-7",
+            from: "openai/gpt-5.6,ollama/llava:latest,anthropic/claude-opus-5",
             hasOpenAI: false,
             hasAnthropic: true,
             hasOllama: false)
-        #expect(model1 == "claude-opus-4-8")
+        #expect(model1 == "claude-opus-5")
 
         let model2 = AIProviderParser.determineDefaultModel(
-            from: "openai/gpt-5.5,anthropic/claude-sonnet-4.5,ollama/llava:latest",
+            from: "openai/gpt-5.6,anthropic/claude-sonnet-4.5,ollama/llava:latest",
             hasOpenAI: false,
             hasAnthropic: true,
             hasOllama: false)
-        #expect(model2 == "claude-opus-4-8")
+        #expect(model2 == "claude-opus-5")
 
         let model3 = AIProviderParser.determineDefaultModel(
-            from: "openai/gpt-5.5,minimax/MiniMax-M2.7",
+            from: "openai/gpt-5.6,minimax/MiniMax-M2.7",
             hasOpenAI: false,
             hasMiniMax: true,
             hasOllama: false)
         #expect(model3 == "MiniMax-M2.7")
 
         let model4 = AIProviderParser.determineDefaultModel(
-            from: "openai/gpt-5.5,minimax-cn/MiniMax-M2.7",
+            from: "openai/gpt-5.6,minimax-cn/MiniMax-M2.7",
             hasOpenAI: false,
             hasMiniMaxChina: true,
             hasOllama: false)
@@ -136,7 +136,7 @@ struct AIProviderParserTests {
     @Test
     func `Determine default model with configured default`() {
         let model = AIProviderParser.determineDefaultModel(
-            from: "openai/gpt-5.5,anthropic/claude-opus-4-7",
+            from: "openai/gpt-5.6,anthropic/claude-opus-5",
             hasOpenAI: true,
             hasAnthropic: true,
             configuredDefault: "my-custom-model")
@@ -150,19 +150,19 @@ struct AIProviderParserTests {
             from: "invalid/model",
             hasOpenAI: false,
             hasAnthropic: true)
-        #expect(model1 == "claude-opus-4-8")
+        #expect(model1 == "claude-opus-5")
 
         let model2 = AIProviderParser.determineDefaultModel(
             from: "",
             hasOpenAI: true,
             hasAnthropic: false)
-        #expect(model2 == "gpt-5.5")
+        #expect(model2 == "gpt-5.6")
 
         let model3 = AIProviderParser.determineDefaultModel(
             from: "",
             hasOpenAI: false,
             hasAnthropic: false)
-        #expect(model3 == "gpt-5.5")
+        #expect(model3 == "gpt-5.6")
 
         let model4 = AIProviderParser.determineDefaultModel(
             from: "",
@@ -174,8 +174,8 @@ struct AIProviderParserTests {
 
     @Test
     func `Extract provider and model`() {
-        #expect(AIProviderParser.extractProvider(from: "openai/gpt-5.5") == "openai")
-        #expect(AIProviderParser.extractModel(from: "openai/gpt-5.5") == "gpt-5.5")
+        #expect(AIProviderParser.extractProvider(from: "openai/gpt-5.6") == "openai")
+        #expect(AIProviderParser.extractModel(from: "openai/gpt-5.6") == "gpt-5.6")
         #expect(AIProviderParser.extractProvider(from: "invalid") == nil)
         #expect(AIProviderParser.extractModel(from: "invalid") == nil)
     }

--- a/Core/PeekabooCore/Tests/PeekabooTests/AIProviderParserTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/AIProviderParserTests.swift
@@ -150,7 +150,7 @@ struct AIProviderParserTests {
             from: "invalid/model",
             hasOpenAI: false,
             hasAnthropic: true)
-        #expect(model1 == "claude-opus-5")
+        #expect(model1 == "claude-opus-4-8")
 
         let model2 = AIProviderParser.determineDefaultModel(
             from: "",

--- a/Core/PeekabooCore/Tests/PeekabooTests/AnthropicModelTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/AnthropicModelTests.swift
@@ -32,14 +32,14 @@ struct AnthropicModelTests {
 
     @Test
     func `Anthropic default model selection`() {
-        // Tachikoma keeps the library-level Claude shortcut stable; Peekaboo chooses Fable separately.
+        // Tachikoma's library-level default and Claude shortcut both track the current Opus generation.
         let defaultModel = Model.default
         let claudeModel = Model.claude
 
         #expect(defaultModel.providerName == "Anthropic")
         #expect(claudeModel.providerName == "Anthropic")
-        #expect(defaultModel.modelId == "claude-opus-4-8")
-        #expect(claudeModel.modelId == "claude-opus-4-8")
+        #expect(defaultModel.modelId == "claude-opus-5")
+        #expect(claudeModel.modelId == "claude-opus-5")
 
         // Test model shortcuts
         let anthropicModels = [

--- a/Core/PeekabooCore/Tests/PeekabooTests/ConfigurationEnvironmentTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/ConfigurationEnvironmentTests.swift
@@ -168,6 +168,24 @@ struct ConfigurationManagerEnvironmentTests {
     }
 
     @Test
+    func `Anthropic custom provider probe uses configured model`() {
+        let configured = Configuration.CustomProvider(
+            name: "Compatible Endpoint",
+            type: .anthropic,
+            options: .init(baseURL: "https://api.example.com", apiKey: "test-key"),
+            models: [
+                "claude-opus-4-8": .init(name: "Claude Opus 4.8"),
+            ])
+        let unconfigured = Configuration.CustomProvider(
+            name: "Compatible Endpoint",
+            type: .anthropic,
+            options: .init(baseURL: "https://api.example.com", apiKey: "test-key"))
+
+        #expect(ConfigurationManager.anthropicProbeModel(for: configured) == "claude-opus-4-8")
+        #expect(ConfigurationManager.anthropicProbeModel(for: unconfigured) == "claude-opus-5")
+    }
+
+    @Test
     func `custom provider apiKey env references stay literal when config is saved`() throws {
         let key = "PEEKABOO_CUSTOM_PROVIDER_KEY"
         setenv(key, "secret-that-must-not-be-written", 1)

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooAIServiceProviderTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooAIServiceProviderTests.swift
@@ -423,6 +423,34 @@ struct PeekabooAIServiceProviderTests {
 
     @Test
     @MainActor
+    func `Auth-only Anthropic discovery keeps the compatibility model`() throws {
+        try self.withIsolatedEnvironment(["ANTHROPIC_API_KEY": "key"]) {
+            let service = PeekabooAIService()
+            #expect(service.resolvedDefaultModel == .anthropic(.opus48))
+            #expect(service.availableModels() == [.anthropic(.opus48)])
+        }
+    }
+
+    @Test
+    @MainActor
+    func `Saved current provider generation selects Opus 5`() throws {
+        try self.withIsolatedEnvironment(
+            ["ANTHROPIC_API_KEY": "key"],
+            configurationJSON: """
+            {
+              "aiProviders": {
+                "providers": "openai/gpt-5.6,anthropic/claude-opus-5"
+              }
+            }
+            """) {
+                let service = PeekabooAIService()
+                #expect(service.resolvedDefaultModel == .anthropic(.opus5))
+                #expect(service.availableModels() == [.anthropic(.opus5)])
+            }
+    }
+
+    @Test
+    @MainActor
     func `Falls back to Gemini when only Gemini key is present`() throws {
         try self.withIsolatedEnvironment(["GEMINI_API_KEY": "key"]) {
             let service = PeekabooAIService()

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooAgentResumeModelContinuityTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooAgentResumeModelContinuityTests.swift
@@ -274,7 +274,7 @@ struct PeekabooAgentResumeModelContinuityTests {
     @MainActor
     private func makeAgentService(
         services: PeekabooServices? = nil,
-        defaultModel: LanguageModel = .anthropic(.opus48)) throws -> (
+        defaultModel: LanguageModel = .anthropic(.opus5)) throws -> (
         service: PeekabooAgentService,
         store: IsolatedAgentSessionStore)
     {

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooAgentServiceModelTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooAgentServiceModelTests.swift
@@ -26,8 +26,7 @@ extension PeekabooAgentServiceTests {
         let mockServices = self.makeServices()
         let agentService = try PeekabooAgentService(services: mockServices)
 
-        // Should default to Claude Opus 4.8 for Anthropic zero-retention compatibility.
-        #expect(agentService.defaultModel == LanguageModel.anthropic(.opus48).description)
+        #expect(agentService.defaultModel == LanguageModel.anthropic(.opus5).description)
     }
 
     @Test
@@ -61,7 +60,7 @@ extension PeekabooAgentServiceTests {
                 let agentService = try PeekabooAgentService(services: services)
 
                 let fableSettings = agentService.generationSettings(for: .anthropic(.fable5))
-                let opusSettings = agentService.generationSettings(for: .anthropic(.opus48))
+                let opusSettings = agentService.generationSettings(for: .anthropic(.opus5))
 
                 #expect(fableSettings.maxTokens == 128_000)
                 #expect(fableSettings.temperature == 0.2)
@@ -1163,7 +1162,7 @@ extension PeekabooAgentServiceTests {
             let services = self.makeServices()
             let agentService = try #require(services.agent as? PeekabooAgentService)
 
-            #expect(agentService.defaultModel == LanguageModel.openai(.gpt55).description)
+            #expect(agentService.defaultModel == LanguageModel.openai(.gpt56Sol).description)
         }
     }
 
@@ -1613,7 +1612,7 @@ extension PeekabooAgentServiceTests {
                 let services = self.makeServices()
                 let agentService = try #require(services.agent as? PeekabooAgentService)
 
-                #expect(agentService.defaultModel == LanguageModel.openai(.gpt55).description)
+                #expect(agentService.defaultModel == LanguageModel.openai(.gpt56Sol).description)
             }
     }
 

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooAgentServiceModelTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooAgentServiceModelTests.swift
@@ -1154,11 +1154,52 @@ extension PeekabooAgentServiceTests {
 
     @Test
     @MainActor
-    func `Generated provider list preserves available model order`() throws {
+    func `Auth-only Anthropic credentials keep the compatible agent fallback`() throws {
+        try self.withIsolatedAgentEnvironment([
+            "ANTHROPIC_API_KEY": "test-anthropic-key",
+        ]) {
+            let services = self.makeServices()
+            let agentService = try #require(services.agent as? PeekabooAgentService)
+
+            #expect(agentService.defaultModel == LanguageModel.anthropic(.opus48).description)
+        }
+    }
+
+    @Test
+    @MainActor
+    func `Saved Anthropic model pin wins over the current generated provider list`() throws {
+        try self.withIsolatedAgentEnvironment(
+            ["ANTHROPIC_API_KEY": "test-anthropic-key"],
+            configurationJSON: """
+            {
+              "aiProviders": {
+                "providers": "openai/gpt-5.6,anthropic/claude-opus-5"
+              },
+              "agent": {
+                "defaultModel": "claude-opus-4-8"
+              }
+            }
+            """) {
+                let services = self.makeServices()
+                let agentService = try #require(services.agent as? PeekabooAgentService)
+
+                #expect(agentService.defaultModel == LanguageModel.anthropic(.opus48).description)
+            }
+    }
+
+    @Test
+    @MainActor
+    func `Saved current provider generation preserves available model order`() throws {
         try self.withIsolatedAgentEnvironment([
             "OPENAI_API_KEY": "test-openai-key",
             "ANTHROPIC_API_KEY": "test-anthropic-key",
-        ]) {
+        ], configurationJSON: """
+        {
+          "aiProviders": {
+            "providers": "openai/gpt-5.6,anthropic/claude-opus-5"
+          }
+        }
+        """) {
             let services = self.makeServices()
             let agentService = try #require(services.agent as? PeekabooAgentService)
 

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooAgentStepLimitTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooAgentStepLimitTests.swift
@@ -966,7 +966,7 @@ struct PeekabooAgentStepLimitTests {
 
     @MainActor
     private func makeAgentService(
-        defaultModel: LanguageModel = .anthropic(.opus48)) throws -> (
+        defaultModel: LanguageModel = .anthropic(.opus5)) throws -> (
         service: PeekabooAgentService,
         store: IsolatedAgentSessionStore)
     {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -170,7 +170,7 @@ PeekabooCore integrates with Tachikoma through `PeekabooAgentService`:
 let services = PeekabooServices()
 services.installAgentRuntimeDefaults()
 let ai = PeekabooAIService(configuration: services.configuration)
-let model = ai.resolveConfiguredModel("anthropic/claude-opus-4-8") ?? .anthropic(.opus48)
+let model = ai.resolveConfiguredModel("anthropic/claude-opus-5") ?? .anthropic(.opus5)
 let agent = try PeekabooAgentService(services: services, defaultModel: model)
 ```
 

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -78,7 +78,7 @@ If your client supports environment variables, add provider and logging settings
       "command": "npx",
       "args": ["-y", "@steipete/peekaboo", "mcp"],
       "env": {
-        "PEEKABOO_AI_PROVIDERS": "openai/gpt-5.5,anthropic/claude-opus-4-8",
+        "PEEKABOO_AI_PROVIDERS": "openai/gpt-5.6,anthropic/claude-opus-5",
         "PEEKABOO_LOG_LEVEL": "info"
       }
     }

--- a/docs/commands/agent.md
+++ b/docs/commands/agent.md
@@ -18,7 +18,7 @@ read_when:
 | `chat [initial-prompt]` | Start the interactive chat loop. |
 | `--dry-run` | Validate and echo the task without calling a model, invoking tools, or creating a session. |
 | `--max-steps <n>` | Cap model turns to `1...100` (default: 100). One turn may contain multiple tool calls. |
-| `--model gpt-5.6|claude-opus-5|claude-fable-5|claude-sonnet-5|gemini-3-flash|minimax|minimax-cn/<model>|openrouter/<provider>/<model>|ollama/<model>|lmstudio/<model>` | Override the default model (`claude-opus-5`). Input is validated against supported hosted providers and local model providers. |
+| `--model gpt-5.6|gpt-5-mini|claude-opus-5|claude-fable-5|claude-sonnet-5|gemini-3-flash|minimax|minimax-cn/<model>|openrouter/<provider>/<model>|ollama/<model>|lmstudio/<model>` | Override the configured model. Concrete OpenAI and Anthropic selections are preserved; generic `gpt`/`openai` select GPT-5.6 Sol. Input is validated against supported hosted providers and local model providers. |
 | `--no-cache` | Run ephemerally without saving a resumable session. Cannot be combined with resume/list flags. |
 | `--quiet` / `--simple` / `--no-color` / `--debug-terminal` | Control output mode; the command auto-detects terminal capabilities when you don’t override it. |
 | `--audio` / `--audio-file <path>` | Use microphone input or pipe audio from disk. |
@@ -28,6 +28,7 @@ read_when:
 - Session metadata lives inside `agentService` (PeekabooCore). `agent resume` grabs the most recent session, `agent sessions` prints the cached list, and `--no-cache` keeps a run in memory.
 - Agent execution stays in the caller process by default. Pass the global `--bridge-socket <path>` option to route its tools through one specific Bridge host; `--no-remote` keeps the run strictly caller-local.
 - All agent executions run under `CommandRuntime.makeDefault()`, so environment variables, credentials, and logging levels match the top-level CLI state.
+- New configurations select GPT-5.6 and Opus 5. Credential-only Anthropic discovery uses Opus 4.8 for zero-retention compatibility, while saved configuration and session model pins remain unchanged.
 - `--dry-run` is a zero-provider task preview: it echoes the task without model reasoning, tool calls, or a resumable session.
 - Audio flags wire into Tachikoma’s audio stack: `--audio` opens the microphone and `--audio-file` loads a WAV/CAF file.
 - Generation uses `agent.temperature` and `agent.maxTokens` from the shared config written by the macOS Settings UI.

--- a/docs/commands/agent.md
+++ b/docs/commands/agent.md
@@ -18,7 +18,7 @@ read_when:
 | `chat [initial-prompt]` | Start the interactive chat loop. |
 | `--dry-run` | Validate and echo the task without calling a model, invoking tools, or creating a session. |
 | `--max-steps <n>` | Cap model turns to `1...100` (default: 100). One turn may contain multiple tool calls. |
-| `--model gpt-5.6|gpt-5.5|claude-fable-5|claude-sonnet-5|gemini-3-flash|minimax|minimax-cn/<model>|openrouter/<provider>/<model>|ollama/<model>|lmstudio/<model>` | Override the default model (`gpt-5.5`). Input is validated against supported hosted providers and local model providers. |
+| `--model gpt-5.6|claude-opus-5|claude-fable-5|claude-sonnet-5|gemini-3-flash|minimax|minimax-cn/<model>|openrouter/<provider>/<model>|ollama/<model>|lmstudio/<model>` | Override the default model (`claude-opus-5`). Input is validated against supported hosted providers and local model providers. |
 | `--no-cache` | Run ephemerally without saving a resumable session. Cannot be combined with resume/list flags. |
 | `--quiet` / `--simple` / `--no-color` / `--debug-terminal` | Control output mode; the command auto-detects terminal capabilities when you don’t override it. |
 | `--audio` / `--audio-file <path>` | Use microphone input or pipe audio from disk. |
@@ -74,8 +74,8 @@ For automation flows that cannot attach to a TTY, use `agent chat` with standard
 
 ## Examples
 ```bash
-# Let the agent sign into Slack using GPT-5.5 with verbose tracing
-peekaboo agent "Check Slack mentions" --model gpt-5.5 --verbose
+# Let the agent sign into Slack using GPT-5.6 with verbose tracing
+peekaboo agent "Check Slack mentions" --model gpt-5.6 --verbose
 
 # Use GPT-5.6 Sol (the gpt-5.6 shortcut selects Sol)
 peekaboo agent "Check the current window" --model gpt-5.6

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -21,7 +21,7 @@ Peekaboo resolves settings in this order (highest → lowest):
 
 | Setting | Config File | Environment Variable | Description |
 |---------|-------------|---------------------|-------------|
-| AI Providers | `aiProviders.providers` | `PEEKABOO_AI_PROVIDERS` | Comma-separated list (`openai/gpt-5.5,anthropic/claude-opus-4-8,grok/grok-4.3,ollama/llava:latest`). First healthy provider wins. |
+| AI Providers | `aiProviders.providers` | `PEEKABOO_AI_PROVIDERS` | Comma-separated list (`openai/gpt-5.6,anthropic/claude-opus-5,grok/grok-4.3,ollama/llava:latest`). First healthy provider wins. |
 | Agent Model | `agent.defaultModel` | `PEEKABOO_AGENT_MODEL` | Default model for `peekaboo agent`; CLI `--model` wins. |
 | Agent Temperature | `agent.temperature` | - | Sampling temperature shared by the app and CLI (default `0.7`); clamped or omitted for models that restrict it. |
 | Agent Max Tokens | `agent.maxTokens` | - | Requested output-token budget shared by the app and CLI (default `16384`, accepted range `1...128000`); clamped to provider capability. |
@@ -53,7 +53,7 @@ Peekaboo resolves settings in this order (highest → lowest):
 
 ## Provider Variables
 
-- `PEEKABOO_AI_PROVIDERS`: `provider/model` CSV. Example: `openai/gpt-5.5,anthropic/claude-opus-4-8,grok/grok-4.3,ollama/llava:latest`.
+- `PEEKABOO_AI_PROVIDERS`: `provider/model` CSV. Example: `openai/gpt-5.6,anthropic/claude-opus-5,grok/grok-4.3,ollama/llava:latest`.
 - `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GROK_API_KEY` | `X_AI_API_KEY` | `XAI_API_KEY`, `GEMINI_API_KEY`, `MINIMAX_API_KEY`, `MINIMAX_CN_API_KEY`, `MOONSHOT_API_KEY` | `KIMI_API_KEY`: required for their respective providers when using API keys.
 - Ollama native endpoint precedence: `PEEKABOO_OLLAMA_BASE_URL` > `OLLAMA_BASE_URL` >
   `aiProviders.ollamaBaseUrl` > `http://localhost:11434`. Set the server base without `/api/chat` or `/v1`; see the

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -18,8 +18,8 @@ pages instead of duplicating provider lists in multiple places.
 
 | Provider | Example model IDs | Credential |
 | --- | --- | --- |
-| **OpenAI** | gpt-5.6-sol, gpt-5.6-terra, gpt-5.6-luna, gpt-5.5, gpt-5-mini, gpt-4.1 | `OPENAI_API_KEY` |
-| **Anthropic** | claude-fable-5, claude-sonnet-5, claude-opus-4-8, claude-sonnet-4-6, claude-haiku-4-5 | `ANTHROPIC_API_KEY` |
+| **OpenAI** | gpt-5.6, gpt-5.6-sol, gpt-5.6-terra, gpt-5.6-luna, gpt-5-mini, gpt-4.1 | `OPENAI_API_KEY` |
+| **Anthropic** | claude-opus-5, claude-fable-5, claude-sonnet-5, claude-sonnet-4-6, claude-haiku-4-5 | `ANTHROPIC_API_KEY` |
 | **xAI** | grok-4 | `XAI_API_KEY` |
 | **Google** | gemini-3.1-pro-preview, gemini-3-flash | `GEMINI_API_KEY` |
 | **MiniMax** | MiniMax-M3, MiniMax-M2.7, MiniMax-M2.7-highspeed | `MINIMAX_API_KEY` |
@@ -60,7 +60,7 @@ peekaboo agent --model gpt-5.6 "summarize this window"
 peekaboo agent --model gpt-5.6-terra "summarize this window"
 peekaboo agent --model claude-fable-5 "summarize this window"
 peekaboo agent --model claude-sonnet-5 "summarize this window"
-peekaboo agent --model claude-opus-4-8 "summarize this window"
+peekaboo agent --model claude-opus-5 "summarize this window"
 peekaboo agent --model gemini-3-flash "summarize this window"
 peekaboo agent --model minimax/MiniMax-M3 "summarize this window"
 peekaboo agent --model minimax-cn/MiniMax-M3 "summarize this window"
@@ -71,10 +71,11 @@ peekaboo agent --model ollama/llama3.1:8b "open System Settings"
 peekaboo agent --model lmstudio/openai/gpt-oss-120b "summarize this window"
 ```
 
-Defaults come from `agent.defaultModel` in `~/.peekaboo/config.json`. Anthropic defaults stay on Opus 4.8 for zero-retention compatibility; select Fable 5 or Sonnet 5 explicitly when your Anthropic organization allows it. Set a per-project default with `PEEKABOO_AGENT_MODEL`.
+Defaults come from `agent.defaultModel` in `~/.peekaboo/config.json`. Anthropic defaults use Opus 5; select Fable 5,
+Sonnet 5, or an older model explicitly when needed. Set a per-project default with `PEEKABOO_AGENT_MODEL`.
 
 The app and CLI share `agent.temperature` and `agent.maxTokens`. Peekaboo clamps those requests to provider
-capabilities; Peekaboo currently catalogs Fable 5 and Sonnet 5 with 1M context windows and up to 128K output. See
+capabilities; Peekaboo currently catalogs Opus 5, Fable 5, and Sonnet 5 with 1M context windows and up to 128K output. See
 [configuration.md](configuration.md#agent-generation-settings).
 
 ## Tool calling

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -18,8 +18,8 @@ pages instead of duplicating provider lists in multiple places.
 
 | Provider | Example model IDs | Credential |
 | --- | --- | --- |
-| **OpenAI** | gpt-5.6, gpt-5.6-sol, gpt-5.6-terra, gpt-5.6-luna, gpt-5-mini, gpt-4.1 | `OPENAI_API_KEY` |
-| **Anthropic** | claude-opus-5, claude-fable-5, claude-sonnet-5, claude-sonnet-4-6, claude-haiku-4-5 | `ANTHROPIC_API_KEY` |
+| **OpenAI** | gpt-5.6, gpt-5.6-sol, gpt-5.6-terra, gpt-5.6-luna, gpt-5.5, gpt-5.4, gpt-5.4-mini, gpt-5.4-nano, gpt-5, gpt-5-pro, gpt-5-mini, gpt-5-nano | `OPENAI_API_KEY` |
+| **Anthropic** | claude-opus-5, claude-fable-5, claude-sonnet-5, claude-opus-4-8, claude-opus-4-7, claude-opus-4-5, claude-sonnet-4-6, claude-sonnet-4-5, claude-haiku-4-5 | `ANTHROPIC_API_KEY` |
 | **xAI** | grok-4 | `XAI_API_KEY` |
 | **Google** | gemini-3.1-pro-preview, gemini-3-flash | `GEMINI_API_KEY` |
 | **MiniMax** | MiniMax-M3, MiniMax-M2.7, MiniMax-M2.7-highspeed | `MINIMAX_API_KEY` |
@@ -71,8 +71,12 @@ peekaboo agent --model ollama/llama3.1:8b "open System Settings"
 peekaboo agent --model lmstudio/openai/gpt-oss-120b "summarize this window"
 ```
 
-Defaults come from `agent.defaultModel` in `~/.peekaboo/config.json`. Anthropic defaults use Opus 5; select Fable 5,
-Sonnet 5, or an older model explicitly when needed. Set a per-project default with `PEEKABOO_AGENT_MODEL`.
+Defaults come from `agent.defaultModel` and `aiProviders.providers` in `~/.peekaboo/config.json`. New generated
+configurations select GPT-5.6 and Opus 5. If Anthropic credentials are discovered without any saved provider
+selection, Peekaboo keeps the compatibility fallback on Opus 4.8 for zero-retention organizations. Explicit CLI,
+configuration, and persisted-session model selections are never upgraded to a different model. The generic `gpt`,
+`openai`, and `openai/gpt` shortcuts select GPT-5.6 Sol; a concrete model such as `gpt-5-mini` stays GPT-5 Mini.
+Set a per-project default with `PEEKABOO_AGENT_MODEL`.
 
 The app and CLI share `agent.temperature` and `agent.maxTokens`. Peekaboo clamps those requests to provider
 capabilities; Peekaboo currently catalogs Opus 5, Fable 5, and Sonnet 5 with 1M context windows and up to 128K output. See

--- a/docs/providers/README.md
+++ b/docs/providers/README.md
@@ -8,7 +8,7 @@ read_when:
 # Providers index
 
 - **OpenAI** — `openai.md`: architecture, migration status, and guidance for adding models.
-- **Anthropic** — `anthropic.md`: Fable 5, Sonnet 5, and other Claude models, output limits, generation settings, and credentials.
+- **Anthropic** — `anthropic.md`: Opus 5, Fable 5, Sonnet 5, and compatible Claude models, output limits, generation settings, and credentials.
 - **Google** — configured with `GEMINI_API_KEY`; supports Gemini 3.1 Pro Preview and Gemini 3 Flash.
 - **MiniMax** — configured with `MINIMAX_API_KEY`; supports MiniMax M3 and M2.7 through the Anthropic-compatible API.
 - **MiniMax China** — use `minimax-cn/...` with `MINIMAX_CN_API_KEY` or the shared `MINIMAX_API_KEY`; routes to `api.minimaxi.com`.
@@ -25,7 +25,7 @@ configuration syntax, and environment variable reference.
 | Provider | Tools | Vision | Streaming | Local/offline | Auth |
 | --- | --- | --- | --- | --- | --- |
 | OpenAI | Yes (function/tool calling) | Yes | Yes | No | API key or OAuth |
-| Anthropic | Yes | Yes | Model-dependent; Fable 5, Sonnet 5, and Opus 4.8 currently non-streaming | No | API key or OAuth (Claude Pro/Max) |
+| Anthropic | Yes | Yes | Model-dependent; Opus 5, Fable 5, Sonnet 5, and Opus 4.8 currently non-streaming | No | API key or OAuth (Claude Pro/Max) |
 | Google | Yes | Yes | Yes | No | API key |
 | MiniMax | Yes | Model-dependent | Yes | No | API key |
 | MiniMax China | Yes | Model-dependent | Yes | No | API key |

--- a/docs/providers/anthropic.md
+++ b/docs/providers/anthropic.md
@@ -14,9 +14,10 @@ tool calls, vision, thinking blocks, and provider-specific event handling.
 
 | Model | Context | Max output | Notes |
 | --- | ---: | ---: | --- |
+| `claude-opus-5` | 1M | 128K | Default Anthropic choice. |
 | `claude-fable-5` | 1M | 128K | Explicit opt-in for long-horizon agent work. |
 | `claude-sonnet-5` | 1M | 128K | Explicit opt-in; not the automatic Anthropic default. |
-| `claude-opus-4-8` | 1M | 128K | Default Anthropic choice; compatible with zero-retention organizations. |
+| `claude-opus-4-8` | 1M | 128K | Previous-generation option; compatible with zero-retention organizations. |
 | `claude-sonnet-4-6` | 1M | 64K | Balanced speed and capability. |
 | `claude-haiku-4-5` | 200K | 64K | Fast, lower-cost tasks. |
 
@@ -40,7 +41,7 @@ Environment credentials remain available for automation:
 
 ```bash
 ANTHROPIC_API_KEY=sk-ant-... \
-  peekaboo agent --model claude-opus-4-8 "describe the current window"
+  peekaboo agent --model claude-opus-5 "describe the current window"
 ```
 
 ## Generation settings
@@ -49,7 +50,7 @@ The app and CLI read the same `agent.temperature` and `agent.maxTokens` values f
 `~/.peekaboo/config.json`. Peekaboo clamps the token request to the selected model's output capability and strips
 sampling parameters from current adaptive-thinking models when the Anthropic API does not accept them.
 
-Fable 5, Sonnet 5, and Opus 4.8 currently use the non-streaming generation path so signed thinking history and
+Opus 5, Fable 5, Sonnet 5, and Opus 4.8 currently use the non-streaming generation path so signed thinking history and
 rollback behavior remain valid. Agent progress events still report start, assistant output, tool activity, completion,
 and errors.
 

--- a/docs/providers/anthropic.md
+++ b/docs/providers/anthropic.md
@@ -14,15 +14,17 @@ tool calls, vision, thinking blocks, and provider-specific event handling.
 
 | Model | Context | Max output | Notes |
 | --- | ---: | ---: | --- |
-| `claude-opus-5` | 1M | 128K | Default Anthropic choice. |
+| `claude-opus-5` | 1M | 128K | Default in new and explicitly generated provider configurations. |
 | `claude-fable-5` | 1M | 128K | Explicit opt-in for long-horizon agent work. |
 | `claude-sonnet-5` | 1M | 128K | Explicit opt-in; not the automatic Anthropic default. |
-| `claude-opus-4-8` | 1M | 128K | Previous-generation option; compatible with zero-retention organizations. |
+| `claude-opus-4-8` | 1M | 128K | Credential-only compatibility fallback for zero-retention organizations. |
 | `claude-sonnet-4-6` | 1M | 64K | Balanced speed and capability. |
 | `claude-haiku-4-5` | 200K | 64K | Fast, lower-cost tasks. |
 
-Fable 5 and Sonnet 5 are not the automatic Anthropic default. Select either explicitly when your Anthropic
-organization allows the model:
+New provider configurations select Opus 5. When Peekaboo discovers Anthropic credentials without a saved provider
+selection, it uses Opus 4.8 so zero-retention organizations keep working. Saved configurations, explicit CLI choices,
+and resumed sessions preserve their exact model instead of crossing that boundary. Fable 5 and Sonnet 5 remain
+explicit choices when your Anthropic organization allows them:
 
 ```bash
 peekaboo agent --model claude-fable-5 "inspect this app and summarize its workflow"
@@ -54,9 +56,9 @@ Opus 5, Fable 5, Sonnet 5, and Opus 4.8 currently use the non-streaming generati
 rollback behavior remain valid. Agent progress events still report start, assistant output, tool activity, completion,
 and errors.
 
-Anthropic-compatible custom providers inherit known Fable 5 and Sonnet 5 capability limits when their model ID is
-`claude-fable-5` or `claude-sonnet-5` (including provider-qualified forms). A custom model's explicit `maxTokens`
-value takes precedence for other IDs.
+Anthropic-compatible custom providers inherit known Opus 5, Fable 5, and Sonnet 5 capability limits when their model
+ID identifies one of those models, including provider-qualified forms. A custom model's explicit `maxTokens` value
+takes precedence for other IDs.
 
 See [configuration.md](../configuration.md) for the shared settings schema and [providers.md](../providers.md) for
 the full provider catalog.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -119,7 +119,7 @@ Common helpers:
 - Lives under `Apps/CLI/Sources/PeekabooCLI/Commands/AI/AgentCommand.swift`.
 - Supports `agent run`, `agent resume [session-id]`, `agent sessions`, `agent chat`, `--dry-run`, `--max-steps`, `--no-cache`, and audio options.
 - Output modes (`minimal`, `compact`, `enhanced`, `quiet`, `verbose`) adapt to terminal capabilities via `TerminalDetector`.
-- Uses Tachikoma to call GPT-5.5, Claude Fable 5/Opus 4.8, or Gemini 3.1. Session metadata is stored via `AgentSessionInfo` for resume flows.
+- Uses Tachikoma to call the GPT-5.6/5.5/5.4/5 families, Claude Opus 5/Fable 5/Sonnet 5 and compatible 4.x models, or Gemini 3.x. New configurations select GPT-5.6 and Opus 5; credential-only Anthropic discovery stays on Opus 4.8 for zero-retention compatibility. Session metadata stores the exact model selection for resume flows.
 
 ### 7.2 MCP (`peekaboo mcp`)
 - `serve` starts `PeekabooMCPServer` over stdio/HTTP/SSE.


### PR DESCRIPTION
## Summary

- bump Tachikoma to `6fb81e9` for Claude Opus 5 support (the tracked submodule URL is already the canonical `openclaw/Tachikoma` URL)
- default new agent configurations, provider fallbacks, verifier/analyzer choices, and Mac settings to GPT-5.6 or Claude Opus 5
- resolve `claude`, `anthropic`, and `opus` to Opus 5, and collapse supported older GPT aliases to GPT-5.6 Sol while retaining explicit Opus 4.8 parsing
- add Opus 5 to the Mac model picker and refresh CLI help, MCP banners, configuration templates, docs, and the 4.0.1 changelog
- preserve explicitly pinned title-generation models and configured Anthropic-compatible probe models while applying current-generation defaults only when no model is pinned

## Behavioral defaults changed

- the default `PeekabooAgentService` and CLI fallback model is Claude Opus 5 instead of Claude Opus 4.8
- the default generated provider list is `openai/gpt-5.6,anthropic/claude-opus-5`
- OpenAI fallback, action verification, vision override, and legacy GPT alias normalization now select GPT-5.6 Sol instead of GPT-5.5
- Anthropic credential fallback, provider-only analyze requests, session titles, and Mac settings now select Claude Opus 5 instead of Claude Opus 4.8
- custom Anthropic-compatible providers without a configured model probe Opus 5; providers with configured model IDs continue to probe one of those IDs

## Proof

- `swift build --package-path Apps/CLI`
- `PEEKABOO_INCLUDE_AUTOMATION_TESTS=true swift build --package-path Apps/CLI --build-tests`
- `pnpm run format` (0 files formatted on final run)
- `pnpm run lint` (21 existing warnings, 0 serious; one warning arrived with upstream PR #359)
- `pnpm run lint:docs`
- `pnpm run test:safe` (763 tests in 92 suites plus 72 tests in 6 suites)
- `./scripts/build-mac-debug.sh`
- `swift test --package-path Apps/CLI --filter 'Current generation CLI model selections validate'`
- `swift test --package-path Core/PeekabooCore --filter 'Anthropic custom provider probe uses configured model'`

Autoreview completed with no accepted or actionable findings after fixing explicit-model preservation for session titles and custom Anthropic-compatible provider probes.
