### PR TITLE
fix(cli): keep AX-only see independent of capture

### DIFF
--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reuse two-second, owner-host-local ScreenCaptureKit exact-window screenshot plans without caching pixels, revalidating process generation, window receipt, display topology, and scale around every capture while exposing miss/hit generation diagnostics.
 
 ### Fixed
+- Keep AX-only `see --tree --no-screenshot` independent of capture backends and ScreenCaptureKit ownership while still requiring Accessibility on the selected execution host.
 - Reduce reusable-daemon window-tracker MainActor work by retaining only bounds and owner PID, avoiding unused per-window application and Accessibility metadata on every reconciliation pass.
 - Refresh AXorcist to dispatch native accessibility actions once with typed AX errors and route legacy `AXSetValue` requests through the `AXValue` attribute instead of action discovery.
 - Preserve terminal input and rendering across fragmented UTF-8 and bracketed paste, exact literal paste state, display-width-safe Unicode, BEL/ST/C1-terminated ANSI and OSC-8 links, styled table truncation, and viewport-bounded Markdown and images, while keeping stop/restart idempotent and preventing queued renders from escaping a stopped session.

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommanderBinder.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommanderBinder.swift
@@ -264,12 +264,14 @@ enum CommanderCLIBinder {
         _ commandType: (any ParsableCommand.Type)?,
         parsedValues: ParsedValues
     ) -> Bool {
-        if commandType == SeeCommand.self ||
-            self.isAgentExecutionCommand(commandType) ||
+        let values = CommanderBindableValues(parsedValues: parsedValues)
+        if commandType == SeeCommand.self {
+            return !values.flag("noScreenshot")
+        }
+        if self.isAgentExecutionCommand(commandType) ||
             commandType == MCPCommand.Serve.self {
             return true
         }
-        let values = CommanderBindableValues(parsedValues: parsedValues)
         if commandType == CaptureLiveCommand.self ||
             commandType == CaptureActionCommand.self {
             let focus = values.singleOption("captureFocus")?

--- a/Apps/CLI/Tests/CoreCLITests/AXOnlySeeRuntimeRoutingTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/AXOnlySeeRuntimeRoutingTests.swift
@@ -1,0 +1,64 @@
+import Commander
+import PeekabooAutomationKit
+import PeekabooBridge
+import PeekabooBridgeTestSupport
+import Testing
+@testable import PeekabooCLI
+
+@Suite(.tags(.safe))
+@MainActor
+struct AXOnlySeeRuntimeRoutingTests {
+    @Test
+    func `AX-only see ignores capture grants but requires selected-host Accessibility`() async throws {
+        let candidate = RuntimeHostResolver.ImplicitRemoteCandidate(
+            socketPath: "/tmp/bridge.sock",
+            requireReusableDaemon: false,
+            requiredHostKind: nil,
+            requiresValidatedHistoricalDaemon: false
+        )
+        let options = try CommanderCLIBinder.makeRuntimeOptions(
+            from: ParsedValues(positional: [], options: [:], flags: ["tree", "noScreenshot"]),
+            commandType: SeeCommand.self
+        )
+        func handshake(accessibility: Bool) -> PeekabooBridgeHandshakeResponse {
+            BridgeTestFixtures.handshake(
+                negotiatedVersion: PeekabooBridgeConstants.protocolVersion,
+                hostKind: .onDemand,
+                build: "ax-only-fixture",
+                supportedOperations: [.inspectAccessibilityTree],
+                permissions: PermissionsStatus(
+                    screenRecording: false,
+                    accessibility: accessibility,
+                    appleScript: false,
+                    postEvent: false
+                ),
+                enabledOperations: [.inspectAccessibilityTree],
+                permissionTags: [
+                    PeekabooBridgeOperation.inspectAccessibilityTree.rawValue: [.accessibility],
+                ]
+            )
+        }
+
+        #expect(!options.requiresDesktopObservation)
+        #expect(!options.requiresScreenCapturePermission)
+        #expect(!options.requiresScreenCaptureKitOwnerCapability)
+        #expect(!options.requiresSilentCapture)
+        #expect(options.requiresInspectAccessibilityTree)
+        #expect(!RuntimeHostResolver.requiresCallerLocalModernOwnerClaim(options: options, environment: [:]))
+        #expect(!RuntimeHostResolver.requiresCallerLocalScreenCaptureKitSafetyCheck(options: options, environment: [:]))
+        #expect(await RuntimeHostResolver.validateRemoteCandidate(
+            candidate,
+            handshake: handshake(accessibility: true),
+            options: options
+        ) != nil)
+        #expect(await RuntimeHostResolver.validateRemoteCandidate(
+            candidate,
+            handshake: handshake(accessibility: false),
+            options: options
+        ) == nil)
+        #expect(BridgeCapabilityPolicy.explicitlyMissingRemotePermissions(
+            for: handshake(accessibility: false),
+            options: options
+        ) == [.accessibility])
+    }
+}

