### PR TITLE
test: serialize window tracking provider overrides

### DIFF
--- a/Apps/CLI/Tests/CoreCLITests/InteractionObservationContextTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/InteractionObservationContextTests.swift
@@ -2,6 +2,7 @@ import Commander
 import CoreGraphics
 import Foundation
 import PeekabooAutomationKit
+import PeekabooAutomationKitTestSupport
 import PeekabooCore
 import PeekabooFoundation
 import Testing
@@ -999,32 +1000,31 @@ struct InteractionObservationContextTests {
         let tracker = CoreWindowTracker(
             bounds: CGRect(x: 30, y: 25, width: 300, height: 200)
         )
-        WindowMovementTracking.provider = tracker
-        defer { WindowMovementTracking.provider = nil }
+        try await WindowMovementTrackingProviderScope.withProvider(tracker) {
+            let point = try await InteractionTargetPointResolver.elementCenter(
+                elementId: "B1",
+                snapshotId: snapshotId,
+                snapshots: snapshots
+            )
 
-        let point = try await InteractionTargetPointResolver.elementCenter(
-            elementId: "B1",
-            snapshotId: snapshotId,
-            snapshots: snapshots
-        )
+            #expect(point == CGPoint(x: 120, y: 95))
 
-        #expect(point == CGPoint(x: 120, y: 95))
+            let resolution = try await InteractionTargetPointResolver.elementCenterResolution(
+                element: Self.buttonElement(id: "B1", label: "Save"),
+                elementId: "B1",
+                snapshotId: snapshotId,
+                snapshots: snapshots
+            )
 
-        let resolution = try await InteractionTargetPointResolver.elementCenterResolution(
-            element: Self.buttonElement(id: "B1", label: "Save"),
-            elementId: "B1",
-            snapshotId: snapshotId,
-            snapshots: snapshots
-        )
-
-        #expect(resolution.point == CGPoint(x: 70, y: 37))
-        #expect(resolution.diagnostics.source == "element")
-        #expect(resolution.diagnostics.elementId == "B1")
-        #expect(resolution.diagnostics.snapshotId == snapshotId)
-        #expect(resolution.diagnostics.original == InteractionPoint(CGPoint(x: 50, y: 32)))
-        #expect(resolution.diagnostics.resolved == InteractionPoint(CGPoint(x: 70, y: 37)))
-        #expect(resolution.diagnostics.windowAdjustment?.status == "adjusted")
-        #expect(resolution.diagnostics.windowAdjustment?.delta == InteractionPoint(CGPoint(x: 20, y: 5)))
+            #expect(resolution.point == CGPoint(x: 70, y: 37))
+            #expect(resolution.diagnostics.source == "element")
+            #expect(resolution.diagnostics.elementId == "B1")
+            #expect(resolution.diagnostics.snapshotId == snapshotId)
+            #expect(resolution.diagnostics.original == InteractionPoint(CGPoint(x: 50, y: 32)))
+            #expect(resolution.diagnostics.resolved == InteractionPoint(CGPoint(x: 70, y: 37)))
+            #expect(resolution.diagnostics.windowAdjustment?.status == "adjusted")
+            #expect(resolution.diagnostics.windowAdjustment?.delta == InteractionPoint(CGPoint(x: 20, y: 5)))
+        }
     }
 
     @Test

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKitTestSupport/WindowMovementTrackingProviderScope.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKitTestSupport/WindowMovementTrackingProviderScope.swift
@@ -1,0 +1,61 @@
+import PeekabooAutomationKit
+
+/// Serializes process-global window-tracking provider overrides across test suites.
+///
+/// This scope is deliberately non-reentrant and cancellation-insensitive: every queued operation runs and restores the
+/// provider before handing the gate to the next test.
+public enum WindowMovementTrackingProviderScope {
+    private static let gate = WindowMovementTrackingProviderGate()
+
+    @MainActor
+    public static func withProvider<Result>(
+        _ provider: any WindowTrackingProviding,
+        operation: @MainActor () async throws -> Result) async rethrows -> Result
+    {
+        try await self.withExclusiveAccess {
+            WindowMovementTracking.provider = provider
+            return try await operation()
+        }
+    }
+
+    @MainActor
+    public static func withExclusiveAccess<Result>(
+        operation: @MainActor () async throws -> Result) async rethrows -> Result
+    {
+        await self.gate.acquire()
+        let previous = WindowMovementTracking.provider
+        do {
+            let result = try await operation()
+            WindowMovementTracking.provider = previous
+            await self.gate.release()
+            return result
+        } catch {
+            WindowMovementTracking.provider = previous
+            await self.gate.release()
+            throw error
+        }
+    }
+}
+
+private actor WindowMovementTrackingProviderGate {
+    private var isHeld = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func acquire() async {
+        guard self.isHeld else {
+            self.isHeld = true
+            return
+        }
+        await withCheckedContinuation { continuation in
+            self.waiters.append(continuation)
+        }
+    }
+
+    func release() {
+        guard !self.waiters.isEmpty else {
+            self.isHeld = false
+            return
+        }
+        self.waiters.removeFirst().resume()
+    }
+}

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKitTestSupport/WindowMovementTrackingProviderScope.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKitTestSupport/WindowMovementTrackingProviderScope.swift
@@ -2,10 +2,20 @@ import PeekabooAutomationKit
 
 /// Serializes process-global window-tracking provider overrides across test suites.
 ///
