### PR TITLE
fix(release): avoid native-only metadata false positives

### DIFF
--- a/scripts/native-only-policy.sh
+++ b/scripts/native-only-policy.sh
@@ -6,7 +6,10 @@
 NATIVE_ONLY_APPLE_EVENT_SOURCE_PATTERN='NSAppleScript|NSUserAppleScriptTask|OSAKit|OSAScript|kOSAComponentType|(^|[^[:alnum:]_])(AE[A-Z][[:lower:]][[:alnum:]_]*|OSA[A-Z][[:lower:]][[:alnum:]_]*)([^[:alnum:]_]|$)|/usr/bin/osascript'
 # shellcheck disable=SC2016
 NATIVE_ONLY_APPLE_EVENT_IMPORT_PATTERN='(^|[[:space:]])_?(AE[A-Z][[:lower:]][[:alnum:]_]*|OSA[A-Z][[:lower:]][[:alnum:]_]*|OBJC_(CLASS|METACLASS)_\$_NSAppleScript)([^[:alnum:]_]|$)'
-NATIVE_ONLY_APPLE_EVENT_STRING_PATTERN='<key>NSAppleEventsUsageDescription</key>|NSAppleScript|NSUserAppleScriptTask|OSAKit\.framework|OSAScript|kOSAComponentType|/usr/bin/osascript|(^|[^[:alnum:]_])(AE[A-Z][[:lower:]][[:alnum:]_]*|OSA[A-Z][[:lower:]][[:alnum:]_]*)([^[:alnum:]_]|$)'
+NATIVE_ONLY_APPLE_EVENT_STRING_PATTERN='<key>NSAppleEventsUsageDescription</key>|NSAppleScript|NSUserAppleScriptTask|OSAKit\.framework|OSAScript|kOSAComponentType|/usr/bin/osascript'
+# `strings` also emits compiler metadata and symbol fragments. Match dynamic lookup names only when
+# the entire string has an Apple Event Manager or OSA API shape with a documented API verb.
+NATIVE_ONLY_DYNAMIC_APPLE_EVENT_STRING_PATTERN='^_?(AE(Build|Call|Check|Coerce|Compare|Count|Create|Decode|Delete|Desc|Determine|Dispose|Duplicate|Flatten|Get|Initialize|Install|Interact|Manager|Object|Print|Process|Put|Remote|Remove|Replace|Reset|Resolve|Resume|Send|Set|Size|Stream|Suspend|Unflatten)[[:alnum:]_]*|OSA(Add|Available|Coerce|Compile|Component|Copy|Display|Dispose|Do|Execute|Generic|Get|Load|Make|Real|Remove|Script|Scripting|Set|Start|Stop|Store)[[:alnum:]_]*)$'
 
 native_only_verify_macho() {
   local binary_path="$1"
@@ -29,7 +32,8 @@ native_only_verify_macho() {
     printf 'Could not inspect %s embedded strings' "${label}"
     return 1
   fi
-  if grep -Eq "${NATIVE_ONLY_APPLE_EVENT_STRING_PATTERN}" <<<"${embedded_strings}"; then
+  if grep -Eq "${NATIVE_ONLY_APPLE_EVENT_STRING_PATTERN}" <<<"${embedded_strings}" ||
+     grep -Eq "${NATIVE_ONLY_DYNAMIC_APPLE_EVENT_STRING_PATTERN}" <<<"${embedded_strings}"; then
     printf '%s embeds an AppleScript or Apple Events execution surface' "${label}"
     return 1
   fi

--- a/scripts/native-only-policy.sh
+++ b/scripts/native-only-policy.sh
@@ -8,8 +8,9 @@ NATIVE_ONLY_APPLE_EVENT_SOURCE_PATTERN='NSAppleScript|NSUserAppleScriptTask|OSAK
 NATIVE_ONLY_APPLE_EVENT_IMPORT_PATTERN='(^|[[:space:]])_?(AE[A-Z][[:lower:]][[:alnum:]_]*|OSA[A-Z][[:lower:]][[:alnum:]_]*|OBJC_(CLASS|METACLASS)_\$_NSAppleScript)([^[:alnum:]_]|$)'
 NATIVE_ONLY_APPLE_EVENT_STRING_PATTERN='<key>NSAppleEventsUsageDescription</key>|NSAppleScript|NSUserAppleScriptTask|OSAKit\.framework|OSAScript|kOSAComponentType|/usr/bin/osascript'
 # `strings` also emits compiler metadata and symbol fragments. Match dynamic lookup names only when
-# the entire string has an Apple Event Manager or OSA API shape with a documented API verb.
-NATIVE_ONLY_DYNAMIC_APPLE_EVENT_STRING_PATTERN='^_?(AE(Build|Call|Check|Coerce|Compare|Count|Create|Decode|Delete|Desc|Determine|Dispose|Duplicate|Flatten|Get|Initialize|Install|Interact|Make|Manager|Object|Print|Process|Put|Remote|Remove|Replace|Reset|Resolve|Resume|Send|Set|Size|Stream|Suspend|Unflatten)[[:alnum:]_]*|OSA(Add|Available|Coerce|Compile|Component|Copy|Display|Dispose|Do|Execute|Generic|Get|Load|Make|Real|Remove|Script|Scripting|Set|Start|Stop|Store)[[:alnum:]_]*)$'
+# the entire string has an API shape. Apple Event APIs have a multi-letter verb (apart from Is/Do),
+# while OSA names keep the original CamelCase boundary because the Release app has no OSA collision.
+NATIVE_ONLY_DYNAMIC_APPLE_EVENT_STRING_PATTERN='^_?(AE([A-Z][[:lower:]]{2}[[:alnum:]_]*|(Is|Do)[A-Z][[:alnum:]_]*)|OSA[A-Z][[:lower:]][[:alnum:]_]*)$'
 
 native_only_verify_macho() {
   local binary_path="$1"

--- a/scripts/native-only-policy.sh
+++ b/scripts/native-only-policy.sh
@@ -9,7 +9,7 @@ NATIVE_ONLY_APPLE_EVENT_IMPORT_PATTERN='(^|[[:space:]])_?(AE[A-Z][[:lower:]][[:a
 NATIVE_ONLY_APPLE_EVENT_STRING_PATTERN='<key>NSAppleEventsUsageDescription</key>|NSAppleScript|NSUserAppleScriptTask|OSAKit\.framework|OSAScript|kOSAComponentType|/usr/bin/osascript'
 # `strings` also emits compiler metadata and symbol fragments. Match dynamic lookup names only when
 # the entire string has an Apple Event Manager or OSA API shape with a documented API verb.
-NATIVE_ONLY_DYNAMIC_APPLE_EVENT_STRING_PATTERN='^_?(AE(Build|Call|Check|Coerce|Compare|Count|Create|Decode|Delete|Desc|Determine|Dispose|Duplicate|Flatten|Get|Initialize|Install|Interact|Manager|Object|Print|Process|Put|Remote|Remove|Replace|Reset|Resolve|Resume|Send|Set|Size|Stream|Suspend|Unflatten)[[:alnum:]_]*|OSA(Add|Available|Coerce|Compile|Component|Copy|Display|Dispose|Do|Execute|Generic|Get|Load|Make|Real|Remove|Script|Scripting|Set|Start|Stop|Store)[[:alnum:]_]*)$'
+NATIVE_ONLY_DYNAMIC_APPLE_EVENT_STRING_PATTERN='^_?(AE(Build|Call|Check|Coerce|Compare|Count|Create|Decode|Delete|Desc|Determine|Dispose|Duplicate|Flatten|Get|Initialize|Install|Interact|Make|Manager|Object|Print|Process|Put|Remote|Remove|Replace|Reset|Resolve|Resume|Send|Set|Size|Stream|Suspend|Unflatten)[[:alnum:]_]*|OSA(Add|Available|Coerce|Compile|Component|Copy|Display|Dispose|Do|Execute|Generic|Get|Load|Make|Real|Remove|Script|Scripting|Set|Start|Stop|Store)[[:alnum:]_]*)$'
 
 native_only_verify_macho() {
   local binary_path="$1"

--- a/scripts/test-release-signing-policy.sh
+++ b/scripts/test-release-signing-policy.sh
@@ -89,8 +89,20 @@ EOF
 cat >"$native_policy_test_dir/strings" <<'EOF'
 #!/usr/bin/env bash
 case "${NATIVE_ONLY_TEST_MODE:-safe}" in
-  safe) printf '%s\n' 'AES-GCM' ;;
-  dynamic) printf '%s\n' 'AESendMessage' ;;
+  safe)
+    printf '%s\n' \
+      'AES-GCM' \
+      'AEGtGG' \
+      'AESgA2fEtGGAbCyAAyAD_A8FtGGAbCyAAyAD_' \
+      'AppleScriptProbeCodingKeys' \
+      '_appleScriptStatus' \
+      '_appleScriptProbe' \
+      'AppleScript probing is no longer supported; current operations use native macOS APIs' \
+      'Avoid shell scripting or osascript pipelines during UI automation.'
+    ;;
+  dynamic-ae) printf '%s\n' 'AESendMessage' ;;
+  dynamic-ae-create) printf '%s\n' 'AECreateDesc' ;;
+  dynamic-osa) printf '%s\n' '_OSADoScript' ;;
   strings-fail) printf '%s\n' 'harmless output'; exit 87 ;;
 esac
 EOF