--- a/Apps/CLI/Tests/CoreCLITests/ScreenCaptureKitOwnerRuntimeTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/ScreenCaptureKitOwnerRuntimeTests.swift
@@ -1,3 +1,4 @@
+import Commander
 import Darwin
 import Foundation
 import PeekabooAutomation
@@ -92,6 +93,61 @@ struct ScreenCaptureKitOwnerRuntimeTests {
         #expect(resolution.selectedRemoteSocketPath == nil)
         #expect(claimCalls == 1)
         #expect(inspectCalls == 1)
+        #expect(localFactoryCalls == 1)
+    }
+
+    @Test
+    func `caller-local AX-only see skips ScreenCaptureKit ownership and old-host discovery`() async throws {
+        var options = try CommanderCLIBinder.makeRuntimeOptions(
+            from: ParsedValues(
+                positional: [],
+                options: [:],
+                flags: ["tree", "noScreenshot"]
+            ),
+            commandType: SeeCommand.self
+        )
+        options.preferRemote = false
+        options.remoteIsolationRequested = true
+        var claimCalls = 0
+        var inspectOwnerCalls = 0
+        var inspectSafetyCalls = 0
+        var localFactoryCalls = 0
+
+        let resolution = try await RuntimeHostResolver.resolveServices(
+            options: options,
+            environment: [:],
+            configurationInput: nil,
+            dependencies: .init(
+                makeLocalServices: { _ in
+                    localFactoryCalls += 1
+                    return PeekabooServices()
+                },
+                claimScreenCaptureKitOwner: {
+                    claimCalls += 1
+                    return Self.ownerReceipt()
+                },
+                inspectScreenCaptureKitOwner: {
+                    inspectOwnerCalls += 1
+                    return Self.ownerReceipt()
+                },
+                inspectScreenCaptureKitSafety: { _, _, _ in
+                    inspectSafetyCalls += 1
+                    return RuntimeHostResolver.ScreenCaptureKitOwnerUnawareHost(
+                        socketPath: "/tmp/old-host.sock",
+                        processIdentifier: 3131,
+                        processStartIdentity: 4141
+                    )
+                }
+            )
+        )
+
+        #expect(resolution.selectedRemoteSocketPath == nil)
+        #expect(!options.requiresDesktopObservation)
+        #expect(!options.requiresScreenCapturePermission)
+        #expect(!options.requiresSilentCapture)
+        #expect(claimCalls == 0)
+        #expect(inspectOwnerCalls == 0)
+        #expect(inspectSafetyCalls == 0)
         #expect(localFactoryCalls == 1)
     }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Reuse two-second, owner-host-local ScreenCaptureKit exact-window screenshot plans without caching pixels, revalidating process generation, window receipt, display topology, and scale around every capture while exposing miss/hit generation diagnostics.
 
 ### Fixed
+- Keep AX-only `see --tree --no-screenshot` independent of capture backends and ScreenCaptureKit ownership while still requiring Accessibility on the selected execution host.
 - Reduce reusable-daemon window-tracker MainActor work by retaining only bounds and owner PID, avoiding unused per-window application and Accessibility metadata on every reconciliation pass.
 - Refresh AXorcist to dispatch native accessibility actions once with typed AX errors and route legacy `AXSetValue` requests through the `AXValue` attribute instead of action discovery.
 - Preserve terminal input and rendering across fragmented UTF-8 and bracketed paste, exact literal paste state, display-width-safe Unicode, BEL/ST/C1-terminated ANSI and OSC-8 links, styled table truncation, and viewport-bounded Markdown and images, while keeping stop/restart idempotent and preventing queued renders from escaping a stopped session.


### PR DESCRIPTION
## Summary

- Classify `see --tree --no-screenshot` as pure Accessibility inspection instead of silent pixel capture.
- Skip ScreenCaptureKit ownership and Screen Recording requirements only for that AX-only route while retaining selected-host Accessibility enforcement.
- Preserve every screenshot-backed ownership/capability check and add local/remote regression coverage.

## Proof

- `AXOnlySeeRuntimeRoutingTests`: 1/1
- `ScreenCaptureKitOwnerRuntimeTests`: 20/20
- `CommanderBinderTests`: 62/62
- `pnpm run test:safe`: 850 safe CLI tests and 83 runtime tests, plus release-signing, native-only, release-preflight, and background-certification gates
- `pnpm run format`, `pnpm run lint` (23 established warnings, 0 serious), and `git diff --check`
- Exact-commit structured review: clean, confidence 0.98

Source-blind live validation passed all six contract clauses. Repeated AX-only Xcode reads returned 14 elements with distinct snapshot IDs, Calendar returned 68 elements, and screenshot fields remained empty. The invalid capture-engine combination still refused before dispatch, while the screenshot-backed control retained `CAPTURE_FAILED` with `mutation_dispatched: false` against the pre-ownership host.
