### PR TITLE
fix(see): report AX timeout and truncation honestly

### DIFF
--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Stop the curated `learn` copy from presenting `shell` as a CLI command: it remains a built-in Agent capability but is not in the MCP catalog and has no `peekaboo shell` CLI root.
 - Ensure action-command JSON validation failures before dispatch report `effect: refused`, including parser and binding errors.
 - Verify app focus against the exact active Workspace PID and visible frontmost-window PID, retry through native AX activation, and report the verified effect as confirmed instead of claiming success for an unfulfilled request.
+- Honor explicit `see` timeouts beyond 20 seconds, rerun deadline/incomplete AX retries instead of replaying cache, distinguish incomplete reads from expired deadlines, and keep CLI/MCP guidance accurate.
 
 ## [4.0.0] - 2026-08-10
 

--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Stop the curated `learn` copy from presenting `shell` as a CLI command: it remains a built-in Agent capability but is not in the MCP catalog and has no `peekaboo shell` CLI root.
 - Ensure action-command JSON validation failures before dispatch report `effect: refused`, including parser and binding errors.
 - Verify app focus against the exact active Workspace PID and visible frontmost-window PID, retry through native AX activation, and report the verified effect as confirmed instead of claiming success for an unfulfilled request.
-- Honor explicit `see` timeouts beyond 20 seconds, rerun deadline/incomplete AX retries instead of replaying cache, distinguish incomplete reads from expired deadlines, and keep CLI/MCP guidance accurate.
+- Honor explicit `see` timeouts beyond 20 seconds, rerun deadline/incomplete AX retries instead of replaying cache, distinguish incomplete reads from expired deadlines, reject unusable empty truncated AX-only results, and keep CLI/MCP guidance accurate.
 
 ## [4.0.0] - 2026-08-10
 

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/AI/SeeCommand+DetectionPipeline.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/AI/SeeCommand+DetectionPipeline.swift
@@ -6,9 +6,15 @@ import PeekabooFoundation
 @available(macOS 14.0, *)
 @MainActor
 extension SeeCommand {
-    func performCaptureWithDetection(snapshotID: String) async throws -> CaptureAndDetectionResult {
+    func performCaptureWithDetection(
+        snapshotID: String,
+        observationTimeoutSeconds: TimeInterval
+    ) async throws -> CaptureAndDetectionResult {
         if self.noScreenshot {
-            return try await self.performTreeOnlyDetection(snapshotID: snapshotID)
+            return try await self.performTreeOnlyDetection(
+                snapshotID: snapshotID,
+                observationTimeoutSeconds: observationTimeoutSeconds
+            )
         }
 
         if let observationResult = try await self.performObservationCaptureWithDetectionIfPossible(
@@ -82,7 +88,11 @@ extension SeeCommand {
         )
     }
 
-    private func performTreeOnlyDetection(snapshotID: String) async throws -> CaptureAndDetectionResult {
+    private func performTreeOnlyDetection(
+        snapshotID: String,
+        observationTimeoutSeconds: TimeInterval
+    ) async throws -> CaptureAndDetectionResult {
+        let observationDeadline = Date().addingTimeInterval(max(observationTimeoutSeconds, 0.001))
         if self.app != nil, self.pid != nil {
             throw ValidationError("Use either --app or --pid, not both")
         }
@@ -91,16 +101,20 @@ extension SeeCommand {
         } else {
             self.app
         }
+        let windowID = try await self.resolvedTreeWindowID()
+        let accessibilityTimeoutSeconds = max(0.001, observationDeadline.timeIntervalSinceNow)
         let result = try await self.services.automation.inspectAccessibilityTree(
             windowContext: WindowContext(
                 applicationName: appName,
                 applicationProcessId: self.pid,
                 windowTitle: self.windowTitle,
-                windowID: self.resolvedTreeWindowID(),
+                windowID: windowID,
                 shouldFocusWebContent: self.webFocus,
-                traversalBudget: self.axTraversalBudget()
+                traversalBudget: self.axTraversalBudget(),
+                accessibilityTimeoutSeconds: accessibilityTimeoutSeconds
             )
         )
+        try self.requireUsableTreeOnlyEvidence(result)
         let bound = ElementDetectionResult(
             snapshotId: snapshotID,
             screenshotPath: "",
@@ -116,6 +130,22 @@ extension SeeCommand {
             metadata: bound.metadata,
             observation: nil,
             coordinateContext: nil
+        )
+    }
+
+    private func requireUsableTreeOnlyEvidence(_ result: ElementDetectionResult) throws {
+        guard result.elements.all.isEmpty,
+              let truncationInfo = result.metadata.truncationInfo,
+              truncationInfo.isTruncated
+        else { return }
+
+        if truncationInfo.deadlineReached {
+            throw CaptureError.detectionTimedOut(self.overallTimeoutSeconds)
+        }
+        throw PeekabooError.operationError(
+            message: truncationInfo.remediationMessage(
+                budget: result.metadata.windowContext?.traversalBudget
+            )
         )
     }
 

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/AI/SeeCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/AI/SeeCommand.swift
@@ -209,7 +209,8 @@ struct SeeCommand: ApplicationResolvable, ErrorHandlingCommand, RuntimeBackedCom
                     try await commandCopy.prepareResult(
                         startTime: commandStartedAt,
                         logger: logger,
-                        snapshotID: snapshotID
+                        snapshotID: snapshotID,
+                        observationTimeoutSeconds: preparationTimeout
                     )
                 }
                 observationCompleted = true
@@ -432,14 +433,18 @@ struct SeeCommand: ApplicationResolvable, ErrorHandlingCommand, RuntimeBackedCom
     private func prepareResult(
         startTime: Date,
         logger: Logger,
-        snapshotID: String
+        snapshotID: String,
+        observationTimeoutSeconds: TimeInterval
     ) async throws -> SeeCommandRenderContext {
         // ScreenCaptureService performs the authoritative permission check inside each capture path.
         // Avoid duplicating that TCC probe here; `see` is often called in latency-sensitive loops.
 
         // Perform capture and element detection
         logger.verbose("Starting capture and detection phase", category: "Capture")
-        let captureResult = try await performCaptureWithDetection(snapshotID: snapshotID)
+        let captureResult = try await performCaptureWithDetection(
+            snapshotID: snapshotID,
+            observationTimeoutSeconds: observationTimeoutSeconds
+        )
         try Task.checkCancellation()
         logger.verbose("Capture completed successfully", category: "Capture", metadata: [
             "snapshotId": captureResult.snapshotId,

--- a/Apps/CLI/Tests/CLIAutomationTests/SeeCommandTests.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/SeeCommandTests.swift
@@ -238,6 +238,134 @@ struct SeeCommandTests {
 struct SeeCommandRuntimeTests {
     @Test
     @MainActor
+    func `tree only See propagates its remaining timeout to accessibility inspection`() async throws {
+        try await self.withTempConfigEnv { _ in
+            let fixture = Self.makeSeeCommandRuntimeFixture()
+            let automation = StubAutomationService()
+            automation.inspectAccessibilityTreeHandler = { _ in fixture.detectionResult }
+            let (context, _) = Self.makeSeeCommandRuntimeContext(
+                automation: automation,
+                screenCapture: fixture.screenCapture,
+                applicationInfo: fixture.applicationInfo,
+                windowInfo: fixture.windowInfo
+            )
+
+            let result = try await InProcessCommandRunner.run(
+                [
+                    "see",
+                    "--app", fixture.applicationInfo.name,
+                    "--tree",
+                    "--no-screenshot",
+                    "--timeout", "60s",
+                    "--json",
+                ],
+                services: context.services
+            )
+
+            #expect(result.exitStatus == 0)
+            let inspectionContext = try #require(automation.inspectAccessibilityTreeCalls.compactMap(\.self).first)
+            let timeout = try #require(inspectionContext.accessibilityTimeoutSeconds)
+            #expect(timeout > 50)
+            #expect(timeout < 60)
+        }
+    }
+
+    @Test
+    @MainActor
+    func `tree only See fails instead of publishing an empty deadline result`() async throws {
+        try await self.withTempConfigEnv { _ in
+            let fixture = Self.makeSeeCommandRuntimeFixture()
+            let automation = StubAutomationService()
+            automation.inspectAccessibilityTreeHandler = { context in
+                let timeout = try #require(context?.accessibilityTimeoutSeconds)
+                #expect(timeout > 4)
+                #expect(timeout <= 5)
+                return ElementDetectionResult(
+                    snapshotId: "system-settings-empty-deadline",
+                    screenshotPath: "",
+                    elements: DetectedElements(),
+                    metadata: DetectionMetadata(
+                        detectionTime: 0.288,
+                        elementCount: 0,
+                        method: "AXorcist",
+                        truncationInfo: DetectionTruncationInfo(deadlineReached: true)
+                    )
+                )
+            }
+            let (context, _) = Self.makeSeeCommandRuntimeContext(
+                automation: automation,
+                screenCapture: fixture.screenCapture,
+                applicationInfo: fixture.applicationInfo,
+                windowInfo: fixture.windowInfo
+            )
+
+            let result = try await InProcessCommandRunner.run(
+                [
+                    "see",
+                    "--app", fixture.applicationInfo.name,
+                    "--tree",
+                    "--no-screenshot",
+                    "--timeout", "5s",
+                    "--json",
+                ],
+                services: context.services
+            )
+
+            #expect(result.exitStatus == 1)
+            #expect(result.combinedOutput.contains("Element detection timed out after 5s"))
+            #expect(!result.combinedOutput.contains("\"snapshot_id\""))
+            #expect(try await context.snapshots.listSnapshots().isEmpty)
+        }
+    }
+
+    @Test
+    @MainActor
+    func `tree only See preserves useful partial evidence at its deadline`() async throws {
+        try await self.withTempConfigEnv { _ in
+            let fixture = Self.makeSeeCommandRuntimeFixture()
+            let automation = StubAutomationService()
+            let partialElement = try #require(fixture.detectionResult.elements.all.first)
+            automation.inspectAccessibilityTreeHandler = { _ in
+                ElementDetectionResult(
+                    snapshotId: "partial-deadline",
+                    screenshotPath: "",
+                    elements: DetectedElements(buttons: [partialElement]),
+                    metadata: DetectionMetadata(
+                        detectionTime: 4.75,
+                        elementCount: 1,
+                        method: "AXorcist",
+                        truncationInfo: DetectionTruncationInfo(deadlineReached: true)
+                    )
+                )
+            }
+            let (context, _) = Self.makeSeeCommandRuntimeContext(
+                automation: automation,
+                screenCapture: fixture.screenCapture,
+                applicationInfo: fixture.applicationInfo,
+                windowInfo: fixture.windowInfo
+            )
+
+            let result = try await InProcessCommandRunner.run(
+                [
+                    "see",
+                    "--app", fixture.applicationInfo.name,
+                    "--tree",
+                    "--no-screenshot",
+                    "--timeout", "5s",
+                    "--json",
+                ],
+                services: context.services
+            )
+
+            #expect(result.exitStatus == 0)
+            #expect(result.combinedOutput.contains(partialElement.id))
+            #expect(result.combinedOutput.contains("\"deadline_reached\" : true") ||
+                result.combinedOutput.contains("\"deadline_reached\":true"))
+        }
+    }
+
+    @Test
+    @MainActor
     func `Remote See publishes a host-certified observation without a caller barrier`() async throws {
         try await self.withTempConfigEnv { tempDir in
             let fixture = Self.makeSeeCommandRuntimeFixture()

--- a/Apps/CLI/Tests/CLIAutomationTests/SeeCommandTests.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/SeeCommandTests.swift
@@ -21,6 +21,59 @@ struct SeeCommandTests {
 
         #expect(summary.deadline_reached)
         #expect(summary.warning.contains("deadline"))
+        #expect(!summary.warning.contains("larger AX traversal limits"))
+    }
+
+    @Test
+    func `CLI deadline warning mentions larger traversal limits only for reported structural caps`() throws {
+        let metadata = DetectionMetadata(
+            detectionTime: 0,
+            elementCount: 0,
+            method: "accessibility",
+            truncationInfo: DetectionTruncationInfo(
+                maxDepthReached: true,
+                deadlineReached: true
+            )
+        )
+
+        let summary = try #require(SeeTruncationSummary(metadata: metadata))
+
+        #expect(summary.warning.contains("--depth"))
+        #expect(summary.warning.contains("larger AX traversal limits"))
+        #expect(!summary.warning.contains("--max-elements"))
+        #expect(!summary.warning.contains("--max-children"))
+    }
+
+    @Test
+    func `CLI structural warning uses the current depth flag`() throws {
+        let metadata = DetectionMetadata(
+            detectionTime: 0,
+            elementCount: 1,
+            method: "accessibility",
+            truncationInfo: DetectionTruncationInfo(maxDepthReached: true)
+        )
+
+        let summary = try #require(SeeTruncationSummary(metadata: metadata))
+
+        #expect(summary.warning.contains("--depth"))
+        #expect(!summary.warning.contains("--max-depth"))
+    }
+
+    @Test
+    func `CLI incomplete AX warning does not promise that a longer timeout fixes app refusal`() throws {
+        let metadata = DetectionMetadata(
+            detectionTime: 0,
+            elementCount: 0,
+            method: "accessibility",
+            truncationInfo: DetectionTruncationInfo(incompleteAccessibilityRead: true)
+        )
+
+        let summary = try #require(SeeTruncationSummary(metadata: metadata))
+
+        #expect(!summary.deadline_reached)
+        #expect(summary.incomplete_accessibility_read)
+        #expect(summary.warning.contains("may not expose a readable Accessibility tree"))
+        #expect(summary.warning.contains("increase the timeout only when the app is slow"))
     }
 
     @Test

--- a/Apps/CLI/Tests/CLIAutomationTests/SeeCommandTests.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/SeeCommandTests.swift
@@ -119,6 +119,18 @@ struct SeeCommandTests {
     }
 
     @Test
+    func `See observation request preserves explicit timeout above twenty seconds`() throws {
+        let command = try SeeCommand.parse(["--app", "Safari", "--timeout", "60s"])
+
+        let request = try command.makeObservationRequest(
+            target: .app(identifier: "Safari", window: .automatic)
+        )
+
+        #expect(request.timeout.overall == 60)
+        #expect(request.timeout.detection == 60)
+    }
+
+    @Test
     func `See command parses screen-index parameter`() throws {
         let command = try SeeCommand.parse(["--mode", "screen", "--screen-index", "1"])
         #expect(command.mode == .screen)

--- a/Apps/CLI/Tests/CLIAutomationTests/Support/TestServices.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/Support/TestServices.swift
@@ -212,6 +212,7 @@ ExactWindowTargetedClickServiceProtocol {
     var targetedClickCalls: [TargetedClickCall] = []
     var waitForElementCalls: [WaitForElementCall] = []
     var detectElementsCalls: [(imageData: Data, snapshotId: String?, windowContext: WindowContext?)] = []
+    var inspectAccessibilityTreeCalls: [WindowContext?] = []
     var supportsTargetedHotkeys = true
     var supportsProcessGenerationPinnedHotkeys = true
     var targetedHotkeyUnavailableReason: String?
@@ -233,6 +234,7 @@ ExactWindowTargetedClickServiceProtocol {
     var waitForElementProvider: ((ClickTarget, TimeInterval, String?) -> WaitForElementResult)?
     private var waitForElementResults: [WaitTargetKey: WaitForElementResult] = [:]
     var detectElementsHandler: ((Data, String?, WindowContext?) async throws -> ElementDetectionResult)?
+    var inspectAccessibilityTreeHandler: ((WindowContext?) async throws -> ElementDetectionResult)?
     var nextDetectionResult: ElementDetectionResult?
     var stubCurrentMouseLocation: CGPoint?
 
@@ -256,6 +258,14 @@ ExactWindowTargetedClickServiceProtocol {
         }
 
         throw TestStubError.unimplemented(#function)
+    }
+
+    func inspectAccessibilityTree(windowContext: WindowContext?) async throws -> ElementDetectionResult {
+        self.inspectAccessibilityTreeCalls.append(windowContext)
+        guard let inspectAccessibilityTreeHandler else {
+            throw TestStubError.unimplemented(#function)
+        }
+        return try await inspectAccessibilityTreeHandler(windowContext)
     }
 
     func click(target: ClickTarget, clickType: ClickType, snapshotId: String?) async throws {

--- a/Apps/CLI/Tests/CoreCLITests/ErrorHandlingTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/ErrorHandlingTests.swift
@@ -42,6 +42,17 @@ struct FocusErrorMappingTests {
     }
 
     @Test
+    func `subsecond capture timeout splits into precise message and current hint`() throws {
+        let description = try #require(CaptureError.detectionTimedOut(0.2).errorDescription)
+
+        let presentation = splitErrorHint(from: description)
+
+        #expect(presentation.message == "Element detection timed out after 200ms.")
+        #expect(presentation.hint?.contains("peekaboo see --timeout 30s") == true)
+        #expect(presentation.hint?.contains("--timeout-seconds") == false)
+    }
+
+    @Test
     func `bridge screen recording permission maps to screen recording error`() {
         let envelope = PeekabooBridgeErrorEnvelope(
             code: .permissionDenied,

--- a/Apps/CLI/Tests/CoreCLITests/SeeCommandRemoteDetectionTimeoutTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/SeeCommandRemoteDetectionTimeoutTests.swift
@@ -8,18 +8,18 @@ import Testing
 @MainActor
 struct SeeCommandRemoteDetectionTimeoutTests {
     @Test
-    func `Timeout-aware automation receives a wall-clock cushion`() async throws {
-        let automation = MockTimeoutAwareAutomationService(minimumRequestTimeoutSec: 16)
+    func `Timeout-aware automation preserves explicit timeout above twenty seconds with a cushion`() async throws {
+        let automation = MockTimeoutAwareAutomationService(minimumRequestTimeoutSec: 64)
 
         let result = try await SeeCommand.detectElements(
             automation: automation,
             imageData: Data([0xFF]),
             windowContext: nil,
-            timeoutSeconds: 12
+            timeoutSeconds: 60
         )
 
         #expect(result.snapshotId == "remote")
-        #expect(automation.recordedRequestTimeoutSec == 17)
+        #expect(automation.recordedRequestTimeoutSec == 65)
         #expect(automation.baseDetectElementsCalls == 0)
         #expect(automation.timeoutAwareCalls == 1)
     }

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Observation/DesktopObservationRequestModels.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Observation/DesktopObservationRequestModels.swift
@@ -163,6 +163,17 @@ extension DetectionTruncationInfo {
     }
 
     public func remediationMessage(budget: AXTraversalBudget?) -> String {
+        self.remediationMessage(budget: budget, style: .commandLine)
+    }
+
+    public func automationToolRemediationMessage(budget: AXTraversalBudget?) -> String {
+        self.remediationMessage(budget: budget, style: .automationTool)
+    }
+
+    private func remediationMessage(
+        budget: AXTraversalBudget?,
+        style: DetectionRemediationStyle) -> String
+    {
         let budget = budget ?? AXTraversalBudget()
         var limits: [String] = []
         if self.maxDepthReached {
@@ -183,27 +194,62 @@ extension DetectionTruncationInfo {
 
         let limitSummary = limits.isEmpty ? "the AX traversal budget" : limits.joined(separator: ", ")
         if self.incompleteAccessibilityRead {
-            return "Warning: AX tree incomplete at \(limitSummary). Retry once; if this persists, the target may " +
-                "not expose a readable Accessibility tree. Use a narrower window target or screenshot/OCR; " +
-                "increase the timeout only when the app is slow to respond."
+            return switch style {
+            case .commandLine:
+                "Warning: AX tree incomplete at \(limitSummary). Retry once; if this persists, the target may " +
+                    "not expose a readable Accessibility tree. Use a narrower window target or screenshot/OCR; " +
+                    "increase the timeout only when the app is slow to respond."
+            case .automationTool:
+                "Warning: AX tree incomplete at \(limitSummary). Retry once with an exact app_target and " +
+                    "window_id. If this persists, the target may not expose a readable Accessibility tree; " +
+                    "use screenshot/OCR evidence instead."
+            }
         }
         if self.deadlineReached {
-            let structuralLimits: [String] = ([
-                self.maxDepthReached ? "--depth" : nil,
-                self.maxElementCountReached ? "--max-elements" : nil,
-                self.maxChildrenPerNodeReached ? "--max-children" : nil,
-            ] as [String?]).compactMap(\.self)
+            let structuralLimits = self.structuralLimitControls(style: style)
             let structuralGuidance = structuralLimits.isEmpty
                 ? ""
                 : " The result also reached \(structuralLimits.joined(separator: ", ")); " +
                 "use larger AX traversal limits only for those reported caps."
-            return "Warning: AX tree truncated at \(limitSummary). Retry with a longer caller timeout or a " +
-                "narrower target.\(structuralGuidance)"
+            let retryGuidance = switch style {
+            case .commandLine:
+                "Retry with a longer caller timeout or a narrower target."
+            case .automationTool:
+                "Retry with an exact app_target and window_id; this tool does not expose a timeout argument."
+            }
+            return "Warning: AX tree truncated at \(limitSummary). \(retryGuidance)\(structuralGuidance)"
         }
-        return "Warning: AX tree truncated at \(limitSummary). Retry with larger --depth, --max-elements, " +
-            "or --max-children values, or set \(AXTraversalBudget.maxDepthEnvironmentKey), " +
-            "\(AXTraversalBudget.maxElementCountEnvironmentKey), or " +
-            "\(AXTraversalBudget.maxChildrenPerNodeEnvironmentKey)."
+
+        switch style {
+        case .commandLine:
+            return "Warning: AX tree truncated at \(limitSummary). Retry with larger --depth, --max-elements, " +
+                "or --max-children values, or set \(AXTraversalBudget.maxDepthEnvironmentKey), " +
+                "\(AXTraversalBudget.maxElementCountEnvironmentKey), or " +
+                "\(AXTraversalBudget.maxChildrenPerNodeEnvironmentKey)."
+        case .automationTool:
+            let controls = self.structuralLimitControls(style: style)
+            let guidance = controls.isEmpty
+                ? "max_depth, max_elements, or max_children"
+                : controls.joined(separator: ", ")
+            return "Warning: AX tree truncated at \(limitSummary). Retry with larger \(guidance) tool arguments."
+        }
+    }
+
+    private func structuralLimitControls(style: DetectionRemediationStyle) -> [String] {
+        switch style {
+        case .commandLine:
+            ([
+                self.maxDepthReached ? "--depth" : nil,
+                self.maxElementCountReached ? "--max-elements" : nil,
+                self.maxChildrenPerNodeReached ? "--max-children" : nil,
+            ] as [String?]).compactMap(\.self)
+        case .automationTool:
+            ([
+                self.maxDepthReached ? "max_depth" : nil,
+                self.maxElementCountReached ? "max_elements" : nil,
+                self.maxChildrenPerNodeReached ? "max_children" : nil,
+            ] as [String?]).compactMap(\.self)
+        }
     }
 
     static func merge(
@@ -219,6 +265,11 @@ extension DetectionTruncationInfo {
             incompleteAccessibilityRead: lhs?.incompleteAccessibilityRead == true ||
                 rhs?.incompleteAccessibilityRead == true)
     }
+}
+
+private enum DetectionRemediationStyle {
+    case commandLine
+    case automationTool
 }
 
 public struct DesktopDetectionOptions: Sendable, Codable, Equatable {

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Observation/DesktopObservationRequestModels.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Observation/DesktopObservationRequestModels.swift
@@ -183,14 +183,24 @@ extension DetectionTruncationInfo {
 
         let limitSummary = limits.isEmpty ? "the AX traversal budget" : limits.joined(separator: ", ")
         if self.incompleteAccessibilityRead {
-            return "Warning: AX tree incomplete at \(limitSummary). Retry the observation; if the problem persists, " +
-                "use a narrower target or a longer caller timeout."
+            return "Warning: AX tree incomplete at \(limitSummary). Retry once; if this persists, the target may " +
+                "not expose a readable Accessibility tree. Use a narrower window target or screenshot/OCR; " +
+                "increase the timeout only when the app is slow to respond."
         }
         if self.deadlineReached {
-            return "Warning: AX tree truncated at \(limitSummary). Retry with a longer caller timeout, a narrower " +
-                "target, or larger AX traversal limits."
+            let structuralLimits: [String] = ([
+                self.maxDepthReached ? "--depth" : nil,
+                self.maxElementCountReached ? "--max-elements" : nil,
+                self.maxChildrenPerNodeReached ? "--max-children" : nil,
+            ] as [String?]).compactMap(\.self)
+            let structuralGuidance = structuralLimits.isEmpty
+                ? ""
+                : " The result also reached \(structuralLimits.joined(separator: ", ")); " +
+                "use larger AX traversal limits only for those reported caps."
+            return "Warning: AX tree truncated at \(limitSummary). Retry with a longer caller timeout or a " +
+                "narrower target.\(structuralGuidance)"
         }
-        return "Warning: AX tree truncated at \(limitSummary). Retry with larger --max-depth, --max-elements, " +
+        return "Warning: AX tree truncated at \(limitSummary). Retry with larger --depth, --max-elements, " +
             "or --max-children values, or set \(AXTraversalBudget.maxDepthEnvironmentKey), " +
             "\(AXTraversalBudget.maxElementCountEnvironmentKey), or " +
             "\(AXTraversalBudget.maxChildrenPerNodeEnvironmentKey)."

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/DetachedAXObservationWorker.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/DetachedAXObservationWorker.swift
@@ -185,7 +185,10 @@ enum DetachedAXObservationWorker {
         do {
             window = try self.resolveWindow(application: application, request: request, deadline: deadline)
         } catch {
-            if let fallback = self.exactWindowUnavailableResult(request) {
+            if let fallback = self.exactWindowUnavailableResult(
+                request,
+                deadlineReached: ContinuousClock.now >= deadline)
+            {
                 try self.validateIdentity(request)
                 return fallback
             }
@@ -271,7 +274,8 @@ enum DetachedAXObservationWorker {
     }
 
     private static func exactWindowUnavailableResult(
-        _ request: DetachedAXObservationRequest) -> DetachedAXObservationResult?
+        _ request: DetachedAXObservationRequest,
+        deadlineReached: Bool) -> DetachedAXObservationResult?
     {
         guard let requestedID = request.windowID,
               let windowID = CGWindowID(exactly: requestedID),
@@ -286,7 +290,17 @@ enum DetachedAXObservationWorker {
             windowTitle: identity.title,
             windowBounds: identity.bounds,
             isDialog: self.isFileDialogTitle(identity.title),
-            truncationInfo: DetectionTruncationInfo(deadlineReached: true))
+            truncationInfo: self.exactWindowResolutionFailureTruncation(
+                deadlineReached: deadlineReached))
+    }
+
+    static func exactWindowResolutionFailureTruncation(
+        deadlineReached: Bool) -> DetectionTruncationInfo
+    {
+        if deadlineReached {
+            return DetectionTruncationInfo(deadlineReached: true)
+        }
+        return DetectionTruncationInfo(incompleteAccessibilityRead: true)
     }
 
     private static func resolveWindow(

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/DetachedAXObservationWorker.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/DetachedAXObservationWorker.swift
@@ -176,20 +176,45 @@ enum DetachedAXObservationWorker {
     }
 
     static func inspect(_ request: DetachedAXObservationRequest) throws -> DetachedAXObservationResult {
-        try self.validateIdentity(request)
+        try self.inspect(
+            request,
+            resolveWindow: { application, request, deadline in
+                try self.resolveWindow(application: application, request: request, deadline: deadline)
+            },
+            exactWindowUnavailableResult: { request, deadlineReached in
+                self.exactWindowUnavailableResult(request, deadlineReached: deadlineReached)
+            },
+            validateIdentity: { request in
+                try self.validateIdentity(request)
+            })
+    }
+
+    static func inspect(
+        _ request: DetachedAXObservationRequest,
+        resolveWindow: (
+            _ application: AXUIElement,
+            _ request: DetachedAXObservationRequest,
+            _ deadline: ContinuousClock.Instant) throws -> AXUIElement,
+        exactWindowUnavailableResult: (
+            _ request: DetachedAXObservationRequest,
+            _ deadlineReached: Bool) -> DetachedAXObservationResult?,
+        validateIdentity: (_ request: DetachedAXObservationRequest) throws -> Void) throws
+        -> DetachedAXObservationResult
+    {
+        try validateIdentity(request)
         let deadline = ContinuousClock.now.advanced(by: .seconds(request.timeoutSeconds))
         let application = AXUIElementCreateApplication(request.processIdentifier)
         self.prepare(application, deadline: deadline)
 
         let window: AXUIElement
         do {
-            window = try self.resolveWindow(application: application, request: request, deadline: deadline)
+            window = try resolveWindow(application, request, deadline)
         } catch {
-            if let fallback = self.exactWindowUnavailableResult(
+            if let fallback = exactWindowUnavailableResult(
                 request,
-                deadlineReached: ContinuousClock.now >= deadline)
+                ContinuousClock.now >= deadline)
             {
-                try self.validateIdentity(request)
+                try validateIdentity(request)
                 return fallback
             }
             throw error
@@ -228,7 +253,7 @@ enum DetachedAXObservationWorker {
             windowBounds: bounds,
             isDialog: ["AXDialog", "AXSystemDialog", "AXSheet"].contains(subrole) || self.isFileDialogTitle(title),
             truncationInfo: state.truncationInfo)
-        try self.validateIdentity(request)
+        try validateIdentity(request)
         return result
     }
 

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/DetachedAXObservationWorker.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/DetachedAXObservationWorker.swift
@@ -33,7 +33,26 @@ struct DetachedAXObservationRequest: Sendable {
     let includeMenuBarElements: Bool
     let appIsActive: Bool
     let traversalBudget: AXTraversalBudget
-    let timeoutSeconds: TimeInterval
+    let timing: DetachedAXObservationTiming
+}
+
+struct DetachedAXObservationTiming: Sendable, Equatable {
+    // AX calls are not cooperatively cancellable. Stop traversal early enough for one bounded
+    // native call plus result publication before the caller's hard timeout abandons the lane.
+    private static let maximumCompletionGrace: TimeInterval = 0.25
+    private static let minimumCompletionGrace: TimeInterval = 0.01
+
+    let cooperativeDeadlineSeconds: TimeInterval
+    let hardTimeoutSeconds: TimeInterval
+
+    init(hardTimeoutSeconds: TimeInterval) {
+        let proportionalGrace = hardTimeoutSeconds * 0.1
+        let completionGrace = min(
+            Self.maximumCompletionGrace,
+            max(Self.minimumCompletionGrace, proportionalGrace))
+        self.cooperativeDeadlineSeconds = max(0.001, hardTimeoutSeconds - completionGrace)
+        self.hardTimeoutSeconds = hardTimeoutSeconds
+    }
 }
 
 struct DetachedAXObservationResult: Sendable {
@@ -202,7 +221,7 @@ enum DetachedAXObservationWorker {
         -> DetachedAXObservationResult
     {
         try validateIdentity(request)
-        let deadline = ContinuousClock.now.advanced(by: .seconds(request.timeoutSeconds))
+        let deadline = ContinuousClock.now.advanced(by: .seconds(request.timing.cooperativeDeadlineSeconds))
         let application = AXUIElementCreateApplication(request.processIdentifier)
         self.prepare(application, deadline: deadline)
 

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/ElementDetectionCache.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/ElementDetectionCache.swift
@@ -85,6 +85,12 @@ import PeekabooFoundation
     }
 
     public func store(_ elements: [DetectedElement], truncationInfo: DetectionTruncationInfo? = nil, for key: Key) {
+        if truncationInfo?.deadlineReached == true || truncationInfo?.incompleteAccessibilityRead == true {
+            // A retry may use a longer timeout or the target may recover from a transient AX refusal.
+            // Remove any older entry too: replaying stale completeness is less honest than recollecting.
+            self.entries.removeValue(forKey: key)
+            return
+        }
         self.entries[key] = Entry(
             cachedAt: self.now(),
             result: CachedElements(elements: elements, truncationInfo: truncationInfo))

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/ElementDetectionService.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/ElementDetectionService.swift
@@ -4,6 +4,23 @@ import Foundation
 import os.log
 import PeekabooFoundation
 
+struct CachedDetachedAXObservationContext: Sendable {
+    let windowID: Int?
+    let windowTitle: String?
+    let windowBounds: CGRect?
+    let isDialog: Bool
+}
+
+struct DetachedAXObservationOutcome: Sendable {
+    let elements: [DetectedElement]
+    let windowID: Int?
+    let windowTitle: String?
+    let windowBounds: CGRect?
+    let isDialog: Bool
+    let truncationInfo: DetectionTruncationInfo?
+    let usedCache: Bool
+}
+
 /**
  * AI-powered UI element detection service for screenshot analysis.
  *
@@ -35,23 +52,49 @@ import PeekabooFoundation
  */
 @MainActor
 public final class ElementDetectionService {
+    typealias DetachedAXObservationRunner = @MainActor @Sendable (
+        DetachedAXObservationRequest) async throws -> DetachedAXObservationResult
+
     private let logger = Logger(subsystem: "boo.peekaboo.core", category: "ElementDetectionService")
     private let snapshotManager: (any SnapshotManagerProtocol)?
     private let windowIdentityService = WindowIdentityService()
     private let windowResolver: ElementDetectionWindowResolver
-    private let axTreeCache = ElementDetectionCache()
+    private let axTreeCache: ElementDetectionCache
+    private let detachedAXObservationRunner: DetachedAXObservationRunner
     private let webFocusFallback = WebFocusFallback()
     private let menuBarElementCollector = MenuBarElementCollector()
     private let axTreeCollector = AXTreeCollector()
 
-    public init(
+    public convenience init(
         snapshotManager: (any SnapshotManagerProtocol)? = nil,
         applicationService: ApplicationService? = nil)
     {
+        self.init(
+            snapshotManager: snapshotManager,
+            applicationService: applicationService,
+            axTreeCache: ElementDetectionCache(),
+            detachedAXObservationRunner: { request in
+                try await ElementDetectionTimeoutRunner.runDetached(
+                    targetProcessIdentifier: request.processIdentifier,
+                    targetProcessStartIdentity: request.expectedProcessStartIdentity,
+                    seconds: request.timeoutSeconds)
+                {
+                    try DetachedAXObservationWorker.inspect(request)
+                }
+            })
+    }
+
+    init(
+        snapshotManager: (any SnapshotManagerProtocol)?,
+        applicationService: ApplicationService?,
+        axTreeCache: ElementDetectionCache,
+        detachedAXObservationRunner: @escaping DetachedAXObservationRunner)
+    {
         self.snapshotManager = snapshotManager
-        self
-            .windowResolver =
+        self.windowResolver =
             ElementDetectionWindowResolver(applicationService: applicationService ?? ApplicationService())
+        self.axTreeCache = axTreeCache
+        self.detachedAXObservationRunner = detachedAXObservationRunner
     }
 
     /// Detect UI elements in a screenshot
@@ -202,6 +245,44 @@ public final class ElementDetectionService {
         !requiresFreshAccessibilityTree && budget == AXTraversalBudget()
     }
 
+    func cachedOrRunDetachedAXObservation(
+        cacheKey: ElementDetectionCache.Key?,
+        invalidatedThrough: Date?,
+        cachedContext: CachedDetachedAXObservationContext,
+        makeRequest: () throws -> DetachedAXObservationRequest) async throws -> DetachedAXObservationOutcome
+    {
+        if let cacheKey,
+           let cached = self.axTreeCache.result(
+               for: cacheKey,
+               invalidatedThrough: invalidatedThrough)
+        {
+            return DetachedAXObservationOutcome(
+                elements: cached.elements,
+                windowID: cachedContext.windowID,
+                windowTitle: cachedContext.windowTitle,
+                windowBounds: cachedContext.windowBounds,
+                isDialog: cachedContext.isDialog,
+                truncationInfo: cached.truncationInfo,
+                usedCache: true)
+        }
+
+        let detachedResult = try await self.detachedAXObservationRunner(makeRequest())
+        if let cacheKey {
+            self.axTreeCache.store(
+                detachedResult.elements,
+                truncationInfo: detachedResult.truncationInfo,
+                for: cacheKey)
+        }
+        return DetachedAXObservationOutcome(
+            elements: detachedResult.elements,
+            windowID: detachedResult.windowID,
+            windowTitle: detachedResult.windowTitle,
+            windowBounds: detachedResult.windowBounds,
+            isDialog: detachedResult.isDialog,
+            truncationInfo: detachedResult.truncationInfo,
+            usedCache: false)
+    }
+
     private func inspectReadOnlyElements(
         targetApp: NSRunningApplication,
         snapshotId: String,
@@ -253,87 +334,60 @@ public final class ElementDetectionService {
                 includeMenuBarElements: includeMenuBarElements)
             : nil
         let invalidatedThrough = self.snapshotManager?.effectiveImplicitLatestInvalidationWatermark
-        if let cacheKey,
-           let cached = self.axTreeCache.result(
-               for: cacheKey,
-               invalidatedThrough: invalidatedThrough)
-        {
-            let cachedContext = WindowContext(
-                applicationName: context?.applicationName ?? targetApp.localizedName,
-                applicationBundleId: context?.applicationBundleId ?? targetApp.bundleIdentifier,
-                applicationProcessId: processIdentifier,
-                windowTitle: context?.windowTitle,
-                windowID: context?.windowID,
-                windowBounds: context?.windowBounds,
-                windowMutationIdentity: context?.windowMutationIdentity,
-                shouldFocusWebContent: false,
-                includeMenuBarElements: includeMenuBarElements,
-                traversalBudget: budget,
-                requiresFreshAccessibilityTree: false,
-                accessibilityTimeoutSeconds: context?.accessibilityTimeoutSeconds)
-            return ElementDetectionResultBuilder.makeResult(
-                snapshotId: snapshotId,
-                elements: cached.elements,
-                usedCache: true,
-                windowContext: cachedContext,
-                isDialog: false,
-                truncationInfo: cached.truncationInfo)
-        }
-
         let timeoutSeconds = Self.normalizedAccessibilityTimeout(context?.accessibilityTimeoutSeconds)
-        let expectedProcessStartIdentity = context?.windowMutationIdentity?.ownerProcessStartIdentity ??
-            SystemIdentityResolver.processStartIdentity(processIdentifier)
-        guard let expectedProcessStartIdentity else {
-            throw PeekabooError.snapshotStale(
-                "Could not capture the target process generation before detached AX observation")
-        }
-        let request = DetachedAXObservationRequest(
-            processIdentifier: processIdentifier,
-            expectedProcessStartIdentity: expectedProcessStartIdentity,
-            windowID: context?.windowID,
-            windowTitle: context?.windowTitle,
-            expectedWindowBounds: context?.windowBounds,
-            windowMutationIdentity: context?.windowMutationIdentity,
-            includeMenuBarElements: includeMenuBarElements,
-            appIsActive: targetApp.isActive,
-            traversalBudget: budget,
-            timeoutSeconds: timeoutSeconds)
-        let detachedResult = try await ElementDetectionTimeoutRunner.runDetached(
-            targetProcessIdentifier: processIdentifier,
-            targetProcessStartIdentity: expectedProcessStartIdentity,
-            seconds: timeoutSeconds)
+        let outcome = try await self.cachedOrRunDetachedAXObservation(
+            cacheKey: cacheKey,
+            invalidatedThrough: invalidatedThrough,
+            cachedContext: CachedDetachedAXObservationContext(
+                windowID: context?.windowID,
+                windowTitle: context?.windowTitle,
+                windowBounds: context?.windowBounds,
+                isDialog: false))
         {
-            try DetachedAXObservationWorker.inspect(request)
+            let expectedProcessStartIdentity = context?.windowMutationIdentity?.ownerProcessStartIdentity ??
+                SystemIdentityResolver.processStartIdentity(processIdentifier)
+            guard let expectedProcessStartIdentity else {
+                throw PeekabooError.snapshotStale(
+                    "Could not capture the target process generation before detached AX observation")
+            }
+            return DetachedAXObservationRequest(
+                processIdentifier: processIdentifier,
+                expectedProcessStartIdentity: expectedProcessStartIdentity,
+                windowID: context?.windowID,
+                windowTitle: context?.windowTitle,
+                expectedWindowBounds: context?.windowBounds,
+                windowMutationIdentity: context?.windowMutationIdentity,
+                includeMenuBarElements: includeMenuBarElements,
+                appIsActive: targetApp.isActive,
+                traversalBudget: budget,
+                timeoutSeconds: timeoutSeconds)
         }
 
         let resolvedContext = WindowContext(
             applicationName: context?.applicationName ?? targetApp.localizedName,
             applicationBundleId: context?.applicationBundleId ?? targetApp.bundleIdentifier,
             applicationProcessId: processIdentifier,
-            windowTitle: detachedResult.windowTitle,
-            windowID: detachedResult.windowID,
-            windowBounds: context?.windowBounds ?? detachedResult.windowBounds,
+            windowTitle: outcome.windowTitle,
+            windowID: outcome.windowID,
+            windowBounds: context?.windowBounds ?? outcome.windowBounds,
             windowMutationIdentity: context?.windowMutationIdentity,
             shouldFocusWebContent: false,
             includeMenuBarElements: includeMenuBarElements,
             traversalBudget: budget,
-            requiresFreshAccessibilityTree: context?.requiresFreshAccessibilityTree ?? false,
-            accessibilityTimeoutSeconds: timeoutSeconds)
+            requiresFreshAccessibilityTree: outcome.usedCache ? false :
+                context?.requiresFreshAccessibilityTree ?? false,
+            accessibilityTimeoutSeconds: outcome.usedCache ? context?.accessibilityTimeoutSeconds : timeoutSeconds)
 
-        if let cacheKey {
-            self.axTreeCache.store(
-                detachedResult.elements,
-                truncationInfo: detachedResult.truncationInfo,
-                for: cacheKey)
+        if !outcome.usedCache {
+            self.logger.info("Detected \(outcome.elements.count) elements on detached AX lane")
         }
-        self.logger.info("Detected \(detachedResult.elements.count) elements on detached AX lane")
         return ElementDetectionResultBuilder.makeResult(
             snapshotId: snapshotId,
-            elements: detachedResult.elements,
-            usedCache: false,
+            elements: outcome.elements,
+            usedCache: outcome.usedCache,
             windowContext: resolvedContext,
-            isDialog: detachedResult.isDialog,
-            truncationInfo: detachedResult.truncationInfo)
+            isDialog: outcome.isDialog,
+            truncationInfo: outcome.truncationInfo)
     }
 
     private static func readOnlyWindowContext(

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/ElementDetectionService.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/ElementDetectionService.swift
@@ -94,7 +94,9 @@ public final class ElementDetectionService {
         let allowWebFocus = windowContext?.shouldFocusWebContent ?? false
         let includeMenuBarElements = windowContext?.includeMenuBarElements ?? true
         let budget = AXTraversalBudget.normalizedForTraversal(windowContext?.traversalBudget)
-        let usesDefaultBudget = budget == AXTraversalBudget()
+        let canReuseAXTree = Self.shouldUseAXTreeCache(
+            budget: budget,
+            requiresFreshAccessibilityTree: windowContext?.requiresFreshAccessibilityTree == true)
         let resolvedWindowBounds = windowContext?.windowBounds ?? windowResolution.window.frame()
         let resolvedWindowMutationIdentity = try Self.validatedExactWindowReceipt(
             windowID: windowContext?.windowID,
@@ -129,7 +131,7 @@ public final class ElementDetectionService {
         let detectedElements: [DetectedElement]
         let usedCache: Bool
         let truncationInfo: DetectionTruncationInfo?
-        let cacheKey = usesDefaultBudget && windowContext?.requiresFreshAccessibilityTree != true
+        let cacheKey = canReuseAXTree
             ? self.axTreeCache.key(
                 windowID: resolvedWindowID,
                 processID: targetApp.processIdentifier,
@@ -188,9 +190,16 @@ public final class ElementDetectionService {
         self.axTreeCache.removeAll()
     }
 
-    private static func normalizedAccessibilityTimeout(_ requested: TimeInterval?) -> TimeInterval {
+    static func normalizedAccessibilityTimeout(_ requested: TimeInterval?) -> TimeInterval {
         guard let requested, requested.isFinite else { return 20 }
-        return min(max(requested, 0.05), 20)
+        return max(requested, 0.05)
+    }
+
+    static func shouldUseAXTreeCache(
+        budget: AXTraversalBudget,
+        requiresFreshAccessibilityTree: Bool) -> Bool
+    {
+        !requiresFreshAccessibilityTree && budget == AXTraversalBudget()
     }
 
     private func inspectReadOnlyElements(
@@ -213,7 +222,9 @@ public final class ElementDetectionService {
 
         let includeMenuBarElements = context?.includeMenuBarElements ?? true
         let budget = AXTraversalBudget.normalizedForTraversal(context?.traversalBudget)
-        let usesDefaultBudget = budget == AXTraversalBudget()
+        let canReuseAXTree = Self.shouldUseAXTreeCache(
+            budget: budget,
+            requiresFreshAccessibilityTree: context?.requiresFreshAccessibilityTree == true)
         let preliminaryContext = WindowContext(
             applicationName: context?.applicationName ?? targetApp.localizedName,
             applicationBundleId: context?.applicationBundleId ?? targetApp.bundleIdentifier,
@@ -234,7 +245,7 @@ public final class ElementDetectionService {
             return gameBridgeResult
         }
 
-        let cacheKey = usesDefaultBudget && context?.requiresFreshAccessibilityTree != true
+        let cacheKey = canReuseAXTree
             ? self.axTreeCache.key(
                 windowID: context?.windowID,
                 processID: processIdentifier,

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/ElementDetectionService.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/ElementDetectionService.swift
@@ -77,7 +77,7 @@ public final class ElementDetectionService {
                 try await ElementDetectionTimeoutRunner.runDetached(
                     targetProcessIdentifier: request.processIdentifier,
                     targetProcessStartIdentity: request.expectedProcessStartIdentity,
-                    seconds: request.timeoutSeconds)
+                    seconds: request.timing.hardTimeoutSeconds)
                 {
                     try DetachedAXObservationWorker.inspect(request)
                 }
@@ -360,7 +360,7 @@ public final class ElementDetectionService {
                 includeMenuBarElements: includeMenuBarElements,
                 appIsActive: targetApp.isActive,
                 traversalBudget: budget,
-                timeoutSeconds: timeoutSeconds)
+                timing: DetachedAXObservationTiming(hardTimeoutSeconds: timeoutSeconds))
         }
 
         let resolvedContext = WindowContext(

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/AXTreeCollectorBudgetTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/AXTreeCollectorBudgetTests.swift
@@ -93,6 +93,31 @@ final class AXTreeCollectorBudgetTests: XCTestCase {
         XCTAssertTrue(info.isTruncated)
     }
 
+    func testAutomationToolDeadlineRemediationNamesOnlyAvailableControls() {
+        let info = DetectionTruncationInfo(maxDepthReached: true, deadlineReached: true)
+
+        let message = info.automationToolRemediationMessage(budget: AXTraversalBudget(maxDepth: 4))
+
+        XCTAssertTrue(message.contains("app_target"))
+        XCTAssertTrue(message.contains("window_id"))
+        XCTAssertTrue(message.contains("max_depth"))
+        XCTAssertTrue(message.contains("does not expose a timeout argument"))
+        XCTAssertFalse(message.contains("--depth"))
+        XCTAssertFalse(message.contains("longer caller timeout"))
+        XCTAssertFalse(message.contains(AXTraversalBudget.maxDepthEnvironmentKey))
+    }
+
+    func testAutomationToolIncompleteRemediationDoesNotInventTimeoutControl() {
+        let info = DetectionTruncationInfo(incompleteAccessibilityRead: true)
+
+        let message = info.automationToolRemediationMessage(budget: nil)
+
+        XCTAssertTrue(message.contains("app_target"))
+        XCTAssertTrue(message.contains("window_id"))
+        XCTAssertFalse(message.contains("increase the timeout"))
+        XCTAssertFalse(message.contains("--"))
+    }
+
     func testMaxDepthOneStopsAtRoot() throws {
         guard let window = self.frontmostWindowElement() else {
             throw XCTSkip("No frontmost window available for AX testing")

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/AXTreeCollectorBudgetTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/AXTreeCollectorBudgetTests.swift
@@ -222,6 +222,36 @@ final class AXTreeCollectorBudgetTests: XCTestCase {
         XCTAssertNotEqual(withoutMenuBar, withMenuBar)
     }
 
+    func testElementCacheDoesNotStoreDeadlineResults() throws {
+        let cache = ElementDetectionCache()
+        let key = try XCTUnwrap(cache.key(windowID: 42, processID: 123, allowWebFocus: false))
+        cache.store([], for: key)
+        XCTAssertNotNil(cache.result(for: key))
+
+        cache.store([], truncationInfo: DetectionTruncationInfo(deadlineReached: true), for: key)
+
+        XCTAssertNil(cache.result(for: key))
+    }
+
+    func testElementCacheDoesNotStoreIncompleteAccessibilityResults() throws {
+        let cache = ElementDetectionCache()
+        let key = try XCTUnwrap(cache.key(windowID: 42, processID: 123, allowWebFocus: false))
+
+        cache.store([], truncationInfo: DetectionTruncationInfo(incompleteAccessibilityRead: true), for: key)
+
+        XCTAssertNil(cache.result(for: key))
+    }
+
+    func testElementCachePreservesStructuralLimitResults() throws {
+        let cache = ElementDetectionCache()
+        let key = try XCTUnwrap(cache.key(windowID: 42, processID: 123, allowWebFocus: false))
+        let truncation = DetectionTruncationInfo(maxDepthReached: true)
+
+        cache.store([], truncationInfo: truncation, for: key)
+
+        XCTAssertEqual(cache.result(for: key)?.truncationInfo, truncation)
+    }
+
     func testExactWindowResolutionDoesNotActivateBackgroundApplication() async throws {
         guard let originalFrontmost = NSWorkspace.shared.frontmostApplication else {
             throw XCTSkip("No frontmost application available")

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/DesktopObservationServiceTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/DesktopObservationServiceTests.swift
@@ -297,7 +297,7 @@ extension DesktopObservationServiceTests {
                 allowWebFocusFallback: false,
                 includeMenuBarElements: false),
             output: DesktopObservationOutputOptions(snapshotID: "snapshot-1"),
-            timeout: DesktopObservationTimeouts(detection: 0.75)))
+            timeout: DesktopObservationTimeouts(detection: 60)))
 
         XCTAssertNotNil(result.elements)
         XCTAssertEqual(automation.detectCalls, 1)
@@ -308,7 +308,7 @@ extension DesktopObservationServiceTests {
         XCTAssertEqual(automation.lastWindowContext?.windowID, 77)
         XCTAssertEqual(automation.lastWindowContext?.shouldFocusWebContent, false)
         XCTAssertEqual(automation.lastWindowContext?.includeMenuBarElements, false)
-        XCTAssertEqual(automation.lastWindowContext?.accessibilityTimeoutSeconds, 0.75)
+        XCTAssertEqual(automation.lastWindowContext?.accessibilityTimeoutSeconds, 60)
         XCTAssertEqual(result.timings.spans.map(\.name), [
             "state.snapshot",
             "target.resolve",

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/DetachedAXObservationWorkerTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/DetachedAXObservationWorkerTests.swift
@@ -195,6 +195,17 @@ struct DetachedAXObservationWorkerTests {
     }
 
     @Test
+    func `AX worker reserves bounded completion grace before the hard timeout`() {
+        let long = DetachedAXObservationTiming(hardTimeoutSeconds: 60)
+        #expect(long.cooperativeDeadlineSeconds == 59.75)
+        #expect(long.hardTimeoutSeconds == 60)
+
+        let short = DetachedAXObservationTiming(hardTimeoutSeconds: 0.05)
+        #expect(abs(short.cooperativeDeadlineSeconds - 0.04) < 0.000_001)
+        #expect(short.hardTimeoutSeconds == 0.05)
+    }
+
+    @Test
     @MainActor
     func `materially different traversal budgets bypass AX cache`() {
         #expect(ElementDetectionService.shouldUseAXTreeCache(
@@ -281,7 +292,7 @@ struct DetachedAXObservationWorkerTests {
             includeMenuBarElements: false,
             appIsActive: false,
             traversalBudget: AXTraversalBudget(),
-            timeoutSeconds: 1)
+            timing: DetachedAXObservationTiming(hardTimeoutSeconds: 1))
     }
 
     private static func errorValue(_ error: AXError) throws -> AXValue {

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/DetachedAXObservationWorkerTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/DetachedAXObservationWorkerTests.swift
@@ -174,6 +174,47 @@ struct DetachedAXObservationWorkerTests {
     }
 
     @Test
+    func `exact window AX refusal is incomplete rather than a fake deadline`() {
+        let immediate = DetachedAXObservationWorker.exactWindowResolutionFailureTruncation(
+            deadlineReached: false)
+        let expired = DetachedAXObservationWorker.exactWindowResolutionFailureTruncation(
+            deadlineReached: true)
+
+        #expect(immediate.incompleteAccessibilityRead)
+        #expect(!immediate.deadlineReached)
+        #expect(expired.deadlineReached)
+        #expect(!expired.incompleteAccessibilityRead)
+    }
+
+    @Test
+    @MainActor
+    func `explicit accessibility timeout is not silently capped`() {
+        #expect(ElementDetectionService.normalizedAccessibilityTimeout(nil) == 20)
+        #expect(ElementDetectionService.normalizedAccessibilityTimeout(60) == 60)
+        #expect(ElementDetectionService.normalizedAccessibilityTimeout(0.01) == 0.05)
+    }
+
+    @Test
+    @MainActor
+    func `materially different traversal budgets bypass AX cache`() {
+        #expect(ElementDetectionService.shouldUseAXTreeCache(
+            budget: AXTraversalBudget(),
+            requiresFreshAccessibilityTree: false))
+        #expect(!ElementDetectionService.shouldUseAXTreeCache(
+            budget: AXTraversalBudget(maxDepth: 4),
+            requiresFreshAccessibilityTree: false))
+        #expect(!ElementDetectionService.shouldUseAXTreeCache(
+            budget: AXTraversalBudget(maxElementCount: 120),
+            requiresFreshAccessibilityTree: false))
+        #expect(!ElementDetectionService.shouldUseAXTreeCache(
+            budget: AXTraversalBudget(maxChildrenPerNode: 40),
+            requiresFreshAccessibilityTree: false))
+        #expect(!ElementDetectionService.shouldUseAXTreeCache(
+            budget: AXTraversalBudget(),
+            requiresFreshAccessibilityTree: true))
+    }
+
+    @Test
     func `process reuse before detached worker fails closed`() {
         let request = Self.identityRequest()
 

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ElementDetectionServiceDetachedObservationTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ElementDetectionServiceDetachedObservationTests.swift
@@ -9,7 +9,7 @@ import Testing
 @MainActor
 struct ElementDetectionServiceDetachedObservationTests {
     @Test
-    func `cooperative AX deadline returns partial evidence before the hard escape timer`() async throws {
+    func `worker cooperative deadline returns structured evidence before the hard escape timer`() async throws {
         let request = RunnerState().makeRequest(timeoutSeconds: 1)
         let result = try await ElementDetectionTimeoutRunner.runDetached(
             targetProcessIdentifier: request.processIdentifier,
@@ -23,6 +23,22 @@ struct ElementDetectionServiceDetachedObservationTests {
 
         #expect(result.truncationInfo?.deadlineReached == true)
         #expect(result.truncationInfo?.incompleteAccessibilityRead == false)
+    }
+
+    @Test
+    func `cooperative AX deadline returns partial evidence before the hard escape timer`() async throws {
+        let request = RunnerState().makeRequest(timeoutSeconds: 1)
+        let result = try await ElementDetectionTimeoutRunner.runDetached(
+            targetProcessIdentifier: request.processIdentifier,
+            targetProcessStartIdentity: request.expectedProcessStartIdentity,
+            seconds: request.timing.hardTimeoutSeconds)
+        {
+            Self.partialDeadlineResult(request)
+        }
+
+        #expect(result.truncationInfo?.deadlineReached == true)
+        #expect(result.truncationInfo?.incompleteAccessibilityRead == false)
+        #expect(result.elements.map(\.id) == [Self.partialElement.id])
     }
 
     @Test
@@ -165,6 +181,29 @@ struct ElementDetectionServiceDetachedObservationTests {
             },
             validateIdentity: { _ in })
     }
+
+    private nonisolated static func partialDeadlineResult(
+        _ request: DetachedAXObservationRequest) -> DetachedAXObservationResult
+    {
+        Thread.sleep(forTimeInterval: request.timing.cooperativeDeadlineSeconds + 0.02)
+        return DetachedAXObservationResult(
+            elements: [self.partialElement],
+            windowID: request.windowID,
+            windowTitle: "Injected fixture",
+            windowBounds: request.expectedWindowBounds,
+            isDialog: false,
+            truncationInfo: DetectionTruncationInfo(deadlineReached: true))
+    }
+
+    private nonisolated static let partialElement = DetectedElement(
+        id: "elem_partial",
+        type: .button,
+        label: "Partial",
+        value: nil,
+        bounds: CGRect(x: 30, y: 40, width: 100, height: 30),
+        isEnabled: true,
+        isSelected: nil,
+        attributes: [:])
 
     private nonisolated static func completeResult(
         _ request: DetachedAXObservationRequest) -> DetachedAXObservationResult

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ElementDetectionServiceDetachedObservationTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ElementDetectionServiceDetachedObservationTests.swift
@@ -9,6 +9,23 @@ import Testing
 @MainActor
 struct ElementDetectionServiceDetachedObservationTests {
     @Test
+    func `cooperative AX deadline returns partial evidence before the hard escape timer`() async throws {
+        let request = RunnerState().makeRequest(timeoutSeconds: 1)
+        let result = try await ElementDetectionTimeoutRunner.runDetached(
+            targetProcessIdentifier: request.processIdentifier,
+            targetProcessStartIdentity: request.expectedProcessStartIdentity,
+            seconds: request.timing.hardTimeoutSeconds)
+        {
+            try Self.resolutionFailure(
+                request,
+                delay: request.timing.cooperativeDeadlineSeconds + 0.02)
+        }
+
+        #expect(result.truncationInfo?.deadlineReached == true)
+        #expect(result.truncationInfo?.incompleteAccessibilityRead == false)
+    }
+
+    @Test
     func `explicit timeout above twenty seconds reaches delayed worker and incomplete read is retried`() async throws {
         let cache = ElementDetectionCache()
         let cacheKey = try #require(cache.key(windowID: 42, processID: 123, allowWebFocus: false))
@@ -23,7 +40,7 @@ struct ElementDetectionServiceDetachedObservationTests {
                     return try await ElementDetectionTimeoutRunner.runDetached(
                         targetProcessIdentifier: request.processIdentifier,
                         targetProcessStartIdentity: request.expectedProcessStartIdentity,
-                        seconds: request.timeoutSeconds)
+                        seconds: request.timing.hardTimeoutSeconds)
                     {
                         try Self.resolutionFailure(
                             request,
@@ -42,7 +59,7 @@ struct ElementDetectionServiceDetachedObservationTests {
         #expect(first.usedCache == false)
         #expect(first.truncationInfo?.incompleteAccessibilityRead == true)
         #expect(first.truncationInfo?.deadlineReached == false)
-        #expect(state.requests.map(\.timeoutSeconds) == [60])
+        #expect(state.requests.map(\.timing.hardTimeoutSeconds) == [60])
         #expect(cache.result(for: cacheKey) == nil)
 
         let second = try await service.cachedOrRunDetachedAXObservation(
@@ -52,7 +69,7 @@ struct ElementDetectionServiceDetachedObservationTests {
             makeRequest: { state.makeRequest(timeoutSeconds: 60) })
         #expect(second.usedCache == false)
         #expect(second.elements.map(\.id) == ["elem_complete"])
-        #expect(state.requests.map(\.timeoutSeconds) == [60, 60])
+        #expect(state.requests.map(\.timing.hardTimeoutSeconds) == [60, 60])
         #expect(cache.result(for: cacheKey)?.elements.map(\.id) == ["elem_complete"])
 
         let third = try await service.cachedOrRunDetachedAXObservation(
@@ -192,6 +209,6 @@ private final class RunnerState {
             includeMenuBarElements: false,
             appIsActive: false,
             traversalBudget: AXTraversalBudget(),
-            timeoutSeconds: timeoutSeconds)
+            timing: DetachedAXObservationTiming(hardTimeoutSeconds: timeoutSeconds))
     }
 }

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ElementDetectionServiceDetachedObservationTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ElementDetectionServiceDetachedObservationTests.swift
@@ -1,0 +1,197 @@
+import ApplicationServices
+import CoreGraphics
+import Foundation
+import PeekabooFoundation
+import Testing
+@testable @_spi(Testing) import PeekabooAutomationKit
+
+@Suite(.serialized)
+@MainActor
+struct ElementDetectionServiceDetachedObservationTests {
+    @Test
+    func `explicit timeout above twenty seconds reaches delayed worker and incomplete read is retried`() async throws {
+        let cache = ElementDetectionCache()
+        let cacheKey = try #require(cache.key(windowID: 42, processID: 123, allowWebFocus: false))
+        let state = RunnerState()
+        let service = ElementDetectionService(
+            snapshotManager: nil,
+            applicationService: nil,
+            axTreeCache: cache,
+            detachedAXObservationRunner: { request in
+                state.requests.append(request)
+                if state.requests.count == 1 {
+                    return try await ElementDetectionTimeoutRunner.runDetached(
+                        targetProcessIdentifier: request.processIdentifier,
+                        targetProcessStartIdentity: request.expectedProcessStartIdentity,
+                        seconds: request.timeoutSeconds)
+                    {
+                        try Self.resolutionFailure(
+                            request,
+                            delay: 0.02)
+                    }
+                }
+                return Self.completeResult(request)
+            })
+
+        let first = try await service.cachedOrRunDetachedAXObservation(
+            cacheKey: cacheKey,
+            invalidatedThrough: nil,
+            cachedContext: Self.cachedContext,
+            makeRequest: { state.makeRequest(timeoutSeconds: 60) })
+
+        #expect(first.usedCache == false)
+        #expect(first.truncationInfo?.incompleteAccessibilityRead == true)
+        #expect(first.truncationInfo?.deadlineReached == false)
+        #expect(state.requests.map(\.timeoutSeconds) == [60])
+        #expect(cache.result(for: cacheKey) == nil)
+
+        let second = try await service.cachedOrRunDetachedAXObservation(
+            cacheKey: cacheKey,
+            invalidatedThrough: nil,
+            cachedContext: Self.cachedContext,
+            makeRequest: { state.makeRequest(timeoutSeconds: 60) })
+        #expect(second.usedCache == false)
+        #expect(second.elements.map(\.id) == ["elem_complete"])
+        #expect(state.requests.map(\.timeoutSeconds) == [60, 60])
+        #expect(cache.result(for: cacheKey)?.elements.map(\.id) == ["elem_complete"])
+
+        let third = try await service.cachedOrRunDetachedAXObservation(
+            cacheKey: cacheKey,
+            invalidatedThrough: nil,
+            cachedContext: Self.cachedContext,
+            makeRequest: {
+                Issue.record("A complete cached result must not rebuild or rerun the AX request")
+                return state.makeRequest(timeoutSeconds: 60)
+            })
+        #expect(third.usedCache)
+        #expect(third.elements.map(\.id) == ["elem_complete"])
+        #expect(state.requests.count == 2)
+        #expect(state.requestBuildCount == 2)
+    }
+
+    @Test
+    func `resolve window failure after deadline is reported honestly and retried`() async throws {
+        let cache = ElementDetectionCache()
+        let cacheKey = try #require(cache.key(windowID: 42, processID: 123, allowWebFocus: false))
+        let state = RunnerState()
+        let service = ElementDetectionService(
+            snapshotManager: nil,
+            applicationService: nil,
+            axTreeCache: cache,
+            detachedAXObservationRunner: { request in
+                state.requests.append(request)
+                if state.requests.count == 1 {
+                    return try Self.resolutionFailure(
+                        request,
+                        delay: 0.03)
+                }
+                return Self.completeResult(request)
+            })
+
+        let first = try await service.cachedOrRunDetachedAXObservation(
+            cacheKey: cacheKey,
+            invalidatedThrough: nil,
+            cachedContext: Self.cachedContext,
+            makeRequest: { state.makeRequest(timeoutSeconds: 0.01) })
+
+        #expect(first.usedCache == false)
+        #expect(first.truncationInfo?.deadlineReached == true)
+        #expect(first.truncationInfo?.incompleteAccessibilityRead == false)
+        #expect(cache.result(for: cacheKey) == nil)
+
+        let second = try await service.cachedOrRunDetachedAXObservation(
+            cacheKey: cacheKey,
+            invalidatedThrough: nil,
+            cachedContext: Self.cachedContext,
+            makeRequest: { state.makeRequest(timeoutSeconds: 0.01) })
+        #expect(second.usedCache == false)
+        #expect(second.elements.map(\.id) == ["elem_complete"])
+
+        let third = try await service.cachedOrRunDetachedAXObservation(
+            cacheKey: cacheKey,
+            invalidatedThrough: nil,
+            cachedContext: Self.cachedContext,
+            makeRequest: {
+                Issue.record("A complete cached retry must not rebuild the AX request")
+                return state.makeRequest(timeoutSeconds: 0.01)
+            })
+        #expect(third.usedCache)
+        #expect(state.requests.count == 2)
+        #expect(state.requestBuildCount == 2)
+    }
+
+    private static let cachedContext = CachedDetachedAXObservationContext(
+        windowID: 42,
+        windowTitle: "Cached fixture",
+        windowBounds: CGRect(x: 10, y: 20, width: 800, height: 600),
+        isDialog: false)
+
+    private nonisolated static func resolutionFailure(
+        _ request: DetachedAXObservationRequest,
+        delay: TimeInterval) throws -> DetachedAXObservationResult
+    {
+        try DetachedAXObservationWorker.inspect(
+            request,
+            resolveWindow: { _, _, _ in
+                Thread.sleep(forTimeInterval: delay)
+                throw PeekabooError.windowNotFound(criteria: "injected AX window resolution failure")
+            },
+            exactWindowUnavailableResult: { request, deadlineReached in
+                DetachedAXObservationResult(
+                    elements: [],
+                    windowID: request.windowID,
+                    windowTitle: "Injected fixture",
+                    windowBounds: request.expectedWindowBounds,
+                    isDialog: false,
+                    truncationInfo: DetachedAXObservationWorker.exactWindowResolutionFailureTruncation(
+                        deadlineReached: deadlineReached))
+            },
+            validateIdentity: { _ in })
+    }
+
+    private nonisolated static func completeResult(
+        _ request: DetachedAXObservationRequest) -> DetachedAXObservationResult
+    {
+        DetachedAXObservationResult(
+            elements: [
+                DetectedElement(
+                    id: "elem_complete",
+                    type: .textField,
+                    label: "Complete",
+                    value: "Complete",
+                    bounds: CGRect(x: 30, y: 40, width: 200, height: 30),
+                    isEnabled: true,
+                    isSelected: nil,
+                    attributes: [:]),
+            ],
+            windowID: request.windowID,
+            windowTitle: "Injected fixture",
+            windowBounds: request.expectedWindowBounds,
+            isDialog: false,
+            truncationInfo: nil)
+    }
+}
+
+@MainActor
+private final class RunnerState {
+    var requests: [DetachedAXObservationRequest] = []
+    var requestBuildCount = 0
+
+    func makeRequest(timeoutSeconds: TimeInterval) -> DetachedAXObservationRequest {
+        self.requestBuildCount += 1
+        return DetachedAXObservationRequest(
+            processIdentifier: 123,
+            expectedProcessStartIdentity: 7,
+            windowID: 42,
+            windowTitle: "Fixture",
+            expectedWindowBounds: CGRect(x: 10, y: 20, width: 800, height: 600),
+            windowMutationIdentity: WindowMutationIdentity(
+                windowID: 42,
+                ownerProcessIdentifier: 123,
+                ownerProcessStartIdentity: 7),
+            includeMenuBarElements: false,
+            appIsActive: false,
+            traversalBudget: AXTraversalBudget(),
+            timeoutSeconds: timeoutSeconds)
+    }
+}

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/InspectUITool+Types.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/InspectUITool+Types.swift
@@ -99,7 +99,8 @@ struct InspectUISummaryBuilder {
         guard let truncationInfo = self.result.metadata.truncationInfo, truncationInfo.isTruncated else {
             return []
         }
-        return [truncationInfo.remediationMessage(budget: self.result.metadata.windowContext?.traversalBudget)]
+        return [truncationInfo.automationToolRemediationMessage(
+            budget: self.result.metadata.windowContext?.traversalBudget)]
     }
 
     private func roleHeader(role: String, elements: [DetectedElement]) -> String {

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/InspectUITool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/InspectUITool.swift
@@ -150,12 +150,12 @@ public struct InspectUITool: MCPTool {
             let hostHasSnapshot = try await self.context.snapshots.listSnapshots().contains { $0.id == snapshotId }
             guard hostHasSnapshot else {
                 throw PeekabooError.snapshotNotFound(
-                    "Snapshot '\(snapshotId)' was not found. Omit --snapshot and run inspect-ui again.")
+                    "Snapshot '\(snapshotId)' was not found. Omit the `snapshot` argument and run `inspect_ui` again.")
             }
             guard let existingSnapshot = await UISnapshotManager.shared.getSnapshot(id: snapshotId) else {
                 throw PeekabooError.snapshotNotFound(
                     "Snapshot '\(snapshotId)' is not available in this process. " +
-                        "Omit --snapshot and run inspect-ui again.")
+                        "Omit the `snapshot` argument and run `inspect_ui` again.")
             }
             return (existingSnapshot, false)
         }

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/InspectUITool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/InspectUITool.swift
@@ -86,6 +86,7 @@ public struct InspectUITool: MCPTool {
 
             let result = try await self.context.automation.inspectAccessibilityTree(
                 windowContext: windowContext)
+            try Self.requireUsableAXOnlyEvidence(result)
             let snapshotResult = self.bindResult(result, to: snapshot.id)
 
             try await self.context.snapshots.storeDetectionResult(
@@ -144,6 +145,17 @@ public struct InspectUITool: MCPTool {
     }
 
     // MARK: - Private Helpers
+
+    private static func requireUsableAXOnlyEvidence(_ result: ElementDetectionResult) throws {
+        guard result.elements.all.isEmpty,
+              let truncationInfo = result.metadata.truncationInfo,
+              truncationInfo.isTruncated
+        else { return }
+
+        throw PeekabooError.operationError(
+            message: truncationInfo.automationToolRemediationMessage(
+                budget: result.metadata.windowContext?.traversalBudget))
+    }
 
     private func getOrCreateSnapshot(snapshotId: String?) async throws -> (snapshot: UISnapshot, isNew: Bool) {
         if let snapshotId {

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/SeeTool+Types.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/SeeTool+Types.swift
@@ -171,7 +171,7 @@ struct SeeSummaryBuilder {
 
     private func truncationWarningLines() -> [String] {
         guard let truncationInfo, truncationInfo.isTruncated else { return [] }
-        return ["", truncationInfo.remediationMessage(budget: self.traversalBudget)]
+        return ["", truncationInfo.automationToolRemediationMessage(budget: self.traversalBudget)]
     }
 
     private func describeElement(_ element: UIElement) -> String {

--- a/Core/PeekabooCore/Sources/PeekabooCore/Support/RemoteUIAutomationService.swift
+++ b/Core/PeekabooCore/Sources/PeekabooCore/Support/RemoteUIAutomationService.swift
@@ -100,7 +100,22 @@ public class RemoteUIAutomationService: DetectElementsRequestTimeoutAdjusting, T
 
         return try await self.client.inspectAccessibilityTree(
             windowContext: windowContext,
-            requestTimeoutSec: 30)
+            requestTimeoutSec: Self.inspectAccessibilityTreeRequestTimeoutSeconds(
+                accessibilityTimeoutSeconds: windowContext?.accessibilityTimeoutSeconds))
+    }
+
+    nonisolated static func inspectAccessibilityTreeRequestTimeoutSeconds(
+        accessibilityTimeoutSeconds: TimeInterval?) -> TimeInterval
+    {
+        let defaultTimeout: TimeInterval = 30
+        let completionGrace: TimeInterval = 5
+        guard let accessibilityTimeoutSeconds,
+              accessibilityTimeoutSeconds.isFinite,
+              accessibilityTimeoutSeconds > 0
+        else {
+            return defaultTimeout
+        }
+        return max(defaultTimeout, accessibilityTimeoutSeconds + completionGrace)
     }
 
     public func click(target: ClickTarget, clickType: ClickType, snapshotId: String?) async throws {

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/InspectUIToolExecutionTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/InspectUIToolExecutionTests.swift
@@ -249,6 +249,9 @@ struct InspectUIToolExecutionTests {
             return
         }
         #expect(output.contains("Snapshot 'missing-snapshot' was not found"))
+        #expect(output.contains("Omit the `snapshot` argument and run `inspect_ui` again"))
+        #expect(!output.contains("--snapshot"))
+        #expect(!output.contains("inspect-ui"))
         #expect(await MainActor.run { automation.lastInspectWindowContext } == nil)
         let hostSnapshotIDsAfter = try await Set(context.snapshots.listSnapshots().map(\.id))
         #expect(hostSnapshotIDsAfter == hostSnapshotIDsBefore)
@@ -278,6 +281,9 @@ struct InspectUIToolExecutionTests {
             return
         }
         #expect(output.contains("Snapshot '\(snapshotId)' is not available in this process"))
+        #expect(output.contains("Omit the `snapshot` argument and run `inspect_ui` again"))
+        #expect(!output.contains("--snapshot"))
+        #expect(!output.contains("inspect-ui"))
         #expect(await MainActor.run { automation.lastInspectWindowContext } == nil)
         let hostSnapshotIDsAfter = try await Set(context.snapshots.listSnapshots().map(\.id))
         #expect(hostSnapshotIDsAfter == hostSnapshotIDsBefore)

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/InspectUIToolExecutionTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/InspectUIToolExecutionTests.swift
@@ -145,6 +145,72 @@ struct InspectUIToolExecutionTests {
     }
 
     @Test
+    func `Inspect UI rejects an empty truncated AX result`() async throws {
+        let detectionResult = ElementDetectionResult(
+            snapshotId: "snapshot-inspect-empty-deadline",
+            screenshotPath: "",
+            elements: DetectedElements(),
+            metadata: DetectionMetadata(
+                detectionTime: 0.288,
+                elementCount: 0,
+                method: "AXorcist",
+                truncationInfo: DetectionTruncationInfo(deadlineReached: true)))
+        let automation = await MainActor.run {
+            InspectUITestAutomationService(
+                accessibilityGranted: true,
+                detectionResult: detectionResult)
+        }
+        let snapshots = await MainActor.run { InMemorySnapshotManager() }
+        let context = await Self.makeContext(automation: automation, snapshots: snapshots)
+
+        let response = try await InspectUITool(context: context).execute(arguments: ToolArguments(raw: [:]))
+
+        #expect(response.isError)
+        guard case let .text(text: output, annotations: _, _meta: _) = response.content.first else {
+            Issue.record("Expected text response for inspect_ui error")
+            return
+        }
+        #expect(output.contains("Failed to inspect UI"))
+        #expect(output.contains("time deadline"))
+        #expect(try await snapshots.listSnapshots().isEmpty)
+    }
+
+    @Test
+    func `Inspect UI preserves useful partial AX evidence at its deadline`() async throws {
+        let base = Self.emptyDetectionResult(id: "partial-deadline")
+        let element = DetectedElement(
+            id: "B1",
+            type: .button,
+            label: "Partial",
+            bounds: CGRect(x: 10, y: 10, width: 80, height: 32))
+        let detectionResult = ElementDetectionResult(
+            snapshotId: base.snapshotId,
+            screenshotPath: "",
+            elements: DetectedElements(buttons: [element]),
+            metadata: DetectionMetadata(
+                detectionTime: 1,
+                elementCount: 1,
+                method: "AXorcist",
+                truncationInfo: DetectionTruncationInfo(deadlineReached: true)))
+        let automation = await MainActor.run {
+            InspectUITestAutomationService(
+                accessibilityGranted: true,
+                detectionResult: detectionResult)
+        }
+        let context = await Self.makeContext(automation: automation)
+
+        let response = try await InspectUITool(context: context).execute(arguments: ToolArguments(raw: [:]))
+
+        #expect(response.isError == false)
+        guard case let .text(text: output, annotations: _, _meta: _) = response.content.first else {
+            Issue.record("Expected text response for inspect_ui output")
+            return
+        }
+        #expect(output.contains("B1"))
+        #expect(output.contains("time deadline"))
+    }
+
+    @Test
     func `Inspect UI tool annotates cached AX results`() async throws {
         let detectionResult = ElementDetectionResult(
             snapshotId: "snapshot-inspect-cached",

--- a/Core/PeekabooCore/Tests/PeekabooTests/RemoteInspectUIBridgeTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/RemoteInspectUIBridgeTests.swift
@@ -1,12 +1,26 @@
 import Foundation
 import PeekabooAutomationKit
 import PeekabooBridge
-import PeekabooCore
 import PeekabooFoundation
 import Testing
+@testable import PeekabooCore
 
 @Suite(.serialized)
 struct RemoteInspectUIBridgeTests {
+    @Test
+    func `remote inspect timeout follows explicit accessibility budget with completion grace`() {
+        #expect(RemoteUIAutomationService.inspectAccessibilityTreeRequestTimeoutSeconds(
+            accessibilityTimeoutSeconds: nil) == 30)
+        #expect(RemoteUIAutomationService.inspectAccessibilityTreeRequestTimeoutSeconds(
+            accessibilityTimeoutSeconds: 20) == 30)
+        #expect(RemoteUIAutomationService.inspectAccessibilityTreeRequestTimeoutSeconds(
+            accessibilityTimeoutSeconds: 60) == 65)
+        #expect(RemoteUIAutomationService.inspectAccessibilityTreeRequestTimeoutSeconds(
+            accessibilityTimeoutSeconds: .infinity) == 30)
+        #expect(RemoteUIAutomationService.inspectAccessibilityTreeRequestTimeoutSeconds(
+            accessibilityTimeoutSeconds: -1) == 30)
+    }
+
     @Test
     func `remote inspect accessibility tree routes through bridge without screenshot payload`() async throws {
         let socketPath = "/tmp/peekaboo-bridge-client-\(UUID().uuidString).sock"
@@ -53,7 +67,10 @@ struct RemoteInspectUIBridgeTests {
                 RemoteUIAutomationService(client: client, supportsInspectAccessibilityTree: true)
             }
             let result = try await remote.inspectAccessibilityTree(
-                windowContext: WindowContext(applicationName: "Safari", windowTitle: "Main"))
+                windowContext: WindowContext(
+                    applicationName: "Safari",
+                    windowTitle: "Main",
+                    accessibilityTimeoutSeconds: 60))
 
             #expect(result.snapshotId == "s")
             let recorded = await MainActor.run {
@@ -66,6 +83,7 @@ struct RemoteInspectUIBridgeTests {
             #expect(recorded.1 == nil)
             #expect(recorded.2?.applicationName == "Safari")
             #expect(recorded.2?.windowTitle == "Main")
+            #expect(recorded.2?.accessibilityTimeoutSeconds == 60)
             await host.stop()
         } catch {
             await host.stop()

--- a/Core/PeekabooFoundation/Sources/PeekabooFoundation/ErrorTypes.swift
+++ b/Core/PeekabooFoundation/Sources/PeekabooFoundation/ErrorTypes.swift
@@ -127,10 +127,21 @@ public enum CaptureError: Error, LocalizedError, Sendable {
             return "Failed to convert captured image to desired format."
         case let .detectionTimedOut(seconds):
             return """
-            Element detection timed out after \(Int(seconds))s. Try narrowing the capture, targeting a specific \
-            window, or increasing the timeout (e.g. `peekaboo see --timeout-seconds 30 ...`).
+            Element detection timed out after \(Self.formattedTimeoutDuration(seconds)). Try narrowing the capture, \
+            targeting a specific window, or increasing the timeout (e.g. `peekaboo see --timeout 30s ...`).
             """
         }
+    }
+
+    private static func formattedTimeoutDuration(_ seconds: TimeInterval) -> String {
+        guard seconds.isFinite, seconds > 0 else { return "\(seconds)s" }
+        if seconds < 1 {
+            return "\(max(1, Int((seconds * 1000).rounded())))ms"
+        }
+        if seconds.rounded() == seconds, seconds <= TimeInterval(Int.max) {
+            return "\(Int(seconds))s"
+        }
+        return String(format: "%.1fs", seconds)
     }
 
     public var exitCode: Int32 {

--- a/Core/PeekabooFoundation/Tests/PeekabooFoundationTests/CaptureErrorDescriptionTests.swift
+++ b/Core/PeekabooFoundation/Tests/PeekabooFoundationTests/CaptureErrorDescriptionTests.swift
@@ -1,0 +1,24 @@
+import Testing
+@testable import PeekabooFoundation
+
+struct CaptureErrorDescriptionTests {
+    @Test
+    func `subsecond detection timeout keeps millisecond precision and current CLI spelling`() throws {
+        let description = try #require(CaptureError.detectionTimedOut(0.2).errorDescription)
+
+        #expect(description.contains("after 200ms"))
+        #expect(description.contains("peekaboo see --timeout 30s"))
+        #expect(!description.contains("after 0s"))
+        #expect(!description.contains("--timeout-seconds"))
+    }
+
+    @Test(arguments: [
+        (2.5, "2.5s"),
+        (20.0, "20s"),
+    ])
+    func `detection timeout formats whole and fractional seconds`(_ seconds: Double, _ expected: String) throws {
+        let description = try #require(CaptureError.detectionTimedOut(seconds).errorDescription)
+
+        #expect(description.contains("after \(expected)"))
+    }
+}

--- a/docs/commands/see.md
+++ b/docs/commands/see.md
@@ -112,7 +112,7 @@ peekaboo see --app "Google Chrome" --json --path /tmp/chrome-see.png \
 ## Troubleshooting tips
 
 - If the CLI reports **blind typing**, pass an explicit `--app`, `--pid`, `--window-id`, or fresh `--snapshot` so `type` can resolve a background target process, or add `--foreground` when the target app requires focused keyboard input.
-- If JSON/text output reports `AX tree truncated`, rerun with larger `--depth`, `--max-elements`, or `--max-children` values. For repeated captures, export the matching `PEEKABOO_AX_MAX_*` environment variable before launching Peekaboo.
+- If JSON/text output reports an AX time deadline, rerun with a longer `--timeout` or a narrower exact-window target. Increase `--depth`, `--max-elements`, or `--max-children` only when the corresponding structural cap is reported. A tree-only inspection that reaches a cap before finding any element exits nonzero instead of publishing an unusable empty snapshot; useful partial evidence remains successful and explicitly truncated.
 - Missing text fields after an explicit `--web-focus` retry usually means the page is shielding its inputs from AX entirely. For Chrome targets, use the `browser` tool (`status` → `connect` → `snapshot`/`fill`/`click`) after enabling Chrome remote debugging; otherwise rely on image-based hit tests.
 - For repeatable local tests, run `RUN_LOCAL_TESTS=true swift test --filter SeeCommandPlaygroundTests` to exercise the Playground fixtures mentioned in `docs/research/interaction-debugging.md`.
 - Rapid repeated `see` calls for the same window reuse a short-lived AX cache (~1.5s); wait a beat if you need a fully fresh traversal.


### PR DESCRIPTION
## Summary

- propagate the caller's explicit accessibility deadline through tree-only `see`, Bridge-backed inspection, and the detached AX worker instead of silently capping long requests
- distinguish native AX read failures from actual deadline exhaustion, reserve bounded completion grace for cooperative partial results, and never cache deadline-truncated or incomplete observations as complete
- preserve useful partial trees with explicit truncation metadata while rejecting empty truncated AX-only results before snapshot publication
- keep CLI and MCP recovery guidance honest about the controls each surface actually exposes, with matching changelog and `see` documentation

## Safety and compatibility

- observation stays background-only: no activation, physical cursor movement, clipboard mutation, AppleScript, or global-input fallback is introduced
- process-generation and exact-window receipts remain pinned across detached work; cancellation and identity drift still fail closed
- structural caps remain successful when they return useful evidence, while empty or deadline-exhausted results return typed failures and are retried fresh rather than replayed from cache
- existing Bridge payloads remain decodable because the new timeout and truncation fields have compatibility defaults
- an explicitly long caller deadline can hold that target process's serial AX observation lane longer than the former 20-second cap; this is an intentional caller-controlled availability tradeoff, still bounded by the requested deadline and per-call native AX timeouts

## Proof

- refreshed on exact global-UI-consent base `a30d58f6`: 46 deterministic AX budget/worker/service tests, 26 Inspect UI/remote Bridge tests, 32 CLI See parser/runtime tests, 2 remote timeout tests, and 2 Foundation error-format tests
- prior full branch proof remains valid because the production patch is unchanged: `pnpm run test:safe` passed 768 CLI/Core safe tests plus 72 runtime tests
- SwiftFormat changed no files; docs lint passed; full SwiftLint completed with 18 warnings and 0 serious violations; `git diff --check` passed
- final branch Autoreview and TruffleHog are clean at 0.99 with no accepted/actionable findings
- Foundation-signed source-blind validation passed 9/9 at 0.99: normal and explicit-timeout reads returned useful explicitly truncated System Settings trees, a 1 ms deadline returned structured `TIMEOUT`, a one-element cap preserved useful evidence, retries used fresh snapshot IDs, and foreground/window, cursor, clipboard, overlays, and forbidden-helper logs stayed unchanged

Source-blind evidence: `/tmp/behavior-validator-ax-timeout.bFDq8S/report.{md,json}`
