### PR TITLE
fix(automation): scope background observation lanes

### DIFF
--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Keep background app launch/open ownership through verified focus reconciliation, restoring only the exact prior process generation without overriding a later user foreground choice.
 - Stop probing, requesting, advertising, or showing AppleScript Automation permission now that application, Dock, and UI operations use native macOS APIs; remove AppleScript code from shipped executables while retaining legacy wire/error decoding for older Bridge hosts.
 - Return generation-pinned CG window inventory promptly when AX enrichment stalls; detached per-process enrichment no longer holds Bridge requests after caller timeout or disconnect.
+- Let generation-pinned background PID/window observations use fair process/window read lanes so unrelated app mutations overlap and queued same-process writes run between live frames; unresolved or focus-capable capture remains globally exclusive.
 - Stop the curated `learn` copy from presenting `shell` as a CLI command: it remains a built-in Agent capability but is not in the MCP catalog and has no `peekaboo shell` CLI root.
 - Ensure action-command JSON validation failures before dispatch report `effect: refused`, including parser and binding errors.
 - Verify app focus against the exact active Workspace PID and visible frontmost-window PID, retry through native AX activation, and report the verified effect as confirmed instead of claiming success for an unfulfilled request.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Keep background app launch/open ownership through verified focus reconciliation, restoring only the exact prior process generation while treating transient frontmost uncertainty and later user foreground choices conservatively.
 - Stop probing, requesting, advertising, or showing AppleScript Automation permission now that application, Dock, and UI operations use native macOS APIs; remove the stale checked-in CLI binary and AppleScript code from shipped executables while retaining legacy wire/error decoding for older Bridge hosts.
 - Return generation-pinned CG window inventory promptly when AX enrichment stalls; detached per-process enrichment now times out without holding the Bridge request or desktop lane after its caller disconnects.
