### PR TITLE
feat(see): add local OCR observations

### DIFF
--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [4.0.1] - Unreleased
 
 ### Added
+- Add `see --ocr` for additive local Vision text with preserved AX warnings, exact snapshot receipts, logical bounds, confidence, and background-only observation.
 - Add `see --roi x,y,width,height` for stateless exact-window crops with fresh snapshot receipts, ROI-local element output, and safe coordinate metadata.
 
 ### Changed
@@ -16,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Pin process-targeted background typing, paste, clicks, and MCP key sequences to one process generation, rejecting Bridge hosts older than protocol 1.22 instead of letting them ignore the receipt or redirect input to a recycled PID.
 - Keep `see --capture-engine` on the selected Bridge host instead of silently moving capture and TCC ownership into the caller; fail before local fallback when no compatible host is available, with `--no-remote` as the explicit caller-local opt-in.
+- Keep OCR bounds correct for Retina captures, retain AX mutation/coordinate receipts through OCR merges and snapshot/ROI round-trips, use one bounded fast local recognition attempt for automation, and refuse only provenance-bound semantic OCR IDs as element action targets.
 - Resolve standalone exact-window AX-only `see` targets from their live owner and bind results to a process-generation/window receipt before publishing actionable element IDs or a snapshot.
 - Retry one passive background observation when its exact capture receipt changes before element detection or output, while leaving mutation-capable observations fail-closed.
 - Keep raw SwiftPM CLI `--version` output stable with explicit `unknown` build placeholders instead of reading the original working copy and wall clock at runtime; stamped debug and release builds retain rich link-time metadata.

--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [4.0.1] - Unreleased
 
 ### Added
-- Add `see --ocr` for additive local Vision text with preserved AX warnings, exact snapshot receipts, logical bounds, confidence, and background-only observation.
+- Add `see --ocr` for additive host-local Vision text with preserved AX warnings, exact snapshot receipts, logical bounds, confidence, background-only observation, and fail-before-dispatch compatibility with older Bridge hosts.
 - Add `see --roi x,y,width,height` for stateless exact-window crops with fresh snapshot receipts, ROI-local element output, and safe coordinate metadata.
 
 ### Changed

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/AI/SeeCommand+CommanderMetadata.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/AI/SeeCommand+CommanderMetadata.swift
@@ -116,7 +116,7 @@ extension SeeCommand: CommanderSignatureProviding {
                 ),
                 .commandFlag(
                     "ocr",
-                    help: "Add local Vision OCR text to the accessibility element map",
+                    help: "Add host-local Vision OCR text to the accessibility element map",
                     long: "ocr"
                 ),
                 .commandFlag(

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/AI/SeeCommand+CommanderMetadata.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/AI/SeeCommand+CommanderMetadata.swift
@@ -115,6 +115,11 @@ extension SeeCommand: CommanderSignatureProviding {
                     long: "no-elements"
                 ),
                 .commandFlag(
+                    "ocr",
+                    help: "Add local Vision OCR text to the accessibility element map",
+                    long: "ocr"
+                ),
+                .commandFlag(
                     "tree",
                     help: "Print the accessibility text tree",
                     long: "tree"

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/AI/SeeCommand+ObservationRequest.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/AI/SeeCommand+ObservationRequest.swift
@@ -107,7 +107,8 @@ extension SeeCommand {
             ),
             timeout: DesktopObservationTimeouts(
                 overall: self.overallTimeoutSeconds,
-                detection: self.overallTimeoutSeconds
+                detection: self.overallTimeoutSeconds,
+                ocr: self.ocr ? self.overallTimeoutSeconds : nil
             )
         )
     }
