### PR TITLE
fix(see): recover exact observation receipts

### DIFF
--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Default new agent configurations to GPT-5.6 and Claude Opus 5 while keeping credential-only Anthropic discovery on Opus 4.8 for zero-retention compatibility and preserving explicit model selections.
 
 ### Fixed
+- Resolve standalone exact-window AX-only `see` targets from their live owner and bind results to a process-generation/window receipt before publishing actionable element IDs or a snapshot.
+- Retry one passive background observation when its exact capture receipt changes before element detection or output, while leaving mutation-capable observations fail-closed.
 - Probe Bridge diagnostic sockets concurrently under a one-second per-host deadline with bounded cancellation while preserving runtime selection and candidate order, so `bridge status --verbose` neither accumulates nor inherits a wedged host's full handshake latency.
 - Require explicit `--foreground` consent before `menubar click` can inspect or open global status-item UI; keep `menubar list` read-only and report missing items as typed retry-safe pre-dispatch refusals.
 - Preserve semantic AX labels, scalar values, roles, descriptions, enabled/selected state, and bounded value-settable capability through background `see` output, persisted snapshots, and agent summaries instead of reducing controls to generic role names.

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/AI/SeeCommand+DetectionPipeline.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/AI/SeeCommand+DetectionPipeline.swift
@@ -115,6 +115,7 @@ extension SeeCommand {
             )
         )
         try self.requireUsableTreeOnlyEvidence(result)
+        try self.requireActionCapableTreeOnlyEvidence(result)
         let bound = ElementDetectionResult(
             snapshotId: snapshotID,
             screenshotPath: "",
@@ -147,6 +148,28 @@ extension SeeCommand {
                 budget: result.metadata.windowContext?.traversalBudget
             )
         )
+    }
+
+    private func requireActionCapableTreeOnlyEvidence(_ result: ElementDetectionResult) throws {
+        guard let context = result.metadata.windowContext,
+              let processIdentifier = context.applicationProcessId,
+              processIdentifier > 0,
+              let windowID = context.windowID,
+              windowID > 0,
+              let bounds = context.windowBounds,
+              bounds.width > 0,
+              bounds.height > 0,
+              let identity = context.windowMutationIdentity,
+              identity.windowID == windowID,
+              identity.ownerProcessIdentifier == processIdentifier,
+              identity.ownerProcessStartIdentity > 0,
+              identity.capturedBounds == bounds
+        else {
+            throw PeekabooError.snapshotStale(
+                "AX-only see could not bind its elements to an exact process-generation, window, and bounds " +
+                    "receipt. Run see again before background input."
+            )
+        }
     }
 
     func resolvedTreeWindowID() async throws -> Int? {

--- a/Apps/CLI/Tests/CLIAutomationTests/SeeCommandReceiptTests.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/SeeCommandReceiptTests.swift
@@ -1,0 +1,120 @@
+import Foundation
+import PeekabooAutomation
+import PeekabooCore
+import PeekabooFoundation
+import Testing
+@testable import PeekabooCLI
+
+extension SeeCommandRuntimeTests {
+    @Test
+    @MainActor
+    func `tree only See publishes elements only with an exact action receipt`() async throws {
+        try await self.withTempConfigEnv { _ in
+            let fixture = Self.makeSeeCommandRuntimeFixture()
+            let automation = StubAutomationService()
+            automation.inspectAccessibilityTreeHandler = { _ in fixture.detectionResult }
+            let (context, _) = Self.makeSeeCommandRuntimeContext(
+                automation: automation,
+                screenCapture: fixture.screenCapture,
+                applicationInfo: fixture.applicationInfo,
+                windowInfo: fixture.windowInfo
+            )
+
+            let result = try await InProcessCommandRunner.run(
+                [
+                    "see",
+                    "--app", fixture.applicationInfo.name,
+                    "--tree",
+                    "--no-screenshot",
+                    "--json",
+                ],
+                services: context.services
+            )
+            let data = try #require(result.stdout.data(using: .utf8))
+            let response = try JSONDecoder().decode(CodableJSONResponse<SeeResult>.self, from: data)
+            let stored = try #require(
+                context.snapshots.detectionResults[response.data.snapshot_id]?.metadata.windowContext
+            )
+
+            #expect(result.exitStatus == 0)
+            #expect(response.data.ui_elements.map(\.id) == ["B1"])
+            #expect(stored.applicationProcessId == fixture.applicationInfo.processIdentifier)
+            #expect(stored.windowID == fixture.windowInfo.windowID)
+            #expect(stored.windowBounds == fixture.windowInfo.bounds)
+            #expect(stored.windowMutationIdentity == fixture.windowInfo.mutationIdentity)
+        }
+    }
+
+    @Test
+    @MainActor
+    func `tree only See refuses incomplete action receipts before snapshot publication`() async throws {
+        try await self.withTempConfigEnv { _ in
+            let fixture = Self.makeSeeCommandRuntimeFixture()
+            let fixtureContext = try #require(fixture.detectionResult.metadata.windowContext)
+            let invalidIdentities: [WindowMutationIdentity?] = [
+                nil,
+                WindowMutationIdentity(
+                    windowID: fixture.windowInfo.windowID,
+                    ownerProcessIdentifier: fixture.applicationInfo.processIdentifier,
+                    ownerProcessStartIdentity: 4242,
+                    capturedBounds: nil
+                ),
+                WindowMutationIdentity(
+                    windowID: fixture.windowInfo.windowID,
+                    ownerProcessIdentifier: fixture.applicationInfo.processIdentifier,
+                    ownerProcessStartIdentity: 0,
+                    capturedBounds: fixture.windowInfo.bounds
+                ),
+            ]
+
+            for invalidIdentity in invalidIdentities {
+                let automation = StubAutomationService()
+                automation.inspectAccessibilityTreeHandler = { _ in
+                    ElementDetectionResult(
+                        snapshotId: "incomplete-receipt-tree",
+                        screenshotPath: "",
+                        elements: fixture.detectionResult.elements,
+                        metadata: DetectionMetadata(
+                            detectionTime: 0.1,
+                            elementCount: fixture.detectionResult.elements.all.count,
+                            method: "stub",
+                            windowContext: WindowContext(
+                                applicationName: fixtureContext.applicationName,
+                                applicationBundleId: fixtureContext.applicationBundleId,
+                                applicationProcessId: fixtureContext.applicationProcessId,
+                                windowTitle: fixtureContext.windowTitle,
+                                windowID: fixtureContext.windowID,
+                                windowBounds: fixtureContext.windowBounds,
+                                windowMutationIdentity: invalidIdentity
+                            )
+                        )
+                    )
+                }
+                let (context, _) = Self.makeSeeCommandRuntimeContext(
+                    automation: automation,
+                    screenCapture: fixture.screenCapture,
+                    applicationInfo: fixture.applicationInfo,
+                    windowInfo: fixture.windowInfo
+                )
+
+                let result = try await InProcessCommandRunner.run(
+                    [
+                        "see",
+                        "--app", fixture.applicationInfo.name,
+                        "--tree",
+                        "--no-screenshot",
+                        "--json",
+                    ],
+                    services: context.services
+                )
+
+                #expect(result.exitStatus == 1)
+                #expect(result.combinedOutput.contains("exact process-generation, window, and bounds receipt"))
+                #expect(!result.combinedOutput.contains("\"snapshot_id\""))
+                #expect(!result.combinedOutput.contains("\"ui_elements\""))
+                #expect(context.snapshots.detectionResults.isEmpty)
+                #expect(try await context.snapshots.listSnapshots().isEmpty)
+            }
+        }
+    }
+}

