### PR TITLE
perf(cli): bound concurrent Bridge diagnostics

### DIFF
--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Default new agent configurations to GPT-5.6 and Claude Opus 5 while keeping credential-only Anthropic discovery on Opus 4.8 for zero-retention compatibility and preserving explicit model selections.
 
 ### Fixed
+- Probe Bridge diagnostic sockets concurrently with bounded cancellation while preserving runtime selection and candidate order, so `bridge status --verbose` no longer accumulates per-host handshake latency.
 - Require explicit `--foreground` consent before `menubar click` can inspect or open global status-item UI; keep `menubar list` read-only and report missing items as typed retry-safe pre-dispatch refusals.
 - Keep background app launch/open ownership through verified focus reconciliation, restoring only the exact prior process generation without overriding a later user foreground choice.
 - Stop probing, requesting, advertising, or showing AppleScript Automation permission now that application, Dock, and UI operations use native macOS APIs; remove AppleScript code from shipped executables while retaining legacy wire/error decoding for older Bridge hosts.

--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Default new agent configurations to GPT-5.6 and Claude Opus 5 while keeping credential-only Anthropic discovery on Opus 4.8 for zero-retention compatibility and preserving explicit model selections.
 
 ### Fixed
-- Probe Bridge diagnostic sockets concurrently with bounded cancellation while preserving runtime selection and candidate order, so `bridge status --verbose` no longer accumulates per-host handshake latency.
+- Probe Bridge diagnostic sockets concurrently under a one-second per-host deadline with bounded cancellation while preserving runtime selection and candidate order, so `bridge status --verbose` neither accumulates nor inherits a wedged host's full handshake latency.
 - Require explicit `--foreground` consent before `menubar click` can inspect or open global status-item UI; keep `menubar list` read-only and report missing items as typed retry-safe pre-dispatch refusals.
 - Keep background app launch/open ownership through verified focus reconciliation, restoring only the exact prior process generation without overriding a later user foreground choice.
 - Stop probing, requesting, advertising, or showing AppleScript Automation permission now that application, Dock, and UI operations use native macOS APIs; remove AppleScript code from shipped executables while retaining legacy wire/error decoding for older Bridge hosts.

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Core/BridgeCommand+Diagnostics.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Core/BridgeCommand+Diagnostics.swift
@@ -4,6 +4,12 @@ import PeekabooBridge
 import Security
 
 struct BridgeDiagnostics {
+    typealias CandidateProbe = @Sendable (
+        _ socketPath: String,
+        _ identity: PeekabooBridgeClientIdentity) async throws -> PeekabooBridgeHandshakeResponse
+
+    nonisolated static let maxConcurrentProbes = 8
+
     private let logger: Logger
 
     init(logger: Logger) {
@@ -11,47 +17,41 @@ struct BridgeDiagnostics {
     }
 
     @MainActor
-    func run(runtimeOptions: CommandRuntimeOptions) async -> BridgeStatusReport {
+    func run(runtimeOptions: CommandRuntimeOptions) async throws -> BridgeStatusReport {
         let environment = ProcessInfo.processInfo.environment
         let effectiveOptions = runtimeOptions.applyingEnvironmentOverrides(environment: environment)
         let configurationInput = PeekabooAutomation.ConfigurationManager.shared.getConfiguration()?.input
         let remoteSkipReason = Self.remoteSkipReason(
             runtimeOptions: effectiveOptions,
             environment: environment,
-            configurationInput: configurationInput
-        )
+            configurationInput: configurationInput)
 
         let identity = PeekabooBridgeClientIdentity(
             bundleIdentifier: Bundle.main.bundleIdentifier,
             teamIdentifier: Self.currentTeamIdentifier(),
             processIdentifier: getpid(),
-            hostname: Host.current().name
-        )
+            hostname: Host.current().name)
 
         if let remoteSkipReason {
             let candidates = Self.diagnosticSocketPaths(
                 runtimeOptions: effectiveOptions,
-                environment: environment
-            )
+                environment: environment)
             self.logger.debug("Bridge status: remote skipped (\(remoteSkipReason))")
             return BridgeStatusReport(
                 remoteSkipped: true,
                 remoteSkipReason: remoteSkipReason,
                 selected: .local(),
                 candidates: candidates.map { BridgeCandidateReport(socketPath: $0, result: .skipped) },
-                client: .init(identity: identity)
-            )
+                client: .init(identity: identity))
         }
 
         let candidatePlan = await RuntimeHostResolver.remoteCandidatePlan(
             options: effectiveOptions,
-            environment: environment
-        )
+            environment: environment)
         let runtimeCandidates = candidatePlan.candidates
         let candidates = Self.diagnosticSocketPaths(
             runtimeCandidateSocketPaths: runtimeCandidates.map(\.socketPath),
-            hasExplicitSocket: candidatePlan.explicitSocket != nil
-        )
+            hasExplicitSocket: candidatePlan.explicitSocket != nil)
         var runtimeCandidateByPath: [String: RuntimeHostResolver.ImplicitRemoteCandidate] = [:]
         for candidate in runtimeCandidates {
             let path = NSString(string: candidate.socketPath).standardizingPath
@@ -60,44 +60,46 @@ struct BridgeDiagnostics {
             }
         }
 
+        let probeResults = try await Self.probeCandidates(
+            socketPaths: candidates,
+            identity: identity)
+
         var results: [BridgeCandidateReport] = []
         var selected: BridgeSelectionReport?
 