-/// This scope is deliberately non-reentrant and cancellation-insensitive: every queued operation runs and restores the
-/// provider before handing the gate to the next test.
+/// This scope is deliberately cancellation-insensitive: every queued operation runs and restores the provider before
+/// handing the gate to the next test. Nested use, including from a child task that inherited the active scope, fails
+/// fast instead of deadlocking. A child task retains inherited ownership for its lifetime and must never enter this
+/// scope, even after its parent leaves. Detached tasks do not inherit ownership and must not be awaited here if they
+/// enter this scope.
 public enum WindowMovementTrackingProviderScope {
     private static let gate = WindowMovementTrackingProviderGate()
+    @TaskLocal private static var ownsProviderGate = false
+
+    static func reentrancyViolationMessage() -> String? {
+        guard self.ownsProviderGate else { return nil }
+        return "WindowMovementTrackingProviderScope cannot be nested or entered from a child task " +
+            "that inherited provider-scope ownership"
+    }
 
     @MainActor
     public static func withProvider<Result>(
@@ -19,20 +29,45 @@ public enum WindowMovementTrackingProviderScope {
     }
 
     @MainActor
+    static func withProvider<Result>(
+        _ provider: any WindowTrackingProviding,
+        queuedSignal: AsyncTestLatch,
+        operation: @MainActor () async throws -> Result) async rethrows -> Result
+    {
+        try await self.withExclusiveAccess(queuedSignal: queuedSignal) {
+            WindowMovementTracking.provider = provider
+            return try await operation()
+        }
+    }
+
+    @MainActor
     public static func withExclusiveAccess<Result>(
         operation: @MainActor () async throws -> Result) async rethrows -> Result
     {
-        await self.gate.acquire()
+        try await self.withExclusiveAccess(queuedSignal: nil, operation: operation)
+    }
+
+    @MainActor
+    private static func withExclusiveAccess<Result>(
+        queuedSignal: AsyncTestLatch?,
+        operation: @MainActor () async throws -> Result) async rethrows -> Result
+    {
+        if let violation = self.reentrancyViolationMessage() {
+            fatalError(violation)
+        }
+        await self.gate.acquire(queuedSignal: queuedSignal)
         let previous = WindowMovementTracking.provider
-        do {
-            let result = try await operation()
-            WindowMovementTracking.provider = previous
-            await self.gate.release()
-            return result
-        } catch {
-            WindowMovementTracking.provider = previous
-            await self.gate.release()
-            throw error
+        return try await self.$ownsProviderGate.withValue(true) {
+            do {
+                let result = try await operation()
+                WindowMovementTracking.provider = previous
+                await self.gate.release()
+                return result
+            } catch {
+                WindowMovementTracking.provider = previous
+                await self.gate.release()
+                throw error
+            }
         }
     }
 }
@@ -41,13 +76,18 @@ private actor WindowMovementTrackingProviderGate {
     private var isHeld = false
     private var waiters: [CheckedContinuation<Void, Never>] = []
 
-    func acquire() async {
+    func acquire(queuedSignal: AsyncTestLatch?) async {
         guard self.isHeld else {
             self.isHeld = true
             return
         }
         await withCheckedContinuation { continuation in
             self.waiters.append(continuation)
+            if let queuedSignal {
+                Task {
+                    await queuedSignal.open()
+                }
+            }
         }
     }
 

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ClickServiceExactWindowTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ClickServiceExactWindowTests.swift
@@ -1,5 +1,6 @@
 import CoreGraphics
 import Foundation
+import PeekabooAutomationKitTestSupport
 import struct PeekabooFoundation.DesktopActionFailure
 import enum PeekabooFoundation.PeekabooError
 import Testing
@@ -190,69 +191,68 @@ struct ClickServiceExactWindowTests {
     func `Window-owned context menu targets remain pinnable`() async throws {
         let pid = getpid()
         let tracker = ExactWindowTracker()
-        let previousTracker = WindowMovementTracking.provider
-        WindowMovementTracking.provider = tracker
-        defer { WindowMovementTracking.provider = previousTracker }
-        let targets = [
-            DetectedElement(
-                id: "context-menu",
-                type: .menu,
-                label: "Context Menu",
-                bounds: CGRect(x: 10, y: 10, width: 40, height: 20),
-                attributes: ["role": "AXMenu"]),
-            DetectedElement(
-                id: "context-menu-item",
-                type: .menuItem,
-                label: "Open",
-                bounds: CGRect(x: 20, y: 30, width: 60, height: 20),
-                attributes: ["role": "AXMenuItem"]),
-        ]
+        try await WindowMovementTrackingProviderScope.withProvider(tracker) {
+            let targets = [
+                DetectedElement(
+                    id: "context-menu",
+                    type: .menu,
+                    label: "Context Menu",
+                    bounds: CGRect(x: 10, y: 10, width: 40, height: 20),
+                    attributes: ["role": "AXMenu"]),
+                DetectedElement(
+                    id: "context-menu-item",
+                    type: .menuItem,
+                    label: "Open",
+                    bounds: CGRect(x: 20, y: 30, width: 60, height: 20),
+                    attributes: ["role": "AXMenuItem"]),
+            ]
 
-        for target in targets {
-            let detectionResult = ElementDetectionResult(
-                snapshotId: "snapshot",
-                screenshotPath: "/tmp/shot.png",
-                elements: DetectedElements(menus: [target]),
-                metadata: DetectionMetadata(
-                    detectionTime: 0.01,
-                    elementCount: 1,
-                    method: "test",
-                    windowContext: WindowContext(
-                        applicationProcessId: pid,
-                        windowID: 42,
-                        windowBounds: CGRect(x: 0, y: 0, width: 100, height: 100),
-                        windowMutationIdentity: WindowMutationIdentity(
+            for target in targets {
+                let detectionResult = ElementDetectionResult(
+                    snapshotId: "snapshot",
+                    screenshotPath: "/tmp/shot.png",
+                    elements: DetectedElements(menus: [target]),
+                    metadata: DetectionMetadata(
+                        detectionTime: 0.01,
+                        elementCount: 1,
+                        method: "test",
+                        windowContext: WindowContext(
+                            applicationProcessId: pid,
                             windowID: 42,
-                            ownerProcessIdentifier: pid,
-                            ownerProcessStartIdentity: 1))))
-            let synthetic = ClickRecordingSyntheticInputDriver()
-            let service = ClickService(
-                snapshotManager: InMemorySnapshotManager(detectionResult: detectionResult),
-                inputPolicy: UIInputPolicy(defaultStrategy: .synthOnly),
-                syntheticInputDriver: synthetic,
-                exactWindowIdentityValidator: { _, _ in true })
+                            windowBounds: CGRect(x: 0, y: 0, width: 100, height: 100),
+                            windowMutationIdentity: WindowMutationIdentity(
+                                windowID: 42,
+                                ownerProcessIdentifier: pid,
+                                ownerProcessStartIdentity: 1))))
+                let synthetic = ClickRecordingSyntheticInputDriver()
+                let service = ClickService(
+                    snapshotManager: InMemorySnapshotManager(detectionResult: detectionResult),
+                    inputPolicy: UIInputPolicy(defaultStrategy: .synthOnly),
+                    syntheticInputDriver: synthetic,
+                    exactWindowIdentityValidator: { _, _ in true })
 
-            let result = try await service.click(
-                target: .elementId(target.id),
-                clickType: .single,
-                snapshotId: "snapshot",
-                targetProcessIdentifier: pid,
-                targetWindowID: 42,
-                expectedWindowIdentity: WindowMutationIdentity(
-                    windowID: 42,
-                    ownerProcessIdentifier: pid,
-                    ownerProcessStartIdentity: 1),
-                expectedWindowBounds: CGRect(x: 0, y: 0, width: 100, height: 100))
-
-            #expect(result.path == .synth)
-            #expect(synthetic.events == [
-                .targetedClick(
-                    point: CGPoint(x: target.bounds.midX, y: target.bounds.midY),
-                    button: .left,
-                    count: 1,
+                let result = try await service.click(
+                    target: .elementId(target.id),
+                    clickType: .single,
+                    snapshotId: "snapshot",
                     targetProcessIdentifier: pid,
-                    targetWindowID: 42),
-            ])
+                    targetWindowID: 42,
+                    expectedWindowIdentity: WindowMutationIdentity(
+                        windowID: 42,
+                        ownerProcessIdentifier: pid,
+                        ownerProcessStartIdentity: 1),
+                    expectedWindowBounds: CGRect(x: 0, y: 0, width: 100, height: 100))
+
+                #expect(result.path == .synth)
+                #expect(synthetic.events == [
+                    .targetedClick(
+                        point: CGPoint(x: target.bounds.midX, y: target.bounds.midY),
+                        button: .left,
+                        count: 1,
+                        targetProcessIdentifier: pid,
+                        targetWindowID: 42),
+                ])
+            }
         }
     }
 

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ClickServiceTargetResolutionTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ClickServiceTargetResolutionTests.swift
@@ -86,49 +86,49 @@ struct ClickServiceTargetResolutionTests {
         let identity = ApplicationProcessIdentity(processIdentifier: getpid(), processStartIdentity: 73)
         let action = ClickSuccessfulActionInputDriver(afterAction: { generation.value = 74 })
         let tracker = ClickWindowTracker(bounds: .zero)
-        WindowMovementTracking.provider = tracker
-        defer { WindowMovementTracking.provider = nil }
-        let detection = ElementDetectionResult(
-            snapshotId: "snapshot",
-            screenshotPath: "/tmp/shot.png",
-            elements: DetectedElements(buttons: [DetectedElement(
-                id: "B1",
-                type: .button,
-                label: "Button",
-                bounds: CGRect(x: 20, y: 30, width: 100, height: 40))]),
-            metadata: DetectionMetadata(
-                detectionTime: 0,
-                elementCount: 1,
-                method: "test",
-                windowContext: WindowContext(
-                    applicationProcessId: identity.processIdentifier,
-                    windowID: 42,
-                    windowBounds: .zero,
-                    windowMutationIdentity: WindowMutationIdentity(
-                        windowID: 42,
-                        ownerProcessIdentifier: identity.processIdentifier,
-                        ownerProcessStartIdentity: identity.processStartIdentity))))
-        let service = UIAutomationService(
-            snapshotManager: InMemorySnapshotManager(detectionResult: detection),
-            inputPolicy: UIInputPolicy(defaultStrategy: .actionOnly),
-            actionInputDriver: action,
-            automationElementResolver: ClickFixedAutomationElementResolver(),
-            exactWindowIdentityValidator: { _, _ in true },
-            processStartIdentityProvider: { _ in generation.value })
-
-        do {
-            try await service.click(
-                target: .elementId("B1"),
-                clickType: .single,
+        try await WindowMovementTrackingProviderScope.withProvider(tracker) {
+            let detection = ElementDetectionResult(
                 snapshotId: "snapshot",
-                expectedProcessIdentity: identity)
-            Issue.record("Expected post-dispatch process drift")
-        } catch let failure as DesktopActionFailure {
-            #expect(failure.outcome.state == .dispatchedUnverified)
-            #expect(failure.outcome.retrySafety == .unsafe)
-            #expect(failure.causeDescription?.contains("generation") == true)
+                screenshotPath: "/tmp/shot.png",
+                elements: DetectedElements(buttons: [DetectedElement(
+                    id: "B1",
+                    type: .button,
+                    label: "Button",
+                    bounds: CGRect(x: 20, y: 30, width: 100, height: 40))]),
+                metadata: DetectionMetadata(
+                    detectionTime: 0,
+                    elementCount: 1,
+                    method: "test",
+                    windowContext: WindowContext(
+                        applicationProcessId: identity.processIdentifier,
+                        windowID: 42,
+                        windowBounds: .zero,
+                        windowMutationIdentity: WindowMutationIdentity(
+                            windowID: 42,
+                            ownerProcessIdentifier: identity.processIdentifier,
+                            ownerProcessStartIdentity: identity.processStartIdentity))))
+            let service = UIAutomationService(
+                snapshotManager: InMemorySnapshotManager(detectionResult: detection),
+                inputPolicy: UIInputPolicy(defaultStrategy: .actionOnly),
+                actionInputDriver: action,
+                automationElementResolver: ClickFixedAutomationElementResolver(),
+                exactWindowIdentityValidator: { _, _ in true },
+                processStartIdentityProvider: { _ in generation.value })
+
+            do {
+                try await service.click(
+                    target: .elementId("B1"),
+                    clickType: .single,
+                    snapshotId: "snapshot",
+                    expectedProcessIdentity: identity)
+                Issue.record("Expected post-dispatch process drift")
+            } catch let failure as DesktopActionFailure {
+                #expect(failure.outcome.state == .dispatchedUnverified)
+                #expect(failure.outcome.retrySafety == .unsafe)
+                #expect(failure.causeDescription?.contains("generation") == true)
+            }
+            #expect(action.performedActionNames == [AXActionNames.kAXPressAction])
         }
-        #expect(action.performedActionNames == [AXActionNames.kAXPressAction])
     }
 
     @Test
@@ -367,56 +367,56 @@ struct ClickServiceTargetResolutionTests {
     func `background element double click falls back from AX to exact synthetic routing`() async throws {
         let pid = getpid()
         let tracker = ClickWindowTracker(bounds: .zero)
-        WindowMovementTracking.provider = tracker
-        defer { WindowMovementTracking.provider = nil }
-        let element = DetectedElement(
-            id: "B1",
-            type: .button,
-            label: "Background Button",
-            bounds: .init(x: 20, y: 30, width: 100, height: 40))
-        let detectionResult = ElementDetectionResult(
-            snapshotId: "snapshot",
-            screenshotPath: "/tmp/shot.png",
-            elements: DetectedElements(buttons: [element]),
-            metadata: DetectionMetadata(
-                detectionTime: 0.01,
-                elementCount: 1,
-                method: "test",
-                windowContext: Self.exactWindowContext(processIdentifier: pid)))
-        let action = ClickSuccessfulActionInputDriver()
-        let unitCount = try #require(DesktopActionOutcome.DispatchUnitCount(4))
-        let expectedOutcome = DesktopActionOutcome.dispatchedUnverified(
-            delivery: .init(mechanism: .windowTargetedEvents, mode: .background),
-            evidence: .deliveryAccepted,
-            unitCount: unitCount)
-        let synthetic = ClickRecordingSyntheticInputDriver(targetedClickOutcome: expectedOutcome)
-        let service = ClickService(
-            snapshotManager: InMemorySnapshotManager(detectionResult: detectionResult),
-            inputPolicy: UIInputPolicy(defaultStrategy: .actionFirst),
-            actionInputDriver: action,
-            syntheticInputDriver: synthetic,
-            automationElementResolver: ClickFixedAutomationElementResolver(),
-            exactWindowIdentityValidator: { _, _ in true })
+        try await WindowMovementTrackingProviderScope.withProvider(tracker) {
+            let element = DetectedElement(
+                id: "B1",
+                type: .button,
+                label: "Background Button",
+                bounds: .init(x: 20, y: 30, width: 100, height: 40))
+            let detectionResult = ElementDetectionResult(
+                snapshotId: "snapshot",
+                screenshotPath: "/tmp/shot.png",
+                elements: DetectedElements(buttons: [element]),
+                metadata: DetectionMetadata(
+                    detectionTime: 0.01,
+                    elementCount: 1,
+                    method: "test",
+                    windowContext: Self.exactWindowContext(processIdentifier: pid)))
+            let action = ClickSuccessfulActionInputDriver()
+            let unitCount = try #require(DesktopActionOutcome.DispatchUnitCount(4))
+            let expectedOutcome = DesktopActionOutcome.dispatchedUnverified(
+                delivery: .init(mechanism: .windowTargetedEvents, mode: .background),
+                evidence: .deliveryAccepted,
+                unitCount: unitCount)
+            let synthetic = ClickRecordingSyntheticInputDriver(targetedClickOutcome: expectedOutcome)
+            let service = ClickService(
+                snapshotManager: InMemorySnapshotManager(detectionResult: detectionResult),
+                inputPolicy: UIInputPolicy(defaultStrategy: .actionFirst),
+                actionInputDriver: action,
+                syntheticInputDriver: synthetic,
+                automationElementResolver: ClickFixedAutomationElementResolver(),
+                exactWindowIdentityValidator: { _, _ in true })
 
-        let result = try await service.click(
-            target: .elementId("B1"),
-            clickType: .double,
-            snapshotId: "snapshot",
-            targetProcessIdentifier: pid)
+            let result = try await service.click(
+                target: .elementId("B1"),
+                clickType: .double,
+                snapshotId: "snapshot",
+                targetProcessIdentifier: pid)
 
-        #expect(result.path == .synth)
-        #expect(result.fallbackReason == .actionUnsupported)
-        #expect(result.outcome == expectedOutcome)
-        #expect(result.outcome.dispatchState.unitCount == unitCount)
-        #expect(action.performedActionNames.isEmpty)
-        #expect(synthetic.events == [
-            .targetedClick(
-                point: CGPoint(x: 70, y: 50),
-                button: .left,
-                count: 2,
-                targetProcessIdentifier: pid,
-                targetWindowID: 42),
-        ])
+            #expect(result.path == .synth)
+            #expect(result.fallbackReason == .actionUnsupported)
+            #expect(result.outcome == expectedOutcome)
+            #expect(result.outcome.dispatchState.unitCount == unitCount)
+            #expect(action.performedActionNames.isEmpty)
+            #expect(synthetic.events == [
+                .targetedClick(
+                    point: CGPoint(x: 70, y: 50),
+                    button: .left,
+                    count: 2,
+                    targetProcessIdentifier: pid,
+                    targetWindowID: 42),
+            ])
+        }
     }
 
     @Test
