### PR TITLE
perf(bridge): wake listener on socket readiness

### DIFF
--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Default new agent configurations to GPT-5.6 and Claude Opus 5 while keeping credential-only Anthropic discovery on Opus 4.8 for zero-retention compatibility and preserving explicit model selections.
 - Encode annotated observations directly from their rendered bitmap, removing redundant PNG/TIFF round trips while preserving exact pixels, metadata, and output paths.
 - Reuse two-second, owner-host-local ScreenCaptureKit exact-window screenshot plans without caching pixels, revalidating process generation, window receipt, display topology, and scale around every capture while exposing miss/hit generation diagnostics.
+- Wake Bridge hosts on kernel listener readiness instead of polling `accept` every 25 ms, draining queued clients per notification while preserving bounded, descriptor-safe shutdown.
 
 ### Fixed
 - Preserve integer-valued Agent tool data across Codable and Foundation JSON conversion instead of mistaking numeric `0` and `1` for booleans.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Default new agent configurations to GPT-5.6 and Claude Opus 5 while keeping credential-only Anthropic discovery on Opus 4.8 for zero-retention compatibility and preserving explicit model selections.
 - Encode annotated observations directly from their rendered bitmap, removing redundant PNG/TIFF round trips while preserving exact pixels, metadata, and output paths.
 - Reuse two-second, owner-host-local ScreenCaptureKit exact-window screenshot plans without caching pixels, revalidating process generation, window receipt, display topology, and scale around every capture while exposing miss/hit generation diagnostics.
+- Wake Bridge hosts on kernel listener readiness instead of polling `accept` every 25 ms, draining queued clients per notification while preserving bounded, descriptor-safe shutdown.
 
 ### Fixed
 - Preserve integer-valued Agent tool data across Codable and Foundation JSON conversion instead of mistaking numeric `0` and `1` for booleans.

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeHost.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeHost.swift
@@ -209,13 +209,28 @@ final class PeekabooBridgeListenerReadiness: @unchecked Sendable {
     }
 }
 
