### PR TITLE
test(bridge): grant event permission in snapshot fixture

### DIFF
--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeTests.swift
@@ -1757,7 +1757,7 @@ extension PeekabooBridgeTests {
                         screenRecording: false,
                         accessibility: true,
                         appleScript: false,
-                        postEvent: false)
+                        postEvent: true)
                 })
         }
         let host = PeekabooBridgeHost(


### PR DESCRIPTION
## Summary

- grant Event Synthesizing permission in the foreground-click snapshot error-restoration fixture
- keep the authoritative Bridge permission policy and all production code unchanged

## Why

The fixture denied `postEvent` and then invoked the classic foreground click operation. The selected-host permission snapshot now correctly refuses that operation before the test can reach its stubbed snapshot error. Granting the operation's required permission lets the test exercise the error-restoration behavior it owns.

## Proof

- reproduced the pre-fix failure: `permissionDeniedEventSynthesizing`
- exact regression: passed
- `PeekabooBridgeTargetedClickTests`: 23/23 passed
- `PeekabooBridgeTests`: 54/54 passed
- full serial Core sweep: passed (1,408 + 55 + 122 tests)
- `pnpm run test:safe`: passed (847 tests + 83 tests)
- `pnpm run format`: clean
- `pnpm run lint`: clean with existing non-serious warnings only
- `git diff --check`: clean
- TruffleHog 3.96.0 (`verified,unknown`): 0 findings
- structured Codex autoreview: clean, no accepted/actionable findings
- range-diff against the pre-rebase commit: identical
