### PR TITLE
chore(deps): update AXorcist

### DIFF
--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reuse two-second, owner-host-local ScreenCaptureKit exact-window screenshot plans without caching pixels, revalidating process generation, window receipt, display topology, and scale around every capture while exposing miss/hit generation diagnostics.
 
 ### Fixed
+- Refresh AXorcist to dispatch native accessibility actions once with typed AX errors and route legacy `AXSetValue` requests through the `AXValue` attribute instead of action discovery.
 - Preserve display-column-safe terminal input and styled table output for wide Unicode, SGR colors, and OSC-8 links, while making terminal stop/restart idempotent and preventing queued renders from escaping a stopped session.
 - Serialize ScreenCaptureKit ownership across Peekaboo processes for the lifetime of the first explicit local-modern claimant or real SCK caller, with build-bound process-awareness receipts, owner-affine auto/modern routing, current-policy capability checks for every transported engine, and fail-closed rolling-upgrade detection for old Bridge and long-running local processes; explicit classic remains a process-isolated, in-process-SCK-free escape hatch and refuses false-preflight captures unless protected WindowServer metadata independently proves access.
 - Keep modern capture inside bounded, coordinator-owned `SCScreenshotManager` calls instead of service-lifetime `SCStream` sessions, eliminating persistent stream overlap and rechecking ownership before every new framework dispatch.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Reuse two-second, owner-host-local ScreenCaptureKit exact-window screenshot plans without caching pixels, revalidating process generation, window receipt, display topology, and scale around every capture while exposing miss/hit generation diagnostics.
 
 ### Fixed
+- Refresh AXorcist to dispatch native accessibility actions once with typed AX errors and route legacy `AXSetValue` requests through the `AXValue` attribute instead of action discovery.
 - Preserve display-column-safe terminal input and styled table output for wide Unicode, SGR colors, and OSC-8 links, while making terminal stop/restart idempotent and preventing queued renders from escaping a stopped session.
 - Reject non-finite, fractional, and overflowing MCP numeric arguments before dispatch, and expose integer-shaped delays, durations, counts, process IDs, window selectors, and Space targets as integers in tool schemas.
 - Reject MCP clipboard `outputPath: "-"` before reading or writing anything, with structured filesystem/text guidance, so arbitrary clipboard bytes can never corrupt the stdio JSON-RPC stream or create a literal `-` file.


### PR DESCRIPTION
## Summary

- update the AXorcist gitlink from `3f722cc375c68d3c9e7a01f2581b109141eef978` to `c04ae9cd082614bc918447a8ab4da16b450bcf5e`
- consume upstream single-dispatch accessibility actions, typed native AX errors, and real `AXValue` routing for the legacy `AXSetValue` token
- document the dependency behavior in the root and CLI Unreleased changelogs

No Peekaboo compatibility shim or source expansion is required.

## Verification

- `swift test --package-path Core/PeekabooAutomationKit --no-parallel --filter 'ActionInputDriverTests|DetachedAXActionRunnerTests'` (53 tests)
- `swift test --package-path Apps/CLI -Xswiftc -DPEEKABOO_SKIP_AUTOMATION --no-parallel --filter 'Phase3CommandParsingTests|InteractionObservationContextTests|FocusErrorMappingTests'` (68 tests)
- `PEEKABOO_INCLUDE_AUTOMATION_TESTS=true swift test --package-path Apps/CLI -Xswiftc -DPEEKABOO_SKIP_AUTOMATION --no-parallel --filter 'ElementActionSnapshotRequiredTests|PreDispatchActionEnvelopeTests'` (4 tests)
- `swift test --package-path Core/PeekabooCore --no-parallel` (1,408 + 55 + 122 tests)
- `pnpm run test:safe` (847 core/CLI tests and 83 runtime tests, plus release, native-only, and certification gates)
- `pnpm run format` (no changes)
- `pnpm run lint` (0 serious violations)
- exact pre/post-rebase range-diff; only root-changelog context moved around newly landed `main`
- exact combined upstream dependency-range structured review: clean, no findings
- built CLI has no AppleScript, OSA, or Apple Events execution API imports; production app/core trees contain no scripting resources
