### PR TITLE
test(e2e): add fail-closed dual-controller overlap contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - Add Bridge protocol 1.26 exact browser connection receipts, binding persistent Chrome DevTools MCP sessions to one process generation or validated loopback DevTools browser identity.
+- Add the source-controlled dual-controller overlap contract and deterministic self-test infrastructure, with live certification held fail-closed until every operation carries a same-connection opaque Bridge host receipt.
 - Add Bridge protocol 1.25 one-shot dialog receipts that uniquely bind an exact process/window, raw dialog or sheet, and semantic AXPress button for background click/dismiss, with read-only targeted listing and canonical postcondition outcomes.
 - Add a background-first native Bridge host runtime for signed macOS apps, with explicit caller allowlists, shared mutation/snapshot state, checked lifecycle, and no Core, provider, browser, daemon, or AppleScript surface.
 - Add capability-gated exact-window background wheel delivery for opaque WKWebView/Tauri scroll targets, preserving the foreground app and physical cursor while refusing hidden, stale, Electron, Chromium, Catalyst, or AX-only routes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 ### Added
 - Add Bridge protocol 1.26 exact browser connection receipts, binding persistent Chrome DevTools MCP sessions to one process generation or validated loopback DevTools browser identity.
-- Add the source-controlled dual-controller overlap contract and deterministic self-test infrastructure, with live certification held fail-closed until every operation carries a same-connection opaque Bridge host receipt.
 - Add Bridge protocol 1.25 one-shot dialog receipts that uniquely bind an exact process/window, raw dialog or sheet, and semantic AXPress button for background click/dismiss, with read-only targeted listing and canonical postcondition outcomes.
 - Add a background-first native Bridge host runtime for signed macOS apps, with explicit caller allowlists, shared mutation/snapshot state, checked lifecycle, and no Core, provider, browser, daemon, or AppleScript surface.
 - Add capability-gated exact-window background wheel delivery for opaque WKWebView/Tauri scroll targets, preserving the foreground app and physical cursor while refusing hidden, stale, Electron, Chromium, Catalyst, or AX-only routes.

--- a/docs/testing/background-computer-use.md
+++ b/docs/testing/background-computer-use.md
@@ -87,12 +87,14 @@ The overlap cell starts two owned TextEdit executable generations during setup, 
 receipts, and then restores an independently selected sentinel window. Two separate controller processes launch
 independently generation- and executable-attested CLI clients through one explicit signed current Bridge socket:
 controller A completes an observe/type/press/type/readback workflow while controller B continuously observes and updates
