### PR TITLE
feat(bridge): carry canonical action outcomes

### DIFF
--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reuse two-second, owner-host-local ScreenCaptureKit exact-window screenshot plans without caching pixels, revalidating process generation, window receipt, display topology, and scale around every capture while exposing miss/hit generation diagnostics.
 
 ### Fixed
+- Carry canonical desktop-action outcomes through capability-gated Bridge protocol 1.23 requests, preserving exact refused, partial, unverified, and indeterminate failures while older hosts remain conservative after a response is lost.
 - Correct `peekaboo bridge --help` and Bridge docs to describe capability-aware reusable-daemon, Peekaboo.app, on-demand-daemon, and local-fallback routing.
 - Refuse public raw `press` chords before dispatch unless `--foreground` is explicit, with canonical retry-safe refusal metadata and honest unverifiable foreground results.
 - Reject excess positional arguments unless a command declares a variadic tail, while preserving explicit multi-chord `press` sequences.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Reuse two-second, owner-host-local ScreenCaptureKit exact-window screenshot plans without caching pixels, revalidating process generation, window receipt, display topology, and scale around every capture while exposing miss/hit generation diagnostics.
 
 ### Fixed
+- Carry canonical desktop-action outcomes through capability-gated Bridge protocol 1.23 requests, preserving exact refused, partial, unverified, and indeterminate failures while older hosts remain conservative after a response is lost.
 - Correct `peekaboo bridge --help` and Bridge docs to describe capability-aware reusable-daemon, Peekaboo.app, on-demand-daemon, and local-fallback routing.
 - Refuse public raw `press` chords before dispatch unless explicit foreground consent is present, keep semantic background alternatives discoverable, and report foreground delivery as unverifiable instead of claiming the intended effect completed.
 - Reject excess positional arguments unless a command declares a variadic tail, while preserving explicit multi-chord `press` sequences.

--- a/Core/PeekabooCore/Package.swift
+++ b/Core/PeekabooCore/Package.swift
@@ -96,6 +96,7 @@ let package = Package(
             dependencies: [
                 .target(name: "PeekabooBridge"),
                 .product(name: "PeekabooAutomationKit", package: "PeekabooAutomationKit"),
+                .product(name: "PeekabooFoundation", package: "PeekabooFoundation"),
             ],
             path: "Sources/PeekabooBridgeTestSupport",
             swiftSettings: approachableConcurrencySettings),

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeActionProjectionModels.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeActionProjectionModels.swift
@@ -1,0 +1,48 @@
+import Foundation
+import PeekabooFoundation
+
+/// Explicit opt-in carriage for a legacy mutating Bridge request.
+///
+/// Bridge connections serve one request each, so a prior handshake cannot select the response
+/// shape of a later connection. A capable client therefore wraps each action request while the
+/// nested request preserves the established wire payload exactly.
+public struct PeekabooBridgeProjectedActionRequest: Codable, Sendable {
+    public let request: PeekabooBridgeRequest
+
+    public init(request: PeekabooBridgeRequest) {
+        self.request = request
+    }
+
+    /// Returns the legacy action request after enforcing the one-layer mutating-only contract.
+    public func validatedRequest() throws -> PeekabooBridgeRequest {
+        if case .projectedAction = self.request {
+            throw PeekabooBridgeErrorEnvelope(
+                code: .invalidRequest,
+                message: "Projected Bridge action requests cannot be nested")
+        }
+        guard self.request.mayMutateDesktop else {
+            throw PeekabooBridgeErrorEnvelope(
+                code: .invalidRequest,
+                message: "Projected Bridge action carriage requires a mutating request")
+        }
+        return self.request
+    }
+}
+
+/// Additive response carriage for one projected action request.
+///
+/// `response` remains the legacy response. `outcome` is optional because older service seams do
+/// not all expose their successful native outcome yet; absence must never be upgraded to a
+/// fabricated confirmation.
+public struct PeekabooBridgeProjectedActionResponse: Codable, Sendable {
+    public let response: PeekabooBridgeResponse
+    public let outcome: DesktopActionOutcome.Projection?
+
+    public init(
+        response: PeekabooBridgeResponse,
+        outcome: DesktopActionOutcome.Projection?)
+    {
+        self.response = response
+        self.outcome = outcome
+    }
+}

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeClient+Transport.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeClient+Transport.swift
@@ -34,9 +34,9 @@ extension PeekabooBridgeClient {
             guard request.mayMutateDesktop else {
                 throw failure.underlying
             }
-            throw Self.indeterminateResponseFailure(
-                failure.underlying,
-                operation: op)
+            throw Self.responseLostFailure(
+                operation: op,
+                causeDescription: "\(failure.underlying)")
         }
         guard !responseData.isEmpty else {
             let details = """
@@ -49,28 +49,40 @@ extension PeekabooBridgeClient {
             PEEKABOO_ALLOW_UNSIGNED_SOCKET_CLIENTS=1 for local development.
             """
 
-            throw PeekabooBridgeErrorEnvelope(
-                code: .internalError,
-                message: request.mayMutateDesktop
-                    ? "Bridge host returned no response after \(op.rawValue); outcome is indeterminate; do not retry"
-                    : "Bridge host returned no response",
-                details: details,
-                operationMayHaveCompleted: request.mayMutateDesktop)
+            guard request.mayMutateDesktop else {
+                throw PeekabooBridgeErrorEnvelope(
+                    code: .internalError,
+                    message: "Bridge host returned no response",
+                    details: details)
+            }
+            throw Self.responseLostFailure(
+                operation: op,
+                causeDescription: details)
         }
 
         let response: PeekabooBridgeResponse
         do {
             response = try self.decoder.decode(PeekabooBridgeResponse.self, from: responseData)
         } catch {
-            let message = request.mayMutateDesktop
-                ? "Bridge host returned an invalid response after \(op.rawValue); " +
-                "outcome is indeterminate; do not retry"
-                : "Bridge host returned an invalid response"
-            throw PeekabooBridgeErrorEnvelope(
-                code: .decodingFailed,
-                message: message,
-                details: "\(error)",
-                operationMayHaveCompleted: request.mayMutateDesktop)
+            guard request.mayMutateDesktop else {
+                throw PeekabooBridgeErrorEnvelope(
+                    code: .decodingFailed,
+                    message: "Bridge host returned an invalid response",
+                    details: "\(error)")
+            }
+            throw Self.responseLostFailure(
+                operation: op,
+                causeDescription: "Bridge response decoding failed: \(error)")
+        }
+        if case let .error(envelope) = response,
+           request.mayMutateDesktop
+        {
+            if let failure = envelope.desktopActionFailure {
+                throw failure
+            }
+            if envelope.operationMayHaveCompleted {
+                throw Self.legacyCompletionUnknownFailure(envelope: envelope)
+            }
         }
         let duration = Date().timeIntervalSince(start)
         self.logger.debug(
@@ -168,22 +180,29 @@ extension PeekabooBridgeClient {
         }
     }
 
-    private nonisolated static func indeterminateResponseFailure(
-        _ error: any Error,
-        operation: PeekabooBridgeOperation) -> PeekabooBridgeErrorEnvelope
+    private nonisolated static func responseLostFailure(
+        operation: PeekabooBridgeOperation,
+        causeDescription: String) -> DesktopActionFailure
     {
-        let code: PeekabooBridgeErrorCode = if let error = error as? POSIXError, error.code == .ETIMEDOUT {
-            .timeout
-        } else {
-            .internalError
-        }
         let message = "Bridge response was lost after \(operation.rawValue) was dispatched; " +
             "outcome is indeterminate; do not retry"
-        return PeekabooBridgeErrorEnvelope(
-            code: code,
+        return DesktopActionFailure.indeterminate(
+            route: .bridge,
+            evidence: .responseLost,
             message: message,
-            details: "\(error)",
-            operationMayHaveCompleted: true)
+            hint: "Observe the target before retrying this operation.",
+            causeDescription: causeDescription)
+    }
+
+    private nonisolated static func legacyCompletionUnknownFailure(
+        envelope: PeekabooBridgeErrorEnvelope) -> DesktopActionFailure
+    {
+        DesktopActionFailure.indeterminate(
+            route: .bridge,
+            evidence: .completionUnknown,
+            message: envelope.message,
+            hint: "Observe the target before retrying this operation.",
+            causeDescription: envelope.details)
     }
 }
 

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeClient+Transport.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeClient+Transport.swift
@@ -7,7 +7,17 @@ extension PeekabooBridgeClient {
         _ request: PeekabooBridgeRequest,
         timeoutSec: TimeInterval? = nil) async throws -> PeekabooBridgeResponse
     {
-        let payload = try self.encoder.encode(request)
+        let explicitlyProjected = if case .projectedAction = request {
+            true
+        } else {
+            false
+        }
+        let expectsProjectedResponse = explicitlyProjected ||
+            (self.actionProjectionEnabled && request.mayMutateDesktop)
+        let wireRequest = expectsProjectedResponse && !explicitlyProjected
+            ? PeekabooBridgeRequest.projectedAction(.init(request: request))
+            : request
+        let payload = try self.encoder.encode(wireRequest)
         let op = request.operation
         let start = Date()
         self.logger.debug("Sending bridge request \(op.rawValue, privacy: .public)")
@@ -60,9 +70,9 @@ extension PeekabooBridgeClient {
                 causeDescription: details)
         }
 