+- Let generation-pinned background PID/window observations use fair process/window read lanes so unrelated app mutations overlap and queued same-process writes run between live frames; keep unresolved or focus-capable capture globally exclusive and fail closed on identity drift.
 - Stop `peekaboo learn` from presenting `shell` as a CLI command: it remains a built-in Agent capability but is not in the MCP catalog and has no `peekaboo shell` CLI root; guard both curated Agent overrides and rendered CLI roots against future drift.
 - Ensure action-command JSON validation failures before dispatch report
   `effect: refused`, including parser and binding errors.

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Observation/DesktopObservationService+OperationLane.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Observation/DesktopObservationService+OperationLane.swift
@@ -1,0 +1,157 @@
+import CoreGraphics
+import Foundation
+
+struct DesktopObservationLanePlan: Sendable {
+    let scope: DesktopOperationScope
+    let access: DesktopOperationAccess
+    let expectedProcessIdentity: ApplicationProcessIdentity?
+    let expectedWindowIdentity: WindowMutationIdentity?
+
+    static let global = DesktopObservationLanePlan(
+        scope: .global,
+        access: .write,
+        expectedProcessIdentity: nil,
+        expectedWindowIdentity: nil)
+}
+
+extension DesktopObservationService {
+    func withDesktopOperationLane<T: Sendable>(
+        for request: DesktopObservationRequest,
+        operation: @escaping @MainActor @Sendable (DesktopObservationLanePlan?) async throws -> T) async throws -> T
+    {
+        switch self.screenCapture.captureTransactionGateOwner {
+        case .caller:
+            let plan = self.operationLanePlan(for: request)
+            return try await self.operationLaneCoordinator.run(scope: plan.scope, access: plan.access) {
+                try self.validateCurrentLaneIdentity(plan)
+                let result = try await operation(plan)
+                try self.validateCurrentLaneIdentity(plan)
+                return result
+            }
+        case .service:
+            // IPC-backed services acquire desktop and capture lanes in the execution host. Holding
+            // either client-side lane across the RPC would make the host wait on its own caller.
+            return try await operation(nil)
+        }
+    }
+
+    func operationLanePlan(for request: DesktopObservationRequest) -> DesktopObservationLanePlan {
+        guard request.capture.focus == .background,
+              !(request.detection.mode != .none && request.detection.allowWebFocusFallback)
+        else {
+            return .global
+        }
+        if case let .menubarPopover(_, openIfNeeded) = request.target, openIfNeeded != nil {
+            return .global
+        }
+
+        switch request.target {
+        case let .windowID(windowID):
+            return self.exactWindowLanePlan(windowID: windowID) ?? .global
+        case let .pid(processIdentifier, window):
+            if case let .id(windowID)? = window,
+               let plan = self.exactWindowLanePlan(windowID: windowID),
+               plan.expectedProcessIdentity?.processIdentifier == processIdentifier
+            {
+                return plan
+            }
+            guard let processStartIdentity = self.processStartIdentityProvider(processIdentifier) else {
+                return .global
+            }
+            let identity = ApplicationProcessIdentity(
+                processIdentifier: processIdentifier,
+                processStartIdentity: processStartIdentity)
+            return DesktopObservationLanePlan(
+                scope: .process(identity),
+                access: .read,
+                expectedProcessIdentity: identity,
+                expectedWindowIdentity: nil)
+        case let .app(_, window):
+            guard case let .id(windowID)? = window else { return .global }
+            return self.exactWindowLanePlan(windowID: windowID) ?? .global
+        case .allScreens, .area, .frontmost, .menubar, .menubarPopover, .screen:
+            return .global
+        }
+    }
+
+    func validateResolvedTarget(
+        _ target: ResolvedObservationTarget,
+        for plan: DesktopObservationLanePlan?) throws
+    {
+        guard let plan else { return }
+        if let expectedWindowIdentity = plan.expectedWindowIdentity {
+            guard let resolvedApplication = target.app,
+                  resolvedApplication.processIdentifier == expectedWindowIdentity.ownerProcessIdentifier,
+                  resolvedApplication.processStartIdentity == expectedWindowIdentity.ownerProcessStartIdentity,
+                  let context = target.detectionContext,
+                  context.windowID == expectedWindowIdentity.windowID,
+                  context.applicationProcessId == expectedWindowIdentity.ownerProcessIdentifier,
+                  let resolvedWindowIdentity = context.windowMutationIdentity,
+                  Self.sameWindowIdentity(resolvedWindowIdentity, expectedWindowIdentity)
+            else {
+                throw DesktopObservationError.targetChanged(
+                    "the resolved exact window no longer matched its process-generation lane")
+            }
+            return
+        }
+        if let expectedProcessIdentity = plan.expectedProcessIdentity {
+            guard let resolvedApplication = target.app,
+                  resolvedApplication.processIdentifier == expectedProcessIdentity.processIdentifier,
+                  resolvedApplication.processStartIdentity == expectedProcessIdentity.processStartIdentity,
+                  target.detectionContext?.applicationProcessId == expectedProcessIdentity.processIdentifier
+            else {
+                throw DesktopObservationError.targetChanged(
+                    "the resolved PID no longer matched its process-generation lane")
+            }
+        }
+    }
+
+    func validateCurrentLaneIdentity(_ plan: DesktopObservationLanePlan?) throws {
+        guard let plan else { return }
+        if let expectedWindowIdentity = plan.expectedWindowIdentity {
+            guard let windowID = CGWindowID(exactly: expectedWindowIdentity.windowID),
+                  let currentWindowIdentity = self.windowMutationIdentityProvider(windowID),
+                  Self.sameWindowIdentity(currentWindowIdentity, expectedWindowIdentity)
+            else {
+                throw DesktopObservationError.targetChanged(
+                    "the exact window owner, process generation, or bounds changed during observation")
+            }
+            return
+        }
+        if let expectedProcessIdentity = plan.expectedProcessIdentity,
+           self.processStartIdentityProvider(expectedProcessIdentity.processIdentifier) !=
+           expectedProcessIdentity.processStartIdentity
+        {
+            throw DesktopObservationError.targetChanged(
+                "the target process generation changed during observation")
+        }
+    }
+
+    private func exactWindowLanePlan(windowID: CGWindowID) -> DesktopObservationLanePlan? {
+        guard let identity = self.windowMutationIdentityProvider(windowID),
+              identity.capturedBounds != nil,
+              self.processStartIdentityProvider(identity.ownerProcessIdentifier) ==
+              identity.ownerProcessStartIdentity
+        else {
+            return nil
+        }
+        let processIdentity = ApplicationProcessIdentity(
+            processIdentifier: identity.ownerProcessIdentifier,
+            processStartIdentity: identity.ownerProcessStartIdentity)
+        return DesktopObservationLanePlan(
+            scope: .window(identity),
+            access: .read,
+            expectedProcessIdentity: processIdentity,
+            expectedWindowIdentity: identity)
+    }
+
+    private static func sameWindowIdentity(
+        _ lhs: WindowMutationIdentity,
+        _ rhs: WindowMutationIdentity) -> Bool
+    {
+        lhs.windowID == rhs.windowID &&
+            lhs.ownerProcessIdentifier == rhs.ownerProcessIdentifier &&
+            lhs.ownerProcessStartIdentity == rhs.ownerProcessStartIdentity &&
+            lhs.capturedBounds == rhs.capturedBounds
+    }
+}

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Observation/DesktopObservationService.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Observation/DesktopObservationService.swift
@@ -1,3 +1,6 @@
+import CoreGraphics
+import Foundation
+
 @MainActor
 public protocol DesktopObservationServiceProtocol: Sendable {
     func observe(_ request: DesktopObservationRequest) async throws -> DesktopObservationResult
@@ -12,6 +15,8 @@ public final class DesktopObservationService: DesktopObservationServiceProtocol 
     let stateSnapshotProvider: any DesktopStateSnapshotProviding
     let ocrRecognizer: any OCRRecognizing
     let operationLaneCoordinator: DesktopOperationLaneCoordinator
+    let processStartIdentityProvider: @Sendable (pid_t) -> UInt64?
+    let windowMutationIdentityProvider: @Sendable (CGWindowID) -> WindowMutationIdentity?
 
     public init(
         screenCapture: any ScreenCaptureServiceProtocol,
@@ -22,7 +27,11 @@ public final class DesktopObservationService: DesktopObservationServiceProtocol 
         snapshotManager: (any SnapshotManagerProtocol)? = nil,
         ocrRecognizer: any OCRRecognizing = OCRService(),
         exactWindowMetadataProvider: any ExactWindowMetadataProviding = SystemExactWindowMetadataProvider(),
-        operationLaneCoordinator: DesktopOperationLaneCoordinator = .shared)
+        operationLaneCoordinator: DesktopOperationLaneCoordinator = .shared,
+        processStartIdentityProvider: @escaping @Sendable (pid_t) -> UInt64? =
+            SystemIdentityResolver.processStartIdentity,
+        windowMutationIdentityProvider: @escaping @Sendable (CGWindowID) -> WindowMutationIdentity? =
+            SystemIdentityResolver.windowMutationIdentity)
     {
         self.screenCapture = screenCapture
         self.automation = automation
@@ -35,6 +44,8 @@ public final class DesktopObservationService: DesktopObservationServiceProtocol 
         self.stateSnapshotProvider = DesktopStateSnapshotProvider(applications: applications)
         self.ocrRecognizer = ocrRecognizer
         self.operationLaneCoordinator = operationLaneCoordinator
+        self.processStartIdentityProvider = processStartIdentityProvider
+        self.windowMutationIdentityProvider = windowMutationIdentityProvider
     }
 
     public init(
@@ -44,7 +55,11 @@ public final class DesktopObservationService: DesktopObservationServiceProtocol 
         outputWriter: ObservationOutputWriter = ObservationOutputWriter(),
         stateSnapshotProvider: any DesktopStateSnapshotProviding = EmptyDesktopStateSnapshotProvider(),
         ocrRecognizer: any OCRRecognizing = OCRService(),
-        operationLaneCoordinator: DesktopOperationLaneCoordinator = .shared)
+        operationLaneCoordinator: DesktopOperationLaneCoordinator = .shared,
+        processStartIdentityProvider: @escaping @Sendable (pid_t) -> UInt64? =
+            SystemIdentityResolver.processStartIdentity,
+        windowMutationIdentityProvider: @escaping @Sendable (CGWindowID) -> WindowMutationIdentity? =
+            SystemIdentityResolver.windowMutationIdentity)
     {
         self.screenCapture = screenCapture
         self.automation = automation
@@ -53,6 +68,8 @@ public final class DesktopObservationService: DesktopObservationServiceProtocol 
         self.stateSnapshotProvider = stateSnapshotProvider
         self.ocrRecognizer = ocrRecognizer
         self.operationLaneCoordinator = operationLaneCoordinator
+        self.processStartIdentityProvider = processStartIdentityProvider
+        self.windowMutationIdentityProvider = windowMutationIdentityProvider
     }
 
     public func observe(_ request: DesktopObservationRequest) async throws -> DesktopObservationResult {
@@ -74,8 +91,8 @@ public final class DesktopObservationService: DesktopObservationServiceProtocol 
         let observeStart = ContinuousClock.now
         let serializesDetection = request.detection.mode != .none && request.detection.allowWebFocusFallback
 
-        let coordinatedCapture: @MainActor @Sendable () async throws
-            -> (DesktopStateSnapshot, ResolvedObservationTarget, CaptureResult, ElementDetectionResult?) = {
+        let coordinatedCapture: @MainActor @Sendable (DesktopObservationLanePlan?) async throws
+            -> (DesktopStateSnapshot, ResolvedObservationTarget, CaptureResult, ElementDetectionResult?) = { lanePlan in
                 try await self.withCaptureTransaction {
                     let stateSnapshot = try await tracer.span("state.snapshot") {
                         try await self.stateSnapshotProvider.snapshot(for: request.target)
@@ -84,11 +101,13 @@ public final class DesktopObservationService: DesktopObservationServiceProtocol 
                     let target = try await tracer.span("target.resolve") {
                         try await self.targetResolver.resolve(request.target, snapshot: stateSnapshot)
                     }
+                    try self.validateResolvedTarget(target, for: lanePlan)
 
                     let rawCapture = try await tracer.span("capture.\(Self.captureSpanName(for: target.kind))") {
                         try await self.capture(target, options: request.capture, snapshot: stateSnapshot)
                     }
                     try Self.validateCaptureReceipt(rawCapture, for: target)
+                    try self.validateCurrentLaneIdentity(lanePlan)
                     let capture = Self.normalize(capture: rawCapture, for: target)
                     let captureBoundTarget = Self.bindingCaptureReceipt(to: target, capture: capture)
                     let detection: ElementDetectionResult? = if serializesDetection {
@@ -104,7 +123,8 @@ public final class DesktopObservationService: DesktopObservationServiceProtocol 
                 }
             }
         let (stateSnapshot, target, capture, serializedDetection) = try await self.withDesktopOperationLane(
-            coordinatedCapture)
+            for: request,
+            operation: coordinatedCapture)
         // Web-focus fallback can AXPress hidden web content, so keep that mutating detection atomic with capture.
         // Read-only AX traversal and OCR can be slow without touching ScreenCaptureKit; let unrelated captures run.
         let detection = if serializesDetection {
@@ -169,19 +189,6 @@ public final class DesktopObservationService: DesktopObservationServiceProtocol 
         case .service:
             // Remote services acquire the cross-process gate in their execution host. Acquiring it here first would
             // make the host wait forever on a lock owned by the client request that is waiting for that host.
-            try await operation()
-        }
-    }
-
-    private func withDesktopOperationLane<T: Sendable>(
-        _ operation: @escaping @MainActor @Sendable () async throws -> T) async throws -> T
-    {
-        switch self.screenCapture.captureTransactionGateOwner {
-        case .caller:
-            try await self.operationLaneCoordinator.run(scope: .global, access: .write, operation: operation)
-        case .service:
-            // IPC-backed services acquire desktop and capture lanes in the execution host. Holding
-            // either client-side lane across the RPC would make the host wait on its own caller.
             try await operation()
         }
     }

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/UIAutomationService+ElementActions.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/UIAutomationService+ElementActions.swift
@@ -1,16 +1,29 @@
 import Foundation
 import PeekabooFoundation
 
+private struct ElementSetValueLanePlan: Sendable {
+    let scope: DesktopOperationScope
+    let expectedProcessIdentity: ApplicationProcessIdentity?
+    let expectedWindowIdentity: WindowMutationIdentity?
+
+    static let global = ElementSetValueLanePlan(
+        scope: .global,
+        expectedProcessIdentity: nil,
+        expectedWindowIdentity: nil)
+}
+
 extension UIAutomationService: ElementActionAutomationServiceProtocol {
     public func setValue(
         target: String,
         value: UIElementValue,
         snapshotId: String?) async throws -> ElementActionResult
     {
-        try await self.operationLaneCoordinator.run(scope: .global, access: .write) {
+        let lanePlan = await self.setValueLanePlan(snapshotId: snapshotId)
+        return try await self.operationLaneCoordinator.run(scope: lanePlan.scope, access: .write) {
             self.logger.debug("Set value requested - target: \(target, privacy: .public)")
             defer { self.elementDetectionService.invalidateCache() }
             let resolved = try await self.resolveActionTarget(target, snapshotId: snapshotId)
+            try self.validateSetValueTarget(resolved.windowContext, plan: lanePlan)
             let oldValue = self.safeValueDescription(resolved.element.value)
                 ?? resolved.element.selectedValue.map(String.init)
             let result = try await self.normalizingSnapshotErrors {
@@ -95,7 +108,7 @@ extension UIAutomationService: ElementActionAutomationServiceProtocol {
     }
 
     private func resolveActionTarget(_ target: String, snapshotId: String?) async throws
-        -> (element: AutomationElement, description: String, bundleIdentifier: String?)
+        -> (element: AutomationElement, description: String, bundleIdentifier: String?, windowContext: WindowContext?)
     {
         let normalized = target.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !normalized.isEmpty else {
@@ -127,7 +140,8 @@ extension UIAutomationService: ElementActionAutomationServiceProtocol {
                 return (
                     element,
                     Self.describe(detected),
-                    detectionResult.metadata.windowContext?.applicationBundleId)
+                    detectionResult.metadata.windowContext?.applicationBundleId,
+                    detectionResult.metadata.windowContext)
             }
 
             throw NotFoundError.element(normalized)
@@ -138,7 +152,7 @@ extension UIAutomationService: ElementActionAutomationServiceProtocol {
             windowContext: nil,
             requireTextInput: false)
         {
-            return (element, element.name ?? normalized, nil)
+            return (element, element.name ?? normalized, nil, nil)
         }
 
         throw PeekabooError.invalidInput(
@@ -167,6 +181,65 @@ extension UIAutomationService: ElementActionAutomationServiceProtocol {
     private static func describe(_ element: DetectedElement) -> String {
         let label = element.label ?? element.value ?? element.attributes["title"] ?? "untitled"
         return "\(element.id) \(element.type.rawValue): \(label)"
+    }
+
+    private func setValueLanePlan(snapshotId: String?) async -> ElementSetValueLanePlan {
+        guard let snapshotId,
+              let detectionResult = try? await self.snapshotManager.getDetectionResult(snapshotId: snapshotId),
+              let context = detectionResult.metadata.windowContext,
+              let identity = context.windowMutationIdentity,
+              let bounds = context.windowBounds,
+              context.applicationProcessId == identity.ownerProcessIdentifier,
+              context.windowID == identity.windowID,
+              identity.capturedBounds == bounds,
+              self.processStartIdentityProvider(identity.ownerProcessIdentifier) ==
+              identity.ownerProcessStartIdentity,
+              self.exactWindowIdentityValidator(identity, bounds)
+        else {
+            return .global
+        }
+        let processIdentity = ApplicationProcessIdentity(
+            processIdentifier: identity.ownerProcessIdentifier,
+            processStartIdentity: identity.ownerProcessStartIdentity)
+        return ElementSetValueLanePlan(
+            scope: .process(processIdentity),
+            expectedProcessIdentity: processIdentity,
+            expectedWindowIdentity: identity)
+    }
+
+    private func validateSetValueTarget(
+        _ context: WindowContext?,
+        plan: ElementSetValueLanePlan) throws
+    {
+        guard let expectedProcessIdentity = plan.expectedProcessIdentity,
+              let expectedWindowIdentity = plan.expectedWindowIdentity
+        else {
+            return
+        }
+        guard let context,
+              context.applicationProcessId == expectedProcessIdentity.processIdentifier,
+              context.windowID == expectedWindowIdentity.windowID,
+              context.windowBounds == expectedWindowIdentity.capturedBounds,
+              let resolvedWindowIdentity = context.windowMutationIdentity,
+              Self.sameSetValueWindowIdentity(resolvedWindowIdentity, expectedWindowIdentity),
+              self.processStartIdentityProvider(expectedProcessIdentity.processIdentifier) ==
+              expectedProcessIdentity.processStartIdentity,
+              let bounds = expectedWindowIdentity.capturedBounds,
+              self.exactWindowIdentityValidator(expectedWindowIdentity, bounds)
+        else {
+            throw PeekabooError.snapshotStale(
+                "target window owner, process generation, or bounds changed before value dispatch")
+        }
+    }
+
+    private nonisolated static func sameSetValueWindowIdentity(
+        _ lhs: WindowMutationIdentity,
+        _ rhs: WindowMutationIdentity) -> Bool
+    {
+        lhs.windowID == rhs.windowID &&
+            lhs.ownerProcessIdentifier == rhs.ownerProcessIdentifier &&
+            lhs.ownerProcessStartIdentity == rhs.ownerProcessStartIdentity &&
+            lhs.capturedBounds == rhs.capturedBounds
     }
 
     private static func isValidActionName(_ actionName: String) -> Bool {

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ActionInputDriverTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ActionInputDriverTests.swift
@@ -436,6 +436,69 @@ struct ActionInputDriverTests {
 
     @MainActor
     @Test
+    func `exact snapshot set value waits only for its process observation frame`() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("peekaboo-set-value-process-lane-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let coordinator = DesktopOperationLaneCoordinator(coordinationRootURL: root)
+        let firstProcess = ApplicationProcessIdentity(processIdentifier: 610, processStartIdentity: 11)
+        let secondProcess = ApplicationProcessIdentity(processIdentifier: 611, processStartIdentity: 12)
+        let frameStarted = ActionLaneLatch()
+        let frameRelease = ActionLaneLatch()
+        let firstResolved = ActionLaneLatch()
+        let secondResolved = ActionLaneLatch()
+        let firstIdentity = self.windowIdentity(windowID: 301, process: firstProcess)
+        let secondIdentity = self.windowIdentity(windowID: 302, process: secondProcess)
+        let firstService = self.makeScopedSetValueService(
+            snapshotID: "first",
+            identity: firstIdentity,
+            coordinator: coordinator,
+            currentGeneration: { pid in
+                pid == firstProcess.processIdentifier
+                    ? firstProcess.processStartIdentity
+                    : secondProcess.processStartIdentity
+            },
+            onResolve: { Task { await firstResolved.open() } })
+        let secondService = self.makeScopedSetValueService(
+            snapshotID: "second",
+            identity: secondIdentity,
+            coordinator: coordinator,
+            currentGeneration: { pid in
+                pid == firstProcess.processIdentifier
+                    ? firstProcess.processStartIdentity
+                    : secondProcess.processStartIdentity
+            },
+            onResolve: { Task { await secondResolved.open() } })
+
+        let frame = Task {
+            try await coordinator.run(scope: .window(firstIdentity), access: .read) {
+                await frameStarted.open()
+                await frameRelease.wait()
+            }
+        }
+        await frameStarted.wait()
+        let firstMutation = Task {
+            try? await firstService.setValue(target: "B1", value: .string("one"), snapshotId: "first")
+        }
+        let secondMutation = Task {
+            try? await secondService.setValue(target: "B1", value: .string("two"), snapshotId: "second")
+        }
+
+        let secondOverlapped = await secondResolved.opensWithin(.seconds(1))
+        let firstOverlapped = await firstResolved.opensWithin(.milliseconds(100))
+        #expect(secondOverlapped)
+        #expect(!firstOverlapped)
+        await frameRelease.open()
+
+        try await frame.value
+        _ = await firstMutation.value
+        _ = await secondMutation.value
+        let firstEventuallyResolved = await firstResolved.isOpen
+        #expect(firstEventuallyResolved)
+    }
+
+    @MainActor
+    @Test
     func `mock element can exercise action click without live AX`() throws {
         let element = MockAutomationElement(
             role: AXRoleNames.kAXButtonRole,
@@ -683,6 +746,54 @@ struct ActionInputDriverTests {
             Issue.record("Unexpected error: \(error)")
         }
     }
+
+    @MainActor
+    private func makeScopedSetValueService(
+        snapshotID: String,
+        identity: WindowMutationIdentity,
+        coordinator: DesktopOperationLaneCoordinator,
+        currentGeneration: @escaping @Sendable (pid_t) -> UInt64?,
+        onResolve: @escaping @MainActor () -> Void) -> UIAutomationService
+    {
+        let detected = DetectedElement(
+            id: "B1",
+            type: .textField,
+            label: "Value",
+            bounds: CGRect(x: 10, y: 10, width: 80, height: 24))
+        let context = WindowContext(
+            applicationProcessId: identity.ownerProcessIdentifier,
+            windowID: identity.windowID,
+            windowBounds: identity.capturedBounds,
+            windowMutationIdentity: identity)
+        let detectionResult = ElementDetectionResult(
+            snapshotId: snapshotID,
+            screenshotPath: "/tmp/\(snapshotID).png",
+            elements: DetectedElements(textFields: [detected]),
+            metadata: DetectionMetadata(
+                detectionTime: 0.01,
+                elementCount: 1,
+                method: "test",
+                windowContext: context))
+        return UIAutomationService(
+            snapshotManager: InMemorySnapshotManager(detectionResult: detectionResult),
+            inputPolicy: UIInputPolicy(defaultStrategy: .actionOnly),
+            actionInputDriver: RecordingActionInputDriver(elementActionError: .staleElement),
+            automationElementResolver: FixedActionAutomationElementResolver(onResolve: onResolve),
+            exactWindowIdentityValidator: { _, _ in true },
+            processStartIdentityProvider: currentGeneration,
+            operationLaneCoordinator: coordinator)
+    }
+
+    private func windowIdentity(
+        windowID: Int,
+        process: ApplicationProcessIdentity) -> WindowMutationIdentity
+    {
+        WindowMutationIdentity(
+            windowID: windowID,
+            ownerProcessIdentifier: process.processIdentifier,
+            ownerProcessStartIdentity: process.processStartIdentity,
+            capturedBounds: CGRect(x: 1, y: 2, width: 300, height: 200))
+    }
 }
 
 @MainActor
@@ -784,9 +895,15 @@ private final class RecordingActionInputDriver: ActionInputDriving {
 @MainActor
 private final class FixedActionAutomationElementResolver: AutomationElementResolving {
     private let element = AutomationElement(Element(AXUIElementCreateApplication(getpid())))
+    private let onResolve: @MainActor () -> Void
+
+    init(onResolve: @escaping @MainActor () -> Void = {}) {
+        self.onResolve = onResolve
+    }
 
     func resolve(detectedElement _: DetectedElement, windowContext _: WindowContext?) -> AutomationElement? {
-        self.element
+        self.onResolve()
+        return self.element
     }
 
     func resolve(
@@ -794,11 +911,13 @@ private final class FixedActionAutomationElementResolver: AutomationElementResol
         windowContext _: WindowContext?,
         targetProcessIdentifier _: pid_t?) -> AutomationElement?
     {
-        self.element
+        self.onResolve()
+        return self.element
     }
 
     func resolve(query _: String, windowContext _: WindowContext?, requireTextInput _: Bool) -> AutomationElement? {
-        self.element
+        self.onResolve()
+        return self.element
     }
 
     func resolve(
@@ -807,7 +926,38 @@ private final class FixedActionAutomationElementResolver: AutomationElementResol
         targetProcessIdentifier _: pid_t?,
         requireTextInput _: Bool) -> AutomationElement?
     {
-        self.element
+        self.onResolve()
+        return self.element
+    }
+}
+
+private actor ActionLaneLatch {
+    private var opened = false
+    private var continuations: [CheckedContinuation<Void, Never>] = []
+
+    var isOpen: Bool {
+        self.opened
+    }
+
+    func open() {
+        guard !self.opened else { return }
+        self.opened = true
+        let pending = self.continuations
+        self.continuations.removeAll()
+        pending.forEach { $0.resume() }
+    }
+
+    func wait() async {
+        guard !self.opened else { return }
+        await withCheckedContinuation { self.continuations.append($0) }
+    }
+
+    func opensWithin(_ duration: Duration) async -> Bool {
+        let deadline = ContinuousClock.now.advanced(by: duration)
+        while !self.opened, ContinuousClock.now < deadline {
+            try? await Task.sleep(for: .milliseconds(5))
+        }
+        return self.opened
     }
 }
 

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/DesktopObservationServiceTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/DesktopObservationServiceTests.swift
@@ -55,7 +55,58 @@ final class DesktopObservationServiceTests: XCTestCase {
 
         XCTAssertEqual(selected?.windowID, 21)
     }
+}
 
+@MainActor
+extension DesktopObservationServiceTests {
+    func testObservationLanePlanNarrowsOnlyPassiveExactTargets() {
+        let process = ApplicationProcessIdentity(processIdentifier: 500, processStartIdentity: 70)
+        let window = WindowMutationIdentity(
+            windowID: 200,
+            ownerProcessIdentifier: process.processIdentifier,
+            ownerProcessStartIdentity: process.processStartIdentity,
+            capturedBounds: CGRect(x: 10, y: 20, width: 300, height: 200))
+        let service = DesktopObservationService(
+            screenCapture: RecordingScreenCaptureService(result: Self.captureResult(
+                app: Self.app(),
+                window: Self.window(id: 1, title: "Fixture", bounds: CGRect(x: 0, y: 0, width: 1, height: 1)))),
+            automation: RecordingUIAutomationService(),
+            applications: RecordingApplicationService(applications: [], windows: []),
+            processStartIdentityProvider: { _ in process.processStartIdentity },
+            windowMutationIdentityProvider: { _ in window })
+        let passivePID = service.operationLanePlan(for: DesktopObservationRequest(
+            target: .pid(process.processIdentifier, window: .automatic),
+            detection: DesktopDetectionOptions(mode: .none)))
+        let passiveWindow = service.operationLanePlan(for: DesktopObservationRequest(
+            target: .windowID(CGWindowID(window.windowID)),
+            detection: DesktopDetectionOptions(mode: .none)))
+        let screen = service.operationLanePlan(for: DesktopObservationRequest(
+            target: .screen(index: 0),
+            detection: DesktopDetectionOptions(mode: .none)))
+        let webFocus = service.operationLanePlan(for: DesktopObservationRequest(
+            target: .pid(process.processIdentifier, window: .automatic),
+            detection: DesktopDetectionOptions(mode: .accessibility, allowWebFocusFallback: true)))
+        let foreground = service.operationLanePlan(for: DesktopObservationRequest(
+            target: .windowID(CGWindowID(window.windowID)),
+            capture: DesktopCaptureOptions(focus: .foreground),
+            detection: DesktopDetectionOptions(mode: .none)))
+        let menuOpening = service.operationLanePlan(for: DesktopObservationRequest(
+            target: .menubarPopover(hints: ["Fixture"], openIfNeeded: .init()),
+            detection: DesktopDetectionOptions(mode: .none)))
+
+        XCTAssertEqual(passivePID.scope, .process(process))
+        XCTAssertEqual(passivePID.access, .read)
+        XCTAssertEqual(passiveWindow.scope, .window(window))
+        XCTAssertEqual(passiveWindow.access, .read)
+        for global in [screen, webFocus, foreground, menuOpening] {
+            XCTAssertEqual(global.scope, .global)
+            XCTAssertEqual(global.access, .write)
+        }
+    }
+}
+
+@MainActor
+extension DesktopObservationServiceTests {
     func testObservationWithoutDetectionCapturesResolvedWindowID() async throws {
         let imageData = Data([1, 2, 3])
         let app = Self.app()
@@ -787,7 +838,175 @@ final class DesktopObservationServiceTests: XCTestCase {
         _ = try await localObservation.value
         _ = try await remoteObservation.value
     }
+}
 
+@MainActor
+extension DesktopObservationServiceTests {
+    func testExactWindowLaneIgnoresMutableMinimizedHint() async throws {
+        let process = ApplicationProcessIdentity(processIdentifier: 123, processStartIdentity: 700)
+        let bounds = CGRect(x: 100, y: 100, width: 400, height: 300)
+        let identity = WindowMutationIdentity(
+            windowID: 42,
+            ownerProcessIdentifier: process.processIdentifier,
+            ownerProcessStartIdentity: process.processStartIdentity,
+            capturedBounds: bounds,
+            isMinimized: false)
+        let app = ServiceApplicationInfo(
+            processIdentifier: process.processIdentifier,
+            processStartIdentity: process.processStartIdentity,
+            bundleIdentifier: "com.example.fixture",
+            name: "Fixture",
+            windowCount: 1)
+        let window = Self.window(
+            id: identity.windowID,
+            title: "Captured",
+            bounds: bounds,
+            mutationIdentity: identity)
+        let service = DesktopObservationService(
+            screenCapture: RecordingScreenCaptureService(result: Self.captureResult(app: app, window: window)),
+            automation: RecordingUIAutomationService(),
+            applications: RecordingApplicationService(applications: [app], windows: [window]),
+            exactWindowMetadataProvider: StableExactWindowMetadataProvider(),
+            processStartIdentityProvider: { _ in process.processStartIdentity },
+            windowMutationIdentityProvider: { _ in identity })
+
+        let result = try await service.observe(DesktopObservationRequest(
+            target: .windowID(CGWindowID(identity.windowID)),
+            detection: DesktopDetectionOptions(mode: .none)))
+
+        XCTAssertEqual(result.target.window?.windowID, identity.windowID)
+    }
+
+    func testExactPIDObservationSerializesOnlyItsProcessFrame() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("peekaboo-observation-process-lane-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let coordinator = DesktopOperationLaneCoordinator(coordinationRootURL: root)
+        let process = ApplicationProcessIdentity(processIdentifier: 510, processStartIdentity: 77)
+        let otherProcess = ApplicationProcessIdentity(processIdentifier: 511, processStartIdentity: 88)
+        let bounds = CGRect(x: 100, y: 100, width: 500, height: 400)
+        let windowIdentity = WindowMutationIdentity(
+            windowID: 201,
+            ownerProcessIdentifier: process.processIdentifier,
+            ownerProcessStartIdentity: process.processStartIdentity,
+            capturedBounds: bounds)
+        let app = ServiceApplicationInfo(
+            processIdentifier: process.processIdentifier,
+            processStartIdentity: process.processStartIdentity,
+            bundleIdentifier: "com.example.fixture",
+            name: "Fixture",
+            windowCount: 1)
+        let window = Self.window(
+            id: windowIdentity.windowID,
+            title: "Scoped",
+            bounds: bounds,
+            mutationIdentity: windowIdentity)
+        let captureStarted = expectation(description: "exact PID frame started")
+        let captureSuspension = ObservationDetectionSuspension { captureStarted.fulfill() }
+        let service = DesktopObservationService(
+            screenCapture: SuspendingObservationCaptureService(
+                result: Self.captureResult(app: app, window: window),
+                suspension: captureSuspension),
+            automation: RecordingUIAutomationService(),
+            applications: RecordingApplicationService(applications: [app], windows: [window]),
+            operationLaneCoordinator: coordinator,
+            processStartIdentityProvider: { pid in
+                pid == process.processIdentifier ? process.processStartIdentity : otherProcess.processStartIdentity
+            },
+            windowMutationIdentityProvider: { _ in windowIdentity })
+        let sameProcessWriterStarted = ObservationLaneLatch()
+        let otherProcessWriterStarted = ObservationLaneLatch()
+
+        let observation = Task {
+            try await service.observe(DesktopObservationRequest(
+                target: .pid(process.processIdentifier, window: .automatic),
+                detection: DesktopDetectionOptions(mode: .none)))
+        }
+        await fulfillment(of: [captureStarted], timeout: 2)
+
+        let sameProcessWriter = Task {
+            try await coordinator.run(scope: .process(process), access: .write) {
+                await sameProcessWriterStarted.open()
+            }
+        }
+        let otherProcessWriter = Task {
+            try await coordinator.run(scope: .process(otherProcess), access: .write) {
+                await otherProcessWriterStarted.open()
+            }
+        }
+
+        let otherProcessOverlapped = await otherProcessWriterStarted.opensWithin(.seconds(1))
+        let sameProcessOverlapped = await sameProcessWriterStarted.opensWithin(.milliseconds(100))
+        XCTAssertTrue(otherProcessOverlapped)
+        XCTAssertFalse(sameProcessOverlapped)
+        captureSuspension.release()
+
+        _ = try await observation.value
+        try await sameProcessWriter.value
+        try await otherProcessWriter.value
+        let sameProcessEventuallyStarted = await sameProcessWriterStarted.isOpen
+        XCTAssertTrue(sameProcessEventuallyStarted)
+    }
+
+    func testCancelledExactPIDObservationReleasesPartialClaimsWithoutCapturing() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("peekaboo-observation-cancel-lane-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let coordinator = DesktopOperationLaneCoordinator(coordinationRootURL: root)
+        let process = ApplicationProcessIdentity(processIdentifier: 520, processStartIdentity: 99)
+        let ownerStarted = ObservationLaneLatch()
+        let ownerRelease = ObservationLaneLatch()
+        let captureStarted = expectation(description: "cancelled observation never captured")
+        captureStarted.isInverted = true
+        let app = ServiceApplicationInfo(
+            processIdentifier: process.processIdentifier,
+            processStartIdentity: process.processStartIdentity,
+            bundleIdentifier: "com.example.fixture",
+            name: "Fixture",
+            windowCount: 1)
+        let window = Self.window(
+            id: 202,
+            title: "Queued",
+            bounds: CGRect(x: 100, y: 100, width: 500, height: 400))
+        let service = DesktopObservationService(
+            screenCapture: RecordingScreenCaptureService(
+                result: Self.captureResult(app: app, window: window),
+                onCapture: { captureStarted.fulfill() }),
+            automation: RecordingUIAutomationService(),
+            applications: RecordingApplicationService(applications: [app], windows: [window]),
+            operationLaneCoordinator: coordinator,
+            processStartIdentityProvider: { _ in process.processStartIdentity })
+
+        let owner = Task {
+            try await coordinator.run(scope: .process(process), access: .write) {
+                await ownerStarted.open()
+                await ownerRelease.wait()
+            }
+        }
+        await ownerStarted.wait()
+        let observation = Task {
+            try await service.observe(DesktopObservationRequest(
+                target: .pid(process.processIdentifier, window: .automatic),
+                detection: DesktopDetectionOptions(mode: .none)))
+        }
+        try await Task.sleep(for: .milliseconds(50))
+        observation.cancel()
+
+        do {
+            _ = try await observation.value
+            XCTFail("Expected queued observation cancellation")
+        } catch is CancellationError {
+            // Expected: cancellation releases the already-held global ancestor claim.
+        }
+        await ownerRelease.open()
+        try await owner.value
+        await fulfillment(of: [captureStarted], timeout: 0.2)
+        try await coordinator.run(scope: .global, access: .write) {}
+    }
+}
+
+@MainActor
+extension DesktopObservationServiceTests {
     private static func app() -> ServiceApplicationInfo {
         ServiceApplicationInfo(
             processIdentifier: 123,
@@ -1196,6 +1415,96 @@ private final class RecordingOCRRecognizer: OCRRecognizing, @unchecked Sendable 
     func recognizeText(in _: Data, timeoutSeconds _: TimeInterval) async throws -> OCRTextResult {
         self.lock.withLock { self.recognizeCalls += 1 }
         return self.result
+    }
+}
+
+@MainActor
+private final class SuspendingObservationCaptureService: ScreenCaptureServiceProtocol {
+    private let result: CaptureResult
+    private let suspension: ObservationDetectionSuspension
+
+    init(result: CaptureResult, suspension: ObservationDetectionSuspension) {
+        self.result = result
+        self.suspension = suspension
+    }
+
+    func captureScreen(
+        displayIndex _: Int?,
+        visualizerMode _: CaptureVisualizerMode,
+        scale _: CaptureScalePreference) async throws -> CaptureResult
+    {
+        await self.suspension.wait()
+        return self.result
+    }
+
+    func captureWindow(
+        appIdentifier _: String,
+        windowIndex _: Int?,
+        visualizerMode _: CaptureVisualizerMode,
+        scale _: CaptureScalePreference) async throws -> CaptureResult
+    {
+        await self.suspension.wait()
+        return self.result
+    }
+
+    func captureWindow(
+        windowID _: CGWindowID,
+        visualizerMode _: CaptureVisualizerMode,
+        scale _: CaptureScalePreference) async throws -> CaptureResult
+    {
+        await self.suspension.wait()
+        return self.result
+    }
+
+    func captureFrontmost(
+        visualizerMode _: CaptureVisualizerMode,
+        scale _: CaptureScalePreference) async throws -> CaptureResult
+    {
+        await self.suspension.wait()
+        return self.result
+    }
+
+    func captureArea(
+        _: CGRect,
+        visualizerMode _: CaptureVisualizerMode,
+        scale _: CaptureScalePreference) async throws -> CaptureResult
+    {
+        await self.suspension.wait()
+        return self.result
+    }
+
+    func hasScreenRecordingPermission() async -> Bool {
+        true
+    }
+}
+
+private actor ObservationLaneLatch {
+    private var opened = false
+    private var continuations: [CheckedContinuation<Void, Never>] = []
+
+    var isOpen: Bool {
+        self.opened
+    }
+
+    func open() {
+        guard !self.opened else { return }
+        self.opened = true
+        let pending = self.continuations
+        self.continuations.removeAll()
+        pending.forEach { $0.resume() }
+    }
+
+    func wait() async {
+        guard !self.opened else { return }
+        await withCheckedContinuation { self.continuations.append($0) }
+    }
+
+    func opensWithin(_ duration: Duration) async -> Bool {
+        let deadline = ContinuousClock.now.advanced(by: duration)
+        while !self.opened, ContinuousClock.now < deadline {
+            try? await Task.sleep(for: .milliseconds(5))
+        }
+        return self.opened
     }
 }
 

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/DesktopOperationLaneCoordinatorTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/DesktopOperationLaneCoordinatorTests.swift
@@ -384,6 +384,51 @@ struct DesktopOperationLaneCoordinatorTests {
         #expect(await laterReaderStarted.isOpen)
     }
 
+    @Test
+    func `Queued process writer closes its turnstile to later window readers`() async throws {
+        let root = Self.temporaryDirectory(named: "process-writer-turnstile")
+        defer { try? FileManager.default.removeItem(at: root) }
+        let coordinator = DesktopOperationLaneCoordinator(coordinationRootURL: root)
+        let process = ApplicationProcessIdentity(processIdentifier: 920, processStartIdentity: 2)
+        let firstWindow = Self.window(windowID: 111, process: process)
+        let secondWindow = Self.window(windowID: 112, process: process)
+        let ownerStarted = AsyncTestLatch()
+        let ownerRelease = AsyncTestLatch()
+        let writerStarted = AsyncTestLatch()
+        let writerRelease = AsyncTestLatch()
+        let laterReaderStarted = AsyncTestLatch()
+
+        let owner = Task {
+            try await coordinator.run(scope: .window(firstWindow), access: .read) {
+                await ownerStarted.open()
+                await ownerRelease.wait()
+            }
+        }
+        await ownerStarted.wait()
+        let writer = Task {
+            try await coordinator.run(scope: .process(process), access: .write) {
+                await writerStarted.open()
+                await writerRelease.wait()
+            }
+        }
+        try await Task.sleep(for: .milliseconds(100))
+        let reader = Task {
+            try await coordinator.run(scope: .window(secondWindow), access: .read) {
+                await laterReaderStarted.open()
+            }
+        }
+
+        await ownerRelease.open()
+        #expect(await writerStarted.opensWithin(.seconds(1)))
+        #expect(await !(laterReaderStarted.opensWithin(.milliseconds(100))))
+        await writerRelease.open()
+
+        try await owner.value
+        try await writer.value
+        try await reader.value
+        #expect(await laterReaderStarted.isOpen)
+    }
+
     private static func window(
         windowID: Int,
         process: ApplicationProcessIdentity = .init(processIdentifier: 600, processStartIdentity: 10),

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer+DesktopReadLane.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer+DesktopReadLane.swift
@@ -1,0 +1,208 @@
+import CoreGraphics
+import Foundation
+import PeekabooAutomationKit
+
+private enum DesktopReadLaneResolution {
+    case lane(scope: DesktopOperationScope, access: DesktopOperationAccess, validatesIdentity: Bool)
+    case exactIdentityUnavailable
+}
+
+extension PeekabooBridgeServer {
+    func validatedDesktopReadOperationLane(
+        for request: PeekabooBridgeRequest,
+        proposed: (scope: DesktopOperationScope, access: DesktopOperationAccess))
+        -> (scope: DesktopOperationScope, access: DesktopOperationAccess)
+    {
+        switch self.desktopReadLaneResolution(for: request, proposed: proposed) {
+        case let .lane(scope, access, validatesIdentity):
+            if validatesIdentity, !self.desktopReadScopeIsCurrent(scope) {
+                return (.global, .write)
+            }
+            return (scope, access)
+        case .exactIdentityUnavailable:
+            return (.global, .write)
+        }
+    }
+
+    func withValidatedDesktopReadOperationLane<T: Sendable>(
+        for request: PeekabooBridgeRequest,
+        proposed: (scope: DesktopOperationScope, access: DesktopOperationAccess),
+        operation: () async throws -> T) async throws -> T
+    {
+        try await self.withValidatedDesktopReadOperationLane(
+            for: request,
+            proposed: proposed)
+        { _ in
+            try await operation()
+        }
+    }
+
+    private func withValidatedDesktopReadOperationLane<T: Sendable>(
+        for request: PeekabooBridgeRequest,
+        proposed: (scope: DesktopOperationScope, access: DesktopOperationAccess),
+        operation: (DesktopOperationScope) async throws -> T) async throws -> T
+    {
+        let resolution = self.desktopReadLaneResolution(for: request, proposed: proposed)
+        guard case let .lane(scope, access, validatesIdentity) = resolution else {
+            throw Self.exactDesktopReadTargetChangedError()
+        }
+        return try await self.desktopOperationLaneCoordinator.run(scope: scope, access: access) {
+            try PeekabooBridgeRequestContext.checkRequestIsActive()
+            if validatesIdentity, !self.desktopReadScopeIsCurrent(scope) {
+                throw Self.exactDesktopReadTargetChangedError()
+            }
+            let result = try await operation(scope)
+            try PeekabooBridgeRequestContext.checkRequestIsActive()
+            if validatesIdentity, !self.desktopReadScopeIsCurrent(scope) {
+                throw Self.exactDesktopReadTargetChangedError()
+            }
+            return result
+        }
+    }
+
+    private func desktopReadLaneResolution(
+        for request: PeekabooBridgeRequest,
+        proposed: (scope: DesktopOperationScope, access: DesktopOperationAccess)) -> DesktopReadLaneResolution
+    {
+        if let exactScope = self.exactDesktopReadScope(for: request) {
+            return .lane(scope: exactScope, access: .read, validatesIdentity: true)
+        }
+        if self.requiresExactDesktopReadIdentity(request) {
+            return .exactIdentityUnavailable
+        }
+        return .lane(scope: proposed.scope, access: proposed.access, validatesIdentity: false)
+    }
+
+    private func exactDesktopReadScope(for request: PeekabooBridgeRequest) -> DesktopOperationScope? {
+        if let identity = request.exactWindowReadIdentity {
+            return .window(identity)
+        }
+
+        switch request {
+        case let .captureWindow(payload):
+            if let rawWindowID = payload.windowId,
+               let windowID = CGWindowID(exactly: rawWindowID)
+            {
+                return self.currentExactWindowReadScope(windowID: windowID)
+            }
+            guard let processIdentifier = Self.explicitProcessIdentifier(payload.appIdentifier) else {
+                return nil
+            }
+            return self.currentExactProcessReadScope(processIdentifier: processIdentifier)
+        case let .desktopObservation(observation):
+            switch observation.target {
+            case let .windowID(windowID):
+                return self.currentExactWindowReadScope(windowID: windowID)
+            case let .pid(processIdentifier, selection):
+                if case let .id(windowID)? = selection {
+                    guard case let .window(identity)? = self.currentExactWindowReadScope(windowID: windowID),
+                          identity.ownerProcessIdentifier == processIdentifier
+                    else {
+                        return nil
+                    }
+                    return .window(identity)
+                }
+                return self.currentExactProcessReadScope(processIdentifier: processIdentifier)
+            case let .app(_, selection):
+                guard case let .id(windowID)? = selection else { return nil }
+                return self.currentExactWindowReadScope(windowID: windowID)
+            case .allScreens, .area, .frontmost, .menubar, .menubarPopover, .screen:
+                return nil
+            }
+        default:
+            return nil
+        }
+    }
+
+    private func requiresExactDesktopReadIdentity(_ request: PeekabooBridgeRequest) -> Bool {
+        if request.exactWindowReadIdentity != nil {
+            return true
+        }
+        switch request {
+        case let .captureWindow(payload):
+            return payload.windowId != nil || Self.explicitProcessIdentifier(payload.appIdentifier) != nil
+        case let .desktopObservation(observation):
+            return switch observation.target {
+            case .pid, .windowID:
+                true
+            case let .app(_, selection):
+                if case .id? = selection {
+                    true
+                } else {
+                    false
+                }
+            case .allScreens, .area, .frontmost, .menubar, .menubarPopover, .screen:
+                false
+            }
+        default:
+            return false
+        }
+    }
+
+    private func currentExactProcessReadScope(processIdentifier: pid_t) -> DesktopOperationScope? {
+        guard processIdentifier > 0,
+              let processStartIdentity = self.processStartIdentityProvider(processIdentifier),
+              self.processStartIdentityProvider(processIdentifier) == processStartIdentity
+        else {
+            return nil
+        }
+        return .process(ApplicationProcessIdentity(
+            processIdentifier: processIdentifier,
+            processStartIdentity: processStartIdentity))
+    }
+
+    private func currentExactWindowReadScope(windowID: CGWindowID) -> DesktopOperationScope? {
+        guard windowID != kCGNullWindowID,
+              let ownerProcessIdentifier = self.windowOwnerProcessIdentifierProvider(windowID),
+              ownerProcessIdentifier > 0,
+              let bounds = self.windowBoundsProvider(windowID),
+              let processStartIdentity = self.processStartIdentityProvider(ownerProcessIdentifier),
+              self.windowOwnerProcessIdentifierProvider(windowID) == ownerProcessIdentifier,
+              self.windowBoundsProvider(windowID) == bounds,
+              self.processStartIdentityProvider(ownerProcessIdentifier) == processStartIdentity
+        else {
+            return nil
+        }
+        return .window(WindowMutationIdentity(
+            windowID: Int(windowID),
+            ownerProcessIdentifier: ownerProcessIdentifier,
+            ownerProcessStartIdentity: processStartIdentity,
+            capturedBounds: bounds))
+    }
+
+    private func desktopReadScopeIsCurrent(_ scope: DesktopOperationScope) -> Bool {
+        switch scope {
+        case .global:
+            return true
+        case let .process(identity):
+            return self.processStartIdentityProvider(identity.processIdentifier) == identity.processStartIdentity
+        case let .window(identity):
+            guard let windowID = CGWindowID(exactly: identity.windowID),
+                  let capturedBounds = identity.capturedBounds
+            else {
+                return false
+            }
+            return self.windowOwnerProcessIdentifierProvider(windowID) == identity.ownerProcessIdentifier &&
+                self.windowBoundsProvider(windowID) == capturedBounds &&
+                self.processStartIdentityProvider(identity.ownerProcessIdentifier) ==
+                identity.ownerProcessStartIdentity
+        }
+    }
+
+    private static func explicitProcessIdentifier(_ identifier: String) -> pid_t? {
+        let trimmed = identifier.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.uppercased().hasPrefix("PID:"),
+              let processIdentifier = pid_t(trimmed.dropFirst("PID:".count)),
+              processIdentifier > 0
+        else {
+            return nil
+        }
+        return processIdentifier
+    }
+
+    private static func exactDesktopReadTargetChangedError() -> PeekabooBridgeErrorEnvelope {
+        PeekabooBridgeErrorEnvelope(
+            code: .invalidRequest,
+            message: "The exact desktop read target changed owner, process generation, or bounds before completion")
+    }
+}

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer.swift
@@ -5,8 +5,6 @@ import PeekabooAutomationKit
 import PeekabooFoundation
 import Security
 
-private struct ExactWindowReadLaneIdentityChanged: Error {}
-
 public struct PeekabooBridgePeer: Sendable {
     public let processIdentifier: pid_t
     public let userIdentifier: uid_t?
@@ -495,61 +493,6 @@ public final class PeekabooBridgeServer {
                 code: .invalidRequest,
                 message: "Pinned window target disappeared or changed owner/process generation/bounds")
         }
-    }
-
-    func validatedDesktopReadOperationLane(
-        for request: PeekabooBridgeRequest,
-        proposed: (scope: DesktopOperationScope, access: DesktopOperationAccess))
-        -> (scope: DesktopOperationScope, access: DesktopOperationAccess)
-    {
-        guard case .window = proposed.scope else { return proposed }
-        guard self.exactWindowReadIdentityIsCurrent(for: request) else {
-            return (.global, .write)
-        }
-        return proposed
-    }
-
-    func withValidatedDesktopReadOperationLane<T: Sendable>(
-        for request: PeekabooBridgeRequest,
-        proposed: (scope: DesktopOperationScope, access: DesktopOperationAccess),
-        operation: () async throws -> T) async throws -> T
-    {
-        let readLane = self.validatedDesktopReadOperationLane(for: request, proposed: proposed)
-        do {
-            return try await self.desktopOperationLaneCoordinator.run(
-                scope: readLane.scope,
-                access: readLane.access)
-            {
-                if case .window = readLane.scope,
-                   !self.exactWindowReadIdentityIsCurrent(for: request)
-                {
-                    throw ExactWindowReadLaneIdentityChanged()
-                }
-                let result = try await operation()
-                if case .window = readLane.scope,
-                   !self.exactWindowReadIdentityIsCurrent(for: request)
-                {
-                    throw ExactWindowReadLaneIdentityChanged()
-                }
-                return result
-            }
-        } catch is ExactWindowReadLaneIdentityChanged {
-            return try await self.desktopOperationLaneCoordinator.run(scope: .global, access: .write) {
-                try await operation()
-            }
-        }
-    }
-
-    private func exactWindowReadIdentityIsCurrent(for request: PeekabooBridgeRequest) -> Bool {
-        guard let identity = request.exactWindowReadIdentity,
-              let windowID = CGWindowID(exactly: identity.windowID),
-              self.windowOwnerProcessIdentifierProvider(windowID) == identity.ownerProcessIdentifier,
-              self.processStartIdentityProvider(identity.ownerProcessIdentifier) ==
-              identity.ownerProcessStartIdentity
-        else {
-            return false
-        }
-        return true
     }
 
     private func completeDesktopMutation(

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeOperationScopeTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeOperationScopeTests.swift
@@ -142,6 +142,7 @@ struct PeekabooBridgeOperationScopeTests {
             allowlistedTeams: [],
             allowlistedBundles: [],
             windowOwnerProcessIdentifierProvider: currentOwner,
+            windowBoundsProvider: { _ in identity.capturedBounds },
             processStartIdentityProvider: { _ in self.process.processStartIdentity })
         let current = currentServer.validatedDesktopReadOperationLane(for: request, proposed: proposed)
         #expect(current.scope == DesktopOperationScope.window(identity))
@@ -152,6 +153,7 @@ struct PeekabooBridgeOperationScopeTests {
             allowlistedTeams: [],
             allowlistedBundles: [],
             windowOwnerProcessIdentifierProvider: currentOwner,
+            windowBoundsProvider: { _ in identity.capturedBounds },
             processStartIdentityProvider: { _ in self.process.processStartIdentity + 1 })
         let recycled = recycledServer.validatedDesktopReadOperationLane(for: request, proposed: proposed)
         #expect(recycled.scope == DesktopOperationScope.global)
@@ -160,7 +162,7 @@ struct PeekabooBridgeOperationScopeTests {
 
     @Test
     @MainActor
-    func `Exact read discards a result when the process generation changes during dispatch`() async throws {
+    func `Exact read fails closed without redispatch when the process generation changes`() async throws {
         let identity = self.window(windowID: 76)
         let request = PeekabooBridgeRequest.inspectAccessibilityTree(.init(windowContext: WindowContext(
             applicationProcessId: self.process.processIdentifier,
@@ -178,22 +180,99 @@ struct PeekabooBridgeOperationScopeTests {
             allowlistedBundles: [],
             desktopOperationLaneCoordinator: DesktopOperationLaneCoordinator(coordinationRootURL: root),
             windowOwnerProcessIdentifierProvider: { _ in identity.ownerProcessIdentifier },
+            windowBoundsProvider: { _ in identity.capturedBounds },
             processStartIdentityProvider: { _ in state.value })
         var dispatchCount = 0
 
-        let result = try await server.withValidatedDesktopReadOperationLane(
-            for: request,
-            proposed: proposed)
-        {
-            dispatchCount += 1
-            if dispatchCount == 1 {
+        await #expect(throws: PeekabooBridgeErrorEnvelope.self) {
+            _ = try await server.withValidatedDesktopReadOperationLane(
+                for: request,
+                proposed: proposed)
+            {
+                dispatchCount += 1
                 state.value = identity.ownerProcessStartIdentity + 1
+                return dispatchCount
             }
-            return dispatchCount
         }
 
-        #expect(result == 2)
-        #expect(dispatchCount == 2)
+        #expect(dispatchCount == 1)
+    }
+
+    @Test
+    @MainActor
+    func `Exact live frames yield to a queued same process writer while other processes overlap`() async throws {
+        let identity = self.window(windowID: 77)
+        let request = PeekabooBridgeRequest.captureWindow(.init(
+            appIdentifier: "",
+            windowIndex: nil,
+            windowId: identity.windowID,
+            visualizerMode: .none,
+            scale: .logical1x))
+        let proposed = try #require(request.desktopReadOperationLane)
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("peekaboo-live-frame-lane-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let coordinator = DesktopOperationLaneCoordinator(coordinationRootURL: root)
+        let server = PeekabooBridgeServer(
+            services: StubServices(),
+            allowlistedTeams: [],
+            allowlistedBundles: [],
+            desktopOperationLaneCoordinator: coordinator,
+            windowOwnerProcessIdentifierProvider: { _ in identity.ownerProcessIdentifier },
+            windowBoundsProvider: { _ in identity.capturedBounds },
+            processStartIdentityProvider: { pid in
+                pid == identity.ownerProcessIdentifier ? identity.ownerProcessStartIdentity : 500
+            })
+        let firstFrameStarted = BridgeScopeLatch()
+        let firstFrameRelease = BridgeScopeLatch()
+        let writerStarted = BridgeScopeLatch()
+        let writerRelease = BridgeScopeLatch()
+        let secondFrameStarted = BridgeScopeLatch()
+        let otherProcessStarted = BridgeScopeLatch()
+
+        let firstFrame = Task {
+            try await server.withValidatedDesktopReadOperationLane(for: request, proposed: proposed) {
+                await firstFrameStarted.open()
+                await firstFrameRelease.wait()
+            }
+        }
+        await firstFrameStarted.wait()
+
+        let otherProcess = ApplicationProcessIdentity(processIdentifier: 402, processStartIdentity: 500)
+        let otherWriter = Task {
+            try await coordinator.run(scope: .process(otherProcess), access: .write) {
+                await otherProcessStarted.open()
+            }
+        }
+        let otherProcessOverlapped = await otherProcessStarted.opensWithin(.seconds(1))
+        #expect(otherProcessOverlapped)
+        try await otherWriter.value
+
+        let sameProcessWriter = Task {
+            try await coordinator.run(scope: .process(self.process), access: .write) {
+                await writerStarted.open()
+                await writerRelease.wait()
+            }
+        }
+        try await Task.sleep(for: .milliseconds(100))
+        let secondFrame = Task {
+            try await server.withValidatedDesktopReadOperationLane(for: request, proposed: proposed) {
+                await secondFrameStarted.open()
+            }
+        }
+
+        await firstFrameRelease.open()
+        let writerWonTurnstile = await writerStarted.opensWithin(.seconds(1))
+        let secondFrameOvertookWriter = await secondFrameStarted.opensWithin(.milliseconds(100))
+        #expect(writerWonTurnstile)
+        #expect(!secondFrameOvertookWriter)
+        await writerRelease.open()
+
+        try await firstFrame.value
+        try await sameProcessWriter.value
+        try await secondFrame.value
+        let secondFrameEventuallyStarted = await secondFrameStarted.isOpen
+        #expect(secondFrameEventuallyStarted)
     }
 
     private func window(windowID: Int) -> WindowMutationIdentity {
@@ -217,5 +296,35 @@ private final class ExactReadGenerationState: @unchecked Sendable {
     var value: UInt64 {
         get { self.lock.withLock { self.storedValue } }
         set { self.lock.withLock { self.storedValue = newValue } }
+    }
+}
+
+private actor BridgeScopeLatch {
+    private var opened = false
+    private var continuations: [CheckedContinuation<Void, Never>] = []
+
+    var isOpen: Bool {
+        self.opened
+    }
+
+    func open() {
+        guard !self.opened else { return }
+        self.opened = true
+        let pending = self.continuations
+        self.continuations.removeAll()
+        pending.forEach { $0.resume() }
+    }
+
+    func wait() async {
+        guard !self.opened else { return }
+        await withCheckedContinuation { self.continuations.append($0) }
+    }
+
+    func opensWithin(_ duration: Duration) async -> Bool {
+        let deadline = ContinuousClock.now.advanced(by: duration)
+        while !self.opened, ContinuousClock.now < deadline {
+            try? await Task.sleep(for: .milliseconds(5))
+        }
+        return self.opened
     }
 }

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeTests.swift
@@ -762,7 +762,10 @@ struct PeekabooBridgeTests {
                 hostKind: .gui,
                 allowlistedTeams: [],
                 allowlistedBundles: [],
-                postEventAccessEvaluator: { true })
+                postEventAccessEvaluator: { true },
+                windowOwnerProcessIdentifierProvider: { _ in 42 },
+                windowBoundsProvider: { _ in CGRect(x: 10, y: 20, width: 300, height: 200) },
+                processStartIdentityProvider: { _ in 7 })
         }
 
         let request = PeekabooBridgeRequest.captureWindow(

--- a/docs/bridge-host.md
+++ b/docs/bridge-host.md
@@ -89,6 +89,8 @@ closed if the PID was recycled. Current clients therefore require a 1.18 on-dema
 
 Protocol `1.18` adds immutable capture-time bounds to destructive window mutation receipts and a native background `restoreWindow` operation. Hosts reject a same-process replacement that reuses the selected CGWindowID with different bounds before move, resize, set-bounds, minimize, restore, maximize, or close dispatch; geometry operations then repin the requested final bounds instead of mistaking the intended transition for replacement. Restore clears only the retained exact AX window's minimized attribute and verifies its receipt without activation or focus. Window mutations are not advertised to older clients, and new clients refuse hosts that would ignore the added receipt evidence or lack restore support.
 
+Exact background PID/window reads are coordinated at the host on generation-pinned process/window read lanes. Each live frame acquires and releases its own lane, so different-process mutations overlap and queued same-process writers cannot be starved by the next frame. The host revalidates owner, process generation, and bounds after admission and completion; drift fails the request without redispatching it against a broader or recycled target. Screen, frontmost, area, unresolved, foreground, web-focus, and menu-opening paths remain globally exclusive. IPC-backed services acquire only in the execution host, never in both client and host.
+
 ## Security
 
 Peekaboo BridgeHost validates callers before processing any request:

--- a/docs/commands/capture.md
+++ b/docs/commands/capture.md
@@ -74,6 +74,7 @@ peekaboo capture video /path/to/demo.mov --every 500ms --no-diff
 ## Design notes
 - Live defaults: max duration 180s, `--max-frames` 800, resolution cap 1440, diff strategy `fast` unless `--diff-strategy quality` is set.
 - Action capture uses the same live sampler and can stop it early once the child command and post-roll complete.
+- Background live capture of an exact PID/window reacquires a generation-pinned read lane for each frame. Unrelated app mutations can overlap, while a queued mutation for the captured process runs before the next frame. Screen, area, frontmost, unresolved, foreground, and focus-capable observations remain globally exclusive.
 - Video ingest uses the same diff/keep logic as live; `--no-diff` keeps every sampled frame. When no motion is detected, you may end up with a single kept frame plus a `noMotion` warning.
 - Core types: `CaptureScope/Options/Result` with a pluggable `CaptureFrameSource` (ScreenCapture for live, AVAssetReader for video). Optional MP4 is written by `VideoWriter` when `--video-out` is set.
 - Quick smokes:


### PR DESCRIPTION
## Summary

- classify exact passive PID/window observations onto generation-pinned process/window read lanes instead of the global exclusive lane
- reacquire scoped lanes per capture frame with writer fairness, so unrelated processes overlap and a same-process mutation can interleave between live frames
- dynamically mint and revalidate exact Bridge read scopes, fail closed on identity drift, and avoid client/host double acquisition

## Why

Current exact-window `capture live` repeatedly takes the global exclusive observation lane. A five-second capture therefore blocks even a separate GUI Bridge from beginning a background mutation until capture ends; the capture sees only zero-change heartbeats. It also serializes unrelated apps unnecessarily.

Scoped, generation-pinned reads preserve atomic frame consistency while allowing the writer turnstile to run mutations between frames. Screen, frontmost, area, unresolved, web-focus, and menu-opening observations remain global/exclusive.

## Proof

- focused observation 30/30, coordinator 11/11, action 45/45, Bridge 50/50, and Bridge cancellation 10/10
- `pnpm run test:safe`: 762 CLI/Core safe tests and 72 runtime tests
- full lint with baseline warnings only, docs lint, release/signing/appcast/DMG/Chrome contracts, SwiftFormat, diff checks
- final Autoreview and TruffleHog clean at 0.99
- Foundation-signed two-host live proof: a daemon captured exact Playground window pixels for 7.054 seconds while the GUI Bridge changed the same inactive slider 50→10 in 0.345 seconds and 10→80 in 0.320 seconds; capture retained motion frames at 1.070s and 2.686s, and fresh readback returned 80
- target app stayed inactive, exact pixels were 1200×852, and controlled GUI/daemon/Playground processes were cleaned up before restoring the installed app host

Runtime evidence: `/tmp/peekaboo-observation-runtime.Ox7Msa/`
