### PR TITLE
fix(bridge): gate capture engine routing

### DIFF
--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Encode annotated observations directly from their rendered bitmap, removing redundant PNG/TIFF round trips while preserving exact pixels, metadata, and output paths.
 
 ### Fixed
+- Require remote hosts to advertise per-request desktop-observation capture-engine support before sending explicit modern/classic selections, and keep those selections out of a reusable daemon's inherited environment so later `auto` requests retain their own backend policy.
 - Pin process-targeted background typing, paste, clicks, and MCP key sequences to one process generation, rejecting Bridge hosts older than protocol 1.22 instead of letting them ignore the receipt or redirect input to a recycled PID.
 - Keep `see --capture-engine` on the selected Bridge host instead of silently moving capture and TCC ownership into the caller; fail before local fallback when no compatible host is available, with `--no-remote` as the explicit caller-local opt-in.
 - Keep OCR bounds correct for Retina captures, retain AX mutation/coordinate receipts through OCR merges and snapshot/ROI round-trips, use one bounded fast local recognition attempt for automation, and refuse only provenance-bound semantic OCR IDs as element action targets.

--- a/Apps/CLI/Sources/PeekabooCLI/CLI/CommanderRuntimeExecutor.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/CLI/CommanderRuntimeExecutor.swift
@@ -52,8 +52,8 @@ enum CommanderRuntimeExecutor {
                 from: resolved.parsedValues,
                 commandType: resolved.type
             )