--- a/Apps/CLI/Tests/CLIAutomationTests/SeeCommandTests.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/SeeCommandTests.swift
@@ -339,6 +339,7 @@ struct SeeCommandRuntimeTests {
                         detectionTime: 4.75,
                         elementCount: 1,
                         method: "AXorcist",
+                        windowContext: fixture.detectionResult.metadata.windowContext,
                         truncationInfo: DetectionTruncationInfo(deadlineReached: true)
                     )
                 )
@@ -366,6 +367,118 @@ struct SeeCommandRuntimeTests {
             #expect(result.combinedOutput.contains(partialElement.id))
             #expect(result.combinedOutput.contains("\"deadline_reached\" : true") ||
                 result.combinedOutput.contains("\"deadline_reached\":true"))
+        }
+    }
+
+    @Test
+    @MainActor
+    func `tree only See publishes elements only with an exact action receipt`() async throws {
+        try await self.withTempConfigEnv { _ in
+            let fixture = Self.makeSeeCommandRuntimeFixture()
+            let automation = StubAutomationService()
+            automation.inspectAccessibilityTreeHandler = { _ in fixture.detectionResult }
+            let (context, _) = Self.makeSeeCommandRuntimeContext(
+                automation: automation,
+                screenCapture: fixture.screenCapture,
+                applicationInfo: fixture.applicationInfo,
+                windowInfo: fixture.windowInfo
+            )
+
+            let result = try await InProcessCommandRunner.run(
+                [
+                    "see",
+                    "--app", fixture.applicationInfo.name,
+                    "--tree",
+                    "--no-screenshot",
+                    "--json",
+                ],
+                services: context.services
+            )
+            let data = try #require(result.stdout.data(using: .utf8))
+            let response = try JSONDecoder().decode(CodableJSONResponse<SeeResult>.self, from: data)
+            let stored = try #require(
+                context.snapshots.detectionResults[response.data.snapshot_id]?.metadata.windowContext
+            )
+
+            #expect(result.exitStatus == 0)
+            #expect(response.data.ui_elements.map(\.id) == ["B1"])
+            #expect(stored.applicationProcessId == fixture.applicationInfo.processIdentifier)
+            #expect(stored.windowID == fixture.windowInfo.windowID)
+            #expect(stored.windowBounds == fixture.windowInfo.bounds)
+            #expect(stored.windowMutationIdentity == fixture.windowInfo.mutationIdentity)
+        }
+    }
+
+    @Test
+    @MainActor
+    func `tree only See refuses incomplete action receipts before snapshot publication`() async throws {
+        try await self.withTempConfigEnv { _ in
+            let fixture = Self.makeSeeCommandRuntimeFixture()
+            let fixtureContext = try #require(fixture.detectionResult.metadata.windowContext)
+            let invalidIdentities: [WindowMutationIdentity?] = [
+                nil,
+                WindowMutationIdentity(
+                    windowID: fixture.windowInfo.windowID,
+                    ownerProcessIdentifier: fixture.applicationInfo.processIdentifier,
+                    ownerProcessStartIdentity: 4242,
+                    capturedBounds: nil
+                ),
+                WindowMutationIdentity(
+                    windowID: fixture.windowInfo.windowID,
+                    ownerProcessIdentifier: fixture.applicationInfo.processIdentifier,
+                    ownerProcessStartIdentity: 0,
+                    capturedBounds: fixture.windowInfo.bounds
+                ),
+            ]
+
+            for invalidIdentity in invalidIdentities {
+                let automation = StubAutomationService()
+                automation.inspectAccessibilityTreeHandler = { _ in
+                    ElementDetectionResult(
+                        snapshotId: "incomplete-receipt-tree",
+                        screenshotPath: "",
+                        elements: fixture.detectionResult.elements,
+                        metadata: DetectionMetadata(
+                            detectionTime: 0.1,
+                            elementCount: fixture.detectionResult.elements.all.count,
+                            method: "stub",
+                            windowContext: WindowContext(
+                                applicationName: fixtureContext.applicationName,
+                                applicationBundleId: fixtureContext.applicationBundleId,
+                                applicationProcessId: fixtureContext.applicationProcessId,
+                                windowTitle: fixtureContext.windowTitle,
+                                windowID: fixtureContext.windowID,
+                                windowBounds: fixtureContext.windowBounds,
+                                windowMutationIdentity: invalidIdentity
+                            )
+                        )
+                    )
+                }
+                let (context, _) = Self.makeSeeCommandRuntimeContext(
+                    automation: automation,
+                    screenCapture: fixture.screenCapture,
+                    applicationInfo: fixture.applicationInfo,
+                    windowInfo: fixture.windowInfo
+                )
+
+                let result = try await InProcessCommandRunner.run(
+                    [
+                        "see",
+                        "--app", fixture.applicationInfo.name,
+                        "--tree",
+                        "--no-screenshot",
+                        "--json",
+                    ],
+                    services: context.services
+                )
+
+                #expect(result.exitStatus == 1)
+                #expect(result.combinedOutput.contains("exact process-generation, window, and bounds receipt"))
+                #expect(!result.combinedOutput.contains("\"snapshot_id\""))
+                #expect(!result.combinedOutput.contains("\"ui_elements\""))
+                #expect(context.snapshots.detectionResults.isEmpty)
+                #expect(try await context.snapshots.listSnapshots().isEmpty)
+            }
         }
     }
 
