### PR TITLE
perf(capture): cache owner-affine exact-window plans

### DIFF
--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Default new agent configurations to GPT-5.6 and Claude Opus 5 while keeping credential-only Anthropic discovery on Opus 4.8 for zero-retention compatibility and preserving explicit model selections.
 - Encode annotated observations directly from their rendered bitmap, removing redundant PNG/TIFF round trips while preserving exact pixels, metadata, and output paths.
+- Reuse two-second, owner-host-local ScreenCaptureKit exact-window screenshot plans without caching pixels, revalidating process generation, window receipt, display topology, and scale around every capture while exposing miss/hit generation diagnostics.
 
 ### Fixed
 - Serialize ScreenCaptureKit ownership across Peekaboo processes for the lifetime of the first explicit local-modern claimant or real SCK caller, with build-bound process-awareness receipts, owner-affine auto/modern routing, current-policy capability checks for every transported engine, and fail-closed rolling-upgrade detection for old Bridge and long-running local processes; explicit classic remains a process-isolated, in-process-SCK-free escape hatch and refuses false-preflight captures unless protected WindowServer metadata independently proves access.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Changed
 - Default new agent configurations to GPT-5.6 and Claude Opus 5 while keeping credential-only Anthropic discovery on Opus 4.8 for zero-retention compatibility and preserving explicit model selections.
 - Encode annotated observations directly from their rendered bitmap, removing redundant PNG/TIFF round trips while preserving exact pixels, metadata, and output paths.
