### PR TITLE
fix(window): bound AX inventory enrichment

### DIFF
--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Keep background app launch/open ownership through verified focus reconciliation, restoring only the exact prior process generation without overriding a later user foreground choice.
 - Stop probing, requesting, advertising, or showing AppleScript Automation permission now that application, Dock, and UI operations use native macOS APIs; remove AppleScript code from shipped executables while retaining legacy wire/error decoding for older Bridge hosts.
+- Return generation-pinned CG window inventory promptly when AX enrichment stalls; detached per-process enrichment no longer holds Bridge requests after caller timeout or disconnect.
 - Stop the curated `learn` copy from presenting `shell` as a CLI command: it remains a built-in Agent capability but is not in the MCP catalog and has no `peekaboo shell` CLI root.
 - Ensure action-command JSON validation failures before dispatch report `effect: refused`, including parser and binding errors.
 - Verify app focus against the exact active Workspace PID and visible frontmost-window PID, retry through native AX activation, and report the verified effect as confirmed instead of claiming success for an unfulfilled request.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Fixed
 - Keep background app launch/open ownership through verified focus reconciliation, restoring only the exact prior process generation while treating transient frontmost uncertainty and later user foreground choices conservatively.
 - Stop probing, requesting, advertising, or showing AppleScript Automation permission now that application, Dock, and UI operations use native macOS APIs; remove the stale checked-in CLI binary and AppleScript code from shipped executables while retaining legacy wire/error decoding for older Bridge hosts.
+- Return generation-pinned CG window inventory promptly when AX enrichment stalls; detached per-process enrichment now times out without holding the Bridge request or desktop lane after its caller disconnects.
 - Stop `peekaboo learn` from presenting `shell` as a CLI command: it remains a built-in Agent capability but is not in the MCP catalog and has no `peekaboo shell` CLI root; guard both curated Agent overrides and rendered CLI roots against future drift.
 - Ensure action-command JSON validation failures before dispatch report
   `effect: refused`, including parser and binding errors.

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/System/ApplicationService+WindowListing.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/System/ApplicationService+WindowListing.swift
@@ -1,5 +1,4 @@
 import AppKit
-import AXorcist
 import Foundation
 import os.log
 import PeekabooFoundation