@@ -424,50 +424,50 @@ struct ClickServiceTargetResolutionTests {
     func `background element click uses action first with targeted synthetic fallback`() async throws {
         let pid = getpid()
         let tracker = ClickWindowTracker(bounds: .zero)
-        WindowMovementTracking.provider = tracker
-        defer { WindowMovementTracking.provider = nil }
-        let element = DetectedElement(
-            id: "B1",
-            type: .button,
-            label: "Background Button",
-            value: nil,
-            bounds: .init(x: 20, y: 30, width: 100, height: 40),
-            isEnabled: true,
-            isSelected: nil,
-            attributes: ["identifier": "background-button", "role": "AXButton"])
-        let detectionResult = ElementDetectionResult(
-            snapshotId: "snapshot",
-            screenshotPath: "/tmp/shot.png",
-            elements: DetectedElements(buttons: [element]),
-            metadata: DetectionMetadata(
-                detectionTime: 0.01,
-                elementCount: 1,
-                method: "test",
-                windowContext: Self.exactWindowContext(processIdentifier: pid)))
-        let synthetic = ClickRecordingSyntheticInputDriver()
-        let service = ClickService(
-            snapshotManager: InMemorySnapshotManager(detectionResult: detectionResult),
-            inputPolicy: UIInputPolicy(defaultStrategy: .actionFirst),
-            syntheticInputDriver: synthetic,
-            exactWindowIdentityValidator: { _, _ in true })
+        try await WindowMovementTrackingProviderScope.withProvider(tracker) {
+            let element = DetectedElement(
+                id: "B1",
+                type: .button,
+                label: "Background Button",
+                value: nil,
+                bounds: .init(x: 20, y: 30, width: 100, height: 40),
+                isEnabled: true,
+                isSelected: nil,
+                attributes: ["identifier": "background-button", "role": "AXButton"])
+            let detectionResult = ElementDetectionResult(
+                snapshotId: "snapshot",
+                screenshotPath: "/tmp/shot.png",
+                elements: DetectedElements(buttons: [element]),
+                metadata: DetectionMetadata(
+                    detectionTime: 0.01,
+                    elementCount: 1,
+                    method: "test",
+                    windowContext: Self.exactWindowContext(processIdentifier: pid)))
+            let synthetic = ClickRecordingSyntheticInputDriver()
+            let service = ClickService(
+                snapshotManager: InMemorySnapshotManager(detectionResult: detectionResult),
+                inputPolicy: UIInputPolicy(defaultStrategy: .actionFirst),
+                syntheticInputDriver: synthetic,
+                exactWindowIdentityValidator: { _, _ in true })
 
-        let result = try await service.click(
-            target: .elementId("B1"),
-            clickType: .single,
-            snapshotId: "snapshot",
-            targetProcessIdentifier: pid)
+            let result = try await service.click(
+                target: .elementId("B1"),
+                clickType: .single,
+                snapshotId: "snapshot",
+                targetProcessIdentifier: pid)
 
-        #expect(result.path == .synth)
-        #expect(result.strategy == .actionFirst)
-        #expect(result.fallbackReason == .missingElement)
-        #expect(synthetic.events == [
-            .targetedClick(
-                point: CGPoint(x: 70, y: 50),
-                button: .left,
-                count: 1,
-                targetProcessIdentifier: pid,
-                targetWindowID: 42),
-        ])
+            #expect(result.path == .synth)
+            #expect(result.strategy == .actionFirst)
+            #expect(result.fallbackReason == .missingElement)
+            #expect(synthetic.events == [
+                .targetedClick(
+                    point: CGPoint(x: 70, y: 50),
+                    button: .left,
+                    count: 1,
+                    targetProcessIdentifier: pid,
+                    targetWindowID: 42),
+            ])
+        }
     }
 
     @Test