+- Reuse two-second, owner-host-local ScreenCaptureKit exact-window screenshot plans without caching pixels, revalidating process generation, window receipt, display topology, and scale around every capture while exposing miss/hit generation diagnostics.
 
 ### Fixed
 - Preserve negative numeric option values through Commander parsing so command-owned range validation reports them accurately instead of misclassifying them as short flags.

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/ScreenCaptureKitOperator+Support.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/ScreenCaptureKitOperator+Support.swift
@@ -41,8 +41,19 @@ extension ScreenCaptureKitOperator {
         ScreenCaptureScaleResolver.plan(
             preference: preference,
             displayID: display.displayID,
-            fallbackPixelWidth: display.width,
+            fallbackPixelWidth: CGDisplayPixelsWide(display.displayID),
             frameWidth: display.frame.width)
+    }
+
+    func scalePlan(
+        for display: ScreenCaptureDisplayTopology.Display,
+        preference: CaptureScalePreference) -> ScreenCaptureScaleResolver.Plan
+    {
+        ScreenCaptureScaleResolver.plan(
+            preference: preference,
+            displayID: display.displayID,
+            fallbackPixelWidth: display.pixelWidth,
+            frameWidth: display.bounds.width)
     }
 
     func display(for window: SCWindow, displays: [SCDisplay]) -> SCDisplay? {

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/ScreenCaptureKitOperator+Window.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/ScreenCaptureKitOperator+Window.swift
@@ -325,11 +325,9 @@ extension ScreenCaptureKitOperator {
         let key = ScreenCaptureKitWindowPlanCache<ExactWindowCapturePlan>.Key(
             windowID: windowID,
             usesNativeScale: scale == .native)
-        var reusedPlan: ExactWindowCapturePlan?
         let result = try await ScreenCaptureWindowPlanExecutor.execute(
             cachedPlan: {
                 let cached = self.exactWindowPlanCache.value(for: key)
-                reusedPlan = cached
                 if cached != nil {
                     self.logger.debug(
                         "Reusing warm ScreenCaptureKit exact-window plan",
@@ -344,17 +342,16 @@ extension ScreenCaptureKitOperator {
                     scale: scale,
                     correlationId: correlationId)
             },
-            capture: { plan in
+            capture: { plan, cacheStatus in
                 let image = try await self.captureImage(
                     filter: plan.filter,
                     configuration: plan.configuration,
                     expectedPixelSize: plan.expectedPixelSize,
                     retrySafeStalePlanOnPixelMismatch: true)
-                let status: CaptureWindowPlanCacheStatus = reusedPlan === plan ? .hit : .miss
                 return try self.exactWindowCaptureOutput(
                     image: image,
                     plan: plan,
-                    cacheStatus: status)
+                    cacheStatus: cacheStatus)
             },
             validation: { self.validation(of: $0) },
             evict: { self.exactWindowPlanCache.removeValue(for: $0.key, ifSameAs: $0) })

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/ScreenCaptureKitOperator+Window.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/ScreenCaptureKitOperator+Window.swift
@@ -7,15 +7,131 @@ import PeekabooFoundation
 
 @MainActor
 extension ScreenCaptureKitOperator {
-    struct WindowMetadataContext {
+    final class ExactWindowCapturePlan {
+        let key: ScreenCaptureKitWindowPlanCache<ExactWindowCapturePlan>.Key
+        let filter: SCContentFilter
+        let configuration: SCStreamConfiguration
+        let expectedPixelSize: (width: Int, height: Int)
+        let displayID: CGDirectDisplayID
+        let scalePlan: ScreenCaptureScaleResolver.Plan
+        let receipt: ScreenCaptureWindowPlanReceipt
+        let topology: ScreenCaptureDisplayTopology
+        let generation: UInt64
+
+        init(
+            key: ScreenCaptureKitWindowPlanCache<ExactWindowCapturePlan>.Key,
+            filter: SCContentFilter,
+            configuration: SCStreamConfiguration,
+            expectedPixelSize: (width: Int, height: Int),
+            displayID: CGDirectDisplayID,
+            scalePlan: ScreenCaptureScaleResolver.Plan,
+            receipt: ScreenCaptureWindowPlanReceipt,
+            topology: ScreenCaptureDisplayTopology,
+            generation: UInt64)
+        {
+            self.key = key
+            self.filter = filter
+            self.configuration = configuration
+            self.expectedPixelSize = expectedPixelSize
+            self.displayID = displayID
+            self.scalePlan = scalePlan
+            self.receipt = receipt
+            self.topology = topology
+            self.generation = generation
+        }
+    }
+
+    private struct ExactWindowCaptureOutput {
+        let image: CGImage
+        let metadataContext: WindowMetadataContext
+    }
+
+    private struct WindowMetadataIdentity {
+        let windowID: CGWindowID
+        let title: String
+        let bounds: CGRect
+        let isOnScreen: Bool
+        let layer: Int
+        let alpha: CGFloat
+        let sharingState: WindowSharingState?
+
+        init(_ window: SCWindow) {
+            self.windowID = window.windowID
+            self.title = window.title ?? ""
+            self.bounds = window.frame
+            self.isOnScreen = window.isOnScreen
+            self.layer = window.windowLayer
+            self.alpha = 1
+            self.sharingState = nil
+        }
+
+        init(_ identity: SystemWindowIdentity) {
+            self.windowID = identity.windowID
+            self.title = identity.title
+            self.bounds = identity.bounds
+            self.isOnScreen = identity.isOnScreen
+            self.layer = identity.layer
+            self.alpha = identity.alpha
+            self.sharingState = identity.sharingState
+        }
+    }
+
+    private struct DisplayMetadataIdentity {
+        let displayID: CGDirectDisplayID
+        let bounds: CGRect
+
+        init(_ display: SCDisplay) {
+            self.displayID = display.displayID
+            self.bounds = display.frame
+        }
+
+        init(_ display: ScreenCaptureDisplayTopology.Display) {
+            self.displayID = display.displayID
+            self.bounds = display.bounds
+        }
+    }
+
+    private struct WindowCaptureResources {
+        let filter: SCContentFilter
+        let configuration: SCStreamConfiguration
+        let expectedPixelSize: (width: Int, height: Int)
+    }
+
+    private struct WindowMetadataContext {
         let mode: CaptureMode
         let applicationInfo: ServiceApplicationInfo?
-        let window: SCWindow
+        let window: WindowMetadataIdentity
         let windowIndex: Int
-        let display: SCDisplay
+        let display: DisplayMetadataIdentity
         let displayIndex: Int
         let scalePlan: ScreenCaptureScaleResolver.Plan
         let mutationIdentity: WindowMutationIdentity?
+        let windowPlanCacheStatus: CaptureWindowPlanCacheStatus?
+        let windowPlanCacheGeneration: UInt64?
+
+        init(
+            mode: CaptureMode,
+            applicationInfo: ServiceApplicationInfo?,
+            window: WindowMetadataIdentity,
+            windowIndex: Int,
+            display: DisplayMetadataIdentity,
+            displayIndex: Int,
+            scalePlan: ScreenCaptureScaleResolver.Plan,
+            mutationIdentity: WindowMutationIdentity?,
+            windowPlanCacheStatus: CaptureWindowPlanCacheStatus? = nil,
+            windowPlanCacheGeneration: UInt64? = nil)
+        {
+            self.mode = mode
+            self.applicationInfo = applicationInfo
+            self.window = window
+            self.windowIndex = windowIndex
+            self.display = display
+            self.displayIndex = displayIndex
+            self.scalePlan = scalePlan
+            self.mutationIdentity = mutationIdentity
+            self.windowPlanCacheStatus = windowPlanCacheStatus
+            self.windowPlanCacheGeneration = windowPlanCacheGeneration
+        }
     }
 
     func captureWindowImpl(
@@ -106,9 +222,9 @@ extension ScreenCaptureKitOperator {
                     bundleIdentifier: app.bundleIdentifier,
                     name: app.name,
                     bundlePath: app.bundlePath),
-                window: targetWindow,
+                window: WindowMetadataIdentity(targetWindow),
                 windowIndex: resolvedIndex,
-                display: targetDisplay,
+                display: DisplayMetadataIdentity(targetDisplay),
                 displayIndex: content.displays.firstIndex(where: { $0.displayID == targetDisplay.displayID }) ?? 0,
                 scalePlan: scalePlan,
                 mutationIdentity: mutationIdentity))
@@ -122,69 +238,35 @@ extension ScreenCaptureKitOperator {
         visualizerMode: CaptureVisualizerMode,
         scale: CaptureScalePreference) async throws -> CaptureResult
     {
-        let content = try await ScreenCaptureKitCaptureGate.shareableContent(
-            excludingDesktopWindows: false,
-            onScreenWindowsOnly: false)
-
-        guard let targetWindow = content.windows.first(where: { $0.windowID == windowID }) else {
-            throw PeekabooError.windowNotFound(criteria: "window_id \(windowID)")
+        let output: ExactWindowCaptureOutput
+        do {
+            output = try await self.captureExactWindow(
+                windowID: windowID,
+                scale: scale,
+                correlationId: correlationId)
+        } catch is ScreenCaptureWindowPlanCacheUnavailableError {
+            return try await self.captureExactWindowFresh(
+                windowID: windowID,
+                correlationId: correlationId,
+                visualizerMode: visualizerMode,
+                scale: scale)
         }
-
-        let owningPid = targetWindow.owningApplication?.processID
-        let appWindows: [SCWindow] = if let owningPid {
-            content.windows.filter { $0.owningApplication?.processID == owningPid }
-        } else {
-            [targetWindow]
-        }
-        let resolvedIndex = appWindows.firstIndex(where: { $0.windowID == windowID }) ?? 0
-        let mutationSnapshot = Self.windowMutationSnapshot(for: targetWindow)
 
         self.logger.debug(
             "Capturing window by id",
             metadata: [
-                "title": targetWindow.title ?? "untitled",
-                "windowID": targetWindow.windowID,
+                "title": output.metadataContext.window.title,
+                "windowID": output.metadataContext.window.windowID,
             ],
             correlationId: correlationId)
 
-        guard let resolution = self.resolveDisplayForWindow(targetWindow, displays: content.displays) else {
-            throw OperationError.captureFailed(reason: "No displays available for window capture")
-        }
-        let targetDisplay = resolution.display
-        if !resolution.isMapped {
-            self.logger.warning(
-                "Window does not map to any enumerated display; using desktop-independent capture filter",
-                metadata: [
-                    "windowID": targetWindow.windowID,
-                    "windowFrame": "\(targetWindow.frame)",
-                    "displayCount": content.displays.count,
-                ],
-                correlationId: correlationId)
-        }
-        let scalePlan = self.scalePlan(for: targetDisplay, preference: scale)
-        let image = try await self.captureWindowImage(
-            targetWindow,
-            scale: scale,
-            scalePlan: scalePlan)
-        let imageData = try image.pngData()
-        let mutationIdentity = mutationSnapshot.flatMap(Self.validatedMutationIdentity)
+        let imageData = try output.image.pngData()
 
-        await self.emitVisualizer(mode: visualizerMode, rect: targetWindow.frame)
+        await self.emitVisualizer(mode: visualizerMode, rect: output.metadataContext.window.bounds)
 
         let metadata = self.windowMetadata(
-            image: image,
-            context: WindowMetadataContext(
-                mode: .window,
-                applicationInfo: self.applicationInfo(
-                    for: owningPid,
-                    processStartIdentity: mutationIdentity?.ownerProcessStartIdentity,
-                    windowCount: appWindows.count),
-                window: targetWindow,
-                windowIndex: resolvedIndex,
-                display: targetDisplay,
-                displayIndex: content.displays.firstIndex(where: { $0.displayID == targetDisplay.displayID }) ?? 0,
-                scalePlan: scalePlan,
-                mutationIdentity: mutationIdentity))
+            image: output.image,
+            context: output.metadataContext)
 
         return CaptureResult(imageData: imageData, metadata: metadata)
     }
@@ -235,6 +317,239 @@ extension ScreenCaptureKitOperator {
         }
     }
 
+    private func captureExactWindow(
+        windowID: CGWindowID,
+        scale: CaptureScalePreference,
+        correlationId: String) async throws -> ExactWindowCaptureOutput
+    {
+        let key = ScreenCaptureKitWindowPlanCache<ExactWindowCapturePlan>.Key(
+            windowID: windowID,
+            usesNativeScale: scale == .native)
+        var reusedPlan: ExactWindowCapturePlan?
+        let result = try await ScreenCaptureWindowPlanExecutor.execute(
+            cachedPlan: {
+                let cached = self.exactWindowPlanCache.value(for: key)
+                reusedPlan = cached
+                if cached != nil {
+                    self.logger.debug(
+                        "Reusing warm ScreenCaptureKit exact-window plan",
+                        metadata: ["windowID": windowID],
+                        correlationId: correlationId)
+                }
+                return cached
+            },
+            buildPlan: {
+                try await self.buildExactWindowPlan(
+                    key: key,
+                    scale: scale,
+                    correlationId: correlationId)
+            },
+            capture: { plan in
+                let image = try await self.captureImage(
+                    filter: plan.filter,
+                    configuration: plan.configuration,
+                    expectedPixelSize: plan.expectedPixelSize,
+                    retrySafeStalePlanOnPixelMismatch: true)
+                let status: CaptureWindowPlanCacheStatus = reusedPlan === plan ? .hit : .miss
+                return try self.exactWindowCaptureOutput(
+                    image: image,
+                    plan: plan,
+                    cacheStatus: status)
+            },
+            validation: { self.validation(of: $0) },
+            evict: { self.exactWindowPlanCache.removeValue(for: $0.key, ifSameAs: $0) })
+        return result.output
+    }
+
+    private func buildExactWindowPlan(
+        key: ScreenCaptureKitWindowPlanCache<ExactWindowCapturePlan>.Key,
+        scale: CaptureScalePreference,
+        correlationId: String) async throws -> ExactWindowCapturePlan
+    {
+        guard let receipt = ScreenCaptureWindowPlanReceipt.current(windowID: key.windowID),
+              let topology = ScreenCaptureDisplayTopology.current()
+        else {
+            throw ScreenCaptureWindowPlanCacheUnavailableError()
+        }
+
+        let content = try await ScreenCaptureKitCaptureGate.shareableContent(
+            excludingDesktopWindows: false,
+            onScreenWindowsOnly: false)
+        guard let targetWindow = content.windows.first(where: { $0.windowID == key.windowID }) else {
+            throw PeekabooError.windowNotFound(criteria: "window_id \(key.windowID)")
+        }
+        guard self.matches(targetWindow, receipt: receipt) else {
+            throw RetrySafeStaleWindowPlanError(terminalError: OperationError.captureFailed(
+                reason: "Exact window changed while ScreenCaptureKit prepared its capture plan"))
+        }
+        guard let resolution = self.resolveDisplayForWindow(targetWindow, displays: content.displays) else {
+            throw OperationError.captureFailed(reason: "No displays available for window capture")
+        }
+        let targetDisplay = resolution.display
+        guard topology.containsScreenCaptureKitDisplay(
+            displayID: targetDisplay.displayID,
+            bounds: targetDisplay.frame,
+            width: targetDisplay.width,
+            height: targetDisplay.height),
+            let topologyDisplay = topology.display(withID: targetDisplay.displayID)
+        else {
+            throw RetrySafeStaleWindowPlanError(terminalError: OperationError.captureFailed(
+                reason: "ScreenCaptureKit display metadata disagreed with the active display topology"))
+        }
+        if !resolution.isMapped {
+            self.logger.warning(
+                "Window does not map to any enumerated display; using desktop-independent capture filter",
+                metadata: [
+                    "windowID": targetWindow.windowID,
+                    "windowFrame": "\(targetWindow.frame)",
+                    "displayCount": content.displays.count,
+                ],
+                correlationId: correlationId)
+        }
+
+        let scalePlan = self.scalePlan(for: topologyDisplay, preference: scale)
+        let resources = self.windowCaptureResources(
+            for: targetWindow,
+            scale: scale,
+            targetScale: scalePlan.nativeScale)
+        let currentTopology = ScreenCaptureDisplayTopology.current()
+        let currentScalePlan = currentTopology?.display(withID: targetDisplay.displayID).map {
+            self.scalePlan(for: $0, preference: scale)
+        }
+        switch ScreenCaptureWindowPlanValidation.result(
+            expectedReceipt: receipt,
+            expectedTopology: topology,
+            currentReceipt: ScreenCaptureWindowPlanReceipt.current(windowID: key.windowID),
+            currentTopology: currentTopology,
+            expectedScalePlan: scalePlan,
+            currentScalePlan: currentScalePlan)
+        {
+        case .matched:
+            break
+        case .unavailable:
+            throw ScreenCaptureWindowPlanCacheUnavailableError()
+        case .changed:
+            throw RetrySafeStaleWindowPlanError(terminalError: OperationError.captureFailed(
+                reason: "Exact window or display topology changed while building its capture plan"))
+        }
+
+        let plan = ExactWindowCapturePlan(
+            key: key,
+            filter: resources.filter,
+            configuration: resources.configuration,
+            expectedPixelSize: resources.expectedPixelSize,
+            displayID: targetDisplay.displayID,
+            scalePlan: scalePlan,
+            receipt: receipt,
+            topology: topology,
+            generation: self.allocateExactWindowPlanGeneration())
+        self.logger.debug(
+            "Building cold ScreenCaptureKit exact-window plan",
+            metadata: [
+                "windowID": key.windowID,
+                "planGeneration": plan.generation,
+            ],
+            correlationId: correlationId)
+        self.exactWindowPlanCache.insert(plan, for: key)
+        return plan
+    }
+
+    private func validation(of plan: ExactWindowCapturePlan) -> ScreenCaptureWindowPlanValidation.Result {
+        guard let currentTopology = ScreenCaptureDisplayTopology.current() else { return .unavailable }
+        let preference: CaptureScalePreference = plan.key.usesNativeScale ? .native : .logical1x
+        let currentScalePlan = currentTopology.display(withID: plan.displayID).map {
+            self.scalePlan(for: $0, preference: preference)
+        }
+        return ScreenCaptureWindowPlanValidation.result(
+            expectedReceipt: plan.receipt,
+            expectedTopology: plan.topology,
+            currentReceipt: ScreenCaptureWindowPlanReceipt.current(windowID: plan.key.windowID),
+            currentTopology: currentTopology,
+            expectedScalePlan: plan.scalePlan,
+            currentScalePlan: currentScalePlan)
+    }
+
+    private func exactWindowCaptureOutput(
+        image: CGImage,
+        plan: ExactWindowCapturePlan,
+        cacheStatus: CaptureWindowPlanCacheStatus) throws -> ExactWindowCaptureOutput
+    {
+        guard let identity = SystemIdentityResolver.stableWindowIdentity(plan.key.windowID),
+              let currentReceipt = ScreenCaptureWindowPlanReceipt.make(identity: identity)
+        else {
+            throw ScreenCaptureWindowPlanCacheUnavailableError()
+        }
+        guard currentReceipt == plan.receipt else {
+            throw RetrySafeStaleWindowPlanError(terminalError: .captureFailed(
+                "Exact window changed while ScreenCaptureKit prepared capture metadata"))
+        }
+
+        let appWindows = SystemIdentityResolver.windowIdentities(
+            ownerProcessIdentifier: plan.receipt.ownerProcessIdentifier)
+        guard !appWindows.isEmpty,
+              let windowIndex = appWindows.firstIndex(where: { $0.windowID == plan.key.windowID }),
+              let listedReceipt = ScreenCaptureWindowPlanReceipt.make(identity: appWindows[windowIndex])
+        else {
+            throw ScreenCaptureWindowPlanCacheUnavailableError()
+        }
+        guard listedReceipt == plan.receipt else {
+            throw RetrySafeStaleWindowPlanError(terminalError: .captureFailed(
+                "Exact window changed while ScreenCaptureKit resolved capture metadata"))
+        }
+
+        guard let topology = ScreenCaptureDisplayTopology.current() else {
+            throw ScreenCaptureWindowPlanCacheUnavailableError()
+        }
+        guard topology == plan.topology,
+              let display = topology.display(withID: plan.displayID)
+        else {
+            throw RetrySafeStaleWindowPlanError(terminalError: .captureFailed(
+                "Display topology changed while ScreenCaptureKit resolved capture metadata"))
+        }
+        let preference: CaptureScalePreference = plan.key.usesNativeScale ? .native : .logical1x
+        guard self.scalePlan(for: display, preference: preference) == plan.scalePlan else {
+            throw RetrySafeStaleWindowPlanError(terminalError: .captureFailed(
+                "Display scale changed while ScreenCaptureKit resolved capture metadata"))
+        }
+        guard SystemIdentityResolver.processStartIdentity(plan.receipt.ownerProcessIdentifier) ==
+            plan.receipt.ownerProcessStartIdentity
+        else {
+            throw RetrySafeStaleWindowPlanError(terminalError: .captureFailed(
+                "Window owner process generation changed while resolving capture metadata"))
+        }
+
+        return ExactWindowCaptureOutput(
+            image: image,
+            metadataContext: WindowMetadataContext(
+                mode: .window,
+                applicationInfo: self.applicationInfo(
+                    for: plan.receipt.ownerProcessIdentifier,
+                    processStartIdentity: plan.receipt.ownerProcessStartIdentity,
+                    windowCount: appWindows.count),
+                window: WindowMetadataIdentity(appWindows[windowIndex]),
+                windowIndex: windowIndex,
+                display: DisplayMetadataIdentity(display),
+                displayIndex: topology.displays.firstIndex(where: { $0.displayID == display.displayID }) ?? 0,
+                scalePlan: plan.scalePlan,
+                mutationIdentity: plan.receipt.mutationIdentity,
+                windowPlanCacheStatus: cacheStatus,
+                windowPlanCacheGeneration: plan.generation))
+    }
+
+    private func matches(_ window: SCWindow, receipt: ScreenCaptureWindowPlanReceipt) -> Bool {
+        window.windowID == receipt.windowID &&
+            window.owningApplication?.processID == receipt.ownerProcessIdentifier &&
+            window.windowLayer == receipt.layer &&
+            window.frame == receipt.bounds &&
+            window.isOnScreen == receipt.isOnScreen
+    }
+
+    private func allocateExactWindowPlanGeneration() -> UInt64 {
+        let generation = self.nextExactWindowPlanGeneration
+        self.nextExactWindowPlanGeneration &+= 1
+        return generation
+    }
+
     /// Capture a window screenshot.
     ///
     /// Window capture uses ScreenCaptureKit's desktop-independent filter. A display-bound filter describes a
@@ -246,41 +561,126 @@ extension ScreenCaptureKitOperator {
         scale: CaptureScalePreference,
         targetScale: CGFloat) async throws -> CGImage
     {
-        let config = SCStreamConfiguration()
-        config.captureResolution = .best
-        config.showsCursor = false
-        config.ignoreShadowsSingleWindow = true
-        config.scalesToFit = true
+        let resources = self.windowCaptureResources(for: window, scale: scale, targetScale: targetScale)
+        return try await self.captureImage(
+            filter: resources.filter,
+            configuration: resources.configuration,
+            expectedPixelSize: resources.expectedPixelSize,
+            retrySafeStalePlanOnPixelMismatch: false)
+    }
+
+    private func windowCaptureResources(
+        for window: SCWindow,
+        scale: CaptureScalePreference,
+        targetScale: CGFloat) -> WindowCaptureResources
+    {
+        let configuration = SCStreamConfiguration()
+        configuration.captureResolution = .best
+        configuration.showsCursor = false
+        configuration.ignoreShadowsSingleWindow = true
+        configuration.scalesToFit = true
         if #available(macOS 14.2, *) {
-            config.includeChildWindows = false
+            configuration.includeChildWindows = false
         }
 
         let filter = SCContentFilter(desktopIndependentWindow: window)
-        let pixelSize = ScreenCapturePlanner.desktopIndependentWindowPixelSize(
+        let expectedPixelSize = ScreenCapturePlanner.desktopIndependentWindowPixelSize(
             filterContentRect: filter.contentRect,
             fallbackWindowFrame: window.frame,
             pointPixelScale: CGFloat(filter.pointPixelScale),
             fallbackNativeScale: targetScale,
             useNativeScale: scale == .native)
-        config.width = pixelSize.width
-        config.height = pixelSize.height
+        configuration.width = expectedPixelSize.width
+        configuration.height = expectedPixelSize.height
+        return WindowCaptureResources(
+            filter: filter,
+            configuration: configuration,
+            expectedPixelSize: expectedPixelSize)
+    }
 
+    private func captureImage(
+        filter: SCContentFilter,
+        configuration: SCStreamConfiguration,
+        expectedPixelSize: (width: Int, height: Int),
+        retrySafeStalePlanOnPixelMismatch: Bool) async throws -> CGImage
+    {
         let image = try await ScreenCaptureKitCaptureGate.captureImage(
             contentFilter: filter,
-            configuration: config)
+            configuration: configuration)
         guard ScreenCapturePlanner.matchesExpectedWindowPixelSize(
             imageWidth: image.width,
             imageHeight: image.height,
-            expected: pixelSize)
+            expected: expectedPixelSize)
         else {
-            throw OperationError.captureFailed(
+            let error = OperationError.captureFailed(
                 reason: "ScreenCaptureKit returned \(image.width)x\(image.height) for a " +
-                    "\(pixelSize.width)x\(pixelSize.height) window capture")
+                    "\(expectedPixelSize.width)x\(expectedPixelSize.height) window capture")
+            if retrySafeStalePlanOnPixelMismatch {
+                throw RetrySafeStaleWindowPlanError(terminalError: error)
+            }
+            throw error
         }
         return image
     }
 
-    func windowMetadata(
+    private func captureExactWindowFresh(
+        windowID: CGWindowID,
+        correlationId: String,
+        visualizerMode: CaptureVisualizerMode,
+        scale: CaptureScalePreference) async throws -> CaptureResult
+    {
+        let content = try await ScreenCaptureKitCaptureGate.shareableContent(
+            excludingDesktopWindows: false,
+            onScreenWindowsOnly: false)
+        guard let targetWindow = content.windows.first(where: { $0.windowID == windowID }) else {
+            throw PeekabooError.windowNotFound(criteria: "window_id \(windowID)")
+        }
+
+        let owningPID = targetWindow.owningApplication?.processID
+        let appWindows = owningPID.map { owner in
+            content.windows.filter { $0.owningApplication?.processID == owner }
+        } ?? [targetWindow]
+        let resolvedIndex = appWindows.firstIndex(where: { $0.windowID == windowID }) ?? 0
+        let mutationSnapshot = Self.windowMutationSnapshot(for: targetWindow)
+        guard let resolution = self.resolveDisplayForWindow(targetWindow, displays: content.displays) else {
+            throw OperationError.captureFailed(reason: "No displays available for window capture")
+        }
+        let targetDisplay = resolution.display
+        let scalePlan = self.scalePlan(for: targetDisplay, preference: scale)
+        let image = try await self.captureWindowImage(
+            targetWindow,
+            scale: scale,
+            scalePlan: scalePlan)
+        let mutationIdentity = mutationSnapshot.flatMap(Self.validatedMutationIdentity)
+        let imageData = try image.pngData()
+
+        self.logger.debug(
+            "Exact-window cache preflight unavailable; used one fresh ScreenCaptureKit plan",
+            metadata: ["windowID": windowID],
+            correlationId: correlationId)
+        await self.emitVisualizer(mode: visualizerMode, rect: targetWindow.frame)
+
+        return CaptureResult(
+            imageData: imageData,
+            metadata: self.windowMetadata(
+                image: image,
+                context: WindowMetadataContext(
+                    mode: .window,
+                    applicationInfo: self.applicationInfo(
+                        for: owningPID,
+                        processStartIdentity: mutationIdentity?.ownerProcessStartIdentity,
+                        windowCount: appWindows.count),
+                    window: WindowMetadataIdentity(targetWindow),
+                    windowIndex: resolvedIndex,
+                    display: DisplayMetadataIdentity(targetDisplay),
+                    displayIndex: content.displays.firstIndex(where: {
+                        $0.displayID == targetDisplay.displayID
+                    }) ?? 0,
+                    scalePlan: scalePlan,
+                    mutationIdentity: mutationIdentity)))
+    }
+
+    private func windowMetadata(
         image: CGImage,
         context: WindowMetadataContext) -> CaptureMetadata
     {
@@ -290,25 +690,28 @@ extension ScreenCaptureKitOperator {
             applicationInfo: context.applicationInfo,
             windowInfo: ServiceWindowInfo(
                 windowID: Int(context.window.windowID),
-                title: context.window.title ?? "",
-                bounds: context.window.frame,
+                title: context.window.title,
+                bounds: context.window.bounds,
                 isMinimized: false,
                 isMainWindow: context.window.isOnScreen,
                 windowLevel: 0,
-                alpha: 1.0,
+                alpha: context.window.alpha,
                 index: context.windowIndex,
                 isOffScreen: !context.window.isOnScreen,
-                layer: 0,
+                layer: context.window.layer,
                 isOnScreen: context.window.isOnScreen,
+                sharingState: context.window.sharingState,
                 mutationIdentity: context.mutationIdentity),
             displayInfo: DisplayInfo(
                 index: context.displayIndex,
                 name: context.display.displayID.description,
-                bounds: context.display.frame,
+                bounds: context.display.bounds,
                 scaleFactor: context.scalePlan.outputScale),
             diagnostics: ScreenCaptureScaleResolver.diagnostics(
                 plan: context.scalePlan,
-                finalPixelSize: CGSize(width: image.width, height: image.height)))
+                finalPixelSize: CGSize(width: image.width, height: image.height),
+                windowPlanCacheStatus: context.windowPlanCacheStatus,
+                windowPlanCacheGeneration: context.windowPlanCacheGeneration))
     }
 
     func applicationInfo(
@@ -316,13 +719,18 @@ extension ScreenCaptureKitOperator {
         processStartIdentity: UInt64?,
         windowCount: Int) -> ServiceApplicationInfo?
     {
-        guard let processID,
-              let runningApplication = NSRunningApplication(processIdentifier: processID)
+        guard let processID else { return nil }
+        if let processStartIdentity,
+           SystemIdentityResolver.processStartIdentity(processID) != processStartIdentity
+        {
+            return nil
+        }
+        guard let runningApplication = NSRunningApplication(processIdentifier: processID),
+              runningApplication.processIdentifier == processID
         else {
             return nil
         }
-
-        return ServiceApplicationInfo(
+        let applicationInfo = ServiceApplicationInfo(
             processIdentifier: runningApplication.processIdentifier,
             processStartIdentity: processStartIdentity,
             bundleIdentifier: runningApplication.bundleIdentifier,
@@ -331,6 +739,12 @@ extension ScreenCaptureKitOperator {
             isActive: runningApplication.isActive,
             isHidden: runningApplication.isHidden,
             windowCount: windowCount)
+        if let processStartIdentity,
+           SystemIdentityResolver.processStartIdentity(processID) != processStartIdentity
+        {
+            return nil
+        }
+        return applicationInfo
     }
 
     private nonisolated static func windowMutationSnapshot(

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/ScreenCaptureKitOperator.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/ScreenCaptureKitOperator.swift
@@ -7,6 +7,8 @@ final class ScreenCaptureKitOperator: ModernScreenCaptureOperating {
     let logger: CategoryLogger
     let feedbackClient: any AutomationFeedbackClient
     let frameSource: any CaptureFrameSource
+    let exactWindowPlanCache = ScreenCaptureKitWindowPlanCache<ExactWindowCapturePlan>()
+    var nextExactWindowPlanGeneration: UInt64 = 1
 
     init(
         logger: CategoryLogger,

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/ScreenCaptureKitWindowPlanCache.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/ScreenCaptureKitWindowPlanCache.swift
@@ -1,0 +1,328 @@
+import CoreGraphics
+import Foundation
+import PeekabooFoundation
+
+/// Short-lived process-local cache for ScreenCaptureKit window capture plans.
+///
+/// Values contain capture filters/configuration, never captured pixels. Every caller must independently
+/// revalidate its exact window receipt and display topology before and after using a cached value.
+@MainActor
+final class ScreenCaptureKitWindowPlanCache<Value: AnyObject> {
+    struct Key: Hashable {
+        let windowID: CGWindowID
+        let usesNativeScale: Bool
+    }
+
+    private struct Entry {
+        let value: Value
+        let insertedAt: ContinuousClock.Instant
+        let sequence: UInt64
+    }
+
+    private let timeToLive: Duration
+    private let capacity: Int
+    private var entries: [Key: Entry] = [:]
+    private var nextSequence: UInt64 = 0
+
+    init(timeToLive: Duration = .seconds(2), capacity: Int = 32) {
+        self.timeToLive = timeToLive
+        self.capacity = max(capacity, 0)
+    }
+
+    var count: Int {
+        self.entries.count
+    }
+
+    var isEmpty: Bool {
+        self.entries.isEmpty
+    }
+
+    func value(for key: Key, now: ContinuousClock.Instant = .now) -> Value? {
+        guard let entry = self.entries[key] else { return nil }
+        guard !self.isExpired(entry, now: now) else {
+            self.entries.removeValue(forKey: key)
+            return nil
+        }
+        return entry.value
+    }
+
+    func insert(_ value: Value, for key: Key, now: ContinuousClock.Instant = .now) {
+        guard self.capacity > 0 else { return }
+        self.removeExpired(now: now)
+
+        if self.entries[key] == nil, self.entries.count >= self.capacity,
+           let oldestKey = self.entries.min(by: { $0.value.sequence < $1.value.sequence })?.key
+        {
+            self.entries.removeValue(forKey: oldestKey)
+        }
+
+        let sequence = self.nextSequence
+        self.entries[key] = Entry(
+            value: value,
+            insertedAt: now,
+            sequence: sequence)
+        self.nextSequence &+= 1
+        self.scheduleExpiration(for: key, sequence: sequence)
+    }
+
+    @discardableResult
+    func removeValue(for key: Key, ifSameAs expected: Value? = nil) -> Bool {
+        guard let stored = self.entries[key] else { return false }
+        if let expected, stored.value !== expected {
+            return false
+        }
+        self.entries.removeValue(forKey: key)
+        return true
+    }
+
+    private func removeExpired(now: ContinuousClock.Instant) {
+        self.entries = self.entries.filter { !self.isExpired($0.value, now: now) }
+    }
+
+    private func isExpired(_ entry: Entry, now: ContinuousClock.Instant) -> Bool {
+        let age = entry.insertedAt.duration(to: now)
+        return age >= .zero && age >= self.timeToLive
+    }
+
+    private func scheduleExpiration(for key: Key, sequence: UInt64) {
+        let timeToLive = self.timeToLive
+        Task { @MainActor [weak self] in
+            try? await Task.sleep(for: timeToLive)
+            guard let self, self.entries[key]?.sequence == sequence else { return }
+            self.entries.removeValue(forKey: key)
+        }
+    }
+}
+
+struct ScreenCaptureDisplayTopology: Equatable {
+    struct Display: Equatable {
+        let displayID: CGDirectDisplayID
+        let bounds: CGRect
+        let pixelWidth: Int
+        let pixelHeight: Int
+        let rotation: Double
+        let isMain: Bool
+        let mirrorOwnerDisplayID: CGDirectDisplayID?
+
+        init(
+            displayID: CGDirectDisplayID,
+            bounds: CGRect,
+            pixelWidth: Int,
+            pixelHeight: Int,
+            rotation: Double,
+            isMain: Bool = false,
+            mirrorOwnerDisplayID: CGDirectDisplayID? = nil)
+        {
+            self.displayID = displayID
+            self.bounds = bounds
+            self.pixelWidth = pixelWidth
+            self.pixelHeight = pixelHeight
+            self.rotation = rotation
+            self.isMain = isMain
+            self.mirrorOwnerDisplayID = mirrorOwnerDisplayID
+        }
+    }
+
+    let displays: [Display]
+
+    static func current() -> ScreenCaptureDisplayTopology? {
+        var count: UInt32 = 0
+        guard CGGetActiveDisplayList(0, nil, &count) == .success, count > 0 else {
+            return nil
+        }
+        var displayIDs = [CGDirectDisplayID](repeating: 0, count: Int(count))
+        guard CGGetActiveDisplayList(count, &displayIDs, &count) == .success else {
+            return nil
+        }
+
+        let displays = displayIDs.prefix(Int(count)).map { displayID in
+            let mirroredDisplayID = CGDisplayMirrorsDisplay(displayID)
+            return Display(
+                displayID: displayID,
+                bounds: CGDisplayBounds(displayID),
+                pixelWidth: CGDisplayPixelsWide(displayID),
+                pixelHeight: CGDisplayPixelsHigh(displayID),
+                rotation: CGDisplayRotation(displayID),
+                isMain: CGDisplayIsMain(displayID) != 0,
+                mirrorOwnerDisplayID: mirroredDisplayID == kCGNullDirectDisplay ? nil : mirroredDisplayID)
+        }
+        return ScreenCaptureDisplayTopology(displays: displays)
+    }
+
+    /// ScreenCaptureKit exposes `SCDisplay.frame` in logical points. Physical pixel dimensions remain
+    /// part of the topology fingerprint, but must never be compared with `SCDisplay.width/height`, which
+    /// are also point dimensions on current SDKs.
+    func containsScreenCaptureKitDisplay(
+        displayID: CGDirectDisplayID,
+        bounds: CGRect,
+        width: Int,
+        height: Int) -> Bool
+    {
+        self.displays.contains {
+            $0.displayID == displayID &&
+                $0.bounds == bounds &&
+                $0.bounds.width == CGFloat(width) &&
+                $0.bounds.height == CGFloat(height)
+        }
+    }
+
+    func display(withID displayID: CGDirectDisplayID) -> Display? {
+        self.displays.first { $0.displayID == displayID }
+    }
+}
+
+struct ScreenCaptureWindowPlanReceipt: Equatable {
+    let windowID: CGWindowID
+    let ownerProcessIdentifier: pid_t
+    let ownerProcessStartIdentity: UInt64
+    let bounds: CGRect
+    let layer: Int
+    let alpha: CGFloat
+    let isOnScreen: Bool
+    let sharingState: Int?
+
+    /// Bracket a WindowServer row with process-generation reads so a recycled PID cannot be combined
+    /// with the earlier process's window fingerprint. CGWindowID has no public incarnation token; same-ID,
+    /// same-owner-generation, identical-fingerprint reuse remains the documented platform residual.
+    static func current(
+        windowID: CGWindowID,
+        windowIdentityProvider: (CGWindowID) -> SystemWindowIdentity? = SystemIdentityResolver.windowIdentity,
+        processStartIdentityProvider: (pid_t) -> UInt64? = SystemIdentityResolver.processStartIdentity)
+        -> ScreenCaptureWindowPlanReceipt?
+    {
+        SystemIdentityResolver.stableWindowIdentity(
+            windowID,
+            windowIdentityProvider: windowIdentityProvider,
+            processStartIdentityProvider: processStartIdentityProvider).flatMap { self.make(identity: $0) }
+    }
+
+    var mutationIdentity: WindowMutationIdentity {
+        WindowMutationIdentity(
+            windowID: Int(self.windowID),
+            ownerProcessIdentifier: self.ownerProcessIdentifier,
+            ownerProcessStartIdentity: self.ownerProcessStartIdentity,
+            capturedBounds: self.bounds,
+            isMinimized: !self.isOnScreen)
+    }
+
+    static func make(identity: SystemWindowIdentity) -> ScreenCaptureWindowPlanReceipt? {
+        guard let processStartIdentity = identity.ownerProcessStartIdentity else { return nil }
+        return ScreenCaptureWindowPlanReceipt(
+            windowID: identity.windowID,
+            ownerProcessIdentifier: identity.ownerProcessIdentifier,
+            ownerProcessStartIdentity: processStartIdentity,
+            bounds: identity.bounds,
+            layer: identity.layer,
+            alpha: identity.alpha,
+            isOnScreen: identity.isOnScreen,
+            sharingState: identity.sharingState?.rawValue)
+    }
+}
+
+enum ScreenCaptureWindowPlanValidation {
+    enum Result: Equatable {
+        case matched
+        case changed
+        case unavailable
+    }
+
+    static func result(
+        expectedReceipt: ScreenCaptureWindowPlanReceipt,
+        expectedTopology: ScreenCaptureDisplayTopology,
+        currentReceipt: ScreenCaptureWindowPlanReceipt?,
+        currentTopology: ScreenCaptureDisplayTopology?,
+        expectedScalePlan: ScreenCaptureScaleResolver.Plan? = nil,
+        currentScalePlan: ScreenCaptureScaleResolver.Plan? = nil) -> Result
+    {
+        guard let currentReceipt, let currentTopology else { return .unavailable }
+        guard currentReceipt == expectedReceipt, currentTopology == expectedTopology else { return .changed }
+        if let expectedScalePlan {
+            guard let currentScalePlan else { return .unavailable }
+            guard currentScalePlan == expectedScalePlan else { return .changed }
+        }
+        return .matched
+    }
+}
+
+struct ScreenCaptureWindowPlanCacheUnavailableError: Error {}
+
+struct RetrySafeStaleWindowPlanError: Error {
+    let terminalError: PeekabooError
+}
+
+@MainActor
+enum ScreenCaptureWindowPlanExecutor {
+    /// Owns the exact plan's one shared recovery budget across cache lookup, construction, and capture.
+    /// Cancellation, timeout, permission, quarantine, and raw framework errors are evicted and rethrown
+    /// unchanged so the outer capture policy remains their sole retry/fallback owner.
+    static func execute<Plan: AnyObject, Output>(
+        cachedPlan: () -> Plan?,
+        buildPlan: () async throws -> Plan,
+        capture: (Plan) async throws -> Output,
+        validation: (Plan) -> ScreenCaptureWindowPlanValidation.Result,
+        evict: (Plan) -> Void) async throws -> (output: Output, plan: Plan)
+    {
+        var candidate = cachedPlan()
+        var recoveryConsumed = false
+
+        while true {
+            let selectedPlan: Plan
+            do {
+                if let candidate {
+                    selectedPlan = candidate
+                } else {
+                    selectedPlan = try await buildPlan()
+                }
+            } catch let error as RetrySafeStaleWindowPlanError {
+                guard !recoveryConsumed else { throw error.terminalError }
+                recoveryConsumed = true
+                candidate = nil
+                continue
+            }
+            candidate = nil
+
+            switch validation(selectedPlan) {
+            case .matched:
+                break
+            case .unavailable:
+                evict(selectedPlan)
+                throw ScreenCaptureWindowPlanCacheUnavailableError()
+            case .changed:
+                evict(selectedPlan)
+                guard !recoveryConsumed else { throw self.repeatedDriftError }
+                recoveryConsumed = true
+                continue
+            }
+
+            let output: Output
+            do {
+                output = try await capture(selectedPlan)
+                try Task.checkCancellation()
+            } catch let error as RetrySafeStaleWindowPlanError {
+                evict(selectedPlan)
+                guard !recoveryConsumed else { throw error.terminalError }
+                recoveryConsumed = true
+                continue
+            } catch {
+                evict(selectedPlan)
+                throw error
+            }
+
+            switch validation(selectedPlan) {
+            case .matched:
+                return (output, selectedPlan)
+            case .unavailable:
+                evict(selectedPlan)
+                throw ScreenCaptureWindowPlanCacheUnavailableError()
+            case .changed:
+                evict(selectedPlan)
+                guard !recoveryConsumed else { throw self.repeatedDriftError }
+                recoveryConsumed = true
+            }
+        }
+    }
+
+    private static var repeatedDriftError: PeekabooError {
+        .captureFailed("Window or display topology changed repeatedly during exact-window capture")
+    }
+}

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/ScreenCaptureKitWindowPlanCache.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/ScreenCaptureKitWindowPlanCache.swift
@@ -258,28 +258,36 @@ enum ScreenCaptureWindowPlanExecutor {
     static func execute<Plan: AnyObject, Output>(
         cachedPlan: () -> Plan?,
         buildPlan: () async throws -> Plan,
-        capture: (Plan) async throws -> Output,
+        capture: (Plan, CaptureWindowPlanCacheStatus) async throws -> Output,
         validation: (Plan) -> ScreenCaptureWindowPlanValidation.Result,
-        evict: (Plan) -> Void) async throws -> (output: Output, plan: Plan)
+        evict: (Plan) -> Void) async throws
+        -> (output: Output, plan: Plan, cacheStatus: CaptureWindowPlanCacheStatus)
     {
         var candidate = cachedPlan()
+        var candidateIsCached = candidate != nil
+        var recoveredCachedPlan = false
         var recoveryConsumed = false
 
         while true {
             let selectedPlan: Plan
+            let selectedPlanIsCached: Bool
             do {
                 if let candidate {
                     selectedPlan = candidate
+                    selectedPlanIsCached = candidateIsCached
                 } else {
                     selectedPlan = try await buildPlan()
+                    selectedPlanIsCached = false
                 }
             } catch let error as RetrySafeStaleWindowPlanError {
                 guard !recoveryConsumed else { throw error.terminalError }
                 recoveryConsumed = true
                 candidate = nil
+                candidateIsCached = false
                 continue
             }
             candidate = nil
+            candidateIsCached = false
 
             switch validation(selectedPlan) {
             case .matched:
@@ -290,17 +298,26 @@ enum ScreenCaptureWindowPlanExecutor {
             case .changed:
                 evict(selectedPlan)
                 guard !recoveryConsumed else { throw self.repeatedDriftError }
+                recoveredCachedPlan = selectedPlanIsCached
                 recoveryConsumed = true
                 continue
             }
 
+            let cacheStatus: CaptureWindowPlanCacheStatus = if selectedPlanIsCached {
+                .hit
+            } else if recoveredCachedPlan {
+                .rebuilt
+            } else {
+                .miss
+            }
             let output: Output
             do {
-                output = try await capture(selectedPlan)
+                output = try await capture(selectedPlan, cacheStatus)
                 try Task.checkCancellation()
             } catch let error as RetrySafeStaleWindowPlanError {
                 evict(selectedPlan)
                 guard !recoveryConsumed else { throw error.terminalError }
+                recoveredCachedPlan = selectedPlanIsCached
                 recoveryConsumed = true
                 continue
             } catch {
@@ -310,13 +327,14 @@ enum ScreenCaptureWindowPlanExecutor {
 
             switch validation(selectedPlan) {
             case .matched:
-                return (output, selectedPlan)
+                return (output, selectedPlan, cacheStatus)
             case .unavailable:
                 evict(selectedPlan)
                 throw ScreenCaptureWindowPlanCacheUnavailableError()
             case .changed:
                 evict(selectedPlan)
                 guard !recoveryConsumed else { throw self.repeatedDriftError }
+                recoveredCachedPlan = selectedPlanIsCached
                 recoveryConsumed = true
             }
         }

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/ScreenCaptureScaleResolver.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/ScreenCaptureScaleResolver.swift
@@ -92,7 +92,9 @@ import CoreGraphics
         plan: Plan,
         finalPixelSize: CGSize,
         engine: ScreenCaptureAPI? = nil,
-        fallbackReason: String? = nil) -> CaptureDiagnostics
+        fallbackReason: String? = nil,
+        windowPlanCacheStatus: CaptureWindowPlanCacheStatus? = nil,
+        windowPlanCacheGeneration: UInt64? = nil) -> CaptureDiagnostics
     {
         CaptureDiagnostics(
             requestedScale: plan.preference,
@@ -101,7 +103,9 @@ import CoreGraphics
             scaleSource: plan.source.rawValue,
             finalPixelSize: finalPixelSize,
             engine: engine?.description,
-            fallbackReason: fallbackReason)
+            fallbackReason: fallbackReason,
+            windowPlanCacheStatus: windowPlanCacheStatus,
+            windowPlanCacheGeneration: windowPlanCacheGeneration)
     }
 
     private static func nativeScaleWithSource(

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Core/Protocols/ScreenCaptureServiceProtocol.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Core/Protocols/ScreenCaptureServiceProtocol.swift
@@ -258,6 +258,7 @@ public struct CaptureViewport: Sendable, Codable, Equatable {
 public enum CaptureWindowPlanCacheStatus: String, Sendable, Codable, Equatable {
     case hit
     case miss
+    case rebuilt
 }
 
 public struct CaptureDiagnostics: Sendable, Codable, Equatable {

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Core/Protocols/ScreenCaptureServiceProtocol.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Core/Protocols/ScreenCaptureServiceProtocol.swift
@@ -255,6 +255,11 @@ public struct CaptureViewport: Sendable, Codable, Equatable {
     }
 }
 
+public enum CaptureWindowPlanCacheStatus: String, Sendable, Codable, Equatable {
+    case hit
+    case miss
+}
+
 public struct CaptureDiagnostics: Sendable, Codable, Equatable {
     public let requestedScale: CaptureScalePreference
     public let nativeScale: CGFloat
@@ -263,6 +268,8 @@ public struct CaptureDiagnostics: Sendable, Codable, Equatable {
     public let finalPixelSize: CGSize
     public let engine: String?
     public let fallbackReason: String?
+    public let windowPlanCacheStatus: CaptureWindowPlanCacheStatus?
+    public let windowPlanCacheGeneration: UInt64?
 
     public init(
         requestedScale: CaptureScalePreference,
@@ -271,7 +278,9 @@ public struct CaptureDiagnostics: Sendable, Codable, Equatable {
         scaleSource: String,
         finalPixelSize: CGSize,
         engine: String? = nil,
-        fallbackReason: String? = nil)
+        fallbackReason: String? = nil,
+        windowPlanCacheStatus: CaptureWindowPlanCacheStatus? = nil,
+        windowPlanCacheGeneration: UInt64? = nil)
     {
         self.requestedScale = requestedScale
         self.nativeScale = nativeScale
@@ -280,6 +289,8 @@ public struct CaptureDiagnostics: Sendable, Codable, Equatable {
         self.finalPixelSize = finalPixelSize
         self.engine = engine
         self.fallbackReason = fallbackReason
+        self.windowPlanCacheStatus = windowPlanCacheStatus
+        self.windowPlanCacheGeneration = windowPlanCacheGeneration
     }
 }
 
@@ -318,7 +329,9 @@ extension CaptureMetadata {
                 scaleSource: diagnostics.scaleSource,
                 finalPixelSize: deliveredPixelSize,
                 engine: diagnostics.engine,
-                fallbackReason: diagnostics.fallbackReason)
+                fallbackReason: diagnostics.fallbackReason,
+                windowPlanCacheStatus: diagnostics.windowPlanCacheStatus,
+                windowPlanCacheGeneration: diagnostics.windowPlanCacheGeneration)
         }
 
         return CaptureMetadata(
@@ -342,7 +355,9 @@ extension CaptureMetadata {
                 scaleSource: diagnostics.scaleSource,
                 finalPixelSize: deliveredPixelSize,
                 engine: diagnostics.engine,
-                fallbackReason: diagnostics.fallbackReason)
+                fallbackReason: diagnostics.fallbackReason,
+                windowPlanCacheStatus: diagnostics.windowPlanCacheStatus,
+                windowPlanCacheGeneration: diagnostics.windowPlanCacheGeneration)
         }
         return CaptureMetadata(
             size: deliveredPixelSize,
@@ -489,7 +504,9 @@ extension CaptureResult {
                 scaleSource: diagnostics.scaleSource,
                 finalPixelSize: diagnostics.finalPixelSize,
                 engine: engine ?? diagnostics.engine,
-                fallbackReason: fallbackReason ?? diagnostics.fallbackReason)),
+                fallbackReason: fallbackReason ?? diagnostics.fallbackReason,
+                windowPlanCacheStatus: diagnostics.windowPlanCacheStatus,
+                windowPlanCacheGeneration: diagnostics.windowPlanCacheGeneration)),
             warning: self.warning)
     }
 }

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Observation/DesktopObservationService.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Observation/DesktopObservationService.swift
@@ -104,9 +104,13 @@ public final class DesktopObservationService: DesktopObservationServiceProtocol 
                     }
                     try self.validateResolvedTarget(target, for: lanePlan)
 
-                    let rawCapture = try await tracer.span("capture.\(Self.captureSpanName(for: target.kind))") {
+                    let captureSpanName = "capture.\(Self.captureSpanName(for: target.kind))"
+                    let rawCapture = try await tracer.span(captureSpanName) {
                         try await self.capture(target, options: request.capture, snapshot: stateSnapshot)
                     }
+                    tracer.annotateLastSpan(
+                        named: captureSpanName,
+                        metadata: rawCapture.metadata.diagnostics?.observationSpanMetadata ?? [:])
                     try Self.validateCaptureReceipt(rawCapture, for: target)
                     try self.validateCurrentLaneIdentity(lanePlan)
                     let capture = Self.normalize(capture: rawCapture, for: target)
@@ -232,5 +236,24 @@ public final class DesktopObservationService: DesktopObservationServiceProtocol 
             return false
         }
         return true
+    }
+}
+
+extension CaptureDiagnostics {
+    fileprivate var observationSpanMetadata: [String: String] {
+        var metadata: [String: String] = [:]
+        if let engine {
+            metadata["engine"] = engine
+        }
+        if let fallbackReason {
+            metadata["fallback_reason"] = fallbackReason
+        }
+        if let windowPlanCacheStatus {
+            metadata["window_plan_cache"] = windowPlanCacheStatus.rawValue
+        }
+        if let windowPlanCacheGeneration {
+            metadata["window_plan_cache_generation"] = String(windowPlanCacheGeneration)
+        }
+        return metadata
     }
 }

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Observation/DesktopObservationTraceRecorder.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Observation/DesktopObservationTraceRecorder.swift
@@ -24,6 +24,19 @@ final class DesktopObservationTraceRecorder {
         self.spans.append(contentsOf: spans)
     }
 
+    func annotateLastSpan(named name: String, metadata: [String: String]) {
+        guard !metadata.isEmpty,
+              let index = self.spans.lastIndex(where: { $0.name == name })
+        else {
+            return
+        }
+        let span = self.spans[index]
+        self.spans[index] = ObservationSpan(
+            name: span.name,
+            durationMS: span.durationMS,
+            metadata: span.metadata.merging(metadata) { _, new in new })
+    }
+
     func record(_ name: String, start: ContinuousClock.Instant, metadata: [String: String] = [:]) {
         let duration = start.duration(to: ContinuousClock.now)
         let milliseconds = Double(duration.components.seconds * 1000)

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/System/SystemIdentityResolver.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/System/SystemIdentityResolver.swift
@@ -43,6 +43,26 @@ public struct SystemWindowIdentity: Sendable, Equatable {
 /// PIDs are generation-bound because they are recycled; CGWindowID is Apple's session-scoped
 /// WindowServer identifier, with owner generation and bounds retained as fail-closed change evidence.
 public enum SystemIdentityResolver {
+    private struct WindowSafetyFingerprint: Equatable {
+        let windowID: CGWindowID
+        let ownerProcessIdentifier: pid_t
+        let bounds: CGRect
+        let layer: Int
+        let alpha: CGFloat
+        let isOnScreen: Bool
+        let sharingState: WindowSharingState?
+
+        init(_ identity: SystemWindowIdentity) {
+            self.windowID = identity.windowID
+            self.ownerProcessIdentifier = identity.ownerProcessIdentifier
+            self.bounds = identity.bounds
+            self.layer = identity.layer
+            self.alpha = identity.alpha
+            self.isOnScreen = identity.isOnScreen
+            self.sharingState = identity.sharingState
+        }
+    }
+
     struct WindowMutationIdentityProviders {
         let processStartIdentity: (pid_t) -> UInt64?
         let windowIdentity: (CGWindowID) -> SystemWindowIdentity?
@@ -96,6 +116,41 @@ public enum SystemIdentityResolver {
             return nil
         }
         return identity
+    }
+
+    /// Captures one generation-bound exact-window identity while allowing descriptive metadata
+    /// such as the title or application name to refresh between reads. Those fields do not define
+    /// WindowServer identity and must not invalidate a safe capture plan by themselves.
+    static func stableWindowIdentity(
+        _ windowID: CGWindowID,
+        windowIdentityProvider: (CGWindowID) -> SystemWindowIdentity? = SystemIdentityResolver.windowIdentity,
+        processStartIdentityProvider: (pid_t) -> UInt64? = SystemIdentityResolver.processStartIdentity)
+        -> SystemWindowIdentity?
+    {
+        guard windowID != kCGNullWindowID,
+              let before = windowIdentityProvider(windowID),
+              before.windowID == windowID,
+              let beforeGeneration = processStartIdentityProvider(before.ownerProcessIdentifier),
+              let after = windowIdentityProvider(windowID),
+              after.windowID == windowID,
+              let afterGeneration = processStartIdentityProvider(after.ownerProcessIdentifier),
+              beforeGeneration == afterGeneration,
+              WindowSafetyFingerprint(before) == WindowSafetyFingerprint(after)
+        else {
+            return nil
+        }
+
+        return SystemWindowIdentity(
+            windowID: after.windowID,
+            ownerProcessIdentifier: after.ownerProcessIdentifier,
+            ownerProcessStartIdentity: afterGeneration,
+            title: after.title,
+            bounds: after.bounds,
+            layer: after.layer,
+            alpha: after.alpha,
+            isOnScreen: after.isOnScreen,
+            sharingState: after.sharingState,
+            applicationName: after.applicationName)
     }
 
     /// Lists one process's current WindowServer entries in front-to-back order without AX traversal.

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/DesktopObservationCacheDiagnosticsTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/DesktopObservationCacheDiagnosticsTests.swift
@@ -1,0 +1,69 @@
+import CoreGraphics
+import PeekabooFoundation
+import XCTest
+@testable import PeekabooAutomationKit
+
+@MainActor
+final class DesktopObservationCacheDiagnosticsTests: XCTestCase {
+    func testObservationPreservesWindowPlanCacheDiagnosticsThroughNormalizationAndCaptureSpan() async throws {
+        let app = ServiceApplicationInfo(
+            processIdentifier: 123,
+            processStartIdentity: 456,
+            bundleIdentifier: "com.example.fixture",
+            name: "Fixture",
+            windowCount: 1)
+        let bounds = CGRect(x: 100, y: 100, width: 400, height: 300)
+        let resolvedWindow = Self.window(title: "Resolved Document", bounds: bounds, index: 0)
+        let capturedWindow = Self.window(title: "Captured Document", bounds: bounds, index: 5)
+        let capture = RecordingScreenCaptureService(result: CaptureResult(
+            imageData: Data([9]),
+            metadata: CaptureMetadata(
+                size: bounds.size,
+                mode: .window,
+                applicationInfo: app,
+                windowInfo: capturedWindow,
+                diagnostics: CaptureDiagnostics(
+                    requestedScale: .logical1x,
+                    nativeScale: 2,
+                    outputScale: 1,
+                    scaleSource: "test",
+                    finalPixelSize: bounds.size,
+                    windowPlanCacheStatus: .hit,
+                    windowPlanCacheGeneration: 17))))
+        let service = DesktopObservationService(
+            screenCapture: capture,
+            automation: RecordingUIAutomationService(fixedResult: ElementDetectionResult(
+                snapshotId: "unused",
+                screenshotPath: "/tmp/unused.png",
+                elements: DetectedElements(),
+                metadata: DetectionMetadata(detectionTime: 0, elementCount: 0, method: "fixture"))),
+            applications: RecordingApplicationService(applications: [app], windows: [resolvedWindow]))
+
+        let result = try await service.observe(DesktopObservationRequest(
+            target: .app(identifier: "Fixture", window: .automatic),
+            detection: DesktopDetectionOptions(mode: .none)))
+
+        XCTAssertEqual(result.capture.metadata.windowInfo?.title, "Resolved Document")
+        XCTAssertEqual(result.capture.metadata.windowInfo?.index, 0)
+        XCTAssertEqual(
+            result.capture.metadata.diagnostics?.windowPlanCacheStatus,
+            CaptureWindowPlanCacheStatus.hit)
+        XCTAssertEqual(result.capture.metadata.diagnostics?.windowPlanCacheGeneration, 17)
+        let captureSpan = try XCTUnwrap(result.timings.spans.first { $0.name == "capture.window" })
+        XCTAssertEqual(captureSpan.metadata["window_plan_cache"], "hit")
+        XCTAssertEqual(captureSpan.metadata["window_plan_cache_generation"], "17")
+    }
+
+    private static func window(title: String, bounds: CGRect, index: Int) -> ServiceWindowInfo {
+        ServiceWindowInfo(
+            windowID: 42,
+            title: title,
+            bounds: bounds,
+            windowLevel: 0,
+            alpha: 1,
+            index: index,
+            layer: 0,
+            isOnScreen: true,
+            sharingState: .readOnly)
+    }
+}

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ScreenCaptureKitWindowPlanCacheTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ScreenCaptureKitWindowPlanCacheTests.swift
@@ -118,7 +118,7 @@ struct ScreenCaptureKitWindowPlanCacheTests {
     }
 
     @Test
-    func `capture diagnostics preserve cache hit and generation receipts`() throws {
+    func `capture diagnostics preserve rebuilt cache and generation receipts`() throws {
         let plan = ScreenCaptureScaleResolver.Plan(
             preference: .logical1x,
             nativeScale: 2,
@@ -127,13 +127,13 @@ struct ScreenCaptureKitWindowPlanCacheTests {
         let diagnostics = ScreenCaptureScaleResolver.diagnostics(
             plan: plan,
             finalPixelSize: CGSize(width: 800, height: 600),
-            windowPlanCacheStatus: .hit,
+            windowPlanCacheStatus: .rebuilt,
             windowPlanCacheGeneration: 17)
 
         let encoded = try JSONEncoder().encode(diagnostics)
         let decoded = try JSONDecoder().decode(CaptureDiagnostics.self, from: encoded)
 
-        #expect(decoded.windowPlanCacheStatus == .hit)
+        #expect(decoded.windowPlanCacheStatus == .rebuilt)
         #expect(decoded.windowPlanCacheGeneration == 17)
     }
 
@@ -353,12 +353,13 @@ struct ScreenCaptureKitWindowPlanCacheTests {
                 buildCalls += 1
                 return Plan()
             },
-            capture: { _ in "pixels" },
+            capture: { _, _ in "pixels" },
             validation: { _ in .matched },
             evict: { _ in evictions += 1 })
 
         #expect(result.plan === cached)
         #expect(result.output == "pixels")
+        #expect(result.cacheStatus == .hit)
         #expect(buildCalls == 0)
         #expect(evictions == 0)
     }
@@ -375,9 +376,9 @@ struct ScreenCaptureKitWindowPlanCacheTests {
         let result = try await ScreenCaptureWindowPlanExecutor.execute(
             cachedPlan: { nil },
             buildPlan: { plans.removeFirst() },
-            capture: {
-                captured.append(ObjectIdentifier($0))
-                return $0 === first ? "stale" : "fresh"
+            capture: { plan, _ in
+                captured.append(ObjectIdentifier(plan))
+                return plan === first ? "stale" : "fresh"
             },
             validation: { plan in
                 let identifier = ObjectIdentifier(plan)
@@ -388,6 +389,7 @@ struct ScreenCaptureKitWindowPlanCacheTests {
 
         #expect(result.output == "fresh")
         #expect(result.plan === second)
+        #expect(result.cacheStatus == .miss)
         #expect(plans.isEmpty)
         #expect(captured == [ObjectIdentifier(first), ObjectIdentifier(second)])
         #expect(evicted == [ObjectIdentifier(first)])
@@ -408,7 +410,7 @@ struct ScreenCaptureKitWindowPlanCacheTests {
                     buildCalls += 1
                     return rebuilt
                 },
-                capture: { _ in "replacement pixels" },
+                capture: { _, _ in "replacement pixels" },
                 validation: { plan in
                     guard plan === rebuilt else { return .changed }
                     rebuiltValidations += 1
@@ -434,7 +436,7 @@ struct ScreenCaptureKitWindowPlanCacheTests {
                     buildCalls += 1
                     return Plan()
                 },
-                capture: { _ in
+                capture: { _, _ in
                     captureCalls += 1
                     return "pixels"
                 },
@@ -456,7 +458,7 @@ struct ScreenCaptureKitWindowPlanCacheTests {
             _ = try await ScreenCaptureWindowPlanExecutor.execute(
                 cachedPlan: { cached },
                 buildPlan: { Plan() },
-                capture: { _ in "unproven pixels" },
+                capture: { _, _ in "unproven pixels" },
                 validation: { _ in
                     validationCalls += 1
                     return validationCalls == 1 ? .matched : .unavailable
@@ -480,7 +482,7 @@ struct ScreenCaptureKitWindowPlanCacheTests {
                 buildCalls += 1
                 return rebuilt
             },
-            capture: { _ in
+            capture: { _, _ in
                 captureCalls += 1
                 if captureCalls == 1 {
                     throw RetrySafeStaleWindowPlanError(terminalError: .captureFailed("stale geometry"))
@@ -492,6 +494,7 @@ struct ScreenCaptureKitWindowPlanCacheTests {
 
         #expect(result.plan === rebuilt)
         #expect(result.output == "fresh pixels")
+        #expect(result.cacheStatus == .rebuilt)
         #expect(buildCalls == 1)
         #expect(captureCalls == 2)
     }
@@ -509,7 +512,7 @@ struct ScreenCaptureKitWindowPlanCacheTests {
                     buildCalls += 1
                     return Plan()
                 },
-                capture: { _ -> String in
+                capture: { _, _ -> String in
                     captureCalls += 1
                     throw RetrySafeStaleWindowPlanError(terminalError: terminal)
                 },
@@ -531,7 +534,7 @@ struct ScreenCaptureKitWindowPlanCacheTests {
                     buildCalls += 1
                     throw PeekabooError.timeout("plan construction")
                 },
-                capture: { _ in "pixels" },
+                capture: { _, _ in "pixels" },
                 validation: { _ in .matched },
                 evict: { _ in })
         }
@@ -545,7 +548,7 @@ struct ScreenCaptureKitWindowPlanCacheTests {
             try await ScreenCaptureWindowPlanExecutor.execute(
                 cachedPlan: { Plan() },
                 buildPlan: { Issue.record("Cancellation must not rebuild"); return Plan() },
-                capture: { _ in
+                capture: { _, _ in
                     withUnsafeCurrentTask { $0?.cancel() }
                     return "discarded pixels"
                 },
@@ -569,7 +572,7 @@ struct ScreenCaptureKitWindowPlanCacheTests {
                     buildCalls += 1
                     return Plan()
                 },
-                capture: { _ -> String in throw expected },
+                capture: { _, _ -> String in throw expected },
                 validation: { _ in .matched },
                 evict: { _ in })
         }
@@ -590,7 +593,7 @@ struct ScreenCaptureKitWindowPlanCacheTests {
             _ = try await ScreenCaptureWindowPlanExecutor.execute(
                 cachedPlan: { Plan() },
                 buildPlan: { Plan() },
-                capture: { _ -> String in
+                capture: { _, _ -> String in
                     captureCalls += 1
                     throw expected
                 },

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ScreenCaptureKitWindowPlanCacheTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ScreenCaptureKitWindowPlanCacheTests.swift
@@ -1,0 +1,684 @@
+import CoreGraphics
+import Foundation
+import PeekabooFoundation
+import Testing
+@_spi(Testing) @testable import PeekabooAutomationKit
+
+@MainActor
+struct ScreenCaptureKitWindowPlanCacheTests {
+    private final class Plan: @unchecked Sendable {}
+
+    @Test
+    func `fresh entries reuse the same plan and expire at the TTL`() {
+        let cache = ScreenCaptureKitWindowPlanCache<Plan>(timeToLive: .seconds(2), capacity: 4)
+        let key = ScreenCaptureKitWindowPlanCache<Plan>.Key(windowID: 42, usesNativeScale: false)
+        let plan = Plan()
+        let start = ContinuousClock.now
+
+        cache.insert(plan, for: key, now: start)
+
+        #expect(cache.value(for: key, now: start.advanced(by: .milliseconds(1999))) === plan)
+        #expect(cache.value(for: key, now: start.advanced(by: .seconds(2))) == nil)
+        #expect(cache.isEmpty)
+    }
+
+    @Test
+    func `scale variants are independent and capacity evicts the oldest live plan`() {
+        let cache = ScreenCaptureKitWindowPlanCache<Plan>(timeToLive: .seconds(10), capacity: 2)
+        let logical = ScreenCaptureKitWindowPlanCache<Plan>.Key(windowID: 42, usesNativeScale: false)
+        let native = ScreenCaptureKitWindowPlanCache<Plan>.Key(windowID: 42, usesNativeScale: true)
+        let other = ScreenCaptureKitWindowPlanCache<Plan>.Key(windowID: 43, usesNativeScale: false)
+        let start = ContinuousClock.now
+        let logicalPlan = Plan()
+        let nativePlan = Plan()
+        let otherPlan = Plan()
+
+        cache.insert(logicalPlan, for: logical, now: start)
+        cache.insert(nativePlan, for: native, now: start.advanced(by: .milliseconds(1)))
+        cache.insert(otherPlan, for: other, now: start.advanced(by: .milliseconds(2)))
+
+        #expect(cache.value(for: logical, now: start.advanced(by: .milliseconds(3))) == nil)
+        #expect(cache.value(for: native, now: start.advanced(by: .milliseconds(3))) === nativePlan)
+        #expect(cache.value(for: other, now: start.advanced(by: .milliseconds(3))) === otherPlan)
+    }
+
+    @Test
+    func `expired entries are purged before a live plan is evicted`() {
+        let cache = ScreenCaptureKitWindowPlanCache<Plan>(timeToLive: .seconds(2), capacity: 2)
+        let expired = ScreenCaptureKitWindowPlanCache<Plan>.Key(windowID: 1, usesNativeScale: false)
+        let live = ScreenCaptureKitWindowPlanCache<Plan>.Key(windowID: 2, usesNativeScale: false)
+        let inserted = ScreenCaptureKitWindowPlanCache<Plan>.Key(windowID: 3, usesNativeScale: false)
+        let start = ContinuousClock.now
+        let livePlan = Plan()
+
+        cache.insert(Plan(), for: expired, now: start)
+        cache.insert(livePlan, for: live, now: start.advanced(by: .milliseconds(1500)))
+        cache.insert(Plan(), for: inserted, now: start.advanced(by: .seconds(2)))
+
+        #expect(cache.value(for: expired, now: start.advanced(by: .seconds(2))) == nil)
+        #expect(cache.value(for: live, now: start.advanced(by: .seconds(2))) === livePlan)
+        #expect(cache.value(for: inserted, now: start.advanced(by: .seconds(2))) != nil)
+    }
+
+    @Test
+    func `stale-plan eviction cannot remove a replacement`() {
+        let cache = ScreenCaptureKitWindowPlanCache<Plan>(timeToLive: .seconds(2), capacity: 2)
+        let key = ScreenCaptureKitWindowPlanCache<Plan>.Key(windowID: 42, usesNativeScale: false)
+        let stale = Plan()
+        let replacement = Plan()
+
+        cache.insert(stale, for: key)
+        cache.insert(replacement, for: key)
+
+        #expect(!cache.removeValue(for: key, ifSameAs: stale))
+        #expect(cache.value(for: key) === replacement)
+        #expect(cache.removeValue(for: key, ifSameAs: replacement))
+    }
+
+    @Test
+    func `independent host caches never share plans`() {
+        let first = ScreenCaptureKitWindowPlanCache<Plan>()
+        let second = ScreenCaptureKitWindowPlanCache<Plan>()
+        let key = ScreenCaptureKitWindowPlanCache<Plan>.Key(windowID: 42, usesNativeScale: false)
+        let firstPlan = Plan()
+        let secondPlan = Plan()
+
+        first.insert(firstPlan, for: key)
+        #expect(first.value(for: key) === firstPlan)
+        #expect(second.value(for: key) == nil)
+
+        second.insert(secondPlan, for: key)
+        #expect(first.value(for: key) === firstPlan)
+        #expect(second.value(for: key) === secondPlan)
+    }
+
+    @Test
+    func `distinct operators own distinct caches and generation sequences`() {
+        let logger = MockLoggingService().logger(category: "test")
+        let first = ScreenCaptureKitOperator(
+            logger: logger,
+            feedbackClient: NoopAutomationFeedbackClient(),
+            frameSource: OperatorNoOpFrameSource())
+        let second = ScreenCaptureKitOperator(
+            logger: logger,
+            feedbackClient: NoopAutomationFeedbackClient(),
+            frameSource: OperatorNoOpFrameSource())
+
+        #expect(first.exactWindowPlanCache !== second.exactWindowPlanCache)
+        #expect(first.nextExactWindowPlanGeneration == 1)
+        #expect(second.nextExactWindowPlanGeneration == 1)
+
+        first.nextExactWindowPlanGeneration &+= 1
+        #expect(first.nextExactWindowPlanGeneration == 2)
+        #expect(second.nextExactWindowPlanGeneration == 1)
+
+        second.nextExactWindowPlanGeneration &+= 1
+        #expect(first.nextExactWindowPlanGeneration == 2)
+        #expect(second.nextExactWindowPlanGeneration == 2)
+    }
+
+    @Test
+    func `capture diagnostics preserve cache hit and generation receipts`() throws {
+        let plan = ScreenCaptureScaleResolver.Plan(
+            preference: .logical1x,
+            nativeScale: 2,
+            outputScale: 1,
+            source: .screenBackingScaleFactor)
+        let diagnostics = ScreenCaptureScaleResolver.diagnostics(
+            plan: plan,
+            finalPixelSize: CGSize(width: 800, height: 600),
+            windowPlanCacheStatus: .hit,
+            windowPlanCacheGeneration: 17)
+
+        let encoded = try JSONEncoder().encode(diagnostics)
+        let decoded = try JSONDecoder().decode(CaptureDiagnostics.self, from: encoded)
+
+        #expect(decoded.windowPlanCacheStatus == .hit)
+        #expect(decoded.windowPlanCacheGeneration == 17)
+    }
+
+    @Test
+    func `observation span publishes cache receipts without changing its duration`() {
+        let tracer = DesktopObservationTraceRecorder()
+        let start = ContinuousClock.now
+        tracer.record("capture.window", start: start, metadata: ["existing": "value"])
+        let original = tracer.timings().spans[0]
+
+        tracer.annotateLastSpan(
+            named: "capture.window",
+            metadata: [
+                "window_plan_cache": "hit",
+                "window_plan_cache_generation": "17",
+            ])
+
+        let span = tracer.timings().spans[0]
+        #expect(span.durationMS == original.durationMS)
+        #expect(span.metadata["existing"] == "value")
+        #expect(span.metadata["window_plan_cache"] == "hit")
+        #expect(span.metadata["window_plan_cache_generation"] == "17")
+    }
+
+    @Test
+    func `idle entries release their retained plan after the TTL`() async throws {
+        let cache = ScreenCaptureKitWindowPlanCache<Plan>(timeToLive: .milliseconds(20), capacity: 1)
+        let key = ScreenCaptureKitWindowPlanCache<Plan>.Key(windowID: 42, usesNativeScale: false)
+        cache.insert(Plan(), for: key)
+
+        try await Task.sleep(for: .milliseconds(50))
+        for _ in 0..<100 where !cache.isEmpty {
+            await Task.yield()
+        }
+
+        #expect(cache.isEmpty)
+    }
+
+    @Test
+    func `receipt and topology validation distinguishes drift from unavailable evidence`() {
+        let bounds = CGRect(x: 10, y: 20, width: 800, height: 600)
+        let receipt = Self.receipt(bounds: bounds)
+        let topology = Self.topology(pixelWidth: 1920)
+
+        #expect(Self.validation(receipt, topology, receipt, topology) == .matched)
+        #expect(Self.validation(
+            receipt,
+            topology,
+            Self.receipt(bounds: CGRect(x: 11, y: 20, width: 800, height: 600)),
+            topology) == .changed)
+        #expect(Self.validation(receipt, topology, Self.receipt(bounds: bounds, windowID: 43), topology) == .changed)
+        #expect(Self.validation(
+            receipt,
+            topology,
+            Self.receipt(bounds: bounds, ownerProcessIdentifier: 124),
+            topology) == .changed)
+        #expect(Self.validation(
+            receipt,
+            topology,
+            Self.receipt(bounds: bounds, ownerProcessStartIdentity: 457),
+            topology) == .changed)
+        #expect(Self.validation(receipt, topology, Self.receipt(bounds: bounds, layer: 1), topology) == .changed)
+        #expect(Self.validation(receipt, topology, Self.receipt(bounds: bounds, isOnScreen: false), topology) ==
+            .changed)
+        #expect(Self.validation(receipt, topology, Self.receipt(bounds: bounds, alpha: 0.5), topology) == .changed)
+        #expect(Self.validation(receipt, topology, Self.receipt(bounds: bounds, sharingState: 0), topology) ==
+            .changed)
+        #expect(Self.validation(receipt, topology, receipt, Self.topology(pixelWidth: 2560)) == .changed)
+        #expect(Self.validation(receipt, topology, nil, topology) == .unavailable)
+        #expect(Self.validation(receipt, topology, receipt, nil) == .unavailable)
+
+        let expectedScale = ScreenCaptureScaleResolver.plan(
+            preference: .native,
+            screenBackingScaleFactor: 2,
+            fallbackPixelWidth: 3840,
+            frameWidth: 1920)
+        let changedScale = ScreenCaptureScaleResolver.plan(
+            preference: .native,
+            screenBackingScaleFactor: 1,
+            fallbackPixelWidth: 1920,
+            frameWidth: 1920)
+        #expect(Self.validation(
+            receipt,
+            topology,
+            receipt,
+            topology,
+            expectedScale,
+            changedScale) == .changed)
+        #expect(Self.validation(receipt, topology, receipt, topology, expectedScale, nil) == .unavailable)
+    }
+
+    @Test
+    func `display topology separates point matching from pixel rotation and mirror fingerprints`() {
+        let retina = Self.topology(pixelWidth: 3840, pixelHeight: 2160)
+
+        #expect(retina.containsScreenCaptureKitDisplay(
+            displayID: 1,
+            bounds: CGRect(x: 0, y: 0, width: 1920, height: 1080),
+            width: 1920,
+            height: 1080))
+        #expect(!retina.containsScreenCaptureKitDisplay(
+            displayID: 1,
+            bounds: CGRect(x: 0, y: 0, width: 1920, height: 1080),
+            width: 2560,
+            height: 1080))
+        #expect(retina != Self.topology(pixelWidth: 1920, pixelHeight: 1080))
+        #expect(retina != Self.topology(pixelWidth: 3840, pixelHeight: 2160, rotation: 90))
+        #expect(retina != Self.topology(
+            pixelWidth: 3840,
+            pixelHeight: 2160,
+            mirrorOwnerDisplayID: 2))
+
+        let mixedScale = ScreenCaptureDisplayTopology(displays: [
+            .init(
+                displayID: 1,
+                bounds: CGRect(x: -1920, y: 0, width: 1920, height: 1080),
+                pixelWidth: 3840,
+                pixelHeight: 2160,
+                rotation: 0),
+            .init(
+                displayID: 2,
+                bounds: CGRect(x: 0, y: 0, width: 2560, height: 1440),
+                pixelWidth: 2560,
+                pixelHeight: 1440,
+                rotation: 0,
+                isMain: true),
+        ])
+        #expect(mixedScale.containsScreenCaptureKitDisplay(
+            displayID: 1,
+            bounds: CGRect(x: -1920, y: 0, width: 1920, height: 1080),
+            width: 1920,
+            height: 1080))
+        #expect(mixedScale != ScreenCaptureDisplayTopology(displays: Array(mixedScale.displays.reversed())))
+    }
+
+    @Test
+    func `physical pixel fallback preserves one and two times display scale`() {
+        let oneX = ScreenCaptureScaleResolver.plan(
+            preference: .native,
+            screenBackingScaleFactor: nil,
+            fallbackPixelWidth: 1920,
+            frameWidth: 1920)
+        let twoX = ScreenCaptureScaleResolver.plan(
+            preference: .native,
+            screenBackingScaleFactor: nil,
+            fallbackPixelWidth: 3840,
+            frameWidth: 1920)
+        let logical = ScreenCaptureScaleResolver.plan(
+            preference: .logical1x,
+            screenBackingScaleFactor: nil,
+            fallbackPixelWidth: 3840,
+            frameWidth: 1920)
+
+        #expect(oneX.nativeScale == 1)
+        #expect(twoX.nativeScale == 2)
+        #expect(twoX.source == .displayPixelRatio)
+        #expect(logical.nativeScale == 2)
+        #expect(logical.outputScale == 1)
+    }
+
+    @Test
+    func `receipt construction brackets window and process generation`() {
+        let identity = Self.systemWindowIdentity()
+        var identities = [identity, identity]
+        var generations: [UInt64] = [456, 456]
+
+        let receipt = ScreenCaptureWindowPlanReceipt.current(
+            windowID: 42,
+            windowIdentityProvider: { _ in identities.removeFirst() },
+            processStartIdentityProvider: { _ in generations.removeFirst() })
+
+        #expect(receipt == Self.receipt(bounds: identity.bounds, sharingState: 2))
+        #expect(identities.isEmpty)
+        #expect(generations.isEmpty)
+    }
+
+    @Test
+    func `receipt construction rejects generation owner and window races but allows title refresh`() {
+        let identity = Self.systemWindowIdentity()
+        let variants = [
+            Self.systemWindowIdentity(bounds: CGRect(x: 11, y: 20, width: 800, height: 600)),
+            Self.systemWindowIdentity(ownerProcessIdentifier: 124),
+        ]
+        for variant in variants {
+            var identities = [identity, variant]
+            var generations: [UInt64] = [456, 456]
+            #expect(ScreenCaptureWindowPlanReceipt.current(
+                windowID: 42,
+                windowIdentityProvider: { _ in identities.removeFirst() },
+                processStartIdentityProvider: { _ in generations.removeFirst() }) == nil)
+        }
+
+        var renamedIdentities = [identity, Self.systemWindowIdentity(title: "Renamed")]
+        var stableGenerations: [UInt64] = [456, 456]
+        #expect(ScreenCaptureWindowPlanReceipt.current(
+            windowID: 42,
+            windowIdentityProvider: { _ in renamedIdentities.removeFirst() },
+            processStartIdentityProvider: { _ in stableGenerations.removeFirst() }) != nil)
+
+        var stableIdentities = [identity, identity]
+        var changedGenerations: [UInt64] = [456, 457]
+        #expect(ScreenCaptureWindowPlanReceipt.current(
+            windowID: 42,
+            windowIdentityProvider: { _ in stableIdentities.removeFirst() },
+            processStartIdentityProvider: { _ in changedGenerations.removeFirst() }) == nil)
+    }
+
+    @Test
+    func `valid cached plan captures without construction`() async throws {
+        let cached = Plan()
+        var buildCalls = 0
+        var evictions = 0
+
+        let result = try await ScreenCaptureWindowPlanExecutor.execute(
+            cachedPlan: { cached },
+            buildPlan: {
+                buildCalls += 1
+                return Plan()
+            },
+            capture: { _ in "pixels" },
+            validation: { _ in .matched },
+            evict: { _ in evictions += 1 })
+
+        #expect(result.plan === cached)
+        #expect(result.output == "pixels")
+        #expect(buildCalls == 0)
+        #expect(evictions == 0)
+    }
+
+    @Test
+    func `cold post-capture drift suppresses stale output and rebuilds once`() async throws {
+        let first = Plan()
+        let second = Plan()
+        var plans = [first, second]
+        var validationCalls: [ObjectIdentifier: Int] = [:]
+        var captured: [ObjectIdentifier] = []
+        var evicted: [ObjectIdentifier] = []
+
+        let result = try await ScreenCaptureWindowPlanExecutor.execute(
+            cachedPlan: { nil },
+            buildPlan: { plans.removeFirst() },
+            capture: {
+                captured.append(ObjectIdentifier($0))
+                return $0 === first ? "stale" : "fresh"
+            },
+            validation: { plan in
+                let identifier = ObjectIdentifier(plan)
+                validationCalls[identifier, default: 0] += 1
+                return plan === first && validationCalls[identifier] == 2 ? .changed : .matched
+            },
+            evict: { evicted.append(ObjectIdentifier($0)) })
+
+        #expect(result.output == "fresh")
+        #expect(result.plan === second)
+        #expect(plans.isEmpty)
+        #expect(captured == [ObjectIdentifier(first), ObjectIdentifier(second)])
+        #expect(evicted == [ObjectIdentifier(first)])
+    }
+
+    @Test
+    func `invalid cached plan consumes the only recovery budget`() async {
+        let stale = Plan()
+        let rebuilt = Plan()
+        var buildCalls = 0
+        var rebuiltValidations = 0
+        var evicted: [ObjectIdentifier] = []
+
+        await #expect(throws: PeekabooError.self) {
+            _ = try await ScreenCaptureWindowPlanExecutor.execute(
+                cachedPlan: { stale },
+                buildPlan: {
+                    buildCalls += 1
+                    return rebuilt
+                },
+                capture: { _ in "replacement pixels" },
+                validation: { plan in
+                    guard plan === rebuilt else { return .changed }
+                    rebuiltValidations += 1
+                    return rebuiltValidations == 1 ? .matched : .changed
+                },
+                evict: { evicted.append(ObjectIdentifier($0)) })
+        }
+        #expect(buildCalls == 1)
+        #expect(evicted == [ObjectIdentifier(stale), ObjectIdentifier(rebuilt)])
+    }
+
+    @Test
+    func `unavailable validation bypasses cache without capture or rebuild`() async {
+        let cached = Plan()
+        var buildCalls = 0
+        var captureCalls = 0
+        var evictions = 0
+
+        await #expect(throws: ScreenCaptureWindowPlanCacheUnavailableError.self) {
+            _ = try await ScreenCaptureWindowPlanExecutor.execute(
+                cachedPlan: { cached },
+                buildPlan: {
+                    buildCalls += 1
+                    return Plan()
+                },
+                capture: { _ in
+                    captureCalls += 1
+                    return "pixels"
+                },
+                validation: { _ in .unavailable },
+                evict: { _ in evictions += 1 })
+        }
+        #expect(buildCalls == 0)
+        #expect(captureCalls == 0)
+        #expect(evictions == 1)
+    }
+
+    @Test
+    func `post-capture unavailable evidence discards pixels and routes fresh`() async {
+        let cached = Plan()
+        var validationCalls = 0
+        var evictions = 0
+
+        await #expect(throws: ScreenCaptureWindowPlanCacheUnavailableError.self) {
+            _ = try await ScreenCaptureWindowPlanExecutor.execute(
+                cachedPlan: { cached },
+                buildPlan: { Plan() },
+                capture: { _ in "unproven pixels" },
+                validation: { _ in
+                    validationCalls += 1
+                    return validationCalls == 1 ? .matched : .unavailable
+                },
+                evict: { _ in evictions += 1 })
+        }
+        #expect(validationCalls == 2)
+        #expect(evictions == 1)
+    }
+
+    @Test
+    func `retry-safe stale capture rebuilds once and returns only fresh output`() async throws {
+        let cached = Plan()
+        let rebuilt = Plan()
+        var captureCalls = 0
+        var buildCalls = 0
+
+        let result = try await ScreenCaptureWindowPlanExecutor.execute(
+            cachedPlan: { cached },
+            buildPlan: {
+                buildCalls += 1
+                return rebuilt
+            },
+            capture: { _ in
+                captureCalls += 1
+                if captureCalls == 1 {
+                    throw RetrySafeStaleWindowPlanError(terminalError: .captureFailed("stale geometry"))
+                }
+                return "fresh pixels"
+            },
+            validation: { _ in .matched },
+            evict: { _ in })
+
+        #expect(result.plan === rebuilt)
+        #expect(result.output == "fresh pixels")
+        #expect(buildCalls == 1)
+        #expect(captureCalls == 2)
+    }
+
+    @Test
+    func `second retry-safe stale failure returns its terminal error`() async {
+        let terminal = PeekabooError.captureFailed("stale twice")
+        var buildCalls = 0
+        var captureCalls = 0
+
+        let thrown = await #expect(throws: PeekabooError.self) {
+            _ = try await ScreenCaptureWindowPlanExecutor.execute(
+                cachedPlan: { Plan() },
+                buildPlan: {
+                    buildCalls += 1
+                    return Plan()
+                },
+                capture: { _ -> String in
+                    captureCalls += 1
+                    throw RetrySafeStaleWindowPlanError(terminalError: terminal)
+                },
+                validation: { _ in .matched },
+                evict: { _ in })
+        }
+        #expect(thrown?.localizedDescription == terminal.localizedDescription)
+        #expect(buildCalls == 1)
+        #expect(captureCalls == 2)
+    }
+
+    @Test
+    func `cold construction timeout is preserved without retry`() async {
+        var buildCalls = 0
+        let thrown = await #expect(throws: PeekabooError.self) {
+            _ = try await ScreenCaptureWindowPlanExecutor.execute(
+                cachedPlan: { nil },
+                buildPlan: { () throws -> Plan in
+                    buildCalls += 1
+                    throw PeekabooError.timeout("plan construction")
+                },
+                capture: { _ in "pixels" },
+                validation: { _ in .matched },
+                evict: { _ in })
+        }
+        #expect(thrown?.code == .timeout)
+        #expect(buildCalls == 1)
+    }
+
+    @Test
+    func `cancellation after capture discards output without rebuild`() async {
+        let task = Task { @MainActor in
+            try await ScreenCaptureWindowPlanExecutor.execute(
+                cachedPlan: { Plan() },
+                buildPlan: { Issue.record("Cancellation must not rebuild"); return Plan() },
+                capture: { _ in
+                    withUnsafeCurrentTask { $0?.cancel() }
+                    return "discarded pixels"
+                },
+                validation: { _ in .matched },
+                evict: { _ in })
+        }
+        await #expect(throws: CancellationError.self) { try await task.value }
+    }
+
+    @Test(arguments: [
+        PeekabooError.timeout("fixture timeout"),
+        PeekabooError.permissionDeniedScreenRecording,
+        PeekabooError.captureFailed("ScreenCaptureKit is quarantined"),
+    ])
+    func `typed capture failures are preserved without rebuild`(expected: PeekabooError) async {
+        var buildCalls = 0
+        let thrown = await #expect(throws: PeekabooError.self) {
+            _ = try await ScreenCaptureWindowPlanExecutor.execute(
+                cachedPlan: { Plan() },
+                buildPlan: {
+                    buildCalls += 1
+                    return Plan()
+                },
+                capture: { _ -> String in throw expected },
+                validation: { _ in .matched },
+                evict: { _ in })
+        }
+        #expect(thrown?.code == expected.code)
+        #expect(thrown?.localizedDescription == expected.localizedDescription)
+        #expect(buildCalls == 0)
+    }
+
+    @Test
+    func `raw ScreenCaptureKit TCC denial is preserved without internal retry`() async {
+        let expected = NSError(
+            domain: "com.apple.ScreenCaptureKit.SCStreamErrorDomain",
+            code: -3801,
+            userInfo: [NSLocalizedDescriptionKey: "The user declined TCCs"])
+        var captureCalls = 0
+
+        do {
+            _ = try await ScreenCaptureWindowPlanExecutor.execute(
+                cachedPlan: { Plan() },
+                buildPlan: { Plan() },
+                capture: { _ -> String in
+                    captureCalls += 1
+                    throw expected
+                },
+                validation: { _ in .matched },
+                evict: { _ in })
+            Issue.record("TCC denial should throw")
+        } catch let error as NSError {
+            #expect(error.domain == expected.domain)
+            #expect(error.code == expected.code)
+        }
+        #expect(captureCalls == 1)
+    }
+
+    private static func receipt(
+        bounds: CGRect,
+        windowID: CGWindowID = 42,
+        ownerProcessIdentifier: pid_t = 123,
+        ownerProcessStartIdentity: UInt64 = 456,
+        layer: Int = 0,
+        alpha: CGFloat = 1,
+        isOnScreen: Bool = true,
+        sharingState: Int? = 1) -> ScreenCaptureWindowPlanReceipt
+    {
+        ScreenCaptureWindowPlanReceipt(
+            windowID: windowID,
+            ownerProcessIdentifier: ownerProcessIdentifier,
+            ownerProcessStartIdentity: ownerProcessStartIdentity,
+            bounds: bounds,
+            layer: layer,
+            alpha: alpha,
+            isOnScreen: isOnScreen,
+            sharingState: sharingState)
+    }
+
+    private static func topology(
+        pixelWidth: Int,
+        pixelHeight: Int = 1080,
+        rotation: Double = 0,
+        mirrorOwnerDisplayID: CGDirectDisplayID? = nil) -> ScreenCaptureDisplayTopology
+    {
+        ScreenCaptureDisplayTopology(displays: [
+            .init(
+                displayID: 1,
+                bounds: CGRect(x: 0, y: 0, width: 1920, height: 1080),
+                pixelWidth: pixelWidth,
+                pixelHeight: pixelHeight,
+                rotation: rotation,
+                mirrorOwnerDisplayID: mirrorOwnerDisplayID),
+        ])
+    }
+
+    private static func systemWindowIdentity(
+        bounds: CGRect = CGRect(x: 10, y: 20, width: 800, height: 600),
+        ownerProcessIdentifier: pid_t = 123,
+        title: String = "Fixture") -> SystemWindowIdentity
+    {
+        SystemWindowIdentity(
+            windowID: 42,
+            ownerProcessIdentifier: ownerProcessIdentifier,
+            title: title,
+            bounds: bounds,
+            layer: 0,
+            alpha: 1,
+            isOnScreen: true,
+            sharingState: .readWrite,
+            applicationName: "Fixture")
+    }
+
+    private static func validation(
+        _ expectedReceipt: ScreenCaptureWindowPlanReceipt,
+        _ expectedTopology: ScreenCaptureDisplayTopology,
+        _ currentReceipt: ScreenCaptureWindowPlanReceipt?,
+        _ currentTopology: ScreenCaptureDisplayTopology?,
+        _ expectedScalePlan: ScreenCaptureScaleResolver.Plan? = nil,
+        _ currentScalePlan: ScreenCaptureScaleResolver.Plan? = nil) -> ScreenCaptureWindowPlanValidation.Result
+    {
+        ScreenCaptureWindowPlanValidation.result(
+            expectedReceipt: expectedReceipt,
+            expectedTopology: expectedTopology,
+            currentReceipt: currentReceipt,
+            currentTopology: currentTopology,
+            expectedScalePlan: expectedScalePlan,
+            currentScalePlan: currentScalePlan)
+    }
+}
+
+private struct OperatorNoOpFrameSource: CaptureFrameSource {
+    func nextFrame() async throws -> (cgImage: CGImage?, metadata: CaptureMetadata)? {
+        nil
+    }
+}

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/SystemIdentityResolverTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/SystemIdentityResolverTests.swift
@@ -26,6 +26,64 @@ struct SystemIdentityResolverTests {
         #expect(identity.isOnScreen == false)
     }
 
