### PR TITLE
fix(cli): stabilize raw build version metadata

### DIFF
--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Resolve standalone exact-window AX-only `see` targets from their live owner and bind results to a process-generation/window receipt before publishing actionable element IDs or a snapshot.
 - Retry one passive background observation when its exact capture receipt changes before element detection or output, while leaving mutation-capable observations fail-closed.
+- Keep raw SwiftPM CLI `--version` output stable with explicit `unknown` build placeholders instead of reading the original working copy and wall clock at runtime; stamped debug and release builds retain rich link-time metadata.
 - Probe Bridge diagnostic sockets concurrently under a one-second per-host deadline with bounded cancellation while preserving runtime selection and candidate order, so `bridge status --verbose` neither accumulates nor inherits a wedged host's full handshake latency.
 - Require explicit `--foreground` consent before `menubar click` can inspect or open global status-item UI; keep `menubar list` read-only and report missing items as typed retry-safe pre-dispatch refusals.
 - Preserve semantic AX labels, scalar values, roles, descriptions, enabled/selected state, and bounded value-settable capability through background `see` output, persisted snapshots, and agent summaries instead of reducing controls to generic role names.

--- a/Apps/CLI/Sources/PeekabooCLI/Version.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Version.swift
@@ -27,16 +27,13 @@ private enum VersionMetadata {
         if let info = valuesFromInfoDictionary() {
             return info
         }
-        if let workingCopy = valuesFromWorkingCopy() {
-            return workingCopy
-        }
 
         return Values(
             current: "Peekaboo 0.0.0",
             gitCommit: "unknown",
             gitCommitDate: "unknown",
             gitBranch: "unknown",
-            buildDate: self.iso8601Now()
+            buildDate: "unknown"
         )
     }
 
@@ -48,88 +45,19 @@ private enum VersionMetadata {
         }
 
         let display = info["PeekabooVersionDisplayString"] as? String ?? "Peekaboo \(shortVersion)"
-        guard let commit = info["PeekabooGitCommit"] as? String,
-              !commit.isEmpty,
-              commit != "unknown"
-        else {
-            return nil
-        }
-        let commitDate = info["PeekabooGitCommitDate"] as? String ?? "unknown"
-        let branch = info["PeekabooGitBranch"] as? String ?? "unknown"
-        let buildDate = info["PeekabooBuildDate"] as? String ?? self.iso8601Now()
 
         return Values(
             current: display,
-            gitCommit: commit,
-            gitCommitDate: commitDate,
-            gitBranch: branch,
-            buildDate: buildDate
+            gitCommit: self.metadataValue("PeekabooGitCommit", in: info),
+            gitCommitDate: self.metadataValue("PeekabooGitCommitDate", in: info),
+            gitBranch: self.metadataValue("PeekabooGitBranch", in: info),
+            buildDate: self.metadataValue("PeekabooBuildDate", in: info)
         )
     }
 