@@ -475,45 +475,45 @@ struct ClickServiceTargetResolutionTests {
     func `background element click succeeds through AX action without synthesis`() async throws {
         let pid = getpid()
         let tracker = ClickWindowTracker(bounds: .zero)
-        WindowMovementTracking.provider = tracker
-        defer { WindowMovementTracking.provider = nil }
-        let element = DetectedElement(
-            id: "B1",
-            type: .button,
-            label: "Background Button",
-            bounds: .init(x: 20, y: 30, width: 100, height: 40))
-        let detectionResult = ElementDetectionResult(
-            snapshotId: "snapshot",
-            screenshotPath: "/tmp/shot.png",
-            elements: DetectedElements(buttons: [element]),
-            metadata: DetectionMetadata(
-                detectionTime: 0.01,
-                elementCount: 1,
-                method: "test",
-                windowContext: Self.exactWindowContext(processIdentifier: pid)))
-        let action = ClickSuccessfulActionInputDriver()
-        let synthetic = ClickRecordingSyntheticInputDriver()
-        let resolver = ClickFixedAutomationElementResolver()
-        let service = ClickService(
-            snapshotManager: InMemorySnapshotManager(detectionResult: detectionResult),
-            inputPolicy: UIInputPolicy(defaultStrategy: .actionFirst),
-            actionInputDriver: action,
-            syntheticInputDriver: synthetic,
-            automationElementResolver: resolver,
-            exactWindowIdentityValidator: { _, _ in true })
+        try await WindowMovementTrackingProviderScope.withProvider(tracker) {
+            let element = DetectedElement(
+                id: "B1",
+                type: .button,
+                label: "Background Button",
+                bounds: .init(x: 20, y: 30, width: 100, height: 40))
+            let detectionResult = ElementDetectionResult(
+                snapshotId: "snapshot",
+                screenshotPath: "/tmp/shot.png",
+                elements: DetectedElements(buttons: [element]),
+                metadata: DetectionMetadata(
+                    detectionTime: 0.01,
+                    elementCount: 1,
+                    method: "test",
+                    windowContext: Self.exactWindowContext(processIdentifier: pid)))
+            let action = ClickSuccessfulActionInputDriver()
+            let synthetic = ClickRecordingSyntheticInputDriver()
+            let resolver = ClickFixedAutomationElementResolver()
+            let service = ClickService(
+                snapshotManager: InMemorySnapshotManager(detectionResult: detectionResult),
+                inputPolicy: UIInputPolicy(defaultStrategy: .actionFirst),
+                actionInputDriver: action,
+                syntheticInputDriver: synthetic,
+                automationElementResolver: resolver,
+                exactWindowIdentityValidator: { _, _ in true })
 
-        let result = try await service.click(
-            target: .elementId("B1"),
-            clickType: .single,
-            snapshotId: "snapshot",
-            targetProcessIdentifier: pid)
+            let result = try await service.click(
+                target: .elementId("B1"),
+                clickType: .single,
+                snapshotId: "snapshot",
+                targetProcessIdentifier: pid)
 
-        #expect(result.path == .action)
-        #expect(result.actionName == "AXPress")
-        #expect(action.clickCount == 0)
-        #expect(action.performedActionNames == [AXActionNames.kAXPressAction])
-        #expect(synthetic.events.isEmpty)
-        #expect(resolver.targetProcessIdentifiers == [pid])
+            #expect(result.path == .action)
+            #expect(result.actionName == "AXPress")
+            #expect(action.clickCount == 0)
+            #expect(action.performedActionNames == [AXActionNames.kAXPressAction])
+            #expect(synthetic.events.isEmpty)
+            #expect(resolver.targetProcessIdentifiers == [pid])
+        }
     }
 
     @Test
@@ -521,93 +521,93 @@ struct ClickServiceTargetResolutionTests {
     func `background element right click succeeds through AXShowMenu without synthesis`() async throws {
         let pid = getpid()
         let tracker = ClickWindowTracker(bounds: .zero)
-        WindowMovementTracking.provider = tracker
-        defer { WindowMovementTracking.provider = nil }
-        let element = DetectedElement(
-            id: "B1",
-            type: .button,
-            label: "Background Button",
-            bounds: .init(x: 20, y: 30, width: 100, height: 40))
-        let detectionResult = ElementDetectionResult(
-            snapshotId: "snapshot",
-            screenshotPath: "/tmp/shot.png",
-            elements: DetectedElements(buttons: [element]),
-            metadata: DetectionMetadata(
-                detectionTime: 0.01,
-                elementCount: 1,
-                method: "test",
-                windowContext: Self.exactWindowContext(processIdentifier: pid)))
-        let action = ClickSuccessfulActionInputDriver()
-        let synthetic = ClickRecordingSyntheticInputDriver()
-        let resolver = ClickFixedAutomationElementResolver()
-        let service = ClickService(
-            snapshotManager: InMemorySnapshotManager(detectionResult: detectionResult),
-            inputPolicy: UIInputPolicy(defaultStrategy: .actionFirst),
-            actionInputDriver: action,
-            syntheticInputDriver: synthetic,
-            automationElementResolver: resolver,
-            exactWindowIdentityValidator: { _, _ in true })
+        try await WindowMovementTrackingProviderScope.withProvider(tracker) {
+            let element = DetectedElement(
+                id: "B1",
+                type: .button,
+                label: "Background Button",
+                bounds: .init(x: 20, y: 30, width: 100, height: 40))
+            let detectionResult = ElementDetectionResult(
+                snapshotId: "snapshot",
+                screenshotPath: "/tmp/shot.png",
+                elements: DetectedElements(buttons: [element]),
+                metadata: DetectionMetadata(
+                    detectionTime: 0.01,
+                    elementCount: 1,
+                    method: "test",
+                    windowContext: Self.exactWindowContext(processIdentifier: pid)))
+            let action = ClickSuccessfulActionInputDriver()
+            let synthetic = ClickRecordingSyntheticInputDriver()
+            let resolver = ClickFixedAutomationElementResolver()
+            let service = ClickService(
+                snapshotManager: InMemorySnapshotManager(detectionResult: detectionResult),
+                inputPolicy: UIInputPolicy(defaultStrategy: .actionFirst),
+                actionInputDriver: action,
+                syntheticInputDriver: synthetic,
+                automationElementResolver: resolver,
+                exactWindowIdentityValidator: { _, _ in true })
 
-        let result = try await service.click(
-            target: .elementId("B1"),
-            clickType: .right,
-            snapshotId: "snapshot",
-            targetProcessIdentifier: pid)
-
-        #expect(result.path == .action)
-        #expect(result.actionName == AXActionNames.kAXShowMenuAction)
-        #expect(action.rightClickCount == 1)
-        #expect(synthetic.events.isEmpty)
-        #expect(resolver.targetProcessIdentifiers == [pid])
-    }
-
-    @Test
-    @MainActor
-    func `background element right click reports synthetic permission when AX fallback fails`() async throws {
-        let pid = getpid()
-        let tracker = ClickWindowTracker(bounds: .zero)
-        WindowMovementTracking.provider = tracker
-        defer { WindowMovementTracking.provider = nil }
-        let element = DetectedElement(
-            id: "B1",
-            type: .button,
-            label: "Background Button",
-            bounds: .init(x: 20, y: 30, width: 100, height: 40))
-        let detectionResult = ElementDetectionResult(
-            snapshotId: "snapshot",
-            screenshotPath: "/tmp/shot.png",
-            elements: DetectedElements(buttons: [element]),
-            metadata: DetectionMetadata(
-                detectionTime: 0.01,
-                elementCount: 1,
-                method: "test",
-                windowContext: Self.exactWindowContext(processIdentifier: pid)))
-        let synthetic = ClickRecordingSyntheticInputDriver(
-            targetedClickError: PeekabooError.permissionDeniedEventSynthesizing)
-        let resolver = ClickFixedAutomationElementResolver()
-        let service = ClickService(
-            snapshotManager: InMemorySnapshotManager(detectionResult: detectionResult),
-            inputPolicy: UIInputPolicy(defaultStrategy: .actionFirst),
-            actionInputDriver: ClickFailingActionInputDriver(error: .permissionDenied),
-            syntheticInputDriver: synthetic,
-            automationElementResolver: resolver,
-            exactWindowIdentityValidator: { _, _ in true })
-
-        do {
-            _ = try await service.click(
+            let result = try await service.click(
                 target: .elementId("B1"),
                 clickType: .right,
                 snapshotId: "snapshot",
                 targetProcessIdentifier: pid)
-            Issue.record("Expected Event Synthesizing permission error")
-        } catch PeekabooError.permissionDeniedEventSynthesizing {
-            // Expected after AX permission failure requests synthetic fallback.
-        } catch {
-            Issue.record("Unexpected error: \(error)")
-        }
 
-        #expect(synthetic.targetedClickAttempts == 1)
-        #expect(resolver.targetProcessIdentifiers == [pid])
+            #expect(result.path == .action)
+            #expect(result.actionName == AXActionNames.kAXShowMenuAction)
+            #expect(action.rightClickCount == 1)
+            #expect(synthetic.events.isEmpty)
+            #expect(resolver.targetProcessIdentifiers == [pid])
+        }
+    }
+
+    @Test
+    @MainActor
+    func `background element right click reports synthetic permission when AX fallback fails`() async {
+        let pid = getpid()
+        let tracker = ClickWindowTracker(bounds: .zero)
+        await WindowMovementTrackingProviderScope.withProvider(tracker) {
+            let element = DetectedElement(
+                id: "B1",
+                type: .button,
+                label: "Background Button",
+                bounds: .init(x: 20, y: 30, width: 100, height: 40))
+            let detectionResult = ElementDetectionResult(
+                snapshotId: "snapshot",
+                screenshotPath: "/tmp/shot.png",
+                elements: DetectedElements(buttons: [element]),
+                metadata: DetectionMetadata(
+                    detectionTime: 0.01,
+                    elementCount: 1,
+                    method: "test",
+                    windowContext: Self.exactWindowContext(processIdentifier: pid)))
+            let synthetic = ClickRecordingSyntheticInputDriver(
+                targetedClickError: PeekabooError.permissionDeniedEventSynthesizing)
+            let resolver = ClickFixedAutomationElementResolver()
+            let service = ClickService(
+                snapshotManager: InMemorySnapshotManager(detectionResult: detectionResult),
+                inputPolicy: UIInputPolicy(defaultStrategy: .actionFirst),
+                actionInputDriver: ClickFailingActionInputDriver(error: .permissionDenied),
+                syntheticInputDriver: synthetic,
+                automationElementResolver: resolver,
+                exactWindowIdentityValidator: { _, _ in true })
+
+            do {
+                _ = try await service.click(
+                    target: .elementId("B1"),
+                    clickType: .right,
+                    snapshotId: "snapshot",
+                    targetProcessIdentifier: pid)
+                Issue.record("Expected Event Synthesizing permission error")
+            } catch PeekabooError.permissionDeniedEventSynthesizing {
+                // Expected after AX permission failure requests synthetic fallback.
+            } catch {
+                Issue.record("Unexpected error: \(error)")
+            }
+
+            #expect(synthetic.targetedClickAttempts == 1)
+            #expect(resolver.targetProcessIdentifiers == [pid])
+        }
     }
 
     @Test
@@ -779,44 +779,43 @@ struct ClickServiceTargetResolutionTests {
     func `background element click rejects vanished window without snapshot bounds`() async {
         let pid = getpid()
         let tracker = ClickWindowTracker(bounds: nil)
-        WindowMovementTracking.provider = tracker
-        defer { WindowMovementTracking.provider = nil }
-
-        let element = DetectedElement(
-            id: "B1",
-            type: .button,
-            label: "Background Button",
-            bounds: .init(x: 20, y: 30, width: 100, height: 40))
-        let detectionResult = ElementDetectionResult(
-            snapshotId: "snapshot",
-            screenshotPath: "/tmp/shot.png",
-            elements: DetectedElements(buttons: [element]),
-            metadata: DetectionMetadata(
-                detectionTime: 0.01,
-                elementCount: 1,
-                method: "test",
-                windowContext: WindowContext(
-                    applicationProcessId: pid,
-                    windowID: 42)))
-        let action = ClickSuccessfulActionInputDriver()
-        let synthetic = ClickRecordingSyntheticInputDriver()
-        let service = ClickService(
-            snapshotManager: InMemorySnapshotManager(detectionResult: detectionResult),
-            inputPolicy: UIInputPolicy(defaultStrategy: .actionFirst),
-            actionInputDriver: action,
-            syntheticInputDriver: synthetic,
-            automationElementResolver: ClickFixedAutomationElementResolver())
-
-        await #expect(throws: (any Error).self) {
-            try await service.click(
-                target: .elementId("B1"),
-                clickType: .single,
+        await WindowMovementTrackingProviderScope.withProvider(tracker) {
+            let element = DetectedElement(
+                id: "B1",
+                type: .button,
+                label: "Background Button",
+                bounds: .init(x: 20, y: 30, width: 100, height: 40))
+            let detectionResult = ElementDetectionResult(
                 snapshotId: "snapshot",
-                targetProcessIdentifier: pid)
-        }
+                screenshotPath: "/tmp/shot.png",
+                elements: DetectedElements(buttons: [element]),
+                metadata: DetectionMetadata(
+                    detectionTime: 0.01,
+                    elementCount: 1,
+                    method: "test",
+                    windowContext: WindowContext(
+                        applicationProcessId: pid,
+                        windowID: 42)))
+            let action = ClickSuccessfulActionInputDriver()
+            let synthetic = ClickRecordingSyntheticInputDriver()
+            let service = ClickService(
+                snapshotManager: InMemorySnapshotManager(detectionResult: detectionResult),
+                inputPolicy: UIInputPolicy(defaultStrategy: .actionFirst),
+                actionInputDriver: action,
+                syntheticInputDriver: synthetic,
+                automationElementResolver: ClickFixedAutomationElementResolver())
 
-        #expect(action.performedActionNames.isEmpty)
-        #expect(synthetic.events.isEmpty)
+            await #expect(throws: (any Error).self) {
+                try await service.click(
+                    target: .elementId("B1"),
+                    clickType: .single,
+                    snapshotId: "snapshot",
+                    targetProcessIdentifier: pid)
+            }
+
+            #expect(action.performedActionNames.isEmpty)
+            #expect(synthetic.events.isEmpty)
+        }
     }
 
     @Test
@@ -824,49 +823,48 @@ struct ClickServiceTargetResolutionTests {
     func `background AX resolution adjusts the snapshot frame after window movement`() async throws {
         let pid = getpid()
         let tracker = ClickWindowTracker(bounds: CGRect(x: 300, y: 400, width: 300, height: 300))
-        WindowMovementTracking.provider = tracker
-        defer { WindowMovementTracking.provider = nil }
+        try await WindowMovementTrackingProviderScope.withProvider(tracker) {
+            let element = DetectedElement(
+                id: "B1",
+                type: .button,
+                label: "Duplicate",
+                bounds: CGRect(x: 120, y: 140, width: 80, height: 30))
+            let detectionResult = ElementDetectionResult(
+                snapshotId: "snapshot",
+                screenshotPath: "/tmp/shot.png",
+                elements: DetectedElements(buttons: [element]),
+                metadata: DetectionMetadata(
+                    detectionTime: 0.01,
+                    elementCount: 1,
+                    method: "test",
+                    windowContext: WindowContext(
+                        applicationProcessId: pid,
+                        windowID: 42,
+                        windowBounds: CGRect(x: 100, y: 100, width: 300, height: 300),
+                        windowMutationIdentity: Self.windowIdentity(processIdentifier: pid))))
+            let resolver = ClickFixedAutomationElementResolver()
+            let synthetic = ClickRecordingSyntheticInputDriver()
+            let service = ClickService(
+                snapshotManager: InMemorySnapshotManager(detectionResult: detectionResult),
+                inputPolicy: UIInputPolicy(defaultStrategy: .actionFirst),
+                actionInputDriver: ClickSuccessfulActionInputDriver(),
+                syntheticInputDriver: synthetic,
+                automationElementResolver: resolver,
+                exactWindowIdentityValidator: { _, _ in true })
 
-        let element = DetectedElement(
-            id: "B1",
-            type: .button,
-            label: "Duplicate",
-            bounds: CGRect(x: 120, y: 140, width: 80, height: 30))
-        let detectionResult = ElementDetectionResult(
-            snapshotId: "snapshot",
-            screenshotPath: "/tmp/shot.png",
-            elements: DetectedElements(buttons: [element]),
-            metadata: DetectionMetadata(
-                detectionTime: 0.01,
-                elementCount: 1,
-                method: "test",
-                windowContext: WindowContext(
-                    applicationProcessId: pid,
-                    windowID: 42,
-                    windowBounds: CGRect(x: 100, y: 100, width: 300, height: 300),
-                    windowMutationIdentity: Self.windowIdentity(processIdentifier: pid))))
-        let resolver = ClickFixedAutomationElementResolver()
-        let synthetic = ClickRecordingSyntheticInputDriver()
-        let service = ClickService(
-            snapshotManager: InMemorySnapshotManager(detectionResult: detectionResult),
-            inputPolicy: UIInputPolicy(defaultStrategy: .actionFirst),
-            actionInputDriver: ClickSuccessfulActionInputDriver(),
-            syntheticInputDriver: synthetic,
-            automationElementResolver: resolver,
-            exactWindowIdentityValidator: { _, _ in true })
+            let result = try await service.click(
+                target: .elementId("B1"),
+                clickType: .single,
+                snapshotId: "snapshot",
+                targetProcessIdentifier: pid)
 
-        let result = try await service.click(
-            target: .elementId("B1"),
-            clickType: .single,
-            snapshotId: "snapshot",
-            targetProcessIdentifier: pid)
-
-        #expect(result.path == .action)
-        #expect(resolver.detectedElements.map(\.bounds) == [
-            CGRect(x: 320, y: 440, width: 80, height: 30),
-        ])
-        #expect(resolver.targetProcessIdentifiers == [pid])
-        #expect(synthetic.events.isEmpty)
+            #expect(result.path == .action)
+            #expect(resolver.detectedElements.map(\.bounds) == [
+                CGRect(x: 320, y: 440, width: 80, height: 30),
+            ])
+            #expect(resolver.targetProcessIdentifiers == [pid])
+            #expect(synthetic.events.isEmpty)
+        }
     }
 
     @Test