+    @Test
+    func `Stable window identity binds generation while allowing descriptive metadata refresh`() throws {
+        let before = Self.identity(title: "Before", applicationName: "Old Name")
+        let after = Self.identity(title: "After", applicationName: "New Name")
+        var identities = [before, after]
+        var generations: [UInt64] = [111, 111]
+
+        let identity = try #require(SystemIdentityResolver.stableWindowIdentity(
+            1790,
+            windowIdentityProvider: { _ in identities.removeFirst() },
+            processStartIdentityProvider: { _ in generations.removeFirst() }))
+
+        #expect(identity.ownerProcessStartIdentity == 111)
+        #expect(identity.title == "After")
+        #expect(identity.applicationName == "New Name")
+    }
+
+    @Test
+    func `Stable window identity rejects generation and safety fingerprint drift`() {
+        let before = Self.identity()
+        let changedBounds = Self.identity(bounds: CGRect(x: 561, y: 371, width: 673, height: 439))
+        let changedOwner = Self.identity(ownerPID: 43)
+
+        for after in [changedBounds, changedOwner] {
+            var identities = [before, after]
+            var generations: [UInt64] = [111, 111]
+            #expect(SystemIdentityResolver.stableWindowIdentity(
+                1790,
+                windowIdentityProvider: { _ in identities.removeFirst() },
+                processStartIdentityProvider: { _ in generations.removeFirst() }) == nil)
+        }
+
+        var stableIdentities = [before, before]
+        var changedGenerations: [UInt64] = [111, 112]
+        #expect(SystemIdentityResolver.stableWindowIdentity(
+            1790,
+            windowIdentityProvider: { _ in stableIdentities.removeFirst() },
+            processStartIdentityProvider: { _ in changedGenerations.removeFirst() }) == nil)
+    }
+
+    private static func identity(
+        ownerPID: pid_t = 42,
+        title: String = "Fixture",
+        bounds: CGRect = CGRect(x: 560, y: 371, width: 673, height: 439),
+        applicationName: String = "Fixture App") -> SystemWindowIdentity
+    {
+        SystemWindowIdentity(
+            windowID: 1790,
+            ownerProcessIdentifier: ownerPID,
+            title: title,
+            bounds: bounds,
+            layer: 0,
+            alpha: 1,
+            isOnScreen: true,
+            sharingState: .readWrite,
+            applicationName: applicationName)
+    }
+
     private static func windowDictionary(
         windowID: Int,
         ownerPID: Int,

--- a/Core/PeekabooCore/Tests/PeekabooTests/RemoteCaptureEnginePlanCacheRoutingTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/RemoteCaptureEnginePlanCacheRoutingTests.swift
@@ -1,0 +1,184 @@
+import CoreGraphics
+import Darwin
+import Foundation
+import PeekabooAutomationKit
+import PeekabooBridge
+import Testing
+@testable import PeekabooCore
+
+@Suite(.serialized)
+@MainActor
+struct RemoteCaptureEnginePlanCacheRoutingTests {
+    @Test
+    func `two clients reuse one owner host plan while classic and auto avoid modern cache`() async throws {
+        let socketPath = "/tmp/peekaboo-capture-engine-plan-route-\(UUID().uuidString).sock"
+        let observation = CountingCaptureEngineObservationService()
+        let fixtureBounds = Self.windowBounds
+        let hostIdentity = PeekabooBridgeHostIdentity(
+            processIdentifier: getpid(),
+            processStartIdentity: SystemIdentityResolver.processStartIdentity(getpid()),
+            bundleIdentifier: "test.capture-engine.host",
+            bundleShortVersion: "4.0.1",
+            bundleVersion: "401",
+            codeSignatureHash: "fixture-cache-host-build")
+        let server = PeekabooBridgeServer(
+            services: StubServices(desktopObservation: observation),
+            hostKind: .onDemand,
+            allowlistedTeams: [],
+            allowlistedBundles: [],
+            allowedOperations: [.desktopObservation],
+            hostIdentity: hostIdentity,
+            hostCapabilities: [
+                PeekabooBridgeHostCapability.desktopObservationCaptureEngine,
+                PeekabooBridgeHostCapability.screenCaptureKitProcessOwnership,
+            ],
+            permissionStatusEvaluator: { _ in
+                PermissionsStatus(
+                    screenRecording: true,
+                    accessibility: true,
+                    appleScript: false,
+                    postEvent: true)
+            },
+            windowOwnerProcessIdentifierProvider: { $0 == 42 ? 123 : nil },
+            windowBoundsProvider: { $0 == 42 ? fixtureBounds : nil },
+            processStartIdentityProvider: { $0 == 123 ? 456 : nil })
+        let host = PeekabooBridgeHost(
+            socketPath: socketPath,
+            server: server,
+            allowedTeamIDs: [],
+            requestTimeoutSec: 2)
+        try await host.startChecked()
+        defer { Task { await host.stop() } }
+
+        let firstClient = PeekabooBridgeClient(socketPath: socketPath, requestTimeoutSec: 2)
+        let handshake = try await firstClient.handshake(client: .init(
+            bundleIdentifier: "test.capture-engine.first",
+            teamIdentifier: nil,
+            processIdentifier: getpid()))
+        #expect(handshake.hostKind == .onDemand)
+        #expect(handshake.hostCapabilities?.contains(
+            PeekabooBridgeHostCapability.desktopObservationCaptureEngine) == true)
+        #expect(handshake.hostCapabilities?.contains(
+            PeekabooBridgeHostCapability.screenCaptureKitProcessOwnership) == true)
+        #expect(handshake.hostIdentity == hostIdentity)
+
+        let firstRemote = RemoteDesktopObservationService(
+            client: firstClient,
+            supportsDesktopObservationCaptureEngine: true)
+        let secondRemote = RemoteDesktopObservationService(
+            client: PeekabooBridgeClient(socketPath: socketPath, requestTimeoutSec: 2),
+            supportsDesktopObservationCaptureEngine: true)
+
+        let first = try await firstRemote.observe(Self.request(engine: .modern))
+        let second = try await secondRemote.observe(Self.request(engine: .modern))
+
+        #expect(first.capture.metadata.diagnostics?.windowPlanCacheStatus == .miss)
+        #expect(second.capture.metadata.diagnostics?.windowPlanCacheStatus == .hit)
+        #expect(first.capture.metadata.diagnostics?.windowPlanCacheGeneration == 1)
+        #expect(second.capture.metadata.diagnostics?.windowPlanCacheGeneration == 1)
+        #expect(observation.modernLookups == 2)
+        #expect(observation.modernBuilds == 1)
+        #expect(observation.modernHits == 1)
+        #expect(observation.legacyCalls == 0)
+
+        _ = try await firstRemote.observe(Self.request(engine: .legacy))
+        _ = try await secondRemote.observe(Self.request(engine: .auto))
+
+        #expect(observation.requestedEngines == [.modern, .modern, .legacy, .auto])
+        #expect(observation.modernLookups == 2)
+        #expect(observation.modernBuilds == 1)
+        #expect(observation.modernHits == 1)
+        #expect(observation.legacyCalls == 2)
+        await host.stop()
+    }
+
+    fileprivate static let windowBounds = CGRect(x: 100, y: 200, width: 800, height: 600)
+
+    private static func request(engine: CaptureEnginePreference) -> DesktopObservationRequest {
+        DesktopObservationRequest(
+            target: .windowID(42),
+            capture: DesktopCaptureOptions(engine: engine),
+            detection: DesktopDetectionOptions(mode: .none))
+    }
+}
+
+@MainActor
+private final class CountingCaptureEngineObservationService: DesktopObservationServiceProtocol {
+    private final class Plan {}
+
+    private var modernPlan: Plan?
+    private(set) var requestedEngines: [CaptureEnginePreference] = []
+    private(set) var modernLookups = 0
+    private(set) var modernBuilds = 0
+    private(set) var modernHits = 0
+    private(set) var legacyCalls = 0
+
+    func observe(_ request: DesktopObservationRequest) async throws -> DesktopObservationResult {
+        self.requestedEngines.append(request.capture.engine)
+        let cacheStatus: CaptureWindowPlanCacheStatus?
+        let generation: UInt64?
+        switch request.capture.engine {
+        case .modern:
+            self.modernLookups += 1
+            if self.modernPlan == nil {
+                self.modernPlan = Plan()
+                self.modernBuilds += 1
+                cacheStatus = .miss
+            } else {
+                self.modernHits += 1
+                cacheStatus = .hit
+            }
+            generation = 1
+        case .legacy, .auto:
+            self.legacyCalls += 1
+            cacheStatus = nil
+            generation = nil
+        }
+
+        let identity = WindowMutationIdentity(
+            windowID: 42,
+            ownerProcessIdentifier: 123,
+            ownerProcessStartIdentity: 456,
+            capturedBounds: RemoteCaptureEnginePlanCacheRoutingTests.windowBounds)
+        return DesktopObservationResult(
+            target: ResolvedObservationTarget(
+                kind: .windowID(42),
+                app: ApplicationIdentity(
+                    processIdentifier: 123,
+                    processStartIdentity: 456,
+                    bundleIdentifier: "test.capture-engine.host",
+                    name: "Capture Engine Host"),
+                window: WindowIdentity(
+                    windowID: 42,
+                    title: "Fixture",
+                    bounds: RemoteCaptureEnginePlanCacheRoutingTests.windowBounds,
+                    index: 0)),
+            capture: CaptureResult(
+                imageData: StubScreenCaptureService.sampleData,
+                metadata: CaptureMetadata(
+                    size: RemoteCaptureEnginePlanCacheRoutingTests.windowBounds.size,
+                    mode: .window,
+                    applicationInfo: ServiceApplicationInfo(
+                        processIdentifier: 123,
+                        processStartIdentity: 456,
+                        bundleIdentifier: "test.capture-engine.host",
+                        name: "Capture Engine Host",
+                        windowCount: 1),
+                    windowInfo: ServiceWindowInfo(
+                        windowID: 42,
+                        title: "Fixture",
+                        bounds: RemoteCaptureEnginePlanCacheRoutingTests.windowBounds,
+                        mutationIdentity: identity),
+                    diagnostics: CaptureDiagnostics(
+                        requestedScale: .logical1x,
+                        nativeScale: 1,
+                        outputScale: 1,
+                        scaleSource: "fixture",
+                        finalPixelSize: RemoteCaptureEnginePlanCacheRoutingTests.windowBounds.size,
+                        engine: request.capture.engine.rawValue,
+                        windowPlanCacheStatus: cacheStatus,
+                        windowPlanCacheGeneration: generation))),
+            elements: nil,
+            files: DesktopObservationFiles())
+    }
+}