@@ -13,16 +12,24 @@ extension ApplicationService {
         let startTime = Date()
         self.logger.info("Listing windows for application: \(appIdentifier)")
         let app = try await findApplication(identifier: appIdentifier)
+        guard let processIdentity = app.processIdentity,
+              self.processStartIdentityProvider(processIdentity.processIdentifier) ==
+              processIdentity.processStartIdentity
+        else {
+            throw PeekabooError.snapshotStale(
+                "Application \(app.name) has no stable process generation for window listing")
+        }
         let hasScreenRecording = self.permissions.checkScreenRecordingPermission()
 
         let context = WindowEnumerationContext(
             service: self,
             app: app,
             startTime: startTime,
-            axTimeout: timeout ?? Self.axTimeout,
+            axTimeout: timeout ?? Self.windowAXEnrichmentTimeout,
             hasScreenRecording: hasScreenRecording,
-            logger: self.logger)
-        return await context.run()
+            logger: self.logger,
+            processIdentity: processIdentity)
+        return try await context.run()
     }
 
     static func normalizeWindowIndices(_ windows: [ServiceWindowInfo]) -> [ServiceWindowInfo] {
@@ -57,50 +64,45 @@ extension ApplicationService {
     }
 
     func createWindowInfo(
-        from window: Element,
+        from descriptor: WindowEnumerationContext.AXWindowDescriptor,
         index: Int,
-        isKeyWindow: Bool? = nil,
-        isFrontmost: Bool? = nil,
-        expectedProcessIdentity: ApplicationProcessIdentity?) async -> ServiceWindowInfo?
+        expectedProcessIdentity: ApplicationProcessIdentity) -> ServiceWindowInfo?
     {
-        guard let title = window.title(),
-              let expectedProcessIdentity,
-              window.pid() == expectedProcessIdentity.processIdentifier
-        else {
-            return nil
-        }
-
-        let bounds = self.windowBounds(for: window)
-        let isMinimized = window.isMinimized()
-        let screen = self.screenInfo(for: bounds)
-        let windowResolution = self.resolveWindowID(for: window, title: title, bounds: bounds, fallbackIndex: index)
-        let windowID = windowResolution.windowID
-        guard windowResolution.isReliable,
-              let mutationIdentity = SystemIdentityResolver.axWindowMutationIdentity(
+        guard let bounds = descriptor.bounds,
+              !descriptor.title.isEmpty,
+              let resolvedID = descriptor.windowID ?? self.matchWindowID(
+                  pid: expectedProcessIdentity.processIdentifier,
+                  title: descriptor.title,
+                  bounds: bounds),
+              let windowID = CGWindowID(exactly: resolvedID),
+              let mutationIdentity = descriptor.mutationIdentity ??
+              SystemIdentityResolver.axWindowMutationIdentity(
                   snapshot: SystemIdentityResolver.WindowMutationSnapshot(
                       windowID: windowID,
                       ownerProcessIdentifier: expectedProcessIdentity.processIdentifier,
                       ownerProcessStartIdentity: expectedProcessIdentity.processStartIdentity,
                       bounds: bounds,
-                      isMinimized: isMinimized),
+                      isMinimized: descriptor.isMinimized),
                   processStartIdentityProvider: SystemIdentityResolver.processStartIdentity,
                   windowIdentityProvider: SystemIdentityResolver.windowIdentity)
         else {
             return nil
         }
+
+        let screen = self.screenInfo(for: bounds)
         let spaces = self.spaceInfo(for: windowID)
         let level = self.windowLevel(for: windowID)
 
-        let minimized = isMinimized ?? false
+        let minimized = descriptor.isMinimized ?? false
         return ServiceWindowInfo(
-            windowID: Int(windowID),
-            title: title,
+            windowID: resolvedID,
+            title: descriptor.title,
             bounds: bounds,
             isMinimized: minimized,
-            isMainWindow: window.isMain() ?? false,
-            isKeyWindow: isKeyWindow,
-            isFrontmost: isFrontmost,
-            subrole: window.subrole(),
+            isMainWindow: descriptor.isMainWindow,
+            isKeyWindow: descriptor.isKeyWindow,
+            isFrontmost: descriptor.isFrontmost,
+            subrole: descriptor.subrole,
             windowLevel: level,
             index: index,
             spaceID: spaces.spaceID,
@@ -113,40 +115,13 @@ extension ApplicationService {
             mutationIdentity: mutationIdentity)
     }
 
-    private func windowBounds(for window: Element) -> CGRect {
-        let position = window.position() ?? .zero
-        let size = window.size() ?? .zero
-        return CGRect(origin: position, size: size)
-    }
-
     private func screenInfo(for bounds: CGRect) -> (index: Int?, name: String?) {
         let screenService = ScreenService()
         let screenInfo = screenService.screenContainingWindow(bounds: bounds)
         return (screenInfo?.index, screenInfo?.name)
     }
 
-    private func resolveWindowID(
-        for window: Element,
-        title: String,
-        bounds: CGRect,
-        fallbackIndex: Int) -> (windowID: CGWindowID, isReliable: Bool)
-    {
-        let windowIdentityService = WindowIdentityService()
-        if let identifier = windowIdentityService.getWindowID(from: window) {
-            return (identifier, true)
-        }
-
-        if let pid = window.pid(), let matched = matchWindowID(pid: pid, title: title, bounds: bounds) {
-            return (matched, true)
-        }
-
-        let missingIdentifierMessage =
-            "Failed to get actual window ID for window '\(title)', using index \(fallbackIndex) as fallback"
-        self.logger.warning("\(missingIdentifierMessage)")
-        return (CGWindowID(fallbackIndex), false)
-    }
-
-    private func matchWindowID(pid: pid_t, title: String, bounds: CGRect) -> CGWindowID? {
+    private func matchWindowID(pid: pid_t, title: String, bounds: CGRect) -> Int? {
         let options: CGWindowListOption = [.optionAll, .excludeDesktopElements]
         guard let windowList = CGWindowListCopyWindowInfo(options, kCGNullWindowID) as? [[String: Any]] else {
             return nil
@@ -165,20 +140,15 @@ extension ApplicationService {
             else {
                 continue
             }
-
-            let cgBounds = CGRect(x: x, y: y, width: width, height: height)
-
-            let withinTolerance = abs(cgBounds.origin.x - bounds.origin.x) < 5 &&
-                abs(cgBounds.origin.y - bounds.origin.y) < 5 &&
-                abs(cgBounds.size.width - bounds.size.width) < 5 &&
-                abs(cgBounds.size.height - bounds.size.height) < 5
-
-            if withinTolerance, let windowNumber = windowInfo[kCGWindowNumber as String] as? Int {
-                self.logger.debug("Found window ID \(windowNumber) via CGWindowList for '\(title)'")
-                return CGWindowID(windowNumber)
+            let candidateBounds = CGRect(x: x, y: y, width: width, height: height)
+            let matchesBounds = abs(candidateBounds.origin.x - bounds.origin.x) < 5 &&
+                abs(candidateBounds.origin.y - bounds.origin.y) < 5 &&
+                abs(candidateBounds.size.width - bounds.size.width) < 5 &&
+                abs(candidateBounds.size.height - bounds.size.height) < 5
+            if matchesBounds, let windowNumber = windowInfo[kCGWindowNumber as String] as? Int {
+                return windowNumber
             }
         }
-
         return nil
     }
 
@@ -228,7 +198,7 @@ extension ApplicationService {
             data: ServiceWindowListData(windows: normalizedWindows, targetApplication: app),
             summary: UnifiedToolOutput.Summary(
                 brief: "Found \(processedCount) window\(processedCount == 1 ? "" : "s") for \(app.name)",
-                status: .success,
+                status: warnings.isEmpty ? .success : .partial,
                 counts: [
                     "windows": processedCount,
                     "minimized": minimizedCount,

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/System/ApplicationService.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/System/ApplicationService.swift
@@ -107,6 +107,10 @@ public final class ApplicationService: ApplicationServiceProtocol {
     /// AX can be sluggish on some apps (e.g., Arc); allow more headroom.
     static let axTimeout: Float = 10.0
 
+    /// Window inventory is CG-first, so AX is bounded enrichment rather than an authoritative read.
+    /// Keep this safely below the Bridge's fixed request deadline so partial CG inventory remains usable.
+    static let windowAXEnrichmentTimeout: Float = 2.0
+
     public convenience init(
         permissions: PermissionsService = PermissionsService(),
         feedbackClient: any AutomationFeedbackClient = NoopAutomationFeedbackClient())

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/System/ApplicationWindowEnumerationContext.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/System/ApplicationWindowEnumerationContext.swift
@@ -1,39 +1,25 @@
 import AppKit
-import AXorcist
 import Foundation
 import os.log
 import PeekabooFoundation
 
 @MainActor
 struct WindowEnumerationContext {
+    typealias AXEnumerator = @Sendable (
+        _ processIdentity: ApplicationProcessIdentity,
+        _ timeoutSeconds: TimeInterval) async throws -> AXWindowResult
+
     struct CGSnapshot {
         let windows: [ServiceWindowInfo]
     }
 
-    struct AXWindowResult {
-        let windows: [Element]
-        let timedOut: Bool
-        let focusedWindowID: Int?
-    }
-
-    /// Plain, testable description of an AX window used to enrich or extend the CG snapshot.
-    ///
-    /// AX windows are associated with CG windows by `CGWindowID` (resolved via `_AXUIElementGetWindow`)
-    /// and, as a fallback, by matching bounds. Title is deliberately *not* an association key: two
-    /// windows of the same app can share a title, and keying by title collapses them onto a single
-    /// CG entry, reordering the enumeration and mis-aligning `--window-index` targets.
+    /// MainActor-owned descriptor used by the existing CG/AX merge contract. Detached workers return
+    /// raw descriptors; process/window receipts and AX-only records are materialized here.
     struct AXWindowDescriptor: Sendable {
-        /// Resolved CGWindowID, when AX could expose one.
         let windowID: Int?
-        /// AX window title (may be empty).
         let title: String
-        /// AX-reported bounds, used only as a fallback matcher when `windowID` is unavailable.
         let bounds: CGRect?
-        /// Fully materialized record for a genuine AX-only window. Set only when `windowID` is a
-        /// reliable resolved CGWindowID absent from the CG snapshot, so appending it cannot introduce
-        /// a phantom entry; nil for CG-matched windows and for windows AX could not resolve to an ID.
         let standaloneInfo: ServiceWindowInfo?
-
         let isMainWindow: Bool
         let isKeyWindow: Bool?
         let isFrontmost: Bool?
@@ -66,29 +52,87 @@ struct WindowEnumerationContext {
         }
     }
 
+    typealias AXWindowResult = DetachedAXWindowEnumerationResult
+
     unowned let service: ApplicationService
     let app: ServiceApplicationInfo
     let startTime: Date
     let axTimeout: Float
     let hasScreenRecording: Bool
     let logger: Logger
+    let processIdentity: ApplicationProcessIdentity
+    let cgSnapshotProvider: (@MainActor () -> CGSnapshot?)?
+    let applicationRunningProvider: (@MainActor () -> Bool)?
+    let axEnumerator: AXEnumerator
 
-    func run() async -> UnifiedToolOutput<ServiceWindowListData> {
-        let snapshot = self.hasScreenRecording ? self.collectCGSnapshot() : nil
+    init(
+        service: ApplicationService,
+        app: ServiceApplicationInfo,
+        startTime: Date,
+        axTimeout: Float,
+        hasScreenRecording: Bool,
+        logger: Logger,
+        processIdentity: ApplicationProcessIdentity,
+        cgSnapshotProvider: (@MainActor () -> CGSnapshot?)? = nil,
+        applicationRunningProvider: (@MainActor () -> Bool)? = nil,
+        axEnumerator: AXEnumerator? = nil)
+    {
+        self.service = service
+        self.app = app
+        self.startTime = startTime
+        self.axTimeout = axTimeout
+        self.hasScreenRecording = hasScreenRecording
+        self.logger = logger
+        self.processIdentity = processIdentity
+        self.cgSnapshotProvider = cgSnapshotProvider
+        self.applicationRunningProvider = applicationRunningProvider
+        self.axEnumerator = axEnumerator ?? { processIdentity, timeoutSeconds in
+            try await DetachedAXWindowEnumerationCoordinator.run(
+                processIdentifier: processIdentity.processIdentifier,
+                processStartIdentity: processIdentity.processStartIdentity,
+                timeoutSeconds: timeoutSeconds)
+        }
+    }
+
+    func run() async throws -> UnifiedToolOutput<ServiceWindowListData> {
+        try self.validateProcessIdentity()
+        let snapshot: CGSnapshot? = if self.hasScreenRecording {
+            if let cgSnapshotProvider {
+                cgSnapshotProvider()
+            } else {
+                self.collectCGSnapshot()
+            }
+        } else {
+            nil
+        }
         guard self.isApplicationRunning else {
             return self.terminatedOutput()
         }
 
-        let axWindows = self.fetchAXWindows()
+        let axWindows = try await self.fetchAXWindows()
+        try Task.checkCancellation()
+        try self.validateProcessIdentity()
         if let snapshot {
             return await self.mergeWithSnapshot(snapshot, axResult: axWindows)
         }
 
-        return await self.buildAXOnlyResult(from: axWindows)
+        return self.buildAXOnlyResult(from: axWindows)
     }
 
     private var isApplicationRunning: Bool {
-        NSRunningApplication(processIdentifier: self.app.processIdentifier)?.isTerminated == false
+        if let applicationRunningProvider {
+            return applicationRunningProvider()
+        }
+        return NSRunningApplication(processIdentifier: self.app.processIdentifier)?.isTerminated == false
+    }
+
+    private func validateProcessIdentity() throws {
+        guard self.service.processStartIdentityProvider(self.processIdentity.processIdentifier) ==
+            self.processIdentity.processStartIdentity
+        else {
+            throw PeekabooError.snapshotStale(
+                "Target PID \(self.processIdentity.processIdentifier) changed process generation during window listing")
+        }
     }
 
     private func collectCGSnapshot() -> CGSnapshot? {
@@ -155,8 +199,7 @@ struct WindowEnumerationContext {
         guard let windowIDValue = windowInfo[kCGWindowNumber as String] as? Int,
               let windowID = CGWindowID(exactly: windowIDValue),
               let ownerPID = windowInfo[kCGWindowOwnerPID as String] as? pid_t,
-              let processIdentity = self.app.processIdentity,
-              ownerPID == processIdentity.processIdentifier
+              ownerPID == self.processIdentity.processIdentifier
         else {
             return nil
         }
@@ -170,7 +213,7 @@ struct WindowEnumerationContext {
         guard let mutationIdentity = SystemIdentityResolver.windowMutationIdentity(
             windowID: windowID,
             expectedOwnerProcessIdentifier: ownerPID,
-            expectedOwnerProcessStartIdentity: processIdentity.processStartIdentity,
+            expectedOwnerProcessStartIdentity: self.processIdentity.processStartIdentity,
             expectedBounds: bounds,
             isMinimized: isMinimized)
         else {
@@ -221,21 +264,20 @@ struct WindowEnumerationContext {
                 warnings: ["Application appears to have terminated"]))
     }
 
-    private func fetchAXWindows() -> AXWindowResult {
-        guard let runningApp = NSRunningApplication(processIdentifier: self.app.processIdentifier) else {
-            return AXWindowResult(windows: [], timedOut: false, focusedWindowID: nil)
+    private func fetchAXWindows() async throws -> AXWindowResult {
+        do {
+            return try await self.axEnumerator(
+                self.processIdentity,
+                TimeInterval(self.axTimeout))
+        } catch let CaptureError.detectionTimedOut(seconds) {
+            self.logger.warning("AX window enrichment escaped its \(seconds)s hard deadline")
+            return AXWindowResult(
+                descriptors: [],
+                focusedWindowID: nil,
+                timedOut: true,
+                incomplete: true,
+                reportedWindowCount: 0)
         }
-        let appElement = AXApp(runningApp).element
-        appElement.setMessagingTimeout(self.axTimeout)
-        defer { appElement.setMessagingTimeout(0) }
-
-        let windowStartTime = Date()
-        let windows = appElement.windowsWithTimeout(timeout: self.axTimeout) ?? []
-        let timedOut = Date().timeIntervalSince(windowStartTime) >= Double(self.axTimeout)
-        let focusedWindowID = appElement.focusedWindow()
-            .flatMap { WindowIdentityService().getWindowID(from: $0) }
-            .map(Int.init)
-        return AXWindowResult(windows: windows, timedOut: timedOut, focusedWindowID: focusedWindowID)
     }
 
     private func mergeWithSnapshot(
@@ -243,15 +285,22 @@ struct WindowEnumerationContext {
         axResult: AXWindowResult) async -> UnifiedToolOutput<ServiceWindowListData>
     {
         var warnings: [String] = []
-        let descriptors = await self.collectAXDescriptors(
+        let descriptors = self.materializeStandaloneWindows(
             axResult: axResult,
-            cgWindowIDs: Set(snapshot.windows.map(\.windowID)),
-            warnings: &warnings)
+            cgWindowIDs: Set(snapshot.windows.map(\.windowID)))
 
         let merged = Self.mergeWindows(cgWindows: snapshot.windows, axDescriptors: descriptors)
 
         if axResult.timedOut {
             warnings.append("Window enumeration timed out after \(self.axTimeout)s, results may be incomplete")
+        }
+        if axResult.incomplete {
+            warnings.append("Accessibility window enrichment was incomplete; returning verified CG inventory")
+        }
+        if axResult.reportedWindowCount > descriptors.count {
+            warnings.append(
+                "Accessibility reported \(axResult.reportedWindowCount) windows; " +
+                    "enriched \(descriptors.count) before the bounded deadline")
         }
 
         return self.service.buildWindowListOutput(
@@ -270,78 +319,64 @@ struct WindowEnumerationContext {
     /// title an untitled CG window by bounds; they are never appended as their own entry, because
     /// `createWindowInfo` would fall back to a synthetic index-based ID and produce exactly the
     /// phantom / duplicate / index-shifting entries this change fixes.
-    private func collectAXDescriptors(
+    private func materializeStandaloneWindows(
         axResult: AXWindowResult,
-        cgWindowIDs: Set<Int>,
-        warnings: inout [String]) async -> [AXWindowDescriptor]
+        cgWindowIDs: Set<Int>) -> [AXWindowDescriptor]
     {
-        let windowIdentityService = WindowIdentityService()
-        var descriptors: [AXWindowDescriptor] = []
-        descriptors.reserveCapacity(axResult.windows.count)
-
-        for (index, axWindow) in axResult.windows.indexed() {
-            if Date().timeIntervalSince(self.startTime) > Double(self.axTimeout * 2) {
-                warnings.append("Stopped enrichment after timeout")
-                break
-            }
-
-            let title = axWindow.title() ?? ""
-            let resolvedID = windowIdentityService.getWindowID(from: axWindow).map(Int.init)
-            let isMinimized = axWindow.isMinimized()
-            let bounds: CGRect? = axWindow.position().map { position in
-                CGRect(origin: position, size: axWindow.size() ?? .zero)
-            }
-            let mutationIdentity: WindowMutationIdentity? = if let resolvedID,
+        axResult.descriptors.enumerated().map { index, raw in
+            let focus = Self.focusMetadata(
+                windowID: raw.windowID,
+                focusedWindowID: axResult.focusedWindowID,
+                appIsActive: self.app.isActive)
+            let mutationIdentity: WindowMutationIdentity? = if let resolvedID = raw.windowID,
                                                                let windowID = CGWindowID(exactly: resolvedID),
-                                                               let bounds,
-                                                               let processIdentity = self.app.processIdentity
+                                                               let bounds = raw.bounds
             {
                 SystemIdentityResolver.axWindowMutationIdentity(
                     snapshot: SystemIdentityResolver.WindowMutationSnapshot(
                         windowID: windowID,
-                        ownerProcessIdentifier: processIdentity.processIdentifier,
-                        ownerProcessStartIdentity: processIdentity.processStartIdentity,
+                        ownerProcessIdentifier: self.processIdentity.processIdentifier,
+                        ownerProcessStartIdentity: self.processIdentity.processStartIdentity,
                         bounds: bounds,
-                        isMinimized: isMinimized),
+                        isMinimized: raw.isMinimized),
                     processStartIdentityProvider: SystemIdentityResolver.processStartIdentity,
                     windowIdentityProvider: SystemIdentityResolver.windowIdentity)
             } else {
                 nil
             }
-
-            var standaloneInfo: ServiceWindowInfo?
-            if let resolvedID, !cgWindowIDs.contains(resolvedID), !title.isEmpty {
-                let focusMetadata = Self.focusMetadata(
-                    windowID: resolvedID,
-                    focusedWindowID: axResult.focusedWindowID,
-                    appIsActive: self.app.isActive)
-                standaloneInfo = await self.service.createWindowInfo(
-                    from: axWindow,
+            let candidate = AXWindowDescriptor(
+                windowID: raw.windowID,
+                title: raw.title,
+                bounds: raw.bounds,
+                standaloneInfo: nil,
+                isMainWindow: raw.isMainWindow,
+                isKeyWindow: focus.isKey,
+                isFrontmost: focus.isFrontmost,
+                subrole: raw.subrole,
+                isMinimized: raw.isMinimized,
+                mutationIdentity: mutationIdentity)
+            let shouldMaterializeStandalone = !raw.title.isEmpty &&
+                raw.windowID.map { !cgWindowIDs.contains($0) } != false
+            let standaloneInfo: ServiceWindowInfo? = if shouldMaterializeStandalone {
+                self.service.createWindowInfo(
+                    from: candidate,
                     index: index,
-                    isKeyWindow: focusMetadata.isKey,
-                    isFrontmost: focusMetadata.isFrontmost,
-                    expectedProcessIdentity: self.app.processIdentity)
+                    expectedProcessIdentity: self.processIdentity)
+            } else {
+                nil
             }
-
-            let focusMetadata = Self.focusMetadata(
-                windowID: resolvedID,
-                focusedWindowID: axResult.focusedWindowID,
-                appIsActive: self.app.isActive)
-
-            descriptors.append(AXWindowDescriptor(
-                windowID: resolvedID,
-                title: title,
-                bounds: bounds,
+            return AXWindowDescriptor(
+                windowID: candidate.windowID,
+                title: candidate.title,
+                bounds: candidate.bounds,
                 standaloneInfo: standaloneInfo,
-                isMainWindow: axWindow.isMain() ?? false,
-                isKeyWindow: focusMetadata.isKey,
-                isFrontmost: focusMetadata.isFrontmost,
-                subrole: axWindow.subrole(),
-                isMinimized: isMinimized,
-                mutationIdentity: mutationIdentity))
+                isMainWindow: candidate.isMainWindow,
+                isKeyWindow: candidate.isKeyWindow,
+                isFrontmost: candidate.isFrontmost,
+                subrole: candidate.subrole,
+                isMinimized: candidate.isMinimized,
+                mutationIdentity: candidate.mutationIdentity)
         }
-
-        return descriptors
     }
 
     /// Merge CG and AX windows preserving CGWindowList enumeration order.
@@ -468,50 +503,21 @@ struct WindowEnumerationContext {
         return (isKey, appIsActive && isKey)
     }
 
-    private func buildAXOnlyResult(from axResult: AXWindowResult) async -> UnifiedToolOutput<ServiceWindowListData> {
+    private func buildAXOnlyResult(from axResult: AXWindowResult) -> UnifiedToolOutput<ServiceWindowListData> {
         self.logger.debug("Using pure AX approach (no screen recording permission)")
         var warnings: [String] = []
-        var windowInfos: [ServiceWindowInfo] = []
-        let maxWindowsToProcess = 100
-        let limitedWindows = Array(axResult.windows.prefix(maxWindowsToProcess))
-
-        if axResult.windows.count > maxWindowsToProcess {
-            let warning =
-                "Application \(self.app.name) has \(axResult.windows.count) windows, " +
-                "processing only first \(maxWindowsToProcess)"
-            self.logger.warning("\(warning)")
-        }
-
-        for (index, window) in limitedWindows.indexed() {
-            if Date().timeIntervalSince(self.startTime) > Double(self.axTimeout) {
-                warnings.append("Stopped processing after \(self.axTimeout)s timeout")
-                break
-            }
-
-            let windowID = WindowIdentityService().getWindowID(from: window).map(Int.init)
-            let focusMetadata = Self.focusMetadata(
-                windowID: windowID,
-                focusedWindowID: axResult.focusedWindowID,
-                appIsActive: self.app.isActive)
-            if let windowInfo = await self.service.createWindowInfo(
-                from: window,
-                index: index,
-                isKeyWindow: focusMetadata.isKey,
-                isFrontmost: focusMetadata.isFrontmost,
-                expectedProcessIdentity: self.app.processIdentity)
-            {
-                windowInfos.append(windowInfo)
-            }
-        }
+        let descriptors = self.materializeStandaloneWindows(axResult: axResult, cgWindowIDs: [])
+        let windowInfos = descriptors.compactMap(\.standaloneInfo)
 
         if axResult.timedOut {
             warnings.append("Window enumeration timed out, results may be incomplete")
         }
-
-        if axResult.windows.count > maxWindowsToProcess {
-            let processedWarning =
-                "Only processed first \(maxWindowsToProcess) of \(axResult.windows.count) windows"
-            warnings.append(processedWarning)
+        if axResult.incomplete {
+            warnings.append("Accessibility window enumeration was incomplete")
+        }
+        if axResult.reportedWindowCount > descriptors.count {
+            warnings.append(
+                "Only processed \(descriptors.count) of \(axResult.reportedWindowCount) accessible windows")
         }
 
         if !self.hasScreenRecording {

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/System/DetachedAXWindowEnumerationWorker.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/System/DetachedAXWindowEnumerationWorker.swift
@@ -1,0 +1,358 @@
+import ApplicationServices
+import CoreGraphics
+import Foundation
+import PeekabooFoundation
+
+struct DetachedAXWindowDescriptor: Sendable, Equatable {
+    let windowID: Int?
+    let title: String
+    let bounds: CGRect?
+    let isMainWindow: Bool
+    let subrole: String?
+    let isMinimized: Bool?
+
+    init(
+        windowID: Int?,
+        title: String,
+        bounds: CGRect?,
+        isMainWindow: Bool = false,
+        subrole: String? = nil,
+        isMinimized: Bool? = nil)
+    {
+        self.windowID = windowID
+        self.title = title
+        self.bounds = bounds
+        self.isMainWindow = isMainWindow
+        self.subrole = subrole
+        self.isMinimized = isMinimized
+    }
+}
+
+struct DetachedAXWindowEnumerationRequest: Sendable {
+    let processIdentifier: Int32
+    let expectedProcessStartIdentity: UInt64
+    let timeoutSeconds: TimeInterval
+    let maximumWindowCount: Int
+}
+
+struct DetachedAXWindowEnumerationResult: Sendable {
+    let descriptors: [DetachedAXWindowDescriptor]
+    let focusedWindowID: Int?
+    let timedOut: Bool
+    let incomplete: Bool
+    let reportedWindowCount: Int
+}
+
+struct DetachedAXWindowEnumerationTiming: Sendable, Equatable {
+    private static let maximumCompletionGrace: TimeInterval = 0.25
+    private static let minimumCompletionGrace: TimeInterval = 0.01
+
+    let softTimeoutSeconds: TimeInterval
+    let hardTimeoutSeconds: TimeInterval
+
+    init(hardTimeoutSeconds: TimeInterval) {
+        let hardTimeoutSeconds = max(0.001, hardTimeoutSeconds)
+        let proportionalGrace = hardTimeoutSeconds * 0.1
+        let completionGrace = min(
+            Self.maximumCompletionGrace,
+            max(Self.minimumCompletionGrace, proportionalGrace))
+        self.softTimeoutSeconds = max(0.001, hardTimeoutSeconds - completionGrace)
+        self.hardTimeoutSeconds = hardTimeoutSeconds
+    }
+}
+
+enum DetachedAXWindowEnumerationCoordinator {
+    static func run(
+        processIdentifier: Int32,
+        processStartIdentity: UInt64,
+        timeoutSeconds: TimeInterval,
+        maximumWindowCount: Int = 100,
+        operation: @escaping @Sendable (DetachedAXWindowEnumerationRequest) throws
+            -> DetachedAXWindowEnumerationResult = DetachedAXWindowEnumerationWorker.enumerate) async throws
+        -> DetachedAXWindowEnumerationResult
+    {
+        let timing = DetachedAXWindowEnumerationTiming(hardTimeoutSeconds: timeoutSeconds)
+        let request = DetachedAXWindowEnumerationRequest(
+            processIdentifier: processIdentifier,
+            expectedProcessStartIdentity: processStartIdentity,
+            timeoutSeconds: timing.softTimeoutSeconds,
+            maximumWindowCount: maximumWindowCount)
+        return try await ElementDetectionTimeoutRunner.runDetached(
+            targetProcessIdentifier: processIdentifier,
+            targetProcessStartIdentity: processStartIdentity,
+            seconds: timing.hardTimeoutSeconds)
+        {
+            try operation(request)
+        }
+    }
+}
+
+/// A bounded, read-only AX worker for window inventory enrichment. Every AX reference is created and
+/// consumed on the generation-pinned detached lane; only immutable descriptors cross back to MainActor.
+enum DetachedAXWindowEnumerationWorker {
+    private static let maximumPerCallTimeout: Float = 0.2
+    private static let descriptorAttributes: [String] = [
+        kAXTitleAttribute,
+        kAXPositionAttribute,
+        kAXSizeAttribute,
+        kAXMinimizedAttribute,
+        kAXMainAttribute,
+        kAXSubroleAttribute,
+    ]
+
+    static func enumerate(_ request: DetachedAXWindowEnumerationRequest) throws
+        -> DetachedAXWindowEnumerationResult
+    {
+        try self.validateIdentity(request)
+        let deadline = ContinuousClock.now.advanced(by: .seconds(request.timeoutSeconds))
+        let application = AXUIElementCreateApplication(request.processIdentifier)
+
+        guard self.remainingMessagingTimeout(until: deadline) != nil else {
+            return DetachedAXWindowEnumerationResult(
+                descriptors: [],
+                focusedWindowID: nil,
+                timedOut: true,
+                incomplete: true,
+                reportedWindowCount: 0)
+        }
+        let windowsRead = self.rawAttributeRead(kAXWindowsAttribute, of: application, deadline: deadline)
+        guard windowsRead.error == .success,
+              let windows = windowsRead.value as? [AXUIElement]
+        else {
+            try self.validateIdentity(request)
+            let incomplete = windowsRead.error == .success ||
+                windowsRead.error == .attributeUnsupported ||
+                windowsRead.error == .parameterizedAttributeUnsupported ||
+                windowsRead.error == .notImplemented ||
+                windowsRead.isIncomplete
+            return DetachedAXWindowEnumerationResult(
+                descriptors: [],
+                focusedWindowID: nil,
+                timedOut: ContinuousClock.now >= deadline,
+                incomplete: incomplete,
+                reportedWindowCount: 0)
+        }
+
+        let focusedWindowRead = self.elementAttribute(
+            kAXFocusedWindowAttribute,
+            of: application,
+            deadline: deadline)
+        let focusedWindowIDRead: ValueRead<Int> = if let focusedWindow = focusedWindowRead.value {
+            self.windowID(of: focusedWindow, deadline: deadline)
+        } else {
+            ValueRead(value: nil, incomplete: false)
+        }
+        let focusedWindowID = focusedWindowIDRead.value
+
+        let limit = max(0, request.maximumWindowCount)
+        var descriptors: [DetachedAXWindowDescriptor] = []
+        descriptors.reserveCapacity(min(windows.count, limit))
+        var incomplete = focusedWindowRead.incomplete || focusedWindowIDRead.incomplete
+        var timedOut = false
+
+        for window in windows.prefix(limit) {
+            guard ContinuousClock.now < deadline else {
+                timedOut = true
+                break
+            }
+            guard let read = self.readDescriptor(
+                window,
+                expectedProcessIdentifier: request.processIdentifier,
+                deadline: deadline)
+            else {
+                incomplete = true
+                if ContinuousClock.now >= deadline {
+                    timedOut = true
+                    break
+                }
+                continue
+            }
+            descriptors.append(read.descriptor)
+            incomplete = incomplete || read.incomplete
+        }
+
+        if windows.count > limit {
+            incomplete = true
+        }
+        try self.validateIdentity(request)
+        return DetachedAXWindowEnumerationResult(
+            descriptors: descriptors,
+            focusedWindowID: focusedWindowID,
+            timedOut: timedOut,
+            incomplete: incomplete,
+            reportedWindowCount: windows.count)
+    }
+
+    static func validateIdentity(
+        _ request: DetachedAXWindowEnumerationRequest,
+        processStartIdentityProvider: (pid_t) -> UInt64? = SystemIdentityResolver.processStartIdentity) throws
+    {
+        guard processStartIdentityProvider(request.processIdentifier) == request.expectedProcessStartIdentity else {
+            throw PeekabooError.snapshotStale(
+                "Target PID \(request.processIdentifier) changed process generation during window enumeration")
+        }
+    }
+
+    private static func readDescriptor(
+        _ window: AXUIElement,
+        expectedProcessIdentifier: pid_t,
+        deadline: ContinuousClock.Instant) -> DescriptorRead?
+    {
+        var ownerPID: pid_t = 0
+        guard AXUIElementGetPid(window, &ownerPID) == .success,
+              self.isExpectedOwner(
+                  observedProcessIdentifier: ownerPID,
+                  expectedProcessIdentifier: expectedProcessIdentifier)
+        else {
+            return nil
+        }
+        guard let values = self.descriptorValues(window, deadline: deadline) else { return nil }
+
+        let title = AXDescriptorReader.stringValue(values[0]) ?? ""
+        let position = AXDescriptorReader.cgPointValue(values[1])
+        let size = AXDescriptorReader.cgSizeValue(values[2])
+        let bounds: CGRect? = if let position, let size {
+            CGRect(origin: position, size: size)
+        } else {
+            nil
+        }
+        let isMinimized = AXDescriptorReader.boolValue(values[3])
+        let isMainWindow = AXDescriptorReader.boolValue(values[4]) ?? false
+        let subrole = AXDescriptorReader.stringValue(values[5])
+        let resolvedID = self.windowID(of: window, deadline: deadline)
+
+        return DescriptorRead(
+            descriptor: DetachedAXWindowDescriptor(
+                windowID: resolvedID.value,
+                title: title,
+                bounds: bounds,
+                isMainWindow: isMainWindow,
+                subrole: subrole,
+                isMinimized: isMinimized),
+            incomplete: resolvedID.incomplete)
+    }
+
+    private static func descriptorValues(
+        _ window: AXUIElement,
+        deadline: ContinuousClock.Instant) -> [Any?]?
+    {
+        guard let timeout = self.remainingMessagingTimeout(until: deadline) else { return nil }
+        AXUIElementSetMessagingTimeout(window, timeout)
+        var rawValues: CFArray?
+        let error = AXUIElementCopyMultipleAttributeValues(
+            window,
+            self.descriptorAttributes as CFArray,
+            [],
+            &rawValues)
+        AXUIElementSetMessagingTimeout(window, 0)
+        let values = rawValues as? [Any]
+        if error == .success,
+           let values,
+           values.count == self.descriptorAttributes.count,
+           !AXAttributeReadCompletenessPolicy.hasIncompleteErrorValue(in: values)
+        {
+            return values.map { value in
+                AXAttributeReadCompletenessPolicy.embeddedError(in: value) == nil ? value : nil
+            }
+        }
+
+        let supportsFallback = error == .attributeUnsupported ||
+            error == .parameterizedAttributeUnsupported ||
+            error == .notImplemented ||
+            (error == .success && values?.count != self.descriptorAttributes.count)
+        guard supportsFallback else { return nil }
+
+        var fallbackValues: [Any?] = []
+        fallbackValues.reserveCapacity(self.descriptorAttributes.count)
+        for attribute in self.descriptorAttributes {
+            let read = self.rawAttributeRead(attribute, of: window, deadline: deadline)
+            guard !read.isIncomplete else { return nil }
+            fallbackValues.append(read.value)
+        }
+        return fallbackValues
+    }
+
+    static func isExpectedOwner(
+        observedProcessIdentifier: pid_t,
+        expectedProcessIdentifier: pid_t) -> Bool
+    {
+        observedProcessIdentifier == expectedProcessIdentifier
+    }
+
+    private static func remainingMessagingTimeout(until deadline: ContinuousClock.Instant) -> Float? {
+        let remaining = ContinuousClock.now.duration(to: deadline).timeInterval
+        guard remaining > 0 else { return nil }
+        return Float(min(TimeInterval(self.maximumPerCallTimeout), max(0.001, remaining)))
+    }
+
+    private static func windowID(of element: AXUIElement, deadline: ContinuousClock.Instant) -> ValueRead<Int> {
+        guard let timeout = self.remainingMessagingTimeout(until: deadline) else {
+            return ValueRead(value: nil, incomplete: true)
+        }
+        AXUIElementSetMessagingTimeout(element, timeout)
+        defer { AXUIElementSetMessagingTimeout(element, 0) }
+        var windowID: CGWindowID = 0
+        let error = AXWindowIDResolver.copyWindowID(element, into: &windowID)
+        let value = error == .success && windowID > 0 ? Int(windowID) : nil
+        return ValueRead(
+            value: value,
+            incomplete: value == nil && AXAttributeReadCompletenessPolicy.isIncomplete(error: error))
+    }
+
+    private static func elementAttribute(
+        _ name: String,
+        of element: AXUIElement,
+        deadline: ContinuousClock.Instant) -> ValueRead<AXUIElement>
+    {
+        let read = self.rawAttributeRead(name, of: element, deadline: deadline)
+        guard let value = read.value,
+              CFGetTypeID(value) == AXUIElementGetTypeID()
+        else {
+            return ValueRead(
+                value: nil,
+                incomplete: read.error == .success || read.isIncomplete)
+        }
+        return ValueRead(value: unsafeDowncast(value, to: AXUIElement.self), incomplete: false)
+    }
+
+    private static func rawAttributeRead(
+        _ name: String,
+        of element: AXUIElement,
+        deadline: ContinuousClock.Instant) -> AttributeRead
+    {
+        guard let timeout = self.remainingMessagingTimeout(until: deadline) else {
+            return AttributeRead(error: .cannotComplete, value: nil)
+        }
+        AXUIElementSetMessagingTimeout(element, timeout)
+        defer { AXUIElementSetMessagingTimeout(element, 0) }
+        var value: CFTypeRef?
+        let error = AXUIElementCopyAttributeValue(element, name as CFString, &value)
+        return AttributeRead(error: error, value: value)
+    }
+
+    private struct AttributeRead {
+        let error: AXError
+        let value: CFTypeRef?
+
+        var isIncomplete: Bool {
+            AXAttributeReadCompletenessPolicy.isIncomplete(error: self.error)
+        }
+    }
+
+    private struct DescriptorRead {
+        let descriptor: DetachedAXWindowDescriptor
+        let incomplete: Bool
+    }
+
+    private struct ValueRead<Value> {
+        let value: Value?
+        let incomplete: Bool
+    }
+}
+
+extension Duration {
+    fileprivate var timeInterval: TimeInterval {
+        let components = self.components
+        return TimeInterval(components.seconds) + TimeInterval(components.attoseconds) / 1e18
+    }
+}

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/WindowEnumerationTimeoutTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/WindowEnumerationTimeoutTests.swift
@@ -1,0 +1,318 @@
+import CoreGraphics
+import Foundation
+import os.log
+import PeekabooFoundation
+import Testing
+@testable import PeekabooAutomationKit
+
+@Suite(.serialized)
+@MainActor
+struct WindowEnumerationTimeoutTests {
+    @Test
+    func `CG inventory survives an AX hard timeout as partial output`() async throws {
+        let identity = ApplicationProcessIdentity(processIdentifier: 42, processStartIdentity: 7)
+        let service = Self.makeService { _ in identity.processStartIdentity }
+        let cgWindow = ServiceWindowInfo(
+            windowID: 333,
+            title: "CG Window",
+            bounds: CGRect(x: 10, y: 20, width: 800, height: 600))
+        let context = WindowEnumerationContext(
+            service: service,
+            app: Self.application(identity: identity),
+            startTime: Date(),
+            axTimeout: 0.05,
+            hasScreenRecording: true,
+            logger: Self.logger,
+            processIdentity: identity,
+            cgSnapshotProvider: { .init(windows: [cgWindow]) },
+            applicationRunningProvider: { true },
+            axEnumerator: { _, _ in throw CaptureError.detectionTimedOut(0.05) })
+
+        let output = try await context.run()
+
+        #expect(output.data.windows.map(\.windowID) == [333])
+        #expect(output.summary.status == .partial)
+        #expect(output.metadata.warnings.contains { $0.contains("timed out") })
+    }
+
+    @Test
+    func `complete AX enrichment preserves CG order and focus metadata`() async throws {
+        let identity = ApplicationProcessIdentity(processIdentifier: 43, processStartIdentity: 8)
+        let service = Self.makeService { _ in identity.processStartIdentity }
+        let bounds = CGRect(x: 20, y: 30, width: 700, height: 500)
+        let cgWindow = ServiceWindowInfo(windowID: 444, title: "", bounds: bounds)
+        let result = DetachedAXWindowEnumerationResult(
+            descriptors: [
+                DetachedAXWindowDescriptor(
+                    windowID: 444,
+                    title: "AX Title",
+                    bounds: bounds,
+                    isMainWindow: true,
+                    subrole: "AXStandardWindow",
+                    isMinimized: false),
+            ],
+            focusedWindowID: 444,
+            timedOut: false,
+            incomplete: false,
+            reportedWindowCount: 1)
+        let context = WindowEnumerationContext(
+            service: service,
+            app: Self.application(identity: identity, isActive: true),
+            startTime: Date(),
+            axTimeout: 0.1,
+            hasScreenRecording: true,
+            logger: Self.logger,
+            processIdentity: identity,
+            cgSnapshotProvider: { .init(windows: [cgWindow]) },
+            applicationRunningProvider: { true },
+            axEnumerator: { _, _ in result })
+
+        let output = try await context.run()
+        let window = try #require(output.data.windows.first)
+
+        #expect(window.windowID == 444)
+        #expect(window.title == "AX Title")
+        #expect(window.isMainWindow)
+        #expect(window.isKeyWindow == true)
+        #expect(window.isFrontmost == true)
+        #expect(output.summary.status == .success)
+        #expect(output.metadata.warnings.isEmpty)
+    }
+
+    @Test
+    func `process generation drift discards the complete inventory`() async throws {
+        let identity = ApplicationProcessIdentity(processIdentifier: 44, processStartIdentity: 9)
+        var generationReadCount = 0
+        let service = Self.makeService { _ in
+            generationReadCount += 1
+            return generationReadCount == 1 ? identity.processStartIdentity : identity.processStartIdentity + 1
+        }
+        let context = WindowEnumerationContext(
+            service: service,
+            app: Self.application(identity: identity),
+            startTime: Date(),
+            axTimeout: 0.1,
+            hasScreenRecording: true,
+            logger: Self.logger,
+            processIdentity: identity,
+            cgSnapshotProvider: {
+                .init(windows: [ServiceWindowInfo(windowID: 555, title: "CG", bounds: .zero)])
+            },
+            applicationRunningProvider: { true },
+            axEnumerator: { _, _ in
+                DetachedAXWindowEnumerationResult(
+                    descriptors: [],
+                    focusedWindowID: nil,
+                    timedOut: false,
+                    incomplete: false,
+                    reportedWindowCount: 0)
+            })
+
+        await #expect(throws: (any Error).self) {
+            _ = try await context.run()
+        }
+    }
+
+    private static let logger = Logger(subsystem: "boo.peekaboo.tests", category: "WindowEnumerationTimeout")
+
+    private static func application(
+        identity: ApplicationProcessIdentity,
+        isActive: Bool = false) -> ServiceApplicationInfo
+    {
+        ServiceApplicationInfo(
+            processIdentifier: identity.processIdentifier,
+            processStartIdentity: identity.processStartIdentity,
+            bundleIdentifier: "com.example.fixture",
+            name: "Fixture",
+            isActive: isActive)
+    }
+
+    private static func makeService(
+        processStartIdentityProvider: @escaping ApplicationService.ProcessStartIdentityProvider) -> ApplicationService
+    {
+        ApplicationService(
+            applicationOpenHandler: { _, _, _ in throw FixtureError.unused },
+            processStartIdentityProvider: processStartIdentityProvider)
+    }
+}
+
+private enum FixtureError: Error {
+    case unused
+}
+
+@Suite(.serialized)
+struct DetachedAXWindowEnumerationCoordinatorTests {
+    @Test
+    func `timing reserves result publication grace before hard escape`() {
+        let timing = DetachedAXWindowEnumerationTiming(hardTimeoutSeconds: 2)
+        #expect(timing.softTimeoutSeconds > 1.7)
+        #expect(timing.softTimeoutSeconds < timing.hardTimeoutSeconds)
+        #expect(timing.hardTimeoutSeconds == 2)
+    }
+
+    @Test
+    func `worker validates process generation and rejects foreign child ownership`() throws {
+        let request = DetachedAXWindowEnumerationRequest(
+            processIdentifier: 42,
+            expectedProcessStartIdentity: 7,
+            timeoutSeconds: 1,
+            maximumWindowCount: 100)
+        try DetachedAXWindowEnumerationWorker.validateIdentity(request) { pid in
+            #expect(pid == 42)
+            return 7
+        }
+        #expect(throws: (any Error).self) {
+            try DetachedAXWindowEnumerationWorker.validateIdentity(request) { _ in 8 }
+        }
+        #expect(DetachedAXWindowEnumerationWorker.isExpectedOwner(
+            observedProcessIdentifier: 42,
+            expectedProcessIdentifier: 42))
+        #expect(!DetachedAXWindowEnumerationWorker.isExpectedOwner(
+            observedProcessIdentifier: 43,
+            expectedProcessIdentifier: 42))
+    }
+
+    @Test
+    func `noncooperative AX work hard-times out without blocking caller`() async throws {
+        let gate = EnumerationBlockingGate()
+        let startedAt = ContinuousClock.now
+
+        await #expect(throws: CaptureError.self) {
+            _ = try await DetachedAXWindowEnumerationCoordinator.run(
+                processIdentifier: 91001,
+                processStartIdentity: 1,
+                timeoutSeconds: 0.05)
+            { _ in
+                gate.markStarted()
+                gate.wait()
+                return Self.emptyResult
+            }
+        }
+        let elapsed = startedAt.duration(to: .now).timeInterval
+        #expect(elapsed < 0.5)
+        gate.release()
+    }
+
+    @Test
+    func `same generation queued work expires without starting while another PID proceeds`() async throws {
+        let gate = EnumerationBlockingGate()
+        let first = Task {
+            try await DetachedAXWindowEnumerationCoordinator.run(
+                processIdentifier: 91002,
+                processStartIdentity: 2,
+                timeoutSeconds: 2)
+            { _ in
+                gate.markStarted()
+                gate.wait()
+                return Self.emptyResult
+            }
+        }
+        #expect(gate.waitUntilStarted())
+
+        let samePIDStarted = EnumerationFlag()
+        await #expect(throws: CaptureError.self) {
+            _ = try await DetachedAXWindowEnumerationCoordinator.run(
+                processIdentifier: 91002,
+                processStartIdentity: 2,
+                timeoutSeconds: 0.05)
+            { _ in
+                samePIDStarted.set()
+                return Self.emptyResult
+            }
+        }
+        #expect(!samePIDStarted.value)
+
+        let otherPID = try await DetachedAXWindowEnumerationCoordinator.run(
+            processIdentifier: 91003,
+            processStartIdentity: 3,
+            timeoutSeconds: 0.5)
+        { request in
+            #expect(request.expectedProcessStartIdentity == 3)
+            return Self.emptyResult
+        }
+        #expect(otherPID.descriptors.isEmpty)
+
+        gate.release()
+        _ = try await first.value
+    }
+
+    @Test
+    @MainActor
+    func `cancellation returns promptly while MainActor remains responsive`() async throws {
+        let gate = EnumerationBlockingGate()
+        var heartbeat = false
+        let task = Task.detached {
+            try await DetachedAXWindowEnumerationCoordinator.run(
+                processIdentifier: 91004,
+                processStartIdentity: 4,
+                timeoutSeconds: 5)
+            { _ in
+                gate.markStarted()
+                gate.wait()
+                return Self.emptyResult
+            }
+        }
+        #expect(gate.waitUntilStarted())
+
+        Task { @MainActor in heartbeat = true }
+        let heartbeatDeadline = ContinuousClock.now.advanced(by: .seconds(1))
+        while !heartbeat, ContinuousClock.now < heartbeatDeadline {
+            await Task.yield()
+        }
+        #expect(heartbeat)
+
+        task.cancel()
+        await #expect(throws: CancellationError.self) {
+            _ = try await task.value
+        }
+        gate.release()
+    }
+
+    private static let emptyResult = DetachedAXWindowEnumerationResult(
+        descriptors: [],
+        focusedWindowID: nil,
+        timedOut: false,
+        incomplete: false,
+        reportedWindowCount: 0)
+}
+
+private final class EnumerationBlockingGate: @unchecked Sendable {
+    private let started = DispatchSemaphore(value: 0)
+    private let releaseGate = DispatchSemaphore(value: 0)
+
+    func markStarted() {
+        self.started.signal()
+    }
+
+    func waitUntilStarted() -> Bool {
+        self.started.wait(timeout: .now() + 1) == .success
+    }
+
+    func wait() {
+        self.releaseGate.wait()
+    }
+
+    func release() {
+        self.releaseGate.signal()
+    }
+}
+
+private final class EnumerationFlag: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storage = false
+
+    var value: Bool {
+        self.lock.withLock { self.storage }
+    }
+
+    func set() {
+        self.lock.withLock { self.storage = true }
+    }
+}
+
+extension Duration {
+    fileprivate var timeInterval: TimeInterval {
+        let components = self.components
+        return TimeInterval(components.seconds) + TimeInterval(components.attoseconds) / 1e18
+    }
+}

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeWindowEnumerationTimeoutTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeWindowEnumerationTimeoutTests.swift
@@ -1,0 +1,167 @@
+import CoreGraphics
+import Foundation
+import PeekabooCore
+import PeekabooFoundation
+import Testing
+@testable import PeekabooAutomationKit
+@testable import PeekabooBridge
+
+@Suite(.serialized)
+struct PeekabooBridgeWindowEnumerationTimeoutTests {
+    @Test
+    @MainActor
+    func `bounded AX enrichment releases Bridge request and lane before late worker finishes`() async throws {
+        let socketPath = "/tmp/pb-window-enumeration-\(UUID().uuidString).sock"
+        defer {
+            try? FileManager.default.removeItem(atPath: socketPath)
+            try? FileManager.default.removeItem(atPath: "\(socketPath).lock")
+        }
+
+        let windows = BoundedWindowEnumerationService()
+        let server = PeekabooBridgeServer(
+            services: StubServices(windows: windows),
+            allowlistedTeams: [],
+            allowlistedBundles: [],
+            allowedOperations: [.listWindows, .permissionsStatus])
+        let host = PeekabooBridgeHost(
+            socketPath: socketPath,
+            server: server,
+            allowedTeamIDs: [],
+            requestTimeoutSec: 2)
+        try await host.startChecked()
+        defer { Task { await host.stop() } }
+
+        let client = PeekabooBridgeClient(socketPath: socketPath, requestTimeoutSec: 1)
+        let remote = RemoteWindowManagementService(client: client)
+        let startedAt = ContinuousClock.now
+        let result = try await remote.listWindows(target: .application("Fixture"))
+        let elapsed = startedAt.duration(to: .now).timeInterval
+
+        #expect(result.map(\.windowID) == [700])
+        #expect(result.first?.mutationIdentity?.ownerProcessIdentifier == 92001)
+        #expect(result.first?.mutationIdentity?.ownerProcessStartIdentity == 1)
+        #expect(elapsed < 0.5)
+        #expect(windows.workerIsStillBlocked)
+        #expect(await host.activeRequestCountForTesting() == 0)
+
+        let followUpStartedAt = ContinuousClock.now
+        let followUp = try await remote.listWindows(target: .application("Fixture"))
+        let followUpElapsed = followUpStartedAt.duration(to: .now).timeInterval
+        #expect(followUp.map(\.windowID) == [700])
+        #expect(followUpElapsed < 0.5)
+        windows.releaseWorker()
+        #expect(windows.waitForWorkerFinish())
+        #expect(result.map(\.windowID) == [700])
+        #expect(await host.activeRequestCountForTesting() == 0)
+        await host.stop()
+    }
+}
+
+@MainActor
+private final class BoundedWindowEnumerationService: WindowManagementServiceProtocol {
+    private let gate = EnumerationServiceGate()
+
+    var workerIsStillBlocked: Bool {
+        self.gate.started && !self.gate.released
+    }
+
+    func listWindows(target _: WindowTarget) async throws -> [ServiceWindowInfo] {
+        let gate = self.gate
+        do {
+            _ = try await DetachedAXWindowEnumerationCoordinator.run(
+                processIdentifier: 92001,
+                processStartIdentity: 1,
+                timeoutSeconds: 0.05)
+            { _ in
+                gate.markStarted()
+                gate.wait()
+                gate.markFinished()
+                return DetachedAXWindowEnumerationResult(
+                    descriptors: [],
+                    focusedWindowID: nil,
+                    timedOut: false,
+                    incomplete: false,
+                    reportedWindowCount: 0)
+            }
+        } catch CaptureError.detectionTimedOut {
+            return [ServiceWindowInfo(
+                windowID: 700,
+                title: "CG",
+                bounds: .zero,
+                mutationIdentity: WindowMutationIdentity(
+                    windowID: 700,
+                    ownerProcessIdentifier: 92001,
+                    ownerProcessStartIdentity: 1,
+                    capturedBounds: .zero))]
+        }
+        return []
+    }
+
+    func releaseWorker() {
+        self.gate.release()
+    }
+
+    func waitForWorkerFinish() -> Bool {
+        self.gate.waitUntilFinished()
+    }
+
+    func closeWindow(target _: WindowTarget) async throws {}
+    func minimizeWindow(target _: WindowTarget) async throws {}
+    func maximizeWindow(target _: WindowTarget) async throws {}
+    func moveWindow(target _: WindowTarget, to _: CGPoint) async throws {}
+    func resizeWindow(target _: WindowTarget, to _: CGSize) async throws {}
+    func setWindowBounds(target _: WindowTarget, bounds _: CGRect) async throws {}
+    func focusWindow(target _: WindowTarget) async throws {}
+    func getFocusedWindow() async throws -> ServiceWindowInfo? {
+        nil
+    }
+}
+
+private final class EnumerationServiceGate: @unchecked Sendable {
+    private let lock = NSLock()
+    private let releaseSemaphore = DispatchSemaphore(value: 0)
+    private let finishedSemaphore = DispatchSemaphore(value: 0)
+    private var didStart = false
+    private var didRelease = false
+    private var didFinish = false
+
+    var started: Bool {
+        self.lock.withLock { self.didStart }
+    }
+
+    var released: Bool {
+        self.lock.withLock { self.didRelease }
+    }
+
+    func markStarted() {
+        self.lock.withLock { self.didStart = true }
+    }
+
+    func wait() {
+        self.releaseSemaphore.wait()
+    }
+
+    func release() {
+        self.lock.withLock { self.didRelease = true }
+        self.releaseSemaphore.signal()
+    }
+
+    func markFinished() {
+        self.lock.withLock { self.didFinish = true }
+        self.finishedSemaphore.signal()
+    }
+
+    func waitUntilFinished() -> Bool {
+        if self.lock.withLock({ self.didFinish }) {
+            return true
+        }
+        return self.finishedSemaphore.wait(timeout: .now() + 1) == .success
+    }
+}
+
+extension Duration {
+    fileprivate var timeInterval: TimeInterval {
+        let components = self.components
+        return TimeInterval(components.seconds) + TimeInterval(components.attoseconds) / 1e18
+    }
+}

--- a/docs/commands/window.md
+++ b/docs/commands/window.md
@@ -36,6 +36,7 @@ read_when:
 - `focus` routes through the exact CG window ID, makes the window main, raises it, and honors the global focus flags (`--space-switch` to jump Spaces, `--bring-to-current-space` to move the window instead, etc.). Success requires macOS Accessibility to report that exact window as focused and Workspace to report its app as frontmost.
 - `focus --verify` performs a second command-level check against the exact focused window ID. A merely topmost/renderable sibling no longer counts as focused.
 - `window list` filters to renderable windows for interaction targeting: entries on non-zero layers, smaller than 60x60, fully transparent, or excluded from the Windows menu are dropped. The surviving windows keep their canonical `index` values, so indexes shown here can have gaps yet still match `--window-index`.
+- Window inventory is CG-first and generation-pinned. Accessibility only enriches titles, focus, minimized state, and AX-only windows on a detached per-process lane with a two-second default bound. If enrichment stalls, an updated host returns the verified CG rows promptly instead of holding the Bridge request after caller timeout; AX-only metadata may be omitted from that result.
 - `window list --json` includes `is_frontmost`, `is_key`, `layer`, and accessibility `subrole` when the host can resolve them. When no window selector is supplied, interaction commands prefer the exact key/frontmost window, then titled standard windows over small untitled panels.
 
 ## Examples


### PR DESCRIPTION
## Summary

- publish the generation-pinned CoreGraphics window inventory promptly, then enrich it with Accessibility data on the existing detached per-PID/process-generation worker
- bound AX enrichment to two seconds with a soft publication grace before the hard escape, while propagating cancellation and process-generation drift
- ensure late or quarantined AX work cannot mutate a returned inventory or keep a timed-out Bridge request and desktop lane alive

## Why

`window list --pid` could spend the full ten-second client timeout in synchronous MainActor AX enrichment, then continue working on the Bridge host for another ten seconds after the caller disconnected. During that leaked request, unrelated status and desktop operations timed out behind the global lane.

The new path treats the WindowServer snapshot as the authoritative prompt baseline and makes AX enrichment optional and bounded. A stalled or unhealthy target still returns verified CG windows instead of wedging the host.

## Proof

- 12 new/preservation AutomationKit cases plus WindowListDedup 17/17, remote windows 4/4, and Bridge cancellation 10/10
- full AutomationKit: 494 tests
- `pnpm run test:safe`: 762 CLI/Core safe tests and 72 runtime tests
- strict/full lint, docs, SwiftFormat, diff checks, and final Autoreview/TruffleHog clean at 0.98
- Foundation-signed source-blind A/B, 3/3: old main timed out at 10.24 seconds and retained the request/lane another 10.4–10.7 seconds; the fix returned exact Calendar window 119 in 0.516–0.631 seconds, immediately reported `activeRequests=0`, and completed follow-up reads in 0.311–0.357 seconds
- foreground app/window, cursor, clipboard, and Peekaboo overlay state remained unchanged; daemon shutdown removed its process/socket cleanly

Runtime evidence: `/tmp/peekaboo-window-inventory-fixed.PI7OU7/report.{md,json}`