@@ -874,47 +872,47 @@ struct ClickServiceTargetResolutionTests {
     func `background AX permission denial falls back to targeted synthesis`() async throws {
         let pid = getpid()
         let tracker = ClickWindowTracker(bounds: .zero)
-        WindowMovementTracking.provider = tracker
-        defer { WindowMovementTracking.provider = nil }
-        let element = DetectedElement(
-            id: "B1",
-            type: .button,
-            label: "Background Button",
-            bounds: .init(x: 20, y: 30, width: 100, height: 40))
-        let detectionResult = ElementDetectionResult(
-            snapshotId: "snapshot",
-            screenshotPath: "/tmp/shot.png",
-            elements: DetectedElements(buttons: [element]),
-            metadata: DetectionMetadata(
-                detectionTime: 0.01,
-                elementCount: 1,
-                method: "test",
-                windowContext: Self.exactWindowContext(processIdentifier: pid)))
-        let synthetic = ClickRecordingSyntheticInputDriver()
-        let service = ClickService(
-            snapshotManager: InMemorySnapshotManager(detectionResult: detectionResult),
-            inputPolicy: UIInputPolicy(defaultStrategy: .actionFirst),
-            actionInputDriver: ClickFailingActionInputDriver(error: .permissionDenied),
-            syntheticInputDriver: synthetic,
-            automationElementResolver: ClickFixedAutomationElementResolver(),
-            exactWindowIdentityValidator: { _, _ in true })
+        try await WindowMovementTrackingProviderScope.withProvider(tracker) {
+            let element = DetectedElement(
+                id: "B1",
+                type: .button,
+                label: "Background Button",
+                bounds: .init(x: 20, y: 30, width: 100, height: 40))
+            let detectionResult = ElementDetectionResult(
+                snapshotId: "snapshot",
+                screenshotPath: "/tmp/shot.png",
+                elements: DetectedElements(buttons: [element]),
+                metadata: DetectionMetadata(
+                    detectionTime: 0.01,
+                    elementCount: 1,
+                    method: "test",
+                    windowContext: Self.exactWindowContext(processIdentifier: pid)))
+            let synthetic = ClickRecordingSyntheticInputDriver()
+            let service = ClickService(
+                snapshotManager: InMemorySnapshotManager(detectionResult: detectionResult),
+                inputPolicy: UIInputPolicy(defaultStrategy: .actionFirst),
+                actionInputDriver: ClickFailingActionInputDriver(error: .permissionDenied),
+                syntheticInputDriver: synthetic,
+                automationElementResolver: ClickFixedAutomationElementResolver(),
+                exactWindowIdentityValidator: { _, _ in true })
 
-        let result = try await service.click(
-            target: .elementId("B1"),
-            clickType: .single,
-            snapshotId: "snapshot",
-            targetProcessIdentifier: pid)
+            let result = try await service.click(
+                target: .elementId("B1"),
+                clickType: .single,
+                snapshotId: "snapshot",
+                targetProcessIdentifier: pid)
 
-        #expect(result.path == .synth)
-        #expect(result.fallbackReason == .actionUnsupported)
-        #expect(synthetic.events == [
-            .targetedClick(
-                point: CGPoint(x: 70, y: 50),
-                button: .left,
-                count: 1,
-                targetProcessIdentifier: pid,
-                targetWindowID: 42),
-        ])
+            #expect(result.path == .synth)
+            #expect(result.fallbackReason == .actionUnsupported)
+            #expect(synthetic.events == [
+                .targetedClick(
+                    point: CGPoint(x: 70, y: 50),
+                    button: .left,
+                    count: 1,
+                    targetProcessIdentifier: pid,
+                    targetWindowID: 42),
+            ])
+        }
     }
 
     @Test