--- a/Core/PeekabooCore/Tests/PeekabooTests/ScreenCaptureServiceFlowTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/ScreenCaptureServiceFlowTests.swift
@@ -238,6 +238,33 @@ struct ScreenCaptureServiceFlowTests {
         #expect(failingOperator.captureScreenAttempts == 1)
     }
 
+    @Test(arguments: [CaptureEnginePreference.legacy, .auto])
+    func `legacy and successful auto exact-window capture never dispatch modern`(
+        engine: CaptureEnginePreference) async throws
+    {
+        let fixtures = self.makeFixtures()
+        let modernOperator = FixtureCaptureOperator(fixtures: fixtures)
+        let legacyOperator = FixtureCaptureOperator(fixtures: fixtures)
+        let dependencies = ScreenCaptureService.Dependencies(
+            feedbackClient: StubAutomationFeedbackClient(),
+            permissionEvaluator: CountingPermissionEvaluator(),
+            fallbackRunner: ScreenCaptureFallbackRunner(apis: [.legacy, .modern]),
+            applicationResolver: FixtureResolver(fixtures: fixtures),
+            makeFrameSource: { _ in NoOpCaptureFrameSource() },
+            makeModernOperator: { _, _ in modernOperator },
+            makeLegacyOperator: { _ in legacyOperator })
+        let service = ScreenCaptureService(loggingService: MockLoggingService(), dependencies: dependencies)
+        let windowID = CGWindowID(truncatingIfNeeded: "Dashboard".hashValue)
+
+        let result = try await service.withCaptureEngine(engine) {
+            try await service.captureWindow(windowID: windowID)
+        }
+
+        #expect(modernOperator.captureWindowIDAttempts == 0)
+        #expect(legacyOperator.captureWindowIDAttempts == 1)
+        #expect(result.metadata.diagnostics?.engine == "CGWindowList")
+    }
+
     @Test
     func `captureScreen checks permission once`() async throws {
         let fixtures = self.makeFixtures()
@@ -381,6 +408,7 @@ private struct FixtureResolver: ApplicationResolving {
 private final class FixtureCaptureOperator: ModernScreenCaptureOperating, LegacyScreenCaptureOperating,
 @unchecked Sendable {
     private let fixtures: ScreenCaptureService.TestFixtures
+    private(set) var captureWindowIDAttempts = 0
 
     init(fixtures: ScreenCaptureService.TestFixtures) {
         self.fixtures = fixtures
@@ -467,8 +495,10 @@ private final class FixtureCaptureOperator: ModernScreenCaptureOperating, Legacy
         visualizerMode _: CaptureVisualizerMode,
         scale: CaptureScalePreference) async throws -> CaptureResult
     {
+        self.captureWindowIDAttempts += 1
         let allWindows = self.fixtures.windowsByPID.values.flatMap(\.self)
-        guard let target = allWindows.first(where: { CGWindowID($0.title.hashValue) == windowID }) else {
+        guard let target = allWindows.first(where: { CGWindowID(truncatingIfNeeded: $0.title.hashValue) == windowID })
+        else {
             throw PeekabooError.windowNotFound(criteria: "window_id \(windowID)")
         }
 
@@ -496,7 +526,13 @@ private final class FixtureCaptureOperator: ModernScreenCaptureOperating, Legacy
                 index: 0,
                 name: self.fixtures.displays.first?.name,
                 bounds: self.fixtures.displays.first?.bounds ?? target.bounds,
-                scaleFactor: scale == .native ? (self.fixtures.displays.first?.scaleFactor ?? 1.0) : 1.0))
+                scaleFactor: scale == .native ? (self.fixtures.displays.first?.scaleFactor ?? 1.0) : 1.0),
+            diagnostics: CaptureDiagnostics(
+                requestedScale: scale,
+                nativeScale: self.fixtures.displays.first?.scaleFactor ?? 1.0,
+                outputScale: scaleFactor,
+                scaleSource: "fixture",
+                finalPixelSize: outputSize))
         return CaptureResult(imageData: imageData, metadata: metadata)
     }
 