-    private static func valuesFromWorkingCopy() -> Values? {
-        let root = self.repositoryRoot()
-        guard FileManager.default.fileExists(atPath: root.path) else { return nil }
-
-        let versionString = self.workingCopyVersion(root: root) ?? "0.0.0"
-        var commit = self.git(["rev-parse", "--short", "HEAD"], root: root) ?? "unknown"
-        let diffStatus = self.git(["status", "--porcelain"], root: root) ?? ""
-        if !diffStatus.isEmpty {
-            commit += "-dirty"
-        }
-
-        let commitDate = self.git(["show", "-s", "--format=%ci", "HEAD"], root: root) ?? "unknown"
-        let branch = self.git(["rev-parse", "--abbrev-ref", "HEAD"], root: root) ?? "unknown"
-
-        return Values(
-            current: "Peekaboo \(versionString)",
-            gitCommit: commit,
-            gitCommitDate: commitDate,
-            gitBranch: branch,
-            buildDate: self.iso8601Now()
-        )
-    }
-
-    private static func repositoryRoot() -> URL {
-        var url = URL(fileURLWithPath: #filePath)
-        for _ in 0..<5 {
-            url.deleteLastPathComponent()
-        }
-        return url
-    }
-
-    private static func workingCopyVersion(root: URL) -> String? {
-        let url = root.appendingPathComponent("version.json")
-        guard let data = try? Data(contentsOf: url) else { return nil }
-        struct VersionFile: Decodable { let version: String }
-        return try? JSONDecoder().decode(VersionFile.self, from: data).version
-    }
-
-    private static func git(_ arguments: [String], root: URL) -> String? {
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
-        process.arguments = ["git"] + arguments
-        process.currentDirectoryURL = root
-
-        let pipe = Pipe()
-        process.standardOutput = pipe
-        process.standardError = Pipe()
-
-        do {
-            try process.run()
-        } catch {
-            return nil
-        }
-        process.waitUntilExit()
-        guard process.terminationStatus == 0 else { return nil }
-
-        let data = pipe.fileHandleForReading.readDataToEndOfFile()
-        return String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines)
-    }
-
-    private static func iso8601Now() -> String {
-        let formatter = ISO8601DateFormatter()
-        formatter.formatOptions = [.withInternetDateTime]
-        return formatter.string(from: Date())
+    private static func metadataValue(_ key: String, in info: [String: Any]) -> String {
+        guard let rawValue = info[key] as? String else { return "unknown" }
+        let value = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        return value.isEmpty ? "unknown" : value
     }
 }

--- a/Apps/CLI/Tests/CLIRuntimeTests/CLIRuntimeSmokeTests.swift
+++ b/Apps/CLI/Tests/CLIRuntimeTests/CLIRuntimeSmokeTests.swift
@@ -21,6 +21,49 @@ struct CLIRuntimeSmokeTests {
     }
 
     @Test
