### PR TITLE
fix(mcp): reject unsafe numeric arguments

### DIFF
--- a/Apps/CLI/Tests/CLIRuntimeTests/ScreenCaptureKitProcessCapabilityRuntimeTests.swift
+++ b/Apps/CLI/Tests/CLIRuntimeTests/ScreenCaptureKitProcessCapabilityRuntimeTests.swift
@@ -7,8 +7,8 @@ import Testing
 struct ScreenCaptureKitProcessCapabilityRuntimeTests {
     @Test
     func `live current CLI subprocess publishes a valid held capability marker`() async throws {
-        let directory = FileManager.default.temporaryDirectory
-            .appendingPathComponent("peekaboo-process-capability-\(UUID().uuidString)", isDirectory: true)
+        let identifier = String(UUID().uuidString.prefix(8)).lowercased()
+        let directory = URL(fileURLWithPath: "/tmp/pb-cap-\(identifier)", isDirectory: true)
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: false)
         defer { try? FileManager.default.removeItem(at: directory) }
 
@@ -20,11 +20,12 @@ struct ScreenCaptureKitProcessCapabilityRuntimeTests {
             "--bridge-socket", directory.appendingPathComponent("bridge.sock").path,
         ]
         process.standardOutput = FileHandle.nullDevice
-        process.standardError = FileHandle.nullDevice
+        let standardError = Pipe()
+        process.standardError = standardError
         try process.run()
         defer { Self.stop(process) }
 
-        let processStartIdentity = try await self.waitForProcessCapability(process)
+        let processStartIdentity = try await self.waitForProcessCapability(process, standardError: standardError)
         let conflicts = try ScreenCaptureKitOwnerLease.liveUncoordinatedProcesses(
             excluding: .current()
         )
@@ -38,10 +39,15 @@ struct ScreenCaptureKitProcessCapabilityRuntimeTests {
         try ScreenCaptureKitOwnerLease.removeStaleProcessCapabilityMarkers()
     }
 
-    private func waitForProcessCapability(_ process: Process) async throws -> UInt64 {
+    private func waitForProcessCapability(_ process: Process, standardError: Pipe) async throws -> UInt64 {
         for _ in 0..<100 {
             guard process.isRunning else {
-                throw RuntimeError("Peekaboo marker fixture exited before registration")
+                let details = String(
+                    decoding: standardError.fileHandleForReading.readDataToEndOfFile(),
+                    as: UTF8.self
+                ).trimmingCharacters(in: .whitespacesAndNewlines)
+                let suffix = details.isEmpty ? "" : ": \(details)"
+                throw RuntimeError("Peekaboo marker fixture exited before registration\(suffix)")
             }
             if let identity = SystemIdentityResolver.processStartIdentity(process.processIdentifier) {
                 let marker = ScreenCaptureKitOwnerLease.processCapabilityMarkerURL(

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Reuse two-second, owner-host-local ScreenCaptureKit exact-window screenshot plans without caching pixels, revalidating process generation, window receipt, display topology, and scale around every capture while exposing miss/hit generation diagnostics.
 
 ### Fixed
+- Reject non-finite, fractional, and overflowing MCP numeric arguments before dispatch, and expose integer-shaped delays, durations, counts, process IDs, window selectors, and Space targets as integers in tool schemas.
 - Preserve negative numeric option values through Commander parsing so command-owned range validation reports them accurately instead of misclassifying them as short flags.
 - Reject invalid live/action capture cadence instead of silently clamping or trapping, apply post-motion timing with a monotonic deadline, and report sampled throughput, capture failures, diff-filtered frames, and retained throughput separately from artifact postprocessing.
 - Keep remote `window close` background-only by default, matching local execution, and require explicit foreground consent before routing a close through focus or global-input fallbacks.

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/MCPToolArgumentValidation.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/MCPToolArgumentValidation.swift
@@ -1,0 +1,79 @@
+import Foundation
+import MCP
+import TachikomaMCP
+
+struct MCPToolArgumentValueError: LocalizedError, Sendable, Equatable {
+    enum Expectation: String, Sendable {
+        case integer = "an exact integer within the supported range"
+        case number = "a finite number"
+    }
+
+    let key: String
+    let expectation: Expectation
+
+    var errorDescription: String? {
+        "Parameter '\(self.key)' must be \(self.expectation.rawValue)."
+    }
+}
+
+extension ToolArguments {
+    func validatedInt(_ key: String) throws -> Int? {
+        guard self.getValue(for: key) != nil else { return nil }
+        guard let value = self.getInt(key) else {
+            throw MCPToolArgumentValueError(key: key, expectation: .integer)
+        }
+        return value
+    }
+
+    func validatedNumber(_ key: String) throws -> Double? {
+        guard self.getValue(for: key) != nil else { return nil }
+        guard let value = self.getNumber(key) else {
+            throw MCPToolArgumentValueError(key: key, expectation: .number)
+        }
+        return value
+    }
+}
+
+enum MCPToolArgumentValidator {
+    static func rejection(tool: any MCPTool, arguments: ToolArguments) -> ToolResponse? {
+        guard case let .object(schema) = tool.inputSchema,
+              case let .object(properties)? = schema["properties"]
+        else {
+            return nil
+        }
+
+        do {
+            for key in properties.keys.sorted() where arguments.getValue(for: key) != nil {
+                guard case let .object(property)? = properties[key],
+                      case let .string(type)? = property["type"]
+                else {
+                    continue
+                }
+
+                switch type {
+                case "integer":
+                    _ = try arguments.validatedInt(key)
+                case "number":
+                    _ = try arguments.validatedNumber(key)
+                default:
+                    continue
+                }
+            }
+            return nil
+        } catch let error as MCPToolArgumentValueError {
+            return ToolResponse.error(
+                error.localizedDescription,
+                meta: .object([
+                    "mutation_dispatched": .bool(false),
+                    "retry_safe": .bool(true),
+                ]))
+        } catch {
+            return ToolResponse.error(
+                "Invalid numeric tool argument: \(error.localizedDescription)",
+                meta: .object([
+                    "mutation_dispatched": .bool(false),
+                    "retry_safe": .bool(true),
+                ]))
+        }
+    }
+}

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/MCPToolContext.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/MCPToolContext.swift
@@ -190,6 +190,9 @@ public struct MCPToolContext: @unchecked Sendable {
         tool: any MCPTool,
         arguments: ToolArguments) async throws -> ToolResponse
     {
+        if let rejection = MCPToolArgumentValidator.rejection(tool: tool, arguments: arguments) {
+            return rejection
+        }
         await UISnapshotManager.shared.synchronizeImplicitLatestInvalidationWatermark(
             self.snapshots.effectiveImplicitLatestInvalidationWatermark)
         let effect = MCPToolSnapshotMutationPolicy.effect(toolName: tool.name, arguments: arguments)

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/BrowserTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/BrowserTool.swift
@@ -55,9 +55,9 @@ public struct BrowserTool: MCPTool {
                 "double": SchemaBuilder.boolean(description: "Double-click for click.", default: false),
                 "bring_to_front": SchemaBuilder.boolean(description: "Bring selected page to front.", default: false),
                 "background": SchemaBuilder.boolean(description: "Open new page in the background.", default: true),
-                "timeout": SchemaBuilder.number(description: "Timeout in milliseconds for navigation/waits."),
-                "page_size": SchemaBuilder.number(description: "Pagination size for console/network listings."),
-                "page_index": SchemaBuilder.number(description: "Zero-based page index for console/network listings."),
+                "timeout": SchemaBuilder.integer(description: "Timeout in milliseconds for navigation/waits."),
+                "page_size": SchemaBuilder.integer(description: "Pagination size for console/network listings."),
+                "page_index": SchemaBuilder.integer(description: "Zero-based page index for console/network listings."),
                 "types": SchemaBuilder.array(
                     items: SchemaBuilder.string(),
                     description: "Console message types to include."),
@@ -67,15 +67,15 @@ public struct BrowserTool: MCPTool {
                 "include_preserved": SchemaBuilder.boolean(
                     description: "Include preserved console/network data from recent navigations.",
                     default: false),
-                "message_id": SchemaBuilder.number(description: "Console message ID for get_console_message."),
-                "request_id": SchemaBuilder.number(description: "Network request ID for get_network_request."),
+                "message_id": SchemaBuilder.integer(description: "Console message ID for get_console_message."),
+                "request_id": SchemaBuilder.integer(description: "Network request ID for get_network_request."),
                 "request_file_path": SchemaBuilder.string(description: "Path for saving a network request body."),
                 "response_file_path": SchemaBuilder.string(description: "Path for saving a network response body."),
                 "path": SchemaBuilder.string(description: "File path for snapshots, screenshots, or trace output."),
                 "format": SchemaBuilder.string(
                     description: "Screenshot format.",
                     enum: ["png", "jpeg", "webp"]),
-                "quality": SchemaBuilder.number(description: "Screenshot quality for jpeg/webp."),
+                "quality": SchemaBuilder.integer(description: "Screenshot quality for jpeg/webp."),
                 "full_page": SchemaBuilder.boolean(description: "Capture a full-page screenshot.", default: false),
                 "trace_action": SchemaBuilder.string(
                     description: "Performance trace operation.",
@@ -138,6 +138,8 @@ public struct BrowserTool: MCPTool {
                     channel: channel)
             }
         } catch let error as BrowserToolError {
+            return ToolResponse.error(error.localizedDescription)
+        } catch let error as MCPToolArgumentValueError {
             return ToolResponse.error(error.localizedDescription)
         } catch {
             return ToolResponse.error(Self.permissionHelp(error: error))
@@ -346,19 +348,21 @@ public enum BrowserMCPCallMapper {
             return try BrowserMCPMappedCall(toolName: "new_page", arguments: self.compact([
                 "url": self.requiredURL(arguments),
                 "background": arguments.getBool("background") ?? true,
-                "timeout": arguments.getInt("timeout"),
+                "timeout": arguments.validatedInt("timeout"),
             ]))
         case .navigate:
-            return BrowserMCPMappedCall(toolName: "navigate_page", arguments: self.navigateArguments(arguments))
+            return try BrowserMCPMappedCall(
+                toolName: "navigate_page",
+                arguments: self.navigateArguments(arguments))
         case .waitFor:
             let text: [String] = if let values = arguments.getStringArray("text") {
                 values
             } else {
                 try [self.requiredString("text", arguments)]
             }
-            return BrowserMCPMappedCall(toolName: "wait_for", arguments: self.compact([
+            return try BrowserMCPMappedCall(toolName: "wait_for", arguments: self.compact([
                 "text": text,
-                "timeout": arguments.getInt("timeout"),
+                "timeout": arguments.validatedInt("timeout"),
             ]))
         default:
             throw BrowserToolError.invalidAction(action.rawValue)
@@ -424,9 +428,9 @@ public enum BrowserMCPCallMapper {
                 "promptText": arguments.getString("text"),
             ]))
         case .screenshot:
-            return BrowserMCPMappedCall(toolName: "take_screenshot", arguments: self.compact([
+            return try BrowserMCPMappedCall(toolName: "take_screenshot", arguments: self.compact([
                 "format": arguments.getString("format") ?? "png",
-                "quality": arguments.getInt("quality"),
+                "quality": arguments.validatedInt("quality"),
                 "uid": arguments.getString("uid"),
                 "fullPage": arguments.getBool("full_page"),
                 "filePath": arguments.getString("path"),
@@ -442,9 +446,9 @@ public enum BrowserMCPCallMapper {
     {
         switch action {
         case .console:
-            return self.consoleCall(arguments)
+            return try self.consoleCall(arguments)
         case .network:
-            return self.networkCall(arguments)
+            return try self.networkCall(arguments)
         case .performanceTrace:
             return try self.performanceCall(arguments)
         default:
@@ -452,39 +456,39 @@ public enum BrowserMCPCallMapper {
         }
     }
 
-    private static func navigateArguments(_ arguments: ToolArguments) -> [String: Any] {
+    private static func navigateArguments(_ arguments: ToolArguments) throws -> [String: Any] {
         let url = self.url(arguments)
         let type = arguments.getString("navigation_type") ?? (url == nil ? "reload" : "url")
-        return self.compact([
+        return try self.compact([
             "type": type,
             "url": url,
-            "timeout": arguments.getInt("timeout"),
+            "timeout": arguments.validatedInt("timeout"),
         ])
     }
 
-    private static func consoleCall(_ arguments: ToolArguments) -> BrowserMCPMappedCall {
-        if let messageId = arguments.getInt("message_id") {
+    private static func consoleCall(_ arguments: ToolArguments) throws -> BrowserMCPMappedCall {
+        if let messageId = try arguments.validatedInt("message_id") {
             return BrowserMCPMappedCall(toolName: "get_console_message", arguments: ["msgid": messageId])
         }
-        return BrowserMCPMappedCall(toolName: "list_console_messages", arguments: self.compact([
-            "pageSize": arguments.getInt("page_size"),
-            "pageIdx": arguments.getInt("page_index"),
+        return try BrowserMCPMappedCall(toolName: "list_console_messages", arguments: self.compact([
+            "pageSize": arguments.validatedInt("page_size"),
+            "pageIdx": arguments.validatedInt("page_index"),
             "types": arguments.getStringArray("types"),
             "includePreservedMessages": arguments.getBool("include_preserved") ?? false,
         ]))
     }
 
-    private static func networkCall(_ arguments: ToolArguments) -> BrowserMCPMappedCall {
-        if let requestId = arguments.getInt("request_id") {
+    private static func networkCall(_ arguments: ToolArguments) throws -> BrowserMCPMappedCall {
+        if let requestId = try arguments.validatedInt("request_id") {
             return BrowserMCPMappedCall(toolName: "get_network_request", arguments: self.compact([
                 "reqid": requestId,
                 "requestFilePath": arguments.getString("request_file_path"),
                 "responseFilePath": arguments.getString("response_file_path"),
             ]))
         }
-        return BrowserMCPMappedCall(toolName: "list_network_requests", arguments: self.compact([
-            "pageSize": arguments.getInt("page_size"),
-            "pageIdx": arguments.getInt("page_index"),
+        return try BrowserMCPMappedCall(toolName: "list_network_requests", arguments: self.compact([
+            "pageSize": arguments.validatedInt("page_size"),
+            "pageIdx": arguments.validatedInt("page_index"),
             "resourceTypes": arguments.getStringArray("resource_types"),
             "includePreservedRequests": arguments.getBool("include_preserved") ?? false,
         ]))

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/CaptureTool+Request.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/CaptureTool+Request.swift
@@ -93,7 +93,7 @@ private struct CaptureInput: Codable {
     let activeFps: Double?
     let thresholdPercent: Double?
     let heartbeatSec: Double?
-    let quietMs: Double?
+    let quietMs: Int?
 
     let input: String?
     let sampleFps: Double?
@@ -198,7 +198,7 @@ extension CaptureRequest {
         }
         let threshold = min(max(input.thresholdPercent ?? 2.5, 0), 100)
         let heartbeat = max(input.heartbeatSec ?? 5, 0)
-        let quiet = max(Int(input.quietMs ?? 1000), 0)
+        let quiet = max(input.quietMs ?? 1000, 0)
         let maxFrames = max(constraints.maxFrames, 1)
         let maxMbAdjusted = constraints.maxMb.flatMap { $0 > 0 ? $0 : nil }
         let focus = try CaptureToolArgumentResolver.captureFocus(from: input.captureFocus)

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/CaptureTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/CaptureTool.swift
@@ -32,10 +32,10 @@ public struct CaptureTool: MCPTool {
                     description: "screen|window|frontmost|area (region alias)",
                     enum: ["screen", "window", "frontmost", "area", "region"]),
                 "app": SchemaBuilder.string(description: "Optional app/bundle/PID target for window mode"),
-                "pid": SchemaBuilder.number(description: "Optional process ID target for window mode"),
+                "pid": SchemaBuilder.integer(description: "Optional process ID target for window mode"),
                 "window_title": SchemaBuilder.string(description: "Optional window title filter"),
-                "window_index": SchemaBuilder.number(description: "Optional window index; requires app or pid"),
-                "screen_index": SchemaBuilder.number(description: "Optional screen index"),
+                "window_index": SchemaBuilder.integer(description: "Optional window index; requires app or pid"),
+                "screen_index": SchemaBuilder.integer(description: "Optional screen index"),
                 "region": SchemaBuilder.string(description: "x,y,width,height for area mode"),
                 "capture_focus": SchemaBuilder.string(
                     description: "background (default)|foreground (activate target)|auto (legacy)",
@@ -58,29 +58,29 @@ public struct CaptureTool: MCPTool {
                     description: "Whole-frame change percent to keep motion frames (default 2.5; 0 keeps all)"),
                 "heartbeat_sec": SchemaBuilder
                     .number(description: "Heartbeat interval seconds (default 5, 0 disables)"),
-                "quiet_ms": SchemaBuilder.number(description: "Calm period before returning to idle (default 1000)"),
+                "quiet_ms": SchemaBuilder.integer(description: "Calm period before returning to idle (default 1000)"),
 
                 // Video sampling
                 "input": SchemaBuilder.string(description: "Video file path (required for source=video)"),
                 "sample_fps": SchemaBuilder.number(description: "Sample FPS (default 2). Exclusive with every_ms."),
-                "every_ms": SchemaBuilder.number(description: "Sample every N ms. Exclusive with sample_fps."),
-                "start_ms": SchemaBuilder.number(description: "Trim start in ms"),
-                "end_ms": SchemaBuilder.number(description: "Trim end in ms"),
+                "every_ms": SchemaBuilder.integer(description: "Sample every N ms. Exclusive with sample_fps."),
+                "start_ms": SchemaBuilder.integer(description: "Trim start in ms"),
+                "end_ms": SchemaBuilder.integer(description: "Trim end in ms"),
                 "no_diff": SchemaBuilder.boolean(description: "Keep all sampled frames (disable diff filtering)"),
 
                 // Shared caps/output
                 "highlight_changes": SchemaBuilder.boolean(description: "Overlay motion boxes on frames"),
-                "max_frames": SchemaBuilder.number(description: "Soft frame cap (default 800)"),
-                "max_mb": SchemaBuilder.number(description: "Soft size cap MB (optional)"),
+                "max_frames": SchemaBuilder.integer(description: "Soft frame cap (default 800)"),
+                "max_mb": SchemaBuilder.integer(description: "Soft size cap MB (optional)"),
                 "resolution_cap": SchemaBuilder.number(description: "Cap longest side px (default 1440)"),
                 "diff_strategy": SchemaBuilder.string(
                     description: "fast|quality (default fast)",
                     enum: ["fast", "quality"],
                     default: "fast"),
                 "diff_budget_ms": SchemaBuilder
-                    .number(description: "Diff time budget ms before falling back to fast (default 30 for quality)"),
+                    .integer(description: "Diff time budget ms before falling back to fast (default 30 for quality)"),
                 "output_dir": SchemaBuilder.string(description: "Optional absolute directory for outputs"),
-                "autoclean_minutes": SchemaBuilder.number(description: "Minutes to keep temp outputs (default 120)"),
+                "autoclean_minutes": SchemaBuilder.integer(description: "Minutes to keep temp outputs (default 120)"),
                 "video_out": SchemaBuilder.string(description: "Optional MP4 output path"),
             ],
             required: [])

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/DialogTool+Inputs.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/DialogTool+Inputs.swift
@@ -60,18 +60,18 @@ struct DialogToolInputs {
 
     let force: Bool?
 
-    init(arguments: ToolArguments) {
+    init(arguments: ToolArguments) throws {
         self.app = arguments.getString("app")
-        self.pid = arguments.getInt("pid")
-        self.windowId = arguments.getInt("window_id")
+        self.pid = try arguments.validatedInt("pid")
+        self.windowId = try arguments.validatedInt("window_id")
         self.windowTitle = arguments.getString("window_title")
-        self.windowIndex = arguments.getInt("window_index")
+        self.windowIndex = try arguments.validatedInt("window_index")
         self.foreground = arguments.getBool("foreground") ?? false
 
         self.button = arguments.getString("button")
         self.text = arguments.getString("text")
         self.field = arguments.getString("field")
-        self.fieldIndex = arguments.getInt("field_index")
+        self.fieldIndex = try arguments.validatedInt("field_index")
         self.clear = arguments.getBool("clear") ?? false
 
         self.path = arguments.getString("path")

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/DialogTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/DialogTool.swift
@@ -46,10 +46,10 @@ public struct DialogTool: MCPTool {
 
                 // Targeting
                 "app": SchemaBuilder.string(description: "Target app name/bundle ID, or 'PID:<n>'."),
-                "pid": SchemaBuilder.number(description: "Target process ID (alternative to app)."),
-                "window_id": SchemaBuilder.number(description: "Window ID (preferred stable selector)."),
+                "pid": SchemaBuilder.integer(description: "Target process ID (alternative to app)."),
+                "window_id": SchemaBuilder.integer(description: "Window ID (preferred stable selector)."),
                 "window_title": SchemaBuilder.string(description: "Window title (substring match)."),
-                "window_index": SchemaBuilder.number(description: "Window index (0-based); requires app/pid."),
+                "window_index": SchemaBuilder.integer(description: "Window index (0-based); requires app/pid."),
                 "foreground": SchemaBuilder.boolean(
                     description: "Allow focus/global input. Required for input, file, and forced dismiss.",
                     default: false),
@@ -60,7 +60,8 @@ public struct DialogTool: MCPTool {
                 // input
                 "text": SchemaBuilder.string(description: "Text to input (for input action)."),
                 "field": SchemaBuilder.string(description: "Field label/placeholder to target (for input action)."),
-                "field_index": SchemaBuilder.number(description: "Field index (0-based) to target (for input action)."),
+                "field_index": SchemaBuilder.integer(
+                    description: "Field index (0-based) to target (for input action)."),
                 "clear": SchemaBuilder.boolean(description: "Clear existing text first.", default: false),
 
                 // file
@@ -90,7 +91,7 @@ public struct DialogTool: MCPTool {
 
         do {
             let action = try DialogToolAction(arguments: arguments)
-            let inputs = DialogToolInputs(arguments: arguments)
+            let inputs = try DialogToolInputs(arguments: arguments)
 
             if action == .list, inputs.foreground {
                 throw DialogToolInputError.invalid("foreground", "dialog list is always read-only/background")

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/DragTool+Types.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/DragTool+Types.swift
@@ -40,10 +40,8 @@ struct DragRequest {
             throw DragToolError("Invalid button '\(buttonName)'. Use 'left' or 'right'.")
         }
 
-        let durationProvided = arguments.getValue(for: "duration") != nil
-        let stepsProvided = arguments.getValue(for: "steps") != nil
-        let durationOverride = durationProvided ? arguments.getNumber("duration").map(Int.init) : nil
-        let stepsOverride = stepsProvided ? arguments.getNumber("steps").map(Int.init) : nil
+        let durationOverride = try arguments.validatedInt("duration")
+        let stepsOverride = try arguments.validatedInt("steps")
 
         if let override = durationOverride {
             guard override > 0 else {

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/DragTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/DragTool.swift
@@ -36,10 +36,10 @@ public struct DragTool: MCPTool {
                 "snapshot": SchemaBuilder.string(
                     description: "Optional. Snapshot ID from `see` or `inspect_ui`. " +
                         "Uses latest snapshot if not specified"),
-                "duration": SchemaBuilder.number(
+                "duration": SchemaBuilder.integer(
                     description: "Optional. Duration in milliseconds (default: 500)",
                     default: 500),
-                "steps": SchemaBuilder.number(
+                "steps": SchemaBuilder.integer(
                     description: "Optional. Number of intermediate steps (default: 10)",
                     default: 10),
                 "profile": SchemaBuilder.string(
@@ -69,6 +69,8 @@ public struct DragTool: MCPTool {
             request = try DragRequest(arguments: arguments)
         } catch let error as DragToolError {
             return ToolResponse.error(error.message)
+        } catch {
+            return ToolResponse.error(error.localizedDescription)
         }
 
         do {

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/InspectUITool+Types.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/InspectUITool+Types.swift
@@ -1,5 +1,6 @@
 import MCP
 import PeekabooAutomationKit
+import PeekabooFoundation
 import TachikomaMCP
 
 struct InspectUIRequest {
@@ -9,20 +10,21 @@ struct InspectUIRequest {
     let webFocus: Bool
     let traversalBudget: AXTraversalBudget
 
-    init(arguments: ToolArguments) {
+    init(arguments: ToolArguments) throws {
         self.appTarget = arguments.getString("app_target")
         self.windowIDValue = arguments.getValue(for: "window_id")
         self.snapshotId = arguments.getString("snapshot")
         self.webFocus = arguments.getBool("web_focus") ?? false
-        self.traversalBudget = AXTraversalBudget.resolved(
+        self.traversalBudget = try AXTraversalBudget.resolved(
             maxDepth: Self.positiveInt("max_depth", in: arguments),
             maxElementCount: Self.positiveInt("max_elements", in: arguments),
             maxChildrenPerNode: Self.positiveInt("max_children", in: arguments))
     }
 
-    private static func positiveInt(_ key: String, in arguments: ToolArguments) -> Int? {
-        guard let value = arguments.getInt(key), value > 0 else {
-            return nil
+    private static func positiveInt(_ key: String, in arguments: ToolArguments) throws -> Int? {
+        guard let value = try arguments.validatedInt(key) else { return nil }
+        guard value > 0 else {
+            throw PeekabooError.invalidInput("\(key) must be a positive integer")
         }
         return value
     }

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/InspectUITool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/InspectUITool.swift
@@ -50,15 +50,18 @@ public struct InspectUITool: MCPTool {
                 "web_focus": SchemaBuilder.boolean(
                     description: "Optional. Allow an AXPress retry on sparse Chromium/Tauri web content.",
                     default: false),
-                "max_depth": SchemaBuilder.number(
-                    description: "Optional. Maximum AX traversal depth. Env fallback: PEEKABOO_AX_MAX_DEPTH."),
-                "max_elements": SchemaBuilder.number(
-                    description: "Optional. Maximum AX elements to collect. Env fallback: PEEKABOO_AX_MAX_ELEMENTS."),
-                "max_children": SchemaBuilder.number(
+                "max_depth": SchemaBuilder.integer(
+                    description: "Optional. Maximum AX traversal depth. Env fallback: PEEKABOO_AX_MAX_DEPTH.",
+                    minimum: 1),
+                "max_elements": SchemaBuilder.integer(
+                    description: "Optional. Maximum AX elements to collect. Env fallback: PEEKABOO_AX_MAX_ELEMENTS.",
+                    minimum: 1),
+                "max_children": SchemaBuilder.integer(
                     description: """
                     Optional. Maximum AX children per node. Env fallback: PEEKABOO_AX_MAX_CHILDREN.
                     Increase this for flat Qt/Electron panels with many sibling controls.
-                    """),
+                    """,
+                    minimum: 1),
             ],
             required: [])
     }
@@ -69,7 +72,12 @@ public struct InspectUITool: MCPTool {
 
     @MainActor
     public func execute(arguments: ToolArguments) async throws -> ToolResponse {
-        let request = InspectUIRequest(arguments: arguments)
+        let request: InspectUIRequest
+        do {
+            request = try InspectUIRequest(arguments: arguments)
+        } catch {
+            return Self.failureResponse(error)
+        }
         var newlyCreatedSnapshotID: String?
         var newlyCreatedSnapshotWasPending = false
 

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/MoveTool+Parsing.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/MoveTool+Parsing.swift
@@ -39,12 +39,8 @@ extension MoveTool {
         }
         let smooth = profile == .human ? true : (arguments.getBool("smooth") ?? false)
 
-        let durationValue = arguments.getNumber("duration")
-        let stepsValue = arguments.getNumber("steps")
-        let durationProvided = arguments.getValue(for: "duration") != nil
-        let stepsProvided = arguments.getValue(for: "steps") != nil
-        let durationOverride = durationProvided ? durationValue.map(Int.init) : nil
-        let stepsOverride = stepsProvided ? stepsValue.map(Int.init) : nil
+        let durationOverride = try arguments.validatedInt("duration")
+        let stepsOverride = try arguments.validatedInt("steps")
 
         if smooth, profile == .linear {
             let durationToValidate = durationOverride ?? 500

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/MoveTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/MoveTool.swift
@@ -39,10 +39,10 @@ public struct MoveTool: MCPTool {
                 "smooth": SchemaBuilder.boolean(
                     description: "Optional. Use smooth animated movement.",
                     default: false),
-                "duration": SchemaBuilder.number(
+                "duration": SchemaBuilder.integer(
                     description: "Optional. Duration in milliseconds for smooth movement. Default: 500.",
                     default: 500),
-                "steps": SchemaBuilder.number(
+                "steps": SchemaBuilder.integer(
                     description: "Optional. Number of steps for smooth movement. Default: 10.",
                     default: 10),
                 "profile": SchemaBuilder.string(

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/PasteTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/PasteTool.swift
@@ -49,13 +49,13 @@ public struct PasteTool: MCPTool {
             properties: [
                 // Targeting
                 "app": SchemaBuilder.string(description: "Target app name/bundle ID, or 'PID:<n>'."),
-                "pid": SchemaBuilder.number(description: "Target process ID (alternative to app)."),
-                "window_id": SchemaBuilder.number(
+                "pid": SchemaBuilder.integer(description: "Target process ID (alternative to app)."),
+                "window_id": SchemaBuilder.integer(
                     description: "Exact window ID for atomic background delivery, or foreground focus when requested."),
                 "window_title": SchemaBuilder
                     .string(description: "Window title substring for atomic exact-window background delivery."),
                 "window_index": SchemaBuilder
-                    .number(description: "Window index (0-based); requires app/pid and pins that exact window."),
+                    .integer(description: "Window index (0-based); requires app/pid and pins that exact window."),
 
                 // Payload
                 "text": SchemaBuilder.string(
@@ -70,7 +70,7 @@ public struct PasteTool: MCPTool {
                 "allowLarge": SchemaBuilder.boolean(description: "Allow payloads larger than 10 MB.", default: false),
 
                 // Restore timing
-                "restore_delay_ms": SchemaBuilder.number(
+                "restore_delay_ms": SchemaBuilder.integer(
                     description: "Delay before restoring the previous clipboard (ms). Default: 150.",
                     minimum: 0,
                     default: 150),
@@ -110,15 +110,15 @@ public struct PasteTool: MCPTool {
         do {
             let target = try MCPInteractionTarget(
                 app: arguments.getString("app"),
-                pid: arguments.getInt("pid"),
+                pid: arguments.validatedInt("pid"),
                 windowTitle: arguments.getString("window_title"),
-                windowIndex: arguments.getInt("window_index"),
-                windowId: arguments.getInt("window_id"))
+                windowIndex: arguments.validatedInt("window_index"),
+                windowId: arguments.validatedInt("window_id"))
 
             let foreground = arguments.getBool("foreground") ?? false
             let expectedPIDIdentity = try Self.explicitPIDIdentity(target: target)
             let payload = try self.makePayload(arguments: arguments)
-            let restoreDelayMs = max(0, arguments.getInt("restore_delay_ms") ?? 150)
+            let restoreDelayMs = try max(0, arguments.validatedInt("restore_delay_ms") ?? 150)
 
             if case let .explicit(request, text?) = payload, !foreground {
                 let destination = try await self.resolveDeliveryDestination(

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/PressTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/PressTool.swift
@@ -83,9 +83,9 @@ public struct PressTool: MCPTool {
     public func execute(arguments: ToolArguments) async throws -> ToolResponse {
         do {
             let chords = try Self.parseChords(arguments: arguments)
-            let count = arguments.getInt("count") ?? 1
-            let delay = arguments.getInt("delay") ?? 100
-            let hold = arguments.getInt("hold") ?? 50
+            let count = try arguments.validatedInt("count") ?? 1
+            let delay = try arguments.validatedInt("delay") ?? 100
+            let hold = try arguments.validatedInt("hold") ?? 50
             guard (1...100).contains(count) else {
                 return ToolResponse.error("count must be between 1 and 100")
             }
@@ -99,10 +99,10 @@ public struct PressTool: MCPTool {
             let foreground = arguments.getBool("foreground") == true
             let target = try MCPInteractionTarget(
                 app: arguments.getString("app"),
-                pid: arguments.getInt("pid"),
+                pid: arguments.validatedInt("pid"),
                 windowTitle: arguments.getString("window_title"),
-                windowIndex: arguments.getInt("window_index"),
-                windowId: arguments.getInt("window_id"))
+                windowIndex: arguments.validatedInt("window_index"),
+                windowId: arguments.validatedInt("window_id"))
             let resolvedWindowTitle = try await target.resolveWindowTitleIfNeeded(windows: self.context.windows)
             let targetIdentity = foreground ? nil : try await target.requireBackgroundProcessIdentity(
                 applications: self.context.applications,

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/ScrollTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/ScrollTool.swift
@@ -35,10 +35,10 @@ public struct ScrollTool: MCPTool {
                 "snapshot": SchemaBuilder.string(
                     description: "Optional. Snapshot ID from `see` or `inspect_ui`. " +
                         "Uses latest snapshot if not specified."),
-                "amount": SchemaBuilder.number(
+                "amount": SchemaBuilder.integer(
                     description: "Optional. Number of scroll ticks/lines. Default: 3.",
                     default: 3),
-                "delay": SchemaBuilder.number(
+                "delay": SchemaBuilder.integer(
                     description: "Optional. Foreground-only delay between scroll ticks in milliseconds. Default: 0.",
                     default: 0),
                 "smooth": SchemaBuilder.boolean(
@@ -98,7 +98,7 @@ public struct ScrollTool: MCPTool {
             throw ScrollToolValidationError("Invalid direction. Must be one of: up, down, left, right")
         }
 
-        let amount = Int(arguments.getNumber("amount") ?? 3)
+        let amount = try arguments.validatedInt("amount") ?? 3
         guard amount > 0 else {
             throw ScrollToolValidationError("Amount must be greater than 0")
         }
@@ -108,7 +108,7 @@ public struct ScrollTool: MCPTool {
 
         let foreground = arguments.getBool("foreground") ?? false
         let elementId = arguments.getString("on")
-        let delay = Int(arguments.getNumber("delay") ?? 0)
+        let delay = try arguments.validatedInt("delay") ?? 0
         let smooth = arguments.getBool("smooth") ?? false
         guard delay >= 0 else {
             throw ScrollToolValidationError("Delay must be zero or greater")

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/SeeTool+Types.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/SeeTool+Types.swift
@@ -36,15 +36,16 @@ struct SeeRequest {
         } else {
             self.roi = nil
         }
-        self.traversalBudget = AXTraversalBudget.resolved(
+        self.traversalBudget = try AXTraversalBudget.resolved(
             maxDepth: Self.positiveInt("max_depth", in: arguments),
             maxElementCount: Self.positiveInt("max_elements", in: arguments),
             maxChildrenPerNode: Self.positiveInt("max_children", in: arguments))
     }
 
-    private static func positiveInt(_ key: String, in arguments: ToolArguments) -> Int? {
-        guard let value = arguments.getInt(key), value > 0 else {
-            return nil
+    private static func positiveInt(_ key: String, in arguments: ToolArguments) throws -> Int? {
+        guard let value = try arguments.validatedInt(key) else { return nil }
+        guard value > 0 else {
+            throw PeekabooError.invalidInput("\(key) must be a positive integer")
         }
         return value
     }

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/SeeTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/SeeTool.swift
@@ -76,15 +76,18 @@ public struct SeeTool: MCPTool {
                 "web_focus": SchemaBuilder.boolean(
                     description: "Optional. Allow an AXPress retry on sparse Chromium/Tauri web content.",
                     default: false),
-                "max_depth": SchemaBuilder.number(
-                    description: "Optional. Maximum AX traversal depth. Env fallback: PEEKABOO_AX_MAX_DEPTH."),
-                "max_elements": SchemaBuilder.number(
-                    description: "Optional. Maximum AX elements to collect. Env fallback: PEEKABOO_AX_MAX_ELEMENTS."),
-                "max_children": SchemaBuilder.number(
+                "max_depth": SchemaBuilder.integer(
+                    description: "Optional. Maximum AX traversal depth. Env fallback: PEEKABOO_AX_MAX_DEPTH.",
+                    minimum: 1),
+                "max_elements": SchemaBuilder.integer(
+                    description: "Optional. Maximum AX elements to collect. Env fallback: PEEKABOO_AX_MAX_ELEMENTS.",
+                    minimum: 1),
+                "max_children": SchemaBuilder.integer(
                     description: """
                     Optional. Maximum AX children per node. Env fallback: PEEKABOO_AX_MAX_CHILDREN.
                     Increase this for flat Qt/Electron panels with many sibling controls.
-                    """),
+                    """,
+                    minimum: 1),
             ],
             required: [])
     }

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/SleepTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/SleepTool.swift
@@ -15,7 +15,7 @@ public struct SleepTool: MCPTool {
     public var inputSchema: Value {
         SchemaBuilder.object(
             properties: [
-                "duration": SchemaBuilder.number(
+                "duration": SchemaBuilder.integer(
                     description: "Sleep duration in milliseconds."),
             ],
             required: ["duration"])
@@ -24,18 +24,19 @@ public struct SleepTool: MCPTool {
     public init() {}
 
     public func execute(arguments: ToolArguments) async throws -> ToolResponse {
-        // Extract duration using the helper method
-        guard let duration = arguments.getNumber("duration") else {
-            return ToolResponse.error("Missing required parameter: duration")
+        let milliseconds: Int
+        do {
+            guard let value = try arguments.validatedInt("duration") else {
+                return ToolResponse.error("Missing required parameter: duration")
+            }
+            milliseconds = value
+        } catch {
+            return ToolResponse.error(error.localizedDescription)
         }
 
-        // Validate duration
-        guard duration > 0 else {
+        guard milliseconds > 0 else {
             return ToolResponse.error("Duration must be positive")
         }
-
-        // Convert to reasonable integer value
-        let milliseconds = Int(duration)
         guard milliseconds <= 600_000 else { // Max 10 minutes
             return ToolResponse.error("Duration cannot exceed 600000ms (10 minutes)")
         }

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/SpaceTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/SpaceTool.swift
@@ -59,13 +59,13 @@ public struct SpaceTool: MCPTool {
                 "action": SchemaBuilder.string(
                     description: "The action to perform",
                     enum: ["list", "switch", "move-window"]),
-                "to": SchemaBuilder.number(
+                "to": SchemaBuilder.integer(
                     description: "Space number to switch to (for switch action)"),
                 "app": SchemaBuilder.string(
                     description: "Application name for move-window action"),
                 "window_title": SchemaBuilder.string(
                     description: "Window title to move"),
-                "window_index": SchemaBuilder.number(
+                "window_index": SchemaBuilder.integer(
                     description: "Window index for multi-window apps"),
                 "to_current": SchemaBuilder.boolean(
                     description: "Move window to current space (for move-window action)",
@@ -99,6 +99,8 @@ public struct SpaceTool: MCPTool {
             parsedAction = try self.parseAction(arguments: arguments)
         } catch let validationError as SpaceActionValidationError {
             return ToolResponse.error(validationError.message)
+        } catch {
+            return ToolResponse.error(error.localizedDescription)
         }
 
         do {
@@ -119,7 +121,7 @@ public struct SpaceTool: MCPTool {
             let detailed = arguments.getBool("detailed") ?? false
             return .list(detailed: detailed)
         case "switch":
-            guard let spaceNumber = arguments.getNumber("to").map(Int.init) else {
+            guard let spaceNumber = try arguments.validatedInt("to") else {
                 throw SpaceActionValidationError("Switch action requires 'to' parameter (space number)")
             }
             return .switchSpace(spaceNumber: spaceNumber)
@@ -137,7 +139,7 @@ public struct SpaceTool: MCPTool {
         }
 
         let toCurrent = arguments.getBool("to_current") ?? false
-        let targetSpace = arguments.getNumber("to").map(Int.init)
+        let targetSpace = try arguments.validatedInt("to")
 
         if toCurrent, targetSpace != nil {
             throw SpaceActionValidationError("Cannot specify both 'to_current' and 'to' parameters")
@@ -148,10 +150,10 @@ public struct SpaceTool: MCPTool {
                 "Move-window action requires either 'to' (space number) or 'to_current' parameter")
         }
 
-        let request = MoveWindowRequest(
+        let request = try MoveWindowRequest(
             appName: appName,
             windowTitle: arguments.getString("window_title"),
-            windowIndex: arguments.getInt("window_index"),
+            windowIndex: arguments.validatedInt("window_index"),
             targetSpaceNumber: targetSpace,
             toCurrent: toCurrent,
             follow: arguments.getBool("follow") ?? false)

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/TypeTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/TypeTool.swift
@@ -34,12 +34,12 @@ public struct TypeTool: MCPTool {
                 "snapshot": SchemaBuilder.string(
                     description: "Optional. Snapshot ID from `see` or `inspect_ui`. " +
                         "When `on` is omitted, the snapshot process is the background typing target."),
-                "delay": SchemaBuilder.number(
+                "delay": SchemaBuilder.integer(
                     description: "Optional. Delay between keystrokes in milliseconds (linear profile). Default: 0.",
                     default: 0),
                 "profile": SchemaBuilder.string(
                     description: "Optional. Typing profile: linear (default) or human."),
-                "wpm": SchemaBuilder.number(
+                "wpm": SchemaBuilder.integer(
                     description: "Optional. Human typing speed (80-220 WPM). Overrides delay when set."),
                 "clear": SchemaBuilder.boolean(
                     description: "Optional. Clear the field before typing (Cmd+A, Delete).",
@@ -49,13 +49,13 @@ public struct TypeTool: MCPTool {
                     default: false),
                 "app": SchemaBuilder.string(
                     description: "Optional. Target app name/bundle ID, or 'PID:<n>' for background typing."),
-                "pid": SchemaBuilder.number(
+                "pid": SchemaBuilder.integer(
                     description: "Optional. Target process ID for background typing when no element snapshot is used."),
-                "window_id": SchemaBuilder.number(description: "Optional. Window ID; requires foreground=true."),
+                "window_id": SchemaBuilder.integer(description: "Optional. Window ID; requires foreground=true."),
                 "window_title": SchemaBuilder
                     .string(description: "Optional. Window title (substring match); requires foreground=true."),
                 "window_index": SchemaBuilder
-                    .number(description: "Optional. Window index (0-based); requires app/pid and foreground=true."),
+                    .integer(description: "Optional. Window index (0-based); requires app/pid and foreground=true."),
             ],
             required: [])
     }
@@ -102,20 +102,20 @@ public struct TypeTool: MCPTool {
     }
 
     private func parseRequest(arguments: ToolArguments) throws -> TypeRequest {
-        let wordsPerMinute = arguments.getNumber("wpm").map { Int($0) }
+        let wordsPerMinute = try arguments.validatedInt("wpm")
         let profile = try self.parseProfile(arguments.getString("profile"), wordsPerMinute: wordsPerMinute)
         let target = try MCPInteractionTarget(
             app: arguments.getString("app"),
-            pid: arguments.getInt("pid"),
+            pid: arguments.validatedInt("pid"),
             windowTitle: arguments.getString("window_title"),
-            windowIndex: arguments.getInt("window_index"),
-            windowId: arguments.getInt("window_id"))
+            windowIndex: arguments.validatedInt("window_index"),
+            windowId: arguments.validatedInt("window_id"))
 
-        let request = TypeRequest(
+        let request = try TypeRequest(
             text: arguments.getString("text"),
             elementId: arguments.getString("on"),
             snapshotId: arguments.getString("snapshot"),
-            delay: Int(arguments.getNumber("delay") ?? 0),
+            delay: arguments.validatedInt("delay") ?? 0,
             profile: profile,
             wordsPerMinute: wordsPerMinute,
             clearField: arguments.getBool("clear") ?? false,

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/WindowTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/WindowTool.swift
@@ -62,9 +62,9 @@ public struct WindowTool: MCPTool {
                     description: "Target application name, bundle ID, or process ID"),
                 "title": SchemaBuilder.string(
                     description: "Window title to target (partial matching supported)"),
-                "index": SchemaBuilder.number(
+                "index": SchemaBuilder.integer(
                     description: "Window index (0-based) for multi-window applications"),
-                "window_id": SchemaBuilder.number(
+                "window_id": SchemaBuilder.integer(
                     description: "Window ID (from window list); preferred stable selector"),
                 "x": SchemaBuilder.number(
                     description: "X coordinate for move or set-bounds action"),
@@ -101,8 +101,14 @@ public struct WindowTool: MCPTool {
 
         let app = arguments.getString("app")
         let title = arguments.getString("title")
-        let index = arguments.getInt("index")
-        let windowId = arguments.getInt("window_id")
+        let index: Int?
+        let windowId: Int?
+        do {
+            index = try arguments.validatedInt("index")
+            windowId = try arguments.validatedInt("window_id")
+        } catch {
+            return ToolResponse.error(error.localizedDescription)
+        }
         let x = arguments.getNumber("x")
         let y = arguments.getNumber("y")
         let width = arguments.getNumber("width")

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPToolArgumentValidationTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPToolArgumentValidationTests.swift
@@ -1,0 +1,137 @@
+import MCP
+import TachikomaMCP
+import Testing
+@testable import PeekabooAgentRuntime
+
+@MainActor
+struct MCPToolArgumentValidationTests {
+    @Test
+    func `unsafe numeric arguments are refused before tool dispatch`() async throws {
+        let context = await MCPToolTestHelpers.makeContext()
+        let counter = MCPNumericDispatchCounter()
+        let typeTool = TypeTool(context: context)
+        let cases: [(any MCPTool, String, Value)] = [
+            (SleepTool(), "duration", .double(1e20)),
+            (typeTool, "pid", .double(1234.9)),
+            (typeTool, "window_id", .string("1234.9")),
+            (typeTool, "delay", .double(.infinity)),
+            (MoveTool(context: context), "duration", .double(.nan)),
+            (DragTool(context: context), "steps", .string("100000000000000000000")),
+            (ScrollTool(context: context), "amount", .double(3.5)),
+            (SpaceTool(context: context), "to", .string("1e20")),
+            (PressTool(context: context), "count", .double(.infinity)),
+            (AppTool(context: context), "wait", .double(.infinity)),
+        ]
+
+        for (index, testCase) in cases.enumerated() {
+            let (sourceTool, key, value) = testCase
+            let probe = MCPNumericSchemaProbeTool(
+                name: "numeric-probe-\(index)",
+                inputSchema: sourceTool.inputSchema,
+                counter: counter)
+            let response = try await context.execute(
+                tool: probe,
+                arguments: ToolArguments(value: .object([key: value])))
+
+            #expect(response.isError, "Expected \(sourceTool.name).\(key) to be rejected")
+            guard case let .object(meta) = response.meta else {
+                Issue.record("Expected refusal metadata for \(sourceTool.name).\(key)")
+                continue
+            }
+            #expect(meta["mutation_dispatched"] == .bool(false))
+            #expect(meta["retry_safe"] == .bool(true))
+        }
+
+        #expect(await counter.value == 0)
+    }
+
+    @Test
+    func `Sleep tool rejects unsafe durations without conversion traps`() async throws {
+        let tool = SleepTool()
+        let invalidValues: [Value] = [
+            .double(0.5),
+            .double(1e20),
+            .double(.nan),
+            .double(.infinity),
+            .string("100000000000000000000"),
+        ]
+
+        for value in invalidValues {
+            let response = try await tool.execute(
+                arguments: ToolArguments(value: .object(["duration": value])))
+            #expect(response.isError)
+        }
+    }
+
+    @Test
+    func `exact whole numeric representations remain accepted`() async throws {
+        let context = await MCPToolTestHelpers.makeContext()
+        let counter = MCPNumericDispatchCounter()
+        let probe = MCPNumericSchemaProbeTool(
+            name: "numeric-probe-valid",
+            inputSchema: TypeTool(context: context).inputSchema,
+            counter: counter)
+
+        for value: Value in [.int(42), .double(42.0), .string("42")] {
+            let response = try await context.execute(
+                tool: probe,
+                arguments: ToolArguments(value: .object(["delay": value])))
+            #expect(!response.isError)
+        }
+
+        #expect(await counter.value == 3)
+    }
+
+    @Test
+    func `unsafe interaction numerics dispatch no automation service calls`() async throws {
+        let automation = MockAutomationService(accessibilityGranted: true)
+        let context = await MCPToolTestHelpers.makeContext(automation: automation)
+        let cases: [(any MCPTool, [String: Value])] = [
+            (TypeTool(context: context), [
+                "text": .string("must-not-type"),
+                "foreground": .bool(true),
+                "delay": .double(1e20),
+            ]),
+            (TypeTool(context: context), [
+                "text": .string("must-not-type"),
+                "pid": .double(1234.9),
+            ]),
+            (ScrollTool(context: context), [
+                "direction": .string("down"),
+                "foreground": .bool(true),
+                "amount": .double(.nan),
+            ]),
+        ]
+
+        for (tool, values) in cases {
+            let response = try await context.execute(
+                tool: tool,
+                arguments: ToolArguments(value: .object(values)))
+            #expect(response.isError)
+        }
+
+        #expect(automation.lastTypeActions == nil)
+        #expect(automation.targetedTypeActionsCalls.isEmpty)
+        #expect(automation.scrollRequests.isEmpty)
+    }
+}
+
+private actor MCPNumericDispatchCounter {
+    private(set) var value = 0
+
+    func increment() {
+        self.value += 1
+    }
+}
+
+private struct MCPNumericSchemaProbeTool: MCPTool {
+    let name: String
+    let description = "Numeric schema validation probe"
+    let inputSchema: Value
+    let counter: MCPNumericDispatchCounter
+
+    func execute(arguments _: ToolArguments) async throws -> ToolResponse {
+        await self.counter.increment()
+        return .text("dispatched")
+    }
+}

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPToolArgumentValidationTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPToolArgumentValidationTests.swift
@@ -21,6 +21,15 @@ struct MCPToolArgumentValidationTests {
             (SpaceTool(context: context), "to", .string("1e20")),
             (PressTool(context: context), "count", .double(.infinity)),
             (AppTool(context: context), "wait", .double(.infinity)),
+            (DialogTool(context: context), "field_index", .double(1.5)),
+            (PasteTool(context: context), "pid", .double(1234.9)),
+            (PasteTool(context: context), "restore_delay_ms", .double(1e20)),
+            (WindowTool(context: context), "window_id", .string("1234.9")),
+            (BrowserTool(context: context), "timeout", .double(1.5)),
+            (SeeTool(context: context), "max_depth", .double(1.5)),
+            (InspectUITool(context: context), "max_children", .string("1e20")),
+            (CaptureTool(context: context), "pid", .double(1234.9)),
+            (CaptureTool(context: context), "quiet_ms", .double(0.5)),
         ]
 
         for (index, testCase) in cases.enumerated() {
@@ -100,6 +109,10 @@ struct MCPToolArgumentValidationTests {
                 "direction": .string("down"),
                 "foreground": .bool(true),
                 "amount": .double(.nan),
+            ]),
+            (PasteTool(context: context), [
+                "text": .string("must-not-type"),
+                "pid": .double(1234.9),
             ]),
         ]
 

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPToolExecutionTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPToolExecutionTests.swift
@@ -21,7 +21,7 @@ struct MCPToolExecutionTests {
         try await MCPToolTestHelpers.withContext {
             let tool = SleepTool()
             // Use a shorter duration for testing
-            let args = ToolArguments(raw: ["duration": 0.01])
+            let args = ToolArguments(raw: ["duration": 1])
 
             let start = Date()
             let response = try await tool.execute(arguments: args)
@@ -1694,7 +1694,7 @@ struct MCPToolIntegrationTests {
             let permissionsTool = PermissionsTool()
             let appTool = AppTool()
 
-            async let sleep = sleepTool.execute(arguments: ToolArguments(raw: ["duration": 0.1]))
+            async let sleep = sleepTool.execute(arguments: ToolArguments(raw: ["duration": 1]))
             async let permissions = permissionsTool.execute(arguments: ToolArguments(raw: [:]))
             async let list = appTool.execute(arguments: ToolArguments(raw: ["action": "list"]))
 

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/ObservationPolicyRequestTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/ObservationPolicyRequestTests.swift
@@ -7,14 +7,14 @@ struct ObservationPolicyRequestTests {
     @Test
     func `MCP observations default web focus off`() throws {
         #expect(try !(SeeRequest(arguments: ToolArguments(raw: [:])).webFocus))
-        #expect(!InspectUIRequest(arguments: ToolArguments(raw: [:])).webFocus)
+        #expect(try !InspectUIRequest(arguments: ToolArguments(raw: [:])).webFocus)
     }
 
     @Test
     func `MCP observations accept explicit web focus`() throws {
         let arguments = ToolArguments(raw: ["web_focus": true])
         #expect(try SeeRequest(arguments: arguments).webFocus)
-        #expect(InspectUIRequest(arguments: arguments).webFocus)
+        #expect(try InspectUIRequest(arguments: arguments).webFocus)
     }
 
     @Test

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -39,6 +39,11 @@ Supported transports:
 - **stdio**: supported and default.
 - **http / sse**: recognized flags, but server transports are not implemented yet.
 
+Peekaboo validates numeric arguments before a tool or mutation lane runs. Fields published as `integer` accept exact
+whole values (including whole-number JSON doubles and integer strings) but reject fractional, non-finite, and
+out-of-range values. Fields published as `number` must be finite. Rejections report `mutation_dispatched: false` and
+`retry_safe: true`; an invalid optional value is never treated as omitted or replaced by a default.
+
 ## Install in MCP clients
 
 Most MCP clients can launch Peekaboo through either the npm package or a local binary.


### PR DESCRIPTION
## Summary

- validate declared MCP integer and number fields before tool execution or mutation-lane acquisition
- expose integer-shaped PID, window, delay, duration, count, steps, and Space inputs as integers and remove trapping/lossy conversions
- bump Tachikoma to the separately landed exact numeric decoder and add dispatch-zero plus live stdio regressions

## Why

MCP numeric helpers previously truncated fractional integer inputs and could trap when oversized finite doubles reached downstream `Int` conversions. Optional invalid fields could also collapse to `nil` and be mistaken for omission, allowing a default or broader target to dispatch. The shared execution boundary now returns a retry-safe pre-dispatch refusal, while each affected parser independently uses exact integer decoding.

## Validation

- focused affected Core/AgentRuntime suites (193 tests, including Browser, Dialog/Paste selectors, Window, observation traversal, Capture, keyboard, and schema validation)
- `pnpm run test:safe` (850 CLI/unit + 82 runtime tests after the review fix)
- `pnpm run lint` (0 serious violations), `swiftformat --lint .`, and `pnpm run lint:docs`
- source-blind stdio behavior validation: 17/17 clauses passed at 0.99 confidence; all 53 integer-backed fields were integer, 11 invalid calls were refusal-safe, and valid follow-ups succeeded in the same process
- ScreenCaptureKit process-capability runtime fixture passed 20/20 after shortening its Unix socket path; the repair also preserves child stderr in future early-exit diagnostics
- local code-diff Autoreview and TruffleHog clean at 0.99 confidence; the accepted ClawSweeper P1 was fixed and the follow-up review cycle is clean
- Tachikoma dependency PR #51 landed separately with 854 tests, clean Autoreview, and green exact-head CI

The complete local Core matrix reproduced five existing `PasteToolExactWindowTests` issues unchanged on pristine `origin/main`; focused affected suites and the repository safe gate are green. The final branch Autoreview helper intentionally refused to re-review the committed gitlink because dependency contents are excluded from its bundle; the Peekaboo diff and dependency were reviewed separately instead.