-        for socketPath in candidates {
-            let client = PeekabooBridgeClient(socketPath: socketPath)
-            do {
-                let handshake = try await client.handshake(client: identity, requestedHost: nil)
+        for probeResult in probeResults {
+            let socketPath = probeResult.socketPath
+            switch probeResult.outcome {
+            case let .success(handshake):
                 let report = BridgeHandshakeReport(from: handshake)
                 self.logger.debug(
                     "Bridge status: handshake OK \(handshake.hostKind.rawValue) via \(socketPath)",
-                    category: "Bridge"
-                )
+                    category: "Bridge")
                 results.append(.init(socketPath: socketPath, result: .success(report)))
 
                 let candidatePath = NSString(string: socketPath).standardizingPath
                 if selected == nil,
-                   let runtimeCandidate = runtimeCandidateByPath[candidatePath] {
+                   let runtimeCandidate = runtimeCandidateByPath[candidatePath]
+                {
                     let validation = await RuntimeHostResolver.validateRemoteCandidate(
                         runtimeCandidate,
                         handshake: handshake,
-                        options: effectiveOptions
-                    )
+                        options: effectiveOptions)
                     if validation != nil {
                         selected = .remote(socketPath: socketPath, handshake: report)
                     }
                 }
-            } catch let envelope as PeekabooBridgeErrorEnvelope {
-                self.logger.debug(
-                    "Bridge status: handshake error \(envelope.code.rawValue) via \(socketPath): \(envelope.message)",
-                    category: "Bridge"
-                )
-                results.append(.init(socketPath: socketPath, result: .failure(.bridgeEnvelope(envelope))))
-            } catch {
-                self.logger.debug(
-                    "Bridge status: handshake error via \(socketPath): \(String(describing: error))",
-                    category: "Bridge"
-                )
-                results.append(.init(socketPath: socketPath, result: .failure(.other(error))))
+            case let .failure(error):
+                if let errorCode = error.code {
+                    self.logger.debug(
+                        "Bridge status: handshake error \(errorCode) via \(socketPath): \(error.message)",
+                        category: "Bridge")
+                } else {
+                    self.logger.debug(
+                        "Bridge status: handshake error via \(socketPath): \(error.details ?? error.message)",
+                        category: "Bridge")
+                }
+                results.append(.init(socketPath: socketPath, result: .failure(error)))
             }
         }
 
@@ -106,21 +108,81 @@ struct BridgeDiagnostics {
             remoteSkipReason: nil,
             selected: selected ?? .local(),
             candidates: results,
-            client: .init(identity: identity)
-        )
+            client: .init(identity: identity))
+    }
+
+    nonisolated static func probeCandidates(
+        socketPaths: [String],
+        identity: PeekabooBridgeClientIdentity,
+        maxConcurrentProbes: Int = Self.maxConcurrentProbes,
+        probe: @escaping CandidateProbe = Self.liveProbe) async throws -> [BridgeDiagnosticProbeResult]
+    {
+        guard !socketPaths.isEmpty else { return [] }
+        precondition(maxConcurrentProbes > 0, "Bridge probe concurrency must be positive")
+        try Task.checkCancellation()
+
+        return try await withThrowingTaskGroup(
+            of: (Int, BridgeDiagnosticProbeOutcome).self,
+            returning: [BridgeDiagnosticProbeResult].self)
+        { group in
+            defer { group.cancelAll() }
+
+            func enqueue(_ index: Int) {
+                let socketPath = socketPaths[index]
+                group.addTask {
+                    do {
+                        let handshake = try await probe(socketPath, identity)
+                        return (index, .success(handshake))
+                    } catch is CancellationError {
+                        throw CancellationError()
+                    } catch let envelope as PeekabooBridgeErrorEnvelope {
+                        return (index, .failure(.bridgeEnvelope(envelope)))
+                    } catch {
+                        return (index, .failure(.other(error)))
+                    }
+                }
+            }
+
+            let initialProbeCount = min(socketPaths.count, maxConcurrentProbes)
+            for index in 0..<initialProbeCount {
+                enqueue(index)
+            }
+
+            var nextIndex = initialProbeCount
+            var orderedResults = [BridgeDiagnosticProbeResult?](repeating: nil, count: socketPaths.count)
+            while let (index, outcome) = try await group.next() {
+                try Task.checkCancellation()
+                orderedResults[index] = BridgeDiagnosticProbeResult(
+                    socketPath: socketPaths[index],
+                    outcome: outcome)
+                if nextIndex < socketPaths.count {
+                    enqueue(nextIndex)
+                    nextIndex += 1
+                }
+            }
+
+            return orderedResults.compactMap(\.self)
+        }
+    }
+
+    private nonisolated static func liveProbe(
+        socketPath: String,
+        identity: PeekabooBridgeClientIdentity) async throws -> PeekabooBridgeHandshakeResponse
+    {
+        let client = PeekabooBridgeClient(socketPath: socketPath)
+        return try await client.handshake(client: identity, requestedHost: nil)
     }
 
     static func remoteSkipReason(
         runtimeOptions: CommandRuntimeOptions,
         environment: [String: String],
-        configurationInput: PeekabooAutomation.Configuration.InputConfig?
-    ) -> String? {
+        configurationInput: PeekabooAutomation.Configuration.InputConfig?) -> String?
+    {
         let decision = RuntimeHostResolver.initialRoutingDecision(
             options: runtimeOptions,
             environment: environment,
             configurationInput: configurationInput,
-            knownSnapshotInvalidationRemoteSocketPaths: []
-        )
+            knownSnapshotInvalidationRemoteSocketPaths: [])
         guard case .local = decision else { return nil }
 
         if environment["PEEKABOO_NO_REMOTE"] != nil {
@@ -132,8 +194,8 @@ struct BridgeDiagnostics {
         if RuntimeHostResolver.inputPolicyRequiresLocal(
             options: runtimeOptions,
             environment: environment,
-            configurationInput: configurationInput
-        ) {
+            configurationInput: configurationInput)
+        {
             return "input strategy policy"
         }
         return "local runtime policy"
@@ -142,51 +204,46 @@ struct BridgeDiagnostics {
     static func runtimeCandidateSocketPaths(
         runtimeOptions: CommandRuntimeOptions,
         environment: [String: String],
-        historicalBuildScopedDaemonSocketPaths: [String] = []
-    ) -> [String] {
+        historicalBuildScopedDaemonSocketPaths: [String] = []) -> [String]
+    {
         if let explicitPath = BridgeSocketResolver.explicitBridgeSocket(
             options: runtimeOptions,
-            environment: environment
-        ) {
+            environment: environment)
+        {
             return [explicitPath]
         }
 
         let daemonPath = DaemonLaunchPolicy.daemonSocketPath(environment: environment)
         let buildScopedPath = DaemonLaunchPolicy.buildScopedDaemonSocketPath(
             daemonSocketPath: daemonPath,
-            runtimeBuildIdentity: DaemonLaunchPolicy.runtimeBuildIdentity()
-        )
+            runtimeBuildIdentity: DaemonLaunchPolicy.runtimeBuildIdentity())
         return RuntimeHostResolver.implicitRemoteCandidates(
             options: runtimeOptions,
             daemonSocketPath: daemonPath,
             buildScopedDaemonSocketPath: buildScopedPath,
-            historicalBuildScopedDaemonSocketPaths: historicalBuildScopedDaemonSocketPaths
-        ).map(\.socketPath)
+            historicalBuildScopedDaemonSocketPaths: historicalBuildScopedDaemonSocketPaths).map(\.socketPath)
     }
 
     static func diagnosticSocketPaths(
         runtimeOptions: CommandRuntimeOptions,
         environment: [String: String],
-        historicalBuildScopedDaemonSocketPaths: [String] = []
-    ) -> [String] {
+        historicalBuildScopedDaemonSocketPaths: [String] = []) -> [String]
+    {
         let runtimePaths = self.runtimeCandidateSocketPaths(
             runtimeOptions: runtimeOptions,
             environment: environment,
-            historicalBuildScopedDaemonSocketPaths: historicalBuildScopedDaemonSocketPaths
-        )
+            historicalBuildScopedDaemonSocketPaths: historicalBuildScopedDaemonSocketPaths)
         return self.diagnosticSocketPaths(
             runtimeCandidateSocketPaths: runtimePaths,
             hasExplicitSocket: BridgeSocketResolver.explicitBridgeSocket(
                 options: runtimeOptions,
-                environment: environment
-            ) != nil
-        )
+                environment: environment) != nil)
     }
 
     private static func diagnosticSocketPaths(
         runtimeCandidateSocketPaths runtimePaths: [String],
-        hasExplicitSocket: Bool
-    ) -> [String] {
+        hasExplicitSocket: Bool) -> [String]
+    {
         if hasExplicitSocket {
             return runtimePaths
         }
@@ -215,4 +272,14 @@ struct BridgeDiagnostics {
 
         return info[kSecCodeInfoTeamIdentifier as String] as? String
     }
+}
+
+struct BridgeDiagnosticProbeResult: Sendable {
+    let socketPath: String
+    let outcome: BridgeDiagnosticProbeOutcome
+}
+
+enum BridgeDiagnosticProbeOutcome: Sendable {
+    case success(PeekabooBridgeHandshakeResponse)
+    case failure(BridgeCandidateErrorReport)
 }

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Core/BridgeCommand+Diagnostics.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Core/BridgeCommand+Diagnostics.swift
@@ -188,7 +188,11 @@ struct BridgeDiagnostics {
             requestTimeoutSec: Self.probeTimeoutSeconds
         )
         do {
-            return try await client.handshake(client: identity, requestedHost: nil)
+            return try await client.handshake(
+                client: identity,
+                requestedHost: nil,
+                overallTimeoutSec: Self.probeTimeoutSeconds
+            )
         } catch let error as POSIXError where error.code == .ETIMEDOUT {
             throw PeekabooBridgeErrorEnvelope(
                 code: .timeout,

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Core/BridgeCommand+Diagnostics.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Core/BridgeCommand+Diagnostics.swift
@@ -10,6 +10,7 @@ struct BridgeDiagnostics {
     ) async throws -> PeekabooBridgeHandshakeResponse
 
     nonisolated static let maxConcurrentProbes = 8
+    nonisolated static let probeTimeoutSeconds: TimeInterval = 1
 
     private let logger: Logger
 
@@ -182,8 +183,19 @@ struct BridgeDiagnostics {
         socketPath: String,
         identity: PeekabooBridgeClientIdentity
     ) async throws -> PeekabooBridgeHandshakeResponse {
-        let client = PeekabooBridgeClient(socketPath: socketPath)
-        return try await client.handshake(client: identity, requestedHost: nil)
+        let client = PeekabooBridgeClient(
+            socketPath: socketPath,
+            requestTimeoutSec: Self.probeTimeoutSeconds
+        )
+        do {
+            return try await client.handshake(client: identity, requestedHost: nil)
+        } catch let error as POSIXError where error.code == .ETIMEDOUT {
+            throw PeekabooBridgeErrorEnvelope(
+                code: .timeout,
+                message: "Bridge diagnostic handshake timed out after \(Self.probeTimeoutSeconds)s",
+                details: "The host at \(socketPath) did not answer before the diagnostic deadline."
+            )
+        }
     }
 
     static func remoteSkipReason(

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Core/BridgeCommand+Diagnostics.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Core/BridgeCommand+Diagnostics.swift
@@ -6,7 +6,8 @@ import Security
 struct BridgeDiagnostics {
     typealias CandidateProbe = @Sendable (
         _ socketPath: String,
-        _ identity: PeekabooBridgeClientIdentity) async throws -> PeekabooBridgeHandshakeResponse
+        _ identity: PeekabooBridgeClientIdentity
+    ) async throws -> PeekabooBridgeHandshakeResponse
 
     nonisolated static let maxConcurrentProbes = 8
 
@@ -24,34 +25,40 @@ struct BridgeDiagnostics {
         let remoteSkipReason = Self.remoteSkipReason(
             runtimeOptions: effectiveOptions,
             environment: environment,
-            configurationInput: configurationInput)
+            configurationInput: configurationInput
+        )
 
         let identity = PeekabooBridgeClientIdentity(
             bundleIdentifier: Bundle.main.bundleIdentifier,
             teamIdentifier: Self.currentTeamIdentifier(),
             processIdentifier: getpid(),
-            hostname: Host.current().name)
+            hostname: Host.current().name
+        )
 
         if let remoteSkipReason {
             let candidates = Self.diagnosticSocketPaths(
                 runtimeOptions: effectiveOptions,
-                environment: environment)
+                environment: environment
+            )
             self.logger.debug("Bridge status: remote skipped (\(remoteSkipReason))")
             return BridgeStatusReport(
                 remoteSkipped: true,
                 remoteSkipReason: remoteSkipReason,
                 selected: .local(),
                 candidates: candidates.map { BridgeCandidateReport(socketPath: $0, result: .skipped) },
-                client: .init(identity: identity))
+                client: .init(identity: identity)
+            )
         }
 
         let candidatePlan = await RuntimeHostResolver.remoteCandidatePlan(
             options: effectiveOptions,
-            environment: environment)
+            environment: environment
+        )
         let runtimeCandidates = candidatePlan.candidates
         let candidates = Self.diagnosticSocketPaths(
             runtimeCandidateSocketPaths: runtimeCandidates.map(\.socketPath),
-            hasExplicitSocket: candidatePlan.explicitSocket != nil)
+            hasExplicitSocket: candidatePlan.explicitSocket != nil
+        )
         var runtimeCandidateByPath: [String: RuntimeHostResolver.ImplicitRemoteCandidate] = [:]
         for candidate in runtimeCandidates {
             let path = NSString(string: candidate.socketPath).standardizingPath
@@ -62,7 +69,8 @@ struct BridgeDiagnostics {
 
         let probeResults = try await Self.probeCandidates(
             socketPaths: candidates,
-            identity: identity)
+            identity: identity
+        )
 
         var results: [BridgeCandidateReport] = []
         var selected: BridgeSelectionReport?
@@ -74,17 +82,18 @@ struct BridgeDiagnostics {
                 let report = BridgeHandshakeReport(from: handshake)
                 self.logger.debug(
                     "Bridge status: handshake OK \(handshake.hostKind.rawValue) via \(socketPath)",
-                    category: "Bridge")
+                    category: "Bridge"
+                )
                 results.append(.init(socketPath: socketPath, result: .success(report)))
 
                 let candidatePath = NSString(string: socketPath).standardizingPath
                 if selected == nil,
-                   let runtimeCandidate = runtimeCandidateByPath[candidatePath]
-                {
+                   let runtimeCandidate = runtimeCandidateByPath[candidatePath] {
                     let validation = await RuntimeHostResolver.validateRemoteCandidate(
                         runtimeCandidate,
                         handshake: handshake,
-                        options: effectiveOptions)
+                        options: effectiveOptions
+                    )
                     if validation != nil {
                         selected = .remote(socketPath: socketPath, handshake: report)
                     }
@@ -93,11 +102,13 @@ struct BridgeDiagnostics {
                 if let errorCode = error.code {
                     self.logger.debug(
                         "Bridge status: handshake error \(errorCode) via \(socketPath): \(error.message)",
-                        category: "Bridge")
+                        category: "Bridge"
+                    )
                 } else {
                     self.logger.debug(
                         "Bridge status: handshake error via \(socketPath): \(error.details ?? error.message)",
-                        category: "Bridge")
+                        category: "Bridge"
+                    )
                 }
                 results.append(.init(socketPath: socketPath, result: .failure(error)))
             }
