### PR TITLE
test(architecture): centralize shared fixtures

### DIFF
--- a/Apps/CLI/Package.swift
+++ b/Apps/CLI/Package.swift
@@ -61,6 +61,8 @@ var targets: [Target] = [
         name: "CoreCLITests",
         dependencies: [
             "PeekabooCLI",
+            .product(name: "PeekabooBridgeTestSupport", package: "PeekabooCore"),
+            .product(name: "PeekabooAutomationKitTestSupport", package: "PeekabooAutomationKit"),
             .product(name: "PeekabooFoundation", package: "PeekabooFoundation"),
             .product(name: "PeekabooAutomation", package: "PeekabooCore"),
             .product(name: "PeekabooAgentRuntime", package: "PeekabooCore"),
@@ -72,6 +74,7 @@ var targets: [Target] = [
         name: "CLIRuntimeTests",
         dependencies: [
             "PeekabooCLI",
+            .product(name: "PeekabooBridgeTestSupport", package: "PeekabooCore"),
             .product(name: "PeekabooFoundation", package: "PeekabooFoundation"),
             .product(name: "Subprocess", package: "swift-subprocess"),
         ],
@@ -85,6 +88,7 @@ if includeAutomationTests {
             name: "CLIAutomationTests",
             dependencies: [
                 "PeekabooCLI",
+                .product(name: "PeekabooAutomationKitTestSupport", package: "PeekabooAutomationKit"),
                 .product(name: "PeekabooFoundation", package: "PeekabooFoundation"),
                 .product(name: "PeekabooCore", package: "PeekabooCore"),
                 .product(name: "PeekabooAgentRuntime", package: "PeekabooCore"),
@@ -118,6 +122,7 @@ let package = Package(
         .package(url: "https://github.com/swiftlang/swift-subprocess.git", from: "1.0.0"),
         .package(path: "../../TauTUI"),
         .package(path: "../../Core/PeekabooFoundation"),
+        .package(path: "../../Core/PeekabooAutomationKit"),
         .package(path: "../../Core/PeekabooVisualizer"),
         .package(path: "../../Core/PeekabooCore"),
         .package(path: "../../Tachikoma"),

--- a/Apps/CLI/Tests/CLIAutomationTests/CommanderRuntimeOutputDeferralTests.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/CommanderRuntimeOutputDeferralTests.swift
@@ -1,5 +1,6 @@
 import Darwin
 import Foundation
+import PeekabooAutomationKitTestSupport
 import PeekabooCore
 import PeekabooFoundation
 import Testing
@@ -318,27 +319,5 @@ private actor ConcurrentRegionProbe {
 
     func markCancelledRegionRan() {
         self.cancelledRegionRan = true
-    }
-}
-
-private actor AsyncTestLatch {
-    private var isOpen = false
-    private var waiters: [CheckedContinuation<Void, Never>] = []
-
-    func wait() async {
-        guard !self.isOpen else { return }
-        await withCheckedContinuation { continuation in
-            self.waiters.append(continuation)
-        }
-    }
-
-    func open() {
-        guard !self.isOpen else { return }
-        self.isOpen = true
-        let waiters = self.waiters
-        self.waiters.removeAll()
-        for waiter in waiters {
-            waiter.resume()
-        }
     }
 }

--- a/Apps/CLI/Tests/CLIRuntimeTests/CommandRuntimeInjectionTests.swift
+++ b/Apps/CLI/Tests/CLIRuntimeTests/CommandRuntimeInjectionTests.swift
@@ -3,6 +3,7 @@ import Foundation
 import PeekabooAgentRuntime
 import PeekabooAutomationKit
 import PeekabooBridge
+import PeekabooBridgeTestSupport
 import PeekabooCore
 import Tachikoma
 import Testing
@@ -56,7 +57,7 @@ struct CommandRuntimeInjectionTests {
 
     @Test
     func `targeted hotkey support requires enabled bridge operation`() {
-        let supported = PeekabooBridgeHandshakeResponse(
+        let supported = BridgeTestFixtures.handshake(
             negotiatedVersion: PeekabooBridgeProtocolVersion(major: 1, minor: 1),
             hostKind: .gui,
             build: nil,
@@ -72,7 +73,7 @@ struct CommandRuntimeInjectionTests {
             ]
         )
 
-        let enabled = PeekabooBridgeHandshakeResponse(
+        let enabled = BridgeTestFixtures.handshake(
             negotiatedVersion: PeekabooBridgeProtocolVersion(major: 1, minor: 1),
             hostKind: .gui,
             build: nil,
@@ -90,7 +91,7 @@ struct CommandRuntimeInjectionTests {
 
     @Test
     func `targeted hotkey availability does not require accessibility`() {
-        let handshake = PeekabooBridgeHandshakeResponse(
+        let handshake = BridgeTestFixtures.handshake(
             negotiatedVersion: PeekabooBridgeProtocolVersion(major: 1, minor: 1),
             hostKind: .gui,
             build: nil,
@@ -115,7 +116,7 @@ struct CommandRuntimeInjectionTests {
 
     @Test
     func `targeted type support requires protocol 1_8 and enabled bridge operation`() {
-        let supported = PeekabooBridgeHandshakeResponse(
+        let supported = BridgeTestFixtures.handshake(
             negotiatedVersion: PeekabooBridgeProtocolVersion(major: 1, minor: 8),
             hostKind: .gui,
             build: nil,
@@ -131,7 +132,7 @@ struct CommandRuntimeInjectionTests {
             ]
         )
 
-        let enabled = PeekabooBridgeHandshakeResponse(
+        let enabled = BridgeTestFixtures.handshake(
             negotiatedVersion: PeekabooBridgeProtocolVersion(major: 1, minor: 8),
             hostKind: .gui,
             build: nil,
@@ -139,7 +140,7 @@ struct CommandRuntimeInjectionTests {
             enabledOperations: [.captureScreen, .targetedTypeActions]
         )
 
-        let oldProtocol = PeekabooBridgeHandshakeResponse(
+        let oldProtocol = BridgeTestFixtures.handshake(
             negotiatedVersion: PeekabooBridgeProtocolVersion(major: 1, minor: 7),
             hostKind: .gui,
             build: nil,
@@ -158,7 +159,7 @@ struct CommandRuntimeInjectionTests {
 
     @Test
     func `targeted click support requires enabled bridge operation`() {
-        let supported = PeekabooBridgeHandshakeResponse(
+        let supported = BridgeTestFixtures.handshake(
             negotiatedVersion: PeekabooBridgeProtocolVersion(major: 1, minor: 6),
             hostKind: .gui,
             build: nil,
@@ -174,7 +175,7 @@ struct CommandRuntimeInjectionTests {
             ]
         )
 
-        let enabled = PeekabooBridgeHandshakeResponse(
+        let enabled = BridgeTestFixtures.handshake(
             negotiatedVersion: PeekabooBridgeProtocolVersion(major: 1, minor: 6),
             hostKind: .gui,
             build: nil,
@@ -192,14 +193,14 @@ struct CommandRuntimeInjectionTests {
 
     @Test
     func `exact window click support requires protocol 1_17 capability`() {
-        let oldHost = PeekabooBridgeHandshakeResponse(
+        let oldHost = BridgeTestFixtures.handshake(
             negotiatedVersion: PeekabooBridgeProtocolVersion(major: 1, minor: 16),
             hostKind: .gui,
             build: nil,
             supportedOperations: [.targetedClick],
             enabledOperations: [.targetedClick]
         )
-        let currentHost = PeekabooBridgeHandshakeResponse(
+        let currentHost = BridgeTestFixtures.handshake(
             negotiatedVersion: PeekabooBridgeProtocolVersion(major: 1, minor: 17),
             hostKind: .gui,
             build: nil,
@@ -213,7 +214,7 @@ struct CommandRuntimeInjectionTests {
 
     @Test
     func `request-aware targeted click capability reports its Accessibility requirement`() {
-        let accessibilityOnly = PeekabooBridgeHandshakeResponse(
+        let accessibilityOnly = BridgeTestFixtures.handshake(
             negotiatedVersion: PeekabooBridgeProtocolVersion(major: 1, minor: 9),
             hostKind: .gui,
             build: nil,
@@ -226,7 +227,7 @@ struct CommandRuntimeInjectionTests {
             enabledOperations: [.captureScreen, .targetedClick],
             permissionTags: [PeekabooBridgeOperation.targetedClick.rawValue: []]
         )
-        let unavailable = PeekabooBridgeHandshakeResponse(
+        let unavailable = BridgeTestFixtures.handshake(
             negotiatedVersion: PeekabooBridgeProtocolVersion(major: 1, minor: 9),
             hostKind: .gui,
             build: nil,
@@ -252,19 +253,19 @@ struct CommandRuntimeInjectionTests {
 
     @Test
     func `post event permission request support requires advertised protocol operation`() {
-        let supported = PeekabooBridgeHandshakeResponse(
+        let supported = BridgeTestFixtures.handshake(
             negotiatedVersion: PeekabooBridgeProtocolVersion(major: 1, minor: 2),
             hostKind: .gui,
             build: nil,
             supportedOperations: [.captureScreen, .requestPostEventPermission]
         )
-        let older = PeekabooBridgeHandshakeResponse(
+        let older = BridgeTestFixtures.handshake(
             negotiatedVersion: PeekabooBridgeProtocolVersion(major: 1, minor: 1),
             hostKind: .gui,
             build: nil,
             supportedOperations: [.captureScreen, .requestPostEventPermission]
         )
-        let hidden = PeekabooBridgeHandshakeResponse(
+        let hidden = BridgeTestFixtures.handshake(
             negotiatedVersion: PeekabooBridgeProtocolVersion(major: 1, minor: 2),
             hostKind: .gui,
             build: nil,
@@ -278,25 +279,25 @@ struct CommandRuntimeInjectionTests {
 
     @Test
     func `desktop observation support requires advertised protocol operation`() {
-        let supported = PeekabooBridgeHandshakeResponse(
+        let supported = BridgeTestFixtures.handshake(
             negotiatedVersion: PeekabooBridgeProtocolVersion(major: 1, minor: 5),
             hostKind: .gui,
             build: nil,
             supportedOperations: [.captureScreen, .desktopObservation]
         )
-        let older = PeekabooBridgeHandshakeResponse(
+        let older = BridgeTestFixtures.handshake(
             negotiatedVersion: PeekabooBridgeProtocolVersion(major: 1, minor: 4),
             hostKind: .gui,
             build: nil,
             supportedOperations: [.captureScreen, .desktopObservation]
         )
-        let hidden = PeekabooBridgeHandshakeResponse(
+        let hidden = BridgeTestFixtures.handshake(
             negotiatedVersion: PeekabooBridgeProtocolVersion(major: 1, minor: 5),
             hostKind: .gui,
             build: nil,
             supportedOperations: [.captureScreen]
         )
-        let disabled = PeekabooBridgeHandshakeResponse(
+        let disabled = BridgeTestFixtures.handshake(
             negotiatedVersion: PeekabooBridgeProtocolVersion(major: 1, minor: 5),
             hostKind: .gui,
             build: nil,
@@ -312,19 +313,19 @@ struct CommandRuntimeInjectionTests {
 
     @Test
     func `inspect UI support requires advertised protocol operation`() {
-        let supported = PeekabooBridgeHandshakeResponse(
+        let supported = BridgeTestFixtures.handshake(
             negotiatedVersion: PeekabooBridgeProtocolVersion(major: 1, minor: 7),
             hostKind: .gui,
             build: nil,
             supportedOperations: [.captureScreen, .inspectAccessibilityTree]
         )
-        let older = PeekabooBridgeHandshakeResponse(
+        let older = BridgeTestFixtures.handshake(
             negotiatedVersion: PeekabooBridgeProtocolVersion(major: 1, minor: 6),
             hostKind: .gui,
             build: nil,
             supportedOperations: [.captureScreen, .inspectAccessibilityTree]
         )
-        let hidden = PeekabooBridgeHandshakeResponse(
+        let hidden = BridgeTestFixtures.handshake(
             negotiatedVersion: PeekabooBridgeProtocolVersion(major: 1, minor: 7),
             hostKind: .gui,
             build: nil,
@@ -340,13 +341,13 @@ struct CommandRuntimeInjectionTests {
     func `remote requirements reject inspect UI when required capability is unavailable`() {
         var options = CommandRuntimeOptions()
         options.requiresInspectAccessibilityTree = true
-        let supported = PeekabooBridgeHandshakeResponse(
+        let supported = BridgeTestFixtures.handshake(
             negotiatedVersion: PeekabooBridgeProtocolVersion(major: 1, minor: 7),
             hostKind: .gui,
             build: nil,
             supportedOperations: [.captureScreen, .inspectAccessibilityTree]
         )
-        let unsupported = PeekabooBridgeHandshakeResponse(
+        let unsupported = BridgeTestFixtures.handshake(
             negotiatedVersion: PeekabooBridgeProtocolVersion(major: 1, minor: 6),
             hostKind: .gui,
             build: nil,
@@ -361,19 +362,19 @@ struct CommandRuntimeInjectionTests {
     func `remote requirements reject browser MCP when required capability is unavailable`() {
         var options = CommandRuntimeOptions()
         options.requiresBrowserMCP = true
-        let supported = PeekabooBridgeHandshakeResponse(
+        let supported = BridgeTestFixtures.handshake(
             negotiatedVersion: PeekabooBridgeProtocolVersion(major: 1, minor: 4),
             hostKind: .gui,
             build: nil,
             supportedOperations: [.captureScreen, .browserStatus, .browserConnect, .browserDisconnect, .browserExecute]
         )
-        let older = PeekabooBridgeHandshakeResponse(
+        let older = BridgeTestFixtures.handshake(
             negotiatedVersion: PeekabooBridgeProtocolVersion(major: 1, minor: 3),
             hostKind: .gui,
             build: nil,
             supportedOperations: [.captureScreen, .browserStatus, .browserConnect, .browserDisconnect, .browserExecute]
         )
-        let missingExecute = PeekabooBridgeHandshakeResponse(
+        let missingExecute = BridgeTestFixtures.handshake(
             negotiatedVersion: PeekabooBridgeProtocolVersion(major: 1, minor: 4),
             hostKind: .gui,
             build: nil,
@@ -561,19 +562,19 @@ struct CommandRuntimeInjectionTests {
 
     @Test
     func `default app fallback accepts GUI hosts and legacy daemons`() {
-        let guiHandshake = PeekabooBridgeHandshakeResponse(
+        let guiHandshake = BridgeTestFixtures.handshake(
             negotiatedVersion: PeekabooBridgeConstants.protocolVersion,
             hostKind: .gui,
             build: nil,
             supportedOperations: [.captureScreen]
         )
-        let daemonHandshake = PeekabooBridgeHandshakeResponse(
+        let daemonHandshake = BridgeTestFixtures.handshake(
             negotiatedVersion: PeekabooBridgeConstants.protocolVersion,
             hostKind: .onDemand,
             build: nil,
             supportedOperations: [.captureScreen]
         )
-        let embeddedHandshake = PeekabooBridgeHandshakeResponse(
+        let embeddedHandshake = BridgeTestFixtures.handshake(
             negotiatedVersion: PeekabooBridgeConstants.protocolVersion,
             hostKind: .inProcess,
             build: nil,

--- a/Apps/CLI/Tests/CoreCLITests/BridgeDiagnosticsConcurrencyTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/BridgeDiagnosticsConcurrencyTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import PeekabooBridge
+import PeekabooBridgeTestSupport
 import Testing
 @testable import PeekabooCLI
 
@@ -111,7 +112,7 @@ struct BridgeDiagnosticsConcurrencyTests {
     }
 
     private nonisolated static func handshake(build: String) -> PeekabooBridgeHandshakeResponse {
-        PeekabooBridgeHandshakeResponse(
+        BridgeTestFixtures.handshake(
             negotiatedVersion: PeekabooBridgeConstants.protocolVersion,
             hostKind: .onDemand,
             build: build,
@@ -131,7 +132,7 @@ private actor BridgeProbeGate {
             self.startedPaths.append(socketPath)
             self.resumeSatisfiedStartWaiters()
         }
-        return PeekabooBridgeHandshakeResponse(
+        return BridgeTestFixtures.handshake(
             negotiatedVersion: PeekabooBridgeConstants.protocolVersion,
             hostKind: .onDemand,
             build: socketPath,

--- a/Apps/CLI/Tests/CoreCLITests/BridgeStatusReportHintTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/BridgeStatusReportHintTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import PeekabooBridge
+import PeekabooBridgeTestSupport
 import PeekabooCore
 import Testing
 @testable import PeekabooCLI
@@ -10,7 +11,7 @@ struct BridgeStatusReportHintTests {
         hostKind: PeekabooBridgeHostKind,
         permissions: PermissionsStatus
     ) -> BridgeCandidateReport {
-        let handshake = PeekabooBridgeHandshakeResponse(
+        let handshake = BridgeTestFixtures.handshake(
             negotiatedVersion: PeekabooBridgeProtocolVersion(major: 1, minor: 1),
             hostKind: hostKind,
             build: nil,
@@ -109,7 +110,7 @@ struct BridgeStatusReportHintTests {
             bundleVersion: "400",
             codeSignatureHash: "abcdef"
         )
-        let handshake = PeekabooBridgeHandshakeResponse(
+        let handshake = BridgeTestFixtures.handshake(
             negotiatedVersion: PeekabooBridgeProtocolVersion(major: 1, minor: 21),
             hostKind: .gui,
             build: "4.0.0 (400)",

--- a/Apps/CLI/Tests/CoreCLITests/CommanderBinderTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/CommanderBinderTests.swift
@@ -2,6 +2,7 @@ import Commander
 import Foundation
 import PeekabooAutomation
 import PeekabooBridge
+import PeekabooBridgeTestSupport
 import Testing
 @testable import PeekabooCLI
 
@@ -179,19 +180,19 @@ struct CommanderBinderTests {
 
     @Test
     func `Element actions require bridge protocol and operation support`() {
-        let current = PeekabooBridgeHandshakeResponse(
+        let current = BridgeTestFixtures.handshake(
             negotiatedVersion: .init(major: 1, minor: 3),
             hostKind: .gui,
             build: nil,
             supportedOperations: [.setValue, .performAction]
         )
-        let oldProtocol = PeekabooBridgeHandshakeResponse(
+        let oldProtocol = BridgeTestFixtures.handshake(
             negotiatedVersion: .init(major: 1, minor: 2),
             hostKind: .gui,
             build: nil,
             supportedOperations: [.setValue, .performAction]
         )
-        let missingOperation = PeekabooBridgeHandshakeResponse(
+        let missingOperation = BridgeTestFixtures.handshake(
             negotiatedVersion: .init(major: 1, minor: 3),
             hostKind: .gui,
             build: nil,
@@ -205,19 +206,19 @@ struct CommanderBinderTests {
 
     @Test
     func `Application launch options require bridge protocol and operation support`() {
-        let current = PeekabooBridgeHandshakeResponse(
+        let current = BridgeTestFixtures.handshake(
             negotiatedVersion: PeekabooBridgeConstants.processGenerationPinnedInteractionVersion,
             hostKind: .gui,
             build: nil,
             supportedOperations: [.launchApplicationWithOptions]
         )
-        let oldProtocol = PeekabooBridgeHandshakeResponse(
+        let oldProtocol = BridgeTestFixtures.handshake(
             negotiatedVersion: .init(major: 1, minor: 8),
             hostKind: .gui,
             build: nil,
             supportedOperations: [.launchApplicationWithOptions]
         )
-        let missingOperation = PeekabooBridgeHandshakeResponse(
+        let missingOperation = BridgeTestFixtures.handshake(
             negotiatedVersion: PeekabooBridgeConstants.processGenerationPinnedInteractionVersion,
             hostKind: .gui,
             build: nil,
@@ -232,13 +233,13 @@ struct CommanderBinderTests {
     @Test
     func `New application instance launch requires bridge protocol 1_13`() {
         let supportedOperations: [PeekabooBridgeOperation] = [.captureScreen, .launchApplicationWithOptions]
-        let current = PeekabooBridgeHandshakeResponse(
+        let current = BridgeTestFixtures.handshake(
             negotiatedVersion: .init(major: 1, minor: 13),
             hostKind: .gui,
             build: nil,
             supportedOperations: supportedOperations
         )
-        let old = PeekabooBridgeHandshakeResponse(
+        let old = BridgeTestFixtures.handshake(
             negotiatedVersion: .init(major: 1, minor: 12),
             hostKind: .gui,
             build: nil,
@@ -256,13 +257,13 @@ struct CommanderBinderTests {
     @Test
     func `window-instance-pinned mutations require bridge protocol 1_18`() {
         let operations: [PeekabooBridgeOperation] = [.moveWindow, .closeWindow, .maximizeWindow]
-        let legacy = PeekabooBridgeHandshakeResponse(
+        let legacy = BridgeTestFixtures.handshake(
             negotiatedVersion: .init(major: 1, minor: 17),
             hostKind: .onDemand,
             build: nil,
             supportedOperations: operations
         )
-        let current = PeekabooBridgeHandshakeResponse(
+        let current = BridgeTestFixtures.handshake(
             negotiatedVersion: .init(major: 1, minor: 18),
             hostKind: .onDemand,
             build: nil,
@@ -512,7 +513,7 @@ struct CommanderBinderTests {
 
     @Test
     func `Capture commands require invalidation only when their focus policy may mutate the desktop`() throws {
-        let ownerAwareBridge = PeekabooBridgeHandshakeResponse(
+        let ownerAwareBridge = BridgeTestFixtures.handshake(
             negotiatedVersion: PeekabooBridgeConstants.protocolVersion,
             hostKind: .onDemand,
             build: nil,
@@ -575,25 +576,25 @@ struct CommanderBinderTests {
             .captureScreen,
             .invalidateImplicitLatestSnapshot,
         ]
-        let current = PeekabooBridgeHandshakeResponse(
+        let current = BridgeTestFixtures.handshake(
             negotiatedVersion: .init(major: 1, minor: 9),
             hostKind: .onDemand,
             build: nil,
             supportedOperations: operations
         )
-        let stale = PeekabooBridgeHandshakeResponse(
+        let stale = BridgeTestFixtures.handshake(
             negotiatedVersion: .init(major: 1, minor: 8),
             hostKind: .onDemand,
             build: nil,
             supportedOperations: operations
         )
-        let missing = PeekabooBridgeHandshakeResponse(
+        let missing = BridgeTestFixtures.handshake(
             negotiatedVersion: .init(major: 1, minor: 9),
             hostKind: .onDemand,
             build: nil,
             supportedOperations: [.captureScreen]
         )
-        let disabled = PeekabooBridgeHandshakeResponse(
+        let disabled = BridgeTestFixtures.handshake(
             negotiatedVersion: .init(major: 1, minor: 9),
             hostKind: .onDemand,
             build: nil,
@@ -632,14 +633,14 @@ struct CommanderBinderTests {
             .targetedHotkey,
             .invalidateImplicitLatestSnapshot,
         ]
-        let legacy = PeekabooBridgeHandshakeResponse(
+        let legacy = BridgeTestFixtures.handshake(
             negotiatedVersion: .init(major: 1, minor: 18),
             hostKind: .onDemand,
             build: nil,
             supportedOperations: operations,
             enabledOperations: operations
         )
-        let current = PeekabooBridgeHandshakeResponse(
+        let current = BridgeTestFixtures.handshake(
             negotiatedVersion: PeekabooBridgeConstants.processGenerationPinnedHotkeyVersion,
             hostKind: .onDemand,
             build: nil,
@@ -687,7 +688,7 @@ struct CommanderBinderTests {
             .exactWindowTargetedClick,
             .invalidateImplicitLatestSnapshot,
         ]
-        let legacy = PeekabooBridgeHandshakeResponse(
+        let legacy = BridgeTestFixtures.handshake(
             negotiatedVersion: .init(major: 1, minor: 21),
             hostKind: .onDemand,
             build: nil,
@@ -695,7 +696,7 @@ struct CommanderBinderTests {
             permissions: PermissionsStatus(screenRecording: true, accessibility: true, postEvent: true),
             enabledOperations: operations
         )
-        let current = PeekabooBridgeHandshakeResponse(
+        let current = BridgeTestFixtures.handshake(
             negotiatedVersion: PeekabooBridgeConstants.processGenerationPinnedInteractionVersion,
             hostKind: .onDemand,
             build: nil,
@@ -835,7 +836,7 @@ struct CommanderBinderTests {
             .invalidateImplicitLatestSnapshot,
             .targetedClick,
         ]
-        let accessibilityOnly = PeekabooBridgeHandshakeResponse(
+        let accessibilityOnly = BridgeTestFixtures.handshake(
             negotiatedVersion: PeekabooBridgeConstants.processGenerationPinnedInteractionVersion,
             hostKind: .onDemand,
             build: nil,
@@ -848,7 +849,7 @@ struct CommanderBinderTests {
             enabledOperations: operations,
             permissionTags: [PeekabooBridgeOperation.targetedClick.rawValue: []]
         )
-        let fullyPermitted = PeekabooBridgeHandshakeResponse(
+        let fullyPermitted = BridgeTestFixtures.handshake(
             negotiatedVersion: PeekabooBridgeConstants.processGenerationPinnedInteractionVersion,
             hostKind: .onDemand,
             build: nil,
@@ -899,7 +900,7 @@ extension CommanderBinderTests {
         #expect(!foreground.requiresAccessibilityPermission)
         #expect(foreground.requiresPostEventPermission)
 
-        let legacy = PeekabooBridgeHandshakeResponse(
+        let legacy = BridgeTestFixtures.handshake(
             negotiatedVersion: .init(major: 1, minor: 10),
             hostKind: .onDemand,
             build: nil,
@@ -911,7 +912,7 @@ extension CommanderBinderTests {
             ),
             enabledOperations: [.captureScreen, .scroll, .invalidateImplicitLatestSnapshot]
         )
-        let current = PeekabooBridgeHandshakeResponse(
+        let current = BridgeTestFixtures.handshake(
             negotiatedVersion: .init(major: 1, minor: 12),
             hostKind: .onDemand,
             build: nil,
@@ -982,25 +983,25 @@ extension CommanderBinderTests {
             .captureScreen,
             .exactWindowTargetedClick,
         ]
-        let capable = PeekabooBridgeHandshakeResponse(
+        let capable = BridgeTestFixtures.handshake(
             negotiatedVersion: .init(major: 1, minor: 17),
             hostKind: .onDemand,
             build: nil,
             supportedOperations: operations
         )
-        let preCompletionValidation = PeekabooBridgeHandshakeResponse(
+        let preCompletionValidation = BridgeTestFixtures.handshake(
             negotiatedVersion: .init(major: 1, minor: 16),
             hostKind: .onDemand,
             build: nil,
             supportedOperations: operations
         )
-        let missing = PeekabooBridgeHandshakeResponse(
+        let missing = BridgeTestFixtures.handshake(
             negotiatedVersion: .init(major: 1, minor: 17),
             hostKind: .onDemand,
             build: nil,
             supportedOperations: [.captureScreen]
         )
-        let disabled = PeekabooBridgeHandshakeResponse(
+        let disabled = BridgeTestFixtures.handshake(
             negotiatedVersion: .init(major: 1, minor: 17),
             hostKind: .onDemand,
             build: nil,
@@ -1023,20 +1024,20 @@ extension CommanderBinderTests {
             .launchApplicationWithOptions,
             .relaunchApplicationWithOptions,
         ]
-        let capable = PeekabooBridgeHandshakeResponse(
+        let capable = BridgeTestFixtures.handshake(
             negotiatedVersion: .init(major: 1, minor: 18),
             hostKind: .onDemand,
             build: nil,
             supportedOperations: operations
         )
-        let relaunchDisabled = PeekabooBridgeHandshakeResponse(
+        let relaunchDisabled = BridgeTestFixtures.handshake(
             negotiatedVersion: .init(major: 1, minor: 18),
             hostKind: .onDemand,
             build: nil,
             supportedOperations: operations,
             enabledOperations: operations.filter { $0 != .relaunchApplicationWithOptions }
         )
-        let guiHost = PeekabooBridgeHandshakeResponse(
+        let guiHost = BridgeTestFixtures.handshake(
             negotiatedVersion: .init(major: 1, minor: 18),
             hostKind: .gui,
             build: nil,
@@ -1055,7 +1056,7 @@ extension CommanderBinderTests {
             PeekabooBridgeOperation.launchApplicationWithOptions,
             .relaunchApplicationWithOptions,
         ] {
-            let incomplete = PeekabooBridgeHandshakeResponse(
+            let incomplete = BridgeTestFixtures.handshake(
                 negotiatedVersion: .init(major: 1, minor: 9),
                 hostKind: .onDemand,
                 build: nil,
@@ -1065,7 +1066,7 @@ extension CommanderBinderTests {
         }
 
         options.requiresApplicationRelaunch = false
-        let launchOnly = PeekabooBridgeHandshakeResponse(
+        let launchOnly = BridgeTestFixtures.handshake(
             negotiatedVersion: .init(major: 1, minor: 9),
             hostKind: .gui,
             build: nil,
@@ -1190,13 +1191,13 @@ extension CommanderBinderTests {
 
     @Test
     func `Remote requirements skip bridges missing required element action support`() {
-        let current = PeekabooBridgeHandshakeResponse(
+        let current = BridgeTestFixtures.handshake(
             negotiatedVersion: .init(major: 1, minor: 3),
             hostKind: .gui,
             build: nil,
             supportedOperations: [.captureScreen, .setValue, .performAction]
         )
-        let oldProtocol = PeekabooBridgeHandshakeResponse(
+        let oldProtocol = BridgeTestFixtures.handshake(
             negotiatedVersion: .init(major: 1, minor: 2),
             hostKind: .gui,
             build: nil,
@@ -1367,26 +1368,26 @@ extension CommanderBinderTests {
     func `Application inventory requires an enabled bridge operation`() {
         var options = CommandRuntimeOptions()
         options.requiresHostApplicationInventory = true
-        let legacyCapable = PeekabooBridgeHandshakeResponse(
+        let legacyCapable = BridgeTestFixtures.handshake(
             negotiatedVersion: .init(major: 1, minor: 8),
             hostKind: .onDemand,
             build: nil,
             supportedOperations: [.captureScreen, .listApplications]
         )
-        let unsupported = PeekabooBridgeHandshakeResponse(
+        let unsupported = BridgeTestFixtures.handshake(
             negotiatedVersion: .init(major: 1, minor: 9),
             hostKind: .gui,
             build: nil,
             supportedOperations: [.captureScreen]
         )
-        let disabled = PeekabooBridgeHandshakeResponse(
+        let disabled = BridgeTestFixtures.handshake(
             negotiatedVersion: .init(major: 1, minor: 9),
             hostKind: .gui,
             build: nil,
             supportedOperations: [.captureScreen, .listApplications],
             enabledOperations: [.captureScreen]
         )
-        let preProtocol = PeekabooBridgeHandshakeResponse(
+        let preProtocol = BridgeTestFixtures.handshake(
             negotiatedVersion: .init(major: 0, minor: 9),
             hostKind: .onDemand,
             build: nil,
@@ -1577,13 +1578,13 @@ extension CommanderBinderTests {
                 flags: ["foreground"]
             )),
         ]
-        let legacy = PeekabooBridgeHandshakeResponse(
+        let legacy = BridgeTestFixtures.handshake(
             negotiatedVersion: .init(major: 1, minor: 11),
             hostKind: .onDemand,
             build: nil,
             supportedOperations: [.captureScreen]
         )
-        let current = PeekabooBridgeHandshakeResponse(
+        let current = BridgeTestFixtures.handshake(
             negotiatedVersion: .init(major: 1, minor: 12),
             hostKind: .onDemand,
             build: nil,

--- a/Apps/CLI/Tests/CoreCLITests/DesktopObservationCaptureEngineRuntimeCapabilityTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/DesktopObservationCaptureEngineRuntimeCapabilityTests.swift
@@ -1,6 +1,7 @@
 import Commander
 import PeekabooAutomationKit
 import PeekabooBridge
+import PeekabooBridgeTestSupport
 import Testing
 @testable import PeekabooCLI
 
@@ -203,7 +204,7 @@ struct DesktopObservationCaptureEngineRuntimeCapabilityTests {
         capabilities: [String]?,
         permissions: PermissionsStatus? = nil
     ) -> PeekabooBridgeHandshakeResponse {
-        PeekabooBridgeHandshakeResponse(
+        BridgeTestFixtures.handshake(
             negotiatedVersion: PeekabooBridgeProtocolVersion(major: 1, minor: 22),
             hostKind: .onDemand,
             build: nil,

--- a/Apps/CLI/Tests/CoreCLITests/DesktopObservationOCRRuntimeCapabilityTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/DesktopObservationOCRRuntimeCapabilityTests.swift
@@ -1,5 +1,6 @@
 import Commander
 import PeekabooBridge
+import PeekabooBridgeTestSupport
 import Testing
 @testable import PeekabooCLI
 
@@ -129,7 +130,7 @@ struct DesktopObservationOCRRuntimeCapabilityTests {
         enabledOperations: [PeekabooBridgeOperation]? = nil,
         capabilities: [String]?
     ) -> PeekabooBridgeHandshakeResponse {
-        PeekabooBridgeHandshakeResponse(
+        BridgeTestFixtures.handshake(
             negotiatedVersion: PeekabooBridgeProtocolVersion(major: 1, minor: 22),
             hostKind: .gui,
             build: nil,

--- a/Apps/CLI/Tests/CoreCLITests/ExactWindowROIRuntimeCapabilityTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/ExactWindowROIRuntimeCapabilityTests.swift
@@ -1,5 +1,6 @@
 import Commander
 import PeekabooBridge
+import PeekabooBridgeTestSupport
 import Testing
 @testable import PeekabooCLI
 
@@ -162,7 +163,7 @@ struct ExactWindowROIRuntimeCapabilityTests {
         operations: [PeekabooBridgeOperation],
         enabledOperations: [PeekabooBridgeOperation]? = nil
     ) -> PeekabooBridgeHandshakeResponse {
-        PeekabooBridgeHandshakeResponse(
+        BridgeTestFixtures.handshake(
             negotiatedVersion: PeekabooBridgeProtocolVersion(major: 1, minor: minor),
             hostKind: hostKind,
             build: nil,

--- a/Apps/CLI/Tests/CoreCLITests/RuntimeHostApplicationSelectionTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/RuntimeHostApplicationSelectionTests.swift
@@ -1,6 +1,7 @@
 import Commander
 import PeekabooAutomation
 import PeekabooBridge
+import PeekabooBridgeTestSupport
 import Testing
 @testable import PeekabooCLI
 
@@ -12,7 +13,7 @@ struct RuntimeHostApplicationSelectionTests {
             commandType: SeeCommand.self
         )
         let supportedOperations: [PeekabooBridgeOperation] = [.captureScreen, .desktopObservation]
-        let supported = PeekabooBridgeHandshakeResponse(
+        let supported = BridgeTestFixtures.handshake(
             negotiatedVersion: PeekabooBridgeConstants.protocolVersion,
             hostKind: .onDemand,
             build: nil,
@@ -23,7 +24,7 @@ struct RuntimeHostApplicationSelectionTests {
                 PeekabooBridgeHostCapability.screenCaptureKitProcessOwnership,
             ]
         )
-        let captureOnly = PeekabooBridgeHandshakeResponse(
+        let captureOnly = BridgeTestFixtures.handshake(
             negotiatedVersion: PeekabooBridgeConstants.protocolVersion,
             hostKind: .onDemand,
             build: nil,
@@ -43,7 +44,7 @@ struct RuntimeHostApplicationSelectionTests {
             requiredHostKind: nil,
             requiresValidatedHistoricalDaemon: false
         )
-        let applicationOnly = PeekabooBridgeHandshakeResponse(
+        let applicationOnly = BridgeTestFixtures.handshake(
             negotiatedVersion: PeekabooBridgeConstants.protocolVersion,
             hostKind: .onDemand,
             build: nil,
@@ -83,13 +84,13 @@ struct RuntimeHostApplicationSelectionTests {
 
     @Test
     func `Remote requirements skip stale bridge hosts for launch commands`() {
-        let current = PeekabooBridgeHandshakeResponse(
+        let current = BridgeTestFixtures.handshake(
             negotiatedVersion: .init(major: 1, minor: 9),
             hostKind: .gui,
             build: nil,
             supportedOperations: [.captureScreen, .launchApplicationWithOptions]
         )
-        let stale = PeekabooBridgeHandshakeResponse(
+        let stale = BridgeTestFixtures.handshake(
             negotiatedVersion: .init(major: 1, minor: 8),
             hostKind: .gui,
             build: nil,
@@ -162,21 +163,21 @@ struct RuntimeHostApplicationSelectionTests {
             .invalidateImplicitLatestSnapshot,
             .quitApplication,
         ]
-        let daemonHost = PeekabooBridgeHandshakeResponse(
+        let daemonHost = BridgeTestFixtures.handshake(
             negotiatedVersion: .init(major: 1, minor: 16),
             hostKind: .onDemand,
             build: nil,
             supportedOperations: operations,
             enabledOperations: operations
         )
-        let guiHost = PeekabooBridgeHandshakeResponse(
+        let guiHost = BridgeTestFixtures.handshake(
             negotiatedVersion: .init(major: 1, minor: 16),
             hostKind: .gui,
             build: nil,
             supportedOperations: operations,
             enabledOperations: operations
         )
-        let legacyDaemonHost = PeekabooBridgeHandshakeResponse(
+        let legacyDaemonHost = BridgeTestFixtures.handshake(
             negotiatedVersion: .init(major: 1, minor: 15),
             hostKind: .onDemand,
             build: nil,
@@ -215,7 +216,7 @@ struct RuntimeHostApplicationSelectionTests {
             .quitApplication,
             .invalidateImplicitLatestSnapshot,
         ]
-        let guiHost = PeekabooBridgeHandshakeResponse(
+        let guiHost = BridgeTestFixtures.handshake(
             negotiatedVersion: .init(major: 1, minor: 18),
             hostKind: .gui,
             build: nil,

--- a/Apps/CLI/Tests/CoreCLITests/RuntimeHostResolverTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/RuntimeHostResolverTests.swift
@@ -1,6 +1,7 @@
 import Commander
 import PeekabooAutomation
 import PeekabooBridge
+import PeekabooBridgeTestSupport
 import Testing
 @testable import PeekabooCLI
 
@@ -163,7 +164,7 @@ struct RuntimeHostResolverTests {
             requiredHostKind: .onDemand,
             requiresValidatedHistoricalDaemon: true
         )
-        let handshake = PeekabooBridgeHandshakeResponse(
+        let handshake = BridgeTestFixtures.handshake(
             negotiatedVersion: PeekabooBridgeConstants.protocolVersion,
             hostKind: .onDemand,
             build: nil,
@@ -227,7 +228,7 @@ struct RuntimeHostResolverTests {
         )
         var options = CommandRuntimeOptions()
         options.requiresPostEventPermission = true
-        let accessibilityOnly = PeekabooBridgeHandshakeResponse(
+        let accessibilityOnly = BridgeTestFixtures.handshake(
             negotiatedVersion: PeekabooBridgeConstants.protocolVersion,
             hostKind: .gui,
             build: nil,
@@ -239,7 +240,7 @@ struct RuntimeHostResolverTests {
             ),
             enabledOperations: [.captureScreen, .targetedClick]
         )
-        let postEventCapable = PeekabooBridgeHandshakeResponse(
+        let postEventCapable = BridgeTestFixtures.handshake(
             negotiatedVersion: PeekabooBridgeConstants.protocolVersion,
             hostKind: .gui,
             build: nil,
@@ -280,7 +281,7 @@ struct RuntimeHostResolverTests {
             let operations: [PeekabooBridgeOperation] = supportsClick
                 ? [.captureScreen, .click, .targetedClick]
                 : [.captureScreen, .targetedClick]
-            return PeekabooBridgeHandshakeResponse(
+            return BridgeTestFixtures.handshake(
                 negotiatedVersion: PeekabooBridgeProtocolVersion(major: 1, minor: minor),
                 hostKind: .gui,
                 build: nil,
@@ -326,7 +327,7 @@ struct RuntimeHostResolverTests {
             .invalidateImplicitLatestSnapshot,
         ]
         func handshake(minor: Int) -> PeekabooBridgeHandshakeResponse {
-            PeekabooBridgeHandshakeResponse(
+            BridgeTestFixtures.handshake(
                 negotiatedVersion: PeekabooBridgeProtocolVersion(major: 1, minor: minor),
                 hostKind: .gui,
                 build: nil,
@@ -384,7 +385,7 @@ struct RuntimeHostResolverTests {
             supported: [PeekabooBridgeOperation],
             enabled: [PeekabooBridgeOperation]
         ) -> PeekabooBridgeHandshakeResponse {
-            PeekabooBridgeHandshakeResponse(
+            BridgeTestFixtures.handshake(
                 negotiatedVersion: .init(major: 1, minor: 18),
                 hostKind: .gui,
                 build: nil,
@@ -431,7 +432,7 @@ struct RuntimeHostResolverTests {
         ]
         func handshake(minor: Int, enabledOperations: [PeekabooBridgeOperation]? = nil)
         -> PeekabooBridgeHandshakeResponse {
-            PeekabooBridgeHandshakeResponse(
+            BridgeTestFixtures.handshake(
                 negotiatedVersion: PeekabooBridgeProtocolVersion(major: 1, minor: minor),
                 hostKind: .onDemand,
                 build: nil,
@@ -501,7 +502,7 @@ struct RuntimeHostResolverTests {
             requiredHostKind: .gui,
             requiresValidatedHistoricalDaemon: false
         )
-        let unpermissioned = PeekabooBridgeHandshakeResponse(
+        let unpermissioned = BridgeTestFixtures.handshake(
             negotiatedVersion: PeekabooBridgeConstants.protocolVersion,
             hostKind: .gui,
             build: "stale-debug",
@@ -538,7 +539,7 @@ struct RuntimeHostResolverTests {
             requiredHostKind: nil,
             requiresValidatedHistoricalDaemon: false
         )
-        let noScreenRecording = PeekabooBridgeHandshakeResponse(
+        let noScreenRecording = BridgeTestFixtures.handshake(
             negotiatedVersion: PeekabooBridgeConstants.protocolVersion,
             hostKind: .onDemand,
             build: nil,
@@ -586,7 +587,7 @@ struct RuntimeHostResolverTests {
             requiredHostKind: nil,
             requiresValidatedHistoricalDaemon: false
         )
-        let untagged = PeekabooBridgeHandshakeResponse(
+        let untagged = BridgeTestFixtures.handshake(
             negotiatedVersion: PeekabooBridgeConstants.protocolVersion,
             hostKind: .gui,
             build: nil,
@@ -616,7 +617,7 @@ struct RuntimeHostResolverTests {
             requiredHostKind: .gui,
             requiresValidatedHistoricalDaemon: false
         )
-        let unknownPermissions = PeekabooBridgeHandshakeResponse(
+        let unknownPermissions = BridgeTestFixtures.handshake(
             negotiatedVersion: PeekabooBridgeConstants.protocolVersion,
             hostKind: .gui,
             build: nil,
@@ -642,7 +643,7 @@ struct RuntimeHostResolverTests {
             major: PeekabooBridgeConstants.protocolVersion.major,
             minor: PeekabooBridgeConstants.protocolVersion.minor - 1
         )
-        let handshake = PeekabooBridgeHandshakeResponse(
+        let handshake = BridgeTestFixtures.handshake(
             negotiatedVersion: olderProtocol,
             hostKind: .onDemand,
             build: "legacy",
@@ -745,7 +746,7 @@ struct RuntimeHostResolverTests {
             requiredHostKind: .gui,
             requiresValidatedHistoricalDaemon: false
         )
-        let permissioned = PeekabooBridgeHandshakeResponse(
+        let permissioned = BridgeTestFixtures.handshake(
             negotiatedVersion: PeekabooBridgeConstants.protocolVersion,
             hostKind: .gui,
             build: nil,
@@ -776,7 +777,7 @@ struct RuntimeHostResolverTests {
             requiresValidatedHistoricalDaemon: false
         )
         // Holds Screen Recording but not Accessibility.
-        let captureOnlyPermissions = PeekabooBridgeHandshakeResponse(
+        let captureOnlyPermissions = BridgeTestFixtures.handshake(
             negotiatedVersion: PeekabooBridgeConstants.protocolVersion,
             hostKind: .onDemand,
             build: nil,
@@ -823,7 +824,7 @@ struct RuntimeHostResolverTests {
             requiredHostKind: .gui,
             requiresValidatedHistoricalDaemon: false
         )
-        let unpermissioned = PeekabooBridgeHandshakeResponse(
+        let unpermissioned = BridgeTestFixtures.handshake(
             negotiatedVersion: PeekabooBridgeConstants.protocolVersion,
             hostKind: .gui,
             build: nil,

--- a/Apps/CLI/Tests/CoreCLITests/ScreenCaptureKitOwnerRuntimeTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/ScreenCaptureKitOwnerRuntimeTests.swift
@@ -3,6 +3,7 @@ import Foundation
 import PeekabooAutomation
 import PeekabooAutomationKit
 import PeekabooBridge
+import PeekabooBridgeTestSupport
 import PeekabooCore
 import PeekabooFoundation
 import Testing
@@ -921,7 +922,7 @@ extension ScreenCaptureKitOwnerRuntimeTests {
         ],
         codeSignatureHash: String = "owner-build"
     ) -> PeekabooBridgeHandshakeResponse {
-        PeekabooBridgeHandshakeResponse(
+        BridgeTestFixtures.handshake(
             negotiatedVersion: PeekabooBridgeConstants.protocolVersion,
             hostKind: .onDemand,
             build: nil,

--- a/Core/PeekabooAutomationKit/Package.swift
+++ b/Core/PeekabooAutomationKit/Package.swift
@@ -22,6 +22,10 @@ let package = Package(
         .library(
             name: "PeekabooAutomationKit",
             targets: ["PeekabooAutomationKit"]),
+        // Test-only support product. Production targets do not depend on or link this module.
+        .library(
+            name: "PeekabooAutomationKitTestSupport",
+            targets: ["PeekabooAutomationKitTestSupport"]),
     ],
     dependencies: [
         .package(path: "../PeekabooFoundation"),
@@ -40,9 +44,16 @@ let package = Package(
             ],
             exclude: ["Core/README.md"],
             swiftSettings: kitTargetSettings),
+        .target(
+            name: "PeekabooAutomationKitTestSupport",
+            dependencies: [
+                "PeekabooAutomationKit",
+                .product(name: "PeekabooFoundation", package: "PeekabooFoundation"),
+            ],
+            swiftSettings: approachableConcurrencySettings),
         .testTarget(
             name: "PeekabooAutomationKitTests",
-            dependencies: ["PeekabooAutomationKit"],
+            dependencies: ["PeekabooAutomationKit", "PeekabooAutomationKitTestSupport"],
             path: "Tests/PeekabooAutomationKitTests",
             swiftSettings: approachableConcurrencySettings),
     ],

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKitTestSupport/AsyncTestLatch.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKitTestSupport/AsyncTestLatch.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+/// A deterministic, reusable one-shot latch for asynchronous tests.
+public actor AsyncTestLatch {
+    private var opened = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    public init() {}
+
+    public var isOpen: Bool {
+        self.opened
+    }
+
+    public func wait() async {
+        guard !self.opened else { return }
+        await withCheckedContinuation { continuation in
+            self.waiters.append(continuation)
+        }
+    }
+
+    public func open() {
+        guard !self.opened else { return }
+        self.opened = true
+        let pending = self.waiters
+        self.waiters.removeAll()
+        for continuation in pending {
+            continuation.resume()
+        }
+    }
+
+    public func opensWithin(_ duration: Duration) async -> Bool {
+        if self.opened {
+            return true
+        }
+        let deadline = ContinuousClock.now.advanced(by: duration)
+        while !self.opened, ContinuousClock.now < deadline {
+            try? await Task.sleep(for: .milliseconds(5))
+        }
+        return self.opened
+    }
+}

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKitTestSupport/AutomationTestFixtures.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKitTestSupport/AutomationTestFixtures.swift
@@ -1,0 +1,206 @@
+import CoreGraphics
+import Foundation
+import PeekabooAutomationKit
+import PeekabooFoundation
+
+/// Canonical deterministic builders for automation tests.
+public enum AutomationTestFixtures {
+    public static func processIdentity(
+        processIdentifier: Int32 = 101,
+        processStartIdentity: UInt64 = 1001) -> ApplicationProcessIdentity
+    {
+        ApplicationProcessIdentity(
+            processIdentifier: processIdentifier,
+            processStartIdentity: processStartIdentity)
+    }
+
+    public static func windowIdentity(
+        windowID: Int = 201,
+        processIdentity: ApplicationProcessIdentity = Self.processIdentity(),
+        bounds: CGRect = CGRect(x: 10, y: 20, width: 640, height: 480),
+        isMinimized: Bool = false) -> WindowMutationIdentity
+    {
+        WindowMutationIdentity(
+            windowID: windowID,
+            ownerProcessIdentifier: processIdentity.processIdentifier,
+            ownerProcessStartIdentity: processIdentity.processStartIdentity,
+            capturedBounds: bounds,
+            isMinimized: isMinimized)
+    }
+
+    public static func application(
+        processIdentifier: Int32 = 101,
+        processStartIdentity: UInt64? = 1001,
+        bundleIdentifier: String? = "com.example.TestApp",
+        name: String = "Test App",
+        isActive: Bool = false,
+        isHidden: Bool = false,
+        isHiddenKnown: Bool? = nil,
+        windowCount: Int = 0,
+        windowIDs: [Int]? = nil,
+        activationPolicy: ServiceApplicationActivationPolicy? = nil) -> ServiceApplicationInfo
+    {
+        ServiceApplicationInfo(
+            processIdentifier: processIdentifier,
+            processStartIdentity: processStartIdentity,
+            bundleIdentifier: bundleIdentifier,
+            name: name,
+            isActive: isActive,
+            isHidden: isHidden,
+            isHiddenKnown: isHiddenKnown,
+            windowCount: windowCount,
+            windowIDs: windowIDs,
+            activationPolicy: activationPolicy)
+    }
+
+    public static func window(
+        windowID: Int = 201,
+        title: String = "Test Window",
+        bounds: CGRect = CGRect(x: 10, y: 20, width: 640, height: 480),
+        processIdentity: ApplicationProcessIdentity = Self.processIdentity(),
+        includesMutationIdentity: Bool = true,
+        isMinimized: Bool = false,
+        isMainWindow: Bool = true,
+        isKeyWindow: Bool? = true,
+        isFrontmost: Bool? = false,
+        index: Int = 0) -> ServiceWindowInfo
+    {
+        ServiceWindowInfo(
+            windowID: windowID,
+            title: title,
+            bounds: bounds,
+            isMinimized: isMinimized,
+            isMainWindow: isMainWindow,
+            isKeyWindow: isKeyWindow,
+            isFrontmost: isFrontmost,
+            index: index,
+            mutationIdentity: includesMutationIdentity
+                ? self.windowIdentity(
+                    windowID: windowID,
+                    processIdentity: processIdentity,
+                    bounds: bounds,
+                    isMinimized: isMinimized)
+                : nil)
+    }
+
+    public static func detectedElement(
+        id: String = "element-1",
+        type: ElementType = .textField,
+        label: String? = "Test Element",
+        value: String? = nil,
+        bounds: CGRect = CGRect(x: 30, y: 40, width: 200, height: 32),
+        isEnabled: Bool = true,
+        isSelected: Bool? = nil,
+        attributes: [String: String] = [:]) -> DetectedElement
+    {
+        DetectedElement(
+            id: id,
+            type: type,
+            label: label,
+            value: value,
+            bounds: bounds,
+            isEnabled: isEnabled,
+            isSelected: isSelected,
+            attributes: attributes)
+    }
+
+    public static func storedElement(
+        id: String = "element-1",
+        role: String = "AXTextField",
+        title: String? = "Test Element",
+        label: String? = nil,
+        value: String? = nil,
+        description: String? = nil,
+        help: String? = nil,
+        roleDescription: String? = nil,
+        identifier: String? = nil,
+        frame: CGRect = CGRect(x: 30, y: 40, width: 200, height: 32),
+        isActionable: Bool = true,
+        isEnabled: Bool? = true,
+        isSelected: Bool? = nil,
+        isValueSettable: Bool? = true) -> UIElement
+    {
+        UIElement(
+            id: id,
+            elementId: id,
+            role: role,
+            title: title,
+            label: label,
+            value: value,
+            description: description,
+            help: help,
+            roleDescription: roleDescription,
+            identifier: identifier,
+            frame: frame,
+            isActionable: isActionable,
+            isEnabled: isEnabled,
+            isSelected: isSelected,
+            isValueSettable: isValueSettable)
+    }
+
+    public static func windowContext(
+        application: ServiceApplicationInfo = Self.application(),
+        window: ServiceWindowInfo = Self.window(),
+        requiresFreshAccessibilityTree: Bool = true) -> WindowContext
+    {
+        if let receipt = window.mutationIdentity {
+            precondition(
+                receipt.ownerProcessIdentifier == application.processIdentifier &&
+                    receipt.ownerProcessStartIdentity == application.processStartIdentity,
+                "Window and application fixtures must describe the same process generation")
+        }
+        return WindowContext(
+            applicationName: application.name,
+            applicationBundleId: application.bundleIdentifier,
+            applicationProcessId: application.processIdentifier,
+            windowTitle: window.title,
+            windowID: window.windowID,
+            windowBounds: window.bounds,
+            windowMutationIdentity: window.mutationIdentity,
+            requiresFreshAccessibilityTree: requiresFreshAccessibilityTree)
+    }
+
+    public static func detectionResult(
+        snapshotID: String = "snapshot-1",
+        screenshotPath: String = "/tmp/peekaboo-test.png",
+        elements: DetectedElements = DetectedElements(),
+        windowContext: WindowContext? = nil,
+        warnings: [String] = []) -> ElementDetectionResult
+    {
+        ElementDetectionResult(
+            snapshotId: snapshotID,
+            screenshotPath: screenshotPath,
+            elements: elements,
+            metadata: DetectionMetadata(
+                detectionTime: 0,
+                elementCount: elements.all.count,
+                method: "test-fixture",
+                warnings: warnings,
+                windowContext: windowContext))
+    }
+
+    public static func snapshot(
+        creatorProcessID: Int32 = 999,
+        elements: [String: UIElement] = [:],
+        application: ServiceApplicationInfo = Self.application(),
+        window: ServiceWindowInfo = Self.window()) -> UIAutomationSnapshot
+    {
+        if let receipt = window.mutationIdentity {
+            precondition(
+                receipt.ownerProcessIdentifier == application.processIdentifier &&
+                    receipt.ownerProcessStartIdentity == application.processStartIdentity,
+                "Window and application fixtures must describe the same process generation")
+        }
+        return UIAutomationSnapshot(
+            creatorProcessId: creatorProcessID,
+            uiMap: elements,
+            lastUpdateTime: Date(timeIntervalSinceReferenceDate: 1),
+            applicationName: application.name,
+            applicationBundleId: application.bundleIdentifier,
+            applicationProcessId: application.processIdentifier,
+            windowTitle: window.title,
+            windowBounds: window.bounds,
+            windowMutationIdentity: window.mutationIdentity,
+            windowID: CGWindowID(window.windowID))
+    }
+}

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/DesktopOperationLaneCoordinatorTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/DesktopOperationLaneCoordinatorTests.swift
@@ -1,5 +1,6 @@
 import CoreGraphics
 import Foundation
+import PeekabooAutomationKitTestSupport
 import Testing
 @testable import PeekabooAutomationKit
 
@@ -445,42 +446,5 @@ struct DesktopOperationLaneCoordinatorTests {
     private static func temporaryDirectory(named name: String) -> URL {
         FileManager.default.temporaryDirectory
             .appendingPathComponent("peekaboo-operation-lanes-\(name)-\(UUID().uuidString)", isDirectory: true)
-    }
-}
-
-private actor AsyncTestLatch {
-    private var opened = false
-    private var continuations: [CheckedContinuation<Void, Never>] = []
-
-    var isOpen: Bool {
-        self.opened
-    }
-
-    func open() {
-        guard !self.opened else { return }
-        self.opened = true
-        let pending = self.continuations
-        self.continuations.removeAll()
-        for continuation in pending {
-            continuation.resume()
-        }
-    }
-
-    func wait() async {
-        guard !self.opened else { return }
-        await withCheckedContinuation { continuation in
-            self.continuations.append(continuation)
-        }
-    }
-
-    func opensWithin(_ duration: Duration) async -> Bool {
-        if self.opened {
-            return true
-        }
-        let deadline = ContinuousClock.now.advanced(by: duration)
-        while !self.opened, ContinuousClock.now < deadline {
-            try? await Task.sleep(for: .milliseconds(5))
-        }
-        return self.opened
     }
 }

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ScreenCaptureKitTimeoutRaceTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ScreenCaptureKitTimeoutRaceTests.swift
@@ -1,5 +1,6 @@
 import Darwin
 import Foundation
+import PeekabooAutomationKitTestSupport
 import PeekabooFoundation
 import Testing
 @testable import PeekabooAutomationKit
@@ -288,33 +289,5 @@ struct ScreenCaptureKitOperationCoordinatorTests {
             try? await Task.sleep(for: .milliseconds(10))
         }
         return predicate()
-    }
-}
-
-private actor AsyncTestLatch {
-    private var openState = false
-    private var waiters: [CheckedContinuation<Void, Never>] = []
-
-    var isOpen: Bool {
-        self.openState
-    }
-
-    func wait() async {
-        if self.openState {
-            return
-        }
-        await withCheckedContinuation { continuation in
-            self.waiters.append(continuation)
-        }
-    }
-
-    func open() {
-        guard !self.openState else { return }
-        self.openState = true
-        let waiters = self.waiters
-        self.waiters.removeAll()
-        for waiter in waiters {
-            waiter.resume()
-        }
     }
 }

--- a/Core/PeekabooCore/Package.swift
+++ b/Core/PeekabooCore/Package.swift
@@ -37,6 +37,10 @@ let package = Package(
         .library(
             name: "PeekabooBridge",
             targets: ["PeekabooBridge"]),
+        // Test-only support product. Production targets do not depend on or link this module.
+        .library(
+            name: "PeekabooBridgeTestSupport",
+            targets: ["PeekabooBridgeTestSupport"]),
         .library(
             name: "PeekabooCore",
             targets: ["PeekabooCore"]),
@@ -87,6 +91,14 @@ let package = Package(
             ],
             path: "Sources/PeekabooBridge",
             swiftSettings: coreTargetSettings),
+        .target(
+            name: "PeekabooBridgeTestSupport",
+            dependencies: [
+                .target(name: "PeekabooBridge"),
+                .product(name: "PeekabooAutomationKit", package: "PeekabooAutomationKit"),
+            ],
+            path: "Sources/PeekabooBridgeTestSupport",
+            swiftSettings: approachableConcurrencySettings),
         .target(
             name: "PeekabooAgentRuntime",
             dependencies: [
@@ -143,6 +155,8 @@ let package = Package(
                 .product(name: "PeekabooVisualizer", package: "PeekabooVisualizer"),
                 "PeekabooFoundation",
                 "PeekabooProtocols",
+                "PeekabooBridgeTestSupport",
+                .product(name: "PeekabooAutomationKitTestSupport", package: "PeekabooAutomationKit"),
             ],
             resources: [
                 .process("Resources"),

--- a/Core/PeekabooCore/Sources/PeekabooBridgeTestSupport/BridgeTestFixtures.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridgeTestSupport/BridgeTestFixtures.swift
@@ -1,0 +1,53 @@
+import PeekabooAutomationKit
+import PeekabooBridge
+
+/// Canonical builders for Bridge protocol and transport tests.
+public enum BridgeTestFixtures {
+    /// Builds one internally coherent handshake while keeping protocol versions explicit at every call site.
+    public static func handshake(
+        negotiatedVersion: PeekabooBridgeProtocolVersion,
+        hostKind: PeekabooBridgeHostKind = .onDemand,
+        build: String? = nil,
+        supportedOperations: [PeekabooBridgeOperation],
+        permissions: PermissionsStatus? = nil,
+        enabledOperations: [PeekabooBridgeOperation]? = nil,
+        permissionTags: [String: [PeekabooBridgePermissionKind]] = [:],
+        hostIdentity: PeekabooBridgeHostIdentity? = nil,
+        hostCapabilities: [String]? = nil) -> PeekabooBridgeHandshakeResponse
+    {
+        if let enabledOperations {
+            precondition(
+                Set(enabledOperations).isSubset(of: Set(supportedOperations)),
+                "Enabled Bridge operations must be a subset of supported operations")
+        }
+        return PeekabooBridgeHandshakeResponse(
+            negotiatedVersion: negotiatedVersion,
+            hostKind: hostKind,
+            build: build,
+            supportedOperations: supportedOperations,
+            permissions: permissions,
+            enabledOperations: enabledOperations,
+            permissionTags: permissionTags,
+            hostIdentity: hostIdentity,
+            hostCapabilities: hostCapabilities)
+    }
+
+    public static func errorResponse(
+        code: PeekabooBridgeErrorCode,
+        message: String,
+        details: String? = nil,
+        permission: PeekabooBridgePermissionKind? = nil,
+        kind: PeekabooBridgeErrorKind? = nil,
+        context: String? = nil,
+        operationMayHaveCompleted: Bool = false) -> PeekabooBridgeResponse
+    {
+        .error(PeekabooBridgeErrorEnvelope(
+            code: code,
+            message: message,
+            details: details,
+            permission: permission,
+            kind: kind,
+            context: context,
+            operationMayHaveCompleted: operationMayHaveCompleted))
+    }
+}

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPKeyboardBackgroundToolTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPKeyboardBackgroundToolTests.swift
@@ -1,5 +1,6 @@
 import CoreGraphics
 import PeekabooAutomationKit
+import PeekabooAutomationKitTestSupport
 import PeekabooFoundation
 import TachikomaMCP
 import Testing
@@ -128,7 +129,7 @@ struct MCPKeyboardBackgroundToolTests {
         await UISnapshotManager.shared.removeAllSnapshots()
         let automation = await MainActor.run { MockAutomationService(accessibilityGranted: true) }
         let applications = await MainActor.run {
-            MockApplicationService(applications: [ServiceApplicationInfo(
+            MockApplicationService(applications: [AutomationTestFixtures.application(
                 processIdentifier: 444,
                 processStartIdentity: 44,
                 bundleIdentifier: "com.example.snapshot",
@@ -144,7 +145,7 @@ struct MCPKeyboardBackgroundToolTests {
             metadata: CaptureMetadata(
                 size: CGSize(width: 200, height: 100),
                 mode: .window,
-                applicationInfo: ServiceApplicationInfo(
+                applicationInfo: AutomationTestFixtures.application(
                     processIdentifier: 444,
                     processStartIdentity: 44,
                     bundleIdentifier: "com.example.snapshot",
@@ -160,7 +161,7 @@ struct MCPKeyboardBackgroundToolTests {
         #expect(calls.count == 1)
         #expect(calls.first?.snapshotId == snapshotId)
         #expect(calls.first?.targetProcessIdentifier == 444)
-        #expect(calls.first?.expectedProcessIdentity == ApplicationProcessIdentity(
+        #expect(calls.first?.expectedProcessIdentity == AutomationTestFixtures.processIdentity(
             processIdentifier: 444,
             processStartIdentity: 44))
         #expect(await MainActor.run { automation.clickCalls.isEmpty })
@@ -189,7 +190,7 @@ struct MCPKeyboardBackgroundToolTests {
         await UISnapshotManager.shared.removeAllSnapshots()
         let automation = await MainActor.run { MockAutomationService(accessibilityGranted: true) }
         let applications = await MainActor.run {
-            MockApplicationService(applications: [ServiceApplicationInfo(
+            MockApplicationService(applications: [AutomationTestFixtures.application(
                 processIdentifier: 445,
                 processStartIdentity: 45,
                 bundleIdentifier: "com.example.snapshot",
@@ -220,7 +221,7 @@ struct MCPKeyboardBackgroundToolTests {
         await UISnapshotManager.shared.removeAllSnapshots()
         let automation = await MainActor.run { MockAutomationService(accessibilityGranted: true) }
         let applications = await MainActor.run {
-            MockApplicationService(applications: [ServiceApplicationInfo(
+            MockApplicationService(applications: [AutomationTestFixtures.application(
                 processIdentifier: 446,
                 processStartIdentity: 46,
                 bundleIdentifier: "com.example.editor",
@@ -232,17 +233,12 @@ struct MCPKeyboardBackgroundToolTests {
         let snapshot = await UISnapshotManager.shared.createSnapshot()
         let snapshotId = await snapshot.id
         await snapshot.setUIElements([
-            UIElement(
+            AutomationTestFixtures.storedElement(
                 id: "T1",
-                elementId: "T1",
                 role: "textField",
                 title: nil,
                 label: "Name",
-                value: nil,
-                description: nil,
-                help: nil,
                 roleDescription: "text field",
-                identifier: nil,
                 frame: CGRect(x: 10, y: 20, width: 160, height: 30),
                 isActionable: true),
         ])
@@ -261,7 +257,7 @@ struct MCPKeyboardBackgroundToolTests {
 
     @Test
     func `Background keyboard tools reject window selectors instead of collapsing to pid`() async throws {
-        let app = ServiceApplicationInfo(
+        let app = AutomationTestFixtures.application(
             processIdentifier: 333,
             processStartIdentity: 33,
             bundleIdentifier: "com.example.editor",
@@ -303,7 +299,7 @@ struct MCPKeyboardBackgroundToolTests {
     func `Type tool uses background click and typing when snapshot process is known`() async throws {
         let automation = await MainActor.run { MockAutomationService(accessibilityGranted: true) }
         let applications = await MainActor.run {
-            MockApplicationService(applications: [ServiceApplicationInfo(
+            MockApplicationService(applications: [AutomationTestFixtures.application(
                 processIdentifier: 111,
                 processStartIdentity: 11,
                 bundleIdentifier: "com.example.snapshot",
@@ -319,7 +315,7 @@ struct MCPKeyboardBackgroundToolTests {
             metadata: CaptureMetadata(
                 size: CGSize(width: 200, height: 100),
                 mode: .window,
-                applicationInfo: ServiceApplicationInfo(
+                applicationInfo: AutomationTestFixtures.application(
                     processIdentifier: 111,
                     processStartIdentity: 11,
                     bundleIdentifier: "com.example.snapshot",
@@ -351,14 +347,14 @@ struct MCPKeyboardBackgroundToolTests {
         let targetedClicks = await MainActor.run { automation.targetedClickCalls }
         #expect(targetedClicks.count == 1)
         #expect(targetedClicks.first?.targetProcessIdentifier == 111)
-        #expect(targetedClicks.first?.expectedProcessIdentity == ApplicationProcessIdentity(
+        #expect(targetedClicks.first?.expectedProcessIdentity == AutomationTestFixtures.processIdentity(
             processIdentifier: 111,
             processStartIdentity: 11))
         let targetedTypes = await MainActor.run { automation.targetedTypeActionsCalls }
         #expect(targetedTypes.count == 1)
         #expect(targetedTypes.first?.snapshotId == snapshotId)
         #expect(targetedTypes.first?.targetProcessIdentifier == 111)
-        #expect(targetedTypes.first?.expectedProcessIdentity == ApplicationProcessIdentity(
+        #expect(targetedTypes.first?.expectedProcessIdentity == AutomationTestFixtures.processIdentity(
             processIdentifier: 111,
             processStartIdentity: 11))
         guard case let .object(meta) = response.meta else {
@@ -387,7 +383,7 @@ struct MCPKeyboardBackgroundToolTests {
             metadata: CaptureMetadata(
                 size: CGSize(width: 200, height: 100),
                 mode: .window,
-                applicationInfo: ServiceApplicationInfo(
+                applicationInfo: AutomationTestFixtures.application(
                     processIdentifier: 113,
                     processStartIdentity: 13,
                     bundleIdentifier: "com.example.snapshot",
@@ -470,7 +466,7 @@ struct MCPKeyboardBackgroundToolTests {
     func `Press tool uses targeted delivery when pid is supplied`() async throws {
         let automation = await MainActor.run { MockAutomationService(accessibilityGranted: true) }
         let applications = await MainActor.run {
-            MockApplicationService(applications: [ServiceApplicationInfo(
+            MockApplicationService(applications: [AutomationTestFixtures.application(
                 processIdentifier: 222,
                 processStartIdentity: 22,
                 bundleIdentifier: "com.example.target",
@@ -491,7 +487,7 @@ struct MCPKeyboardBackgroundToolTests {
         #expect(calls.count == 1)
         #expect(calls.first?.keys == "cmd,l")
         #expect(calls.first?.targetProcessIdentifier == 222)
-        #expect(calls.first?.expectedProcessIdentity == ApplicationProcessIdentity(
+        #expect(calls.first?.expectedProcessIdentity == AutomationTestFixtures.processIdentity(
             processIdentifier: 222,
             processStartIdentity: 22))
         #expect(await MainActor.run { automation.lastHotkeyKeys } == nil)
@@ -505,8 +501,8 @@ struct MCPKeyboardBackgroundToolTests {
 
     @Test
     func `Press sequence reports process reuse after partial delivery as retry unsafe`() async throws {
-        let original = ApplicationProcessIdentity(processIdentifier: 223, processStartIdentity: 22)
-        let replacement = ApplicationProcessIdentity(processIdentifier: 223, processStartIdentity: 23)
+        let original = AutomationTestFixtures.processIdentity(processIdentifier: 223, processStartIdentity: 22)
+        let replacement = AutomationTestFixtures.processIdentity(processIdentifier: 223, processStartIdentity: 23)
         var current = original
         let automation = await MainActor.run {
             let automation = MockAutomationService(accessibilityGranted: true)
@@ -515,7 +511,7 @@ struct MCPKeyboardBackgroundToolTests {
             return automation
         }
         let applications = await MainActor.run {
-            MockApplicationService(applications: [ServiceApplicationInfo(
+            MockApplicationService(applications: [AutomationTestFixtures.application(
                 processIdentifier: original.processIdentifier,
                 processStartIdentity: original.processStartIdentity,
                 bundleIdentifier: "com.example.target",
@@ -544,7 +540,7 @@ struct MCPKeyboardBackgroundToolTests {
 
     @Test
     func `Press sequence includes prior chords in indeterminate emitted count`() async throws {
-        let identity = ApplicationProcessIdentity(processIdentifier: 224, processStartIdentity: 24)
+        let identity = AutomationTestFixtures.processIdentity(processIdentifier: 224, processStartIdentity: 24)
         let automation = await MainActor.run {
             let automation = MockAutomationService(accessibilityGranted: true)
             automation.pinnedHotkeyError = { keys in
@@ -557,7 +553,7 @@ struct MCPKeyboardBackgroundToolTests {
             return automation
         }
         let applications = await MainActor.run {
-            MockApplicationService(applications: [ServiceApplicationInfo(
+            MockApplicationService(applications: [AutomationTestFixtures.application(
                 processIdentifier: identity.processIdentifier,
                 processStartIdentity: identity.processStartIdentity,
                 bundleIdentifier: "com.example.target",
@@ -586,7 +582,7 @@ struct MCPKeyboardBackgroundToolTests {
 
     @Test
     func `Press sequence preserves unknown count for indeterminate current chord`() async throws {
-        let identity = ApplicationProcessIdentity(processIdentifier: 225, processStartIdentity: 25)
+        let identity = AutomationTestFixtures.processIdentity(processIdentifier: 225, processStartIdentity: 25)
         let automation = await MainActor.run {
             let automation = MockAutomationService(accessibilityGranted: true)
             automation.pinnedHotkeyError = { keys in
@@ -598,7 +594,7 @@ struct MCPKeyboardBackgroundToolTests {
             return automation
         }
         let applications = await MainActor.run {
-            MockApplicationService(applications: [ServiceApplicationInfo(
+            MockApplicationService(applications: [AutomationTestFixtures.application(
                 processIdentifier: identity.processIdentifier,
                 processStartIdentity: identity.processStartIdentity,
                 bundleIdentifier: "com.example.target",
@@ -627,7 +623,7 @@ struct MCPKeyboardBackgroundToolTests {
 
     @Test
     func `Type and press tools use targeted delivery when app process is known`() async throws {
-        let app = ServiceApplicationInfo(
+        let app = AutomationTestFixtures.application(
             processIdentifier: 333,
             processStartIdentity: 33,
             bundleIdentifier: "com.example.editor",
@@ -654,13 +650,13 @@ struct MCPKeyboardBackgroundToolTests {
         let typeCalls = await MainActor.run { automation.targetedTypeActionsCalls }
         #expect(typeCalls.count == 1)
         #expect(typeCalls.first?.targetProcessIdentifier == 333)
-        #expect(typeCalls.first?.expectedProcessIdentity == ApplicationProcessIdentity(
+        #expect(typeCalls.first?.expectedProcessIdentity == AutomationTestFixtures.processIdentity(
             processIdentifier: 333,
             processStartIdentity: 33))
         let hotkeyCalls = await MainActor.run { automation.targetedHotkeyCalls }
         #expect(hotkeyCalls.count == 1)
         #expect(hotkeyCalls.first?.targetProcessIdentifier == 333)
-        #expect(hotkeyCalls.first?.expectedProcessIdentity == ApplicationProcessIdentity(
+        #expect(hotkeyCalls.first?.expectedProcessIdentity == AutomationTestFixtures.processIdentity(
             processIdentifier: 333,
             processStartIdentity: 33))
         #expect(await MainActor.run { automation.lastHotkeyKeys } == nil)
@@ -668,7 +664,7 @@ struct MCPKeyboardBackgroundToolTests {
 
     @Test
     func `Paste tool uses targeted delivery when app process is known`() async throws {
-        let app = ServiceApplicationInfo(
+        let app = AutomationTestFixtures.application(
             processIdentifier: 333,
             processStartIdentity: 33,
             bundleIdentifier: "com.example.editor",
@@ -700,7 +696,7 @@ struct MCPKeyboardBackgroundToolTests {
         let calls = await MainActor.run { automation.targetedTypeActionsCalls }
         #expect(calls.count == 1)
         #expect(calls.first?.targetProcessIdentifier == 333)
-        #expect(calls.first?.expectedProcessIdentity == ApplicationProcessIdentity(
+        #expect(calls.first?.expectedProcessIdentity == AutomationTestFixtures.processIdentity(
             processIdentifier: 333,
             processStartIdentity: 33))
         #expect(await MainActor.run { automation.lastHotkeyKeys } == nil)
@@ -716,7 +712,7 @@ struct MCPKeyboardBackgroundToolTests {
 
     @Test
     func `Paste tool routes UTF8 data through targeted text delivery`() async throws {
-        let app = ServiceApplicationInfo(
+        let app = AutomationTestFixtures.application(
             processIdentifier: 333,
             processStartIdentity: 33,
             bundleIdentifier: "com.example.editor",
@@ -747,7 +743,7 @@ struct MCPKeyboardBackgroundToolTests {
 
     @Test
     func `Paste tool warns without inviting retry when clipboard restoration fails`() async throws {
-        let app = ServiceApplicationInfo(
+        let app = AutomationTestFixtures.application(
             processIdentifier: 333,
             processStartIdentity: 33,
             bundleIdentifier: "com.example.editor",
@@ -806,7 +802,7 @@ struct MCPKeyboardBackgroundToolTests {
             metadata: CaptureMetadata(
                 size: CGSize(width: 200, height: 100),
                 mode: .window,
-                applicationInfo: ServiceApplicationInfo(
+                applicationInfo: AutomationTestFixtures.application(
                     processIdentifier: processIdentifier,
                     processStartIdentity: processStartIdentity,
                     bundleIdentifier: "com.example.snapshot",

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeClientTransportOutcomeTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeClientTransportOutcomeTests.swift
@@ -2,6 +2,7 @@ import CoreGraphics
 import Darwin
 import Foundation
 import PeekabooAutomationKit
+import PeekabooBridgeTestSupport
 import Testing
 @testable import PeekabooBridge
 @testable import PeekabooCore
@@ -316,9 +317,9 @@ private final class VersionMismatchBridgePeer: @unchecked Sendable {
                 Self.drainRequest(client)
                 if attempt == 0 {
                     try? await Task.sleep(for: .seconds(firstResponseDelay))
-                    let response = PeekabooBridgeResponse.error(.init(
+                    let response = BridgeTestFixtures.errorResponse(
                         code: .versionMismatch,
-                        message: "scripted version mismatch"))
+                        message: "scripted version mismatch")
                     if let data = try? JSONEncoder.peekabooBridgeEncoder().encode(response) {
                         _ = data.withUnsafeBytes { bytes in
                             Darwin.write(client, bytes.baseAddress, bytes.count)

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeHostIdentityTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeHostIdentityTests.swift
@@ -1,6 +1,7 @@
 import Darwin
 import Foundation
 import PeekabooAutomationKit
+import PeekabooBridgeTestSupport
 import PeekabooCore
 import Testing
 @testable import PeekabooBridge
@@ -125,6 +126,7 @@ struct PeekabooBridgeHostIdentityTests {
             PeekabooBridgeHostCapability.desktopObservationCaptureEngine,
             PeekabooBridgeHostCapability.desktopObservationOCR,
             PeekabooBridgeHostCapability.hostGenerationIdentity,
+            PeekabooBridgeHostCapability.screenCaptureKitProcessOwnership,
         ])
     }
 
@@ -182,7 +184,7 @@ struct PeekabooBridgeHostIdentityTests {
 
     @Test
     func `legacy clients ignore additive host handshake fields`() throws {
-        let response = PeekabooBridgeHandshakeResponse(
+        let response = BridgeTestFixtures.handshake(
             negotiatedVersion: PeekabooBridgeConstants.protocolVersion,
             hostKind: .gui,
             build: "4.0.0 (400)",


### PR DESCRIPTION
## Summary

- add test-only `PeekabooAutomationKitTestSupport` and `PeekabooBridgeTestSupport` library products without linking either into a production target
- centralize deterministic process/window/application/snapshot/element fixtures, one reusable async latch, explicit-version Bridge handshakes, and Bridge error responses
- delete all three local `AsyncTestLatch` actors and replace all 103 direct test handshake constructors
- migrate the background keyboard fixture slice, reducing direct `ServiceApplicationInfo` test constructors from 201 to 184 and `ApplicationProcessIdentity` constructors from 88 to 77
- align one stale host-capability expectation with already-landed ScreenCaptureKit process ownership

## Architecture boundary

The support modules are regular SwiftPM targets because external packages cannot consume test targets. Only test targets declare them as dependencies. Production targets and products have no dependency on either support module, and no production source file changes in this PR.

Bridge fixtures require an explicit negotiated protocol version. Enabled operations must be a subset of supported operations, so ordinary test fixtures cannot silently construct contradictory handshakes.

## Proof

- `pnpm run format`
- `pnpm run lint` (21 existing warnings, 0 serious)
- `pnpm run test:safe` (846 CLI + 82 runtime tests)
- `swift test` in `Core/PeekabooAutomationKit` (572-test matrix; one first-run environment/flaky issue, clean rerun; focused latch suites 19/19)
- `swift test --filter PeekabooBridgeHostIdentityTests` in `Core/PeekabooCore` (8/8)
- focused Core Bridge transport/background-keyboard suites (30/30)
- focused CLI binder/runtime suites (101/101)
- conditional automation latch suite compiled and its migrated concurrency cases passed; one unchanged click-output wording assertion remains a baseline failure
- final post-rebase Autoreview/TruffleHog: clean, 0.99

No changelog entry: test architecture only, with no user-visible or runtime behavior change.
