### PR TITLE
fix(capture): preserve bounded failure semantics

### DIFF
--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Stop probing, requesting, advertising, or showing AppleScript Automation permission now that application, Dock, and UI operations use native macOS APIs; remove AppleScript code from shipped executables while retaining legacy wire/error decoding for older Bridge hosts.
 - Return generation-pinned CG window inventory promptly when AX enrichment stalls; detached per-process enrichment no longer holds Bridge requests after caller timeout or disconnect.
 - Let generation-pinned background PID/window observations use fair process/window read lanes so unrelated app mutations overlap and queued same-process writes run between live frames; unresolved or focus-capable capture remains globally exclusive.
+- Report empty live/video capture as `CAPTURE_NO_VALID_FRAMES` with actual-dispatch retry metadata, retain bounded capture/decode causes without laundering cancellation or I/O errors, bound video sampling, and remove incomplete MP4 output on failure.
 - Stop the curated `learn` copy from presenting `shell` as a CLI command: it remains a built-in Agent capability but is not in the MCP catalog and has no `peekaboo shell` CLI root.
 - Ensure action-command JSON validation failures before dispatch report `effect: refused`, including parser and binding errors.
 - Verify app focus against the exact active Workspace PID and visible frontmost-window PID, retry through native AX activation, and report the verified effect as confirmed instead of claiming success for an unfulfilled request.

