### PR TITLE
fix(permissions): report selected host snapshot

### DIFF
--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Core/PermissionsCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Core/PermissionsCommand.swift
@@ -44,11 +44,7 @@ extension PermissionsCommand {
             self.runtime = runtime
 
             if self.allSources {
-                let response = await PermissionHelpers.getAllPermissionSources(
-                    services: runtime.services,
-                    allowRemote: !self.noRemote,
-                    socketPath: self.bridgeSocket
-                )
+                let response = try await PermissionHelpers.getAllPermissionSources(services: runtime.services)
 
                 if self.jsonOutput {
                     outputSuccessCodable(data: response, logger: self.outputLogger)
@@ -63,11 +59,7 @@ extension PermissionsCommand {
                 return
             }
 
-            let response = await PermissionHelpers.getCurrentPermissionsWithSource(
-                services: runtime.services,
-                allowRemote: !self.noRemote,
-                socketPath: self.bridgeSocket
-            )
+            let response = try await PermissionHelpers.getCurrentPermissionsWithSource(services: runtime.services)
 
             if self.jsonOutput {
                 outputSuccessCodable(data: response, logger: self.outputLogger)
@@ -91,7 +83,7 @@ extension PermissionsCommand {
         mutating func run(using runtime: CommandRuntime) async throws {
             self.runtime = runtime
 
-            let permissions = await PermissionHelpers.getCurrentPermissions(services: runtime.services)
+            let permissions = try await PermissionHelpers.getCurrentPermissions(services: runtime.services)
             if self.jsonOutput {
                 outputSuccessCodable(data: permissions, logger: self.outputLogger)
             } else {

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Core/PermissionsCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Core/PermissionsCommand.swift
@@ -43,6 +43,10 @@ extension PermissionsCommand {
         mutating func run(using runtime: CommandRuntime) async throws {
             self.runtime = runtime
 
+            // CommanderCLIBinder applies --no-remote and --bridge-socket before it resolves
+            // CommandRuntime. The injected services therefore already represent the exact
+            // caller-selected host; resolving another host here would split ownership again.
+
             if self.allSources {
                 let response = try await PermissionHelpers.getAllPermissionSources(services: runtime.services)
 

--- a/Apps/CLI/Sources/PeekabooCLI/Helpers/PermissionHelpers.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Helpers/PermissionHelpers.swift
@@ -42,169 +42,54 @@ enum PermissionHelpers {
     Update the host or run with --no-remote to request it for the local CLI.
     """
 
-    /// Try to fetch permissions from a remote Peekaboo Bridge host; falls back to local services on failure.
-    @MainActor
-    private static func remotePermissionsStatus(
-        services: any PeekabooServiceProviding,
-        socketPath override: String? = nil
-    ) async -> PermissionsStatus? {
-        let environment = ProcessInfo.processInfo.environment
-        let envSocket = environment["PEEKABOO_BRIDGE_SOCKET"]
-        let resolvedOverride = override ?? envSocket
-
-        if resolvedOverride == nil,
-           let remoteServices = services as? RemotePeekabooServices,
-           let status = try? await remoteServices.permissionsStatus() {
-            return status
-        }
-
-        let candidates = self.remotePermissionSocketPaths(
-            explicitSocket: resolvedOverride,
-            environment: environment
-        )
-
-        let identity = PeekabooBridgeClientIdentity(
-            bundleIdentifier: Bundle.main.bundleIdentifier,
-            teamIdentifier: nil,
-            processIdentifier: getpid(),
-            hostname: Host.current().name
-        )
-
-        for socketPath in candidates {
-            let client = PeekabooBridgeClient(socketPath: socketPath)
-            do {
-                let handshake = try await client.handshake(client: identity, requestedHost: nil)
-                if resolvedOverride == nil {
-                    guard let role = DaemonLaunchPolicy.implicitRuntimeCandidateRole(
-                        socketPath: socketPath,
-                        daemonSocketPath: DaemonLaunchPolicy.daemonSocketPath(environment: environment),
-                        buildScopedDaemonSocketPath: DaemonLaunchPolicy.buildScopedDaemonSocketPath(
-                            daemonSocketPath: DaemonLaunchPolicy.daemonSocketPath(environment: environment),
-                            runtimeBuildIdentity: DaemonLaunchPolicy.runtimeBuildIdentity()
-                        )
-                    ) else {
-                        continue
-                    }
-                    let daemonStatus = handshake.hostKind == .gui
-                        ? nil
-                        : await DaemonControlClient(socketPath: socketPath).fetchStatus()
-                    guard DaemonLaunchPolicy.isSelectableImplicitRuntimeCandidate(
-                        role: role,
-                        handshake: handshake,
-                        daemonStatus: daemonStatus
-                    ) else {
-                        continue
-                    }
-                }
-                guard handshake.supportedOperations.contains(.permissionsStatus) else { continue }
-                return try await client.permissionsStatus()
-            } catch {
-                continue
-            }
-        }
-        return nil
-    }
-
-    static func remotePermissionSocketPaths(
-        explicitSocket: String?,
-        environment: [String: String] = ProcessInfo.processInfo.environment
-    ) -> [String] {
-        if let explicitSocket, !explicitSocket.isEmpty {
-            return [explicitSocket]
-        }
-        let daemonPath = DaemonLaunchPolicy.daemonSocketPath(environment: environment)
-        guard DaemonLaunchPolicy.shouldMigrateLegacyDaemon(targetSocketPath: daemonPath) else {
-            return [daemonPath]
-        }
-        let buildScopedPath = DaemonLaunchPolicy.buildScopedDaemonSocketPath(
-            daemonSocketPath: daemonPath,
-            runtimeBuildIdentity: DaemonLaunchPolicy.runtimeBuildIdentity()
-        )
-        return [daemonPath, buildScopedPath, PeekabooBridgeConstants.peekabooSocketPath].compactMap(\.self)
-    }
-
     /// Get current permission status for all Peekaboo permissions
     static func getCurrentPermissions(
-        services: any PeekabooServiceProviding,
-        allowRemote: Bool = true,
-        socketPath: String? = nil
-    ) async -> [PermissionInfo] {
-        let response = await getCurrentPermissionsWithSource(
-            services: services,
-            allowRemote: allowRemote,
-            socketPath: socketPath
-        )
+        services: any PeekabooServiceProviding
+    ) async throws -> [PermissionInfo] {
+        let response = try await getCurrentPermissionsWithSource(services: services)
         return response.permissions
     }
 
-    /// Get current permission status along with whether a remote helper responded.
+    /// Read one complete snapshot from the runtime-selected execution host.
     static func getCurrentPermissionsWithSource(
-        services: any PeekabooServiceProviding,
-        allowRemote: Bool = true,
-        socketPath: String? = nil
-    ) async -> PermissionStatusResponse {
-        // Prefer remote host when available so sandboxes can reuse existing TCC grants.
-        let remoteStatus = allowRemote
-            ? await remotePermissionsStatus(services: services, socketPath: socketPath)
-            : nil
-
-        let status: PermissionsStatus
-        let source: String
-        if let remoteStatus {
-            status = remoteStatus
-            source = "bridge"
-        } else {
-            status = await self.localPermissionsStatus(services: services)
-            source = "local"
-        }
+        services: any PeekabooServiceProviding
+    ) async throws -> PermissionStatusResponse {
+        let status = try await services.permissionsStatus()
+        let source = services is RemotePeekabooServices ? "bridge" : "local"
         return PermissionStatusResponse(source: source, permissions: self.permissionList(from: status))
     }
 
     static func getAllPermissionSources(
-        services: any PeekabooServiceProviding,
-        allowRemote: Bool = true,
-        socketPath: String? = nil
-    ) async -> PermissionSourcesResponse {
-        let remoteStatus = allowRemote
-            ? await remotePermissionsStatus(services: services, socketPath: socketPath)
-            : nil
-        let localStatus = await localPermissionsStatus(services: services)
-        let selectedSource = remoteStatus != nil ? "bridge" : "local"
+        services: any PeekabooServiceProviding
+    ) async throws -> PermissionSourcesResponse {
+        let selectedStatus = try await services.permissionsStatus()
+        let selectedSource = services is RemotePeekabooServices ? "bridge" : "local"
         var sources: [PermissionSourceStatus] = []
 
-        if let remoteStatus {
+        if selectedSource == "bridge" {
             sources.append(PermissionSourceStatus(
                 source: "bridge",
                 displayName: "Peekaboo Bridge",
-                isSelected: selectedSource == "bridge",
-                permissions: self.permissionList(from: remoteStatus)
+                isSelected: true,
+                permissions: self.permissionList(from: selectedStatus)
+            ))
+            let localStatus = try await PermissionsService().permissionsStatus()
+            sources.append(PermissionSourceStatus(
+                source: "local",
+                displayName: "local runtime",
+                isSelected: false,
+                permissions: self.permissionList(from: localStatus)
+            ))
+        } else {
+            sources.append(PermissionSourceStatus(
+                source: "local",
+                displayName: "local runtime",
+                isSelected: true,
+                permissions: self.permissionList(from: selectedStatus)
             ))
         }
 
-        sources.append(PermissionSourceStatus(
-            source: "local",
-            displayName: "local runtime",
-            isSelected: selectedSource == "local",
-            permissions: self.permissionList(from: localStatus)
-        ))
-
         return PermissionSourcesResponse(selectedSource: selectedSource, sources: sources)
-    }
-
-    private static func localPermissionsStatus(services: any PeekabooServiceProviding) async -> PermissionsStatus {
-        await Task { @MainActor in
-            let localServices: any PeekabooServiceProviding = services is RemotePeekabooServices
-                ? PeekabooServices()
-                : services
-            let screenRecording = await localServices.screenCapture.hasScreenRecordingPermission()
-            let accessibility = await localServices.automation.hasAccessibilityPermission()
-            let postEvent = localServices.permissions.checkPostEventPermission()
-            return PermissionsStatus(
-                screenRecording: screenRecording,
-                accessibility: accessibility,
-                postEvent: postEvent
-            )
-        }.value
     }
 
     private static func permissionList(from status: PermissionsStatus) -> [PermissionInfo] {

--- a/Apps/CLI/Tests/CLIAutomationTests/PermissionCommandTests.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/PermissionCommandTests.swift
@@ -18,7 +18,7 @@ struct PermissionCommandTests {
     }
 
     @Test
-    func `permissions command emits JSON with stub statuses`() async {
+    func `permissions command emits JSON with stub statuses`() async throws {
         let automation = StubAutomationService()
         automation.accessibilityPermissionGranted = false
         let screenCapture = StubScreenCaptureService(permissionGranted: false)
@@ -30,9 +30,10 @@ struct PermissionCommandTests {
             )
         }
 
-        let payload = await CodableJSONResponse(
+        let permissions = try await PermissionHelpers.getCurrentPermissions(services: services)
+        let payload = CodableJSONResponse(
             success: true,
-            data: PermissionHelpers.getCurrentPermissions(services: services, allowRemote: false),
+            data: permissions,
             messages: nil,
             debug_logs: []
         )

--- a/Apps/CLI/Tests/CoreCLITests/CommanderBinderCommandBindingTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/CommanderBinderCommandBindingTests.swift
@@ -214,12 +214,27 @@ struct CommanderBinderCommandBindingTests {
     }
 
     @Test
-    func `Permissions status binding`() throws {
-        let parsed = ParsedValues(positional: [], options: [:], flags: [])
-        _ = try CommanderCLIBinder.instantiateCommand(
+    func `Permissions status host selectors configure the runtime owner`() throws {
+        let local = try CommanderCLIBinder.instantiateCommand(
             ofType: PermissionsCommand.StatusSubcommand.self,
-            parsedValues: parsed
+            parsedValues: ParsedValues(positional: [], options: [:], flags: ["no-remote"])
         )
+        #expect(local.noRemote)
+        #expect(!local.runtimeOptions.preferRemote)
+        #expect(local.runtimeOptions.remoteIsolationRequested)
+
+        let socketPath = "/tmp/selected-permission-host.sock"
+        let explicit = try CommanderCLIBinder.instantiateCommand(
+            ofType: PermissionsCommand.StatusSubcommand.self,
+            parsedValues: ParsedValues(
+                positional: [],
+                options: ["bridge-socket": [socketPath]],
+                flags: []
+            )
+        )
+        #expect(explicit.bridgeSocket == socketPath)
+        #expect(explicit.runtimeOptions.preferRemote)
+        #expect(explicit.runtimeOptions.bridgeSocketPath == socketPath)
     }
 
     @Test

--- a/Apps/CLI/Tests/CoreCLITests/PermissionHelpersTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/PermissionHelpersTests.swift
@@ -40,44 +40,6 @@ struct PermissionHelpersTests {
     }
 
     @Test
-    func `permission bridge follows the runtime daemon socket`() {
-        let paths = PermissionHelpers.remotePermissionSocketPaths(
-            explicitSocket: nil,
-            environment: ["PEEKABOO_DAEMON_SOCKET": "/tmp/custom-daemon.sock"]
-        )
-
-        #expect(paths == ["/tmp/custom-daemon.sock"])
-    }
-
-    @Test
-    func `permission bridge includes the default legacy runtime fallback`() throws {
-        let paths = PermissionHelpers.remotePermissionSocketPaths(
-            explicitSocket: nil,
-            environment: [:]
-        )
-
-        let buildScopedPath = DaemonLaunchPolicy.buildScopedDaemonSocketPath(
-            daemonSocketPath: PeekabooBridgeConstants.daemonSocketPath,
-            runtimeBuildIdentity: DaemonLaunchPolicy.runtimeBuildIdentity()
-        )
-        #expect(try paths == [
-            PeekabooBridgeConstants.daemonSocketPath,
-            #require(buildScopedPath),
-            PeekabooBridgeConstants.peekabooSocketPath,
-        ])
-    }
-
-    @Test
-    func `permission bridge explicit socket overrides the daemon`() {
-        let paths = PermissionHelpers.remotePermissionSocketPaths(
-            explicitSocket: "/tmp/explicit.sock",
-            environment: ["PEEKABOO_DAEMON_SOCKET": "/tmp/custom-daemon.sock"]
-        )
-
-        #expect(paths == ["/tmp/explicit.sock"])
-    }
-
-    @Test
     func `bridge hint explains remote screen recording denial`() {
         let response = PermissionHelpers.PermissionStatusResponse(
             source: "bridge",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Preserve display-column-safe terminal input and styled table output for wide Unicode, SGR colors, and OSC-8 links, while making terminal stop/restart idempotent and preventing queued renders from escaping a stopped session.
 - Reject non-finite, fractional, and overflowing MCP numeric arguments before dispatch, and expose integer-shaped delays, durations, counts, process IDs, window selectors, and Space targets as integers in tool schemas.
 - Reject MCP clipboard `outputPath: "-"` before reading or writing anything, with structured filesystem/text guidance, so arbitrary clipboard bytes can never corrupt the stdio JSON-RPC stream or create a literal `-` file.
+- Report Screen Recording, Accessibility, and Event Synthesizing from one selected-host permission snapshot across CLI and MCP, treating missing Accessibility as required while keeping Event Synthesizing action-specific.
 - Preserve negative numeric option values through Commander parsing so command-owned range validation reports them accurately instead of misclassifying them as short flags.
 - Reject invalid live/action capture cadence instead of silently clamping or trapping, apply post-motion timing with a monotonic deadline, and report sampled throughput, capture failures, diff-filtered frames, and retained throughput separately from artifact postprocessing.
 - Keep remote `window close` background-only by default, matching local execution, and require explicit foreground consent before routing a close through focus or global-input fallbacks.

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/System/PermissionsService.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/System/PermissionsService.swift
@@ -307,6 +307,18 @@ public final class PermissionsService {
     }
 }
 
+/// Provides one permission snapshot owned by the selected execution host.
+@MainActor
+public protocol PermissionsStatusProviding: Sendable {
+    func permissionsStatus() async throws -> PermissionsStatus
+}
+
+extension PermissionsService: PermissionsStatusProviding {
+    public func permissionsStatus() async throws -> PermissionsStatus {
+        self.checkAllPermissions()
+    }
+}
+
 /// Status of system permissions
 public struct PermissionsStatus: Sendable, Codable {
     public let screenRecording: Bool

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/MCPToolContext.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/MCPToolContext.swift
@@ -21,6 +21,7 @@ public struct MCPToolContext: @unchecked Sendable {
     public let screens: any ScreenServiceProtocol
     public let agent: (any AgentServiceProtocol)?
     public let permissions: PermissionsService
+    public let permissionsStatusProvider: any PermissionsStatusProviding
     public let clipboard: any ClipboardServiceProtocol
     public let browser: any BrowserMCPClientProviding
     public let snapshotMutationCoordinator: (any MCPToolSnapshotMutationCoordinating)?
@@ -134,6 +135,7 @@ public struct MCPToolContext: @unchecked Sendable {
         permissions: PermissionsService,
         clipboard: any ClipboardServiceProtocol,
         browser: any BrowserMCPClientProviding,
+        permissionsStatusProvider: (any PermissionsStatusProviding)? = nil,
         snapshotMutationCoordinator: (any MCPToolSnapshotMutationCoordinating)? = nil,
         snapshotExecutionGate: MCPToolSnapshotExecutionGate? = nil)
     {
@@ -149,6 +151,7 @@ public struct MCPToolContext: @unchecked Sendable {
         self.screens = screens
         self.agent = agent
         self.permissions = permissions
+        self.permissionsStatusProvider = permissionsStatusProvider ?? permissions
         self.clipboard = clipboard
         self.browser = browser
         self.snapshotMutationCoordinator = snapshotMutationCoordinator
@@ -181,6 +184,7 @@ public struct MCPToolContext: @unchecked Sendable {
             permissions: services.permissions,
             clipboard: services.clipboard,
             browser: services.browser,
+            permissionsStatusProvider: services,
             snapshotMutationCoordinator: snapshotMutationCoordinator,
             snapshotExecutionGate: resolvedSnapshotExecutionGate)
     }

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Server/MCPToolResponseMetadataProjector.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Server/MCPToolResponseMetadataProjector.swift
@@ -34,6 +34,15 @@ enum MCPToolResponseMetadataProjector {
         "warnings",
     ]
 
+    private static let permissionKeys: Set<String> = [
+        "accessibility",
+        "event_synthesizing",
+        "event_synthesizing_limits",
+        "permission_snapshot_available",
+        "required_permissions_granted",
+        "screen_recording",
+    ]
+
     static func externalFields(from value: Value?, toolName: String?) -> [String: Value] {
         guard case let .object(fields)? = value else { return [:] }
         var allowed = Self.safetyKeys
@@ -42,12 +51,17 @@ enum MCPToolResponseMetadataProjector {
             allowed.formUnion(Self.captureErrorKeys)
             allowed.formUnion(Self.captureSuccessKeys)
         }
+        if toolName == "permissions" {
+            allowed.formUnion(Self.permissionKeys)
+        }
         return fields.filter { allowed.contains($0.key) }
     }
 
     static func agentFields(from value: Value?) -> [String: Value] {
         guard case let .object(fields)? = value else { return [:] }
-        let allowed = Self.safetyKeys.union(Self.captureErrorKeys)
+        let allowed = Self.safetyKeys
+            .union(Self.captureErrorKeys)
+            .union(Self.permissionKeys)
         return fields.filter { allowed.contains($0.key) }
     }
 }

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/PermissionsTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/PermissionsTool.swift
@@ -1,6 +1,7 @@
 import Foundation
 import MCP
 import PeekabooAutomation
+import PeekabooAutomationKit
 import TachikomaMCP
 
 /// MCP tool for checking macOS system permissions
@@ -10,8 +11,8 @@ public struct PermissionsTool: MCPTool {
     public let name = "permissions"
     public let description = """
     Check macOS system permissions required for automation.
-    Verifies both Screen Recording and Accessibility permissions.
-    Returns the current permission status for each required permission.
+    Verifies Screen Recording and Accessibility as required permissions and reports
+    Event Synthesizing as an action-specific input limitation when it is unavailable.
     \(PeekabooMCPVersion.banner) using openai/gpt-5.6, anthropic/claude-opus-5
     """
 
@@ -27,25 +28,45 @@ public struct PermissionsTool: MCPTool {
 
     @MainActor
     public func execute(arguments: ToolArguments) async throws -> ToolResponse {
-        // Get permissions from PeekabooCore services
-        let screenRecording = await self.context.screenCapture.hasScreenRecordingPermission()
-        let accessibility = await self.context.automation.hasAccessibilityPermission()
+        _ = arguments
+        let status: PermissionsStatus
+        do {
+            status = try await self.context.permissionsStatusProvider.permissionsStatus()
+        } catch {
+            let meta: Value = .object([
+                "permission_snapshot_available": .bool(false),
+                "screen_recording": .null,
+                "accessibility": .null,
+                "event_synthesizing": .null,
+                "required_permissions_granted": .null,
+                "event_synthesizing_limits": .array([]),
+            ])
+            let summary = ToolEventSummary(
+                actionDescription: "Permissions",
+                notes: "Selected-host permission snapshot unavailable")
+            return ToolResponse.error(
+                "Could not read permissions from the selected execution host: \(error.localizedDescription)",
+                meta: ToolEventSummary.merge(summary: summary, into: meta))
+        }
 
-        // Build response text
         var lines: [String] = []
         lines.append("macOS Permissions Status:")
         lines.append("")
-        let screenRecordingStatus = screenRecording
+        let screenRecordingStatus = status.screenRecording
             ? "\(AgentDisplayTokens.Status.success) Granted"
             : "\(AgentDisplayTokens.Status.failure) Not Granted"
-        let accessibilityStatus = accessibility
+        let accessibilityStatus = status.accessibility
             ? "\(AgentDisplayTokens.Status.success) Granted"
-            : "\(AgentDisplayTokens.Status.warning) Not Granted (Optional)"
+            : "\(AgentDisplayTokens.Status.failure) Not Granted"
+        let eventSynthesizingStatus = status.postEvent
+            ? "\(AgentDisplayTokens.Status.success) Granted"
+            : "\(AgentDisplayTokens.Status.warning) Not Granted"
 
-        lines.append("Screen Recording: \(screenRecordingStatus)")
-        lines.append("Accessibility: \(accessibilityStatus)")
+        lines.append("Screen Recording (Required): \(screenRecordingStatus)")
+        lines.append("Accessibility (Required): \(accessibilityStatus)")
+        lines.append("Event Synthesizing (Action-specific): \(eventSynthesizingStatus)")
 
-        if !screenRecording {
+        if !status.screenRecording {
             lines.append("")
             let warning = "\(AgentDisplayTokens.Status.warning) Screen Recording permission is REQUIRED " +
                 "for capturing screenshots."
@@ -53,30 +74,46 @@ public struct PermissionsTool: MCPTool {
             lines.append("Grant via: System Settings > Privacy & Security > Screen Recording")
         }
 
-        if !accessibility {
+        if !status.accessibility {
             lines.append("")
-            lines.append("ℹ️  Accessibility permission is optional but needed for UI automation.")
+            lines.append("\(AgentDisplayTokens.Status.warning) Accessibility permission is REQUIRED " +
+                "for UI automation.")
             lines.append("Grant via: System Settings > Privacy & Security > Accessibility")
         }
 
-        let responseText = lines.joined(separator: "\n")
-
-        // Return error response if required permissions are missing
-        if !screenRecording {
-            let summary = ToolEventSummary(actionDescription: "Permissions", notes: "Screen Recording missing")
-            return ToolResponse.error(responseText, meta: ToolEventSummary.merge(summary: summary, into: nil))
+        let eventSynthesizingLimits: [String] = status.postEvent
+            ? []
+            : ["background keyboard input", "foreground synthetic pointer input"]
+        if !eventSynthesizingLimits.isEmpty {
+            lines.append("")
+            lines.append("Event Synthesizing is not globally required, but these actions are unavailable: " +
+                eventSynthesizingLimits.joined(separator: ", ") + ".")
+            lines.append("Background Accessibility actions remain available.")
         }
 
+        let responseText = lines.joined(separator: "\n")
+        let requiredPermissionsGranted = status.screenRecording && status.accessibility
         let baseMeta: [String: Value] = [
-            "screen_recording": .bool(screenRecording),
-            "accessibility": .bool(accessibility),
+            "permission_snapshot_available": .bool(true),
+            "screen_recording": .bool(status.screenRecording),
+            "accessibility": .bool(status.accessibility),
+            "event_synthesizing": .bool(status.postEvent),
+            "required_permissions_granted": .bool(requiredPermissionsGranted),
+            "event_synthesizing_limits": .array(eventSynthesizingLimits.map(Value.string)),
         ]
         let summary = ToolEventSummary(
             actionDescription: "Permissions",
-            notes: "Screen Recording ✅, Accessibility \(accessibility ? "✅" : "⚠️")")
+            notes: "Screen Recording \(status.screenRecording ? "✅" : "❌"), " +
+                "Accessibility \(status.accessibility ? "✅" : "❌"), " +
+                "Event Synthesizing \(status.postEvent ? "✅" : "⚠️")")
+        let meta = ToolEventSummary.merge(summary: summary, into: .object(baseMeta))
+
+        if !requiredPermissionsGranted {
+            return ToolResponse.error(responseText, meta: meta)
+        }
 
         return ToolResponse.text(
             responseText,
-            meta: ToolEventSummary.merge(summary: summary, into: .object(baseMeta)))
+            meta: meta)
     }
 }

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/Support/PeekabooServiceProviding.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/Support/PeekabooServiceProviding.swift
@@ -1,9 +1,10 @@
 import Foundation
 import PeekabooAutomation
+import PeekabooAutomationKit
 
 /// Aggregated service provider protocol exposed to higher-level modules.
 @MainActor
-public protocol PeekabooServiceProviding: AnyObject, Sendable {
+public protocol PeekabooServiceProviding: AnyObject, Sendable, PermissionsStatusProviding {
     var logging: any LoggingServiceProtocol { get }
     var desktopObservation: any DesktopObservationServiceProtocol { get }
     var screenCapture: any ScreenCaptureServiceProtocol { get }
@@ -28,6 +29,16 @@ public protocol PeekabooServiceProviding: AnyObject, Sendable {
 
 @MainActor
 extension PeekabooServiceProviding {
+    public func permissionsStatus() async throws -> PermissionsStatus {
+        let screenRecording = await self.screenCapture.hasScreenRecordingPermission()
+        let accessibility = await self.automation.hasAccessibilityPermission()
+        let postEvent = self.permissions.checkPostEventPermission()
+        return PermissionsStatus(
+            screenRecording: screenRecording,
+            accessibility: accessibility,
+            postEvent: postEvent)
+    }
+
     public var desktopObservation: any DesktopObservationServiceProtocol {
         DesktopObservationService(
             screenCapture: self.screenCapture,

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer+Handlers.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer+Handlers.swift
@@ -7,11 +7,12 @@ import PeekabooFoundation
 extension PeekabooBridgeServer {
     func handleAuthorized(
         _ request: PeekabooBridgeRequest,
-        peer: PeekabooBridgePeer?) async throws -> PeekabooBridgeResponse
+        peer: PeekabooBridgePeer?,
+        permissions: PermissionsStatus) async throws -> PeekabooBridgeResponse
     {
         switch request.operation {
         case .permissionsStatus, .requestPostEventPermission, .daemonStatus, .daemonStop:
-            try await self.handleCoreRequest(request, peer: peer)
+            try await self.handleCoreRequest(request, peer: peer, permissions: permissions)
         case .browserStatus, .browserConnect, .browserDisconnect, .browserExecute:
             try await self.handleBrowserRequest(request)
         case .captureScreen, .captureWindow, .captureFrontmost, .captureArea:
@@ -74,11 +75,12 @@ extension PeekabooBridgeServer {
 
     private func handleCoreRequest(
         _ request: PeekabooBridgeRequest,
-        peer: PeekabooBridgePeer?) async throws -> PeekabooBridgeResponse
+        peer: PeekabooBridgePeer?,
+        permissions: PermissionsStatus) async throws -> PeekabooBridgeResponse
     {
         switch request {
         case .permissionsStatus:
-            return .permissionsStatus(self.currentPermissions())
+            return .permissionsStatus(permissions)
         case .requestPostEventPermission:
             return .bool(self.postEventAccessRequester())
         case .daemonStatus:
@@ -106,7 +108,7 @@ extension PeekabooBridgeServer {
             let stopped = await daemonControl.requestStop(expectedPID: payload.expectedPID)
             return .bool(stopped)
         case let .handshake(payload):
-            return try self.handleHandshake(payload, peer: peer)
+            return try self.handleHandshake(payload, peer: peer, permissions: permissions)
         default:
             throw Self.invalidRequest(for: request)
         }

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer+Handshake.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer+Handshake.swift
@@ -12,7 +12,8 @@ extension PeekabooBridgeServer {
 
     func handleHandshake(
         _ payload: PeekabooBridgeHandshake,
-        peer: PeekabooBridgePeer?) throws -> PeekabooBridgeResponse
+        peer: PeekabooBridgePeer?,
+        permissions: PermissionsStatus) throws -> PeekabooBridgeResponse
     {
         let resolvedBundle = peer?.bundleIdentifier ?? payload.client.bundleIdentifier
         let resolvedTeam = peer?.teamIdentifier ?? payload.client.teamIdentifier
@@ -57,7 +58,6 @@ extension PeekabooBridgeServer {
             max(payload.protocolVersion, self.supportedVersions.lowerBound),
             self.supportedVersions.upperBound)
 
-        let permissions = self.currentPermissions()
         let advertisedOps = Array(self.operationsCompatibleWithNegotiatedVersion(
             self.allowedOperationsToAdvertise(),
             negotiated)).sorted { $0.rawValue < $1.rawValue }
@@ -202,7 +202,7 @@ extension PeekabooBridgeServer {
             screenRecording: permissions.screenRecording,
             accessibility: permissions.accessibility,
             appleScript: false,
-            postEvent: self.postEventAccessEvaluator())
+            postEvent: permissions.postEvent)
     }
 
     static func bridgePermission(for error: PeekabooError) -> PeekabooBridgePermissionKind? {

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer.swift
@@ -35,7 +35,6 @@ public final class PeekabooBridgeServer {
     let hostIdentity: PeekabooBridgeHostIdentity?
     let hostCapabilities: Set<String>
     let daemonControl: (any PeekabooDaemonControlProviding)?
-    let postEventAccessEvaluator: @MainActor @Sendable () -> Bool
     let postEventAccessRequester: @MainActor @Sendable () -> Bool
     let permissionStatusEvaluator: @MainActor @Sendable (_ allowAppleScriptLaunch: Bool) -> PermissionsStatus
     let windowOwnerProcessIdentifierProvider: @Sendable (CGWindowID) -> pid_t?
@@ -107,17 +106,24 @@ public final class PeekabooBridgeServer {
         self.windowOwnerProcessIdentifierProvider = windowOwnerProcessIdentifierProvider
         self.windowBoundsProvider = windowBoundsProvider
         self.processStartIdentityProvider = processStartIdentityProvider
-        self.postEventAccessEvaluator = postEventAccessEvaluator ?? { [services] in
+        let resolvedPostEventAccessEvaluator = postEventAccessEvaluator ?? { [services] in
             services.permissions.checkPostEventPermission()
         }
         self.postEventAccessRequester = postEventAccessRequester ?? { [services] in
             services.permissions.requestPostEventPermission(interactive: true)
         }
-        if let permissionStatusEvaluator {
+        if let permissionStatusEvaluator, postEventAccessEvaluator != nil {
+            self.permissionStatusEvaluator = { allowAppleScriptLaunch in
+                permissionStatusEvaluator(allowAppleScriptLaunch)
+                    .withPostEvent(resolvedPostEventAccessEvaluator())
+            }
+        } else if let permissionStatusEvaluator {
             self.permissionStatusEvaluator = permissionStatusEvaluator
         } else {
             self.permissionStatusEvaluator = { [services] _ in
-                services.permissions.checkAllPermissions()
+                let status = services.permissions.checkAllPermissions()
+                guard postEventAccessEvaluator != nil else { return status }
+                return status.withPostEvent(resolvedPostEventAccessEvaluator())
             }
         }
         self.encoder = encoder
@@ -187,7 +193,10 @@ public final class PeekabooBridgeServer {
                     await daemonControl.recordActivityStart(operation: op)
                 }
                 do {
-                    let response = try await self.handleAuthorizedWithDesktopMutationBarrier(request, peer: peer)
+                    let response = try await self.handleAuthorizedWithDesktopMutationBarrier(
+                        request,
+                        peer: peer,
+                        permissions: permissions)
                     await daemonControl.recordActivityEnd(operation: op)
                     return response
                 } catch {
@@ -196,7 +205,10 @@ public final class PeekabooBridgeServer {
                 }
             }
 
-            return try await self.handleAuthorizedWithDesktopMutationBarrier(request, peer: peer)
+            return try await self.handleAuthorizedWithDesktopMutationBarrier(
+                request,
+                peer: peer,
+                permissions: permissions)
         } catch let envelope as PeekabooBridgeErrorEnvelope {
             failed = true
             let duration = Date().timeIntervalSince(start)
@@ -442,7 +454,8 @@ public final class PeekabooBridgeServer {
 
     private func handleAuthorizedWithDesktopMutationBarrier(
         _ request: PeekabooBridgeRequest,
-        peer: PeekabooBridgePeer?) async throws -> PeekabooBridgeResponse
+        peer: PeekabooBridgePeer?,
+        permissions: PermissionsStatus) async throws -> PeekabooBridgeResponse
     {
         let nativeLeafOwnsLane = request.nativeLeafOwnsDesktopOperationLane &&
             self.services.ownsDesktopOperationLane(for: request.operation)
@@ -451,7 +464,10 @@ public final class PeekabooBridgeServer {
                 for: request,
                 proposed: proposedReadLane)
             {
-                try await self.handleAuthorizedWithOwnedDesktopOperationLane(request, peer: peer)
+                try await self.handleAuthorizedWithOwnedDesktopOperationLane(
+                    request,
+                    peer: peer,
+                    permissions: permissions)
             }
         }
 
@@ -460,24 +476,31 @@ public final class PeekabooBridgeServer {
                 scope: request.desktopOperationScope,
                 access: .write)
             {
-                try await self.handleAuthorizedWithOwnedDesktopOperationLane(request, peer: peer)
+                try await self.handleAuthorizedWithOwnedDesktopOperationLane(
+                    request,
+                    peer: peer,
+                    permissions: permissions)
             }
         }
-        return try await self.handleAuthorizedWithOwnedDesktopOperationLane(request, peer: peer)
+        return try await self.handleAuthorizedWithOwnedDesktopOperationLane(
+            request,
+            peer: peer,
+            permissions: permissions)
     }
 
     private func handleAuthorizedWithOwnedDesktopOperationLane(
         _ request: PeekabooBridgeRequest,
-        peer: PeekabooBridgePeer?) async throws -> PeekabooBridgeResponse
+        peer: PeekabooBridgePeer?,
+        permissions: PermissionsStatus) async throws -> PeekabooBridgeResponse
     {
         guard request.mayMutateDesktop else {
-            return try await self.handleAuthorized(request, peer: peer)
+            return try await self.handleAuthorized(request, peer: peer, permissions: permissions)
         }
 
         guard let desktopMutationWatermarkStore else {
             try PeekabooBridgeRequestContext.checkRequestIsActive()
             try self.validatePinnedWindowMutation(request)
-            return try await self.handleAuthorized(request, peer: peer)
+            return try await self.handleAuthorized(request, peer: peer, permissions: permissions)
         }
         try PeekabooBridgeRequestContext.checkRequestIsActive()
         try self.validatePinnedWindowMutation(request)
@@ -510,7 +533,7 @@ public final class PeekabooBridgeServer {
         let response: PeekabooBridgeResponse?
         let operationError: (any Error)?
         do {
-            response = try await self.handleAuthorized(request, peer: peer)
+            response = try await self.handleAuthorized(request, peer: peer, permissions: permissions)
             operationError = nil
         } catch {
             response = nil

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPToolExecutionTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPToolExecutionTests.swift
@@ -54,25 +54,6 @@ struct MCPToolExecutionTests {
     // MARK: - Permissions Tool Tests
 
     @Test
-    func `Permissions tool execution`() async throws {
-        let automation = await MainActor.run { MockAutomationService(accessibilityGranted: true) }
-        let screenCapture = await MainActor.run { MockScreenCaptureService(screenRecordingGranted: true) }
-        let context = await MCPToolTestHelpers.makeContext(
-            automation: automation,
-            screenCapture: screenCapture)
-        let tool = PermissionsTool(context: context)
-        let args = ToolArguments(raw: [:])
-
-        let response = try await tool.execute(arguments: args)
-        #expect(response.isError == false)
-
-        if case let .text(text: output, annotations: _, _meta: _) = response.content.first {
-            // Should contain information about permissions
-            #expect(output.contains("Accessibility") || output.contains("Screen Recording"))
-        }
-    }
-
-    @Test
     func `Image tool returns MCP error response when screen recording is missing`() async throws {
         let screenCapture = await MainActor.run { MockScreenCaptureService(screenRecordingGranted: false) }
         let context = await MCPToolTestHelpers.makeContext(screenCapture: screenCapture)
@@ -871,6 +852,7 @@ enum MCPToolTestHelpers {
         screens: (any ScreenServiceProtocol)? = nil,
         clipboard: (any ClipboardServiceProtocol)? = nil,
         snapshots: (any SnapshotManagerProtocol)? = nil,
+        permissionsStatusProvider: (any PermissionsStatusProviding)? = nil,
         snapshotMutationCoordinator: (any MCPToolSnapshotMutationCoordinating)? = nil,
         snapshotExecutionGate: MCPToolSnapshotExecutionGate = MCPToolSnapshotExecutionGate(),
         exactWindowMetadataProvider: any ExactWindowMetadataProviding = SystemExactWindowMetadataProvider()) async
@@ -901,6 +883,7 @@ enum MCPToolTestHelpers {
                 permissions: services.permissions,
                 clipboard: clipboard ?? services.clipboard,
                 browser: services.browser,
+                permissionsStatusProvider: permissionsStatusProvider,
                 snapshotMutationCoordinator: snapshotMutationCoordinator,
                 snapshotExecutionGate: snapshotExecutionGate)
         }

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/PeekabooMCPServerTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/PeekabooMCPServerTests.swift
@@ -58,6 +58,41 @@ struct PeekabooMCPServerTests {
     }
 
     @Test
+    func `server preserves the complete permission snapshot on MCP failures`() throws {
+        let response = ToolResponse.error(
+            "Accessibility is required.",
+            meta: .object([
+                "permission_snapshot_available": .bool(true),
+                "screen_recording": .bool(true),
+                "accessibility": .bool(false),
+                "event_synthesizing": .bool(false),
+                "required_permissions_granted": .bool(false),
+                "event_synthesizing_limits": .array([
+                    .string("background keyboard input"),
+                    .string("foreground synthetic pointer input"),
+                ]),
+                "internal_diagnostics": .string("private"),
+            ]))
+
+        let result = PeekabooMCPServer.callToolResult(from: response, toolName: "permissions")
+        let encoded = try JSONEncoder().encode(result)
+        let json = try #require(JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+        let metadata = try #require(json["_meta"] as? [String: Any])
+
+        #expect(result.isError == true)
+        #expect(metadata["permission_snapshot_available"] as? Bool == true)
+        #expect(metadata["screen_recording"] as? Bool == true)
+        #expect(metadata["accessibility"] as? Bool == false)
+        #expect(metadata["event_synthesizing"] as? Bool == false)
+        #expect(metadata["required_permissions_granted"] as? Bool == false)
+        #expect(metadata["event_synthesizing_limits"] as? [String] == [
+            "background keyboard input",
+            "foreground synthetic pointer input",
+        ])
+        #expect(metadata["internal_diagnostics"] == nil)
+    }
+
+    @Test
     @MainActor
     func `click wire schema requires an exclusive target and a background coordinate receipt`() async throws {
         let context = await MCPToolTestHelpers.makeContext()

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/PermissionsToolSelectedHostTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/PermissionsToolSelectedHostTests.swift
@@ -1,0 +1,184 @@
+import Foundation
+import MCP
+import PeekabooAutomationKit
+import TachikomaMCP
+import Testing
+@testable import PeekabooAgentRuntime
+@testable import PeekabooBridge
+@testable import PeekabooCore
+
+@Suite(.serialized)
+struct PermissionsToolSelectedHostTests {
+    @Test
+    func `permission provider remains additive at protocol 1_22`() {
+        #expect(PeekabooBridgeConstants.protocolVersion == .init(major: 1, minor: 22))
+    }
+
+    private struct PermissionCase: Sendable, CustomTestStringConvertible {
+        let screenRecording: Bool
+        let accessibility: Bool
+        let postEvent: Bool
+
+        var testDescription: String {
+            "screen=\(self.screenRecording)-accessibility=\(self.accessibility)-postEvent=\(self.postEvent)"
+        }
+
+        var status: PermissionsStatus {
+            PermissionsStatus(
+                screenRecording: self.screenRecording,
+                accessibility: self.accessibility,
+                postEvent: self.postEvent)
+        }
+    }
+
+    private static let permissionCases: [PermissionCase] = [false, true].flatMap { screenRecording in
+        [false, true].flatMap { accessibility in
+            [false, true].map { postEvent in
+                PermissionCase(
+                    screenRecording: screenRecording,
+                    accessibility: accessibility,
+                    postEvent: postEvent)
+            }
+        }
+    }
+
+    @Test(arguments: permissionCases)
+    @MainActor
+    private func `one selected-host snapshot projects every permission combination`(
+        permissionCase: PermissionCase) async throws
+    {
+        let provider = RecordingPermissionsStatusProvider(status: permissionCase.status)
+        let context = await MCPToolTestHelpers.makeContext(permissionsStatusProvider: provider)
+        let response = try await PermissionsTool(context: context).execute(arguments: ToolArguments(raw: [:]))
+
+        #expect(provider.callCount == 1)
+        #expect(response.isError == !(permissionCase.screenRecording && permissionCase.accessibility))
+
+        let text = try #require(Self.text(from: response))
+        #expect(text.contains("Screen Recording (Required)"))
+        #expect(text.contains("Accessibility (Required)"))
+        #expect(text.contains("Event Synthesizing (Action-specific)"))
+        #expect(text.contains("Event Synthesizing is not globally required") == !permissionCase.postEvent)
+
+        let meta = try #require(Self.meta(from: response))
+        #expect(meta["permission_snapshot_available"] == .bool(true))
+        #expect(meta["screen_recording"] == .bool(permissionCase.screenRecording))
+        #expect(meta["accessibility"] == .bool(permissionCase.accessibility))
+        #expect(meta["event_synthesizing"] == .bool(permissionCase.postEvent))
+        #expect(meta["required_permissions_granted"] ==
+            .bool(permissionCase.screenRecording && permissionCase.accessibility))
+        let expectedLimits: Value = permissionCase.postEvent
+            ? .array([])
+            : .array([
+                .string("background keyboard input"),
+                .string("foreground synthetic pointer input"),
+            ])
+        #expect(meta["event_synthesizing_limits"] == expectedLimits)
+    }
+
+    @Test
+    @MainActor
+    func `provider failure preserves the structured permission shape`() async throws {
+        let provider = RecordingPermissionsStatusProvider(error: PermissionProviderError.unavailable)
+        let context = await MCPToolTestHelpers.makeContext(permissionsStatusProvider: provider)
+        let response = try await PermissionsTool(context: context).execute(arguments: ToolArguments(raw: [:]))
+
+        #expect(response.isError)
+        #expect(provider.callCount == 1)
+        let meta = try #require(Self.meta(from: response))
+        #expect(meta["permission_snapshot_available"] == .bool(false))
+        #expect(meta["screen_recording"] == .null)
+        #expect(meta["accessibility"] == .null)
+        #expect(meta["event_synthesizing"] == .null)
+        #expect(meta["required_permissions_granted"] == .null)
+        #expect(meta["event_synthesizing_limits"] == .array([]))
+    }
+
+    @Test
+    @MainActor
+    func `remote selected host wins and performs one complete Bridge permission read`() async throws {
+        let socketPath = "/tmp/peekaboo-selected-permissions-\(UUID().uuidString).sock"
+        let expected = PermissionsStatus(
+            screenRecording: false,
+            accessibility: true,
+            postEvent: true)
+        let evaluations = PermissionEvaluationRecorder(status: expected)
+        let server = PeekabooBridgeServer(
+            services: StubServices(),
+            allowlistedTeams: [],
+            allowlistedBundles: [],
+            allowedOperations: [.permissionsStatus],
+            permissionStatusEvaluator: { _ in evaluations.evaluate() })
+        let host = PeekabooBridgeHost(
+            socketPath: socketPath,
+            server: server,
+            allowedTeamIDs: [],
+            requestTimeoutSec: 1)
+        try await host.startChecked()
+        defer { Task { await host.stop() } }
+
+        let remote = RemotePeekabooServices(
+            client: PeekabooBridgeClient(socketPath: socketPath, requestTimeoutSec: 1))
+        let context = MCPToolContext(services: remote)
+        let response = try await PermissionsTool(context: context).execute(arguments: ToolArguments(raw: [:]))
+
+        #expect(evaluations.callCount == 1)
+        #expect(response.isError)
+        let meta = try #require(Self.meta(from: response))
+        #expect(meta["screen_recording"] == .bool(false))
+        #expect(meta["accessibility"] == .bool(true))
+        #expect(meta["event_synthesizing"] == .bool(true))
+    }
+
+    private static func text(from response: ToolResponse) -> String? {
+        guard case let .text(text, _, _) = response.content.first else { return nil }
+        return text
+    }
+
+    private static func meta(from response: ToolResponse) -> [String: Value]? {
+        guard case let .object(meta)? = response.meta else { return nil }
+        return meta
+    }
+}
+
+@MainActor
+private final class RecordingPermissionsStatusProvider: PermissionsStatusProviding {
+    private let result: Result<PermissionsStatus, any Error>
+    private(set) var callCount = 0
+
+    init(status: PermissionsStatus) {
+        self.result = .success(status)
+    }
+
+    init(error: any Error) {
+        self.result = .failure(error)
+    }
+
+    func permissionsStatus() async throws -> PermissionsStatus {
+        self.callCount += 1
+        return try self.result.get()
+    }
+}
+
+@MainActor
+private final class PermissionEvaluationRecorder {
+    private let status: PermissionsStatus
+    private(set) var callCount = 0
+
+    init(status: PermissionsStatus) {
+        self.status = status
+    }
+
+    func evaluate() -> PermissionsStatus {
+        self.callCount += 1
+        return self.status
+    }
+}
+
+private enum PermissionProviderError: LocalizedError {
+    case unavailable
+
+    var errorDescription: String? {
+        "selected host unavailable"
+    }
+}

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -258,6 +258,9 @@ Use the shared physical pointer only with explicit foreground consent:
 ## Troubleshooting
 
 - Ensure Screen Recording + Accessibility permissions are granted (`peekaboo permissions status`).
+- The `permissions` tool reads one complete snapshot from the selected execution host. Missing Screen Recording or
+  Accessibility is a tool failure; missing Event Synthesizing remains a structured limitation for background keyboard
+  and foreground synthetic pointer actions rather than a global failure.
 - If the MCP client cannot connect, confirm you are launching Peekaboo with `mcp` or `mcp serve` and that the client is using stdio transport.
 - Use absolute binary paths for local checkouts.
 - Confirm the binary is executable (`chmod +x /path/to/peekaboo`).

--- a/docs/commands/permissions.md
+++ b/docs/commands/permissions.md
@@ -9,6 +9,12 @@ read_when:
 
 `peekaboo permissions` centralizes entitlement checks. The default `status` subcommand reports the runtime view of Screen Recording, Accessibility, and Event Synthesizing. `grant` prints the same table plus human-readable steps so you can fix issues without hunting through docs.
 
+Status is one snapshot from the execution host selected by normal runtime routing. A Bridge-backed CLI or MCP session
+therefore reports the Bridge host's three grants with one request; it never mixes remote Screen Recording or
+Accessibility with caller-local Event Synthesizing state. Screen Recording and Accessibility are required. Event
+Synthesizing remains optional globally and is reported with the actions it limits: background keyboard input and
+foreground synthetic pointer input.
+
 Peekaboo's application, Dock, and UI operations use native macOS APIs. It does not probe, request, or require
 Automation (AppleScript) permission. The Bridge protocol still decodes the legacy field so mixed-version clients
 receive a structured compatibility result instead of failing the whole handshake.
@@ -25,6 +31,8 @@ receive a structured compatibility result instead of failing the whole handshake
 - The command executes entirely on the main actor, avoiding extra prompts or sandbox warnings—the same code path runs at CLI startup to warn if entitlements are missing.
 - JSON mode uses `outputSuccessCodable`, which means status results include a `permissions` array with `{name, isRequired, isGranted, grantInstructions}` entries that can be diffed over time.
 - `--all-sources --json` returns `{selectedSource, sources}` so callers can distinguish Bridge TCC grants from local CLI grants.
+- The MCP `permissions` tool returns an error when either required permission is missing, while retaining all three
+  permission fields and the action-specific Event Synthesizing limitations in response metadata.
 
 ## Examples
 ```bash

--- a/docs/manual-testing.md
+++ b/docs/manual-testing.md
@@ -17,7 +17,7 @@ Use this checklist to exercise the Swift MCP server with mcporter. It mirrors th
   `export MCPORTER="${MCPORTER:-npx mcporter}"`  
   If you have the local repo, prefer `MCPORTER="pnpm --dir ~/Projects/mcporter exec tsx ~/Projects/mcporter/src/cli.ts"`.
 - mcporter timeouts are **milliseconds**. Use `--timeout 15000` (15s), not `--timeout 15`.
-- Permissions: run `$PEEKABOO_BIN permissions status` once to confirm Screen Recording + Accessibility are granted; the `permissions` tool will fail if screen capture is blocked.
+- Permissions: run `$PEEKABOO_BIN permissions status` once to confirm Screen Recording + Accessibility are granted; the `permissions` tool fails when either required grant is missing and reports Event Synthesizing separately.
 - AI analysis (optional steps below) needs providers set in `~/.peekaboo/config.json` and env keys (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, etc.).
 
 ## Test cases (run in order)

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -24,7 +24,7 @@ If you use a Bridge host, grant permissions to the host reported by `peekaboo pe
 
 - **macOS 15.0+ (Sequoia)** – core automation APIs depend on Sequoia.
 - **Screen Recording (required)** – enables CGWindow capture and multi-app automation.
-- **Accessibility (recommended)** – improves window focus, menu interaction, dialog control, and action-based element/query clicks.
+- **Accessibility (required)** – enables window, menu, dialog, and action-based element/query automation.
 - **Event Synthesizing (optional)** – enables background keyboard input and explicitly foreground synthetic pointer input (`click --foreground`, targetless/smooth scroll, move, drag, and swipe). Background clicks use Accessibility.
 
 For build and runtime version details, see [platform-support.md](platform-support.md).

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -19,7 +19,7 @@ peekaboo permissions grant
 peekaboo permissions request screen-recording
 ```
 
-`grant` opens System Settings to the right pane. You need **Screen Recording** (required) and **Accessibility** (recommended). Re-run `permissions status` until both are green. Background keyboard input and foreground synthetic pointer tools need **Event Synthesizing**; background element/query/coordinate clicks use Accessibility. See [permissions.md](permissions.md).
+`grant` opens System Settings to the right pane. You need **Screen Recording** and **Accessibility**; both are required. Re-run `permissions status` until both are green. Background keyboard input and foreground synthetic pointer tools need **Event Synthesizing**; it is an action-specific grant rather than a global requirement. Background element/query/coordinate clicks use Accessibility. See [permissions.md](permissions.md).
 
 ## 2. Take a screenshot
 


### PR DESCRIPTION
## Summary

- read Screen Recording, Accessibility, and Event Synthesizing from one runtime-selected host provider across CLI, MCP, Agent, and Bridge paths
- reuse the Bridge admission snapshot for handshake and `permissionsStatus` responses, avoiding duplicate permission evaluation and duplicate remote RPCs
- make missing Accessibility a required MCP failure while keeping Event Synthesizing an action-specific limitation, with the complete structured snapshot retained on success, denial, and provider failure
- remove the duplicate CLI permission-socket discovery path so normal runtime host routing remains the single selection owner

## Tests

- `swift test --package-path Core/PeekabooCore --filter 'PermissionsToolSelectedHostTests|PeekabooMCPServerTests'` (15 passed)
- `pnpm run test:safe` (847 Core/CLI tests and 82 runtime tests passed)
- `pnpm run build:cli`
- `pnpm run lint` (20 established warnings, 0 serious)
- `pnpm run docs:lint`
- `pnpm run format:swift`
- `git diff --check`
- Autoreview: clean, no accepted/actionable findings

## Behavior validation

Source-blind validation exercised the compiled CLI twice through ordinary and `--all-sources` status, then called the stdio MCP tool twice through `mcporter` and twice through direct JSON-RPC. The final run passed: every MCP response exposed identical `_meta` fields for all three grants, required-permission state, snapshot availability, and Event Synthesizing limitations.

No permission prompts, TCC changes, UI automation, AppleScript, or protocol-version bump were used.