@@ -100,7 +112,7 @@ export NATIVE_ONLY_TEST_MODE=safe
 native_only_verify_macho \
   "$native_policy_test_dir/fixture" fixture \
   "$native_policy_test_dir/nm" "$native_policy_test_dir/strings"
-for policy_case in ae ae-send osa dynamic nm-fail strings-fail; do
+for policy_case in ae ae-send osa dynamic-ae dynamic-ae-create dynamic-osa nm-fail strings-fail; do
   export NATIVE_ONLY_TEST_MODE="$policy_case"
   if native_only_verify_macho \
     "$native_policy_test_dir/fixture" fixture \

--- a/scripts/test-release-signing-policy.sh
+++ b/scripts/test-release-signing-policy.sh
@@ -104,6 +104,7 @@ case "${NATIVE_ONLY_TEST_MODE:-safe}" in
   dynamic-ae-create) printf '%s\n' 'AECreateDesc' ;;
   dynamic-ae-make) printf '%s\n' 'AEMakeDesc' ;;
   dynamic-osa) printf '%s\n' '_OSADoScript' ;;
+  dynamic-osa-show) printf '%s\n' 'OSAShowScriptingComponent' ;;
   strings-fail) printf '%s\n' 'harmless output'; exit 87 ;;
 esac
 EOF
