### PR TITLE
test: pin paste fixtures to process generations

### DIFF
--- a/Apps/CLI/Tests/CLIAutomationTests/PasteCommandInventoryEligibilityTests.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/PasteCommandInventoryEligibilityTests.swift
@@ -1,3 +1,4 @@
+import PeekabooAutomationKitTestSupport
 import Testing
 @testable import PeekabooCLI
 @testable import PeekabooCore
@@ -8,8 +9,9 @@ struct PasteCommandInventoryEligibilityTests {
     @MainActor
     func `Background paste refuses prohibited and incomplete inventory rows before dispatch`() async throws {
         let ineligibleApplications = [
-            ServiceApplicationInfo(
+            AutomationTestFixtures.application(
                 processIdentifier: 2468,
+                processStartIdentity: 24,
                 bundleIdentifier: "com.example.helper",
                 name: "Prohibited Helper",
                 isHiddenKnown: true,
@@ -17,6 +19,7 @@ struct PasteCommandInventoryEligibilityTests {
             ),
             ServiceApplicationInfo(
                 processIdentifier: 9753,
+                processStartIdentity: 97,
                 bundleIdentifier: nil,
                 name: "Incomplete Helper",
                 isHiddenKnown: false,

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/PasteToolExactWindowTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/PasteToolExactWindowTests.swift
@@ -2,6 +2,7 @@ import CoreGraphics
 import Foundation
 import MCP
 import PeekabooAutomationKit
+import PeekabooAutomationKitTestSupport
 import PeekabooFoundation
 import TachikomaMCP
 import Testing
@@ -140,8 +141,9 @@ struct PasteToolExactWindowTests {
     @Test
     @MainActor
     func `Process text prefix failure is indeterminate retry unsafe and leaves clipboard untouched`() async throws {
-        let application = ServiceApplicationInfo(
+        let application = AutomationTestFixtures.application(
             processIdentifier: 333,
+            processStartIdentity: 33,
             bundleIdentifier: "com.example.editor",
             name: "Editor")
         let automation = PartialProcessPasteAutomationService(
@@ -166,6 +168,10 @@ struct PasteToolExactWindowTests {
         #expect(self.responseText(response).contains("Paste outcome is indeterminate"))
         #expect(self.responseText(response).contains("do not retry"))
         #expect(await MainActor.run { automation.deliveredText } == "partial")
+        #expect(automation.targetedTypeActionsCalls.count == 1)
+        #expect(automation.targetedTypeActionsCalls.first?.expectedProcessIdentity ==
+            AutomationTestFixtures.processIdentity(processIdentifier: 333, processStartIdentity: 33))
+        #expect(automation.lastTypeActions == nil)
         self.expectIndeterminateTextMetadata(
             response,
             requestedCharacters: "partial delivery".count,
@@ -177,8 +183,9 @@ struct PasteToolExactWindowTests {
     @Test
     @MainActor
     func `Known pre-dispatch text failure remains an ordinary retryable failure`() async throws {
-        let application = ServiceApplicationInfo(
+        let application = AutomationTestFixtures.application(
             processIdentifier: 333,
+            processStartIdentity: 33,
             bundleIdentifier: "com.example.editor",
             name: "Editor")
         let automation = PredispatchProcessPasteAutomationService(accessibilityGranted: true)
@@ -201,6 +208,10 @@ struct PasteToolExactWindowTests {
         #expect(self.responseText(response).contains("Paste failed"))
         #expect(!self.responseText(response).contains("indeterminate"))
         #expect(response.meta == nil)
+        #expect(automation.targetedTypeActionsCalls.count == 1)
+        #expect(automation.targetedTypeActionsCalls.first?.expectedProcessIdentity ==
+            AutomationTestFixtures.processIdentity(processIdentifier: 333, processStartIdentity: 33))
+        #expect(automation.lastTypeActions == nil)
         self.expectClipboardUntouched(clipboard)
     }
 
@@ -459,31 +470,26 @@ private final class PartialProcessPasteAutomationService: MockAutomationService 
     init(accessibilityGranted: Bool, deliveredPrefix: String) {
         self.deliveredPrefix = deliveredPrefix
         super.init(accessibilityGranted: accessibilityGranted)
-    }
-
-    override func typeActions(
-        _: [TypeAction],
-        cadence _: TypingCadence,
-        snapshotId _: String?,
-        targetProcessIdentifier _: pid_t) async throws -> TypeResult
-    {
-        self.deliveredText = self.deliveredPrefix
-        throw InputDeliveryIndeterminateError(
-            operation: .type,
-            emittedUnitCount: self.deliveredPrefix.count,
-            causeDescription: "simulated failure after a text prefix was delivered")
+        self.pinnedTypeError = { [weak self] _ in
+            guard let self else {
+                return PeekabooError.invalidInput("partial paste fixture was released")
+            }
+            self.deliveredText = self.deliveredPrefix
+            return InputDeliveryIndeterminateError(
+                operation: .type,
+                emittedUnitCount: self.deliveredPrefix.count,
+                causeDescription: "simulated failure after a text prefix was delivered")
+        }
     }
 }
 
 @MainActor
 private final class PredispatchProcessPasteAutomationService: MockAutomationService {
-    override func typeActions(
-        _: [TypeAction],
-        cadence _: TypingCadence,
-        snapshotId _: String?,
-        targetProcessIdentifier _: pid_t) async throws -> TypeResult
-    {
-        throw PeekabooError.invalidInput("simulated pre-dispatch validation failure")
+    init(accessibilityGranted: Bool) {
+        super.init(accessibilityGranted: accessibilityGranted)
+        self.pinnedTypeError = { _ in
+            PeekabooError.invalidInput("simulated pre-dispatch validation failure")
+        }
     }
 }
 

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/PasteToolTransactionGateTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/PasteToolTransactionGateTests.swift
@@ -1,6 +1,7 @@
 import Darwin
 import Foundation
 import PeekabooAutomationKit
+import PeekabooAutomationKitTestSupport
 import PeekabooFoundation
 import TachikomaMCP
 import Testing
@@ -21,10 +22,7 @@ struct PasteToolTransactionGateTests {
             close(heldFD)
         }
 
-        let app = ServiceApplicationInfo(
-            processIdentifier: 333,
-            bundleIdentifier: "com.example.editor",
-            name: "Editor")
+        let app = Self.editorApplication()
         let automation = await MainActor.run { MockAutomationService(accessibilityGranted: true) }
         let applications = await MainActor.run { MockApplicationService(applications: [app]) }
         let clipboard = await MainActor.run { TransactionGateClipboardService() }
@@ -47,10 +45,7 @@ struct PasteToolTransactionGateTests {
         #expect(await MainActor.run { clipboard.current.textPreview } == "prior")
         await MainActor.run {
             applications.replaceApplicationsForTesting([
-                ServiceApplicationInfo(
-                    processIdentifier: 444,
-                    bundleIdentifier: "com.example.editor",
-                    name: "Editor"),
+                Self.editorApplication(processIdentifier: 444, processStartIdentity: 44),
             ])
         }
 
@@ -61,6 +56,9 @@ struct PasteToolTransactionGateTests {
         #expect(response.isError)
         #expect(await MainActor.run { automation.targetedHotkeyCalls.map(\.keys) } == ["cmd,v"])
         #expect(await MainActor.run { automation.targetedHotkeyCalls.first?.targetProcessIdentifier } == 444)
+        #expect(await MainActor.run { automation.targetedHotkeyCalls.first?.expectedProcessIdentity } ==
+            AutomationTestFixtures.processIdentity(processIdentifier: 444, processStartIdentity: 44))
+        #expect(await MainActor.run { automation.lastHotkeyKeys } == nil)
         #expect(await MainActor.run { clipboard.current.textPreview } == "prior")
         #expect(await MainActor.run { clipboard.restoreCallCount } == 1)
         guard case let .object(meta) = response.meta else {
@@ -75,10 +73,7 @@ struct PasteToolTransactionGateTests {
 
     @Test
     func `MCP capability refusal never reads or mutates the clipboard`() async throws {
-        let app = ServiceApplicationInfo(
-            processIdentifier: 333,
-            bundleIdentifier: "com.example.editor",
-            name: "Editor")
+        let app = Self.editorApplication()
         let automation = await MainActor.run {
             let service = MockAutomationService(accessibilityGranted: true)
             service.supportsTargetedHotkeys = false
@@ -110,14 +105,16 @@ struct PasteToolTransactionGateTests {
     @Test
     func `MCP background paste refuses prohibited and incomplete inventory rows before dispatch`() async throws {
         let ineligibleApplications = [
-            ServiceApplicationInfo(
+            AutomationTestFixtures.application(
                 processIdentifier: 333,
+                processStartIdentity: 33,
                 bundleIdentifier: "com.example.helper",
                 name: "Prohibited Helper",
                 isHiddenKnown: true,
                 activationPolicy: .prohibited),
             ServiceApplicationInfo(
                 processIdentifier: 444,
+                processStartIdentity: 44,
                 bundleIdentifier: nil,
                 name: "Incomplete Helper",
                 isHiddenKnown: false,
@@ -151,10 +148,7 @@ struct PasteToolTransactionGateTests {
 
     @Test
     func `MCP clipboard read failure is not treated as empty`() async throws {
-        let app = ServiceApplicationInfo(
-            processIdentifier: 333,
-            bundleIdentifier: "com.example.editor",
-            name: "Editor")
+        let app = Self.editorApplication()
         let automation = await MainActor.run { MockAutomationService(accessibilityGranted: true) }
         let applications = await MainActor.run { MockApplicationService(applications: [app]) }
         let clipboard = await MainActor.run {
@@ -210,10 +204,7 @@ struct PasteToolTransactionGateTests {
 
     @Test
     func `MCP cancellation after snapshot but before write never restores or clears`() async throws {
-        let app = ServiceApplicationInfo(
-            processIdentifier: 333,
-            bundleIdentifier: "com.example.editor",
-            name: "Editor")
+        let app = Self.editorApplication()
         let automation = await MainActor.run { MockAutomationService(accessibilityGranted: true) }
         let applications = await MainActor.run { MockApplicationService(applications: [app]) }
         let clipboard = await MainActor.run {
@@ -250,10 +241,7 @@ struct PasteToolTransactionGateTests {
 
     @Test
     func `MCP cancellation during clipboard write restores before dispatch`() async throws {
-        let app = ServiceApplicationInfo(
-            processIdentifier: 333,
-            bundleIdentifier: "com.example.editor",
-            name: "Editor")
+        let app = Self.editorApplication()
         let automation = await MainActor.run { MockAutomationService(accessibilityGranted: true) }
         let applications = await MainActor.run { MockApplicationService(applications: [app]) }
         let clipboard = await MainActor.run {
@@ -288,10 +276,7 @@ struct PasteToolTransactionGateTests {
 
     @Test(arguments: [false, true])
     func `MCP set failure restores prior clipboard before dispatch`(mutatesBeforeThrow: Bool) async throws {
-        let app = ServiceApplicationInfo(
-            processIdentifier: 333,
-            bundleIdentifier: "com.example.editor",
-            name: "Editor")
+        let app = Self.editorApplication()
         let automation = await MainActor.run { MockAutomationService(accessibilityGranted: true) }
         let applications = await MainActor.run { MockApplicationService(applications: [app]) }
         let clipboard = await MainActor.run {
@@ -323,10 +308,7 @@ struct PasteToolTransactionGateTests {
 
     @Test
     func `MCP set and restoration failure reports integrity risk without dispatch`() async throws {
-        let app = ServiceApplicationInfo(
-            processIdentifier: 333,
-            bundleIdentifier: "com.example.editor",
-            name: "Editor")
+        let app = Self.editorApplication()
         let automation = await MainActor.run { MockAutomationService(accessibilityGranted: true) }
         let applications = await MainActor.run { MockApplicationService(applications: [app]) }
         let clipboard = await MainActor.run {
@@ -357,10 +339,7 @@ struct PasteToolTransactionGateTests {
 
     @Test
     func `Cancellation during restore delay waits for consumption before restoring`() async throws {
-        let app = ServiceApplicationInfo(
-            processIdentifier: 333,
-            bundleIdentifier: "com.example.editor",
-            name: "Editor")
+        let app = Self.editorApplication()
         let delivered = PasteDeliveryLatch()
         let automation = await MainActor.run {
             SignalingAutomationService(accessibilityGranted: true, delivered: delivered)
@@ -394,6 +373,9 @@ struct PasteToolTransactionGateTests {
         #expect(response.isError)
         #expect(self.responseText(response).contains("may have pasted; do not retry"))
         #expect(self.responseText(response).contains("indeterminate"))
+        #expect(await MainActor.run { automation.targetedHotkeyCalls.first?.expectedProcessIdentity } ==
+            AutomationTestFixtures.processIdentity(processIdentifier: 333, processStartIdentity: 33))
+        #expect(await MainActor.run { automation.lastHotkeyKeys } == nil)
         #expect(clock.now - canceledAt >= .milliseconds(150))
         #expect(clock.now - canceledAt < .seconds(1))
         #expect(await MainActor.run { clipboard.current.textPreview } == "prior")
@@ -511,10 +493,7 @@ struct PasteToolTransactionGateTests {
 
     @Test
     func `Throwing dispatch settles before MCP restore and unlock`() async throws {
-        let app = ServiceApplicationInfo(
-            processIdentifier: 333,
-            bundleIdentifier: "com.example.editor",
-            name: "Editor")
+        let app = Self.editorApplication()
         let delivered = PasteDeliveryLatch()
         let automation = await MainActor.run {
             SignalingAutomationService(
@@ -552,6 +531,9 @@ struct PasteToolTransactionGateTests {
         #expect(response.isError)
         #expect(self.responseText(response).contains("may have pasted; do not retry"))
         #expect(self.responseText(response).contains("indeterminate"))
+        #expect(await MainActor.run { automation.targetedHotkeyCalls.first?.expectedProcessIdentity } ==
+            AutomationTestFixtures.processIdentity(processIdentifier: 333, processStartIdentity: 33))
+        #expect(await MainActor.run { automation.lastHotkeyKeys } == nil)
         #expect(clock.now - dispatchedAt >= .milliseconds(150))
         #expect(await MainActor.run { clipboard.current.textPreview } == "prior")
         #expect(await MainActor.run { clipboard.restoreCallCount } == 1)
@@ -561,10 +543,7 @@ struct PasteToolTransactionGateTests {
 
     @Test
     func `Current clipboard background paste is explicitly unverified`() async throws {
-        let app = ServiceApplicationInfo(
-            processIdentifier: 333,
-            bundleIdentifier: "com.example.editor",
-            name: "Editor")
+        let app = Self.editorApplication()
         let automation = await MainActor.run { MockAutomationService(accessibilityGranted: true) }
         let applications = await MainActor.run { MockApplicationService(applications: [app]) }
         let clipboard = await MainActor.run { TransactionGateClipboardService() }
@@ -582,6 +561,9 @@ struct PasteToolTransactionGateTests {
         #expect(self.responseText(response).contains("Background paste delivery could not be verified"))
         #expect(self.responseText(response).contains("may have pasted; do not retry"))
         #expect(await MainActor.run { automation.targetedHotkeyCalls.map(\.keys) } == ["cmd,v"])
+        #expect(await MainActor.run { automation.targetedHotkeyCalls.first?.expectedProcessIdentity } ==
+            AutomationTestFixtures.processIdentity(processIdentifier: 333, processStartIdentity: 33))
+        #expect(await MainActor.run { automation.lastHotkeyKeys } == nil)
         #expect(await MainActor.run { clipboard.current.textPreview } == "prior")
         #expect(await MainActor.run { clipboard.restoreCallCount } == 0)
         guard case let .object(meta) = response.meta else {
@@ -645,10 +627,7 @@ struct PasteToolTransactionGateTests {
     func `MCP mutation wrapper invalidates snapshots for unverified paste outcomes`() async throws {
         await UISnapshotManager.shared.removeAllSnapshots()
         _ = await UISnapshotManager.shared.createSnapshot()
-        let app = ServiceApplicationInfo(
-            processIdentifier: 333,
-            bundleIdentifier: "com.example.editor",
-            name: "Editor")
+        let app = Self.editorApplication()
         let automation = await MainActor.run { MockAutomationService(accessibilityGranted: true) }
         let applications = await MainActor.run { MockApplicationService(applications: [app]) }
         let clipboard = await MainActor.run { TransactionGateClipboardService() }
@@ -698,6 +677,17 @@ struct PasteToolTransactionGateTests {
     private func responseText(_ response: ToolResponse) -> String {
         guard case let .text(text, _, _)? = response.content.first else { return "" }
         return text
+    }
+
+    private static func editorApplication(
+        processIdentifier: Int32 = 333,
+        processStartIdentity: UInt64 = 33) -> ServiceApplicationInfo
+    {
+        AutomationTestFixtures.application(
+            processIdentifier: processIdentifier,
+            processStartIdentity: processStartIdentity,
+            bundleIdentifier: "com.example.editor",
+            name: "Editor")
     }
 
     private func holdPasteTransactionLock() throws -> Int32 {
@@ -809,17 +799,10 @@ private final class SignalingAutomationService: MockAutomationService {
         self.delivered = delivered
         self.errorAfterDelivery = errorAfterDelivery
         super.init(accessibilityGranted: accessibilityGranted)
-    }
-
-    override func hotkey(keys: String, holdDuration: Int, targetProcessIdentifier: pid_t) async throws {
-        try await super.hotkey(
-            keys: keys,
-            holdDuration: holdDuration,
-            targetProcessIdentifier: targetProcessIdentifier)
-        await self.delivered.open()
-        if let errorAfterDelivery {
-            throw errorAfterDelivery
+        self.afterPinnedHotkey = {
+            Task { await delivered.open() }
         }
+        self.pinnedHotkeyError = { _ in errorAfterDelivery }
     }
 
     override func hotkey(keys: String, holdDuration: Int) async throws {


### PR DESCRIPTION
## Summary

- pin complete MCP and CLI paste test applications to explicit process generations
- migrate partial and throwing paste mocks to generation-pinned hooks instead of legacy PID-only overloads
- assert pinned receipts and prove the generic/global keyboard fallback remains unused
- keep production fail-closed behavior and existing missing-generation coverage unchanged

## Proof

- `swift test --package-path Core/PeekabooCore --no-parallel --filter PasteToolExactWindowTests` (11/11)
- related Core/MCP composite covering paste, target validation, keyboard background delivery, registry, and server tests (87/87)
- related CLI paste suites with automation fixtures enabled (31/31)
- `pnpm run test:safe`
- `pnpm run format`
- `pnpm run lint` (0 serious; existing warnings only)
- TruffleHog diff scan: clean
- structured autoreview: clean, no actionable findings

Full Core completed 1,407 tests with one unrelated baseline failure in `PeekabooBridgeTests`: `remote automation restores snapshot errors for foreground clicks and element actions` received `permissionDeniedEventSynthesizing`. The exact test fails identically on untouched `main` at the PR base, so this fixture-only change does not alter it.

No production code, changelog, or submodule pointers changed.
