### PR TITLE
fix(cli): describe bridge runtime selection

### DIFF
--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reuse two-second, owner-host-local ScreenCaptureKit exact-window screenshot plans without caching pixels, revalidating process generation, window receipt, display topology, and scale around every capture while exposing miss/hit generation diagnostics.
 
 ### Fixed
+- Correct `peekaboo bridge --help` and Bridge docs to describe capability-aware reusable-daemon, Peekaboo.app, on-demand-daemon, and local-fallback routing.
 - Keep AX-only `see --tree --no-screenshot` independent of capture backends and ScreenCaptureKit ownership while still requiring Accessibility on the selected execution host.
 - Reduce reusable-daemon window-tracker MainActor work by retaining only bounds and owner PID, avoiding unused per-window application and Accessibility metadata on every reconciliation pass.
 - Refresh AXorcist to dispatch native accessibility actions once with typed AX errors and route legacy `AXSetValue` requests through the `AXValue` attribute instead of action discovery.

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Core/BridgeCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Core/BridgeCommand.swift
@@ -9,8 +9,10 @@ struct BridgeCommand: ParsableCommand {
         Peekaboo Bridge lets the CLI run permission-bound operations (Screen Recording, Accessibility,
         and Event Synthesizing) via a host app that already has the needed TCC grants.
 
-        By default, automation commands use the dedicated Peekaboo daemon and fall back to local execution.
-        Peekaboo.app, Claude.app, and ClawdBot.app sockets are shown for diagnostics and can be selected explicitly.
+        Most automation commands first reuse a healthy Peekaboo daemon, then try a capable Peekaboo.app Bridge host,
+        and otherwise start a daemon on demand. Operations that allow local fallback can finally run in the caller.
+        Application inventory and launch prefer Peekaboo.app; relaunch and quit require a reusable daemon.
+        Claude.app and ClawdBot.app sockets are diagnostic-only unless selected explicitly.
 
         Examples:
           peekaboo bridge status

--- a/Apps/CLI/Tests/CoreCLITests/CommandHelpRendererTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/CommandHelpRendererTests.swift
@@ -56,6 +56,24 @@ struct CommandHelpRendererTests {
         #expect(help.contains("--duration 2s"))
         #expect(help.contains("--delay 50ms"))
     }
+
+    @Test
+    func `Bridge help describes the selectable GUI host and on demand fallback`() {
+        let help = BridgeCommand.helpMessage()
+            .split(whereSeparator: \.isWhitespace)
+            .joined(separator: " ")
+
+        #expect(help.contains(
+            "Most automation commands first reuse a healthy Peekaboo daemon, then try a capable " +
+                "Peekaboo.app Bridge host, and otherwise start a daemon on demand."
+        ))
+        #expect(help.contains(
+            "Application inventory and launch prefer Peekaboo.app; relaunch and quit require a reusable daemon."
+        ))
+        #expect(help.contains("Claude.app and ClawdBot.app sockets are diagnostic-only unless selected explicitly."))
+        #expect(!help.contains("dedicated Peekaboo daemon and fall back to local execution"))
+        #expect(!help.contains("Peekaboo.app, Claude.app, and ClawdBot.app sockets are shown for diagnostics"))
+    }
 }
 
 private struct SampleHelpCommand: ParsableCommand {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Reuse two-second, owner-host-local ScreenCaptureKit exact-window screenshot plans without caching pixels, revalidating process generation, window receipt, display topology, and scale around every capture while exposing miss/hit generation diagnostics.
 
 ### Fixed
+- Correct `peekaboo bridge --help` and Bridge docs to describe capability-aware reusable-daemon, Peekaboo.app, on-demand-daemon, and local-fallback routing.
 - Keep AX-only `see --tree --no-screenshot` independent of capture backends and ScreenCaptureKit ownership while still requiring Accessibility on the selected execution host.
 - Reduce reusable-daemon window-tracker MainActor work by retaining only bounds and owner PID, avoiding unused per-window application and Accessibility metadata on every reconciliation pass.
 - Refresh AXorcist to dispatch native accessibility actions once with typed AX errors and route legacy `AXSetValue` requests through the `AXValue` attribute instead of action discovery.

--- a/docs/bridge-host.md
+++ b/docs/bridge-host.md
@@ -14,8 +14,10 @@ This replaces the previous XPC-based helper approach.
 
 ## Hosts and discovery
 
-Normal CLI automation commands prefer the on-demand Peekaboo daemon socket and will auto-start that daemon when it
-is missing. This keeps bursty command sequences warm without probing unrelated host apps.
+Most CLI automation commands first reuse a healthy Peekaboo daemon. If none can satisfy the operation, they try a
+capable Peekaboo.app GUI Bridge host before starting a daemon on demand. Operations that permit process-local fallback
+can use it when no compatible host is available. Application inventory and launch prefer the GUI host, while relaunch
+and quit require a reusable daemon that survives the caller.
 
 Bridge diagnostics inspect sockets in this order:
 
@@ -27,11 +29,10 @@ Bridge diagnostics inspect sockets in this order:
    - Socket: `~/Library/Application Support/Claude/bridge.sock`
 4. **Clawdbot.app** (fallback host)
    - Socket: `~/Library/Application Support/clawdbot/bridge.sock`
-5. **Local in-process** (no host available; requires the caller process to have TCC grants)
+5. **Local in-process** (operation-dependent fallback or explicit `--no-remote`; requires caller-process TCC grants)
 
-Normal runtime selection prefers the reusable daemon, then a healthy Peekaboo.app GUI host before starting a daemon.
-This preserves existing app-held TCC grants while keeping socket ownership separate. Other app-host sockets remain
-diagnostic-only unless selected with `--bridge-socket` or `PEEKABOO_BRIDGE_SOCKET`.
+This selection preserves existing app-held TCC grants while keeping socket ownership separate. Claude.app and
+Clawdbot.app sockets remain diagnostic-only unless selected with `--bridge-socket` or `PEEKABOO_BRIDGE_SOCKET`.
 
 There is **no auto-launch** of Peekaboo.app.
 

--- a/docs/commands/bridge.md
+++ b/docs/commands/bridge.md
@@ -16,7 +16,9 @@ read_when:
 | `status` (default) | Probes the configured socket paths, attempts a Bridge handshake, and reports which host would be selected (or if Peekaboo will fall back to local in-process execution). |
 
 ## Notes
-- Host discovery order is documented in `docs/bridge-host.md`.
+- Normal automation routing reuses a healthy daemon, then tries a capable Peekaboo.app host before starting a daemon
+  on demand; operation-specific requirements can prefer the GUI host or require a surviving daemon. The complete host
+  discovery order is documented in `docs/bridge-host.md`.
 - `--no-remote` (or `PEEKABOO_NO_REMOTE`) skips remote probing and forces local execution.
 - `--bridge-socket <path>` (or `PEEKABOO_BRIDGE_SOCKET`) overrides host discovery and probes only that socket.
 - Status probes run concurrently and give each candidate one second to complete its read-only diagnostic handshake. A `timeout` entry means that host missed the diagnostic deadline; other candidates are still reported and normal runtime selection order is unchanged.
@@ -43,7 +45,7 @@ peekaboo bridge status --bridge-socket \
 peekaboo bridge status --bridge-socket \
   ~/Library/Application\ Support/Claude/bridge.sock
 
-# Force local (skip Peekaboo.app / Clawdbot.app hosts)
+# Force local (skip the reusable daemon and all Bridge app hosts)
 peekaboo bridge status --no-remote
 
 # OpenClaw/subprocess capture workaround when the caller already has Screen Recording


### PR DESCRIPTION
## Summary

- make `peekaboo bridge --help` describe the capability-aware runtime order, including automatic Peekaboo.app selection
- document the application lifecycle exceptions and distinguish diagnostic-only app sockets from Peekaboo.app
- add a rendered-help regression and align the Bridge command/host docs plus both Unreleased changelogs

## Validation

- `pnpm run format`
- `pnpm run lint:docs`
- `pnpm run lint` (23 established warnings, 0 serious)
- `swift test --package-path Apps/CLI -Xswiftc -DPEEKABOO_SKIP_AUTOMATION --filter CommandHelpRendererTests` (4 tests)
- `pnpm run test:safe` (all shell/Node gates, 865 Core CLI tests, 83 runtime tests)
- source-blind behavior validation of `bridge --help` and `bridge -h` (identical output, retired phrases absent)
- autoreview clean with no accepted/actionable findings