@@ -108,23 +119,24 @@ struct BridgeDiagnostics {
             remoteSkipReason: nil,
             selected: selected ?? .local(),
             candidates: results,
-            client: .init(identity: identity))
+            client: .init(identity: identity)
+        )
     }
 
     nonisolated static func probeCandidates(
         socketPaths: [String],
         identity: PeekabooBridgeClientIdentity,
         maxConcurrentProbes: Int = Self.maxConcurrentProbes,
-        probe: @escaping CandidateProbe = Self.liveProbe) async throws -> [BridgeDiagnosticProbeResult]
-    {
+        probe: @escaping CandidateProbe = Self.liveProbe
+    ) async throws -> [BridgeDiagnosticProbeResult] {
         guard !socketPaths.isEmpty else { return [] }
         precondition(maxConcurrentProbes > 0, "Bridge probe concurrency must be positive")
         try Task.checkCancellation()
 
         return try await withThrowingTaskGroup(
             of: (Int, BridgeDiagnosticProbeOutcome).self,
-            returning: [BridgeDiagnosticProbeResult].self)
-        { group in
+            returning: [BridgeDiagnosticProbeResult].self
+        ) { group in
             defer { group.cancelAll() }
 
             func enqueue(_ index: Int) {
@@ -154,7 +166,8 @@ struct BridgeDiagnostics {
                 try Task.checkCancellation()
                 orderedResults[index] = BridgeDiagnosticProbeResult(
                     socketPath: socketPaths[index],
-                    outcome: outcome)
+                    outcome: outcome
+                )
                 if nextIndex < socketPaths.count {
                     enqueue(nextIndex)
                     nextIndex += 1
@@ -167,8 +180,8 @@ struct BridgeDiagnostics {
 
     private nonisolated static func liveProbe(
         socketPath: String,
-        identity: PeekabooBridgeClientIdentity) async throws -> PeekabooBridgeHandshakeResponse
-    {
+        identity: PeekabooBridgeClientIdentity
+    ) async throws -> PeekabooBridgeHandshakeResponse {
         let client = PeekabooBridgeClient(socketPath: socketPath)
         return try await client.handshake(client: identity, requestedHost: nil)
     }
@@ -176,13 +189,14 @@ struct BridgeDiagnostics {
     static func remoteSkipReason(
         runtimeOptions: CommandRuntimeOptions,
         environment: [String: String],
-        configurationInput: PeekabooAutomation.Configuration.InputConfig?) -> String?
-    {
+        configurationInput: PeekabooAutomation.Configuration.InputConfig?
+    ) -> String? {
         let decision = RuntimeHostResolver.initialRoutingDecision(
             options: runtimeOptions,
             environment: environment,
             configurationInput: configurationInput,
-            knownSnapshotInvalidationRemoteSocketPaths: [])
+            knownSnapshotInvalidationRemoteSocketPaths: []
+        )
         guard case .local = decision else { return nil }
 
         if environment["PEEKABOO_NO_REMOTE"] != nil {
@@ -194,8 +208,8 @@ struct BridgeDiagnostics {
         if RuntimeHostResolver.inputPolicyRequiresLocal(
             options: runtimeOptions,
             environment: environment,
-            configurationInput: configurationInput)
-        {
+            configurationInput: configurationInput
+        ) {
             return "input strategy policy"
         }
         return "local runtime policy"
@@ -204,46 +218,51 @@ struct BridgeDiagnostics {
     static func runtimeCandidateSocketPaths(
         runtimeOptions: CommandRuntimeOptions,
         environment: [String: String],
-        historicalBuildScopedDaemonSocketPaths: [String] = []) -> [String]
-    {
+        historicalBuildScopedDaemonSocketPaths: [String] = []
+    ) -> [String] {
         if let explicitPath = BridgeSocketResolver.explicitBridgeSocket(
             options: runtimeOptions,
-            environment: environment)
-        {
+            environment: environment
+        ) {
             return [explicitPath]
         }
 
         let daemonPath = DaemonLaunchPolicy.daemonSocketPath(environment: environment)
         let buildScopedPath = DaemonLaunchPolicy.buildScopedDaemonSocketPath(
             daemonSocketPath: daemonPath,
-            runtimeBuildIdentity: DaemonLaunchPolicy.runtimeBuildIdentity())
+            runtimeBuildIdentity: DaemonLaunchPolicy.runtimeBuildIdentity()
+        )
         return RuntimeHostResolver.implicitRemoteCandidates(
             options: runtimeOptions,
             daemonSocketPath: daemonPath,
             buildScopedDaemonSocketPath: buildScopedPath,
-            historicalBuildScopedDaemonSocketPaths: historicalBuildScopedDaemonSocketPaths).map(\.socketPath)
+            historicalBuildScopedDaemonSocketPaths: historicalBuildScopedDaemonSocketPaths
+        ).map(\.socketPath)
     }
 
     static func diagnosticSocketPaths(
         runtimeOptions: CommandRuntimeOptions,
         environment: [String: String],
-        historicalBuildScopedDaemonSocketPaths: [String] = []) -> [String]
-    {
+        historicalBuildScopedDaemonSocketPaths: [String] = []
+    ) -> [String] {
         let runtimePaths = self.runtimeCandidateSocketPaths(
             runtimeOptions: runtimeOptions,
             environment: environment,
-            historicalBuildScopedDaemonSocketPaths: historicalBuildScopedDaemonSocketPaths)
+            historicalBuildScopedDaemonSocketPaths: historicalBuildScopedDaemonSocketPaths
+        )
         return self.diagnosticSocketPaths(
             runtimeCandidateSocketPaths: runtimePaths,
             hasExplicitSocket: BridgeSocketResolver.explicitBridgeSocket(
                 options: runtimeOptions,
-                environment: environment) != nil)
+                environment: environment
+            ) != nil
+        )
     }
 
     private static func diagnosticSocketPaths(
         runtimeCandidateSocketPaths runtimePaths: [String],
-        hasExplicitSocket: Bool) -> [String]
-    {
+        hasExplicitSocket: Bool
+    ) -> [String] {
         if hasExplicitSocket {
             return runtimePaths
         }

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Core/BridgeCommand+Models.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Core/BridgeCommand+Models.swift
@@ -159,7 +159,8 @@ struct BridgeCandidateErrorReport: Codable, Sendable {
             code: envelope.code.rawValue,
             message: envelope.message,
             details: envelope.details,
-            hint: hint)
+            hint: hint
+        )
     }
 
     nonisolated static func other(_ error: any Error) -> BridgeCandidateErrorReport {
@@ -168,7 +169,8 @@ struct BridgeCandidateErrorReport: Codable, Sendable {
             code: nil,
             message: error.localizedDescription,
             details: String(describing: error),
-            hint: nil)
+            hint: nil
+        )
     }
 
     var humanSummary: String {

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Core/BridgeCommand+Models.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Core/BridgeCommand+Models.swift
@@ -151,6 +151,8 @@ struct BridgeCandidateErrorReport: Codable, Sendable {
         case .internalError:
             "Host closed the connection without a valid response. This commonly indicates code-sign checks " +
                 "or a mismatched Bridge protocol."
+        case .timeout:
+            "Inspect or restart this specific host; other diagnostic candidates were still probed."
         default:
             nil
         }

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Core/BridgeCommand+Models.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Core/BridgeCommand+Models.swift
@@ -133,14 +133,14 @@ struct BridgeHandshakeReport: Codable {
     }
 }
 
-struct BridgeCandidateErrorReport: Codable {
+struct BridgeCandidateErrorReport: Codable, Sendable {
     let kind: String
     let code: String?
     let message: String
     let details: String?
     let hint: String?
 
-    static func bridgeEnvelope(_ envelope: PeekabooBridgeErrorEnvelope) -> BridgeCandidateErrorReport {
+    nonisolated static func bridgeEnvelope(_ envelope: PeekabooBridgeErrorEnvelope) -> BridgeCandidateErrorReport {
         let hint: String? = switch envelope.code {
         case .unauthorizedClient:
             "Client not signed by an allowed TeamID. For local dev, set " +
@@ -159,18 +159,16 @@ struct BridgeCandidateErrorReport: Codable {
             code: envelope.code.rawValue,
             message: envelope.message,
             details: envelope.details,
-            hint: hint
-        )
+            hint: hint)
     }
 
-    static func other(_ error: any Error) -> BridgeCandidateErrorReport {
+    nonisolated static func other(_ error: any Error) -> BridgeCandidateErrorReport {
         BridgeCandidateErrorReport(
             kind: "system",
             code: nil,
             message: error.localizedDescription,
             details: String(describing: error),
-            hint: nil
-        )
+            hint: nil)
     }
 
     var humanSummary: String {

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Core/BridgeCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Core/BridgeCommand.swift
@@ -23,8 +23,7 @@ struct BridgeCommand: ParsableCommand {
             StatusSubcommand.self,
         ],
         defaultSubcommand: StatusSubcommand.self,
-        showHelpOnEmptyInvocation: true
-    )
+        showHelpOnEmptyInvocation: true)
 }
 
 extension BridgeCommand {
@@ -34,8 +33,7 @@ extension BridgeCommand {
             MainActorCommandDescription.describe {
                 CommandDescription(
                     commandName: "status",
-                    abstract: "Report which Bridge host would be used"
-                )
+                    abstract: "Report which Bridge host would be used")
             }
         }
 
@@ -58,7 +56,7 @@ extension BridgeCommand {
             self.runtime = runtime
             self.logger.setJsonOutputMode(self.jsonOutput)
 
-            let report = await BridgeDiagnostics(logger: self.logger).run(runtimeOptions: self.runtimeOptions)
+            let report = try await BridgeDiagnostics(logger: self.logger).run(runtimeOptions: self.runtimeOptions)
             if self.jsonOutput {
                 outputSuccessCodable(data: report, logger: self.outputLogger)
                 return

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Core/BridgeCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Core/BridgeCommand.swift
@@ -23,7 +23,8 @@ struct BridgeCommand: ParsableCommand {
             StatusSubcommand.self,
         ],
         defaultSubcommand: StatusSubcommand.self,
-        showHelpOnEmptyInvocation: true)
+        showHelpOnEmptyInvocation: true
+    )
 }
 
 extension BridgeCommand {
@@ -33,7 +34,8 @@ extension BridgeCommand {
             MainActorCommandDescription.describe {
                 CommandDescription(
                     commandName: "status",
-                    abstract: "Report which Bridge host would be used")
+                    abstract: "Report which Bridge host would be used"
+                )
             }
         }
 

--- a/Apps/CLI/Tests/CoreCLITests/BridgeDiagnosticsConcurrencyTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/BridgeDiagnosticsConcurrencyTests.swift
@@ -8,7 +8,8 @@ struct BridgeDiagnosticsConcurrencyTests {
         bundleIdentifier: "test.peekaboo",
         teamIdentifier: nil,
         processIdentifier: 42,
-        hostname: "test-host")
+        hostname: "test-host"
+    )
 
     @Test
     func `probes run concurrently with a bound and return in candidate order`() async throws {
@@ -21,7 +22,8 @@ struct BridgeDiagnosticsConcurrencyTests {
                 maxConcurrentProbes: 2,
                 probe: { socketPath, _ in
                     await gate.probe(socketPath)
-                })
+                }
+            )
         }
 
         await gate.waitUntilStarted(count: 2)