+    func `raw CLI version is stable across processes and working copy changes`() async throws {
+        guard Self.ensureLocalRuntimeAvailable() else { return }
+        let temporaryDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("peekaboo-version-stability-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: temporaryDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: temporaryDirectory) }
+
+        let fakeGit = temporaryDirectory.appendingPathComponent("git")
+        let inheritedPath = ProcessInfo.processInfo.environment["PATH"] ?? "/usr/bin:/bin"
+        let environment = ["PATH": "\(temporaryDirectory.path):\(inheritedPath)"]
+
+        try Self.writeFakeGit(to: fakeGit, identity: "first")
+        let first = try await TestChildProcess.runPeekaboo(["--version"], environment: environment)
+        try await Task.sleep(for: .seconds(1.1))
+        try Self.writeFakeGit(to: fakeGit, identity: "second")
+        let second = try await TestChildProcess.runPeekaboo(["--version"], environment: environment)
+
+        #expect(first.status == .exited(0))
+        #expect(second.status == .exited(0))
+        #expect(first.standardError.isEmpty)
+        #expect(second.standardError.isEmpty)
+        #expect(first.standardOutput == second.standardOutput)
+        if ProcessInfo.processInfo.environment["PEEKABOO_CLI_BINARY"] == nil {
+            #expect(first.standardOutput.contains("(unknown/unknown, built: unknown)"))
+        }
+    }
+
+    private static func writeFakeGit(to url: URL, identity: String) throws {
+        let script = """
+        #!/bin/sh
+        case "$*" in
+          "rev-parse --short HEAD") echo "\(identity)-commit" ;;
+          "status --porcelain") exit 0 ;;
+          "show -s --format=%ci HEAD") echo "2026-01-01 00:00:00 +0000" ;;
+          "rev-parse --abbrev-ref HEAD") echo "\(identity)-branch" ;;
+          *) exit 2 ;;
+        esac
+        """
+        try Data(script.utf8).write(to: url, options: .atomic)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: url.path)
+    }
+
+    @Test
     func `peekaboo app list emits JSON via Commander`() async throws {
         guard Self.ensureLocalRuntimeAvailable() else { return }
         let result = try await TestChildProcess.runPeekaboo(["app", "list", "--json", "--no-remote"])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Fixed
 - Resolve standalone exact-window AX-only `see` targets from their live owner and bind results to a process-generation/window receipt before publishing actionable element IDs or a snapshot.
 - Retry one passive background observation when its exact capture receipt changes before element detection or output, while leaving mutation-capable observations fail-closed.
+- Keep raw SwiftPM CLI `--version` output stable with explicit `unknown` build placeholders instead of reading the original working copy and wall clock at runtime; stamped debug and release builds retain rich link-time metadata.
 - Probe Bridge diagnostic sockets concurrently under a one-second per-host deadline with bounded cancellation while preserving runtime selection and candidate order, so `bridge status --verbose` neither accumulates nor inherits a wedged host's full handshake latency.
 - Require explicit foreground consent before Dock/menu-bar global UI or targetless frontmost application-menu clicks; keep discovery read-only/background and return typed refusals before lookup or dispatch.
 - Preserve semantic AX labels, scalar values, roles, descriptions, enabled/selected state, and bounded value-settable capability through background `see` output, persisted snapshots, and agent summaries instead of reducing controls to generic role names.

--- a/docs/install.md
+++ b/docs/install.md
@@ -50,6 +50,8 @@ pnpm run build:swift:all   # universal release
 ```
 
 The output binary lives under `Apps/CLI/.build/...`. See [building.md](building.md) for signing and notarization.
+Raw SwiftPM/debug builds use stable `unknown` placeholders for Git and build-time metadata. Use the repository's
+stamped debug or release build scripts when `peekaboo --version` must include immutable commit and build-date provenance.
 
 ## Verify
 

--- a/scripts/test-extracted-cli-artifact.sh
+++ b/scripts/test-extracted-cli-artifact.sh
@@ -28,6 +28,17 @@ tar -xzf "$ARCHIVE_PATH" -C "$EXTRACT_DIR"
 
 EXTRACTED_DIR="$EXTRACT_DIR/peekaboo-macos-universal"
 "$ROOT_DIR/scripts/verify-swift-runtime-libraries.sh" "$EXTRACTED_DIR/peekaboo" "$EXTRACTED_DIR"
-"$EXTRACTED_DIR/peekaboo" --version | grep -Fq "Peekaboo $VERSION"
+VERSION_OUTPUT_1=$("$EXTRACTED_DIR/peekaboo" --version)
+sleep 1
+VERSION_OUTPUT_2=$("$EXTRACTED_DIR/peekaboo" --version)
+[ "$VERSION_OUTPUT_1" = "$VERSION_OUTPUT_2" ] || {
+    echo "Extracted CLI version output changed between invocations" >&2
+    exit 1
+}
+printf '%s\n' "$VERSION_OUTPUT_1" | grep -Fq "Peekaboo $VERSION"
+if printf '%s\n' "$VERSION_OUTPUT_1" | grep -Fq "unknown"; then
+    echo "Extracted release CLI is missing embedded build metadata" >&2
+    exit 1
+fi
 
 echo "test-extracted-cli-artifact: ok"


### PR DESCRIPTION
## Summary

- make embedded binary metadata authoritative for `peekaboo --version`
- keep semantic version data from partial SwiftPM plists while using stable `unknown` placeholders for missing commit/branch/build fields
- remove runtime reads of the original source checkout and invocation-time wall clock
- add separate-process regression coverage with changing fake Git state and strengthen release-artifact version stability checks

## Why

A copied raw SwiftPM binary could keep the same bytes, SHA-256, and mtime while changing its reported Git commit, branch, dirty state, and `built:` timestamp. The fallback derived the original repository from compile-time `#filePath`, read that checkout at runtime, and generated a new build date on every process launch.

Raw builds now report a stable version such as `Peekaboo 4.0.0 (unknown/unknown, built: unknown)`. Repository-stamped debug and release scripts already embed complete metadata and retain their immutable rich version output.

## Tests

- `swift test --package-path Apps/CLI --filter CLIRuntimeSmokeTests` (19 passed; separate-process stability regression included)
- `pnpm run test:safe` (including 73 runtime tests)
- strict SwiftLint on both changed Swift files (0 violations)
- SwiftFormat, ShellCheck, docs lint, and `git diff --check`
- Autoreview and TruffleHog (clean, 0.99)

Release artifacts are not affected by the original bug because the universal/release build path already links a complete generated metadata plist.