@@ -113,7 +114,9 @@ export NATIVE_ONLY_TEST_MODE=safe
 native_only_verify_macho \
   "$native_policy_test_dir/fixture" fixture \
   "$native_policy_test_dir/nm" "$native_policy_test_dir/strings"
-for policy_case in ae ae-send osa dynamic-ae dynamic-ae-create dynamic-ae-make dynamic-osa nm-fail strings-fail; do
+for policy_case in \
+  ae ae-send osa dynamic-ae dynamic-ae-create dynamic-ae-make dynamic-osa dynamic-osa-show \
+  nm-fail strings-fail; do
   export NATIVE_ONLY_TEST_MODE="$policy_case"
   if native_only_verify_macho \
     "$native_policy_test_dir/fixture" fixture \

--- a/scripts/test-release-signing-policy.sh
+++ b/scripts/test-release-signing-policy.sh
@@ -102,6 +102,7 @@ case "${NATIVE_ONLY_TEST_MODE:-safe}" in
     ;;
   dynamic-ae) printf '%s\n' 'AESendMessage' ;;
   dynamic-ae-create) printf '%s\n' 'AECreateDesc' ;;
+  dynamic-ae-make) printf '%s\n' 'AEMakeDesc' ;;
   dynamic-osa) printf '%s\n' '_OSADoScript' ;;
   strings-fail) printf '%s\n' 'harmless output'; exit 87 ;;
 esac
@@ -112,7 +113,7 @@ export NATIVE_ONLY_TEST_MODE=safe
 native_only_verify_macho \
   "$native_policy_test_dir/fixture" fixture \
   "$native_policy_test_dir/nm" "$native_policy_test_dir/strings"
-for policy_case in ae ae-send osa dynamic-ae dynamic-ae-create dynamic-osa nm-fail strings-fail; do
+for policy_case in ae ae-send osa dynamic-ae dynamic-ae-create dynamic-ae-make dynamic-osa nm-fail strings-fail; do
   export NATIVE_ONLY_TEST_MODE="$policy_case"
   if native_only_verify_macho \
     "$native_policy_test_dir/fixture" fixture \


### PR DESCRIPTION
## Summary

- stop Swift compiler metadata such as `AEGtGG` and `AESgA2f...` from being misclassified as dynamic Apple Event APIs
- retain fail-closed source and linked-import inspection while requiring embedded dynamic lookup names to have a documented Apple Event Manager or OSA verb
- cover the exact Release-app false positives plus dynamic `AECreateDesc`, `AESendMessage`, and `_OSADoScript` refusals

## Root cause

The broad embedded-string expression accepted any standalone CamelCase-looking `AE...` or `OSA...` token. Release Swift metadata happened to contain eleven opaque strings with that shape, so a native-only app with no forbidden imports failed before installation. Legacy Bridge decoding names and help/error prose were present too, but they did not match the policy and remain intact for rolling upgrades.

## Proof

- `scripts/test-release-signing-policy.sh`
- `scripts/verify-native-only-app.sh --source-root "$PWD"`
- `scripts/verify-native-only-app.sh --app <Foundation-signed Release Peekaboo.app>` on both current main and the companion-installer branch artifact
- strict deep code-sign verification on the companion-installer Release artifact
- matcher exercised against all 172 AE/OSA callable names exposed by the current macOS SDK: zero misses
- Bash syntax, ShellCheck, and `git diff --check`
- structured autoreview: clean, no actionable findings

This changes only release-policy detection and fixtures; the app binary and legacy wire/error compatibility are unchanged.