@@ -985,40 +983,40 @@ struct ClickServiceTargetResolutionTests {
     func `targeted action-only permission denial maps to accessibility permission`() async {
         let pid = getpid()
         let tracker = ClickWindowTracker(bounds: .zero)
-        WindowMovementTracking.provider = tracker
-        defer { WindowMovementTracking.provider = nil }
-        let element = DetectedElement(
-            id: "B1",
-            type: .button,
-            label: "Background Button",
-            bounds: .init(x: 20, y: 30, width: 100, height: 40))
-        let detectionResult = ElementDetectionResult(
-            snapshotId: "snapshot",
-            screenshotPath: "/tmp/shot.png",
-            elements: DetectedElements(buttons: [element]),
-            metadata: DetectionMetadata(
-                detectionTime: 0.01,
-                elementCount: 1,
-                method: "test",
-                windowContext: Self.exactWindowContext(processIdentifier: pid)))
-        let service = ClickService(
-            snapshotManager: InMemorySnapshotManager(detectionResult: detectionResult),
-            inputPolicy: UIInputPolicy(defaultStrategy: .actionOnly),
-            actionInputDriver: ClickFailingActionInputDriver(error: .permissionDenied),
-            automationElementResolver: ClickFixedAutomationElementResolver(),
-            exactWindowIdentityValidator: { _, _ in true })
-
-        do {
-            try await service.click(
-                target: .elementId("B1"),
-                clickType: .single,
+        await WindowMovementTrackingProviderScope.withProvider(tracker) {
+            let element = DetectedElement(
+                id: "B1",
+                type: .button,
+                label: "Background Button",
+                bounds: .init(x: 20, y: 30, width: 100, height: 40))
+            let detectionResult = ElementDetectionResult(
                 snapshotId: "snapshot",
-                targetProcessIdentifier: pid)
-            Issue.record("Expected Accessibility permission error")
-        } catch PeekabooError.permissionDeniedAccessibility {
-            // Expected.
-        } catch {
-            Issue.record("Unexpected error: \(error)")
+                screenshotPath: "/tmp/shot.png",
+                elements: DetectedElements(buttons: [element]),
+                metadata: DetectionMetadata(
+                    detectionTime: 0.01,
+                    elementCount: 1,
+                    method: "test",
+                    windowContext: Self.exactWindowContext(processIdentifier: pid)))
+            let service = ClickService(
+                snapshotManager: InMemorySnapshotManager(detectionResult: detectionResult),
+                inputPolicy: UIInputPolicy(defaultStrategy: .actionOnly),
+                actionInputDriver: ClickFailingActionInputDriver(error: .permissionDenied),
+                automationElementResolver: ClickFixedAutomationElementResolver(),
+                exactWindowIdentityValidator: { _, _ in true })
+
+            do {
+                try await service.click(
+                    target: .elementId("B1"),
+                    clickType: .single,
+                    snapshotId: "snapshot",
+                    targetProcessIdentifier: pid)
+                Issue.record("Expected Accessibility permission error")
+            } catch PeekabooError.permissionDeniedAccessibility {
+                // Expected.
+            } catch {
+                Issue.record("Unexpected error: \(error)")
+            }
         }
     }
 

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/WindowMovementTrackingProviderScopeTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/WindowMovementTrackingProviderScopeTests.swift
@@ -1,0 +1,93 @@
+import CoreGraphics
+import PeekabooAutomationKitTestSupport
+import Testing
+@testable import PeekabooAutomationKit
+
+struct WindowMovementTrackingProviderScopeTests {
+    @Test
+    @MainActor
+    func `Provider scopes exclude concurrent overrides until restoration`() async {
+        let firstProvider = ProviderScopeWindowTracker(bounds: CGRect(x: 0, y: 0, width: 100, height: 100))
+        let secondProvider = ProviderScopeWindowTracker(bounds: .zero)
+        let firstInstalled = AsyncTestLatch()
+        let releaseFirst = AsyncTestLatch()
+        let secondInstalled = AsyncTestLatch()
+
+        let firstTask = Task { @MainActor in
+            await WindowMovementTrackingProviderScope.withProvider(firstProvider) {
+                #expect(WindowMovementTracking.provider === firstProvider)
+                await firstInstalled.open()
+                await releaseFirst.wait()
+                #expect(WindowMovementTracking.provider === firstProvider)
+            }
+        }
+        let secondTask = Task { @MainActor in
+            await firstInstalled.wait()
+            await WindowMovementTrackingProviderScope.withProvider(secondProvider) {
+                #expect(WindowMovementTracking.provider === secondProvider)
+                await secondInstalled.open()
+            }
+        }
+
+        await firstInstalled.wait()
+        let installedBeforeRelease = await secondInstalled.opensWithin(.milliseconds(50))
+        #expect(!installedBeforeRelease)
+        #expect(WindowMovementTracking.provider === firstProvider)
+        await releaseFirst.open()
+        await firstTask.value
+        await secondTask.value
+        #expect(await secondInstalled.isOpen)
+    }
+
+    @Test
+    @MainActor
+    func `Throwing provider scope restores provider and releases next waiter`() async {
+        let initialProvider = await WindowMovementTrackingProviderScope.withExclusiveAccess {
+            WindowMovementTracking.provider
+        }
+        let throwingProvider = ProviderScopeWindowTracker(bounds: .zero)
+
+        do {
+            try await WindowMovementTrackingProviderScope.withProvider(throwingProvider) {
+                #expect(WindowMovementTracking.provider === throwingProvider)
+                throw ProviderScopeTestError.expected
+            }
+            Issue.record("Expected provider operation to throw")
+        } catch ProviderScopeTestError.expected {
+            // Expected.
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+
+        let restoredProvider = await WindowMovementTrackingProviderScope.withExclusiveAccess {
+            WindowMovementTracking.provider
+        }
+        #expect(restoredProvider === initialProvider)
+
+        let nextProvider = ProviderScopeWindowTracker(bounds: CGRect(x: 0, y: 0, width: 50, height: 50))
+        await WindowMovementTrackingProviderScope.withProvider(nextProvider) {
+            #expect(WindowMovementTracking.provider === nextProvider)
+        }
+    }
+}
+
+private enum ProviderScopeTestError: Error {
+    case expected
+}
+
+@MainActor
+private final class ProviderScopeWindowTracker: WindowTrackingProviding {
+    let bounds: CGRect
+
+    init(bounds: CGRect) {
+        self.bounds = bounds
+    }
+
+    func windowBounds(for _: CGWindowID) -> CGRect? {
+        self.bounds
+    }
+
+    func windowOwnerProcessIdentifier(for _: CGWindowID) -> pid_t? {
+        nil
+    }
+}

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/WindowMovementTrackingProviderScopeTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/WindowMovementTrackingProviderScopeTests.swift
@@ -1,7 +1,7 @@
 import CoreGraphics
-import PeekabooAutomationKitTestSupport
 import Testing
 @testable import PeekabooAutomationKit
+@testable import PeekabooAutomationKitTestSupport
 
 struct WindowMovementTrackingProviderScopeTests {
     @Test
@@ -68,6 +68,100 @@ struct WindowMovementTrackingProviderScopeTests {
         await WindowMovementTrackingProviderScope.withProvider(nextProvider) {
             #expect(WindowMovementTracking.provider === nextProvider)
         }
+    }
+
+    @Test
+    @MainActor
+    func `Cancelled queued scope still acquires restores and releases in FIFO order`() async {
+        let initialProvider = await WindowMovementTrackingProviderScope.withExclusiveAccess {
+            WindowMovementTracking.provider
+        }
+        let holdingProvider = ProviderScopeWindowTracker(bounds: .zero)
+        let cancelledProvider = ProviderScopeWindowTracker(bounds: CGRect(x: 10, y: 10, width: 10, height: 10))
+        let finalProvider = ProviderScopeWindowTracker(bounds: CGRect(x: 20, y: 20, width: 20, height: 20))
+        let holderInstalled = AsyncTestLatch()
+        let releaseHolder = AsyncTestLatch()
+        let cancelledQueued = AsyncTestLatch()
+        let finalQueued = AsyncTestLatch()
+        var entryOrder: [String] = []
+
+        let holderTask = Task { @MainActor in
+            await WindowMovementTrackingProviderScope.withProvider(holdingProvider) {
+                await holderInstalled.open()
+                await releaseHolder.wait()
+            }
+        }
+        await holderInstalled.wait()
+
+        var cancelledTaskReachedScope = false
+        let cancelledTask = Task { @MainActor in
+            cancelledTaskReachedScope = true
+            await WindowMovementTrackingProviderScope.withProvider(
+                cancelledProvider,
+                queuedSignal: cancelledQueued)
+            {
+                #expect(Task.isCancelled)
+                #expect(WindowMovementTracking.provider === cancelledProvider)
+                entryOrder.append("cancelled")
+            }
+        }
+        #expect(await cancelledQueued.opensWithin(.seconds(1)))
+        #expect(cancelledTaskReachedScope)
+        cancelledTask.cancel()
+
+        var finalTaskReachedScope = false
+        let finalTask = Task { @MainActor in
+            finalTaskReachedScope = true
+            await WindowMovementTrackingProviderScope.withProvider(
+                finalProvider,
+                queuedSignal: finalQueued)
+            {
+                #expect(!Task.isCancelled)
+                #expect(WindowMovementTracking.provider === finalProvider)
+                entryOrder.append("final")
+            }
+        }
+        #expect(await finalQueued.opensWithin(.seconds(1)))
+        #expect(finalTaskReachedScope)
+
+        await releaseHolder.open()
+        await holderTask.value
+        await cancelledTask.value
+        await finalTask.value
+
+        #expect(entryOrder == ["cancelled", "final"])
+        let restoredProvider = await WindowMovementTrackingProviderScope.withExclusiveAccess {
+            WindowMovementTracking.provider
+        }
+        #expect(restoredProvider === initialProvider)
+    }
+
+    @Test
+    @MainActor
+    func `Provider scope diagnoses inherited reentrancy without leaking to detached tasks`() async {
+        let releaseDelayedChild = AsyncTestLatch()
+        let result = await WindowMovementTrackingProviderScope.withExclusiveAccess {
+            let sameTaskMessage = WindowMovementTrackingProviderScope.reentrancyViolationMessage()
+            let childTaskMessage = await Task {
+                WindowMovementTrackingProviderScope.reentrancyViolationMessage()
+            }.value
+            let delayedChildTask = Task {
+                await releaseDelayedChild.wait()
+                return WindowMovementTrackingProviderScope.reentrancyViolationMessage()
+            }
+            let detachedTaskMessage = await Task.detached {
+                WindowMovementTrackingProviderScope.reentrancyViolationMessage()
+            }.value
+            return (sameTaskMessage, childTaskMessage, delayedChildTask, detachedTaskMessage)
+        }
+        await releaseDelayedChild.open()
+        let delayedChildMessage = await result.2.value
+
+        #expect(result.0?.contains("cannot be nested") == true)
+        #expect(result.1 == result.0)
+        #expect(delayedChildMessage == result.0)
+        #expect(result.3 == nil)
+        #expect(WindowMovementTrackingProviderScope.reentrancyViolationMessage() == nil)
     }
 }
 

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/WindowTrackerServiceTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/WindowTrackerServiceTests.swift
@@ -1,11 +1,12 @@
 import CoreGraphics
+import PeekabooAutomationKitTestSupport
 import Testing
 @testable import PeekabooAutomationKit
 
 struct WindowTrackerServiceTests {
     @Test
     @MainActor
-    func `Movement tracking refreshes exact window on cache miss and preserves cache hits`() {
+    func `Movement tracking refreshes exact window on cache miss and preserves cache hits`() async {
         let windowID = CGWindowID(42)
         let bounds = CGRect(x: 40, y: 50, width: 300, height: 200)
         let source = WindowInfoSource(currentInfo: Self.windowInfo(
@@ -15,27 +16,26 @@ struct WindowTrackerServiceTests {
         let tracker = WindowTrackerService(
             configuration: WindowTrackerConfiguration(useAXNotifications: false),
             exactWindowIdentityProvider: { source.info(for: $0) })
-        let previousTracker = WindowMovementTracking.provider
-        WindowMovementTracking.provider = tracker
-        defer { WindowMovementTracking.provider = previousTracker }
-        let snapshot = UIAutomationSnapshot(
-            applicationProcessId: 111,
-            windowBounds: bounds,
-            windowID: windowID)
+        await WindowMovementTrackingProviderScope.withProvider(tracker) {
+            let snapshot = UIAutomationSnapshot(
+                applicationProcessId: 111,
+                windowBounds: bounds,
+                windowID: windowID)
 
-        let firstResult = WindowMovementTracking.adjustPoint(CGPoint(x: 80, y: 90), snapshot: snapshot)
-        source.currentInfo = nil
-        let secondResult = WindowMovementTracking.adjustPoint(CGPoint(x: 80, y: 90), snapshot: snapshot)
+            let firstResult = WindowMovementTracking.adjustPoint(CGPoint(x: 80, y: 90), snapshot: snapshot)
+            source.currentInfo = nil
+            let secondResult = WindowMovementTracking.adjustPoint(CGPoint(x: 80, y: 90), snapshot: snapshot)
 
-        guard case .unchanged = firstResult else {
-            Issue.record("Expected exact-window refresh to recover the cache miss, got \(firstResult)")
-            return
+            guard case .unchanged = firstResult else {
+                Issue.record("Expected exact-window refresh to recover the cache miss, got \(firstResult)")
+                return
+            }
+            guard case .unchanged = secondResult else {
+                Issue.record("Expected cached exact-window hit, got \(secondResult)")
+                return
+            }
+            #expect(source.requestedWindowIDs == [windowID])
         }
-        guard case .unchanged = secondResult else {
-            Issue.record("Expected cached exact-window hit, got \(secondResult)")
-            return
-        }
-        #expect(source.requestedWindowIDs == [windowID])
     }
 
     @Test

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooDaemonTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooDaemonTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import PeekabooAutomationKit
+import PeekabooAutomationKitTestSupport
 import PeekabooBridge
 import Testing
 @testable import PeekabooCore
@@ -137,14 +138,16 @@ struct PeekabooDaemonTests {
 
     @Test
     func `embedded MCP shutdown completes tracker cleanup`() async throws {
-        let daemon = PeekabooDaemon(configuration: .embeddedMCP())
-        try await daemon.startChecked()
-        #expect(WindowMovementTracking.provider != nil)
+        try await WindowMovementTrackingProviderScope.withExclusiveAccess {
+            let daemon = PeekabooDaemon(configuration: .embeddedMCP())
+            try await daemon.startChecked()
+            #expect(WindowMovementTracking.provider != nil)
 
-        #expect(await daemon.requestStop())
-        await daemon.waitUntilStopped()
+            #expect(await daemon.requestStop())
+            await daemon.waitUntilStopped()
 
-        #expect(WindowMovementTracking.provider == nil)
+            #expect(WindowMovementTracking.provider == nil)
+        }
     }
 
     @Test

--- a/Core/PeekabooCore/Tests/PeekabooTests/WindowMovementTrackingTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/WindowMovementTrackingTests.swift
@@ -1,38 +1,38 @@
 import CoreGraphics
 import Foundation
 import PeekabooAutomationKit
+import PeekabooAutomationKitTestSupport
 import Testing
 
 @Suite(.tags(.safe))
 struct WindowMovementTrackingTests {
     @Test
     @MainActor
-    func `Adjusts points when window moves`() {
+    func `Adjusts points when window moves`() async {
         let snapshot = UIAutomationSnapshot(
             windowBounds: CGRect(x: 100, y: 100, width: 200, height: 200),
             windowID: 42)
 
         let tracker = StubWindowTracker(bounds: CGRect(x: 140, y: 150, width: 200, height: 200))
-        WindowMovementTracking.provider = tracker
-        defer { WindowMovementTracking.provider = nil }
+        await WindowMovementTrackingProviderScope.withProvider(tracker) {
+            let original = CGPoint(x: 150, y: 150)
+            let result = WindowMovementTracking.adjustPoint(original, snapshot: snapshot)
 
-        let original = CGPoint(x: 150, y: 150)
-        let result = WindowMovementTracking.adjustPoint(original, snapshot: snapshot)
-
-        #expect(tracker.refreshCount == 0)
-        switch result {
-        case let .adjusted(point, delta):
-            #expect(delta.x == 40)
-            #expect(delta.y == 50)
-            #expect(point == CGPoint(x: 190, y: 200))
-        default:
-            Issue.record("Expected adjusted point, got \(result)")
+            #expect(tracker.refreshCount == 0)
+            switch result {
+            case let .adjusted(point, delta):
+                #expect(delta.x == 40)
+                #expect(delta.y == 50)
+                #expect(point == CGPoint(x: 190, y: 200))
+            default:
+                Issue.record("Expected adjusted point, got \(result)")
+            }
         }
     }
 
     @Test
     @MainActor
-    func `Refreshes exact window after provider cache miss`() {
+    func `Refreshes exact window after provider cache miss`() async {
         let snapshot = UIAutomationSnapshot(
             applicationProcessId: 321,
             windowBounds: CGRect(x: 100, y: 100, width: 200, height: 200),
@@ -41,23 +41,22 @@ struct WindowMovementTrackingTests {
             bounds: nil,
             refreshedBounds: CGRect(x: 140, y: 150, width: 200, height: 200),
             refreshedOwnerProcessIdentifier: 321)
-        WindowMovementTracking.provider = tracker
-        defer { WindowMovementTracking.provider = nil }
+        await WindowMovementTrackingProviderScope.withProvider(tracker) {
+            let result = WindowMovementTracking.adjustPoint(CGPoint(x: 150, y: 150), snapshot: snapshot)
 
-        let result = WindowMovementTracking.adjustPoint(CGPoint(x: 150, y: 150), snapshot: snapshot)
-
-        #expect(tracker.refreshedWindowIDs == [42])
-        guard case let .adjusted(point, delta) = result else {
-            Issue.record("Expected adjusted point after exact-window refresh, got \(result)")
-            return
+            #expect(tracker.refreshedWindowIDs == [42])
+            guard case let .adjusted(point, delta) = result else {
+                Issue.record("Expected adjusted point after exact-window refresh, got \(result)")
+                return
+            }
+            #expect(delta == CGPoint(x: 40, y: 50))
+            #expect(point == CGPoint(x: 190, y: 200))
         }
-        #expect(delta == CGPoint(x: 40, y: 50))
-        #expect(point == CGPoint(x: 190, y: 200))
     }
 
     @Test
     @MainActor
-    func `Returns stale when window resizes`() {
+    func `Returns stale when window resizes`() async {
         let snapshot = UIAutomationSnapshot(
             applicationName: "TextEdit",
             windowTitle: "Notes",
@@ -65,47 +64,45 @@ struct WindowMovementTrackingTests {
             windowID: 99)
 
         let tracker = StubWindowTracker(bounds: CGRect(x: 0, y: 0, width: 300, height: 200))
-        WindowMovementTracking.provider = tracker
-        defer { WindowMovementTracking.provider = nil }
-
-        let result = WindowMovementTracking.adjustPoint(CGPoint(x: 10, y: 10), snapshot: snapshot)
-        switch result {
-        case let .stale(message):
-            #expect(message.contains("changed size"))
-            #expect(message.contains("windowID: 99"))
-            #expect(message.contains("app: TextEdit"))
-            #expect(message.contains("title: Notes"))
-            #expect(message.contains("Previous bounds:"))
-            #expect(message.contains("current bounds:"))
-        default:
-            Issue.record("Expected stale result, got \(result)")
+        await WindowMovementTrackingProviderScope.withProvider(tracker) {
+            let result = WindowMovementTracking.adjustPoint(CGPoint(x: 10, y: 10), snapshot: snapshot)
+            switch result {
+            case let .stale(message):
+                #expect(message.contains("changed size"))
+                #expect(message.contains("windowID: 99"))
+                #expect(message.contains("app: TextEdit"))
+                #expect(message.contains("title: Notes"))
+                #expect(message.contains("Previous bounds:"))
+                #expect(message.contains("current bounds:"))
+            default:
+                Issue.record("Expected stale result, got \(result)")
+            }
         }
     }
 
     @Test
     @MainActor
-    func `Allows tiny window size jitter`() {
+    func `Allows tiny window size jitter`() async {
         let snapshot = UIAutomationSnapshot(
             windowBounds: CGRect(x: 100, y: 100, width: 200, height: 200),
             windowID: 98)
 
         let tracker = StubWindowTracker(bounds: CGRect(x: 110, y: 120, width: 203, height: 204))
-        WindowMovementTracking.provider = tracker
-        defer { WindowMovementTracking.provider = nil }
-
-        let result = WindowMovementTracking.adjustPoint(CGPoint(x: 150, y: 150), snapshot: snapshot)
-        switch result {
-        case let .adjusted(point, delta):
-            #expect(delta == CGPoint(x: 10, y: 20))
-            #expect(point == CGPoint(x: 160, y: 170))
-        default:
-            Issue.record("Expected adjusted point for tiny size jitter, got \(result)")
+        await WindowMovementTrackingProviderScope.withProvider(tracker) {
+            let result = WindowMovementTracking.adjustPoint(CGPoint(x: 150, y: 150), snapshot: snapshot)
+            switch result {
+            case let .adjusted(point, delta):
+                #expect(delta == CGPoint(x: 10, y: 20))
+                #expect(point == CGPoint(x: 160, y: 170))
+            default:
+                Issue.record("Expected adjusted point for tiny size jitter, got \(result)")
+            }
         }
     }
 
     @Test
     @MainActor
-    func `Returns stale when tracked window disappears`() {
+    func `Returns stale when tracked window disappears`() async {
         let snapshot = UIAutomationSnapshot(
             applicationBundleId: "com.apple.TextEdit",
             windowTitle: "Notes",
@@ -113,44 +110,42 @@ struct WindowMovementTrackingTests {
             windowID: 100)
 
         let tracker = StubWindowTracker(bounds: nil)
-        WindowMovementTracking.provider = tracker
-        defer { WindowMovementTracking.provider = nil }
-
-        let result = WindowMovementTracking.adjustPoint(CGPoint(x: 10, y: 10), snapshot: snapshot)
-        switch result {
-        case let .stale(message):
-            #expect(message.contains("no longer available"))
-            #expect(message.contains("windowID: 100"))
-            #expect(message.contains("bundle: com.apple.TextEdit"))
-            #expect(message.contains("title: Notes"))
-        default:
-            Issue.record("Expected stale result, got \(result)")
+        await WindowMovementTrackingProviderScope.withProvider(tracker) {
+            let result = WindowMovementTracking.adjustPoint(CGPoint(x: 10, y: 10), snapshot: snapshot)
+            switch result {
+            case let .stale(message):
+                #expect(message.contains("no longer available"))
+                #expect(message.contains("windowID: 100"))
+                #expect(message.contains("bundle: com.apple.TextEdit"))
+                #expect(message.contains("title: Notes"))
+            default:
+                Issue.record("Expected stale result, got \(result)")
+            }
         }
     }
 
     @Test
     @MainActor
-    func `Returns stale when window without snapshot bounds disappears`() {
+    func `Returns stale when window without snapshot bounds disappears`() async {
         let snapshot = UIAutomationSnapshot(
             applicationProcessId: 321,
             windowID: 100)
 
         let tracker = StubWindowTracker(bounds: nil)
-        WindowMovementTracking.provider = tracker
-        defer { WindowMovementTracking.provider = nil }
-
-        let result = WindowMovementTracking.adjustPoint(CGPoint(x: 10, y: 10), snapshot: snapshot)
-        guard case let .stale(message) = result else {
-            Issue.record("Expected stale result, got \(result)")
-            return
+        await WindowMovementTrackingProviderScope.withProvider(tracker) {
+            let result = WindowMovementTracking.adjustPoint(CGPoint(x: 10, y: 10), snapshot: snapshot)
+            guard case let .stale(message) = result else {
+                Issue.record("Expected stale result, got \(result)")
+                return
+            }
+            #expect(message.contains("no longer available"))
+            #expect(message.contains("windowID: 100"))
         }
-        #expect(message.contains("no longer available"))
-        #expect(message.contains("windowID: 100"))
     }
 
     @Test
     @MainActor
-    func `Returns stale when window ID belongs to another process`() {
+    func `Returns stale when window ID belongs to another process`() async {
         let snapshot = UIAutomationSnapshot(
             applicationProcessId: 321,
             windowID: 100)
@@ -158,16 +153,15 @@ struct WindowMovementTrackingTests {
         let tracker = StubWindowTracker(
             bounds: CGRect(x: 0, y: 0, width: 200, height: 200),
             ownerProcessIdentifier: 654)
-        WindowMovementTracking.provider = tracker
-        defer { WindowMovementTracking.provider = nil }
-
-        let result = WindowMovementTracking.adjustPoint(CGPoint(x: 10, y: 10), snapshot: snapshot)
-        guard case let .stale(message) = result else {
-            Issue.record("Expected stale result, got \(result)")
-            return
+        await WindowMovementTrackingProviderScope.withProvider(tracker) {
+            let result = WindowMovementTracking.adjustPoint(CGPoint(x: 10, y: 10), snapshot: snapshot)
+            guard case let .stale(message) = result else {
+                Issue.record("Expected stale result, got \(result)")
+                return
+            }
+            #expect(message.contains("now belongs to PID 654"))
+            #expect(message.contains("not PID 321"))
         }
-        #expect(message.contains("now belongs to PID 654"))
-        #expect(message.contains("not PID 321"))
     }
 
     @Test
@@ -179,15 +173,14 @@ struct WindowMovementTrackingTests {
         let snapshots = PointSnapshotManager(snapshot: snapshot)
 
         let tracker = StubWindowTracker(bounds: CGRect(x: 15, y: 35, width: 200, height: 200))
-        WindowMovementTracking.provider = tracker
-        defer { WindowMovementTracking.provider = nil }
+        try await WindowMovementTrackingProviderScope.withProvider(tracker) {
+            let adjusted = try await WindowMovementTracking.adjustPoint(
+                CGPoint(x: 50, y: 60),
+                snapshotId: "snapshot-id",
+                snapshots: snapshots)
 
-        let adjusted = try await WindowMovementTracking.adjustPoint(
-            CGPoint(x: 50, y: 60),
-            snapshotId: "snapshot-id",
-            snapshots: snapshots)
-
-        #expect(adjusted == CGPoint(x: 55, y: 75))
+            #expect(adjusted == CGPoint(x: 55, y: 75))
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

- serialize process-global window-tracking provider overrides across parallel test suites
- restore the prior provider and release the cancellation-insensitive FIFO gate after both successful and throwing test bodies
- fail fast on same-task and inherited-child reentrancy instead of deadlocking, with the TaskLocal lifetime boundary documented and covered
- migrate every affected AutomationKit, Core, daemon, and CLI test to the shared scope

## Why

Swift Testing runs suites concurrently. Tests that directly replaced the process-global window-tracking provider could restore another suite's provider, causing unrelated exact-window and click tests to observe `nil` or the wrong fixture. A deterministic two-task reproduction failed at the provider identity assertion before this change.

The gate deliberately remains cancellation-insensitive: a waiter canceled after queueing still acquires in FIFO order, runs while canceled, restores the provider, and releases the next waiter. Per-waiter enqueue signals make that regression deterministic without assuming the rest of the test process is idle.

This is test-support only; production window tracking and dispatch behavior are unchanged.

## Proof

- affected AutomationKit suites: 52 tests passed
- affected suites repeated 100 times: 5,200 tests passed
- full PeekabooAutomationKit: 623 Swift Testing tests passed; 156 XCTest tests passed, 5 skipped for unavailable frontmost-window fixtures
- focused PeekabooCore: 17 tests passed
- focused CLI: 37 tests passed
- SwiftFormat: clean
- SwiftLint: 23 established warnings, zero serious violations
- structured branch autoreview: clean, no actionable findings, 0.98 confidence

## Superseded CI note

On the previous head, PeekabooCore and CLI CI passed. Tachikoma did not reach build or tests: its runner failed while cloning the Swift Argument Parser fork with `SSL certificate problem: self signed certificate` (exit 128). That is runner/TLS infrastructure failure, unrelated to this test-only patch. The new exact head must still rerun the full chain.