--- a/docs/engine.md
+++ b/docs/engine.md
@@ -96,7 +96,26 @@ Aliases:
 
 ## Logging & telemetry
 - ScreenCaptureService logs which engine was attempted and when fallback occurs.
+- Exact-window ScreenCaptureKit observations include `window_plan_cache=miss|hit` and a process-local
+  `window_plan_cache_generation` in the `capture.window` observation span. The Bridge host identity identifies the owning
+  process; the plan generation is meaningful only inside that exact owner process.
 - Consider adding env `PEEKABOO_DISABLE_CGWINDOWLIST` if you want to dogfood pure SC.
+
+## Exact-window warm plans
+
+The modern exact-`window_id` path retains at most 32 screenshot plans for two seconds inside each
+`ScreenCaptureKitOperator`. A plan contains only an `SCContentFilter`, screenshot configuration, expected pixel size,
+and immutable receipt/topology/scale evidence. It contains no `SCStream`, captured pixels, or cached result metadata.
+The process owner is rechecked at every ScreenCaptureKit leaf even on a cache hit.
+
+Before and after capture, Peekaboo validates the exact window owner generation, bounds, layer, visibility, sharing
+state, active-display logical and physical topology, rotation, mirroring, and scale. Known drift evicts and rebuilds
+once. Unavailable evidence bypasses the cache for one fresh capture. Cancellation, timeout, permission, and quarantine
+failures are evicted and returned unchanged; they never trigger an internal cache retry or backend fallback.
+
+The cache belongs to the selected owner host. Separate caller-local CLI processes cannot share it, and a replacement
+host starts again at generation 1. `classic` never touches the cache. A successful `auto` CoreGraphics capture does not
+touch it; only an allowed ScreenCaptureKit attempt uses the warm-plan path.
 
 ## When to use which
 - Prefer **auto** for regular commands. Use **modern** for explicit ScreenCaptureKit regression checks.