@@ -1093,6 +1206,7 @@ extension SeeCommandRuntimeTests {
     fileprivate static func makeSeeFixtureApplicationInfo() -> ServiceApplicationInfo {
         ServiceApplicationInfo(
             processIdentifier: 4242,
+            processStartIdentity: 4242,
             bundleIdentifier: "com.example.app",
             name: "ExampleApp",
             isActive: true,
@@ -1101,11 +1215,18 @@ extension SeeCommandRuntimeTests {
     }
 
     fileprivate static func makeSeeFixtureWindowInfo(windowBounds: CGRect) -> ServiceWindowInfo {
-        ServiceWindowInfo(
+        let mutationIdentity = WindowMutationIdentity(
+            windowID: 101,
+            ownerProcessIdentifier: 4242,
+            ownerProcessStartIdentity: 4242,
+            capturedBounds: windowBounds
+        )
+        return ServiceWindowInfo(
             windowID: 101,
             title: "Main Window",
             bounds: windowBounds,
-            isMainWindow: true
+            isMainWindow: true,
+            mutationIdentity: mutationIdentity
         )
     }
 
@@ -1146,8 +1267,12 @@ extension SeeCommandRuntimeTests {
             method: "stub",
             windowContext: WindowContext(
                 applicationName: applicationInfo.name,
+                applicationBundleId: applicationInfo.bundleIdentifier,
+                applicationProcessId: applicationInfo.processIdentifier,
                 windowTitle: windowInfo.title,
-                windowBounds: windowBounds
+                windowID: windowInfo.windowID,
+                windowBounds: windowBounds,
+                windowMutationIdentity: windowInfo.mutationIdentity
             )
         )
         return ElementDetectionResult(

--- a/Apps/CLI/Tests/CLIAutomationTests/SeeCommandTests.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/SeeCommandTests.swift
@@ -372,118 +372,6 @@ struct SeeCommandRuntimeTests {
 
     @Test
     @MainActor
-    func `tree only See publishes elements only with an exact action receipt`() async throws {
-        try await self.withTempConfigEnv { _ in
-            let fixture = Self.makeSeeCommandRuntimeFixture()
-            let automation = StubAutomationService()
-            automation.inspectAccessibilityTreeHandler = { _ in fixture.detectionResult }
-            let (context, _) = Self.makeSeeCommandRuntimeContext(
-                automation: automation,
-                screenCapture: fixture.screenCapture,
-                applicationInfo: fixture.applicationInfo,
-                windowInfo: fixture.windowInfo
-            )
-
-            let result = try await InProcessCommandRunner.run(
-                [
-                    "see",
-                    "--app", fixture.applicationInfo.name,
-                    "--tree",
-                    "--no-screenshot",
-                    "--json",
-                ],
-                services: context.services
-            )
-            let data = try #require(result.stdout.data(using: .utf8))
-            let response = try JSONDecoder().decode(CodableJSONResponse<SeeResult>.self, from: data)
-            let stored = try #require(
-                context.snapshots.detectionResults[response.data.snapshot_id]?.metadata.windowContext
-            )
-
-            #expect(result.exitStatus == 0)
-            #expect(response.data.ui_elements.map(\.id) == ["B1"])
-            #expect(stored.applicationProcessId == fixture.applicationInfo.processIdentifier)
-            #expect(stored.windowID == fixture.windowInfo.windowID)
-            #expect(stored.windowBounds == fixture.windowInfo.bounds)
-            #expect(stored.windowMutationIdentity == fixture.windowInfo.mutationIdentity)
-        }
-    }
-
-    @Test
-    @MainActor
-    func `tree only See refuses incomplete action receipts before snapshot publication`() async throws {
-        try await self.withTempConfigEnv { _ in
-            let fixture = Self.makeSeeCommandRuntimeFixture()
-            let fixtureContext = try #require(fixture.detectionResult.metadata.windowContext)
-            let invalidIdentities: [WindowMutationIdentity?] = [
-                nil,
-                WindowMutationIdentity(
-                    windowID: fixture.windowInfo.windowID,
-                    ownerProcessIdentifier: fixture.applicationInfo.processIdentifier,
-                    ownerProcessStartIdentity: 4242,
-                    capturedBounds: nil
-                ),
-                WindowMutationIdentity(
-                    windowID: fixture.windowInfo.windowID,
-                    ownerProcessIdentifier: fixture.applicationInfo.processIdentifier,
-                    ownerProcessStartIdentity: 0,
-                    capturedBounds: fixture.windowInfo.bounds
-                ),
-            ]
-
-            for invalidIdentity in invalidIdentities {
-                let automation = StubAutomationService()
-                automation.inspectAccessibilityTreeHandler = { _ in
-                    ElementDetectionResult(
-                        snapshotId: "incomplete-receipt-tree",
-                        screenshotPath: "",
-                        elements: fixture.detectionResult.elements,
-                        metadata: DetectionMetadata(
-                            detectionTime: 0.1,
-                            elementCount: fixture.detectionResult.elements.all.count,
-                            method: "stub",
-                            windowContext: WindowContext(
-                                applicationName: fixtureContext.applicationName,
-                                applicationBundleId: fixtureContext.applicationBundleId,
-                                applicationProcessId: fixtureContext.applicationProcessId,
-                                windowTitle: fixtureContext.windowTitle,
-                                windowID: fixtureContext.windowID,
-                                windowBounds: fixtureContext.windowBounds,
-                                windowMutationIdentity: invalidIdentity
-                            )
-                        )
-                    )
-                }
-                let (context, _) = Self.makeSeeCommandRuntimeContext(
-                    automation: automation,
-                    screenCapture: fixture.screenCapture,
-                    applicationInfo: fixture.applicationInfo,
-                    windowInfo: fixture.windowInfo
-                )
-
-                let result = try await InProcessCommandRunner.run(
-                    [
-                        "see",
-                        "--app", fixture.applicationInfo.name,
-                        "--tree",
-                        "--no-screenshot",
-                        "--json",
-                    ],
-                    services: context.services
-                )
-
-                #expect(result.exitStatus == 1)
-                #expect(result.combinedOutput.contains("exact process-generation, window, and bounds receipt"))
-                #expect(!result.combinedOutput.contains("\"snapshot_id\""))
-                #expect(!result.combinedOutput.contains("\"ui_elements\""))
-                #expect(context.snapshots.detectionResults.isEmpty)
-                #expect(try await context.snapshots.listSnapshots().isEmpty)
-            }
-        }
-    }
-
-    @Test
-    @MainActor
     func `Remote See publishes a host-certified observation without a caller barrier`() async throws {
         try await self.withTempConfigEnv { tempDir in
             let fixture = Self.makeSeeCommandRuntimeFixture()
@@ -1112,7 +1000,7 @@ struct SeeCommandRuntimeTests {
         }
     }
 
-    private func withTempConfigEnv<T>(
+    func withTempConfigEnv<T>(
         _ body: @escaping (URL) async throws -> T
     ) async throws -> T {
         let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
@@ -1143,7 +1031,7 @@ struct SeeCommandRuntimeTests {
 }
 
 extension SeeCommandRuntimeTests {
-    fileprivate struct RuntimeFixture {
+    struct RuntimeFixture {
         let snapshotId: String
         let applicationInfo: ServiceApplicationInfo
         let windowInfo: ServiceWindowInfo
@@ -1151,7 +1039,7 @@ extension SeeCommandRuntimeTests {
         let detectionResult: ElementDetectionResult
     }
 
-    fileprivate static func makeSeeCommandRuntimeFixture() -> RuntimeFixture {
+    static func makeSeeCommandRuntimeFixture() -> RuntimeFixture {
         let snapshotId = UUID().uuidString
         let windowBounds = CGRect(x: 10, y: 20, width: 800, height: 600)
         let applicationInfo = Self.makeSeeFixtureApplicationInfo()
@@ -1177,7 +1065,7 @@ extension SeeCommandRuntimeTests {
         )
     }
 
-    fileprivate static func makeSeeCommandRuntimeContext(
+    static func makeSeeCommandRuntimeContext(
         automation: StubAutomationService,
         screenCapture: StubScreenCaptureService,
         applicationInfo: ServiceApplicationInfo? = nil,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 - Default new agent configurations to GPT-5.6 and Claude Opus 5 while keeping credential-only Anthropic discovery on Opus 4.8 for zero-retention compatibility and preserving explicit model selections.
 
 ### Fixed
+- Resolve standalone exact-window AX-only `see` targets from their live owner and bind results to a process-generation/window receipt before publishing actionable element IDs or a snapshot.
+- Retry one passive background observation when its exact capture receipt changes before element detection or output, while leaving mutation-capable observations fail-closed.
 - Probe Bridge diagnostic sockets concurrently under a one-second per-host deadline with bounded cancellation while preserving runtime selection and candidate order, so `bridge status --verbose` neither accumulates nor inherits a wedged host's full handshake latency.
 - Require explicit foreground consent before Dock/menu-bar global UI or targetless frontmost application-menu clicks; keep discovery read-only/background and return typed refusals before lookup or dispatch.
 - Preserve semantic AX labels, scalar values, roles, descriptions, enabled/selected state, and bounded value-settable capability through background `see` output, persisted snapshots, and agent summaries instead of reducing controls to generic role names.

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Observation/DesktopObservationService.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Observation/DesktopObservationService.swift
@@ -123,9 +123,13 @@ public final class DesktopObservationService: DesktopObservationServiceProtocol 
                     return (stateSnapshot, captureBoundTarget, capture, detection)
                 }
             }
-        let (stateSnapshot, target, capture, serializedDetection) = try await self.withDesktopOperationLane(
-            for: request,
-            operation: coordinatedCapture)
+        let (stateSnapshot, target, capture, serializedDetection) = try await self.withPassiveCaptureReceiptRecovery(
+            for: request)
+        {
+            try await self.withDesktopOperationLane(
+                for: request,
+                operation: coordinatedCapture)
+        }
         // Web-focus fallback can AXPress hidden web content, so keep that mutating detection atomic with capture.
         // Read-only AX traversal and OCR can be slow without touching ScreenCaptureKit; let unrelated captures run.
         let detection = if serializesDetection {
@@ -199,5 +203,34 @@ public final class DesktopObservationService: DesktopObservationServiceProtocol 
             // make the host wait forever on a lock owned by the client request that is waiting for that host.
             try await operation()
         }
+    }
+
+    private func withPassiveCaptureReceiptRecovery<T: Sendable>(
+        for request: DesktopObservationRequest,
+        operation: @escaping @MainActor @Sendable () async throws -> T) async throws -> T
+    {
+        do {
+            return try await operation()
+        } catch let error as DesktopObservationError {
+            guard Self.allowsPassiveCaptureReceiptRecovery(request), case .targetChanged = error else {
+                throw error
+            }
+            try Task.checkCancellation()
+            return try await operation()
+        }
+    }
+
+    private nonisolated static func allowsPassiveCaptureReceiptRecovery(
+        _ request: DesktopObservationRequest) -> Bool
+    {
+        guard request.capture.focus == .background,
+              !request.detection.allowWebFocusFallback
+        else {
+            return false
+        }
+        if case let .menubarPopover(_, openIfNeeded) = request.target, openIfNeeded != nil {
+            return false
+        }
+        return true
     }
 }

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/ElementDetectionService.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/ElementDetectionService.swift
@@ -395,28 +395,27 @@ public final class ElementDetectionService {
         requested: WindowContext?) throws -> WindowContext?
     {
         if let requestedWindowID = requested?.windowID {
+            let actionableReceipt = try Self.resolveActionableWindowReceipt(
+                windowID: requestedWindowID,
+                processIdentifier: targetApp.processIdentifier,
+                capturedBounds: requested?.windowBounds,
+                receipt: requested?.windowMutationIdentity)
             guard let windowID = CGWindowID(exactly: requestedWindowID),
                   let liveWindow = SystemIdentityResolver.windowIdentity(windowID),
-                  liveWindow.ownerProcessIdentifier == targetApp.processIdentifier
+                  liveWindow.ownerProcessIdentifier == targetApp.processIdentifier,
+                  liveWindow.bounds == actionableReceipt.bounds
             else {
                 throw PeekabooError.snapshotStale(
                     "Exact observation window changed before its process-generation receipt was captured")
             }
-            let bounds = requested?.windowBounds ?? liveWindow.bounds
-            let mutationIdentity = try Self.validatedExactWindowReceipt(
-                windowID: requestedWindowID,
-                processIdentifier: targetApp.processIdentifier,
-                capturedBounds: requested?.windowBounds,
-                receipt: requested?.windowMutationIdentity,
-                requiresActionCapability: false)
             return WindowContext(
                 applicationName: requested?.applicationName ?? targetApp.localizedName,
                 applicationBundleId: requested?.applicationBundleId ?? targetApp.bundleIdentifier,
                 applicationProcessId: targetApp.processIdentifier,
                 windowTitle: requested?.windowTitle ?? liveWindow.title,
                 windowID: requestedWindowID,
-                windowBounds: bounds,
-                windowMutationIdentity: mutationIdentity,
+                windowBounds: actionableReceipt.bounds,
+                windowMutationIdentity: actionableReceipt.identity,
                 shouldFocusWebContent: requested?.shouldFocusWebContent,
                 includeMenuBarElements: requested?.includeMenuBarElements,
                 traversalBudget: requested?.traversalBudget,
@@ -436,19 +435,62 @@ public final class ElementDetectionService {
         else {
             return requested
         }
+        let actionableReceipt = try Self.resolveActionableWindowReceipt(
+            windowID: window.windowID,
+            processIdentifier: targetApp.processIdentifier,
+            capturedBounds: window.bounds,
+            receipt: window.mutationIdentity)
         return WindowContext(
             applicationName: requested?.applicationName ?? targetApp.localizedName,
             applicationBundleId: requested?.applicationBundleId ?? targetApp.bundleIdentifier,
             applicationProcessId: targetApp.processIdentifier,
             windowTitle: window.title,
             windowID: window.windowID,
-            windowBounds: window.bounds,
-            windowMutationIdentity: nil,
+            windowBounds: actionableReceipt.bounds,
+            windowMutationIdentity: actionableReceipt.identity,
             shouldFocusWebContent: requested?.shouldFocusWebContent,
             includeMenuBarElements: requested?.includeMenuBarElements,
             traversalBudget: requested?.traversalBudget,
             requiresFreshAccessibilityTree: requested?.requiresFreshAccessibilityTree ?? false,
             accessibilityTimeoutSeconds: requested?.accessibilityTimeoutSeconds)
+    }
+
+    nonisolated struct ActionableWindowReceipt: Equatable {
+        let identity: WindowMutationIdentity
+        let bounds: CGRect
+    }
+
+    nonisolated static func resolveActionableWindowReceipt(
+        windowID: Int,
+        processIdentifier: pid_t,
+        capturedBounds: CGRect?,
+        receipt: WindowMutationIdentity?,
+        receiptProvider: (CGWindowID) -> WindowMutationIdentity? = {
+            SystemIdentityResolver.windowMutationIdentity(windowID: $0)
+        },
+        validator: (WindowMutationIdentity, CGRect) -> Bool = {
+            SystemIdentityResolver.validateWindowMutationIdentity($0, expectedBounds: $1)
+        }) throws -> ActionableWindowReceipt
+    {
+        guard windowID > 0, let cgWindowID = CGWindowID(exactly: windowID) else {
+            throw PeekabooError.snapshotStale("Exact AX observation window identifier is invalid")
+        }
+        guard let candidate = receipt ?? receiptProvider(cgWindowID),
+              let bounds = capturedBounds ?? candidate.capturedBounds,
+              candidate.ownerProcessStartIdentity > 0,
+              candidate.capturedBounds == bounds,
+              let identity = try Self.validatedExactWindowReceipt(
+                  windowID: windowID,
+                  processIdentifier: processIdentifier,
+                  capturedBounds: bounds,
+                  receipt: candidate,
+                  requiresActionCapability: true,
+                  validator: validator)
+        else {
+            throw PeekabooError.snapshotStale(
+                "AX-only observation could not capture an exact process-generation, window, and bounds receipt")
+        }
+        return ActionableWindowReceipt(identity: identity, bounds: bounds)
     }
 
     nonisolated static func validatedExactWindowReceipt(

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/ElementDetectionWindowResolver.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/ElementDetectionWindowResolver.swift
@@ -12,9 +12,19 @@ struct ElementDetectionWindowResolver {
     private let applicationService: ApplicationService
     private let windowIdentityService = WindowIdentityService()
     private let windowManagementService = WindowManagementService()
+    private let exactWindowIdentityProvider: (CGWindowID) -> SystemWindowIdentity?
+    private let processStartIdentityProvider: (pid_t) -> UInt64?
 
-    init(applicationService: ApplicationService) {
+    init(
+        applicationService: ApplicationService,
+        exactWindowIdentityProvider: @escaping (CGWindowID) -> SystemWindowIdentity? =
+            SystemIdentityResolver.windowIdentity,
+        processStartIdentityProvider: @escaping (pid_t) -> UInt64? =
+            SystemIdentityResolver.processStartIdentity)
+    {
         self.applicationService = applicationService
+        self.exactWindowIdentityProvider = exactWindowIdentityProvider
+        self.processStartIdentityProvider = processStartIdentityProvider
     }
 
     func resolveApplication(windowContext: WindowContext?) async throws -> NSRunningApplication {
@@ -55,11 +65,57 @@ struct ElementDetectionWindowResolver {
             return runningApp
         }
 
+        if let windowID = windowContext?.windowID {
+            guard let processIdentifier = Self.stableExactWindowOwner(
+                windowID: windowID,
+                receipt: windowContext?.windowMutationIdentity,
+                windowIdentityProvider: self.exactWindowIdentityProvider,
+                processStartIdentityProvider: self.processStartIdentityProvider),
+                let runningApp = NSRunningApplication(processIdentifier: processIdentifier)
+            else {
+                throw PeekabooError.windowNotFound(criteria: "live owner for exact window id \(windowID)")
+            }
+            self.logger.debug("Resolved application via exact window \(windowID), PID: \(processIdentifier)")
+            return runningApp
+        }
+
         guard let frontmost = NSWorkspace.shared.frontmostApplication else {
             self.logger.error("No frontmost application")
             throw PeekabooError.operationError(message: "No frontmost application")
         }
         return frontmost
+    }
+
+    nonisolated static func stableExactWindowOwner(
+        windowID: Int,
+        receipt: WindowMutationIdentity?,
+        windowIdentityProvider: (CGWindowID) -> SystemWindowIdentity?,
+        processStartIdentityProvider: (pid_t) -> UInt64?) -> pid_t?
+    {
+        guard windowID > 0,
+              let cgWindowID = CGWindowID(exactly: windowID),
+              let before = windowIdentityProvider(cgWindowID),
+              let beforeGeneration = processStartIdentityProvider(before.ownerProcessIdentifier),
+              let after = windowIdentityProvider(cgWindowID),
+              let afterGeneration = processStartIdentityProvider(after.ownerProcessIdentifier),
+              before.windowID == cgWindowID,
+              after.windowID == cgWindowID,
+              before.ownerProcessIdentifier == after.ownerProcessIdentifier,
+              before.bounds == after.bounds,
+              beforeGeneration == afterGeneration
+        else {
+            return nil
+        }
+        if let receipt {
+            guard receipt.windowID == windowID,
+                  receipt.ownerProcessIdentifier == before.ownerProcessIdentifier,
+                  receipt.ownerProcessStartIdentity == beforeGeneration,
+                  receipt.capturedBounds == nil || receipt.capturedBounds == before.bounds
+            else {
+                return nil
+            }
+        }
+        return before.ownerProcessIdentifier
     }
 
     func resolveWindow(

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/DesktopObservationReceiptRecoveryTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/DesktopObservationReceiptRecoveryTests.swift
@@ -1,0 +1,344 @@
+import CoreGraphics
+import Foundation
+import PeekabooFoundation
+import XCTest
+@testable import PeekabooAutomationKit
+
+@MainActor
+final class DesktopObservationReceiptRecoveryTests: XCTestCase {
+    func testPassiveObservationRetriesOneChangedCaptureReceiptBeforeDetectionAndOutput() async throws {
+        let bounds = CGRect(x: 100, y: 100, width: 500, height: 400)
+        let changedBounds = CGRect(x: 101, y: 100, width: 500, height: 400)
+        let resolver = RecordingReceiptTargetResolver(target: Self.receiptedTarget(bounds: bounds))
+        var captures = [
+            Self.receiptedCapture(bounds: changedBounds),
+            Self.receiptedCapture(bounds: bounds),
+        ]
+        let capture = ReceiptRecoveryCaptureService(resultProvider: { captures.removeFirst() })
+        let automation = ReceiptRecoveryAutomationService()
+        let outputPath = FileManager.default.temporaryDirectory
+            .appendingPathComponent("peekaboo-observation-receipt-retry-\(UUID().uuidString).png")
+        defer { try? FileManager.default.removeItem(at: outputPath) }
+        let service = DesktopObservationService(
+            screenCapture: capture,
+            automation: automation,
+            targetResolver: resolver)
+
+        let result = try await service.observe(DesktopObservationRequest(
+            target: .app(identifier: "Fixture", window: .automatic),
+            detection: DesktopDetectionOptions(mode: .accessibility),
+            output: DesktopObservationOutputOptions(path: outputPath.path, saveRawScreenshot: true)))
+
+        XCTAssertEqual(resolver.resolveCalls, 2)
+        XCTAssertEqual(capture.windowIDs, [42, 42])
+        XCTAssertEqual(automation.detectCalls, 1)
+        XCTAssertEqual(result.timings.spans.filter { $0.name == "detection.ax" }.count, 1)
+        XCTAssertEqual(result.timings.spans.filter { $0.name == "output.write" }.count, 1)
+        XCTAssertEqual(result.target.window?.bounds, bounds)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: outputPath.path))
+    }
+
+    func testPassiveObservationStopsAfterOneChangedCaptureReceiptRetry() async throws {
+        let bounds = CGRect(x: 100, y: 100, width: 500, height: 400)
+        let resolver = RecordingReceiptTargetResolver(target: Self.receiptedTarget(bounds: bounds))
+        let capture = ReceiptRecoveryCaptureService(
+            result: Self.receiptedCapture(bounds: CGRect(x: 101, y: 100, width: 500, height: 400)))
+        let service = DesktopObservationService(
+            screenCapture: capture,
+            automation: ReceiptRecoveryAutomationService(),
+            targetResolver: resolver)
+
+        do {
+            _ = try await service.observe(DesktopObservationRequest(
+                target: .app(identifier: "Fixture", window: .automatic),
+                detection: DesktopDetectionOptions(mode: .none)))
+            XCTFail("Expected the second changed capture receipt to fail")
+        } catch let error as DesktopObservationError {
+            guard case .targetChanged = error else {
+                XCTFail("Expected targetChanged, got \(error)")
+                return
+            }
+        }
+
+        XCTAssertEqual(resolver.resolveCalls, 2)
+        XCTAssertEqual(capture.captureCalls, 2)
+    }
+
+    func testPassiveObservationDoesNotRetryNonrecoverableCaptureErrors() async throws {
+        let target = Self.receiptedTarget(bounds: CGRect(x: 100, y: 100, width: 500, height: 400))
+
+        let notFoundResolver = RecordingReceiptTargetResolver(target: target)
+        let notFoundCapture = ReceiptRecoveryCaptureService(resultProvider: {
+            throw DesktopObservationError.targetNotFound("fixture")
+        })
+        let notFoundService = DesktopObservationService(
+            screenCapture: notFoundCapture,
+            automation: ReceiptRecoveryAutomationService(),
+            targetResolver: notFoundResolver)
+        do {
+            _ = try await notFoundService.observe(DesktopObservationRequest(
+                target: .app(identifier: "Fixture", window: .automatic),
+                detection: DesktopDetectionOptions(mode: .none)))
+            XCTFail("Expected targetNotFound")
+        } catch let error as DesktopObservationError {
+            guard case .targetNotFound = error else {
+                XCTFail("Expected targetNotFound, got \(error)")
+                return
+            }
+        }
+        XCTAssertEqual(notFoundResolver.resolveCalls, 1)
+        XCTAssertEqual(notFoundCapture.captureCalls, 1)
+
+        let captureFailedResolver = RecordingReceiptTargetResolver(target: target)
+        let captureFailedCapture = ReceiptRecoveryCaptureService(resultProvider: {
+            throw OperationError.captureFailed(reason: "fixture")
+        })
+        let captureFailedService = DesktopObservationService(
+            screenCapture: captureFailedCapture,
+            automation: ReceiptRecoveryAutomationService(),
+            targetResolver: captureFailedResolver)
+        do {
+            _ = try await captureFailedService.observe(DesktopObservationRequest(
+                target: .app(identifier: "Fixture", window: .automatic),
+                detection: DesktopDetectionOptions(mode: .none)))
+            XCTFail("Expected capture failure")
+        } catch is OperationError {
+            // Expected.
+        }
+        XCTAssertEqual(captureFailedResolver.resolveCalls, 1)
+        XCTAssertEqual(captureFailedCapture.captureCalls, 1)
+    }
+
+    func testMutatingObservationModesDoNotRetryChangedCaptureReceipts() async throws {
+        let bounds = CGRect(x: 100, y: 100, width: 500, height: 400)
+        let target = Self.receiptedTarget(bounds: bounds)
+        let changedCapture = Self.receiptedCapture(
+            bounds: CGRect(x: 101, y: 100, width: 500, height: 400))
+        let requests = [
+            DesktopObservationRequest(
+                target: .app(identifier: "Fixture", window: .automatic),
+                capture: DesktopCaptureOptions(focus: .foreground),
+                detection: DesktopDetectionOptions(mode: .none)),
+            DesktopObservationRequest(
+                target: .app(identifier: "Fixture", window: .automatic),
+                detection: DesktopDetectionOptions(mode: .accessibility, allowWebFocusFallback: true)),
+            DesktopObservationRequest(
+                target: .menubarPopover(hints: ["Fixture"], openIfNeeded: MenuBarPopoverOpenOptions()),
+                detection: DesktopDetectionOptions(mode: .none)),
+        ]
+
+        for request in requests {
+            let resolver = RecordingReceiptTargetResolver(target: target)
+            let capture = ReceiptRecoveryCaptureService(result: changedCapture)
+            let service = DesktopObservationService(
+                screenCapture: capture,
+                automation: ReceiptRecoveryAutomationService(),
+                targetResolver: resolver)
+
+            do {
+                _ = try await service.observe(request)
+                XCTFail("Expected changed capture receipt")
+            } catch let error as DesktopObservationError {
+                guard case .targetChanged = error else {
+                    XCTFail("Expected targetChanged, got \(error)")
+                    continue
+                }
+            }
+            XCTAssertEqual(resolver.resolveCalls, 1)
+            XCTAssertEqual(capture.captureCalls, 1)
+        }
+    }
+
+    private static func receiptedTarget(bounds: CGRect) -> ResolvedObservationTarget {
+        let receipt = self.receipt(bounds: bounds)
+        return ResolvedObservationTarget(
+            kind: .windowID(42),
+            app: ApplicationIdentity(
+                processIdentifier: 123,
+                processStartIdentity: 700,
+                bundleIdentifier: "com.example.fixture",
+                name: "Fixture"),
+            window: WindowIdentity(windowID: 42, title: "Fixture", bounds: bounds, index: 0),
+            bounds: bounds,
+            detectionContext: WindowContext(
+                applicationName: "Fixture",
+                applicationBundleId: "com.example.fixture",
+                applicationProcessId: 123,
+                windowTitle: "Fixture",
+                windowID: 42,
+                windowBounds: bounds,
+                windowMutationIdentity: receipt))
+    }
+
+    private static func receiptedCapture(bounds: CGRect) -> CaptureResult {
+        CaptureResult(
+            imageData: Data([9]),
+            metadata: CaptureMetadata(
+                size: bounds.size,
+                mode: .window,
+                applicationInfo: ServiceApplicationInfo(
+                    processIdentifier: 123,
+                    processStartIdentity: 700,
+                    bundleIdentifier: "com.example.fixture",
+                    name: "Fixture",
+                    windowCount: 1),
+                windowInfo: ServiceWindowInfo(
+                    windowID: 42,
+                    title: "Fixture",
+                    bounds: bounds,
+                    windowLevel: 0,
+                    alpha: 1,
+                    layer: 0,
+                    isOnScreen: true,
+                    sharingState: .readOnly,
+                    mutationIdentity: self.receipt(bounds: bounds))))
+    }
+
+    private static func receipt(bounds: CGRect) -> WindowMutationIdentity {
+        WindowMutationIdentity(
+            windowID: 42,
+            ownerProcessIdentifier: 123,
+            ownerProcessStartIdentity: 700,
+            capturedBounds: bounds)
+    }
+}
+
+@MainActor
+private final class RecordingReceiptTargetResolver: ObservationTargetResolving {
+    private let target: ResolvedObservationTarget
+    private(set) var resolveCalls = 0
+
+    init(target: ResolvedObservationTarget) {
+        self.target = target
+    }
+
+    func resolve(
+        _: DesktopObservationTargetRequest,
+        snapshot _: DesktopStateSnapshot) async throws -> ResolvedObservationTarget
+    {
+        self.resolveCalls += 1
+        return self.target
+    }
+}
+
+@MainActor
+private final class ReceiptRecoveryCaptureService: ScreenCaptureServiceProtocol {
+    private let resultProvider: @MainActor () throws -> CaptureResult
+    private(set) var captureCalls = 0
+    private(set) var windowIDs: [Int] = []
+
+    init(result: CaptureResult) {
+        self.resultProvider = { result }
+    }
+
+    init(resultProvider: @escaping @MainActor () throws -> CaptureResult) {
+        self.resultProvider = resultProvider
+    }
+
+    func captureScreen(
+        displayIndex _: Int?,
+        visualizerMode _: CaptureVisualizerMode,
+        scale _: CaptureScalePreference) async throws -> CaptureResult
+    {
+        try self.capture()
+    }
+
+    func captureWindow(
+        appIdentifier _: String,
+        windowIndex _: Int?,
+        visualizerMode _: CaptureVisualizerMode,
+        scale _: CaptureScalePreference) async throws -> CaptureResult
+    {
+        try self.capture()
+    }
+
+    func captureWindow(
+        windowID: CGWindowID,
+        visualizerMode _: CaptureVisualizerMode,
+        scale _: CaptureScalePreference) async throws -> CaptureResult
+    {
+        self.windowIDs.append(Int(windowID))
+        return try self.capture()
+    }
+
+    func captureFrontmost(
+        visualizerMode _: CaptureVisualizerMode,
+        scale _: CaptureScalePreference) async throws -> CaptureResult
+    {
+        try self.capture()
+    }
+
+    func captureArea(
+        _: CGRect,
+        visualizerMode _: CaptureVisualizerMode,
+        scale _: CaptureScalePreference) async throws -> CaptureResult
+    {
+        try self.capture()
+    }
+
+    func hasScreenRecordingPermission() async -> Bool {
+        true
+    }
+
+    private func capture() throws -> CaptureResult {
+        self.captureCalls += 1
+        return try self.resultProvider()
+    }
+}
+
+@MainActor
+private final class ReceiptRecoveryAutomationService: UIAutomationServiceProtocol {
+    private(set) var detectCalls = 0
+
+    func detectElements(
+        in _: Data,
+        snapshotId: String?,
+        windowContext _: WindowContext?) async throws -> ElementDetectionResult
+    {
+        self.detectCalls += 1
+        return ElementDetectionResult(
+            snapshotId: snapshotId ?? "generated",
+            screenshotPath: "/tmp/fake.png",
+            elements: DetectedElements(),
+            metadata: DetectionMetadata(detectionTime: 0, elementCount: 0, method: "fake"))
+    }
+
+    func click(target _: ClickTarget, clickType _: ClickType, snapshotId _: String?) async throws {}
+    func type(
+        text _: String,
+        target _: String?,
+        clearExisting _: Bool,
+        typingDelay _: Int,
+        snapshotId _: String?) async throws {}
+    func typeActions(_: [TypeAction], cadence _: TypingCadence, snapshotId _: String?) async throws -> TypeResult {
+        TypeResult(totalCharacters: 0, keyPresses: 0)
+    }
+
+    func scroll(_: ScrollRequest) async throws {}
+    func hotkey(keys _: String, holdDuration _: Int) async throws {}
+    func swipe(
+        from _: CGPoint,
+        to _: CGPoint,
+        duration _: Int,
+        steps _: Int,
+        profile _: MouseMovementProfile) async throws {}
+    func hasAccessibilityPermission() async -> Bool {
+        true
+    }
+
+    func waitForElement(target _: ClickTarget, timeout _: TimeInterval, snapshotId _: String?) async throws
+        -> WaitForElementResult
+    {
+        WaitForElementResult(found: false, element: nil, waitTime: 0)
+    }
+
+    func drag(_: DragOperationRequest) async throws {}
+    func moveMouse(to _: CGPoint, duration _: Int, steps _: Int, profile _: MouseMovementProfile) async throws {}
+    func getFocusedElement() -> UIFocusInfo? {
+        nil
+    }
+
+    func findElement(matching _: UIElementSearchCriteria, in _: String?) async throws -> DetectedElement {
+        DetectedElement(id: "B1", type: .button, bounds: .zero)
+    }
+}

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/DesktopObservationServiceTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/DesktopObservationServiceTests.swift
@@ -239,7 +239,10 @@ extension DesktopObservationServiceTests {
             }
         }
 
-        XCTAssertEqual(capture.operations, [.windowID(42, .logical1x, .auto)])
+        XCTAssertEqual(capture.operations, [
+            .windowID(42, .logical1x, .auto),
+            .windowID(42, .logical1x, .auto),
+        ])
         XCTAssertNil(automation.lastWindowContext?.windowMutationIdentity)
     }
 

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ElementDetectionExactWindowOwnerTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ElementDetectionExactWindowOwnerTests.swift
@@ -1,0 +1,71 @@
+import CoreGraphics
+import XCTest
+@testable import PeekabooAutomationKit
+
+final class ElementDetectionExactWindowOwnerTests: XCTestCase {
+    func testExactWindowOnlyContextResolvesStableOwnerInsteadOfFrontmostApplication() {
+        let identity = Self.identity(owner: 4242)
+
+        let owner = ElementDetectionWindowResolver.stableExactWindowOwner(
+            windowID: 707,
+            receipt: nil,
+            windowIdentityProvider: { _ in identity },
+            processStartIdentityProvider: { _ in 11 })
+
+        XCTAssertEqual(owner, 4242)
+    }
+
+    func testExactWindowOwnerRejectsOwnerChangeDuringResolution() {
+        var identities = [Self.identity(owner: 4242), Self.identity(owner: 9001)]
+
+        let owner = ElementDetectionWindowResolver.stableExactWindowOwner(
+            windowID: 707,
+            receipt: nil,
+            windowIdentityProvider: { _ in identities.removeFirst() },
+            processStartIdentityProvider: { _ in 11 })
+
+        XCTAssertNil(owner)
+    }
+
+    func testExactWindowOwnerRejectsProcessGenerationChangeDuringResolution() {
+        let identity = Self.identity(owner: 4242)
+        var generations: [UInt64] = [11, 12]
+
+        let owner = ElementDetectionWindowResolver.stableExactWindowOwner(
+            windowID: 707,
+            receipt: nil,
+            windowIdentityProvider: { _ in identity },
+            processStartIdentityProvider: { _ in generations.removeFirst() })
+
+        XCTAssertNil(owner)
+    }
+
+    func testExactWindowOwnerRejectsMismatchedCaptureReceipt() {
+        let identity = Self.identity(owner: 4242)
+        let receipt = WindowMutationIdentity(
+            windowID: 707,
+            ownerProcessIdentifier: 4242,
+            ownerProcessStartIdentity: 99,
+            capturedBounds: identity.bounds)
+
+        let owner = ElementDetectionWindowResolver.stableExactWindowOwner(
+            windowID: 707,
+            receipt: receipt,
+            windowIdentityProvider: { _ in identity },
+            processStartIdentityProvider: { _ in 11 })
+
+        XCTAssertNil(owner)
+    }
+
+    private static func identity(owner: pid_t) -> SystemWindowIdentity {
+        SystemWindowIdentity(
+            windowID: 707,
+            ownerProcessIdentifier: owner,
+            title: "Fixture",
+            bounds: CGRect(x: 10, y: 20, width: 800, height: 600),
+            layer: 0,
+            alpha: 1,
+            isOnScreen: true,
+            sharingState: .readOnly)
+    }
+}

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ElementDetectionReadOnlyWindowSelectionTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ElementDetectionReadOnlyWindowSelectionTests.swift
@@ -143,6 +143,126 @@ final class ElementDetectionReadOnlyWindowSelectionTests: XCTestCase {
         }
     }
 
+    func testExactReadOnlyObservationCapturesActionableReceiptWhenCallerHasNone() throws {
+        let bounds = CGRect(x: 1, y: 2, width: 300, height: 200)
+        let receipt = Self.receipt(windowID: 42, processIdentifier: 123, bounds: bounds)
+        var captureCount = 0
+        var validationCount = 0
+
+        let resolved = try ElementDetectionService.resolveActionableWindowReceipt(
+            windowID: 42,
+            processIdentifier: 123,
+            capturedBounds: nil,
+            receipt: nil,
+            receiptProvider: { windowID in
+                captureCount += 1
+                XCTAssertEqual(windowID, 42)
+                return receipt
+            },
+            validator: { candidate, candidateBounds in
+                validationCount += 1
+                return candidate == receipt && candidateBounds == bounds
+            })
+
+        XCTAssertEqual(resolved.identity, receipt)
+        XCTAssertEqual(resolved.bounds, bounds)
+        XCTAssertEqual(captureCount, 1)
+        XCTAssertEqual(validationCount, 1)
+    }
+
+    func testExistingReadOnlyObservationReceiptIsPreservedAndRevalidated() throws {
+        let bounds = CGRect(x: 1, y: 2, width: 300, height: 200)
+        let receipt = Self.receipt(windowID: 42, processIdentifier: 123, bounds: bounds)
+
+        let resolved = try ElementDetectionService.resolveActionableWindowReceipt(
+            windowID: 42,
+            processIdentifier: 123,
+            capturedBounds: bounds,
+            receipt: receipt,
+            receiptProvider: { _ in
+                XCTFail("An existing capture receipt must not be replaced")
+                return nil
+            },
+            validator: { candidate, candidateBounds in
+                candidate == receipt && candidateBounds == bounds
+            })
+
+        XCTAssertEqual(resolved.identity, receipt)
+        XCTAssertEqual(resolved.bounds, bounds)
+    }
+
+    func testReadOnlyObservationReceiptDriftFailsClosed() {
+        let bounds = CGRect(x: 1, y: 2, width: 300, height: 200)
+        let receipt = Self.receipt(windowID: 42, processIdentifier: 123, bounds: bounds)
+
+        XCTAssertThrowsError(try ElementDetectionService.resolveActionableWindowReceipt(
+            windowID: 42,
+            processIdentifier: 123,
+            capturedBounds: bounds,
+            receipt: receipt,
+            receiptProvider: { _ in receipt },
+            validator: { _, _ in false }))
+        { error in
+            XCTAssertTrue(error.localizedDescription.contains("changed before AX traversal"))
+        }
+    }
+
+    func testReadOnlyObservationRejectsReceiptForAnotherProcess() {
+        let bounds = CGRect(x: 1, y: 2, width: 300, height: 200)
+        let receipt = Self.receipt(windowID: 42, processIdentifier: 999, bounds: bounds)
+
+        XCTAssertThrowsError(try ElementDetectionService.resolveActionableWindowReceipt(
+            windowID: 42,
+            processIdentifier: 123,
+            capturedBounds: bounds,
+            receipt: nil,
+            receiptProvider: { _ in receipt },
+            validator: { _, _ in true }))
+        { error in
+            XCTAssertTrue(error.localizedDescription.contains("changed before AX traversal"))
+        }
+    }
+
+    func testReadOnlyObservationRejectsLegacyReceiptWithoutEmbeddedBounds() {
+        let bounds = CGRect(x: 1, y: 2, width: 300, height: 200)
+        let receipt = WindowMutationIdentity(
+            windowID: 42,
+            ownerProcessIdentifier: 123,
+            ownerProcessStartIdentity: 7,
+            capturedBounds: nil)
+
+        XCTAssertThrowsError(try ElementDetectionService.resolveActionableWindowReceipt(
+            windowID: 42,
+            processIdentifier: 123,
+            capturedBounds: bounds,
+            receipt: receipt,
+            receiptProvider: { _ in receipt },
+            validator: { _, _ in true }))
+        { error in
+            XCTAssertTrue(error.localizedDescription.contains("could not capture"))
+        }
+    }
+
+    func testReadOnlyObservationRejectsZeroProcessGeneration() {
+        let bounds = CGRect(x: 1, y: 2, width: 300, height: 200)
+        let receipt = WindowMutationIdentity(
+            windowID: 42,
+            ownerProcessIdentifier: 123,
+            ownerProcessStartIdentity: 0,
+            capturedBounds: bounds)
+
+        XCTAssertThrowsError(try ElementDetectionService.resolveActionableWindowReceipt(
+            windowID: 42,
+            processIdentifier: 123,
+            capturedBounds: bounds,
+            receipt: receipt,
+            receiptProvider: { _ in receipt },
+            validator: { _, _ in true }))
+        { error in
+            XCTAssertTrue(error.localizedDescription.contains("could not capture"))
+        }
+    }
+
     private static func window(
         id: Int,
         title: String,
@@ -163,5 +283,17 @@ final class ElementDetectionReadOnlyWindowSelectionTests: XCTestCase {
             isOnScreen: true,
             sharingState: .readOnly,
             isExcludedFromWindowsMenu: false)
+    }
+
+    private static func receipt(
+        windowID: Int,
+        processIdentifier: pid_t,
+        bounds: CGRect) -> WindowMutationIdentity
+    {
+        WindowMutationIdentity(
+            windowID: windowID,
+            ownerProcessIdentifier: processIdentifier,
+            ownerProcessStartIdentity: 7,
+            capturedBounds: bounds)
     }
 }

--- a/docs/commands/see.md
+++ b/docs/commands/see.md
@@ -40,7 +40,7 @@ peekaboo see --window-id 12345 --roi 100,80,500,300 --json --path /tmp/window-ro
 | `--format png|jpg` / `--retina` | Select the image encoding and native display scale. |
 | `--no-elements` | Skip element detection for the cheapest screenshot-only CLI path. |
 | `--tree` | Print the accessibility text tree. |
-| `--no-screenshot` | Skip pixel capture; requires `--tree`. This is the AX-only inspection form. |
+| `--no-screenshot` | Skip pixel capture; requires `--tree`. This AX-only form publishes element IDs and a snapshot only after pinning the exact process generation, window, and bounds; target drift or a missing receipt fails before publication. |
 | `--annotate` | Overlay element bounds/IDs on the output image. |
 | `--path <file>` / `--save` / `--output` / `-o` | Save the screenshot/annotation to disk. |
 | `--json` | Emit structured metadata (recommended for scripting). |
@@ -55,6 +55,8 @@ peekaboo see --window-id 12345 --roi 100,80,500,300 --json --path /tmp/window-ro
 Note: `--app menubar` captures only the menu bar strip; `--menubar` attempts to find the active popover and OCR its text.
 
 For agent and automation runs, pass `--path` to a known temporary file when using `see` so capture artifacts land where expected. Use `peekaboo see --tree --no-screenshot --json` when you need AX metadata without a screenshot artifact.
+
+Passive background observations retry one resolve-and-capture transaction when the target's exact receipt changes during capture, then fail closed if it changes again. Foreground capture, explicit web-focus fallback, and menu-opening observations never retry because they can mutate visible desktop state.
 
 When `--json` is used without `--path`, Peekaboo retains the raw image only in managed snapshot storage and returns empty `screenshot_raw` and `screenshot_annotated` fields. Pass `--path` when the caller needs a directly accessible image file.
 


### PR DESCRIPTION
## Summary

- resolve standalone `see --window-id … --tree --no-screenshot` targets from the exact live window owner instead of falling back to the frontmost app
- publish AX-only element IDs and snapshots only after binding and revalidating an exact process-generation, window, and bounds receipt
- retry one passive background resolve/capture transaction when its target changes during capture, before detection or output; foreground, web-focus, and menu-opening observations remain single-attempt and fail-closed
- document the action-capable AX-only contract and passive retry behavior

## Why

AX-only `see` could return a snapshot ID and actionable element IDs that a following background click correctly rejected because the snapshot had no capture-time receipt. A standalone exact window ID could also be resolved against the unrelated frontmost app. Separately, benign launch-time window layout drift could invalidate an otherwise passive observation without one bounded recovery attempt.

The producer now establishes the same exact receipt that mutation consumers require, refuses before publication when it cannot, and retries only the passive capture transaction that is safe to repeat.

## Tests

- `swift test --package-path Core/PeekabooAutomationKit --filter 'DesktopObservationReceiptRecoveryTests|DesktopObservationServiceTests|ObservationCaptureReceiptBindingTests|ElementDetectionReadOnlyWindowSelectionTests|ElementDetectionExactWindowOwnerTests'` (59 passed on the rebased head)
- `PEEKABOO_INCLUDE_AUTOMATION_TESTS=true swift test --package-path Apps/CLI --filter 'SeeCommandTests|SeeCommandRuntimeTests'` (34 passed)
- `pnpm run test:safe`
- `pnpm run lint` (19 established warnings, 0 serious)
- strict SwiftLint on all 10 changed Swift files (0 violations)
- SwiftFormat and `git diff --check`
- source-blind signed CLI acceptance: standalone Calculator window-ID AX-only observation succeeded three times, its snapshot drove a confirmed background `All Clear` click with real state change, an impossible ID failed with no data, and the foreground app remained unchanged (7/7, confidence 0.99)
- final post-rebase branch Autoreview and TruffleHog (clean, 0.98)
