### PR TITLE
fix(bridge): keep remote window close background-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Encode annotated observations directly from their rendered bitmap, removing redundant PNG/TIFF round trips while preserving exact pixels, metadata, and output paths.
 
 ### Fixed
+- Keep remote `window close` background-only by default, matching local execution, and require explicit foreground consent before routing a close through focus or global-input fallbacks.
 - Require remote hosts to advertise per-request desktop-observation capture-engine support before sending explicit modern/classic selections, and keep those selections out of a reusable daemon's inherited environment so later `auto` requests retain their own backend policy.
 - Keep `see --capture-engine` on the selected Bridge host instead of silently moving capture and TCC ownership into the caller; fail before local fallback when no compatible host is available, with `--no-remote` as the explicit caller-local opt-in.
 - Keep OCR bounds correct for Retina captures, retain AX mutation/coordinate receipts through OCR merges and snapshot/ROI round-trips, use one bounded fast local recognition attempt for automation, and refuse only provenance-bound semantic OCR IDs as element action targets.

--- a/Core/PeekabooCore/Sources/PeekabooCore/Support/RemoteWindowManagementService.swift
+++ b/Core/PeekabooCore/Sources/PeekabooCore/Support/RemoteWindowManagementService.swift
@@ -25,7 +25,7 @@ public final class RemoteWindowManagementService: WindowManagementServiceProtoco
     }
 
     public func closeWindow(target: WindowTarget) async throws {
-        try await self.closeWindow(target: target, allowForegroundFallback: true)
+        try await self.closeWindow(target: target, allowForegroundFallback: false)
     }
 
     public func closeWindow(target: WindowTarget, allowForegroundFallback: Bool) async throws {

--- a/Core/PeekabooCore/Tests/PeekabooTests/RemoteWindowManagementServiceTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/RemoteWindowManagementServiceTests.swift
@@ -54,7 +54,7 @@ struct RemoteWindowManagementServiceTests {
         let pinnedMutations = await windows.pinnedMutations
         #expect(legacyMutations.isEmpty)
         #expect(pinnedMutations.map(\.operation) == [
-            "close",
+            "background-close",
             "close",
             "minimize",
             "restore",
@@ -69,7 +69,7 @@ struct RemoteWindowManagementServiceTests {
     }
 
     @Test
-    func `default close forwards foreground compatibility while strict close requires capability`() async throws {
+    func `default close remains background-only while explicit foreground fallback propagates`() async throws {
         let socketPath = "/tmp/peekaboo-remote-window-close-compat-\(UUID().uuidString).sock"
         let windows = RemoteWindowMutationFixture(identity: self.identity)
         let server = PeekabooBridgeServer(
@@ -92,14 +92,13 @@ struct RemoteWindowManagementServiceTests {
             client: PeekabooBridgeClient(socketPath: socketPath, requestTimeoutSec: 2),
             supportsBackgroundClose: false,
             supportsPinnedWindowMutations: true)
-        try await remote.closeWindow(target: .title("Fixture"))
-
         do {
-            try await remote.closeWindow(target: .title("Fixture"), allowForegroundFallback: false)
-            Issue.record("Expected strict background close to require the advertised capability")
+            try await remote.closeWindow(target: .title("Fixture"))
+            Issue.record("Expected default background close to require the advertised capability")
         } catch let error as PeekabooBridgeErrorEnvelope {
             #expect(error.code == .operationNotSupported)
         }
+        try await remote.closeWindow(target: .title("Fixture"), allowForegroundFallback: true)
         #expect(await windows.pinnedMutations.map(\.operation) == ["close"])
         await host.stop()
     }


### PR DESCRIPTION
## What Problem This Solves

Remote `window close` silently defaulted to allowing foreground fallback even though the local service and raw Bridge client default to background-only. Merely routing the same operation through a remote host could therefore change the user's foreground-consent policy.

## What Changed

- Keep the remote service's default close path background-only.
- Preserve explicit foreground fallback when the caller deliberately requests it.
- Update Bridge-level regression coverage for capable and compatibility hosts.
- Document the user-visible safety correction in the changelog.

## Evidence

- `swift test --package-path Core/PeekabooCore --filter RemoteWindowManagementServiceTests --no-parallel` — 4/4 passed on the exact PR head.
- `BridgeStrictBackgroundOperationTests` plus `RemoteApplicationServiceTests` — 22/22 passed.
- Source-blind isolated compiled-test validation — 4/4 passed twice.
- SwiftFormat, SwiftLint, docs lint, and diff checks passed.
- Structured pre-commit review reported no accepted/actionable findings.

No AppleScript, JXA, System Events, UI interaction, installation, or runtime state mutation was used for this change.