--- a/docs/engine.md
+++ b/docs/engine.md
@@ -96,7 +96,7 @@ Aliases:
 
 ## Logging & telemetry
 - ScreenCaptureService logs which engine was attempted and when fallback occurs.
-- Exact-window ScreenCaptureKit observations include `window_plan_cache=miss|hit` and a process-local
+- Exact-window ScreenCaptureKit observations include `window_plan_cache=miss|hit|rebuilt` and a process-local
   `window_plan_cache_generation` in the `capture.window` observation span. The Bridge host identity identifies the owning
   process; the plan generation is meaningful only inside that exact owner process.
 - Consider adding env `PEEKABOO_DISABLE_CGWINDOWLIST` if you want to dogfood pure SC.


### PR DESCRIPTION
## What Problem This Solves

Exact-window modern capture repeatedly enumerates `SCShareableContent` and reconstructs the same `SCContentFilter` / `SCStreamConfiguration` before each screenshot. After process ownership is made fail-closed, that metadata planning remains the dominant warm-path cost for routed background agents.

## What Changed

- Add a per-`ScreenCaptureKitOperator` exact-window plan cache with a two-second TTL and 32-entry capacity.
- Cache only `SCContentFilter`, screenshot configuration, expected output size, and exact identity/topology/scale receipts—never pixels, `CGImage`, result metadata, or `SCStream`.
- Key and validate PID/process generation, WindowServer ID, bounds, sharing/layer/visibility state, display topology, physical pixels, rotation, mirroring, order, and scale preference.
- Validate before and after capture; stale evidence gets one typed rebuild budget and stale pixels never escape.
- Preserve raw cancellation, timeout, TCC/permission, quarantine, and unsupported-engine failures unchanged.
- Release cached SCK objects at TTL/capacity eviction.
- Refresh titles/application metadata on every result even when the capture plan hits.
- Publish `window_plan_cache` (`miss|hit|rebuilt`) and process-local `window_plan_cache_generation` diagnostics through service results, observation traces, and the real capture span.
- Keep every owner lease/leaf recheck active on cache hits.
- Add routed two-client owner-affinity proof plus classic/successful-auto zero-modern-dispatch coverage.