-its different exact window. Both restore their original text, cleanup uses the launch
-receipts, and the validator requires real bidirectional interval overlap plus independent readback with no cross-target
-token. The native monitor keeps focus, top-window, session-global Peekaboo input, clipboard change count, visible
-Peekaboo alpha windows, host generation, and heartbeat liveness fail-closed through cleanup. Physical cursor motion is
-recorded as observational evidence and never fails the cell because the user may be working concurrently. Every CLI
-generation is registered before it can run and has a 30-second deadline (bounded to 1–300 seconds with
+its different exact window. Restoration is serialized: after A restores, both targets are read before B may restore,
+then both targets are read again, so a cross-target mutation cannot be overwritten by the peer restoration. Cleanup uses
+the launch receipts, and the validator requires real bidirectional interval overlap plus independent readback with no
+cross-target token. The native monitor keeps focus, top-window, session-global Peekaboo input, clipboard change count,
+visible Peekaboo alpha windows, host generation, and heartbeat liveness fail-closed through cleanup.
+Physical cursor motion is recorded as observational evidence and never fails the cell because the user may be working
+concurrently. Every CLI generation is registered before it can run and has a 30-second deadline (bounded to 1–300
+seconds with
 `PEEKABOO_OVERLAP_OPERATION_TIMEOUT_SECONDS`); timeout and abort cleanup escalate from TERM to KILL while the invariant
 monitor remains active. Each target starts as a stopped direct child: its intended executable path and process generation
 are recorded durably before resume, then the live executable path is verified after `exec`; cleanup never infers ownership

--- a/docs/testing/background-computer-use.md
+++ b/docs/testing/background-computer-use.md
@@ -80,9 +80,46 @@ not certified merely because the cases that happened to execute passed. The mach
 `certification.json` beside the normal summary.
 
 Completeness is relative to this source-controlled 34-case single-controller matrix; it is not a claim that every
-Peekaboo CLI combination is represented. Dual-controller overlap is intentionally outside these rows and is not yet an
-in-tree certification cell. Once source-controlled, it should remain one complementary workflow-level cell rather than
-duplicating its internal steps in this catalog.
+Peekaboo CLI combination is represented. `scripts/test-dual-controller-overlap.sh` is the complementary workflow-level
+cell; its internal steps deliberately stay outside the 34-row command catalog.
+
+The overlap cell starts two owned TextEdit executable generations during setup, pins their exact process/window
+receipts, and then restores an independently selected sentinel window. Two separate controller processes launch
+independently generation- and executable-attested CLI clients through one explicit signed current Bridge socket:
+controller A completes an observe/type/press/type/readback workflow while controller B continuously observes and updates
+its different exact window. Both restore their original text, cleanup uses the launch
+receipts, and the validator requires real bidirectional interval overlap plus independent readback with no cross-target
+token. The native monitor keeps focus, top-window, session-global Peekaboo input, clipboard change count, visible
+Peekaboo alpha windows, host generation, and heartbeat liveness fail-closed through cleanup. Physical cursor motion is
+recorded as observational evidence and never fails the cell because the user may be working concurrently. Every CLI
+generation is registered before it can run and has a 30-second deadline (bounded to 1–300 seconds with
+`PEEKABOO_OVERLAP_OPERATION_TIMEOUT_SECONDS`); timeout and abort cleanup escalate from TERM to KILL while the invariant
+monitor remains active. Each target starts as a stopped direct child: its intended executable path and process generation
+are recorded durably before resume, then the live executable path is verified after `exec`; cleanup never infers ownership
+from an ambient application-inventory delta or a response that can be interrupted.
+
+Live execution is deliberately reserved until the CLI exposes an opaque host receipt from `bridge status` and validates
+that receipt on the same authenticated connection that performs every operation. The current command refuses before UI
+setup; its deterministic contract/self-test is landable infrastructure, not signed-live certification. After the receipt
+owner lands, the opt-in invocation will require a clean source tree, matching stamped CLI/host source commits, one exact
+signed Bridge host, and an already-running sentinel receipt:
+
+```bash
+PEEKABOO_RUN_DUAL_CONTROLLER_OVERLAP=1 \
+scripts/test-dual-controller-overlap.sh \
+  --bin /absolute/path/to/peekaboo \
+  --bridge-socket /absolute/path/to/bridge.sock \
+  --sentinel-pid 1234 \
+  --sentinel-window-id 5678 \
+  --artifacts /absolute/new/artifact-directory
+```
+
+The safe source/contract gate never touches UI:
+
+```bash
+scripts/test-dual-controller-overlap.sh --self-test \
+  --artifacts /absolute/new/self-test-directory
+```
 
 For the interaction commands exercised here, background is the omission contract: `--foreground` is the only consent
 for focus/activation, global keyboard input, physical cursor movement, or synthetic pointer/wheel events. Explicit app

--- a/docs/testing/background-computer-use.md
+++ b/docs/testing/background-computer-use.md
@@ -96,9 +96,12 @@ Physical cursor motion is recorded as observational evidence and never fails the
 concurrently. Every CLI generation is registered before it can run and has a 30-second deadline (bounded to 1–300
 seconds with
 `PEEKABOO_OVERLAP_OPERATION_TIMEOUT_SECONDS`); timeout and abort cleanup escalate from TERM to KILL while the invariant
-monitor remains active. Each target starts as a stopped direct child: its intended executable path and process generation
-are recorded durably before resume, then the live executable path is verified after `exec`; cleanup never infers ownership
-from an ambient application-inventory delta or a response that can be interrupted.
+monitor remains active. Peer synchronization uses one monotonic deadline derived from that timeout plus the bounded
+registration/attestation handoff for each maximum remaining operation: 6 for initial/final readback, 8 to establish the
+overlap witness, 30 for the longer controller workflow, and 15 for restoration plus its two-target checkpoint. A peer
+generation exit still refuses immediately. Each target starts as a stopped direct child: its intended executable path
+and process generation are recorded durably before resume, then the live executable path is verified after `exec`;
+cleanup never infers ownership from an ambient application-inventory delta or a response that can be interrupted.
 
 Live execution is deliberately reserved until the CLI exposes an opaque host receipt from `bridge status` and validates
 that receipt on the same authenticated connection that performs every operation. The current command refuses before UI

--- a/scripts/dual-controller-overlap-catalog.json
+++ b/scripts/dual-controller-overlap-catalog.json
@@ -1,0 +1,25 @@
+{
+  "version": 1,
+  "controllers": [
+    {"id":"A","workflow_commands":["type","press","type"],"restoration_command":"type","minimum_observations":3},
+    {"id":"B","workflow_commands":["type","type","type","type"],"restoration_command":"type","minimum_observations":4}
+  ],
+  "invariants": [
+    "signed_host_generation",
+    "sentinel_frontmost_pid",
+    "sentinel_top_window",
+    "no_cross_target_dispatch",
+    "no_peekaboo_global_input",
+    "clipboard_change_count",
+    "peekaboo_alpha_overlay",
+    "monitor_liveness"
+  ],
+  "cursor_policy": "observational",
+  "required_evidence": [
+    "exact_target_receipts",
+    "independent_readback",
+    "overlapping_intervals",
+    "restoration",
+    "generation_pinned_cleanup"
+  ]
+}

--- a/scripts/support/background-computer-use-probe.swift
+++ b/scripts/support/background-computer-use-probe.swift
@@ -44,6 +44,9 @@ private struct WatchHeartbeat: Codable {
     let inputAttributionAvailable: Bool
     let allowedProducerRevision: UInt64
     let phase: String
+    let cursorMovementObserved: Bool
+    let pendingActivationCount: Int
+    let pendingFocusedWindowChange: Bool
 }
 
 private struct ContaminationRecord: Codable {
@@ -62,7 +65,25 @@ private struct AppIdentity: Codable {
 
 private struct ProcessIdentity: Codable {
     let pid: Int32
-    let startIdentity: UInt64
+    let startIdentity: String
+}
+
+private struct ProcessExecutable: Codable {
+    let pid: Int32
+    let startIdentity: String
+    let path: String
+    let sha256: String
+}
+
+private struct ProcessExecutableIdentity: Codable {
+    let pid: Int32
+    let startIdentity: String
+    let path: String
+}
+
+private struct ClockSample: Codable {
+    let wallTime: Double
+    let monotonicSeconds: Double
 }
 
 private enum ProbeError: Error, CustomStringConvertible {
@@ -126,6 +147,7 @@ private struct InvariantEvaluationContext {
     let interactiveBaseline: InteractiveBaseline
     let allowClipboardMutation: Bool
     let evaluateInteractiveInvariants: Bool
+    let cursorObservational: Bool
     let projection: InvariantProjection
 }
 
@@ -137,6 +159,11 @@ private struct InputEventBatch {
     let externalSourcePIDs: [Int32]
     let externalEventTypes: [UInt32]
     let attributionFailed: Bool
+}
+
+private func physicalInputIsObservational(_ batch: InputEventBatch, enabled: Bool) -> Bool {
+    enabled && batch.externalEventCount > 0 && batch.externalSourcePIDs == [0] &&
+        batch.externalEventTypes == [CGEventType.mouseMoved.rawValue]
 }
 
 private struct AllowedEventProducer: Codable, Hashable {
@@ -590,7 +617,7 @@ private func violations(current: SystemSample, context: InvariantEvaluationConte
 
         let cursorMoved = abs(current.cursor.x - context.interactiveBaseline.cursor.x) > 0.5 ||
             abs(current.cursor.y - context.interactiveBaseline.cursor.y) > 0.5
-        if cursorMoved {
+        if cursorMoved, !context.cursorObservational {
             result.insert(Violation(
                 kind: context.projection[.physicalCursor],
                 expected: "\(context.interactiveBaseline.cursor.x),\(context.interactiveBaseline.cursor.y)",
@@ -670,6 +697,8 @@ private struct WatchState {
     let baseline: SystemSample
     let interactiveBaseline: InteractiveBaseline
     let allowClipboardMutation: Bool
+    let physicalInputObservational: Bool
+    let cursorObservational: Bool
     let projection: InvariantProjection
     let outputPath: String
     let contaminationOutputPath: String
@@ -683,6 +712,7 @@ private struct WatchState {
     private var allowedProducerReceipts: [Int32: String] = [:]
     private var pendingActivations: [Int32] = []
     private var pendingFocusedWindowChange = false
+    private var cursorMovementObserved = false
 
     mutating func applyProducerSet(
         _ producerSet: AllowedEventProducerSet,
@@ -723,6 +753,11 @@ private struct WatchState {
         unexpectedActivations: [Int32],
         focusedWindowChanged: Bool) throws -> WatchHeartbeat
     {
+        if abs(current.cursor.x - self.interactiveBaseline.cursor.x) > 0.5 ||
+            abs(current.cursor.y - self.interactiveBaseline.cursor.y) > 0.5
+        {
+            self.cursorMovementObserved = true
+        }
         let deferredActivations = self.pendingActivations
         let deferredFocusedWindowChange = self.pendingFocusedWindowChange
         self.pendingActivations = unexpectedActivations
@@ -748,7 +783,10 @@ private struct WatchState {
                 attributionFailed: true,
                 countsRetry: false)
         }
-        if inputBatch.externalEventCount > 0 {
+        let observesPhysicalInput = physicalInputIsObservational(
+            inputBatch,
+            enabled: self.physicalInputObservational)
+        if inputBatch.externalEventCount > 0, !observesPhysicalInput {
             try self.block(
                 reason: phase == "setup" ? "blocked_setup_attempt" : "blocked_active_attempt",
                 sourcePIDs: inputBatch.externalSourcePIDs,
@@ -756,7 +794,8 @@ private struct WatchState {
                 attributionFailed: false,
                 countsRetry: true)
         }
-        let evaluateInteractive = inputBatch.externalEventCount == 0 &&
+        let externalInputPermitsEvaluation = observesPhysicalInput || inputBatch.externalEventCount == 0
+        let evaluateInteractive = externalInputPermitsEvaluation &&
             unexpectedActivations.isEmpty && !focusedWindowChanged && self.inputAttributionAvailable &&
             self.contaminationState.permitsInteractiveEvaluation
         let context = InvariantEvaluationContext(
@@ -764,11 +803,12 @@ private struct WatchState {
             interactiveBaseline: self.interactiveBaseline,
             allowClipboardMutation: self.allowClipboardMutation,
             evaluateInteractiveInvariants: evaluateInteractive,
+            cursorObservational: self.cursorObservational,
             projection: self.projection)
         var currentViolations = violations(current: current, context: context)
         if self.contaminationState.permitsInteractiveEvaluation {
             currentViolations.formUnion(transientFocusViolations(
-                externalEventCount: inputBatch.externalEventCount,
+                externalEventCount: observesPhysicalInput ? 0 : inputBatch.externalEventCount,
                 unexpectedActivations: deferredActivations,
                 focusedWindowChanged: deferredFocusedWindowChange,
                 baseline: self.interactiveBaseline,
@@ -796,7 +836,10 @@ private struct WatchState {
             contaminationBlocked: self.contaminationState.blocked,
             inputAttributionAvailable: self.inputAttributionAvailable,
             allowedProducerRevision: self.allowedProducerRevision ?? 0,
-            phase: phase)
+            phase: phase,
+            cursorMovementObserved: self.cursorMovementObserved,
+            pendingActivationCount: self.pendingActivations.count,
+            pendingFocusedWindowChange: self.pendingFocusedWindowChange)
     }
 
     private mutating func block(
@@ -877,6 +920,8 @@ private func runWatch(arguments: [String]) throws -> Never {
         throw ProbeError.invalidArguments("watch interval must be valid")
     }
     let allowClipboardMutation = arguments.contains("--allow-clipboard-mutation")
+    let physicalInputObservational = arguments.contains("--physical-input-observational")
+    let cursorObservational = arguments.contains("--cursor-observational")
     let invariantProjection = try InvariantProjection(json: invariantNamesJSON)
     let baselineData = try Data(contentsOf: URL(fileURLWithPath: baselinePath))
     let baseline = try JSONDecoder().decode(SystemSample.self, from: baselineData)
@@ -905,6 +950,8 @@ private func runWatch(arguments: [String]) throws -> Never {
             frontmostWindowID: baseline.frontmostWindowID,
             cursor: baseline.cursor),
         allowClipboardMutation: allowClipboardMutation,
+        physicalInputObservational: physicalInputObservational,
+        cursorObservational: cursorObservational,
         projection: invariantProjection,
         outputPath: outputPath,
         contaminationOutputPath: contaminationOutputPath)
@@ -941,6 +988,81 @@ private func runWatch(arguments: [String]) throws -> Never {
     }
 }
 
+private func producerReceiptSchemaIsLossless() -> Bool {
+    let data = Data(#"{"revision":1,"producers":[{"pid":42,"startIdentity":"987654321"}]}"#.utf8)
+    guard let decoded = try? JSONDecoder().decode(AllowedEventProducerSet.self, from: data) else { return false }
+    return decoded.revision == 1 &&
+        decoded.producers.first?.pid == 42 &&
+        decoded.producers.first?.startIdentity == "987654321"
+}
+
+private func physicalInputPolicyIsSafe() -> Bool {
+    let physicalBatch = InputEventBatch(
+        producerEventCount: 0,
+        producerSourcePIDs: [],
+        producerEventTypes: [],
+        externalEventCount: 1,
+        externalSourcePIDs: [0],
+        externalEventTypes: [CGEventType.mouseMoved.rawValue],
+        attributionFailed: false)
+    let processBatch = InputEventBatch(
+        producerEventCount: 0,
+        producerSourcePIDs: [],
+        producerEventTypes: [],
+        externalEventCount: 1,
+        externalSourcePIDs: [4242],
+        externalEventTypes: [CGEventType.keyDown.rawValue],
+        attributionFailed: false)
+    let physicalKeyBatch = InputEventBatch(
+        producerEventCount: 0,
+        producerSourcePIDs: [],
+        producerEventTypes: [],
+        externalEventCount: 1,
+        externalSourcePIDs: [0],
+        externalEventTypes: [CGEventType.keyDown.rawValue],
+        attributionFailed: false)
+    let physicalClickBatch = InputEventBatch(
+        producerEventCount: 0,
+        producerSourcePIDs: [],
+        producerEventTypes: [],
+        externalEventCount: 1,
+        externalSourcePIDs: [0],
+        externalEventTypes: [CGEventType.leftMouseDown.rawValue],
+        attributionFailed: false)
+    let physicalScrollBatch = InputEventBatch(
+        producerEventCount: 0,
+        producerSourcePIDs: [],
+        producerEventTypes: [],
+        externalEventCount: 1,
+        externalSourcePIDs: [0],
+        externalEventTypes: [CGEventType.scrollWheel.rawValue],
+        attributionFailed: false)
+    let mixedPhysicalBatch = InputEventBatch(
+        producerEventCount: 0,
+        producerSourcePIDs: [],
+        producerEventTypes: [],
+        externalEventCount: 2,
+        externalSourcePIDs: [0],
+        externalEventTypes: [CGEventType.mouseMoved.rawValue, CGEventType.keyDown.rawValue],
+        attributionFailed: false)
+    let unattributedBatch = InputEventBatch(
+        producerEventCount: 0,
+        producerSourcePIDs: [],
+        producerEventTypes: [],
+        externalEventCount: 1,
+        externalSourcePIDs: [],
+        externalEventTypes: [CGEventType.keyDown.rawValue],
+        attributionFailed: false)
+    return physicalInputIsObservational(physicalBatch, enabled: true) &&
+        !physicalInputIsObservational(physicalKeyBatch, enabled: true) &&
+        !physicalInputIsObservational(physicalClickBatch, enabled: true) &&
+        !physicalInputIsObservational(physicalScrollBatch, enabled: true) &&
+        !physicalInputIsObservational(mixedPhysicalBatch, enabled: true) &&
+        !physicalInputIsObservational(processBatch, enabled: true) &&
+        !physicalInputIsObservational(unattributedBatch, enabled: true) &&
+        !physicalInputIsObservational(physicalBatch, enabled: false)
+}
+
 private func runSelfTest() throws {
     let projection = InvariantProjection(names: InvariantSlot.allCases.map { "slot-\($0.rawValue)" })
     let baseline = SystemSample(
@@ -963,6 +1085,7 @@ private func runSelfTest() throws {
         interactiveBaseline: interactiveBaseline,
         allowClipboardMutation: false,
         evaluateInteractiveInvariants: true,
+        cursorObservational: false,
         projection: projection)
     guard violations(current: baseline, context: baselineContext).isEmpty
     else {
@@ -986,6 +1109,7 @@ private func runSelfTest() throws {
             interactiveBaseline: interactiveBaseline,
             allowClipboardMutation: false,
             evaluateInteractiveInvariants: true,
+            cursorObservational: false,
             projection: projection)).map(\.kind))
     let expected = Set(projection.names).subtracting([projection[.globalInputEvent]])
     guard kinds == expected else {
@@ -998,6 +1122,7 @@ private func runSelfTest() throws {
             interactiveBaseline: interactiveBaseline,
             allowClipboardMutation: true,
             evaluateInteractiveInvariants: true,
+            cursorObservational: false,
             projection: projection)).map(\.kind))
     guard !allowedKinds.contains(projection[.clipboardChangeCount]) else {
         throw ProbeError.invalidArguments("clipboard mutation allowance was ignored")
@@ -1010,6 +1135,7 @@ private func runSelfTest() throws {
             interactiveBaseline: interactiveBaseline,
             allowClipboardMutation: false,
             evaluateInteractiveInvariants: false,
+            cursorObservational: false,
             projection: projection)).map(\.kind))
     guard !contaminatedKinds.contains(projection[.frontmostPID]),
           !contaminatedKinds.contains(projection[.frontmostWindow]),
@@ -1040,6 +1166,9 @@ private func runSelfTest() throws {
     else {
         throw ProbeError.invalidArguments("global producer input was not retained as an invariant violation")
     }
+    guard physicalInputPolicyIsSafe() else {
+        throw ProbeError.invalidArguments("only hardware-origin cursor motion may be observational")
+    }
     guard let selfIdentity = processStartIdentity(pid: getpid()),
           producerEventsMatchReceipts(
               batch: producerBatch,
@@ -1054,6 +1183,9 @@ private func runSelfTest() throws {
     }
     guard InputEventTracker.validateMonitoredEventMask() else {
         throw ProbeError.invalidArguments("input event mask does not cover the complete public input family")
+    }
+    guard producerReceiptSchemaIsLossless() else {
+        throw ProbeError.invalidArguments("producer start identities must decode as lossless decimal strings")
     }
     let transientKinds = Set(transientFocusViolations(
         externalEventCount: 0,
@@ -1072,7 +1204,23 @@ private func runSelfTest() throws {
         throw ProbeError.invalidArguments("transient focus attribution did not distinguish external input")
     }
 
-    try writeJSON(SelfTestResult(success: true, tests: 11), to: nil)
+    let cursorObservationalKinds = Set(violations(
+        current: changed,
+        context: InvariantEvaluationContext(
+            baseline: baseline,
+            interactiveBaseline: interactiveBaseline,
+            allowClipboardMutation: false,
+            evaluateInteractiveInvariants: true,
+            cursorObservational: true,
+            projection: projection)).map(\.kind))
+    guard !cursorObservationalKinds.contains(projection[.physicalCursor]),
+          cursorObservationalKinds.contains(projection[.frontmostPID]),
+          cursorObservationalKinds.contains(projection[.frontmostWindow])
+    else {
+        throw ProbeError.invalidArguments("observational cursor mode weakened focus invariants")
+    }
+
+    try writeJSON(SelfTestResult(success: true, tests: 14), to: nil)
 }
 
 private func findApp(arguments: [String]) throws {
@@ -1100,8 +1248,73 @@ private func writeProcessIdentity(arguments: [String]) throws {
         throw ProbeError.invalidArguments("process-identity requires a live positive --pid")
     }
     try writeJSON(
-        ProcessIdentity(pid: pid, startIdentity: startIdentity),
+        ProcessIdentity(pid: pid, startIdentity: String(startIdentity)),
         to: argument("--output", in: arguments))
+}
+
+private func writeProcessExecutable(arguments: [String]) throws {
+    guard let value = argument("--pid", in: arguments),
+          let pid = Int32(value),
+          let startIdentity = processStartIdentity(pid: pid)
+    else {
+        throw ProbeError.invalidArguments("process-executable requires a live positive --pid")
+    }
+    var buffer = [CChar](repeating: 0, count: Int(MAXPATHLEN) * 4)
+    let length = proc_pidpath(pid, &buffer, UInt32(buffer.count))
+    guard length > 0 else {
+        throw ProbeError.invalidArguments("process-executable could not resolve the executable path")
+    }
+    let executablePath = String(cString: buffer)
+    let executableData = try Data(contentsOf: URL(fileURLWithPath: executablePath), options: .mappedIfSafe)
+    let digest = SHA256.hash(data: executableData).map { String(format: "%02x", $0) }.joined()
+    guard processStartIdentity(pid: pid) == startIdentity else {
+        throw ProbeError.invalidArguments("process-executable generation changed while hashing")
+    }
+    try writeJSON(
+        ProcessExecutable(
+            pid: pid,
+            startIdentity: String(startIdentity),
+            path: executablePath,
+            sha256: digest),
+        to: argument("--output", in: arguments))
+}
+
+private func writeProcessExecutableIdentity(arguments: [String]) throws {
+    guard let value = argument("--pid", in: arguments),
+          let pid = Int32(value),
+          let startIdentity = processStartIdentity(pid: pid)
+    else {
+        throw ProbeError.invalidArguments("process-executable-identity requires a live positive --pid")
+    }
+    var buffer = [CChar](repeating: 0, count: Int(MAXPATHLEN) * 4)
+    guard proc_pidpath(pid, &buffer, UInt32(buffer.count)) > 0,
+          processStartIdentity(pid: pid) == startIdentity
+    else {
+        throw ProbeError.invalidArguments("process-executable-identity generation changed while resolving")
+    }
+    try writeJSON(
+        ProcessExecutableIdentity(
+            pid: pid,
+            startIdentity: String(startIdentity),
+            path: String(cString: buffer)),
+        to: argument("--output", in: arguments))
+}
+
+private func clockSample() -> ClockSample {
+    var timebase = mach_timebase_info_data_t()
+    mach_timebase_info(&timebase)
+    let ticks = mach_continuous_time()
+    let nanoseconds = Double(ticks) * Double(timebase.numer) / Double(timebase.denom)
+    return ClockSample(
+        wallTime: Date().timeIntervalSince1970,
+        monotonicSeconds: nanoseconds / 1_000_000_000)
+}
+
+private func runIgnoringTermination() -> Never {
+    signal(SIGTERM, SIG_IGN)
+    while true {
+        pause()
+    }
 }
 
 private struct SelfTestResult: Encodable {
@@ -1112,17 +1325,29 @@ private struct SelfTestResult: Encodable {
 do {
     let arguments = Array(CommandLine.arguments.dropFirst())
     guard let mode = arguments.first else {
-        throw ProbeError.invalidArguments("expected sample, watch, find-app, process-identity, or self-test")
+        throw ProbeError.invalidArguments(
+            "expected sample, clock, watch, find-app, process-identity, process-executable, " +
+                "process-executable-identity, ignore-term, or self-test")
     }
     switch mode {
     case "sample":
-        try writeJSON(sample(), to: argument("--output", in: arguments))
+        try writeJSON(
+            sample(includeClipboardDigest: !arguments.contains("--no-clipboard-digest")),
+            to: argument("--output", in: arguments))
+    case "clock":
+        try writeJSON(clockSample(), to: argument("--output", in: arguments))
     case "watch":
         try runWatch(arguments: arguments)
     case "find-app":
         try findApp(arguments: arguments)
     case "process-identity":
         try writeProcessIdentity(arguments: arguments)
+    case "process-executable":
+        try writeProcessExecutable(arguments: arguments)
+    case "process-executable-identity":
+        try writeProcessExecutableIdentity(arguments: arguments)
+    case "ignore-term":
+        runIgnoringTermination()
     case "self-test":
         try runSelfTest()
     default:

--- a/scripts/test-background-certification.sh
+++ b/scripts/test-background-certification.sh
@@ -10,3 +10,7 @@ trap 'rm -rf "$ARTIFACT_ROOT"' EXIT
   --bridge-socket "$ARTIFACT_ROOT/explicit-bridge.sock" \
   --artifacts "$ARTIFACT_ROOT/harness"
 node --test "$ROOT_DIR/tests/background-computer-use-report.test.mjs"
+node --test "$ROOT_DIR/tests/dual-controller-overlap-report.test.mjs"
+"$ROOT_DIR/scripts/test-dual-controller-overlap.sh" \
+  --self-test \
+  --artifacts "$ARTIFACT_ROOT/dual-controller-overlap"

--- a/scripts/test-background-computer-use.sh
+++ b/scripts/test-background-computer-use.sh
@@ -433,7 +433,8 @@ if $SELF_TEST_ONLY; then
     "$PROBE_BIN" process-identity --pid "$$" \
         --output "$ARTIFACT_ROOT/probe-process-identity.json"
     jq -e --argjson pid "$$" \
-        '.pid == $pid and (.startIdentity | type) == "number" and .startIdentity > 0' \
+        '.pid == $pid and (.startIdentity | type) == "string" and
+            (.startIdentity | test("^[1-9][0-9]*$"))' \
         "$ARTIFACT_ROOT/probe-process-identity.json" >/dev/null
     same_process_generation 7 7
     if same_process_generation 7 8 || same_process_generation "" 7; then

--- a/scripts/test-dual-controller-overlap.sh
+++ b/scripts/test-dual-controller-overlap.sh
@@ -1,0 +1,1874 @@
+#!/usr/bin/env bash
+set -euo pipefail
+umask 077
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CATALOG="$ROOT_DIR/scripts/dual-controller-overlap-catalog.json"
+REPORTER="$ROOT_DIR/scripts/validate-dual-controller-overlap-report.mjs"
+PROBE_SOURCE="$ROOT_DIR/scripts/support/background-computer-use-probe.swift"
+PEEKABOO_BIN="${PEEKABOO_BIN:-}"
+BRIDGE_SOCKET="${PEEKABOO_BRIDGE_SOCKET:-}"
+TEXTEDIT_APP="/System/Applications/TextEdit.app"
+TEXTEDIT_EXECUTABLE=""
+ARTIFACT_ROOT=""
+SENTINEL_PID=""
+SENTINEL_WINDOW_ID=""
+SELF_TEST_ONLY=false
+MONITOR_PID=""
+WATCHDOG_PID=""
+OVERLAP_WITNESS_PID=""
+CLIENT_A_PID=""
+CLIENT_B_PID=""
+CLIENT_A_RECEIPT_PID=""
+CLIENT_B_RECEIPT_PID=""
+CLIENT_A_IDENTITY=""
+CLIENT_B_IDENTITY=""
+TARGET_A_PID=""
+TARGET_A_IDENTITY=""
+TARGET_B_PID=""
+TARGET_B_IDENTITY=""
+CLEANUP_COMPLETE=false
+CLEANUP_STARTED=false
+PENDING_LAUNCHER_PID=""
+OPERATION_TIMEOUT_SECONDS="${PEEKABOO_OVERLAP_OPERATION_TIMEOUT_SECONDS:-30}"
+
+usage() {
+    cat <<'EOF'
+Usage: scripts/test-dual-controller-overlap.sh [options]
+
+Runs two independent Peekaboo clients through one exact signed Bridge host.
+Both clients mutate different launch-owned TextEdit windows in the background
+while an independently selected sentinel PID/window must remain foreground.
+
+Live mode is reserved until same-connection opaque Bridge host receipts land.
+The future live invocation will require PEEKABOO_RUN_DUAL_CONTROLLER_OVERLAP=1 and:
+  --bin PATH                 Signed current Peekaboo CLI
+  --bridge-socket PATH       Exact signed current Bridge socket
+  --sentinel-pid PID         Already-running sentinel process
+  --sentinel-window-id ID    Exact sentinel WindowServer window
+
+Options:
+  --textedit-app PATH        TextEdit.app path (default: /System/Applications/TextEdit.app)
+  --artifacts PATH           New/empty private artifact directory
+  --self-test                Compile the monitor and run contract tests only
+  -h, --help                 Show help
+
+PEEKABOO_OVERLAP_OPERATION_TIMEOUT_SECONDS sets the per-command deadline
+(default 30; accepted range 1 through 300).
+
+Physical cursor movement is recorded but never fails this cell. Focus/top-window,
+global Peekaboo input, clipboard change count, and visible Peekaboo overlays remain
+strict invariants. No AppleScript, JXA, System Events, or clipboard content is used.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --bin|--bridge-socket|--sentinel-pid|--sentinel-window-id|--textedit-app|--artifacts)
+            option="$1"
+            [[ $# -ge 2 && -n "$2" && "$2" != --* ]] || {
+                printf 'Option requires a value: %s\n' "$option" >&2
+                exit 2
+            }
+            case "$option" in
+                --bin) PEEKABOO_BIN="$2" ;;
+                --bridge-socket) BRIDGE_SOCKET="$2" ;;
+                --sentinel-pid) SENTINEL_PID="$2" ;;
+                --sentinel-window-id) SENTINEL_WINDOW_ID="$2" ;;
+                --textedit-app) TEXTEDIT_APP="$2" ;;
+                --artifacts) ARTIFACT_ROOT="$2" ;;
+            esac
+            shift 2
+            ;;
+        --self-test) SELF_TEST_ONLY=true; shift ;;
+        -h|--help) usage; exit 0 ;;
+        *) printf 'Unknown option: %s\n' "$1" >&2; usage >&2; exit 2 ;;
+    esac
+done
+
+if [[ -z "$ARTIFACT_ROOT" ]]; then
+    ARTIFACT_ROOT="$ROOT_DIR/.artifacts/dual-controller-overlap/$(date -u +%Y%m%dT%H%M%SZ)"
+elif [[ "$ARTIFACT_ROOT" != /* ]]; then
+    ARTIFACT_ROOT="$ROOT_DIR/$ARTIFACT_ROOT"
+fi
+if [[ -e "$ARTIFACT_ROOT" && ! -d "$ARTIFACT_ROOT" ]]; then
+    printf 'Artifact path is not a directory: %s\n' "$ARTIFACT_ROOT" >&2
+    exit 2
+fi
+if [[ -d "$ARTIFACT_ROOT" ]] && \
+   [[ -n "$(find "$ARTIFACT_ROOT" -mindepth 1 -maxdepth 1 -print -quit)" ]]; then
+    printf 'Artifact directory must be new or empty: %s\n' "$ARTIFACT_ROOT" >&2
+    exit 2
+fi
+mkdir -p "$ARTIFACT_ROOT/bin" "$ARTIFACT_ROOT/controllers" "$ARTIFACT_ROOT/results"
+ARTIFACT_ROOT="$(cd "$ARTIFACT_ROOT" && pwd -P)"
+chmod 700 "$ARTIFACT_ROOT" "$ARTIFACT_ROOT/bin" "$ARTIFACT_ROOT/controllers" "$ARTIFACT_ROOT/results"
+
+for command_name in awk jq node plutil ps rg shasum swiftc uuidgen; do
+    command -v "$command_name" >/dev/null 2>&1 || {
+        printf 'Missing required command: %s\n' "$command_name" >&2
+        exit 2
+    }
+done
+if ! [[ "$OPERATION_TIMEOUT_SECONDS" =~ ^[1-9][0-9]*$ ]] || ((OPERATION_TIMEOUT_SECONDS > 300)); then
+    printf '%s\n' 'PEEKABOO_OVERLAP_OPERATION_TIMEOUT_SECONDS must be an integer from 1 through 300.' >&2
+    exit 2
+fi
+
+write_owned_generation_receipt() {
+    local pid="$1"
+    local identity="$2"
+    local ownership_result="$3"
+    local temporary="$ownership_result.tmp"
+    [[ "$pid" =~ ^[1-9][0-9]*$ && "$identity" =~ ^[1-9][0-9]*$ ]] || return 1
+    jq -n --argjson pid "$pid" --arg identity "$identity" \
+        '{pid: $pid, start_identity: $identity}' > "$temporary"
+    mv "$temporary" "$ownership_result"
+}
+
+persist_owned_generation() {
+    local id="$1"
+    local pid="$2"
+    local identity="$3"
+    local ownership_result="$4"
+    [[ "$id" == A || "$id" == B ]] || return 1
+    write_owned_generation_receipt "$pid" "$identity" "$ownership_result"
+    if [[ "$id" == A ]]; then
+        TARGET_A_PID="$pid"
+        TARGET_A_IDENTITY="$identity"
+    else
+        TARGET_B_PID="$pid"
+        TARGET_B_IDENTITY="$identity"
+    fi
+}
+
+run_launch_ownership_self_test() {
+    persist_owned_generation A 4242 987654321 \
+        "$ARTIFACT_ROOT/results/launch-ownership-self-test-a.json"
+    persist_owned_generation B 5252 123456789 \
+        "$ARTIFACT_ROOT/results/launch-ownership-self-test-b.json"
+    jq -n --argjson success "$([[ "$TARGET_A_PID" == 4242 && \
+        "$TARGET_A_IDENTITY" == 987654321 && "$TARGET_B_PID" == 5252 && \
+        "$TARGET_B_IDENTITY" == 123456789 ]] && \
+        printf true || printf false)" \
+        --argjson pid "$TARGET_A_PID" --arg identity "$TARGET_A_IDENTITY" \
+        --argjson secondPID "$TARGET_B_PID" --arg secondIdentity "$TARGET_B_IDENTITY" '
+        {
+            success: $success,
+            cleanup_received: {pid: $pid, start_identity: $identity},
+            second_cleanup_received: {pid: $secondPID, start_identity: $secondIdentity}
+        }
+    '
+}
+
+PROBE_BIN="$ARTIFACT_ROOT/bin/background-computer-use-probe"
+swiftc "$PROBE_SOURCE" -o "$PROBE_BIN" \
+    -framework AppKit -framework ApplicationServices -framework CoreGraphics -framework CryptoKit
+"$PROBE_BIN" self-test > "$ARTIFACT_ROOT/probe-self-test.json"
+
+pb() {
+    local prefix
+    prefix="$ARTIFACT_ROOT/results/bounded-pb-$(uuidgen | tr '[:upper:]' '[:lower:]')"
+    if ! spawn_controlled_cli "$prefix" "$PEEKABOO_BIN" "$@" --bridge-socket "$BRIDGE_SOCKET"; then
+        [[ ! -f "$prefix.stderr" ]] || cat "$prefix.stderr" >&2
+        return 1
+    fi
+    local command_pid="$SPAWNED_PID"
+    local command_identity="$SPAWNED_IDENTITY"
+    local command_resumed_at="$SPAWNED_RESUMED_AT"
+    local inflight="$SPAWNED_INFLIGHT"
+    local command_exit=0
+    set +e
+    wait_for_spawned_cli "$command_pid" "$command_identity" "$prefix" "$command_resumed_at"
+    command_exit=$?
+    set -e
+    rm -f "$inflight"
+    [[ ! -f "$prefix.json" ]] || cat "$prefix.json"
+    [[ ! -f "$prefix.stderr" ]] || cat "$prefix.stderr" >&2
+    return "$command_exit"
+}
+
+process_generation_state() {
+    local pid="$1"
+    local identity="$2"
+    local current state
+    if ! state="$(ps -o state= -p "$pid" 2>/dev/null | tr -d '[:space:]')"; then
+        kill -0 "$pid" >/dev/null 2>&1 && return 2
+        return 1
+    fi
+    [[ -n "$state" ]] || {
+        kill -0 "$pid" >/dev/null 2>&1 && return 2
+        return 1
+    }
+    [[ "$state" != Z* ]] || return 1
+    if ! current="$("$PROBE_BIN" process-identity --pid "$pid" 2>/dev/null | \
+        jq -er '.startIdentity | tostring' 2>/dev/null)"; then
+        kill -0 "$pid" >/dev/null 2>&1 && return 2
+        return 1
+    fi
+    [[ "$current" == "$identity" ]] && return 0
+    return 1
+}
+
+process_alive() {
+    process_generation_state "$1" "$2"
+}
+
+owned_generation_gone() {
+    local pid="$1"
+    local identity="$2"
+    local state=0
+    process_generation_state "$pid" "$identity" || state=$?
+    case "$state" in
+        0) return 1 ;;
+        1) return 0 ;;
+        *) return 2 ;;
+    esac
+}
+
+terminate_owned_generation_directly() {
+    local id="$1"
+    local pid="$2"
+    local identity="$3"
+    local reason="$4"
+    local output="$ARTIFACT_ROOT/results/cleanup-${id}-direct.json"
+    local term_sent=false kill_sent=false
+    local parent_pid generation_state=0
+    parent_pid="$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d '[:space:]' || true)"
+    process_generation_state "$pid" "$identity" || generation_state=$?
+    if [[ $generation_state -eq 0 ]]; then
+        kill "$pid" >/dev/null 2>&1 || true
+        term_sent=true
+        for _ in $(seq 1 100); do
+            owned_generation_gone "$pid" "$identity" && break
+            sleep 0.01
+        done
+    fi
+    generation_state=0
+    process_generation_state "$pid" "$identity" || generation_state=$?
+    if [[ $generation_state -eq 0 || ($generation_state -eq 2 && "$parent_pid" == "$$") ]]; then
+        kill -KILL "$pid" >/dev/null 2>&1 || true
+        kill_sent=true
+        for _ in $(seq 1 100); do
+            owned_generation_gone "$pid" "$identity" && break
+            sleep 0.01
+        done
+    fi
+    local gone=false
+    owned_generation_gone "$pid" "$identity" && gone=true
+    if $gone; then
+        wait "$pid" >/dev/null 2>&1 || true
+    fi
+    jq -n --arg id "$id" --argjson pid "$pid" --arg identity "$identity" \
+        --arg reason "$reason" --argjson termSent "$term_sent" \
+        --argjson killSent "$kill_sent" --argjson gone "$gone" '
+        {
+            id: $id,
+            pid: $pid,
+            start_identity: $identity,
+            reason: $reason,
+            term_sent: $termSent,
+            kill_sent: $killSent,
+            gone: $gone
+        }
+    ' > "$output"
+    $gone
+}
+
+quit_owned_target() {
+    local id="$1"
+    local pid="$2"
+    local identity="$3"
+    [[ "$pid" =~ ^[1-9][0-9]*$ && "$identity" =~ ^[1-9][0-9]*$ ]] || return 0
+    local gone_status=0
+    owned_generation_gone "$pid" "$identity" || gone_status=$?
+    [[ $gone_status -ne 0 ]] || return 0
+    if [[ $gone_status -eq 2 ]]; then
+        terminate_owned_generation_directly "$id" "$pid" "$identity" generation_unknown || true
+        return 1
+    fi
+    if ! capture_host_receipt "$ARTIFACT_ROOT/results/cleanup-${id}-host-before.json"; then
+        terminate_owned_generation_directly "$id" "$pid" "$identity" bridge_unavailable || true
+        return 1
+    fi
+    local quit_exit=0
+    pb app quit --pid "$pid" --expected-process-start-identity "$identity" --force --json \
+        > "$ARTIFACT_ROOT/results/cleanup-${id}.json" 2> "$ARTIFACT_ROOT/results/cleanup-${id}.stderr" || \
+        quit_exit=$?
+    for _ in $(seq 1 150); do
+        gone_status=0
+        owned_generation_gone "$pid" "$identity" || gone_status=$?
+        if [[ $gone_status -eq 0 ]]; then
+            wait "$pid" >/dev/null 2>&1 || true
+            if [[ $quit_exit -eq 0 ]] && \
+               jq -e '.success == true' "$ARTIFACT_ROOT/results/cleanup-${id}.json" >/dev/null && \
+               capture_host_receipt "$ARTIFACT_ROOT/results/cleanup-${id}-host-after.json"; then
+                return 0
+            fi
+            terminate_owned_generation_directly "$id" "$pid" "$identity" bridge_cleanup_unverified || true
+            return 1
+        fi
+        if [[ $gone_status -eq 2 ]]; then
+            terminate_owned_generation_directly "$id" "$pid" "$identity" generation_unknown || true
+            return 1
+        fi
+        sleep 0.02
+    done
+    terminate_owned_generation_directly "$id" "$pid" "$identity" bridge_cleanup_incomplete || true
+    return 1
+}
+
+quit_recovery_targets() {
+    local receipt pid identity index=0 failed=false
+    while IFS= read -r receipt; do
+        [[ -n "$receipt" ]] || continue
+        pid="$(jq -er '.pid' "$receipt" 2>/dev/null || true)"
+        identity="$(jq -er '.start_identity' "$receipt" 2>/dev/null || true)"
+        [[ "$pid" =~ ^[1-9][0-9]*$ && "$identity" =~ ^[1-9][0-9]*$ ]] || continue
+        index=$((index + 1))
+        quit_owned_target "recovery-${index}" "$pid" "$identity" || failed=true
+    done < <(find "$ARTIFACT_ROOT/controllers" -maxdepth 1 -type f -name 'owned-target-*.json' -print)
+    ! $failed
+}
+
+stop_inflight_operations() {
+    local receipt pid identity owner_pid failed=false
+    while IFS= read -r receipt; do
+        [[ -n "$receipt" ]] || continue
+        pid="$(jq -er '.pid' "$receipt" 2>/dev/null || true)"
+        identity="$(jq -er '.start_identity' "$receipt" 2>/dev/null || true)"
+        owner_pid="$(jq -er '.owner_pid // empty' "$receipt" 2>/dev/null || true)"
+        [[ "$pid" =~ ^[1-9][0-9]*$ && "$identity" =~ ^[1-9][0-9]*$ ]] || continue
+        if process_alive "$pid" "$identity"; then
+            kill "$pid" >/dev/null 2>&1 || true
+            for _ in $(seq 1 100); do
+                owned_generation_gone "$pid" "$identity" && break
+                sleep 0.01
+            done
+            local post_term_state=0 parent_pid
+            process_generation_state "$pid" "$identity" || post_term_state=$?
+            parent_pid="$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d '[:space:]' || true)"
+            if [[ $post_term_state -eq 0 || \
+                  ($post_term_state -eq 2 && "$owner_pid" =~ ^[1-9][0-9]*$ && "$parent_pid" == "$owner_pid") ]]; then
+                kill -KILL "$pid" >/dev/null 2>&1 || true
+                for _ in $(seq 1 100); do
+                    owned_generation_gone "$pid" "$identity" && break
+                    sleep 0.01
+                done
+            elif [[ $post_term_state -eq 2 ]]; then
+                failed=true
+            fi
+            if ! owned_generation_gone "$pid" "$identity"; then
+                printf 'Inflight client generation survived cleanup: %s:%s\n' "$pid" "$identity" >&2
+                failed=true
+            fi
+        else
+            local generation_state=0
+            process_generation_state "$pid" "$identity" || generation_state=$?
+            if [[ $generation_state -eq 2 ]]; then
+                local parent_pid
+                parent_pid="$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d '[:space:]' || true)"
+                if [[ "$owner_pid" =~ ^[1-9][0-9]*$ && "$parent_pid" == "$owner_pid" ]]; then
+                    kill -KILL "$pid" >/dev/null 2>&1 || true
+                    wait "$pid" >/dev/null 2>&1 || true
+                    owned_generation_gone "$pid" "$identity" || failed=true
+                else
+                    failed=true
+                fi
+            elif [[ $generation_state -ne 1 ]]; then
+                failed=true
+            fi
+        fi
+    done < <(find "$ARTIFACT_ROOT/controllers" -maxdepth 1 -type f -name 'inflight-*.json' -print)
+    ! $failed
+}
+
+freeze_and_register_controller_children() {
+    local controller_pid="$1"
+    [[ "$controller_pid" =~ ^[1-9][0-9]*$ ]] || return 0
+    kill -STOP "$controller_pid" >/dev/null 2>&1 || return 0
+    local child_pid identity_result identity receipt
+    while IFS= read -r child_pid; do
+        [[ "$child_pid" =~ ^[1-9][0-9]*$ ]] || continue
+        identity_result="$ARTIFACT_ROOT/controllers/emergency-${controller_pid}-${child_pid}-identity.json"
+        if "$PROBE_BIN" process-identity --pid "$child_pid" --output "$identity_result" 2>/dev/null; then
+            identity="$(jq -er '.startIdentity' "$identity_result" 2>/dev/null || true)"
+            if [[ "$identity" =~ ^[1-9][0-9]*$ ]]; then
+                receipt="$ARTIFACT_ROOT/controllers/inflight-emergency-${child_pid}-${identity}.json"
+                jq -n --argjson pid "$child_pid" --arg startIdentity "$identity" \
+                    --argjson ownerPID "$controller_pid" '
+                    {pid: $pid, start_identity: $startIdentity, owner_pid: $ownerPID}
+                ' > "$receipt.tmp"
+                mv "$receipt.tmp" "$receipt"
+                continue
+            fi
+        fi
+        kill -KILL "$child_pid" >/dev/null 2>&1 || true
+        jq -n --argjson pid "$child_pid" --argjson ownerPID "$controller_pid" '
+            {pid: $pid, owner_pid: $ownerPID, reason: "identity_unavailable_before_wrapper_cleanup"}
+        ' > "$ARTIFACT_ROOT/controllers/emergency-kill-${controller_pid}-${child_pid}.json"
+    done < <(ps -axo pid=,ppid= | awk -v parent="$controller_pid" '$2 == parent {print $1}')
+}
+
+finish_monitoring() {
+    local pre_cleanup_sequence="$1"
+    local final_sample_path="$2"
+    local settled=false watchdog_exit=0 sample_succeeded=true
+    if [[ ! "$MONITOR_PID" =~ ^[1-9][0-9]*$ ]]; then
+        if [[ "$WATCHDOG_PID" =~ ^[1-9][0-9]*$ ]]; then
+            kill -KILL "$WATCHDOG_PID" >/dev/null 2>&1 || true
+            wait "$WATCHDOG_PID" >/dev/null 2>&1 || true
+            WATCHDOG_PID=""
+        fi
+        return 0
+    fi
+    if ! kill -0 "$MONITOR_PID" >/dev/null 2>&1; then
+        printf '%s\n' 'Invariant monitor exited before cleanup completed.' >&2
+        if [[ "$WATCHDOG_PID" =~ ^[1-9][0-9]*$ ]]; then
+            : > "$ARTIFACT_ROOT/monitor-watchdog.stop"
+            wait "$WATCHDOG_PID" >/dev/null 2>&1 || true
+            WATCHDOG_PID=""
+        fi
+        MONITOR_PID=""
+        return 1
+    fi
+    "$PROBE_BIN" sample --no-clipboard-digest --output "$final_sample_path" || sample_succeeded=false
+    for _ in $(seq 1 100); do
+        local current_sequence heartbeat_timestamp pending_activations pending_focus final_sample_timestamp
+        current_sequence="$(jq -r '.sequence // 0' "$ARTIFACT_ROOT/monitor-heartbeat.json" 2>/dev/null || printf 0)"
+        heartbeat_timestamp="$(jq -r '.timestamp // 0' "$ARTIFACT_ROOT/monitor-heartbeat.json" 2>/dev/null || printf 0)"
+        pending_activations="$(jq -r '.pendingActivationCount // -1' \
+            "$ARTIFACT_ROOT/monitor-heartbeat.json" 2>/dev/null || printf -- -1)"
+        pending_focus="$(jq -r '.pendingFocusedWindowChange // true' \
+            "$ARTIFACT_ROOT/monitor-heartbeat.json" 2>/dev/null || printf true)"
+        final_sample_timestamp="$(jq -r '.timestamp // 0' "$final_sample_path" 2>/dev/null || printf 0)"
+        if [[ "$current_sequence" =~ ^[0-9]+$ && "$current_sequence" -gt "$pre_cleanup_sequence" ]] && \
+           [[ "$pending_activations" == 0 && "$pending_focus" == false ]] && \
+           awk -v heartbeat="$heartbeat_timestamp" -v final="$final_sample_timestamp" \
+               'BEGIN { exit !(heartbeat >= final) }'; then
+            settled=true
+            break
+        fi
+        sleep 0.02
+    done
+    if [[ "$WATCHDOG_PID" =~ ^[1-9][0-9]*$ ]]; then
+        : > "$ARTIFACT_ROOT/monitor-watchdog.stop"
+        wait "$WATCHDOG_PID" || watchdog_exit=$?
+        WATCHDOG_PID=""
+    fi
+    if kill -0 "$MONITOR_PID" >/dev/null 2>&1; then
+        kill "$MONITOR_PID"
+        wait "$MONITOR_PID" >/dev/null 2>&1 || true
+    fi
+    MONITOR_PID=""
+    if ! $sample_succeeded; then
+        printf '%s\n' 'Could not capture the completed cleanup sample.' >&2
+        return 1
+    fi
+    if [[ $watchdog_exit -ne 0 ]]; then
+        printf '%s\n' 'Invariant monitor heartbeat stalled during the certified interval.' >&2
+        return 1
+    fi
+    if ! $settled; then
+        printf '%s\n' 'Invariant monitor did not observe the completed cleanup state.' >&2
+        return 1
+    fi
+    return 0
+}
+
+cleanup() {
+    $CLEANUP_STARTED && return
+    CLEANUP_STARTED=true
+    trap - EXIT INT TERM
+    local controller_pids=("$CLIENT_A_PID" "$CLIENT_B_PID")
+    local controller_identities=("$CLIENT_A_IDENTITY" "$CLIENT_B_IDENTITY")
+    local pids=("$OVERLAP_WITNESS_PID")
+    local pending_launcher_pid="$PENDING_LAUNCHER_PID"
+    local pre_cleanup_sequence=0
+    if [[ -s "$ARTIFACT_ROOT/monitor-heartbeat.json" ]]; then
+        pre_cleanup_sequence="$(jq -r '.sequence // 0' \
+            "$ARTIFACT_ROOT/monitor-heartbeat.json" 2>/dev/null || printf 0)"
+    fi
+    CLIENT_A_PID=""
+    CLIENT_B_PID=""
+    OVERLAP_WITNESS_PID=""
+    PENDING_LAUNCHER_PID=""
+    if [[ "$pending_launcher_pid" =~ ^[1-9][0-9]*$ ]]; then
+        kill -KILL "$pending_launcher_pid" >/dev/null 2>&1 || true
+        wait "$pending_launcher_pid" >/dev/null 2>&1 || true
+    fi
+    local cleanup_failed=false
+    local controller_index controller_state controller_identity
+    for controller_index in "${!controller_pids[@]}"; do
+        pid="${controller_pids[$controller_index]}"
+        controller_identity="${controller_identities[$controller_index]}"
+        [[ "$pid" =~ ^[1-9][0-9]*$ ]] || continue
+        if ! [[ "$controller_identity" =~ ^[1-9][0-9]*$ ]]; then
+            local controller_parent
+            controller_parent="$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d '[:space:]' || true)"
+            if [[ "$controller_parent" == "$$" ]]; then
+                freeze_and_register_controller_children "$pid"
+            else
+                cleanup_failed=true
+            fi
+            continue
+        fi
+        controller_state=0
+        process_generation_state "$pid" "$controller_identity" || controller_state=$?
+        if [[ $controller_state -eq 0 ]]; then
+            freeze_and_register_controller_children "$pid"
+        elif [[ $controller_state -eq 2 ]]; then
+            cleanup_failed=true
+        fi
+    done
+    stop_inflight_operations || cleanup_failed=true
+    for controller_index in "${!controller_pids[@]}"; do
+        pid="${controller_pids[$controller_index]}"
+        controller_identity="${controller_identities[$controller_index]}"
+        [[ "$pid" =~ ^[1-9][0-9]*$ ]] || continue
+        if ! [[ "$controller_identity" =~ ^[1-9][0-9]*$ ]]; then
+            local controller_parent
+            controller_parent="$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d '[:space:]' || true)"
+            if [[ "$controller_parent" == "$$" ]]; then
+                kill -KILL "$pid" >/dev/null 2>&1 || true
+                wait "$pid" >/dev/null 2>&1 || true
+            else
+                cleanup_failed=true
+            fi
+            continue
+        fi
+        controller_state=0
+        process_generation_state "$pid" "$controller_identity" || controller_state=$?
+        if [[ $controller_state -eq 0 ]]; then
+            kill -KILL "$pid" >/dev/null 2>&1 || true
+            wait "$pid" >/dev/null 2>&1 || true
+        elif [[ $controller_state -eq 2 ]]; then
+            cleanup_failed=true
+        fi
+    done
+    for pid in "${pids[@]}"; do
+        [[ "$pid" =~ ^[1-9][0-9]*$ ]] || continue
+        kill "$pid" >/dev/null 2>&1 || true
+        wait "$pid" >/dev/null 2>&1 || true
+    done
+    stop_inflight_operations || cleanup_failed=true
+    if ! $CLEANUP_COMPLETE; then
+        quit_owned_target A "$TARGET_A_PID" "$TARGET_A_IDENTITY" || cleanup_failed=true
+        quit_owned_target B "$TARGET_B_PID" "$TARGET_B_IDENTITY" || cleanup_failed=true
+        quit_recovery_targets || cleanup_failed=true
+    fi
+    finish_monitoring "$pre_cleanup_sequence" "$ARTIFACT_ROOT/cleanup-final-sample.json" || cleanup_failed=true
+    if $cleanup_failed; then
+        return 1
+    fi
+    return 0
+}
+trap cleanup EXIT
+trap 'exit 130' INT TERM
+
+clock_value() {
+    "$PROBE_BIN" clock | jq -er '.monotonicSeconds'
+}
+
+tracked_input_matches_commit() {
+    local file="$1"
+    local relative="${file#"$ROOT_DIR"/}"
+    local working_blob committed_blob
+    working_blob="$(git -C "$ROOT_DIR" hash-object "$file")" || return 1
+    committed_blob="$(git -C "$ROOT_DIR" rev-parse "$SOURCE_COMMIT:$relative")" || return 1
+    [[ "$working_blob" == "$committed_blob" ]]
+}
+
+capture_process_identity() {
+    local pid="$1"
+    local output="$2"
+    for _ in $(seq 1 50); do
+        if "$PROBE_BIN" process-identity --pid "$pid" --output "$output" 2>/dev/null; then
+            return 0
+        fi
+        sleep 0.005
+    done
+    return 1
+}
+
+capture_process_executable_identity() {
+    local pid="$1"
+    local output="$2"
+    local expected_path="$3"
+    for _ in $(seq 1 50); do
+        if "$PROBE_BIN" process-executable-identity --pid "$pid" --output "$output.tmp" 2>/dev/null && \
+           [[ "$(jq -r '.path // empty' "$output.tmp")" == "$expected_path" ]]; then
+            mv "$output.tmp" "$output"
+            return 0
+        fi
+        local state
+        state="$(ps -o state= -p "$pid" 2>/dev/null | tr -d '[:space:]' || true)"
+        [[ -n "$state" && "$state" != Z* ]] || break
+        sleep 0.005
+    done
+    rm -f "$output.tmp"
+    return 1
+}
+
+kill_and_reap_stopped_launcher() {
+    local pid="$1"
+    kill -KILL "$pid" >/dev/null 2>&1 || true
+    wait "$pid" >/dev/null 2>&1 || true
+    if [[ "$PENDING_LAUNCHER_PID" == "$pid" ]]; then
+        PENDING_LAUNCHER_PID=""
+    fi
+}
+
+wait_for_spawned_cli() {
+    local pid="$1"
+    local identity="$2"
+    local prefix="$3"
+    local resumed_at="$4"
+    local timeout_marker="$prefix-timeout.json"
+    local deadline term_at
+    deadline="$(awk -v resumed="$resumed_at" -v seconds="$OPERATION_TIMEOUT_SECONDS" \
+        'BEGIN { printf "%.9f", resumed + seconds }')"
+    term_at="$(awk -v resumed="$resumed_at" -v deadline="$deadline" \
+        -v seconds="$OPERATION_TIMEOUT_SECONDS" '
+        BEGIN {
+            grace = seconds * 0.1
+            if (grace > 1) grace = 1
+            candidate = deadline - grace
+            printf "%.9f", (candidate > resumed ? candidate : resumed)
+        }
+    ')"
+    (
+        local term_sent=false now
+        while true; do
+            local generation_state=0
+            process_generation_state "$pid" "$identity" || generation_state=$?
+            [[ $generation_state -ne 1 ]] || exit 0
+            now="$(clock_value 2>/dev/null || true)"
+            if ! [[ "$now" =~ ^[0-9]+([.][0-9]+)?$ ]]; then
+                jq -n --argjson pid "$pid" --arg identity "$identity" \
+                    '{pid: $pid, start_identity: $identity, reason: "clock_failed"}' \
+                    > "$timeout_marker.tmp"
+                mv "$timeout_marker.tmp" "$timeout_marker"
+                kill -KILL "$pid" >/dev/null 2>&1 || true
+                exit 0
+            fi
+            if awk -v now="$now" -v deadline="$deadline" 'BEGIN { exit !(now >= deadline) }'; then
+                if [[ -s "$timeout_marker" ]]; then
+                    jq --argjson killAt "$now" '. + {kill_at: $killAt}' \
+                        "$timeout_marker" > "$timeout_marker.tmp"
+                else
+                    jq -n --argjson pid "$pid" --arg identity "$identity" \
+                        --argjson resumedAt "$resumed_at" --argjson deadline "$deadline" \
+                        --argjson killAt "$now" --argjson seconds "$OPERATION_TIMEOUT_SECONDS" '
+                        {
+                            pid: $pid,
+                            start_identity: $identity,
+                            resumed_at: $resumedAt,
+                            deadline: $deadline,
+                            kill_at: $killAt,
+                            timeout_seconds: $seconds
+                        }
+                    ' > "$timeout_marker.tmp"
+                fi
+                mv "$timeout_marker.tmp" "$timeout_marker"
+                kill -KILL "$pid" >/dev/null 2>&1 || true
+                exit 0
+            fi
+            if ! $term_sent && \
+               awk -v now="$now" -v termAt="$term_at" 'BEGIN { exit !(now >= termAt) }'; then
+                jq -n --argjson pid "$pid" --arg identity "$identity" \
+                    --argjson resumedAt "$resumed_at" --argjson termAt "$term_at" \
+                    --argjson deadline "$deadline" --argjson seconds "$OPERATION_TIMEOUT_SECONDS" '
+                    {
+                        pid: $pid,
+                        start_identity: $identity,
+                        resumed_at: $resumedAt,
+                        term_at: $termAt,
+                        deadline: $deadline,
+                        timeout_seconds: $seconds
+                    }
+                ' > "$timeout_marker.tmp"
+                mv "$timeout_marker.tmp" "$timeout_marker"
+                kill "$pid" >/dev/null 2>&1 || exit 0
+                term_sent=true
+            fi
+            sleep 0.02
+        done
+    ) &
+    local timeout_pid=$!
+    local command_exit=0
+    wait "$pid" 2>/dev/null || command_exit=$?
+    kill -KILL "$timeout_pid" >/dev/null 2>&1 || true
+    wait "$timeout_pid" >/dev/null 2>&1 || true
+    [[ ! -s "$timeout_marker" ]] || return 124
+    return "$command_exit"
+}
+
+spawn_controlled_process() {
+    local prefix="$1"
+    local expected_path="$2"
+    shift 2
+    SPAWNED_PID=""
+    SPAWNED_IDENTITY=""
+    SPAWNED_PATH=""
+    SPAWNED_INFLIGHT=""
+    SPAWNED_RESUMED_AT=""
+    local ready="$prefix-launcher.ready"
+    local deferred_signal=""
+    trap 'deferred_signal=INT' INT
+    trap 'deferred_signal=TERM' TERM
+    /bin/sh -c '
+        ready=$1
+        shift
+        printf "%s\n" ready > "$ready"
+        kill -STOP "$$"
+        exec "$@"
+    ' sh "$ready" "$@" > "$prefix.json" 2> "$prefix.stderr" &
+    local pid
+    pid=$!
+    PENDING_LAUNCHER_PID="$pid"
+    trap 'exit 130' INT TERM
+    if [[ -n "$deferred_signal" ]]; then
+        kill_and_reap_stopped_launcher "$pid"
+        return 130
+    fi
+    for _ in $(seq 1 100); do
+        if [[ -s "$ready" && "$(ps -o state= -p "$pid" 2>/dev/null | tr -d '[:space:]')" == T* ]]; then
+            break
+        fi
+        sleep 0.005
+    done
+    if [[ ! -s "$ready" || "$(ps -o state= -p "$pid" 2>/dev/null | tr -d '[:space:]')" != T* ]]; then
+        kill_and_reap_stopped_launcher "$pid"
+        return 1
+    fi
+    if ! capture_process_identity "$pid" "$prefix-client-identity.json"; then
+        kill_and_reap_stopped_launcher "$pid"
+        return 1
+    fi
+    local identity
+    if ! identity="$(jq -er '.startIdentity' "$prefix-client-identity.json")"; then
+        kill_and_reap_stopped_launcher "$pid"
+        return 1
+    fi
+    local owner_pid
+    owner_pid="$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d '[:space:]' || true)"
+    [[ "$owner_pid" =~ ^[1-9][0-9]*$ ]] || {
+        kill_and_reap_stopped_launcher "$pid"
+        return 1
+    }
+    local inflight="$ARTIFACT_ROOT/controllers/inflight-${pid}-${identity}.json"
+    if ! jq -n --argjson pid "$pid" --arg identity "$identity" --arg expectedPath "$expected_path" \
+        --argjson ownerPID "$owner_pid" '
+        {
+            pid: $pid,
+            start_identity: $identity,
+            expected_executable_path: $expectedPath,
+            owner_pid: $ownerPID
+        }
+    ' > "$inflight.tmp" || \
+       ! mv "$inflight.tmp" "$inflight"; then
+        rm -f "$inflight.tmp"
+        kill_and_reap_stopped_launcher "$pid"
+        return 1
+    fi
+    PENDING_LAUNCHER_PID=""
+    SPAWNED_RESUMED_AT="$(clock_value)"
+    kill -CONT "$pid"
+    if ! capture_process_executable_identity "$pid" "$prefix-client.json" "$expected_path"; then
+        local process_state
+        process_state="$(ps -o state= -p "$pid" 2>/dev/null | tr -d '[:space:]' || true)"
+        if [[ "$process_state" != Z* && -n "$process_state" ]]; then
+            return 1
+        fi
+        jq -n --argjson pid "$pid" --arg identity "$identity" --arg path "$expected_path" '
+            {
+                pid: $pid,
+                startIdentity: $identity,
+                path: $path,
+                evidence: "exact exec argument; process exited before live path sampling"
+            }
+        ' > "$prefix-client.json"
+    fi
+    SPAWNED_PID="$pid"
+    SPAWNED_IDENTITY="$identity"
+    SPAWNED_PATH="$(jq -er '.path' "$prefix-client.json")"
+    SPAWNED_INFLIGHT="$inflight"
+}
+
+spawn_controlled_cli() {
+    local prefix="$1"
+    shift
+    spawn_controlled_process "$prefix" "$PEEKABOO_BIN" "$@"
+}
+
+monitor_watchdog() {
+    local last_sequence last_progress now maximum_stall=0 samples=0
+    last_sequence="$(jq -er '.sequence' "$ARTIFACT_ROOT/monitor-heartbeat.json")"
+    last_progress=$SECONDS
+    while [[ ! -f "$ARTIFACT_ROOT/monitor-watchdog.stop" ]]; do
+        local sequence
+        sequence="$(jq -r '.sequence // 0' "$ARTIFACT_ROOT/monitor-heartbeat.json" 2>/dev/null || printf '0')"
+        now=$SECONDS
+        if [[ "$sequence" =~ ^[0-9]+$ && "$sequence" -gt "$last_sequence" ]]; then
+            local stall=$((now - last_progress))
+            ((stall > maximum_stall)) && maximum_stall=$stall
+            last_sequence="$sequence"
+            last_progress=$now
+            samples=$((samples + 1))
+        elif ((now - last_progress >= 2)); then
+            jq -n --argjson success false --argjson lastSequence "$last_sequence" \
+                --argjson maximumStall "$((now - last_progress))" --argjson samples "$samples" \
+                '{success: $success, last_sequence: $lastSequence, maximum_stall_seconds: $maximumStall, samples: $samples}' \
+                > "$ARTIFACT_ROOT/monitor-watchdog.json"
+            return 1
+        fi
+        sleep 0.05
+    done
+    now=$SECONDS
+    local final_stall=$((now - last_progress))
+    ((final_stall > maximum_stall)) && maximum_stall=$final_stall
+    jq -n --argjson success true --argjson lastSequence "$last_sequence" \
+        --argjson maximumStall "$maximum_stall" --argjson samples "$samples" \
+        '{success: $success, last_sequence: $lastSequence, maximum_stall_seconds: $maximumStall, samples: $samples}' \
+        > "$ARTIFACT_ROOT/monitor-watchdog.json"
+}
+
+run_client_lifecycle_self_test() {
+    local saved_bin="$PEEKABOO_BIN"
+    local saved_bridge_socket="$BRIDGE_SOCKET"
+    local saved_probe_bin="$PROBE_BIN"
+    local saved_timeout="$OPERATION_TIMEOUT_SECONDS"
+    local timeout_exit=0 fast_exit=0 bounded_exit=0 mismatch_exit=0 direct_cleanup_exit=0
+    local timeout_pid timeout_identity timeout_inflight timeout_started timeout_finished timeout_elapsed
+    local timeout_deadline timeout_kill_at timeout_kill_overrun timeout_completion_overrun
+    PEEKABOO_BIN="$PROBE_BIN"
+    OPERATION_TIMEOUT_SECONDS=1
+    spawn_controlled_cli "$ARTIFACT_ROOT/results/lifecycle-timeout" "$PROBE_BIN" ignore-term
+    timeout_pid="$SPAWNED_PID"
+    timeout_identity="$SPAWNED_IDENTITY"
+    timeout_inflight="$SPAWNED_INFLIGHT"
+    timeout_started="$SPAWNED_RESUMED_AT"
+    set +e
+    wait_for_spawned_cli "$timeout_pid" "$timeout_identity" \
+        "$ARTIFACT_ROOT/results/lifecycle-timeout" "$SPAWNED_RESUMED_AT"
+    timeout_exit=$?
+    set -e
+    timeout_finished="$(clock_value)"
+    timeout_elapsed="$(awk -v started="$timeout_started" -v finished="$timeout_finished" \
+        'BEGIN { printf "%.6f", finished - started }')"
+    timeout_deadline="$(jq -er '.deadline' "$ARTIFACT_ROOT/results/lifecycle-timeout-timeout.json")"
+    timeout_kill_at="$(jq -er '.kill_at' "$ARTIFACT_ROOT/results/lifecycle-timeout-timeout.json")"
+    timeout_kill_overrun="$(awk -v deadline="$timeout_deadline" -v killed="$timeout_kill_at" \
+        'BEGIN { printf "%.6f", killed - deadline }')"
+    timeout_completion_overrun="$(awk -v deadline="$timeout_deadline" -v finished="$timeout_finished" \
+        'BEGIN { printf "%.6f", finished - deadline }')"
+    rm -f "$timeout_inflight"
+
+    spawn_controlled_process "$ARTIFACT_ROOT/results/lifecycle-direct-cleanup" /bin/sleep /bin/sleep 60
+    local direct_pid="$SPAWNED_PID"
+    local direct_identity="$SPAWNED_IDENTITY"
+    local direct_inflight="$SPAWNED_INFLIGHT"
+    set +e
+    terminate_owned_generation_directly lifecycle-self-test "$direct_pid" "$direct_identity" forced_self_test
+    direct_cleanup_exit=$?
+    set -e
+    local direct_generation_gone=false
+    owned_generation_gone "$direct_pid" "$direct_identity" && direct_generation_gone=true
+    $direct_generation_gone && rm -f "$direct_inflight"
+
+    spawn_controlled_process "$ARTIFACT_ROOT/results/lifecycle-unknown-cleanup" /bin/sleep /bin/sleep 60
+    local unknown_pid="$SPAWNED_PID"
+    local unknown_identity="$SPAWNED_IDENTITY"
+    PROBE_BIN=/usr/bin/false
+    local unknown_state=0
+    process_generation_state "$unknown_pid" "$unknown_identity" || unknown_state=$?
+    stop_inflight_operations
+    PROBE_BIN="$saved_probe_bin"
+    local unknown_cleanup_gone=false
+    owned_generation_gone "$unknown_pid" "$unknown_identity" && unknown_cleanup_gone=true
+
+    PEEKABOO_BIN=/usr/bin/true
+    spawn_controlled_cli "$ARTIFACT_ROOT/results/lifecycle-fast" /usr/bin/true
+    local fast_pid="$SPAWNED_PID"
+    local fast_identity="$SPAWNED_IDENTITY"
+    local fast_path="$SPAWNED_PATH"
+    local fast_inflight="$SPAWNED_INFLIGHT"
+    local fast_zombie_rejected=false fast_state
+    for _ in $(seq 1 100); do
+        fast_state="$(ps -o state= -p "$fast_pid" 2>/dev/null | tr -d '[:space:]' || true)"
+        if [[ -z "$fast_state" || "$fast_state" == Z* ]]; then
+            local fast_generation_state=0
+            process_generation_state "$fast_pid" "$fast_identity" || fast_generation_state=$?
+            [[ $fast_generation_state -eq 1 ]] && fast_zombie_rejected=true
+            break
+        fi
+        sleep 0.005
+    done
+    set +e
+    wait_for_spawned_cli "$fast_pid" "$fast_identity" \
+        "$ARTIFACT_ROOT/results/lifecycle-fast" "$SPAWNED_RESUMED_AT"
+    fast_exit=$?
+    set -e
+    rm -f "$fast_inflight"
+
+    BRIDGE_SOCKET=/tmp/peekaboo-lifecycle-self-test.sock
+    set +e
+    pb lifecycle-self-test >/dev/null
+    bounded_exit=$?
+    set -e
+
+    set +e
+    spawn_controlled_cli "$ARTIFACT_ROOT/results/lifecycle-mismatch" /bin/sleep 60
+    mismatch_exit=$?
+    set -e
+    local mismatch_receipt mismatch_pid mismatch_identity
+    mismatch_receipt="$(find "$ARTIFACT_ROOT/controllers" -maxdepth 1 -type f \
+        -name 'inflight-*.json' -print -quit)"
+    mismatch_pid="$(jq -er '.pid' "$mismatch_receipt")"
+    mismatch_identity="$(jq -er '.start_identity' "$mismatch_receipt")"
+    stop_inflight_operations
+    local mismatch_gone=false
+    owned_generation_gone "$mismatch_pid" "$mismatch_identity" && mismatch_gone=true
+
+    PEEKABOO_BIN="$saved_bin"
+    BRIDGE_SOCKET="$saved_bridge_socket"
+    OPERATION_TIMEOUT_SECONDS="$saved_timeout"
+    jq -n \
+        --argjson timeoutExit "$timeout_exit" --argjson fastExit "$fast_exit" \
+        --argjson timeoutElapsed "$timeout_elapsed" \
+        --argjson timeoutKillOverrun "$timeout_kill_overrun" \
+        --argjson timeoutCompletionOverrun "$timeout_completion_overrun" \
+        --argjson directCleanupExit "$direct_cleanup_exit" \
+        --argjson directGenerationGone "$direct_generation_gone" \
+        --argjson unknownState "$unknown_state" --argjson unknownCleanupGone "$unknown_cleanup_gone" \
+        --arg fastPath "$fast_path" --argjson boundedExit "$bounded_exit" \
+        --argjson fastZombieRejected "$fast_zombie_rejected" \
+        --argjson mismatchExit "$mismatch_exit" \
+        --argjson mismatchGone "$mismatch_gone" '
+        {
+            success: (
+                $timeoutExit == 124 and $timeoutElapsed >= 0.8 and
+                $timeoutKillOverrun >= 0 and $timeoutCompletionOverrun >= 0 and
+                $timeoutCompletionOverrun <= 0.5 and
+                $directCleanupExit == 0 and $directGenerationGone and
+                $unknownState == 2 and $unknownCleanupGone and
+                $fastExit == 0 and $fastPath == "/usr/bin/true" and
+                $fastZombieRejected and $boundedExit == 0 and
+                $mismatchExit != 0 and $mismatchGone
+            ),
+            timeout_exit: $timeoutExit,
+            timeout_elapsed_seconds: $timeoutElapsed,
+            timeout_kill_overrun_seconds: $timeoutKillOverrun,
+            timeout_completion_overrun_seconds: $timeoutCompletionOverrun,
+            direct_cleanup_exit: $directCleanupExit,
+            direct_generation_gone: $directGenerationGone,
+            unknown_state: $unknownState,
+            unknown_cleanup_gone: $unknownCleanupGone,
+            fast_exit: $fastExit,
+            fast_path: $fastPath,
+            fast_zombie_rejected: $fastZombieRejected,
+            bounded_runner_exit: $boundedExit,
+            mismatch_exit: $mismatchExit,
+            mismatch_generation_gone: $mismatchGone
+        }
+    '
+}
+
+self_test_cleanup() {
+    local pending_launcher_pid="$PENDING_LAUNCHER_PID"
+    PENDING_LAUNCHER_PID=""
+    if [[ "$pending_launcher_pid" =~ ^[1-9][0-9]*$ ]]; then
+        kill -KILL "$pending_launcher_pid" >/dev/null 2>&1 || true
+        wait "$pending_launcher_pid" >/dev/null 2>&1 || true
+    fi
+    stop_inflight_operations || true
+}
+
+if $SELF_TEST_ONLY; then
+    trap self_test_cleanup EXIT
+    node "$REPORTER" --self-test --catalog "$CATALOG" > "$ARTIFACT_ROOT/contract-self-test.json"
+    run_launch_ownership_self_test > "$ARTIFACT_ROOT/launch-ownership-self-test.json"
+    run_client_lifecycle_self_test > "$ARTIFACT_ROOT/client-lifecycle-self-test.json"
+    jq -n \
+        --slurpfile probe "$ARTIFACT_ROOT/probe-self-test.json" \
+        --slurpfile contract "$ARTIFACT_ROOT/contract-self-test.json" \
+        --slurpfile ownership "$ARTIFACT_ROOT/launch-ownership-self-test.json" \
+        --slurpfile lifecycle "$ARTIFACT_ROOT/client-lifecycle-self-test.json" \
+        '{
+            success: (
+                $probe[0].success and $contract[0].success and $ownership[0].success and
+                $lifecycle[0].success
+            ),
+            probe: $probe[0],
+            contract: $contract[0],
+            launch_ownership: $ownership[0],
+            client_lifecycle: $lifecycle[0]
+        }' \
+        > "$ARTIFACT_ROOT/summary.json"
+    jq -e '.success == true' "$ARTIFACT_ROOT/summary.json" >/dev/null
+    trap - EXIT INT TERM
+    printf 'Dual-controller overlap self-test passed: %s\n' "$ARTIFACT_ROOT"
+    exit 0
+fi
+
+live_overlap_receipt_contract_available() {
+    return 1
+}
+if ! live_overlap_receipt_contract_available; then
+    printf '%s\n' \
+        'Live overlap is reserved until every operation carries a same-connection opaque Bridge host receipt.' >&2
+    exit 2
+fi
+
+if [[ "${PEEKABOO_RUN_DUAL_CONTROLLER_OVERLAP:-}" != "1" ]]; then
+    printf '%s\n' 'Live overlap requires PEEKABOO_RUN_DUAL_CONTROLLER_OVERLAP=1.' >&2
+    exit 2
+fi
+if [[ "$(uname -s)" != "Darwin" ]]; then
+    printf '%s\n' 'Live overlap requires macOS.' >&2
+    exit 2
+fi
+if [[ "$PEEKABOO_BIN" != /* || ! -x "$PEEKABOO_BIN" ]]; then
+    printf '%s\n' '--bin must name an absolute executable.' >&2
+    exit 2
+fi
+if [[ "$BRIDGE_SOCKET" != /* || ! -S "$BRIDGE_SOCKET" ]]; then
+    printf '%s\n' '--bridge-socket must name one existing absolute Unix socket.' >&2
+    exit 2
+fi
+if [[ "$TEXTEDIT_APP" != /* || ! -d "$TEXTEDIT_APP" ]]; then
+    printf '%s\n' '--textedit-app must name an absolute app bundle.' >&2
+    exit 2
+fi
+TEXTEDIT_APP="$(cd "$TEXTEDIT_APP" && pwd -P)"
+TEXTEDIT_EXECUTABLE_NAME="$(plutil -extract CFBundleExecutable raw -o - "$TEXTEDIT_APP/Contents/Info.plist")"
+TEXTEDIT_EXECUTABLE="$TEXTEDIT_APP/Contents/MacOS/$TEXTEDIT_EXECUTABLE_NAME"
+if [[ "$TEXTEDIT_EXECUTABLE_NAME" == */* || ! -x "$TEXTEDIT_EXECUTABLE" ]]; then
+    printf '%s\n' '--textedit-app does not contain one valid main executable.' >&2
+    exit 2
+fi
+if ! [[ "$SENTINEL_PID" =~ ^[1-9][0-9]*$ && "$SENTINEL_WINDOW_ID" =~ ^[1-9][0-9]*$ ]]; then
+    printf '%s\n' '--sentinel-pid and --sentinel-window-id must be positive integers.' >&2
+    exit 2
+fi
+for command_name in codesign git; do
+    command -v "$command_name" >/dev/null 2>&1 || {
+        printf 'Missing required command: %s\n' "$command_name" >&2
+        exit 2
+    }
+done
+
+source_status="$ARTIFACT_ROOT/source-status.txt"
+git -C "$ROOT_DIR" status --porcelain --untracked-files=all > "$source_status"
+if [[ -s "$source_status" ]]; then
+    printf '%s\n' 'Live overlap requires one exact clean source tree.' >&2
+    exit 2
+fi
+SOURCE_COMMIT="$(git -C "$ROOT_DIR" rev-parse HEAD)"
+[[ "$SOURCE_COMMIT" =~ ^[0-9a-f]{40}$ ]] || exit 2
+SOURCE_INPUTS=(
+    "$ROOT_DIR/scripts/dual-controller-overlap-catalog.json"
+    "$ROOT_DIR/scripts/validate-dual-controller-overlap-report.mjs"
+    "$ROOT_DIR/scripts/support/background-computer-use-probe.swift"
+    "$ROOT_DIR/scripts/test-dual-controller-overlap.sh"
+)
+for source_input in "${SOURCE_INPUTS[@]}"; do
+    tracked_input_matches_commit "$source_input" || {
+        printf 'Certification input does not match %s: %s\n' "$SOURCE_COMMIT" "$source_input" >&2
+        exit 2
+    }
+done
+
+codesign --verify --strict "$PEEKABOO_BIN"
+codesign --verify --strict "$TEXTEDIT_APP"
+codesign -dv --verbose=4 "$PEEKABOO_BIN" > "$ARTIFACT_ROOT/cli-signature.txt" 2>&1
+if ! rg -q '^TeamIdentifier=[A-Z0-9]+$' "$ARTIFACT_ROOT/cli-signature.txt" || \
+   rg -q '^TeamIdentifier=not set$' "$ARTIFACT_ROOT/cli-signature.txt"; then
+    printf '%s\n' 'Live overlap requires a team-signed CLI.' >&2
+    exit 2
+fi
+CLI_CDHASH="$(sed -n 's/^CDHash=//p' "$ARTIFACT_ROOT/cli-signature.txt" | head -1)"
+CLI_SHA256="$(shasum -a 256 "$PEEKABOO_BIN" | awk '{print $1}')"
+[[ "$CLI_CDHASH" =~ ^[0-9a-f]{40}$ && "$CLI_SHA256" =~ ^[0-9a-f]{64}$ ]] || {
+    printf '%s\n' 'CLI signature does not expose a canonical code or file hash.' >&2
+    exit 2
+}
+CERTIFIED_PEEKABOO_BIN="$ARTIFACT_ROOT/bin/peekaboo-certified"
+cp -p "$PEEKABOO_BIN" "$CERTIFIED_PEEKABOO_BIN"
+chmod 500 "$CERTIFIED_PEEKABOO_BIN"
+codesign --verify --strict "$CERTIFIED_PEEKABOO_BIN"
+[[ "$(shasum -a 256 "$CERTIFIED_PEEKABOO_BIN" | awk '{print $1}')" == "$CLI_SHA256" ]] || {
+    printf '%s\n' 'Private CLI copy differs from the verified executable.' >&2
+    exit 2
+}
+PEEKABOO_BIN="$CERTIFIED_PEEKABOO_BIN"
+pb --version --json > "$ARTIFACT_ROOT/cli-version.json"
+CLI_SOURCE_COMMIT="$(jq -er '.data.sourceCommit | select(test("^[0-9a-f]{40}$"))' \
+    "$ARTIFACT_ROOT/cli-version.json")"
+if [[ "$CLI_SOURCE_COMMIT" != "$SOURCE_COMMIT" ]]; then
+    printf '%s\n' 'CLI source receipt does not match the clean checkout.' >&2
+    exit 2
+fi
+SOURCE_CATALOG="$CATALOG"
+SOURCE_REPORTER="$REPORTER"
+SOURCE_PROBE_SOURCE="$PROBE_SOURCE"
+CATALOG_SHA256_INITIAL="$(shasum -a 256 "$SOURCE_CATALOG" | awk '{print $1}')"
+REPORTER_SHA256_INITIAL="$(shasum -a 256 "$SOURCE_REPORTER" | awk '{print $1}')"
+PROBE_SOURCE_SHA256_INITIAL="$(shasum -a 256 "$SOURCE_PROBE_SOURCE" | awk '{print $1}')"
+CATALOG="$ARTIFACT_ROOT/bin/dual-controller-overlap-catalog.json"
+REPORTER="$ARTIFACT_ROOT/bin/validate-dual-controller-overlap-report.mjs"
+CERTIFIED_PROBE_SOURCE="$ARTIFACT_ROOT/bin/background-computer-use-probe.swift"
+cp -p "$SOURCE_CATALOG" "$CATALOG"
+cp -p "$SOURCE_REPORTER" "$REPORTER"
+cp -p "$SOURCE_PROBE_SOURCE" "$CERTIFIED_PROBE_SOURCE"
+chmod 400 "$CATALOG" "$REPORTER" "$CERTIFIED_PROBE_SOURCE"
+swiftc "$CERTIFIED_PROBE_SOURCE" -o "$PROBE_BIN" \
+    -framework AppKit -framework ApplicationServices -framework CoreGraphics -framework CryptoKit
+"$PROBE_BIN" self-test > "$ARTIFACT_ROOT/probe-live-self-test.json"
+
+pb bridge status --verbose --json > "$ARTIFACT_ROOT/bridge-before.json"
+jq -e --arg socket "$BRIDGE_SOCKET" --arg source "$SOURCE_COMMIT" '
+    .success == true and .data.selected.source == "remote" and
+    .data.selected.socketPath == $socket and
+    .data.selected.handshake.hostIdentity.sourceCommit == $source and
+    (.data.selected.handshake.hostIdentity.processIdentifier | type) == "number" and
+    ((.data.selected.handshake.hostIdentity.processStartIdentityDecimal // "") | test("^[1-9][0-9]*$")) and
+    ((.data.selected.handshake.hostIdentity.codeSignatureHash // "") | test("^[0-9a-f]{40}$"))
+' "$ARTIFACT_ROOT/bridge-before.json" >/dev/null || {
+    printf '%s\n' 'Bridge did not expose one signed current exact host generation.' >&2
+    exit 2
+}
+HOST_PID="$(jq -er '.data.selected.handshake.hostIdentity.processIdentifier' \
+    "$ARTIFACT_ROOT/bridge-before.json")"
+HOST_IDENTITY="$(jq -er '.data.selected.handshake.hostIdentity.processStartIdentityDecimal' \
+    "$ARTIFACT_ROOT/bridge-before.json")"
+HOST_CDHASH="$(jq -er '.data.selected.handshake.hostIdentity.codeSignatureHash' \
+    "$ARTIFACT_ROOT/bridge-before.json")"
+HOST_PROTOCOL_MAJOR="$(jq -er '.data.selected.handshake.negotiatedVersion.major' \
+    "$ARTIFACT_ROOT/bridge-before.json")"
+HOST_PROTOCOL_MINOR="$(jq -er '.data.selected.handshake.negotiatedVersion.minor' \
+    "$ARTIFACT_ROOT/bridge-before.json")"
+"$PROBE_BIN" process-executable --pid "$HOST_PID" --output "$ARTIFACT_ROOT/host-executable-before.json"
+HOST_SHA256="$(jq -er --arg identity "$HOST_IDENTITY" '
+    select((.startIdentity | tostring) == $identity) | .sha256 | select(test("^[0-9a-f]{64}$"))
+' "$ARTIFACT_ROOT/host-executable-before.json")"
+
+capture_host_receipt() {
+    local output="$1"
+    pb bridge status --verbose --json > "$output"
+    jq -e --argjson pid "$HOST_PID" --arg identity "$HOST_IDENTITY" \
+        --arg source "$SOURCE_COMMIT" --arg cdhash "$HOST_CDHASH" --arg socket "$BRIDGE_SOCKET" '
+        .data.selected.source == "remote" and .data.selected.socketPath == $socket and
+        .data.selected.handshake.hostIdentity.processIdentifier == $pid and
+        .data.selected.handshake.hostIdentity.processStartIdentityDecimal == $identity and
+        .data.selected.handshake.hostIdentity.sourceCommit == $source and
+        .data.selected.handshake.hostIdentity.codeSignatureHash == $cdhash
+    ' "$output" >/dev/null
+}
+
+capture_observation_route() {
+    local prefix="$1"
+    local target_pid="$2"
+    local target_window="$3"
+    local command_pid command_exit command_identity command_path target_identity_after reported_target_pid inflight
+    capture_host_receipt "$prefix-route-host-before.json"
+    spawn_controlled_cli "$prefix-route" \
+        "$PEEKABOO_BIN" window list --pid "$target_pid" --json --bridge-socket "$BRIDGE_SOCKET"
+    command_pid="$SPAWNED_PID"
+    command_identity="$SPAWNED_IDENTITY"
+    command_path="$SPAWNED_PATH"
+    inflight="$SPAWNED_INFLIGHT"
+    set +e
+    wait_for_spawned_cli "$command_pid" "$command_identity" "$prefix-route" "$SPAWNED_RESUMED_AT"
+    command_exit=$?
+    set -e
+    rm -f "$inflight"
+    [[ $command_exit -eq 0 ]]
+    capture_host_receipt "$prefix-route-host-after.json"
+    reported_target_pid="$(jq -er --argjson window "$target_window" '
+        select(.success == true and any(.data.windows[]; .window_id == $window)) |
+        .data.target_application_info.pid
+    ' "$prefix-route.json")"
+    "$PROBE_BIN" process-identity --pid "$target_pid" --output "$prefix-route-target-after.json"
+    target_identity_after="$(jq -er '.startIdentity' "$prefix-route-target-after.json")"
+    jq -n --argjson clientPID "$command_pid" --arg clientIdentity "$command_identity" \
+        --arg clientPath "$command_path" --argjson hostPID "$HOST_PID" \
+        --arg hostIdentity "$HOST_IDENTITY" --arg hostCDHash "$HOST_CDHASH" \
+        --argjson reportedTargetPID "$reported_target_pid" --argjson reportedWindow "$target_window" \
+        --arg targetIdentityAfter "$target_identity_after" '
+        {
+            client_pid: $clientPID,
+            client_start_identity: $clientIdentity,
+            client_executable_path: $clientPath,
+            host_pid: $hostPID,
+            host_start_identity: $hostIdentity,
+            host_code_signature_hash: $hostCDHash,
+            reported_target_pid: $reportedTargetPID,
+            reported_window_id: $reportedWindow,
+            target_start_identity_after: $targetIdentityAfter,
+            result_success: true
+        }
+    ' > "$prefix-route-receipt.json"
+}
+
+SENTINEL_IDENTITY="$("$PROBE_BIN" process-identity --pid "$SENTINEL_PID" | \
+    jq -er '.startIdentity | tostring')"
+pb window focus --pid "$SENTINEL_PID" --window-id "$SENTINEL_WINDOW_ID" --verify --json \
+    > "$ARTIFACT_ROOT/sentinel-focus.json"
+
+launch_textedit() {
+    local id="$1"
+    local prefix="$ARTIFACT_ROOT/results/launch-${id}-process"
+    local ownership_result="$ARTIFACT_ROOT/controllers/owned-target-${id}-direct.json"
+    local window_result="$ARTIFACT_ROOT/results/launch-${id}-window.json"
+    spawn_controlled_process "$prefix" "$TEXTEDIT_EXECUTABLE" \
+        "$TEXTEDIT_EXECUTABLE" -ApplePersistenceIgnoreState YES -NSQuitAlwaysKeepsWindows NO
+    local pid="$SPAWNED_PID"
+    local identity="$SPAWNED_IDENTITY"
+    local inflight="$SPAWNED_INFLIGHT"
+    [[ "$SPAWNED_PATH" == "$TEXTEDIT_EXECUTABLE" ]] || return 1
+    persist_owned_generation "$id" "$pid" "$identity" "$ownership_result"
+    rm -f "$inflight"
+    process_alive "$pid" "$identity" || return 1
+    pb app launch "PID:$pid" --wait-for-window --json > "$window_result"
+    LAUNCHED_WINDOW_ID="$(jq -er --argjson pid "$pid" --arg identity "$identity" '
+        .data as $data |
+        $data.process_start_identity_decimal as $returnedIdentity |
+        select(.success == true and $data.pid == $pid and $returnedIdentity == $identity and
+            $data.window_ready == true and $data.window_identity == "exact" and
+            ($data.window_ids | type) == "array" and ($data.window_ids | length) == 1 and
+            ($data.window_ids[0] | type) == "number" and $data.window_ids[0] > 0) |
+        $data.window_ids[0]
+    ' "$window_result")"
+}
+
+launch_textedit A
+TARGET_A_WINDOW_ID="$LAUNCHED_WINDOW_ID"
+launch_textedit B
+TARGET_B_WINDOW_ID="$LAUNCHED_WINDOW_ID"
+if [[ "$TARGET_A_PID" == "$TARGET_B_PID" || "$TARGET_A_WINDOW_ID" == "$TARGET_B_WINDOW_ID" ]]; then
+    printf '%s\n' 'TextEdit launch receipts are not distinct.' >&2
+    exit 1
+fi
+
+RUN_ID="overlap-$(uuidgen | tr '[:upper:]' '[:lower:]')"
+TOKEN_A_INITIAL="${RUN_ID}-a-initial"
+TOKEN_A_FIRST_APPEND="${RUN_ID}-a-first"
+TOKEN_A_AFTER_FIRST="${TOKEN_A_INITIAL}${TOKEN_A_FIRST_APPEND}"
+TOKEN_A_SECOND="${RUN_ID}-a-final"
+TOKEN_A_FINAL="${TOKEN_A_AFTER_FIRST}"$'\n'"${TOKEN_A_SECOND}"
+TOKEN_B_INITIAL="${RUN_ID}-b-initial"
+TOKEN_B_FINAL="${TOKEN_B_INITIAL}${RUN_ID}-b-1${RUN_ID}-b-2${RUN_ID}-b-3${RUN_ID}-b-4"
+
+pb type "$TOKEN_A_INITIAL" --pid "$TARGET_A_PID" --window-id "$TARGET_A_WINDOW_ID" --clear --json \
+    > "$ARTIFACT_ROOT/results/setup-a.json"
+pb type "$TOKEN_B_INITIAL" --pid "$TARGET_B_PID" --window-id "$TARGET_B_WINDOW_ID" --clear --json \
+    > "$ARTIFACT_ROOT/results/setup-b.json"
+pb window focus --pid "$SENTINEL_PID" --window-id "$SENTINEL_WINDOW_ID" --verify --json \
+    > "$ARTIFACT_ROOT/sentinel-refocus.json"
+"$PROBE_BIN" sample --no-clipboard-digest --output "$ARTIFACT_ROOT/baseline.json"
+jq -e --argjson pid "$SENTINEL_PID" --argjson window "$SENTINEL_WINDOW_ID" '
+    .frontmostPID == $pid and .frontmostWindowID == $window and .clipboardDigest == ""
+' "$ARTIFACT_ROOT/baseline.json" >/dev/null || {
+    printf '%s\n' 'Sentinel was not exact before monitoring.' >&2
+    exit 1
+}
+
+INVARIANT_NAMES='["sentinel_frontmost_pid","sentinel_top_window","physical_cursor","no_peekaboo_global_input","clipboard_change_count","peekaboo_alpha_overlay"]'
+printf '%s\n' running > "$ARTIFACT_ROOT/monitor-phase.txt"
+jq -n --argjson pid "$HOST_PID" --arg identity "$HOST_IDENTITY" \
+    '{revision: 1, producers: [{pid: $pid, startIdentity: $identity}]}' \
+    > "$ARTIFACT_ROOT/allowed-producers.json"
+"$PROBE_BIN" watch \
+    --baseline "$ARTIFACT_ROOT/baseline.json" \
+    --output "$ARTIFACT_ROOT/monitor-violations.jsonl" \
+    --contamination-output "$ARTIFACT_ROOT/monitor-contamination.jsonl" \
+    --ready "$ARTIFACT_ROOT/monitor.ready" \
+    --heartbeat "$ARTIFACT_ROOT/monitor-heartbeat.json" \
+    --phase "$ARTIFACT_ROOT/monitor-phase.txt" \
+    --allowed-producers "$ARTIFACT_ROOT/allowed-producers.json" \
+    --invariant-names "$INVARIANT_NAMES" \
+    --cursor-observational \
+    --physical-input-observational \
+    --interval-ms 20 &
+MONITOR_PID=$!
+for _ in $(seq 1 200); do
+    [[ -s "$ARTIFACT_ROOT/monitor.ready" && -s "$ARTIFACT_ROOT/monitor-heartbeat.json" ]] && break
+    sleep 0.01
+done
+if [[ ! -s "$ARTIFACT_ROOT/monitor.ready" || ! -s "$ARTIFACT_ROOT/monitor-heartbeat.json" ]]; then
+    printf '%s\n' 'Native invariant monitor did not become ready.' >&2
+    exit 1
+fi
+(monitor_watchdog) &
+WATCHDOG_PID=$!
+record_mutation() {
+    local controller="$1"
+    local index="$2"
+    local command_name="$3"
+    local mutation_phase="$4"
+    local target_pid="$5"
+    local target_window="$6"
+    shift 6
+    local prefix="$ARTIFACT_ROOT/results/${controller}-mutation-${index}"
+    local started finished command_exit=0 command_pid command_identity command_path target_identity_after inflight
+    capture_host_receipt "$prefix-host-before.json"
+    spawn_controlled_cli "$prefix" "$PEEKABOO_BIN" "$@" --json --bridge-socket "$BRIDGE_SOCKET"
+    command_pid="$SPAWNED_PID"
+    command_identity="$SPAWNED_IDENTITY"
+    command_path="$SPAWNED_PATH"
+    inflight="$SPAWNED_INFLIGHT"
+    started="$(clock_value)"
+    jq -n --arg controller "$controller" --argjson index "$index" \
+        --arg phase "$mutation_phase" --argjson pid "$command_pid" --arg identity "$command_identity" \
+        '{controller: $controller, index: $index, phase: $phase, pid: $pid, start_identity: $identity}' \
+        > "$ARTIFACT_ROOT/controllers/${controller}-active.tmp"
+    mv "$ARTIFACT_ROOT/controllers/${controller}-active.tmp" \
+        "$ARTIFACT_ROOT/controllers/${controller}-active.json"
+    set +e
+    wait_for_spawned_cli "$command_pid" "$command_identity" "$prefix" "$SPAWNED_RESUMED_AT"
+    command_exit=$?
+    set -e
+    finished="$(clock_value)"
+    rm -f "$inflight"
+    capture_host_receipt "$prefix-host-after.json"
+    "$PROBE_BIN" process-identity --pid "$target_pid" --output "$prefix-target-after.json"
+    target_identity_after="$(jq -er '.startIdentity | tostring' "$prefix-target-after.json")"
+    jq -n \
+        --argjson index "$index" --arg command "$command_name" --arg phase "$mutation_phase" \
+        --argjson started "$started" --argjson finished "$finished" \
+        --argjson targetPID "$target_pid" --argjson targetWindow "$target_window" \
+        --argjson clientPID "$command_pid" --arg clientIdentity "$command_identity" \
+        --arg clientPath "$command_path" --argjson hostPID "$HOST_PID" \
+        --arg hostIdentity "$HOST_IDENTITY" --arg hostCDHash "$HOST_CDHASH" \
+        --arg targetIdentityAfter "$target_identity_after" \
+        --argjson commandExit "$command_exit" --slurpfile result "$prefix.json" '
+        ($result[0] // {}) as $result |
+        {
+            index: $index,
+            command: $command,
+            phase: $phase,
+            started_at: $started,
+            finished_at: $finished,
+            target_pid: $targetPID,
+            target_window_id: $targetWindow,
+            client_pid: $clientPID,
+            client_start_identity: $clientIdentity,
+            client_executable_path: $clientPath,
+            host_pid: $hostPID,
+            host_start_identity: $hostIdentity,
+            host_code_signature_hash: $hostCDHash,
+            reported_target_pid: ($result.data.targetPID // $result.data.target_pid // null),
+            reported_target_window_id: ($result.data.targetWindowID // $result.data.target_window_id // null),
+            target_start_identity_after: $targetIdentityAfter,
+            delivery_mode: ($result.data.deliveryMode // $result.data.delivery_mode // null),
+            success: ($commandExit == 0 and $result.success == true),
+            effect: ($result.outcome.effect // $result.effect // null),
+            mutation_dispatched: (
+                if (($result.outcome | type) == "object" and ($result.outcome | has("mutation_dispatched")))
+                then $result.outcome.mutation_dispatched
+                elif (($result.error | type) == "object" and ($result.error | has("mutation_dispatched")))
+                then $result.error.mutation_dispatched else null end
+            ),
+            retry_safe: (
+                if (($result.outcome | type) == "object" and ($result.outcome | has("retry_safe")))
+                then $result.outcome.retry_safe
+                elif (($result.error | type) == "object" and ($result.error | has("retry_safe")))
+                then $result.error.retry_safe else null end
+            ),
+            foreground: false
+        }
+    ' >> "$ARTIFACT_ROOT/controllers/${controller}-mutations.jsonl"
+    [[ $command_exit -eq 0 ]]
+}
+
+record_observation() {
+    local controller="$1"
+    local index="$2"
+    local target_pid="$3"
+    local target_window="$4"
+    local expected_token="$5"
+    local prefix="$ARTIFACT_ROOT/results/${controller}-observation-${index}"
+    local started finished command_pid command_exit command_identity command_path target_identity_after inflight
+    capture_host_receipt "$prefix-host-before.json"
+    spawn_controlled_cli "$prefix" \
+        "$PEEKABOO_BIN" see --tree --no-screenshot --pid "$target_pid" --window-id "$target_window" \
+        --json --bridge-socket "$BRIDGE_SOCKET"
+    command_pid="$SPAWNED_PID"
+    command_identity="$SPAWNED_IDENTITY"
+    command_path="$SPAWNED_PATH"
+    inflight="$SPAWNED_INFLIGHT"
+    started="$(clock_value)"
+    set +e
+    wait_for_spawned_cli "$command_pid" "$command_identity" "$prefix" "$SPAWNED_RESUMED_AT"
+    command_exit=$?
+    set -e
+    rm -f "$inflight"
+    capture_host_receipt "$prefix-host-after.json"
+    [[ $command_exit -eq 0 ]]
+    "$PROBE_BIN" process-identity --pid "$target_pid" --output "$prefix-target-after.json"
+    target_identity_after="$(jq -er '.startIdentity' "$prefix-target-after.json")"
+    capture_observation_route "$prefix" "$target_pid" "$target_window"
+    finished="$(clock_value)"
+    jq -n \
+        --argjson index "$index" --argjson started "$started" --argjson finished "$finished" \
+        --argjson targetPID "$target_pid" --argjson targetWindow "$target_window" \
+        --argjson clientPID "$command_pid" --arg clientIdentity "$command_identity" \
+        --arg clientPath "$command_path" --argjson hostPID "$HOST_PID" \
+        --arg hostIdentity "$HOST_IDENTITY" --arg hostCDHash "$HOST_CDHASH" \
+        --arg targetIdentityAfter "$target_identity_after" \
+        --arg expected "$expected_token" --arg runID "$RUN_ID" \
+        --slurpfile result "$prefix.json" --slurpfile route "$prefix-route-receipt.json" '
+        [$result[0].data.ui_elements[]? | .value? | select(type == "string")] as $values |
+        ($values | any(. == $expected)) as $present |
+        ($values | all((contains($runID) | not) or . == $expected)) as $otherAbsent |
+        {
+            index: $index,
+            started_at: $started,
+            finished_at: $finished,
+            target_pid: $targetPID,
+            target_window_id: $targetWindow,
+            client_pid: $clientPID,
+            client_start_identity: $clientIdentity,
+            client_executable_path: $clientPath,
+            host_pid: $hostPID,
+            host_start_identity: $hostIdentity,
+            host_code_signature_hash: $hostCDHash,
+            result_success: ($result[0].success == true),
+            reported_window_id: ($result[0].data.observation.target.window_id // null),
+            target_start_identity_after: $targetIdentityAfter,
+            route_receipt: $route[0],
+            expected_token: $expected,
+            token_present: $present,
+            other_token_absent: $otherAbsent
+        }
+    ' >> "$ARTIFACT_ROOT/controllers/${controller}-observations.jsonl"
+    jq -e --arg expected "$expected_token" --arg runID "$RUN_ID" '
+        select(.success == true) |
+        [.data.ui_elements[]? | .value? | select(type == "string")] as $values |
+        ($values | any(. == $expected)) and
+        ($values | all((contains($runID) | not) or . == $expected))
+    ' "$prefix.json" >/dev/null
+}
+
+first_mutation_barrier() {
+    local controller="$1"
+    : > "$ARTIFACT_ROOT/controllers/${controller}-first-mutation.ready"
+    for _ in $(seq 1 500); do
+        if [[ -f "$ARTIFACT_ROOT/controllers/A-first-mutation.ready" && \
+              -f "$ARTIFACT_ROOT/controllers/B-first-mutation.ready" ]]; then
+            return 0
+        fi
+        sleep 0.01
+    done
+    return 1
+}
+
+phase_barrier() {
+    local phase="$1"
+    local controller="$2"
+    : > "$ARTIFACT_ROOT/controllers/${controller}-${phase}.ready"
+    for _ in $(seq 1 500); do
+        if [[ -f "$ARTIFACT_ROOT/controllers/A-${phase}.ready" && \
+              -f "$ARTIFACT_ROOT/controllers/B-${phase}.ready" ]]; then
+            return 0
+        fi
+        sleep 0.01
+    done
+    return 1
+}
+
+overlap_witness() {
+    local a_marker="$ARTIFACT_ROOT/controllers/A-active.json"
+    local b_marker="$ARTIFACT_ROOT/controllers/B-active.json"
+    local a_snapshot="$ARTIFACT_ROOT/controllers/witness-A-active.json"
+    local b_snapshot="$ARTIFACT_ROOT/controllers/witness-B-active.json"
+    for _ in $(seq 1 1000); do
+        if [[ -s "$a_marker" && -s "$b_marker" ]]; then
+            local a_pid a_identity b_pid b_identity
+            local a_checked_before_at b_checked_at a_checked_after_at
+            cp "$a_marker" "$a_snapshot.tmp" || continue
+            cp "$b_marker" "$b_snapshot.tmp" || continue
+            mv "$a_snapshot.tmp" "$a_snapshot"
+            mv "$b_snapshot.tmp" "$b_snapshot"
+            if ! jq -e '
+                keys == ["controller", "index", "phase", "pid", "start_identity"] and
+                .controller == "A" and (.index | type) == "number" and .index > 0 and
+                .phase == "workflow" and (.pid | type) == "number" and .pid > 0 and
+                ((.start_identity // "") | test("^[1-9][0-9]*$"))
+            ' "$a_snapshot" >/dev/null || \
+               ! jq -e '
+                keys == ["controller", "index", "phase", "pid", "start_identity"] and
+                .controller == "B" and (.index | type) == "number" and .index > 0 and
+                .phase == "workflow" and (.pid | type) == "number" and .pid > 0 and
+                ((.start_identity // "") | test("^[1-9][0-9]*$"))
+            ' "$b_snapshot" >/dev/null; then
+                sleep 0.01
+                continue
+            fi
+            a_pid="$(jq -er '.pid' "$a_snapshot")"
+            a_identity="$(jq -er '.start_identity' "$a_snapshot")"
+            b_pid="$(jq -er '.pid' "$b_snapshot")"
+            b_identity="$(jq -er '.start_identity' "$b_snapshot")"
+            if process_alive "$a_pid" "$a_identity"; then
+                a_checked_before_at="$(clock_value)"
+                if ! process_alive "$b_pid" "$b_identity"; then
+                    sleep 0.01
+                    continue
+                fi
+                b_checked_at="$(clock_value)"
+                if ! process_alive "$a_pid" "$a_identity"; then
+                    sleep 0.01
+                    continue
+                fi
+                a_checked_after_at="$(clock_value)"
+                if ! cmp -s "$a_snapshot" "$a_marker" || ! cmp -s "$b_snapshot" "$b_marker"; then
+                    sleep 0.01
+                    continue
+                fi
+                jq -n --argjson aPID "$a_pid" --arg aIdentity "$a_identity" \
+                    --argjson bPID "$b_pid" --arg bIdentity "$b_identity" \
+                    --argjson aCheckedBeforeAt "$a_checked_before_at" \
+                    --argjson bCheckedAt "$b_checked_at" \
+                    --argjson aCheckedAfterAt "$a_checked_after_at" \
+                    --slurpfile aMarker "$a_snapshot" --slurpfile bMarker "$b_snapshot" '
+                    {
+                        a_pid: $aPID, a_start_identity: $aIdentity,
+                        b_pid: $bPID, b_start_identity: $bIdentity,
+                        a_checked_before_at: $aCheckedBeforeAt,
+                        b_checked_at: $bCheckedAt,
+                        a_checked_after_at: $aCheckedAfterAt,
+                        observed_at: $bCheckedAt,
+                        a_active_marker: $aMarker[0],
+                        b_active_marker: $bMarker[0],
+                        markers_unchanged: true
+                    }
+                ' > "$ARTIFACT_ROOT/controllers/simultaneous-liveness.json"
+                return 0
+            fi
+        fi
+        sleep 0.01
+    done
+    return 1
+}
+
+controller_a() {
+    while [[ ! -f "$ARTIFACT_ROOT/controllers/start.barrier" ]]; do sleep 0.01; done
+    local started finished
+    started="$(clock_value)"
+    record_observation A 1 "$TARGET_A_PID" "$TARGET_A_WINDOW_ID" "$TOKEN_A_INITIAL"
+    first_mutation_barrier A
+    record_mutation A 1 type workflow "$TARGET_A_PID" "$TARGET_A_WINDOW_ID" \
+        type "$TOKEN_A_FIRST_APPEND" --pid "$TARGET_A_PID" --window-id "$TARGET_A_WINDOW_ID" --delay 15ms
+    record_observation A 2 "$TARGET_A_PID" "$TARGET_A_WINDOW_ID" "$TOKEN_A_AFTER_FIRST"
+    sleep 0.05
+    record_mutation A 2 press workflow "$TARGET_A_PID" "$TARGET_A_WINDOW_ID" \
+        press Return --pid "$TARGET_A_PID" --window-id "$TARGET_A_WINDOW_ID"
+    record_mutation A 3 type workflow "$TARGET_A_PID" "$TARGET_A_WINDOW_ID" \
+        type "$TOKEN_A_SECOND" --pid "$TARGET_A_PID" --window-id "$TARGET_A_WINDOW_ID"
+    phase_barrier workflow-complete A
+    record_observation A 3 "$TARGET_A_PID" "$TARGET_A_WINDOW_ID" "$TOKEN_A_FINAL"
+    record_mutation A 4 type restoration "$TARGET_A_PID" "$TARGET_A_WINDOW_ID" \
+        type "$TOKEN_A_INITIAL" --pid "$TARGET_A_PID" --window-id "$TARGET_A_WINDOW_ID" --clear
+    phase_barrier restoration-complete A
+    record_observation A 4 "$TARGET_A_PID" "$TARGET_A_WINDOW_ID" "$TOKEN_A_INITIAL"
+    finished="$(clock_value)"
+    jq -s '.' "$ARTIFACT_ROOT/controllers/A-mutations.jsonl" > "$ARTIFACT_ROOT/controllers/A-mutations.json"
+    jq -s '.' "$ARTIFACT_ROOT/controllers/A-observations.jsonl" > "$ARTIFACT_ROOT/controllers/A-observations.json"
+    jq -n --argjson started "$started" --argjson finished "$finished" \
+        --arg initial "$TOKEN_A_INITIAL" --arg final "$TOKEN_A_FINAL" \
+        '{started_at: $started, finished_at: $finished, initial_token: $initial, final_token: $final}' \
+        > "$ARTIFACT_ROOT/controllers/A-meta.json"
+}
+
+controller_b() {
+    while [[ ! -f "$ARTIFACT_ROOT/controllers/start.barrier" ]]; do sleep 0.01; done
+    local started finished token state
+    started="$(clock_value)"
+    state="$TOKEN_B_INITIAL"
+    record_observation B 1 "$TARGET_B_PID" "$TARGET_B_WINDOW_ID" "$state"
+    first_mutation_barrier B
+    for index in 1 2 3 4; do
+        token="${RUN_ID}-b-${index}"
+        if [[ $index -eq 1 ]]; then
+            record_mutation B "$index" type workflow "$TARGET_B_PID" "$TARGET_B_WINDOW_ID" \
+                type "$token" --pid "$TARGET_B_PID" --window-id "$TARGET_B_WINDOW_ID" --delay 15ms
+        else
+            record_mutation B "$index" type workflow "$TARGET_B_PID" "$TARGET_B_WINDOW_ID" \
+                type "$token" --pid "$TARGET_B_PID" --window-id "$TARGET_B_WINDOW_ID"
+        fi
+        state="${state}${token}"
+        if [[ $index -lt 4 ]]; then
+            record_observation B "$((index + 1))" "$TARGET_B_PID" "$TARGET_B_WINDOW_ID" "$state"
+        fi
+        sleep 0.08
+    done
+    phase_barrier workflow-complete B
+    record_observation B 5 "$TARGET_B_PID" "$TARGET_B_WINDOW_ID" "$state"
+    record_mutation B 5 type restoration "$TARGET_B_PID" "$TARGET_B_WINDOW_ID" \
+        type "$TOKEN_B_INITIAL" --pid "$TARGET_B_PID" --window-id "$TARGET_B_WINDOW_ID" --clear
+    phase_barrier restoration-complete B
+    record_observation B 6 "$TARGET_B_PID" "$TARGET_B_WINDOW_ID" "$TOKEN_B_INITIAL"
+    finished="$(clock_value)"
+    jq -s '.' "$ARTIFACT_ROOT/controllers/B-mutations.jsonl" > "$ARTIFACT_ROOT/controllers/B-mutations.json"
+    jq -s '.' "$ARTIFACT_ROOT/controllers/B-observations.jsonl" > "$ARTIFACT_ROOT/controllers/B-observations.json"
+    jq -n --argjson started "$started" --argjson finished "$finished" \
+        --arg initial "$TOKEN_B_INITIAL" --arg final "$TOKEN_B_FINAL" \
+        '{started_at: $started, finished_at: $finished, initial_token: $initial, final_token: $final}' \
+        > "$ARTIFACT_ROOT/controllers/B-meta.json"
+}
+
+(controller_a) &
+CLIENT_A_PID=$!
+CLIENT_A_RECEIPT_PID="$CLIENT_A_PID"
+"$PROBE_BIN" process-identity --pid "$CLIENT_A_PID" --output "$ARTIFACT_ROOT/controllers/A-client.json"
+CLIENT_A_IDENTITY="$(jq -er '.startIdentity | tostring' "$ARTIFACT_ROOT/controllers/A-client.json")"
+(controller_b) &
+CLIENT_B_PID=$!
+CLIENT_B_RECEIPT_PID="$CLIENT_B_PID"
+"$PROBE_BIN" process-identity --pid "$CLIENT_B_PID" --output "$ARTIFACT_ROOT/controllers/B-client.json"
+CLIENT_B_IDENTITY="$(jq -er '.startIdentity | tostring' "$ARTIFACT_ROOT/controllers/B-client.json")"
+(overlap_witness) &
+OVERLAP_WITNESS_PID=$!
+: > "$ARTIFACT_ROOT/controllers/start.barrier"
+
+set +e
+wait "$CLIENT_A_PID"; CLIENT_A_EXIT=$?
+CLIENT_A_PID=""
+wait "$CLIENT_B_PID"; CLIENT_B_EXIT=$?
+CLIENT_B_PID=""
+wait "$OVERLAP_WITNESS_PID"; OVERLAP_WITNESS_EXIT=$?
+OVERLAP_WITNESS_PID=""
+set -e
+if [[ $CLIENT_A_EXIT -ne 0 || $CLIENT_B_EXIT -ne 0 || $OVERLAP_WITNESS_EXIT -ne 0 ]]; then
+    printf 'Overlap clients failed: A=%s B=%s witness=%s\n' \
+        "$CLIENT_A_EXIT" "$CLIENT_B_EXIT" "$OVERLAP_WITNESS_EXIT" >&2
+    exit 1
+fi
+
+PRE_CLEANUP_SEQUENCE="$(jq -er '.sequence' "$ARTIFACT_ROOT/monitor-heartbeat.json")"
+quit_owned_target A "$TARGET_A_PID" "$TARGET_A_IDENTITY"
+quit_owned_target B "$TARGET_B_PID" "$TARGET_B_IDENTITY"
+A_GONE=true
+B_GONE=true
+CLEANUP_COMPLETE=true
+finish_monitoring "$PRE_CLEANUP_SEQUENCE" "$ARTIFACT_ROOT/final-sample.json"
+
+pb bridge status --verbose --json > "$ARTIFACT_ROOT/bridge-after.json"
+"$PROBE_BIN" process-executable --pid "$HOST_PID" --output "$ARTIFACT_ROOT/host-executable-after.json"
+HOST_STABLE=false
+if jq -e --argjson pid "$HOST_PID" --arg identity "$HOST_IDENTITY" --arg source "$SOURCE_COMMIT" \
+    --arg cdhash "$HOST_CDHASH" --arg socket "$BRIDGE_SOCKET" '
+    .data.selected.source == "remote" and .data.selected.socketPath == $socket and
+    .data.selected.handshake.hostIdentity.processIdentifier == $pid and
+    .data.selected.handshake.hostIdentity.processStartIdentityDecimal == $identity and
+    .data.selected.handshake.hostIdentity.sourceCommit == $source and
+    .data.selected.handshake.hostIdentity.codeSignatureHash == $cdhash
+' "$ARTIFACT_ROOT/bridge-after.json" >/dev/null && \
+   jq -e --arg identity "$HOST_IDENTITY" --arg sha "$HOST_SHA256" '
+    (.startIdentity | tostring) == $identity and .sha256 == $sha
+' "$ARTIFACT_ROOT/host-executable-after.json" >/dev/null; then
+    HOST_STABLE=true
+fi
+
+MONITOR_CLEAN=false
+if [[ ! -s "$ARTIFACT_ROOT/monitor-violations.jsonl" && \
+      ! -s "$ARTIFACT_ROOT/monitor-contamination.jsonl" ]] && \
+   jq -e '.success == true and .samples > 0 and .maximum_stall_seconds < 2' \
+      "$ARTIFACT_ROOT/monitor-watchdog.json" >/dev/null && \
+   jq -e --argjson sequence "$PRE_CLEANUP_SEQUENCE" --slurpfile final "$ARTIFACT_ROOT/final-sample.json" '
+      .inputAttributionAvailable == true and .contaminationBlocked == false and
+      .allowedProducerRevision == 1 and .sequence > $sequence and .timestamp >= $final[0].timestamp and
+      .pendingActivationCount == 0 and .pendingFocusedWindowChange == false
+   ' \
+      "$ARTIFACT_ROOT/monitor-heartbeat.json" >/dev/null; then
+    MONITOR_CLEAN=true
+fi
+git -C "$ROOT_DIR" status --porcelain --untracked-files=all > "$ARTIFACT_ROOT/source-status-final.txt"
+for source_input in "${SOURCE_INPUTS[@]}"; do
+    tracked_input_matches_commit "$source_input" || {
+        printf 'Certification input changed from %s: %s\n' "$SOURCE_COMMIT" "$source_input" >&2
+        exit 1
+    }
+done
+if [[ "$(git -C "$ROOT_DIR" rev-parse HEAD)" != "$SOURCE_COMMIT" || \
+      -s "$ARTIFACT_ROOT/source-status-final.txt" || \
+      "$(shasum -a 256 "$SOURCE_CATALOG" | awk '{print $1}')" != "$CATALOG_SHA256_INITIAL" || \
+      "$(shasum -a 256 "$SOURCE_REPORTER" | awk '{print $1}')" != "$REPORTER_SHA256_INITIAL" || \
+      "$(shasum -a 256 "$SOURCE_PROBE_SOURCE" | awk '{print $1}')" != "$PROBE_SOURCE_SHA256_INITIAL" ]]; then
+    printf '%s\n' 'Source head or certification contract changed during the live run.' >&2
+    exit 1
+fi
+CATALOG_SHA256="$CATALOG_SHA256_INITIAL"
+
+jq -n \
+    --arg id A --argjson clientPID "$CLIENT_A_RECEIPT_PID" \
+    --arg clientIdentity "$CLIENT_A_IDENTITY" \
+    --argjson targetPID "$TARGET_A_PID" --arg targetIdentity "$TARGET_A_IDENTITY" \
+    --argjson targetWindow "$TARGET_A_WINDOW_ID" \
+    --slurpfile meta "$ARTIFACT_ROOT/controllers/A-meta.json" \
+    --slurpfile mutations "$ARTIFACT_ROOT/controllers/A-mutations.json" \
+    --slurpfile observations "$ARTIFACT_ROOT/controllers/A-observations.json" '
+    {
+        id: $id,
+        controller_process: {pid: $clientPID, start_identity: $clientIdentity},
+        target: {pid: $targetPID, start_identity: $targetIdentity, window_id: $targetWindow},
+        started_at: $meta[0].started_at,
+        finished_at: $meta[0].finished_at,
+        mutations: $mutations[0],
+        observations: $observations[0],
+        initial_token: $meta[0].initial_token,
+        final_token: $meta[0].final_token,
+        readback_token: $meta[0].final_token,
+        restored_token: $meta[0].initial_token,
+        restoration_readback: $meta[0].initial_token,
+        cross_target_clear: (all($observations[0][]; .other_token_absent == true))
+    }
+' > "$ARTIFACT_ROOT/controllers/A-report.json"
+
+jq -n \
+    --arg id B --argjson clientPID "$CLIENT_B_RECEIPT_PID" \
+    --arg clientIdentity "$CLIENT_B_IDENTITY" \
+    --argjson targetPID "$TARGET_B_PID" --arg targetIdentity "$TARGET_B_IDENTITY" \
+    --argjson targetWindow "$TARGET_B_WINDOW_ID" \
+    --slurpfile meta "$ARTIFACT_ROOT/controllers/B-meta.json" \
+    --slurpfile mutations "$ARTIFACT_ROOT/controllers/B-mutations.json" \
+    --slurpfile observations "$ARTIFACT_ROOT/controllers/B-observations.json" '
+    {
+        id: $id,
+        controller_process: {pid: $clientPID, start_identity: $clientIdentity},
+        target: {pid: $targetPID, start_identity: $targetIdentity, window_id: $targetWindow},
+        started_at: $meta[0].started_at,
+        finished_at: $meta[0].finished_at,
+        mutations: $mutations[0],
+        observations: $observations[0],
+        initial_token: $meta[0].initial_token,
+        final_token: $meta[0].final_token,
+        readback_token: $meta[0].final_token,
+        restored_token: $meta[0].initial_token,
+        restoration_readback: $meta[0].initial_token,
+        cross_target_clear: (all($observations[0][]; .other_token_absent == true))
+    }
+' > "$ARTIFACT_ROOT/controllers/B-report.json"
+
+jq -n \
+    --argjson a "$(cat "$ARTIFACT_ROOT/controllers/A-report.json")" \
+    --argjson b "$(cat "$ARTIFACT_ROOT/controllers/B-report.json")" \
+    --slurpfile witness "$ARTIFACT_ROOT/controllers/simultaneous-liveness.json" '
+    [
+        ($a.mutations[] | select(.phase == "workflow")) as $am |
+        ($b.mutations[] | select(.phase == "workflow")) as $bm |
+        ([$am.started_at, $bm.started_at] | max) as $pairStart |
+        ([$am.finished_at, $bm.finished_at] | min) as $pairFinish |
+        select($pairFinish > $pairStart) |
+        {
+            a_index: $am.index,
+            b_index: $bm.index,
+            a_client_pid: $am.client_pid,
+            a_client_start_identity: $am.client_start_identity,
+            b_client_pid: $bm.client_pid,
+            b_client_start_identity: $bm.client_start_identity,
+            started_at: $pairStart,
+            finished_at: $pairFinish,
+            seconds: ($pairFinish - $pairStart)
+        }
+    ] as $pairs |
+    ($pairs | map(.started_at) | min) as $start |
+    ($pairs | map(.finished_at) | max) as $finish |
+    {
+        started_at: $start,
+        finished_at: $finish,
+        seconds: ($pairs | map(.seconds) | add // 0),
+        a_mutations_during_b: ([$pairs[].a_index] | unique | length),
+        b_mutations_during_a: ([$pairs[].b_index] | unique | length),
+        concurrent_mutation_pairs: $pairs,
+        simultaneous_liveness_witness: $witness[0]
+    }
+' > "$ARTIFACT_ROOT/overlap.json"
+
+jq -n \
+    --argjson version 1 --arg catalogSHA "$CATALOG_SHA256" --arg runID "$RUN_ID" \
+    --arg source "$SOURCE_COMMIT" --arg cliCDHash "$CLI_CDHASH" --arg cliSHA "$CLI_SHA256" \
+    --arg cliPath "$PEEKABOO_BIN" \
+    --argjson hostPID "$HOST_PID" --arg hostIdentity "$HOST_IDENTITY" \
+    --arg socket "$BRIDGE_SOCKET" --arg cdhash "$HOST_CDHASH" --arg hostSHA "$HOST_SHA256" \
+    --argjson protocolMajor "$HOST_PROTOCOL_MAJOR" --argjson protocolMinor "$HOST_PROTOCOL_MINOR" \
+    --argjson hostStable "$HOST_STABLE" \
+    --argjson sentinelPID "$SENTINEL_PID" --arg sentinelIdentity "$SENTINEL_IDENTITY" \
+    --argjson sentinelWindow "$SENTINEL_WINDOW_ID" \
+    --slurpfile baseline "$ARTIFACT_ROOT/baseline.json" --slurpfile final "$ARTIFACT_ROOT/final-sample.json" \
+    --slurpfile heartbeat "$ARTIFACT_ROOT/monitor-heartbeat.json" \
+    --slurpfile a "$ARTIFACT_ROOT/controllers/A-report.json" \
+    --slurpfile b "$ARTIFACT_ROOT/controllers/B-report.json" \
+    --slurpfile overlap "$ARTIFACT_ROOT/overlap.json" \
+    --argjson monitorClean "$MONITOR_CLEAN" --argjson aGone "$A_GONE" --argjson bGone "$B_GONE" '
+    {
+        version: $version,
+        catalog_sha256: $catalogSHA,
+        run_id: $runID,
+        source_commit: $source,
+        cli: {
+            source_commit: $source,
+            code_signature_hash: $cliCDHash,
+            executable_sha256: $cliSHA,
+            executable_path: $cliPath
+        },
+        host: {
+            pid: $hostPID, start_identity: $hostIdentity, socket_path: $socket,
+            source_commit: $source, code_signature_hash: $cdhash,
+            protocol_major: $protocolMajor, protocol_minor: $protocolMinor,
+            executable_sha256: $hostSHA, stable: $hostStable
+        },
+        sentinel: {
+            pid: $sentinelPID, start_identity: $sentinelIdentity, window_id: $sentinelWindow,
+            initial_frontmost_pid: $baseline[0].frontmostPID,
+            initial_top_window_id: $baseline[0].frontmostWindowID,
+            final_frontmost_pid: $final[0].frontmostPID,
+            final_top_window_id: $final[0].frontmostWindowID
+        },
+        controllers: [$a[0], $b[0]],
+        overlap: $overlap[0],
+        invariants: [
+            {name: "signed_host_generation", passed: $hostStable, evidence: "bridge-before.json+bridge-after.json"},
+            {name: "sentinel_frontmost_pid", passed: ($monitorClean and $final[0].frontmostPID == $sentinelPID), evidence: "monitor-violations.jsonl+final-sample.json"},
+            {name: "sentinel_top_window", passed: ($monitorClean and $final[0].frontmostWindowID == $sentinelWindow), evidence: "monitor-violations.jsonl+final-sample.json"},
+            {name: "no_cross_target_dispatch", passed: ($a[0].cross_target_clear and $b[0].cross_target_clear), evidence: "controllers/*-observations.json"},
+            {name: "no_peekaboo_global_input", passed: $monitorClean, evidence: "monitor-violations.jsonl"},
+            {name: "clipboard_change_count", passed: ($baseline[0].clipboardChangeCount == $final[0].clipboardChangeCount), evidence: "baseline.json+final-sample.json"},
+            {name: "peekaboo_alpha_overlay", passed: $monitorClean, evidence: "monitor-violations.jsonl"},
+            {name: "monitor_liveness", passed: $monitorClean, evidence: "monitor-heartbeat.json"}
+        ],
+        cursor_observation: {
+            policy: "observational",
+            start_x: $baseline[0].cursor.x, start_y: $baseline[0].cursor.y,
+            end_x: $final[0].cursor.x, end_y: $final[0].cursor.y,
+            moved: ($heartbeat[0].cursorMovementObserved == true)
+        },
+        restoration: {
+            controller_a: ($a[0].restoration_readback == $a[0].initial_token),
+            controller_b: ($b[0].restoration_readback == $b[0].initial_token),
+            sentinel: ($final[0].frontmostPID == $sentinelPID and $final[0].frontmostWindowID == $sentinelWindow)
+        },
+        cleanup: [
+            {id: "A", pid: $a[0].target.pid, start_identity: $a[0].target.start_identity, gone: $aGone},
+            {id: "B", pid: $b[0].target.pid, start_identity: $b[0].target.start_identity, gone: $bGone}
+        ],
+        evidence: {
+            exact_target_receipts: true,
+            independent_readback: true,
+            overlapping_intervals: ($overlap[0].seconds > 0),
+            restoration: true,
+            generation_pinned_cleanup: ($aGone and $bGone)
+        }
+    }
+' > "$ARTIFACT_ROOT/observed.json"
+
+node "$REPORTER" --catalog "$CATALOG" --report "$ARTIFACT_ROOT/observed.json" \
+    --output "$ARTIFACT_ROOT/certification.json"
+jq -n \
+    --slurpfile certification "$ARTIFACT_ROOT/certification.json" \
+    --slurpfile overlap "$ARTIFACT_ROOT/overlap.json" \
+    '{success: $certification[0].success, overlap: $overlap[0], certification: $certification[0]}' \
+    > "$ARTIFACT_ROOT/summary.json"
+printf 'Dual-controller overlap certification passed: %s\n' "$ARTIFACT_ROOT"

--- a/scripts/test-dual-controller-overlap.sh
+++ b/scripts/test-dual-controller-overlap.sh
@@ -1419,13 +1419,13 @@ record_mutation() {
     [[ $command_exit -eq 0 ]]
 }
 
-record_observation() {
-    local controller="$1"
-    local index="$2"
-    local target_pid="$3"
-    local target_window="$4"
-    local expected_token="$5"
-    local prefix="$ARTIFACT_ROOT/results/${controller}-observation-${index}"
+capture_observation_receipt() {
+    local prefix="$1"
+    local receipt="$2"
+    local index="$3"
+    local target_pid="$4"
+    local target_window="$5"
+    local expected_token="$6"
     local started finished command_pid command_exit command_identity command_path target_identity_after inflight
     capture_host_receipt "$prefix-host-before.json"
     spawn_controlled_cli "$prefix" \
@@ -1479,13 +1479,49 @@ record_observation() {
             token_present: $present,
             other_token_absent: $otherAbsent
         }
-    ' >> "$ARTIFACT_ROOT/controllers/${controller}-observations.jsonl"
+    ' > "$receipt"
     jq -e --arg expected "$expected_token" --arg runID "$RUN_ID" '
         select(.success == true) |
         [.data.ui_elements[]? | .value? | select(type == "string")] as $values |
         ($values | any(. == $expected)) and
         ($values | all((contains($runID) | not) or . == $expected))
     ' "$prefix.json" >/dev/null
+}
+
+record_observation() {
+    local controller="$1"
+    local index="$2"
+    local target_pid="$3"
+    local target_window="$4"
+    local expected_token="$5"
+    local prefix="$ARTIFACT_ROOT/results/${controller}-observation-${index}"
+    local receipt="$prefix-receipt.json"
+    capture_observation_receipt \
+        "$prefix" "$receipt" "$index" "$target_pid" "$target_window" "$expected_token"
+    cat "$receipt" >> "$ARTIFACT_ROOT/controllers/${controller}-observations.jsonl"
+}
+
+record_restoration_checkpoint() {
+    local controller="$1"
+    local expected_a="$2"
+    local expected_b="$3"
+    local prefix_a="$ARTIFACT_ROOT/results/restoration-${controller}-target-A"
+    local prefix_b="$ARTIFACT_ROOT/results/restoration-${controller}-target-B"
+    local receipt_a="$prefix_a-receipt.json"
+    local receipt_b="$prefix_b-receipt.json"
+    local checkpoint="$ARTIFACT_ROOT/controllers/${controller}-restoration-checkpoint.json"
+    capture_observation_receipt \
+        "$prefix_a" "$receipt_a" 1 "$TARGET_A_PID" "$TARGET_A_WINDOW_ID" "$expected_a"
+    capture_observation_receipt \
+        "$prefix_b" "$receipt_b" 2 "$TARGET_B_PID" "$TARGET_B_WINDOW_ID" "$expected_b"
+    jq -n --arg controller "$controller" \
+        --slurpfile observationA "$receipt_a" --slurpfile observationB "$receipt_b" '
+        {
+            after_controller: $controller,
+            observations: [$observationA[0], $observationB[0]]
+        }
+    ' > "$checkpoint.tmp"
+    mv "$checkpoint.tmp" "$checkpoint"
 }
 
 first_mutation_barrier() {
@@ -1510,6 +1546,25 @@ phase_barrier() {
               -f "$ARTIFACT_ROOT/controllers/B-${phase}.ready" ]]; then
             return 0
         fi
+        sleep 0.01
+    done
+    return 1
+}
+
+wait_for_restoration_checkpoint() {
+    local controller="$1"
+    local checkpoint="$ARTIFACT_ROOT/controllers/${controller}-restoration-checkpoint.json"
+    local peer_pid peer_identity
+    if [[ "$controller" == A ]]; then
+        peer_pid="$CLIENT_A_PID"
+        peer_identity="$CLIENT_A_IDENTITY"
+    else
+        peer_pid="$CLIENT_B_PID"
+        peer_identity="$CLIENT_B_IDENTITY"
+    fi
+    for _ in $(seq 1 10000); do
+        [[ -s "$checkpoint" ]] && return 0
+        process_alive "$peer_pid" "$peer_identity" || return 1
         sleep 0.01
     done
     return 1
@@ -1605,8 +1660,10 @@ controller_a() {
         type "$TOKEN_A_SECOND" --pid "$TARGET_A_PID" --window-id "$TARGET_A_WINDOW_ID"
     phase_barrier workflow-complete A
     record_observation A 3 "$TARGET_A_PID" "$TARGET_A_WINDOW_ID" "$TOKEN_A_FINAL"
+    phase_barrier workflow-readback-complete A
     record_mutation A 4 type restoration "$TARGET_A_PID" "$TARGET_A_WINDOW_ID" \
         type "$TOKEN_A_INITIAL" --pid "$TARGET_A_PID" --window-id "$TARGET_A_WINDOW_ID" --clear
+    record_restoration_checkpoint A "$TOKEN_A_INITIAL" "$TOKEN_B_FINAL"
     phase_barrier restoration-complete A
     record_observation A 4 "$TARGET_A_PID" "$TARGET_A_WINDOW_ID" "$TOKEN_A_INITIAL"
     finished="$(clock_value)"
@@ -1642,8 +1699,11 @@ controller_b() {
     done
     phase_barrier workflow-complete B
     record_observation B 5 "$TARGET_B_PID" "$TARGET_B_WINDOW_ID" "$state"
+    phase_barrier workflow-readback-complete B
+    wait_for_restoration_checkpoint A
     record_mutation B 5 type restoration "$TARGET_B_PID" "$TARGET_B_WINDOW_ID" \
         type "$TOKEN_B_INITIAL" --pid "$TARGET_B_PID" --window-id "$TARGET_B_WINDOW_ID" --clear
+    record_restoration_checkpoint B "$TOKEN_A_INITIAL" "$TOKEN_B_INITIAL"
     phase_barrier restoration-complete B
     record_observation B 6 "$TARGET_B_PID" "$TARGET_B_WINDOW_ID" "$TOKEN_B_INITIAL"
     finished="$(clock_value)"
@@ -1788,6 +1848,11 @@ jq -n \
     }
 ' > "$ARTIFACT_ROOT/controllers/B-report.json"
 
+jq -s '.' \
+    "$ARTIFACT_ROOT/controllers/A-restoration-checkpoint.json" \
+    "$ARTIFACT_ROOT/controllers/B-restoration-checkpoint.json" \
+    > "$ARTIFACT_ROOT/restoration-checkpoints.json"
+
 jq -n \
     --argjson a "$(cat "$ARTIFACT_ROOT/controllers/A-report.json")" \
     --argjson b "$(cat "$ARTIFACT_ROOT/controllers/B-report.json")" \
@@ -1838,6 +1903,7 @@ jq -n \
     --slurpfile a "$ARTIFACT_ROOT/controllers/A-report.json" \
     --slurpfile b "$ARTIFACT_ROOT/controllers/B-report.json" \
     --slurpfile overlap "$ARTIFACT_ROOT/overlap.json" \
+    --slurpfile restorationCheckpoints "$ARTIFACT_ROOT/restoration-checkpoints.json" \
     --argjson monitorClean "$MONITOR_CLEAN" --argjson aGone "$A_GONE" --argjson bGone "$B_GONE" '
     {
         version: $version,
@@ -1869,7 +1935,11 @@ jq -n \
             {name: "signed_host_generation", passed: $hostStable, evidence: "bridge-before.json+bridge-after.json"},
             {name: "sentinel_frontmost_pid", passed: ($monitorClean and $final[0].frontmostPID == $sentinelPID), evidence: "monitor-violations.jsonl+final-sample.json"},
             {name: "sentinel_top_window", passed: ($monitorClean and $final[0].frontmostWindowID == $sentinelWindow), evidence: "monitor-violations.jsonl+final-sample.json"},
-            {name: "no_cross_target_dispatch", passed: ($a[0].cross_target_clear and $b[0].cross_target_clear), evidence: "controllers/*-observations.json"},
+            {name: "no_cross_target_dispatch", passed: (
+                $a[0].cross_target_clear and $b[0].cross_target_clear and
+                all($restorationCheckpoints[0][]?.observations[]?;
+                    .token_present == true and .other_token_absent == true)
+            ), evidence: "controllers/*-observations.json+restoration-checkpoints.json"},
             {name: "no_peekaboo_global_input", passed: $monitorClean, evidence: "monitor-violations.jsonl"},
             {name: "clipboard_change_count", passed: ($baseline[0].clipboardChangeCount == $final[0].clipboardChangeCount), evidence: "baseline.json+final-sample.json"},
             {name: "peekaboo_alpha_overlay", passed: $monitorClean, evidence: "monitor-violations.jsonl"},
@@ -1886,6 +1956,7 @@ jq -n \
             controller_b: ($b[0].restoration_readback == $b[0].initial_token),
             sentinel: ($final[0].frontmostPID == $sentinelPID and $final[0].frontmostWindowID == $sentinelWindow)
         },
+        restoration_checkpoints: $restorationCheckpoints[0],
         cleanup: [
             {id: "A", pid: $a[0].target.pid, start_identity: $a[0].target.start_identity, gone: $aGone},
             {id: "B", pid: $b[0].target.pid, start_identity: $b[0].target.start_identity, gone: $bGone}

--- a/scripts/test-dual-controller-overlap.sh
+++ b/scripts/test-dual-controller-overlap.sh
@@ -31,6 +31,16 @@ CLEANUP_COMPLETE=false
 CLEANUP_STARTED=false
 PENDING_LAUNCHER_PID=""
 OPERATION_TIMEOUT_SECONDS="${PEEKABOO_OVERLAP_OPERATION_TIMEOUT_SECONDS:-30}"
+CONTROLLED_OPERATION_HANDOFF_SECONDS=1
+MUTATION_BOUNDED_OPERATION_COUNT=3
+OBSERVATION_BOUNDED_OPERATION_COUNT=6
+INITIAL_READBACK_REMAINING_OPERATION_COUNT="$OBSERVATION_BOUNDED_OPERATION_COUNT"
+OVERLAP_WITNESS_REMAINING_OPERATION_COUNT=$((OBSERVATION_BOUNDED_OPERATION_COUNT + 2))
+WORKFLOW_REMAINING_OPERATION_COUNT=$((4 * MUTATION_BOUNDED_OPERATION_COUNT + \
+    3 * OBSERVATION_BOUNDED_OPERATION_COUNT))
+FINAL_READBACK_REMAINING_OPERATION_COUNT="$OBSERVATION_BOUNDED_OPERATION_COUNT"
+RESTORATION_REMAINING_OPERATION_COUNT=$((MUTATION_BOUNDED_OPERATION_COUNT + \
+    2 * OBSERVATION_BOUNDED_OPERATION_COUNT))
 
 usage() {
     cat <<'EOF'
@@ -581,6 +591,73 @@ clock_value() {
     "$PROBE_BIN" clock | jq -er '.monotonicSeconds'
 }
 
+synchronization_budget_seconds() {
+    local maximum_remaining_operations="$1"
+    [[ "$maximum_remaining_operations" =~ ^[1-9][0-9]*$ ]] || return 1
+    # Two 50 x 5 ms registration/attestation probes plus deadline completion polling fit one handoff second.
+    awk -v operations="$maximum_remaining_operations" \
+        -v timeout="$OPERATION_TIMEOUT_SECONDS" \
+        -v handoff="$CONTROLLED_OPERATION_HANDOFF_SECONDS" '
+        BEGIN { printf "%.9f", operations * (timeout + handoff) }
+    '
+}
+
+synchronization_deadline() {
+    local maximum_remaining_operations="$1"
+    local started_at="${2:-}"
+    local budget
+    [[ -n "$started_at" ]] || started_at="$(clock_value)"
+    budget="$(synchronization_budget_seconds "$maximum_remaining_operations")" || return 1
+    awk -v started="$started_at" -v budget="$budget" '
+        BEGIN { printf "%.9f", started + budget }
+    '
+}
+
+synchronization_deadline_reached() {
+    local deadline="$1"
+    local now="${2:-}"
+    [[ -n "$now" ]] || now="$(clock_value)"
+    awk -v now="$now" -v deadline="$deadline" 'BEGIN { exit !(now >= deadline) }'
+}
+
+synchronization_marker_ready() {
+    local marker="$1"
+    local readiness="$2"
+    case "$readiness" in
+        exists) [[ -e "$marker" ]] ;;
+        nonempty) [[ -s "$marker" ]] ;;
+        *) return 1 ;;
+    esac
+}
+
+wait_for_synchronization_until() {
+    local marker="$1"
+    local peer_pid="$2"
+    local peer_identity="$3"
+    local deadline="$4"
+    local readiness="${5:-exists}"
+    while true; do
+        synchronization_deadline_reached "$deadline" && return 1
+        process_alive "$peer_pid" "$peer_identity" || return 1
+        synchronization_deadline_reached "$deadline" && return 1
+        synchronization_marker_ready "$marker" "$readiness" && return 0
+        sleep 0.01
+    done
+}
+
+wait_for_controller_marker() {
+    local marker="$1"
+    local peer_controller="$2"
+    local maximum_remaining_operations="$3"
+    local readiness="${4:-exists}"
+    local receipt="$ARTIFACT_ROOT/controllers/${peer_controller}-client.json"
+    local peer_pid peer_identity deadline
+    peer_pid="$(jq -er '.pid' "$receipt")" || return 1
+    peer_identity="$(jq -er '.startIdentity' "$receipt")" || return 1
+    deadline="$(synchronization_deadline "$maximum_remaining_operations")" || return 1
+    wait_for_synchronization_until "$marker" "$peer_pid" "$peer_identity" "$deadline" "$readiness"
+}
+
 tracked_input_matches_commit() {
     local file="$1"
     local relative="${file#"$ROOT_DIR"/}"
@@ -854,6 +931,12 @@ run_client_lifecycle_self_test() {
     local timeout_pid timeout_identity timeout_inflight timeout_started timeout_finished timeout_elapsed
     local timeout_deadline timeout_kill_at timeout_kill_overrun timeout_completion_overrun
     local settled_focus_preserved=false missing_focus_blocks=false null_focus_blocks=false
+    local initial_budget overlap_budget workflow_budget restoration_budget max_restoration_budget
+    local initial_deadline restoration_deadline
+    local slow_phase_budget_accepted=false slow_restoration_budget_accepted=false
+    local synchronization_wait_accepted=false synchronization_deadline_refused=false
+    local late_marker_refused=false empty_checkpoint_waited_for_nonempty=false
+    local synchronization_peer_exit_refused=false synchronization_peer_exit_elapsed=999
     jq -n '{pendingFocusedWindowChange: false}' \
         > "$ARTIFACT_ROOT/results/lifecycle-settled-heartbeat.json"
     if [[ "$(read_pending_focus_state \
@@ -893,6 +976,111 @@ run_client_lifecycle_self_test() {
     timeout_completion_overrun="$(awk -v deadline="$timeout_deadline" -v finished="$timeout_finished" \
         'BEGIN { printf "%.6f", finished - deadline }')"
     rm -f "$timeout_inflight"
+
+    OPERATION_TIMEOUT_SECONDS=30
+    initial_budget="$(synchronization_budget_seconds "$INITIAL_READBACK_REMAINING_OPERATION_COUNT")"
+    overlap_budget="$(synchronization_budget_seconds "$OVERLAP_WITNESS_REMAINING_OPERATION_COUNT")"
+    workflow_budget="$(synchronization_budget_seconds "$WORKFLOW_REMAINING_OPERATION_COUNT")"
+    restoration_budget="$(synchronization_budget_seconds "$RESTORATION_REMAINING_OPERATION_COUNT")"
+    initial_deadline="$(synchronization_deadline "$INITIAL_READBACK_REMAINING_OPERATION_COUNT" 1000)"
+    restoration_deadline="$(synchronization_deadline "$RESTORATION_REMAINING_OPERATION_COUNT" 1000)"
+    if ! synchronization_deadline_reached "$initial_deadline" 1006; then
+        slow_phase_budget_accepted=true
+    fi
+    if ! synchronization_deadline_reached "$restoration_deadline" 1101; then
+        slow_restoration_budget_accepted=true
+    fi
+    OPERATION_TIMEOUT_SECONDS=300
+    max_restoration_budget="$(synchronization_budget_seconds "$RESTORATION_REMAINING_OPERATION_COUNT")"
+
+    OPERATION_TIMEOUT_SECONDS=1
+    spawn_controlled_process "$ARTIFACT_ROOT/results/synchronization-peer" /bin/sleep /bin/sleep 5
+    local synchronization_pid="$SPAWNED_PID"
+    local synchronization_identity="$SPAWNED_IDENTITY"
+    local synchronization_inflight="$SPAWNED_INFLIGHT"
+    local synchronization_marker="$ARTIFACT_ROOT/results/synchronization-peer.ready"
+    local synchronization_writer_pid synchronization_wait_exit=0
+    (
+        sleep 0.05
+        : > "$synchronization_marker.tmp"
+        mv "$synchronization_marker.tmp" "$synchronization_marker"
+    ) &
+    synchronization_writer_pid=$!
+    local synchronization_wait_deadline
+    synchronization_wait_deadline="$(synchronization_deadline 1)"
+    set +e
+    wait_for_synchronization_until "$synchronization_marker" \
+        "$synchronization_pid" "$synchronization_identity" "$synchronization_wait_deadline"
+    synchronization_wait_exit=$?
+    set -e
+    wait "$synchronization_writer_pid"
+    [[ $synchronization_wait_exit -eq 0 ]] && synchronization_wait_accepted=true
+
+    rm -f "$synchronization_marker"
+    local expired_deadline synchronization_deadline_exit=0
+    expired_deadline="$(awk -v now="$(clock_value)" 'BEGIN { printf "%.9f", now - 0.001 }')"
+    set +e
+    wait_for_synchronization_until "$synchronization_marker" \
+        "$synchronization_pid" "$synchronization_identity" "$expired_deadline"
+    synchronization_deadline_exit=$?
+    set -e
+    [[ $synchronization_deadline_exit -ne 0 ]] && synchronization_deadline_refused=true
+
+    local late_marker="$ARTIFACT_ROOT/results/synchronization-late.ready"
+    local late_marker_deadline late_marker_exit=0
+    late_marker_deadline="$(awk -v now="$(clock_value)" 'BEGIN { printf "%.9f", now - 0.001 }')"
+    : > "$late_marker"
+    set +e
+    wait_for_synchronization_until "$late_marker" \
+        "$synchronization_pid" "$synchronization_identity" "$late_marker_deadline"
+    late_marker_exit=$?
+    set -e
+    [[ $late_marker_exit -ne 0 ]] && late_marker_refused=true
+
+    local checkpoint_marker="$ARTIFACT_ROOT/results/synchronization-checkpoint.json"
+    local checkpoint_writer_pid checkpoint_wait_exit=0 checkpoint_started checkpoint_finished checkpoint_elapsed
+    : > "$checkpoint_marker"
+    (
+        sleep 0.05
+        printf '%s\n' '{"complete":true}' > "$checkpoint_marker.tmp"
+        mv "$checkpoint_marker.tmp" "$checkpoint_marker"
+    ) &
+    checkpoint_writer_pid=$!
+    checkpoint_started="$(clock_value)"
+    synchronization_wait_deadline="$(synchronization_deadline 1 "$checkpoint_started")"
+    set +e
+    wait_for_synchronization_until "$checkpoint_marker" \
+        "$synchronization_pid" "$synchronization_identity" "$synchronization_wait_deadline" nonempty
+    checkpoint_wait_exit=$?
+    set -e
+    checkpoint_finished="$(clock_value)"
+    wait "$checkpoint_writer_pid"
+    checkpoint_elapsed="$(awk -v started="$checkpoint_started" -v finished="$checkpoint_finished" \
+        'BEGIN { printf "%.6f", finished - started }')"
+    if [[ $checkpoint_wait_exit -eq 0 && -s "$checkpoint_marker" ]] && \
+       awk -v elapsed="$checkpoint_elapsed" 'BEGIN { exit !(elapsed >= 0.02) }'; then
+        empty_checkpoint_waited_for_nonempty=true
+    fi
+    rm -f "$late_marker" "$checkpoint_marker"
+
+    terminate_owned_generation_directly synchronization-self-test \
+        "$synchronization_pid" "$synchronization_identity" forced_self_test
+    rm -f "$synchronization_inflight"
+    local peer_exit_started peer_exit_finished peer_exit_deadline peer_exit_result=0
+    peer_exit_started="$(clock_value)"
+    peer_exit_deadline="$(synchronization_deadline 1 "$peer_exit_started")"
+    set +e
+    wait_for_synchronization_until "$synchronization_marker" \
+        "$synchronization_pid" "$synchronization_identity" "$peer_exit_deadline"
+    peer_exit_result=$?
+    set -e
+    peer_exit_finished="$(clock_value)"
+    synchronization_peer_exit_elapsed="$(awk -v started="$peer_exit_started" -v finished="$peer_exit_finished" \
+        'BEGIN { printf "%.6f", finished - started }')"
+    if [[ $peer_exit_result -ne 0 ]] && \
+       awk -v elapsed="$synchronization_peer_exit_elapsed" 'BEGIN { exit !(elapsed < 0.5) }'; then
+        synchronization_peer_exit_refused=true
+    fi
 
     spawn_controlled_process "$ARTIFACT_ROOT/results/lifecycle-direct-cleanup" /bin/sleep /bin/sleep 60
     local direct_pid="$SPAWNED_PID"
@@ -977,7 +1165,25 @@ run_client_lifecycle_self_test() {
         --argjson mismatchGone "$mismatch_gone" \
         --argjson settledFocusPreserved "$settled_focus_preserved" \
         --argjson missingFocusBlocks "$missing_focus_blocks" \
-        --argjson nullFocusBlocks "$null_focus_blocks" '
+        --argjson nullFocusBlocks "$null_focus_blocks" \
+        --argjson initialBudget "$initial_budget" \
+        --argjson overlapBudget "$overlap_budget" \
+        --argjson workflowBudget "$workflow_budget" \
+        --argjson restorationBudget "$restoration_budget" \
+        --argjson maxRestorationBudget "$max_restoration_budget" \
+        --argjson slowPhaseBudgetAccepted "$slow_phase_budget_accepted" \
+        --argjson slowRestorationBudgetAccepted "$slow_restoration_budget_accepted" \
+        --argjson synchronizationWaitAccepted "$synchronization_wait_accepted" \
+        --argjson synchronizationDeadlineRefused "$synchronization_deadline_refused" \
+        --argjson lateMarkerRefused "$late_marker_refused" \
+        --argjson emptyCheckpointWaitedForNonempty "$empty_checkpoint_waited_for_nonempty" \
+        --argjson synchronizationPeerExitRefused "$synchronization_peer_exit_refused" \
+        --argjson synchronizationPeerExitElapsed "$synchronization_peer_exit_elapsed" \
+        --argjson mutationCount "$MUTATION_BOUNDED_OPERATION_COUNT" \
+        --argjson observationCount "$OBSERVATION_BOUNDED_OPERATION_COUNT" \
+        --argjson overlapCount "$OVERLAP_WITNESS_REMAINING_OPERATION_COUNT" \
+        --argjson workflowCount "$WORKFLOW_REMAINING_OPERATION_COUNT" \
+        --argjson restorationCount "$RESTORATION_REMAINING_OPERATION_COUNT" '
         {
             success: (
                 $timeoutExit == 124 and $timeoutElapsed >= 0.8 and
@@ -988,7 +1194,16 @@ run_client_lifecycle_self_test() {
                 $fastExit == 0 and $fastPath == "/usr/bin/true" and
                 $fastZombieRejected and $boundedExit == 0 and
                 $mismatchExit != 0 and $mismatchGone and
-                $settledFocusPreserved and $missingFocusBlocks and $nullFocusBlocks
+                $settledFocusPreserved and $missingFocusBlocks and $nullFocusBlocks and
+                $mutationCount == 3 and $observationCount == 6 and $overlapCount == 8 and
+                $workflowCount == 30 and $restorationCount == 15 and
+                $initialBudget == 186 and $overlapBudget == 248 and
+                $workflowBudget == 930 and $restorationBudget == 465 and
+                $maxRestorationBudget == 4515 and
+                $slowPhaseBudgetAccepted and $slowRestorationBudgetAccepted and
+                $synchronizationWaitAccepted and $synchronizationDeadlineRefused and
+                $lateMarkerRefused and $emptyCheckpointWaitedForNonempty and
+                $synchronizationPeerExitRefused and $synchronizationPeerExitElapsed < 0.5
             ),
             timeout_exit: $timeoutExit,
             timeout_elapsed_seconds: $timeoutElapsed,
@@ -1006,7 +1221,27 @@ run_client_lifecycle_self_test() {
             mismatch_generation_gone: $mismatchGone,
             settled_focus_preserved: $settledFocusPreserved,
             missing_focus_blocks: $missingFocusBlocks,
-            null_focus_blocks: $nullFocusBlocks
+            null_focus_blocks: $nullFocusBlocks,
+            synchronization: {
+                mutation_operation_count: $mutationCount,
+                observation_operation_count: $observationCount,
+                overlap_witness_remaining_operation_count: $overlapCount,
+                workflow_remaining_operation_count: $workflowCount,
+                restoration_remaining_operation_count: $restorationCount,
+                initial_readback_budget_seconds: $initialBudget,
+                overlap_witness_budget_seconds: $overlapBudget,
+                workflow_budget_seconds: $workflowBudget,
+                restoration_budget_seconds: $restorationBudget,
+                maximum_timeout_restoration_budget_seconds: $maxRestorationBudget,
+                slow_phase_budget_accepted: $slowPhaseBudgetAccepted,
+                slow_restoration_budget_accepted: $slowRestorationBudgetAccepted,
+                marker_wait_accepted: $synchronizationWaitAccepted,
+                exceeded_deadline_refused: $synchronizationDeadlineRefused,
+                late_marker_refused: $lateMarkerRefused,
+                empty_checkpoint_waited_for_nonempty: $emptyCheckpointWaitedForNonempty,
+                peer_exit_refused: $synchronizationPeerExitRefused,
+                peer_exit_elapsed_seconds: $synchronizationPeerExitElapsed
+            }
         }
     '
 }
@@ -1526,48 +1761,42 @@ record_restoration_checkpoint() {
 
 first_mutation_barrier() {
     local controller="$1"
+    local peer_controller=A
+    [[ "$controller" == A ]] && peer_controller=B
     : > "$ARTIFACT_ROOT/controllers/${controller}-first-mutation.ready"
-    for _ in $(seq 1 500); do
-        if [[ -f "$ARTIFACT_ROOT/controllers/A-first-mutation.ready" && \
-              -f "$ARTIFACT_ROOT/controllers/B-first-mutation.ready" ]]; then
-            return 0
-        fi
-        sleep 0.01
-    done
-    return 1
+    wait_for_controller_marker \
+        "$ARTIFACT_ROOT/controllers/${peer_controller}-first-mutation.ready" \
+        "$peer_controller" "$INITIAL_READBACK_REMAINING_OPERATION_COUNT"
 }
 
 phase_barrier() {
     local phase="$1"
     local controller="$2"
+    local peer_controller=A maximum_remaining_operations
+    [[ "$controller" == A ]] && peer_controller=B
+    case "$phase" in
+        workflow-complete)
+            maximum_remaining_operations="$WORKFLOW_REMAINING_OPERATION_COUNT"
+            ;;
+        workflow-readback-complete)
+            maximum_remaining_operations="$FINAL_READBACK_REMAINING_OPERATION_COUNT"
+            ;;
+        restoration-complete)
+            maximum_remaining_operations="$RESTORATION_REMAINING_OPERATION_COUNT"
+            ;;
+        *) return 1 ;;
+    esac
     : > "$ARTIFACT_ROOT/controllers/${controller}-${phase}.ready"
-    for _ in $(seq 1 500); do
-        if [[ -f "$ARTIFACT_ROOT/controllers/A-${phase}.ready" && \
-              -f "$ARTIFACT_ROOT/controllers/B-${phase}.ready" ]]; then
-            return 0
-        fi
-        sleep 0.01
-    done
-    return 1
+    wait_for_controller_marker \
+        "$ARTIFACT_ROOT/controllers/${peer_controller}-${phase}.ready" \
+        "$peer_controller" "$maximum_remaining_operations"
 }
 
 wait_for_restoration_checkpoint() {
     local controller="$1"
     local checkpoint="$ARTIFACT_ROOT/controllers/${controller}-restoration-checkpoint.json"
-    local peer_pid peer_identity
-    if [[ "$controller" == A ]]; then
-        peer_pid="$CLIENT_A_PID"
-        peer_identity="$CLIENT_A_IDENTITY"
-    else
-        peer_pid="$CLIENT_B_PID"
-        peer_identity="$CLIENT_B_IDENTITY"
-    fi
-    for _ in $(seq 1 10000); do
-        [[ -s "$checkpoint" ]] && return 0
-        process_alive "$peer_pid" "$peer_identity" || return 1
-        sleep 0.01
-    done
-    return 1
+    wait_for_controller_marker \
+        "$checkpoint" "$controller" "$RESTORATION_REMAINING_OPERATION_COUNT" nonempty
 }
 
 overlap_witness() {
@@ -1575,7 +1804,16 @@ overlap_witness() {
     local b_marker="$ARTIFACT_ROOT/controllers/B-active.json"
     local a_snapshot="$ARTIFACT_ROOT/controllers/witness-A-active.json"
     local b_snapshot="$ARTIFACT_ROOT/controllers/witness-B-active.json"
-    for _ in $(seq 1 1000); do
+    local a_controller_pid a_controller_identity b_controller_pid b_controller_identity deadline
+    a_controller_pid="$(jq -er '.pid' "$ARTIFACT_ROOT/controllers/A-client.json")"
+    a_controller_identity="$(jq -er '.startIdentity' "$ARTIFACT_ROOT/controllers/A-client.json")"
+    b_controller_pid="$(jq -er '.pid' "$ARTIFACT_ROOT/controllers/B-client.json")"
+    b_controller_identity="$(jq -er '.startIdentity' "$ARTIFACT_ROOT/controllers/B-client.json")"
+    deadline="$(synchronization_deadline "$OVERLAP_WITNESS_REMAINING_OPERATION_COUNT")"
+    while true; do
+        synchronization_deadline_reached "$deadline" && return 1
+        process_alive "$a_controller_pid" "$a_controller_identity" || return 1
+        process_alive "$b_controller_pid" "$b_controller_identity" || return 1
         if [[ -s "$a_marker" && -s "$b_marker" ]]; then
             local a_pid a_identity b_pid b_identity
             local a_checked_before_at b_checked_at a_checked_after_at
@@ -1618,6 +1856,7 @@ overlap_witness() {
                     sleep 0.01
                     continue
                 fi
+                synchronization_deadline_reached "$deadline" && return 1
                 jq -n --argjson aPID "$a_pid" --arg aIdentity "$a_identity" \
                     --argjson bPID "$b_pid" --arg bIdentity "$b_identity" \
                     --argjson aCheckedBeforeAt "$a_checked_before_at" \
@@ -1641,7 +1880,6 @@ overlap_witness() {
         fi
         sleep 0.01
     done
-    return 1
 }
 
 controller_a() {

--- a/scripts/test-dual-controller-overlap.sh
+++ b/scripts/test-dual-controller-overlap.sh
@@ -410,6 +410,17 @@ freeze_and_register_controller_children() {
     done < <(ps -axo pid=,ppid= | awk -v parent="$controller_pid" '$2 == parent {print $1}')
 }
 
+read_pending_focus_state() {
+    local heartbeat_path="${1:?Heartbeat path required}"
+    jq -r '
+        if has("pendingFocusedWindowChange") and
+            (.pendingFocusedWindowChange | type) == "boolean"
+        then .pendingFocusedWindowChange
+        else true
+        end
+    ' "$heartbeat_path"
+}
+
 finish_monitoring() {
     local pre_cleanup_sequence="$1"
     local final_sample_path="$2"
@@ -439,7 +450,7 @@ finish_monitoring() {
         heartbeat_timestamp="$(jq -r '.timestamp // 0' "$ARTIFACT_ROOT/monitor-heartbeat.json" 2>/dev/null || printf 0)"
         pending_activations="$(jq -r '.pendingActivationCount // -1' \
             "$ARTIFACT_ROOT/monitor-heartbeat.json" 2>/dev/null || printf -- -1)"
-        pending_focus="$(jq -r '.pendingFocusedWindowChange // true' \
+        pending_focus="$(read_pending_focus_state \
             "$ARTIFACT_ROOT/monitor-heartbeat.json" 2>/dev/null || printf true)"
         final_sample_timestamp="$(jq -r '.timestamp // 0' "$final_sample_path" 2>/dev/null || printf 0)"
         if [[ "$current_sequence" =~ ^[0-9]+$ && "$current_sequence" -gt "$pre_cleanup_sequence" ]] && \
@@ -842,6 +853,24 @@ run_client_lifecycle_self_test() {
     local timeout_exit=0 fast_exit=0 bounded_exit=0 mismatch_exit=0 direct_cleanup_exit=0
     local timeout_pid timeout_identity timeout_inflight timeout_started timeout_finished timeout_elapsed
     local timeout_deadline timeout_kill_at timeout_kill_overrun timeout_completion_overrun
+    local settled_focus_preserved=false missing_focus_blocks=false null_focus_blocks=false
+    jq -n '{pendingFocusedWindowChange: false}' \
+        > "$ARTIFACT_ROOT/results/lifecycle-settled-heartbeat.json"
+    if [[ "$(read_pending_focus_state \
+        "$ARTIFACT_ROOT/results/lifecycle-settled-heartbeat.json")" == false ]]; then
+        settled_focus_preserved=true
+    fi
+    jq -n '{}' > "$ARTIFACT_ROOT/results/lifecycle-missing-focus-heartbeat.json"
+    if [[ "$(read_pending_focus_state \
+        "$ARTIFACT_ROOT/results/lifecycle-missing-focus-heartbeat.json")" == true ]]; then
+        missing_focus_blocks=true
+    fi
+    jq -n '{pendingFocusedWindowChange: null}' \
+        > "$ARTIFACT_ROOT/results/lifecycle-null-focus-heartbeat.json"
+    if [[ "$(read_pending_focus_state \
+        "$ARTIFACT_ROOT/results/lifecycle-null-focus-heartbeat.json")" == true ]]; then
+        null_focus_blocks=true
+    fi
     PEEKABOO_BIN="$PROBE_BIN"
     OPERATION_TIMEOUT_SECONDS=1
     spawn_controlled_cli "$ARTIFACT_ROOT/results/lifecycle-timeout" "$PROBE_BIN" ignore-term
@@ -945,7 +974,10 @@ run_client_lifecycle_self_test() {
         --arg fastPath "$fast_path" --argjson boundedExit "$bounded_exit" \
         --argjson fastZombieRejected "$fast_zombie_rejected" \
         --argjson mismatchExit "$mismatch_exit" \
-        --argjson mismatchGone "$mismatch_gone" '
+        --argjson mismatchGone "$mismatch_gone" \
+        --argjson settledFocusPreserved "$settled_focus_preserved" \
+        --argjson missingFocusBlocks "$missing_focus_blocks" \
+        --argjson nullFocusBlocks "$null_focus_blocks" '
         {
             success: (
                 $timeoutExit == 124 and $timeoutElapsed >= 0.8 and
@@ -955,7 +987,8 @@ run_client_lifecycle_self_test() {
                 $unknownState == 2 and $unknownCleanupGone and
                 $fastExit == 0 and $fastPath == "/usr/bin/true" and
                 $fastZombieRejected and $boundedExit == 0 and
-                $mismatchExit != 0 and $mismatchGone
+                $mismatchExit != 0 and $mismatchGone and
+                $settledFocusPreserved and $missingFocusBlocks and $nullFocusBlocks
             ),
             timeout_exit: $timeoutExit,
             timeout_elapsed_seconds: $timeoutElapsed,
@@ -970,7 +1003,10 @@ run_client_lifecycle_self_test() {
             fast_zombie_rejected: $fastZombieRejected,
             bounded_runner_exit: $boundedExit,
             mismatch_exit: $mismatchExit,
-            mismatch_generation_gone: $mismatchGone
+            mismatch_generation_gone: $mismatchGone,
+            settled_focus_preserved: $settledFocusPreserved,
+            missing_focus_blocks: $missingFocusBlocks,
+            null_focus_blocks: $nullFocusBlocks
         }
     '
 }

--- a/scripts/validate-dual-controller-overlap-report.mjs
+++ b/scripts/validate-dual-controller-overlap-report.mjs
@@ -310,12 +310,90 @@ function validateController(observed, expected, other, runID, cli, host, failure
   }
 }
 
+function validateRestorationCheckpoints(report, failures) {
+  const checkpoints = report.restoration_checkpoints;
+  const [controllerA, controllerB] = report.controllers ?? [];
+  if (!Array.isArray(checkpoints) || checkpoints.length !== 2
+      || checkpoints.map((entry) => entry?.after_controller).join(',') !== 'A,B'
+      || checkpoints.some((entry) => !exactKeys(entry, ['after_controller', 'observations'])
+        || !Array.isArray(entry.observations) || entry.observations.length !== 2)) {
+    failures.push(failure(
+      'restoration_checkpoint_schema',
+      'Restoration checkpoints must read both targets after exact ordered A and B restorations',
+    ));
+    return;
+  }
+
+  const restorationA = controllerA?.mutations?.at(-1);
+  const restorationB = controllerB?.mutations?.at(-1);
+  const expected = [
+    {
+      after: 'A',
+      tokens: [controllerA?.initial_token, controllerB?.final_token],
+      notBefore: restorationA?.finished_at,
+      notAfter: restorationB?.started_at,
+    },
+    {
+      after: 'B',
+      tokens: [controllerA?.initial_token, controllerB?.initial_token],
+      notBefore: restorationB?.finished_at,
+      notAfter: Math.min(controllerA?.finished_at ?? -Infinity, controllerB?.finished_at ?? -Infinity),
+    },
+  ];
+  if (restorationA?.phase !== 'restoration' || restorationB?.phase !== 'restoration'
+      || !finiteTimestamp(restorationA.finished_at) || !finiteTimestamp(restorationB.started_at)
+      || restorationA.finished_at > restorationB.started_at) {
+    failures.push(failure(
+      'restoration_checkpoint_timing',
+      'Controller A restoration must finish and be audited before controller B restoration starts',
+    ));
+  }
+
+  checkpoints.forEach((checkpoint, checkpointIndex) => {
+    const requirement = expected[checkpointIndex];
+    checkpoint.observations.forEach((observation, targetIndex) => {
+      const targetController = [controllerA, controllerB][targetIndex];
+      validateObservation(
+        observation,
+        `restoration-${requirement.after}`,
+        targetController?.target ?? {},
+        report.cli,
+        report.host,
+        targetIndex + 1,
+        failures,
+      );
+      if (observation?.expected_token !== requirement.tokens[targetIndex]
+          || observation?.token_present !== true || observation?.other_token_absent !== true) {
+        failures.push(failure(
+          'restoration_checkpoint_contract',
+          `Checkpoint after controller ${requirement.after} did not preserve both exact target states`,
+          requirement.after,
+        ));
+      }
+    });
+    const [first, second] = checkpoint.observations;
+    if (!finiteTimestamp(requirement.notBefore) || !finiteTimestamp(requirement.notAfter)
+        || requirement.notAfter < requirement.notBefore
+        || checkpoint.observations.some((observation) => (
+          !finiteTimestamp(observation?.started_at) || !finiteTimestamp(observation?.finished_at)
+            || observation.started_at < requirement.notBefore
+            || observation.finished_at > requirement.notAfter
+        )) || first.finished_at > second.started_at) {
+      failures.push(failure(
+        'restoration_checkpoint_timing',
+        `Checkpoint after controller ${requirement.after} was not durably captured before the next state change`,
+        requirement.after,
+      ));
+    }
+  });
+}
+
 export function validateOverlapCertification(catalog, report, expectedCatalogSHA256 = null) {
   const failures = validateCatalog(catalog);
   if (!exactKeys(report, [
     'version', 'catalog_sha256', 'run_id', 'source_commit', 'cli', 'host', 'sentinel',
     'controllers', 'overlap', 'invariants', 'cursor_observation', 'restoration',
-    'cleanup', 'evidence',
+    'restoration_checkpoints', 'cleanup', 'evidence',
   ]) || report?.version !== 1) {
     failures.push(failure('report_schema', 'Report must be one closed version-1 object'));
     return { success: false, failures };
@@ -360,7 +438,16 @@ export function validateOverlapCertification(catalog, report, expectedCatalogSHA
         `${operation.route_receipt?.client_pid}:${operation.route_receipt?.client_start_identity}`,
       ]),
     ]);
-    const allClientGenerations = [...wrapperGenerations, ...operationGenerations];
+    const checkpointGenerations = (Array.isArray(report.restoration_checkpoints)
+      ? report.restoration_checkpoints : []).flatMap((checkpoint) => (
+      Array.isArray(checkpoint?.observations) ? checkpoint.observations : []
+    )).flatMap((operation) => [
+      `${operation?.client_pid}:${operation?.client_start_identity}`,
+      `${operation?.route_receipt?.client_pid}:${operation?.route_receipt?.client_start_identity}`,
+    ]);
+    const allClientGenerations = [
+      ...wrapperGenerations, ...operationGenerations, ...checkpointGenerations,
+    ];
     if (new Set(allClientGenerations).size !== allClientGenerations.length) {
       failures.push(failure('client_isolation', 'Controllers and operations must use distinct process generations'));
     }
@@ -375,6 +462,7 @@ export function validateOverlapCertification(catalog, report, expectedCatalogSHA
   }
 
   const [controllerA, controllerB] = report.controllers ?? [];
+  validateRestorationCheckpoints(report, failures);
   const workflowMutationsA = (controllerA?.mutations ?? []).filter((entry) => entry?.phase === 'workflow');
   const workflowMutationsB = (controllerB?.mutations ?? []).filter((entry) => entry?.phase === 'workflow');
   const overlap = report.overlap;
@@ -557,6 +645,14 @@ export function makePassingOverlapReport(catalog, catalogSHA256 = 'f'.repeat(64)
     token_present: true,
     other_token_absent: true,
   });
+  const checkpointObservation = (index, startedAt, token, targetReceipt, generationSeed) => {
+    const receipt = observation(index, startedAt, token, targetReceipt);
+    receipt.client_pid = 6000 + generationSeed;
+    receipt.client_start_identity = `${receipt.client_pid}00`;
+    receipt.route_receipt.client_pid = 7000 + generationSeed;
+    receipt.route_receipt.client_start_identity = `${receipt.route_receipt.client_pid}00`;
+    return receipt;
+  };
   const controller = (expected, clientPID, targetReceipt, startedAt, finishedAt, observationCount) => {
     const { id } = expected;
     const namespace = `${runID}-${id.toLowerCase()}-`;
@@ -613,6 +709,30 @@ export function makePassingOverlapReport(catalog, catalogSHA256 = 'f'.repeat(64)
   };
   const controllerA = controller(catalog.controllers[0], 301, target(101, '10100', 201), 10, 15, 4);
   const controllerB = controller(catalog.controllers[1], 302, target(202, '20200', 302), 9, 16, 5);
+  const restorationA = controllerA.mutations.at(-1);
+  const restorationB = controllerB.mutations.at(-1);
+  restorationB.started_at = 12.5;
+  restorationB.finished_at = 12.7;
+  controllerA.observations.at(-1).started_at = 13.2;
+  controllerA.observations.at(-1).finished_at = 13.3;
+  controllerB.observations.at(-1).started_at = 13.35;
+  controllerB.observations.at(-1).finished_at = 13.45;
+  const restorationCheckpoints = [
+    {
+      after_controller: 'A',
+      observations: [
+        checkpointObservation(1, restorationA.finished_at + 0.2, controllerA.initial_token, controllerA.target, 1),
+        checkpointObservation(2, restorationA.finished_at + 0.35, controllerB.final_token, controllerB.target, 2),
+      ],
+    },
+    {
+      after_controller: 'B',
+      observations: [
+        checkpointObservation(1, restorationB.finished_at + 0.1, controllerA.initial_token, controllerA.target, 3),
+        checkpointObservation(2, restorationB.finished_at + 0.25, controllerB.initial_token, controllerB.target, 4),
+      ],
+    },
+  ];
   return {
     version: 1,
     catalog_sha256: catalogSHA256,
@@ -696,6 +816,7 @@ export function makePassingOverlapReport(catalog, catalogSHA256 = 'f'.repeat(64)
       policy: 'observational', start_x: 20, start_y: 30, end_x: 40, end_y: 50, moved: true,
     },
     restoration: { controller_a: true, controller_b: true, sentinel: true },
+    restoration_checkpoints: restorationCheckpoints,
     cleanup: [
       { id: 'A', pid: 101, start_identity: '10100', gone: true },
       { id: 'B', pid: 202, start_identity: '20200', gone: true },
@@ -735,6 +856,21 @@ export function runOverlapContractSelfTest(catalog, catalogSHA256) {
     ['changed active marker', (report) => {
       report.overlap.simultaneous_liveness_witness.markers_unchanged = false;
     }, 'overlap'],
+    ['missing restoration checkpoint', (report) => {
+      report.restoration_checkpoints.pop();
+    }, 'restoration_checkpoint_schema'],
+    ['masked cross-target restoration', (report) => {
+      report.restoration_checkpoints[0].observations[1].token_present = false;
+    }, 'restoration_checkpoint_contract'],
+    ['masked peer cross-target restoration', (report) => {
+      report.restoration_checkpoints[1].observations[0].token_present = false;
+    }, 'restoration_checkpoint_contract'],
+    ['concurrent peer restoration', (report) => {
+      const checkpoint = report.restoration_checkpoints[0].observations[1];
+      const restoration = report.controllers[1].mutations.at(-1);
+      restoration.started_at = checkpoint.finished_at - 0.05;
+      restoration.finished_at = restoration.started_at + 0.2;
+    }, 'restoration_checkpoint_timing'],
     ['restoration counted as workflow', (report) => { report.controllers[0].mutations.splice(1, 1); }, 'mutation_count'],
     ['workflow command drift', (report) => { report.controllers[0].mutations[1].command = 'type'; }, 'mutation_sequence'],
   ];

--- a/scripts/validate-dual-controller-overlap-report.mjs
+++ b/scripts/validate-dual-controller-overlap-report.mjs
@@ -1,0 +1,795 @@
+#!/usr/bin/env node
+
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+const hex40 = /^[0-9a-f]{40}$/;
+const hex64 = /^[0-9a-f]{64}$/;
+const decimalIdentity = /^[1-9][0-9]*$/;
+
+function failure(rule, message, controller = null) {
+  return { rule, message, controller };
+}
+
+function exactKeys(value, expected) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const actual = Object.keys(value).sort();
+  const wanted = [...expected].sort();
+  return actual.length === wanted.length && actual.every((key, index) => key === wanted[index]);
+}
+
+function positiveInteger(value) {
+  return Number.isSafeInteger(value) && value > 0;
+}
+
+function finiteTimestamp(value) {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0;
+}
+
+function exactProcessReceipt(value) {
+  return exactKeys(value, ['pid', 'start_identity'])
+    && validProcessFields(value);
+}
+
+function validProcessFields(value) {
+  return positiveInteger(value?.pid)
+    && typeof value.start_identity === 'string'
+    && decimalIdentity.test(value.start_identity);
+}
+
+function exactTargetReceipt(value) {
+  return exactKeys(value, ['pid', 'start_identity', 'window_id'])
+    && validTargetFields(value);
+}
+
+function validTargetFields(value) {
+  return validProcessFields(value) && positiveInteger(value?.window_id);
+}
+
+function validateCatalog(catalog) {
+  const failures = [];
+  if (!exactKeys(catalog, [
+    'version', 'controllers', 'invariants', 'cursor_policy', 'required_evidence',
+  ]) || catalog?.version !== 1) {
+    return [failure('catalog_schema', 'Catalog must be one closed version-1 object')];
+  }
+  if (!Array.isArray(catalog.controllers) || catalog.controllers.length !== 2
+      || catalog.controllers.map((entry) => entry?.id).join(',') !== 'A,B'
+      || catalog.controllers.some((entry) => !exactKeys(
+        entry,
+        ['id', 'workflow_commands', 'restoration_command', 'minimum_observations'],
+      ) || !Array.isArray(entry.workflow_commands) || entry.workflow_commands.length === 0
+        || entry.workflow_commands.some((command) => !['type', 'press'].includes(command))
+        || !['type', 'press'].includes(entry.restoration_command)
+        || !positiveInteger(entry.minimum_observations))) {
+    failures.push(failure('catalog_controllers', 'Catalog must define exact A and B controller requirements'));
+  }
+  for (const field of ['invariants', 'required_evidence']) {
+    const values = catalog[field];
+    if (!Array.isArray(values) || values.length === 0
+        || values.some((value) => typeof value !== 'string' || value.length === 0)
+        || new Set(values).size !== values.length) {
+      failures.push(failure('catalog_schema', `${field} must contain unique nonempty names`));
+    }
+  }
+  if (catalog.cursor_policy !== 'observational') {
+    failures.push(failure('catalog_cursor_policy', 'Physical cursor policy must remain observational'));
+  }
+  return failures;
+}
+
+function validateHost(report, failures) {
+  const host = report.host;
+  if (!exactKeys(host, [
+    'pid', 'start_identity', 'socket_path', 'source_commit', 'code_signature_hash',
+    'protocol_major', 'protocol_minor', 'executable_sha256', 'stable',
+  ]) || !validProcessFields(host)
+      || typeof host.socket_path !== 'string' || !path.isAbsolute(host.socket_path)
+      || !hex40.test(host.source_commit ?? '')
+      || !hex40.test(host.code_signature_hash ?? '')
+      || !hex64.test(host.executable_sha256 ?? '')
+      || !positiveInteger(host.protocol_major)
+      || !Number.isSafeInteger(host.protocol_minor) || host.protocol_minor < 0
+      || host.stable !== true) {
+    failures.push(failure('host_receipt', 'Signed current host receipt is incomplete, malformed, or unstable'));
+  }
+  if (host?.source_commit !== report.source_commit) {
+    failures.push(failure('host_source', 'Host source commit differs from the certified CLI source'));
+  }
+}
+
+function validateCLI(report, failures) {
+  const cli = report.cli;
+  if (!exactKeys(cli, ['source_commit', 'code_signature_hash', 'executable_sha256', 'executable_path'])
+      || cli.source_commit !== report.source_commit
+      || !hex40.test(cli.code_signature_hash ?? '')
+      || !hex64.test(cli.executable_sha256 ?? '')
+      || typeof cli.executable_path !== 'string' || !path.isAbsolute(cli.executable_path)) {
+    failures.push(failure('cli_receipt', 'CLI build receipt is incomplete or differs from the certified source'));
+  }
+}
+
+function validateMutation(entry, controller, target, cli, host, index, failures) {
+  if (!exactKeys(entry, [
+    'index', 'command', 'phase', 'started_at', 'finished_at', 'target_pid', 'target_window_id',
+    'success', 'effect', 'mutation_dispatched', 'retry_safe', 'foreground', 'client_pid',
+    'client_start_identity', 'reported_target_pid', 'reported_target_window_id',
+    'target_start_identity_after', 'delivery_mode', 'client_executable_path',
+    'host_pid', 'host_start_identity', 'host_code_signature_hash',
+  ]) || entry.index !== index
+      || !['type', 'press'].includes(entry.command)
+      || !['workflow', 'restoration'].includes(entry.phase)
+      || !finiteTimestamp(entry.started_at) || !finiteTimestamp(entry.finished_at)
+      || entry.finished_at <= entry.started_at
+      || entry.target_pid !== target.pid || entry.target_window_id !== target.window_id
+      || !positiveInteger(entry.client_pid)
+      || typeof entry.client_start_identity !== 'string'
+      || !decimalIdentity.test(entry.client_start_identity)
+      || entry.client_executable_path !== cli.executable_path
+      || entry.host_pid !== host.pid
+      || entry.host_start_identity !== host.start_identity
+      || entry.host_code_signature_hash !== host.code_signature_hash
+      || entry.reported_target_pid !== target.pid
+      || entry.reported_target_window_id !== target.window_id
+      || entry.target_start_identity_after !== target.start_identity
+      || entry.delivery_mode !== 'background'
+      || entry.success !== true
+      || !['confirmed', 'unverifiable'].includes(entry.effect)
+      || entry.mutation_dispatched !== true || entry.retry_safe !== false
+      || entry.foreground !== false) {
+    failures.push(failure('mutation_contract', `Controller ${controller} mutation ${index} is not exact`, controller));
+  }
+}
+
+function validateObservation(entry, controller, target, cli, host, index, failures) {
+  if (!exactKeys(entry, [
+    'index', 'started_at', 'finished_at', 'target_pid', 'target_window_id',
+    'expected_token', 'token_present', 'other_token_absent', 'client_pid',
+    'client_start_identity', 'reported_window_id', 'target_start_identity_after', 'route_receipt',
+    'client_executable_path', 'host_pid', 'host_start_identity', 'host_code_signature_hash',
+    'result_success',
+  ]) || entry.index !== index
+      || !finiteTimestamp(entry.started_at) || !finiteTimestamp(entry.finished_at)
+      || entry.finished_at <= entry.started_at
+      || entry.target_pid !== target.pid || entry.target_window_id !== target.window_id
+      || !positiveInteger(entry.client_pid)
+      || typeof entry.client_start_identity !== 'string'
+      || !decimalIdentity.test(entry.client_start_identity)
+      || entry.client_executable_path !== cli.executable_path
+      || entry.host_pid !== host.pid
+      || entry.host_start_identity !== host.start_identity
+      || entry.host_code_signature_hash !== host.code_signature_hash
+      || entry.reported_window_id !== target.window_id
+      || entry.target_start_identity_after !== target.start_identity
+      || entry.result_success !== true
+      || typeof entry.expected_token !== 'string' || entry.expected_token.length === 0
+      || entry.token_present !== true || entry.other_token_absent !== true) {
+    failures.push(failure('observation_contract', `Controller ${controller} observation ${index} is not exact`, controller));
+  }
+  const route = entry?.route_receipt;
+  if (!exactKeys(route, [
+    'client_pid', 'client_start_identity', 'client_executable_path', 'host_pid',
+    'host_start_identity', 'host_code_signature_hash', 'reported_target_pid',
+    'reported_window_id', 'target_start_identity_after', 'result_success',
+  ]) || !positiveInteger(route.client_pid)
+      || typeof route.client_start_identity !== 'string'
+      || !decimalIdentity.test(route.client_start_identity)
+      || route.client_executable_path !== cli.executable_path
+      || route.host_pid !== host.pid
+      || route.host_start_identity !== host.start_identity
+      || route.host_code_signature_hash !== host.code_signature_hash
+      || route.reported_target_pid !== target.pid
+      || route.reported_window_id !== target.window_id
+      || route.target_start_identity_after !== target.start_identity
+      || route.result_success !== true) {
+    failures.push(failure('observation_route', `Controller ${controller} route receipt ${index} is not exact`, controller));
+  }
+}
+
+function validateController(observed, expected, other, runID, cli, host, failures) {
+  if (!exactKeys(observed, [
+    'id', 'controller_process', 'target', 'started_at', 'finished_at', 'mutations', 'observations',
+    'initial_token', 'final_token', 'readback_token', 'restored_token',
+    'restoration_readback', 'cross_target_clear',
+  ]) || observed?.id !== expected.id || !exactProcessReceipt(observed?.controller_process)
+      || !exactTargetReceipt(observed?.target)
+      || !finiteTimestamp(observed?.started_at) || !finiteTimestamp(observed?.finished_at)
+      || observed.finished_at <= observed.started_at
+      || typeof observed.initial_token !== 'string' || observed.initial_token.length === 0
+      || typeof observed.final_token !== 'string' || observed.final_token.length === 0
+      || observed.final_token === observed.initial_token
+      || observed.readback_token !== observed.final_token
+      || observed.restored_token !== observed.initial_token
+      || observed.restoration_readback !== observed.initial_token
+      || observed.cross_target_clear !== true) {
+    failures.push(failure('controller_schema', `Controller ${expected.id} receipt or postcondition is invalid`, expected.id));
+    return;
+  }
+  if (observed.target.pid === other?.target?.pid
+      || observed.target.window_id === other?.target?.window_id) {
+    failures.push(failure('target_isolation', 'Controllers must own distinct process and window receipts', expected.id));
+  }
+  const namespace = `${runID}-${expected.id.toLowerCase()}-`;
+  const ownTokens = new Set([
+    observed.initial_token,
+    observed.final_token,
+    ...(observed.observations ?? []).map((entry) => entry?.expected_token),
+  ]);
+  const otherTokens = new Set([
+    other?.initial_token,
+    other?.final_token,
+    ...(other?.observations ?? []).map((entry) => entry?.expected_token),
+  ]);
+  if ([...ownTokens].some((token) => typeof token !== 'string' || !token.startsWith(namespace))
+      || [...ownTokens].some((token) => otherTokens.has(token))) {
+    failures.push(failure('token_namespace', `Controller ${expected.id} token namespace is not isolated`, expected.id));
+  }
+  const workflowMutations = Array.isArray(observed.mutations)
+    ? observed.mutations.filter((entry) => entry?.phase === 'workflow')
+    : [];
+  const restorationMutations = Array.isArray(observed.mutations)
+    ? observed.mutations.filter((entry) => entry?.phase === 'restoration')
+    : [];
+  if (!Array.isArray(observed.mutations)
+      || workflowMutations.length !== expected.workflow_commands.length
+      || restorationMutations.length !== 1
+      || observed.mutations.at(-1)?.phase !== 'restoration'
+      || observed.mutations.slice(0, -1).some((entry) => entry?.phase !== 'workflow')) {
+    failures.push(failure('mutation_count', `Controller ${expected.id} did not complete enough mutations`, expected.id));
+  } else {
+    observed.mutations.forEach((entry, index) => (
+      validateMutation(entry, expected.id, observed.target, cli, host, index + 1, failures)
+    ));
+    if (workflowMutations.some((entry, index) => entry.command !== expected.workflow_commands[index])
+        || restorationMutations[0]?.command !== expected.restoration_command) {
+      failures.push(failure(
+        'mutation_sequence',
+        `Controller ${expected.id} did not execute the exact catalog workflow`,
+        expected.id,
+      ));
+    }
+    if (observed.mutations.some((entry) => (
+      entry.started_at < observed.started_at || entry.finished_at > observed.finished_at
+    ))) {
+      failures.push(failure('mutation_timing', `Controller ${expected.id} mutation escaped its interval`, expected.id));
+    }
+    const restorationMutation = restorationMutations[0];
+    if (workflowMutations.some((entry, index) => (
+      entry.finished_at > restorationMutation.started_at
+        || (index > 0 && entry.started_at < workflowMutations[index - 1].finished_at)
+    ))) {
+      failures.push(failure('mutation_timing', `Controller ${expected.id} workflow is not ordered before restoration`, expected.id));
+    }
+  }
+  if (!Array.isArray(observed.observations) || observed.observations.length - 1 < expected.minimum_observations) {
+    failures.push(failure('observation_count', `Controller ${expected.id} did not complete enough observations`, expected.id));
+  } else {
+    observed.observations.forEach((entry, index) => (
+      validateObservation(entry, expected.id, observed.target, cli, host, index + 1, failures)
+    ));
+    if (observed.observations.some((entry) => (
+      entry.started_at < observed.started_at || entry.finished_at > observed.finished_at
+    ))) {
+      failures.push(failure('observation_timing', `Controller ${expected.id} observation escaped its interval`, expected.id));
+    }
+    const firstMutation = observed.mutations?.[0];
+    const restorationMutation = observed.mutations?.at(-1);
+    const finalWorkflowMutation = workflowMutations.at(-1);
+    const initialReadback = observed.observations[0];
+    const finalReadback = observed.observations.find((entry) => (
+      entry.expected_token === observed.final_token
+        && entry.token_present === true
+        && entry.started_at >= (finalWorkflowMutation?.finished_at ?? Infinity)
+        && entry.finished_at <= (restorationMutation?.started_at ?? -Infinity)
+    ));
+    const restorationReadback = observed.observations.at(-1);
+    const workflowObservations = observed.observations.slice(0, -1);
+    const observationsOrdered = workflowObservations.every((entry, index) => (
+      entry.finished_at <= (restorationMutation?.started_at ?? -Infinity)
+        && (index === 0 || entry.started_at >= workflowObservations[index - 1].finished_at)
+    ));
+    const sequenceBound = initialReadback?.expected_token === observed.initial_token
+      && initialReadback?.token_present === true
+      && initialReadback.finished_at <= (firstMutation?.started_at ?? -Infinity)
+      && finalReadback !== undefined
+      && restorationReadback?.expected_token === observed.initial_token
+      && restorationReadback?.token_present === true
+      && restorationReadback.started_at >= (restorationMutation?.finished_at ?? Infinity)
+      && observationsOrdered;
+    if (!sequenceBound) {
+      failures.push(failure(
+        'independent_readback',
+        `Controller ${expected.id} readbacks are missing or out of mutation order`,
+        expected.id,
+      ));
+    }
+  }
+}
+
+export function validateOverlapCertification(catalog, report, expectedCatalogSHA256 = null) {
+  const failures = validateCatalog(catalog);
+  if (!exactKeys(report, [
+    'version', 'catalog_sha256', 'run_id', 'source_commit', 'cli', 'host', 'sentinel',
+    'controllers', 'overlap', 'invariants', 'cursor_observation', 'restoration',
+    'cleanup', 'evidence',
+  ]) || report?.version !== 1) {
+    failures.push(failure('report_schema', 'Report must be one closed version-1 object'));
+    return { success: false, failures };
+  }
+  if (!hex64.test(report.catalog_sha256 ?? '')
+      || (expectedCatalogSHA256 !== null && report.catalog_sha256 !== expectedCatalogSHA256)) {
+    failures.push(failure('catalog_hash', 'Report is not bound to the exact catalog bytes'));
+  }
+  if (typeof report.run_id !== 'string' || !/^overlap-[0-9a-f-]{36}$/.test(report.run_id)) {
+    failures.push(failure('run_id', 'Run ID must be one exact overlap UUID'));
+  }
+  if (!hex40.test(report.source_commit ?? '')) {
+    failures.push(failure('source_commit', 'Source commit must be canonical 40-hex'));
+  }
+  validateHost(report, failures);
+  validateCLI(report, failures);
+
+  const sentinel = report.sentinel;
+  if (!exactKeys(sentinel, [
+    'pid', 'start_identity', 'window_id', 'initial_frontmost_pid', 'initial_top_window_id',
+    'final_frontmost_pid', 'final_top_window_id',
+  ]) || !validTargetFields(sentinel)
+      || sentinel.initial_frontmost_pid !== sentinel.pid
+      || sentinel.initial_top_window_id !== sentinel.window_id
+      || sentinel.final_frontmost_pid !== sentinel.pid
+      || sentinel.final_top_window_id !== sentinel.window_id) {
+    failures.push(failure('sentinel_receipt', 'Sentinel did not retain exact frontmost and top-window identity'));
+  }
+
+  if (!Array.isArray(report.controllers) || report.controllers.length !== catalog.controllers.length
+      || report.controllers.map((entry) => entry?.id).join(',') !== 'A,B') {
+    failures.push(failure('controllers', 'Report must contain exact ordered A and B controller rows'));
+  } else {
+    const generationKey = (receipt) => `${receipt?.pid}:${receipt?.start_identity}`;
+    const wrapperGenerations = report.controllers.map((entry) => generationKey(entry.controller_process));
+    const operationGenerations = report.controllers.flatMap((entry) => [
+      ...(entry.mutations ?? []).map((operation) => (
+        `${operation.client_pid}:${operation.client_start_identity}`
+      )),
+      ...(entry.observations ?? []).flatMap((operation) => [
+        `${operation.client_pid}:${operation.client_start_identity}`,
+        `${operation.route_receipt?.client_pid}:${operation.route_receipt?.client_start_identity}`,
+      ]),
+    ]);
+    const allClientGenerations = [...wrapperGenerations, ...operationGenerations];
+    if (new Set(allClientGenerations).size !== allClientGenerations.length) {
+      failures.push(failure('client_isolation', 'Controllers and operations must use distinct process generations'));
+    }
+    validateController(
+      report.controllers[0], catalog.controllers[0], report.controllers[1], report.run_id,
+      report.cli, report.host, failures,
+    );
+    validateController(
+      report.controllers[1], catalog.controllers[1], report.controllers[0], report.run_id,
+      report.cli, report.host, failures,
+    );
+  }
+
+  const [controllerA, controllerB] = report.controllers ?? [];
+  const workflowMutationsA = (controllerA?.mutations ?? []).filter((entry) => entry?.phase === 'workflow');
+  const workflowMutationsB = (controllerB?.mutations ?? []).filter((entry) => entry?.phase === 'workflow');
+  const overlap = report.overlap;
+  const calculatedPairs = [];
+  for (const aMutation of workflowMutationsA) {
+    for (const bMutation of workflowMutationsB) {
+      const startedAt = Math.max(aMutation.started_at, bMutation.started_at);
+      const finishedAt = Math.min(aMutation.finished_at, bMutation.finished_at);
+      if (finishedAt > startedAt) {
+        calculatedPairs.push({
+          a_index: aMutation.index,
+          b_index: bMutation.index,
+          a_client_pid: aMutation.client_pid,
+          a_client_start_identity: aMutation.client_start_identity,
+          b_client_pid: bMutation.client_pid,
+          b_client_start_identity: bMutation.client_start_identity,
+          started_at: startedAt,
+          finished_at: finishedAt,
+          seconds: finishedAt - startedAt,
+        });
+      }
+    }
+  }
+  const calculatedStart = Math.min(...calculatedPairs.map((pair) => pair.started_at));
+  const calculatedEnd = Math.max(...calculatedPairs.map((pair) => pair.finished_at));
+  const calculatedSeconds = calculatedPairs.reduce((total, pair) => total + pair.seconds, 0);
+  const calculatedAMutations = new Set(calculatedPairs.map((pair) => pair.a_index)).size;
+  const calculatedBMutations = new Set(calculatedPairs.map((pair) => pair.b_index)).size;
+  const witness = overlap?.simultaneous_liveness_witness;
+  const validActiveMarker = (marker, controller, pid, identity) => exactKeys(marker, [
+    'controller', 'index', 'phase', 'pid', 'start_identity',
+  ]) && marker.controller === controller
+    && positiveInteger(marker.index)
+    && marker.phase === 'workflow'
+    && marker.pid === pid
+    && marker.start_identity === identity;
+  if (!exactKeys(overlap, [
+    'started_at', 'finished_at', 'seconds', 'a_mutations_during_b', 'b_mutations_during_a',
+    'concurrent_mutation_pairs', 'simultaneous_liveness_witness',
+  ]) || overlap.started_at !== calculatedStart || overlap.finished_at !== calculatedEnd
+      || Math.abs(overlap.seconds - calculatedSeconds) > 0.000_001
+      || overlap.seconds <= 0
+      || overlap.a_mutations_during_b !== calculatedAMutations
+      || overlap.b_mutations_during_a !== calculatedBMutations
+      || !positiveInteger(calculatedAMutations)
+      || !positiveInteger(calculatedBMutations)
+      || !Array.isArray(overlap.concurrent_mutation_pairs)
+      || overlap.concurrent_mutation_pairs.length === 0
+      || JSON.stringify(overlap.concurrent_mutation_pairs) !== JSON.stringify(calculatedPairs)
+      || !exactKeys(witness, [
+        'a_pid', 'a_start_identity', 'b_pid', 'b_start_identity',
+        'a_checked_before_at', 'b_checked_at', 'a_checked_after_at', 'observed_at',
+        'a_active_marker', 'b_active_marker', 'markers_unchanged',
+      ])
+      || !validActiveMarker(witness?.a_active_marker, 'A', witness?.a_pid, witness?.a_start_identity)
+      || !validActiveMarker(witness?.b_active_marker, 'B', witness?.b_pid, witness?.b_start_identity)
+      || witness?.markers_unchanged !== true
+      || ![witness?.a_checked_before_at, witness?.b_checked_at, witness?.a_checked_after_at]
+        .every((value) => typeof value === 'number' && Number.isFinite(value))
+      || witness?.a_checked_before_at > witness?.b_checked_at
+      || witness?.b_checked_at > witness?.a_checked_after_at
+      || witness?.observed_at !== witness?.b_checked_at
+      || !calculatedPairs.some((pair) => (
+        pair.a_client_pid === witness.a_pid
+          && pair.a_client_start_identity === witness.a_start_identity
+          && pair.b_client_pid === witness.b_pid
+          && pair.b_client_start_identity === witness.b_start_identity
+          && pair.a_index === witness.a_active_marker.index
+          && pair.b_index === witness.b_active_marker.index
+          && witness.a_checked_before_at >= pair.started_at
+          && witness.a_checked_after_at <= pair.finished_at
+      ))) {
+    failures.push(failure('overlap', 'Controller intervals do not prove real bidirectional overlap'));
+  }
+
+  if (!Array.isArray(report.invariants) || report.invariants.length !== catalog.invariants.length
+      || report.invariants.map((entry) => entry?.name).join(',') !== catalog.invariants.join(',')) {
+    failures.push(failure('invariant_schema', 'Invariant results must exactly match catalog order'));
+  } else {
+    for (const invariant of report.invariants) {
+      if (!exactKeys(invariant, ['name', 'passed', 'evidence'])
+          || invariant.passed !== true
+          || typeof invariant.evidence !== 'string' || invariant.evidence.length === 0) {
+        failures.push(failure('invariant_failed', `Invariant '${invariant?.name ?? 'unknown'}' did not pass`));
+      }
+    }
+  }
+
+  const cursor = report.cursor_observation;
+  if (!exactKeys(cursor, ['policy', 'start_x', 'start_y', 'end_x', 'end_y', 'moved'])
+      || cursor.policy !== 'observational'
+      || [cursor.start_x, cursor.start_y, cursor.end_x, cursor.end_y].some((value) => (
+        typeof value !== 'number' || !Number.isFinite(value)
+      )) || typeof cursor.moved !== 'boolean') {
+    failures.push(failure('cursor_observation', 'Cursor evidence must be observational and well formed'));
+  }
+
+  if (!exactKeys(report.restoration, ['controller_a', 'controller_b', 'sentinel'])
+      || Object.values(report.restoration).some((value) => value !== true)) {
+    failures.push(failure('restoration', 'Target and sentinel restoration did not complete'));
+  }
+  if (!Array.isArray(report.cleanup) || report.cleanup.length !== 2
+      || report.cleanup.map((entry) => entry?.id).join(',') !== 'A,B'
+      || report.cleanup.some((entry, index) => !exactKeys(
+        entry,
+        ['id', 'pid', 'start_identity', 'gone'],
+      ) || entry.id !== ['A', 'B'][index]
+        || entry.pid !== report.controllers?.[index]?.target?.pid
+        || entry.start_identity !== report.controllers?.[index]?.target?.start_identity
+        || entry.gone !== true)) {
+    failures.push(failure('cleanup', 'Cleanup must remove exactly the two owned target generations'));
+  }
+  if (!exactKeys(report.evidence, Object.keys(Object.fromEntries(
+    catalog.required_evidence.map((name) => [name, true]),
+  ))) || catalog.required_evidence.some((name) => report.evidence[name] !== true)) {
+    failures.push(failure('evidence', 'Every catalog evidence family must pass'));
+  }
+  return { success: failures.length === 0, failures };
+}
+
+export function makePassingOverlapReport(catalog, catalogSHA256 = 'f'.repeat(64)) {
+  const runID = 'overlap-01234567-89ab-cdef-0123-456789abcdef';
+  const target = (pid, startIdentity, windowID) => ({
+    pid,
+    start_identity: startIdentity,
+    window_id: windowID,
+  });
+  const mutation = (index, command, phase, startedAt, targetReceipt) => ({
+    index,
+    command,
+    phase,
+    started_at: startedAt,
+    finished_at: startedAt + 0.2,
+    target_pid: targetReceipt.pid,
+    target_window_id: targetReceipt.window_id,
+    client_pid: targetReceipt.pid + 1000 + index,
+    client_start_identity: `${targetReceipt.pid + 1000 + index}00`,
+    client_executable_path: '/artifacts/bin/peekaboo-certified',
+    host_pid: 401,
+    host_start_identity: '40100',
+    host_code_signature_hash: 'a'.repeat(40),
+    reported_target_pid: targetReceipt.pid,
+    reported_target_window_id: targetReceipt.window_id,
+    target_start_identity_after: targetReceipt.start_identity,
+    delivery_mode: 'background',
+    success: true,
+    effect: 'confirmed',
+    mutation_dispatched: true,
+    retry_safe: false,
+    foreground: false,
+  });
+  const observation = (index, startedAt, token, targetReceipt) => ({
+    index,
+    started_at: startedAt,
+    finished_at: startedAt + 0.1,
+    target_pid: targetReceipt.pid,
+    target_window_id: targetReceipt.window_id,
+    client_pid: targetReceipt.pid + 2000 + index,
+    client_start_identity: `${targetReceipt.pid + 2000 + index}00`,
+    client_executable_path: '/artifacts/bin/peekaboo-certified',
+    host_pid: 401,
+    host_start_identity: '40100',
+    host_code_signature_hash: 'a'.repeat(40),
+    result_success: true,
+    reported_window_id: targetReceipt.window_id,
+    target_start_identity_after: targetReceipt.start_identity,
+    route_receipt: {
+      client_pid: targetReceipt.pid + 3000 + index,
+      client_start_identity: `${targetReceipt.pid + 3000 + index}00`,
+      client_executable_path: '/artifacts/bin/peekaboo-certified',
+      host_pid: 401,
+      host_start_identity: '40100',
+      host_code_signature_hash: 'a'.repeat(40),
+      reported_target_pid: targetReceipt.pid,
+      reported_window_id: targetReceipt.window_id,
+      target_start_identity_after: targetReceipt.start_identity,
+      result_success: true,
+    },
+    expected_token: token,
+    token_present: true,
+    other_token_absent: true,
+  });
+  const controller = (expected, clientPID, targetReceipt, startedAt, finishedAt, observationCount) => {
+    const { id } = expected;
+    const namespace = `${runID}-${id.toLowerCase()}-`;
+    const initial = `${namespace}initial`;
+    const final = `${namespace}final`;
+    const mutationCommands = [...expected.workflow_commands, expected.restoration_command];
+    const mutations = mutationCommands.map((command, index) => (
+      mutation(
+        index + 1,
+        command,
+        index === mutationCommands.length - 1 ? 'restoration' : 'workflow',
+        startedAt + 0.2 + index * 0.5,
+        targetReceipt,
+      )
+    ));
+    const restorationMutation = mutations.at(-1);
+    const finalWorkflowMutation = mutations.at(-2);
+    const observations = [observation(1, startedAt + 0.05, initial, targetReceipt)];
+    for (let index = 0; index < observationCount - 3; index += 1) {
+      observations.push(observation(
+        observations.length + 1,
+        mutations[0].finished_at + 0.05 + index * 0.1,
+        `${namespace}checkpoint-${index + 1}`,
+        targetReceipt,
+      ));
+    }
+    observations.push(observation(
+      observations.length + 1,
+      finalWorkflowMutation.finished_at + 0.05,
+      final,
+      targetReceipt,
+    ));
+    observations.push(observation(
+      observations.length + 1,
+      restorationMutation.finished_at + 0.05,
+      initial,
+      targetReceipt,
+    ));
+    return {
+      id,
+      controller_process: { pid: clientPID, start_identity: `${clientPID}00` },
+      target: targetReceipt,
+      started_at: startedAt,
+      finished_at: finishedAt,
+      mutations,
+      observations,
+      initial_token: initial,
+      final_token: final,
+      readback_token: final,
+      restored_token: initial,
+      restoration_readback: initial,
+      cross_target_clear: true,
+    };
+  };
+  const controllerA = controller(catalog.controllers[0], 301, target(101, '10100', 201), 10, 15, 4);
+  const controllerB = controller(catalog.controllers[1], 302, target(202, '20200', 302), 9, 16, 5);
+  return {
+    version: 1,
+    catalog_sha256: catalogSHA256,
+    run_id: runID,
+    source_commit: '0123456789abcdef0123456789abcdef01234567',
+    cli: {
+      source_commit: '0123456789abcdef0123456789abcdef01234567',
+      code_signature_hash: 'd'.repeat(40),
+      executable_sha256: 'c'.repeat(64),
+      executable_path: '/artifacts/bin/peekaboo-certified',
+    },
+    host: {
+      pid: 401,
+      start_identity: '40100',
+      socket_path: '/tmp/peekaboo-overlap/bridge.sock',
+      source_commit: '0123456789abcdef0123456789abcdef01234567',
+      code_signature_hash: 'a'.repeat(40),
+      protocol_major: 1,
+      protocol_minor: 25,
+      executable_sha256: 'b'.repeat(64),
+      stable: true,
+    },
+    sentinel: {
+      ...target(501, '50100', 601),
+      initial_frontmost_pid: 501,
+      initial_top_window_id: 601,
+      final_frontmost_pid: 501,
+      final_top_window_id: 601,
+    },
+    controllers: [controllerA, controllerB],
+    overlap: {
+      started_at: 10.2,
+      finished_at: 10.899999999999999,
+      seconds: 0.3999999999999986,
+      a_mutations_during_b: 2,
+      b_mutations_during_a: 2,
+      concurrent_mutation_pairs: [
+        {
+          a_index: 1,
+          b_index: 3,
+          a_client_pid: 1102,
+          a_client_start_identity: '110200',
+          b_client_pid: 1205,
+          b_client_start_identity: '120500',
+          started_at: 10.2,
+          finished_at: 10.399999999999999,
+          seconds: 0.1999999999999993,
+        },
+        {
+          a_index: 2,
+          b_index: 4,
+          a_client_pid: 1103,
+          a_client_start_identity: '110300',
+          b_client_pid: 1206,
+          b_client_start_identity: '120600',
+          started_at: 10.7,
+          finished_at: 10.899999999999999,
+          seconds: 0.1999999999999993,
+        },
+      ],
+      simultaneous_liveness_witness: {
+        a_pid: 1102,
+        a_start_identity: '110200',
+        b_pid: 1205,
+        b_start_identity: '120500',
+        a_checked_before_at: 10.25,
+        b_checked_at: 10.3,
+        a_checked_after_at: 10.35,
+        observed_at: 10.3,
+        a_active_marker: {
+          controller: 'A', index: 1, phase: 'workflow', pid: 1102, start_identity: '110200',
+        },
+        b_active_marker: {
+          controller: 'B', index: 3, phase: 'workflow', pid: 1205, start_identity: '120500',
+        },
+        markers_unchanged: true,
+      },
+    },
+    invariants: catalog.invariants.map((name) => ({ name, passed: true, evidence: `${name}.json` })),
+    cursor_observation: {
+      policy: 'observational', start_x: 20, start_y: 30, end_x: 40, end_y: 50, moved: true,
+    },
+    restoration: { controller_a: true, controller_b: true, sentinel: true },
+    cleanup: [
+      { id: 'A', pid: 101, start_identity: '10100', gone: true },
+      { id: 'B', pid: 202, start_identity: '20200', gone: true },
+    ],
+    evidence: Object.fromEntries(catalog.required_evidence.map((name) => [name, true])),
+  };
+}
+
+export function runOverlapContractSelfTest(catalog, catalogSHA256) {
+  const passing = makePassingOverlapReport(catalog, catalogSHA256);
+  assert.equal(validateOverlapCertification(catalog, passing, catalogSHA256).success, true);
+  const corruptions = [
+    ['missing controller', (report) => report.controllers.pop(), 'controllers'],
+    ['reused target', (report) => { report.controllers[1].target.pid = report.controllers[0].target.pid; }, 'target_isolation'],
+    ['reused controller generation', (report) => {
+      report.controllers[1].controller_process = structuredClone(report.controllers[0].controller_process);
+    }, 'client_isolation'],
+    ['serialized intervals', (report) => {
+      report.controllers[1].mutations.filter((entry) => entry.phase === 'workflow').forEach((entry) => {
+        entry.started_at += 20;
+        entry.finished_at += 20;
+      });
+    }, 'overlap'],
+    ['foreground mutation', (report) => { report.controllers[0].mutations[0].foreground = true; }, 'mutation_contract'],
+    ['false target receipt', (report) => { report.controllers[0].mutations[0].reported_target_pid = 102; }, 'mutation_contract'],
+    ['cross target leak', (report) => { report.controllers[0].cross_target_clear = false; }, 'controller_schema'],
+    ['host restart', (report) => { report.host.stable = false; }, 'host_receipt'],
+    ['sentinel focus theft', (report) => { report.sentinel.final_frontmost_pid = 999; }, 'sentinel_receipt'],
+    ['global input', (report) => { report.invariants[4].passed = false; }, 'invariant_failed'],
+    ['clipboard drift', (report) => { report.invariants[5].passed = false; }, 'invariant_failed'],
+    ['overlay leak', (report) => { report.invariants[6].passed = false; }, 'invariant_failed'],
+    ['cursor made strict', (report) => { report.cursor_observation.policy = 'unchanged'; }, 'cursor_observation'],
+    ['bare cleanup pid', (report) => { report.cleanup[0].start_identity = ''; }, 'cleanup'],
+    ['unknown report key', (report) => { report.ignored = true; }, 'report_schema'],
+    ['catalog mismatch', (report) => { report.catalog_sha256 = '0'.repeat(64); }, 'catalog_hash'],
+    ['no concurrent commands', (report) => { report.overlap.concurrent_mutation_pairs = []; }, 'overlap'],
+    ['changed active marker', (report) => {
+      report.overlap.simultaneous_liveness_witness.markers_unchanged = false;
+    }, 'overlap'],
+    ['restoration counted as workflow', (report) => { report.controllers[0].mutations.splice(1, 1); }, 'mutation_count'],
+    ['workflow command drift', (report) => { report.controllers[0].mutations[1].command = 'type'; }, 'mutation_sequence'],
+  ];
+  for (const [name, mutate, expectedRule] of corruptions) {
+    const report = structuredClone(passing);
+    mutate(report);
+    const result = validateOverlapCertification(catalog, report, catalogSHA256);
+    assert.equal(result.success, false, name);
+    assert.ok(result.failures.some((entry) => entry.rule === expectedRule), name);
+  }
+  return { success: true, tests: corruptions.length + 1 };
+}
+
+function parseArguments(argv) {
+  const result = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const value = argv[index];
+    if (value === '--self-test') result.selfTest = true;
+    else if (['--catalog', '--report', '--output'].includes(value) && argv[index + 1]) {
+      result[value.slice(2)] = argv[index + 1];
+      index += 1;
+    } else throw new Error(`Unknown or incomplete argument: ${value}`);
+  }
+  return result;
+}
+
+function runCLI() {
+  const args = parseArguments(process.argv.slice(2));
+  if (args.selfTest) {
+    if (!args.catalog) throw new Error('--catalog is required with --self-test');
+    const catalogBytes = fs.readFileSync(args.catalog);
+    const catalog = JSON.parse(catalogBytes);
+    const catalogSHA256 = createHash('sha256').update(catalogBytes).digest('hex');
+    process.stdout.write(`${JSON.stringify(runOverlapContractSelfTest(catalog, catalogSHA256))}\n`);
+    return;
+  }
+  if (!args.catalog || !args.report) throw new Error('--catalog and --report are required');
+  const catalogBytes = fs.readFileSync(args.catalog);
+  const catalog = JSON.parse(catalogBytes);
+  const report = JSON.parse(fs.readFileSync(args.report, 'utf8'));
+  const catalogSHA256 = createHash('sha256').update(catalogBytes).digest('hex');
+  const result = validateOverlapCertification(catalog, report, catalogSHA256);
+  const output = `${JSON.stringify(result, null, 2)}\n`;
+  if (args.output) fs.writeFileSync(args.output, output);
+  else process.stdout.write(output);
+  if (!result.success) process.exitCode = 1;
+}
+
+const invokedAsScript = process.argv[1]
+  && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (invokedAsScript) {
+  try {
+    runCLI();
+  } catch (error) {
+    process.stderr.write(`dual-controller overlap reporter: ${error.message}\n`);
+    process.exitCode = 2;
+  }
+}

--- a/tests/dual-controller-overlap-report.test.mjs
+++ b/tests/dual-controller-overlap-report.test.mjs
@@ -1,0 +1,247 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import {
+  makePassingOverlapReport,
+  validateOverlapCertification,
+} from '../scripts/validate-dual-controller-overlap-report.mjs';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const catalog = JSON.parse(fs.readFileSync(
+  path.join(root, 'scripts/dual-controller-overlap-catalog.json'),
+  'utf8',
+));
+
+function validate(report) {
+  return validateOverlapCertification(catalog, report, report.catalog_sha256);
+}
+
+function rules(result) {
+  return new Set(result.failures.map((entry) => entry.rule));
+}
+
+test('passing report proves exact targets and bidirectional overlap', () => {
+  const report = makePassingOverlapReport(catalog);
+  const result = validate(report);
+  assert.equal(result.success, true);
+  assert.deepEqual(result.failures, []);
+});
+
+test('missing duplicate and unknown controllers fail closed', () => {
+  const missing = makePassingOverlapReport(catalog);
+  missing.controllers.pop();
+  assert.ok(rules(validate(missing)).has('controllers'));
+
+  const duplicate = makePassingOverlapReport(catalog);
+  duplicate.controllers[1] = structuredClone(duplicate.controllers[0]);
+  assert.ok(rules(validate(duplicate)).has('controllers'));
+
+  const unknown = makePassingOverlapReport(catalog);
+  unknown.controllers[1].id = 'C';
+  assert.ok(rules(validate(unknown)).has('controllers'));
+});
+
+test('target receipts require distinct process generations and windows', () => {
+  const report = makePassingOverlapReport(catalog);
+  report.controllers[1].target.pid = report.controllers[0].target.pid;
+  report.controllers[1].target.start_identity = report.controllers[0].target.start_identity;
+  report.controllers[1].target.window_id = report.controllers[0].target.window_id;
+  const result = validate(report);
+  assert.equal(result.success, false);
+  assert.ok(rules(result).has('target_isolation'));
+});
+
+test('controller and operation process generations must be distinct', () => {
+  const wrapperReuse = makePassingOverlapReport(catalog);
+  wrapperReuse.controllers[1].controller_process = structuredClone(
+    wrapperReuse.controllers[0].controller_process,
+  );
+  assert.ok(rules(validate(wrapperReuse)).has('client_isolation'));
+
+  const operationReuse = makePassingOverlapReport(catalog);
+  operationReuse.controllers[1].mutations[0].client_pid =
+    operationReuse.controllers[0].mutations[0].client_pid;
+  operationReuse.controllers[1].mutations[0].client_start_identity =
+    operationReuse.controllers[0].mutations[0].client_start_identity;
+  assert.ok(rules(validate(operationReuse)).has('client_isolation'));
+
+  const wrapperOperationReuse = makePassingOverlapReport(catalog);
+  wrapperOperationReuse.controllers[0].mutations[0].client_pid =
+    wrapperOperationReuse.controllers[0].controller_process.pid;
+  wrapperOperationReuse.controllers[0].mutations[0].client_start_identity =
+    wrapperOperationReuse.controllers[0].controller_process.start_identity;
+  assert.ok(rules(validate(wrapperOperationReuse)).has('client_isolation'));
+});
+
+test('serialized or one-way work cannot claim overlap', () => {
+  const serialized = makePassingOverlapReport(catalog);
+  serialized.controllers[1].mutations.filter((entry) => entry.phase === 'workflow').forEach((entry) => {
+    entry.started_at += 20;
+    entry.finished_at += 20;
+  });
+  assert.ok(rules(validate(serialized)).has('overlap'));
+
+  const oneWay = makePassingOverlapReport(catalog);
+  oneWay.overlap.b_mutations_during_a = 0;
+  assert.ok(rules(validate(oneWay)).has('overlap'));
+
+  const noConcurrentCommands = makePassingOverlapReport(catalog);
+  const starts = [10.45, 10.95, 11.45, 11.95, 12.2];
+  noConcurrentCommands.controllers[1].mutations.forEach((mutation, index) => {
+    mutation.started_at = starts[index];
+    mutation.finished_at = starts[index] + 0.1;
+  });
+  noConcurrentCommands.overlap.b_mutations_during_a = 4;
+  noConcurrentCommands.overlap.concurrent_mutation_pairs = [];
+  assert.ok(rules(validate(noConcurrentCommands)).has('overlap'));
+
+  const falseLivenessWitness = makePassingOverlapReport(catalog);
+  falseLivenessWitness.overlap.simultaneous_liveness_witness.a_start_identity = '999';
+  assert.ok(rules(validate(falseLivenessWitness)).has('overlap'));
+
+  const changedMarkers = makePassingOverlapReport(catalog);
+  changedMarkers.overlap.simultaneous_liveness_witness.markers_unchanged = false;
+  assert.ok(rules(validate(changedMarkers)).has('overlap'));
+
+  const staleMarker = makePassingOverlapReport(catalog);
+  staleMarker.overlap.simultaneous_liveness_witness.b_active_marker.index = 4;
+  assert.ok(rules(validate(staleMarker)).has('overlap'));
+
+  const unbracketed = makePassingOverlapReport(catalog);
+  unbracketed.overlap.simultaneous_liveness_witness.a_checked_after_at = 10.45;
+  assert.ok(rules(validate(unbracketed)).has('overlap'));
+});
+
+test('foreground or cross-target mutations fail', () => {
+  const foreground = makePassingOverlapReport(catalog);
+  foreground.controllers[0].mutations[0].foreground = true;
+  assert.ok(rules(validate(foreground)).has('mutation_contract'));
+
+  const leaked = makePassingOverlapReport(catalog);
+  leaked.controllers[1].cross_target_clear = false;
+  assert.ok(rules(validate(leaked)).has('controller_schema'));
+
+  const falseReceipt = makePassingOverlapReport(catalog);
+  falseReceipt.controllers[0].mutations[0].reported_target_pid = falseReceipt.controllers[1].target.pid;
+  assert.ok(rules(validate(falseReceipt)).has('mutation_contract'));
+
+  const falseObservationReceipt = makePassingOverlapReport(catalog);
+  falseObservationReceipt.controllers[0].observations[0].route_receipt.reported_target_pid =
+    falseObservationReceipt.controllers[1].target.pid;
+  assert.ok(rules(validate(falseObservationReceipt)).has('observation_route'));
+});
+
+test('independent readback and restoration are mandatory', () => {
+  const staleReadback = makePassingOverlapReport(catalog);
+  staleReadback.controllers[0].readback_token = staleReadback.controllers[0].initial_token;
+  assert.ok(rules(validate(staleReadback)).has('controller_schema'));
+
+  const missingRestore = makePassingOverlapReport(catalog);
+  missingRestore.restoration.controller_b = false;
+  assert.ok(rules(validate(missingRestore)).has('restoration'));
+
+  const earlyRestore = makePassingOverlapReport(catalog);
+  earlyRestore.controllers[0].observations.at(-1).started_at =
+    earlyRestore.controllers[0].mutations.at(-1).started_at;
+  earlyRestore.controllers[0].observations.at(-1).finished_at =
+    earlyRestore.controllers[0].mutations.at(-1).started_at + 0.05;
+  assert.ok(rules(validate(earlyRestore)).has('independent_readback'));
+});
+
+test('workflow minima exclude restoration operations', () => {
+  const report = makePassingOverlapReport(catalog);
+  report.controllers[0].mutations.splice(1, 1);
+  const result = validate(report);
+  assert.equal(result.success, false);
+  assert.ok(rules(result).has('mutation_count'));
+});
+
+test('catalog binds exact controller workflows and restoration commands', () => {
+  const missingReturn = makePassingOverlapReport(catalog);
+  missingReturn.controllers[0].mutations[1].command = 'type';
+  assert.ok(rules(validate(missingReturn)).has('mutation_sequence'));
+
+  const unexpectedPress = makePassingOverlapReport(catalog);
+  unexpectedPress.controllers[1].mutations[2].command = 'press';
+  assert.ok(rules(validate(unexpectedPress)).has('mutation_sequence'));
+
+  const wrongRestore = makePassingOverlapReport(catalog);
+  wrongRestore.controllers[0].mutations.at(-1).command = 'press';
+  assert.ok(rules(validate(wrongRestore)).has('mutation_sequence'));
+});
+
+test('observations and route receipts require successful JSON envelopes', () => {
+  const failedObservation = makePassingOverlapReport(catalog);
+  failedObservation.controllers[0].observations[0].result_success = false;
+  assert.ok(rules(validate(failedObservation)).has('observation_contract'));
+
+  const failedRoute = makePassingOverlapReport(catalog);
+  failedRoute.controllers[0].observations[0].route_receipt.result_success = false;
+  assert.ok(rules(validate(failedRoute)).has('observation_route'));
+});
+
+test('controller token namespaces are run-bound and disjoint', () => {
+  const report = makePassingOverlapReport(catalog);
+  report.controllers[1].initial_token = report.controllers[0].initial_token;
+  const result = validate(report);
+  assert.equal(result.success, false);
+  assert.ok(rules(result).has('token_namespace'));
+});
+
+test('host restart and sentinel drift fail', () => {
+  const hostRestart = makePassingOverlapReport(catalog);
+  hostRestart.host.stable = false;
+  assert.ok(rules(validate(hostRestart)).has('host_receipt'));
+
+  const focusTheft = makePassingOverlapReport(catalog);
+  focusTheft.sentinel.final_frontmost_pid = 999;
+  assert.ok(rules(validate(focusTheft)).has('sentinel_receipt'));
+});
+
+test('every named invariant is unsuppressible', () => {
+  for (let index = 0; index < catalog.invariants.length; index += 1) {
+    const report = makePassingOverlapReport(catalog);
+    report.invariants[index].passed = false;
+    const result = validate(report);
+    assert.equal(result.success, false, catalog.invariants[index]);
+    assert.ok(rules(result).has('invariant_failed'), catalog.invariants[index]);
+  }
+});
+
+test('physical cursor is evidence but never an unchanged oracle', () => {
+  const moved = makePassingOverlapReport(catalog);
+  moved.cursor_observation.moved = true;
+  assert.equal(validate(moved).success, true);
+
+  const strict = makePassingOverlapReport(catalog);
+  strict.cursor_observation.policy = 'unchanged';
+  assert.ok(rules(validate(strict)).has('cursor_observation'));
+});
+
+test('cleanup requires exact process generation receipts', () => {
+  const report = makePassingOverlapReport(catalog);
+  report.cleanup[0].start_identity = '';
+  const result = validate(report);
+  assert.equal(result.success, false);
+  assert.ok(rules(result).has('cleanup'));
+});
+
+test('unknown fields and legacy aggregate results fail closed', () => {
+  const unknown = makePassingOverlapReport(catalog);
+  unknown.ignored = true;
+  assert.ok(rules(validate(unknown)).has('report_schema'));
+
+  const aggregate = makePassingOverlapReport(catalog);
+  aggregate.invariants = { violations: 0 };
+  assert.ok(rules(validate(aggregate)).has('invariant_schema'));
+});
+
+test('catalog hash must match independently supplied bytes', () => {
+  const report = makePassingOverlapReport(catalog);
+  const result = validateOverlapCertification(catalog, report, '0'.repeat(64));
+  assert.equal(result.success, false);
+  assert.ok(rules(result).has('catalog_hash'));
+});

--- a/tests/dual-controller-overlap-report.test.mjs
+++ b/tests/dual-controller-overlap-report.test.mjs
@@ -151,6 +151,27 @@ test('independent readback and restoration are mandatory', () => {
   assert.ok(rules(validate(earlyRestore)).has('independent_readback'));
 });
 
+test('serialized restoration checkpoints prevent peer restoration from masking cross-target dispatch', () => {
+  const missingCheckpoint = makePassingOverlapReport(catalog);
+  missingCheckpoint.restoration_checkpoints.pop();
+  assert.ok(rules(validate(missingCheckpoint)).has('restoration_checkpoint_schema'));
+
+  const maskedCrossTargetClear = makePassingOverlapReport(catalog);
+  maskedCrossTargetClear.restoration_checkpoints[0].observations[1].token_present = false;
+  assert.ok(rules(validate(maskedCrossTargetClear)).has('restoration_checkpoint_contract'));
+
+  const maskedPeerCrossTargetClear = makePassingOverlapReport(catalog);
+  maskedPeerCrossTargetClear.restoration_checkpoints[1].observations[0].token_present = false;
+  assert.ok(rules(validate(maskedPeerCrossTargetClear)).has('restoration_checkpoint_contract'));
+
+  const concurrentPeerRestore = makePassingOverlapReport(catalog);
+  const firstCheckpoint = concurrentPeerRestore.restoration_checkpoints[0].observations[1];
+  const peerRestoration = concurrentPeerRestore.controllers[1].mutations.at(-1);
+  peerRestoration.started_at = firstCheckpoint.finished_at - 0.05;
+  peerRestoration.finished_at = peerRestoration.started_at + 0.2;
+  assert.ok(rules(validate(concurrentPeerRestore)).has('restoration_checkpoint_timing'));
+});
+
 test('workflow minima exclude restoration operations', () => {
   const report = makePassingOverlapReport(catalog);
   report.controllers[0].mutations.splice(1, 1);


### PR DESCRIPTION
## Summary

- replace the earlier foreground-controller prototype with one deterministic, source-controlled dual-controller overlap contract
- define exact controller A and B workflows in a closed catalog, validate complete per-operation target/host/route evidence, and reject serialized work, one-way overlap, cross-target leakage, stale markers, missing cleanup, schema drift, or any named invariant failure
- extend the native monitor and Bash 3.2 lifecycle harness with stopped-before-registration child ownership, exact executable/process-generation receipts, monotonic operation deadlines, TERM/KILL escalation, and generation-pinned cleanup
- register the no-UI overlap tests in the normal background-certification and safe gates

## Fail-closed boundary

Live execution is unconditionally refused before UI setup until Peekaboo exposes an opaque exact-host receipt from `bridge status` and validates that receipt on the same authenticated connection that performs every operation. This PR therefore lands deterministic infrastructure only; it makes no signed-live certification claim.

The intended live cell keeps focus, top-window identity, Peekaboo global input, clipboard change count, visible Peekaboo overlays, host generation, and monitor liveness fail-closed through cleanup. Physical cursor motion is observational because another user/controller may move it concurrently. No AppleScript, JXA, System Events, or clipboard content is used.

## Validation

- source-blind contract clauses 1-8 pass; exact-host and live clauses 9-14 are explicitly blocked
- `pnpm run test:background-certification` — 18 existing certification tests, 17 overlap corruption tests, native probe, catalog, lifecycle, and cleanup self-tests pass
- `/bin/bash` 3.2 self-test — TERM-ignoring timeout exits 124 at the monotonic deadline; fast/direct/mismatch and two exact cleanup paths pass with no surviving generation
- Bash syntax, ShellCheck, SwiftFormat, strict SwiftLint, docs lint, native-only source scan, and diff hygiene pass
- `pnpm run test:safe`
- structured P0-P2 autoreview

## Follow-up

After the production exact-host receipt owner lands, the live clauses will be enabled and exercised with one identical signed CLI/Peekaboo/Playground/OpenClaw artifact set locally and on the personal Mac Studio, concurrently with integrated Computer Use. Until then, every live invocation refuses rather than inferring host affinity from before/after status probes.
