### PR TITLE
perf(daemon): slim window tracker reconciliation

### DIFF
--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reuse two-second, owner-host-local ScreenCaptureKit exact-window screenshot plans without caching pixels, revalidating process generation, window receipt, display topology, and scale around every capture while exposing miss/hit generation diagnostics.
 
 ### Fixed
+- Reduce reusable-daemon window-tracker MainActor work by retaining only bounds and owner PID, avoiding unused per-window application and Accessibility metadata on every reconciliation pass.
 - Refresh AXorcist to dispatch native accessibility actions once with typed AX errors and route legacy `AXSetValue` requests through the `AXValue` attribute instead of action discovery.
 - Preserve display-column-safe terminal input and styled table output for wide Unicode, SGR colors, and OSC-8 links, while making terminal stop/restart idempotent and preventing queued renders from escaping a stopped session.
 - Serialize ScreenCaptureKit ownership across Peekaboo processes for the lifetime of the first explicit local-modern claimant or real SCK caller, with build-bound process-awareness receipts, owner-affine auto/modern routing, current-policy capability checks for every transported engine, and fail-closed rolling-upgrade detection for old Bridge and long-running local processes; explicit classic remains a process-isolated, in-process-SCK-free escape hatch and refuses false-preflight captures unless protected WindowServer metadata independently proves access.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Reuse two-second, owner-host-local ScreenCaptureKit exact-window screenshot plans without caching pixels, revalidating process generation, window receipt, display topology, and scale around every capture while exposing miss/hit generation diagnostics.
 
 ### Fixed
+- Reduce reusable-daemon window-tracker MainActor work by retaining only bounds and owner PID, avoiding unused per-window application and Accessibility metadata on every reconciliation pass.
 - Refresh AXorcist to dispatch native accessibility actions once with typed AX errors and route legacy `AXSetValue` requests through the `AXValue` attribute instead of action discovery.
 - Preserve display-column-safe terminal input and styled table output for wide Unicode, SGR colors, and OSC-8 links, while making terminal stop/restart idempotent and preventing queued renders from escaping a stopped session.
 - Reject non-finite, fractional, and overflowing MCP numeric arguments before dispatch, and expose integer-shaped delays, durations, counts, process IDs, window selectors, and Space targets as integers in tool schemas.

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Support/WindowTrackerService.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Support/WindowTrackerService.swift
@@ -1,4 +1,4 @@
-import AppKit
+import ApplicationServices
 import AXorcist
 import CoreGraphics
 import Foundation