--- a/Apps/CLI/Sources/PeekabooCLI/CLI/Output/JSONOutput.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/CLI/Output/JSONOutput.swift
@@ -73,17 +73,42 @@ struct ErrorInfo: Codable {
     let message: String
     let hint: String?
     let details: String?
+    let retry_safe: Bool?
+    let mutation_dispatched: Bool?
 
-    init(message: String, code: ErrorCode, hint: String? = nil, details: String? = nil) {
-        self.init(message: message, code: code.rawValue, hint: hint, details: details)
+    init(
+        message: String,
+        code: ErrorCode,
+        hint: String? = nil,
+        details: String? = nil,
+        retrySafe: Bool? = nil,
+        mutationDispatched: Bool? = nil
+    ) {
+        self.init(
+            message: message,
+            code: code.rawValue,
+            hint: hint,
+            details: details,
+            retrySafe: retrySafe,
+            mutationDispatched: mutationDispatched
+        )
     }
 
-    init(message: String, code: String, hint: String? = nil, details: String? = nil) {
+    init(
+        message: String,
+        code: String,
+        hint: String? = nil,
+        details: String? = nil,
+        retrySafe: Bool? = nil,
+        mutationDispatched: Bool? = nil
+    ) {
         let presentation = splitErrorHint(from: message)
         self.code = code
         self.message = presentation.message
         self.hint = hint ?? presentation.hint
         self.details = details
+        self.retry_safe = retrySafe
+        self.mutation_dispatched = mutationDispatched
     }
 }
 
@@ -113,6 +138,7 @@ enum ErrorCode: String, Codable {
     case NO_POINT_SPECIFIED, INVALID_COORDINATES, DOCK_LIST_NOT_FOUND, DOCK_ITEM_NOT_FOUND
     case POSITION_NOT_FOUND, SCRIPT_ERROR, MISSING_API_KEY, AGENT_ERROR, INTERACTION_FAILED, TIMEOUT
     case INVALID_INPUT
+    case CAPTURE_NO_VALID_FRAMES
 }
 
 func outputSuccessCodable(
@@ -165,6 +191,8 @@ func outputError(
     hint: String? = nil,
     details: String? = nil,
     effect: ActionEffect? = nil,
+    retrySafe: Bool? = nil,
+    mutationDispatched: Bool? = nil,
     logger: Logger
 ) {
     let response = ResultEnvelope<Empty?>(
@@ -172,7 +200,14 @@ func outputError(
         effect: effect ?? (ResultEnvelopeContext.isActionCommand ? defaultActionErrorEffect(code) : nil),
         data: nil,
         debug_logs: logger.getDebugLogs(),
-        error: ErrorInfo(message: message, code: code, hint: hint, details: details)
+        error: ErrorInfo(
+            message: message,
+            code: code,
+            hint: hint,
+            details: details,
+            retrySafe: retrySafe,
+            mutationDispatched: mutationDispatched
+        )
     )
     outputJSONCodable(response, logger: logger)
 }

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommandErrorHandling.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommandErrorHandling.swift
@@ -17,6 +17,7 @@ extension ErrorHandlingCommand {
     func handleError(_ error: any Error, customCode: ErrorCode? = nil) {
         if jsonOutput {
             let errorCode = customCode ?? self.mapErrorToCode(error)
+            let captureReceipt = self.captureFailureReceipt(for: error)
             let logger: Logger = if let formattable = self as? any OutputFormattable {
                 formattable.outputLogger
             } else {
@@ -27,10 +28,14 @@ extension ErrorHandlingCommand {
                 code: errorCode,
                 hint: (error as? any ResultEnvelopeError)?.envelopeHint,
                 details: errorDetails(for: error),
-                effect: (error as? any ResultEnvelopeError)?.envelopeEffect ??
+                effect: captureReceipt?.mutationDispatched == true
+                    ? .partial
+                    : (error as? any ResultEnvelopeError)?.envelopeEffect ??
                     ((self as? any ActionOutputFormattable)?.defaultEffect == nil
                         ? nil
                         : defaultActionErrorEffect(errorCode)),
+                retrySafe: captureReceipt?.retrySafe,
+                mutationDispatched: captureReceipt?.mutationDispatched,
                 logger: logger
             )
         } else {
@@ -51,8 +56,12 @@ extension ErrorHandlingCommand {
     }
 
     /// Map various error types to error codes
-    private func mapErrorToCode(_ error: any Error) -> ErrorCode {
+    func mapErrorToCode(_ error: any Error) -> ErrorCode {
         switch error {
+        case let cleanupError as CaptureArtifactCleanupError:
+            self.mapErrorToCode(cleanupError.primaryError)
+        case is CaptureNoValidFramesError:
+            .CAPTURE_NO_VALID_FRAMES
         case let focusError as FocusError:
             self.mapFocusErrorToCode(focusError)
         case let peekabooError as PeekabooError:
@@ -226,6 +235,33 @@ extension ErrorHandlingCommand {
     private func mapFocusErrorToCode(_ error: FocusError) -> ErrorCode {
         errorCode(for: error)
     }
+
+    var captureMutationDispatched: Bool {
+        if let command = self as? CaptureLiveCommand {
+            return command.captureMutationDispatched
+        }
+        if let command = self as? CaptureActionCommand {
+            return command.captureMutationDispatched
+        }
+        return false
+    }
+
+    func captureFailureReceipt(for error: any Error) -> CaptureFailureReceipt? {
+        guard self is CaptureLiveCommand || self is CaptureVideoCommand || self is CaptureActionCommand else {
+            return nil
+        }
+        let mutationDispatched = self.captureMutationDispatched
+        let errorAllowsRetry = (error as? CaptureNoValidFramesError)?.retrySafe ?? true
+        return CaptureFailureReceipt(
+            retrySafe: errorAllowsRetry && !mutationDispatched,
+            mutationDispatched: mutationDispatched
+        )
+    }
+}
+
+struct CaptureFailureReceipt: Equatable {
+    let retrySafe: Bool
+    let mutationDispatched: Bool
 }
 
 func peekabooAutomationErrorCode(for error: PeekabooError) -> ErrorCode? {

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Core/CaptureCommand+Action.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Core/CaptureCommand+Action.swift
@@ -40,6 +40,7 @@ RuntimeOptionsConfigurable, InjectedRuntimeBackedCommand {
 
     @RuntimeStorage var runtime: CommandRuntime?
     var runtimeOptions = CommandRuntimeOptions()
+    var captureMutationDispatched = false
 
     nonisolated(unsafe) static var commandDescription: CommandDescription {
         MainActorCommandDescription.describe {
@@ -114,6 +115,7 @@ RuntimeOptionsConfigurable, InjectedRuntimeBackedCommand {
                     command: self.command,
                     timeoutSeconds: timing.actionTimeout
                 )
+                self.captureMutationDispatched = true
                 try await Self.sleep(milliseconds: timing.postRollMs)
                 session.requestStop()
 
@@ -201,6 +203,9 @@ RuntimeOptionsConfigurable, InjectedRuntimeBackedCommand {
         }
         if !result.validation.ok {
             print("artifact validation failed: \(result.validation.missing.joined(separator: ", "))")
+        }
+        for warning in result.capture.warnings {
+            print("warning: \(warning.code.rawValue): \(warning.message)")
         }
     }
 
@@ -460,11 +465,13 @@ extension CaptureActionCommand {
         return CGRect(x: x, y: y, width: width, height: height)
     }
 
-    func focusIfNeeded(appIdentifier: String) async throws {
+    mutating func focusIfNeeded(appIdentifier: String) async throws {
         switch self.captureFocus {
         case .background:
             return
         case .auto:
+            let windowTitle = self.windowTitle
+            let services = self.services
             let options = FocusOptions(
                 autoFocus: true,
                 focusTimeout: nil,
@@ -472,15 +479,17 @@ extension CaptureActionCommand {
                 spaceSwitch: false,
                 bringToCurrentSpace: false
             )
-            try await withCaptureFocusMutation {
+            try await self.withCaptureFocusDispatchReceipt {
                 try await ensureFocused(
                     applicationName: appIdentifier,
-                    windowTitle: self.windowTitle,
+                    windowTitle: windowTitle,
                     options: options,
-                    services: self.services
+                    services: services
                 )
             }
         case .foreground:
+            let windowTitle = self.windowTitle
+            let services = self.services
             let options = FocusOptions(
                 autoFocus: true,
                 focusTimeout: nil,
@@ -488,12 +497,12 @@ extension CaptureActionCommand {
                 spaceSwitch: true,
                 bringToCurrentSpace: true
             )
-            try await withCaptureFocusMutation {
+            try await self.withCaptureFocusDispatchReceipt {
                 try await ensureFocused(
                     applicationName: appIdentifier,
-                    windowTitle: self.windowTitle,
+                    windowTitle: windowTitle,
                     options: options,
-                    services: self.services
+                    services: services
                 )
             }
         }

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Core/CaptureCommand+Live.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Core/CaptureCommand+Live.swift
@@ -61,6 +61,7 @@ InjectedRuntimeBackedCommand {
 
     @RuntimeStorage var runtime: CommandRuntime?
     var runtimeOptions = CommandRuntimeOptions()
+    var captureMutationDispatched = false
 
     func withCaptureFocusMutation(_ operation: () async throws -> Void) async rethrows {
         try await self.resolvedRuntime.withCaptureFocusMutation(operation)

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Core/CaptureCommand+LiveFocus.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Core/CaptureCommand+LiveFocus.swift
@@ -1,11 +1,29 @@
 import PeekabooCore
 
 @MainActor
+protocol CaptureFocusReceiptCommand {
+    var captureMutationDispatched: Bool { get set }
+    func withCaptureFocusMutation(_ operation: () async throws -> Void) async rethrows
+}
+
+extension CaptureFocusReceiptCommand {
+    mutating func withCaptureFocusDispatchReceipt(_ operation: () async throws -> Void) async rethrows {
+        self.captureMutationDispatched = true
+        try await self.withCaptureFocusMutation(operation)
+    }
+}
+
+extension CaptureLiveCommand: CaptureFocusReceiptCommand {}
+extension CaptureActionCommand: CaptureFocusReceiptCommand {}
+
+@MainActor
 extension CaptureLiveCommand {
-    func focusIfNeeded(appIdentifier: String) async throws {
+    mutating func focusIfNeeded(appIdentifier: String) async throws {
         switch captureFocus {
         case .background: return
         case .auto:
+            let windowTitle = self.windowTitle
+            let services = self.services
             let options = FocusOptions(
                 autoFocus: true,
                 focusTimeout: nil,
@@ -13,15 +31,17 @@ extension CaptureLiveCommand {
                 spaceSwitch: false,
                 bringToCurrentSpace: false
             )
-            try await withCaptureFocusMutation {
+            try await self.withCaptureFocusDispatchReceipt {
                 try await ensureFocused(
                     applicationName: appIdentifier,
-                    windowTitle: self.windowTitle,
+                    windowTitle: windowTitle,
                     options: options,
-                    services: self.services
+                    services: services
                 )
             }
         case .foreground:
+            let windowTitle = self.windowTitle
+            let services = self.services
             let options = FocusOptions(
                 autoFocus: true,
                 focusTimeout: nil,
@@ -29,12 +49,12 @@ extension CaptureLiveCommand {
                 spaceSwitch: true,
                 bringToCurrentSpace: true
             )
-            try await withCaptureFocusMutation {
+            try await self.withCaptureFocusDispatchReceipt {
                 try await ensureFocused(
                     applicationName: appIdentifier,
-                    windowTitle: self.windowTitle,
+                    windowTitle: windowTitle,
                     options: options,
-                    services: self.services
+                    services: services
                 )
             }
         }

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Core/CaptureCommand+Video.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Core/CaptureCommand+Video.swift
@@ -145,7 +145,7 @@ InjectedRuntimeBackedCommand {
         }
         print("""
         🎥 capture(video) kept \(result.stats.framesKept) frames (dropped \(result.stats
-            .framesDropped)), contact sheet: \(meta.contactPath)
+            .framesDropped), decode failures \(result.stats.decodeFailures)), contact sheet: \(meta.contactPath)
         """)
         for frame in result.frames {
             print("🖼️  \(frame.reason.rawValue) t=\(frame.timestampMs)ms → \(frame.path)")

--- a/Apps/CLI/Tests/CoreCLITests/ResultEnvelopeTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/ResultEnvelopeTests.swift
@@ -1,4 +1,6 @@
 import Foundation
+import PeekabooAutomationKit
+import PeekabooFoundation
 import Testing
 @testable import PeekabooCLI
 
@@ -32,6 +34,25 @@ struct ResultEnvelopeTests {
 
         #expect(error.message == "Invalid direction.")
         #expect(error.hint == "Use up, down, left, or right.")
+    }
+
+    @Test func `capture failure carries retry and mutation metadata without an action effect`() throws {
+        let error = ErrorInfo(
+            message: "Video capture produced no decodable frames.",
+            code: .CAPTURE_NO_VALID_FRAMES,
+            retrySafe: true,
+            mutationDispatched: false
+        )
+        let envelope = ResultEnvelope<Empty?>(success: false, data: nil, error: error)
+        let object = try #require(
+            JSONSerialization.jsonObject(with: JSONEncoder().encode(envelope)) as? [String: Any]
+        )
+        let encodedError = try #require(object["error"] as? [String: Any])
+
+        #expect(object["effect"] == nil)
+        #expect(encodedError["code"] as? String == "CAPTURE_NO_VALID_FRAMES")
+        #expect(encodedError["retry_safe"] as? Bool == true)
+        #expect(encodedError["mutation_dispatched"] as? Bool == false)
     }
 
     @Test func `safety refusal carries refused effect and explicit hint`() {
@@ -69,5 +90,85 @@ struct ResultEnvelopeTests {
         let set = ClipboardCommand.SetSubcommand()
         #expect((get as? any ActionOutputFormattable)?.defaultEffect == nil)
         #expect(set.defaultEffect == .unverifiable)
+    }
+
+    @Test @MainActor func `typed no-frame error maps to capture code and actual mutation receipt`() {
+        let error = CaptureNoValidFramesError(
+            source: .live,
+            framesDropped: 2,
+            decodeFailures: 0,
+            firstDecodeError: nil,
+            lastDecodeError: nil,
+            lastCaptureError: "transient"
+        )
+        let handler = StubErrorHandlingCommand()
+        #expect(handler.mapErrorToCode(error) == .CAPTURE_NO_VALID_FRAMES)
+
+        var live = CaptureLiveCommand()
+        #expect(!live.captureMutationDispatched)
+        live.captureFocus = .foreground
+        #expect(!live.captureMutationDispatched)
+        live.captureMutationDispatched = true
+        #expect(live.captureMutationDispatched)
+
+        var action = CaptureActionCommand()
+        action.captureFocus = .background
+        #expect(!action.captureMutationDispatched)
+        action.captureMutationDispatched = true
+        #expect(action.captureMutationDispatched)
+    }
+
+    @Test @MainActor func `all capture failures preserve actual dispatch receipts`() {
+        let error = PeekabooError.fileIOError("artifact write failed")
+        var live = CaptureLiveCommand()
+        #expect(live.captureFailureReceipt(for: error) == CaptureFailureReceipt(
+            retrySafe: true,
+            mutationDispatched: false
+        ))
+        live.captureMutationDispatched = true
+        #expect(live.captureFailureReceipt(for: error) == CaptureFailureReceipt(
+            retrySafe: false,
+            mutationDispatched: true
+        ))
+
+        let video = CaptureVideoCommand()
+        #expect(video.captureFailureReceipt(for: error) == CaptureFailureReceipt(
+            retrySafe: true,
+            mutationDispatched: false
+        ))
+        #expect(StubErrorHandlingCommand().captureFailureReceipt(for: error) == nil)
+
+        let combined = CaptureArtifactCleanupError(
+            primaryError: error,
+            cleanupError: PeekabooError.fileIOError("cleanup failed"),
+            artifactPath: "/tmp/capture.mp4"
+        )
+        #expect(StubErrorHandlingCommand().mapErrorToCode(combined) == .FILE_IO_ERROR)
+    }
+
+    @Test @MainActor func `capture focus receipt survives a throwing focus operation`() async {
+        enum FocusFailure: Error { case verificationFailed }
+
+        var command = StubCaptureFocusReceiptCommand()
+        await #expect(throws: FocusFailure.self) {
+            try await command.withCaptureFocusDispatchReceipt {
+                throw FocusFailure.verificationFailed
+            }
+        }
+        #expect(command.captureMutationDispatched)
+    }
+}
+
+@MainActor
+private struct StubErrorHandlingCommand: ErrorHandlingCommand {
+    let jsonOutput = true
+}
+
+@MainActor
+private struct StubCaptureFocusReceiptCommand: CaptureFocusReceiptCommand {
+    var captureMutationDispatched = false
+
+    func withCaptureFocusMutation(_ operation: () async throws -> Void) async rethrows {
+        try await operation()
     }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Stop probing, requesting, advertising, or showing AppleScript Automation permission now that application, Dock, and UI operations use native macOS APIs; remove the stale checked-in CLI binary and AppleScript code from shipped executables while retaining legacy wire/error decoding for older Bridge hosts.
 - Return generation-pinned CG window inventory promptly when AX enrichment stalls; detached per-process enrichment now times out without holding the Bridge request or desktop lane after its caller disconnects.
 - Let generation-pinned background PID/window observations use fair process/window read lanes so unrelated app mutations overlap and queued same-process writes run between live frames; keep unresolved or focus-capable capture globally exclusive and fail closed on identity drift.
+- Fail empty live/video sessions with typed `CAPTURE_NO_VALID_FRAMES` errors before contact-sheet work, preserve bounded capture/decode causes without laundering cancellation or I/O errors, bound video sampling, clean incomplete MP4s, and base retry metadata on actual focus/action dispatch.
 - Stop `peekaboo learn` from presenting `shell` as a CLI command: it remains a built-in Agent capability but is not in the MCP catalog and has no `peekaboo shell` CLI root; guard both curated Agent overrides and rendered CLI roots against future drift.
 - Ensure action-command JSON validation failures before dispatch report
   `effect: refused`, including parser and binding errors.

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Core/Errors/CaptureArtifactCleanupError.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Core/Errors/CaptureArtifactCleanupError.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+public struct CaptureArtifactCleanupError: LocalizedError {
+    public let primaryError: any Error
+    public let cleanupError: any Error
+    public let artifactPath: String
+
+    public init(primaryError: any Error, cleanupError: any Error, artifactPath: String) {
+        self.primaryError = primaryError
+        self.cleanupError = cleanupError
+        self.artifactPath = artifactPath
+    }
+
+    public var errorDescription: String? {
+        let primary = CaptureDiagnosticSanitizer.sanitize(
+            self.primaryError.localizedDescription,
+            maximumUTF8Bytes: 180) ??
+            "Capture failed"
+        let path = CaptureDiagnosticSanitizer.sanitize(
+            self.artifactPath,
+            maximumUTF8Bytes: 96) ?? "<unknown path>"
+        let cleanup = CaptureDiagnosticSanitizer.sanitize(
+            self.cleanupError.localizedDescription,
+            maximumUTF8Bytes: 160) ??
+            "cleanup failed"
+        return CaptureDiagnosticSanitizer.sanitize(
+            "Primary capture error: \(primary). Incomplete video cleanup failed at \(path): \(cleanup)")
+    }
+}

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Core/Errors/CaptureDiagnosticSanitizer.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Core/Errors/CaptureDiagnosticSanitizer.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+enum CaptureDiagnosticSanitizer {
+    static let maximumUTF8Bytes = 512
+
+    static func sanitize(_ value: String?, maximumUTF8Bytes: Int = Self.maximumUTF8Bytes) -> String? {
+        guard let value, maximumUTF8Bytes > 0 else { return nil }
+        let ellipsis = "…"
+        let contentBudget = max(0, maximumUTF8Bytes - ellipsis.utf8.count)
+        var output = ""
+        var byteCount = 0
+        var pendingSpace = false
+        var truncated = false
+        for scalar in value.unicodeScalars {
+            if CharacterSet.whitespacesAndNewlines.contains(scalar) || CharacterSet.controlCharacters.contains(scalar) {
+                pendingSpace = !output.isEmpty
+                continue
+            }
+            let text = String(scalar)
+            let additionalBytes = text.utf8.count + (pendingSpace ? 1 : 0)
+            guard byteCount + additionalBytes <= contentBudget else {
+                truncated = true
+                break
+            }
+            if pendingSpace {
+                output.append(" ")
+                byteCount += 1
+                pendingSpace = false
+            }
+            output.append(text)
+            byteCount += text.utf8.count
+        }
+        guard !output.isEmpty else { return nil }
+        return truncated ? output + ellipsis : output
+    }
+}

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Core/Errors/CaptureNoValidFramesError.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Core/Errors/CaptureNoValidFramesError.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+public struct CaptureNoValidFramesError: LocalizedError, Sendable, Equatable {
+    public let source: CaptureSessionResult.Source
+    public let framesDropped: Int
+    public let decodeFailures: Int
+    public let firstDecodeError: String?
+    public let lastDecodeError: String?
+    public let lastCaptureError: String?
+
+    public init(
+        source: CaptureSessionResult.Source,
+        framesDropped: Int,
+        decodeFailures: Int,
+        firstDecodeError: String?,
+        lastDecodeError: String?,
+        lastCaptureError: String?)
+    {
+        self.source = source
+        self.framesDropped = max(0, framesDropped)
+        self.decodeFailures = max(0, decodeFailures)
+        self.firstDecodeError = CaptureDiagnosticSanitizer.sanitize(firstDecodeError)
+        self.lastDecodeError = CaptureDiagnosticSanitizer.sanitize(lastDecodeError)
+        self.lastCaptureError = CaptureDiagnosticSanitizer.sanitize(lastCaptureError)
+    }
+
+    public var retrySafe: Bool {
+        true
+    }
+
+    public var errorDescription: String? {
+        let message: String
+        switch self.source {
+        case .live:
+            var liveMessage = "Live capture produced no valid frames after \(self.framesDropped) dropped frame(s)."
+            if let lastCaptureError {
+                liveMessage += " Last capture error: \(lastCaptureError)"
+            }
+            message = liveMessage
+        case .video:
+            var videoMessage = "Video capture produced no decodable frames"
+            if self.decodeFailures > 0 {
+                videoMessage += " after \(self.decodeFailures) decode failure(s)"
+            }
+            videoMessage += "."
+            if let firstDecodeError {
+                videoMessage += " First decode error: \(firstDecodeError)"
+            }
+            if let lastDecodeError, lastDecodeError != firstDecodeError {
+                videoMessage += " Last decode error: \(lastDecodeError)"
+            }
+            message = videoMessage
+        }
+        return CaptureDiagnosticSanitizer.sanitize(message)
+    }
+}

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Core/Models/CaptureFrameModels.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Core/Models/CaptureFrameModels.swift
@@ -43,6 +43,7 @@ public struct CaptureStats: Codable, Sendable, Equatable {
     public let fpsEffective: Double
     public let framesKept: Int
     public let framesDropped: Int
+    public let decodeFailures: Int
     public let maxFramesHit: Bool
     public let maxMbHit: Bool
 
@@ -53,6 +54,7 @@ public struct CaptureStats: Codable, Sendable, Equatable {
         fpsEffective: Double,
         framesKept: Int,
         framesDropped: Int,
+        decodeFailures: Int = 0,
         maxFramesHit: Bool,
         maxMbHit: Bool)
     {
@@ -62,8 +64,47 @@ public struct CaptureStats: Codable, Sendable, Equatable {
         self.fpsEffective = fpsEffective
         self.framesKept = framesKept
         self.framesDropped = framesDropped
+        self.decodeFailures = decodeFailures
         self.maxFramesHit = maxFramesHit
         self.maxMbHit = maxMbHit
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case durationMs
+        case fpsIdle
+        case fpsActive
+        case fpsEffective
+        case framesKept
+        case framesDropped
+        case decodeFailures
+        case maxFramesHit
+        case maxMbHit
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.durationMs = try container.decode(Int.self, forKey: .durationMs)
+        self.fpsIdle = try container.decode(Double.self, forKey: .fpsIdle)
+        self.fpsActive = try container.decode(Double.self, forKey: .fpsActive)
+        self.fpsEffective = try container.decode(Double.self, forKey: .fpsEffective)
+        self.framesKept = try container.decode(Int.self, forKey: .framesKept)
+        self.framesDropped = try container.decode(Int.self, forKey: .framesDropped)
+        self.decodeFailures = try container.decodeIfPresent(Int.self, forKey: .decodeFailures) ?? 0
+        self.maxFramesHit = try container.decode(Bool.self, forKey: .maxFramesHit)
+        self.maxMbHit = try container.decode(Bool.self, forKey: .maxMbHit)
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(self.durationMs, forKey: .durationMs)
+        try container.encode(self.fpsIdle, forKey: .fpsIdle)
+        try container.encode(self.fpsActive, forKey: .fpsActive)
+        try container.encode(self.fpsEffective, forKey: .fpsEffective)
+        try container.encode(self.framesKept, forKey: .framesKept)
+        try container.encode(self.framesDropped, forKey: .framesDropped)
+        try container.encode(self.decodeFailures, forKey: .decodeFailures)
+        try container.encode(self.maxFramesHit, forKey: .maxFramesHit)
+        try container.encode(self.maxMbHit, forKey: .maxMbHit)
     }
 }
 
@@ -103,6 +144,7 @@ public struct CaptureWarning: Codable, Sendable, Equatable {
         case diffDowngraded
         case autoclean
         case transientCaptureFailure
+        case videoDecodeFailure
     }
 
     public let code: Code

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/CaptureFrameSource.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/CaptureFrameSource.swift
@@ -53,6 +53,26 @@ public protocol CaptureFrameSource {
     func nextFrame(maxAge: TimeInterval?) async throws -> (cgImage: CGImage?, metadata: CaptureMetadata)?
 }
 
+public struct CaptureFrameSourceDiagnostics: Sendable, Equatable {
+    public let decodeFailures: Int
+    public let firstDecodeError: String?
+    public let lastDecodeError: String?
+
+    public init(
+        decodeFailures: Int = 0,
+        firstDecodeError: String? = nil,
+        lastDecodeError: String? = nil)
+    {
+        self.decodeFailures = max(0, decodeFailures)
+        self.firstDecodeError = CaptureDiagnosticSanitizer.sanitize(firstDecodeError)
+        self.lastDecodeError = CaptureDiagnosticSanitizer.sanitize(lastDecodeError)
+    }
+}
+
+public protocol CaptureFrameSourceDiagnosticsProviding: CaptureFrameSource {
+    @MainActor var captureDiagnostics: CaptureFrameSourceDiagnostics { get }
+}
+
 extension CaptureFrameSource {
     @MainActor
     public func start(request _: CaptureFrameRequest) async throws {}

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/ScreenCaptureEngineSupport.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/ScreenCaptureEngineSupport.swift
@@ -136,6 +136,7 @@ import PeekabooFoundation
         precondition(!selectedAPIs.isEmpty, "At least one API must be provided")
 
         for (index, api) in selectedAPIs.indexed() {
+            try Task.checkCancellation()
             do {
                 logger.debug(
                     "Attempting \(operationName) via \(api.description)",
@@ -155,6 +156,7 @@ import PeekabooFoundation
             } catch {
                 lastError = error
                 self.observer?(operationName, api, 0, false, error)
+                var currentError = error
                 if let delay = ScreenCaptureKitTransientError.retryDelayNanoseconds(after: error) {
                     logger.warning(
                         "\(api.description) capture hit transient ScreenCaptureKit denial; retrying once",
@@ -177,18 +179,23 @@ import PeekabooFoundation
                         return result
                     } catch {
                         lastError = error
+                        currentError = error
                         self.observer?(operationName, api, 0, false, error)
                     }
                 }
+                if currentError is CancellationError {
+                    throw currentError
+                }
+                try Task.checkCancellation()
                 let hasFallback = index < (selectedAPIs.count - 1)
-                if self.shouldFallback(after: error, api: api, hasFallback: hasFallback) {
+                if self.shouldFallback(after: currentError, api: api, hasFallback: hasFallback) {
                     logger.warning(
                         "\(api.description) capture failed, retrying with fallback API",
-                        metadata: ["error": String(describing: error)],
+                        metadata: ["error": String(describing: currentError)],
                         correlationId: correlationId)
                     continue
                 }
-                throw error
+                throw currentError
             }
         }
 
@@ -210,6 +217,7 @@ import PeekabooFoundation
         precondition(!selectedAPIs.isEmpty, "At least one API must be provided")
 
         for (index, api) in selectedAPIs.indexed() {
+            try Task.checkCancellation()
             do {
                 logger.debug(
                     "Attempting \(operationName) via \(api.description)",
@@ -231,6 +239,7 @@ import PeekabooFoundation
             } catch {
                 lastError = error
                 self.observer?(operationName, api, 0, false, error)
+                var currentError = error
                 if let delay = ScreenCaptureKitTransientError.retryDelayNanoseconds(after: error) {
                     logger.warning(
                         "\(api.description) capture hit transient ScreenCaptureKit denial; retrying once",
@@ -255,19 +264,24 @@ import PeekabooFoundation
                             fallbackReason: fallbackReason)
                     } catch {
                         lastError = error
+                        currentError = error
                         self.observer?(operationName, api, 0, false, error)
                     }
                 }
+                if currentError is CancellationError {
+                    throw currentError
+                }
+                try Task.checkCancellation()
                 let hasFallback = index < (selectedAPIs.count - 1)
-                if self.shouldFallback(after: error, api: api, hasFallback: hasFallback) {
-                    fallbackReason = "\(api.description) failed: \(String(describing: error))"
+                if self.shouldFallback(after: currentError, api: api, hasFallback: hasFallback) {
+                    fallbackReason = "\(api.description) failed: \(String(describing: currentError))"
                     logger.warning(
                         "\(api.description) capture failed, retrying with fallback API",
-                        metadata: ["error": String(describing: error)],
+                        metadata: ["error": String(describing: currentError)],
                         correlationId: correlationId)
                     continue
                 }
-                throw error
+                throw currentError
             }
         }
 
@@ -298,10 +312,12 @@ enum ScreenCaptureKitTransientError {
             error.localizedDescription,
             nsError.domain,
         ].joined(separator: " ").lowercased()
-        let looksTransient = nsError.domain.localizedCaseInsensitiveContains("ScreenCaptureKit") ||
-            message.contains("declined tcc") ||
-            message.contains("user declined") ||
-            message.contains("application, window, display capture")
+        let isScreenCaptureKitDenial = nsError.domain == "com.apple.ScreenCaptureKit.SCStreamErrorDomain" &&
+            nsError.code == -3801
+        let looksLikeObservedContention = message.contains("declined tcc") ||
+            message.contains("transient tcc") ||
+            message.contains("temporary tcc")
+        let looksTransient = isScreenCaptureKitDenial && looksLikeObservedContention
         guard looksTransient else {
             return nil
         }

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/VideoFrameSource.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/VideoFrameSource.swift
@@ -5,10 +5,28 @@ import PeekabooFoundation
 
 /// Frame source that samples frames from a video asset.
 public final class VideoFrameSource: CaptureFrameSource {
-    private let generator: AVAssetImageGenerator
+    private let decoder: any VideoFrameDecoding
+    private let sourceURL: URL?
     private var timeline: VideoFrameTimeline
     private let mode: CaptureMode = .screen
+    private var decodeFailures = 0
+    private var firstDecodeError: String?
+    private var lastDecodeError: String?
+    private let decodeTimeout: Duration
     public let effectiveFPS: Double
+
+    init(
+        timeline: VideoFrameTimeline,
+        effectiveFPS: Double,
+        decoder: any VideoFrameDecoding,
+        decodeTimeout: Duration = .seconds(5))
+    {
+        self.timeline = timeline
+        self.effectiveFPS = effectiveFPS
+        self.decoder = decoder
+        self.decodeTimeout = decodeTimeout
+        self.sourceURL = nil
+    }
 
     public init(
         url: URL,
@@ -18,6 +36,24 @@ public final class VideoFrameSource: CaptureFrameSource {
         endMs: Int?,
         resolutionCap: CGFloat?) async throws
     {
+        self.sourceURL = url
+        self.decodeTimeout = .seconds(5)
+        if let sampleFps, !sampleFps.isFinite || sampleFps <= 0 {
+            throw PeekabooError.invalidInput("sample-fps must be a positive finite value")
+        }
+        if let everyMs, everyMs <= 0 {
+            throw PeekabooError.invalidInput("every-ms must be greater than zero")
+        }
+        if let startMs, startMs < 0 {
+            throw PeekabooError.invalidInput("start-ms must be zero or greater")
+        }
+        if let endMs, endMs < 0 {
+            throw PeekabooError.invalidInput("end-ms must be zero or greater")
+        }
+        if let resolutionCap, !resolutionCap.isFinite || resolutionCap <= 0 {
+            throw PeekabooError.invalidInput("resolution-cap must be a positive finite value")
+        }
+
         let asset = AVAsset(url: url)
         let duration: CMTime = if #available(macOS 13.0, *) {
             try await asset.load(.duration)
@@ -29,7 +65,11 @@ public final class VideoFrameSource: CaptureFrameSource {
         }
 
         let start = CMTime(milliseconds: startMs ?? 0)
-        let end = endMs.map { CMTime(milliseconds: $0) } ?? duration
+        guard start < duration else {
+            throw PeekabooError.invalidInput("start-ms must be before the end of the video")
+        }
+        let requestedEnd = endMs.map { CMTime(milliseconds: $0) } ?? duration
+        let end = min(requestedEnd, duration)
         guard end > start else { throw PeekabooError.captureFailed(reason: "end-ms must exceed start-ms") }
 
         // Derive sampling cadence from either fps or fixed millisecond interval,
@@ -49,22 +89,26 @@ public final class VideoFrameSource: CaptureFrameSource {
             end: end,
             interval: interval)
 
-        self.generator = AVAssetImageGenerator(asset: asset)
-        self.generator.appliesPreferredTrackTransform = true
-        self.generator.requestedTimeToleranceBefore = .zero
-        self.generator.requestedTimeToleranceAfter = .zero
+        let generator = AVAssetImageGenerator(asset: asset)
+        generator.appliesPreferredTrackTransform = true
+        generator.requestedTimeToleranceBefore = .zero
+        generator.requestedTimeToleranceAfter = .zero
         if let cap = resolutionCap {
-            self.generator.maximumSize = CGSize(width: cap, height: cap)
+            generator.maximumSize = CGSize(width: cap, height: cap)
         }
+        self.decoder = VideoFrameDecoder(generator: generator)
     }
 
     @MainActor
     public func nextFrame() async throws -> (cgImage: CGImage?, metadata: CaptureMetadata)? {
         guard let time = self.timeline.next() else { return nil }
 
-        var actual = CMTime.zero
         do {
-            let image = try self.generator.copyCGImage(at: time, actualTime: &actual)
+            try Task.checkCancellation()
+            let generated = try await self.decodeFrame(at: time)
+            try Task.checkCancellation()
+            let image = generated.image
+            let actual = generated.actualTime
             let size = CGSize(width: image.width, height: image.height)
             let millis = Self.milliseconds(from: actual, fallback: time)
             let meta = CaptureMetadata(
@@ -77,16 +121,80 @@ public final class VideoFrameSource: CaptureFrameSource {
                 timestamp: Date())
             return (image, meta)
         } catch {
+            if error is CancellationError {
+                throw error
+            }
+            try Task.checkCancellation()
+            if let sourceURL = self.sourceURL,
+               !FileManager.default.isReadableFile(atPath: sourceURL.path)
+            {
+                throw PeekabooError.fileIOError("Video input became unreadable: \(sourceURL.path)")
+            }
+            if Self.isFileIOError(error) {
+                throw error
+            }
+            let description = CaptureDiagnosticSanitizer.sanitize(error.localizedDescription) ??
+                "Video frame decode failed"
+            self.decodeFailures += 1
+            self.firstDecodeError = self.firstDecodeError ?? description
+            self.lastDecodeError = description
             // Skip unreadable frames but keep advancing
             let meta = CaptureMetadata(
                 size: .zero,
                 mode: self.mode,
-                videoTimestampMs: Self.milliseconds(from: actual, fallback: time),
+                videoTimestampMs: Self.milliseconds(from: .zero, fallback: time),
                 applicationInfo: nil,
                 windowInfo: nil,
                 displayInfo: nil,
                 timestamp: Date())
             return (nil, meta)
+        }
+    }
+
+    private func decodeFrame(at time: CMTime) async throws -> (image: CGImage, actualTime: CMTime) {
+        let decoder = self.decoder
+        let decodeTask = Task<DecodedVideoFrame, any Error> {
+            let result = try await decoder.image(at: time)
+            return DecodedVideoFrame(image: result.image, actualTime: result.actualTime)
+        }
+        let timeout = self.decodeTimeout
+        let timeoutTask = Task<DecodedVideoFrame, any Error> {
+            try await Task.sleep(for: timeout)
+            throw PeekabooError.captureTimeout
+        }
+        defer {
+            decodeTask.cancel()
+            timeoutTask.cancel()
+        }
+
+        do {
+            let decoded = try await withTaskCancellationHandler {
+                let result: DecodedVideoFrame = try await withCheckedThrowingContinuation { continuation in
+                    let gate = VideoDecodeContinuation(continuation: continuation)
+                    Task {
+                        await gate.resume(with: decodeTask.result)
+                    }
+                    Task {
+                        await gate.resume(with: timeoutTask.result)
+                    }
+                }
+                try Task.checkCancellation()
+                return result
+            } onCancel: {
+                decoder.cancelPendingDecodes()
+                decodeTask.cancel()
+                timeoutTask.cancel()
+            }
+            return (decoded.image, decoded.actualTime)
+        } catch {
+            if error is CancellationError {
+                decoder.cancelPendingDecodes()
+            } else if let peekabooError = error as? PeekabooError,
+                      case .captureTimeout = peekabooError
+            {
+                decoder.cancelPendingDecodes()
+            }
+            throw error
         }
     }
 
@@ -96,6 +204,98 @@ public final class VideoFrameSource: CaptureFrameSource {
         let resolved = hasActual ? time : fallback
         guard resolved.isNumeric else { return nil }
         return Int((resolved.seconds * 1000).rounded())
+    }
+
+    private static func isFileIOError(_ error: any Error) -> Bool {
+        if let peekabooError = error as? PeekabooError {
+            if case .fileIOError = peekabooError {
+                return true
+            }
+            return false
+        }
+        if let captureError = error as? CaptureError {
+            switch captureError {
+            case .fileIOError, .fileWriteError:
+                return true
+            default:
+                return false
+            }
+        }
+        if error is POSIXError {
+            return true
+        }
+        let nsError = error as NSError
+        if nsError.domain == NSPOSIXErrorDomain {
+            return true
+        }
+        if nsError.domain == NSCocoaErrorDomain, (256...263).contains(nsError.code) {
+            return true
+        }
+        if let underlying = nsError.userInfo[NSUnderlyingErrorKey] as? any Error,
+           underlying as NSError !== nsError
+        {
+            return self.isFileIOError(underlying)
+        }
+        return false
+    }
+}
+
+protocol VideoFrameDecoding: Sendable {
+    func image(at time: CMTime) async throws -> (image: CGImage, actualTime: CMTime)
+    func cancelPendingDecodes()
+}
+
+extension VideoFrameDecoding {
+    func cancelPendingDecodes() {}
+}
+
+private struct DecodedVideoFrame: @unchecked Sendable {
+    let image: CGImage
+    let actualTime: CMTime
+}
+
+private final class VideoDecodeContinuation: @unchecked Sendable {
+    private let lock = NSLock()
+    private var continuation: CheckedContinuation<DecodedVideoFrame, any Error>?
+
+    init(continuation: CheckedContinuation<DecodedVideoFrame, any Error>) {
+        self.continuation = continuation
+    }
+
+    func resume(with result: Result<DecodedVideoFrame, any Error>) {
+        self.lock.lock()
+        let continuation = self.continuation
+        self.continuation = nil
+        self.lock.unlock()
+        continuation?.resume(with: result)
+    }
+}
+
+private final class VideoFrameDecoder: @unchecked Sendable, VideoFrameDecoding {
+    private let generator: AVAssetImageGenerator
+
+    init(generator: AVAssetImageGenerator) {
+        self.generator = generator
+    }
+
+    func image(at time: CMTime) async throws -> (image: CGImage, actualTime: CMTime) {
+        try Task.checkCancellation()
+        let generated = try await self.generator.image(at: time)
+        try Task.checkCancellation()
+        return generated
+    }
+
+    func cancelPendingDecodes() {
+        self.generator.cancelAllCGImageGeneration()
+    }
+}
+
+extension VideoFrameSource: CaptureFrameSourceDiagnosticsProviding {
+    @MainActor public var captureDiagnostics: CaptureFrameSourceDiagnostics {
+        CaptureFrameSourceDiagnostics(
+            decodeFailures: self.decodeFailures,
+            firstDecodeError: self.firstDecodeError,
+            lastDecodeError: self.lastDecodeError)
     }
 }
 
@@ -113,19 +313,19 @@ struct VideoFrameTimeline {
 
     mutating func next() -> CMTime? {
         guard !self.exhausted else { return nil }
-        let current = self.nextTime
-        if current >= self.end {
+        guard self.nextTime < self.end else {
             self.exhausted = true
-            return current
+            return nil
         }
+        let current = self.nextTime
 
         let next = CMTimeAdd(current, self.interval)
         guard next.isNumeric, next > current else {
             self.exhausted = true
-            return current
+            return nil
         }
 
-        self.nextTime = next >= self.end ? self.end : next
+        self.nextTime = min(next, self.end)
         return current
     }
 }

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/VideoWriter.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/VideoWriter.swift
@@ -1,22 +1,36 @@
 import AVFoundation
 import CoreGraphics
+import Darwin
 import Foundation
 import PeekabooFoundation
 
 /// Simple MP4 writer that appends CGImages as video frames.
-final class VideoWriter {
+final class VideoWriter: @unchecked Sendable {
     private let writer: AVAssetWriter
     private let input: AVAssetWriterInput
     private let adaptor: AVAssetWriterInputPixelBufferAdaptor
     private let frameDuration: CMTime
     private var frameIndex: Int64 = 0
+    private let outputExistedBeforeInitialization: Bool
+    private let fileManager: FileManager
 
     var finalURL: URL {
         self.writer.outputURL
     }
 
-    init(outputPath: String, width: Int, height: Int, fps: Double) throws {
+    init(
+        outputPath: String,
+        width: Int,
+        height: Int,
+        fps: Double,
+        fileManager: FileManager = .default) throws
+    {
+        self.fileManager = fileManager
         let url = URL(fileURLWithPath: outputPath)
+        self.outputExistedBeforeInitialization = fileManager.fileExists(atPath: url.path)
+        guard !self.outputExistedBeforeInitialization else {
+            throw PeekabooError.fileIOError("Video output already exists: \(url.path)")
+        }
         self.writer = try AVAssetWriter(outputURL: url, fileType: .mp4)
 
         let settings: [String: Any] = [
@@ -53,9 +67,19 @@ final class VideoWriter {
         self.writer.startSession(atSourceTime: .zero)
     }
 
-    func append(image: CGImage) throws {
+    func append(image: CGImage) async throws {
         try self.startIfNeeded()
-        guard self.input.isReadyForMoreMediaData else { return }
+        let readinessDeadline = ContinuousClock.now.advanced(by: .seconds(2))
+        while !self.input.isReadyForMoreMediaData {
+            try Task.checkCancellation()
+            if self.writer.status == .failed || self.writer.status == .cancelled {
+                throw self.writer.error ?? PeekabooError.captureFailed("Video writer stopped accepting frames")
+            }
+            guard ContinuousClock.now < readinessDeadline else {
+                throw PeekabooError.captureTimeout
+            }
+            try await Task.sleep(for: .milliseconds(5))
+        }
 
         var pixelBuffer: CVPixelBuffer?
         let width = image.width
@@ -74,10 +98,12 @@ final class VideoWriter {
             kCVPixelFormatType_32BGRA,
             attrs as CFDictionary,
             &pixelBuffer)
-        guard let buffer = pixelBuffer else { return }
+        guard let buffer = pixelBuffer else {
+            throw PeekabooError.captureFailed("Failed to allocate a video pixel buffer")
+        }
 
         CVPixelBufferLockBaseAddress(buffer, [])
-        if let ctx = CGContext(
+        guard let ctx = CGContext(
             data: CVPixelBufferGetBaseAddress(buffer),
             width: width,
             height: height,
@@ -85,26 +111,69 @@ final class VideoWriter {
             bytesPerRow: CVPixelBufferGetBytesPerRow(buffer),
             space: CGColorSpaceCreateDeviceRGB(),
             bitmapInfo: CGImageAlphaInfo.premultipliedFirst.rawValue)
-        {
-            ctx.draw(image, in: CGRect(x: 0, y: 0, width: width, height: height))
+        else {
+            CVPixelBufferUnlockBaseAddress(buffer, [])
+            throw PeekabooError.captureFailed("Failed to create the video frame drawing context")
         }
+        ctx.draw(image, in: CGRect(x: 0, y: 0, width: width, height: height))
         CVPixelBufferUnlockBaseAddress(buffer, [])
 
         let pts = CMTimeMultiply(self.frameDuration, multiplier: Int32(self.frameIndex))
-        self.adaptor.append(buffer, withPresentationTime: pts)
+        guard self.adaptor.append(buffer, withPresentationTime: pts) else {
+            throw self.writer.error ?? PeekabooError.captureFailed("Failed to append a video frame")
+        }
         self.frameIndex += 1
     }
 
     func finish() async throws {
+        try Task.checkCancellation()
         guard self.writer.status != .completed else { return }
         self.input.markAsFinished()
-        await withCheckedContinuation { continuation in
-            self.writer.finishWriting {
-                continuation.resume()
+        await withTaskCancellationHandler {
+            await withCheckedContinuation { continuation in
+                self.writer.finishWriting {
+                    continuation.resume()
+                }
             }
+        } onCancel: {
+            self.writer.cancelWriting()
         }
+        try Task.checkCancellation()
         if self.writer.status != .completed {
             throw self.writer.error ?? PeekabooError.captureFailed(reason: "Failed to finalize video")
         }
+    }
+
+    func abortAndRemovePartialOutput() throws {
+        if self.writer.status == .writing || self.writer.status == .unknown {
+            self.writer.cancelWriting()
+        }
+        guard !self.outputExistedBeforeInitialization else { return }
+        do {
+            try self.fileManager.removeItem(at: self.writer.outputURL)
+        } catch {
+            if Self.isMissingOutputError(error) {
+                return
+            }
+            let detail = CaptureDiagnosticSanitizer.sanitize(error.localizedDescription) ?? "unknown error"
+            throw PeekabooError.fileIOError(
+                "Failed to remove incomplete video output at \(self.writer.outputURL.path): \(detail)")
+        }
+    }
+
+    private static func isMissingOutputError(_ error: any Error) -> Bool {
+        let nsError = error as NSError
+        if nsError.domain == NSCocoaErrorDomain, nsError.code == NSFileNoSuchFileError {
+            return true
+        }
+        if nsError.domain == NSPOSIXErrorDomain, nsError.code == ENOENT {
+            return true
+        }
+        if let underlying = nsError.userInfo[NSUnderlyingErrorKey] as? any Error,
+           underlying as NSError !== nsError
+        {
+            return self.isMissingOutputError(underlying)
+        }
+        return false
     }
 }

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/WatchCaptureArtifactWriter.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/WatchCaptureArtifactWriter.swift
@@ -12,6 +12,9 @@ enum WatchCaptureArtifactWriter {
         columns: Int,
         thumbSize: CGSize) throws -> WatchContactSheet
     {
+        guard !frames.isEmpty else {
+            throw PeekabooError.captureFailed(reason: "Cannot build a contact sheet without valid frames")
+        }
         let maxCells = columns * columns
         let framesToUse: [CaptureFrameInfo]
         let sampledIndexes: [Int]
@@ -39,7 +42,9 @@ enum WatchCaptureArtifactWriter {
         }
 
         for (idx, frame) in framesToUse.enumerated() {
-            guard let image = self.makeCGImage(fromFile: frame.path) else { continue }
+            guard let image = self.makeCGImage(fromFile: frame.path) else {
+                throw PeekabooError.fileIOError("Contact sheet source frame is unreadable: \(frame.file)")
+            }
             let resized = self.resize(image: image, to: thumbSize) ?? image
             let row = idx / columns
             let col = idx % columns
@@ -101,17 +106,23 @@ enum WatchCaptureArtifactWriter {
             image
         }
 
-        guard let destination = CGImageDestinationCreateWithURL(
-            url as CFURL,
+        let encoded = NSMutableData()
+        guard let destination = CGImageDestinationCreateWithData(
+            encoded,
             UTType.png.identifier as CFString,
             1,
             nil)
         else {
-            throw PeekabooError.captureFailed(reason: "Failed to create image destination")
+            throw PeekabooError.fileIOError("Failed to create PNG encoder for: \(url.path)")
         }
         CGImageDestinationAddImage(destination, finalImage, nil)
         if !CGImageDestinationFinalize(destination) {
-            throw PeekabooError.captureFailed(reason: "Failed to write PNG")
+            throw PeekabooError.fileIOError("Failed to encode PNG for: \(url.path)")
+        }
+        do {
+            try (encoded as Data).write(to: url, options: .atomic)
+        } catch {
+            throw PeekabooError.fileIOError("Failed to write PNG to \(url.path): \(error.localizedDescription)")
         }
     }
 

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/WatchCaptureResultBuilder.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/WatchCaptureResultBuilder.swift
@@ -15,8 +15,10 @@ struct WatchCaptureResultBuilder {
         let metadataURL: URL
         let durationMs: Int
         let framesDropped: Int
+        let frameAttempts: Int
         let totalBytes: Int
         let warnings: [CaptureWarning]
+        let sourceDiagnostics: CaptureFrameSourceDiagnostics
     }
 
     func build(_ input: Input) -> CaptureSessionResult {
@@ -27,26 +29,42 @@ struct WatchCaptureResultBuilder {
             frames: input.frames,
             contactSheet: input.contactSheet,
             metadataFile: input.metadataURL.path,
-            stats: self.makeStats(
-                durationMs: input.durationMs,
-                frames: input.frames,
-                framesDropped: input.framesDropped,
-                totalBytes: input.totalBytes),
+            stats: self.makeStats(input),
             scope: self.scope,
             diffAlgorithm: self.options.diffStrategy.rawValue,
             diffScale: self.diffScale,
             options: self.makeOptionsSnapshot(),
-            warnings: self.warningsWithNoMotionCheck(frames: input.frames, warnings: input.warnings))
+            warnings: self.captureWarnings(
+                frames: input.frames,
+                warnings: input.warnings,
+                sourceDiagnostics: input.sourceDiagnostics))
     }
 
-    private func warningsWithNoMotionCheck(
+    private func captureWarnings(
         frames: [CaptureFrameInfo],
-        warnings: [CaptureWarning]) -> [CaptureWarning]
+        warnings: [CaptureWarning],
+        sourceDiagnostics: CaptureFrameSourceDiagnostics) -> [CaptureWarning]
     {
         var output = warnings
-        if frames.isEmpty {
-            output.append(WatchWarning(code: .noMotion, message: "No frames were captured"))
-        } else if frames.count < 2 {
+        if self.sourceKind == .video,
+           sourceDiagnostics.decodeFailures > 0,
+           !output.contains(where: { $0.code == .videoDecodeFailure })
+        {
+            var details = ["count": "\(sourceDiagnostics.decodeFailures)"]
+            if let first = sourceDiagnostics.firstDecodeError {
+                details["first_error"] = first
+            }
+            if let last = sourceDiagnostics.lastDecodeError {
+                details["last_error"] = last
+            }
+            output.append(WatchWarning(
+                code: .videoDecodeFailure,
+                message: "Skipped \(sourceDiagnostics.decodeFailures) undecodable video sample(s)",
+                details: details))
+        }
+        let hadCaptureLoss = sourceDiagnostics.decodeFailures > 0 ||
+            warnings.contains(where: { $0.code == .transientCaptureFailure })
+        if frames.count < 2, !hadCaptureLoss {
             output.append(WatchWarning(code: .noMotion, message: "No motion detected; only key frames captured"))
         }
         return output
@@ -70,22 +88,23 @@ struct WatchCaptureResultBuilder {
             video: self.videoOptions)
     }
 
-    private func makeStats(
-        durationMs: Int,
-        frames: [CaptureFrameInfo],
-        framesDropped: Int,
-        totalBytes: Int) -> WatchStats
-    {
+    private func makeStats(_ input: Input) -> WatchStats {
         let maxMbHit = self.options.maxMegabytes != nil
-            && totalBytes / (1024 * 1024) >= (self.options.maxMegabytes ?? 0)
+            && input.totalBytes / (1024 * 1024) >= (self.options.maxMegabytes ?? 0)
+        let maxFramesHit = if self.sourceKind == .video {
+            input.frameAttempts >= self.options.maxFrames
+        } else {
+            input.frames.count >= self.options.maxFrames
+        }
         return WatchStats(
-            durationMs: durationMs,
+            durationMs: input.durationMs,
             fpsIdle: self.options.idleFps,
             fpsActive: self.options.activeFps,
-            fpsEffective: Self.computeEffectiveFps(frameCount: frames.count, durationMs: durationMs),
-            framesKept: frames.count,
-            framesDropped: framesDropped,
-            maxFramesHit: frames.count >= self.options.maxFrames,
+            fpsEffective: Self.computeEffectiveFps(frameCount: input.frames.count, durationMs: input.durationMs),
+            framesKept: input.frames.count,
+            framesDropped: input.framesDropped,
+            decodeFailures: input.sourceDiagnostics.decodeFailures,
+            maxFramesHit: maxFramesHit,
             maxMbHit: maxMbHit)
     }
 

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/WatchCaptureSession+Loop.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/WatchCaptureSession+Loop.swift
@@ -17,6 +17,9 @@ extension WatchCaptureSession {
         var activeMode: Bool
         var lastDiffBuffer: WatchFrameDiffer.LumaBuffer?
         var frameIndex: Int
+        var frameAttempts: Int
+        var consecutiveDecodeFailures: Int
+        var consecutiveTransientCaptureFailures: Int
         var transientCaptureWarningEmitted: Bool
     }
 
@@ -25,6 +28,11 @@ extension WatchCaptureSession {
         let motionBoxes: [CGRect]?
         let buffer: WatchFrameDiffer.LumaBuffer
         let enterActive: Bool
+    }
+
+    enum CaptureAttemptResult: @unchecked Sendable {
+        case frame(WatchCaptureFrame?, warning: WatchWarning?)
+        case stopRequested
     }
 
     func makeTiming(start: Date) -> SessionTiming {
@@ -51,25 +59,35 @@ extension WatchCaptureSession {
             activeMode: false,
             lastDiffBuffer: nil,
             frameIndex: 0,
+            frameAttempts: 0,
+            consecutiveDecodeFailures: 0,
+            consecutiveTransientCaptureFailures: 0,
             transientCaptureWarningEmitted: false)
 
-        while true {
+        captureLoop: while true {
             let now = Date()
             let elapsedNs = Self.elapsedNanoseconds(since: timing.start, now: now)
             if self.shouldEndSession(elapsedNs: elapsedNs, durationNs: timing.durationNs) {
                 break
             }
-            if self.hitFrameCap() || self.hitSizeCap() {
+            if self.hitFrameCap(videoFrameAttempts: state.frameAttempts) || self.hitSizeCap() {
                 break
             }
 
             let frameStart = Date()
             let cadence = state.activeMode ? timing.cadenceActiveNs : timing.cadenceIdleNs
-            let capture: WatchCaptureFrame?
+            let attemptResult: CaptureAttemptResult
             do {
-                capture = try await self.captureFrame()
+                attemptResult = try await self.captureFrameOrStop()
             } catch {
                 if let delay = ScreenCaptureKitTransientError.retryDelayNanoseconds(after: error) {
+                    state.consecutiveTransientCaptureFailures += 1
+                    guard state.consecutiveTransientCaptureFailures <= 3 else {
+                        throw error
+                    }
+                    let boundedError = CaptureDiagnosticSanitizer.sanitize(error.localizedDescription) ??
+                        "Transient ScreenCaptureKit capture failure"
+                    self.lastCaptureErrorDescription = boundedError
                     self.framesDropped += 1
                     if !state.transientCaptureWarningEmitted {
                         state.transientCaptureWarningEmitted = true
@@ -77,7 +95,7 @@ extension WatchCaptureSession {
                             WatchWarning(
                                 code: .transientCaptureFailure,
                                 message: "Dropped a frame after a transient ScreenCaptureKit capture failure",
-                                details: ["error": error.localizedDescription]))
+                                details: ["error": boundedError]))
                     }
                     // SCK can report a temporary TCC denial while another CLI capture is settling.
                     // Treat that as a dropped live frame; the next sample or fallback frame can recover.
@@ -87,21 +105,52 @@ extension WatchCaptureSession {
                 }
                 throw error
             }
+            state.consecutiveTransientCaptureFailures = 0
+
+            let capture: WatchCaptureFrame?
+            switch attemptResult {
+            case let .frame(frame, warning):
+                if let warning {
+                    self.warnings.append(warning)
+                }
+                capture = frame
+            case .stopRequested:
+                break captureLoop
+            }
 
             guard let capture else {
                 // Frame source exhausted, usually from finite video input.
                 break
             }
+            state.frameAttempts += 1
+            self.frameAttempts = state.frameAttempts
             let timestampMs = capture.metadata.videoTimestampMs ?? Int(elapsedNs / 1_000_000)
 
             guard let cgImage = capture.cgImage else {
                 self.framesDropped += 1
+                state.consecutiveDecodeFailures += 1
+                if self.sourceKind == .video, state.consecutiveDecodeFailures >= 32 {
+                    let diagnostics = self.captureSourceDiagnostics
+                    var details = ["count": "\(diagnostics.decodeFailures)"]
+                    if let first = diagnostics.firstDecodeError {
+                        details["first_error"] = first
+                    }
+                    if let last = diagnostics.lastDecodeError {
+                        details["last_error"] = last
+                    }
+                    self.warnings.append(WatchWarning(
+                        code: .videoDecodeFailure,
+                        message: "Stopped video sampling after 32 consecutive undecodable samples",
+                        details: details))
+                    break
+                }
                 try await self.sleep(ns: cadence, since: frameStart)
                 continue
             }
+            state.consecutiveDecodeFailures = 0
 
             if self.keepAllFrames {
-                try self.keepAllFrame(
+                try await self.keepAllFrame(
                     cgImage: cgImage,
                     capture: capture,
                     timestampMs: timestampMs,
@@ -131,7 +180,7 @@ extension WatchCaptureSession {
                     changePercent: diff.changePercent,
                     reason: decision.reason,
                     motionBoxes: diff.motionBoxes)
-                let saved = try self.saveFrame(cgImage: cgImage, context: saveContext)
+                let saved = try await self.saveFrame(cgImage: cgImage, context: saveContext)
                 self.frames.append(saved)
                 state.lastKeptTime = now
             } else {
@@ -147,10 +196,10 @@ extension WatchCaptureSession {
         cgImage: CGImage,
         capture: WatchCaptureFrame,
         timestampMs: Int,
-        state: inout SessionState) throws
+        state: inout SessionState) async throws
     {
         let reason: CaptureFrameInfo.Reason = self.frames.isEmpty ? .first : .motion
-        let saved = try self.saveFrame(
+        let saved = try await self.saveFrame(
             cgImage: cgImage,
             context: FrameSaveContext(
                 capture: capture,
@@ -163,12 +212,38 @@ extension WatchCaptureSession {
         state.frameIndex += 1
     }
 
-    func captureFrame() async throws -> WatchCaptureFrame? {
-        let output = try await self.frameProvider.captureFrame()
-        if let warning = output.warning {
-            self.warnings.append(warning)
+    func captureFrameOrStop() async throws -> CaptureAttemptResult {
+        guard !self.hasStopRequest() else { return .stopRequested }
+        let provider = self.frameProvider
+        let captureTask = Task<CaptureAttemptResult, any Error> { @MainActor in
+            let output = try await provider.captureFrame()
+            return .frame(output.frame, warning: output.warning)
         }
-        return output.frame
+        let stopTask = Task<CaptureAttemptResult, any Error> { [weak self] in
+            await self?.waitForStopRequest()
+            try Task.checkCancellation()
+            return .stopRequested
+        }
+        defer {
+            captureTask.cancel()
+            stopTask.cancel()
+        }
+        return try await withTaskCancellationHandler {
+            let result: CaptureAttemptResult = try await withCheckedThrowingContinuation { continuation in
+                let gate = WatchCaptureAttemptContinuation(continuation: continuation)
+                Task {
+                    await gate.resume(with: captureTask.result)
+                }
+                Task {
+                    await gate.resume(with: stopTask.result)
+                }
+            }
+            try Task.checkCancellation()
+            return result
+        } onCancel: {
+            captureTask.cancel()
+            stopTask.cancel()
+        }
     }
 
     static func elapsedNanoseconds(since start: Date, now: Date) -> UInt64 {
@@ -179,10 +254,14 @@ extension WatchCaptureSession {
         self.hasStopRequest() || elapsedNs >= durationNs
     }
 
-    func hitFrameCap() -> Bool {
-        guard self.frames.count >= self.options.maxFrames else { return false }
+    func hitFrameCap(videoFrameAttempts: Int = 0) -> Bool {
+        let count = self.sourceKind == .video ? videoFrameAttempts : self.frames.count
+        guard count >= self.options.maxFrames else { return false }
+        let message = self.sourceKind == .video
+            ? "Stopped after reaching max-frames video sampling cap"
+            : "Stopped after reaching max-frames cap"
         self.warnings.append(
-            WatchWarning(code: .frameCap, message: "Stopped after reaching max-frames cap"))
+            WatchWarning(code: .frameCap, message: message))
         return true
     }
 
@@ -295,5 +374,22 @@ extension WatchCaptureSession {
             group.cancelAll()
             try Task.checkCancellation()
         }
+    }
+}
+
+private final class WatchCaptureAttemptContinuation: @unchecked Sendable {
+    private let lock = NSLock()
+    private var continuation: CheckedContinuation<WatchCaptureSession.CaptureAttemptResult, any Error>?
+
+    init(continuation: CheckedContinuation<WatchCaptureSession.CaptureAttemptResult, any Error>) {
+        self.continuation = continuation
+    }
+
+    func resume(with result: Result<WatchCaptureSession.CaptureAttemptResult, any Error>) {
+        self.lock.lock()
+        let continuation = self.continuation
+        self.continuation = nil
+        self.lock.unlock()
+        continuation?.resume(with: result)
     }
 }

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/WatchCaptureSession+Saving.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/WatchCaptureSession+Saving.swift
@@ -1,5 +1,6 @@
 import CoreGraphics
 import Foundation
+import PeekabooFoundation
 
 @MainActor
 extension WatchCaptureSession {
@@ -28,10 +29,10 @@ extension WatchCaptureSession {
         return (scaledWidth, scaledHeight)
     }
 
-    func saveFrame(cgImage: CGImage, context: FrameSaveContext) throws -> CaptureFrameInfo {
+    func saveFrame(cgImage: CGImage, context: FrameSaveContext) async throws -> CaptureFrameInfo {
         try self.prepareVideoWriterIfNeeded(for: cgImage)
         if let writer = self.videoWriter {
-            try writer.append(image: cgImage)
+            try await writer.append(image: cgImage)
         }
 
         let fileName = String(format: "keep-%04d.png", self.frames.count + 1)
@@ -41,8 +42,17 @@ extension WatchCaptureSession {
             to: url,
             highlight: self.options.highlightChanges ? context.motionBoxes : nil)
 
-        if let data = try? Data(contentsOf: url) {
-            self.totalBytes += data.count
+        do {
+            let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
+            guard let size = attributes[.size] as? NSNumber else {
+                throw PeekabooError.fileIOError("Missing file size after writing \(fileName)")
+            }
+            self.totalBytes += size.intValue
+        } catch let error as PeekabooError {
+            throw error
+        } catch {
+            throw PeekabooError
+                .fileIOError("Failed to inspect written frame \(fileName): \(error.localizedDescription)")
         }
 
         return CaptureFrameInfo(
@@ -68,20 +78,6 @@ extension WatchCaptureSession {
             width: size.width,
             height: size.height,
             fps: fps)
-    }
-
-    func ensureFallbackFrame() async throws {
-        guard self.frames.isEmpty else { return }
-        guard let capture = try? await self.captureFrame(), let cg = capture.cgImage else { return }
-        let context = FrameSaveContext(
-            capture: capture,
-            index: 0,
-            timestampMs: 0,
-            changePercent: 0,
-            reason: .first,
-            motionBoxes: nil)
-        let saved = try self.saveFrame(cgImage: cg, context: context)
-        self.frames.append(saved)
     }
 
     func elapsedMilliseconds(since start: Date) -> Int {

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/WatchCaptureSession.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/WatchCaptureSession.swift
@@ -152,7 +152,9 @@ public final class WatchCaptureSession {
     var frames: [CaptureFrameInfo] = []
     var warnings: [CaptureWarning] = []
     var framesDropped: Int = 0
+    var frameAttempts: Int = 0
     var totalBytes: Int = 0
+    var lastCaptureErrorDescription: String?
     private let stopSignal = WatchCaptureStopSignal()
 
     public init(dependencies: WatchCaptureDependencies, configuration: WatchCaptureConfiguration) {
@@ -185,46 +187,76 @@ public final class WatchCaptureSession {
     }
 
     public func run() async throws -> CaptureSessionResult {
-        try self.store.prepareOutputRoot()
-        if let autocleanWarning = self.store.performAutoclean() {
-            self.warnings.append(autocleanWarning)
-        }
-        // videoWriter is created lazily on first saved frame to match actual dimensions.
+        do {
+            try self.store.prepareOutputRoot()
+            if let autocleanWarning = self.store.performAutoclean() {
+                self.warnings.append(autocleanWarning)
+            }
+            // videoWriter is created lazily on first saved frame to match actual dimensions.
 
-        let timing = self.makeTiming(start: Date())
-        try await self.captureFrames(timing: timing)
-        try await self.ensureFallbackFrame()
+            let timing = self.makeTiming(start: Date())
+            try await self.captureFrames(timing: timing)
+            try Task.checkCancellation()
 
-        if let writer = self.videoWriter {
-            try await writer.finish()
-        }
+            let sourceDiagnostics = self.captureSourceDiagnostics
+            guard !self.frames.isEmpty else {
+                throw CaptureNoValidFramesError(
+                    source: self.sourceKind,
+                    framesDropped: self.framesDropped,
+                    decodeFailures: sourceDiagnostics.decodeFailures,
+                    firstDecodeError: sourceDiagnostics.firstDecodeError,
+                    lastDecodeError: sourceDiagnostics.lastDecodeError,
+                    lastCaptureError: self.lastCaptureErrorDescription)
+            }
 
-        let contact = try WatchCaptureArtifactWriter.buildContactSheet(
-            frames: self.frames,
-            outputRoot: self.outputRoot,
-            columns: Constants.contactMaxColumns,
-            thumbSize: CGSize(width: Constants.contactThumb, height: Constants.contactThumb))
-        let durationMs = self.elapsedMilliseconds(since: timing.start)
-        let metadataURL = self.outputRoot.appendingPathComponent("metadata.json")
-        let metadata = WatchCaptureResultBuilder(
-            sourceKind: self.sourceKind,
-            videoIn: self.videoIn,
-            videoOut: self.videoWriter?.finalURL.path,
-            scope: self.scope,
-            options: self.options,
-            videoOptions: self.videoOptions,
-            diffScale: "w\(Int(Constants.diffScaleWidth))")
-            .build(.init(
+            if let writer = self.videoWriter {
+                try await writer.finish()
+            }
+
+            let contact = try WatchCaptureArtifactWriter.buildContactSheet(
                 frames: self.frames,
-                contactSheet: contact,
-                metadataURL: metadataURL,
-                durationMs: durationMs,
-                framesDropped: self.framesDropped,
-                totalBytes: self.totalBytes,
-                warnings: self.warnings))
+                outputRoot: self.outputRoot,
+                columns: Constants.contactMaxColumns,
+                thumbSize: CGSize(width: Constants.contactThumb, height: Constants.contactThumb))
+            let durationMs = self.elapsedMilliseconds(since: timing.start)
+            let metadataURL = self.outputRoot.appendingPathComponent("metadata.json")
+            let metadata = WatchCaptureResultBuilder(
+                sourceKind: self.sourceKind,
+                videoIn: self.videoIn,
+                videoOut: self.videoWriter?.finalURL.path,
+                scope: self.scope,
+                options: self.options,
+                videoOptions: self.videoOptions,
+                diffScale: "w\(Int(Constants.diffScaleWidth))")
+                .build(.init(
+                    frames: self.frames,
+                    contactSheet: contact,
+                    metadataURL: metadataURL,
+                    durationMs: durationMs,
+                    framesDropped: self.framesDropped,
+                    frameAttempts: self.frameAttempts,
+                    totalBytes: self.totalBytes,
+                    warnings: self.warnings,
+                    sourceDiagnostics: sourceDiagnostics))
 
-        try self.store.writeJSON(metadata, to: metadataURL)
-        return metadata
+            try self.store.writeJSON(metadata, to: metadataURL)
+            return metadata
+        } catch {
+            let primaryError = error
+            if let videoWriter = self.videoWriter {
+                do {
+                    try videoWriter.abortAndRemovePartialOutput()
+                } catch {
+                    self.videoWriter = nil
+                    throw CaptureArtifactCleanupError(
+                        primaryError: primaryError,
+                        cleanupError: error,
+                        artifactPath: videoWriter.finalURL.path)
+                }
+            }
+            self.videoWriter = nil
+            throw primaryError
+        }
     }
 
     public func requestStop() {
@@ -237,5 +269,10 @@ public final class WatchCaptureSession {
 
     func waitForStopRequest() async {
         await self.stopSignal.wait()
+    }
+
+    var captureSourceDiagnostics: CaptureFrameSourceDiagnostics {
+        (self.frameSource as? any CaptureFrameSourceDiagnosticsProviding)?.captureDiagnostics ??
+            CaptureFrameSourceDiagnostics()
     }
 }

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/WatchCaptureSessionStore.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/WatchCaptureSessionStore.swift
@@ -1,4 +1,5 @@
 import Foundation
+import PeekabooFoundation
 
 struct WatchCaptureSessionStore {
     let outputRoot: URL
@@ -11,6 +12,20 @@ struct WatchCaptureSessionStore {
         try self.fileManager.createDirectory(
             at: self.outputRoot,
             withIntermediateDirectories: true)
+        let contents = try self.fileManager.contentsOfDirectory(
+            at: self.outputRoot,
+            includingPropertiesForKeys: nil,
+            options: [.skipsHiddenFiles])
+        let staleArtifacts = contents.filter { url in
+            url.lastPathComponent == "contact.png" ||
+                url.lastPathComponent == "metadata.json" ||
+                (url.lastPathComponent.hasPrefix("keep-") && url.pathExtension.lowercased() == "png")
+        }
+        guard staleArtifacts.isEmpty else {
+            let names = staleArtifacts.map(\.lastPathComponent).sorted().prefix(5).joined(separator: ", ")
+            throw PeekabooError.fileIOError(
+                "Capture output directory already contains capture artifacts (\(names)); choose an empty directory")
+        }
     }
 
     func performAutoclean() -> WatchWarning? {

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/Agent/AgentExecutionTrace.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/Agent/AgentExecutionTrace.swift
@@ -199,6 +199,12 @@ private enum AgentExecutionTraceBuilder {
             "action", "app", "click", "dialog", "dock", "drag", "menu", "move", "paste", "press",
             "scroll", "set_value", "space", "type", "window",
         ]
+        if name == "capture" || name == "image" {
+            let focus = call.arguments["capture_focus"]?.stringValue?
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+                .lowercased() ?? "background"
+            return focus != "background"
+        }
         guard mutatingTools.contains(name) else { return false }
 
         let readOnlyActions: [String: Set<String>] = [

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/Agent/AgentToolMCPBridge.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/Agent/AgentToolMCPBridge.swift
@@ -136,12 +136,8 @@ enum AgentToolMCPBridge {
             "error": AnyAgentToolValue(string: message),
             "success": AnyAgentToolValue(bool: false),
         ]
-        if case let .object(metadata)? = response.meta {
-            for key in ["mutation_dispatched", "retry_safe"] {
-                if case let .bool(value)? = metadata[key] {
-                    payload[key] = AnyAgentToolValue(bool: value)
-                }
-            }
+        for (key, value) in MCPToolResponseMetadataProjector.agentFields(from: response.meta) {
+            payload[key] = TypedValueBridge.anyAgentValue(from: value)
         }
         return AgentToolMCPBridgeResult(value: AnyAgentToolValue(object: payload), images: [])
     }
@@ -157,6 +153,9 @@ enum AgentToolMCPBridge {
             "result": contentValue,
             "meta": TypedValueBridge.anyAgentValue(from: metadata),
         ]
+        for (key, value) in MCPToolResponseMetadataProjector.agentFields(from: response.meta) {
+            payload[key] = TypedValueBridge.anyAgentValue(from: value)
+        }
         if let text = contentValue.stringValue {
             payload["text"] = AnyAgentToolValue(string: text)
         }

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Server/MCPToolResponseMetadataProjector.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Server/MCPToolResponseMetadataProjector.swift
@@ -1,0 +1,53 @@
+import MCP
+
+enum MCPToolResponseMetadataProjector {
+    private static let safetyKeys: Set<String> = [
+        "effect",
+        "error_code",
+        "mutation_dispatched",
+        "retry_safe",
+    ]
+
+    private static let captureErrorKeys: Set<String> = [
+        "decode_failures",
+        "first_decode_error",
+        "frames_dropped",
+        "last_capture_error",
+        "last_decode_error",
+        "source",
+    ]
+
+    private static let captureSuccessKeys: Set<String> = [
+        "contact",
+        "contact_columns",
+        "contact_rows",
+        "contact_sampled_indexes",
+        "contact_thumb_height",
+        "contact_thumb_width",
+        "diff_algorithm",
+        "diff_scale",
+        "frames",
+        "metadata",
+        "stats",
+        "video_in",
+        "video_out",
+        "warnings",
+    ]
+
+    static func externalFields(from value: Value?, toolName: String?) -> [String: Value] {
+        guard case let .object(fields)? = value else { return [:] }
+        var allowed = Self.safetyKeys
+        allowed.insert("coordinate_context")
+        if toolName == "capture" {
+            allowed.formUnion(Self.captureErrorKeys)
+            allowed.formUnion(Self.captureSuccessKeys)
+        }
+        return fields.filter { allowed.contains($0.key) }
+    }
+
+    static func agentFields(from value: Value?) -> [String: Value] {
+        guard case let .object(fields)? = value else { return [:] }
+        let allowed = Self.safetyKeys.union(Self.captureErrorKeys)
+        return fields.filter { allowed.contains($0.key) }
+    }
+}

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Server/PeekabooMCPServer.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Server/PeekabooMCPServer.swift
@@ -83,7 +83,7 @@ public actor PeekabooMCPServer {
             // Execute tool on main thread
             let response = try await self.toolContext.execute(tool: tool, arguments: arguments)
 
-            return Self.callToolResult(from: response)
+            return Self.callToolResult(from: response, toolName: params.name)
         }
 
         // Resources list handler (empty for now, but prevents inspector errors)
@@ -133,14 +133,9 @@ public actor PeekabooMCPServer {
         }
     }
 
-    static func callToolResult(from response: ToolResponse) -> CallTool.Result {
-        let metadata: Metadata? = if case let .object(fields)? = response.meta,
-                                     let coordinateContext = fields["coordinate_context"]
-        {
-            Metadata(additionalFields: ["coordinate_context": coordinateContext])
-        } else {
-            nil
-        }
+    static func callToolResult(from response: ToolResponse, toolName: String? = nil) -> CallTool.Result {
+        let fields = MCPToolResponseMetadataProjector.externalFields(from: response.meta, toolName: toolName)
+        let metadata = fields.isEmpty ? nil : Metadata(additionalFields: fields)
 
         return CallTool.Result(
             content: response.content,

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/CaptureTool+Meta.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/CaptureTool+Meta.swift
@@ -2,12 +2,55 @@ import MCP
 import PeekabooAutomationKit
 
 enum CaptureMetaBuilder {
+    static func failureMeta(_ error: any Error, mutationDispatched: Bool) -> Value {
+        if let noValidFrames = error as? CaptureNoValidFramesError {
+            return self.noValidFramesMeta(noValidFrames, mutationDispatched: mutationDispatched)
+        }
+        var meta: [String: Value] = [
+            "retry_safe": .bool(!mutationDispatched),
+            "mutation_dispatched": .bool(mutationDispatched),
+        ]
+        if mutationDispatched {
+            meta["effect"] = .string("partial")
+        }
+        return .object(meta)
+    }
+
+    static func noValidFramesMeta(
+        _ error: CaptureNoValidFramesError,
+        mutationDispatched: Bool) -> Value
+    {
+        var meta: [String: Value] = [
+            "error_code": .string("CAPTURE_NO_VALID_FRAMES"),
+            "retry_safe": .bool(error.retrySafe && !mutationDispatched),
+            "mutation_dispatched": .bool(mutationDispatched),
+            "source": .string(error.source.rawValue),
+            "frames_dropped": .int(error.framesDropped),
+            "decode_failures": .int(error.decodeFailures),
+        ]
+        if mutationDispatched {
+            meta["effect"] = .string("partial")
+        }
+        if let first = error.firstDecodeError {
+            meta["first_decode_error"] = .string(first)
+        }
+        if let last = error.lastDecodeError {
+            meta["last_decode_error"] = .string(last)
+        }
+        if let last = error.lastCaptureError {
+            meta["last_capture_error"] = .string(last)
+        }
+        return .object(meta)
+    }
+
     static func buildMeta(from summary: CaptureMetaSummary) -> Value {
         .object(self.summaryMeta(from: summary))
     }
 
-    static func buildMeta(from result: CaptureSessionResult) -> Value {
+    static func buildMeta(from result: CaptureSessionResult, mutationDispatched: Bool = false) -> Value {
         var meta = self.summaryMeta(from: .make(from: result))
+        meta["mutation_dispatched"] = .bool(mutationDispatched)
+        meta["retry_safe"] = .bool(!mutationDispatched)
         meta["source"] = .string(result.source.rawValue)
         if let videoIn = result.videoIn {
             meta["video_in"] = .string(videoIn)
@@ -22,6 +65,7 @@ enum CaptureMetaBuilder {
             "fps_effective": .double(result.stats.fpsEffective),
             "frames_kept": .int(result.stats.framesKept),
             "frames_dropped": .int(result.stats.framesDropped),
+            "decode_failures": .int(result.stats.decodeFailures),
             "max_frames_hit": .bool(result.stats.maxFramesHit),
             "max_mb_hit": .bool(result.stats.maxMbHit),
         ])

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/CaptureTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/CaptureTool.swift
@@ -83,65 +83,98 @@ public struct CaptureTool: MCPTool {
 
     @MainActor
     public func execute(arguments: ToolArguments) async throws -> ToolResponse {
-        let request = try await CaptureRequest(arguments: arguments, windows: self.context.windows)
-        try await self.prepareCaptureFocus(request)
-        let dependencies = WatchCaptureDependencies(
-            screenCapture: self.context.screenCapture,
-            screenService: self.context.screens,
-            frameSource: request.frameSource)
-        let configuration = WatchCaptureConfiguration(
-            scope: request.scope,
-            options: request.options,
-            outputRoot: request.outputDirectory,
-            autoclean: WatchAutocleanConfig(
-                minutes: request.autocleanMinutes,
-                managed: request.usesDefaultOutput),
-            sourceKind: request.source,
-            videoIn: request.videoIn,
-            videoOut: request.videoOut,
-            keepAllFrames: request.keepAllFrames,
-            videoOptions: request.videoOptions)
-        let session = WatchCaptureSession(
-            dependencies: dependencies,
-            configuration: configuration)
-        let result = try await session.run()
+        let focusReceipt = CaptureFocusDispatchReceipt()
+        do {
+            let request = try await CaptureRequest(arguments: arguments, windows: self.context.windows)
+            try await self.prepareCaptureFocus(request, receipt: focusReceipt)
+            let dependencies = WatchCaptureDependencies(
+                screenCapture: self.context.screenCapture,
+                screenService: self.context.screens,
+                frameSource: request.frameSource)
+            let configuration = WatchCaptureConfiguration(
+                scope: request.scope,
+                options: request.options,
+                outputRoot: request.outputDirectory,
+                autoclean: WatchAutocleanConfig(
+                    minutes: request.autocleanMinutes,
+                    managed: request.usesDefaultOutput),
+                sourceKind: request.source,
+                videoIn: request.videoIn,
+                videoOut: request.videoOut,
+                keepAllFrames: request.keepAllFrames,
+                videoOptions: request.videoOptions)
+            let session = WatchCaptureSession(
+                dependencies: dependencies,
+                configuration: configuration)
+            let result = try await session.run()
 
-        var summaryLines = [
-            "capture kept \(result.stats.framesKept) frames (dropped \(result.stats.framesDropped))",
-            "contact: \(result.contactSheet.path)",
-            "metadata: \(result.metadataFile)",
-            "frames: \(result.frames.count) files",
-        ]
-        if let videoOut = result.videoOut {
-            summaryLines.insert("video: \(videoOut)", at: 3)
-        }
-        if !result.warnings.isEmpty {
-            let warnings = result.warnings.map(\.message).joined(separator: "; ")
-            summaryLines.append("warnings: \(warnings)")
-        }
-        let summary = summaryLines.joined(separator: "\n")
-        let meta = ToolEventSummary(
-            actionDescription: "Capture",
-            notes: summary)
+            var summaryLines = [
+                "capture kept \(result.stats.framesKept) frames (dropped \(result.stats.framesDropped))",
+                "contact: \(result.contactSheet.path)",
+                "metadata: \(result.metadataFile)",
+                "frames: \(result.frames.count) files",
+            ]
+            if let videoOut = result.videoOut {
+                summaryLines.insert("video: \(videoOut)", at: 3)
+            }
+            if !result.warnings.isEmpty {
+                let warnings = result.warnings.map(\.message).joined(separator: "; ")
+                summaryLines.append("warnings: \(warnings)")
+            }
+            let summary = summaryLines.joined(separator: "\n")
+            let meta = ToolEventSummary(
+                actionDescription: "Capture",
+                notes: summary)
 
-        return ToolResponse.text(
-            summary,
-            meta: ToolEventSummary.merge(
-                summary: meta,
-                into: CaptureMetaBuilder.buildMeta(from: result)))
+            return ToolResponse.text(
+                summary,
+                meta: ToolEventSummary.merge(
+                    summary: meta,
+                    into: CaptureMetaBuilder.buildMeta(
+                        from: result,
+                        mutationDispatched: focusReceipt.mutationDispatched)))
+        } catch let error as CaptureArtifactCleanupError {
+            return Self.failureResponse(error, mutationDispatched: focusReceipt.mutationDispatched)
+        } catch let error as CancellationError {
+            throw error
+        } catch {
+            try Task.checkCancellation()
+            return Self.failureResponse(error, mutationDispatched: focusReceipt.mutationDispatched)
+        }
+    }
+
+    static func failureResponse(
+        _ error: any Error,
+        mutationDispatched: Bool) -> ToolResponse
+    {
+        ToolResponse.error(
+            error.localizedDescription,
+            meta: CaptureMetaBuilder.failureMeta(
+                error,
+                mutationDispatched: mutationDispatched))
     }
 
     @MainActor
-    private func prepareCaptureFocus(_ request: CaptureRequest) async throws {
+    private func prepareCaptureFocus(
+        _ request: CaptureRequest,
+        receipt: CaptureFocusDispatchReceipt) async throws
+    {
         guard request.source == .live, request.options.captureFocus != .background else { return }
 
         if request.options.captureFocus == .foreground, let windowID = request.scope.windowId {
+            receipt.mutationDispatched = true
             try await self.context.windows.focusWindow(target: .windowId(Int(windowID)))
         } else if let identifier = request.scope.applicationIdentifier {
+            receipt.mutationDispatched = true
             try await self.context.applications.activateApplication(identifier: identifier)
         } else {
             return
         }
         try await Task.sleep(nanoseconds: 50_000_000)
     }
+}
+
+@MainActor
+private final class CaptureFocusDispatchReceipt {
+    var mutationDispatched = false
 }

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/ImageTool+Capture.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/ImageTool+Capture.swift
@@ -123,10 +123,13 @@ extension ImageTool {
         format: ImageFormatOption,
         savedFiles: [MCPSavedFile],
         captureResults: [CaptureResult],
-        observation: DesktopObservationResult?) -> ToolResponse
+        observation: DesktopObservationResult?,
+        mutationDispatched: Bool = false) -> ToolResponse
     {
         var metadata: [String: Value] = [
             "savedFiles": .array(savedFiles.map { Value.string($0.path) }),
+            "mutation_dispatched": .bool(mutationDispatched),
+            "retry_safe": .bool(!mutationDispatched),
         ]
         if let firstCapture = captureResults.first {
             metadata["coordinate_context"] = CaptureCoordinateContextMetadata.value(for: firstCapture.metadata)

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/ImageTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/ImageTool.swift
@@ -79,7 +79,8 @@ public struct ImageTool: MCPTool {
             format: request.format,
             savedFiles: savedFiles,
             captureResults: captureResults,
-            observation: captureSet.observation)
+            observation: captureSet.observation,
+            mutationDispatched: request.captureFocus != .background && request.focusIdentifier != nil)
     }
 
     private func screenRecordingPermissionError() -> ToolResponse {

--- a/Core/PeekabooCore/Tests/PeekabooAgentRuntimeTests/AgentExecutionTraceTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooAgentRuntimeTests/AgentExecutionTraceTests.swift
@@ -1,6 +1,8 @@
 import Foundation
+import MCP
 import PeekabooCore
 import Tachikoma
+import TachikomaMCP
 import Testing
 @testable import PeekabooAgentRuntime
 
@@ -128,6 +130,85 @@ struct AgentExecutionTraceTests {
         #expect(summary["mutation_dispatch"]?.stringValue == "not_dispatched")
         #expect(summary["retry_safe"]?.boolValue == true)
         #expect(summary["error_present"]?.boolValue == true)
+    }
+
+    @Test
+    func `Capture and image traces classify only focus-capable requests as mutations`() {
+        let calls = [
+            AgentToolCall(
+                id: "capture-background",
+                name: "capture",
+                arguments: ["capture_focus": AnyAgentToolValue(string: "background")]),
+            AgentToolCall(
+                id: "capture-foreground",
+                name: "capture",
+                arguments: ["capture_focus": AnyAgentToolValue(string: "foreground")]),
+            AgentToolCall(
+                id: "image-auto",
+                name: "image",
+                arguments: ["capture_focus": AnyAgentToolValue(string: "auto")]),
+        ]
+        let messages = [
+            ModelMessage(role: .assistant, content: calls.map(ModelMessage.ContentPart.toolCall)),
+            ModelMessage(role: .tool, content: calls.map { call in
+                .toolResult(AgentToolResult(
+                    toolCallId: call.id,
+                    result: AnyAgentToolValue(object: [
+                        "mutation_dispatched": AnyAgentToolValue(bool: call.id != "capture-background"),
+                        "success": AnyAgentToolValue(bool: true),
+                    ]),
+                    isError: false))
+            }),
+        ]
+        let result = AgentExecutionResult(
+            content: "",
+            messages: messages,
+            metadata: AgentMetadata(
+                executionTime: 0,
+                toolCallCount: calls.count,
+                modelName: "test",
+                startTime: Date(),
+                endTime: Date()))
+
+        let trace = result.executionTrace()
+        #expect(trace.entries[0].mutationDispatch == nil)
+        #expect(trace.entries[1].mutationDispatch == .dispatched)
+        #expect(trace.entries[2].mutationDispatch == .dispatched)
+    }
+
+    @Test
+    func `Native capture success receipt reaches execution trace through the real agent bridge`() throws {
+        let call = AgentToolCall(
+            id: "capture-focused",
+            name: "capture",
+            arguments: ["capture_focus": AnyAgentToolValue(string: "foreground")])
+        let bridged = convertToolResponseToAgentToolResult(ToolResponse.text(
+            "captured",
+            meta: .object([
+                "mutation_dispatched": .bool(true),
+                "retry_safe": .bool(false),
+            ])))
+        let messages = [
+            ModelMessage(role: .assistant, content: [.toolCall(call)]),
+            ModelMessage(role: .tool, content: [.toolResult(AgentToolResult(
+                toolCallId: call.id,
+                result: bridged,
+                isError: false))]),
+        ]
+        let result = AgentExecutionResult(
+            content: "",
+            messages: messages,
+            metadata: AgentMetadata(
+                executionTime: 0,
+                toolCallCount: 1,
+                modelName: "test",
+                startTime: Date(),
+                endTime: Date()))
+
+        let entry = try #require(result.executionTrace().entries.first)
+        #expect(entry.mutationDispatch == .dispatched)
+        #expect(entry.result?.objectValue?["mutation_dispatched"]?.boolValue == true)
+        #expect(entry.result?.objectValue?["retry_safe"]?.boolValue == false)
     }
 
     @Test

--- a/Core/PeekabooCore/Tests/PeekabooAgentRuntimeTests/AgentToolMCPBridgeMetaTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooAgentRuntimeTests/AgentToolMCPBridgeMetaTests.swift
@@ -57,6 +57,51 @@ struct AgentToolMCPBridgeMetaTests {
     }
 
     @Test
+    func `Capture error keeps only safe bounded metadata for the agent`() throws {
+        let response = ToolResponse.error(
+            "no frames",
+            meta: .object([
+                "decode_failures": .int(2),
+                "effect": .string("partial"),
+                "error_code": .string("CAPTURE_NO_VALID_FRAMES"),
+                "first_decode_error": .string("first"),
+                "internal_diagnostics": .string("private"),
+                "mutation_dispatched": .bool(true),
+                "retry_safe": .bool(false),
+                "source": .string("video"),
+            ]))
+
+        let converted = convertToolResponseToAgentToolResult(response)
+        let payload = try #require(try converted.toJSON() as? [String: Any])
+
+        #expect(payload["error_code"] as? String == "CAPTURE_NO_VALID_FRAMES")
+        #expect(payload["effect"] as? String == "partial")
+        #expect(payload["decode_failures"] as? Int == 2)
+        #expect(payload["mutation_dispatched"] as? Bool == true)
+        #expect(payload["retry_safe"] as? Bool == false)
+        #expect(payload["internal_diagnostics"] == nil)
+    }
+
+    @Test
+    func `Successful focus-capable capture promotes dispatch receipt for the agent`() throws {
+        let response = ToolResponse.text(
+            "captured",
+            meta: .object([
+                "mutation_dispatched": .bool(true),
+                "retry_safe": .bool(false),
+                "stats": .object(["frames_kept": .int(2)]),
+            ]))
+
+        let converted = convertToolResponseToAgentToolResult(response)
+        let payload = try #require(try converted.toJSON() as? [String: Any])
+
+        #expect(payload["mutation_dispatched"] as? Bool == true)
+        #expect(payload["retry_safe"] as? Bool == false)
+        #expect(payload["stats"] == nil)
+        #expect((payload["meta"] as? [String: Any])?["stats"] != nil)
+    }
+
+    @Test
     func `Shell tool metadata survives native bridge`() async throws {
         let command = "echo bridge-meta-test"
         let tool = ShellTool()

--- a/Core/PeekabooCore/Tests/PeekabooAutomationTests/CaptureSessionTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooAutomationTests/CaptureSessionTests.swift
@@ -2,6 +2,7 @@ import CoreGraphics
 import Foundation
 import PeekabooFoundation
 import Testing
+@testable import PeekabooAutomationKit
 @testable import PeekabooCore
 
 @MainActor
@@ -102,6 +103,307 @@ struct CaptureSessionTests {
         #expect(result.videoIn == "/tmp/input.mov")
         #expect(result.options.video == videoOptions)
     }
+
+    @Test
+    func `finite source with no valid image fails before contact or metadata output`() async throws {
+        let outputDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("peekaboo-empty-capture-test-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: outputDir) }
+        let source = DiagnosticFrameSource(steps: [.invalid("missing image")])
+        let session = Self.makeSession(source: source, sourceKind: .live, outputDir: outputDir)
+
+        let thrown = await #expect(throws: CaptureNoValidFramesError.self) {
+            _ = try await session.run()
+        }
+        let error = try #require(thrown)
+
+        #expect(error.source == .live)
+        #expect(error.framesDropped == 1)
+        #expect(!FileManager.default.fileExists(atPath: outputDir.appendingPathComponent("contact.png").path))
+        #expect(!FileManager.default.fileExists(atPath: outputDir.appendingPathComponent("metadata.json").path))
+    }
+
+    @Test
+    func `contact sheet rejects empty and unreadable source frames`() throws {
+        let outputDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("peekaboo-contact-honesty-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: outputDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: outputDir) }
+
+        #expect(throws: PeekabooError.self) {
+            _ = try WatchCaptureArtifactWriter.buildContactSheet(
+                frames: [],
+                outputRoot: outputDir,
+                columns: 2,
+                thumbSize: CGSize(width: 20, height: 20))
+        }
+
+        let missing = CaptureFrameInfo(
+            index: 7,
+            path: outputDir.appendingPathComponent("missing.png").path,
+            file: "missing.png",
+            timestampMs: 0,
+            changePercent: 0,
+            reason: .first)
+        let thrown = #expect(throws: PeekabooError.self) {
+            _ = try WatchCaptureArtifactWriter.buildContactSheet(
+                frames: [missing],
+                outputRoot: outputDir,
+                columns: 2,
+                thumbSize: CGSize(width: 20, height: 20))
+        }
+        guard case .fileIOError = try #require(thrown) else {
+            Issue.record("Expected unreadable contact source to remain a file-I/O error")
+            return
+        }
+        #expect(!FileManager.default.fileExists(atPath: outputDir.appendingPathComponent("contact.png").path))
+    }
+
+    @Test
+    func `existing capture artifacts are rejected without being mistaken for current output`() async throws {
+        let outputDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("peekaboo-stale-capture-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: outputDir, withIntermediateDirectories: true)
+        let oldContact = outputDir.appendingPathComponent("contact.png")
+        try Data("old-contact".utf8).write(to: oldContact)
+        defer { try? FileManager.default.removeItem(at: outputDir) }
+        let session = Self.makeSession(
+            source: DiagnosticFrameSource(steps: [.invalid("missing image")]),
+            sourceKind: .video,
+            outputDir: outputDir)
+
+        let thrown = await #expect(throws: PeekabooError.self) {
+            _ = try await session.run()
+        }
+        guard case .fileIOError = try #require(thrown) else {
+            Issue.record("Expected stale capture output to fail as file I/O")
+            return
+        }
+        #expect(try Data(contentsOf: oldContact) == Data("old-contact".utf8))
+        #expect(!FileManager.default.fileExists(atPath: outputDir.appendingPathComponent("metadata.json").path))
+    }
+
+    @Test
+    func `persistent transient live failure stops after bounded retries without laundering the error`() async throws {
+        let outputDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("peekaboo-transient-empty-test-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: outputDir) }
+        let transient = NSError(
+            domain: "com.apple.ScreenCaptureKit.SCStreamErrorDomain",
+            code: -3801,
+            userInfo: [NSLocalizedDescriptionKey: "The user declined TCC for application, window, display capture"])
+        let service = AlwaysFailingScreenCaptureService(error: transient)
+        let session = WatchCaptureSession(
+            dependencies: WatchCaptureDependencies(
+                screenCapture: service,
+                screenService: NoOpScreenService()),
+            configuration: WatchCaptureConfiguration(
+                scope: CaptureScope(kind: .frontmost),
+                options: Self.options(duration: 10),
+                outputRoot: outputDir,
+                autoclean: WatchAutocleanConfig(minutes: 120, managed: false),
+                sourceKind: .live,
+                keepAllFrames: true))
+
+        let thrown = await #expect(throws: NSError.self) {
+            _ = try await session.run()
+        }
+        let error = try #require(thrown)
+
+        #expect(error.domain == "com.apple.ScreenCaptureKit.SCStreamErrorDomain")
+        #expect(service.attemptCount == 4)
+    }
+
+    @Test
+    func `partial video decode keeps valid frame and reports decode failures separately`() async throws {
+        let outputDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("peekaboo-partial-video-test-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: outputDir) }
+        let source = DiagnosticFrameSource(steps: [
+            .invalid("first decode failure"),
+            .valid,
+            .invalid("last decode failure"),
+        ])
+        let session = Self.makeSession(source: source, sourceKind: .video, outputDir: outputDir)
+
+        let result = try await session.run()
+
+        #expect(result.frames.count == 1)
+        #expect(result.stats.framesDropped == 2)
+        #expect(result.stats.decodeFailures == 2)
+        let warning = try #require(result.warnings.first(where: { $0.code == .videoDecodeFailure }))
+        #expect(warning.details?["count"] == "2")
+        #expect(warning.details?["first_error"] == "first decode failure")
+        #expect(warning.details?["last_error"] == "last decode failure")
+        #expect(!result.warnings.contains(where: { $0.code == .noMotion }))
+    }
+
+    @Test
+    func `all-bad video fails with bounded decode diagnostics`() async throws {
+        let outputDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("peekaboo-bad-video-test-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: outputDir) }
+        let source = DiagnosticFrameSource(steps: [
+            .invalid(String(repeating: "界", count: 700)),
+            .invalid(String(repeating: "x", count: 700)),
+        ])
+        let session = Self.makeSession(source: source, sourceKind: .video, outputDir: outputDir)
+
+        let thrown = await #expect(throws: CaptureNoValidFramesError.self) {
+            _ = try await session.run()
+        }
+        let error = try #require(thrown)
+
+        #expect(error.source == .video)
+        #expect(error.decodeFailures == 2)
+        #expect((error.firstDecodeError?.utf8.count ?? 0) <= CaptureDiagnosticSanitizer.maximumUTF8Bytes)
+        #expect((error.lastDecodeError?.utf8.count ?? 0) <= CaptureDiagnosticSanitizer.maximumUTF8Bytes)
+        #expect(error.firstDecodeError?.hasSuffix("…") == true)
+        #expect(error.lastDecodeError?.hasSuffix("…") == true)
+        #expect(error.localizedDescription.contains("Video capture produced no decodable frames"))
+    }
+
+    @Test
+    func `video decode attempts honor max-frames even when every sample is invalid`() async throws {
+        let outputDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("peekaboo-video-attempt-cap-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: outputDir) }
+        let source = DiagnosticFrameSource(steps: Array(repeating: .invalid("bad sample"), count: 10))
+        let session = Self.makeSession(
+            source: source,
+            sourceKind: .video,
+            outputDir: outputDir,
+            maxFrames: 2)
+
+        let thrown = await #expect(throws: CaptureNoValidFramesError.self) {
+            _ = try await session.run()
+        }
+        let error = try #require(thrown)
+
+        #expect(error.framesDropped == 2)
+        #expect(error.decodeFailures == 2)
+        #expect(source.remainingStepCount == 8)
+    }
+
+    @Test
+    func `partial video reports max-frames hit from sample attempts`() async throws {
+        let outputDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("peekaboo-video-partial-cap-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: outputDir) }
+        let source = DiagnosticFrameSource(steps: [.invalid("bad sample"), .valid, .valid])
+        let session = Self.makeSession(
+            source: source,
+            sourceKind: .video,
+            outputDir: outputDir,
+            maxFrames: 2)
+
+        let result = try await session.run()
+
+        #expect(result.frames.count == 1)
+        #expect(result.stats.decodeFailures == 1)
+        #expect(result.stats.maxFramesHit)
+        #expect(result.warnings.contains { $0.code == .frameCap })
+        #expect(source.remainingStepCount == 1)
+    }
+
+    @Test
+    func `cancellation and permanent source errors propagate without no-frame reclassification`() async throws {
+        let cancelDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("peekaboo-cancel-source-\(UUID().uuidString)", isDirectory: true)
+        let failureDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("peekaboo-failed-source-\(UUID().uuidString)", isDirectory: true)
+        defer {
+            try? FileManager.default.removeItem(at: cancelDir)
+            try? FileManager.default.removeItem(at: failureDir)
+        }
+
+        let cancelled = Self.makeSession(
+            source: DiagnosticFrameSource(steps: [.failure(CancellationError())]),
+            sourceKind: .video,
+            outputDir: cancelDir)
+        await #expect(throws: CancellationError.self) {
+            _ = try await cancelled.run()
+        }
+
+        let permanentError = PeekabooError.fileIOError("permanent source failure")
+        let failed = Self.makeSession(
+            source: DiagnosticFrameSource(steps: [.failure(permanentError)]),
+            sourceKind: .video,
+            outputDir: failureDir)
+        let thrown = await #expect(throws: PeekabooError.self) {
+            _ = try await failed.run()
+        }
+        #expect(try #require(thrown).localizedDescription.contains("permanent source failure"))
+    }
+
+    @Test
+    func `video writer is removed when frame persistence fails after append`() async throws {
+        let outputDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("peekaboo-video-abort-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: outputDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(
+            at: outputDir.appendingPathComponent("keep-0001.png"),
+            withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: outputDir) }
+        let videoURL = outputDir.appendingPathComponent("capture.mp4")
+        let session = WatchCaptureSession(
+            dependencies: WatchCaptureDependencies(
+                screenCapture: NoOpScreenCaptureService(),
+                screenService: NoOpScreenService(),
+                frameSource: FakeFrameSource(frameCount: 1, size: CGSize(width: 100, height: 80))),
+            configuration: WatchCaptureConfiguration(
+                scope: CaptureScope(kind: .frontmost),
+                options: Self.options(duration: 1),
+                outputRoot: outputDir,
+                autoclean: WatchAutocleanConfig(minutes: 120, managed: false),
+                sourceKind: .video,
+                videoIn: "/tmp/input.mov",
+                videoOut: videoURL.path,
+                keepAllFrames: true))
+
+        await #expect(throws: PeekabooError.self) {
+            _ = try await session.run()
+        }
+        #expect(!FileManager.default.fileExists(atPath: videoURL.path))
+    }
+
+    private static func makeSession(
+        source: some CaptureFrameSource,
+        sourceKind: CaptureSessionResult.Source,
+        outputDir: URL,
+        maxFrames: Int = 50) -> WatchCaptureSession
+    {
+        WatchCaptureSession(
+            dependencies: WatchCaptureDependencies(
+                screenCapture: NoOpScreenCaptureService(),
+                screenService: NoOpScreenService(),
+                frameSource: source),
+            configuration: WatchCaptureConfiguration(
+                scope: CaptureScope(kind: .frontmost),
+                options: self.options(duration: 1, maxFrames: maxFrames),
+                outputRoot: outputDir,
+                autoclean: WatchAutocleanConfig(minutes: 120, managed: false),
+                sourceKind: sourceKind,
+                videoIn: sourceKind == .video ? "/tmp/input.mov" : nil,
+                keepAllFrames: true))
+    }
+
+    private static func options(duration: TimeInterval, maxFrames: Int = 50) -> CaptureOptions {
+        CaptureOptions(
+            duration: duration,
+            idleFps: 60,
+            activeFps: 60,
+            changeThresholdPercent: 0,
+            heartbeatSeconds: 0,
+            quietMsToIdle: 0,
+            maxFrames: maxFrames,
+            maxMegabytes: nil,
+            highlightChanges: false,
+            captureFocus: .background,
+            resolutionCap: nil,
+            diffStrategy: .fast,
+            diffBudgetMs: nil)
+    }
 }
 
 // MARK: - Fakes
@@ -123,7 +425,7 @@ private final class FakeFrameSource: CaptureFrameSource {
         return (image, meta)
     }
 
-    private static func makeSolidImage(size: CGSize) -> CGImage? {
+    fileprivate static func makeSolidImage(size: CGSize) -> CGImage? {
         let colorSpace = CGColorSpaceCreateDeviceRGB()
         let bytesPerPixel = 4
         let width = Int(size.width)
@@ -139,6 +441,98 @@ private final class FakeFrameSource: CaptureFrameSource {
             space: colorSpace,
             bitmapInfo: CGImageAlphaInfo.noneSkipLast.rawValue)
         return ctx?.makeImage()
+    }
+}
+
+@MainActor
+private final class DiagnosticFrameSource: CaptureFrameSourceDiagnosticsProviding {
+    enum Step {
+        case failure(any Error)
+        case invalid(String)
+        case valid
+    }
+
+    private var steps: [Step]
+    private var decodeErrors: [String] = []
+
+    init(steps: [Step]) {
+        self.steps = steps
+    }
+
+    var remainingStepCount: Int {
+        self.steps.count
+    }
+
+    var captureDiagnostics: CaptureFrameSourceDiagnostics {
+        CaptureFrameSourceDiagnostics(
+            decodeFailures: self.decodeErrors.count,
+            firstDecodeError: self.decodeErrors.first,
+            lastDecodeError: self.decodeErrors.last)
+    }
+
+    func nextFrame() async throws -> (cgImage: CGImage?, metadata: CaptureMetadata)? {
+        guard !self.steps.isEmpty else { return nil }
+        let step = self.steps.removeFirst()
+        let metadata = CaptureMetadata(size: CGSize(width: 100, height: 80), mode: .screen, timestamp: Date())
+        switch step {
+        case let .failure(error):
+            throw error
+        case let .invalid(message):
+            self.decodeErrors.append(message)
+            return (nil, metadata)
+        case .valid:
+            return (FakeFrameSource.makeSolidImage(size: metadata.size), metadata)
+        }
+    }
+}
+
+@MainActor
+private final class AlwaysFailingScreenCaptureService: ScreenCaptureServiceProtocol {
+    let error: any Error
+    private(set) var attemptCount = 0
+
+    init(error: any Error) {
+        self.error = error
+    }
+
+    func captureScreen(
+        displayIndex _: Int?,
+        visualizerMode _: CaptureVisualizerMode,
+        scale _: CaptureScalePreference) async throws -> CaptureResult
+    {
+        self.attemptCount += 1
+        throw self.error
+    }
+
+    func captureWindow(
+        appIdentifier _: String,
+        windowIndex _: Int?,
+        visualizerMode _: CaptureVisualizerMode,
+        scale _: CaptureScalePreference) async throws -> CaptureResult
+    {
+        self.attemptCount += 1
+        throw self.error
+    }
+
+    func captureFrontmost(
+        visualizerMode _: CaptureVisualizerMode,
+        scale _: CaptureScalePreference) async throws -> CaptureResult
+    {
+        self.attemptCount += 1
+        throw self.error
+    }
+
+    func captureArea(
+        _: CGRect,
+        visualizerMode _: CaptureVisualizerMode,
+        scale _: CaptureScalePreference) async throws -> CaptureResult
+    {
+        self.attemptCount += 1
+        throw self.error
+    }
+
+    func hasScreenRecordingPermission() async -> Bool {
+        true
     }
 }
 

--- a/Core/PeekabooCore/Tests/PeekabooAutomationTests/VideoWriterTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooAutomationTests/VideoWriterTests.swift
@@ -3,6 +3,7 @@ import CoreGraphics
 import Foundation
 import PeekabooFoundation
 import Testing
+@testable import PeekabooAutomationKit
 @testable import PeekabooCore
 
 @MainActor
@@ -126,6 +127,47 @@ struct VideoWriterTests {
         let observed = result.frames.map(\.timestampMs)
         #expect(observed == timestamps)
     }
+
+    @Test
+    func `partial video cleanup failure is surfaced and retains the artifact`() throws {
+        let outputDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("peekaboo-video-cleanup-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: outputDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: outputDir) }
+        let output = outputDir.appendingPathComponent("partial.mp4")
+        let writer = try VideoWriter(
+            outputPath: output.path,
+            width: 20,
+            height: 20,
+            fps: 2,
+            fileManager: FailingRemovalFileManager())
+        try Data("partial".utf8).write(to: output)
+
+        let thrown = #expect(throws: PeekabooError.self) {
+            try writer.abortAndRemovePartialOutput()
+        }
+        guard case .fileIOError = try #require(thrown) else {
+            Issue.record("Expected cleanup failure to retain file-I/O identity")
+            return
+        }
+        #expect(FileManager.default.fileExists(atPath: output.path))
+
+        let primary = PeekabooError.captureFailed("frame persistence failed")
+        let combined = try CaptureArtifactCleanupError(
+            primaryError: primary,
+            cleanupError: #require(thrown),
+            artifactPath: output.path)
+        #expect((combined.primaryError as? PeekabooError)?.localizedDescription == primary.localizedDescription)
+        #expect(combined.localizedDescription.contains("Incomplete video cleanup failed"))
+
+        let longPrimary = CaptureArtifactCleanupError(
+            primaryError: PeekabooError.captureFailed(String(repeating: "primary-", count: 200)),
+            cleanupError: PeekabooError.fileIOError("cleanup-marker"),
+            artifactPath: String(repeating: "/long-path", count: 80))
+        #expect(longPrimary.localizedDescription.contains("Incomplete video cleanup failed"))
+        #expect(longPrimary.localizedDescription.contains("cleanup-marker"))
+        #expect(longPrimary.localizedDescription.utf8.count <= 512)
+    }
 }
 
 // MARK: - Test fakes
@@ -232,5 +274,15 @@ private struct NoOpScreenService: ScreenServiceProtocol {
 
     var primaryScreen: ScreenInfo? {
         nil
+    }
+}
+
+private final class FailingRemovalFileManager: FileManager, @unchecked Sendable {
+    override func fileExists(atPath _: String) -> Bool {
+        false
+    }
+
+    override func removeItem(at URL: URL) throws {
+        throw CocoaError(.fileWriteNoPermission, userInfo: [NSFilePathErrorKey: URL.path])
     }
 }

--- a/Core/PeekabooCore/Tests/PeekabooAutomationTests/WatchCLISmokeTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooAutomationTests/WatchCLISmokeTests.swift
@@ -63,4 +63,18 @@ struct WatchCLISmokeTests {
         #expect(result.diffScale == "w256")
         #expect(result.options.diffBudgetMs == 30)
     }
+
+    @Test
+    func `Legacy capture stats decode with zero video failures`() throws {
+        let data = Data("""
+        {
+          "durationMs": 1000, "fpsIdle": 2, "fpsActive": 8, "fpsEffective": 1,
+          "framesKept": 1, "framesDropped": 2, "maxFramesHit": false, "maxMbHit": false
+        }
+        """.utf8)
+
+        let stats = try JSONDecoder().decode(CaptureStats.self, from: data)
+
+        #expect(stats.decodeFailures == 0)
+    }
 }

--- a/Core/PeekabooCore/Tests/PeekabooAutomationTests/WatchCaptureSessionTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooAutomationTests/WatchCaptureSessionTests.swift
@@ -2,11 +2,98 @@
 import CoreGraphics
 import Foundation
 import ImageIO
+import PeekabooFoundation
 import Testing
 import UniformTypeIdentifiers
-@testable import PeekabooAutomationKit
+@testable @_spi(Testing) import PeekabooAutomationKit
 
 struct WatchCaptureSessionTests {
+    @Test
+    @MainActor
+    func `video decoder suspension releases MainActor`() async throws {
+        let image = try #require(WatchCaptureArtifactWriter.makeCGImage(from: Self.makePNG(
+            size: CGSize(width: 20, height: 20))))
+        let decoder = ControlledVideoFrameDecoder(image: image)
+        let source = VideoFrameSource(
+            timeline: VideoFrameTimeline(
+                start: .zero,
+                end: CMTime(seconds: 1, preferredTimescale: 1000),
+                interval: CMTime(seconds: 0.5, preferredTimescale: 1000)),
+            effectiveFPS: 2,
+            decoder: decoder)
+
+        let frameTask = Task { @MainActor in
+            try await source.nextFrame()
+        }
+        await decoder.waitUntilEntered()
+        let mainActorRemainedResponsive = await MainActor.run { true }
+        #expect(mainActorRemainedResponsive)
+        await decoder.release()
+        #expect(try await frameTask.value?.cgImage != nil)
+    }
+
+    @Test
+    @MainActor
+    func `video decoder timeout cancels generator without awaiting noncooperative work`() async throws {
+        let image = try #require(WatchCaptureArtifactWriter.makeCGImage(from: Self.makePNG(
+            size: CGSize(width: 20, height: 20))))
+        let decoder = NoncooperativeVideoFrameDecoder(image: image)
+        let source = VideoFrameSource(
+            timeline: VideoFrameTimeline(
+                start: .zero,
+                end: CMTime(seconds: 1, preferredTimescale: 1000),
+                interval: CMTime(seconds: 0.5, preferredTimescale: 1000)),
+            effectiveFPS: 2,
+            decoder: decoder,
+            decodeTimeout: .milliseconds(30))
+
+        let releaseTask = Task { @MainActor in
+            try? await Task.sleep(for: .milliseconds(300))
+            decoder.release()
+        }
+        let started = ContinuousClock.now
+        let frame = try await source.nextFrame()
+        let elapsed = started.duration(to: .now)
+
+        #expect(frame?.cgImage == nil)
+        #expect(elapsed < .milliseconds(150))
+        #expect(decoder.cancelCount == 1)
+        #expect(source.captureDiagnostics.decodeFailures == 1)
+        await releaseTask.value
+    }
+
+    @Test
+    @MainActor
+    func `video decoder file IO errors are not counted as recoverable decode loss`() async throws {
+        let source = VideoFrameSource(
+            timeline: VideoFrameTimeline(
+                start: .zero,
+                end: CMTime(seconds: 1, preferredTimescale: 1000),
+                interval: CMTime(seconds: 0.5, preferredTimescale: 1000)),
+            effectiveFPS: 2,
+            decoder: FailingVideoFrameDecoder(error: PeekabooError.fileIOError("read failed")))
+
+        let thrown = await #expect(throws: PeekabooError.self) {
+            _ = try await source.nextFrame()
+        }
+        guard case .fileIOError = try #require(thrown) else {
+            Issue.record("Expected file-I/O decode failure to retain its type")
+            return
+        }
+        #expect(source.captureDiagnostics.decodeFailures == 0)
+
+        let recoverable = VideoFrameSource(
+            timeline: VideoFrameTimeline(
+                start: .zero,
+                end: CMTime(seconds: 1, preferredTimescale: 1000),
+                interval: CMTime(seconds: 0.5, preferredTimescale: 1000)),
+            effectiveFPS: 2,
+            decoder: FailingVideoFrameDecoder(error: PeekabooError.captureFailed("decode failed")))
+        let output = try await recoverable.nextFrame()
+        #expect(output?.cgImage == nil)
+        #expect(recoverable.captureDiagnostics.decodeFailures == 1)
+    }
+
     @Test
     func `Fast diff detects change and bounding box`() {
         let prev = WatchFrameDiffer.LumaBuffer(width: 2, height: 2, pixels: [0, 0, 0, 0])
@@ -109,6 +196,88 @@ struct WatchCaptureSessionTests {
         #expect(timeline.next() == .zero)
         #expect(timeline.next() == CMTime(value: 1, timescale: 1000))
         #expect(timeline.next() == CMTime(value: 2, timescale: 1000))
+    }
+
+    @Test
+    func `Video frame timeline treats trim end as exclusive`() {
+        var timeline = VideoFrameTimeline(
+            start: .zero,
+            end: CMTime(value: 2, timescale: 1000),
+            interval: CMTime(value: 1, timescale: 1000))
+
+        #expect(timeline.next() == .zero)
+        #expect(timeline.next() == CMTime(value: 1, timescale: 1000))
+        #expect(timeline.next() == nil)
+    }
+
+    @Test
+    func `Video source rejects invalid sampling trim and resolution admission before file access`() async {
+        let missing = URL(fileURLWithPath: "/tmp/peekaboo-missing-video-\(UUID().uuidString).mov")
+        await #expect(throws: PeekabooError.self) {
+            _ = try await VideoFrameSource(
+                url: missing,
+                sampleFps: 0,
+                everyMs: nil,
+                startMs: nil,
+                endMs: nil,
+                resolutionCap: nil)
+        }
+        await #expect(throws: PeekabooError.self) {
+            _ = try await VideoFrameSource(
+                url: missing,
+                sampleFps: nil,
+                everyMs: 0,
+                startMs: nil,
+                endMs: nil,
+                resolutionCap: nil)
+        }
+        await #expect(throws: PeekabooError.self) {
+            _ = try await VideoFrameSource(
+                url: missing,
+                sampleFps: nil,
+                everyMs: nil,
+                startMs: -1,
+                endMs: nil,
+                resolutionCap: nil)
+        }
+        await #expect(throws: PeekabooError.self) {
+            _ = try await VideoFrameSource(
+                url: missing,
+                sampleFps: nil,
+                everyMs: nil,
+                startMs: nil,
+                endMs: -1,
+                resolutionCap: nil)
+        }
+        await #expect(throws: PeekabooError.self) {
+            _ = try await VideoFrameSource(
+                url: missing,
+                sampleFps: nil,
+                everyMs: nil,
+                startMs: nil,
+                endMs: nil,
+                resolutionCap: 0)
+        }
+    }
+
+    @Test
+    func `Only the observed TCC contention signature receives a transient retry`() {
+        let contention = NSError(
+            domain: "com.apple.ScreenCaptureKit.SCStreamErrorDomain",
+            code: -3801,
+            userInfo: [NSLocalizedDescriptionKey: "The user declined TCC for application, window, display capture"])
+        let invalidParameter = NSError(
+            domain: "com.apple.ScreenCaptureKit.SCStreamErrorDomain",
+            code: -3812,
+            userInfo: [NSLocalizedDescriptionKey: "Invalid parameter"])
+        let unrelatedDenial = NSError(
+            domain: "example.test",
+            code: -3801,
+            userInfo: [NSLocalizedDescriptionKey: "The user declined TCC"])
+
+        #expect(ScreenCaptureKitTransientError.retryDelayNanoseconds(after: contention) != nil)
+        #expect(ScreenCaptureKitTransientError.retryDelayNanoseconds(after: invalidParameter) == nil)
+        #expect(ScreenCaptureKitTransientError.retryDelayNanoseconds(after: unrelatedDenial) == nil)
     }
 
     @Test
@@ -246,7 +415,7 @@ struct WatchCaptureSessionTests {
 
     @Test
     @MainActor
-    func `Stops at size cap and emits warning`() async throws {
+    func `Size cap is honored before any fallback capture`() async throws {
         let png = Self.makePNG(size: CGSize(width: 50, height: 50))
         let capture = StubScreenCaptureService(result: png, size: CGSize(width: 50, height: 50))
         let screens = StubScreenService()
@@ -287,8 +456,10 @@ struct WatchCaptureSessionTests {
             autoclean: WatchAutocleanConfig(minutes: 1, managed: false))
         let session = WatchCaptureSession(dependencies: dependencies, configuration: configuration)
 
-        let result = try await session.run()
-        #expect(result.warnings.contains { $0.code == .sizeCap })
+        let thrown = await #expect(throws: CaptureNoValidFramesError.self) {
+            _ = try await session.run()
+        }
+        #expect(try #require(thrown).framesDropped == 0)
     }
 
     @Test
@@ -338,7 +509,61 @@ struct WatchCaptureSessionTests {
 
     @Test
     @MainActor
-    func `Stop request wakes transient capture backoff`() async throws {
+    func `Stop request returns while an in-flight frame source ignores cancellation`() async throws {
+        let image = try #require(WatchCaptureArtifactWriter.makeCGImage(from: Self.makePNG(
+            size: CGSize(width: 20, height: 20))))
+        let source = NoncooperativeCaptureFrameSource(image: image)
+        let output = FileManager.default.temporaryDirectory
+            .appendingPathComponent("watch-noncooperative-stop-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: output) }
+        let options = CaptureOptions(
+            duration: 30,
+            idleFps: 5,
+            activeFps: 5,
+            changeThresholdPercent: 100,
+            heartbeatSeconds: 0,
+            quietMsToIdle: 0,
+            maxFrames: 10,
+            maxMegabytes: nil,
+            highlightChanges: false,
+            captureFocus: .background,
+            resolutionCap: nil,
+            diffStrategy: .fast,
+            diffBudgetMs: nil)
+        let session = WatchCaptureSession(
+            dependencies: WatchCaptureDependencies(
+                screenCapture: StubScreenCaptureService(
+                    result: Self.makePNG(size: CGSize(width: 20, height: 20)),
+                    size: CGSize(width: 20, height: 20)),
+                screenService: StubScreenService(),
+                frameSource: source),
+            configuration: WatchCaptureConfiguration(
+                scope: CaptureScope(kind: .frontmost),
+                options: options,
+                outputRoot: output,
+                autoclean: WatchAutocleanConfig(minutes: 1, managed: false),
+                sourceKind: .live,
+                keepAllFrames: true))
+
+        let task = Task { @MainActor in try await session.run() }
+        await source.waitUntilBlocked()
+        let releaseTask = Task { @MainActor in
+            try? await Task.sleep(for: .milliseconds(300))
+            source.release()
+        }
+        let started = ContinuousClock.now
+        session.requestStop()
+        let result = try await task.value
+        let elapsed = started.duration(to: .now)
+
+        #expect(result.frames.count == 1)
+        #expect(elapsed < .milliseconds(150))
+        await releaseTask.value
+    }
+
+    @Test
+    @MainActor
+    func `Stop request cancels in-flight transient capture backoff`() async throws {
         let png = Self.makePNG(size: CGSize(width: 20, height: 20))
         let capture = StubTransientScreenCaptureService(result: png, size: CGSize(width: 20, height: 20))
         let screens = StubScreenService()
@@ -395,7 +620,11 @@ struct WatchCaptureSessionTests {
 
         print("PROOF transient_stop_elapsed_ms=\(Int(stopElapsed * 1000))")
 
-        #expect(result.warnings.contains { $0.code == .transientCaptureFailure })
+        // The fallback runner owns this retry and cancellation wins before it surfaces an error
+        // to the session, so reporting a dropped transient frame here would be fabricated.
+        #expect(!result.warnings.contains { $0.code == .transientCaptureFailure })
+        #expect(result.frames.count == 1)
+        #expect(result.warnings.contains { $0.code == .noMotion })
         // Unfixed raw Task.sleep still waits ~350ms before the loop can observe stop.
         #expect(stopElapsed < 0.08)
     }
@@ -571,6 +800,133 @@ struct WatchCaptureSessionTests {
 
 // MARK: - Stubs
 
+private final class NoncooperativeVideoFrameDecoder: @unchecked Sendable, VideoFrameDecoding {
+    private let lock = NSLock()
+    private let image: CGImage
+    private var releaseContinuation: CheckedContinuation<Void, Never>?
+    private var cancellationCount = 0
+
+    init(image: CGImage) {
+        self.image = image
+    }
+
+    func image(at time: CMTime) async throws -> (image: CGImage, actualTime: CMTime) {
+        await withCheckedContinuation { continuation in
+            self.lock.lock()
+            self.releaseContinuation = continuation
+            self.lock.unlock()
+        }
+        return (self.image, time)
+    }
+
+    func cancelPendingDecodes() {
+        self.lock.lock()
+        self.cancellationCount += 1
+        self.lock.unlock()
+    }
+
+    var cancelCount: Int {
+        self.lock.lock()
+        defer { self.lock.unlock() }
+        return self.cancellationCount
+    }
+
+    func release() {
+        self.lock.lock()
+        let continuation = self.releaseContinuation
+        self.releaseContinuation = nil
+        self.lock.unlock()
+        continuation?.resume()
+    }
+}
+
+@MainActor
+private final class NoncooperativeCaptureFrameSource: CaptureFrameSource {
+    private let image: CGImage
+    private var callCount = 0
+    private var blocked = false
+    private var blockedContinuation: CheckedContinuation<Void, Never>?
+    private var releaseContinuation: CheckedContinuation<Void, Never>?
+
+    init(image: CGImage) {
+        self.image = image
+    }
+
+    func nextFrame() async throws -> (cgImage: CGImage?, metadata: CaptureMetadata)? {
+        self.callCount += 1
+        if self.callCount == 1 {
+            return (self.image, self.metadata)
+        }
+        self.blocked = true
+        self.blockedContinuation?.resume()
+        self.blockedContinuation = nil
+        await withCheckedContinuation { continuation in
+            self.releaseContinuation = continuation
+        }
+        return (self.image, self.metadata)
+    }
+
+    func waitUntilBlocked() async {
+        guard !self.blocked else { return }
+        await withCheckedContinuation { continuation in
+            self.blockedContinuation = continuation
+        }
+    }
+
+    func release() {
+        self.releaseContinuation?.resume()
+        self.releaseContinuation = nil
+    }
+
+    private var metadata: CaptureMetadata {
+        CaptureMetadata(
+            size: CGSize(width: self.image.width, height: self.image.height),
+            mode: .screen,
+            timestamp: Date())
+    }
+}
+
+private actor ControlledVideoFrameDecoder: VideoFrameDecoding {
+    private let image: CGImage
+    private var entered = false
+    private var enteredContinuation: CheckedContinuation<Void, Never>?
+    private var releaseContinuation: CheckedContinuation<Void, Never>?
+
+    init(image: CGImage) {
+        self.image = image
+    }
+
+    func image(at time: CMTime) async throws -> (image: CGImage, actualTime: CMTime) {
+        self.entered = true
+        self.enteredContinuation?.resume()
+        self.enteredContinuation = nil
+        await withCheckedContinuation { continuation in
+            self.releaseContinuation = continuation
+        }
+        return (self.image, time)
+    }
+
+    func waitUntilEntered() async {
+        guard !self.entered else { return }
+        await withCheckedContinuation { continuation in
+            self.enteredContinuation = continuation
+        }
+    }
+
+    func release() {
+        self.releaseContinuation?.resume()
+        self.releaseContinuation = nil
+    }
+}
+
+private struct FailingVideoFrameDecoder: VideoFrameDecoding {
+    let error: any Error & Sendable
+
+    func image(at _: CMTime) async throws -> (image: CGImage, actualTime: CMTime) {
+        throw self.error
+    }
+}
+
 @MainActor
 private final class StubTransientScreenCaptureService: ScreenCaptureServiceProtocol {
     private let success: StubScreenCaptureService
@@ -617,14 +973,22 @@ private final class StubTransientScreenCaptureService: ScreenCaptureServiceProto
         visualizerMode: CaptureVisualizerMode,
         scale: CaptureScalePreference) async throws -> CaptureResult
     {
-        self.attemptCount += 1
-        if self.attemptCount == 1 {
+        if self.attemptCount == 0 {
+            self.attemptCount += 1
             return try await self.success.captureFrontmost(
                 visualizerMode: visualizerMode,
                 scale: scale)
         }
-        self.onTransientFailure?()
-        throw Self.transientError
+        let runner = ScreenCaptureFallbackRunner(apis: [.modern])
+        return try await runner.run(
+            operationName: "captureFrontmost",
+            logger: MockLoggingService().logger(category: "test"),
+            correlationId: "watch-stop-inner-retry")
+        { _ in
+            self.attemptCount += 1
+            self.onTransientFailure?()
+            throw Self.transientError
+        }
     }
 
     func captureArea(

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/CaptureToolPathResolverTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/CaptureToolPathResolverTests.swift
@@ -1,10 +1,12 @@
 import Foundation
+import MCP
 import PeekabooAutomation
 import PeekabooAutomationKit
 import PeekabooFoundation
 import TachikomaMCP
 import Testing
 @testable import PeekabooAgentRuntime
+@testable import PeekabooCore
 
 struct CaptureToolPathResolverTests {
     @Test
@@ -174,6 +176,134 @@ struct CaptureToolPathResolverTests {
         }
     }
 
+    @Test
+    func `no-valid-frame MCP response preserves retry and focus effect honesty`() throws {
+        let error = CaptureNoValidFramesError(
+            source: .video,
+            framesDropped: 3,
+            decodeFailures: 3,
+            firstDecodeError: "first",
+            lastDecodeError: "last",
+            lastCaptureError: nil)
+
+        let background = CaptureTool.failureResponse(error, mutationDispatched: false)
+        let backgroundMeta = try #require(Self.meta(from: background))
+        #expect(background.isError)
+        #expect(backgroundMeta["error_code"] == .string("CAPTURE_NO_VALID_FRAMES"))
+        #expect(backgroundMeta["retry_safe"] == .bool(true))
+        #expect(backgroundMeta["mutation_dispatched"] == .bool(false))
+        #expect(backgroundMeta["effect"] == nil)
+        #expect(backgroundMeta["decode_failures"] == .int(3))
+
+        let foreground = CaptureTool.failureResponse(error, mutationDispatched: true)
+        let foregroundMeta = try #require(Self.meta(from: foreground))
+        #expect(foregroundMeta["effect"] == .string("partial"))
+        #expect(foregroundMeta["mutation_dispatched"] == .bool(true))
+        #expect(foregroundMeta["retry_safe"] == .bool(false))
+    }
+
+    @Test
+    func `all MCP capture failures preserve actual focus dispatch receipts`() throws {
+        let error = PeekabooError.fileIOError("metadata write failed")
+        let background = CaptureTool.failureResponse(error, mutationDispatched: false)
+        let foreground = CaptureTool.failureResponse(error, mutationDispatched: true)
+        let backgroundMeta = try #require(Self.meta(from: background))
+        let foregroundMeta = try #require(Self.meta(from: foreground))
+
+        #expect(background.isError)
+        #expect(backgroundMeta["mutation_dispatched"] == .bool(false))
+        #expect(backgroundMeta["retry_safe"] == .bool(true))
+        #expect(backgroundMeta["effect"] == nil)
+        #expect(foreground.isError)
+        #expect(foregroundMeta["mutation_dispatched"] == .bool(true))
+        #expect(foregroundMeta["retry_safe"] == .bool(false))
+        #expect(foregroundMeta["effect"] == .string("partial"))
+    }
+
+    @Test
+    @MainActor
+    func `capture request setup failure returns explicit pre-dispatch receipt`() async throws {
+        let response = try await CaptureTool(context: MCPToolContext(services: PeekabooServices())).execute(
+            arguments: ToolArguments(raw: ["source": "camera"]))
+        let meta = try #require(Self.meta(from: response))
+
+        #expect(response.isError)
+        #expect(meta["mutation_dispatched"] == .bool(false))
+        #expect(meta["retry_safe"] == .bool(true))
+        #expect(meta["effect"] == nil)
+    }
+
+    @Test
+    @MainActor
+    func `partial focus failure returns conservative capture dispatch receipt`() async throws {
+        let focusError = PeekabooError.operationError(message: "focus verification failed after dispatch")
+        let windows = CaptureWindowResolverWindowService(
+            windows: [Self.window(id: 42, title: "Main Document", index: 0)],
+            focusError: focusError)
+        let services = PeekabooServices()
+        let context = MCPToolContext(
+            automation: services.automation,
+            menu: services.menu,
+            windows: windows,
+            applications: services.applications,
+            dialogs: services.dialogs,
+            dock: services.dock,
+            screenCapture: services.screenCapture,
+            desktopObservation: services.desktopObservation,
+            snapshots: services.snapshots,
+            screens: services.screens,
+            agent: services.agent,
+            permissions: services.permissions,
+            clipboard: services.clipboard,
+            browser: services.browser)
+        let response = try await CaptureTool(context: context).execute(arguments: ToolArguments(raw: [
+            "source": "live",
+            "mode": "window",
+            "app": "TextEdit",
+            "window_title": "Main Document",
+            "capture_focus": "foreground",
+        ]))
+        let meta = try #require(Self.meta(from: response))
+
+        #expect(response.isError)
+        #expect(windows.focusCallCount == 1)
+        #expect(meta["mutation_dispatched"] == .bool(true))
+        #expect(meta["retry_safe"] == .bool(false))
+        #expect(meta["effect"] == .string("partial"))
+    }
+
+    @Test
+    @MainActor
+    func `successful image response reports actual focus dispatch`() throws {
+        let tool = ImageTool(context: MCPToolContext(services: PeekabooServices()))
+        let background = tool.buildCaptureResponse(
+            format: .png,
+            savedFiles: [],
+            captureResults: [],
+            observation: nil,
+            mutationDispatched: false)
+        let foreground = tool.buildCaptureResponse(
+            format: .png,
+            savedFiles: [],
+            captureResults: [],
+            observation: nil,
+            mutationDispatched: true)
+        let backgroundMeta = try #require(Self.meta(from: background))
+        let foregroundMeta = try #require(Self.meta(from: foreground))
+
+        #expect(backgroundMeta["mutation_dispatched"] == .bool(false))
+        #expect(backgroundMeta["retry_safe"] == .bool(true))
+        #expect(backgroundMeta["effect"] == nil)
+        #expect(foregroundMeta["mutation_dispatched"] == .bool(true))
+        #expect(foregroundMeta["retry_safe"] == .bool(false))
+        #expect(foregroundMeta["effect"] == nil)
+    }
+
+    private static func meta(from response: ToolResponse) -> [String: Value]? {
+        guard case let .object(meta) = response.meta else { return nil }
+        return meta
+    }
+
     private static func window(
         id: Int,
         title: String,
@@ -190,10 +320,13 @@ struct CaptureToolPathResolverTests {
 
 private final class CaptureWindowResolverWindowService: WindowManagementServiceProtocol, @unchecked Sendable {
     let windows: [ServiceWindowInfo]
+    let focusError: (any Error)?
     var requestedTargets: [WindowTarget] = []
+    var focusCallCount = 0
 
-    init(windows: [ServiceWindowInfo]) {
+    init(windows: [ServiceWindowInfo], focusError: (any Error)? = nil) {
         self.windows = windows
+        self.focusError = focusError
     }
 
     func closeWindow(target _: WindowTarget) async throws {}
@@ -208,7 +341,12 @@ private final class CaptureWindowResolverWindowService: WindowManagementServiceP
 
     func setWindowBounds(target _: WindowTarget, bounds _: CGRect) async throws {}
 
-    func focusWindow(target _: WindowTarget) async throws {}
+    func focusWindow(target _: WindowTarget) async throws {
+        self.focusCallCount += 1
+        if let focusError {
+            throw focusError
+        }
+    }
 
     func listWindows(target: WindowTarget) async throws -> [ServiceWindowInfo] {
         self.requestedTargets.append(target)

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/PeekabooMCPServerTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/PeekabooMCPServerTests.swift
@@ -58,6 +58,35 @@ struct PeekabooMCPServerTests {
     }
 
     @Test
+    func `server projects bounded capture failure metadata onto the MCP wire`() throws {
+        let response = ToolResponse.error(
+            "Video capture produced no decodable frames.",
+            meta: .object([
+                "decode_failures": .int(3),
+                "effect": .string("partial"),
+                "error_code": .string("CAPTURE_NO_VALID_FRAMES"),
+                "first_decode_error": .string("first"),
+                "internal_diagnostics": .string("private"),
+                "mutation_dispatched": .bool(true),
+                "retry_safe": .bool(false),
+                "source": .string("video"),
+            ]))
+
+        let result = PeekabooMCPServer.callToolResult(from: response, toolName: "capture")
+        let data = try JSONEncoder().encode(result)
+        let json = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let metadata = try #require(json["_meta"] as? [String: Any])
+
+        #expect(metadata["error_code"] as? String == "CAPTURE_NO_VALID_FRAMES")
+        #expect(metadata["effect"] as? String == "partial")
+        #expect(metadata["mutation_dispatched"] as? Bool == true)
+        #expect(metadata["retry_safe"] as? Bool == false)
+        #expect(metadata["decode_failures"] as? Int == 3)
+        #expect(metadata["source"] as? String == "video")
+        #expect(metadata["internal_diagnostics"] == nil)
+    }
+
+    @Test
     @MainActor
     func `server filters action-only tools with runtime input policy`() async throws {
         let services = PeekabooServices(inputPolicy: UIInputPolicy(

--- a/Core/PeekabooCore/Tests/PeekabooTests/ScreenCaptureFallbackRunnerTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/ScreenCaptureFallbackRunnerTests.swift
@@ -1,5 +1,6 @@
 import CoreGraphics
 import Foundation
+import PeekabooFoundation
 import Testing
 @_spi(Testing) import PeekabooAutomationKit
 
@@ -149,6 +150,90 @@ struct ScreenCaptureFallbackRunnerTests {
 
         #expect(value == "ok_modern")
         #expect(calls == [.modern, .modern])
+    }
+
+    @MainActor
+    @Test
+    func `permanent retry error replaces the first transient denial`() async {
+        let logger = LoggingService(subsystem: "test.logger").logger(category: "test")
+        let runner = ScreenCaptureFallbackRunner(apis: [.modern])
+        var genericAttempts = 0
+        let genericError = PeekabooError.fileIOError("retry file failure")
+
+        let genericThrown = await #expect(throws: PeekabooError.self) {
+            _ = try await runner.run(
+                operationName: "test",
+                logger: logger,
+                correlationId: "retry-generic")
+            { _ -> String in
+                genericAttempts += 1
+                if genericAttempts == 1 {
+                    throw Self.transientDenial
+                }
+                throw genericError
+            }
+        }
+        guard case .fileIOError = genericThrown else {
+            Issue.record("Expected generic retry to retain the permanent file error")
+            return
+        }
+
+        var captureAttempts = 0
+        let captureThrown = await #expect(throws: PeekabooError.self) {
+            _ = try await runner.runCapture(
+                operationName: "capture",
+                logger: logger,
+                correlationId: "retry-capture")
+            { _ in
+                captureAttempts += 1
+                if captureAttempts == 1 {
+                    throw Self.transientDenial
+                }
+                throw genericError
+            }
+        }
+        guard case .fileIOError = captureThrown else {
+            Issue.record("Expected capture retry to retain the permanent file error")
+            return
+        }
+    }
+
+    @MainActor
+    @Test
+    func `retry cancellation never dispatches a fallback capture API`() async {
+        let logger = LoggingService(subsystem: "test.logger").logger(category: "test")
+        let runner = ScreenCaptureFallbackRunner(apis: [.modern, .legacy])
+        var genericCalls: [ScreenCaptureAPI] = []
+        await #expect(throws: CancellationError.self) {
+            _ = try await runner.run(
+                operationName: "test",
+                logger: logger,
+                correlationId: "cancel-generic-fallback")
+            { api -> String in
+                genericCalls.append(api)
+                if genericCalls.count == 1 {
+                    throw Self.transientDenial
+                }
+                throw CancellationError()
+            }
+        }
+        #expect(genericCalls == [.modern, .modern])
+
+        var captureCalls: [ScreenCaptureAPI] = []
+        await #expect(throws: CancellationError.self) {
+            _ = try await runner.runCapture(
+                operationName: "capture",
+                logger: logger,
+                correlationId: "cancel-capture-fallback")
+            { api in
+                captureCalls.append(api)
+                if captureCalls.count == 1 {
+                    throw Self.transientDenial
+                }
+                throw CancellationError()
+            }
+        }
+        #expect(captureCalls == [.modern, .modern])
     }
 
     @MainActor

--- a/docs/commands/capture.md
+++ b/docs/commands/capture.md
@@ -23,7 +23,7 @@ The MCP server exposes the same primitive as the `capture` tool. MCP arguments u
 - `metadata.json` (`CaptureResult`) with stats, warnings, grid info, and source (live|video)
 - Optional MP4 (`--video-out`) built from kept frames
 
-For `capture video`, `metadata.json` and JSON stdout include `options.video` with the requested sampling/trim options plus the effective FPS used by the frame reader.
+For `capture video`, `metadata.json` and JSON stdout include `options.video` with the requested sampling/trim options plus the effective FPS used by the frame reader. `stats.decodeFailures` identifies the decode-failure subset of `stats.framesDropped`; ordinary diff drops remain in `framesDropped` without increasing `decodeFailures`. A bounded `videoDecodeFailure` warning retains the first and last decode errors when later samples still succeed.
 
 ## `capture live` flags
 - Targeting: `--mode screen|window|frontmost|area`, `--screen-index`, `--app`, `--pid`, `--window-title`, `--window-index`, `--region x,y,width,height` (global coords)
@@ -48,7 +48,11 @@ The command exits non-zero if the child command exits non-zero, times out, or re
 - Caps/output: `--max-frames`, `--max-mb`, `--resolution-cap` (default 1440), `--diff-strategy`, `--diff-budget`, `--video-out`
 - Paths: `--path`, `--autoclean`
 
-Validation: video source rejects targeting/focus/cadence flags; live rejects sampling/trim/no-diff. Video runs may keep a single frame when no motion is detected (emits a `noMotion` warning) instead of failing.
+Validation: video source rejects targeting/focus/cadence flags; live rejects sampling/trim/no-diff. Video runs may keep a single valid frame when no motion is detected (emits a `noMotion` warning) instead of failing. A partial decode run remains successful but reports `decodeFailures` and `videoDecodeFailure`; it is not mislabeled as no motion when decode loss leaves only one valid frame.
+
+Live and video sessions require at least one valid image. Peekaboo fails before contact-sheet or metadata creation with `CAPTURE_NO_VALID_FRAMES` and the bounded capture/decode cause; cancellation, permanent capture failures, and file/video-writer errors keep their original error instead. Retry metadata follows actual dispatch: a read-only capture reports `mutation_dispatched: false` and `retry_safe: true`, while a completed focus operation or `capture action` child dispatch reports `mutation_dispatched: true`, `effect: partial`, and `retry_safe: false`.
+
+An explicit `--path` may reuse an existing directory only when it contains no prior capture-owned `contact.png`, `metadata.json`, or `keep-*.png` artifacts. Choose a new directory when rerunning a capture instead of silently reusing stale output.
 
 ## Examples
 ```bash
@@ -75,8 +79,9 @@ peekaboo capture video /path/to/demo.mov --every 500ms --no-diff
 - Live defaults: max duration 180s, `--max-frames` 800, resolution cap 1440, diff strategy `fast` unless `--diff-strategy quality` is set.
 - Action capture uses the same live sampler and can stop it early once the child command and post-roll complete.
 - Background live capture of an exact PID/window reacquires a generation-pinned read lane for each frame. Unrelated app mutations can overlap, while a queued mutation for the captured process runs before the next frame. Screen, area, frontmost, unresolved, foreground, and focus-capable observations remain globally exclusive.
-- Video ingest uses the same diff/keep logic as live; `--no-diff` keeps every sampled frame. When no motion is detected, you may end up with a single kept frame plus a `noMotion` warning.
-- Core types: `CaptureScope/Options/Result` with a pluggable `CaptureFrameSource` (ScreenCapture for live, AVAssetReader for video). Optional MP4 is written by `VideoWriter` when `--video-out` is set.
+- Video ingest uses the same diff/keep logic as live; `--no-diff` keeps every sampled frame. `--max-frames` also bounds video sample attempts, 32 consecutive decode failures stop sampling early, and each decode has a five-second deadline that cancels pending generator work. Negative/zero sampling values and trim offsets are rejected, trim end is exclusive and capped to the asset duration, and the resolution cap must be positive and finite. When no motion is detected without capture/decode loss, you may end up with a single kept frame plus a `noMotion` warning. Undecodable samples remain bounded warnings when later samples succeed; if every admitted sample is invalid, the command fails instead of returning an empty contact sheet.
+- MP4 output is transactional with session success: writer, frame, contact-sheet, metadata, or cancellation failures cancel the writer and remove its incomplete output. If removal itself fails, Peekaboo reports that cleanup failure alongside the primary capture error instead of silently leaving a corrupt artifact. Contact-sheet creation fails if any advertised source frame is unreadable instead of emitting blank cells with false sampled indexes.
+- Core types: `CaptureScope/Options/Result` with a pluggable `CaptureFrameSource` (ScreenCapture for live, asynchronous AVAssetImageGenerator sampling for video). Optional MP4 is written by `VideoWriter` when `--video-out` is set.
 - Quick smokes:
   - `peekaboo capture live --mode screen --duration 5s --active-fps 8 --threshold 0` → frames > 0, contact sheet exists.
   - `peekaboo capture video /path/demo.mov --sample-fps 2 --start 5s --video-out /tmp/demo.mp4` → ≥2 kept frames and MP4 written.


### PR DESCRIPTION
## Summary

- Fail empty live/video sessions with typed `CAPTURE_NO_VALID_FRAMES` errors while preserving cancellation, permanent capture, and file/writer errors.
- Bound video sampling and individual decode work, cancel pending generator work on timeout, make stop responsive to noncooperative frame sources, and surface incomplete-MP4 cleanup failures without losing the primary error.
- Carry conservative mutation/effect/retry receipts through CLI JSON, external MCP, the internal agent bridge, and execution traces; reject stale capture-owned output instead of reusing it.

Background capture remains the default. Foreground focus is still explicit, and any focus-capable or child-dispatch failure is reported as partial and retry-unsafe. No AppleScript path is introduced or used.

## Documentation

- Updated both changelogs.
- Documented decode limits, transactional MP4 cleanup, stale-output refusal, and the existing exact-window background read-lane behavior.

## Proof

- Exact `aaed5ced` rebase: 52 focused Core tests (capture MCP/path, capture session, video writer, and watch session) and 11 CLI result-envelope tests passed.
- Earlier complete serialized gates: Core 1,293 Peekaboo + 51 Automation + 119 AgentRuntime tests; AutomationKit 499/499; safe gate 765 + 72 runtime tests.
- Source-blind behavior validation: 7/7 clauses, including varied 2-sample/1-sample decode failures, real stdio MCP metadata, and independently decoded PNG/contact-sheet/metadata/MP4 artifacts (`/tmp/behavior-validator-capture-rerun.9eEQ9A`).
- SwiftFormat; strict SwiftLint 0/0 across 38 touched Swift files; docs lint and diff check clean.
- Final P0-P2 Autoreview and secret scan clean. The production/test patch hash is unchanged by the latest-main rebase; only changelog/docs conflicts were reconciled to preserve both streams.