Static source checks require no `SCStream(`, `ScreenCaptureKitFrameSource`, `useFastStream`, `fallbackFrameSource`, or `FrameSourcePolicy` anywhere under Core/Apps.

## Evidence

- Focused AutomationKit: 58 tests.
- Focused Core: 37 tests.
- Focused CLI owner/runtime/capability/startup suites: 84 tests.
- Full AutomationKit: 599 tests, one unrelated AX-budget skip, zero failures.
- Full `pnpm run test:safe`: 846 Core/CLI plus 82 runtime tests and all signing/release/native-only/installer/report gates passed.
- Touched SwiftFormat: 0/14 files require formatting; full SwiftLint completed at 21 existing warnings/0 serious.
- Structured review and secret scan reported no findings; patch correctness confidence 0.98.
- Exact Foundation-signed head `ecf4efdfe`: SHA-256 `777d6c1369045d0dd46951ae0076f63f95e023bf4bff90272fdec509cec19c89`, Team `FWJYW4S8P8`, CDHash `21e0686facad61918819535289e7c08300352b80`.
- Mixed-upgrade behavior is correctly fail-closed: the installed owner-unaware Bridge 1.19 caused modern observation to refuse in 0.42s with `CAPTURE_FAILED`, `effect=refused`, `retry_safe=true`, `mutation_dispatched=false`, and no dispatch/image. That run is reported as blocked for cache/performance clauses, never passed.