-            if let capturePreference = runtimeOptions.captureEnginePreference,
-               !capturePreference.isEmpty {
+            if self.shouldExportCaptureEnginePreference(runtimeOptions),
+               let capturePreference = runtimeOptions.captureEnginePreference {
                 // Respect explicit engine choice; also allow disabling CG globally.
                 setenv("PEEKABOO_CAPTURE_ENGINE", capturePreference, 1)
             }
@@ -79,6 +79,10 @@ enum CommanderRuntimeExecutor {
 
         var plainCommand = command
         try await plainCommand.run()
+    }
+
+    static func shouldExportCaptureEnginePreference(_ options: CommandRuntimeOptions) -> Bool {
+        options.captureEnginePreference?.isEmpty == false && !options.transportsCaptureEnginePreference
     }
 
     static func catchUpSelectedHostIfNeeded(

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommandRuntime.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommandRuntime.swift
@@ -27,6 +27,9 @@ struct CommandRuntimeOptions {
     /// An explicit engine must run on a compatible host or fail; local fallback would silently
     /// change capture/TCC ownership. Explicit `--no-remote` remains the local opt-in.
     var requiresCaptureEnginePreferenceHost = false
+    /// Non-auto engine values need an additive host capability so an older host cannot silently
+    /// ignore the transported preference and run its default backend.
+    var requiresCaptureEnginePreferenceCapability = false
     var requiresDesktopObservation = false
     /// `accessibilityAndOCR` is additive inside protocol 1.22. Require a raw host capability so
     /// an older 1.22 host cannot try to decode the enum case before the client can fail safely.
@@ -102,6 +105,10 @@ struct CommandRuntimeOptions {
             options.captureEnginePreference = captureEngine
             if options.transportsCaptureEnginePreference {
                 options.requiresCaptureEnginePreferenceHost = true
+                options.requiresCaptureEnginePreferenceCapability = ObservationCommandSupport.captureEnginePreference(
+                    cliValue: captureEngine,
+                    configuredValue: nil
+                ) != .auto
             } else if !options.requiresApplicationLaunchOptions, !options.requiresHostApplicationInventory {
                 options.preferRemote = false
             }
@@ -357,6 +364,12 @@ extension CommandRuntime {
 
     static func supportsDesktopObservationOCR(for handshake: PeekabooBridgeHandshakeResponse) -> Bool {
         BridgeCapabilityPolicy.supportsDesktopObservationOCR(for: handshake)
+    }
+
+    static func supportsDesktopObservationCaptureEngine(
+        for handshake: PeekabooBridgeHandshakeResponse
+    ) -> Bool {
+        BridgeCapabilityPolicy.supportsDesktopObservationCaptureEngine(for: handshake)
     }
 
     static func supportsExactWindowROIObservation(for handshake: PeekabooBridgeHandshakeResponse) -> Bool {

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommanderBinder.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommanderBinder.swift
@@ -211,6 +211,10 @@ enum CommanderCLIBinder {
         options.captureEnginePreference = captureEngine
         if options.transportsCaptureEnginePreference {
             options.requiresCaptureEnginePreferenceHost = true
+            options.requiresCaptureEnginePreferenceCapability = ObservationCommandSupport.captureEnginePreference(
+                cliValue: captureEngine,
+                configuredValue: nil
+            ) != .auto
         } else if !options.requiresApplicationLaunchOptions, !options.requiresHostApplicationInventory {
             options.preferRemote = false
         }

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/BridgeCapabilityPolicy.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/BridgeCapabilityPolicy.swift
@@ -111,6 +111,10 @@ enum BridgeCapabilityPolicy {
         if options.requiresDesktopObservationOCR, !self.supportsDesktopObservationOCR(for: handshake) {
             return false
         }
+        if options.requiresCaptureEnginePreferenceCapability,
+           !self.supportsDesktopObservationCaptureEngine(for: handshake) {
+            return false
+        }
         if options.requiresExactWindowROIObservation,
            !self.supportsExactWindowROIObservation(for: handshake) {
             return false
@@ -319,6 +323,15 @@ enum BridgeCapabilityPolicy {
     static func supportsDesktopObservationOCR(for handshake: PeekabooBridgeHandshakeResponse) -> Bool {
         self.supportsDesktopObservation(for: handshake) &&
             handshake.hostCapabilities?.contains(PeekabooBridgeHostCapability.desktopObservationOCR) == true
+    }
+
+    static func supportsDesktopObservationCaptureEngine(
+        for handshake: PeekabooBridgeHandshakeResponse
+    ) -> Bool {
+        self.supportsDesktopObservation(for: handshake) &&
+            handshake.hostCapabilities?.contains(
+                PeekabooBridgeHostCapability.desktopObservationCaptureEngine
+            ) == true
     }
 
     static func supportsExactWindowROIObservation(for handshake: PeekabooBridgeHandshakeResponse) -> Bool {

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/DaemonLaunchPolicy.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/DaemonLaunchPolicy.swift
@@ -129,6 +129,12 @@ enum DaemonLaunchPolicy {
         return PeekabooBridgeConstants.daemonSocketPath
     }
 
+    static func onDemandDaemonEnvironment(_ environment: [String: String]) -> [String: String] {
+        var sanitized = environment
+        sanitized.removeValue(forKey: "PEEKABOO_CAPTURE_ENGINE")
+        return sanitized
+    }
+
     static func runtimeBuildIdentity(
         executableURL: URL? = Bundle.main.executableURL,
         executableUUIDProvider: (URL) -> [String] = executableUUIDs
@@ -495,6 +501,7 @@ enum DaemonLaunchPolicy {
         }
 
         let fallbackIdleTimeoutSeconds = self.daemonIdleTimeoutSeconds(environment: environment)
+        let launchEnvironment = self.onDemandDaemonEnvironment(environment)
         var launchArguments = self.daemonArguments(
             socketPath: socketPath,
             mode: .auto,
@@ -514,7 +521,8 @@ enum DaemonLaunchPolicy {
 
                 guard let replacement = try? await launchDaemon(
                     socketPath: socketPath,
-                    arguments: launchArguments
+                    arguments: launchArguments,
+                    environment: launchEnvironment
                 )
                 else {
                     return await self.compatibleLegacyFallbackSocketPath {
@@ -566,7 +574,8 @@ enum DaemonLaunchPolicy {
         do {
             _ = try await self.launchDaemon(
                 socketPath: socketPath,
-                arguments: launchArguments
+                arguments: launchArguments,
+                environment: launchEnvironment
             )
             return socketPath
         } catch {
@@ -677,7 +686,8 @@ enum DaemonLaunchPolicy {
         arguments: [String],
         timeout: TimeInterval = 3,
         executableURL: URL? = nil,
-        logHandle: FileHandle? = nil
+        logHandle: FileHandle? = nil,
+        environment: [String: String]? = nil
     ) async throws -> LaunchResult {
         try Task.checkCancellation()
         guard let executableURL = executableURL ?? self.daemonExecutableURL() else {
@@ -687,6 +697,9 @@ enum DaemonLaunchPolicy {
         let process = Process()
         process.executableURL = executableURL
         process.arguments = arguments
+        if let environment {
+            process.environment = environment
+        }
         let daemonLogURL = DaemonPaths.daemonLogURL()
         let outputHandle = logHandle ?? DaemonPaths.openDaemonLogForAppend() ?? FileHandle.nullDevice
         process.standardOutput = outputHandle

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/RuntimeHostResolver.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/RuntimeHostResolver.swift
@@ -644,6 +644,8 @@ enum RuntimeHostResolver {
             supportsElementActions: BridgeCapabilityPolicy.supportsElementActions(for: handshake),
             supportsDesktopObservation: BridgeCapabilityPolicy.supportsDesktopObservation(for: handshake),
             supportsDesktopObservationOCR: BridgeCapabilityPolicy.supportsDesktopObservationOCR(for: handshake),
+            supportsDesktopObservationCaptureEngine: BridgeCapabilityPolicy
+                .supportsDesktopObservationCaptureEngine(for: handshake),
             supportsExactWindowROIObservation: BridgeCapabilityPolicy.supportsExactWindowROIObservation(for: handshake),
             supportsImplicitLatestSnapshotInvalidation: BridgeCapabilityPolicy.supportsImplicitSnapshotInvalidation(
                 for: handshake

--- a/Apps/CLI/Tests/CLIRuntimeTests/DaemonLaunchPolicyTests.swift
+++ b/Apps/CLI/Tests/CLIRuntimeTests/DaemonLaunchPolicyTests.swift
@@ -133,6 +133,37 @@ struct DaemonLaunchPolicyTests {
         }
     }
 
+    @Test
+    func `on demand daemon launch removes request scoped capture engine environment`() async throws {
+        let outputURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("peekaboo-daemon-engine-env-\(UUID().uuidString).txt")
+        defer { try? FileManager.default.removeItem(at: outputURL) }
+        let command = "printf '%s' \"${PEEKABOO_CAPTURE_ENGINE-unset}\" > \(outputURL.path); exec /bin/sleep 30"
+        let environment = DaemonLaunchPolicy.onDemandDaemonEnvironment([
+            "PATH": "/usr/bin:/bin",
+            "PEEKABOO_CAPTURE_ENGINE": "modern",
+        ])
+
+        do {
+            _ = try await DaemonLaunchPolicy.launchDaemon(
+                socketPath: "/tmp/peekaboo-daemon-engine-env-\(UUID().uuidString).sock",
+                arguments: ["-c", command],
+                timeout: 0.2,
+                executableURL: URL(fileURLWithPath: "/bin/sh"),
+                logHandle: .nullDevice,
+                environment: environment
+            )
+            Issue.record("Expected daemon readiness to time out")
+        } catch let error as DaemonLaunchPolicy.DaemonLaunchError {
+            guard case .timedOut = error else {
+                Issue.record("Expected a readiness timeout, got \(error)")
+                return
+            }
+        }
+
+        #expect(try String(contentsOf: outputURL, encoding: .utf8) == "unset")
+    }
+
     @Test(.timeLimit(.minutes(1)))
     func `daemon timeout bounds termination for a TERM ignoring child`() async throws {
         let pidURL = URL(fileURLWithPath: "/tmp/peekaboo-daemon-term-\(UUID().uuidString).pid")

--- a/Apps/CLI/Tests/CoreCLITests/DesktopObservationCaptureEngineRuntimeCapabilityTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/DesktopObservationCaptureEngineRuntimeCapabilityTests.swift
@@ -1,0 +1,112 @@
+import Commander
+import PeekabooBridge
+import Testing
+@testable import PeekabooCLI
+
+@Suite(.tags(.safe))
+@MainActor
+struct DesktopObservationCaptureEngineRuntimeCapabilityTests {
+    private static let operations: [PeekabooBridgeOperation] = [
+        .captureScreen,
+        .desktopObservation,
+    ]
+
+    @Test
+    func `non auto engine selection requires the additive host capability`() {
+        let capable = Self.handshake(
+            capabilities: [PeekabooBridgeHostCapability.desktopObservationCaptureEngine]
+        )
+        let legacy = Self.handshake(capabilities: nil)
+        let empty = Self.handshake(capabilities: [])
+        let missingOperation = Self.handshake(
+            operations: [.captureScreen],
+            capabilities: [PeekabooBridgeHostCapability.desktopObservationCaptureEngine]
+        )
+        let disabled = Self.handshake(
+            enabledOperations: [.captureScreen],
+            capabilities: [PeekabooBridgeHostCapability.desktopObservationCaptureEngine]
+        )
+
+        #expect(CommandRuntime.supportsDesktopObservationCaptureEngine(for: capable))
+        #expect(!CommandRuntime.supportsDesktopObservationCaptureEngine(for: legacy))
+        #expect(!CommandRuntime.supportsDesktopObservationCaptureEngine(for: empty))
+        #expect(!CommandRuntime.supportsDesktopObservationCaptureEngine(for: missingOperation))
+        #expect(!CommandRuntime.supportsDesktopObservationCaptureEngine(for: disabled))
+    }
+
+    @Test(arguments: ["modern", "sckit", "classic", "cg"])
+    func `explicit non auto engine requires a capable remote host`(engine: String) throws {
+        let options = try Self.options(engine: engine)
+        let capable = Self.handshake(
+            capabilities: [PeekabooBridgeHostCapability.desktopObservationCaptureEngine]
+        )
+        let legacy = Self.handshake(capabilities: nil)
+
+        #expect(options.requiresCaptureEnginePreferenceHost)
+        #expect(options.requiresCaptureEnginePreferenceCapability)
+        #expect(CommandRuntime.supportsRemoteRequirements(for: capable, options: options))
+        #expect(!CommandRuntime.supportsRemoteRequirements(for: legacy, options: options))
+    }
+
+    @Test
+    func `auto remains compatible and no remote remains caller local`() throws {
+        let auto = try Self.options(engine: "auto")
+        let localModern = try CommanderCLIBinder.makeRuntimeOptions(
+            from: ParsedValues(
+                positional: [],
+                options: ["captureEngine": ["modern"]],
+                flags: ["no-remote"]
+            ),
+            commandType: SeeCommand.self
+        )
+        let legacy = Self.handshake(capabilities: nil)
+
+        #expect(auto.requiresCaptureEnginePreferenceHost)
+        #expect(!auto.requiresCaptureEnginePreferenceCapability)
+        #expect(CommandRuntime.supportsRemoteRequirements(for: legacy, options: auto))
+        #expect(localModern.requiresCaptureEnginePreferenceCapability)
+        #expect(localModern.remoteIsolationRequested)
+        #expect(!RuntimeHostResolver.shouldResolveKnownRemoteEndpoints(
+            options: localModern,
+            environment: [:],
+            configurationInput: nil
+        ))
+    }
+
+    @Test
+    func `transported engine preferences never become daemon lifetime environment`() throws {
+        let modern = try Self.options(engine: "modern")
+        var localOnly = CommandRuntimeOptions()
+        localOnly.captureEnginePreference = "modern"
+        localOnly.transportsCaptureEnginePreference = false
+
+        #expect(!CommanderRuntimeExecutor.shouldExportCaptureEnginePreference(modern))
+        #expect(CommanderRuntimeExecutor.shouldExportCaptureEnginePreference(localOnly))
+    }
+
+    private static func options(engine: String) throws -> CommandRuntimeOptions {
+        try CommanderCLIBinder.makeRuntimeOptions(
+            from: ParsedValues(
+                positional: [],
+                options: ["captureEngine": [engine]],
+                flags: []
+            ),
+            commandType: SeeCommand.self
+        )
+    }
+
+    private static func handshake(
+        operations: [PeekabooBridgeOperation] = Self.operations,
+        enabledOperations: [PeekabooBridgeOperation]? = nil,
+        capabilities: [String]?
+    ) -> PeekabooBridgeHandshakeResponse {
+        PeekabooBridgeHandshakeResponse(
+            negotiatedVersion: PeekabooBridgeProtocolVersion(major: 1, minor: 22),
+            hostKind: .onDemand,
+            build: nil,
+            supportedOperations: operations,
+            enabledOperations: enabledOperations,
+            hostCapabilities: capabilities
+        )
+    }
+}

--- a/Apps/CLI/Tests/CoreCLITests/DesktopObservationCaptureEngineRuntimeCapabilityTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/DesktopObservationCaptureEngineRuntimeCapabilityTests.swift
@@ -82,6 +82,15 @@ struct DesktopObservationCaptureEngineRuntimeCapabilityTests {
 
         #expect(!CommanderRuntimeExecutor.shouldExportCaptureEnginePreference(modern))
         #expect(CommanderRuntimeExecutor.shouldExportCaptureEnginePreference(localOnly))
+
+        let launchEnvironment = DaemonLaunchPolicy.onDemandDaemonEnvironment([
+            "PATH": "/usr/bin:/bin",
+            "PEEKABOO_CAPTURE_ENGINE": "modern",
+            "PEEKABOO_LOG_LEVEL": "debug",
+        ])
+        #expect(launchEnvironment["PEEKABOO_CAPTURE_ENGINE"] == nil)
+        #expect(launchEnvironment["PATH"] == "/usr/bin:/bin")
+        #expect(launchEnvironment["PEEKABOO_LOG_LEVEL"] == "debug")
     }
 
     private static func options(engine: String) throws -> CommandRuntimeOptions {

--- a/Apps/CLI/Tests/CoreCLITests/RuntimeHostApplicationSelectionTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/RuntimeHostApplicationSelectionTests.swift
@@ -17,7 +17,8 @@ struct RuntimeHostApplicationSelectionTests {
             hostKind: .onDemand,
             build: nil,
             supportedOperations: supportedOperations,
-            enabledOperations: supportedOperations
+            enabledOperations: supportedOperations,
+            hostCapabilities: [PeekabooBridgeHostCapability.desktopObservationCaptureEngine]
         )
         let captureOnly = PeekabooBridgeHandshakeResponse(
             negotiatedVersion: PeekabooBridgeConstants.protocolVersion,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Encode annotated observations directly from their rendered bitmap, removing redundant PNG/TIFF round trips while preserving exact pixels, metadata, and output paths.
 
 ### Fixed
+- Require remote hosts to advertise per-request desktop-observation capture-engine support before sending explicit modern/classic selections, and keep those selections out of a reusable daemon's inherited environment so later `auto` requests retain their own backend policy.
 - Keep `see --capture-engine` on the selected Bridge host instead of silently moving capture and TCC ownership into the caller; fail before local fallback when no compatible host is available, with `--no-remote` as the explicit caller-local opt-in.
 - Keep OCR bounds correct for Retina captures, retain AX mutation/coordinate receipts through OCR merges and snapshot/ROI round-trips, use one bounded fast local recognition attempt for automation, and refuse only provenance-bound semantic OCR IDs as element action targets.
 - Resolve standalone exact-window AX-only `see` targets from their live owner and bind results to a process-generation/window receipt before publishing actionable element IDs or a snapshot.

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeModels.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeModels.swift
@@ -294,6 +294,7 @@ public enum PeekabooBridgeHostCapability {
     public static let codeSignatureBuildIdentity = "codeSignatureBuildIdentity"
     public static let backgroundBridgeHost = "backgroundBridgeHost"
     public static let desktopObservationOCR = "desktopObservationOCR"
+    public static let desktopObservationCaptureEngine = "desktopObservationCaptureEngine"
 }
 
 public struct PeekabooBridgeHandshakeResponse: Codable, Sendable {

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer.swift
@@ -90,7 +90,9 @@ public final class PeekabooBridgeServer {
         }
         if self.allowedOperations.contains(.desktopObservation) {
             resolvedHostCapabilities.insert(PeekabooBridgeHostCapability.desktopObservationOCR)
-            resolvedHostCapabilities.insert(PeekabooBridgeHostCapability.desktopObservationCaptureEngine)
+            if services.supportsDesktopObservationCaptureEngine {
+                resolvedHostCapabilities.insert(PeekabooBridgeHostCapability.desktopObservationCaptureEngine)
+            }
         }
         self.hostCapabilities = resolvedHostCapabilities
         self.daemonControl = daemonControl

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer.swift
@@ -90,6 +90,7 @@ public final class PeekabooBridgeServer {
         }
         if self.allowedOperations.contains(.desktopObservation) {
             resolvedHostCapabilities.insert(PeekabooBridgeHostCapability.desktopObservationOCR)
+            resolvedHostCapabilities.insert(PeekabooBridgeHostCapability.desktopObservationCaptureEngine)
         }
         self.hostCapabilities = resolvedHostCapabilities
         self.daemonControl = daemonControl

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServiceProviding.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServiceProviding.swift
@@ -16,6 +16,7 @@ public protocol PeekabooBridgeServiceProviding: AnyObject, Sendable {
     var dialogs: any DialogServiceProtocol { get }
     var snapshots: any SnapshotManagerProtocol { get }
     var desktopObservation: any DesktopObservationServiceProtocol { get }
+    var supportsDesktopObservationCaptureEngine: Bool { get }
 
     /// Whether the concrete native service owns the lane for this exact operation.
     /// Test doubles and older hosts default to Bridge-owned conservative coordination.
@@ -30,6 +31,10 @@ public protocol PeekabooBridgeServiceProviding: AnyObject, Sendable {
 
 @MainActor
 extension PeekabooBridgeServiceProviding {
+    public var supportsDesktopObservationCaptureEngine: Bool {
+        self.screenCapture is any EngineAwareScreenCaptureServiceProtocol
+    }
+
     public func ownsDesktopOperationLane(for _: PeekabooBridgeOperation) -> Bool {
         false
     }

--- a/Core/PeekabooCore/Sources/PeekabooCore/Support/RemoteDesktopObservationService.swift
+++ b/Core/PeekabooCore/Sources/PeekabooCore/Support/RemoteDesktopObservationService.swift
@@ -18,23 +18,39 @@ enum RemoteDesktopObservationCapabilityPolicy {
             or use --no-remote to explicitly run Vision OCR in the caller process.
             """)
     }
+
+    static func requiresCaptureEnginePreferenceCapability(_ request: DesktopObservationRequest) -> Bool {
+        request.capture.engine != .auto
+    }
+
+    static func captureEnginePreferenceUnavailableError() -> PeekabooBridgeErrorEnvelope {
+        PeekabooBridgeErrorEnvelope(
+            code: .operationNotSupported,
+            message: """
+            Remote Bridge host does not advertise desktopObservationCaptureEngine. Update and relaunch Peekaboo on \
+            that host, or use --no-remote to explicitly run the selected capture engine in the caller process.
+            """)
+    }
 }
 
 @MainActor
 public final class RemoteDesktopObservationService: DesktopObservationServiceProtocol {
     private let client: PeekabooBridgeClient
     private let supportsDesktopObservationOCR: Bool
+    private let supportsDesktopObservationCaptureEngine: Bool
     private let supportsExactWindowROIObservation: Bool
     private let artifactInstallationPreflight: @MainActor @Sendable () throws -> Void
 
     public convenience init(
         client: PeekabooBridgeClient,
         supportsDesktopObservationOCR: Bool = false,
+        supportsDesktopObservationCaptureEngine: Bool = false,
         supportsExactWindowROIObservation: Bool = false)
     {
         self.init(
             client: client,
             supportsDesktopObservationOCR: supportsDesktopObservationOCR,
+            supportsDesktopObservationCaptureEngine: supportsDesktopObservationCaptureEngine,
             supportsExactWindowROIObservation: supportsExactWindowROIObservation,
             artifactInstallationPreflight: {})
     }
@@ -42,11 +58,13 @@ public final class RemoteDesktopObservationService: DesktopObservationServicePro
     package init(
         client: PeekabooBridgeClient,
         supportsDesktopObservationOCR: Bool = false,
+        supportsDesktopObservationCaptureEngine: Bool = false,
         supportsExactWindowROIObservation: Bool,
         artifactInstallationPreflight: @escaping @MainActor @Sendable () throws -> Void)
     {
         self.client = client
         self.supportsDesktopObservationOCR = supportsDesktopObservationOCR
+        self.supportsDesktopObservationCaptureEngine = supportsDesktopObservationCaptureEngine
         self.supportsExactWindowROIObservation = supportsExactWindowROIObservation
         self.artifactInstallationPreflight = artifactInstallationPreflight
     }
@@ -56,6 +74,11 @@ public final class RemoteDesktopObservationService: DesktopObservationServicePro
             self.supportsDesktopObservationOCR
         else {
             throw RemoteDesktopObservationCapabilityPolicy.ocrUnavailableError()
+        }
+        guard !RemoteDesktopObservationCapabilityPolicy.requiresCaptureEnginePreferenceCapability(request) ||
+            self.supportsDesktopObservationCaptureEngine
+        else {
+            throw RemoteDesktopObservationCapabilityPolicy.captureEnginePreferenceUnavailableError()
         }
         guard request.capture.roi != nil else {
             return try await self.client.desktopObservation(request)

--- a/Core/PeekabooCore/Sources/PeekabooCore/Support/RemotePeekabooServices.swift
+++ b/Core/PeekabooCore/Sources/PeekabooCore/Support/RemotePeekabooServices.swift
@@ -57,6 +57,7 @@ public final class RemotePeekabooServices: PeekabooServiceProviding {
         supportsElementActions: Bool = false,
         supportsDesktopObservation: Bool = false,
         supportsDesktopObservationOCR: Bool = false,
+        supportsDesktopObservationCaptureEngine: Bool = false,
         supportsExactWindowROIObservation: Bool = false,
         supportsImplicitLatestSnapshotInvalidation: Bool = false,
         supportsApplicationLaunchOptions: Bool = false,
@@ -70,6 +71,8 @@ public final class RemotePeekabooServices: PeekabooServiceProviding {
         self.client = client
         self.supportsPostEventPermissionRequest = supportsPostEventPermissionRequest
         let supportsRemoteDesktopObservationOCR = supportsDesktopObservation && supportsDesktopObservationOCR
+        let supportsRemoteCaptureEnginePreference = supportsDesktopObservation &&
+            supportsDesktopObservationCaptureEngine
 
         self.logging = LoggingService()
         self.screenCapture = RemoteScreenCaptureService(client: client)
@@ -144,6 +147,7 @@ public final class RemotePeekabooServices: PeekabooServiceProviding {
             RemoteDesktopObservationService(
                 client: client,
                 supportsDesktopObservationOCR: supportsRemoteDesktopObservationOCR,
+                supportsDesktopObservationCaptureEngine: supportsRemoteCaptureEnginePreference,
                 supportsExactWindowROIObservation: supportsExactWindowROIObservation)
         } else {
             LegacyRemoteDesktopObservationService(delegate: DesktopObservationService(
@@ -201,6 +205,9 @@ private final class LegacyRemoteDesktopObservationService: DesktopObservationSer
     }
 
     func observe(_ request: DesktopObservationRequest) async throws -> DesktopObservationResult {
+        guard !RemoteDesktopObservationCapabilityPolicy.requiresCaptureEnginePreferenceCapability(request) else {
+            throw RemoteDesktopObservationCapabilityPolicy.captureEnginePreferenceUnavailableError()
+        }
         guard !RemoteDesktopObservationCapabilityPolicy.requiresOCRCapability(request) else {
             throw RemoteDesktopObservationCapabilityPolicy.ocrUnavailableError()
         }

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeHostIdentityTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeHostIdentityTests.swift
@@ -122,6 +122,7 @@ struct PeekabooBridgeHostIdentityTests {
         #expect(handshake.hostCapabilities == [
             PeekabooBridgeHostCapability.backgroundBridgeHost,
             PeekabooBridgeHostCapability.codeSignatureBuildIdentity,
+            PeekabooBridgeHostCapability.desktopObservationCaptureEngine,
             PeekabooBridgeHostCapability.desktopObservationOCR,
             PeekabooBridgeHostCapability.hostGenerationIdentity,
         ])
@@ -129,7 +130,7 @@ struct PeekabooBridgeHostIdentityTests {
 
     @Test
     @MainActor
-    func `host advertises desktop observation OCR only when desktop observation is allowed`() {
+    func `host advertises desktop observation extensions only when desktop observation is allowed`() {
         let observationServer = PeekabooBridgeServer(
             services: PeekabooServices(),
             allowlistedTeams: [],
@@ -144,7 +145,11 @@ struct PeekabooBridgeHostIdentityTests {
             hostIdentity: nil)
 
         #expect(observationServer.hostCapabilities.contains(PeekabooBridgeHostCapability.desktopObservationOCR))
+        #expect(observationServer.hostCapabilities.contains(
+            PeekabooBridgeHostCapability.desktopObservationCaptureEngine))
         #expect(!captureOnlyServer.hostCapabilities.contains(PeekabooBridgeHostCapability.desktopObservationOCR))
+        #expect(!captureOnlyServer.hostCapabilities.contains(
+            PeekabooBridgeHostCapability.desktopObservationCaptureEngine))
     }
 
     @Test

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeHostIdentityTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeHostIdentityTests.swift
@@ -143,12 +143,20 @@ struct PeekabooBridgeHostIdentityTests {
             allowlistedBundles: [],
             allowedOperations: [.captureScreen],
             hostIdentity: nil)
+        let unverifiedObservationServer = PeekabooBridgeServer(
+            services: StubServices(),
+            allowlistedTeams: [],
+            allowlistedBundles: [],
+            allowedOperations: [.desktopObservation],
+            hostIdentity: nil)
 
         #expect(observationServer.hostCapabilities.contains(PeekabooBridgeHostCapability.desktopObservationOCR))
         #expect(observationServer.hostCapabilities.contains(
             PeekabooBridgeHostCapability.desktopObservationCaptureEngine))
         #expect(!captureOnlyServer.hostCapabilities.contains(PeekabooBridgeHostCapability.desktopObservationOCR))
         #expect(!captureOnlyServer.hostCapabilities.contains(
+            PeekabooBridgeHostCapability.desktopObservationCaptureEngine))
+        #expect(!unverifiedObservationServer.hostCapabilities.contains(
             PeekabooBridgeHostCapability.desktopObservationCaptureEngine))
     }
 

--- a/Core/PeekabooCore/Tests/PeekabooTests/RemoteCaptureGateOwnershipTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/RemoteCaptureGateOwnershipTests.swift
@@ -72,6 +72,43 @@ struct RemoteCaptureGateOwnershipTests {
         #expect(error?.message.contains("--no-remote") == true)
     }
 
+    @Test(arguments: [CaptureEnginePreference.modern, .legacy])
+    func `remote capture engine rejects a host without capability before transport`(
+        engine: CaptureEnginePreference) async
+    {
+        let remote = RemoteDesktopObservationService(client: PeekabooBridgeClient(
+            socketPath: "/tmp/nonexistent-capture-engine-\(UUID().uuidString).sock",
+            requestTimeoutSec: 1))
+
+        let error = await #expect(throws: PeekabooBridgeErrorEnvelope.self) {
+            _ = try await remote.observe(DesktopObservationRequest(
+                target: .screen(index: 0),
+                capture: DesktopCaptureOptions(engine: engine),
+                detection: DesktopDetectionOptions(mode: .none)))
+        }
+
+        #expect(error?.code == .operationNotSupported)
+        #expect(error?.message.contains(PeekabooBridgeHostCapability.desktopObservationCaptureEngine) == true)
+        #expect(error?.message.contains("--no-remote") == true)
+    }
+
+    @Test
+    func `legacy remote observation rejects capture engine before local fallback transport`() async {
+        let remote = RemotePeekabooServices(client: PeekabooBridgeClient(
+            socketPath: "/tmp/nonexistent-legacy-capture-engine-\(UUID().uuidString).sock",
+            requestTimeoutSec: 1))
+
+        let error = await #expect(throws: PeekabooBridgeErrorEnvelope.self) {
+            _ = try await remote.desktopObservation.observe(DesktopObservationRequest(
+                target: .screen(index: 0),
+                capture: DesktopCaptureOptions(engine: .modern),
+                detection: DesktopDetectionOptions(mode: .none)))
+        }
+
+        #expect(error?.code == .operationNotSupported)
+        #expect(error?.message.contains(PeekabooBridgeHostCapability.desktopObservationCaptureEngine) == true)
+    }
+
     @Test
     func `legacy remote observation rejects OCR before local fallback capture transport`() async {
         let remote = RemotePeekabooServices(client: PeekabooBridgeClient(
@@ -133,6 +170,18 @@ struct RemoteCaptureGateOwnershipTests {
         _ = try await legacyRemote.observe(preferredOCRRequest)
 
         #expect(services.desktopObservationStub.lastRequest == preferredOCRRequest)
+
+        let engineRemote = RemoteDesktopObservationService(
+            client: client,
+            supportsDesktopObservationCaptureEngine: true)
+        let engineRequest = DesktopObservationRequest(
+            target: .screen(index: 0),
+            capture: DesktopCaptureOptions(engine: .modern),
+            detection: DesktopDetectionOptions(mode: .none))
+
+        _ = try await engineRemote.observe(engineRequest)
+
+        #expect(services.desktopObservationStub.lastRequest == engineRequest)
         await host.stop()
     }
 

--- a/docs/bridge-host.md
+++ b/docs/bridge-host.md
@@ -141,6 +141,13 @@ moving explicit additive OCR into the caller process. The older `preferOCR` requ
 `see --menubar` remains compatible without this new capability. Relaunch an updated host, or use
 explicit `--no-remote` caller-local CLI execution when that ownership change is intended.
 
+The additive `desktopObservationCaptureEngine` capability likewise identifies hosts that apply a
+non-`auto` capture-engine preference inside each desktop-observation request. Clients refuse
+explicit remote `modern` or `classic` selection before transport when this capability or the
+enabled `desktopObservation` operation is absent; an older host cannot silently ignore the field
+and run its default backend. `auto` remains compatible, and request-scoped selection does not alter
+the long-lived daemon's fallback policy.
+
 Protocol `1.22` adds process-generation receipts to process-targeted typing and clicks. Current CLI, Agent, and MCP background input retain the application discovery receipt through Bridge admission and native dispatch. Typing revalidates it before every emitted unit; clicks validate before dispatch and report a retry-unsafe indeterminate outcome if the generation changes after dispatch. Process-targeted Cmd+V uses the generation-pinned hotkey contract introduced in 1.19. New clients refuse older hosts before sending these inputs because an older decoder could otherwise ignore the optional receipt and route input using only a reusable PID. Legacy raw-PID payloads remain decodable for old clients, but current user-facing paths never select them.
 
 ## Security

--- a/docs/commands/see.md
+++ b/docs/commands/see.md
@@ -41,7 +41,7 @@ peekaboo see --app Calendar --window-id 12345 --ocr --json --path /tmp/calendar.
 | `--mode screen|window|frontmost|multi|area` | Override the target picker. `multi` captures every screen; `area` uses `--region`. |
 | `--region x,y,width,height` | Capture a rectangular region (`area` mode is inferred). |
 | `--format png|jpg` / `--retina` | Select the image encoding and native display scale. |
-| `--capture-engine auto|modern|sckit|classic|cg` | Select the engine on the chosen Bridge host without changing runtime ownership. If no compatible host is available, Peekaboo fails instead of capturing locally; add `--no-remote` to explicitly opt into caller-local capture. |
+| `--capture-engine auto|modern|sckit|classic|cg` | Select the engine for this request on the chosen Bridge host without changing runtime ownership. Explicit remote modern/classic selection requires the host's `desktopObservationCaptureEngine` capability. If no compatible host is available, Peekaboo fails instead of capturing locally; add `--no-remote` to explicitly opt into caller-local capture. |
 | `--no-elements` | Skip element detection for the cheapest screenshot-only CLI path. |
 | `--ocr` | Add Apple Vision text recognized on the selected runtime host to the AX element map. Requires screenshot-backed element detection and cannot be combined with `--no-elements`, `--no-screenshot`, `--path -`, `area`, or `multi`. |
 | `--tree` | Print the accessibility text tree. |

--- a/docs/engine.md
+++ b/docs/engine.md
@@ -16,7 +16,7 @@ Peekaboo supports two capture backends:
 - Environment:
   - `PEEKABOO_CAPTURE_ENGINE=auto|modern|sckit|classic|cg` (preferred)
   - Back-compat: `PEEKABOO_USE_MODERN_CAPTURE=true|false|modern-only|legacy`
-- CLI flags (set the env for this invocation):
+- CLI flags (select the backend for this invocation):
   - `peekaboo capture live --capture-engine auto|modern|sckit|classic|cg`
   - `peekaboo see --no-elements --capture-engine ...`
   - `peekaboo see --capture-engine ...`
@@ -26,6 +26,12 @@ silently move capture or TCC ownership into the CLI process. If no compatible Br
 fails before caller-local capture. Add `--no-remote` only when caller-local execution is intentional and that process
 is known to own Screen Recording in the active Aqua session. Other capture commands remain caller-local until their
 remote protocols explicitly carry the engine preference.
+
+Remote `modern` and `classic` selections require a host that advertises
+`desktopObservationCaptureEngine`; older hosts are refused before the observation request is sent rather than silently
+running `auto`. The `auto` value retains backward-compatible observation semantics. Transported `see` preferences stay
+inside the individual request and never become a reusable daemon's inherited process environment, so one explicit
+`modern` request cannot make later `auto` requests modern-only.
 
 Aliases:
 - modern: `modern`, `sckit`, `sc`, `sck`


### PR DESCRIPTION
## Summary

- add the raw `desktopObservationCaptureEngine` Bridge host capability for request-scoped non-`auto` capture engines
- refuse older or non-engine-aware hosts before observation transport instead of letting them silently run their default backend
- keep transported CLI and ambient engine preferences out of reusable auto-daemon environments while preserving manual-daemon inheritance and explicit `--no-remote` caller-local behavior

## Why

Bridge protocol 1.22 already carries the capture-engine field, but an older 1.22 host can decode the request while ignoring the preference. That makes `--capture-engine modern|cg` look successful even though the selected host may run `auto`. The additive raw capability lets current clients prove that the selected desktop-observation host applies the field before dispatch.

Request-scoped engine selection also must not become process-global daemon policy. Auto-started daemons now receive a sanitized environment, so an explicit or ambient request cannot make later `auto` observations modern-only. Manually started daemons retain their existing environment contract.

## Tests

- focused CLI routing/capability/host-selection suites: 79 passed
- process-level routing plus real daemon-launch environment suites: 11 passed
- Core remote dispatch and host-identity suites: 30 passed; the two fresh-build one-second socket timeouts were rerun serially as 22 + 8 clean passes
- `pnpm run test:safe`: 818 safe tests and 77 runtime tests, plus all release/native-only policy subgates
- SwiftFormat on all 16 touched Swift files; strict touched SwiftLint 0 violations
- full SwiftLint: 21 established warnings, 0 serious; docs lint and `git diff --check` clean
- source-blind old-host/capable-host/`--no-remote`/auto-taint contract: 4/4 clauses passed on candidate SHA-256 `3b86cc868542a4a011208baca816f82dee73568a4b8c757b56a95ab5f4f7ae5b`
- final P1 Autoreview and TruffleHog clean on exact head `1643ab81` (confidence 0.89)

## Safety

- no Bridge protocol bump; older clients ignore the additive raw capability
- `auto` remains compatible with older desktop-observation hosts
- capability advertisement requires both the desktop-observation operation and an actually engine-aware capture service
- no capture pixels, receipts, target selection, UI behavior, AppleScript/JXA/System Events path, or installed artifact changes
