### PR TITLE
fix(mcp): refuse clipboard stdout output

### DIFF
--- a/Apps/CLI/Tests/CLIRuntimeTests/MCPStdioEOFTests.swift
+++ b/Apps/CLI/Tests/CLIRuntimeTests/MCPStdioEOFTests.swift
@@ -48,4 +48,57 @@ struct MCPStdioEOFTests {
         let error = try #require(response["error"] as? [String: Any])
         #expect(error["code"] as? Int == -32700)
     }
+
+    @Test(.timeLimit(.minutes(1)))
+    func `clipboard stdout path refusal preserves JSON-RPC stream and filesystem`() async throws {
+        guard TestChildProcess.canLocatePeekabooBinary() else {
+            Issue.record("Build peekaboo (or set PEEKABOO_CLI_BINARY) before running CLI runtime tests.")
+            return
+        }
+
+        let workingDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("peekaboo-mcp-clipboard-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: workingDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: workingDirectory) }
+
+        let callRequest =
+            #"{"jsonrpc":"2.0","method":"tools/call","params":{"name":"clipboard","# +
+            #""arguments":{"action":"get","outputPath":"-"}},"id":41}"#
+        let listRequest = #"{"jsonrpc":"2.0","method":"tools/list","id":42}"#
+        let request = "\(callRequest)\n\(listRequest)\n"
+        let child = try await TestChildProcess.runPeekaboo(
+            ["mcp", "--no-remote"],
+            workingDirectory: workingDirectory,
+            standardInput: request
+        )
+
+        #expect(child.status == .exited(0))
+        #expect(child.standardError.isEmpty)
+        let lines = child.standardOutput.split(separator: "\n")
+        #expect(lines.count == 2)
+
+        var responses: [Int: [String: Any]] = [:]
+        for line in lines {
+            let data = Data(line.utf8)
+            let response = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+            let id = try #require(response["id"] as? Int)
+            responses[id] = response
+        }
+
+        let refusal = try #require(responses[41]?["result"] as? [String: Any])
+        #expect(refusal["isError"] as? Bool == true)
+        let metadata = try #require(refusal["_meta"] as? [String: Any])
+        #expect(metadata["effect"] as? String == "refused")
+        #expect(metadata["error_code"] as? String == "MCP_CLIPBOARD_STDOUT_UNAVAILABLE")
+        #expect(metadata["mutation_dispatched"] as? Bool == false)
+        #expect(metadata["retry_safe"] as? Bool == true)
+        let content = try #require(refusal["content"] as? [[String: Any]])
+        let message = try #require(content.first?["text"] as? String)
+        #expect(message.contains("stdout carries JSON-RPC"))
+        #expect(responses[42]?["result"] != nil)
+
+        let literalDash = workingDirectory.appendingPathComponent("-")
+        #expect(!FileManager.default.fileExists(atPath: literalDash.path))
+        #expect(try FileManager.default.contentsOfDirectory(atPath: workingDirectory.path).isEmpty)
+    }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 ### Fixed
 - Preserve display-column-safe terminal input and styled table output for wide Unicode, SGR colors, and OSC-8 links, while making terminal stop/restart idempotent and preventing queued renders from escaping a stopped session.
 - Reject non-finite, fractional, and overflowing MCP numeric arguments before dispatch, and expose integer-shaped delays, durations, counts, process IDs, window selectors, and Space targets as integers in tool schemas.
+- Reject MCP clipboard `outputPath: "-"` before reading or writing anything, with structured filesystem/text guidance, so arbitrary clipboard bytes can never corrupt the stdio JSON-RPC stream or create a literal `-` file.
 - Preserve negative numeric option values through Commander parsing so command-owned range validation reports them accurately instead of misclassifying them as short flags.
 - Reject invalid live/action capture cadence instead of silently clamping or trapping, apply post-motion timing with a monotonic deadline, and report sampled throughput, capture failures, diff-filtered frames, and retained throughput separately from artifact postprocessing.
 - Keep remote `window close` background-only by default, matching local execution, and require explicit foreground consent before routing a close through focus or global-input fallbacks.

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/ClipboardTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/ClipboardTool.swift
@@ -16,7 +16,8 @@ public struct ClipboardTool: MCPTool {
     public var description: String {
         """
         Work with the macOS clipboard (pasteboard). Actions: get, set, clear, save, restore.
-        - get: read the clipboard; optionally prefer a UTI and/or write binary data to a file.
+        - get: read the clipboard; optionally prefer a UTI and/or write binary data to a filesystem path.
+          MCP stdout is reserved for JSON-RPC, so outputPath '-' is rejected.
         - set: write text, file, image, or base64+UTI data to the clipboard (optionally also set plain text).
         - clear: empty the clipboard.
         - save/restore: snapshot and restore clipboard contents to/from a named slot (default slot \"0\").
@@ -35,7 +36,9 @@ public struct ClipboardTool: MCPTool {
                 "uti": SchemaBuilder.string(description: "Uniform Type Identifier for data_base64 or to force type"),
                 "prefer": SchemaBuilder.string(description: "Preferred UTI when reading clipboard"),
                 "outputPath": SchemaBuilder
-                    .string(description: "When reading, path to write binary data. Use '-' for stdout."),
+                    .string(description: "When reading, filesystem path to write binary data. " +
+                        "The '-' stdout sentinel is not supported because MCP stdout carries JSON-RPC; " +
+                        "omit outputPath to receive UTF-8 text in the tool response."),
                 "slot": SchemaBuilder.string(description: "Save/restore slot name (default: \"0\")"),
                 "alsoText": SchemaBuilder.string(description: "Optional plain text companion when setting binary data"),
                 "allowLarge": SchemaBuilder.boolean(description: "Allow writes larger than the 10 MB guard"),
@@ -73,6 +76,19 @@ public struct ClipboardTool: MCPTool {
 
     @MainActor
     private func handleGet(arguments: ToolArguments) throws -> ToolResponse {
+        if arguments.getString("outputPath") == "-" {
+            return ToolResponse.error(
+                "outputPath '-' is not supported by the MCP clipboard tool because stdout carries JSON-RPC " +
+                    "messages. Omit outputPath to receive UTF-8 clipboard text in the tool response, or provide " +
+                    "a filesystem path for binary data.",
+                meta: .object([
+                    "effect": .string("refused"),
+                    "error_code": .string("MCP_CLIPBOARD_STDOUT_UNAVAILABLE"),
+                    "mutation_dispatched": .bool(false),
+                    "retry_safe": .bool(true),
+                ]))
+        }
+
         let preferUTI = arguments.getString("prefer").flatMap { UTType($0) }
         guard let result = try self.context.clipboard.get(prefer: preferUTI) else {
             return ToolResponse.error("Clipboard is empty.")

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/ToolRegistry/ToolRegistry.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/ToolRegistry/ToolRegistry.swift
@@ -112,7 +112,8 @@ public enum ToolRegistry {
             abstract: "Read/write the macOS clipboard (text, images, files) with save/restore slots.",
             discussion: """
             Use `action: set` with text, file_path, or data_base64+uti to write the clipboard.
-            Use `action: get` to read it (optionally prefer a UTI or write binary to outputPath).
+            Use `action: get` to read it (optionally prefer a UTI or write binary to a filesystem outputPath).
+            MCP stdout carries JSON-RPC, so outputPath `-` is rejected; omit it to receive UTF-8 text.
             `save`/`restore` keep user content safe while automating; `clear` empties the pasteboard.
             """,
             examples: [

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPSpecificToolTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPSpecificToolTests.swift
@@ -28,7 +28,9 @@ struct MCPSpecificToolTests {
         guard case let .object(schema) = tool.inputSchema,
               case let .object(properties)? = schema["properties"],
               case let .object(action)? = properties["action"],
-              case let .array(actions)? = action["enum"]
+              case let .array(actions)? = action["enum"],
+              case let .object(outputPath)? = properties["outputPath"],
+              case let .string(outputPathDescription)? = outputPath["description"]
         else {
             Issue.record("Expected clipboard schema properties and action enum")
             return
@@ -41,6 +43,35 @@ struct MCPSpecificToolTests {
         #expect(properties["dataBase64"] == nil)
         #expect(!actions.contains(.string("load")))
         #expect(actions == ["get", "set", "clear", "save", "restore"].map(Value.string))
+        #expect(outputPathDescription.contains("'-' stdout sentinel is not supported"))
+        #expect(outputPathDescription.contains("JSON-RPC"))
+    }
+
+    @Test
+    func `Clipboard rejects stdout output path before reading`() async throws {
+        let tool = makeTestTool(ClipboardTool.init)
+        let response = try await tool.execute(arguments: ToolArguments(raw: [
+            "action": "get",
+            "outputPath": "-",
+        ]))
+
+        #expect(response.isError)
+        guard case let .text(text, _, _) = response.content.first else {
+            Issue.record("Expected actionable clipboard stdout refusal")
+            return
+        }
+        #expect(text.contains("stdout carries JSON-RPC"))
+        #expect(text.contains("Omit outputPath"))
+        #expect(text.contains("filesystem path"))
+
+        guard case let .object(meta)? = response.meta else {
+            Issue.record("Expected structured clipboard stdout refusal metadata")
+            return
+        }
+        #expect(meta["effect"] == .string("refused"))
+        #expect(meta["error_code"] == .string("MCP_CLIPBOARD_STDOUT_UNAVAILABLE"))
+        #expect(meta["mutation_dispatched"] == .bool(false))
+        #expect(meta["retry_safe"] == .bool(true))
     }
 
     // MARK: - See Tool Tests

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -44,6 +44,10 @@ whole values (including whole-number JSON doubles and integer strings) but rejec
 out-of-range values. Fields published as `number` must be finite. Rejections report `mutation_dispatched: false` and
 `retry_safe: true`; an invalid optional value is never treated as omitted or replaced by a default.
 
+The stdio server reserves stdout exclusively for newline-delimited JSON-RPC messages. Tools never stream raw payload
+bytes onto that channel. In particular, MCP `clipboard` rejects `outputPath: "-"`; omit `outputPath` for UTF-8 text or
+provide a filesystem path for binary clipboard data. The separate CLI `clipboard get --output -` contract is unchanged.
+
 ## Install in MCP clients
 
 Most MCP clients can launch Peekaboo through either the npm package or a local binary.

--- a/docs/clipboard.md
+++ b/docs/clipboard.md
@@ -31,6 +31,7 @@ Peekaboo ships one `clipboard` domain in the CLI and MCP server for text, images
 - Required parameter: `action` with `get | set | clear | save | restore`.
 - Optional parameters: `text`, `file_path`, `data_base64`, `uti`, `prefer`, `outputPath`, `slot`, `alsoText`, and `allowLarge`.
 - Results use normal MCP text responses plus metadata such as `uti`, `size`, `textPreview`, `filePath`, and `slot` when available.
+- MCP `outputPath` accepts a filesystem path only. `outputPath: "-"` is rejected because MCP stdout is the JSON-RPC transport; omit `outputPath` to receive UTF-8 text in the tool response, or provide a path for binary data. Peekaboo does not put arbitrary clipboard bytes on the protocol stream.
 
 The MCP surface does not expose the CLI-only `--verify` readback option.
 


### PR DESCRIPTION
## Summary

- reject MCP clipboard `outputPath: "-"` before clipboard or filesystem access
- return an actionable structured refusal while keeping stdout exclusively JSON-RPC
- align the live tool schema, agent guidance, MCP docs, clipboard docs, and changelog

## Why

The MCP schema advertised the CLI-style stdout sentinel even though MCP uses stdout as its newline-delimited JSON-RPC transport. The implementation instead treated `-` as a relative filename, which could create a literal file. Streaming arbitrary clipboard bytes would be worse because it would corrupt the protocol stream, and the current MCP result has no bounded arbitrary-binary contract.

## Contract

`outputPath: "-"` now returns `isError: true` with `effect: "refused"`, `error_code: "MCP_CLIPBOARD_STDOUT_UNAVAILABLE"`, `mutation_dispatched: false`, and `retry_safe: true`. Callers should omit `outputPath` for UTF-8 text or provide a filesystem path for binary data. The separate CLI `clipboard get --output -` behavior is unchanged.

## Proof

- `pnpm run test:safe` (846 core/CLI tests and 83 runtime tests)
- focused `Clipboard` tool/schema tests
- compiled stdio subprocess test: refusal plus a following `tools/list` remain exactly two parseable JSON-RPC lines, with empty stderr and no filesystem entry
- `pnpm run lint`, `pnpm run lint:docs`, and SwiftFormat check
- source-blind live-binary behavior validation
- autoreview clean with no accepted/actionable findings
