### PR TITLE
fix(release): allow exact Swift metadata strings

### DIFF
--- a/scripts/native-only-policy.sh
+++ b/scripts/native-only-policy.sh
@@ -7,6 +7,9 @@ NATIVE_ONLY_APPLE_EVENT_SOURCE_PATTERN='NSAppleScript|NSUserAppleScriptTask|OSAK
 # shellcheck disable=SC2016
 NATIVE_ONLY_APPLE_EVENT_IMPORT_PATTERN='(^|[[:space:]])_?(AE[A-Z][[:lower:]][[:alnum:]_]*|OSA[A-Z][[:lower:]][[:alnum:]_]*|OBJC_(CLASS|METACLASS)_\$_NSAppleScript)([^[:alnum:]_]|$)'
 NATIVE_ONLY_APPLE_EVENT_STRING_PATTERN='<key>NSAppleEventsUsageDescription</key>|NSAppleScript|NSUserAppleScriptTask|OSAKit\.framework|OSAScript|kOSAComponentType|/usr/bin/osascript'
+# Exact Swift compiler metadata observed in signed Release artifacts. Keep this closed: every entry
+# must be reproduced by an artifact fixture before it can bypass the dynamic API-name matcher.
+NATIVE_ONLY_COMPILER_METADATA_STRING_PATTERN='^(AESgtGG|AESgtGGGSgtGG)$'
 # `strings` also emits compiler metadata and symbol fragments. Match dynamic lookup names only when
 # the entire string has an API shape. Apple Event APIs have a multi-letter verb (apart from Is/Do),
 # while OSA names keep the original CamelCase boundary because the Release app has no OSA collision.
@@ -33,8 +36,13 @@ native_only_verify_macho() {
     printf 'Could not inspect %s embedded strings' "${label}"
     return 1
   fi
-  if grep -Eq "${NATIVE_ONLY_APPLE_EVENT_STRING_PATTERN}" <<<"${embedded_strings}" ||
-     grep -Eq "${NATIVE_ONLY_DYNAMIC_APPLE_EVENT_STRING_PATTERN}" <<<"${embedded_strings}"; then
+  if grep -Eq "${NATIVE_ONLY_APPLE_EVENT_STRING_PATTERN}" <<<"${embedded_strings}"; then
+    printf '%s embeds an AppleScript or Apple Events execution surface' "${label}"
+    return 1
+  fi
+  local inspected_strings
+  inspected_strings="$(grep -Ev "${NATIVE_ONLY_COMPILER_METADATA_STRING_PATTERN}" <<<"${embedded_strings}" || true)"
+  if grep -Eq "${NATIVE_ONLY_DYNAMIC_APPLE_EVENT_STRING_PATTERN}" <<<"${inspected_strings}"; then
     printf '%s embeds an AppleScript or Apple Events execution surface' "${label}"
     return 1
   fi

--- a/scripts/test-release-signing-policy.sh
+++ b/scripts/test-release-signing-policy.sh
@@ -92,8 +92,12 @@ case "${NATIVE_ONLY_TEST_MODE:-safe}" in
   safe)
     printf '%s\n' \
       'AES-GCM' \
-      'AEGtGG' \
-      'AESgA2fEtGGAbCyAAyAD_A8FtGGAbCyAAyAD_' \
+      'AESgtGG' \
+      'AESgtGGGSgtGG' \
+      '_AEQo__AGQo_' \
+      '_AEQo__AGQo_t' \
+      '_AEQo__SSQo_' \
+      '_AEQo__SSQo_t' \
       'AppleScriptProbeCodingKeys' \
       '_appleScriptStatus' \
       '_appleScriptProbe' \
@@ -102,8 +106,13 @@ case "${NATIVE_ONLY_TEST_MODE:-safe}" in
     ;;
   dynamic-ae) printf '%s\n' 'AESendMessage' ;;
   dynamic-ae-create) printf '%s\n' 'AECreateDesc' ;;
+  dynamic-ae-get) printf '%s\n' 'AEGetDescData' ;;
+  dynamic-ae-install) printf '%s\n' 'AEInstallEventHandler' ;;
   dynamic-ae-make) printf '%s\n' 'AEMakeDesc' ;;
+  dynamic-compiler-near-miss) printf '%s\n' 'AESgtGGX' 'AESgtGGGSgtGGX' ;;
+  dynamic-osa-compile) printf '%s\n' 'OSACompile' ;;
   dynamic-osa) printf '%s\n' '_OSADoScript' ;;
+  dynamic-osa-execute) printf '%s\n' 'OSAExecute' ;;
   dynamic-osa-show) printf '%s\n' 'OSAShowScriptingComponent' ;;
   strings-fail) printf '%s\n' 'harmless output'; exit 87 ;;
 esac
@@ -115,7 +124,8 @@ native_only_verify_macho \
   "$native_policy_test_dir/fixture" fixture \
   "$native_policy_test_dir/nm" "$native_policy_test_dir/strings"
 for policy_case in \
-  ae ae-send osa dynamic-ae dynamic-ae-create dynamic-ae-make dynamic-osa dynamic-osa-show \
+  ae ae-send osa dynamic-ae dynamic-ae-create dynamic-ae-get dynamic-ae-install dynamic-ae-make \
+  dynamic-compiler-near-miss dynamic-osa dynamic-osa-compile dynamic-osa-execute dynamic-osa-show \
   nm-fail strings-fail; do
   export NATIVE_ONLY_TEST_MODE="$policy_case"
   if native_only_verify_macho \


### PR DESCRIPTION
## Summary

- exempt only the exact `AESgtGG` and `AESgtGGGSgtGG` Swift compiler metadata lines before the structural dynamic AE/OSA lookup-name scan
- keep source checks, imported-symbol checks, and the separate high-signal embedded-string scan on their original unfiltered inputs
- cover the signed app metadata plus API-name and suffix near-miss refusals

## Proof

- `scripts/test-release-signing-policy.sh`
- Bash syntax, ShellCheck, source native-only verification, and `git diff --check`
- native-only verification on the exact signed CLI, compatibility dylib, Peekaboo.app, and Playground.app
- strict deep code-sign verification on all four signed artifact classes
- current macOS 27.0 SDK audit: all 288 AE/OSA names match the source, import, and dynamic detectors, including underscore-prefixed variants; zero metadata-allowlist overlap; inventory SHA-256 `564f3ebf9c1bb3dff9d49e5dd211a8ac1694ab72d4e0366438b70caac3d9deda`
- `scripts/test-restart-peekaboo.sh`
- structured P0-P2 autoreview: clean, no actionable findings

No changelog entry: this repairs an internal release-policy false positive without changing shipped behavior.