Full Core currently has an unrelated baseline hang in `PasteToolExactWindowTests` / `PasteToolTransactionGateTests`; the same isolated filter hangs on clean public main. Cache/owner-focused Core suites are green and no timeout was raised.

## Merge Hold: Paired Modern Performance Gate

Do not merge this PR merely because unit/hosted CI is green. The installed old host prevents honest modern-hit measurements without stopping or replacing user runtime, which this lane intentionally did not do.

After the authorized paired modern deployment, require on one exact nonfrontmost target and owner:

- five batches of one miss plus four hits, with more than two seconds between batches;
- warm hit p50 at most 80% of owner-only p50;
- warm p95 no worse than owner-only p95;
- cold miss p50 within 15% of owner-only p50;
- zero failures, exact target pixels/receipts, same owner PID/generation/build, and unchanged foreground/cursor/clipboard/overlays;
- concurrent caller-local modern fast refusals and classic zero-SCK successes while routed cache hits continue;
- TTL generation rollover, title refresh on hits, and process-exit cache reset/recovery.

Earlier prototype evidence reached approximately 73 ms warm p50, but that predates the final owner scan and is not claimed as current performance. If the exact-head cache does not materially win this gate, close the PR rather than land the architectural tax.

No AppleScript, JXA, System Events, installed-host stop/replacement, TCC, UI, remote Mac, or release state was changed.