@@ -39,15 +39,15 @@ public struct WindowTrackerConfiguration: Sendable {
 @MainActor
 public final class WindowTrackerService: WindowTrackingProviding {
     private struct TrackedWindow {
-        let info: WindowIdentityInfo
-        var lastEventAt: Date?
-        var lastUpdatedAt: Date?
+        let bounds: CGRect
+        let ownerProcessIdentifier: pid_t
     }
 
     private let logger = Logger(subsystem: "boo.peekaboo.core", category: "WindowTracker")
     private let config: WindowTrackerConfiguration
     private let windowIdentityService = WindowIdentityService()
-    private let windowInfoProvider: (@MainActor (CGWindowID) -> WindowIdentityInfo?)?
+    private let exactWindowIdentityProvider: @MainActor (CGWindowID) -> SystemWindowIdentity?
+    private let visibleWindowInfoProvider: @MainActor () -> [[String: Any]]?
 
     private var windows: [CGWindowID: TrackedWindow] = [:]
     private var watchers: [NotificationWatcher] = []
@@ -57,15 +57,18 @@ public final class WindowTrackerService: WindowTrackingProviding {
 
     public init(configuration: WindowTrackerConfiguration = WindowTrackerConfiguration()) {
         self.config = configuration
-        self.windowInfoProvider = nil
+        self.exactWindowIdentityProvider = SystemIdentityResolver.windowIdentity
+        self.visibleWindowInfoProvider = WindowInfoHelper.getVisibleWindows
     }
 
     init(
         configuration: WindowTrackerConfiguration = WindowTrackerConfiguration(),
-        windowInfoProvider: @escaping @MainActor (CGWindowID) -> WindowIdentityInfo?)
+        exactWindowIdentityProvider: @escaping @MainActor (CGWindowID) -> SystemWindowIdentity?,
+        visibleWindowInfoProvider: @escaping @MainActor () -> [[String: Any]]? = WindowInfoHelper.getVisibleWindows)
     {
         self.config = configuration
-        self.windowInfoProvider = windowInfoProvider
+        self.exactWindowIdentityProvider = exactWindowIdentityProvider
+        self.visibleWindowInfoProvider = visibleWindowInfoProvider
     }
 
     public func start() {
@@ -88,14 +91,15 @@ public final class WindowTrackerService: WindowTrackingProviding {
             watcher.stop()
         }
         self.watchers.removeAll()
+        self.windows.removeAll()
     }
 
     public func windowBounds(for windowID: CGWindowID) -> CGRect? {
-        self.windows[windowID]?.info.bounds
+        self.windows[windowID]?.bounds
     }
 
     public func windowOwnerProcessIdentifier(for windowID: CGWindowID) -> pid_t? {
-        guard let ownerProcessIdentifier = self.windows[windowID]?.info.ownerPID,
+        guard let ownerProcessIdentifier = self.windows[windowID]?.ownerProcessIdentifier,
               ownerProcessIdentifier > 0
         else {
             return nil
@@ -179,46 +183,33 @@ public final class WindowTrackerService: WindowTrackingProviding {
     }
 
     func refreshWindow(windowID: CGWindowID) {
-        let info = if let windowInfoProvider {
-            windowInfoProvider(windowID)
-        } else {
-            self.windowIdentityService.getWindowInfo(windowID: windowID)
-        }
-        guard let info else {
+        guard let identity = self.exactWindowIdentityProvider(windowID) else {
             self.windows[windowID] = nil
             return
         }
 
-        let now = Date()
         self.windows[windowID] = TrackedWindow(
-            info: info,
-            lastEventAt: now,
-            lastUpdatedAt: now)
+            bounds: identity.bounds,
+            ownerProcessIdentifier: identity.ownerProcessIdentifier)
     }
 
-    private func refreshAllWindows() {
-        guard let windowInfo = WindowInfoHelper.getVisibleWindows() else {
+    func refreshAllWindows() {
+        guard let windowInfo = self.visibleWindowInfoProvider() else {
             return
         }
 
         var newWindows: [CGWindowID: TrackedWindow] = [:]
-        let now = Date()
 
         for entry in windowInfo {
             guard let windowID = entry[kCGWindowNumber as String] as? Int else { continue }
-            guard let info = self.buildIdentityInfo(from: entry, windowID: windowID) else { continue }
-
-            let previous = self.windows[CGWindowID(windowID)]
-            newWindows[CGWindowID(windowID)] = TrackedWindow(
-                info: info,
-                lastEventAt: previous?.lastEventAt,
-                lastUpdatedAt: now)
+            guard let trackedWindow = Self.buildTrackedWindow(from: entry) else { continue }
+            newWindows[CGWindowID(windowID)] = trackedWindow
         }
 
         self.windows = newWindows
     }
 
-    private func buildIdentityInfo(from dict: [String: Any], windowID: Int) -> WindowIdentityInfo? {
+    private static func buildTrackedWindow(from dict: [String: Any]) -> TrackedWindow? {
         guard let boundsDict = dict[kCGWindowBounds as String] as? [String: CGFloat] else { return nil }
 
         let bounds = CGRect(
@@ -227,21 +218,15 @@ public final class WindowTrackerService: WindowTrackingProviding {
             width: boundsDict["Width"] ?? 0,
             height: boundsDict["Height"] ?? 0)
 
-        let ownerPID = dict[kCGWindowOwnerPID as String] as? Int ?? 0
-        let app = NSRunningApplication(processIdentifier: pid_t(ownerPID))
-        let title = dict[kCGWindowName as String] as? String
-        let layer = dict[kCGWindowLayer as String] as? Int ?? 0
-        let alpha = dict[kCGWindowAlpha as String] as? CGFloat ?? 1.0
+        guard let ownerPID = dict[kCGWindowOwnerPID as String] as? Int,
+              let ownerProcessIdentifier = pid_t(exactly: ownerPID),
+              ownerProcessIdentifier > 0
+        else {
+            return nil
+        }
 
-        return WindowIdentityInfo(
-            windowID: CGWindowID(windowID),
-            title: title,
+        return TrackedWindow(
             bounds: bounds,
-            ownerPID: pid_t(ownerPID),
-            applicationName: app?.localizedName,
-            bundleIdentifier: app?.bundleIdentifier,
-            layer: layer,
-            alpha: alpha,
-            axIdentifier: nil)
+            ownerProcessIdentifier: ownerProcessIdentifier)
     }
 }

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/WindowTrackerServiceTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/WindowTrackerServiceTests.swift
@@ -14,7 +14,7 @@ struct WindowTrackerServiceTests {
             ownerPID: 111))
         let tracker = WindowTrackerService(
             configuration: WindowTrackerConfiguration(useAXNotifications: false),
-            windowInfoProvider: { source.info(for: $0) })
+            exactWindowIdentityProvider: { source.info(for: $0) })
         let previousTracker = WindowMovementTracking.provider
         WindowMovementTracking.provider = tracker
         defer { WindowMovementTracking.provider = previousTracker }
@@ -48,7 +48,7 @@ struct WindowTrackerServiceTests {
             ownerPID: 111))
         let tracker = WindowTrackerService(
             configuration: WindowTrackerConfiguration(useAXNotifications: false),
-            windowInfoProvider: { _ in source.currentInfo })
+            exactWindowIdentityProvider: { _ in source.currentInfo })
 
         tracker.refreshWindow(windowID: windowID)
         #expect(tracker.windowBounds(for: windowID) == CGRect(x: 10, y: 20, width: 300, height: 200))
@@ -68,35 +68,122 @@ struct WindowTrackerServiceTests {
         #expect(tracker.windowOwnerProcessIdentifier(for: windowID) == nil)
     }
 
+    @Test
+    @MainActor
+    func `Full reconciliation keeps only bounds and owner and removes vanished windows`() {
+        let exactSource = WindowInfoSource(currentInfo: nil)
+        let catalog = VisibleWindowCatalog(rows: [
+            Self.windowDictionary(
+                windowID: 42,
+                bounds: CGRect(x: 10, y: 20, width: 300, height: 200),
+                ownerPID: 111),
+            Self.windowDictionary(
+                windowID: 43,
+                bounds: CGRect(x: 30, y: 40, width: 500, height: 400),
+                ownerPID: 222),
+        ])
+        let tracker = WindowTrackerService(
+            configuration: WindowTrackerConfiguration(useAXNotifications: false),
+            exactWindowIdentityProvider: { exactSource.info(for: $0) },
+            visibleWindowInfoProvider: { catalog.rows })
+
+        tracker.refreshAllWindows()
+        #expect(tracker.windowBounds(for: 42) == CGRect(x: 10, y: 20, width: 300, height: 200))
+        #expect(tracker.windowOwnerProcessIdentifier(for: 42) == 111)
+        #expect(tracker.windowBounds(for: 43) == CGRect(x: 30, y: 40, width: 500, height: 400))
+        #expect(exactSource.requestedWindowIDs.isEmpty)
+
+        catalog.rows = [
+            Self.windowDictionary(
+                windowID: 42,
+                bounds: CGRect(x: 70, y: 80, width: 300, height: 200),
+                ownerPID: 333),
+        ]
+        tracker.refreshAllWindows()
+
+        #expect(tracker.windowBounds(for: 42) == CGRect(x: 70, y: 80, width: 300, height: 200))
+        #expect(tracker.windowOwnerProcessIdentifier(for: 42) == 333)
+        #expect(tracker.windowBounds(for: 43) == nil)
+        #expect(exactSource.requestedWindowIDs.isEmpty)
+    }
+
+    @Test
+    @MainActor
+    func `Stop clears cached window state`() {
+        let windowID = CGWindowID(42)
+        let source = WindowInfoSource(currentInfo: Self.windowInfo(
+            windowID: windowID,
+            bounds: CGRect(x: 10, y: 20, width: 300, height: 200),
+            ownerPID: 111))
+        let tracker = WindowTrackerService(
+            configuration: WindowTrackerConfiguration(useAXNotifications: false),
+            exactWindowIdentityProvider: { source.info(for: $0) })
+
+        tracker.refreshWindow(windowID: windowID)
+        #expect(tracker.windowBounds(for: windowID) != nil)
+
+        tracker.stop()
+
+        #expect(tracker.windowBounds(for: windowID) == nil)
+        #expect(tracker.windowOwnerProcessIdentifier(for: windowID) == nil)
+    }
+
     private static func windowInfo(
         windowID: CGWindowID,
         bounds: CGRect,
-        ownerPID: pid_t) -> WindowIdentityInfo
+        ownerPID: pid_t) -> SystemWindowIdentity
     {
-        WindowIdentityInfo(
+        SystemWindowIdentity(
             windowID: windowID,
-            title: nil,
+            ownerProcessIdentifier: ownerPID,
+            title: "",
             bounds: bounds,
-            ownerPID: ownerPID,
-            applicationName: nil,
-            bundleIdentifier: nil,
             layer: 0,
             alpha: 1,
-            axIdentifier: nil)
+            isOnScreen: true,
+            sharingState: nil)
+    }
+
+    private static func windowDictionary(
+        windowID: Int,
+        bounds: CGRect,
+        ownerPID: Int) -> [String: Any]
+    {
+        [
+            kCGWindowNumber as String: windowID,
+            kCGWindowOwnerPID as String: ownerPID,
+            kCGWindowBounds as String: [
+                "X": bounds.origin.x,
+                "Y": bounds.origin.y,
+                "Width": bounds.size.width,
+                "Height": bounds.size.height,
+            ],
+            kCGWindowOwnerName as String: "Ignored Owner",
+            kCGWindowName as String: "Ignored Title",
+        ]
     }
 }
 
 @MainActor
 private final class WindowInfoSource {
-    var currentInfo: WindowIdentityInfo?
+    var currentInfo: SystemWindowIdentity?
     private(set) var requestedWindowIDs: [CGWindowID] = []
 
-    init(currentInfo: WindowIdentityInfo?) {
+    init(currentInfo: SystemWindowIdentity?) {
         self.currentInfo = currentInfo
     }
 
-    func info(for windowID: CGWindowID) -> WindowIdentityInfo? {
+    func info(for windowID: CGWindowID) -> SystemWindowIdentity? {
         self.requestedWindowIDs.append(windowID)
         return self.currentInfo
+    }
+}
+
+@MainActor
+private final class VisibleWindowCatalog {
+    var rows: [[String: Any]]
+
+    init(rows: [[String: Any]]) {
+        self.rows = rows
     }
 }

--- a/docs/daemon.md
+++ b/docs/daemon.md
@@ -80,7 +80,7 @@ Older daemons may still occupy Peekaboo.app's `bridge.sock`. Current daemon cont
 - active requests, last activity, idle timeout, and idle deadline
 - Screen Recording, Accessibility, and Event Synthesizing permissions
 - snapshot count and last access
-- tracked windows, AX observers, and poll interval
+- tracked windows, AX observers, and poll interval; reconciliation retains only the exact bounds and owner PID needed for move-aware input
 - browser MCP connection, tool count, and detected browsers
 
 See [`peekaboo daemon`](commands/daemon.md) for command flags and [Bridge host](bridge-host.md) for transport and


### PR DESCRIPTION
## Summary

- retain only the window bounds and owner PID consumed by move-aware input instead of constructing unused AppKit/AX metadata for every visible window each second
- use the existing CoreGraphics-only exact-window identity path for notification/cache-miss refreshes
- preserve the one-second reconciliation as the AX-observer-loss backstop, including window churn/removal, and clear cached state on shutdown
- add injected catalog/exact-identity coverage plus Unreleased notes and daemon status documentation

## Performance

On the current 19-window desktop, 500 production-shaped main-thread iterations measured:

| Reconciliation | p50 | p95 | max |
| --- | ---: | ---: | ---: |
| Current per-window AppKit metadata | 1.94 ms | 5.21 ms | 37.53 ms |
| Bounds and owner PID only | 0.26 ms | 0.42 ms | 2.13 ms |

The optimized p95 is about 92% lower. Exact one-window lookup averaged 0.13 ms over 1,000 iterations.

I deliberately did not disable polling: cache hits currently depend on reconciliation when AX notifications are missed. Full idle dormancy belongs after action-time exact receipts become authoritative in the shared planner.

## Rebase integrity

- rebased onto `main` at `2f350a02a3c1db9b7ee941b530ebdfb8beda3ff3`
- source, test, and daemon-doc patch ID is unchanged before/after rebase: `ea07383901832ce676418b3a93e239038adf3f58`
- no intervening `main` commit touched the tracker source, tracker tests, or daemon documentation
- only the two append-only changelogs conflicted; their existing entry was retained once at the current insertion point

## Proof

- `swift test --package-path Core/PeekabooAutomationKit --no-parallel --filter 'WindowTrackerServiceTests|ClickServiceExactWindowTests|ClickServiceTargetResolutionTests'` — 48 passed
- `swift test --package-path Core/PeekabooCore --no-parallel --filter 'WindowMovementTrackingTests|PeekabooDaemonTests'` — 17 passed
- full serialized AutomationKit — passed, including 619 Swift Testing tests and the XCTest tranche
- full serialized Core — 1,584 passed; one unchanged live-Accessibility fixture could not find an accessible window for its spawned PID and fails identically in isolation
- `pnpm run test:safe` — exit 0; 847 Core/CLI and 83 runtime tests plus release, native-only, browser, and background-certification gates
- `pnpm run lint` — 23 established warnings, 0 serious
- `pnpm run lint:docs`, SwiftFormat, native-only source verification, and diff check — passed
- final Autoreview and TruffleHog — clean

The existing source-blind signed behavior validation remains applicable because the branch-owned executable source patch is unchanged and no intervening commit touched its owner files. It passed 14/14 using CLI `81f49ff42` (SHA-256 `0fbf065dd058a88014734d1c5797a7f7993bb7f4e521f95b32c9715a81e650b8`, Team `FWJYW4S8P8`). Three public status reads proved stable PID/generation, 19 tracked windows, 100 ms polling, and advancing `lastPollAt`. The native 10 ms monitor recorded 2,781 clean samples with zero violation or contamination bytes and unchanged foreground window, cursor, clipboard, and Peekaboo window set. Cleanup removed only the custom daemon/socket; installed app/daemon/socket generations were unchanged.

Report: `/private/tmp/behavior-validator-daemon-window-tracker.z1oDE6/behavior-report.md`