@@ -61,7 +63,8 @@ struct BridgeDiagnosticsConcurrencyTests {
                     await starts.record(socketPath)
                     try await Task.sleep(for: .seconds(30))
                     return Self.handshake(build: socketPath)
-                })
+                }
+            )
         }
 
         await starts.waitUntilStarted(count: 2)
@@ -80,7 +83,8 @@ struct BridgeDiagnosticsConcurrencyTests {
             negotiatedVersion: PeekabooBridgeConstants.protocolVersion,
             hostKind: .onDemand,
             build: build,
-            supportedOperations: [.permissionsStatus])
+            supportedOperations: [.permissionsStatus]
+        )
     }
 }
 
@@ -99,7 +103,8 @@ private actor BridgeProbeGate {
             negotiatedVersion: PeekabooBridgeConstants.protocolVersion,
             hostKind: .onDemand,
             build: socketPath,
-            supportedOperations: [.permissionsStatus])
+            supportedOperations: [.permissionsStatus]
+        )
     }
 
     func waitUntilStarted(count: Int) async {

--- a/Apps/CLI/Tests/CoreCLITests/BridgeDiagnosticsConcurrencyTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/BridgeDiagnosticsConcurrencyTests.swift
@@ -78,6 +78,38 @@ struct BridgeDiagnosticsConcurrencyTests {
         #expect(await Set(starts.paths) == Set(["/one", "/two"]))
     }
 
+    @Test
+    func `probe failures preserve typed errors and candidate order`() async throws {
+        let paths = ["/slow", "/healthy"]
+        let results = try await BridgeDiagnostics.probeCandidates(
+            socketPaths: paths,
+            identity: self.identity,
+            maxConcurrentProbes: 2,
+            probe: { socketPath, _ in
+                if socketPath == "/slow" {
+                    throw PeekabooBridgeErrorEnvelope(
+                        code: .timeout,
+                        message: "diagnostic deadline exceeded"
+                    )
+                }
+                return Self.handshake(build: socketPath)
+            }
+        )
+
+        #expect(results.map(\.socketPath) == paths)
+        guard case let .failure(failure) = results[0].outcome else {
+            Issue.record("Expected the first diagnostic candidate to fail")
+            return
+        }
+        #expect(failure.code == PeekabooBridgeErrorCode.timeout.rawValue)
+        #expect(failure.message == "diagnostic deadline exceeded")
+        guard case let .success(handshake) = results[1].outcome else {
+            Issue.record("Expected the second diagnostic candidate to succeed")
+            return
+        }
+        #expect(handshake.build == "/healthy")
+    }
+
     private nonisolated static func handshake(build: String) -> PeekabooBridgeHandshakeResponse {
         PeekabooBridgeHandshakeResponse(
             negotiatedVersion: PeekabooBridgeConstants.protocolVersion,

--- a/Apps/CLI/Tests/CoreCLITests/BridgeDiagnosticsConcurrencyTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/BridgeDiagnosticsConcurrencyTests.swift
@@ -1,0 +1,140 @@
+import Foundation
+import PeekabooBridge
+import Testing
+@testable import PeekabooCLI
+
+struct BridgeDiagnosticsConcurrencyTests {
+    private let identity = PeekabooBridgeClientIdentity(
+        bundleIdentifier: "test.peekaboo",
+        teamIdentifier: nil,
+        processIdentifier: 42,
+        hostname: "test-host")
+
+    @Test
+    func `probes run concurrently with a bound and return in candidate order`() async throws {
+        let gate = BridgeProbeGate()
+        let paths = ["/one", "/two", "/three", "/four"]
+        let probeTask = Task {
+            try await BridgeDiagnostics.probeCandidates(
+                socketPaths: paths,
+                identity: self.identity,
+                maxConcurrentProbes: 2,
+                probe: { socketPath, _ in
+                    await gate.probe(socketPath)
+                })
+        }
+
+        await gate.waitUntilStarted(count: 2)
+        #expect(await Set(gate.startedPaths) == Set(["/one", "/two"]))
+
+        await gate.release("/two")
+        await gate.waitUntilStarted(count: 3)
+        #expect(await Set(gate.startedPaths) == Set(["/one", "/two", "/three"]))
+
+        await gate.release("/three")
+        await gate.waitUntilStarted(count: 4)
+        #expect(await Set(gate.startedPaths) == Set(paths))
+
+        await gate.release("/four")
+        await gate.release("/one")
+
+        let results = try await probeTask.value
+        #expect(results.map(\.socketPath) == paths)
+        #expect(results.compactMap { result in
+            if case let .success(handshake) = result.outcome {
+                return handshake.build
+            }
+            return nil
+        } == paths)
+    }
+
+    @Test
+    func `cancellation stops active probes without starting queued candidates`() async throws {
+        let starts = BridgeProbeStarts()
+        let paths = ["/one", "/two", "/three", "/four"]
+        let probeTask = Task {
+            try await BridgeDiagnostics.probeCandidates(
+                socketPaths: paths,
+                identity: self.identity,
+                maxConcurrentProbes: 2,
+                probe: { socketPath, _ in
+                    await starts.record(socketPath)
+                    try await Task.sleep(for: .seconds(30))
+                    return Self.handshake(build: socketPath)
+                })
+        }
+
+        await starts.waitUntilStarted(count: 2)
+        let cancelledAt = ContinuousClock.now
+        probeTask.cancel()
+
+        await #expect(throws: CancellationError.self) {
+            _ = try await probeTask.value
+        }
+        #expect(cancelledAt.duration(to: .now) < .seconds(1))
+        #expect(await Set(starts.paths) == Set(["/one", "/two"]))
+    }
+
+    private nonisolated static func handshake(build: String) -> PeekabooBridgeHandshakeResponse {
+        PeekabooBridgeHandshakeResponse(
+            negotiatedVersion: PeekabooBridgeConstants.protocolVersion,
+            hostKind: .onDemand,
+            build: build,
+            supportedOperations: [.permissionsStatus])
+    }
+}
+
+private actor BridgeProbeGate {
+    private var continuations: [String: CheckedContinuation<Void, Never>] = [:]
+    private var startWaiters: [(count: Int, continuation: CheckedContinuation<Void, Never>)] = []
+    private(set) var startedPaths: [String] = []
+
+    func probe(_ socketPath: String) async -> PeekabooBridgeHandshakeResponse {
+        await withCheckedContinuation { continuation in
+            self.continuations[socketPath] = continuation
+            self.startedPaths.append(socketPath)
+            self.resumeSatisfiedStartWaiters()
+        }
+        return PeekabooBridgeHandshakeResponse(
+            negotiatedVersion: PeekabooBridgeConstants.protocolVersion,
+            hostKind: .onDemand,
+            build: socketPath,
+            supportedOperations: [.permissionsStatus])
+    }
+
+    func waitUntilStarted(count: Int) async {
+        guard self.startedPaths.count < count else { return }
+        await withCheckedContinuation { continuation in
+            self.startWaiters.append((count, continuation))
+        }
+    }
+
+    func release(_ socketPath: String) {
+        self.continuations.removeValue(forKey: socketPath)?.resume()
+    }
+
+    private func resumeSatisfiedStartWaiters() {
+        let satisfied = self.startWaiters.filter { $0.count <= self.startedPaths.count }
+        self.startWaiters.removeAll { $0.count <= self.startedPaths.count }
+        satisfied.forEach { $0.continuation.resume() }
+    }
+}
+
+private actor BridgeProbeStarts {
+    private var startWaiters: [(count: Int, continuation: CheckedContinuation<Void, Never>)] = []
+    private(set) var paths: [String] = []
+
+    func record(_ socketPath: String) {
+        self.paths.append(socketPath)
+        let satisfied = self.startWaiters.filter { $0.count <= self.paths.count }
+        self.startWaiters.removeAll { $0.count <= self.paths.count }
+        satisfied.forEach { $0.continuation.resume() }
+    }
+
+    func waitUntilStarted(count: Int) async {
+        guard self.paths.count < count else { return }
+        await withCheckedContinuation { continuation in
+            self.startWaiters.append((count, continuation))
+        }
+    }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Default new agent configurations to GPT-5.6 and Claude Opus 5 while keeping credential-only Anthropic discovery on Opus 4.8 for zero-retention compatibility and preserving explicit model selections.
 
 ### Fixed
+- Probe Bridge diagnostic sockets concurrently with bounded cancellation while preserving runtime selection and candidate order, so `bridge status --verbose` no longer accumulates per-host handshake latency.
 - Require explicit foreground consent before Dock/menu-bar global UI or targetless frontmost application-menu clicks; keep discovery read-only/background and return typed refusals before lookup or dispatch.
 - Keep background app launch/open ownership through verified focus reconciliation, restoring only the exact prior process generation while treating transient frontmost uncertainty and later user foreground choices conservatively.
 - Stop probing, requesting, advertising, or showing AppleScript Automation permission now that application, Dock, and UI operations use native macOS APIs; remove the stale checked-in CLI binary and AppleScript code from shipped executables while retaining legacy wire/error decoding for older Bridge hosts.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 - Default new agent configurations to GPT-5.6 and Claude Opus 5 while keeping credential-only Anthropic discovery on Opus 4.8 for zero-retention compatibility and preserving explicit model selections.
 
 ### Fixed
-- Probe Bridge diagnostic sockets concurrently with bounded cancellation while preserving runtime selection and candidate order, so `bridge status --verbose` no longer accumulates per-host handshake latency.
+- Probe Bridge diagnostic sockets concurrently under a one-second per-host deadline with bounded cancellation while preserving runtime selection and candidate order, so `bridge status --verbose` neither accumulates nor inherits a wedged host's full handshake latency.
 - Require explicit foreground consent before Dock/menu-bar global UI or targetless frontmost application-menu clicks; keep discovery read-only/background and return typed refusals before lookup or dispatch.
 - Keep background app launch/open ownership through verified focus reconciliation, restoring only the exact prior process generation while treating transient frontmost uncertainty and later user foreground choices conservatively.
 - Stop probing, requesting, advertising, or showing AppleScript Automation permission now that application, Dock, and UI operations use native macOS APIs; remove the stale checked-in CLI binary and AppleScript code from shipped executables while retaining legacy wire/error decoding for older Bridge hosts.

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeClient.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeClient.swift
@@ -29,14 +29,25 @@ public actor PeekabooBridgeClient {
     public func handshake(
         client: PeekabooBridgeClientIdentity,
         requestedHost: PeekabooBridgeHostKind? = nil,
-        protocolVersion: PeekabooBridgeProtocolVersion = PeekabooBridgeConstants.protocolVersion)
+        protocolVersion: PeekabooBridgeProtocolVersion = PeekabooBridgeConstants.protocolVersion,
+        overallTimeoutSec: TimeInterval? = nil)
         async throws -> PeekabooBridgeHandshakeResponse
     {
+        let deadline: Date?
+        if let overallTimeoutSec {
+            guard overallTimeoutSec.isFinite, overallTimeoutSec > 0 else {
+                throw POSIXError(.EINVAL)
+            }
+            deadline = Date().addingTimeInterval(overallTimeoutSec)
+        } else {
+            deadline = nil
+        }
         do {
             return try await self.performHandshake(
                 client: client,
                 requestedHost: requestedHost,
-                protocolVersion: protocolVersion)
+                protocolVersion: protocolVersion,
+                timeoutSec: self.remainingHandshakeTimeout(deadline: deadline))
         } catch let envelope as PeekabooBridgeErrorEnvelope
             where envelope.code == .versionMismatch &&
             protocolVersion == PeekabooBridgeConstants.protocolVersion &&
@@ -50,7 +61,8 @@ public actor PeekabooBridgeClient {
                     return try await self.performHandshake(
                         client: client,
                         requestedHost: requestedHost,
-                        protocolVersion: version)
+                        protocolVersion: version,
+                        timeoutSec: self.remainingHandshakeTimeout(deadline: deadline))
                 } catch let fallbackEnvelope as PeekabooBridgeErrorEnvelope
                     where fallbackEnvelope.code == .versionMismatch
                 {
@@ -65,13 +77,14 @@ public actor PeekabooBridgeClient {
     private func performHandshake(
         client: PeekabooBridgeClientIdentity,
         requestedHost: PeekabooBridgeHostKind?,
-        protocolVersion: PeekabooBridgeProtocolVersion) async throws -> PeekabooBridgeHandshakeResponse
+        protocolVersion: PeekabooBridgeProtocolVersion,
+        timeoutSec: TimeInterval?) async throws -> PeekabooBridgeHandshakeResponse
     {
         let payload = PeekabooBridgeHandshake(
             protocolVersion: protocolVersion,
             client: client,
             requestedHostKind: requestedHost)
-        let response = try await self.send(.handshake(payload))
+        let response = try await self.send(.handshake(payload), timeoutSec: timeoutSec)
 
         switch response {
         case let .handshake(handshake):
@@ -81,5 +94,14 @@ public actor PeekabooBridgeClient {
         default:
             throw PeekabooBridgeErrorEnvelope(code: .invalidRequest, message: "Unexpected handshake response")
         }
+    }
+
+    private func remainingHandshakeTimeout(deadline: Date?) throws -> TimeInterval? {
+        guard let deadline else { return nil }
+        let remaining = deadline.timeIntervalSinceNow
+        guard remaining > 0 else {
+            throw POSIXError(.ETIMEDOUT)
+        }
+        return min(self.requestTimeoutSec, remaining)
     }
 }

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeClientTransportOutcomeTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeClientTransportOutcomeTests.swift
@@ -40,6 +40,31 @@ struct PeekabooBridgeClientTransportOutcomeTests {
     }
 
     @Test
+    func `handshake timeout is shared across protocol fallback attempts`() async throws {
+        let peer = try VersionMismatchBridgePeer(firstResponseDelay: 0.3)
+        let client = PeekabooBridgeClient(socketPath: peer.socketPath, requestTimeoutSec: 1)
+        let identity = PeekabooBridgeClientIdentity(
+            bundleIdentifier: "dev.peekaboo.tests",
+            teamIdentifier: nil,
+            processIdentifier: getpid(),
+            hostname: nil)
+        let startedAt = ContinuousClock.now
+
+        do {
+            _ = try await client.handshake(client: identity, overallTimeoutSec: 1)
+            Issue.record("Expected the negotiated handshake to exhaust its shared deadline")
+        } catch let error as POSIXError {
+            #expect(error.code == .ETIMEDOUT)
+        }
+
+        let elapsed = startedAt.duration(to: .now)
+        #expect(elapsed >= .milliseconds(850))
+        #expect(elapsed < .milliseconds(1200))
+        #expect(await peer.acceptedConnectionCount == 2)
+        await peer.stop()
+    }
+
+    @Test
     func `mutation response EOF is indeterminate and retry unsafe`() async throws {
         let peer = try ScriptedBridgePeer(behavior: .closeWithoutResponse)
         let client = PeekabooBridgeClient(socketPath: peer.socketPath, requestTimeoutSec: 1)
@@ -226,5 +251,107 @@ private final class ScriptedBridgePeer: @unchecked Sendable {
     func waitUntilFinished() async {
         await self.task?.value
         self.task = nil
+    }
+}
+
+private actor VersionMismatchBridgePeerState {
+    private(set) var acceptedConnectionCount = 0
+
+    func recordConnection() {
+        self.acceptedConnectionCount += 1
+    }
+}
+
+private final class VersionMismatchBridgePeer: @unchecked Sendable {
+    let socketPath: String
+    private let listener: Int32
+    private let state = VersionMismatchBridgePeerState()
+    private var task: Task<Void, Never>?
+
+    var acceptedConnectionCount: Int {
+        get async { await self.state.acceptedConnectionCount }
+    }
+
+    init(firstResponseDelay: TimeInterval) throws {
+        self.socketPath = "/tmp/pb-handshake-fallback-\(UUID().uuidString).sock"
+        self.listener = socket(AF_UNIX, SOCK_STREAM, 0)
+        guard self.listener >= 0 else {
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
+        do {
+            var address = sockaddr_un()
+            address.sun_family = sa_family_t(AF_UNIX)
+            address.sun_len = UInt8(MemoryLayout.size(ofValue: address))
+            let copied = self.socketPath.withCString { source in
+                strlcpy(&address.sun_path.0, source, MemoryLayout.size(ofValue: address.sun_path))
+            }
+            guard copied < MemoryLayout.size(ofValue: address.sun_path) else {
+                throw POSIXError(.ENAMETOOLONG)
+            }
+            let length = socklen_t(MemoryLayout.size(ofValue: address))
+            let bindResult = withUnsafePointer(to: &address) { pointer in
+                Darwin.bind(self.listener, UnsafePointer<sockaddr>(OpaquePointer(pointer)), length)
+            }
+            guard bindResult == 0, listen(self.listener, 2) == 0 else {
+                throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+            }
+        } catch {
+            Darwin.close(self.listener)
+            try? FileManager.default.removeItem(atPath: self.socketPath)
+            throw error
+        }
+
+        let listener = self.listener
+        let socketPath = self.socketPath
+        let state = self.state
+        self.task = Task.detached {
+            defer {
+                Darwin.close(listener)
+                try? FileManager.default.removeItem(atPath: socketPath)
+            }
+            for attempt in 0..<2 {
+                let client = accept(listener, nil, nil)
+                guard client >= 0 else { return }
+                await state.recordConnection()
+                Self.drainRequest(client)
+                if attempt == 0 {
+                    try? await Task.sleep(for: .seconds(firstResponseDelay))
+                    let response = PeekabooBridgeResponse.error(.init(
+                        code: .versionMismatch,
+                        message: "scripted version mismatch"))
+                    if let data = try? JSONEncoder.peekabooBridgeEncoder().encode(response) {
+                        _ = data.withUnsafeBytes { bytes in
+                            Darwin.write(client, bytes.baseAddress, bytes.count)
+                        }
+                    }
+                } else {
+                    try? await Task.sleep(for: .seconds(5))
+                }
+                Darwin.close(client)
+            }
+        }
+    }
+
+    func stop() async {
+        self.task?.cancel()
+        _ = shutdown(self.listener, SHUT_RDWR)
+        await self.task?.value
+        self.task = nil
+    }
+
+    private nonisolated static func drainRequest(_ descriptor: Int32) {
+        var buffer = [UInt8](repeating: 0, count: 4096)
+        while true {
+            let count = buffer.withUnsafeMutableBytes { bytes in
+                Darwin.read(descriptor, bytes.baseAddress, bytes.count)
+            }
+            if count > 0 {
+                continue
+            }
+            if count < 0, errno == EINTR {
+                continue
+            }
+            return
+        }
     }
 }

--- a/docs/commands/bridge.md
+++ b/docs/commands/bridge.md
@@ -19,6 +19,7 @@ read_when:
 - Host discovery order is documented in `docs/bridge-host.md`.
 - `--no-remote` (or `PEEKABOO_NO_REMOTE`) skips remote probing and forces local execution.
 - `--bridge-socket <path>` (or `PEEKABOO_BRIDGE_SOCKET`) overrides host discovery and probes only that socket.
+- Status probes run concurrently and give each candidate one second to complete its read-only diagnostic handshake. A `timeout` entry means that host missed the diagnostic deadline; other candidates are still reported and normal runtime selection order is unchanged.
 - Hosts validate callers by code signature TeamID. If the host rejects the client (`unauthorizedClient`), install a signed Peekaboo CLI build or enable the debug-only escape hatch on the host.
 - If `bridge status` reports `internalError` / “Bridge host returned no response”, the probed host likely closed the socket without replying (older host builds). Hosts built from `main` after 2025-12-18 return a structured `unauthorizedClient` error instead, which is much easier to debug.
 - If a candidate reports `perm: SR=N`, grant Screen Recording to that host app. For capture-only subprocesses whose caller already has Screen Recording, bypass Bridge with `--no-remote --capture-engine cg`.


### PR DESCRIPTION
## Summary

- Probe Bridge diagnostic socket candidates concurrently with a fixed concurrency bound while retaining deterministic candidate and runtime-selection order.
- Give each read-only diagnostic handshake a one-second deadline so a stale host cannot hold `bridge status --verbose` for the normal ten-second request timeout.
- Share that deadline across every protocol-version fallback attempt; an older host cannot reset the budget by slowly rejecting each negotiated version.
- Preserve per-candidate failures, including a typed `timeout` result and recovery hint, and propagate command cancellation without starting queued probes.

## Why

`bridge status --verbose` intentionally inspects every known GUI, daemon, and legacy socket. Sequential probing accumulated handshake latency, while the first concurrent version still inherited the slowest host's full request timeout. Diagnostics should report that host as slow without delaying healthy candidates or changing which runtime normal commands select.

## Proof

- `swift test --package-path Apps/CLI --filter BridgeDiagnosticsConcurrencyTests` (3/3)
- `swift test --package-path Core/PeekabooCore --filter PeekabooBridgeClientTransportOutcomeTests` (9/9), including a real delayed version-mismatch UNIX peer that exhausts the shared deadline in 1.002 seconds
- `swift test --package-path Core/PeekabooCore --filter PeekabooBridgeQuitIdentityTests` (6/6)
- `swift test --package-path Core/PeekabooCore --filter PeekabooBridge --no-parallel` (167/167 across 15 suites)
- `pnpm run format`
- `pnpm run lint:docs`
- strict SwiftLint on all four touched Swift files (0 violations)
- `git diff --check origin/main...HEAD`
- Source-blind stress: 25 required invocations completed in 0.490–1.518 seconds; three intermittent GUI stalls remained visible as typed one-second timeout candidates; explicit invalid-socket and cancellation cleanup probes passed; the selected healthy daemon and foreground application stayed unchanged.
- Final branch review reported no accepted/actionable findings.

The original diagnostic production, test, and command-documentation blobs were byte-identical to the source-blind-validated pre-rebase head when replayed onto `main` after #383. The follow-up shared-deadline fix adds the real negotiated-handshake regression above without changing runtime routing.