-private enum PeekabooBridgeAcceptLoop {
+enum PeekabooBridgeAcceptLoop {
     typealias ClientHandler = @Sendable (Int32, PeekabooBridgeConnectionLiveness) async -> Void
+    typealias ConnectionAcceptor = @Sendable (Int32) async -> AcceptResult
+    typealias ConnectionRegistration = @Sendable (PeekabooBridgeConnectionLiveness) async -> Void
     typealias PreparedConnection = (fd: Int32, connection: PeekabooBridgeConnectionLiveness)
+
+    enum AcceptResult: Sendable {
+        case prepared(PreparedConnection)
+        case retry
+        case drained
+        case listenerClosed
+        case failure(Int32)
+    }
+
+    enum DrainOutcome: Equatable, Sendable {
+        case rearm
+        case stop
+    }
 
     private static let logger = Logger(subsystem: "boo.peekaboo.bridge", category: "host")
 
-    static func run(
+    fileprivate static func run(
         listenFD: Int32,
         readiness: PeekabooBridgeListenerReadiness,
         context: PeekabooBridgeClientContext,
@@ -224,51 +239,74 @@ private enum PeekabooBridgeAcceptLoop {
         defer { readiness.cancel() }
         for await _ in readiness.events {
             guard !Task.isCancelled else { return }
-            guard let connections = await self.drainConnections(listenFD: listenFD) else { return }
-            for (index, prepared) in connections.enumerated() {
-                guard !Task.isCancelled else {
-                    connections[index...].forEach { $0.connection.close() }
-                    return
-                }
-                await context.connectionTracker.begin(connection: prepared.connection)
-                Task.detached(priority: .userInitiated) {
-                    await clientHandler(prepared.fd, prepared.connection)
-                    prepared.connection.close()
-                    await context.connectionTracker.end(connection: prepared.connection)
-                }
-            }
+            let outcome = await self.drainConnections(
+                listenFD: listenFD,
+                acceptConnection: self.acceptConnection,
+                registerConnection: { connection in
+                    await context.connectionTracker.begin(connection: connection)
+                },
+                unregisterConnection: { connection in
+                    await context.connectionTracker.end(connection: connection)
+                },
+                clientHandler: clientHandler)
+            guard outcome == .rearm else { return }
             readiness.rearm()
         }
     }
 
-    private static func drainConnections(listenFD: Int32) async -> [PreparedConnection]? {
-        var connections: [PreparedConnection] = []
+    static func drainConnections(
+        listenFD: Int32,
+        acceptConnection: @escaping ConnectionAcceptor,
+        registerConnection: @escaping ConnectionRegistration,
+        unregisterConnection: @escaping ConnectionRegistration,
+        clientHandler: @escaping ClientHandler) async -> DrainOutcome
+    {
         while !Task.isCancelled {
-            var addr = sockaddr()
-            var len = socklen_t(MemoryLayout<sockaddr>.size)
-            let client = accept(listenFD, &addr, &len)
-            if client >= 0 {
-                if let prepared = self.prepareConnection(client) {
-                    connections.append(prepared)
+            switch await acceptConnection(listenFD) {
+            case let .prepared(prepared):
+                await registerConnection(prepared.connection)
+                guard !Task.isCancelled else {
+                    prepared.connection.close()
+                    await unregisterConnection(prepared.connection)
+                    return .stop
                 }
+                Task.detached(priority: .userInitiated) {
+                    await clientHandler(prepared.fd, prepared.connection)
+                    prepared.connection.close()
+                    await unregisterConnection(prepared.connection)
+                }
+            case .retry:
                 continue
+            case .drained:
+                return .rearm
+            case .listenerClosed:
+                return .stop
+            case let .failure(code):
+                self.logger.error("accept failed: \(code, privacy: .public)")
+                try? await Task.sleep(nanoseconds: 50_000_000)
+                return Task.isCancelled ? .stop : .rearm
             }
-            if errno == EINTR {
-                continue
-            }
-            if errno == EAGAIN || errno == EWOULDBLOCK {
-                return connections
-            }
-            if errno == EBADF || errno == EINVAL {
-                connections.forEach { $0.connection.close() }
-                return nil
-            }
-            self.logger.error("accept failed: \(errno, privacy: .public)")
-            try? await Task.sleep(nanoseconds: 50_000_000)
-            return connections
         }
-        connections.forEach { $0.connection.close() }
-        return nil
+        return .stop
+    }
+
+    private static func acceptConnection(_ listenFD: Int32) async -> AcceptResult {
+        var addr = sockaddr()
+        var len = socklen_t(MemoryLayout<sockaddr>.size)
+        let client = accept(listenFD, &addr, &len)
+        if client >= 0 {
+            return self.prepareConnection(client).map(AcceptResult.prepared) ?? .retry
+        }
+        if errno == EINTR {
+            return .retry
+        }
+        if errno == EAGAIN || errno == EWOULDBLOCK {
+            return .drained
+        }
+        if errno == EBADF || errno == EINVAL {
+            return .listenerClosed
+        }
+        return .failure(errno)
     }
 
     private static func prepareConnection(_ client: Int32) -> PreparedConnection? {

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeHost.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeHost.swift
@@ -94,6 +94,203 @@ private func waitForPeekabooBridgeRequestsToDrain(
     return true
 }
 
+/// Converts listener readability into a coalesced async sequence.
+///
+/// A UNIX listener is level-triggered: one notification can represent several queued clients, so the accept loop
+/// drains until `EAGAIN` before waiting for the next event. Keeping the source alive for the listener lifetime avoids
+/// a polling sleep and lets shutdown explicitly finish the sequence before the descriptor is closed.
+final class PeekabooBridgeListenerReadiness: @unchecked Sendable {
+    let events: AsyncStream<Void>
+
+    private let continuation: AsyncStream<Void>.Continuation
+    private let cancellationEvents: AsyncStream<Void>
+    private let source: any DispatchSourceRead
+    private let lock = NSLock()
+    private var isCancelled = false
+    private var isFinishing = false
+    private var isSuspended = false
+    private var notificationCount = 0
+
+    init(fileDescriptor: Int32) {
+        let pair = AsyncStream<Void>.makeStream(bufferingPolicy: .bufferingNewest(1))
+        let cancellationPair = AsyncStream<Void>.makeStream(bufferingPolicy: .bufferingNewest(1))
+        self.events = pair.stream
+        self.continuation = pair.continuation
+        self.cancellationEvents = cancellationPair.stream
+        self.source = DispatchSource.makeReadSource(
+            fileDescriptor: fileDescriptor,
+            queue: DispatchQueue.global(qos: .userInitiated))
+        self.source.setEventHandler { [weak self] in
+            self?.notifyReadable()
+        }
+        self.source.setCancelHandler {
+            close(fileDescriptor)
+            cancellationPair.continuation.yield(())
+            cancellationPair.continuation.finish()
+        }
+        self.source.activate()
+    }
+
+    deinit {
+        self.cancel()
+    }
+
+    func cancel() {
+        self.lock.lock()
+        guard !self.isCancelled else {
+            self.lock.unlock()
+            return
+        }
+        self.isCancelled = true
+        let mustResume = self.isSuspended
+        self.isSuspended = false
+        self.lock.unlock()
+
+        // A cancelled Dispatch source does not deliver its cancellation while suspended.
+        if mustResume {
+            self.source.resume()
+        }
+        self.continuation.finish()
+        self.source.cancel()
+    }
+
+    /// Stops the async consumer before source cancellation closes the descriptor.
+    func finishEvents() {
+        self.lock.lock()
+        guard !self.isFinishing else {
+            self.lock.unlock()
+            return
+        }
+        self.isFinishing = true
+        self.lock.unlock()
+        self.continuation.finish()
+    }
+
+    /// Waits until all queued source handlers have drained, making it safe for the owner to close the descriptor.
+    func waitUntilCancelled() async {
+        for await _ in self.cancellationEvents {
+            return
+        }
+    }
+
+    /// Re-enables listener notifications after the accept queue has been drained to `EAGAIN`.
+    func rearm() {
+        self.lock.lock()
+        guard !self.isCancelled, !self.isFinishing, self.isSuspended else {
+            self.lock.unlock()
+            return
+        }
+        self.isSuspended = false
+        self.lock.unlock()
+        self.source.resume()
+    }
+
+    #if DEBUG
+    var notificationCountForTesting: Int {
+        self.lock.lock()
+        defer { self.lock.unlock() }
+        return self.notificationCount
+    }
+    #endif
+
+    private func notifyReadable() {
+        self.lock.lock()
+        guard !self.isCancelled, !self.isFinishing, !self.isSuspended else {
+            self.lock.unlock()
+            return
+        }
+        // Dispatch read sources are level-triggered. Suspend until the async consumer drains accept(), otherwise a
+        // queued client can repeatedly invoke this lightweight handler faster than the consumer gets scheduled.
+        self.isSuspended = true
+        self.notificationCount += 1
+        self.source.suspend()
+        self.lock.unlock()
+        self.continuation.yield(())
+    }
+}
+
+private enum PeekabooBridgeAcceptLoop {
+    typealias ClientHandler = @Sendable (Int32, PeekabooBridgeConnectionLiveness) async -> Void
+    typealias PreparedConnection = (fd: Int32, connection: PeekabooBridgeConnectionLiveness)
+
+    private static let logger = Logger(subsystem: "boo.peekaboo.bridge", category: "host")
+
+    static func run(
+        listenFD: Int32,
+        readiness: PeekabooBridgeListenerReadiness,
+        context: PeekabooBridgeClientContext,
+        clientHandler: @escaping ClientHandler) async
+    {
+        defer { readiness.cancel() }
+        for await _ in readiness.events {
+            guard !Task.isCancelled else { return }
+            guard let connections = await self.drainConnections(listenFD: listenFD) else { return }
+            for (index, prepared) in connections.enumerated() {
+                guard !Task.isCancelled else {
+                    connections[index...].forEach { $0.connection.close() }
+                    return
+                }
+                await context.connectionTracker.begin(connection: prepared.connection)
+                Task.detached(priority: .userInitiated) {
+                    await clientHandler(prepared.fd, prepared.connection)
+                    prepared.connection.close()
+                    await context.connectionTracker.end(connection: prepared.connection)
+                }
+            }
+            readiness.rearm()
+        }
+    }
+
+    private static func drainConnections(listenFD: Int32) async -> [PreparedConnection]? {
+        var connections: [PreparedConnection] = []
+        while !Task.isCancelled {
+            var addr = sockaddr()
+            var len = socklen_t(MemoryLayout<sockaddr>.size)
+            let client = accept(listenFD, &addr, &len)
+            if client >= 0 {
+                if let prepared = self.prepareConnection(client) {
+                    connections.append(prepared)
+                }
+                continue
+            }
+            if errno == EINTR {
+                continue
+            }
+            if errno == EAGAIN || errno == EWOULDBLOCK {
+                return connections
+            }
+            if errno == EBADF || errno == EINVAL {
+                connections.forEach { $0.connection.close() }
+                return nil
+            }
+            self.logger.error("accept failed: \(errno, privacy: .public)")
+            try? await Task.sleep(nanoseconds: 50_000_000)
+            return connections
+        }
+        connections.forEach { $0.connection.close() }
+        return nil
+    }
+
+    private static func prepareConnection(_ client: Int32) -> PreparedConnection? {
+        var one: Int32 = 1
+        _ = setsockopt(client, SOL_SOCKET, SO_NOSIGPIPE, &one, socklen_t(MemoryLayout.size(ofValue: one)))
+        do {
+            try PeekabooBridgeSocketIO.configureConnectedSocket(client)
+        } catch {
+            self.logger.error("failed to configure bridge client socket: \(error.localizedDescription)")
+            close(client)
+            return nil
+        }
+        do {
+            return try (client, PeekabooBridgeConnectionLiveness(fd: client))
+        } catch {
+            self.logger.error("failed to create bridge liveness probe: \(error.localizedDescription)")
+            close(client)
+            return nil
+        }
+    }
+}
+
 /// Lightweight UNIX-domain socket host for Peekaboo automation.
 ///
 /// This is a single-request-per-connection protocol: clients write one JSON request then half-close,
@@ -148,6 +345,8 @@ public final actor PeekabooBridgeHost {
     private var leaseFD: Int32 = -1
     private var socketIdentity: SocketIdentity?
     private var acceptTask: Task<Void, Never>?
+    private var listenerReadiness: PeekabooBridgeListenerReadiness?
+    private var stopTask: Task<PeekabooBridgeHostStopOutcome, Never>?
     private var ownershipCleanupTask: Task<Void, Never>?
     private let connectionTracker = PeekabooBridgeConnectionTracker()
     private let requestTracker = PeekabooBridgeRequestTracker()
@@ -185,6 +384,11 @@ public final actor PeekabooBridgeHost {
     }
 
     public func startChecked() throws {
+        guard self.stopTask == nil else {
+            throw PeekabooBridgeHostError.requestsStillDraining(
+                path: self.socketPath,
+                pendingCount: self.requestTracker.activeCount)
+        }
         guard self.listenFD == -1 else { return }
         guard self.ownershipCleanupTask == nil,
               self.leaseFD == -1,
@@ -219,6 +423,8 @@ public final actor PeekabooBridgeHost {
         }
 
         let fd = self.listenFD
+        let listenerReadiness = PeekabooBridgeListenerReadiness(fileDescriptor: fd)
+        self.listenerReadiness = listenerReadiness
         self.requestTracker.startAccepting()
 
         let context = PeekabooBridgeClientContext(
@@ -230,14 +436,35 @@ public final actor PeekabooBridgeHost {
             requestTracker: self.requestTracker)
 
         self.acceptTask = Task.detached(priority: .userInitiated) {
-            await Self.acceptLoop(
+            await PeekabooBridgeAcceptLoop.run(
                 listenFD: fd,
+                readiness: listenerReadiness,
                 context: context)
+            { fd, connection in
+                await Self.handleClient(
+                    fd: fd,
+                    connection: connection,
+                    context: context)
+            }
         }
     }
 
     @discardableResult
     public func stop() async -> PeekabooBridgeHostStopOutcome {
+        if let stopTask = self.stopTask {
+            return await stopTask.value
+        }
+
+        let stopTask = Task { [self] in
+            await self.stopOnce()
+        }
+        self.stopTask = stopTask
+        let outcome = await stopTask.value
+        self.stopTask = nil
+        return outcome
+    }
+
+    private func stopOnce() async -> PeekabooBridgeHostStopOutcome {
         if self.ownershipCleanupTask != nil {
             let snapshot = self.requestTracker.drainSnapshot
             return .ownershipRetained(
@@ -248,12 +475,16 @@ public final actor PeekabooBridgeHost {
         let acceptTask = self.acceptTask
         acceptTask?.cancel()
         self.acceptTask = nil
+        let listenerReadiness = self.listenerReadiness
+        listenerReadiness?.finishEvents()
+        self.listenerReadiness = nil
+        await acceptTask?.value
+        listenerReadiness?.cancel()
+        await listenerReadiness?.waitUntilCancelled()
         if self.listenFD != -1 {
-            close(self.listenFD)
             self.listenFD = -1
         }
         await self.connectionTracker.disconnectAll()
-        await acceptTask?.value
         // Catch a connection accepted between the first snapshot and listener shutdown.
         await self.connectionTracker.disconnectAll()
         self.requestTracker.stopAcceptingAndCancelAll()
@@ -325,6 +556,10 @@ public final actor PeekabooBridgeHost {
 
     func activeRequestCountForTesting() -> Int {
         self.requestTracker.activeCount
+    }
+
+    func listenerReadinessNotificationCountForTesting() -> Int? {
+        self.listenerReadiness?.notificationCountForTesting
     }
 
     var isRetainingOwnershipForRequestsForTesting: Bool {
@@ -1189,58 +1424,6 @@ public final actor PeekabooBridgeHost {
         }
     }
 
-    private nonisolated static func acceptLoop(
-        listenFD: Int32,
-        context: PeekabooBridgeClientContext) async
-    {
-        while !Task.isCancelled {
-            var addr = sockaddr()
-            var len = socklen_t(MemoryLayout<sockaddr>.size)
-            let client = accept(listenFD, &addr, &len)
-            if client < 0 {
-                if errno == EINTR {
-                    continue
-                }
-                if errno == EAGAIN || errno == EWOULDBLOCK {
-                    try? await Task.sleep(for: .milliseconds(25))
-                    continue
-                }
-                if errno == EBADF || errno == EINVAL {
-                    return
-                }
-                self.logger.error("accept failed: \(errno, privacy: .public)")
-                try? await Task.sleep(nanoseconds: 50_000_000)
-                continue
-            }
-
-            Self.disableSigPipe(fd: client)
-            do {
-                try PeekabooBridgeSocketIO.configureConnectedSocket(client)
-            } catch {
-                self.logger.error("failed to configure bridge client socket: \(error.localizedDescription)")
-                close(client)
-                continue
-            }
-            let connection: PeekabooBridgeConnectionLiveness
-            do {
-                connection = try PeekabooBridgeConnectionLiveness(fd: client)
-            } catch {
-                self.logger.error("failed to create bridge liveness probe: \(error.localizedDescription)")
-                close(client)
-                continue
-            }
-            await context.connectionTracker.begin(connection: connection)
-            Task.detached(priority: .userInitiated) {
-                await Self.handleClient(
-                    fd: client,
-                    connection: connection,
-                    context: context)
-                connection.close()
-                await context.connectionTracker.end(connection: connection)
-            }
-        }
-    }
-
     private nonisolated static func handleClient(
         fd: Int32,
         connection: PeekabooBridgeConnectionLiveness,
@@ -1290,11 +1473,6 @@ public final actor PeekabooBridgeHost {
         } catch {
             self.logger.error("bridge socket request failed: \(error.localizedDescription, privacy: .public)")
         }
-    }
-
-    private nonisolated static func disableSigPipe(fd: Int32) {
-        var one: Int32 = 1
-        _ = setsockopt(fd, SOL_SOCKET, SO_NOSIGPIPE, &one, socklen_t(MemoryLayout.size(ofValue: one)))
     }
 
     private nonisolated static func peerInfoIfAllowed(fd: Int32, allowedTeamIDs: Set<String>) -> PeekabooBridgePeer? {

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeHostOwnershipTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeHostOwnershipTests.swift
@@ -498,6 +498,108 @@ struct PeekabooBridgeHostOwnershipTests {
     }
 
     @Test
+    func `accept drain hands off each connection before reaching EAGAIN`() async throws {
+        var sockets = [Int32](repeating: -1, count: 2)
+        guard socketpair(AF_UNIX, SOCK_STREAM, 0, &sockets) == 0 else {
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
+        let transportFD = sockets[0]
+        let peerFD = sockets[1]
+        defer { close(peerFD) }
+
+        let connection = try PeekabooBridgeConnectionLiveness(fd: transportFD)
+        defer { connection.close() }
+        let prepared = PeekabooBridgeAcceptLoop.PreparedConnection(transportFD, connection)
+        let state = BridgeAcceptLoopTestState()
+
+        let outcome = await PeekabooBridgeAcceptLoop.drainConnections(
+            listenFD: -1,
+            acceptConnection: { _ in
+                switch state.nextAcceptCall() {
+                case 1:
+                    return .prepared(prepared)
+                default:
+                    let started = await Self.waitUntil { state.handlerCallCount == 1 }
+                    state.recordHandlerStartedBeforeDrain(started)
+                    return .drained
+                }
+            },
+            registerConnection: { _ in
+                state.recordRegistration()
+            },
+            unregisterConnection: { _ in
+                state.recordUnregistration()
+            },
+            clientHandler: { fd, _ in
+                state.recordHandler(fd: fd)
+            })
+
+        #expect(outcome == .rearm)
+        #expect(state.handlerStartedBeforeDrain)
+        #expect(state.handlerDescriptors == [transportFD])
+        #expect(await Self.waitUntil { state.unregistrationCount == 1 })
+        #expect(state.registrationCount == 1)
+    }
+
+    @Test
+    func `cancellation after accept registration closes without dispatch or rearm`() async throws {
+        var sockets = [Int32](repeating: -1, count: 2)
+        guard socketpair(AF_UNIX, SOCK_STREAM, 0, &sockets) == 0 else {
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
+        let transportFD = sockets[0]
+        let peerFD = sockets[1]
+        defer { close(peerFD) }
+        let probeFD = fcntl(transportFD, F_DUPFD_CLOEXEC, 0)
+        guard probeFD >= 0 else {
+            close(transportFD)
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
+
+        let state = BridgeAcceptLoopTestState()
+        let connection = try PeekabooBridgeConnectionLiveness(
+            fd: transportFD,
+            probeFD: probeFD,
+            closeHandler: { fd in
+                state.recordClosedDescriptor(fd)
+                Darwin.close(fd)
+            })
+        defer { connection.close() }
+        let prepared = PeekabooBridgeAcceptLoop.PreparedConnection(transportFD, connection)
+
+        let drainTask = Task {
+            await PeekabooBridgeAcceptLoop.drainConnections(
+                listenFD: -1,
+                acceptConnection: { _ in
+                    state.recordAcceptCall()
+                    return .prepared(prepared)
+                },
+                registerConnection: { _ in
+                    state.recordRegistration()
+                    while !state.releaseRegistration {
+                        try? await Task.sleep(for: .milliseconds(1))
+                    }
+                },
+                unregisterConnection: { _ in
+                    state.recordUnregistration()
+                },
+                clientHandler: { fd, _ in
+                    state.recordHandler(fd: fd)
+                })
+        }
+
+        #expect(await Self.waitUntil { state.registrationCount == 1 })
+        drainTask.cancel()
+        state.allowRegistrationToReturn()
+        let outcome = await drainTask.value
+
+        #expect(outcome == .stop)
+        #expect(state.handlerCallCount == 0)
+        #expect(state.unregistrationCount == 1)
+        #expect(state.closedDescriptors.sorted() == [transportFD, probeFD].sorted())
+    }
+
+    @Test
     func `concurrent stop is idempotent and host can restart on the same path`() async throws {
         let socketPath = Self.socketPath()
         defer { Self.removeSocketArtifacts(socketPath) }
@@ -582,6 +684,20 @@ struct PeekabooBridgeHostOwnershipTests {
         }
     }
 
+    private static func waitUntil(
+        timeout: Duration = .seconds(1),
+        condition: @escaping @Sendable () -> Bool) async -> Bool
+    {
+        let deadline = ContinuousClock.now.advanced(by: timeout)
+        while ContinuousClock.now < deadline {
+            if condition() {
+                return true
+            }
+            try? await Task.sleep(for: .milliseconds(1))
+        }
+        return condition()
+    }
+
     private static func removeSocketArtifacts(_ socketPath: String) {
         unlink(socketPath)
         unlink("\(socketPath).lock")
@@ -639,5 +755,105 @@ struct PeekabooBridgeHostOwnershipTests {
         guard copied < capacity else { throw POSIXError(.ENAMETOOLONG) }
         address.sun_len = UInt8(MemoryLayout.size(ofValue: address))
         return address
+    }
+}
+
+private final class BridgeAcceptLoopTestState: @unchecked Sendable {
+    private let lock = NSLock()
+    private var acceptCalls = 0
+    private var registrations = 0
+    private var unregistrations = 0
+    private var handlerFDs: [Int32] = []
+    private var closedFDs: [Int32] = []
+    private var handlerWasStartedBeforeDrain = false
+    private var mayReturnFromRegistration = false
+
+    func nextAcceptCall() -> Int {
+        self.lock.lock()
+        defer { self.lock.unlock() }
+        self.acceptCalls += 1
+        return self.acceptCalls
+    }
+
+    func recordAcceptCall() {
+        _ = self.nextAcceptCall()
+    }
+
+    func recordRegistration() {
+        self.lock.lock()
+        self.registrations += 1
+        self.lock.unlock()
+    }
+
+    func recordUnregistration() {
+        self.lock.lock()
+        self.unregistrations += 1
+        self.lock.unlock()
+    }
+
+    func recordHandler(fd: Int32) {
+        self.lock.lock()
+        self.handlerFDs.append(fd)
+        self.lock.unlock()
+    }
+
+    func recordHandlerStartedBeforeDrain(_ started: Bool) {
+        self.lock.lock()
+        self.handlerWasStartedBeforeDrain = started
+        self.lock.unlock()
+    }
+
+    func recordClosedDescriptor(_ fd: Int32) {
+        self.lock.lock()
+        self.closedFDs.append(fd)
+        self.lock.unlock()
+    }
+
+    func allowRegistrationToReturn() {
+        self.lock.lock()
+        self.mayReturnFromRegistration = true
+        self.lock.unlock()
+    }
+
+    var registrationCount: Int {
+        self.lock.lock()
+        defer { self.lock.unlock() }
+        return self.registrations
+    }
+
+    var unregistrationCount: Int {
+        self.lock.lock()
+        defer { self.lock.unlock() }
+        return self.unregistrations
+    }
+
+    var handlerCallCount: Int {
+        self.lock.lock()
+        defer { self.lock.unlock() }
+        return self.handlerFDs.count
+    }
+
+    var handlerDescriptors: [Int32] {
+        self.lock.lock()
+        defer { self.lock.unlock() }
+        return self.handlerFDs
+    }
+
+    var closedDescriptors: [Int32] {
+        self.lock.lock()
+        defer { self.lock.unlock() }
+        return self.closedFDs
+    }
+
+    var handlerStartedBeforeDrain: Bool {
+        self.lock.lock()
+        defer { self.lock.unlock() }
+        return self.handlerWasStartedBeforeDrain
+    }
+
+    var releaseRegistration: Bool {
+        self.lock.lock()
+        defer { self.lock.unlock() }
+        return self.mayReturnFromRegistration
     }
 }

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeHostOwnershipTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeHostOwnershipTests.swift
@@ -406,6 +406,118 @@ struct PeekabooBridgeHostOwnershipTests {
         #expect(await host.activeConnectionCountForTesting() == 0)
     }
 
+    @Test
+    func `listener stays dormant while idle and wakes once per sequential request`() async throws {
+        let socketPath = Self.socketPath()
+        defer { Self.removeSocketArtifacts(socketPath) }
+
+        let host = await Self.makeHost(socketPath: socketPath)
+        try await host.startChecked()
+        defer { Task { await host.stop() } }
+
+        try await Task.sleep(for: .milliseconds(100))
+        #expect(await host.listenerReadinessNotificationCountForTesting() == 0)
+
+        let client = Self.client(socketPath: socketPath)
+        let identity = Self.clientIdentity()
+        var durationsMS: [Double] = []
+        durationsMS.reserveCapacity(100)
+        for _ in 0..<100 {
+            let startedAt = ContinuousClock.now
+            _ = try await client.handshake(client: identity)
+            durationsMS.append(Self.milliseconds(startedAt.duration(to: .now)))
+        }
+
+        let notificationsAfterRequests = await host.listenerReadinessNotificationCountForTesting()
+        #expect(notificationsAfterRequests == 100)
+        try await Task.sleep(for: .milliseconds(100))
+        #expect(await host.listenerReadinessNotificationCountForTesting() == notificationsAfterRequests)
+
+        let sorted = durationsMS.sorted()
+        print(
+            "bridge listener 100-request benchmark: " +
+                "p50=\(String(format: "%.3f", sorted[49]))ms " +
+                "p95=\(String(format: "%.3f", sorted[94]))ms " +
+                "max=\(String(format: "%.3f", sorted[99]))ms " +
+                "notifications=\(notificationsAfterRequests ?? -1)")
+    }
+
+    @Test
+    func `listener coalesces clients queued before activation and closes its descriptor once`() async throws {
+        let socketPath = Self.socketPath()
+        defer { Self.removeSocketArtifacts(socketPath) }
+
+        let listener = try Self.bindSocket(path: socketPath, listen: true)
+        try PeekabooBridgeSocketIO.configureConnectedSocket(listener)
+        var clients: [Int32] = []
+        defer { clients.forEach { close($0) } }
+        for _ in 0..<64 {
+            let client = socket(AF_UNIX, SOCK_STREAM, 0)
+            #expect(client >= 0)
+            #expect(Self.connect(fd: client, path: socketPath) == 0)
+            clients.append(client)
+        }
+
+        let readiness = PeekabooBridgeListenerReadiness(fileDescriptor: listener)
+        #expect(await Self.receivesReadinessEvent(from: readiness))
+        #expect(readiness.notificationCountForTesting == 1)
+
+        var acceptedClients: [Int32] = []
+        defer { acceptedClients.forEach { close($0) } }
+        while true {
+            let accepted = accept(listener, nil, nil)
+            if accepted >= 0 {
+                acceptedClients.append(accepted)
+                continue
+            }
+            if errno == EINTR {
+                continue
+            }
+            #expect(errno == EAGAIN || errno == EWOULDBLOCK)
+            break
+        }
+        #expect(acceptedClients.count == clients.count)
+        readiness.rearm()
+        try await Task.sleep(for: .milliseconds(50))
+        #expect(readiness.notificationCountForTesting == 1)
+
+        readiness.finishEvents()
+        readiness.cancel()
+        await readiness.waitUntilCancelled()
+        errno = 0
+        let closedResult = fcntl(listener, F_GETFD)
+        let closedError = errno
+        #expect(closedResult == -1)
+        #expect(closedError == EBADF)
+
+        let replacement = socket(AF_UNIX, SOCK_STREAM, 0)
+        #expect(replacement >= 0)
+        defer { close(replacement) }
+        readiness.cancel()
+        #expect(fcntl(replacement, F_GETFD) >= 0)
+    }
+
+    @Test
+    func `concurrent stop is idempotent and host can restart on the same path`() async throws {
+        let socketPath = Self.socketPath()
+        defer { Self.removeSocketArtifacts(socketPath) }
+
+        let host = await Self.makeHost(socketPath: socketPath)
+        try await host.startChecked()
+
+        async let first = host.stop()
+        async let second = host.stop()
+        let firstOutcome = await first
+        let secondOutcome = await second
+        #expect(firstOutcome == .stopped)
+        #expect(secondOutcome == .stopped)
+
+        try await host.startChecked()
+        let handshake = try await Self.client(socketPath: socketPath).handshake(client: Self.clientIdentity())
+        #expect(handshake.hostKind == .gui)
+        #expect(await host.stop() == .stopped)
+    }
+
     private static func makeHost(
         socketPath: String,
         requestTimeoutSec: TimeInterval = 2) async -> PeekabooBridgeHost
@@ -445,6 +557,29 @@ struct PeekabooBridgeHostOwnershipTests {
 
     private static func socketPath() -> String {
         "/tmp/peekaboo-bridge-ownership-\(UUID().uuidString).sock"
+    }
+
+    private static func milliseconds(_ duration: Duration) -> Double {
+        Double(duration.components.seconds * 1000) +
+            Double(duration.components.attoseconds) / 1_000_000_000_000_000
+    }
+
+    private static func receivesReadinessEvent(from readiness: PeekabooBridgeListenerReadiness) async -> Bool {
+        await withTaskGroup(of: Bool.self) { group in
+            group.addTask {
+                for await _ in readiness.events {
+                    return true
+                }
+                return false
+            }
+            group.addTask {
+                try? await Task.sleep(for: .seconds(1))
+                return false
+            }
+            let result = await group.next() ?? false
+            group.cancelAll()
+            return result
+        }
     }
 
     private static func removeSocketArtifacts(_ socketPath: String) {

--- a/docs/bridge-host.md
+++ b/docs/bridge-host.md
@@ -89,6 +89,8 @@ the window tracker and other process-local support.
 - Shutdown removes the socket only when its filesystem identity still matches the listener that created it.
 - Connect, request read, and response write paths are nonblocking and deadline-bound so abandoned clients release their
   connection tasks instead of exhausting the host.
+- Listener acceptance is kernel-readiness-driven: one coalesced notification drains the queued connection backlog to
+  `EAGAIN`, while source cancellation owns descriptor closure and bounded shutdown waits for queued handlers to drain.
 
 Protocol `1.3` adds element action operations:
 


### PR DESCRIPTION
## Summary

- replace the Bridge host's 25 ms nonblocking `accept` polling loop with kernel-driven listener readiness
- coalesce readiness notifications and drain the queued connection backlog to `EAGAIN` before rearming
- hand every already-accepted client to its request handler before observing listener cancellation, so drain/stop cannot strand a valid connection
- make the readiness source own listener descriptor closure and serialize concurrent stop/restart without reuse or double-close
- preserve the single-request-per-connection wire contract, authorization, permissions, deadlines, and disconnect handling

## Performance

Matched 100-request in-process handshake benchmark on the original reviewed branch:

| | current main | this branch | change |
|---|---:|---:|---:|
| p50 | 28.780 ms | 18.271 ms | -36.5% |
| p95 | 30.318 ms | 19.554 ms | -35.5% |
| max | 62.067 ms | 21.374 ms | -65.6% |

Foundation-signed black-box CLI/daemon validation completed 100/100 alternating requests and a 64/64 concurrent burst. A matched idle interval reduced context switches from 491 to 134 and Unix syscalls from 1,292 to 366.

The current-main replay's 100-request ownership benchmark reports p95 3.847 ms inside the focused in-process fixture.

## Current-main proof

- exact base: `fa86e33df1cc3eb7108903b336baab7384a4561a`
- exact head: `c9ab6ac2baeda8bb3e5120f4063e7f96afee431f`
- both patches range-diff identical to the previously reviewed listener + accepted-client handoff commits
- Release `PeekabooCore` build: pass
- `PeekabooBridgeHostOwnershipTests`: 24/24 pass after one unrelated partial-lease test flaked once, then passed isolated and in the full rerun
- `PeekabooBridgeCancellationTests`: 10/10 pass
- `git diff --check`: pass
- P0-P2 autoreview: no accepted/actionable finding; one claimed Release-only accessor failure was rejected because both testing accessors are `#if DEBUG`, confirmed by the successful Release build

## Compatibility

This remains an internal listener/lifecycle change. Bridge request/response payloads, socket paths, host selection, authorization, and permission policy are unchanged.
