### PR TITLE
fix(cli): preserve capture engine host routing

### DIFF
--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Pin process-targeted background typing, paste, clicks, and MCP key sequences to one process generation, rejecting Bridge hosts older than protocol 1.22 instead of letting them ignore the receipt or redirect input to a recycled PID.
+- Keep `see --capture-engine` on the selected Bridge host instead of silently moving capture and TCC ownership into the caller; fail before local fallback when no compatible host is available, with `--no-remote` as the explicit caller-local opt-in.
 - Resolve standalone exact-window AX-only `see` targets from their live owner and bind results to a process-generation/window receipt before publishing actionable element IDs or a snapshot.
 - Retry one passive background observation when its exact capture receipt changes before element detection or output, while leaving mutation-capable observations fail-closed.
 - Keep raw SwiftPM CLI `--version` output stable with explicit `unknown` build placeholders instead of reading the original working copy and wall clock at runtime; stamped debug and release builds retain rich link-time metadata.

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/AI/SeeCommand+CommanderMetadata.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/AI/SeeCommand+CommanderMetadata.swift
@@ -63,7 +63,8 @@ extension SeeCommand: CommanderSignatureProviding {
                 ),
                 .commandOption(
                     "captureEngine",
-                    help: "Capture engine: auto|classic|cg|modern|sckit (defaults to auto)",
+                    help: "Capture engine on the selected host: auto|classic|cg|modern|sckit; " +
+                        "use --no-remote for caller-local capture",
                     long: "capture-engine"
                 ),
                 .commandOption(

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/AI/SeeCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/AI/SeeCommand.swift
@@ -85,7 +85,8 @@ struct SeeCommand: ApplicationResolvable, ErrorHandlingCommand, RuntimeBackedCom
         help: """
         Capture engine: auto|modern|sckit|classic|cg (default: auto).
         modern/sckit force ScreenCaptureKit; classic/cg force CGWindowList;
-        auto tries CGWindowList then falls back when allowed.
+        auto tries CGWindowList then falls back when allowed. The preference is sent to the
+        selected Bridge host; add --no-remote to explicitly capture in the caller process.
         """
     )
     var captureEngine: String?