-        let response: PeekabooBridgeResponse
+        let wireResponse: PeekabooBridgeResponse
         do {
-            response = try self.decoder.decode(PeekabooBridgeResponse.self, from: responseData)
+            wireResponse = try self.decoder.decode(PeekabooBridgeResponse.self, from: responseData)
         } catch {
             guard request.mayMutateDesktop else {
                 throw PeekabooBridgeErrorEnvelope(
@@ -74,6 +84,10 @@ extension PeekabooBridgeClient {
                 operation: op,
                 causeDescription: "Bridge response decoding failed: \(error)")
         }
+        let response = try Self.unwrapResponse(
+            wireResponse,
+            expectsProjectedResponse: expectsProjectedResponse,
+            request: request)
         if case let .error(envelope) = response,
            request.mayMutateDesktop
         {
@@ -88,6 +102,43 @@ extension PeekabooBridgeClient {
         self.logger.debug(
             "bridge \(op.rawValue, privacy: .public) completed in \(duration, format: .fixed(precision: 3))s")
         return response
+    }
+
+    private nonisolated static func unwrapResponse(
+        _ response: PeekabooBridgeResponse,
+        expectsProjectedResponse: Bool,
+        request: PeekabooBridgeRequest) throws -> PeekabooBridgeResponse
+    {
+        if expectsProjectedResponse {
+            guard case let .projectedAction(payload) = response else {
+                throw self.responseLostFailure(
+                    operation: request.operation,
+                    causeDescription: "A projection-capable Bridge host returned an unwrapped action response")
+            }
+            if case .projectedAction = payload.response {
+                throw Self.responseLostFailure(
+                    operation: request.operation,
+                    causeDescription: "A projection-capable Bridge host returned nested action carriage")
+            }
+            if case let .error(envelope) = payload.response,
+               payload.outcome != envelope.actionOutcome
+            {
+                throw Self.responseLostFailure(
+                    operation: request.operation,
+                    causeDescription: "Bridge action response and error envelope carried contradictory outcomes")
+            }
+            return payload.response
+        }
+
+        guard case .projectedAction = response else { return response }
+        if request.mayMutateDesktop {
+            throw self.responseLostFailure(
+                operation: request.operation,
+                causeDescription: "Bridge host returned unrequested action projection carriage")
+        }
+        throw PeekabooBridgeErrorEnvelope(
+            code: .decodingFailed,
+            message: "Bridge host returned an unexpected projected response")
     }
 
     func sendExpectOK(

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeClient.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeClient.swift
@@ -10,6 +10,7 @@ public actor PeekabooBridgeClient {
     let encoder: JSONEncoder
     let decoder: JSONDecoder
     let logger = Logger(subsystem: "boo.peekaboo.bridge", category: "client")
+    var actionProjectionEnabled = false
 
     public init(
         socketPath: String = PeekabooBridgeConstants.peekabooSocketPath,
@@ -33,6 +34,7 @@ public actor PeekabooBridgeClient {
         overallTimeoutSec: TimeInterval? = nil)
         async throws -> PeekabooBridgeHandshakeResponse
     {
+        self.actionProjectionEnabled = false
         let deadline: Date?
         if let overallTimeoutSec {
             guard overallTimeoutSec.isFinite, overallTimeoutSec > 0 else {
@@ -88,6 +90,10 @@ public actor PeekabooBridgeClient {
 
         switch response {
         case let .handshake(handshake):
+            self.actionProjectionEnabled =
+                handshake.negotiatedVersion >= PeekabooBridgeConstants.desktopActionOutcomeProjectionVersion &&
+                handshake.hostCapabilities?.contains(
+                    PeekabooBridgeHostCapability.desktopActionOutcomeProjection) == true
             return handshake
         case let .error(envelope):
             throw envelope

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeConstants.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeConstants.swift
@@ -28,7 +28,11 @@ public enum PeekabooBridgeConstants {
     }
 
     /// Current protocol version supported by this build.
-    public static let protocolVersion = PeekabooBridgeProtocolVersion(major: 1, minor: 22)
+    public static let protocolVersion = PeekabooBridgeProtocolVersion(major: 1, minor: 23)
+
+    /// First protocol with explicit per-request canonical desktop-action outcome carriage.
+    public static let desktopActionOutcomeProjectionVersion =
+        PeekabooBridgeProtocolVersion(major: 1, minor: 23)
 
     /// First protocol that carries process-generation receipts with process-targeted typing and clicks.
     public static let processGenerationPinnedInteractionVersion =

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeErrorEnvelope+Projection.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeErrorEnvelope+Projection.swift
@@ -1,0 +1,17 @@
+extension PeekabooBridgeErrorEnvelope {
+    /// Removes negotiated canonical fields while retaining the conservative legacy dispatch bit.
+    ///
+    /// Old request shapes must receive the old response shape. Previous clients can still avoid
+    /// an unsafe retry through `operationMayHaveCompleted`, while only projected requests receive
+    /// the richer canonical failure.
+    var legacyCompatible: PeekabooBridgeErrorEnvelope {
+        PeekabooBridgeErrorEnvelope(
+            code: self.code,
+            message: self.message,
+            details: self.details,
+            permission: self.permission,
+            kind: self.kind,
+            context: self.context,
+            operationMayHaveCompleted: self.operationMayHaveCompleted)
+    }
+}

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeModels.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeModels.swift
@@ -299,6 +299,7 @@ public enum PeekabooBridgeHostCapability {
     public static let safeBackgroundApplicationLaunchNoOp = "safeBackgroundApplicationLaunchNoOp"
     public static let processGenerationPinnedApplicationActivation =
         "processGenerationPinnedApplicationActivation"
+    public static let desktopActionOutcomeProjection = "desktopActionOutcomeProjection"
 }
 
 public struct PeekabooBridgeHandshakeResponse: Codable, Sendable {

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeModels.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeModels.swift
@@ -422,6 +422,9 @@ public struct PeekabooBridgeErrorEnvelope: Codable, Sendable, LocalizedError {
     public let kind: PeekabooBridgeErrorKind?
     public let context: String?
     public let operationMayHaveCompleted: Bool
+    public let actionOutcome: DesktopActionOutcome.Projection?
+    public let actionFailureHint: String?
+    public let actionFailureCauseDescription: String?
 
     private enum CodingKeys: String, CodingKey {
         case code
@@ -431,6 +434,9 @@ public struct PeekabooBridgeErrorEnvelope: Codable, Sendable, LocalizedError {
         case kind
         case context
         case operationMayHaveCompleted
+        case actionOutcome
+        case actionFailureHint
+        case actionFailureCauseDescription
     }
 
     public init(
@@ -449,6 +455,29 @@ public struct PeekabooBridgeErrorEnvelope: Codable, Sendable, LocalizedError {
         self.kind = kind
         self.context = context
         self.operationMayHaveCompleted = operationMayHaveCompleted
+        self.actionOutcome = nil
+        self.actionFailureHint = nil
+        self.actionFailureCauseDescription = nil
+    }
+
+    public init(
+        code: PeekabooBridgeErrorCode,
+        actionFailure: DesktopActionFailure,
+        details: String? = nil,
+        permission: PeekabooBridgePermissionKind? = nil,
+        kind: PeekabooBridgeErrorKind? = nil,
+        context: String? = nil)
+    {
+        self.code = code
+        self.message = actionFailure.message
+        self.details = details
+        self.permission = permission
+        self.kind = kind
+        self.context = context
+        self.operationMayHaveCompleted = actionFailure.outcome.projection.mutationDispatched
+        self.actionOutcome = actionFailure.outcome.projection
+        self.actionFailureHint = actionFailure.hint
+        self.actionFailureCauseDescription = actionFailure.causeDescription
     }
 
     public init(from decoder: any Decoder) throws {
@@ -460,9 +489,44 @@ public struct PeekabooBridgeErrorEnvelope: Codable, Sendable, LocalizedError {
         self.context = try container.decodeIfPresent(String.self, forKey: .context)
         let rawKind = try container.decodeIfPresent(String.self, forKey: .kind)
         self.kind = rawKind.flatMap(PeekabooBridgeErrorKind.init(rawValue:))
-        self.operationMayHaveCompleted = try container.decodeIfPresent(
+        let encodedOperationMayHaveCompleted = try container.decodeIfPresent(
             Bool.self,
-            forKey: .operationMayHaveCompleted) ?? false
+            forKey: .operationMayHaveCompleted)
+        self.actionOutcome = try container.decodeIfPresent(
+            DesktopActionOutcome.Projection.self,
+            forKey: .actionOutcome)
+        self.actionFailureHint = try container.decodeIfPresent(String.self, forKey: .actionFailureHint)
+        self.actionFailureCauseDescription = try container.decodeIfPresent(
+            String.self,
+            forKey: .actionFailureCauseDescription)
+        if let actionOutcome = self.actionOutcome {
+            guard !actionOutcome.outcome.isConfirmed else {
+                throw DecodingError.dataCorruptedError(
+                    forKey: .actionOutcome,
+                    in: container,
+                    debugDescription: "A Bridge error envelope cannot carry a confirmed desktop action outcome")
+            }
+            let expected = actionOutcome.mutationDispatched
+            if let encodedOperationMayHaveCompleted,
+               encodedOperationMayHaveCompleted != expected
+            {
+                throw DecodingError.dataCorruptedError(
+                    forKey: .operationMayHaveCompleted,
+                    in: container,
+                    debugDescription: "Compatibility field contradicts the canonical desktop action outcome")
+            }
+            self.operationMayHaveCompleted = expected
+        } else {
+            guard self.actionFailureHint == nil,
+                  self.actionFailureCauseDescription == nil
+            else {
+                throw DecodingError.dataCorruptedError(
+                    forKey: .actionOutcome,
+                    in: container,
+                    debugDescription: "Desktop action failure context requires a canonical outcome")
+            }
+            self.operationMayHaveCompleted = encodedOperationMayHaveCompleted ?? false
+        }
     }
 
     public func encode(to encoder: any Encoder) throws {
@@ -476,6 +540,11 @@ public struct PeekabooBridgeErrorEnvelope: Codable, Sendable, LocalizedError {
         if self.operationMayHaveCompleted {
             try container.encode(true, forKey: .operationMayHaveCompleted)
         }
+        try container.encodeIfPresent(self.actionOutcome, forKey: .actionOutcome)
+        try container.encodeIfPresent(self.actionFailureHint, forKey: .actionFailureHint)
+        try container.encodeIfPresent(
+            self.actionFailureCauseDescription,
+            forKey: .actionFailureCauseDescription)
     }
 
     public var errorDescription: String? {
@@ -487,6 +556,15 @@ public struct PeekabooBridgeErrorEnvelope: Codable, Sendable, LocalizedError {
               context.hasPrefix(Self.standardizedErrorContextPrefix)
         else { return nil }
         return StandardErrorCode(rawValue: String(context.dropFirst(Self.standardizedErrorContextPrefix.count)))
+    }
+
+    public var desktopActionFailure: DesktopActionFailure? {
+        guard let actionOutcome else { return nil }
+        return DesktopActionFailure(
+            outcome: actionOutcome.outcome,
+            message: self.message,
+            hint: self.actionFailureHint,
+            causeDescription: self.actionFailureCauseDescription)
     }
 }
 
@@ -505,6 +583,12 @@ extension PeekabooBridgeErrorEnvelope: PendingSnapshotFailureDispositionProvidin
         default:
             false
         }
+    }
+}
+
+extension DesktopActionFailure: @retroactive PendingSnapshotFailureDispositionProviding {
+    public var mayCompleteSnapshotWorkAfterFailure: Bool {
+        self.outcome.dispatchState != .none
     }
 }
 

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeRequest+DesktopMutation.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeRequest+DesktopMutation.swift
@@ -227,6 +227,9 @@ extension PeekabooBridgeRequest {
     }
 
     var mayMutateDesktop: Bool {
+        if case let .projectedAction(payload) = self {
+            return payload.request.mayMutateDesktop
+        }
         if case let .dialogFindActive(request) = self {
             return request.windowTitle != nil
         }

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeRequestPreflight.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeRequestPreflight.swift
@@ -1,0 +1,111 @@
+import Foundation
+
+enum PeekabooBridgeRequestPreflight {
+    static let maximumJSONNestingDepth = 128
+    private static let projectedActionKeyBytes = Array("projectedAction".utf8)
+
+    /// Rejects recursive projection carriage before `JSONDecoder` constructs its payload.
+    ///
+    /// The projected enum case has one stable synthesized-Codable path: the outer case key is at
+    /// depth one and the nested legacy request case key is at depth four. Arbitrary operation
+    /// payload keys live below that boundary, so they remain untouched.
+    static func validate(_ data: Data) throws {
+        try data.withUnsafeBytes { rawBuffer in
+            let bytes = rawBuffer.bindMemory(to: UInt8.self)
+            var index = 0
+            var depth = 0
+            var outerProjectionSeen = false
+
+            while index < bytes.count {
+                switch bytes[index] {
+                case UInt8(ascii: "{"), UInt8(ascii: "["):
+                    depth += 1
+                    guard depth <= Self.maximumJSONNestingDepth else {
+                        throw PeekabooBridgeErrorEnvelope(
+                            code: .invalidRequest,
+                            message: "Bridge request JSON exceeds the maximum nesting depth")
+                    }
+                    index += 1
+                case UInt8(ascii: "}"), UInt8(ascii: "]"):
+                    depth = max(0, depth - 1)
+                    index += 1
+                case UInt8(ascii: "\""):
+                    let stringStart = index
+                    index += 1
+                    var escaped = false
+                    while index < bytes.count {
+                        let byte = bytes[index]
+                        if escaped {
+                            escaped = false
+                        } else if byte == UInt8(ascii: "\\") {
+                            escaped = true
+                        } else if byte == UInt8(ascii: "\"") {
+                            break
+                        }
+                        index += 1
+                    }
+                    guard index < bytes.count else { return }
+                    let stringEnd = index
+                    index += 1
+                    var lookahead = index
+                    while lookahead < bytes.count, Self.isJSONWhitespace(bytes[lookahead]) {
+                        lookahead += 1
+                    }
+                    guard lookahead < bytes.count,
+                          bytes[lookahead] == UInt8(ascii: ":")
+                    else { continue }
+
+                    guard Self.isProjectedActionKey(
+                        bytes,
+                        stringStart: stringStart,
+                        stringEnd: stringEnd)
+                    else { continue }
+
+                    if depth == 1 {
+                        outerProjectionSeen = true
+                    } else if outerProjectionSeen, depth == 4 {
+                        throw PeekabooBridgeErrorEnvelope(
+                            code: .invalidRequest,
+                            message: "Projected Bridge action requests cannot be nested")
+                    }
+                default:
+                    index += 1
+                }
+            }
+        }
+    }
+
+    private static func isJSONWhitespace(_ byte: UInt8) -> Bool {
+        byte == UInt8(ascii: " ") ||
+            byte == UInt8(ascii: "\t") ||
+            byte == UInt8(ascii: "\n") ||
+            byte == UInt8(ascii: "\r")
+    }
+
+    private static func isProjectedActionKey(
+        _ bytes: UnsafeBufferPointer<UInt8>,
+        stringStart: Int,
+        stringEnd: Int) -> Bool
+    {
+        let contentStart = stringStart + 1
+        let contentCount = stringEnd - contentStart
+        if contentCount == Self.projectedActionKeyBytes.count {
+            var matchesPlainKey = true
+            for offset in Self.projectedActionKeyBytes.indices
+                where bytes[contentStart + offset] != Self.projectedActionKeyBytes[offset]
+            {
+                matchesPlainKey = false
+                break
+            }
+            if matchesPlainKey {
+                return true
+            }
+        }
+
+        guard contentCount <= Self.projectedActionKeyBytes.count * 6,
+              bytes[contentStart..<stringEnd].contains(UInt8(ascii: "\\"))
+        else { return false }
+        let keyData = Data(bytes[stringStart...stringEnd])
+        return (try? JSONDecoder().decode(String.self, from: keyData)) == "projectedAction"
+    }
+}

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeRequestResponse.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeRequestResponse.swift
@@ -3,6 +3,7 @@ import Foundation
 import PeekabooAutomationKit
 
 public enum PeekabooBridgeRequest: Codable, Sendable {
+    indirect case projectedAction(PeekabooBridgeProjectedActionRequest)
     case handshake(PeekabooBridgeHandshake)
     case permissionsStatus
     case requestPostEventPermission
@@ -104,6 +105,7 @@ public enum PeekabooBridgeRequest: Codable, Sendable {
 extension PeekabooBridgeRequest {
     public var operation: PeekabooBridgeOperation {
         switch self {
+        case let .projectedAction(payload): payload.request.operation
         case .handshake: .permissionsStatus
         case .permissionsStatus: .permissionsStatus
         case .requestPostEventPermission: .requestPostEventPermission
@@ -206,6 +208,7 @@ extension PeekabooBridgeRequest {
 }
 
 public enum PeekabooBridgeResponse: Codable, Sendable {
+    indirect case projectedAction(PeekabooBridgeProjectedActionResponse)
     case handshake(PeekabooBridgeHandshakeResponse)
     case permissionsStatus(PermissionsStatus)
     case daemonStatus(PeekabooDaemonStatus)

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer.swift
@@ -81,6 +81,9 @@ public final class PeekabooBridgeServer {
         self.allowedOperations = allowedOperations.subtracting([._appleScriptProbe])
         self.hostIdentity = hostIdentity
         var resolvedHostCapabilities = hostCapabilities
+        if supportedVersions.upperBound >= PeekabooBridgeConstants.desktopActionOutcomeProjectionVersion {
+            resolvedHostCapabilities.insert(PeekabooBridgeHostCapability.desktopActionOutcomeProjection)
+        }
         let registeredScreenCaptureKitOwnership = services.supportsScreenCaptureKitProcessOwnership &&
             (try? ScreenCaptureKitOwnerLease.registerCurrentProcessCapability()) != nil
         if hostIdentity?.processStartIdentity != nil {
@@ -143,12 +146,16 @@ public final class PeekabooBridgeServer {
 
     public func decodeAndHandle(_ requestData: Data, peer: PeekabooBridgePeer?) async -> Data {
         do {
+            try PeekabooBridgeRequestPreflight.validate(requestData)
             let request = try self.decoder.decode(PeekabooBridgeRequest.self, from: requestData)
+            if case let .projectedAction(payload) = request {
+                return await self.handleProjectedAction(payload, peer: peer)
+            }
             let response = try await self.route(request, peer: peer)
             return try self.encoder.encode(response)
         } catch let envelope as PeekabooBridgeErrorEnvelope {
             self.logger.error("bridge request failed: \(envelope.message, privacy: .public)")
-            return PeekabooBridgeResponse.encodeError(envelope, using: self.encoder)
+            return PeekabooBridgeResponse.encodeError(envelope.legacyCompatible, using: self.encoder)
         } catch is CancellationError {
             self.logger.debug("bridge request cancelled after its client disconnected")
             let envelope = PeekabooBridgeErrorEnvelope(
@@ -162,6 +169,53 @@ public final class PeekabooBridgeServer {
                 message: "Failed to decode request",
                 details: "\(error)")
             return PeekabooBridgeResponse.encodeError(envelope, using: self.encoder)
+        }
+    }
+
+    private func handleProjectedAction(
+        _ payload: PeekabooBridgeProjectedActionRequest,
+        peer: PeekabooBridgePeer?) async -> Data
+    {
+        do {
+            let request = try payload.validatedRequest()
+            let response = try await self.route(request, peer: peer)
+            return try self.encoder.encode(PeekabooBridgeResponse.projectedAction(.init(
+                response: response,
+                outcome: Self.actionOutcome(in: response))))
+        } catch let envelope as PeekabooBridgeErrorEnvelope {
+            self.logger.error("projected bridge request failed: \(envelope.message, privacy: .public)")
+            return self.encodeProjectedError(envelope)
+        } catch is CancellationError {
+            self.logger.debug("projected bridge request cancelled after its client disconnected")
+            return self.encodeProjectedError(PeekabooBridgeErrorEnvelope(
+                code: .timeout,
+                message: "Bridge request was cancelled"))
+        } catch {
+            self.logger.error("projected bridge request failed: \(error.localizedDescription, privacy: .public)")
+            return self.encodeProjectedError(PeekabooBridgeErrorEnvelope(
+                code: .internalError,
+                message: error.localizedDescription,
+                details: "\(error)"))
+        }
+    }
+
+    private func encodeProjectedError(_ envelope: PeekabooBridgeErrorEnvelope) -> Data {
+        let response = PeekabooBridgeResponse.projectedAction(.init(
+            response: .error(envelope),
+            outcome: envelope.actionOutcome))
+        guard let data = try? self.encoder.encode(response), !data.isEmpty else {
+            return PeekabooBridgeResponse.encodeError(envelope, using: self.encoder)
+        }
+        return data
+    }
+
+    private static func actionOutcome(
+        in response: PeekabooBridgeResponse) -> DesktopActionOutcome.Projection?
+    {
+        switch response {
+        case let .error(envelope): envelope.actionOutcome
+        case let .projectedAction(payload): payload.outcome
+        default: nil
         }
     }
 
@@ -244,6 +298,9 @@ public final class PeekabooBridgeServer {
         for error: any Error,
         operation: PeekabooBridgeOperation) -> PeekabooBridgeErrorEnvelope
     {
+        if let envelope = self.actionFailureEnvelope(for: error) {
+            return envelope
+        }
         if let error = error as? ApplicationLifecycleRefusalError {
             return .init(
                 code: .internalError,
@@ -271,13 +328,6 @@ public final class PeekabooBridgeServer {
            let envelope = bridgeErrorEnvelope(for: error, operation: operation)
         {
             return envelope
-        }
-        if let error = error as? InputDeliveryIndeterminateError {
-            return .init(
-                code: .internalError,
-                message: error.localizedDescription,
-                details: "\(error)",
-                operationMayHaveCompleted: error.operationMayHaveCompleted)
         }
         if let error = error as? DesktopObservationError {
             switch error {
@@ -347,6 +397,28 @@ public final class PeekabooBridgeServer {
         return .init(
             code: .internalError,
             message: userMessage.isEmpty ? "Bridge operation failed" : userMessage,
+            details: "\(error)")
+    }
+
+    private static func actionFailureEnvelope(for error: any Error) -> PeekabooBridgeErrorEnvelope? {
+        if let failure = error as? DesktopActionFailure {
+            return .init(
+                code: .internalError,
+                actionFailure: failure.routed(to: .bridge),
+                details: "\(error)")
+        }
+        guard let error = error as? InputDeliveryIndeterminateError else { return nil }
+        let unitCount = error.emittedUnitCount.flatMap { DesktopActionOutcome.DispatchUnitCount($0) }
+        let failure = DesktopActionFailure.indeterminate(
+            route: .bridge,
+            evidence: .completionUnknown,
+            unitCount: unitCount,
+            message: error.localizedDescription,
+            hint: "Observe the target before retrying this operation.",
+            causeDescription: error.causeDescription)
+        return .init(
+            code: .internalError,
+            actionFailure: failure,
             details: "\(error)")
     }
 

--- a/Core/PeekabooCore/Sources/PeekabooBridgeTestSupport/BridgeTestFixtures.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridgeTestSupport/BridgeTestFixtures.swift
@@ -1,5 +1,6 @@
 import PeekabooAutomationKit
 import PeekabooBridge
+import PeekabooFoundation
 
 /// Canonical builders for Bridge protocol and transport tests.
 public enum BridgeTestFixtures {
@@ -32,6 +33,7 @@ public enum BridgeTestFixtures {
             hostCapabilities: hostCapabilities)
     }
 
+    /// Builds the pre-canonical Bridge error shape for compatibility tests.
     public static func errorResponse(
         code: PeekabooBridgeErrorCode,
         message: String,
@@ -49,5 +51,22 @@ public enum BridgeTestFixtures {
             kind: kind,
             context: context,
             operationMayHaveCompleted: operationMayHaveCompleted))
+    }
+
+    public static func actionFailureResponse(
+        code: PeekabooBridgeErrorCode = .internalError,
+        failure: DesktopActionFailure,
+        details: String? = nil,
+        permission: PeekabooBridgePermissionKind? = nil,
+        kind: PeekabooBridgeErrorKind? = nil,
+        context: String? = nil) -> PeekabooBridgeResponse
+    {
+        .error(PeekabooBridgeErrorEnvelope(
+            code: code,
+            actionFailure: failure,
+            details: details,
+            permission: permission,
+            kind: kind,
+            context: context))
     }
 }

--- a/Core/PeekabooCore/Sources/PeekabooBridgeTestSupport/BridgeTestFixtures.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridgeTestSupport/BridgeTestFixtures.swift
@@ -4,6 +4,35 @@ import PeekabooFoundation
 
 /// Canonical builders for Bridge protocol and transport tests.
 public enum BridgeTestFixtures {
+    /// One valid outcome for every canonical desktop-action state.
+    public static var canonicalActionOutcomes: [DesktopActionOutcome] {
+        let backgroundAccessibilityAction = DesktopActionOutcome.Delivery(
+            mechanism: .accessibilityAction,
+            mode: .background)
+        let backgroundTargetedEvents = DesktopActionOutcome.Delivery(
+            mechanism: .processTargetedEvents,
+            mode: .background)
+        let oneUnit = self.dispatchUnitCount(1)
+        let twoUnits = self.dispatchUnitCount(2)
+        let threeUnits = self.dispatchUnitCount(3)
+
+        return [
+            .confirmedChange(delivery: backgroundAccessibilityAction, unitCount: oneUnit),
+            .confirmedNoChange(),
+            .partial(delivery: backgroundAccessibilityAction, unitCount: twoUnits),
+            .dispatchedUnverified(
+                delivery: backgroundTargetedEvents,
+                evidence: .operationStillRunning,
+                unitCount: threeUnits),
+            .suspectedNoop(delivery: backgroundAccessibilityAction, unitCount: oneUnit),
+            .refused(reason: .permissionDenied),
+            .indeterminate(
+                delivery: backgroundTargetedEvents,
+                evidence: .responseLost,
+                unitCount: twoUnits),
+        ]
+    }
+
     /// Builds one internally coherent handshake while keeping protocol versions explicit at every call site.
     public static func handshake(
         negotiatedVersion: PeekabooBridgeProtocolVersion,
@@ -68,5 +97,12 @@ public enum BridgeTestFixtures {
             permission: permission,
             kind: kind,
             context: context))
+    }
+
+    private static func dispatchUnitCount(_ value: Int) -> DesktopActionOutcome.DispatchUnitCount {
+        guard let unitCount = DesktopActionOutcome.DispatchUnitCount(value) else {
+            preconditionFailure("Bridge fixture dispatch counts must be positive")
+        }
+        return unitCount
     }
 }

--- a/Core/PeekabooCore/Sources/PeekabooCore/Support/RemoteUIAutomationService.swift
+++ b/Core/PeekabooCore/Sources/PeekabooCore/Support/RemoteUIAutomationService.swift
@@ -160,8 +160,6 @@ public class RemoteUIAutomationService: DetectElementsRequestTimeoutAdjusting, T
                 clickType: clickType,
                 snapshotId: snapshotId,
                 targetProcessIdentifier: targetProcessIdentifier)
-        } catch let envelope as PeekabooBridgeErrorEnvelope where envelope.operationMayHaveCompleted {
-            throw Self.inputDeliveryIndeterminateError(for: envelope, operation: .click)
         } catch let envelope as PeekabooBridgeErrorEnvelope {
             throw Self.automationError(for: envelope, snapshotId: snapshotId)
         }
@@ -183,8 +181,6 @@ public class RemoteUIAutomationService: DetectElementsRequestTimeoutAdjusting, T
                 clickType: clickType,
                 snapshotId: snapshotId,
                 expectedProcessIdentity: expectedProcessIdentity)
-        } catch let envelope as PeekabooBridgeErrorEnvelope where envelope.operationMayHaveCompleted {
-            throw Self.inputDeliveryIndeterminateError(for: envelope, operation: .click)
         } catch let envelope as PeekabooBridgeErrorEnvelope {
             throw Self.automationError(for: envelope, snapshotId: snapshotId)
         }
@@ -215,8 +211,6 @@ public class RemoteUIAutomationService: DetectElementsRequestTimeoutAdjusting, T
                 snapshotId: snapshotId,
                 expectedWindowIdentity: expectedWindowIdentity,
                 expectedWindowBounds: expectedWindowBounds)
-        } catch let envelope as PeekabooBridgeErrorEnvelope where envelope.operationMayHaveCompleted {
-            throw Self.inputDeliveryIndeterminateError(for: envelope, operation: .click)
         } catch let envelope as PeekabooBridgeErrorEnvelope {
             throw Self.automationError(for: envelope, snapshotId: snapshotId)
         }
@@ -270,9 +264,6 @@ public class RemoteUIAutomationService: DetectElementsRequestTimeoutAdjusting, T
                 snapshotId: snapshotId,
                 expectedProcessIdentity: expectedProcessIdentity)
         } catch let envelope as PeekabooBridgeErrorEnvelope {
-            if envelope.operationMayHaveCompleted {
-                throw Self.inputDeliveryIndeterminateError(for: envelope, operation: .type)
-            }
             throw Self.automationError(for: envelope, snapshotId: snapshotId)
         }
     }
@@ -296,9 +287,6 @@ public class RemoteUIAutomationService: DetectElementsRequestTimeoutAdjusting, T
                 snapshotId: snapshotId,
                 targetProcessIdentifier: targetProcessIdentifier)
         } catch let envelope as PeekabooBridgeErrorEnvelope {
-            if envelope.operationMayHaveCompleted {
-                throw Self.inputDeliveryIndeterminateError(for: envelope, operation: .type)
-            }
             throw Self.automationError(for: envelope, snapshotId: snapshotId)
         }
     }
@@ -332,9 +320,6 @@ public class RemoteUIAutomationService: DetectElementsRequestTimeoutAdjusting, T
                 holdDuration: holdDuration,
                 targetProcessIdentifier: targetProcessIdentifier)
         } catch let envelope as PeekabooBridgeErrorEnvelope {
-            if envelope.operationMayHaveCompleted {
-                throw Self.inputDeliveryIndeterminateError(for: envelope, operation: .hotkey)
-            }
             switch envelope.code {
             case .permissionDenied:
                 throw Self.permissionDeniedError(for: envelope)
@@ -365,9 +350,6 @@ public class RemoteUIAutomationService: DetectElementsRequestTimeoutAdjusting, T
                 holdDuration: holdDuration,
                 expectedProcessIdentity: expectedProcessIdentity)
         } catch let envelope as PeekabooBridgeErrorEnvelope {
-            if envelope.operationMayHaveCompleted {
-                throw Self.inputDeliveryIndeterminateError(for: envelope, operation: .hotkey)
-            }
             switch envelope.code {
             case .permissionDenied:
                 throw Self.permissionDeniedError(for: envelope)
@@ -409,16 +391,6 @@ public class RemoteUIAutomationService: DetectElementsRequestTimeoutAdjusting, T
         default:
             envelope
         }
-    }
-
-    private static func inputDeliveryIndeterminateError(
-        for envelope: PeekabooBridgeErrorEnvelope,
-        operation: InputDeliveryIndeterminateError.Operation) -> InputDeliveryIndeterminateError
-    {
-        InputDeliveryIndeterminateError(
-            operation: operation,
-            emittedUnitCount: nil,
-            causeDescription: envelope.message)
     }
 
     private static func targetedHotkeyUnavailableError(
@@ -535,16 +507,12 @@ public class RemoteUIAutomationService: DetectElementsRequestTimeoutAdjusting, T
                 self.exactWindowTargetedKeyboardUnavailableReason ??
                     "Atomic exact-window background typing is unavailable")
         }
-        do {
-            return try await self.client.typeActions(
-                actions,
-                cadence: cadence,
-                snapshotId: snapshotId,
-                expectedWindowIdentity: expectedWindowIdentity,
-                expectedWindowBounds: expectedWindowBounds)
-        } catch let envelope as PeekabooBridgeErrorEnvelope where envelope.operationMayHaveCompleted {
-            throw Self.inputDeliveryIndeterminateError(for: envelope, operation: .type)
-        }
+        return try await self.client.typeActions(
+            actions,
+            cadence: cadence,
+            snapshotId: snapshotId,
+            expectedWindowIdentity: expectedWindowIdentity,
+            expectedWindowBounds: expectedWindowBounds)
     }
 
     public func hotkey(
@@ -558,15 +526,11 @@ public class RemoteUIAutomationService: DetectElementsRequestTimeoutAdjusting, T
                 self.exactWindowTargetedKeyboardUnavailableReason ??
                     "Atomic exact-window background hotkeys are unavailable")
         }
-        do {
-            try await self.client.hotkey(
-                keys: keys,
-                holdDuration: holdDuration,
-                expectedWindowIdentity: expectedWindowIdentity,
-                expectedWindowBounds: expectedWindowBounds)
-        } catch let envelope as PeekabooBridgeErrorEnvelope where envelope.operationMayHaveCompleted {
-            throw Self.inputDeliveryIndeterminateError(for: envelope, operation: .hotkey)
-        }
+        try await self.client.hotkey(
+            keys: keys,
+            holdDuration: holdDuration,
+            expectedWindowIdentity: expectedWindowIdentity,
+            expectedWindowBounds: expectedWindowBounds)
     }
 
     public func typeActions(
@@ -580,15 +544,11 @@ public class RemoteUIAutomationService: DetectElementsRequestTimeoutAdjusting, T
                 self.exactWindowTargetedKeyboardUnavailableReason ??
                     "Atomic exact-window background typing is unavailable")
         }
-        do {
-            return try await self.client.typeActions(
-                actions,
-                cadence: cadence,
-                snapshotId: snapshotId,
-                target: target)
-        } catch let envelope as PeekabooBridgeErrorEnvelope where envelope.operationMayHaveCompleted {
-            throw Self.inputDeliveryIndeterminateError(for: envelope, operation: .type)
-        }
+        return try await self.client.typeActions(
+            actions,
+            cadence: cadence,
+            snapshotId: snapshotId,
+            target: target)
     }
 
     public func hotkey(
@@ -601,14 +561,10 @@ public class RemoteUIAutomationService: DetectElementsRequestTimeoutAdjusting, T
                 self.exactWindowTargetedKeyboardUnavailableReason ??
                     "Atomic exact-window background hotkeys are unavailable")
         }
-        do {
-            try await self.client.hotkey(
-                keys: keys,
-                holdDuration: holdDuration,
-                target: target)
-        } catch let envelope as PeekabooBridgeErrorEnvelope where envelope.operationMayHaveCompleted {
-            throw Self.inputDeliveryIndeterminateError(for: envelope, operation: .hotkey)
-        }
+        try await self.client.hotkey(
+            keys: keys,
+            holdDuration: holdDuration,
+            target: target)
     }
 
     public func findElement(matching criteria: UIElementSearchCriteria, in appName: String?) async throws

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/PermissionsToolSelectedHostTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/PermissionsToolSelectedHostTests.swift
@@ -11,7 +11,7 @@ import Testing
 struct PermissionsToolSelectedHostTests {
     @Test
     func `permission provider remains additive at protocol 1_22`() {
-        #expect(PeekabooBridgeConstants.protocolVersion == .init(major: 1, minor: 22))
+        #expect(PeekabooBridgeConstants.protocolVersion == .init(major: 1, minor: 23))
     }
 
     private struct PermissionCase: Sendable, CustomTestStringConvertible {

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeActionOutcomeProjectionTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeActionOutcomeProjectionTests.swift
@@ -1,4 +1,5 @@
 import CoreGraphics
+import Darwin
 import Foundation
 import PeekabooAutomationKit
 import PeekabooBridgeTestSupport
@@ -60,6 +61,82 @@ struct PeekabooBridgeActionOutcomeProjectionTests {
         }
         #expect(handshake.hostCapabilities?.contains(
             PeekabooBridgeHostCapability.desktopActionOutcomeProjection) == true)
+    }
+
+    @Test
+    func `client wraps mutations only after current capability negotiation`() async throws {
+        let currentHandshake = BridgeTestFixtures.handshake(
+            negotiatedVersion: PeekabooBridgeConstants.protocolVersion,
+            supportedOperations: [.click],
+            hostCapabilities: [PeekabooBridgeHostCapability.desktopActionOutcomeProjection])
+        let currentPeer = try NegotiatedProjectionBridgePeer(responses: [
+            .handshake(currentHandshake),
+            .projectedAction(.init(response: .ok, outcome: nil)),
+        ])
+        let currentClient = PeekabooBridgeClient(socketPath: currentPeer.socketPath, requestTimeoutSec: 1)
+
+        _ = try await currentClient.handshake(client: Self.clientIdentity)
+        try await currentClient.sendExpectOK(Self.clickRequest)
+        let currentRequests = await currentPeer.requests
+        #expect(currentRequests.count == 2)
+        let currentAction = try JSONDecoder.peekabooBridgeDecoder().decode(
+            PeekabooBridgeRequest.self,
+            from: currentRequests[1])
+        guard case let .projectedAction(payload) = currentAction,
+              case .click = payload.request
+        else {
+            Issue.record("Expected a projected click after current capability negotiation")
+            await currentPeer.waitUntilFinished()
+            return
+        }
+        await currentPeer.waitUntilFinished()
+
+        let previousHandshake = BridgeTestFixtures.handshake(
+            negotiatedVersion: .init(major: 1, minor: 22),
+            supportedOperations: [.click],
+            hostCapabilities: [PeekabooBridgeHostCapability.desktopActionOutcomeProjection])
+        let previousPeer = try NegotiatedProjectionBridgePeer(responses: [
+            .handshake(previousHandshake),
+            .ok,
+        ])
+        let previousClient = PeekabooBridgeClient(socketPath: previousPeer.socketPath, requestTimeoutSec: 1)
+
+        _ = try await previousClient.handshake(client: Self.clientIdentity)
+        try await previousClient.sendExpectOK(Self.clickRequest)
+        let previousRequests = await previousPeer.requests
+        #expect(previousRequests.count == 2)
+        let previousAction = try JSONDecoder.peekabooBridgeDecoder().decode(
+            PeekabooBridgeRequest.self,
+            from: previousRequests[1])
+        guard case .click = previousAction else {
+            Issue.record("Expected legacy click carriage for a previous protocol host")
+            await previousPeer.waitUntilFinished()
+            return
+        }
+        await previousPeer.waitUntilFinished()
+    }
+
+    @Test
+    func `capable client treats a missing projected response as lost`() async throws {
+        let handshake = BridgeTestFixtures.handshake(
+            negotiatedVersion: PeekabooBridgeConstants.protocolVersion,
+            supportedOperations: [.click],
+            hostCapabilities: [PeekabooBridgeHostCapability.desktopActionOutcomeProjection])
+        let peer = try NegotiatedProjectionBridgePeer(responses: [.handshake(handshake), .ok])
+        let client = PeekabooBridgeClient(socketPath: peer.socketPath, requestTimeoutSec: 1)
+
+        _ = try await client.handshake(client: Self.clientIdentity)
+        do {
+            try await client.sendExpectOK(Self.clickRequest)
+            Issue.record("Expected unwrapped capable-host response to fail closed")
+        } catch let failure as DesktopActionFailure {
+            #expect(failure.outcome.route == .bridge)
+            #expect(failure.outcome.state == .indeterminate)
+            #expect(failure.outcome.evidence == .responseLost)
+            #expect(failure.outcome.projection.requiresFreshObservation)
+            #expect(!failure.outcome.projection.retrySafe)
+        }
+        await peer.waitUntilFinished()
     }
 
     @Test
@@ -261,6 +338,68 @@ struct PeekabooBridgeActionOutcomeProjectionTests {
     }
 
     @Test
+    @MainActor
+    func `projected request preflight rejects unsafe shapes before routing or recursive decode`() async throws {
+        let services = StubServices()
+        var permissionEvaluationCount = 0
+        let server = PeekabooBridgeServer(
+            services: services,
+            allowlistedTeams: [],
+            allowlistedBundles: [],
+            hostIdentity: nil,
+            permissionStatusEvaluator: { _ in
+                permissionEvaluationCount += 1
+                return PermissionsStatus(
+                    screenRecording: false,
+                    accessibility: false,
+                    postEvent: false)
+            })
+
+        let readOnly = try await Self.send(.projectedAction(.init(request: .permissionsStatus)), to: server)
+        Self.expectProjectedInvalidResponse(readOnly)
+        let handshake = PeekabooBridgeRequest.handshake(.init(
+            protocolVersion: PeekabooBridgeConstants.protocolVersion,
+            client: Self.clientIdentity))
+        let wrappedHandshake = try await Self.send(.projectedAction(.init(request: handshake)), to: server)
+        Self.expectProjectedInvalidResponse(wrappedHandshake)
+        #expect(permissionEvaluationCount == 0)
+        #expect(services.automationStub.lastClick == nil)
+
+        let escapedNestedWrapper = Data(
+            #"{"projectedAction":{"_0":{"request":{"projected\u0041ction":{"_0":{"request":BROKEN}}}}}}"#.utf8)
+        let nestedResponse = try await Self.decodeRaw(escapedNestedWrapper, with: server)
+        guard case let .error(nestedEnvelope) = nestedResponse else {
+            Issue.record("Expected raw preflight to reject nested projection carriage")
+            return
+        }
+        #expect(nestedEnvelope.code == .invalidRequest)
+        #expect(nestedEnvelope.message == "Projected Bridge action requests cannot be nested")
+
+        let deepPrefix = #"{"projectedAction":{"_0":{"request":{"click":{"_0":{"target":"#
+        let deepRequest = Data((
+            deepPrefix +
+                String(repeating: "[", count: PeekabooBridgeRequestPreflight.maximumJSONNestingDepth + 1))
+            .utf8)
+        let deepResponse = try await Self.decodeRaw(deepRequest, with: server)
+        guard case let .error(deepEnvelope) = deepResponse else {
+            Issue.record("Expected raw preflight to reject excessive JSON depth")
+            return
+        }
+        #expect(deepEnvelope.code == .invalidRequest)
+        #expect(deepEnvelope.message == "Bridge request JSON exceeds the maximum nesting depth")
+        #expect(permissionEvaluationCount == 0)
+        #expect(services.automationStub.lastClick == nil)
+
+        let arbitraryPayloadKey = PeekabooBridgeRequest.projectedAction(.init(request: .browserExecute(.init(
+            toolName: "fixture",
+            arguments: ["projectedAction": .string("ordinary nested browser payload")]))))
+        let arbitraryPayloadData = try JSONEncoder.peekabooBridgeEncoder().encode(arbitraryPayloadKey)
+        #expect(throws: Never.self) {
+            try PeekabooBridgeRequestPreflight.validate(arbitraryPayloadData)
+        }
+    }
+
+    @Test
     func `projection capability is introduced at protocol 1 23`() {
         let expectedVersion = PeekabooBridgeProtocolVersion(major: 1, minor: 23)
 
@@ -284,6 +423,17 @@ struct PeekabooBridgeActionOutcomeProjectionTests {
         } catch {
             Issue.record("Expected a Bridge invalid-request envelope, got \(error)")
         }
+    }
+
+    private static func expectProjectedInvalidResponse(_ response: PeekabooBridgeResponse) {
+        guard case let .projectedAction(payload) = response,
+              case let .error(envelope) = payload.response
+        else {
+            Issue.record("Expected projected invalid-request response")
+            return
+        }
+        #expect(envelope.code == .invalidRequest)
+        #expect(payload.outcome == nil)
     }
 
     private static func legacyResponse(for outcome: DesktopActionOutcome) -> PeekabooBridgeResponse {
@@ -385,9 +535,24 @@ struct PeekabooBridgeActionOutcomeProjectionTests {
         return try JSONDecoder.peekabooBridgeDecoder().decode(PeekabooBridgeResponse.self, from: responseData)
     }
 
+    @MainActor
+    private static func decodeRaw(
+        _ requestData: Data,
+        with server: PeekabooBridgeServer) async throws -> PeekabooBridgeResponse
+    {
+        let responseData = await server.decodeAndHandle(requestData, peer: nil)
+        return try JSONDecoder.peekabooBridgeDecoder().decode(PeekabooBridgeResponse.self, from: responseData)
+    }
+
     private static let clickRequest = PeekabooBridgeRequest.click(.init(
         target: .coordinates(CGPoint(x: 17, y: 29)),
         clickType: .single))
+
+    private static let clientIdentity = PeekabooBridgeClientIdentity(
+        bundleIdentifier: "dev.peekaboo.tests",
+        teamIdentifier: nil,
+        processIdentifier: getpid(),
+        hostname: nil)
 
     private static let legacyClickRequestData = Data(
         #"{"click":{"_0":{"clickType":"single","target":{"kind":"coordinates","x":17,"y":29}}}}"#.utf8)
@@ -507,5 +672,114 @@ struct PeekabooBridgeActionOutcomeProjectionTests {
         let mutationDispatched: Bool
         let retrySafe: Bool
         let requiresFreshObservation: Bool
+    }
+}
+
+private actor NegotiatedProjectionBridgePeerState {
+    private(set) var requests: [Data] = []
+
+    func record(_ request: Data) {
+        self.requests.append(request)
+    }
+}
+
+private final class NegotiatedProjectionBridgePeer: @unchecked Sendable {
+    let socketPath: String
+    private let listener: Int32
+    private let state = NegotiatedProjectionBridgePeerState()
+    private var task: Task<Void, Never>?
+
+    var requests: [Data] {
+        get async { await self.state.requests }
+    }
+
+    init(responses: [PeekabooBridgeResponse]) throws {
+        self.socketPath = "/tmp/pb-projection-negotiation-\(UUID().uuidString).sock"
+        self.listener = socket(AF_UNIX, SOCK_STREAM, 0)
+        guard self.listener >= 0 else {
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
+        do {
+            var address = sockaddr_un()
+            address.sun_family = sa_family_t(AF_UNIX)
+            address.sun_len = UInt8(MemoryLayout.size(ofValue: address))
+            let copied = self.socketPath.withCString { source in
+                strlcpy(&address.sun_path.0, source, MemoryLayout.size(ofValue: address.sun_path))
+            }
+            guard copied < MemoryLayout.size(ofValue: address.sun_path) else {
+                throw POSIXError(.ENAMETOOLONG)
+            }
+            let length = socklen_t(MemoryLayout.size(ofValue: address))
+            let bindResult = withUnsafePointer(to: &address) { pointer in
+                Darwin.bind(self.listener, UnsafePointer<sockaddr>(OpaquePointer(pointer)), length)
+            }
+            guard bindResult == 0, listen(self.listener, Int32(responses.count)) == 0 else {
+                throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+            }
+        } catch {
+            Darwin.close(self.listener)
+            try? FileManager.default.removeItem(atPath: self.socketPath)
+            throw error
+        }
+
+        let listener = self.listener
+        let socketPath = self.socketPath
+        let state = self.state
+        self.task = Task.detached {
+            defer {
+                Darwin.close(listener)
+                try? FileManager.default.removeItem(atPath: socketPath)
+            }
+            for response in responses {
+                let client = accept(listener, nil, nil)
+                guard client >= 0 else { return }
+                let request = Self.readRequest(from: client)
+                await state.record(request)
+                if let data = try? JSONEncoder.peekabooBridgeEncoder().encode(response) {
+                    Self.write(data, to: client)
+                }
+                Darwin.close(client)
+            }
+        }
+    }
+
+    func waitUntilFinished() async {
+        await self.task?.value
+        self.task = nil
+    }
+
+    private nonisolated static func readRequest(from descriptor: Int32) -> Data {
+        var result = Data()
+        var buffer = [UInt8](repeating: 0, count: 4096)
+        while true {
+            let count = buffer.withUnsafeMutableBytes { bytes in
+                Darwin.read(descriptor, bytes.baseAddress, bytes.count)
+            }
+            if count > 0 {
+                result.append(contentsOf: buffer.prefix(count))
+                continue
+            }
+            if count < 0, errno == EINTR {
+                continue
+            }
+            return result
+        }
+    }
+
+    private nonisolated static func write(_ data: Data, to descriptor: Int32) {
+        data.withUnsafeBytes { bytes in
+            guard let baseAddress = bytes.baseAddress else { return }
+            var offset = 0
+            while offset < bytes.count {
+                let count = Darwin.write(descriptor, baseAddress.advanced(by: offset), bytes.count - offset)
+                if count > 0 {
+                    offset += count
+                } else if count < 0, errno == EINTR {
+                    continue
+                } else {
+                    return
+                }
+            }
+        }
     }
 }

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeActionOutcomeProjectionTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeActionOutcomeProjectionTests.swift
@@ -1,0 +1,511 @@
+import CoreGraphics
+import Foundation
+import PeekabooAutomationKit
+import PeekabooBridgeTestSupport
+import PeekabooFoundation
+import Testing
+@testable import PeekabooBridge
+
+struct PeekabooBridgeActionOutcomeProjectionTests {
+    @Test
+    @MainActor
+    func `current server preserves legacy shape and honors projected opt in`() async throws {
+        let server = PeekabooBridgeServer(
+            services: StubServices(),
+            hostKind: .onDemand,
+            allowlistedTeams: [],
+            allowlistedBundles: [],
+            hostIdentity: nil,
+            postEventAccessEvaluator: { false },
+            postEventAccessRequester: { true },
+            permissionStatusEvaluator: { _ in
+                PermissionsStatus(
+                    screenRecording: false,
+                    accessibility: false,
+                    postEvent: false)
+            })
+
+        let legacyResponse = try await Self.send(.requestPostEventPermission, to: server)
+        guard case let .bool(granted) = legacyResponse else {
+            Issue.record("Expected a bare legacy bool response")
+            return
+        }
+        #expect(granted)
+
+        let projectedResponse = try await Self.send(
+            .projectedAction(.init(request: .requestPostEventPermission)),
+            to: server)
+        guard case let .projectedAction(projectedPayload) = projectedResponse else {
+            Issue.record("Expected an explicitly projected response")
+            return
+        }
+        guard case let .bool(projectedGranted) = projectedPayload.response else {
+            Issue.record("Expected the legacy bool response inside projected carriage")
+            return
+        }
+        #expect(projectedGranted)
+        #expect(projectedPayload.outcome == nil)
+
+        let handshakeResponse = try await Self.send(.handshake(.init(
+            protocolVersion: PeekabooBridgeConstants.protocolVersion,
+            client: .init(
+                bundleIdentifier: "dev.peekaboo.tests",
+                teamIdentifier: nil,
+                processIdentifier: 42,
+                hostname: nil),
+            requestedHostKind: .onDemand)), to: server)
+        guard case let .handshake(handshake) = handshakeResponse else {
+            Issue.record("Expected a current handshake response")
+            return
+        }
+        #expect(handshake.hostCapabilities?.contains(
+            PeekabooBridgeHostCapability.desktopActionOutcomeProjection) == true)
+    }
+
+    @Test
+    @MainActor
+    func `current server projects action failures only for opted in requests`() async throws {
+        let services = StubServices()
+        let unitCount = try #require(DesktopActionOutcome.DispatchUnitCount(2))
+        let failure = DesktopActionFailure.partial(
+            delivery: .init(mechanism: .accessibilityAction, mode: .background),
+            unitCount: unitCount,
+            message: "Primary click changed state but cleanup failed",
+            hint: "Recover the remaining side effect before another click.",
+            causeDescription: "cleanup receipt was unavailable")
+        services.automationStub.clickError = failure
+        let server = PeekabooBridgeServer(
+            services: services,
+            hostKind: .onDemand,
+            allowlistedTeams: [],
+            allowlistedBundles: [],
+            hostIdentity: nil,
+            postEventAccessEvaluator: { true },
+            permissionStatusEvaluator: { _ in
+                PermissionsStatus(
+                    screenRecording: false,
+                    accessibility: true,
+                    postEvent: true)
+            })
+
+        let legacyResponse = try await Self.send(Self.clickRequest, to: server)
+        guard case let .error(legacyError) = legacyResponse else {
+            Issue.record("Expected a bare legacy error response")
+            return
+        }
+        #expect(legacyError.actionOutcome == nil)
+        #expect(legacyError.operationMayHaveCompleted)
+
+        let projectedResponse = try await Self.send(
+            .projectedAction(.init(request: Self.clickRequest)),
+            to: server)
+        guard case let .projectedAction(projectedPayload) = projectedResponse else {
+            Issue.record("Expected projected action failure carriage")
+            return
+        }
+        guard case let .error(projectedError) = projectedPayload.response else {
+            Issue.record("Expected the legacy error response inside projected carriage")
+            return
+        }
+
+        let expectedOutcome = failure.routed(to: .bridge).outcome.projection
+        #expect(projectedPayload.outcome == expectedOutcome)
+        #expect(projectedError.actionOutcome == expectedOutcome)
+        #expect(projectedPayload.outcome == projectedError.actionOutcome)
+        #expect(projectedError.operationMayHaveCompleted)
+        #expect(projectedError.message == failure.message)
+        #expect(projectedError.actionFailureHint == failure.hint)
+        #expect(projectedError.actionFailureCauseDescription == failure.causeDescription)
+    }
+
+    @Test
+    func `projected response round trips every canonical action outcome`() throws {
+        let outcomes = BridgeTestFixtures.canonicalActionOutcomes
+        let expectations = Self.projectionExpectations
+
+        #expect(outcomes.map(\.state) == [
+            .confirmedChange,
+            .confirmedNoChange,
+            .partial,
+            .dispatchedUnverified,
+            .suspectedNoop,
+            .refused,
+            .indeterminate,
+        ])
+        #expect(outcomes.count == expectations.count)
+
+        for (outcome, expectation) in zip(outcomes, expectations) {
+            let legacyResponse = Self.legacyResponse(for: outcome)
+            let response = PeekabooBridgeResponse.projectedAction(.init(
+                response: legacyResponse,
+                outcome: outcome.projection))
+            let data = try JSONEncoder.peekabooBridgeEncoder().encode(response)
+            let projection = try #require(Self.projectedAssociation(from: data)["outcome"] as? [String: Any])
+            Self.expectProjection(projection, equals: expectation)
+            let decoded = try JSONDecoder.peekabooBridgeDecoder().decode(
+                PeekabooBridgeResponse.self,
+                from: data)
+
+            guard case let .projectedAction(payload) = decoded else {
+                Issue.record("Expected a projected Bridge response for \(outcome.state.rawValue)")
+                continue
+            }
+            #expect(payload.outcome == outcome.projection)
+            Self.expectResponseKind(payload.response, matches: outcome)
+        }
+    }
+
+    @Test
+    func `projected wrappers preserve the legacy payload under one additive wire layer`() throws {
+        let legacyRequest = Self.clickRequest
+        let projectedRequest = PeekabooBridgeRequest.projectedAction(.init(request: legacyRequest))
+        let requestData = try JSONEncoder.peekabooBridgeEncoder().encode(projectedRequest)
+        let requestRoot = try Self.object(from: requestData)
+        let requestCase = try #require(requestRoot["projectedAction"] as? [String: Any])
+        let requestAssociation = try #require(requestCase["_0"] as? [String: Any])
+        let requestWrapper = try #require(requestAssociation["request"] as? [String: Any])
+        let legacyRequestObject = try Self.object(from: Self.legacyClickRequestData)
+
+        #expect(Set(requestRoot.keys) == ["projectedAction"])
+        #expect(Set(requestCase.keys) == ["_0"])
+        #expect(Set(requestAssociation.keys) == ["request"])
+        #expect(try Self.canonicalJSON(requestWrapper) == Self.canonicalJSON(legacyRequestObject))
+
+        let outcome = BridgeTestFixtures.canonicalActionOutcomes[0]
+        let projectedResponse = PeekabooBridgeResponse.projectedAction(.init(
+            response: .ok,
+            outcome: outcome.projection))
+        let responseData = try JSONEncoder.peekabooBridgeEncoder().encode(projectedResponse)
+        let responseRoot = try Self.object(from: responseData)
+        let responseCase = try #require(responseRoot["projectedAction"] as? [String: Any])
+        let responseAssociation = try #require(responseCase["_0"] as? [String: Any])
+
+        #expect(Set(responseRoot.keys) == ["projectedAction"])
+        #expect(Set(responseCase.keys) == ["_0"])
+        #expect(Set(responseAssociation.keys) == ["response", "outcome"])
+        #expect((responseAssociation["response"] as? [String: Any])?["ok"] != nil)
+        let projection = try #require(responseAssociation["outcome"] as? [String: Any])
+        #expect(projection["state"] as? String == "confirmed_change")
+        #expect(projection["delivery_mode"] as? String == "background")
+        #expect(projection["mutation_dispatched"] as? Bool == true)
+    }
+
+    @Test
+    func `legacy unwrapped requests and responses remain wire compatible`() throws {
+        let requestData = try JSONEncoder.peekabooBridgeEncoder().encode(Self.clickRequest)
+        let requestObject = try Self.object(from: requestData)
+        let legacyRequestObject = try Self.object(from: Self.legacyClickRequestData)
+        #expect(try Self.canonicalJSON(requestObject) == Self.canonicalJSON(legacyRequestObject))
+
+        let decodedRequest = try JSONDecoder.peekabooBridgeDecoder().decode(
+            PeekabooBridgeRequest.self,
+            from: Self.legacyClickRequestData)
+        guard case .click = decodedRequest else {
+            Issue.record("Expected the legacy click request to remain unwrapped")
+            return
+        }
+
+        let legacyResponseData = Data(#"{"ok":{}}"#.utf8)
+        let decodedResponse = try JSONDecoder.peekabooBridgeDecoder().decode(
+            PeekabooBridgeResponse.self,
+            from: legacyResponseData)
+        guard case .ok = decodedResponse else {
+            Issue.record("Expected the previous protocol's bare ok response")
+            return
+        }
+        let reencodedResponse = try JSONEncoder.peekabooBridgeEncoder().encode(decodedResponse)
+        #expect(try Set(Self.object(from: reencodedResponse).keys) == ["ok"])
+    }
+
+    @Test
+    func `projected response permits an omitted outcome`() throws {
+        let response = PeekabooBridgeResponse.projectedAction(.init(response: .ok, outcome: nil))
+        let data = try JSONEncoder.peekabooBridgeEncoder().encode(response)
+        let root = try Self.object(from: data)
+        let projectedCase = try #require(root["projectedAction"] as? [String: Any])
+        let payload = try #require(projectedCase["_0"] as? [String: Any])
+
+        #expect(payload["outcome"] == nil)
+
+        let decoded = try JSONDecoder.peekabooBridgeDecoder().decode(PeekabooBridgeResponse.self, from: data)
+        guard case let .projectedAction(decodedPayload) = decoded else {
+            Issue.record("Expected a projected Bridge response")
+            return
+        }
+        #expect(decodedPayload.outcome == nil)
+        guard case .ok = decodedPayload.response else {
+            Issue.record("Expected the wrapped legacy ok response")
+            return
+        }
+    }
+
+    @Test
+    func `projected request validation accepts one mutation layer only`() throws {
+        let wrapper = PeekabooBridgeProjectedActionRequest(request: Self.clickRequest)
+        let validated = try wrapper.validatedRequest()
+
+        guard case .click = validated else {
+            Issue.record("Expected projected request validation to preserve the click request")
+            return
+        }
+
+        self.expectInvalidProjectedRequest(.init(request: .permissionsStatus))
+        self.expectInvalidProjectedRequest(.init(request: .handshake(.init(
+            protocolVersion: PeekabooBridgeConstants.protocolVersion,
+            client: .init(
+                bundleIdentifier: "dev.peekaboo.tests",
+                teamIdentifier: nil,
+                processIdentifier: 42,
+                hostname: nil)))))
+        self.expectInvalidProjectedRequest(.init(request: .projectedAction(wrapper)))
+    }
+
+    @Test
+    func `projection capability is introduced at protocol 1 23`() {
+        let expectedVersion = PeekabooBridgeProtocolVersion(major: 1, minor: 23)
+
+        #expect(PeekabooBridgeConstants.protocolVersion == expectedVersion)
+        #expect(PeekabooBridgeConstants.supportedProtocolRange.upperBound == expectedVersion)
+        #expect(PeekabooBridgeHostCapability.desktopActionOutcomeProjection == "desktopActionOutcomeProjection")
+
+        let handshake = BridgeTestFixtures.handshake(
+            negotiatedVersion: expectedVersion,
+            supportedOperations: [.click],
+            hostCapabilities: [PeekabooBridgeHostCapability.desktopActionOutcomeProjection])
+        #expect(handshake.hostCapabilities == ["desktopActionOutcomeProjection"])
+    }
+
+    private func expectInvalidProjectedRequest(_ request: PeekabooBridgeProjectedActionRequest) {
+        do {
+            _ = try request.validatedRequest()
+            Issue.record("Expected projected request validation to reject \(request.request.operation.rawValue)")
+        } catch let error as PeekabooBridgeErrorEnvelope {
+            #expect(error.code == .invalidRequest)
+        } catch {
+            Issue.record("Expected a Bridge invalid-request envelope, got \(error)")
+        }
+    }
+
+    private static func legacyResponse(for outcome: DesktopActionOutcome) -> PeekabooBridgeResponse {
+        guard !outcome.isConfirmed else { return .ok }
+        return BridgeTestFixtures.errorResponse(
+            code: .internalError,
+            message: "Fixture \(outcome.state.rawValue)",
+            details: "Fixture details \(outcome.state.rawValue)",
+            permission: .accessibility,
+            kind: .appNotFound,
+            context: "fixture:\(outcome.state.rawValue)",
+            operationMayHaveCompleted: outcome.projection.mutationDispatched)
+    }
+
+    private static func expectResponseKind(
+        _ response: PeekabooBridgeResponse,
+        matches outcome: DesktopActionOutcome)
+    {
+        switch (response, outcome.isConfirmed) {
+        case (.ok, true):
+            break
+        case let (.error(error), false):
+            #expect(error.code == .internalError)
+            #expect(error.message == "Fixture \(outcome.state.rawValue)")
+            #expect(error.details == "Fixture details \(outcome.state.rawValue)")
+            #expect(error.permission == .accessibility)
+            #expect(error.kind == .appNotFound)
+            #expect(error.context == "fixture:\(outcome.state.rawValue)")
+            #expect(error.operationMayHaveCompleted == outcome.projection.mutationDispatched)
+        default:
+            Issue.record("Legacy response kind contradicted \(outcome.state.rawValue)")
+        }
+    }
+
+    private static func expectProjection(
+        _ projection: [String: Any],
+        equals expected: ProjectionExpectation)
+    {
+        var expectedKeys: Set = [
+            "state",
+            "effect",
+            "route",
+            "evidence",
+            "dispatch_state",
+            "retry_safety",
+            "escalation",
+            "mutation_dispatched",
+            "retry_safe",
+            "requires_fresh_observation",
+        ]
+        if expected.deliveryMechanism != nil {
+            expectedKeys.formUnion(["delivery_mechanism", "delivery_mode"])
+        }
+        if expected.dispatchedUnitCount != nil {
+            expectedKeys.insert("dispatched_unit_count")
+        }
+        if expected.refusalReason != nil {
+            expectedKeys.insert("refusal_reason")
+        }
+
+        #expect(Set(projection.keys) == expectedKeys)
+        #expect(projection["state"] as? String == expected.state)
+        #expect(projection["effect"] as? String == expected.effect)
+        #expect(projection["route"] as? String == "local")
+        #expect(projection["delivery_mechanism"] as? String == expected.deliveryMechanism)
+        #expect(projection["delivery_mode"] as? String == expected.deliveryMode)
+        #expect(projection["evidence"] as? String == expected.evidence)
+        #expect(projection["dispatch_state"] as? String == expected.dispatchState)
+        #expect(projection["dispatched_unit_count"] as? Int == expected.dispatchedUnitCount)
+        #expect(projection["retry_safety"] as? String == expected.retrySafety)
+        #expect(projection["escalation"] as? String == expected.escalation)
+        #expect(projection["refusal_reason"] as? String == expected.refusalReason)
+        #expect(projection["mutation_dispatched"] as? Bool == expected.mutationDispatched)
+        #expect(projection["retry_safe"] as? Bool == expected.retrySafe)
+        #expect(projection["requires_fresh_observation"] as? Bool == expected.requiresFreshObservation)
+    }
+
+    private static func object(from data: Data) throws -> [String: Any] {
+        try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+    }
+
+    private static func canonicalJSON(_ object: Any) throws -> Data {
+        try JSONSerialization.data(withJSONObject: object, options: [.sortedKeys])
+    }
+
+    private static func projectedAssociation(from data: Data) throws -> [String: Any] {
+        let root = try Self.object(from: data)
+        let projectedCase = try #require(root["projectedAction"] as? [String: Any])
+        return try #require(projectedCase["_0"] as? [String: Any])
+    }
+
+    @MainActor
+    private static func send(
+        _ request: PeekabooBridgeRequest,
+        to server: PeekabooBridgeServer) async throws -> PeekabooBridgeResponse
+    {
+        let requestData = try JSONEncoder.peekabooBridgeEncoder().encode(request)
+        let responseData = await server.decodeAndHandle(requestData, peer: nil)
+        return try JSONDecoder.peekabooBridgeDecoder().decode(PeekabooBridgeResponse.self, from: responseData)
+    }
+
+    private static let clickRequest = PeekabooBridgeRequest.click(.init(
+        target: .coordinates(CGPoint(x: 17, y: 29)),
+        clickType: .single))
+
+    private static let legacyClickRequestData = Data(
+        #"{"click":{"_0":{"clickType":"single","target":{"kind":"coordinates","x":17,"y":29}}}}"#.utf8)
+
+    private static let projectionExpectations: [ProjectionExpectation] = [
+        .init(
+            state: "confirmed_change",
+            effect: "confirmed",
+            deliveryMechanism: "accessibility_action",
+            deliveryMode: "background",
+            evidence: "verified_change",
+            dispatchState: "dispatched",
+            dispatchedUnitCount: 1,
+            retrySafety: "not_applicable",
+            escalation: "none",
+            refusalReason: nil,
+            mutationDispatched: true,
+            retrySafe: false,
+            requiresFreshObservation: false),
+        .init(
+            state: "confirmed_no_change",
+            effect: "confirmed",
+            deliveryMechanism: nil,
+            deliveryMode: nil,
+            evidence: "verified_no_change",
+            dispatchState: "none",
+            dispatchedUnitCount: nil,
+            retrySafety: "not_applicable",
+            escalation: "none",
+            refusalReason: nil,
+            mutationDispatched: false,
+            retrySafe: false,
+            requiresFreshObservation: false),
+        .init(
+            state: "partial",
+            effect: "partial",
+            deliveryMechanism: "accessibility_action",
+            deliveryMode: "background",
+            evidence: "primary_change_verified_cleanup_failed",
+            dispatchState: "dispatched",
+            dispatchedUnitCount: 2,
+            retrySafety: "unsafe",
+            escalation: "recover_side_effect",
+            refusalReason: nil,
+            mutationDispatched: true,
+            retrySafe: false,
+            requiresFreshObservation: false),
+        .init(
+            state: "dispatched_unverified",
+            effect: "unverifiable",
+            deliveryMechanism: "process_targeted_events",
+            deliveryMode: "background",
+            evidence: "operation_still_running",
+            dispatchState: "dispatched",
+            dispatchedUnitCount: 3,
+            retrySafety: "unsafe",
+            escalation: "observe_before_retry",
+            refusalReason: nil,
+            mutationDispatched: true,
+            retrySafe: false,
+            requiresFreshObservation: true),
+        .init(
+            state: "suspected_noop",
+            effect: "suspected_noop",
+            deliveryMechanism: "accessibility_action",
+            deliveryMode: "background",
+            evidence: "observed_no_change",
+            dispatchState: "dispatched",
+            dispatchedUnitCount: 1,
+            retrySafety: "safe",
+            escalation: "refresh_target",
+            refusalReason: nil,
+            mutationDispatched: true,
+            retrySafe: true,
+            requiresFreshObservation: false),
+        .init(
+            state: "refused",
+            effect: "refused",
+            deliveryMechanism: nil,
+            deliveryMode: nil,
+            evidence: "request_refused",
+            dispatchState: "none",
+            dispatchedUnitCount: nil,
+            retrySafety: "safe",
+            escalation: "grant_permission",
+            refusalReason: "permission_denied",
+            mutationDispatched: false,
+            retrySafe: true,
+            requiresFreshObservation: false),
+        .init(
+            state: "indeterminate",
+            effect: "unverifiable",
+            deliveryMechanism: "process_targeted_events",
+            deliveryMode: "background",
+            evidence: "response_lost",
+            dispatchState: "may_have_dispatched",
+            dispatchedUnitCount: 2,
+            retrySafety: "unsafe",
+            escalation: "observe_before_retry",
+            refusalReason: nil,
+            mutationDispatched: true,
+            retrySafe: false,
+            requiresFreshObservation: true),
+    ]
+
+    private struct ProjectionExpectation {
+        let state: String
+        let effect: String
+        let deliveryMechanism: String?
+        let deliveryMode: String?
+        let evidence: String
+        let dispatchState: String
+        let dispatchedUnitCount: Int?
+        let retrySafety: String
+        let escalation: String
+        let refusalReason: String?
+        let mutationDispatched: Bool
+        let retrySafe: Bool
+        let requiresFreshObservation: Bool
+    }
+}

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeApplicationLaunchTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeApplicationLaunchTests.swift
@@ -242,12 +242,17 @@ struct PeekabooBridgeApplicationLaunchTests {
         do {
             _ = try await clientTask.value
             Issue.record("Expected the disconnected client request to be cancelled")
-        } catch let error as PeekabooBridgeErrorEnvelope {
-            #expect(error.code == .internalError)
-            #expect(error.operationMayHaveCompleted)
-            #expect(error.message.contains("indeterminate"))
-            #expect(error.message.contains("do not retry"))
-            #expect(PendingSnapshotCleanupPolicy.shouldPreserveReservation(after: error))
+        } catch let failure as DesktopActionFailure {
+            #expect(failure.outcome.route == .bridge)
+            #expect(failure.outcome.state == .indeterminate)
+            #expect(failure.outcome.evidence == .responseLost)
+            #expect(failure.outcome.retrySafety == .unsafe)
+            #expect(failure.outcome.projection.requiresFreshObservation)
+            #expect(failure.message.contains("indeterminate"))
+            #expect(failure.message.contains("do not retry"))
+            #expect(PendingSnapshotCleanupPolicy.shouldPreserveReservation(after: failure))
+        } catch {
+            Issue.record("Expected response-lost failure, got \(error)")
         }
         try await Self.waitForActiveConnectionCount(0, host: host)
 

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeCancellationTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeCancellationTests.swift
@@ -3,6 +3,7 @@ import Dispatch
 import Foundation
 import PeekabooAutomationKit
 import PeekabooCore
+import PeekabooFoundation
 import Testing
 @testable import PeekabooBridge
 
@@ -235,9 +236,10 @@ struct PeekabooBridgeCancellationTests {
         do {
             _ = try await queuedTask.value
             Issue.record("Expected the queued client request to time out")
-        } catch let error as PeekabooBridgeErrorEnvelope {
-            #expect(error.code == .timeout)
-            #expect(error.operationMayHaveCompleted)
+        } catch let failure as DesktopActionFailure {
+            Self.expectResponseLostFailure(failure)
+        } catch {
+            Issue.record("Expected response-lost failure, got \(error)")
         }
 
         observations.releaseFirstObservation()
@@ -313,9 +315,10 @@ struct PeekabooBridgeCancellationTests {
         do {
             _ = try await requestTask.value
             Issue.record("Expected the client request blocked on the watermark lock to time out")
-        } catch let error as PeekabooBridgeErrorEnvelope {
-            #expect(error.code == .timeout)
-            #expect(error.operationMayHaveCompleted)
+        } catch let failure as DesktopActionFailure {
+            Self.expectResponseLostFailure(failure)
+        } catch {
+            Issue.record("Expected response-lost failure, got \(error)")
         }
 
         let followUpClient = PeekabooBridgeClient(socketPath: socketPath, requestTimeoutSec: 1)
@@ -388,9 +391,10 @@ struct PeekabooBridgeCancellationTests {
         do {
             _ = try await firstTask.value
             Issue.record("Expected the first client to time out")
-        } catch let error as PeekabooBridgeErrorEnvelope {
-            #expect(error.code == .timeout)
-            #expect(error.operationMayHaveCompleted)
+        } catch let failure as DesktopActionFailure {
+            Self.expectResponseLostFailure(failure)
+        } catch {
+            Issue.record("Expected response-lost failure, got \(error)")
         }
 
         #expect(try await Self.waitForConnectionCount(0, host: host))
@@ -552,6 +556,14 @@ struct PeekabooBridgeCancellationTests {
             capture: DesktopCaptureOptions(focus: .background),
             detection: DesktopDetectionOptions(mode: .accessibility, allowWebFocusFallback: true),
             output: DesktopObservationOutputOptions(snapshotID: snapshotID))
+    }
+
+    private static func expectResponseLostFailure(_ failure: DesktopActionFailure) {
+        #expect(failure.outcome.route == .bridge)
+        #expect(failure.outcome.state == .indeterminate)
+        #expect(failure.outcome.evidence == .responseLost)
+        #expect(failure.outcome.retrySafety == .unsafe)
+        #expect(failure.outcome.projection.requiresFreshObservation)
     }
 
     private static func nonmutatingObservationRequest(snapshotID: String) -> DesktopObservationRequest {

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeCapabilityTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeCapabilityTests.swift
@@ -72,7 +72,7 @@ struct PeekabooBridgeCapabilityTests {
 
     @Test
     @MainActor
-    func `production bridge classifier preserves indeterminate input delivery`() {
+    func `production bridge classifier preserves indeterminate input delivery`() throws {
         let error = InputDeliveryIndeterminateError(
             operation: .type,
             emittedUnitCount: 1,
@@ -84,6 +84,13 @@ struct PeekabooBridgeCapabilityTests {
         #expect(envelope.operationMayHaveCompleted)
         #expect(envelope.message.contains("do not retry blindly"))
         #expect(envelope.message.contains("window focus drifted"))
+        let failure = try #require(envelope.desktopActionFailure)
+        #expect(failure.outcome.route == .bridge)
+        #expect(failure.outcome.state == .indeterminate)
+        #expect(failure.outcome.evidence == .completionUnknown)
+        #expect(failure.outcome.dispatchState.unitCount?.rawValue == 1)
+        #expect(failure.outcome.projection.requiresFreshObservation)
+        #expect(failure.causeDescription == "window focus drifted")
     }
 
     @Test

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeClientTransportOutcomeTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeClientTransportOutcomeTests.swift
@@ -3,6 +3,7 @@ import Darwin
 import Foundation
 import PeekabooAutomationKit
 import PeekabooBridgeTestSupport
+import PeekabooFoundation
 import Testing
 @testable import PeekabooBridge
 @testable import PeekabooCore
@@ -17,11 +18,8 @@ struct PeekabooBridgeClientTransportOutcomeTests {
         do {
             try await client.sendExpectOK(Self.clickRequest)
             Issue.record("Expected the response read to time out")
-        } catch let error as PeekabooBridgeErrorEnvelope {
-            #expect(error.code == .timeout)
-            #expect(error.operationMayHaveCompleted)
-            #expect(error.message.contains("indeterminate"))
-            #expect(error.message.contains("do not retry"))
+        } catch let failure as DesktopActionFailure {
+            Self.expectResponseLostFailure(failure)
         }
         await peer.waitUntilFinished()
     }
@@ -73,11 +71,8 @@ struct PeekabooBridgeClientTransportOutcomeTests {
         do {
             try await client.sendExpectOK(Self.clickRequest)
             Issue.record("Expected response EOF")
-        } catch let error as PeekabooBridgeErrorEnvelope {
-            #expect(error.code == .internalError)
-            #expect(error.operationMayHaveCompleted)
-            #expect(error.message.contains("indeterminate"))
-            #expect(error.message.contains("do not retry"))
+        } catch let failure as DesktopActionFailure {
+            Self.expectResponseLostFailure(failure)
         }
         await peer.waitUntilFinished()
     }
@@ -105,11 +100,8 @@ struct PeekabooBridgeClientTransportOutcomeTests {
         do {
             try await client.sendExpectOK(Self.clickRequest)
             Issue.record("Expected response decoding failure")
-        } catch let error as PeekabooBridgeErrorEnvelope {
-            #expect(error.code == .decodingFailed)
-            #expect(error.operationMayHaveCompleted)
-            #expect(error.message.contains("indeterminate"))
-            #expect(error.message.contains("do not retry"))
+        } catch let failure as DesktopActionFailure {
+            Self.expectResponseLostFailure(failure)
         }
         await peer.waitUntilFinished()
     }
@@ -146,12 +138,128 @@ struct PeekabooBridgeClientTransportOutcomeTests {
                 snapshotId: nil,
                 targetProcessIdentifier: 42)
             Issue.record("Expected indeterminate targeted click delivery")
-        } catch let error as InputDeliveryIndeterminateError {
-            #expect(error.operation == .click)
-            #expect(error.operationMayHaveCompleted)
-            #expect(!error.retrySafe)
+        } catch let failure as DesktopActionFailure {
+            Self.expectResponseLostFailure(failure)
         }
         await peer.waitUntilFinished()
+    }
+
+    @Test
+    func `canonical action failures reconstruct exactly once in shared transport`() async throws {
+        let delivery = DesktopActionOutcome.Delivery(
+            mechanism: .accessibilityAction,
+            mode: .background)
+        let twoUnits = try #require(DesktopActionOutcome.DispatchUnitCount(2))
+        let failures = [
+            DesktopActionFailure.refused(
+                route: .bridge,
+                reason: .permissionDenied,
+                message: "Accessibility permission was refused",
+                hint: "Grant Accessibility permission.",
+                causeDescription: "AX is not trusted"),
+            DesktopActionFailure.dispatchedUnverified(
+                route: .bridge,
+                delivery: delivery,
+                evidence: .deliveryAccepted,
+                unitCount: twoUnits,
+                message: "Delivery was accepted but not verified",
+                hint: "Observe before retrying.",
+                causeDescription: "post-dispatch verification timed out"),
+            DesktopActionFailure.partial(
+                route: .bridge,
+                delivery: delivery,
+                unitCount: twoUnits,
+                message: "The action changed the target but cleanup failed",
+                hint: "Recover the remaining side effect.",
+                causeDescription: "cleanup receipt was unavailable"),
+            DesktopActionFailure.indeterminate(
+                route: .bridge,
+                delivery: delivery,
+                evidence: .completionUnknown,
+                unitCount: twoUnits,
+                message: "The final action state is unknown",
+                hint: "Observe before retrying.",
+                causeDescription: "the host lost its verification receipt"),
+        ]
+
+        for expected in failures {
+            let response = BridgeTestFixtures.actionFailureResponse(failure: expected)
+            let data = try JSONEncoder.peekabooBridgeEncoder().encode(response)
+            let peer = try ScriptedBridgePeer(behavior: .respond(data))
+            let client = PeekabooBridgeClient(socketPath: peer.socketPath, requestTimeoutSec: 1)
+
+            do {
+                try await client.sendExpectOK(Self.clickRequest)
+                Issue.record("Expected canonical desktop action failure")
+            } catch let actual as DesktopActionFailure {
+                #expect(actual == expected)
+            }
+            await peer.waitUntilFinished()
+        }
+    }
+
+    @Test
+    func `legacy may-have-completed response becomes completion-unknown`() async throws {
+        let response = BridgeTestFixtures.errorResponse(
+            code: .internalError,
+            message: "Legacy host could not verify completion",
+            details: "legacy detail",
+            operationMayHaveCompleted: true)
+        let data = try JSONEncoder.peekabooBridgeEncoder().encode(response)
+        let peer = try ScriptedBridgePeer(behavior: .respond(data))
+        let client = PeekabooBridgeClient(socketPath: peer.socketPath, requestTimeoutSec: 1)
+
+        do {
+            try await client.sendExpectOK(Self.clickRequest)
+            Issue.record("Expected conservative legacy desktop action failure")
+        } catch let failure as DesktopActionFailure {
+            #expect(failure.outcome.route == .bridge)
+            #expect(failure.outcome.state == .indeterminate)
+            #expect(failure.outcome.evidence == .completionUnknown)
+            #expect(failure.outcome.retrySafety == .unsafe)
+            #expect(failure.outcome.projection.requiresFreshObservation)
+            #expect(failure.message == "Legacy host could not verify completion")
+            #expect(failure.causeDescription == "legacy detail")
+        }
+        await peer.waitUntilFinished()
+    }
+
+    @Test
+    func `read-only request never reconstructs a desktop action failure`() async throws {
+        let failure = DesktopActionFailure.indeterminate(
+            route: .bridge,
+            evidence: .completionUnknown,
+            message: "Fixture action failure on a read-only request")
+        let response = BridgeTestFixtures.actionFailureResponse(failure: failure)
+        let data = try JSONEncoder.peekabooBridgeEncoder().encode(response)
+        let peer = try ScriptedBridgePeer(behavior: .respond(data))
+        let client = PeekabooBridgeClient(socketPath: peer.socketPath, requestTimeoutSec: 1)
+
+        let actual = try await client.send(.permissionsStatus)
+        guard case let .error(envelope) = actual else {
+            Issue.record("Expected the read-only request to retain its Bridge error envelope")
+            await peer.waitUntilFinished()
+            return
+        }
+        #expect(envelope.desktopActionFailure == failure)
+        await peer.waitUntilFinished()
+    }
+
+    @Test
+    func `error envelope rejects compatibility Boolean contradicting canonical outcome`() throws {
+        let failure = DesktopActionFailure.indeterminate(
+            route: .bridge,
+            evidence: .completionUnknown,
+            message: "Completion unknown")
+        let envelope = PeekabooBridgeErrorEnvelope(code: .internalError, actionFailure: failure)
+        let data = try JSONEncoder.peekabooBridgeEncoder().encode(envelope)
+        var object = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        object["operationMayHaveCompleted"] = false
+        let forged = try JSONSerialization.data(withJSONObject: object)
+
+        #expect(throws: DecodingError.self) {
+            try JSONDecoder.peekabooBridgeDecoder().decode(PeekabooBridgeErrorEnvelope.self, from: forged)
+        }
     }
 
     @Test
@@ -168,6 +276,17 @@ struct PeekabooBridgeClientTransportOutcomeTests {
     private static let clickRequest = PeekabooBridgeRequest.click(.init(
         target: .coordinates(CGPoint(x: 10, y: 20)),
         clickType: .single))
+
+    private static func expectResponseLostFailure(_ failure: DesktopActionFailure) {
+        #expect(failure.outcome.route == .bridge)
+        #expect(failure.outcome.state == .indeterminate)
+        #expect(failure.outcome.evidence == .responseLost)
+        #expect(failure.outcome.retrySafety == .unsafe)
+        #expect(failure.outcome.projection.requiresFreshObservation)
+        #expect(failure.message.contains("indeterminate"))
+        #expect(failure.message.contains("do not retry"))
+        #expect(PendingSnapshotCleanupPolicy.shouldPreserveReservation(after: failure))
+    }
 }
 
 private final class ScriptedBridgePeer: @unchecked Sendable {

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeHostIdentityTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeHostIdentityTests.swift
@@ -123,6 +123,7 @@ struct PeekabooBridgeHostIdentityTests {
         #expect(handshake.hostCapabilities == [
             PeekabooBridgeHostCapability.backgroundBridgeHost,
             PeekabooBridgeHostCapability.codeSignatureBuildIdentity,
+            PeekabooBridgeHostCapability.desktopActionOutcomeProjection,
             PeekabooBridgeHostCapability.desktopObservationCaptureEngine,
             PeekabooBridgeHostCapability.desktopObservationOCR,
             PeekabooBridgeHostCapability.hostGenerationIdentity,

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeTests.swift
@@ -1526,7 +1526,7 @@ extension PeekabooBridgeTests {
     }
 
     @Test
-    func `remote targeted and exact input restore indeterminate delivery errors`() async throws {
+    func `remote targeted and exact input conservatively adapt legacy indeterminate delivery errors`() async throws {
         let socketPath = "/tmp/peekaboo-bridge-input-indeterminate-\(UUID().uuidString).sock"
         let targetedTypeSourceError = InputDeliveryIndeterminateError(
             operation: .type,
@@ -1596,10 +1596,8 @@ extension PeekabooBridgeTests {
                 expectedWindowIdentity: expectedWindowIdentity,
                 expectedWindowBounds: expectedWindowBounds)
             Issue.record("Expected exact click outcome to be indeterminate")
-        } catch let error as InputDeliveryIndeterminateError {
-            #expect(error.operation == .click)
-            #expect(error.emittedUnitCount == nil)
-            #expect(error.causeDescription == clickSourceError.localizedDescription)
+        } catch let failure as DesktopActionFailure {
+            Self.expectLegacyIndeterminateFailure(failure, source: clickSourceError)
         } catch {
             Issue.record("Expected exact click indeterminate error, got \(error)")
         }
@@ -1611,10 +1609,8 @@ extension PeekabooBridgeTests {
                 snapshotId: "snapshot",
                 targetProcessIdentifier: 4242)
             Issue.record("Expected targeted type outcome to be indeterminate")
-        } catch let error as InputDeliveryIndeterminateError {
-            #expect(error.operation == .type)
-            #expect(error.emittedUnitCount == nil)
-            #expect(error.causeDescription == targetedTypeSourceError.localizedDescription)
+        } catch let failure as DesktopActionFailure {
+            Self.expectLegacyIndeterminateFailure(failure, source: targetedTypeSourceError)
         } catch {
             Issue.record("Expected targeted type indeterminate error, got \(error)")
         }
@@ -1627,10 +1623,8 @@ extension PeekabooBridgeTests {
                 expectedWindowIdentity: expectedWindowIdentity,
                 expectedWindowBounds: expectedWindowBounds)
             Issue.record("Expected exact type outcome to be indeterminate")
-        } catch let error as InputDeliveryIndeterminateError {
-            #expect(error.operation == .type)
-            #expect(error.emittedUnitCount == nil)
-            #expect(error.causeDescription == exactTypeSourceError.localizedDescription)
+        } catch let failure as DesktopActionFailure {
+            Self.expectLegacyIndeterminateFailure(failure, source: exactTypeSourceError)
         } catch {
             Issue.record("Expected exact type indeterminate error, got \(error)")
         }
@@ -1638,10 +1632,8 @@ extension PeekabooBridgeTests {
         do {
             try await remote.hotkey(keys: "cmd,l", holdDuration: 50, targetProcessIdentifier: 4242)
             Issue.record("Expected targeted hotkey outcome to be indeterminate")
-        } catch let error as InputDeliveryIndeterminateError {
-            #expect(error.operation == .hotkey)
-            #expect(error.emittedUnitCount == nil)
-            #expect(error.causeDescription == targetedHotkeySourceError.localizedDescription)
+        } catch let failure as DesktopActionFailure {
+            Self.expectLegacyIndeterminateFailure(failure, source: targetedHotkeySourceError)
         } catch {
             Issue.record("Expected targeted hotkey indeterminate error, got \(error)")
         }
@@ -1653,13 +1645,24 @@ extension PeekabooBridgeTests {
                 expectedWindowIdentity: expectedWindowIdentity,
                 expectedWindowBounds: expectedWindowBounds)
             Issue.record("Expected exact hotkey outcome to be indeterminate")
-        } catch let error as InputDeliveryIndeterminateError {
-            #expect(error.operation == .hotkey)
-            #expect(error.emittedUnitCount == nil)
-            #expect(error.causeDescription == exactHotkeySourceError.localizedDescription)
+        } catch let failure as DesktopActionFailure {
+            Self.expectLegacyIndeterminateFailure(failure, source: exactHotkeySourceError)
         } catch {
             Issue.record("Expected exact hotkey indeterminate error, got \(error)")
         }
+    }
+
+    private static func expectLegacyIndeterminateFailure(
+        _ failure: DesktopActionFailure,
+        source: InputDeliveryIndeterminateError)
+    {
+        #expect(failure.outcome.route == .bridge)
+        #expect(failure.outcome.state == .indeterminate)
+        #expect(failure.outcome.evidence == .completionUnknown)
+        #expect(failure.outcome.dispatchState.unitCount == nil)
+        #expect(failure.outcome.retrySafety == .unsafe)
+        #expect(failure.outcome.projection.requiresFreshObservation)
+        #expect(failure.message == source.localizedDescription)
     }
 
     @Test

--- a/Core/PeekabooCore/Tests/PeekabooTests/RemoteApplicationServiceTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/RemoteApplicationServiceTests.swift
@@ -543,9 +543,12 @@ struct RemoteApplicationServiceTests {
         do {
             try await hideTask.value
             Issue.record("Expected indeterminate bridge completion failure")
-        } catch let envelope as PeekabooBridgeErrorEnvelope {
-            #expect(envelope.code == .internalError)
-            #expect(envelope.operationMayHaveCompleted)
+        } catch let failure as DesktopActionFailure {
+            #expect(failure.outcome.route == .bridge)
+            #expect(failure.outcome.state == .indeterminate)
+            #expect(failure.outcome.evidence == .completionUnknown)
+            #expect(failure.outcome.retrySafety == .unsafe)
+            #expect(failure.outcome.projection.requiresFreshObservation)
         }
 
         let hiddenIdentifiers = await MainActor.run { fallback.hiddenIdentifiers }

--- a/Core/PeekabooFoundation/Sources/PeekabooFoundation/DesktopActionOutcome+Projection.swift
+++ b/Core/PeekabooFoundation/Sources/PeekabooFoundation/DesktopActionOutcome+Projection.swift
@@ -1,0 +1,137 @@
+import Foundation
+
+extension DesktopActionOutcome {
+    /// Flat transport projection of one validated desktop action outcome.
+    ///
+    /// The canonical state machine remains owned by ``DesktopActionOutcome``. This type has no
+    /// fieldwise initializer: callers project a validated outcome, while decoding reconstructs and
+    /// validates that outcome before accepting the compatibility booleans.
+    public struct Projection: Codable, Equatable, Sendable {
+        public let outcome: DesktopActionOutcome
+
+        public var state: State {
+            self.outcome.state
+        }
+
+        public var effect: Effect {
+            self.outcome.effect
+        }
+
+        public var route: Route {
+            self.outcome.route
+        }
+
+        public var deliveryMechanism: Delivery.Mechanism? {
+            self.outcome.delivery?.mechanism
+        }
+
+        public var deliveryMode: Delivery.Mode? {
+            self.outcome.delivery?.mode
+        }
+
+        public var evidence: Evidence {
+            self.outcome.evidence
+        }
+
+        public var dispatchState: DispatchState {
+            self.outcome.dispatchState
+        }
+
+        public var dispatchedUnitCount: DispatchUnitCount? {
+            self.outcome.dispatchState.unitCount
+        }
+
+        public var retrySafety: RetrySafety {
+            self.outcome.retrySafety
+        }
+
+        public var escalation: Escalation {
+            self.outcome.escalation
+        }
+
+        public var refusalReason: RefusalReason? {
+            self.outcome.refusalReason
+        }
+
+        /// Compatibility field retained for existing result consumers.
+        public var mutationDispatched: Bool {
+            self.outcome.dispatchState.mutationDispatched
+        }
+
+        /// Compatibility field retained for existing result consumers.
+        ///
+        /// `.notApplicable` is intentionally false: only a canonical `.safe` outcome is retry-safe.
+        public var retrySafe: Bool {
+            self.outcome.retrySafety == .safe
+        }
+
+        /// Whether a dispatched or potentially dispatched action must be observed before retrying.
+        public var requiresFreshObservation: Bool {
+            self.outcome.dispatchState != .none && self.outcome.escalation == .observeBeforeRetry
+        }
+
+        public init(outcome: DesktopActionOutcome) {
+            self.outcome = outcome
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case mutationDispatched = "mutation_dispatched"
+            case retrySafe = "retry_safe"
+            case requiresFreshObservation = "requires_fresh_observation"
+        }
+
+        public func encode(to encoder: any Encoder) throws {
+            try self.outcome.encode(to: encoder)
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(self.mutationDispatched, forKey: .mutationDispatched)
+            try container.encode(self.retrySafe, forKey: .retrySafe)
+            try container.encode(self.requiresFreshObservation, forKey: .requiresFreshObservation)
+        }
+
+        public init(from decoder: any Decoder) throws {
+            let outcome = try DesktopActionOutcome(from: decoder)
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            let encodedMutationDispatched = try container.decode(Bool.self, forKey: .mutationDispatched)
+            let encodedRetrySafe = try container.decode(Bool.self, forKey: .retrySafe)
+            let encodedRequiresFreshObservation = try container.decode(
+                Bool.self,
+                forKey: .requiresFreshObservation)
+            let projection = Self(outcome: outcome)
+
+            try Self.validateCompatibilityField(
+                encodedMutationDispatched,
+                equals: projection.mutationDispatched,
+                forKey: .mutationDispatched,
+                in: container)
+            try Self.validateCompatibilityField(
+                encodedRetrySafe,
+                equals: projection.retrySafe,
+                forKey: .retrySafe,
+                in: container)
+            try Self.validateCompatibilityField(
+                encodedRequiresFreshObservation,
+                equals: projection.requiresFreshObservation,
+                forKey: .requiresFreshObservation,
+                in: container)
+            self = projection
+        }
+
+        private static func validateCompatibilityField(
+            _ encoded: Bool,
+            equals expected: Bool,
+            forKey key: CodingKeys,
+            in container: KeyedDecodingContainer<CodingKeys>) throws
+        {
+            guard encoded == expected else {
+                throw DecodingError.dataCorruptedError(
+                    forKey: key,
+                    in: container,
+                    debugDescription: "Compatibility field contradicts the validated desktop action outcome")
+            }
+        }
+    }
+
+    public var projection: Projection {
+        Projection(outcome: self)
+    }
+}

--- a/Core/PeekabooFoundation/Sources/PeekabooFoundation/DesktopActionOutcome.swift
+++ b/Core/PeekabooFoundation/Sources/PeekabooFoundation/DesktopActionOutcome.swift
@@ -339,6 +339,22 @@ public struct DesktopActionOutcome: Codable, Equatable, Sendable {
             escalation: .observeBeforeRetry)
     }
 
+    /// Reassigns only the transport route of an already-validated outcome.
+    ///
+    /// Bridge code uses this at its ownership boundary instead of rebuilding state-specific
+    /// fields and risking a second, contradictory outcome model.
+    public func routed(to route: Route) -> DesktopActionOutcome {
+        Self(
+            state: self.state,
+            route: route,
+            delivery: self.delivery,
+            evidence: self.evidence,
+            dispatchState: self.dispatchState,
+            retrySafety: self.retrySafety,
+            escalation: self.escalation,
+            refusalReason: self.refusalReason)
+    }
+
     private enum CodingKeys: String, CodingKey {
         case state
         case effect
@@ -645,6 +661,15 @@ public struct DesktopActionFailure: Codable, Equatable, LocalizedError, Sendable
 
     public var recoverySuggestion: String? {
         self.hint
+    }
+
+    /// Reassigns the route while preserving the validated failure state and its exact context.
+    public func routed(to route: DesktopActionOutcome.Route) -> DesktopActionFailure {
+        Self(
+            validatedOutcome: self.outcome.routed(to: route),
+            message: self.message,
+            hint: self.hint,
+            causeDescription: self.causeDescription)
     }
 
     private enum CodingKeys: String, CodingKey {

--- a/Core/PeekabooFoundation/Tests/PeekabooFoundationTests/DesktopActionOutcomeProjectionTests.swift
+++ b/Core/PeekabooFoundation/Tests/PeekabooFoundationTests/DesktopActionOutcomeProjectionTests.swift
@@ -1,0 +1,296 @@
+import Foundation
+import PeekabooFoundation
+import Testing
+
+struct DesktopActionOutcomeProjectionTests {
+    private let backgroundAX = DesktopActionOutcome.Delivery(
+        mechanism: .accessibilityAction,
+        mode: .background)
+
+    @Test
+    func `projection exposes the exhaustive seven-state table`() throws {
+        let oneUnit = try self.positiveUnitCount(1)
+        let twoUnits = try self.positiveUnitCount(2)
+        let threeUnits = try self.positiveUnitCount(3)
+        let cases = [
+            ProjectionCase(
+                outcome: .confirmedChange(delivery: self.backgroundAX, unitCount: oneUnit),
+                state: .confirmedChange,
+                effect: .confirmed,
+                route: .local,
+                delivery: self.backgroundAX,
+                evidence: .verifiedChange,
+                dispatchState: .dispatched(unitCount: oneUnit),
+                unitCount: oneUnit,
+                retrySafety: .notApplicable,
+                escalation: .none,
+                refusalReason: nil,
+                mutationDispatched: true,
+                retrySafe: false,
+                requiresFreshObservation: false),
+            ProjectionCase(
+                outcome: .confirmedNoChange(route: .bridge),
+                state: .confirmedNoChange,
+                effect: .confirmed,
+                route: .bridge,
+                delivery: nil,
+                evidence: .verifiedNoChange,
+                dispatchState: .none,
+                unitCount: nil,
+                retrySafety: .notApplicable,
+                escalation: .none,
+                refusalReason: nil,
+                mutationDispatched: false,
+                retrySafe: false,
+                requiresFreshObservation: false),
+            ProjectionCase(
+                outcome: .partial(route: .bridge, delivery: self.backgroundAX, unitCount: twoUnits),
+                state: .partial,
+                effect: .partial,
+                route: .bridge,
+                delivery: self.backgroundAX,
+                evidence: .primaryChangeVerifiedCleanupFailed,
+                dispatchState: .dispatched(unitCount: twoUnits),
+                unitCount: twoUnits,
+                retrySafety: .unsafe,
+                escalation: .recoverSideEffect,
+                refusalReason: nil,
+                mutationDispatched: true,
+                retrySafe: false,
+                requiresFreshObservation: false),
+            ProjectionCase(
+                outcome: .dispatchedUnverified(
+                    delivery: self.backgroundAX,
+                    evidence: .operationStillRunning,
+                    unitCount: threeUnits),
+                state: .dispatchedUnverified,
+                effect: .unverifiable,
+                route: .local,
+                delivery: self.backgroundAX,
+                evidence: .operationStillRunning,
+                dispatchState: .dispatched(unitCount: threeUnits),
+                unitCount: threeUnits,
+                retrySafety: .unsafe,
+                escalation: .observeBeforeRetry,
+                refusalReason: nil,
+                mutationDispatched: true,
+                retrySafe: false,
+                requiresFreshObservation: true),
+            ProjectionCase(
+                outcome: .suspectedNoop(delivery: self.backgroundAX),
+                state: .suspectedNoop,
+                effect: .suspectedNoop,
+                route: .local,
+                delivery: self.backgroundAX,
+                evidence: .observedNoChange,
+                dispatchState: .dispatched(unitCount: nil),
+                unitCount: nil,
+                retrySafety: .safe,
+                escalation: .refreshTarget,
+                refusalReason: nil,
+                mutationDispatched: true,
+                retrySafe: true,
+                requiresFreshObservation: false),
+            ProjectionCase(
+                outcome: .refused(route: .bridge, reason: .permissionDenied),
+                state: .refused,
+                effect: .refused,
+                route: .bridge,
+                delivery: nil,
+                evidence: .requestRefused,
+                dispatchState: .none,
+                unitCount: nil,
+                retrySafety: .safe,
+                escalation: .grantPermission,
+                refusalReason: .permissionDenied,
+                mutationDispatched: false,
+                retrySafe: true,
+                requiresFreshObservation: false),
+            ProjectionCase(
+                outcome: .indeterminate(
+                    route: .bridge,
+                    evidence: .responseLost,
+                    unitCount: threeUnits),
+                state: .indeterminate,
+                effect: .unverifiable,
+                route: .bridge,
+                delivery: nil,
+                evidence: .responseLost,
+                dispatchState: .mayHaveDispatched(unitCount: threeUnits),
+                unitCount: threeUnits,
+                retrySafety: .unsafe,
+                escalation: .observeBeforeRetry,
+                refusalReason: nil,
+                mutationDispatched: true,
+                retrySafe: false,
+                requiresFreshObservation: true),
+        ]
+
+        #expect(cases.map(\.state) == DesktopActionOutcome.State.allProjectionStates)
+        for item in cases {
+            let projection = item.outcome.projection
+            #expect(projection.outcome == item.outcome)
+            #expect(projection.state == item.state)
+            #expect(projection.effect == item.effect)
+            #expect(projection.route == item.route)
+            #expect(projection.deliveryMechanism == item.delivery?.mechanism)
+            #expect(projection.deliveryMode == item.delivery?.mode)
+            #expect(projection.evidence == item.evidence)
+            #expect(projection.dispatchState == item.dispatchState)
+            #expect(projection.dispatchedUnitCount == item.unitCount)
+            #expect(projection.retrySafety == item.retrySafety)
+            #expect(projection.escalation == item.escalation)
+            #expect(projection.refusalReason == item.refusalReason)
+            #expect(projection.mutationDispatched == item.mutationDispatched)
+            #expect(projection.retrySafe == item.retrySafe)
+            #expect(projection.requiresFreshObservation == item.requiresFreshObservation)
+        }
+    }
+
+    @Test
+    func `projection round trips every canonical field and compatibility derivation`() throws {
+        for outcome in try self.allOutcomes() {
+            let projection = outcome.projection
+            let data = try JSONEncoder().encode(projection)
+            let object = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+
+            #expect(object["state"] as? String == projection.state.rawValue)
+            #expect(object["effect"] as? String == projection.effect.rawValue)
+            #expect(object["route"] as? String == projection.route.rawValue)
+            #expect(object["delivery_mechanism"] as? String == projection.deliveryMechanism?.rawValue)
+            #expect(object["delivery_mode"] as? String == projection.deliveryMode?.rawValue)
+            #expect(object["evidence"] as? String == projection.evidence.rawValue)
+            #expect(object["dispatch_state"] as? String == Self.dispatchStateName(projection.dispatchState))
+            #expect(object["dispatched_unit_count"] as? Int == projection.dispatchedUnitCount?.rawValue)
+            #expect(object["retry_safety"] as? String == projection.retrySafety.rawValue)
+            #expect(object["escalation"] as? String == projection.escalation.rawValue)
+            #expect(object["refusal_reason"] as? String == projection.refusalReason?.rawValue)
+            #expect(object["mutation_dispatched"] as? Bool == projection.mutationDispatched)
+            #expect(object["retry_safe"] as? Bool == projection.retrySafe)
+            #expect(object["requires_fresh_observation"] as? Bool == projection.requiresFreshObservation)
+            #expect(try JSONDecoder().decode(DesktopActionOutcome.Projection.self, from: data) == projection)
+        }
+    }
+
+    @Test
+    func `projection decoder rejects every forged compatibility boolean`() throws {
+        for outcome in try self.allOutcomes() {
+            let projection = outcome.projection
+            for (key, value) in [
+                ("mutation_dispatched", projection.mutationDispatched),
+                ("retry_safe", projection.retrySafe),
+                ("requires_fresh_observation", projection.requiresFreshObservation),
+            ] {
+                let data = try self.mutatedJSON(projection) { object in
+                    object[key] = !value
+                }
+                #expect(throws: DecodingError.self) {
+                    try JSONDecoder().decode(DesktopActionOutcome.Projection.self, from: data)
+                }
+            }
+        }
+    }
+
+    @Test
+    func `projection decoder requires all compatibility booleans`() throws {
+        let projection = DesktopActionOutcome.refused(reason: .invalidRequest).projection
+        for key in ["mutation_dispatched", "retry_safe", "requires_fresh_observation"] {
+            let data = try self.mutatedJSON(projection) { object in
+                object.removeValue(forKey: key)
+            }
+            #expect(throws: DecodingError.self) {
+                try JSONDecoder().decode(DesktopActionOutcome.Projection.self, from: data)
+            }
+        }
+    }
+
+    @Test
+    func `projection decoder delegates forged canonical fields to outcome validation`() throws {
+        let projection = DesktopActionOutcome.indeterminate(evidence: .responseLost).projection
+        for mutation in [
+            { (object: inout [String: Any]) in object["effect"] = "confirmed" },
+            { (object: inout [String: Any]) in object["dispatch_state"] = "none" },
+            { (object: inout [String: Any]) in object["retry_safety"] = "safe" },
+            { (object: inout [String: Any]) in object["escalation"] = "none" },
+        ] {
+            let data = try self.mutatedJSON(projection, mutation: mutation)
+            #expect(throws: DecodingError.self) {
+                try JSONDecoder().decode(DesktopActionOutcome.Projection.self, from: data)
+            }
+        }
+    }
+
+    @Test
+    func `lost response is dispatched retry unsafe and requires fresh observation`() {
+        let projection = DesktopActionOutcome.indeterminate(evidence: .responseLost).projection
+
+        #expect(projection.dispatchState == .mayHaveDispatched(unitCount: nil))
+        #expect(projection.mutationDispatched)
+        #expect(!projection.retrySafe)
+        #expect(projection.requiresFreshObservation)
+    }
+
+    private func allOutcomes() throws -> [DesktopActionOutcome] {
+        let oneUnit = try self.positiveUnitCount(1)
+        return [
+            .confirmedChange(delivery: self.backgroundAX, unitCount: oneUnit),
+            .confirmedNoChange(route: .bridge),
+            .partial(delivery: self.backgroundAX),
+            .dispatchedUnverified(delivery: self.backgroundAX, evidence: .deliveryAccepted),
+            .suspectedNoop(delivery: self.backgroundAX),
+            .refused(route: .bridge, reason: .runtimeIncompatible),
+            .indeterminate(route: .bridge, evidence: .completionUnknown, unitCount: oneUnit),
+        ]
+    }
+
+    private func mutatedJSON(
+        _ projection: DesktopActionOutcome.Projection,
+        mutation: (inout [String: Any]) -> Void) throws -> Data
+    {
+        let data = try JSONEncoder().encode(projection)
+        var object = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        mutation(&object)
+        return try JSONSerialization.data(withJSONObject: object)
+    }
+
+    private func positiveUnitCount(_ value: Int) throws -> DesktopActionOutcome.DispatchUnitCount {
+        try #require(DesktopActionOutcome.DispatchUnitCount(value))
+    }
+
+    private static func dispatchStateName(_ state: DesktopActionOutcome.DispatchState) -> String {
+        switch state {
+        case .none: "none"
+        case .dispatched: "dispatched"
+        case .mayHaveDispatched: "may_have_dispatched"
+        }
+    }
+
+    private struct ProjectionCase {
+        let outcome: DesktopActionOutcome
+        let state: DesktopActionOutcome.State
+        let effect: DesktopActionOutcome.Effect
+        let route: DesktopActionOutcome.Route
+        let delivery: DesktopActionOutcome.Delivery?
+        let evidence: DesktopActionOutcome.Evidence
+        let dispatchState: DesktopActionOutcome.DispatchState
+        let unitCount: DesktopActionOutcome.DispatchUnitCount?
+        let retrySafety: DesktopActionOutcome.RetrySafety
+        let escalation: DesktopActionOutcome.Escalation
+        let refusalReason: DesktopActionOutcome.RefusalReason?
+        let mutationDispatched: Bool
+        let retrySafe: Bool
+        let requiresFreshObservation: Bool
+    }
+}
+
+extension DesktopActionOutcome.State {
+    fileprivate static let allProjectionStates: [Self] = [
+        .confirmedChange,
+        .confirmedNoChange,
+        .partial,
+        .dispatchedUnverified,
+        .suspectedNoop,
+        .refused,
+        .indeterminate,
+    ]
+}

--- a/Core/PeekabooFoundation/Tests/PeekabooFoundationTests/DesktopActionOutcomeTests.swift
+++ b/Core/PeekabooFoundation/Tests/PeekabooFoundationTests/DesktopActionOutcomeTests.swift
@@ -175,6 +175,31 @@ struct DesktopActionOutcomeTests {
             hint: "Observe before retrying")
         #expect(typedFailure.outcome.evidence == .operationStillRunning)
         #expect(typedFailure.outcome.effect == .unverifiable)
+
+        let routedFailure = typedFailure.routed(to: .bridge)
+        #expect(routedFailure.outcome.route == .bridge)
+        #expect(routedFailure.message == typedFailure.message)
+        #expect(routedFailure.hint == typedFailure.hint)
+        #expect(routedFailure.causeDescription == typedFailure.causeDescription)
+    }
+
+    @Test
+    func `rerouting preserves every validated outcome field except route`() throws {
+        let original = try DesktopActionOutcome.partial(
+            delivery: self.backgroundAX,
+            unitCount: self.positiveUnitCount(2))
+
+        let routed = original.routed(to: .bridge)
+
+        #expect(routed.route == .bridge)
+        #expect(routed.state == original.state)
+        #expect(routed.effect == original.effect)
+        #expect(routed.delivery == original.delivery)
+        #expect(routed.evidence == original.evidence)
+        #expect(routed.dispatchState == original.dispatchState)
+        #expect(routed.retrySafety == original.retrySafety)
+        #expect(routed.escalation == original.escalation)
+        #expect(routed.refusalReason == original.refusalReason)
     }
 
     @Test


### PR DESCRIPTION
## Summary

- add a Foundation-owned, decoder-validated projection for all seven canonical `DesktopActionOutcome` states and their compatibility fields
- add capability-gated Bridge protocol 1.23 per-request action carriage while preserving every legacy request/response shape for older clients and hosts
- reconstruct canonical `DesktopActionFailure` once in shared client transport instead of operation-specific input catches
- keep response-loss and contradictory/malformed projection paths conservative, retry-unsafe, and fresh-observation-required
- reject nested or excessively deep projected wrappers from raw bytes before JSON decoding, authorization, lane acquisition, or handler dispatch
- keep success projection optional until result-bearing service APIs migrate; never infer confirmation from an operation name, `.ok`, or an error code

## Compatibility

- old client to new host: legacy request and legacy response
- new client to old host: capability absent, legacy request and conservative legacy failure behavior
- new client to capable host: explicit one-layer projected request and matching projected response
- capable host returning an unwrapped or contradictory response: canonical indeterminate response-loss failure
- legacy `operationMayHaveCompleted` remains available and is derived from the canonical dispatch state whenever a projection exists

## Proof

- Foundation projection debug and release: 24/24 each
- Bridge projection/preflight: 11 passed
- client transport/lost-response: 13 passed
- Bridge behavior/compatibility: 54 passed
- error classification: 9 passed
- full non-clipboard safe matrix: 881 Core/CLI tests + 86 runtime tests passed
- release `PeekabooBridge` target build, format, diff hygiene, native-only policy, strict touched-file lint: passed
- pre-commit P0-P2 autoreview: clean at 0.90
- final integrated P0-P2 autoreview: clean at 0.96; TruffleHog clean
- post-rebase tree is byte-identical to the reviewed tree

Full Core debug additionally ran 1,437 tests; its only failure is the existing deterministic `AgentToolImageLifecycleTests` cancellation baseline, reproduced unchanged in a clean-base worktree. Full Core release test compilation remains blocked by the existing `CaptureOutputTests` release-only injection-hook gap; the production Release Bridge target builds successfully.

No authorization, selector, lane, clipboard, or AppleScript/JXA/OSA behavior changed.