@@ -165,8 +166,9 @@ extension SeeCommand {
             )
         default:
             DesktopDetectionOptions(
-                mode: .accessibility,
+                mode: self.ocr ? .accessibilityAndOCR : .accessibility,
                 allowWebFocusFallback: self.webFocus,
+                preferOCR: false,
                 traversalBudget: self.axTraversalBudget()
             )
         }

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/AI/SeeCommand+Output.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/AI/SeeCommand+Output.swift
@@ -68,6 +68,7 @@ extension SeeCommand {
                 role_description: element.attributes["roleDescription"],
                 help: element.attributes["help"],
                 identifier: element.attributes["identifier"],
+                confidence: element.attributes["confidence"].flatMap(Double.init),
                 bounds: UIElementBounds(element.bounds),
                 is_actionable: element.isActionable,
                 is_enabled: element.knownIsEnabled,

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/AI/SeeCommand+Types.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/AI/SeeCommand+Types.swift
@@ -56,6 +56,7 @@ struct UIElementSummary: Codable {
     let role_description: String?
     let help: String?
     let identifier: String?
+    let confidence: Double?
     let bounds: UIElementBounds
     let is_actionable: Bool
     let is_enabled: Bool?

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/AI/SeeCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/AI/SeeCommand.swift
@@ -59,6 +59,9 @@ struct SeeCommand: ApplicationResolvable, ErrorHandlingCommand, RuntimeBackedCom
     @Flag(help: "Skip element detection for a faster screenshot-only capture")
     var noElements = false
 
+    @Flag(help: "Add local Vision OCR text to the accessibility element map")
+    var ocr = false
+
     @Flag(help: "Print the accessibility text tree")
     var tree = false
 
@@ -319,6 +322,17 @@ struct SeeCommand: ApplicationResolvable, ErrorHandlingCommand, RuntimeBackedCom
     ) throws {
         if self.tree, self.noElements {
             throw ValidationError("--tree cannot be combined with --no-elements")
+        }
+        if self.ocr, self.noElements {
+            throw ValidationError("--ocr cannot be combined with --no-elements")
+        }
+        if self.ocr, self.noScreenshot {
+            throw ValidationError("--ocr cannot be combined with --no-screenshot")
+        }
+        if self.ocr, forcesPixelOnlyMode || self.streamsImageToStdout {
+            throw ValidationError(
+                "--ocr requires screenshot-backed element detection for frontmost or app/window targets"
+            )
         }
         if self.noScreenshot, !self.tree {
             throw ValidationError("--no-screenshot requires --tree")
@@ -700,6 +714,7 @@ extension SeeCommand: CommanderBindableCommand {
         self.menubar = values.flag("menubar")
         self.retina = values.flag("retina")
         self.noElements = values.flag("noElements")
+        self.ocr = values.flag("ocr")
         self.tree = values.flag("tree")
         self.noScreenshot = values.flag("noScreenshot")
     }

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/AI/SeeCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/AI/SeeCommand.swift
@@ -59,7 +59,7 @@ struct SeeCommand: ApplicationResolvable, ErrorHandlingCommand, RuntimeBackedCom
     @Flag(help: "Skip element detection for a faster screenshot-only capture")
     var noElements = false
 
-    @Flag(help: "Add local Vision OCR text to the accessibility element map")
+    @Flag(help: "Add host-local Vision OCR text to the accessibility element map")
     var ocr = false
 
     @Flag(help: "Print the accessibility text tree")

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommandRuntime.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommandRuntime.swift
@@ -28,6 +28,9 @@ struct CommandRuntimeOptions {
     /// change capture/TCC ownership. Explicit `--no-remote` remains the local opt-in.
     var requiresCaptureEnginePreferenceHost = false
     var requiresDesktopObservation = false
+    /// `accessibilityAndOCR` is additive inside protocol 1.22. Require a raw host capability so
+    /// an older 1.22 host cannot try to decode the enum case before the client can fail safely.
+    var requiresDesktopObservationOCR = false
     var inputStrategy: UIInputStrategy?
     var preferRemote = true
     var remoteIsolationRequested = false
@@ -350,6 +353,10 @@ extension CommandRuntime {
 
     static func supportsDesktopObservation(for handshake: PeekabooBridgeHandshakeResponse) -> Bool {
         BridgeCapabilityPolicy.supportsDesktopObservation(for: handshake)
+    }
+
+    static func supportsDesktopObservationOCR(for handshake: PeekabooBridgeHandshakeResponse) -> Bool {
+        BridgeCapabilityPolicy.supportsDesktopObservationOCR(for: handshake)
     }
 
     static func supportsExactWindowROIObservation(for handshake: PeekabooBridgeHandshakeResponse) -> Bool {

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommanderBinder.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommanderBinder.swift
@@ -66,8 +66,7 @@ enum CommanderCLIBinder {
         let seeSkipsPixels = commandType == SeeCommand.self &&
             commandValues.flag("noScreenshot")
         options.requiresDesktopObservation = commandType == SeeCommand.self && !seeSkipsPixels
-        options.requiresDesktopObservationOCR = commandType == SeeCommand.self &&
-            (commandValues.flag("ocr") || commandValues.flag("menubar"))
+        options.requiresDesktopObservationOCR = commandType == SeeCommand.self && commandValues.flag("ocr")
         options.transportsCaptureEnginePreference = options.requiresDesktopObservation
         options.ignoresCaptureEnginePreference = seeSkipsPixels
         options.requiresImplicitSnapshotInvalidation = Self.requiresImplicitSnapshotInvalidation(

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommanderBinder.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommanderBinder.swift
@@ -44,18 +44,19 @@ enum CommanderCLIBinder {
         environment: [String: String] = ProcessInfo.processInfo.environment
     ) throws -> CommandRuntimeOptions {
         var options = CommandRuntimeOptions()
+        let commandValues = CommanderBindableValues(parsedValues: parsedValues)
         options.requiresApplicationLaunchOptions = Self.requiresApplicationLaunchOptions(commandType)
         options.requiresNewApplicationInstanceLaunch = commandType == AppCommand.LaunchSubcommand.self &&
-            CommanderBindableValues(parsedValues: parsedValues).flag("newInstance")
+            commandValues.flag("newInstance")
         options.requiresApplicationWindowReadiness =
             commandType == AppCommand.LaunchSubcommand.self &&
-            CommanderBindableValues(parsedValues: parsedValues).flag("waitForWindow")
+            commandValues.flag("waitForWindow")
         options.requiresApplicationRelaunch = commandType == AppCommand.RelaunchSubcommand.self
         options.requiresSurvivingApplicationHost = commandType == AppCommand.QuitSubcommand.self
         options.requiresProcessGenerationPinnedApplicationQuit = commandType == AppCommand.QuitSubcommand.self
         options.requiresProcessGenerationPinnedHotkeys = commandType == PressCommand.self &&
-            !CommanderBindableValues(parsedValues: parsedValues).flag("foreground")
-        let usesBackgroundInput = !CommanderBindableValues(parsedValues: parsedValues).flag("foreground")
+            !commandValues.flag("foreground")
+        let usesBackgroundInput = !commandValues.flag("foreground")
         options.requiresProcessGenerationPinnedTypeActions =
             (commandType == TypeCommand.self || commandType == PasteCommand.self) && usesBackgroundInput
         if commandType == PasteCommand.self, usesBackgroundInput {
@@ -63,8 +64,10 @@ enum CommanderCLIBinder {
         }
         options.requiresHostApplicationInventory = Self.requiresHostApplicationInventory(commandType)
         let seeSkipsPixels = commandType == SeeCommand.self &&
-            CommanderBindableValues(parsedValues: parsedValues).flag("noScreenshot")
+            commandValues.flag("noScreenshot")
         options.requiresDesktopObservation = commandType == SeeCommand.self && !seeSkipsPixels
+        options.requiresDesktopObservationOCR = commandType == SeeCommand.self &&
+            (commandValues.flag("ocr") || commandValues.flag("menubar"))
         options.transportsCaptureEnginePreference = options.requiresDesktopObservation
         options.ignoresCaptureEnginePreference = seeSkipsPixels
         options.requiresImplicitSnapshotInvalidation = Self.requiresImplicitSnapshotInvalidation(
@@ -89,7 +92,7 @@ enum CommanderCLIBinder {
             options.requiresProcessGenerationPinnedClicks = true
         }
         options.requiresTargetedScroll = commandType == ScrollCommand.self &&
-            !CommanderBindableValues(parsedValues: parsedValues).flag("foreground")
+            !commandValues.flag("foreground")
         options.requiresPostEventPermission = Self.requiresPostEventPermission(
             commandType,
             parsedValues: parsedValues
@@ -98,7 +101,6 @@ enum CommanderCLIBinder {
             commandType,
             parsedValues: parsedValues
         )
-        let commandValues = CommanderBindableValues(parsedValues: parsedValues)
         options.requiresLongPressClick = commandType == ClickCommand.self &&
             commandValues.flag("longPress") && commandValues.flag("foreground")
         options.requiresBackgroundWindowClose = commandType == WindowCommand.CloseSubcommand.self &&

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/BridgeCapabilityPolicy.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/BridgeCapabilityPolicy.swift
@@ -27,12 +27,7 @@ enum BridgeCapabilityPolicy {
             return false
         }
 
-        if options.requiresDesktopObservation, !self.supportsDesktopObservation(for: handshake) {
-            return false
-        }
-
-        if options.requiresExactWindowROIObservation,
-           !self.supportsExactWindowROIObservation(for: handshake) {
+        if !self.supportsObservationRequirements(for: handshake, options: options) {
             return false
         }
 
@@ -103,6 +98,23 @@ enum BridgeCapabilityPolicy {
             return false
         }
 
+        return true
+    }
+
+    private static func supportsObservationRequirements(
+        for handshake: PeekabooBridgeHandshakeResponse,
+        options: CommandRuntimeOptions
+    ) -> Bool {
+        if options.requiresDesktopObservation, !self.supportsDesktopObservation(for: handshake) {
+            return false
+        }
+        if options.requiresDesktopObservationOCR, !self.supportsDesktopObservationOCR(for: handshake) {
+            return false
+        }
+        if options.requiresExactWindowROIObservation,
+           !self.supportsExactWindowROIObservation(for: handshake) {
+            return false
+        }
         return true
     }
 
@@ -302,6 +314,11 @@ enum BridgeCapabilityPolicy {
     static func supportsDesktopObservation(for handshake: PeekabooBridgeHandshakeResponse) -> Bool {
         handshake.negotiatedVersion >= PeekabooBridgeProtocolVersion(major: 1, minor: 5) &&
             self.supportsOperation(.desktopObservation, for: handshake)
+    }
+
+    static func supportsDesktopObservationOCR(for handshake: PeekabooBridgeHandshakeResponse) -> Bool {
+        self.supportsDesktopObservation(for: handshake) &&
+            handshake.hostCapabilities?.contains(PeekabooBridgeHostCapability.desktopObservationOCR) == true
     }
 
     static func supportsExactWindowROIObservation(for handshake: PeekabooBridgeHandshakeResponse) -> Bool {

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/RuntimeHostResolver.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/RuntimeHostResolver.swift
@@ -225,6 +225,10 @@ enum RuntimeHostResolver {
     }
 
     static func requiredHostFailure(explicitSocket: String?, options: CommandRuntimeOptions) -> String? {
+        if options.requiresDesktopObservationOCR {
+            return "No compatible Bridge host advertises desktopObservationOCR. Update and relaunch Peekaboo " +
+                "on the selected host, or pass --no-remote to explicitly run Vision OCR in the caller process."
+        }
         if explicitSocket != nil, options.requiresExactWindowROIObservation {
             return "The explicitly selected Bridge host does not support exact-window ROI observation; " +
                 "protocol 1.21 with enabled observation and atomic snapshot publication is required."
@@ -639,6 +643,7 @@ enum RuntimeHostResolver {
             ),
             supportsElementActions: BridgeCapabilityPolicy.supportsElementActions(for: handshake),
             supportsDesktopObservation: BridgeCapabilityPolicy.supportsDesktopObservation(for: handshake),
+            supportsDesktopObservationOCR: BridgeCapabilityPolicy.supportsDesktopObservationOCR(for: handshake),
             supportsExactWindowROIObservation: BridgeCapabilityPolicy.supportsExactWindowROIObservation(for: handshake),
             supportsImplicitLatestSnapshotInvalidation: BridgeCapabilityPolicy.supportsImplicitSnapshotInvalidation(
                 for: handshake

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/ClickCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/ClickCommand.swift
@@ -580,7 +580,7 @@ struct ClickCommand: ActionOutputFormattable, ErrorHandlingCommand, OutputFormat
         }
 
         let matches = detectionResult.elements.all.filter { element in
-            guard element.isEnabled else { return false }
+            guard element.isEnabled, !element.isOCRSemanticEvidence else { return false }
             let candidates = [
                 element.id,
                 element.label,

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Shared/InteractionTargetPointResolver.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Shared/InteractionTargetPointResolver.swift
@@ -12,6 +12,9 @@ enum InteractionTargetPointResolver {
         snapshotId: String?,
         snapshots: any SnapshotManagerProtocol
     ) async throws -> InteractionTargetPointResolution {
+        guard !element.isOCRSemanticEvidence else {
+            throw PeekabooError.invalidInput(OCRSemanticEvidencePolicy.interactionRefusalMessage)
+        }
         let originalPoint = CGPoint(x: element.bounds.midX, y: element.bounds.midY)
         return try await self.resolve(
             originalPoint: originalPoint,

--- a/Apps/CLI/Tests/CLIAutomationTests/SeeCommandTests.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/SeeCommandTests.swift
@@ -171,6 +171,7 @@ struct SeeCommandTests {
             role_description: nil,
             help: nil,
             identifier: nil,
+            confidence: nil,
             bounds: UIElementBounds(CGRect(x: 0, y: 0, width: 100, height: 30)),
             is_actionable: true,
             is_enabled: true,

--- a/Apps/CLI/Tests/CoreCLITests/DesktopObservationOCRRuntimeCapabilityTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/DesktopObservationOCRRuntimeCapabilityTests.swift
@@ -50,10 +50,11 @@ struct DesktopObservationOCRRuntimeCapabilityTests {
         let legacy = Self.handshake(capabilities: nil)
 
         #expect(ocr.requiresDesktopObservationOCR)
-        #expect(menubar.requiresDesktopObservationOCR)
+        #expect(!menubar.requiresDesktopObservationOCR)
         #expect(!ordinary.requiresDesktopObservationOCR)
         #expect(CommandRuntime.supportsRemoteRequirements(for: capable, options: ocr))
         #expect(!CommandRuntime.supportsRemoteRequirements(for: legacy, options: ocr))
+        #expect(CommandRuntime.supportsRemoteRequirements(for: legacy, options: menubar))
         #expect(CommandRuntime.supportsRemoteRequirements(for: legacy, options: ordinary))
     }
 

--- a/Apps/CLI/Tests/CoreCLITests/DesktopObservationOCRRuntimeCapabilityTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/DesktopObservationOCRRuntimeCapabilityTests.swift
@@ -1,0 +1,130 @@
+import Commander
+import PeekabooBridge
+import Testing
+@testable import PeekabooCLI
+
+@Suite(.tags(.safe))
+@MainActor
+struct DesktopObservationOCRRuntimeCapabilityTests {
+    private static let observationOperations: [PeekabooBridgeOperation] = [
+        .captureScreen,
+        .desktopObservation,
+    ]
+
+    @Test
+    func `desktop observation OCR requires the operation and additive host capability`() {
+        let capable = Self.handshake(capabilities: [PeekabooBridgeHostCapability.desktopObservationOCR])
+        let legacy = Self.handshake(capabilities: nil)
+        let empty = Self.handshake(capabilities: [])
+        let missingOperation = Self.handshake(
+            operations: [.captureScreen],
+            capabilities: [PeekabooBridgeHostCapability.desktopObservationOCR]
+        )
+        let disabled = Self.handshake(
+            enabledOperations: [.captureScreen],
+            capabilities: [PeekabooBridgeHostCapability.desktopObservationOCR]
+        )
+
+        #expect(CommandRuntime.supportsDesktopObservationOCR(for: capable))
+        #expect(!CommandRuntime.supportsDesktopObservationOCR(for: legacy))
+        #expect(!CommandRuntime.supportsDesktopObservationOCR(for: empty))
+        #expect(!CommandRuntime.supportsDesktopObservationOCR(for: missingOperation))
+        #expect(!CommandRuntime.supportsDesktopObservationOCR(for: disabled))
+    }
+
+    @Test
+    func `See OCR requires a capable remote host while ordinary see stays compatible`() throws {
+        let ocr = try CommanderCLIBinder.makeRuntimeOptions(
+            from: ParsedValues(positional: [], options: [:], flags: ["ocr"]),
+            commandType: SeeCommand.self
+        )
+        let ordinary = try CommanderCLIBinder.makeRuntimeOptions(
+            from: ParsedValues(positional: [], options: [:], flags: []),
+            commandType: SeeCommand.self
+        )
+        let menubar = try CommanderCLIBinder.makeRuntimeOptions(
+            from: ParsedValues(positional: [], options: [:], flags: ["menubar"]),
+            commandType: SeeCommand.self
+        )
+        let capable = Self.handshake(capabilities: [PeekabooBridgeHostCapability.desktopObservationOCR])
+        let legacy = Self.handshake(capabilities: nil)
+
+        #expect(ocr.requiresDesktopObservationOCR)
+        #expect(menubar.requiresDesktopObservationOCR)
+        #expect(!ordinary.requiresDesktopObservationOCR)
+        #expect(CommandRuntime.supportsRemoteRequirements(for: capable, options: ocr))
+        #expect(!CommandRuntime.supportsRemoteRequirements(for: legacy, options: ocr))
+        #expect(CommandRuntime.supportsRemoteRequirements(for: legacy, options: ordinary))
+    }
+
+    @Test
+    func `candidate validation refuses legacy and accepts capable protocol 1_22 hosts`() async {
+        let candidate = RuntimeHostResolver.ImplicitRemoteCandidate(
+            socketPath: "/tmp/bridge.sock",
+            requireReusableDaemon: false,
+            requiredHostKind: nil,
+            requiresValidatedHistoricalDaemon: false
+        )
+        var options = CommandRuntimeOptions()
+        options.requiresDesktopObservation = true
+        options.requiresDesktopObservationOCR = true
+        let legacy = Self.handshake(capabilities: nil)
+        let capable = Self.handshake(capabilities: [PeekabooBridgeHostCapability.desktopObservationOCR])
+
+        #expect(await RuntimeHostResolver.validateRemoteCandidate(
+            candidate,
+            handshake: legacy,
+            options: options
+        ) == nil)
+        #expect(await RuntimeHostResolver.validateRemoteCandidate(
+            candidate,
+            handshake: capable,
+            options: options
+        ) != nil)
+    }
+
+    @Test
+    func `remote OCR refusal is actionable and no remote explicitly selects local services`() throws {
+        let remoteOCR = try CommanderCLIBinder.makeRuntimeOptions(
+            from: ParsedValues(positional: [], options: [:], flags: ["ocr"]),
+            commandType: SeeCommand.self
+        )
+        let localOCR = try CommanderCLIBinder.makeRuntimeOptions(
+            from: ParsedValues(positional: [], options: [:], flags: ["ocr", "no-remote"]),
+            commandType: SeeCommand.self
+        )
+
+        let failure = RuntimeHostResolver.requiredHostFailure(explicitSocket: nil, options: remoteOCR)
+        #expect(failure?.contains(PeekabooBridgeHostCapability.desktopObservationOCR) == true)
+        #expect(failure?.contains("Update and relaunch") == true)
+        #expect(failure?.contains("--no-remote") == true)
+        #expect(localOCR.remoteIsolationRequested)
+        #expect(!RuntimeHostResolver.shouldResolveKnownRemoteEndpoints(
+            options: localOCR,
+            environment: [:],
+            configurationInput: nil
+        ))
+        #expect(RuntimeHostResolver.initialRoutingDecision(
+            options: localOCR,
+            environment: [:],
+            configurationInput: nil,
+            knownSnapshotInvalidationRemoteSocketPaths: []
+        ) ==
+            .local(snapshotInvalidationRemoteSocketPaths: []))
+    }
+
+    private static func handshake(
+        operations: [PeekabooBridgeOperation] = Self.observationOperations,
+        enabledOperations: [PeekabooBridgeOperation]? = nil,
+        capabilities: [String]?
+    ) -> PeekabooBridgeHandshakeResponse {
+        PeekabooBridgeHandshakeResponse(
+            negotiatedVersion: PeekabooBridgeProtocolVersion(major: 1, minor: 22),
+            hostKind: .gui,
+            build: nil,
+            supportedOperations: operations,
+            enabledOperations: enabledOperations,
+            hostCapabilities: capabilities
+        )
+    }
+}

--- a/Apps/CLI/Tests/CoreCLITests/InteractionObservationContextTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/InteractionObservationContextTests.swift
@@ -1028,6 +1028,30 @@ struct InteractionObservationContextTests {
     }
 
     @Test
+    func `Element target point resolver refuses OCR evidence before coordinate resolution`() async {
+        let snapshots = CoreSnapshotManagerStub()
+        let element = DetectedElement(
+            id: "ocr_1",
+            type: .staticText,
+            label: "August",
+            bounds: CGRect(x: 50, y: 70, width: 100, height: 40),
+            attributes: [
+                "description": "ocr",
+                "confidence": "0.93",
+            ]
+        )
+
+        await #expect(throws: PeekabooError.self) {
+            _ = try await InteractionTargetPointResolver.elementCenterResolution(
+                element: element,
+                elementId: "ocr_1",
+                snapshotId: nil,
+                snapshots: snapshots
+            )
+        }
+    }
+
+    @Test
     func `Target point diagnostics describe coordinate targets`() {
         let point = CGPoint(x: 10, y: 20)
         let resolution = InteractionTargetPointResolver.coordinate(point, source: .coordinates)

--- a/Apps/CLI/Tests/CoreCLITests/SeeCommandAnnotationTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/SeeCommandAnnotationTests.swift
@@ -436,6 +436,7 @@ struct SeeCommandAnnotationTests {
                     role_description: nil,
                     help: nil,
                     identifier: nil,
+                    confidence: nil,
                     bounds: UIElementBounds(CGRect(x: 5, y: 5, width: 10, height: 5)),
                     is_actionable: true,
                     is_enabled: true,

--- a/Apps/CLI/Tests/CoreCLITests/SeeCommandOCRTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/SeeCommandOCRTests.swift
@@ -1,0 +1,69 @@
+import Commander
+import PeekabooAutomationKit
+import Testing
+@testable import PeekabooCLI
+
+@Suite(.tags(.fast))
+@MainActor
+struct SeeCommandOCRTests {
+    @Test
+    func `OCR flag binds and maps to a bounded additive detection request`() throws {
+        let command = try CommanderCLIBinder.instantiateCommand(
+            ofType: SeeCommand.self,
+            parsedValues: ParsedValues(
+                positional: [],
+                options: [
+                    "app": ["Calendar"],
+                    "windowId": ["119"],
+                    "timeout": ["7s"],
+                ],
+                flags: ["ocr"]
+            )
+        )
+
+        #expect(command.ocr)
+        try command.validateMergedOptions()
+        let request = try command.makeObservationRequest(
+            target: .app(identifier: "Calendar", window: .id(119))
+        )
+
+        #expect(request.detection.mode == .accessibilityAndOCR)
+        #expect(!request.detection.preferOCR)
+        #expect(!request.detection.allowWebFocusFallback)
+        #expect(request.timeout.overall == 7)
+        #expect(request.timeout.detection == 7)
+        #expect(request.timeout.ocr == 7)
+        #expect(request.capture.focus == .background)
+    }
+
+    @Test
+    func `OCR stays opt in and is discoverable in See help`() throws {
+        let command = try SeeCommand.parse(["--app", "Calendar"])
+        let request = try command.makeObservationRequest(
+            target: .app(identifier: "Calendar", window: .automatic)
+        )
+        let ocrFlag = try #require(SeeCommand.commanderSignature().flags.first { $0.label == "ocr" })
+
+        #expect(!command.ocr)
+        #expect(request.detection.mode == .accessibility)
+        #expect(!request.detection.preferOCR)
+        #expect(request.timeout.ocr == nil)
+        #expect(ocrFlag.names.contains(.long("ocr")))
+        #expect(ocrFlag.help?.contains("local Vision OCR") == true)
+    }
+
+    @Test(arguments: [
+        ["--ocr", "--no-elements"],
+        ["--ocr", "--tree", "--no-screenshot"],
+        ["--ocr", "--path", "-"],
+        ["--ocr", "--mode", "area", "--region", "0,0,100,100"],
+        ["--ocr", "--mode", "multi"],
+    ])
+    func `OCR refuses incompatible capture shapes before dispatch`(arguments: [String]) throws {
+        let command = try SeeCommand.parse(arguments)
+
+        #expect(throws: ValidationError.self) {
+            try command.validateMergedOptions()
+        }
+    }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Add opt-in local Vision OCR to CLI/MCP `see`, preserving incomplete AX evidence, exact snapshot receipts, logical bounds, confidence, and background-only observation.
+- Add opt-in host-local Vision OCR to CLI/MCP `see`, preserving incomplete AX evidence, exact snapshot receipts, logical bounds, confidence, background-only observation, and fail-before-dispatch compatibility with older Bridge hosts.
 - Stateless exact-window ROI capture for CLI/MCP `see`, with generation-pinned
   full-window receipts, AX/OCR filtering, snapshot-bound pixel mapping, and
   fail-closed remote-host validation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Add opt-in local Vision OCR to CLI/MCP `see`, preserving incomplete AX evidence, exact snapshot receipts, logical bounds, confidence, and background-only observation.
 - Stateless exact-window ROI capture for CLI/MCP `see`, with generation-pinned
   full-window receipts, AX/OCR filtering, snapshot-bound pixel mapping, and
   fail-closed remote-host validation.
@@ -13,6 +14,7 @@
 
 ### Fixed
 - Keep `see --capture-engine` on the selected Bridge host instead of silently moving capture and TCC ownership into the caller; fail before local fallback when no compatible host is available, with `--no-remote` as the explicit caller-local opt-in.
+- Keep OCR bounds correct for Retina captures, retain AX mutation/coordinate receipts through OCR merges and snapshot/ROI round-trips, use one bounded fast local recognition attempt for automation, and refuse only provenance-bound semantic OCR IDs as element action targets.
 - Resolve standalone exact-window AX-only `see` targets from their live owner and bind results to a process-generation/window receipt before publishing actionable element IDs or a snapshot.
 - Retry one passive background observation when its exact capture receipt changes before element detection or output, while leaving mutation-capable observations fail-closed.
 - Keep raw SwiftPM CLI `--version` output stable with explicit `unknown` build placeholders instead of reading the original working copy and wall clock at runtime; stamped debug and release builds retain rich link-time metadata.

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Core/Models/Snapshot.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Core/Models/Snapshot.swift
@@ -75,6 +75,7 @@ public nonisolated struct UIElement: Codable, Sendable {
     public let help: String?
     public let roleDescription: String?
     public let identifier: String?
+    public let confidence: Double?
     public var frame: CGRect
     public let isActionable: Bool
     public let isEnabled: Bool?
@@ -83,6 +84,15 @@ public nonisolated struct UIElement: Codable, Sendable {
     public let parentId: String?
     public let children: [String]
     public let keyboardShortcut: String?
+
+    public var isOCRSemanticEvidence: Bool {
+        OCRSemanticEvidencePolicy.isSemanticEvidence(
+            id: self.id,
+            isStaticText: self.role.caseInsensitiveCompare("AXStaticText") == .orderedSame ||
+                self.role.caseInsensitiveCompare("staticText") == .orderedSame,
+            isActionable: self.isActionable,
+            description: self.description)
+    }
 
     public init(
         id: String,
@@ -95,6 +105,7 @@ public nonisolated struct UIElement: Codable, Sendable {
         help: String? = nil,
         roleDescription: String? = nil,
         identifier: String? = nil,
+        confidence: Double? = nil,
         frame: CGRect,
         isActionable: Bool,
         isEnabled: Bool? = nil,
@@ -114,6 +125,7 @@ public nonisolated struct UIElement: Codable, Sendable {
         self.help = help
         self.roleDescription = roleDescription
         self.identifier = identifier
+        self.confidence = confidence
         self.frame = frame
         self.isActionable = isActionable
         self.isEnabled = isEnabled

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Core/Protocols/ElementDetectionModels.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Core/Protocols/ElementDetectionModels.swift
@@ -124,6 +124,15 @@ public struct DetectedElement: Sendable, Codable {
         self.attributes["isValueSettable"].flatMap(Bool.init)
     }
 
+    public var isOCRSemanticEvidence: Bool {
+        OCRSemanticEvidencePolicy.isSemanticEvidence(
+            id: self.id,
+            isStaticText: self.type == .staticText,
+            isActionable: self.isActionable,
+            description: self.attributes["description"],
+            source: self.attributes["source"])
+    }
+
     public var knownIsEnabled: Bool? {
         guard let enabledKnown = self.attributes["axEnabledKnown"] else {
             return self.isEnabled
@@ -149,6 +158,28 @@ public struct DetectedElement: Sendable, Codable {
         self.isEnabled = isEnabled
         self.isSelected = isSelected
         self.attributes = attributes
+    }
+}
+
+public enum OCRSemanticEvidencePolicy {
+    public static let interactionRefusalMessage =
+        "OCR text is semantic evidence, not an actionable element. Use explicit coordinates with the exact " +
+        "snapshot/reference receipt when a pixel action is intentional."
+
+    public static func isSemanticEvidence(
+        id: String,
+        isStaticText: Bool,
+        isActionable: Bool,
+        description: String?,
+        source: String? = nil) -> Bool
+    {
+        if source?.caseInsensitiveCompare("ocr") == .orderedSame {
+            return true
+        }
+        return id.lowercased().hasPrefix("ocr_") &&
+            isStaticText &&
+            !isActionable &&
+            description?.caseInsensitiveCompare("ocr") == .orderedSame
     }
 }
 

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Observation/DesktopObservationROI.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Observation/DesktopObservationROI.swift
@@ -381,8 +381,12 @@ public enum DesktopObservationROIProcessor {
                 help: element.help,
                 roleDescription: element.roleDescription,
                 identifier: element.identifier,
+                confidence: element.confidence,
                 frame: frame,
                 isActionable: element.isActionable,
+                isEnabled: element.isEnabled,
+                isSelected: element.isSelected,
+                isValueSettable: element.isValueSettable,
                 parentId: element.parentId,
                 children: element.children,
                 keyboardShortcut: element.keyboardShortcut)

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Observation/DesktopObservationService+Detection.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Observation/DesktopObservationService+Detection.swift
@@ -67,7 +67,10 @@ extension DesktopObservationService {
                             timeoutSeconds: timeout,
                             regions: semanticRegions)
                     }
-                    return try await recognizer.recognizeText(in: imageData, timeoutSeconds: timeout)
+                    return try await recognizer.recognizeText(
+                        in: imageData,
+                        timeoutSeconds: timeout,
+                        quality: .fast)
                 }
             } catch let CaptureError.detectionTimedOut(seconds) {
                 return OCRTextResult.incomplete(

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Observation/ObservationOCRService.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Observation/ObservationOCRService.swift
@@ -80,8 +80,17 @@ extension OCRServiceError: LocalizedError {
     }
 }
 
+public enum OCRRecognitionQuality: String, Sendable, Equatable {
+    case accurate
+    case fast
+}
+
 public protocol OCRRecognizing: Sendable {
     func recognizeText(in imageData: Data, timeoutSeconds: TimeInterval) async throws -> OCRTextResult
+    func recognizeText(
+        in imageData: Data,
+        timeoutSeconds: TimeInterval,
+        quality: OCRRecognitionQuality) async throws -> OCRTextResult
     func recognizeText(
         in imageData: Data,
         timeoutSeconds: TimeInterval,
@@ -89,6 +98,14 @@ public protocol OCRRecognizing: Sendable {
 }
 
 extension OCRRecognizing {
+    public func recognizeText(
+        in imageData: Data,
+        timeoutSeconds: TimeInterval,
+        quality _: OCRRecognitionQuality) async throws -> OCRTextResult
+    {
+        try await self.recognizeText(in: imageData, timeoutSeconds: timeoutSeconds)
+    }
+
     public func recognizeText(
         in imageData: Data,
         timeoutSeconds: TimeInterval,
@@ -116,8 +133,19 @@ public struct OCRService: OCRRecognizing {
         in imageData: Data,
         timeoutSeconds: TimeInterval = Self.defaultTimeoutSeconds) async throws -> OCRTextResult
     {
+        try await self.recognizeText(
+            in: imageData,
+            timeoutSeconds: timeoutSeconds,
+            quality: .accurate)
+    }
+
+    public nonisolated func recognizeText(
+        in imageData: Data,
+        timeoutSeconds: TimeInterval,
+        quality: OCRRecognitionQuality) async throws -> OCRTextResult
+    {
         try await OCRExecutionRunner.run(seconds: timeoutSeconds) {
-            try Self.performRecognition(in: imageData)
+            try Self.performRecognition(in: imageData, quality: quality)
         }
     }
 
@@ -134,21 +162,27 @@ public struct OCRService: OCRRecognizing {
         }
     }
 
-    private nonisolated static func performRecognition(in imageData: Data) throws -> OCRTextResult {
+    private nonisolated static func performRecognition(
+        in imageData: Data,
+        quality: OCRRecognitionQuality) throws -> OCRTextResult
+    {
         guard let source = CGImageSourceCreateWithData(imageData as CFData, nil),
               let image = CGImageSourceCreateImageAtIndex(source, 0, nil)
         else {
             throw OCRServiceError.invalidImageData
         }
 
-        let request = VNRecognizeTextRequest()
-        request.recognitionLevel = .accurate
-        request.usesLanguageCorrection = false
-
-        let handler = VNImageRequestHandler(cgImage: image, options: [:])
-        try handler.perform([request])
-
-        let observations = (request.results ?? []).compactMap { observation -> OCRTextObservation? in
+        let results = switch quality {
+        case .accurate:
+            try self.withRecognitionFallback(
+                primary: { try self.visionResults(in: image, recognitionLevel: .accurate) },
+                fallback: { try self.visionResults(in: image, recognitionLevel: .fast) })
+        case .fast:
+            try self.withSingleRecognitionAttempt {
+                try self.visionResults(in: image, recognitionLevel: .fast)
+            }
+        }
+        let observations = results.compactMap { observation -> OCRTextObservation? in
             guard let candidate = observation.topCandidates(1).first else { return nil }
             let text = candidate.string.trimmingCharacters(in: .whitespacesAndNewlines)
             guard !text.isEmpty else { return nil }
@@ -176,11 +210,10 @@ public struct OCRService: OCRRecognizing {
         var observations: [OCRTextObservation] = []
         for region in regions {
             guard let crop = self.targetedCrop(region.normalizedBounds, from: image) else { continue }
-            let request = VNRecognizeTextRequest()
-            request.recognitionLevel = .fast
-            request.usesLanguageCorrection = false
-            try VNImageRequestHandler(cgImage: crop.image, options: [:]).perform([request])
-            observations.append(contentsOf: (request.results ?? []).compactMap { observation in
+            let results = try self.withSingleRecognitionAttempt {
+                try self.visionResults(in: crop.image, recognitionLevel: .fast)
+            }
+            observations.append(contentsOf: results.compactMap { observation in
                 guard let candidate = observation.topCandidates(1).first else { return nil }
                 let text = candidate.string.trimmingCharacters(in: .whitespacesAndNewlines)
                 guard !text.isEmpty else { return nil }
@@ -196,6 +229,57 @@ public struct OCRService: OCRRecognizing {
         return OCRTextResult(
             observations: observations,
             imageSize: CGSize(width: image.width, height: image.height))
+    }
+
+    private nonisolated static func visionResults(
+        in image: CGImage,
+        recognitionLevel: VNRequestTextRecognitionLevel) throws -> [VNRecognizedTextObservation]
+    {
+        let request = VNRecognizeTextRequest()
+        request.recognitionLevel = recognitionLevel
+        request.usesLanguageCorrection = recognitionLevel == .fast
+        try VNImageRequestHandler(cgImage: image, options: [:]).perform([request])
+        return request.results ?? []
+    }
+
+    static func withRecognitionFallback<T>(
+        primary: () throws -> T,
+        fallback: () throws -> T) throws -> T
+    {
+        try Task.checkCancellation()
+        do {
+            let result = try primary()
+            try Task.checkCancellation()
+            return result
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch {
+            try Task.checkCancellation()
+            do {
+                let result = try fallback()
+                try Task.checkCancellation()
+                return result
+            } catch is CancellationError {
+                throw CancellationError()
+            } catch {
+                throw OCRServiceError.incomplete(
+                    "Apple Vision text recognition failed in both primary and fast fallback modes")
+            }
+        }
+    }
+
+    static func withSingleRecognitionAttempt<T>(_ operation: () throws -> T) throws -> T {
+        try Task.checkCancellation()
+        do {
+            let result = try operation()
+            try Task.checkCancellation()
+            return result
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch {
+            try Task.checkCancellation()
+            throw OCRServiceError.incomplete("Apple Vision fast text recognition failed")
+        }
     }
 
     private nonisolated static func targetedCrop(
@@ -537,7 +621,6 @@ public enum ObservationOCRMapper {
         for observation in result.observations where observation.confidence >= minConfidence {
             let rect = self.screenRect(
                 from: observation.boundingBox,
-                imageSize: result.imageSize,
                 windowBounds: windowBounds)
 
             guard rect.width > 2, rect.height > 2 else { continue }
@@ -545,6 +628,7 @@ public enum ObservationOCRMapper {
             let attributes = [
                 "description": "ocr",
                 "confidence": String(format: "%.2f", observation.confidence),
+                "source": "ocr",
             ]
 
             elements.append(
@@ -602,7 +686,10 @@ public enum ObservationOCRMapper {
                     metadata.truncationInfo,
                     ocrResult.isComplete ? nil : DetectionTruncationInfo(
                         deadlineReached: ocrResult.deadlineReached,
-                        incompleteAccessibilityRead: false))))
+                        incompleteAccessibilityRead: false)),
+                desktopMutationCompletedAt: metadata.desktopMutationCompletedAt,
+                desktopMutationPreservationAllowed: metadata.desktopMutationPreservationAllowed,
+                captureCoordinateContext: metadata.captureCoordinateContext))
     }
 
     @_spi(Testing) public static func recoverSemanticLabels(
@@ -741,13 +828,12 @@ public enum ObservationOCRMapper {
 
     private static func screenRect(
         from normalizedBox: CGRect,
-        imageSize: CGSize,
         windowBounds: CGRect) -> CGRect
     {
-        let width = normalizedBox.width * imageSize.width
-        let height = normalizedBox.height * imageSize.height
-        let x = normalizedBox.origin.x * imageSize.width
-        let y = (1.0 - normalizedBox.origin.y - normalizedBox.height) * imageSize.height
+        let width = normalizedBox.width * windowBounds.width
+        let height = normalizedBox.height * windowBounds.height
+        let x = normalizedBox.origin.x * windowBounds.width
+        let y = (1.0 - normalizedBox.origin.y - normalizedBox.height) * windowBounds.height
         return CGRect(
             x: windowBounds.origin.x + x,
             y: windowBounds.origin.y + y,

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Support/InMemorySnapshotManager+DetectionMapping.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Support/InMemorySnapshotManager+DetectionMapping.swift
@@ -31,6 +31,7 @@ extension InMemorySnapshotManager {
                 help: element.attributes["help"],
                 roleDescription: element.attributes["roleDescription"],
                 identifier: element.attributes["identifier"],
+                confidence: element.attributes["confidence"].flatMap(Double.init),
                 frame: element.bounds,
                 isActionable: element.isActionable,
                 isEnabled: element.knownIsEnabled,
@@ -109,6 +110,9 @@ extension InMemorySnapshotManager {
             if let roleDescription = uiElement.roleDescription {
                 attributes["roleDescription"] = roleDescription
             }
+            if let confidence = uiElement.confidence {
+                attributes["confidence"] = String(format: "%.2f", confidence)
+            }
             attributes["isActionable"] = String(uiElement.isActionable)
             attributes["axEnabledKnown"] = String(uiElement.isEnabled != nil)
             if let isValueSettable = uiElement.isValueSettable {
@@ -172,7 +176,12 @@ extension InMemorySnapshotManager {
         case "AXGroup": .group
         case "AXSlider": .slider
         case "AXCheckBox": .checkbox
-        case "AXMenu", "AXMenuItem": .menu
+        case "AXMenu": .menu
+        case "AXMenuItem": .menuItem
+        case "AXStaticText": .staticText
+        case "AXRadioButton": .radioButton
+        case "AXWindow": .window
+        case "AXDialog": .dialog
         default: .other
         }
     }

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Support/SnapshotManager+Helpers.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Support/SnapshotManager+Helpers.swift
@@ -461,7 +461,12 @@ extension SnapshotManager {
         case "AXGroup": .group
         case "AXSlider": .slider
         case "AXCheckBox": .checkbox
-        case "AXMenu", "AXMenuItem": .menu
+        case "AXMenu": .menu
+        case "AXMenuItem": .menuItem
+        case "AXStaticText": .staticText
+        case "AXRadioButton": .radioButton
+        case "AXWindow": .window
+        case "AXDialog": .dialog
         default: .other
         }
     }

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Support/SnapshotManager.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Support/SnapshotManager.swift
@@ -103,6 +103,7 @@ public final class SnapshotManager: SnapshotManagerProtocol {
                 help: element.attributes["help"],
                 roleDescription: element.attributes["roleDescription"],
                 identifier: element.attributes["identifier"],
+                confidence: element.attributes["confidence"].flatMap(Double.init),
                 frame: element.bounds,
                 isActionable: element.isActionable,
                 isEnabled: element.knownIsEnabled,
@@ -155,6 +156,9 @@ public final class SnapshotManager: SnapshotManagerProtocol {
             }
             if let roleDescription = uiElement.roleDescription {
                 attributes["roleDescription"] = roleDescription
+            }
+            if let confidence = uiElement.confidence {
+                attributes["confidence"] = String(format: "%.2f", confidence)
             }
             attributes["isActionable"] = String(uiElement.isActionable)
             attributes["axEnabledKnown"] = String(uiElement.isEnabled != nil)

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/ClickService.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/ClickService.swift
@@ -315,6 +315,9 @@ public final class ClickService {
             guard let element = detectionResult.elements.findById(id) else {
                 throw ActionInputError.unsupported(.missingElement)
             }
+            guard !element.isOCRSemanticEvidence else {
+                throw PeekabooError.invalidInput(OCRSemanticEvidencePolicy.interactionRefusalMessage)
+            }
             try self.requireExactWindowForTargetedAction(
                 element: element,
                 windowContext: detectionResult.metadata.windowContext,
@@ -546,6 +549,9 @@ public final class ClickService {
         guard let element = detectionResult.elements.findById(id) else {
             throw NotFoundError.element(id)
         }
+        guard !element.isOCRSemanticEvidence else {
+            throw PeekabooError.invalidInput(OCRSemanticEvidencePolicy.interactionRefusalMessage)
+        }
         try self.requireExactWindowForTargetedSynthesis(
             targetProcessIdentifier: destination.processIdentifier,
             targetWindowID: destination.windowID)
@@ -728,7 +734,7 @@ public final class ClickService {
         var bestMatch: DetectedElement?
         var bestScore = Int.min
 
-        for element in detectionResult.elements.all where element.isEnabled {
+        for element in detectionResult.elements.all where element.isEnabled && !element.isOCRSemanticEvidence {
             let label = element.label?.lowercased()
             let value = element.value?.lowercased()
             let identifier = element.attributes["identifier"]?.lowercased()

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/ScrollService.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/ScrollService.swift
@@ -120,6 +120,9 @@ public final class ScrollService {
             if let detected = detectionResult.elements.findById(target) ??
                 Self.findDetectedElement(matching: target, in: detectionResult)
             {
+                guard !detected.isOCRSemanticEvidence else {
+                    throw PeekabooError.invalidInput(OCRSemanticEvidencePolicy.interactionRefusalMessage)
+                }
                 guard let element = self.automationElementResolver.resolve(
                     detectedElement: detected,
                     windowContext: detectionResult.metadata.windowContext)
@@ -166,7 +169,8 @@ public final class ScrollService {
         guard !query.isEmpty else { return nil }
 
         return detectionResult.elements.all.first { element in
-            [
+            guard !element.isOCRSemanticEvidence else { return false }
+            return [
                 element.label,
                 element.value,
                 element.attributes["title"],
@@ -232,6 +236,9 @@ public final class ScrollService {
             throw ActionInputError.staleElement
         }
         guard let element = detectionResult.elements.findById(target) else { return nil }
+        guard !element.isOCRSemanticEvidence else {
+            throw PeekabooError.invalidInput(OCRSemanticEvidencePolicy.interactionRefusalMessage)
+        }
 
         let point = CGPoint(x: element.bounds.midX, y: element.bounds.midY)
         return try await WindowMovementTracking.adjustPoint(

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/TypeService+TargetResolution.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/TypeService+TargetResolution.swift
@@ -42,7 +42,7 @@ extension TypeService {
         var bestMatch: DetectedElement?
         var bestScore = Int.min
 
-        for element in detectionResult.elements.all where element.isEnabled {
+        for element in detectionResult.elements.all where element.isEnabled && !element.isOCRSemanticEvidence {
             let label = element.label?.lowercased()
             let value = element.value?.lowercased()
             let identifier = element.attributes["identifier"]?.lowercased()

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/TypeService.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/TypeService.swift
@@ -160,6 +160,9 @@ public final class TypeService {
                let detectionResult = try? await snapshotManager.getDetectionResult(snapshotId: snapshotId),
                let element = detectionResult.elements.findById(target)
             {
+                guard !element.isOCRSemanticEvidence else {
+                    throw PeekabooError.invalidInput(OCRSemanticEvidencePolicy.interactionRefusalMessage)
+                }
                 elementFound = true
                 elementFrame = element.bounds
                 elementId = element.id
@@ -422,6 +425,9 @@ public final class TypeService {
             if let element = detectionResult.elements.findById(target) ??
                 Self.resolveTargetElement(query: target, in: detectionResult)
             {
+                guard !element.isOCRSemanticEvidence else {
+                    throw PeekabooError.invalidInput(OCRSemanticEvidencePolicy.interactionRefusalMessage)
+                }
                 guard let resolved = self.automationElementResolver.resolve(
                     detectedElement: element,
                     windowContext: detectionResult.metadata.windowContext)

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/UIAutomationService+ElementActions.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/UIAutomationService+ElementActions.swift
@@ -134,6 +134,9 @@ extension UIAutomationService: ElementActionAutomationServiceProtocol {
         if let detected = detectionResult.elements.findById(normalized) ??
             Self.findDetectedElement(matching: normalized, in: detectionResult)
         {
+            guard !detected.isOCRSemanticEvidence else {
+                throw PeekabooError.invalidInput(OCRSemanticEvidencePolicy.interactionRefusalMessage)
+            }
             guard let element = self.automationElementResolver.resolve(
                 detectedElement: detected,
                 windowContext: detectionResult.metadata.windowContext)
@@ -168,7 +171,8 @@ extension UIAutomationService: ElementActionAutomationServiceProtocol {
         guard !query.isEmpty else { return nil }
 
         return detectionResult.elements.all.first { element in
-            [
+            guard !element.isOCRSemanticEvidence else { return false }
+            return [
                 element.label,
                 element.value,
                 element.attributes["title"],

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ActionInputDriverTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ActionInputDriverTests.swift
@@ -462,6 +462,66 @@ struct ActionInputDriverTests {
 
     @MainActor
     @Test
+    func `owner pinned element actions refuse OCR evidence before resolution or dispatch`() async throws {
+        let processIdentifier = getpid()
+        let processStartIdentity: UInt64 = 99
+        let bounds = CGRect(x: 100, y: 100, width: 800, height: 600)
+        let identity = WindowMutationIdentity(
+            windowID: 42,
+            ownerProcessIdentifier: processIdentifier,
+            ownerProcessStartIdentity: processStartIdentity,
+            capturedBounds: bounds)
+        let detected = DetectedElement(
+            id: "ocr_1",
+            type: .staticText,
+            label: "August",
+            bounds: CGRect(x: 120, y: 140, width: 100, height: 20),
+            attributes: [
+                "description": "ocr",
+                "confidence": "0.93",
+            ])
+        let detectionResult = ElementDetectionResult(
+            snapshotId: "snapshot",
+            screenshotPath: "/tmp/calendar.png",
+            elements: DetectedElements(other: [detected]),
+            metadata: DetectionMetadata(
+                detectionTime: 0.01,
+                elementCount: 1,
+                method: "AXorcist+OCR",
+                windowContext: WindowContext(
+                    applicationProcessId: processIdentifier,
+                    windowID: 42,
+                    windowBounds: bounds,
+                    windowMutationIdentity: identity)))
+        let service = UIAutomationService(
+            snapshotManager: InMemorySnapshotManager(detectionResult: detectionResult),
+            inputPolicy: UIInputPolicy(defaultStrategy: .actionOnly),
+            actionInputDriver: RecordingActionInputDriver(),
+            automationElementResolver: FixedActionAutomationElementResolver {
+                Issue.record("OCR action reached target resolution")
+            },
+            exactWindowIdentityValidator: { actual, actualBounds in
+                actual == identity && actualBounds == bounds
+            },
+            processStartIdentityProvider: { _ in processStartIdentity })
+
+        for operation in [
+            { try await service.performAction(target: "ocr_1", actionName: "AXPress", snapshotId: "snapshot") },
+            { try await service.setValue(target: "ocr_1", value: .string("unsafe"), snapshotId: "snapshot") },
+        ] {
+            do {
+                _ = try await operation()
+                Issue.record("Expected OCR semantic evidence refusal")
+            } catch let PeekabooError.invalidInput(message) {
+                #expect(message.contains("semantic evidence"))
+            } catch {
+                Issue.record("Unexpected error: \(error)")
+            }
+        }
+    }
+
+    @MainActor
+    @Test
     func `exact snapshot element mutations wait only for their process observation frame`() async throws {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("peekaboo-element-mutation-process-lane-\(UUID().uuidString)", isDirectory: true)

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ClickServiceTargetResolutionTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ClickServiceTargetResolutionTests.swift
@@ -203,6 +203,86 @@ struct ClickServiceTargetResolutionTests {
 
     @Test
     @MainActor
+    func `OCR semantic element refuses before exact owner delivery or synthetic fallback`() async {
+        let pid = getpid()
+        let element = DetectedElement(
+            id: "ocr_1",
+            type: .staticText,
+            label: "August 10, 2026",
+            bounds: CGRect(x: 100, y: 120, width: 180, height: 24),
+            attributes: [
+                "description": "ocr",
+                "confidence": "0.93",
+            ])
+        let detectionResult = ElementDetectionResult(
+            snapshotId: "snapshot",
+            screenshotPath: "/tmp/calendar.png",
+            elements: DetectedElements(other: [element]),
+            metadata: DetectionMetadata(
+                detectionTime: 0.01,
+                elementCount: 1,
+                method: "AXorcist+OCR",
+                windowContext: Self.exactWindowContext(processIdentifier: pid)))
+        let action = ClickSuccessfulActionInputDriver()
+        let synthetic = ClickRecordingSyntheticInputDriver()
+        let resolver = ClickFixedAutomationElementResolver()
+        let service = ClickService(
+            snapshotManager: InMemorySnapshotManager(detectionResult: detectionResult),
+            inputPolicy: UIInputPolicy(defaultStrategy: .actionFirst),
+            actionInputDriver: action,
+            syntheticInputDriver: synthetic,
+            automationElementResolver: resolver,
+            exactWindowIdentityValidator: { _, _ in true })
+
+        do {
+            _ = try await service.click(
+                target: .elementId("ocr_1"),
+                clickType: .single,
+                snapshotId: "snapshot",
+                targetProcessIdentifier: pid)
+            Issue.record("Expected OCR semantic evidence refusal")
+        } catch let PeekabooError.invalidInput(message) {
+            #expect(message.contains("semantic evidence"))
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+
+        #expect(action.performedActionNames.isEmpty)
+        #expect(action.clickCount == 0)
+        #expect(synthetic.events.isEmpty)
+        #expect(resolver.targetProcessIdentifiers.isEmpty)
+    }
+
+    @Test
+    @MainActor
+    func `query resolution skips OCR when a later ordinary nonactionable match exists`() throws {
+        let ocr = DetectedElement(
+            id: "ocr_1",
+            type: .staticText,
+            label: "August",
+            bounds: CGRect(x: 10, y: 10, width: 100, height: 20),
+            attributes: [
+                "description": "ocr",
+                "confidence": "0.93",
+            ])
+        let ordinary = DetectedElement(
+            id: "S1",
+            type: .staticText,
+            label: "August",
+            bounds: CGRect(x: 10, y: 40, width: 100, height: 20))
+        let result = ElementDetectionResult(
+            snapshotId: "snapshot",
+            screenshotPath: "/tmp/calendar.png",
+            elements: DetectedElements(other: [ocr, ordinary]),
+            metadata: DetectionMetadata(detectionTime: 0, elementCount: 2, method: "test"))
+
+        let match = try #require(ClickService.resolveTargetElement(query: "August", in: result))
+
+        #expect(match.id == "S1")
+    }
+
+    @Test
+    @MainActor
     func `background coordinate click refuses PID only routing`() async {
         let synthetic = ClickRecordingSyntheticInputDriver()
         let service = ClickService(

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/DesktopObservationCalendarOCRTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/DesktopObservationCalendarOCRTests.swift
@@ -1,0 +1,102 @@
+import CoreGraphics
+import Foundation
+import XCTest
+@testable import PeekabooAutomationKit
+
+@MainActor
+final class DesktopObservationCalendarOCRTests: XCTestCase {
+    func testIncompleteAccessibilityObservationSucceedsWithOCR() async throws {
+        let app = ServiceApplicationInfo(
+            processIdentifier: 858,
+            processStartIdentity: 4242,
+            bundleIdentifier: "com.apple.iCal",
+            name: "Calendar",
+            windowCount: 1)
+        let bounds = CGRect(x: 200, y: 300, width: 800, height: 600)
+        let identity = WindowMutationIdentity(
+            windowID: 119,
+            ownerProcessIdentifier: 858,
+            ownerProcessStartIdentity: 4242,
+            capturedBounds: bounds)
+        let window = ServiceWindowInfo(
+            windowID: 119,
+            title: "Calendar",
+            bounds: bounds,
+            mutationIdentity: identity)
+        let context = WindowContext(
+            applicationName: "Calendar",
+            applicationBundleId: "com.apple.iCal",
+            applicationProcessId: 858,
+            windowTitle: "Calendar",
+            windowID: 119,
+            windowBounds: bounds,
+            windowMutationIdentity: identity)
+        let incompleteAX = ElementDetectionResult(
+            snapshotId: "calendar-ocr",
+            screenshotPath: "/tmp/calendar.png",
+            elements: DetectedElements(),
+            metadata: DetectionMetadata(
+                detectionTime: 0.1,
+                elementCount: 0,
+                method: "AXorcist",
+                warnings: ["ax_incomplete_read"],
+                windowContext: context,
+                truncationInfo: DetectionTruncationInfo(incompleteAccessibilityRead: true)))
+        let automation = RecordingUIAutomationService(fixedResult: incompleteAX)
+        let ocr = RecordingOCRRecognizer(result: OCRTextResult(
+            observations: [OCRTextObservation(
+                text: "August 10, 2026",
+                confidence: 0.93,
+                boundingBox: CGRect(x: 0.05, y: 0.85, width: 0.225, height: 0.04))],
+            imageSize: CGSize(width: 1600, height: 1200)))
+        let capture = CaptureResult(
+            imageData: Data([1]),
+            metadata: CaptureMetadata(
+                size: bounds.size,
+                mode: .window,
+                applicationInfo: app,
+                windowInfo: window))
+        let service = DesktopObservationService(
+            screenCapture: RecordingScreenCaptureService(result: capture),
+            automation: automation,
+            applications: RecordingApplicationService(applications: [app], windows: [window]),
+            ocrRecognizer: ocr,
+            exactWindowMetadataProvider: CalendarExactWindowMetadataProvider(bounds: bounds),
+            processStartIdentityProvider: { _ in 4242 },
+            windowMutationIdentityProvider: { _ in identity })
+
+        let result = try await service.observe(DesktopObservationRequest(
+            target: .app(identifier: "Calendar", window: .automatic),
+            detection: DesktopDetectionOptions(mode: .accessibilityAndOCR, preferOCR: false),
+            output: DesktopObservationOutputOptions(snapshotID: "calendar-ocr")))
+
+        let element = try XCTUnwrap(result.elements?.elements.other.first)
+        XCTAssertEqual(element.label, "August 10, 2026")
+        XCTAssertEqual(element.type, .staticText)
+        XCTAssertEqual(element.attributes["confidence"], "0.93")
+        XCTAssertFalse(element.isActionable)
+        XCTAssertEqual(result.elements?.metadata.warnings, ["ax_incomplete_read"])
+        XCTAssertEqual(result.elements?.metadata.truncationInfo?.incompleteAccessibilityRead, true)
+        XCTAssertEqual(result.elements?.metadata.windowContext?.windowMutationIdentity, identity)
+        XCTAssertEqual(result.diagnostics.warnings, ["ax_incomplete_read"])
+        XCTAssertEqual(ocr.qualities, [.fast])
+    }
+}
+
+private struct CalendarExactWindowMetadataProvider: ExactWindowMetadataProviding {
+    let bounds: CGRect
+
+    func metadata(for windowID: CGWindowID) -> ExactWindowObservationMetadata? {
+        guard windowID == 119 else { return nil }
+        return ExactWindowObservationMetadata(
+            ownerProcessIdentifier: 858,
+            ownerProcessStartIdentity: 4242,
+            title: "Calendar",
+            bounds: self.bounds,
+            applicationName: "Calendar")
+    }
+
+    func processStartIdentity(for _: Int32) -> UInt64? {
+        4242
+    }
+}

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/DesktopObservationServiceTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/DesktopObservationServiceTests.swift
@@ -349,6 +349,7 @@ extension DesktopObservationServiceTests {
 
         XCTAssertEqual(automation.detectCalls, 1)
         XCTAssertEqual(ocr.recognizeCalls, 1)
+        XCTAssertEqual(ocr.qualities, [.fast])
         XCTAssertEqual(result.ocr?.observations.first?.text, "Document Title")
         XCTAssertEqual(result.elements?.elements.buttons.map(\.id), ["B1"])
         XCTAssertEqual(result.elements?.elements.other.first?.label, "Document Title")
@@ -1186,7 +1187,7 @@ private struct StableExactWindowMetadataProvider: ExactWindowMetadataProviding {
 }
 
 @MainActor
-private final class RecordingApplicationService: ApplicationServiceProtocol {
+final class RecordingApplicationService: ApplicationServiceProtocol {
     let applications: [ServiceApplicationInfo]
     let windows: [ServiceWindowInfo]
     var listApplicationsCalls = 0
@@ -1251,7 +1252,7 @@ private final class RecordingApplicationService: ApplicationServiceProtocol {
 }
 
 @MainActor
-private final class RecordingScreenCaptureService: ScreenCaptureServiceProtocol,
+final class RecordingScreenCaptureService: ScreenCaptureServiceProtocol,
 EngineAwareScreenCaptureServiceProtocol {
     enum Operation: Equatable {
         case screen(Int?, CaptureScalePreference, CaptureEnginePreference)
@@ -1343,25 +1344,36 @@ EngineAwareScreenCaptureServiceProtocol {
 }
 
 @MainActor
-private final class RecordingUIAutomationService: UIAutomationServiceProtocol {
+final class RecordingUIAutomationService: UIAutomationServiceProtocol {
     private let delay: TimeInterval
     private let ignoresCancellation: Bool
     private let elements: DetectedElements
+    private let result: ElementDetectionResult?
     private let detectionSuspension: ObservationDetectionSuspension?
     var detectCalls = 0
     var lastSnapshotID: String?
     var lastWindowContext: WindowContext?
 
-    init(
+    fileprivate init(
         delay: TimeInterval = 0,
         ignoresCancellation: Bool = false,
         elements: DetectedElements = DetectedElements(),
+        result: ElementDetectionResult? = nil,
         detectionSuspension: ObservationDetectionSuspension? = nil)
     {
         self.delay = delay
         self.ignoresCancellation = ignoresCancellation
         self.elements = elements
+        self.result = result
         self.detectionSuspension = detectionSuspension
+    }
+
+    init(fixedResult: ElementDetectionResult) {
+        self.delay = 0
+        self.ignoresCancellation = false
+        self.elements = fixedResult.elements
+        self.result = fixedResult
+        self.detectionSuspension = nil
     }
 
     func detectElements(
@@ -1384,6 +1396,9 @@ private final class RecordingUIAutomationService: UIAutomationServiceProtocol {
         self.detectCalls += 1
         self.lastSnapshotID = snapshotId
         self.lastWindowContext = windowContext
+        if let result = self.result {
+            return result
+        }
         return ElementDetectionResult(
             snapshotId: snapshotId ?? "generated",
             screenshotPath: "/tmp/fake.png",
@@ -1455,14 +1470,19 @@ private final class ObservationDetectionSuspension {
     }
 }
 
-private final class RecordingOCRRecognizer: OCRRecognizing, @unchecked Sendable {
+final class RecordingOCRRecognizer: OCRRecognizing, @unchecked Sendable {
     private let lock = NSLock()
     private let result: OCRTextResult
     var recognizeCalls = 0
     private var recordedTargetedRegions: [OCRRecognitionRegion] = []
+    private var recordedQualities: [OCRRecognitionQuality] = []
 
     var targetedRegions: [OCRRecognitionRegion] {
         self.lock.withLock { self.recordedTargetedRegions }
+    }
+
+    var qualities: [OCRRecognitionQuality] {
+        self.lock.withLock { self.recordedQualities }
     }
 
     init(result: OCRTextResult) {
@@ -1471,6 +1491,18 @@ private final class RecordingOCRRecognizer: OCRRecognizing, @unchecked Sendable 
 
     func recognizeText(in _: Data, timeoutSeconds _: TimeInterval) async throws -> OCRTextResult {
         self.lock.withLock { self.recognizeCalls += 1 }
+        return self.result
+    }
+
+    func recognizeText(
+        in _: Data,
+        timeoutSeconds _: TimeInterval,
+        quality: OCRRecognitionQuality) async throws -> OCRTextResult
+    {
+        self.lock.withLock {
+            self.recognizeCalls += 1
+            self.recordedQualities.append(quality)
+        }
         return self.result
     }
 

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ObservationOCRCoordinateTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ObservationOCRCoordinateTests.swift
@@ -1,0 +1,266 @@
+import CoreGraphics
+import os
+import XCTest
+@testable import PeekabooAutomationKit
+
+final class ObservationOCRCoordinateTests: XCTestCase {
+    func testVisionRecognitionFallbackRunsOnlyAfterPrimaryFailure() throws {
+        var calls: [String] = []
+
+        let result = try OCRService.withRecognitionFallback(
+            primary: { () throws -> String in
+                calls.append("primary")
+                throw OCRFallbackTestError.failed
+            },
+            fallback: {
+                calls.append("fallback")
+                return "recovered"
+            })
+
+        XCTAssertEqual(result, "recovered")
+        XCTAssertEqual(calls, ["primary", "fallback"])
+    }
+
+    func testVisionRecognitionFallbackReturnsIncompleteWhenBothModesFail() {
+        XCTAssertThrowsError(try OCRService.withRecognitionFallback(
+            primary: { throw OCRFallbackTestError.failed },
+            fallback: { throw OCRFallbackTestError.failed }))
+        { error in
+            XCTAssertEqual(
+                error as? OCRServiceError,
+                .incomplete("Apple Vision text recognition failed in both primary and fast fallback modes"))
+        }
+    }
+
+    func testVisionRecognitionCancellationAfterPrimaryFailureSkipsFallback() async {
+        let fallbackCalled = OSAllocatedUnfairLock(initialState: false)
+        let task = Task {
+            try OCRService.withRecognitionFallback(
+                primary: { () throws -> String in
+                    withUnsafeCurrentTask { $0?.cancel() }
+                    throw OCRFallbackTestError.failed
+                },
+                fallback: {
+                    fallbackCalled.withLock { $0 = true }
+                    return "unsafe"
+                })
+        }
+
+        do {
+            _ = try await task.value
+            XCTFail("Expected cancellation")
+        } catch is CancellationError {
+            XCTAssertFalse(fallbackCalled.withLock { $0 })
+        } catch {
+            XCTFail("Expected CancellationError, got \(error)")
+        }
+    }
+
+    func testFastRecognitionUsesOneAttemptAndMapsFailureToIncomplete() throws {
+        var attempts = 0
+        let value = try OCRService.withSingleRecognitionAttempt {
+            attempts += 1
+            return "fast"
+        }
+
+        XCTAssertEqual(value, "fast")
+        XCTAssertEqual(attempts, 1)
+        XCTAssertThrowsError(try OCRService.withSingleRecognitionAttempt {
+            attempts += 1
+            throw OCRFallbackTestError.failed
+        }) { error in
+            XCTAssertEqual(error as? OCRServiceError, .incomplete("Apple Vision fast text recognition failed"))
+        }
+        XCTAssertEqual(attempts, 2)
+    }
+
+    func testFastRecognitionPreservesCancellationAfterFrameworkFailure() async {
+        let task = Task {
+            try OCRService.withSingleRecognitionAttempt { () throws -> String in
+                withUnsafeCurrentTask { $0?.cancel() }
+                throw OCRFallbackTestError.failed
+            }
+        }
+
+        do {
+            _ = try await task.value
+            XCTFail("Expected cancellation")
+        } catch is CancellationError {
+            // Expected.
+        } catch {
+            XCTFail("Expected CancellationError, got \(error)")
+        }
+    }
+
+    func testOCRGlobalBoundsUseLogicalCaptureBoundsAtRetinaScale() throws {
+        let result = OCRTextResult(
+            observations: [OCRTextObservation(
+                text: "Calendar",
+                confidence: 0.93,
+                boundingBox: CGRect(x: 0.1, y: 0.7, width: 0.25, height: 0.1))],
+            imageSize: CGSize(width: 1600, height: 1200))
+
+        let element = try XCTUnwrap(ObservationOCRMapper.elements(
+            from: result,
+            windowBounds: CGRect(x: 200, y: 300, width: 800, height: 600)).first)
+
+        XCTAssertEqual(element.bounds, CGRect(x: 280, y: 420, width: 200, height: 60))
+        XCTAssertEqual(element.attributes["confidence"], "0.93")
+        XCTAssertEqual(element.type, .staticText)
+        XCTAssertFalse(element.isActionable)
+    }
+
+    func testLegacyOCRMarkerRemainsSemanticEvidenceWithoutConfidence() throws {
+        let detected = DetectedElement(
+            id: "ocr_legacy",
+            type: .staticText,
+            label: "August",
+            bounds: CGRect(x: 10, y: 20, width: 100, height: 20),
+            attributes: ["description": "ocr"])
+        let legacyJSON = Data((
+            #"{"id":"ocr_legacy","elementId":"ocr_legacy","role":"AXStaticText", "# +
+                #""description":"ocr","frame":[[10,20],[100,20]],"isActionable":false,"children":[]}"#).utf8)
+        let stored = try JSONDecoder().decode(UIElement.self, from: legacyJSON)
+
+        XCTAssertTrue(detected.isOCRSemanticEvidence)
+        XCTAssertNil(stored.confidence)
+        XCTAssertTrue(stored.isOCRSemanticEvidence)
+
+        let ordinary = DetectedElement(
+            id: "S1",
+            type: .staticText,
+            label: "OCR",
+            bounds: CGRect(x: 10, y: 50, width: 100, height: 20),
+            attributes: ["description": "OCR"])
+        XCTAssertFalse(ordinary.isOCRSemanticEvidence)
+    }
+
+    func testOCRMergePreservesAXWarningAndPublicationReceipts() throws {
+        let completedAt = Date(timeIntervalSinceReferenceDate: 123)
+        let bounds = CGRect(x: 200, y: 300, width: 800, height: 600)
+        let coordinateContext = CaptureCoordinateContext(
+            metadata: CaptureMetadata(
+                size: CGSize(width: 1600, height: 1200),
+                mode: .window,
+                windowInfo: ServiceWindowInfo(windowID: 119, title: "Calendar", bounds: bounds),
+                diagnostics: CaptureDiagnostics(
+                    requestedScale: .native,
+                    nativeScale: 2,
+                    outputScale: 2,
+                    scaleSource: "fixture",
+                    finalPixelSize: CGSize(width: 1600, height: 1200))),
+            referenceID: "calendar-snapshot")
+        let base = ElementDetectionResult(
+            snapshotId: "calendar-snapshot",
+            screenshotPath: "/tmp/calendar.png",
+            elements: DetectedElements(),
+            metadata: DetectionMetadata(
+                detectionTime: 0.1,
+                elementCount: 0,
+                method: "AXorcist",
+                warnings: ["ax_incomplete_read"],
+                truncationInfo: DetectionTruncationInfo(incompleteAccessibilityRead: true),
+                desktopMutationCompletedAt: completedAt,
+                desktopMutationPreservationAllowed: true,
+                captureCoordinateContext: coordinateContext))
+        let ocr = OCRTextResult(
+            observations: [OCRTextObservation(
+                text: "August",
+                confidence: 0.9,
+                boundingBox: CGRect(x: 0.1, y: 0.7, width: 0.25, height: 0.1))],
+            imageSize: CGSize(width: 1600, height: 1200))
+        let ocrElements = try ObservationOCRMapper.elements(
+            from: ocr,
+            windowBounds: XCTUnwrap(coordinateContext.logicalBounds))
+
+        let merged = ObservationOCRMapper.merge(
+            ocrResult: ocr,
+            ocrElements: ocrElements,
+            into: base)
+
+        XCTAssertEqual(merged.metadata.warnings, ["ax_incomplete_read"])
+        XCTAssertEqual(merged.metadata.truncationInfo?.incompleteAccessibilityRead, true)
+        XCTAssertEqual(merged.metadata.desktopMutationCompletedAt, completedAt)
+        XCTAssertEqual(merged.metadata.desktopMutationPreservationAllowed, true)
+        XCTAssertEqual(merged.metadata.captureCoordinateContext, coordinateContext)
+    }
+
+    @MainActor
+    func testOCRConfidenceAndStaticTextRoleRoundTripThroughSnapshotStorage() async throws {
+        let manager = InMemorySnapshotManager()
+        let snapshotID = try await manager.createSnapshot()
+        try await manager.storeScreenshot(SnapshotScreenshotRequest(
+            snapshotId: snapshotID,
+            screenshotPath: "/tmp/calendar.png",
+            applicationBundleId: "com.apple.iCal",
+            applicationProcessId: 858,
+            applicationName: "Calendar",
+            windowTitle: "Calendar",
+            windowBounds: CGRect(x: 200, y: 300, width: 800, height: 600)))
+        let element = DetectedElement(
+            id: "ocr_1",
+            type: .staticText,
+            label: "August",
+            bounds: CGRect(x: 280, y: 420, width: 200, height: 60),
+            attributes: [
+                "description": "ocr",
+                "confidence": "0.93",
+            ])
+        try await manager.storeDetectionResult(
+            snapshotId: snapshotID,
+            result: ElementDetectionResult(
+                snapshotId: snapshotID,
+                screenshotPath: "/tmp/calendar.png",
+                elements: DetectedElements(other: [element]),
+                metadata: DetectionMetadata(
+                    detectionTime: 0.1,
+                    elementCount: 1,
+                    method: "AXorcist+OCR")))
+
+        let storedSnapshot = try await manager.getUIAutomationSnapshot(snapshotId: snapshotID)
+        let stored = try XCTUnwrap(storedSnapshot)
+        XCTAssertEqual(stored.uiMap["ocr_1"]?.confidence, 0.93)
+        let reloadedDetection = try await manager.getDetectionResult(snapshotId: snapshotID)
+        let reloaded = try XCTUnwrap(reloadedDetection)
+        let reloadedElement = try XCTUnwrap(reloaded.elements.other.first)
+        XCTAssertEqual(reloadedElement.type, .staticText)
+        XCTAssertEqual(reloadedElement.attributes["confidence"], "0.93")
+        XCTAssertFalse(reloadedElement.isActionable)
+    }
+
+    func testROIPresentationPreservesOCRConfidenceAndElementState() throws {
+        let sourceBounds = CGRect(x: 200, y: 300, width: 800, height: 600)
+        let viewport = CaptureViewport(
+            sourceLogicalBounds: sourceBounds,
+            requestedWindowRelativeBounds: CGRect(x: 20, y: 30, width: 400, height: 300),
+            deliveredWindowRelativeBounds: CGRect(x: 20, y: 30, width: 400, height: 300),
+            logicalBounds: CGRect(x: 220, y: 330, width: 400, height: 300),
+            sourceImageSize: CGSize(width: 1600, height: 1200))
+        let element = UIElement(
+            id: "ocr_1",
+            elementId: "ocr_1",
+            role: "AXStaticText",
+            label: "August",
+            description: "ocr",
+            confidence: 0.93,
+            frame: CGRect(x: 280, y: 420, width: 200, height: 60),
+            isActionable: false,
+            isEnabled: true,
+            isSelected: false,
+            isValueSettable: false)
+
+        let presented = try XCTUnwrap(DesktopObservationROIProcessor.presentationElements(
+            [element],
+            viewport: viewport).first)
+
+        XCTAssertEqual(presented.frame, CGRect(x: 60, y: 90, width: 200, height: 60))
+        XCTAssertEqual(presented.confidence, 0.93)
+        XCTAssertEqual(presented.isEnabled, true)
+        XCTAssertEqual(presented.isSelected, false)
+        XCTAssertEqual(presented.isValueSettable, false)
+    }
+}
+
+private enum OCRFallbackTestError: Error {
+    case failed
+}

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ScrollServiceTargetResolutionTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ScrollServiceTargetResolutionTests.swift
@@ -105,6 +105,47 @@ struct ScrollServiceTargetResolutionTests {
 
     @Test
     @MainActor
+    func `foreground OCR target refuses before pointer motion or scroll dispatch`() async {
+        let element = DetectedElement(
+            id: "ocr_1",
+            type: .staticText,
+            label: "August",
+            bounds: CGRect(x: 10, y: 20, width: 100, height: 20),
+            attributes: [
+                "description": "ocr",
+                "confidence": "0.93",
+            ])
+        let result = ElementDetectionResult(
+            snapshotId: "snapshot",
+            screenshotPath: "/tmp/calendar.png",
+            elements: DetectedElements(other: [element]),
+            metadata: DetectionMetadata(detectionTime: 0, elementCount: 1, method: "AXorcist+OCR"))
+        let synthetic = ScrollRecordingSyntheticInputDriver()
+        let service = ScrollService(
+            snapshotManager: InMemorySnapshotManager(detectionResult: result),
+            inputPolicy: UIInputPolicy(defaultStrategy: .synthFirst),
+            syntheticInputDriver: synthetic)
+
+        do {
+            try await service.scroll(ScrollRequest(
+                direction: .down,
+                amount: 1,
+                target: "ocr_1",
+                smooth: true,
+                snapshotId: "snapshot",
+                foreground: true))
+            Issue.record("Expected OCR semantic evidence refusal")
+        } catch let PeekabooError.invalidInput(message) {
+            #expect(message.contains("semantic evidence"))
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+
+        #expect(synthetic.events.isEmpty)
+    }
+
+    @Test
+    @MainActor
     func `background unresolved snapshot target requires foreground without synthetic fallback`() async throws {
         let element = DetectedElement(
             id: "S1",

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/TypeServiceTargetResolutionTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/TypeServiceTargetResolutionTests.swift
@@ -175,6 +175,51 @@ struct TypeServiceTargetResolutionTests {
     }
 
     @Test
+    @MainActor
+    func `direct OCR target refuses before AX resolution or typing`() async {
+        let element = DetectedElement(
+            id: "ocr_1",
+            type: .staticText,
+            label: "August",
+            bounds: CGRect(x: 10, y: 20, width: 100, height: 20),
+            attributes: [
+                "description": "ocr",
+                "confidence": "0.93",
+            ])
+        let result = ElementDetectionResult(
+            snapshotId: "snapshot",
+            screenshotPath: "/tmp/calendar.png",
+            elements: DetectedElements(other: [element]),
+            metadata: DetectionMetadata(detectionTime: 0, elementCount: 1, method: "AXorcist+OCR"))
+        let resolver = RecordingTypeAutomationElementResolver()
+        var typed: [Character] = []
+        let service = TypeService(
+            snapshotManager: InMemorySnapshotManager(detectionResult: result),
+            inputPolicy: UIInputPolicy(defaultStrategy: .actionFirst),
+            automationElementResolver: resolver,
+            randomSource: SystemTypingCadenceRandomSource(),
+            targetedCharacterTyper: { character, _ in typed.append(character) })
+
+        do {
+            try await service.type(
+                text: "unsafe",
+                target: "ocr_1",
+                clearExisting: false,
+                typingDelay: 0,
+                snapshotId: "snapshot")
+            Issue.record("Expected OCR semantic evidence refusal")
+        } catch let PeekabooError.invalidInput(message) {
+            #expect(message.contains("semantic evidence"))
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+
+        #expect(resolver.detectedResolutionCount == 0)
+        #expect(resolver.queryResolutionCount == 0)
+        #expect(typed.isEmpty)
+    }
+
+    @Test
     func `special key mapping preserves raw SpecialKey semantics`() {
         #expect(TypeServiceSpecialKeyMapping.keyCode(for: .return) == 0x24)
         #expect(TypeServiceSpecialKeyMapping.keyCode(for: .enter) == 0x4C)
@@ -306,10 +351,12 @@ private enum TypeDeliveryTestError: LocalizedError {
 
 @MainActor
 private final class RecordingTypeAutomationElementResolver: AutomationElementResolving {
+    private(set) var detectedResolutionCount = 0
     private(set) var queryResolutionCount = 0
 
     func resolve(detectedElement _: DetectedElement, windowContext _: WindowContext?) -> AutomationElement? {
-        nil
+        self.detectedResolutionCount += 1
+        return nil
     }
 
     func resolve(query _: String, windowContext _: WindowContext?, requireTextInput _: Bool) -> AutomationElement? {

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/ClickTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/ClickTool.swift
@@ -614,6 +614,9 @@ public struct ClickTool: MCPTool {
             throw ClickToolError(
                 "Element '\(id)' not found in current snapshot. Run 'see' or 'inspect_ui' to update UI state.")
         }
+        guard !element.isOCRSemanticEvidence else {
+            throw ClickToolError(OCRSemanticEvidencePolicy.interactionRefusalMessage)
+        }
         return element
     }
 
@@ -630,7 +633,10 @@ public struct ClickTool: MCPTool {
             throw ClickToolError("No elements found matching query: '\(query)'")
         }
 
-        return matches.first { $0.isActionable } ?? matches[0]
+        guard let match = SnapshotElementQuerySelector.preferred(in: matches) else {
+            throw ClickToolError(OCRSemanticEvidencePolicy.interactionRefusalMessage)
+        }
+        return match
     }
 }
 

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/DetectedElementSnapshotConverter.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/DetectedElementSnapshotConverter.swift
@@ -14,6 +14,7 @@ enum DetectedElementSnapshotConverter {
                 help: element.attributes["help"],
                 roleDescription: element.attributes["roleDescription"],
                 identifier: element.attributes["identifier"],
+                confidence: element.attributes["confidence"].flatMap(Double.init),
                 frame: element.bounds,
                 isActionable: element.isActionable,
                 isEnabled: element.knownIsEnabled,

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/DragTool+Resolution.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/DragTool+Resolution.swift
@@ -19,6 +19,9 @@ extension DragTool {
             let screenshotMetadata = await snapshot.screenshotMetadata
             let windowID = screenshotMetadata?.windowInfo?.windowID
             if let element = await snapshot.getElement(byId: query) {
+                guard !element.isOCRSemanticEvidence else {
+                    throw CoordinateParseError(message: OCRSemanticEvidencePolicy.interactionRefusalMessage)
+                }
                 return DragPointDescription(
                     point: element.dragCenterPoint,
                     description: "element \(query) (\(element.dragHumanDescription))",
@@ -41,7 +44,9 @@ extension DragTool {
                 throw CoordinateParseError(message: "No elements found matching '\(query)' for \(parameterName)")
             }
 
-            let element = matches.first { $0.isActionable } ?? matches[0]
+            guard let element = SnapshotElementQuerySelector.preferred(in: matches) else {
+                throw CoordinateParseError(message: OCRSemanticEvidencePolicy.interactionRefusalMessage)
+            }
             return DragPointDescription(
                 point: element.dragCenterPoint,
                 description: element.dragHumanDescription,

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/MoveTool+Execution.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/MoveTool+Execution.swift
@@ -38,6 +38,9 @@ extension MoveTool {
                     "Element '\(elementId)' not found in current snapshot. " +
                         "Run 'see' or 'inspect_ui' to update UI state.")
             }
+            guard !element.isOCRSemanticEvidence else {
+                throw MoveToolValidationError(OCRSemanticEvidencePolicy.interactionRefusalMessage)
+            }
             let location = CGPoint(x: element.frame.midX, y: element.frame.midY)
             let label = element.title ?? element.label ?? "untitled"
             let summary = "element \(elementId) (\(element.role): \(label))"

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/ScrollTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/ScrollTool.swift
@@ -194,6 +194,9 @@ public struct ScrollTool: MCPTool {
             throw ScrollToolValidationError(
                 "Element '\(elementId)' not found in current snapshot. Run 'see' or 'inspect_ui' to update UI state.")
         }
+        guard !element.isOCRSemanticEvidence else {
+            throw ScrollToolValidationError(OCRSemanticEvidencePolicy.interactionRefusalMessage)
+        }
 
         let label = element.title ?? element.label ?? "untitled"
         let description = "on \(element.role): \(label)"

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/SeeTool+Formatting.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/SeeTool+Formatting.swift
@@ -26,6 +26,9 @@ struct SeeElementTextFormatter {
         if let identifier = element.identifier, !identifier.isEmpty {
             parts.append("identifier: \(identifier)")
         }
+        if let confidence = element.confidence {
+            parts.append(String(format: "confidence: %.0f%%", confidence * 100))
+        }
         if let isValueSettable = element.isValueSettable {
             parts.append(isValueSettable ? "[value settable]" : "[value read-only]")
         }

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/SeeTool+Types.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/SeeTool+Types.swift
@@ -10,6 +10,7 @@ struct SeeRequest {
     let path: String?
     let snapshotId: String?
     let annotate: Bool
+    let ocr: Bool
     let webFocus: Bool
     let traversalBudget: AXTraversalBudget
     let roi: CaptureRegionOfInterest?
@@ -20,6 +21,7 @@ struct SeeRequest {
         self.path = arguments.getString("path")
         self.snapshotId = arguments.getString("snapshot")
         self.annotate = arguments.getBool("annotate") ?? false
+        self.ocr = arguments.getBool("ocr") ?? false
         self.webFocus = arguments.getBool("web_focus") ?? false
         if let rawROI = arguments.getString("roi")?.trimmingCharacters(in: .whitespacesAndNewlines),
            !rawROI.isEmpty
@@ -130,7 +132,7 @@ struct SeeSummaryBuilder {
         lines.append("")
         lines.append(contentsOf: self.elementSection())
         lines.append("")
-        lines.append("Copy opaque element IDs exactly into click, type, and other interaction commands.")
+        lines.append("Use opaque element IDs for interaction only when the element is marked actionable.")
         return lines.joined(separator: "\n")
     }
 

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/SeeTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/SeeTool.swift
@@ -63,8 +63,8 @@ public struct SeeTool: MCPTool {
                     default: false),
                 "ocr": SchemaBuilder.boolean(
                     description: """
-                    Optional. Add text recognized locally with Apple Vision to the accessibility element map.
-                    OCR text is non-actionable and does not replace accessible controls.
+                    Optional. Add text recognized locally on the selected host with Apple Vision to the accessibility
+                    element map. OCR text is non-actionable and does not replace accessible controls.
                     """,
                     default: false),
                 "roi": SchemaBuilder.string(

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/SeeTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/SeeTool.swift
@@ -61,6 +61,12 @@ public struct SeeTool: MCPTool {
                     Optional. Add interaction markers and IDs to the returned screenshot.
                     """,
                     default: false),
+                "ocr": SchemaBuilder.boolean(
+                    description: """
+                    Optional. Add text recognized locally with Apple Vision to the accessibility element map.
+                    OCR text is non-actionable and does not replace accessible controls.
+                    """,
+                    default: false),
                 "roi": SchemaBuilder.string(
                     description: """
                     Optional. Crop the exact window as x,y,width,height in window-local logical points. Requires
@@ -189,8 +195,9 @@ public struct SeeTool: MCPTool {
             target: target.observationTarget,
             capture: DesktopCaptureOptions(visualizerMode: .none, roi: request.roi),
             detection: DesktopDetectionOptions(
-                mode: .accessibility,
+                mode: request.ocr ? .accessibilityAndOCR : .accessibility,
                 allowWebFocusFallback: request.webFocus,
+                preferOCR: false,
                 traversalBudget: request.traversalBudget),
             output: DesktopObservationOutputOptions(
                 path: path,

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/SnapshotElementQuerySelector.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/SnapshotElementQuerySelector.swift
@@ -1,0 +1,7 @@
+import PeekabooAutomationKit
+
+enum SnapshotElementQuerySelector {
+    static func preferred(in matches: [UIElement]) -> UIElement? {
+        matches.first(where: { $0.isActionable }) ?? matches.first(where: { !$0.isOCRSemanticEvidence })
+    }
+}

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/TypeTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/TypeTool.swift
@@ -359,6 +359,9 @@ public struct TypeTool: MCPTool {
             throw TypeToolValidationError(
                 "Element '\(elementId)' not found in current snapshot. Run 'see' or 'inspect_ui' to update UI state.")
         }
+        guard !element.isOCRSemanticEvidence else {
+            throw TypeToolValidationError(OCRSemanticEvidencePolicy.interactionRefusalMessage)
+        }
 
         return TargetElementContext(snapshot: snapshot, element: element)
     }

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeModels.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeModels.swift
@@ -293,6 +293,7 @@ public enum PeekabooBridgeHostCapability {
     public static let hostGenerationIdentity = "hostGenerationIdentity"
     public static let codeSignatureBuildIdentity = "codeSignatureBuildIdentity"
     public static let backgroundBridgeHost = "backgroundBridgeHost"
+    public static let desktopObservationOCR = "desktopObservationOCR"
 }
 
 public struct PeekabooBridgeHandshakeResponse: Codable, Sendable {

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer.swift
@@ -88,6 +88,9 @@ public final class PeekabooBridgeServer {
         if hostIdentity?.codeSignatureHash != nil {
             resolvedHostCapabilities.insert(PeekabooBridgeHostCapability.codeSignatureBuildIdentity)
         }
+        if self.allowedOperations.contains(.desktopObservation) {
+            resolvedHostCapabilities.insert(PeekabooBridgeHostCapability.desktopObservationOCR)
+        }
         self.hostCapabilities = resolvedHostCapabilities
         self.daemonControl = daemonControl
         self.desktopMutationWatermarkStore = desktopMutationWatermarkStore

--- a/Core/PeekabooCore/Sources/PeekabooCore/Support/RemoteDesktopObservationService.swift
+++ b/Core/PeekabooCore/Sources/PeekabooCore/Support/RemoteDesktopObservationService.swift
@@ -5,8 +5,9 @@ import PeekabooBridge
 import PeekabooFoundation
 
 enum RemoteDesktopObservationCapabilityPolicy {
-    static func requiresOCR(_ request: DesktopObservationRequest) -> Bool {
-        request.detection.mode == .accessibilityAndOCR || request.detection.preferOCR
+    /// `preferOCR` predates the additive enum case and remains compatible with older hosts.
+    static func requiresOCRCapability(_ request: DesktopObservationRequest) -> Bool {
+        request.detection.mode == .accessibilityAndOCR
     }
 
     static func ocrUnavailableError() -> PeekabooBridgeErrorEnvelope {
@@ -51,7 +52,8 @@ public final class RemoteDesktopObservationService: DesktopObservationServicePro
     }
 
     public func observe(_ request: DesktopObservationRequest) async throws -> DesktopObservationResult {
-        guard !RemoteDesktopObservationCapabilityPolicy.requiresOCR(request) || self.supportsDesktopObservationOCR
+        guard !RemoteDesktopObservationCapabilityPolicy.requiresOCRCapability(request) ||
+            self.supportsDesktopObservationOCR
         else {
             throw RemoteDesktopObservationCapabilityPolicy.ocrUnavailableError()
         }

--- a/Core/PeekabooCore/Sources/PeekabooCore/Support/RemoteDesktopObservationService.swift
+++ b/Core/PeekabooCore/Sources/PeekabooCore/Support/RemoteDesktopObservationService.swift
@@ -4,33 +4,57 @@ import PeekabooAutomationKit
 import PeekabooBridge
 import PeekabooFoundation
 
+enum RemoteDesktopObservationCapabilityPolicy {
+    static func requiresOCR(_ request: DesktopObservationRequest) -> Bool {
+        request.detection.mode == .accessibilityAndOCR || request.detection.preferOCR
+    }
+
+    static func ocrUnavailableError() -> PeekabooBridgeErrorEnvelope {
+        PeekabooBridgeErrorEnvelope(
+            code: .operationNotSupported,
+            message: """
+            Remote Bridge host does not advertise desktopObservationOCR. Update and relaunch Peekaboo on that host, \
+            or use --no-remote to explicitly run Vision OCR in the caller process.
+            """)
+    }
+}
+
 @MainActor
 public final class RemoteDesktopObservationService: DesktopObservationServiceProtocol {
     private let client: PeekabooBridgeClient
+    private let supportsDesktopObservationOCR: Bool
     private let supportsExactWindowROIObservation: Bool
     private let artifactInstallationPreflight: @MainActor @Sendable () throws -> Void
 
     public convenience init(
         client: PeekabooBridgeClient,
+        supportsDesktopObservationOCR: Bool = false,
         supportsExactWindowROIObservation: Bool = false)
     {
         self.init(
             client: client,
+            supportsDesktopObservationOCR: supportsDesktopObservationOCR,
             supportsExactWindowROIObservation: supportsExactWindowROIObservation,
             artifactInstallationPreflight: {})
     }
 
     package init(
         client: PeekabooBridgeClient,
+        supportsDesktopObservationOCR: Bool = false,
         supportsExactWindowROIObservation: Bool,
         artifactInstallationPreflight: @escaping @MainActor @Sendable () throws -> Void)
     {
         self.client = client
+        self.supportsDesktopObservationOCR = supportsDesktopObservationOCR
         self.supportsExactWindowROIObservation = supportsExactWindowROIObservation
         self.artifactInstallationPreflight = artifactInstallationPreflight
     }
 
     public func observe(_ request: DesktopObservationRequest) async throws -> DesktopObservationResult {
+        guard !RemoteDesktopObservationCapabilityPolicy.requiresOCR(request) || self.supportsDesktopObservationOCR
+        else {
+            throw RemoteDesktopObservationCapabilityPolicy.ocrUnavailableError()
+        }
         guard request.capture.roi != nil else {
             return try await self.client.desktopObservation(request)
         }

--- a/Core/PeekabooCore/Sources/PeekabooCore/Support/RemotePeekabooServices.swift
+++ b/Core/PeekabooCore/Sources/PeekabooCore/Support/RemotePeekabooServices.swift
@@ -56,6 +56,7 @@ public final class RemotePeekabooServices: PeekabooServiceProviding {
         supportsPostEventPermissionRequest: Bool = false,
         supportsElementActions: Bool = false,
         supportsDesktopObservation: Bool = false,
+        supportsDesktopObservationOCR: Bool = false,
         supportsExactWindowROIObservation: Bool = false,
         supportsImplicitLatestSnapshotInvalidation: Bool = false,
         supportsApplicationLaunchOptions: Bool = false,
@@ -68,6 +69,7 @@ public final class RemotePeekabooServices: PeekabooServiceProviding {
     {
         self.client = client
         self.supportsPostEventPermissionRequest = supportsPostEventPermissionRequest
+        let supportsRemoteDesktopObservationOCR = supportsDesktopObservation && supportsDesktopObservationOCR
 
         self.logging = LoggingService()
         self.screenCapture = RemoteScreenCaptureService(client: client)
@@ -141,9 +143,10 @@ public final class RemotePeekabooServices: PeekabooServiceProviding {
         self.desktopObservation = if supportsDesktopObservation {
             RemoteDesktopObservationService(
                 client: client,
+                supportsDesktopObservationOCR: supportsRemoteDesktopObservationOCR,
                 supportsExactWindowROIObservation: supportsExactWindowROIObservation)
         } else {
-            ExactWindowROIUnsupportedDesktopObservationService(delegate: DesktopObservationService(
+            LegacyRemoteDesktopObservationService(delegate: DesktopObservationService(
                 screenCapture: self.screenCapture,
                 automation: self.automation,
                 applications: self.applications,
@@ -190,7 +193,7 @@ public final class RemotePeekabooServices: PeekabooServiceProviding {
 }
 
 @MainActor
-private final class ExactWindowROIUnsupportedDesktopObservationService: DesktopObservationServiceProtocol {
+private final class LegacyRemoteDesktopObservationService: DesktopObservationServiceProtocol {
     private let delegate: any DesktopObservationServiceProtocol
 
     init(delegate: any DesktopObservationServiceProtocol) {
@@ -198,6 +201,9 @@ private final class ExactWindowROIUnsupportedDesktopObservationService: DesktopO
     }
 
     func observe(_ request: DesktopObservationRequest) async throws -> DesktopObservationResult {
+        guard !RemoteDesktopObservationCapabilityPolicy.requiresOCR(request) else {
+            throw RemoteDesktopObservationCapabilityPolicy.ocrUnavailableError()
+        }
         guard request.capture.roi == nil else {
             throw PeekabooBridgeErrorEnvelope(
                 code: .operationNotSupported,

--- a/Core/PeekabooCore/Sources/PeekabooCore/Support/RemotePeekabooServices.swift
+++ b/Core/PeekabooCore/Sources/PeekabooCore/Support/RemotePeekabooServices.swift
@@ -201,7 +201,7 @@ private final class LegacyRemoteDesktopObservationService: DesktopObservationSer
     }
 
     func observe(_ request: DesktopObservationRequest) async throws -> DesktopObservationResult {
-        guard !RemoteDesktopObservationCapabilityPolicy.requiresOCR(request) else {
+        guard !RemoteDesktopObservationCapabilityPolicy.requiresOCRCapability(request) else {
             throw RemoteDesktopObservationCapabilityPolicy.ocrUnavailableError()
         }
         guard request.capture.roi == nil else {

--- a/Core/PeekabooCore/Tests/PeekabooAgentRuntimeTests/MCPTextFormattingTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooAgentRuntimeTests/MCPTextFormattingTests.swift
@@ -82,4 +82,29 @@ struct MCPTextFormattingTests {
 
         #expect(line == #"  T1 - "value: search query" - at (20, 40) size 180×24"#)
     }
+
+    @Test
+    func `snapshot query selection never falls back to OCR semantic evidence`() throws {
+        let ocr = UIElement(
+            id: "ocr_1",
+            elementId: "ocr_1",
+            role: "AXStaticText",
+            label: "August",
+            description: "ocr",
+            confidence: 0.93,
+            frame: CGRect(x: 20, y: 40, width: 100, height: 20),
+            isActionable: false)
+        let ordinary = UIElement(
+            id: "S1",
+            elementId: "S1",
+            role: "AXStaticText",
+            label: "August",
+            frame: CGRect(x: 20, y: 70, width: 100, height: 20),
+            isActionable: false)
+
+        let selected = try #require(SnapshotElementQuerySelector.preferred(in: [ocr, ordinary]))
+
+        #expect(selected.id == "S1")
+        #expect(SnapshotElementQuerySelector.preferred(in: [ocr]) == nil)
+    }
 }

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/SeeToolOCRTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/SeeToolOCRTests.swift
@@ -2,6 +2,8 @@ import CoreGraphics
 import Foundation
 import MCP
 import PeekabooAutomationKit
+import PeekabooBridge
+import PeekabooCore
 import PeekabooFoundation
 import TachikomaMCP
 import Testing
@@ -118,6 +120,38 @@ struct SeeToolOCRTests {
         let request = try SeeRequest(arguments: ToolArguments(raw: [:]))
 
         #expect(!request.ocr)
+    }
+
+    @Test
+    func `remote MCP See OCR refuses an incapable host before transport`() async throws {
+        let snapshots = await MainActor.run { InMemorySnapshotManager() }
+        let remoteObservation = await MainActor.run {
+            RemotePeekabooServices(
+                client: PeekabooBridgeClient(
+                    socketPath: "/tmp/nonexistent-mcp-ocr-\(UUID().uuidString).sock",
+                    requestTimeoutSec: 1),
+                supportsDesktopObservation: true,
+                supportsDesktopObservationOCR: false)
+                .desktopObservation
+        }
+        let context = await self.makeContext(
+            desktopObservation: remoteObservation,
+            snapshots: snapshots)
+
+        let response = try await SeeTool(context: context).execute(arguments: ToolArguments(raw: [
+            "ocr": true,
+        ]))
+
+        #expect(response.isError)
+        guard let first = response.content.first,
+              case let .text(message, annotations: _, _meta: _) = first
+        else {
+            Issue.record("Expected structured remote OCR capability refusal")
+            return
+        }
+        #expect(message.contains(PeekabooBridgeHostCapability.desktopObservationOCR))
+        #expect(message.contains("Update and relaunch"))
+        #expect(message.contains("--no-remote"))
     }
 
     private func makeContext(

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/SeeToolOCRTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/SeeToolOCRTests.swift
@@ -1,0 +1,266 @@
+import CoreGraphics
+import Foundation
+import MCP
+import PeekabooAutomationKit
+import PeekabooFoundation
+import TachikomaMCP
+import Testing
+@testable import PeekabooAgentRuntime
+
+@Suite(.serialized)
+struct SeeToolOCRTests {
+    @Test
+    func `See declares local additive OCR as an opt in boolean`() async {
+        let context = await MCPToolTestHelpers.makeContext()
+        let tool = SeeTool(context: context)
+        guard case let .object(root) = tool.inputSchema,
+              case let .object(properties)? = root["properties"],
+              case let .object(ocr)? = properties["ocr"]
+        else {
+            Issue.record("Expected OCR schema")
+            return
+        }
+
+        #expect(ocr["type"] == .string("boolean"))
+        #expect(ocr["default"] == .bool(false))
+        guard case let .string(description)? = ocr["description"] else {
+            Issue.record("Expected OCR description")
+            return
+        }
+        #expect(description.contains("locally"))
+        #expect(description.contains("non-actionable"))
+    }
+
+    @Test
+    func `Calendar shaped incomplete AX observation succeeds with exact OCR evidence`() async throws {
+        await UISnapshotManager.shared.removeAllSnapshots()
+        let snapshots = await MainActor.run { InMemorySnapshotManager() }
+        let observation = await MainActor.run { CalendarOCRObservationService(snapshots: snapshots) }
+        let context = await self.makeContext(desktopObservation: observation, snapshots: snapshots)
+        defer {
+            Task { await UISnapshotManager.shared.removeAllSnapshots() }
+        }
+
+        let response = try await SeeTool(context: context).execute(arguments: ToolArguments(raw: [
+            "app_target": "PID:858",
+            "window_id": 119,
+            "ocr": true,
+        ]))
+
+        #expect(!response.isError)
+        let recordedRequest = await MainActor.run { observation.lastRequest }
+        let request = try #require(recordedRequest)
+        #expect(request.target == .pid(858, window: .id(119)))
+        #expect(request.detection.mode == .accessibilityAndOCR)
+        #expect(!request.detection.preferOCR)
+        #expect(!request.detection.allowWebFocusFallback)
+        #expect(request.capture.focus == .background)
+
+        guard let first = response.content.first,
+              case let .text(summary, annotations: _, _meta: _) = first,
+              case let .object(meta)? = response.meta,
+              case let .string(snapshotID)? = meta["snapshot_id"],
+              case let .object(coordinateContext)? = meta["coordinate_context"],
+              case let .object(window)? = coordinateContext["window"],
+              case let .object(observationMeta)? = meta["observation"],
+              case let .array(warnings)? = observationMeta["warnings"]
+        else {
+            Issue.record("Expected successful OCR response metadata")
+            return
+        }
+
+        #expect(summary.contains("August 10, 2026"))
+        #expect(summary.contains("desc: \"ocr\""))
+        #expect(summary.contains("confidence: 93%"))
+        #expect(summary.contains("[not actionable]"))
+        #expect(summary.contains("AX tree incomplete"))
+        #expect(meta["actionable_count"] == .double(0))
+        #expect(coordinateContext["reference_id"] == .string(snapshotID))
+        #expect(window["window_id"] == .int(119))
+        #expect(warnings.contains(.string("ax_incomplete_read")))
+
+        let snapshotValue = await UISnapshotManager.shared.getSnapshot(id: snapshotID)
+        let snapshot = try #require(snapshotValue)
+        let ocrElementValue = await snapshot.getElement(byId: "ocr_1")
+        let ocrElement = try #require(ocrElementValue)
+        #expect(ocrElement.frame == CGRect(x: 240, y: 340, width: 180, height: 24))
+        #expect(ocrElement.confidence == 0.93)
+        #expect(ocrElement.description == "ocr")
+        #expect(!ocrElement.isActionable)
+        #expect(snapshot.applicationProcessId == 858)
+        #expect(snapshot.windowID == 119)
+        let expectedIdentity = await MainActor.run { CalendarOCRObservationService.identity }
+        #expect(snapshot.windowMutationIdentity == expectedIdentity)
+        let storedValue = try await context.snapshots.getUIAutomationSnapshot(snapshotId: snapshotID)
+        let stored = try #require(storedValue)
+        #expect(stored.captureCoordinateContext?.referenceID == snapshotID)
+        #expect(stored.windowMutationIdentity == expectedIdentity)
+
+        let clickResponse = try await ClickTool(context: context).execute(arguments: ToolArguments(raw: [
+            "on": "ocr_1",
+            "snapshot": snapshotID,
+        ]))
+        #expect(clickResponse.isError)
+        guard let errorContent = clickResponse.content.first,
+              case let .text(errorText, annotations: _, _meta: _) = errorContent,
+              case let .object(clickMeta)? = clickResponse.meta
+        else {
+            Issue.record("Expected structured OCR interaction refusal")
+            return
+        }
+        #expect(errorText.contains("semantic evidence"))
+        #expect(clickMeta["mutation_dispatched"] == .bool(false))
+        #expect(clickMeta["retry_safe"] == .bool(true))
+    }
+
+    @Test
+    func `See request keeps OCR disabled by default`() throws {
+        let request = try SeeRequest(arguments: ToolArguments(raw: [:]))
+
+        #expect(!request.ocr)
+    }
+
+    private func makeContext(
+        desktopObservation: any DesktopObservationServiceProtocol,
+        snapshots: any SnapshotManagerProtocol) async -> MCPToolContext
+    {
+        let base = await MCPToolTestHelpers.makeContext()
+        return await MainActor.run {
+            MCPToolContext(
+                automation: base.automation,
+                menu: base.menu,
+                windows: base.windows,
+                applications: base.applications,
+                dialogs: base.dialogs,
+                dock: base.dock,
+                screenCapture: base.screenCapture,
+                desktopObservation: desktopObservation,
+                snapshots: snapshots,
+                screens: base.screens,
+                agent: base.agent,
+                permissions: base.permissions,
+                clipboard: base.clipboard,
+                browser: base.browser,
+                snapshotMutationCoordinator: base.snapshotMutationCoordinator,
+                snapshotExecutionGate: base.snapshotExecutionGate)
+        }
+    }
+}
+
+@MainActor
+private final class CalendarOCRObservationService: DesktopObservationServiceProtocol {
+    static let bounds = CGRect(x: 200, y: 300, width: 800, height: 600)
+    static let identity = WindowMutationIdentity(
+        windowID: 119,
+        ownerProcessIdentifier: 858,
+        ownerProcessStartIdentity: 4242,
+        capturedBounds: bounds)
+
+    private(set) var lastRequest: DesktopObservationRequest?
+
+    private let snapshots: any SnapshotManagerProtocol
+
+    init(snapshots: any SnapshotManagerProtocol) {
+        self.snapshots = snapshots
+    }
+
+    func observe(_ request: DesktopObservationRequest) async throws -> DesktopObservationResult {
+        self.lastRequest = request
+        let path = try #require(request.output.path)
+        try Data("calendar-ocr-pixels".utf8).write(to: URL(fileURLWithPath: path), options: .atomic)
+
+        let application = ServiceApplicationInfo(
+            processIdentifier: 858,
+            processStartIdentity: 4242,
+            bundleIdentifier: "com.apple.iCal",
+            name: "Calendar",
+            windowCount: 1)
+        let window = ServiceWindowInfo(
+            windowID: 119,
+            title: "Calendar",
+            bounds: Self.bounds,
+            mutationIdentity: Self.identity)
+        let context = WindowContext(
+            applicationName: "Calendar",
+            applicationBundleId: "com.apple.iCal",
+            applicationProcessId: 858,
+            windowTitle: "Calendar",
+            windowID: 119,
+            windowBounds: Self.bounds,
+            windowMutationIdentity: Self.identity)
+        let ocrElement = DetectedElement(
+            id: "ocr_1",
+            type: .staticText,
+            label: "August 10, 2026",
+            bounds: CGRect(x: 240, y: 340, width: 180, height: 24),
+            isEnabled: true,
+            attributes: [
+                "description": "ocr",
+                "confidence": "0.93",
+            ])
+        let capture = CaptureResult(
+            imageData: Data(),
+            savedPath: path,
+            metadata: CaptureMetadata(
+                size: Self.bounds.size,
+                mode: .window,
+                applicationInfo: application,
+                windowInfo: window,
+                diagnostics: CaptureDiagnostics(
+                    requestedScale: .logical1x,
+                    nativeScale: 2,
+                    outputScale: 1,
+                    scaleSource: "fixture",
+                    finalPixelSize: Self.bounds.size)))
+
+        let detection = ElementDetectionResult(
+            snapshotId: request.output.snapshotID ?? "calendar-ocr",
+            screenshotPath: path,
+            elements: DetectedElements(other: [ocrElement]),
+            metadata: DetectionMetadata(
+                detectionTime: 0.1,
+                elementCount: 1,
+                method: "AXorcist+OCR",
+                warnings: ["ax_incomplete_read"],
+                windowContext: context,
+                truncationInfo: DetectionTruncationInfo(incompleteAccessibilityRead: true)))
+        if let snapshotID = request.output.snapshotID {
+            try await self.snapshots.storeScreenshot(SnapshotScreenshotRequest(
+                snapshotId: snapshotID,
+                screenshotPath: path,
+                applicationBundleId: "com.apple.iCal",
+                applicationProcessId: 858,
+                applicationName: "Calendar",
+                windowTitle: "Calendar",
+                windowBounds: Self.bounds,
+                windowID: 119,
+                windowMutationIdentity: Self.identity,
+                captureCoordinateContext: CaptureCoordinateContext(
+                    metadata: capture.metadata,
+                    referenceID: snapshotID)))
+            try await self.snapshots.storeDetectionResult(snapshotId: snapshotID, result: detection)
+        }
+
+        return DesktopObservationResult(
+            target: ResolvedObservationTarget(
+                kind: .windowID(119),
+                app: ApplicationIdentity(
+                    processIdentifier: 858,
+                    processStartIdentity: 4242,
+                    bundleIdentifier: "com.apple.iCal",
+                    name: "Calendar"),
+                window: WindowIdentity(windowID: 119, title: "Calendar", bounds: Self.bounds, index: 0),
+                bounds: Self.bounds,
+                detectionContext: context),
+            capture: capture,
+            elements: detection,
+            ocr: OCRTextResult(
+                observations: [OCRTextObservation(
+                    text: "August 10, 2026",
+                    confidence: 0.93,
+                    boundingBox: CGRect(x: 0.05, y: 0.85, width: 0.225, height: 0.04))],
+                imageSize: Self.bounds.size),
+            files: DesktopObservationFiles(rawScreenshotPath: path),
+            diagnostics: DesktopObservationDiagnostics(warnings: ["ax_incomplete_read"]))
+    }
+}

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeHostIdentityTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeHostIdentityTests.swift
@@ -122,8 +122,29 @@ struct PeekabooBridgeHostIdentityTests {
         #expect(handshake.hostCapabilities == [
             PeekabooBridgeHostCapability.backgroundBridgeHost,
             PeekabooBridgeHostCapability.codeSignatureBuildIdentity,
+            PeekabooBridgeHostCapability.desktopObservationOCR,
             PeekabooBridgeHostCapability.hostGenerationIdentity,
         ])
+    }
+
+    @Test
+    @MainActor
+    func `host advertises desktop observation OCR only when desktop observation is allowed`() {
+        let observationServer = PeekabooBridgeServer(
+            services: PeekabooServices(),
+            allowlistedTeams: [],
+            allowlistedBundles: [],
+            allowedOperations: [.desktopObservation],
+            hostIdentity: nil)
+        let captureOnlyServer = PeekabooBridgeServer(
+            services: PeekabooServices(),
+            allowlistedTeams: [],
+            allowlistedBundles: [],
+            allowedOperations: [.captureScreen],
+            hostIdentity: nil)
+
+        #expect(observationServer.hostCapabilities.contains(PeekabooBridgeHostCapability.desktopObservationOCR))
+        #expect(!captureOnlyServer.hostCapabilities.contains(PeekabooBridgeHostCapability.desktopObservationOCR))
     }
 
     @Test

--- a/Core/PeekabooCore/Tests/PeekabooTests/RemoteCaptureGateOwnershipTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/RemoteCaptureGateOwnershipTests.swift
@@ -56,6 +56,99 @@ struct RemoteCaptureGateOwnershipTests {
     }
 
     @Test
+    func `remote OCR rejects a host without capability before transport`() async {
+        let remote = RemoteDesktopObservationService(client: PeekabooBridgeClient(
+            socketPath: "/tmp/nonexistent-ocr-\(UUID().uuidString).sock",
+            requestTimeoutSec: 1))
+
+        let error = await #expect(throws: PeekabooBridgeErrorEnvelope.self) {
+            _ = try await remote.observe(DesktopObservationRequest(
+                target: .screen(index: 0),
+                detection: DesktopDetectionOptions(mode: .accessibilityAndOCR)))
+        }
+
+        #expect(error?.code == .operationNotSupported)
+        #expect(error?.message.contains(PeekabooBridgeHostCapability.desktopObservationOCR) == true)
+        #expect(error?.message.contains("--no-remote") == true)
+    }
+
+    @Test
+    func `remote preferred OCR rejects a host without capability before transport`() async {
+        let remote = RemoteDesktopObservationService(client: PeekabooBridgeClient(
+            socketPath: "/tmp/nonexistent-preferred-ocr-\(UUID().uuidString).sock",
+            requestTimeoutSec: 1))
+
+        let error = await #expect(throws: PeekabooBridgeErrorEnvelope.self) {
+            _ = try await remote.observe(DesktopObservationRequest(
+                target: .menubarPopover(hints: [], openIfNeeded: nil),
+                detection: DesktopDetectionOptions(mode: .none, preferOCR: true)))
+        }
+
+        #expect(error?.code == .operationNotSupported)
+        #expect(error?.message.contains(PeekabooBridgeHostCapability.desktopObservationOCR) == true)
+    }
+
+    @Test
+    func `legacy remote observation rejects OCR before local fallback capture transport`() async {
+        let remote = RemotePeekabooServices(client: PeekabooBridgeClient(
+            socketPath: "/tmp/nonexistent-legacy-ocr-\(UUID().uuidString).sock",
+            requestTimeoutSec: 1))
+
+        let error = await #expect(throws: PeekabooBridgeErrorEnvelope.self) {
+            _ = try await remote.desktopObservation.observe(DesktopObservationRequest(
+                target: .screen(index: 0),
+                detection: DesktopDetectionOptions(mode: .accessibilityAndOCR)))
+        }
+
+        #expect(error?.code == .operationNotSupported)
+        #expect(error?.message.contains(PeekabooBridgeHostCapability.desktopObservationOCR) == true)
+
+        let preferredError = await #expect(throws: PeekabooBridgeErrorEnvelope.self) {
+            _ = try await remote.desktopObservation.observe(DesktopObservationRequest(
+                target: .menubarPopover(hints: [], openIfNeeded: nil),
+                detection: DesktopDetectionOptions(mode: .none, preferOCR: true)))
+        }
+        #expect(preferredError?.code == .operationNotSupported)
+        #expect(preferredError?.message.contains(PeekabooBridgeHostCapability.desktopObservationOCR) == true)
+    }
+
+    @Test
+    func `remote OCR reaches a capable host`() async throws {
+        let socketPath = "/tmp/peekaboo-remote-capable-ocr-\(UUID().uuidString).sock"
+        let services = StubServices()
+        let server = PeekabooBridgeServer(
+            services: services,
+            allowlistedTeams: [],
+            allowlistedBundles: [],
+            allowedOperations: [.desktopObservation],
+            permissionStatusEvaluator: { _ in
+                PermissionsStatus(
+                    screenRecording: true,
+                    accessibility: true,
+                    appleScript: false,
+                    postEvent: true)
+            })
+        let host = PeekabooBridgeHost(
+            socketPath: socketPath,
+            server: server,
+            allowedTeamIDs: [],
+            requestTimeoutSec: 1)
+        try await host.startChecked()
+        defer { Task { await host.stop() } }
+        let remote = RemoteDesktopObservationService(
+            client: PeekabooBridgeClient(socketPath: socketPath, requestTimeoutSec: 1),
+            supportsDesktopObservationOCR: true)
+        let request = DesktopObservationRequest(
+            target: .screen(index: 0),
+            detection: DesktopDetectionOptions(mode: .accessibilityAndOCR))
+
+        _ = try await remote.observe(request)
+
+        #expect(services.desktopObservationStub.lastRequest == request)
+        await host.stop()
+    }
+
+    @Test
     func `remote ROI rejects an exhausted overall deadline before transport`() async {
         let remote = RemoteDesktopObservationService(
             client: PeekabooBridgeClient(

--- a/Core/PeekabooCore/Tests/PeekabooTests/RemoteCaptureGateOwnershipTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/RemoteCaptureGateOwnershipTests.swift
@@ -73,22 +73,6 @@ struct RemoteCaptureGateOwnershipTests {
     }
 
     @Test
-    func `remote preferred OCR rejects a host without capability before transport`() async {
-        let remote = RemoteDesktopObservationService(client: PeekabooBridgeClient(
-            socketPath: "/tmp/nonexistent-preferred-ocr-\(UUID().uuidString).sock",
-            requestTimeoutSec: 1))
-
-        let error = await #expect(throws: PeekabooBridgeErrorEnvelope.self) {
-            _ = try await remote.observe(DesktopObservationRequest(
-                target: .menubarPopover(hints: [], openIfNeeded: nil),
-                detection: DesktopDetectionOptions(mode: .none, preferOCR: true)))
-        }
-
-        #expect(error?.code == .operationNotSupported)
-        #expect(error?.message.contains(PeekabooBridgeHostCapability.desktopObservationOCR) == true)
-    }
-
-    @Test
     func `legacy remote observation rejects OCR before local fallback capture transport`() async {
         let remote = RemotePeekabooServices(client: PeekabooBridgeClient(
             socketPath: "/tmp/nonexistent-legacy-ocr-\(UUID().uuidString).sock",
@@ -102,18 +86,10 @@ struct RemoteCaptureGateOwnershipTests {
 
         #expect(error?.code == .operationNotSupported)
         #expect(error?.message.contains(PeekabooBridgeHostCapability.desktopObservationOCR) == true)
-
-        let preferredError = await #expect(throws: PeekabooBridgeErrorEnvelope.self) {
-            _ = try await remote.desktopObservation.observe(DesktopObservationRequest(
-                target: .menubarPopover(hints: [], openIfNeeded: nil),
-                detection: DesktopDetectionOptions(mode: .none, preferOCR: true)))
-        }
-        #expect(preferredError?.code == .operationNotSupported)
-        #expect(preferredError?.message.contains(PeekabooBridgeHostCapability.desktopObservationOCR) == true)
     }
 
     @Test
-    func `remote OCR reaches a capable host`() async throws {
+    func `remote OCR gates the new mode but preserves legacy preferred OCR`() async throws {
         let socketPath = "/tmp/peekaboo-remote-capable-ocr-\(UUID().uuidString).sock"
         let services = StubServices()
         let server = PeekabooBridgeServer(
@@ -135,16 +111,28 @@ struct RemoteCaptureGateOwnershipTests {
             requestTimeoutSec: 1)
         try await host.startChecked()
         defer { Task { await host.stop() } }
+        let client = PeekabooBridgeClient(socketPath: socketPath, requestTimeoutSec: 1)
         let remote = RemoteDesktopObservationService(
-            client: PeekabooBridgeClient(socketPath: socketPath, requestTimeoutSec: 1),
+            client: client,
             supportsDesktopObservationOCR: true)
-        let request = DesktopObservationRequest(
+        let explicitOCRRequest = DesktopObservationRequest(
             target: .screen(index: 0),
             detection: DesktopDetectionOptions(mode: .accessibilityAndOCR))
 
-        _ = try await remote.observe(request)
+        _ = try await remote.observe(explicitOCRRequest)
 
-        #expect(services.desktopObservationStub.lastRequest == request)
+        #expect(services.desktopObservationStub.lastRequest == explicitOCRRequest)
+
+        let legacyRemote = RemoteDesktopObservationService(
+            client: client,
+            supportsDesktopObservationOCR: false)
+        let preferredOCRRequest = DesktopObservationRequest(
+            target: .menubarPopover(hints: [], openIfNeeded: nil),
+            detection: DesktopDetectionOptions(mode: .none, preferOCR: true))
+
+        _ = try await legacyRemote.observe(preferredOCRRequest)
+
+        #expect(services.desktopObservationStub.lastRequest == preferredOCRRequest)
         await host.stop()
     }
 

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -151,11 +151,13 @@ multiple calls intentionally share the same `path`, each response still returns 
 path remains the caller-requested publication destination and therefore contains whichever concurrent write finishes
 last.
 
-Set `ocr: true` on `see` to add text recognized locally by Apple Vision to the Accessibility map. OCR is additive,
-never replaces accessible controls, preserves incomplete-AX warnings and exact capture receipts, and does not use a
-provider or network upload. OCR rows include confidence and global logical bounds, are marked non-actionable, and are
-refused by element interaction tools. If a deliberate pixel action is necessary, use explicit coordinates bound to
-the exact `snapshot`/`coordinate_reference` returned by `see`.
+Set `ocr: true` on `see` to add text recognized locally by Apple Vision on the selected runtime host to the
+Accessibility map. OCR is additive, never replaces accessible controls, preserves incomplete-AX warnings and exact
+capture receipts, and does not use a provider or network upload. Remote OCR requires a Bridge host advertising
+`desktopObservationOCR`; MCP refuses an incapable host before sending the dynamic observation request. Update and
+relaunch that host, or use a caller-local MCP runtime when local OCR is intentional. OCR rows include confidence and
+global logical bounds, are marked non-actionable, and are refused by element interaction tools. If a deliberate pixel
+action is necessary, use explicit coordinates bound to the exact `snapshot`/`coordinate_reference` returned by `see`.
 
 Observation and capture do not activate a target by default. `see` and `inspect_ui` only perform the focus-changing `AXWebArea` retry when `web_focus: true` is supplied. `image` and live `capture` use `capture_focus: "background"` by default; pass `capture_focus: "foreground"` when activating the target is intentional. The legacy `auto` value remains accepted for focus-if-needed compatibility.
 

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -28,7 +28,7 @@ Inventory is exposed on the nouns: use `app` with `action: "list"` for running a
 duplicate `server_status` view are not exposed. `menu` supports only application-menu `list` and `click` actions;
 status items use the dedicated menubar surface. MCP retains `sleep` because an MCP client may not have shell access.
 
-Call `see` first and pass element IDs through these tools when possible. Element-targeted calls preserve action-first routing; coordinate calls always use the synthetic path.
+Call `see` first and pass actionable element IDs through these tools when possible. Element-targeted calls preserve action-first routing; coordinate calls always use the synthetic path. OCR-only text is semantic evidence, not an element-action target.
 The same action tools are available to CLI users as `peekaboo set-value` and `peekaboo action`.
 `set_value` and `action` are exposed only when their resolved input strategy enables action invocation
 (`actionFirst` or `actionOnly`). They are hidden under `synthFirst` or `synthOnly`, because these operations do not
@@ -150,6 +150,12 @@ Every successful MCP `see` response includes the selected raw or annotated scree
 multiple calls intentionally share the same `path`, each response still returns pixels owned by its own capture; the
 path remains the caller-requested publication destination and therefore contains whichever concurrent write finishes
 last.
+
+Set `ocr: true` on `see` to add text recognized locally by Apple Vision to the Accessibility map. OCR is additive,
+never replaces accessible controls, preserves incomplete-AX warnings and exact capture receipts, and does not use a
+provider or network upload. OCR rows include confidence and global logical bounds, are marked non-actionable, and are
+refused by element interaction tools. If a deliberate pixel action is necessary, use explicit coordinates bound to
+the exact `snapshot`/`coordinate_reference` returned by `see`.
 
 Observation and capture do not activate a target by default. `see` and `inspect_ui` only perform the focus-changing `AXWebArea` retry when `web_focus: true` is supplied. `image` and live `capture` use `capture_focus: "background"` by default; pass `capture_focus: "foreground"` when activating the target is intentional. The legacy `auto` value remains accepted for focus-if-needed compatibility.
 

--- a/docs/bridge-host.md
+++ b/docs/bridge-host.md
@@ -132,6 +132,14 @@ can require the `backgroundBridgeHost`, `hostGenerationIdentity`, and
 `codeSignatureBuildIdentity` capabilities, then compare the reported PID/process-start identity
 and code-signature hash with the newly installed app generation before committing an update.
 
+Current hosts with enabled desktop observation also advertise the additive
+`desktopObservationOCR` capability without advancing protocol 1.22. Clients require both the
+enabled `desktopObservation` operation and that raw capability before sending OCR-bearing
+observation requests, including dynamic MCP `see` calls. This prevents an older 1.22 host from
+trying to decode the newer `accessibilityAndOCR` mode, and prevents a remote runtime from silently
+moving Vision recognition into the caller process. Relaunch an updated host, or use explicit
+`--no-remote` caller-local CLI execution when that ownership change is intended.
+
 Protocol `1.22` adds process-generation receipts to process-targeted typing and clicks. Current CLI, Agent, and MCP background input retain the application discovery receipt through Bridge admission and native dispatch. Typing revalidates it before every emitted unit; clicks validate before dispatch and report a retry-unsafe indeterminate outcome if the generation changes after dispatch. Process-targeted Cmd+V uses the generation-pinned hotkey contract introduced in 1.19. New clients refuse older hosts before sending these inputs because an older decoder could otherwise ignore the optional receipt and route input using only a reusable PID. Legacy raw-PID payloads remain decodable for old clients, but current user-facing paths never select them.
 
 ## Security

--- a/docs/bridge-host.md
+++ b/docs/bridge-host.md
@@ -134,11 +134,12 @@ and code-signature hash with the newly installed app generation before committin
 
 Current hosts with enabled desktop observation also advertise the additive
 `desktopObservationOCR` capability without advancing protocol 1.22. Clients require both the
-enabled `desktopObservation` operation and that raw capability before sending OCR-bearing
-observation requests, including dynamic MCP `see` calls. This prevents an older 1.22 host from
-trying to decode the newer `accessibilityAndOCR` mode, and prevents a remote runtime from silently
-moving Vision recognition into the caller process. Relaunch an updated host, or use explicit
-`--no-remote` caller-local CLI execution when that ownership change is intended.
+enabled `desktopObservation` operation and that raw capability before sending the new
+`accessibilityAndOCR` mode, including dynamic MCP `see {ocr:true}` calls. This prevents an older
+1.22 host from trying to decode the newer enum case, and prevents a remote runtime from silently
+moving explicit additive OCR into the caller process. The older `preferOCR` request used by
+`see --menubar` remains compatible without this new capability. Relaunch an updated host, or use
+explicit `--no-remote` caller-local CLI execution when that ownership change is intended.
 
 Protocol `1.22` adds process-generation receipts to process-targeted typing and clicks. Current CLI, Agent, and MCP background input retain the application discovery receipt through Bridge admission and native dispatch. Typing revalidates it before every emitted unit; clicks validate before dispatch and report a retry-unsafe indeterminate outcome if the generation changes after dispatch. Process-targeted Cmd+V uses the generation-pinned hotkey contract introduced in 1.19. New clients refuse older hosts before sending these inputs because an older decoder could otherwise ignore the optional receipt and route input using only a reusable PID. Legacy raw-PID payloads remain decodable for old clients, but current user-facing paths never select them.
 

--- a/docs/commands/see.md
+++ b/docs/commands/see.md
@@ -21,7 +21,7 @@ peekaboo see --app "Google Chrome" --window-title "Login" --json --path /tmp/chr
 # Crop one exact window without activating it
 peekaboo see --window-id 12345 --roi 100,80,500,300 --json --path /tmp/window-roi.png
 
-# Add local Vision text when an app exposes a sparse or incomplete AX tree
+# Add host-local Vision text when an app exposes a sparse or incomplete AX tree
 peekaboo see --app Calendar --window-id 12345 --ocr --json --path /tmp/calendar.png
 ```
 
@@ -43,7 +43,7 @@ peekaboo see --app Calendar --window-id 12345 --ocr --json --path /tmp/calendar.
 | `--format png|jpg` / `--retina` | Select the image encoding and native display scale. |
 | `--capture-engine auto|modern|sckit|classic|cg` | Select the engine on the chosen Bridge host without changing runtime ownership. If no compatible host is available, Peekaboo fails instead of capturing locally; add `--no-remote` to explicitly opt into caller-local capture. |
 | `--no-elements` | Skip element detection for the cheapest screenshot-only CLI path. |
-| `--ocr` | Add locally recognized Apple Vision text to the AX element map. Requires screenshot-backed element detection and cannot be combined with `--no-elements`, `--no-screenshot`, `--path -`, `area`, or `multi`. |
+| `--ocr` | Add Apple Vision text recognized on the selected runtime host to the AX element map. Requires screenshot-backed element detection and cannot be combined with `--no-elements`, `--no-screenshot`, `--path -`, `area`, or `multi`. |
 | `--tree` | Print the accessibility text tree. |
 | `--no-screenshot` | Skip pixel capture; requires `--tree` and rejects `--capture-engine` because no backend runs. Ambient engine configuration is ignored so it cannot reroute this AX-only form. Element IDs and a snapshot publish only after pinning the exact process generation, window, and bounds; target drift or a missing receipt fails before publication. |
 | `--annotate` | Overlay element bounds/IDs on the output image. |
@@ -62,9 +62,11 @@ Note: `--app menubar` captures only the menu bar strip; `--menubar` attempts to 
 `--ocr` is additive: Accessibility controls remain the authoritative actionable elements, while Vision text is
 returned as `staticText` with global logical bounds and confidence. OCR rows are marked non-actionable and are
 refused as element targets; use an explicit exact-window coordinate plus the returned snapshot/reference receipt
-when a deliberate pixel click is required. Recognition runs locally on macOS and does not use an AI provider,
-upload pixels, or activate the target app. Incomplete AX warnings remain in the successful result so OCR text never
-turns missing Accessibility evidence into a false completeness claim.
+when a deliberate pixel click is required. Recognition runs locally on the selected macOS runtime host and does not
+use an AI provider, upload pixels, or activate the target app. Remote OCR requires a current Bridge host advertising
+`desktopObservationOCR`; older hosts are refused before the observation request is sent. Update and relaunch that host,
+or pass `--no-remote` to explicitly run Vision OCR in the caller process. Incomplete AX warnings remain in the
+successful result so OCR text never turns missing Accessibility evidence into a false completeness claim.
 
 For agent and automation runs, pass `--path` to a known temporary file when using `see` so capture artifacts land where expected. Use `peekaboo see --tree --no-screenshot --json` when you need AX metadata without a screenshot artifact.
 

--- a/docs/commands/see.md
+++ b/docs/commands/see.md
@@ -20,6 +20,9 @@ peekaboo see --app "Google Chrome" --window-title "Login" --json --path /tmp/chr
 
 # Crop one exact window without activating it
 peekaboo see --window-id 12345 --roi 100,80,500,300 --json --path /tmp/window-roi.png
+
+# Add local Vision text when an app exposes a sparse or incomplete AX tree
+peekaboo see --app Calendar --window-id 12345 --ocr --json --path /tmp/calendar.png
 ```
 
 ## When to use
@@ -40,6 +43,7 @@ peekaboo see --window-id 12345 --roi 100,80,500,300 --json --path /tmp/window-ro
 | `--format png|jpg` / `--retina` | Select the image encoding and native display scale. |
 | `--capture-engine auto|modern|sckit|classic|cg` | Select the engine on the chosen Bridge host without changing runtime ownership. If no compatible host is available, Peekaboo fails instead of capturing locally; add `--no-remote` to explicitly opt into caller-local capture. |
 | `--no-elements` | Skip element detection for the cheapest screenshot-only CLI path. |
+| `--ocr` | Add locally recognized Apple Vision text to the AX element map. Requires screenshot-backed element detection and cannot be combined with `--no-elements`, `--no-screenshot`, `--path -`, `area`, or `multi`. |
 | `--tree` | Print the accessibility text tree. |
 | `--no-screenshot` | Skip pixel capture; requires `--tree` and rejects `--capture-engine` because no backend runs. Ambient engine configuration is ignored so it cannot reroute this AX-only form. Element IDs and a snapshot publish only after pinning the exact process generation, window, and bounds; target drift or a missing receipt fails before publication. |
 | `--annotate` | Overlay element bounds/IDs on the output image. |
@@ -54,6 +58,13 @@ peekaboo see --window-id 12345 --roi 100,80,500,300 --json --path /tmp/window-ro
 | `--max-children <n>` | Override maximum AX children visited per node (`PEEKABOO_AX_MAX_CHILDREN` fallback, default 250). |
 
 Note: `--app menubar` captures only the menu bar strip; `--menubar` attempts to find the active popover and OCR its text.
+
+`--ocr` is additive: Accessibility controls remain the authoritative actionable elements, while Vision text is
+returned as `staticText` with global logical bounds and confidence. OCR rows are marked non-actionable and are
+refused as element targets; use an explicit exact-window coordinate plus the returned snapshot/reference receipt
+when a deliberate pixel click is required. Recognition runs locally on macOS and does not use an AI provider,
+upload pixels, or activate the target app. Incomplete AX warnings remain in the successful result so OCR text never
+turns missing Accessibility evidence into a false completeness claim.
 
 For agent and automation runs, pass `--path` to a known temporary file when using `see` so capture artifacts land where expected. Use `peekaboo see --tree --no-screenshot --json` when you need AX metadata without a screenshot artifact.
 

--- a/docs/commands/see.md
+++ b/docs/commands/see.md
@@ -63,10 +63,11 @@ Note: `--app menubar` captures only the menu bar strip; `--menubar` attempts to 
 returned as `staticText` with global logical bounds and confidence. OCR rows are marked non-actionable and are
 refused as element targets; use an explicit exact-window coordinate plus the returned snapshot/reference receipt
 when a deliberate pixel click is required. Recognition runs locally on the selected macOS runtime host and does not
-use an AI provider, upload pixels, or activate the target app. Remote OCR requires a current Bridge host advertising
-`desktopObservationOCR`; older hosts are refused before the observation request is sent. Update and relaunch that host,
-or pass `--no-remote` to explicitly run Vision OCR in the caller process. Incomplete AX warnings remain in the
-successful result so OCR text never turns missing Accessibility evidence into a false completeness claim.
+use an AI provider, upload pixels, or activate the target app. Explicit remote `--ocr` requires a current Bridge host
+advertising `desktopObservationOCR`; older hosts are refused before the new observation mode is sent. Update and
+relaunch that host, or pass `--no-remote` to explicitly run Vision OCR in the caller process. The existing `--menubar`
+preferred-OCR path retains its legacy Bridge contract. Incomplete AX warnings remain in the successful result so OCR
+text never turns missing Accessibility evidence into a false completeness claim.
 
 For agent and automation runs, pass `--path` to a known temporary file when using `see` so capture artifacts land where expected. Use `peekaboo see --tree --no-screenshot --json` when you need AX metadata without a screenshot artifact.
 


### PR DESCRIPTION
## Summary

- expose additive host-local Apple Vision OCR through CLI `see --ocr` and MCP `see {ocr:true}`
- preserve incomplete Accessibility truth, exact process/window/coordinate receipts, logical Retina geometry, confidence, and snapshot/ROI metadata
- mark OCR text as provenance-bound semantic evidence and refuse it across element-action paths, directing deliberate pixel actions to exact snapshot coordinates
- use one bounded fast recognition attempt for background automation while retaining cancellation-aware accurate-to-fast fallback for explicit general OCR callers
- keep Bridge protocol 1.22 while requiring the additive `desktopObservationOCR` capability only for the new explicit CLI/MCP OCR mode, refusing old/nil hosts and legacy caller-local fallback before dispatch; `--no-remote` remains the explicit caller-local opt-in and the pre-existing `preferOCR` / `--menubar` contract stays old-host compatible

## Testing

- `pnpm run format`
- `pnpm run lint` (21 current-main warnings, 0 serious)
- `pnpm run lint:docs`
- `pnpm run test:safe` on the original exact feature head; post-#395 range-diff preserves the production patch
- post-#395 focused CLI, AutomationKit, serialized MCP, and capture-engine routing suites: 268 tests
- post-#395 P1 Autoreview + TruffleHog: clean at 0.86, no actionable findings
- post-capability repair focused CLI/Core/Bridge/MCP proof: 116 tests
- post-capability repair P1 Autoreview + TruffleHog: clean at 0.94, no actionable findings
- legacy-menubar compatibility correction: 31 focused tests, including positive old-host `preferOCR` transport and explicit OCR zero-dispatch refusal
- final narrowed-delta P1 Autoreview + TruffleHog: clean at 0.98, no actionable findings
- source-blind signed-binary certification: 20 pass, 0 fail, 0 blocked, 3 help-evidenced out of scope

The final Foundation-signed binary was SHA-256 `5c97afa68b2d95fd5f783a342fe79382fae520bd258be1c2c2bed85eeb01dad1`. Across 33 monitored CLI and live MCP invocations, its SHA/inode/size/mtime/signature stayed fixed and a 10 ms monitor recorded zero foreground-window, clipboard, Peekaboo-overlay, or cursor drift. Exact Calendar 1x/Retina/retry, TextEdit, Settings, safe OCR-ID refusals, five invalid shapes, and live MCP `see {ocr:true}` all passed.