@@ -142,13 +143,13 @@ struct SeeCommand: ApplicationResolvable, ErrorHandlingCommand, RuntimeBackedCom
         ])
 
         do {
+            try self.validateMergedOptions()
             if let requiredHostFailure = runtime.requiredHostFailure {
                 throw PeekabooBridgeErrorEnvelope(
                     code: .operationNotSupported,
                     message: requiredHostFailure
                 )
             }
-            try self.validateMergedOptions()
             if self.usesPixelOnlyCapture {
                 try await self.runPixelOnlyCapture()
                 logger.operationComplete("see_command", metadata: ["success": true, "pixelOnly": true])
@@ -280,6 +281,7 @@ struct SeeCommand: ApplicationResolvable, ErrorHandlingCommand, RuntimeBackedCom
     }
 
     func validateMergedOptions() throws {
+        try self.validateCaptureEngineOption()
         let resolvedMode = self.determineMode()
         let forcesPixelOnlyMode = resolvedMode == .area || resolvedMode == .multi
         try self.validateExactWindowIdentifier()
@@ -296,6 +298,18 @@ struct SeeCommand: ApplicationResolvable, ErrorHandlingCommand, RuntimeBackedCom
         try self.validateTarget(
             for: resolvedMode,
             windowSelectorCount: windowSelectorCount
+        )
+    }
+
+    private func validateCaptureEngineOption() throws {
+        guard let value = (self.captureEngine ?? self.configuredCaptureEnginePreference)?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+            !value.isEmpty,
+            !ObservationCommandSupport.isSupportedCaptureEngineValue(value)
+        else { return }
+
+        throw ValidationError(
+            "Invalid capture engine '\(value)'; expected auto, modern/sckit, or classic/cg"
         )
     }
 

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommandRuntime.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommandRuntime.swift
@@ -18,6 +18,16 @@ struct CommandRuntimeOptions {
     var jsonOutput = false
     var logLevel: LogLevel?
     var captureEnginePreference: String?
+    /// This command carries the capture-engine choice in its remote request instead of
+    /// requiring the caller process to own capture/TCC.
+    var transportsCaptureEnginePreference = false
+    /// AX-only command forms do not run a capture backend; ambient engine configuration must
+    /// not alter their runtime host.
+    var ignoresCaptureEnginePreference = false
+    /// An explicit engine must run on a compatible host or fail; local fallback would silently
+    /// change capture/TCC ownership. Explicit `--no-remote` remains the local opt-in.
+    var requiresCaptureEnginePreferenceHost = false
+    var requiresDesktopObservation = false
     var inputStrategy: UIInputStrategy?
     var preferRemote = true
     var remoteIsolationRequested = false
@@ -83,10 +93,13 @@ struct CommandRuntimeOptions {
 
     func applyingEnvironmentOverrides(environment: [String: String]) -> CommandRuntimeOptions {
         var options = self
-        if options.captureEnginePreference == nil,
+        if !options.ignoresCaptureEnginePreference,
+           options.captureEnginePreference == nil,
            let captureEngine = Self.captureEnginePreference(environment: environment) {
             options.captureEnginePreference = captureEngine
-            if !options.requiresApplicationLaunchOptions, !options.requiresHostApplicationInventory {
+            if options.transportsCaptureEnginePreference {
+                options.requiresCaptureEnginePreferenceHost = true
+            } else if !options.requiresApplicationLaunchOptions, !options.requiresHostApplicationInventory {
                 options.preferRemote = false
             }
         }

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommanderBinder.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommanderBinder.swift
@@ -124,30 +124,7 @@ enum CommanderCLIBinder {
         if let level: LogLevel = try values.decodeOption("logLevel", as: LogLevel.self) {
             options.logLevel = level
         }
-        if let captureEngine = values.singleOption("captureEngine")?
-            .trimmingCharacters(in: .whitespacesAndNewlines),
-            !captureEngine.isEmpty {
-            guard ObservationCommandSupport.isSupportedCaptureEngineValue(captureEngine) else {
-                throw CommanderBindingError.invalidArgument(
-                    label: "capture-engine",
-                    value: captureEngine,
-                    reason: "expected auto, modern/sckit, or classic/cg"
-                )
-            }
-            if seeSkipsPixels {
-                throw CommanderBindingError.invalidArgument(
-                    label: "capture-engine",
-                    value: captureEngine,
-                    reason: "cannot be used with --no-screenshot because no capture backend runs"
-                )
-            }
-            options.captureEnginePreference = captureEngine
-            if options.transportsCaptureEnginePreference {
-                options.requiresCaptureEnginePreferenceHost = true
-            } else if !options.requiresApplicationLaunchOptions, !options.requiresHostApplicationInventory {
-                options.preferRemote = false
-            }
-        }
+        try Self.applyCaptureEnginePreference(to: &options, values: values, seeSkipsPixels: seeSkipsPixels)
         if let rawInputStrategy = values.singleOption("inputStrategy")?
             .trimmingCharacters(in: .whitespacesAndNewlines),
             !rawInputStrategy.isEmpty {
@@ -204,6 +181,38 @@ enum CommanderCLIBinder {
             options.requiresBrowserMCP = true
         }
         return options
+    }
+
+    private static func applyCaptureEnginePreference(
+        to options: inout CommandRuntimeOptions,
+        values: CommanderBindableValues,
+        seeSkipsPixels: Bool
+    ) throws {
+        guard let captureEngine = values.singleOption("captureEngine")?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+            !captureEngine.isEmpty
+        else { return }
+
+        guard ObservationCommandSupport.isSupportedCaptureEngineValue(captureEngine) else {
+            throw CommanderBindingError.invalidArgument(
+                label: "capture-engine",
+                value: captureEngine,
+                reason: "expected auto, modern/sckit, or classic/cg"
+            )
+        }
+        if seeSkipsPixels {
+            throw CommanderBindingError.invalidArgument(
+                label: "capture-engine",
+                value: captureEngine,
+                reason: "cannot be used with --no-screenshot because no capture backend runs"
+            )
+        }
+        options.captureEnginePreference = captureEngine
+        if options.transportsCaptureEnginePreference {
+            options.requiresCaptureEnginePreferenceHost = true
+        } else if !options.requiresApplicationLaunchOptions, !options.requiresHostApplicationInventory {
+            options.preferRemote = false
+        }
     }
 
     private static func requiresApplicationLaunchOptions(_ commandType: (any ParsableCommand.Type)?) -> Bool {

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommanderBinder.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommanderBinder.swift
@@ -62,6 +62,11 @@ enum CommanderCLIBinder {
             options.requiresProcessGenerationPinnedHotkeys = true
         }
         options.requiresHostApplicationInventory = Self.requiresHostApplicationInventory(commandType)
+        let seeSkipsPixels = commandType == SeeCommand.self &&
+            CommanderBindableValues(parsedValues: parsedValues).flag("noScreenshot")
+        options.requiresDesktopObservation = commandType == SeeCommand.self && !seeSkipsPixels
+        options.transportsCaptureEnginePreference = options.requiresDesktopObservation
+        options.ignoresCaptureEnginePreference = seeSkipsPixels
         options.requiresImplicitSnapshotInvalidation = Self.requiresImplicitSnapshotInvalidation(
             commandType,
             parsedValues: parsedValues
@@ -122,8 +127,24 @@ enum CommanderCLIBinder {
         if let captureEngine = values.singleOption("captureEngine")?
             .trimmingCharacters(in: .whitespacesAndNewlines),
             !captureEngine.isEmpty {
+            guard ObservationCommandSupport.isSupportedCaptureEngineValue(captureEngine) else {
+                throw CommanderBindingError.invalidArgument(
+                    label: "capture-engine",
+                    value: captureEngine,
+                    reason: "expected auto, modern/sckit, or classic/cg"
+                )
+            }
+            if seeSkipsPixels {
+                throw CommanderBindingError.invalidArgument(
+                    label: "capture-engine",
+                    value: captureEngine,
+                    reason: "cannot be used with --no-screenshot because no capture backend runs"
+                )
+            }
             options.captureEnginePreference = captureEngine
-            if !options.requiresApplicationLaunchOptions, !options.requiresHostApplicationInventory {
+            if options.transportsCaptureEnginePreference {
+                options.requiresCaptureEnginePreferenceHost = true
+            } else if !options.requiresApplicationLaunchOptions, !options.requiresHostApplicationInventory {
                 options.preferRemote = false
             }
         }

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/BridgeCapabilityPolicy.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/BridgeCapabilityPolicy.swift
@@ -27,6 +27,10 @@ enum BridgeCapabilityPolicy {
             return false
         }
 
+        if options.requiresDesktopObservation, !self.supportsDesktopObservation(for: handshake) {
+            return false
+        }
+
         if options.requiresExactWindowROIObservation,
            !self.supportsExactWindowROIObservation(for: handshake) {
             return false

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/RuntimeHostResolver.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/RuntimeHostResolver.swift
@@ -191,8 +191,22 @@ enum RuntimeHostResolver {
             }
         }
 
+        return self.localFallbackResolution(
+            options: options,
+            explicitSocket: explicitSocket,
+            snapshotInvalidationRemoteSocketPaths: snapshotInvalidationRemoteSocketPaths,
+            permissionRejections: permissionRejections
+        )
+    }
+
+    private static func localFallbackResolution(
+        options: CommandRuntimeOptions,
+        explicitSocket: String?,
+        snapshotInvalidationRemoteSocketPaths: [String],
+        permissionRejections: [String]
+    ) -> Resolution {
         // Name the hosts skipped for missing TCC permissions so a fallback is explainable
-        // instead of the previous silent selection of a permission-less bridge host.
+        // instead of silently selecting a permission-less bridge host.
         let rejectionSummary = permissionRejections.isEmpty
             ? ""
             : "; rejected " + permissionRejections.joined(separator: "; ")
@@ -211,9 +225,17 @@ enum RuntimeHostResolver {
     }
 
     static func requiredHostFailure(explicitSocket: String?, options: CommandRuntimeOptions) -> String? {
-        guard explicitSocket != nil, options.requiresExactWindowROIObservation else { return nil }
-        return "The explicitly selected Bridge host does not support exact-window ROI observation; " +
-            "protocol 1.21 with enabled observation and atomic snapshot publication is required."
+        if explicitSocket != nil, options.requiresExactWindowROIObservation {
+            return "The explicitly selected Bridge host does not support exact-window ROI observation; " +
+                "protocol 1.21 with enabled observation and atomic snapshot publication is required."
+        }
+        if options.requiresCaptureEnginePreferenceHost {
+            let engine = options.captureEnginePreference ?? "requested"
+            return "Capture engine '\(engine)' could not be delivered to a compatible Bridge host. " +
+                "Peekaboo will not switch capture or TCC ownership silently; start a current Bridge host, " +
+                "or pass --no-remote to explicitly run capture in the caller process."
+        }
+        return nil
     }
 
     static func remoteRoutingAllowed(

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Shared/ObservationCommandSupport.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Shared/ObservationCommandSupport.swift
@@ -2,6 +2,18 @@ import Foundation
 import PeekabooCore
 
 enum ObservationCommandSupport {
+    private static let supportedCaptureEngineValues: Set<String> = [
+        "auto",
+        "modern", "modern-only", "sckit", "sc", "screen-capture-kit", "sck",
+        "classic", "cg", "legacy", "legacy-only", "false", "0", "no",
+    ]
+
+    static func isSupportedCaptureEngineValue(_ value: String) -> Bool {
+        self.supportedCaptureEngineValues.contains(
+            value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        )
+    }
+
     static func captureEnginePreference(cliValue: String?, configuredValue: String?) -> CaptureEnginePreference {
         let value = (cliValue ?? configuredValue)?
             .trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Apps/CLI/Tests/CLIRuntimeTests/CaptureEngineRoutingCLITests.swift
+++ b/Apps/CLI/Tests/CLIRuntimeTests/CaptureEngineRoutingCLITests.swift
@@ -1,0 +1,111 @@
+import Foundation
+import Testing
+
+struct CaptureEngineRoutingCLITests {
+    @Test
+    func `Unknown capture engine is structured and never dispatches`() async throws {
+        guard TestChildProcess.canLocatePeekabooBinary() else {
+            Issue.record("Build peekaboo before running CLI runtime tests.")
+            return
+        }
+
+        let output = FileManager.default.temporaryDirectory
+            .appendingPathComponent("peekaboo-invalid-engine-\(UUID().uuidString).png")
+        defer { try? FileManager.default.removeItem(at: output) }
+
+        let result = try await TestChildProcess.runPeekaboo([
+            "see",
+            "--mode", "screen",
+            "--no-elements",
+            "--path", output.path,
+            "--capture-engine", "warp-drive",
+            "--json",
+        ])
+
+        #expect(result.status == .exited(1))
+        #expect(result.standardError.isEmpty)
+        #expect(!FileManager.default.fileExists(atPath: output.path))
+
+        let object = try JSONSerialization.jsonObject(with: Data(result.standardOutput.utf8))
+        let json = try #require(object as? [String: Any])
+        let error = try #require(json["error"] as? [String: Any])
+        #expect(json["success"] as? Bool == false)
+        #expect(error["code"] as? String == "INVALID_ARGUMENT")
+        #expect((error["message"] as? String)?.contains("capture-engine") == true)
+        #expect((error["message"] as? String)?.contains("warp-drive") == true)
+    }
+
+    @Test
+    func `Unknown ambient capture engine is structured and never dispatches`() async throws {
+        guard TestChildProcess.canLocatePeekabooBinary() else {
+            Issue.record("Build peekaboo before running CLI runtime tests.")
+            return
+        }
+
+        let output = FileManager.default.temporaryDirectory
+            .appendingPathComponent("peekaboo-invalid-ambient-engine-\(UUID().uuidString).png")
+        defer { try? FileManager.default.removeItem(at: output) }
+
+        let result = try await TestChildProcess.runPeekaboo(
+            [
+                "see",
+                "--mode", "screen",
+                "--no-elements",
+                "--path", output.path,
+                "--json",
+            ],
+            environment: ["PEEKABOO_CAPTURE_ENGINE": "warp-drive"]
+        )
+
+        #expect(result.status == .exited(1))
+        #expect(result.standardError.isEmpty)
+        #expect(!FileManager.default.fileExists(atPath: output.path))
+
+        let object = try JSONSerialization.jsonObject(with: Data(result.standardOutput.utf8))
+        let json = try #require(object as? [String: Any])
+        let error = try #require(json["error"] as? [String: Any])
+        #expect(json["success"] as? Bool == false)
+        #expect(error["code"] as? String == "VALIDATION_ERROR")
+        #expect((error["message"] as? String)?.contains("warp-drive") == true)
+    }
+
+    @Test
+    func `Explicit capture engine refuses missing Bridge without local dispatch`() async throws {
+        guard TestChildProcess.canLocatePeekabooBinary() else {
+            Issue.record("Build peekaboo before running CLI runtime tests.")
+            return
+        }
+
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("peekaboo-engine-routing-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let output = directory.appendingPathComponent("must-not-exist.png")
+        let missingSocket = directory.appendingPathComponent("missing.sock")
+        let result = try await TestChildProcess.runPeekaboo(
+            [
+                "see",
+                "--mode", "screen",
+                "--no-elements",
+                "--path", output.path,
+                "--capture-engine", "cg",
+                "--bridge-socket", missingSocket.path,
+                "--json",
+            ],
+            isolateFromRemoteHosts: false
+        )
+
+        #expect(result.status == .exited(1))
+        #expect(result.standardError.isEmpty)
+        #expect(!FileManager.default.fileExists(atPath: output.path))
+
+        let object = try JSONSerialization.jsonObject(with: Data(result.standardOutput.utf8))
+        let json = try #require(object as? [String: Any])
+        let error = try #require(json["error"] as? [String: Any])
+        #expect(json["success"] as? Bool == false)
+        #expect(error["code"] as? String == "VALIDATION_ERROR")
+        #expect((error["message"] as? String)?.contains("could not be delivered") == true)
+        #expect((error["message"] as? String)?.contains("--no-remote") == true)
+    }
+}

--- a/Apps/CLI/Tests/CLIRuntimeTests/Support/TestChildProcess.swift
+++ b/Apps/CLI/Tests/CLIRuntimeTests/Support/TestChildProcess.swift
@@ -18,16 +18,20 @@ enum TestChildProcess {
         environment extraEnvironment: [String: String] = [:],
         executablePathOverride: String? = nil,
         workingDirectory: URL? = nil,
-        standardInput: String? = nil
+        standardInput: String? = nil,
+        isolateFromRemoteHosts: Bool = true
     ) async throws -> Result {
         let binaryURL = try Self.peekabooBinaryURL()
         var environmentOverrides: [Environment.Key: String?] = [:]
 
         // Keep CLI runtime smoke tests deterministic: avoid opportunistically switching to
         // a remote GUI runtime when a bridge socket happens to exist on the machine.
-        if extraEnvironment["PEEKABOO_NO_REMOTE"] == nil,
-           let envKey = Environment.Key(rawValue: "PEEKABOO_NO_REMOTE") {
-            environmentOverrides[envKey] = "1"
+        if let envKey = Environment.Key(rawValue: "PEEKABOO_NO_REMOTE") {
+            if isolateFromRemoteHosts, extraEnvironment["PEEKABOO_NO_REMOTE"] == nil {
+                environmentOverrides[envKey] = "1"
+            } else if !isolateFromRemoteHosts {
+                environmentOverrides[envKey] = nil
+            }
         }
 
         for (key, value) in extraEnvironment {

--- a/Apps/CLI/Tests/CoreCLITests/CaptureEngineRoutingTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/CaptureEngineRoutingTests.swift
@@ -1,0 +1,108 @@
+import Commander
+import PeekabooAutomation
+import Testing
+@testable import PeekabooCLI
+
+@Suite(.tags(.safe))
+@MainActor
+struct CaptureEngineRoutingTests {
+    @Test
+    func `See capture engine selection preserves Bridge routing`() throws {
+        let cliOptions = try CommanderCLIBinder.makeRuntimeOptions(
+            from: ParsedValues(
+                positional: [],
+                options: ["captureEngine": ["cg"]],
+                flags: []
+            ),
+            commandType: SeeCommand.self
+        )
+        let ambientBase = try CommanderCLIBinder.makeRuntimeOptions(
+            from: ParsedValues(positional: [], options: [:], flags: []),
+            commandType: SeeCommand.self
+        )
+        let ambientOptions = ambientBase.applyingEnvironmentOverrides(environment: [
+            "PEEKABOO_CAPTURE_ENGINE": "modern",
+        ])
+
+        for options in [cliOptions, ambientOptions] {
+            #expect(RuntimeHostResolver.initialRoutingDecision(
+                options: options,
+                environment: [:],
+                configurationInput: nil,
+                knownSnapshotInvalidationRemoteSocketPaths: []
+            ) == .remote)
+            #expect(RuntimeHostResolver.shouldResolveKnownRemoteEndpoints(
+                options: options,
+                environment: [:],
+                configurationInput: nil
+            ))
+        }
+    }
+
+    @Test
+    func `No remote remains the explicit caller-local capture opt in`() throws {
+        let options = try CommanderCLIBinder.makeRuntimeOptions(
+            from: ParsedValues(
+                positional: [],
+                options: ["captureEngine": ["cg"]],
+                flags: ["no-remote"]
+            ),
+            commandType: SeeCommand.self
+        )
+
+        #expect(options.remoteIsolationRequested)
+        #expect(RuntimeHostResolver.initialRoutingDecision(
+            options: options,
+            environment: [:],
+            configurationInput: nil,
+            knownSnapshotInvalidationRemoteSocketPaths: ["/tmp/gui.sock"]
+        ) == .local(snapshotInvalidationRemoteSocketPaths: []))
+        #expect(!RuntimeHostResolver.shouldResolveKnownRemoteEndpoints(
+            options: options,
+            environment: [:],
+            configurationInput: nil
+        ))
+    }
+
+    @Test
+    func `Capture engine selection refuses silent local fallback`() throws {
+        let options = try CommanderCLIBinder.makeRuntimeOptions(
+            from: ParsedValues(positional: [], options: ["captureEngine": ["cg"]], flags: []),
+            commandType: SeeCommand.self
+        )
+
+        let failure = try #require(RuntimeHostResolver.requiredHostFailure(
+            explicitSocket: nil,
+            options: options
+        ))
+        #expect(failure.contains("Capture engine 'cg'"))
+        #expect(failure.contains("will not switch capture or TCC ownership silently"))
+        #expect(failure.contains("--no-remote"))
+
+        var defaultOptions = options
+        defaultOptions.captureEnginePreference = nil
+        defaultOptions.requiresCaptureEnginePreferenceHost = false
+        #expect(RuntimeHostResolver.requiredHostFailure(explicitSocket: nil, options: defaultOptions) == nil)
+    }
+
+    @Test
+    func `Ambient capture engine cannot reroute AX only see`() throws {
+        let base = try CommanderCLIBinder.makeRuntimeOptions(
+            from: ParsedValues(positional: [], options: [:], flags: ["noScreenshot"]),
+            commandType: SeeCommand.self
+        )
+        let options = base.applyingEnvironmentOverrides(environment: [
+            "PEEKABOO_CAPTURE_ENGINE": "cg",
+        ])
+
+        #expect(options.ignoresCaptureEnginePreference)
+        #expect(options.captureEnginePreference == nil)
+        #expect(options.preferRemote)
+        #expect(RuntimeHostResolver.initialRoutingDecision(
+            options: options,
+            environment: ["PEEKABOO_CAPTURE_ENGINE": "cg"],
+            configurationInput: nil,
+            knownSnapshotInvalidationRemoteSocketPaths: []
+        ) == .remote)
+    }
+}

--- a/Apps/CLI/Tests/CoreCLITests/CommanderBinderCommandBindingTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/CommanderBinderCommandBindingTests.swift
@@ -580,6 +580,10 @@ struct CommanderBinderCommandBindingTests {
 
         let runtimeOptions = try CommanderCLIBinder.makeRuntimeOptions(from: parsed)
         #expect(runtimeOptions.captureEnginePreference == "classic")
+
+        let captureEngine = SeeCommand.commanderSignature().options.first { $0.label == "captureEngine" }
+        #expect(captureEngine?.help?.contains("selected host") == true)
+        #expect(captureEngine?.help?.contains("--no-remote") == true)
     }
 
     @Test

--- a/Apps/CLI/Tests/CoreCLITests/CommanderBinderTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/CommanderBinderTests.swift
@@ -43,11 +43,70 @@ struct CommanderBinderTests {
     }
 
     @Test
-    func `Runtime options map capture engine option and force local mode`() throws {
+    func `See capture engine option remains remotely routable`() throws {
         let parsed = ParsedValues(positional: [], options: ["captureEngine": ["cg"]], flags: [])
         let options = try CommanderCLIBinder.makeRuntimeOptions(from: parsed, commandType: SeeCommand.self)
         #expect(options.captureEnginePreference == "cg")
-        #expect(options.preferRemote == false)
+        #expect(options.preferRemote)
+        #expect(options.transportsCaptureEnginePreference)
+        #expect(options.requiresCaptureEnginePreferenceHost)
+        #expect(options.requiresDesktopObservation)
+    }
+
+    @Test
+    func `See capture engine environment override remains remotely routable`() throws {
+        let base = try CommanderCLIBinder.makeRuntimeOptions(
+            from: ParsedValues(positional: [], options: [:], flags: []),
+            commandType: SeeCommand.self
+        )
+        let options = base.applyingEnvironmentOverrides(environment: [
+            "PEEKABOO_CAPTURE_ENGINE": " modern ",
+        ])
+
+        #expect(options.captureEnginePreference == "modern")
+        #expect(options.preferRemote)
+        #expect(options.transportsCaptureEnginePreference)
+        #expect(options.requiresCaptureEnginePreferenceHost)
+        #expect(options.requiresDesktopObservation)
+    }
+
+    @Test
+    func `Capture engine option stays local when a command cannot transport it`() throws {
+        let parsed = ParsedValues(positional: [], options: ["captureEngine": ["cg"]], flags: [])
+        let options = try CommanderCLIBinder.makeRuntimeOptions(from: parsed, commandType: CaptureLiveCommand.self)
+
+        #expect(options.captureEnginePreference == "cg")
+        #expect(!options.preferRemote)
+        #expect(!options.transportsCaptureEnginePreference)
+        #expect(!options.requiresCaptureEnginePreferenceHost)
+    }
+
+    @Test
+    func `Tree only see rejects an unused capture engine`() {
+        #expect(throws: CommanderBindingError.self) {
+            try CommanderCLIBinder.makeRuntimeOptions(
+                from: ParsedValues(
+                    positional: [],
+                    options: ["captureEngine": ["cg"]],
+                    flags: ["noScreenshot"]
+                ),
+                commandType: SeeCommand.self
+            )
+        }
+    }
+
+    @Test
+    func `See rejects an unknown capture engine before runtime resolution`() {
+        #expect(throws: CommanderBindingError.self) {
+            try CommanderCLIBinder.makeRuntimeOptions(
+                from: ParsedValues(
+                    positional: [],
+                    options: ["captureEngine": ["warp-drive"]],
+                    flags: []
+                ),
+                commandType: SeeCommand.self
+            )
+        }
     }
 
     @Test
@@ -457,7 +516,7 @@ struct CommanderBinderTests {
             negotiatedVersion: .init(major: 1, minor: 12),
             hostKind: .onDemand,
             build: nil,
-            supportedOperations: [.captureScreen]
+            supportedOperations: [.captureScreen, .desktopObservation]
         )
 
         let readOnlyCaptures: [(any ParsableCommand.Type, ParsedValues)] = [

--- a/Apps/CLI/Tests/CoreCLITests/ObservationPolicyDefaultsTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/ObservationPolicyDefaultsTests.swift
@@ -32,6 +32,17 @@ struct ObservationPolicyDefaultsTests {
     }
 
     @Test
+    func `See carries its capture engine in the desktop observation request`() throws {
+        var classic = try SeeCommand.parse([])
+        classic.captureEngine = "cg"
+        var modern = try SeeCommand.parse([])
+        modern.captureEngine = "sckit"
+
+        #expect(try classic.makeObservationRequest(target: .frontmost).capture.engine == .legacy)
+        #expect(try modern.makeObservationRequest(target: .frontmost).capture.engine == .modern)
+    }
+
+    @Test
     func `See web focus fallback is a positive opt in`() throws {
         let enabled = try SeeCommand.parse(["--web-focus"])
         #expect(enabled.webFocus)

--- a/Apps/CLI/Tests/CoreCLITests/RuntimeHostApplicationSelectionTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/RuntimeHostApplicationSelectionTests.swift
@@ -6,6 +6,32 @@ import Testing
 
 struct RuntimeHostApplicationSelectionTests {
     @Test
+    func `See capture engine requires a desktop observation host`() throws {
+        let options = try CommanderCLIBinder.makeRuntimeOptions(
+            from: ParsedValues(positional: [], options: ["captureEngine": ["cg"]], flags: []),
+            commandType: SeeCommand.self
+        )
+        let supportedOperations: [PeekabooBridgeOperation] = [.captureScreen, .desktopObservation]
+        let supported = PeekabooBridgeHandshakeResponse(
+            negotiatedVersion: PeekabooBridgeConstants.protocolVersion,
+            hostKind: .onDemand,
+            build: nil,
+            supportedOperations: supportedOperations,
+            enabledOperations: supportedOperations
+        )
+        let captureOnly = PeekabooBridgeHandshakeResponse(
+            negotiatedVersion: PeekabooBridgeConstants.protocolVersion,
+            hostKind: .onDemand,
+            build: nil,
+            supportedOperations: [.captureScreen],
+            enabledOperations: [.captureScreen]
+        )
+
+        #expect(CommandRuntime.supportsRemoteRequirements(for: supported, options: options))
+        #expect(!CommandRuntime.supportsRemoteRequirements(for: captureOnly, options: options))
+    }
+
+    @Test
     func `Non-capture commands do not require the capture operation`() async {
         let candidate = RuntimeHostResolver.ImplicitRemoteCandidate(
             socketPath: "/tmp/bridge.sock",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Default new agent configurations to GPT-5.6 and Claude Opus 5 while keeping credential-only Anthropic discovery on Opus 4.8 for zero-retention compatibility and preserving explicit model selections.
 
 ### Fixed
+- Keep `see --capture-engine` on the selected Bridge host instead of silently moving capture and TCC ownership into the caller; fail before local fallback when no compatible host is available, with `--no-remote` as the explicit caller-local opt-in.
 - Resolve standalone exact-window AX-only `see` targets from their live owner and bind results to a process-generation/window receipt before publishing actionable element IDs or a snapshot.
 - Retry one passive background observation when its exact capture receipt changes before element detection or output, while leaving mutation-capable observations fail-closed.
 - Keep raw SwiftPM CLI `--version` output stable with explicit `unknown` build placeholders instead of reading the original working copy and wall clock at runtime; stamped debug and release builds retain rich link-time metadata.

--- a/docs/commands/permissions.md
+++ b/docs/commands/permissions.md
@@ -58,7 +58,9 @@ peekaboo permissions request event-synthesizing
   running in the active
   Aqua GUI session and already has permission. SSH, LaunchAgent, Codex, and other background launchd sessions can
   still return wallpaper-only pixels despite TCC grants, so prefer Bridge there.
-- Treat `see --no-elements --capture-engine` as a local-debug override: it disables Bridge selection for that capture command.
+- `see --capture-engine` applies the engine on the selected Bridge host without changing TCC ownership. Add
+  `--no-remote` only for an intentional caller-local debug capture; without it, an unavailable compatible host fails
+  before local fallback.
 - If capture returns a blank desktop, wallpaper, or no windows while `permissions status` reports Screen Recording as denied, run `peekaboo permissions request screen-recording` and then restart the affected Peekaboo process. Homebrew upgrades can move the CLI to a new Cellar path, so confirm the enabled System Settings row belongs to the current binary.
 - Confirm your target with `peekaboo app list`, `peekaboo window list`, or `peekaboo see` before rerunning.
 - Re-run with `--json` or `--verbose` to surface detailed errors.

--- a/docs/commands/see.md
+++ b/docs/commands/see.md
@@ -38,9 +38,10 @@ peekaboo see --window-id 12345 --roi 100,80,500,300 --json --path /tmp/window-ro
 | `--mode screen|window|frontmost|multi|area` | Override the target picker. `multi` captures every screen; `area` uses `--region`. |
 | `--region x,y,width,height` | Capture a rectangular region (`area` mode is inferred). |
 | `--format png|jpg` / `--retina` | Select the image encoding and native display scale. |
+| `--capture-engine auto|modern|sckit|classic|cg` | Select the engine on the chosen Bridge host without changing runtime ownership. If no compatible host is available, Peekaboo fails instead of capturing locally; add `--no-remote` to explicitly opt into caller-local capture. |
 | `--no-elements` | Skip element detection for the cheapest screenshot-only CLI path. |
 | `--tree` | Print the accessibility text tree. |
-| `--no-screenshot` | Skip pixel capture; requires `--tree`. This AX-only form publishes element IDs and a snapshot only after pinning the exact process generation, window, and bounds; target drift or a missing receipt fails before publication. |
+| `--no-screenshot` | Skip pixel capture; requires `--tree` and rejects `--capture-engine` because no backend runs. Ambient engine configuration is ignored so it cannot reroute this AX-only form. Element IDs and a snapshot publish only after pinning the exact process generation, window, and bounds; target drift or a missing receipt fails before publication. |
 | `--annotate` | Overlay element bounds/IDs on the output image. |
 | `--path <file>` / `--save` / `--output` / `-o` | Save the screenshot/annotation to disk. |
 | `--json` | Emit structured metadata (recommended for scripting). |

--- a/docs/engine.md
+++ b/docs/engine.md
@@ -21,6 +21,12 @@ Peekaboo supports two capture backends:
   - `peekaboo see --no-elements --capture-engine ...`
   - `peekaboo see --capture-engine ...`
 
+`see --capture-engine` selects the backend on the same Bridge host that normal runtime routing chooses; it does not
+silently move capture or TCC ownership into the CLI process. If no compatible Bridge host is available, the command
+fails before caller-local capture. Add `--no-remote` only when caller-local execution is intentional and that process
+is known to own Screen Recording in the active Aqua session. Other capture commands remain caller-local until their
+remote protocols explicitly carry the engine preference.
+
 Aliases:
 - modern: `modern`, `sckit`, `sc`, `sck`
 - classic: `classic`, `cg`, `legacy`

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -70,8 +70,9 @@ peekaboo see --mode screen --screen-index 0 --no-remote --capture-engine cg --js
 This is useful for app-launched subprocess runners where the parent process has TCC grants but the selected host
 does not. For SSH, LaunchAgent, Codex, and other background launchd sessions, prefer the Bridge path even when
 TCC appears granted; CoreGraphics can otherwise report success while returning only the desktop wallpaper or a
-redacted image. Passing `--capture-engine` is a local-debug override and disables Bridge selection for that
-command.
+redacted image. `--capture-engine` alone keeps the selected Bridge host and applies the backend there. The
+caller-local debug override is the explicit combination with `--no-remote`; without that opt-in, an unavailable
+compatible host fails before local fallback.
 
 Use `peekaboo permissions status --all-sources` to compare the selected Bridge host and local CLI process side by side.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -37,8 +37,8 @@ peekaboo see --no-elements --app Safari --path safari.png
 The output is a regular PNG. Add `--format jpg` for JPEG output. See [commands/see.md](commands/see.md) for every flag.
 
 If you are running from SSH, a LaunchAgent, Codex, or another background launchd session, use a Peekaboo Bridge
-host with Screen Recording permission. Local capture-engine overrides are for debugging and can produce
-wallpaper-only screenshots in background sessions.
+host with Screen Recording permission. `--capture-engine` keeps that selected host; caller-local overrides require
+`--no-remote` and are for debugging because they can produce wallpaper-only screenshots in background sessions.
 
 Normal CLI automation uses a healthy reusable daemon, then a capable Peekaboo.app Bridge host, and otherwise starts
 the daemon on demand. `peekaboo bridge status --verbose` shows the selected runtime.


### PR DESCRIPTION
## Summary

- keep `see --capture-engine` on the runtime host selected by normal Bridge routing
- require a desktop-observation-capable host and refuse before caller-local fallback when an explicit engine cannot be delivered
- make `--no-remote` the explicit caller-local opt-in, validate unknown/unused engine values, and ignore ambient engine configuration for AX-only inspection
- update CLI help, capture/permission docs, changelogs, and structured no-dispatch regression coverage

## Why

Passing `see --capture-engine` previously forced the CLI into local services before runtime selection. That silently changed which process owned Screen Recording/TCC and could turn a reliable Bridge-backed background capture into caller-local wallpaper-only output.

Desktop observation already transports the engine preference in its request. Peekaboo now preserves the selected Bridge and applies `auto`, `cg`, or `modern` there. If no compatible host is available, the command fails with actionable structured guidance instead of changing ownership. Users who intentionally need caller-local capture can still say so with `--no-remote`.

## Tests

- exact-binary focused routing, binder, capability, request-payload, and process-level CLI suites (123/123 passed)
- `pnpm run test:safe` (806 Core/CLI tests and 76 runtime tests, plus all release/native-only policy gates)
- strict SwiftLint on the touched binder (0 violations); full SwiftLint (22 established warnings, 0 serious)
- SwiftFormat, docs lint, and `git diff --check`
- source-blind CLI contract on SHA-256 `bcdc88515d224d7609c9984ccf2ef27e3372785be37f2796e7f4f468eda1f734`: help, two missing-host engines, unknown/unused values, ambient AX-only routing, empty stderr, and zero artifacts (5/5 clauses; 6/6 probes)
- P0–P2 Autoreview and TruffleHog on the exact branch: no accepted/actionable findings; one P2 was rejected because every pixel-only `see` mode, including area and multi, already sends a `DesktopObservationRequest` carrying the engine preference
