### PR TITLE
fix: require foreground consent for global UI

### DIFF
--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Default new agent configurations to GPT-5.6 and Claude Opus 5 while keeping credential-only Anthropic discovery on Opus 4.8 for zero-retention compatibility and preserving explicit model selections.
 
 ### Fixed
+- Require explicit `--foreground` consent before `menubar click` can inspect or open global status-item UI; keep `menubar list` read-only and report missing items as typed retry-safe pre-dispatch refusals.
 - Keep background app launch/open ownership through verified focus reconciliation, restoring only the exact prior process generation without overriding a later user foreground choice.
 - Stop probing, requesting, advertising, or showing AppleScript Automation permission now that application, Dock, and UI operations use native macOS APIs; remove AppleScript code from shipped executables while retaining legacy wire/error decoding for older Bridge hosts.
 - Return generation-pinned CG window inventory promptly when AX enrichment stalls; detached per-process enrichment no longer holds Bridge requests after caller timeout or disconnect.

--- a/Apps/CLI/Sources/PeekabooCLI/CLI/Output/JSONOutput.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/CLI/Output/JSONOutput.swift
@@ -24,8 +24,25 @@ extension ConfirmedActionOutputFormattable { var defaultEffect: ActionEffect? {
 } }
 
 nonisolated protocol ResultEnvelopeError: Error, Sendable {
+    var envelopeCode: ErrorCode? { get }
     var envelopeEffect: ActionEffect? { get }
     var envelopeHint: String? { get }
+    var envelopeRetrySafe: Bool? { get }
+    var envelopeMutationDispatched: Bool? { get }
+}
+
+extension ResultEnvelopeError {
+    nonisolated var envelopeCode: ErrorCode? {
+        nil
+    }
+
+    nonisolated var envelopeRetrySafe: Bool? {
+        nil
+    }
+
+    nonisolated var envelopeMutationDispatched: Bool? {
+        nil
+    }
 }
 
 struct ActionRefusalError: LocalizedError, ResultEnvelopeError {
@@ -42,6 +59,36 @@ struct ActionRefusalError: LocalizedError, ResultEnvelopeError {
 
     nonisolated var envelopeHint: String? {
         self.hint
+    }
+}
+
+struct PreDispatchActionError: LocalizedError, ResultEnvelopeError {
+    let message: String
+    let code: ErrorCode
+    let hint: String?
+
+    nonisolated var errorDescription: String? {
+        self.message
+    }
+
+    nonisolated var envelopeCode: ErrorCode? {
+        self.code
+    }
+
+    nonisolated var envelopeEffect: ActionEffect? {
+        .refused
+    }
+
+    nonisolated var envelopeHint: String? {
+        self.hint
+    }
+
+    nonisolated var envelopeRetrySafe: Bool? {
+        true
+    }
+
+    nonisolated var envelopeMutationDispatched: Bool? {
+        false
     }
 }
 
@@ -128,7 +175,7 @@ func splitErrorHint(from text: String) -> (message: String, hint: String?) {
     return (text, nil)
 }
 
-enum ErrorCode: String, Codable {
+nonisolated enum ErrorCode: String, Codable, Sendable {
     case PERMISSION_ERROR_SCREEN_RECORDING, PERMISSION_ERROR_ACCESSIBILITY
     case PERMISSION_ERROR_EVENT_SYNTHESIZING, PERMISSION_ERROR_APPLESCRIPT, PERMISSION_DENIED
     case APP_NOT_FOUND, AMBIGUOUS_APP_IDENTIFIER, WINDOW_NOT_FOUND, CAPTURE_FAILED, FILE_IO_ERROR

--- a/Apps/CLI/Sources/PeekabooCLI/CLI/PeekabooEntryPoint.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/CLI/PeekabooEntryPoint.swift
@@ -77,20 +77,31 @@ private func printCommanderError(_ error: CommanderProgramError, jsonOutput: Boo
 }
 
 private func printGenericError(_ error: any Error, jsonOutput: Bool) {
-    let code: ErrorCode = if error is CommanderBindingError || error is CommanderUsageError {
+    let envelopeError = error as? any ResultEnvelopeError
+    let fallbackCode: ErrorCode = if error is CommanderBindingError || error is CommanderUsageError {
         .INVALID_ARGUMENT
     } else if error is Commander.ValidationError {
         .VALIDATION_ERROR
     } else {
         .UNKNOWN_ERROR
     }
+    let code = envelopeError?.envelopeCode ?? fallbackCode
 
     guard jsonOutput else {
-        fputs("Error: \(error.localizedDescription)\n", stderr)
+        let hint = envelopeError?.envelopeHint.map { " Hint: \($0)" } ?? ""
+        fputs("Error: \(error.localizedDescription)\(hint)\n", stderr)
         return
     }
 
     let logger = Logger.shared
     logger.setJsonOutputMode(true)
-    outputError(message: error.localizedDescription, code: code, logger: logger)
+    outputError(
+        message: error.localizedDescription,
+        code: code,
+        hint: envelopeError?.envelopeHint,
+        effect: envelopeError?.envelopeEffect,
+        retrySafe: envelopeError?.envelopeRetrySafe,
+        mutationDispatched: envelopeError?.envelopeMutationDispatched,
+        logger: logger
+    )
 }

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommandErrorHandling.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommandErrorHandling.swift
@@ -16,7 +16,8 @@ extension ErrorHandlingCommand {
     /// Handle errors with appropriate output format
     func handleError(_ error: any Error, customCode: ErrorCode? = nil) {
         if jsonOutput {
-            let errorCode = customCode ?? self.mapErrorToCode(error)
+            let envelopeError = error as? any ResultEnvelopeError
+            let errorCode = customCode ?? envelopeError?.envelopeCode ?? self.mapErrorToCode(error)
             let captureReceipt = self.captureFailureReceipt(for: error)
             let logger: Logger = if let formattable = self as? any OutputFormattable {
                 formattable.outputLogger
@@ -26,16 +27,16 @@ extension ErrorHandlingCommand {
             outputError(
                 message: errorMessage(for: error),
                 code: errorCode,
-                hint: (error as? any ResultEnvelopeError)?.envelopeHint,
+                hint: envelopeError?.envelopeHint,
                 details: errorDetails(for: error),
                 effect: captureReceipt?.mutationDispatched == true
                     ? .partial
-                    : (error as? any ResultEnvelopeError)?.envelopeEffect ??
+                    : envelopeError?.envelopeEffect ??
                     ((self as? any ActionOutputFormattable)?.defaultEffect == nil
                         ? nil
                         : defaultActionErrorEffect(errorCode)),
-                retrySafe: captureReceipt?.retrySafe,
-                mutationDispatched: captureReceipt?.mutationDispatched,
+                retrySafe: captureReceipt?.retrySafe ?? envelopeError?.envelopeRetrySafe,
+                mutationDispatched: captureReceipt?.mutationDispatched ?? envelopeError?.envelopeMutationDispatched,
                 logger: logger
             )
         } else {

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/DockCommand+Launch.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/DockCommand+Launch.swift
@@ -7,12 +7,16 @@ extension DockCommand {
     // MARK: - Launch from Dock
 
     @MainActor
-    struct LaunchSubcommand: ConfirmedActionOutputFormattable, OutputFormattable, InjectedRuntimeBackedCommand {
+    struct LaunchSubcommand: ConfirmedActionOutputFormattable, ErrorHandlingCommand, OutputFormattable,
+    InjectedRuntimeBackedCommand {
         @Argument(help: "Application name in the Dock")
         var app: String
 
         @Flag(help: "Verify the app is running after launch")
         var verify = false
+
+        @Flag(help: "Confirm activation of the Dock item and its application")
+        var foreground = false
         @RuntimeStorage var runtime: CommandRuntime?
 
         @MainActor
@@ -21,6 +25,12 @@ extension DockCommand {
             self.logger.setJsonOutputMode(self.jsonOutput)
 
             do {
+                guard self.foreground else {
+                    throw ActionRefusalError(
+                        message: "dock launch activates its target and requires explicit foreground consent.",
+                        hint: "Use --foreground to allow the Dock and target application to come forward."
+                    )
+                }
                 self.resolvedRuntime.beginInteractionMutation()
                 try await DockServiceBridge.launchFromDock(dock: self.services.dock, appName: self.app)
                 let dockItem = try await DockServiceBridge.findDockItem(dock: self.services.dock, name: self.app)
@@ -44,7 +54,7 @@ extension DockCommand {
                 handleDockServiceError(error, jsonOutput: self.jsonOutput, logger: self.outputLogger)
                 throw ExitCode(1)
             } catch {
-                handleGenericError(error, jsonOutput: self.jsonOutput, logger: self.outputLogger)
+                self.handleError(error)
                 throw ExitCode(1)
             }
         }

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/DockCommand+RightClick.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/DockCommand+RightClick.swift
@@ -5,12 +5,16 @@ extension DockCommand {
     // MARK: - Right-Click Dock Item
 
     @MainActor
-    struct RightClickSubcommand: ConfirmedActionOutputFormattable, OutputFormattable, InjectedRuntimeBackedCommand {
+    struct RightClickSubcommand: ConfirmedActionOutputFormattable, ErrorHandlingCommand, OutputFormattable,
+    InjectedRuntimeBackedCommand {
         @Option(help: "Application name in the Dock")
         var app: String
 
         @Option(help: "Menu item to select after right-clicking")
         var select: String?
+
+        @Flag(help: "Confirm opening the global Dock context menu")
+        var foreground = false
         @RuntimeStorage var runtime: CommandRuntime?
 
         @MainActor
@@ -19,6 +23,12 @@ extension DockCommand {
             self.logger.setJsonOutputMode(self.jsonOutput)
 
             do {
+                guard self.foreground else {
+                    throw ActionRefusalError(
+                        message: "dock right-click opens global Dock UI and requires explicit foreground consent.",
+                        hint: "Use --foreground to allow the Dock context menu to open."
+                    )
+                }
                 let dockItem = try await DockServiceBridge.findDockItem(dock: self.services.dock, name: self.app)
                 self.resolvedRuntime.beginInteractionMutation()
                 try await DockServiceBridge.rightClickDockItem(
@@ -51,7 +61,7 @@ extension DockCommand {
                 handleDockServiceError(error, jsonOutput: self.jsonOutput, logger: self.outputLogger)
                 throw ExitCode(1)
             } catch {
-                handleGenericError(error, jsonOutput: self.jsonOutput, logger: self.outputLogger)
+                self.handleError(error)
                 throw ExitCode(1)
             }
         }

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/DockCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/DockCommand.swift
@@ -15,10 +15,10 @@ struct DockCommand: ParsableCommand {
 
                 EXAMPLES:
                   # Launch an app from the Dock
-                  peekaboo dock launch Safari
+                  peekaboo dock launch Safari --foreground
 
                   # Right-click a Dock item
-                  peekaboo dock right-click --app Finder --select "New Window"
+                  peekaboo dock right-click --app Finder --select "New Window" --foreground
 
                   # Show/hide the Dock
                   peekaboo dock hide
@@ -58,6 +58,7 @@ extension DockCommand.LaunchSubcommand: CommanderBindableCommand {
     mutating func applyCommanderValues(_ values: CommanderBindableValues) throws {
         self.app = try values.decodePositional(0, label: "app")
         self.verify = values.flag("verify")
+        self.foreground = values.flag("foreground")
     }
 }
 
@@ -80,6 +81,7 @@ extension DockCommand.RightClickSubcommand: CommanderBindableCommand {
     mutating func applyCommanderValues(_ values: CommanderBindableValues) throws {
         self.app = try values.requireOption("app", as: String.self)
         self.select = values.singleOption("select")
+        self.foreground = values.flag("foreground")
     }
 }
 

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/MenuBarCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/MenuBarCommand.swift
@@ -4,6 +4,23 @@ import Foundation
 import PeekabooCore
 import PeekabooFoundation
 
+private enum MenuBarClickPreflight {
+    static let foregroundConsentRequired = PreDispatchActionError(
+        message: "Menu bar clicks require --foreground because status items open global UI.",
+        code: .VALIDATION_ERROR,
+        hint: "Re-run with --foreground only when interrupting the user's menu bar is acceptable. " +
+            "Use 'peekaboo menubar list' for read-only discovery."
+    )
+
+    static func itemNotFound(_ item: String, hint: String) -> PreDispatchActionError {
+        PreDispatchActionError(
+            message: "Menu bar item not found: \(item)",
+            code: .MENU_ITEM_NOT_FOUND,
+            hint: hint
+        )
+    }
+}
+
 /// Command for interacting with macOS menu bar items (status items).
 @MainActor
 struct MenuBarActionCommand: ErrorHandlingCommand, OutputFormattable, InjectedRuntimeBackedCommand {
@@ -20,6 +37,9 @@ struct MenuBarActionCommand: ErrorHandlingCommand, OutputFormattable, InjectedRu
 
     @Flag(help: "Verify the click by checking for a matching popover window")
     var verify: Bool = false
+
+    @Flag(help: "Allow opening global menu bar UI (required for click)")
+    var foreground: Bool = false
     @RuntimeStorage var runtime: CommandRuntime?
 
     private var configuration: CommandRuntime.Configuration {
@@ -71,18 +91,28 @@ struct MenuBarActionCommand: ErrorHandlingCommand, OutputFormattable, InjectedRu
         let startTime = Date()
 
         do {
-            let verifyTarget = try await self.resolveVerificationTargetIfNeeded()
+            guard self.foreground else {
+                throw MenuBarClickPreflight.foregroundConsentRequired
+            }
+
+            let resolvedItem = try await self.resolveClickTarget()
+            let verifyTarget = self.verify ? Self.makeVerificationTarget(from: resolvedItem) : nil
             let verifier = MenuBarClickVerifier(services: self.services)
             let focusSnapshot = self.verify ? try await verifier.captureFocusSnapshot() : nil
+            self.resolvedRuntime.beginInteractionMutation()
             let result: PeekabooCore.ClickResult
             if let idx = self.index {
-                self.resolvedRuntime.beginInteractionMutation()
                 result = try await MenuServiceBridge.clickMenuBarItem(at: idx, menu: self.services.menu)
             } else if let name = self.itemName {
-                self.resolvedRuntime.beginInteractionMutation()
+                // Keep name-based dispatch bound to the name. Reusing the preflight index
+                // could click a different global item if status items reorder between calls.
                 result = try await MenuServiceBridge.clickMenuBarItem(named: name, menu: self.services.menu)
             } else {
-                throw PeekabooError.invalidInput("Please provide either a menu bar item name or use --index")
+                throw PreDispatchActionError(
+                    message: "Provide a menu bar item name or use --index.",
+                    code: .VALIDATION_ERROR,
+                    hint: "Run 'peekaboo menubar list' to discover available status items."
+                )
             }
 
             let verification: MenuBarClickVerification?
@@ -122,57 +152,57 @@ struct MenuBarActionCommand: ErrorHandlingCommand, OutputFormattable, InjectedRu
                 }
             }
         } catch {
-            if self.jsonOutput {
-                self.handleError(error)
-                throw ExitCode(1)
-            } else {
-                // Provide helpful hints for common errors
-                if error.localizedDescription.contains("not found") {
-                    print("❌ Error: \(error.localizedDescription)")
-                    print("\n💡 Hints:")
-                    print("  • Menu bar items often require clicking on their icon coordinates")
-                    print("  • Try 'peekaboo see' first to get element IDs")
-                    print("  • Use 'peekaboo menubar list' to see available items")
-                    throw ExitCode(1)
-                } else {
-                    throw error
-                }
-            }
+            self.handleError(error)
+            throw ExitCode(1)
         }
     }
 
-    private func resolveVerificationTargetIfNeeded() async throws -> MenuBarVerifyTarget? {
-        guard self.verify else { return nil }
+    private func resolveClickTarget() async throws -> MenuBarItemInfo {
+        let requestedName: String?
+        if self.index == nil {
+            guard let name = self.itemName?.trimmingCharacters(in: .whitespacesAndNewlines),
+                  !name.isEmpty
+            else {
+                throw PreDispatchActionError(
+                    message: "Provide a menu bar item name or use --index.",
+                    code: .VALIDATION_ERROR,
+                    hint: "Run 'peekaboo menubar list' to discover available status items."
+                )
+            }
+            requestedName = name
+        } else {
+            requestedName = nil
+        }
 
         let items = try await MenuServiceBridge.listMenuBarItems(
             menu: self.services.menu,
-            includeRaw: true
+            includeRaw: self.verify
         )
 
         if let idx = self.index {
             guard let item = items.first(where: { $0.index == idx }) else {
-                throw PeekabooError.invalidInput("Menu bar item index \(idx) is out of range")
+                throw MenuBarClickPreflight.itemNotFound(
+                    "index \(idx)",
+                    hint: "Run 'peekaboo menubar list' and retry with a current index."
+                )
             }
-            return MenuBarVerifyTarget(
-                title: item.title ?? item.rawTitle,
-                ownerPID: item.rawOwnerPID,
-                ownerName: item.ownerName,
-                bundleIdentifier: item.bundleIdentifier,
-                preferredX: item.frame?.midX
+            return item
+        }
+
+        let name = requestedName ?? ""
+        guard let item = matchMenuBarItem(named: name, items: items) else {
+            throw MenuBarClickPreflight.itemNotFound(
+                name,
+                hint: "Run 'peekaboo menubar list' and retry with an exact current name or index."
             )
         }
 
-        guard let name = self.itemName?.trimmingCharacters(in: .whitespacesAndNewlines),
-              !name.isEmpty else {
-            throw PeekabooError.invalidInput("Please provide a menu bar item name or use --index")
-        }
+        return item
+    }
 
-        guard let item = matchMenuBarItem(named: name, items: items) else {
-            throw PeekabooError.operationError(message: "Unable to resolve '\(name)' for verification")
-        }
-
-        return MenuBarVerifyTarget(
-            title: item.title ?? item.rawTitle ?? name,
+    private static func makeVerificationTarget(from item: MenuBarItemInfo) -> MenuBarVerifyTarget {
+        MenuBarVerifyTarget(
+            title: item.title ?? item.rawTitle,
             ownerPID: item.rawOwnerPID,
             ownerName: item.ownerName,
             bundleIdentifier: item.bundleIdentifier,
@@ -198,6 +228,7 @@ struct MenuBarCommand: ParsableCommand {
                 discussion: """
                 List status items or click one by fuzzy title match or list index.
                 Application menus such as File and Edit are handled by `peekaboo menu`.
+                Clicking a status item requires explicit `--foreground` consent because it opens global UI.
                 """,
                 subcommands: [ListSubcommand.self, ClickSubcommand.self],
                 showHelpOnEmptyInvocation: true
@@ -239,6 +270,9 @@ struct MenuBarCommand: ParsableCommand {
         @Flag(name: .long, help: "Verify the click by checking for a matching popover window")
         var verify = false
 
+        @Flag(name: .long, help: "Allow opening global menu bar UI (required)")
+        var foreground = false
+
         @RuntimeStorage var runtime: CommandRuntime?
         var runtimeOptions = CommandRuntimeOptions()
 
@@ -247,6 +281,7 @@ struct MenuBarCommand: ParsableCommand {
             command.itemName = self.itemName
             command.index = self.index
             command.verify = self.verify
+            command.foreground = self.foreground
             try await command.run(using: runtime)
         }
     }
@@ -268,6 +303,7 @@ extension MenuBarCommand.ClickSubcommand: CommanderBindableCommand {
         self.itemName = try values.decodeOptionalPositional(0, label: "itemName")
         self.index = try values.decodeOption("index", as: Int.self)
         self.verify = values.flag("verify")
+        self.foreground = values.flag("foreground")
         if self.itemName != nil, self.index != nil {
             throw CommanderBindingError.invalidArgument(
                 label: "item-name or --index",
@@ -277,6 +313,9 @@ extension MenuBarCommand.ClickSubcommand: CommanderBindableCommand {
         }
         guard self.itemName != nil || self.index != nil else {
             throw CommanderBindingError.missingArgument(label: "item-name or --index")
+        }
+        guard self.foreground else {
+            throw MenuBarClickPreflight.foregroundConsentRequired
         }
     }
 }

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/MenuCommand+Click.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/MenuCommand+Click.swift
@@ -55,6 +55,7 @@ extension MenuCommand {
             do {
                 try self.target.validate()
                 try self.validateForegroundOptions()
+                try self.validateTargetConsent()
                 let appIdentifier = try await self.resolveTargetApplicationIdentifier()
                 if self.foreground {
                     let windowID = try await self.target.resolveWindowID(services: self.services)
@@ -156,6 +157,14 @@ extension MenuCommand {
         private func validateForegroundOptions() throws {
             guard self.foreground || !self.focusOptions.hasForegroundFocusOverrides else {
                 throw ValidationError("Menu focus options require --foreground")
+            }
+        }
+
+        private func validateTargetConsent() throws {
+            guard self.target.app != nil || self.target.pid != nil || self.foreground else {
+                throw ValidationError(
+                    "Background menu click requires --app or --pid; use --foreground to target the frontmost app"
+                )
             }
         }
     }

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/MenuCommand+CommanderMetadata.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/MenuCommand+CommanderMetadata.swift
@@ -18,7 +18,7 @@ extension MenuCommand.ClickSubcommand: CommanderSignatureProviding {
             flags: [
                 .commandFlag(
                     "foreground",
-                    help: "Focus the target before using its menu",
+                    help: "Allow frontmost-menu targeting or focus a target; background clicks require --app/--pid",
                     long: "foreground"
                 ),
             ],

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/MenuCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/MenuCommand.swift
@@ -50,6 +50,10 @@ struct MenuCommand: ParsableCommand {
 
                   # List all menu items for an app
                   peekaboo menu list --app Finder
+
+                TARGETING:
+                  Background clicks require --app or --pid.
+                  Use --foreground to intentionally target the frontmost application's menu.
                 """,
                 subcommands: [
                     ClickSubcommand.self,

--- a/Apps/CLI/Tests/CLIAutomationTests/MenuBarCommandConsentTests.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/MenuBarCommandConsentTests.swift
@@ -1,0 +1,235 @@
+import CoreGraphics
+import Foundation
+import PeekabooAutomationKit
+import PeekabooCore
+import Testing
+@testable import PeekabooCLI
+
+@Suite(.tags(.safe), .serialized)
+struct MenuBarCommandConsentTests {
+    @Test
+    @MainActor
+    func `named click without foreground refuses before lookup or dispatch`() async throws {
+        let menu = RecordingMenuBarService()
+        let result = try await InProcessCommandRunner.run(
+            ["menubar", "click", "Wi-Fi", "--verify", "--json"],
+            services: TestServicesFactory.makePeekabooServices(menu: menu)
+        )
+
+        #expect(result.exitStatus == 1)
+        #expect(result.stderr.isEmpty)
+        let payload = try self.decodeResponse(result)
+        #expect(payload.effect == .refused)
+        #expect(payload.error?.code == ErrorCode.VALIDATION_ERROR.rawValue)
+        #expect(payload.error?.retry_safe == true)
+        #expect(payload.error?.mutation_dispatched == false)
+        #expect(payload.error?.hint?.contains("menubar list") == true)
+        #expect(menu.listCallCount == 0)
+        #expect(menu.namedClickCalls.isEmpty)
+        #expect(menu.indexClickCalls.isEmpty)
+    }
+
+    @Test
+    @MainActor
+    func `index click without foreground refuses before lookup or dispatch`() async throws {
+        let menu = RecordingMenuBarService()
+        let result = try await InProcessCommandRunner.run(
+            ["menubar", "click", "--index", "2", "--json"],
+            services: TestServicesFactory.makePeekabooServices(menu: menu)
+        )
+
+        #expect(result.exitStatus == 1)
+        let payload = try self.decodeResponse(result)
+        #expect(payload.effect == .refused)
+        #expect(payload.error?.retry_safe == true)
+        #expect(payload.error?.mutation_dispatched == false)
+        #expect(menu.listCallCount == 0)
+        #expect(menu.namedClickCalls.isEmpty)
+        #expect(menu.indexClickCalls.isEmpty)
+    }
+
+    @Test(arguments: [false, true])
+    @MainActor
+    func `missing named item is one typed pre-dispatch refusal`(verify: Bool) async throws {
+        let menu = RecordingMenuBarService()
+        var arguments = ["menubar", "click", "Missing", "--foreground", "--json"]
+        if verify {
+            arguments.append("--verify")
+        }
+
+        let result = try await InProcessCommandRunner.run(
+            arguments,
+            services: TestServicesFactory.makePeekabooServices(menu: menu)
+        )
+
+        #expect(result.exitStatus == 1)
+        #expect(result.stderr.isEmpty)
+        let payload = try self.decodeResponse(result)
+        #expect(payload.effect == .refused)
+        #expect(payload.error?.code == ErrorCode.MENU_ITEM_NOT_FOUND.rawValue)
+        #expect(payload.error?.message == "Menu bar item not found: Missing")
+        #expect(payload.error?.retry_safe == true)
+        #expect(payload.error?.mutation_dispatched == false)
+        #expect(menu.listCallCount == 1)
+        #expect(menu.namedClickCalls.isEmpty)
+        #expect(menu.indexClickCalls.isEmpty)
+    }
+
+    @Test
+    @MainActor
+    func `human consent refusal is actionable and performs no lookup`() async throws {
+        let menu = RecordingMenuBarService()
+        let result = try await InProcessCommandRunner.run(
+            ["menubar", "click", "Wi-Fi"],
+            services: TestServicesFactory.makePeekabooServices(menu: menu)
+        )
+
+        #expect(result.exitStatus == 1)
+        #expect(result.stdout.isEmpty)
+        #expect(result.stderr.contains("Menu bar clicks require --foreground"))
+        #expect(result.stderr.contains("Use 'peekaboo menubar list' for read-only discovery"))
+        #expect(menu.listCallCount == 0)
+        #expect(menu.namedClickCalls.isEmpty)
+        #expect(menu.indexClickCalls.isEmpty)
+    }
+
+    @Test
+    @MainActor
+    func `list remains read-only without foreground`() async throws {
+        let menu = RecordingMenuBarService(items: [Self.item])
+        let result = try await InProcessCommandRunner.run(
+            ["menubar", "list", "--json"],
+            services: TestServicesFactory.makePeekabooServices(menu: menu)
+        )
+
+        #expect(result.exitStatus == 0)
+        let data = try #require(result.stdout.data(using: .utf8))
+        let json = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        #expect(json["success"] as? Bool == true)
+        #expect(json["effect"] == nil)
+        #expect(menu.listCallCount == 1)
+        #expect(menu.namedClickCalls.isEmpty)
+        #expect(menu.indexClickCalls.isEmpty)
+    }
+
+    @Test
+    @MainActor
+    func `foreground named click preserves name-based dispatch`() async throws {
+        let menu = RecordingMenuBarService(items: [Self.item])
+        let result = try await InProcessCommandRunner.run(
+            ["menubar", "click", "Wi-Fi", "--foreground", "--json"],
+            services: TestServicesFactory.makePeekabooServices(menu: menu)
+        )
+
+        #expect(result.exitStatus == 0)
+        #expect(menu.listCallCount == 1)
+        #expect(menu.namedClickCalls == ["Wi-Fi"])
+        #expect(menu.indexClickCalls.isEmpty)
+    }
+
+    @Test
+    @MainActor
+    func `foreground index click dispatches the requested index`() async throws {
+        let menu = RecordingMenuBarService(items: [Self.item])
+        let result = try await InProcessCommandRunner.run(
+            ["menubar", "click", "--index", "2", "--foreground", "--json"],
+            services: TestServicesFactory.makePeekabooServices(menu: menu)
+        )
+
+        #expect(result.exitStatus == 0)
+        #expect(menu.listCallCount == 1)
+        #expect(menu.namedClickCalls.isEmpty)
+        #expect(menu.indexClickCalls == [2])
+    }
+
+    @Test
+    func `click help exposes foreground while list does not`() async throws {
+        let click = try await InProcessCommandRunner.runShared(["menubar", "click", "--help"])
+        let list = try await InProcessCommandRunner.runShared(["menubar", "list", "--help"])
+
+        #expect(click.stdout.contains("--foreground"))
+        #expect(click.stdout.contains("required"))
+        #expect(!list.stdout.contains("--foreground"))
+    }
+
+    @MainActor
+    private func decodeResponse(_ result: CommandRunResult) throws -> JSONResponse {
+        let data = try #require(result.stdout.data(using: .utf8))
+        return try JSONDecoder().decode(JSONResponse.self, from: data)
+    }
+
+    private static let item = MenuBarItemInfo(
+        title: "Wi-Fi",
+        index: 2,
+        isVisible: true,
+        description: "Wi-Fi status",
+        rawTitle: "WiFi",
+        bundleIdentifier: "com.apple.controlcenter",
+        ownerName: "Control Center",
+        frame: CGRect(x: 300, y: 0, width: 20, height: 20),
+        identifier: "com.apple.controlcenter.wifi",
+        rawOwnerPID: 42
+    )
+}
+
+@MainActor
+private final class RecordingMenuBarService: MenuServiceProtocol {
+    let items: [MenuBarItemInfo]
+    private(set) var listCallCount = 0
+    private(set) var namedClickCalls: [String] = []
+    private(set) var indexClickCalls: [Int] = []
+
+    init(items: [MenuBarItemInfo] = []) {
+        self.items = items
+    }
+
+    func listMenus(for appIdentifier: String) async throws -> MenuStructure {
+        self.emptyStructure(application: appIdentifier)
+    }
+
+    func listFrontmostMenus() async throws -> MenuStructure {
+        self.emptyStructure(application: "frontmost")
+    }
+
+    func clickMenuItem(app _: String, itemPath _: String) async throws {}
+    func clickMenuItemByName(app _: String, itemName _: String) async throws {}
+    func clickMenuExtra(title _: String) async throws {}
+
+    func isMenuExtraMenuOpen(title _: String, ownerPID _: pid_t?) async throws -> Bool {
+        false
+    }
+
+    func menuExtraOpenMenuFrame(title _: String, ownerPID _: pid_t?) async throws -> CGRect? {
+        nil
+    }
+
+    func listMenuExtras() async throws -> [MenuExtraInfo] {
+        []
+    }
+
+    func listMenuBarItems(includeRaw _: Bool) async throws -> [MenuBarItemInfo] {
+        self.listCallCount += 1
+        return self.items
+    }
+
+    func clickMenuBarItem(named name: String) async throws -> PeekabooCore.ClickResult {
+        self.namedClickCalls.append(name)
+        return PeekabooCore.ClickResult(elementDescription: "Menu bar item: \(name)", location: nil)
+    }
+
+    func clickMenuBarItem(at index: Int) async throws -> PeekabooCore.ClickResult {
+        self.indexClickCalls.append(index)
+        return PeekabooCore.ClickResult(elementDescription: "Menu bar item [\(index)]", location: nil)
+    }
+
+    private func emptyStructure(application: String) -> MenuStructure {
+        MenuStructure(
+            application: ServiceApplicationInfo(
+                processIdentifier: 1,
+                bundleIdentifier: "test.menu",
+                name: application
+            ),
+            menus: []
+        )
+    }
+}

--- a/Apps/CLI/Tests/CoreCLITests/CommanderBinderCommandBindingMenuTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/CommanderBinderCommandBindingMenuTests.swift
@@ -91,12 +91,13 @@ struct CommanderBinderMenuDockTests {
 
     @Test
     func `Dock launch binding`() throws {
-        let parsed = ParsedValues(positional: ["Safari"], options: [:], flags: [])
+        let parsed = ParsedValues(positional: ["Safari"], options: [:], flags: ["foreground"])
         let command = try CommanderCLIBinder.instantiateCommand(
             ofType: DockCommand.LaunchSubcommand.self,
             parsedValues: parsed
         )
         #expect(command.app == "Safari")
+        #expect(command.foreground)
     }
 
     @Test
@@ -107,7 +108,7 @@ struct CommanderBinderMenuDockTests {
                 "app": ["Finder"],
                 "select": ["New Window"]
             ],
-            flags: []
+            flags: ["foreground"]
         )
         let command = try CommanderCLIBinder.instantiateCommand(
             ofType: DockCommand.RightClickSubcommand.self,
@@ -115,6 +116,7 @@ struct CommanderBinderMenuDockTests {
         )
         #expect(command.app == "Finder")
         #expect(command.select == "New Window")
+        #expect(command.foreground)
     }
 
     @Test

--- a/Apps/CLI/Tests/CoreCLITests/DockCommandForegroundConsentTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/DockCommandForegroundConsentTests.swift
@@ -1,0 +1,187 @@
+import Commander
+import PeekabooAgentRuntime
+import PeekabooAutomation
+import PeekabooCore
+import Testing
+@testable import PeekabooCLI
+
+@MainActor
+struct DockCommandForegroundConsentTests {
+    @Test
+    func `dock launch refuses before dispatch without foreground consent`() async {
+        let dock = RecordingDockService()
+        var command = DockCommand.LaunchSubcommand()
+        command.app = "Finder"
+
+        await #expect(throws: ExitCode.self) {
+            try await command.run(using: self.makeRuntime(dock: dock))
+        }
+
+        #expect(dock.launchRequests.isEmpty)
+    }
+
+    @Test
+    func `dock right-click refuses before dispatch without foreground consent`() async {
+        let dock = RecordingDockService()
+        var command = DockCommand.RightClickSubcommand()
+        command.app = "Finder"
+
+        await #expect(throws: ExitCode.self) {
+            try await command.run(using: self.makeRuntime(dock: dock))
+        }
+
+        #expect(dock.rightClickRequests.isEmpty)
+    }
+
+    @Test
+    func `explicit foreground consent dispatches Dock mutations`() async throws {
+        let dock = RecordingDockService()
+        var launch = DockCommand.LaunchSubcommand()
+        launch.app = "Finder"
+        launch.foreground = true
+        try await launch.run(using: self.makeRuntime(dock: dock))
+
+        var rightClick = DockCommand.RightClickSubcommand()
+        rightClick.app = "Finder"
+        rightClick.select = "New Window"
+        rightClick.foreground = true
+        try await rightClick.run(using: self.makeRuntime(dock: dock))
+
+        #expect(dock.launchRequests == ["Finder"])
+        #expect(dock.rightClickRequests.count == 1)
+        #expect(dock.rightClickRequests.first?.appName == "Finder")
+        #expect(dock.rightClickRequests.first?.menuItem == "New Window")
+    }
+
+    private func makeRuntime(dock: RecordingDockService) -> CommandRuntime {
+        CommandRuntime(
+            configuration: .init(verbose: false, jsonOutput: false, logLevel: nil),
+            services: ServicesWithDockStub(dock: dock)
+        )
+    }
+}
+
+@MainActor
+private final class RecordingDockService: DockServiceProtocol {
+    private(set) var launchRequests: [String] = []
+    private(set) var rightClickRequests: [(appName: String, menuItem: String?)] = []
+
+    func listDockItems(includeAll _: Bool) async throws -> [DockItem] {
+        [self.finderItem]
+    }
+
+    func launchFromDock(appName: String) async throws {
+        self.launchRequests.append(appName)
+    }
+
+    func addToDock(path _: String, persistent _: Bool) async throws {}
+    func removeFromDock(appName _: String) async throws {}
+
+    func rightClickDockItem(appName: String, menuItem: String?) async throws {
+        self.rightClickRequests.append((appName, menuItem))
+    }
+
+    func hideDock() async throws {}
+    func showDock() async throws {}
+    func isDockAutoHidden() async -> Bool {
+        false
+    }
+
+    func findDockItem(name _: String) async throws -> DockItem {
+        self.finderItem
+    }
+
+    private var finderItem: DockItem {
+        DockItem(
+            index: 0,
+            title: "Finder",
+            itemType: .application,
+            isRunning: true,
+            bundleIdentifier: "com.apple.finder",
+            position: nil,
+            size: nil
+        )
+    }
+}
+
+@MainActor
+private final class ServicesWithDockStub: PeekabooServiceProviding {
+    private let base = PeekabooServices()
+    private let stubDock: any DockServiceProtocol
+
+    init(dock: any DockServiceProtocol) {
+        self.stubDock = dock
+    }
+
+    func ensureVisualizerConnection() {
+        self.base.ensureVisualizerConnection()
+    }
+
+    var logging: any LoggingServiceProtocol {
+        self.base.logging
+    }
+
+    var screenCapture: any ScreenCaptureServiceProtocol {
+        self.base.screenCapture
+    }
+
+    var applications: any ApplicationServiceProtocol {
+        self.base.applications
+    }
+
+    var automation: any UIAutomationServiceProtocol {
+        self.base.automation
+    }
+
+    var windows: any WindowManagementServiceProtocol {
+        self.base.windows
+    }
+
+    var menu: any MenuServiceProtocol {
+        self.base.menu
+    }
+
+    var dock: any DockServiceProtocol {
+        self.stubDock
+    }
+
+    var dialogs: any DialogServiceProtocol {
+        self.base.dialogs
+    }
+
+    var snapshots: any SnapshotManagerProtocol {
+        self.base.snapshots
+    }
+
+    var files: any FileServiceProtocol {
+        self.base.files
+    }
+
+    var clipboard: any ClipboardServiceProtocol {
+        self.base.clipboard
+    }
+
+    var configuration: PeekabooCore.ConfigurationManager {
+        self.base.configuration
+    }
+
+    var permissions: PermissionsService {
+        self.base.permissions
+    }
+
+    var audioInput: AudioInputService {
+        self.base.audioInput
+    }
+
+    var screens: any ScreenServiceProtocol {
+        self.base.screens
+    }
+
+    var browser: any BrowserMCPClientProviding {
+        self.base.browser
+    }
+
+    var agent: (any AgentServiceProtocol)? {
+        self.base.agent
+    }
+}

--- a/Apps/CLI/Tests/CoreCLITests/OpenCommandFlowTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/OpenCommandFlowTests.swift
@@ -407,23 +407,116 @@ struct AppCommandLaunchFlowTests {
 }
 
 @MainActor
+struct MenuCommandTargetConsentTests {
+    @Test(arguments: ["path", "item"])
+    func `Targetless background click refuses before lookup or dispatch`(_ selectionKind: String) async {
+        let fixture = self.makeFixture()
+        var command = MenuCommand.ClickSubcommand()
+        if selectionKind == "path" {
+            command.path = "File > Close"
+        } else {
+            command.item = "Close"
+        }
+        let tracker = InteractionMutationTracker()
+        let runtime = self.makeRuntime(fixture: fixture, tracker: tracker)
+
+        await #expect(throws: ExitCode.self) {
+            try await command.run(using: runtime)
+        }
+
+        #expect(fixture.applications.frontmostCallCount == 0)
+        #expect(fixture.menu.operationCallCount == 0)
+        #expect(!tracker.hasPendingDurableMutation)
+    }
+
+    @Test
+    func `Explicit app preserves background menu dispatch`() async throws {
+        let fixture = self.makeFixture()
+        var command = MenuCommand.ClickSubcommand()
+        command.target.app = "Finder"
+        command.item = "Close"
+
+        try await command.run(using: self.makeRuntime(fixture: fixture))
+
+        #expect(fixture.applications.frontmostCallCount == 0)
+        let click = try #require(fixture.menu.clickedItems.first)
+        #expect(fixture.menu.clickedItems.count == 1)
+        #expect(click.app == "Finder")
+        #expect(click.item == "Close")
+    }
+
+    @Test
+    func `Explicit foreground preserves intentional frontmost menu dispatch`() async throws {
+        let fixture = self.makeFixture()
+        var command = MenuCommand.ClickSubcommand()
+        command.item = "Close"
+        command.foreground = true
+        command.focusOptions.noAutoFocus = true
+
+        try await command.run(using: self.makeRuntime(fixture: fixture))
+
+        #expect(fixture.applications.frontmostCallCount == 1)
+        let click = try #require(fixture.menu.clickedItems.first)
+        #expect(fixture.menu.clickedItems.count == 1)
+        #expect(click.app == "com.apple.finder")
+        #expect(click.item == "Close")
+    }
+
+    private func makeFixture() -> MenuConsentFixture {
+        let app = ServiceApplicationInfo(
+            processIdentifier: 101,
+            processStartIdentity: 1,
+            bundleIdentifier: "com.apple.finder",
+            name: "Finder"
+        )
+        return MenuConsentFixture(
+            applications: RecordingApplicationService(applications: [app]),
+            menu: RecordingMenuConsentService(application: app)
+        )
+    }
+
+    private func makeRuntime(
+        fixture: MenuConsentFixture,
+        tracker: InteractionMutationTracker = InteractionMutationTracker()
+    ) -> CommandRuntime {
+        CommandRuntime(
+            configuration: .init(verbose: false, jsonOutput: false, logLevel: nil),
+            services: ServicesWithApplicationStub(
+                applications: fixture.applications,
+                menu: fixture.menu
+            ),
+            interactionMutationTracker: tracker
+        )
+    }
+}
+
+@MainActor
+private struct MenuConsentFixture {
+    let applications: RecordingApplicationService
+    let menu: RecordingMenuConsentService
+}
+
+@MainActor
 private final class ServicesWithApplicationStub: PeekabooServiceProviding {
     private let base = PeekabooServices(snapshotManager: InMemorySnapshotManager())
     private let stubApplications: any ApplicationServiceProtocol
     private let stubAutomation: any UIAutomationServiceProtocol
     private let stubScreenCapture: any ScreenCaptureServiceProtocol
     private let stubSnapshots: any SnapshotManagerProtocol
+    private let stubMenu: any MenuServiceProtocol
 
     init(
         applications: any ApplicationServiceProtocol,
         automation: (any UIAutomationServiceProtocol)? = nil,
         screenCapture: (any ScreenCaptureServiceProtocol)? = nil,
-        snapshots: (any SnapshotManagerProtocol)? = nil
+        snapshots: (any SnapshotManagerProtocol)? = nil,
+        menu: (any MenuServiceProtocol)? = nil
     ) {
         self.stubApplications = applications
         self.stubAutomation = automation ?? self.base.automation
         self.stubScreenCapture = screenCapture ?? self.base.screenCapture
         self.stubSnapshots = snapshots ?? self.base.snapshots
+        self.stubMenu = menu ?? self.base.menu
     }
 
     func ensureVisualizerConnection() {
@@ -451,7 +544,7 @@ private final class ServicesWithApplicationStub: PeekabooServiceProviding {
     }
 
     var menu: any MenuServiceProtocol {
-        self.base.menu
+        self.stubMenu
     }
 
     var dock: any DockServiceProtocol {
@@ -572,6 +665,7 @@ private final class RecordingApplicationService: ApplicationServiceProtocol {
     private(set) var quitRequests: [ApplicationQuitRequest] = []
     private(set) var findCalls: [String] = []
     private(set) var listCallCount = 0
+    private(set) var frontmostCallCount = 0
 
     init(applications: [ServiceApplicationInfo], launchResponse: ServiceApplicationInfo? = nil) {
         self.applications = applications
@@ -625,6 +719,7 @@ private final class RecordingApplicationService: ApplicationServiceProtocol {
     }
 
     func getFrontmostApplication() async throws -> ServiceApplicationInfo {
+        self.frontmostCallCount += 1
         guard let first = applications.first else {
             throw PeekabooError.appNotFound("frontmost")
         }
@@ -694,6 +789,70 @@ private final class RecordingApplicationService: ApplicationServiceProtocol {
     private static func parsePID(_ identifier: String) -> Int32? {
         guard identifier.uppercased().hasPrefix("PID:") else { return nil }
         return Int32(identifier.dropFirst(4))
+    }
+}
+
+@MainActor
+private final class RecordingMenuConsentService: MenuServiceProtocol {
+    private let application: ServiceApplicationInfo
+    private(set) var clickedItems: [(app: String, item: String)] = []
+    private(set) var operationCallCount = 0
+
+    init(application: ServiceApplicationInfo) {
+        self.application = application
+    }
+
+    func listMenus(for _: String) async throws -> MenuStructure {
+        self.operationCallCount += 1
+        return MenuStructure(application: self.application, menus: [])
+    }
+
+    func listFrontmostMenus() async throws -> MenuStructure {
+        self.operationCallCount += 1
+        return MenuStructure(application: self.application, menus: [])
+    }
+
+    func clickMenuItem(app _: String, itemPath _: String) async throws {
+        self.operationCallCount += 1
+    }
+
+    func clickMenuItemByName(app: String, itemName: String) async throws {
+        self.operationCallCount += 1
+        self.clickedItems.append((app, itemName))
+    }
+
+    func clickMenuExtra(title _: String) async throws {
+        self.operationCallCount += 1
+    }
+
+    func isMenuExtraMenuOpen(title _: String, ownerPID _: pid_t?) async throws -> Bool {
+        self.operationCallCount += 1
+        return false
+    }
+
+    func menuExtraOpenMenuFrame(title _: String, ownerPID _: pid_t?) async throws -> CGRect? {
+        self.operationCallCount += 1
+        return nil
+    }
+
+    func listMenuExtras() async throws -> [MenuExtraInfo] {
+        self.operationCallCount += 1
+        return []
+    }
+
+    func listMenuBarItems(includeRaw _: Bool) async throws -> [MenuBarItemInfo] {
+        self.operationCallCount += 1
+        return []
+    }
+
+    func clickMenuBarItem(named _: String) async throws -> PeekabooCore.ClickResult {
+        self.operationCallCount += 1
+        return PeekabooCore.ClickResult(elementDescription: "unused", location: nil)
+    }
+
+    func clickMenuBarItem(at _: Int) async throws -> PeekabooCore.ClickResult {
+        self.operationCallCount += 1
+        return PeekabooCore.ClickResult(elementDescription: "unused", location: nil)
     }
 }
 

--- a/Apps/Playground/PLAYGROUND_TEST.md
+++ b/Apps/Playground/PLAYGROUND_TEST.md
@@ -425,8 +425,8 @@
 - **Artifacts**: `.artifacts/playground-tools/20251116-141824-menubar-list.json`
 - **Commands**:
   1. `polter peekaboo -- menubar list --json-output`
-  2. `polter peekaboo -- menubar click "Wi-Fi"`
-  3. `polter peekaboo -- menubar click --index 2`
+  2. `polter peekaboo -- menubar click "Wi-Fi" --foreground`
+  3. `polter peekaboo -- menubar click --index 2 --foreground`
 - **Notes**: CLI output confirms the clicked items (Wi-Fi by title, Control Center by index). Still no dedicated menubar logger—`playground-log.sh -c Menu` remains empty for these operations, so rely on CLI artifacts for evidence.
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 - Default new agent configurations to GPT-5.6 and Claude Opus 5 while keeping credential-only Anthropic discovery on Opus 4.8 for zero-retention compatibility and preserving explicit model selections.
 
 ### Fixed
-- Require explicit foreground consent before Dock launch/context-menu actions or targetless frontmost application-menu clicks; CLI and MCP refuse before lookup or dispatch by default.
+- Require explicit foreground consent before Dock/menu-bar global UI or targetless frontmost application-menu clicks; keep discovery read-only/background and return typed refusals before lookup or dispatch.
 - Keep background app launch/open ownership through verified focus reconciliation, restoring only the exact prior process generation while treating transient frontmost uncertainty and later user foreground choices conservatively.
 - Stop probing, requesting, advertising, or showing AppleScript Automation permission now that application, Dock, and UI operations use native macOS APIs; remove the stale checked-in CLI binary and AppleScript code from shipped executables while retaining legacy wire/error decoding for older Bridge hosts.
 - Return generation-pinned CG window inventory promptly when AX enrichment stalls; detached per-process enrichment now times out without holding the Bridge request or desktop lane after its caller disconnects.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 - Default new agent configurations to GPT-5.6 and Claude Opus 5 while keeping credential-only Anthropic discovery on Opus 4.8 for zero-retention compatibility and preserving explicit model selections.
 
 ### Fixed
-- Require explicit foreground consent before Dock launch or context-menu actions activate global UI; CLI and MCP now refuse before dispatch by default.
+- Require explicit foreground consent before Dock launch/context-menu actions or targetless frontmost application-menu clicks; CLI and MCP refuse before lookup or dispatch by default.
 - Keep background app launch/open ownership through verified focus reconciliation, restoring only the exact prior process generation while treating transient frontmost uncertainty and later user foreground choices conservatively.
 - Stop probing, requesting, advertising, or showing AppleScript Automation permission now that application, Dock, and UI operations use native macOS APIs; remove the stale checked-in CLI binary and AppleScript code from shipped executables while retaining legacy wire/error decoding for older Bridge hosts.
 - Return generation-pinned CG window inventory promptly when AX enrichment stalls; detached per-process enrichment now times out without holding the Bridge request or desktop lane after its caller disconnects.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Default new agent configurations to GPT-5.6 and Claude Opus 5 while keeping credential-only Anthropic discovery on Opus 4.8 for zero-retention compatibility and preserving explicit model selections.
 
 ### Fixed
+- Require explicit foreground consent before Dock launch or context-menu actions activate global UI; CLI and MCP now refuse before dispatch by default.
 - Keep background app launch/open ownership through verified focus reconciliation, restoring only the exact prior process generation while treating transient frontmost uncertainty and later user foreground choices conservatively.
 - Stop probing, requesting, advertising, or showing AppleScript Automation permission now that application, Dock, and UI operations use native macOS APIs; remove the stale checked-in CLI binary and AppleScript code from shipped executables while retaining legacy wire/error decoding for older Bridge hosts.
 - Return generation-pinned CG window inventory promptly when AX enrichment stalls; detached per-process enrichment now times out without holding the Bridge request or desktop lane after its caller disconnects.

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/DockTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/DockTool.swift
@@ -16,6 +16,7 @@ public struct DockTool: MCPTool {
         """
         Interact with the macOS Dock - launch apps, show context menus, hide/show dock.
         Actions: launch, right-click (with menu selection), hide, show, list
+        launch and right-click activate global Dock UI and require foreground=true.
         Can list all dock items including persistent and running applications.
         \(PeekabooMCPVersion.banner) using openai/gpt-5.6
         and anthropic/claude-opus-5
@@ -32,6 +33,9 @@ public struct DockTool: MCPTool {
                     description: "Application name for launch/right-click actions"),
                 "select": SchemaBuilder.string(
                     description: "Menu item to select after right-clicking"),
+                "foreground": SchemaBuilder.boolean(
+                    description: "Confirm foreground/global Dock UI for launch and right-click actions.",
+                    default: false),
                 "include_all": SchemaBuilder.boolean(
                     description: "Include all items when listing (default: false)",
                     default: false),
@@ -52,6 +56,12 @@ public struct DockTool: MCPTool {
         let app = arguments.getString("app")
         let select = arguments.getString("select")
         let includeAll = arguments.getBool("include_all") ?? false
+        let foreground = arguments.getBool("foreground") ?? false
+
+        if action == "launch" || action == "right-click", !foreground {
+            return ToolResponse.error(
+                "Dock \(action) activates global Dock UI and requires foreground=true.")
+        }
 
         let dockService = self.context.dock
 

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPSpecificToolTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPSpecificToolTests.swift
@@ -347,6 +347,32 @@ struct MCPSpecificToolTests {
     // MARK: - Window Tool Tests
 
     @Test
+    func `Dock tool requires foreground consent for global UI actions`() async throws {
+        let tool = makeTestTool(DockTool.init)
+        guard case let .object(schema) = tool.inputSchema,
+              case let .object(properties)? = schema["properties"],
+              case let .object(foreground)? = properties["foreground"],
+              case .bool(false)? = foreground["default"]
+        else {
+            Issue.record("Expected Dock foreground schema default")
+            return
+        }
+
+        for action in ["launch", "right-click"] {
+            let response = try await tool.execute(arguments: ToolArguments(raw: [
+                "action": action,
+                "app": "Finder",
+            ]))
+            #expect(response.isError)
+            guard case let .text(text: message, annotations: _, _meta: _) = response.content.first else {
+                Issue.record("Expected Dock foreground validation error")
+                continue
+            }
+            #expect(message.contains("foreground=true"))
+        }
+    }
+
+    @Test
     func `Window tool complex action schema`() {
         let tool = makeTestTool(WindowTool.init)
 

--- a/docs/commands/dock.md
+++ b/docs/commands/dock.md
@@ -12,13 +12,13 @@ read_when:
 ## Subcommands
 | Name | Purpose | Key options |
 | --- | --- | --- |
-| `launch <app>` | Left-click a Dock icon to launch/activate it. | Positional app title as shown in the Dock; add `--verify` to wait for the app to be running. |
-| `right-click` | Open a Dock item’s context menu (and optionally pick a menu item). | `--app <Dock title>` plus optional `--select "Keep in Dock"`, `--select "New Window"`, etc. |
+| `launch <app>` | Left-click a Dock icon to launch/activate it. | Requires `--foreground`; add `--verify` to wait for the app to be running. |
+| `right-click` | Open a Dock item’s context menu (and optionally pick a menu item). | Requires `--foreground`; use `--app <Dock title>` plus optional `--select <title>`. |
 | `hide` / `show` | Toggle Dock visibility (same as System Settings ➝ Dock & Menu Bar). | No options. |
 | `list` | Enumerate Dock items, their bundle IDs, and whether they’re running/pinned. | `--json` prints structured info; prefer `data.dock_items`. |
 
 ## Implementation notes
-- Item resolution is AX-based, so names match what VoiceOver would read (case-sensitive). Launching returns success even when the app is already running; the Dock is still clicked to bring it forward.
+- Item resolution is AX-based, so names match what VoiceOver would read (case-sensitive). Launch and right-click open global Dock UI, so both refuse before dispatch unless `--foreground` is explicit.
 - `launch --verify` polls for the app to appear in the running-application list before returning success.
 - `right-click` first finds the item, then triggers the context menu, then optionally selects `--select <title>`. If you omit `--select`, it just opens the menu (useful if you want to inspect it with `see`).
 - Hide/show operations call the Dock service and return JSON/text acknowledgements; they don’t fiddle with defaults commands, so they’re instantaneous and reversible.
@@ -28,13 +28,13 @@ read_when:
 ## Examples
 ```bash
 # Launch Safari directly from the Dock
-peekaboo dock launch Safari
+peekaboo dock launch Safari --foreground
 
 # Launch and verify the app is running
-peekaboo dock launch Safari --verify
+peekaboo dock launch Safari --verify --foreground
 
 # Right-click Finder and choose "New Window"
-peekaboo dock right-click --app Finder --select "New Window"
+peekaboo dock right-click --app Finder --select "New Window" --foreground
 
 # Hide the Dock before recording a video
 peekaboo dock hide

--- a/docs/commands/menu.md
+++ b/docs/commands/menu.md
@@ -12,11 +12,11 @@ read_when:
 ## Subcommands
 | Subcommand | Purpose | Key options |
 | --- | --- | --- |
-| `click` | Activate an application menu item via `--item` (single-level) or `--path "File > Export > PDF"`. | Target flags `--app <name|bundle|PID:1234>`, optional `--pid`, optional `--window-id`/`--window-title`/`--window-index`; `--foreground` opts into focus flags. Paths are normalized automatically if you accidentally pass a `'>'` string to `--item`. |
+| `click` | Activate an application menu item via `--item` (single-level) or `--path "File > Export > PDF"`. | Background delivery requires `--app` or `--pid`; `--foreground` explicitly permits the frontmost app fallback and focus options. Paths are normalized automatically if you accidentally pass a `'>'` string to `--item`. |
 | `list` | Dump the menu tree for a specific app (optionally showing disabled items). | Same target flags as `click`, plus `--include-disabled`; remains background unless `--foreground` is explicit. |
 
 ## Implementation notes
-- `click`/`list` accept the same target flags as other interaction commands (`--app`/`--pid` plus optional `--window-id`/`--window-title`/`--window-index`) without changing focus. When no `--app`/`--pid` is provided, Peekaboo targets the frontmost app.
+- `click`/`list` accept the same target flags as other interaction commands (`--app`/`--pid` plus optional `--window-id`/`--window-title`/`--window-index`) without changing focus. A background click refuses before menu lookup unless `--app` or `--pid` is explicit. The frontmost-menu fallback remains available only with `--foreground`; read-only list may still inspect the frontmost app without that consent.
 - `--foreground` opts into `ensureFocusIgnoringMissingWindows`, which tolerates apps that keep a menu bar without a visible window (e.g., Finder when all windows are closed). Focus options without `--foreground` are rejected instead of silently activating the app.
 - Any `--item` string that already contains `'>'` is automatically interpreted as a `--path` so agents don’t have to rewrite their inputs. The command even prints a note when this normalization occurs.
 - Errors bubble up as typed `MenuError`s; JSON mode maps them to specific error codes (`MENU_ITEM_NOT_FOUND`, `MENU_BAR_NOT_FOUND`, etc.) so CI can distinguish between missing apps vs. absent menu items.
@@ -25,6 +25,9 @@ read_when:
 ```bash
 # Click File > New Window in Safari
 peekaboo menu click --app Safari --path "File > New Window"
+
+# Intentionally use the current frontmost application's menu
+peekaboo menu click --foreground --path "File > Close"
 
 # Inspect the Finder menu tree, including disabled actions
 peekaboo menu list --app Finder --include-disabled

--- a/docs/commands/menubar.md
+++ b/docs/commands/menubar.md
@@ -7,7 +7,7 @@ read_when:
 
 # `peekaboo menubar`
 
-`menubar` is a lightweight helper for macOS status items (a.k.a. menu bar extras). It talks directly to `MenuServiceBridge` so you can list every icon with its index or click one by title/index. Use the `menu` command for traditional application menus; this command is strictly for the right-hand side of the menu bar.
+`menubar` is a lightweight helper for macOS status items (a.k.a. menu bar extras). It talks directly to `MenuServiceBridge` so you can list every icon with its index or click one by title/index. Listing is read-only and stays in the background. Clicking opens global menu bar UI and therefore requires explicit `--foreground` consent. Use the `menu` command for traditional application menus; this command is strictly for the right-hand side of the menu bar.
 
 ## Subcommands
 | Subcommand | Description |
@@ -20,13 +20,15 @@ read_when:
 | --- | --- |
 | `[itemName]` | Optional positional argument passed to `click`. |
 | `--index <n>` | Target by numeric index (matches the ordering from `menubar list`). |
+| `--foreground` | Required for `click`; permits Peekaboo to open global status-item UI and interrupt the current foreground workflow. |
 | `--verify` | After clicking, confirm a popover owned by the same PID appears, or that focus moved to the owning app/window (fallback OCR). OCR requires the popover text to include the target title/owner name and anchors verification to the clicked item’s X position when available. |
 | Global flags | `--json` returns structured payloads; `--verbose` adds descriptions when listing. |
 
 ## Implementation notes
 - The command name is `menubar` (no hyphen). `list` and `click` are real Commander subcommands.
 - Listing uses `MenuServiceBridge.listMenuBarItems`, and verbose mode prints extra diagnostics (owner name, hidden state). JSON mode always includes the raw title, bundle ID, owner name, identifier, visibility, and description.
-- Clicking resolves either `--index` or item text (case-insensitive). When an item isn’t found, text mode prints troubleshooting hints; JSON mode surfaces `MENU_ITEM_NOT_FOUND`.
+- `click` refuses before status-item lookup unless `--foreground` is present. Missing names and stale indices then fail before dispatch as `MENU_ITEM_NOT_FOUND` with `effect: refused`, `retry_safe: true`, and `mutation_dispatched: false` in JSON.
+- Clicking resolves either `--index` or item text (case-insensitive). Name-based targets remain name-based at dispatch so a status-item reorder cannot redirect the click to a different index.
 - `--verify` waits briefly for a popover owned by the same PID, checks for a focused-window change for the owning app, then falls back to any visible owner window (layer 0). OCR verification is on by default (set `PEEKABOO_MENUBAR_OCR_VERIFY=0` to disable) and now requires the popover text to include the target title/owner; AX menu checks remain opt-in via `PEEKABOO_MENUBAR_AX_VERIFY=1` (OCR requires Screen Recording permission).
 - Coordinate data (if available) is recorded in the click result so you can correlate where on screen the interaction happened.
 
@@ -36,13 +38,13 @@ read_when:
 peekaboo menubar list
 
 # Click the Wi-Fi icon by name
-peekaboo menubar click "Wi-Fi"
+peekaboo menubar click "Wi-Fi" --foreground
 
 # Click and verify the popover opened
-peekaboo menubar click "Wi-Fi" --verify
+peekaboo menubar click "Wi-Fi" --verify --foreground
 
 # Click the third item regardless of name and capture JSON output
-peekaboo menubar click --index 3 --json
+peekaboo menubar click --index 3 --foreground --json
 ```
 
 ## Troubleshooting

--- a/docs/testing/tools.md
+++ b/docs/testing/tools.md
@@ -397,8 +397,8 @@ The following subsections spell out the concrete steps, required Playground surf
 - **Target**: macOS status items (Wi-Fi, Battery) or custom extras.
 - **Test cases**:
   1. `peekaboo menubar list --json-output > .artifacts/playground-tools/20251116-141824-menubar-list.json`.
-  2. `peekaboo menubar click "Wi-Fi"` (or `--index 9`) and close Control Center manually afterward.
-  3. `peekaboo menubar click --index 2` to exercise Control Center by index.
+  2. `peekaboo menubar click "Wi-Fi" --foreground` (or `--index 9 --foreground`) and close Control Center manually afterward.
+  3. `peekaboo menubar click --index 2 --foreground` to exercise Control Center by index.
 - **2025-11-16 run**: Commands above succeeded; no dedicated Playground log yet (menu bar actions don’t flow through the app logger). The new list artifact reflects the current order, and the CLI output confirms the clicked items (Wi-Fi and Control Center).
 
 #### `app`

--- a/docs/testing/trimmy.md
+++ b/docs/testing/trimmy.md
@@ -22,7 +22,7 @@ Goal: Validate Trimmy’s clipboard flattening with direct `peekaboo clipboard` 
    - Wait ~0.3s; `peekaboo clipboard get` → expect `ls | wc -l`.
 
 2) Auto-Trim OFF path  
-   - `peekaboo menubar click --index <idx>` → `peekaboo click "Auto-Trim"` (toggle off).  
+   - `peekaboo menubar click --index <idx> --foreground` → `peekaboo click "Auto-Trim"` (toggle off).
    - Reseat text as above; wait; `get` should stay multi-line.  
    - Toggle Auto-Trim back on.
 

--- a/docs/v4-migration.md
+++ b/docs/v4-migration.md
@@ -31,7 +31,7 @@ bespoke ones. Full rationale: `docs/v4-cli-plan.md`.
 | `peekaboo commander` | removed (internal diagnostics) |
 | `peekaboo agent permission …` | `permissions …` |
 | `peekaboo capture watch …` | `capture live …` |
-| `peekaboo menu click-extra <item>` | `menubar click <item>` |
+| `peekaboo menu click-extra <item>` | `menubar click <item> --foreground` |
 | `peekaboo menu list-all` | `menu list` for application menus plus `menubar list` for status items |
 
 ## Restructured commands
@@ -40,7 +40,7 @@ bespoke ones. Full rationale: `docs/v4-cli-plan.md`.
 |---|---|
 | `clipboard --action <verb>` / `clipboard -a <verb>` / positional actions | `clipboard get\|set\|clear\|save\|restore` |
 | `clipboard load <path>` | `clipboard set --file-path <path>` |
-| `menubar <action> [item]` | `menubar list` / `menubar click <item>` |
+| `menubar <action> [item]` | `menubar list` / `menubar click <item> --foreground` |
 | `config add-provider` | `config provider add` |
 | `config remove-provider` | `config provider remove` |
 | `config list-providers` | `config provider list` |


### PR DESCRIPTION
## Summary

- Require explicit foreground consent for Dock launch and context-menu actions in both the CLI and MCP tool.
- Require an explicit app/PID for background application-menu clicks; preserve intentional frontmost-menu targeting behind `--foreground`.
- Require `--foreground` before `menubar click` can inspect or open global status-item UI, while keeping list/discovery read-only and background-safe.
- Return typed, retry-safe pre-dispatch errors for stale or missing menu-bar targets and document the shared consent contract across help and command docs.

## Why

These commands could previously cross a global/frontmost UI boundary without an explicit foreground decision: Dock actions activated apps, targetless application-menu clicks consulted the current frontmost app, and menu-bar clicks opened shared status-item UI. The new guards fail before lookup or dispatch unless the caller supplies a background-safe target or explicitly opts into foreground interaction.

## Validation

- `pnpm run test:safe` — 780 CLI/Core tests and 72 runtime tests passed, including all release-preflight gates.
- `PEEKABOO_INCLUDE_AUTOMATION_TESTS=true swift test --package-path Apps/CLI --filter MenuBarCommandConsentTests --no-parallel` — 8 passed.
- Focused Dock/menu/Commander/pre-dispatch/result-envelope suites — 32 passed.
- Four CLI black-box refusal probes emitted clean JSON with `effect: refused`; Dock MCP schema exposes `foreground: false` by default.
- `pnpm run format`, docs lint, strict lint across all 16 touched Swift files, and full SwiftLint passed with no serious findings.
- Final Codex Autoreview and TruffleHog were clean at confidence 0.99.

No AppleScript, JXA, or System Events path is introduced.
