### PR TITLE
fix(mcp): project canonical action outcomes

### DIFF
--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Carry canonical desktop-action outcomes through capability-gated Bridge protocol 1.23 requests, preserving exact refused, partial, unverified, and indeterminate failures while older hosts remain conservative after a response is lost.
+- Project canonical desktop-action outcomes into MCP metadata, so partial failures retain recovery-side-effect semantics instead of incorrectly demanding a fresh observation.
 - Correct `peekaboo bridge --help` and Bridge docs to describe capability-aware reusable-daemon, Peekaboo.app, on-demand-daemon, and local-fallback routing.
 - Refuse public raw `press` chords before dispatch unless `--foreground` is explicit, with canonical retry-safe refusal metadata and honest unverifiable foreground results.
 - Reject excess positional arguments unless a command declares a variadic tail, while preserving explicit multi-chord `press` sequences.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### Fixed
 - Carry canonical desktop-action outcomes through capability-gated Bridge protocol 1.23 requests, preserving exact refused, partial, unverified, and indeterminate failures while older hosts remain conservative after a response is lost.
+- Project canonical desktop-action outcomes into MCP metadata, so partial failures retain recovery-side-effect semantics instead of incorrectly demanding a fresh observation.
 - Correct `peekaboo bridge --help` and Bridge docs to describe capability-aware reusable-daemon, Peekaboo.app, on-demand-daemon, and local-fallback routing.
 - Refuse public raw `press` chords before dispatch unless explicit foreground consent is present, keep semantic background alternatives discoverable, and report foreground delivery as unverifiable instead of claiming the intended effect completed.
 - Reject excess positional arguments unless a command declares a variadic tail, while preserving explicit multi-chord `press` sequences.

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Server/MCPToolResponseMetadataProjector.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Server/MCPToolResponseMetadataProjector.swift
@@ -3,14 +3,27 @@ import PeekabooFoundation
 import TachikomaMCP
 
 enum MCPToolResponseMetadataProjector {
-    private static let safetyKeys: Set<String> = [
+    private static let actionOutcomeKeys: Set<String> = [
+        "delivery_mechanism",
+        "delivery_mode",
+        "dispatch_state",
+        "dispatched_unit_count",
         "effect",
-        "error_code",
-        "execution_policy",
+        "escalation",
+        "evidence",
         "mutation_dispatched",
+        "refusal_reason",
         "requires_fresh_observation",
         "retry_safe",
+        "retry_safety",
+        "route",
+        "state",
     ]
+
+    private static let safetyKeys = Self.actionOutcomeKeys.union([
+        "error_code",
+        "execution_policy",
+    ])
 
     private static let captureErrorKeys: Set<String> = [
         "decode_failures",
@@ -69,23 +82,20 @@ enum MCPToolResponseMetadataProjector {
         return fields.filter { allowed.contains($0.key) }
     }
 
+    static func fields(
+        for projection: DesktopActionOutcome.Projection) throws -> [String: Value]
+    {
+        guard case let .object(fields) = try Value(projection) else {
+            throw ProjectionError.expectedObject
+        }
+        return fields
+    }
+
     static func errorResponse(
         for failure: DesktopActionFailure,
-        invalidatedSnapshotID: String?) -> ToolResponse
+        invalidatedSnapshotID: String?) throws -> ToolResponse
     {
-        let outcome = failure.outcome
-        let retrySafe = switch outcome.retrySafety {
-        case .safe: true
-        case .unsafe, .notApplicable: false
-        }
-        var fields: [String: Value] = [
-            "effect": .string(outcome.effect.rawValue),
-            "mutation_dispatched": .bool(outcome.dispatchState.mutationDispatched),
-            "retry_safe": .bool(retrySafe),
-        ]
-        if outcome.dispatchState.mutationDispatched {
-            fields["requires_fresh_observation"] = .bool(true)
-        }
+        var fields = try self.fields(for: failure.outcome.projection)
         if let invalidatedSnapshotID {
             fields["invalidated_snapshot"] = .string(invalidatedSnapshotID)
         }
@@ -93,6 +103,10 @@ enum MCPToolResponseMetadataProjector {
         return ToolResponse.error(
             self.message(for: failure),
             meta: .object(fields))
+    }
+
+    private enum ProjectionError: Error {
+        case expectedObject
     }
 
     private static func message(for failure: DesktopActionFailure) -> String {

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/ClickTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/ClickTool.swift
@@ -176,7 +176,7 @@ public struct ClickTool: MCPTool {
         } catch let failure as DesktopActionFailure {
             let invalidatedSnapshotId = await UISnapshotManager.shared
                 .invalidateActiveSnapshot(id: snapshotIdToInvalidate)
-            return MCPToolResponseMetadataProjector.errorResponse(
+            return try MCPToolResponseMetadataProjector.errorResponse(
                 for: failure,
                 invalidatedSnapshotID: invalidatedSnapshotId)
         } catch let error as InputDeliveryIndeterminateError {

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPDesktopActionOutcomeProjectionTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPDesktopActionOutcomeProjectionTests.swift
@@ -1,0 +1,92 @@
+import Foundation
+import MCP
+import PeekabooBridgeTestSupport
+import PeekabooFoundation
+import Testing
+@testable import PeekabooAgentRuntime
+
+struct MCPDesktopActionOutcomeProjectionTests {
+    @Test
+    func `canonical projection drives the complete seven state MCP matrix`() throws {
+        let expectations: [ProjectionExpectation] = [
+            .init(state: .confirmedChange, dispatched: true, retrySafe: false, fresh: false, escalation: .none),
+            .init(state: .confirmedNoChange, dispatched: false, retrySafe: false, fresh: false, escalation: .none),
+            .init(state: .partial, dispatched: true, retrySafe: false, fresh: false, escalation: .recoverSideEffect),
+            .init(
+                state: .dispatchedUnverified,
+                dispatched: true,
+                retrySafe: false,
+                fresh: true,
+                escalation: .observeBeforeRetry),
+            .init(state: .suspectedNoop, dispatched: true, retrySafe: true, fresh: false, escalation: .refreshTarget),
+            .init(state: .refused, dispatched: false, retrySafe: true, fresh: false, escalation: .grantPermission),
+            .init(
+                state: .indeterminate,
+                dispatched: true,
+                retrySafe: false,
+                fresh: true,
+                escalation: .observeBeforeRetry),
+        ]
+
+        for (outcome, expectation) in zip(BridgeTestFixtures.canonicalActionOutcomes, expectations) {
+            let fields = try MCPToolResponseMetadataProjector.fields(for: outcome.projection)
+
+            #expect(fields["state"] == .string(expectation.state.rawValue))
+            #expect(fields["mutation_dispatched"] == .bool(expectation.dispatched))
+            #expect(fields["retry_safe"] == .bool(expectation.retrySafe))
+            #expect(fields["requires_fresh_observation"] == .bool(expectation.fresh))
+            #expect(fields["escalation"] == .string(expectation.escalation.rawValue))
+
+            let external = MCPToolResponseMetadataProjector.externalFields(
+                from: .object(fields.merging(["untrusted": .string("drop")]) { current, _ in current }),
+                toolName: "click")
+            let agent = MCPToolResponseMetadataProjector.agentFields(
+                from: .object(fields.merging(["untrusted": .string("drop")]) { current, _ in current }))
+            #expect(external == fields)
+            #expect(agent == fields)
+        }
+    }
+
+    @Test
+    func `partial failure stays dispatched without demanding fresh observation`() throws {
+        let twoUnits = try #require(DesktopActionOutcome.DispatchUnitCount(rawValue: 2))
+        let failure = DesktopActionFailure.partial(
+            delivery: .init(mechanism: .accessibilityAction, mode: .background),
+            unitCount: twoUnits,
+            message: "Primary change completed but cleanup failed",
+            hint: "Recover the remaining side effect.")
+
+        let response = try MCPToolResponseMetadataProjector.errorResponse(
+            for: failure,
+            invalidatedSnapshotID: "snapshot-1")
+        guard case let .object(meta) = response.meta else {
+            Issue.record("Expected canonical partial failure metadata")
+            return
+        }
+        #expect(meta["state"] == .string("partial"))
+        #expect(meta["effect"] == .string("partial"))
+        #expect(meta["mutation_dispatched"] == .bool(true))
+        #expect(meta["retry_safe"] == .bool(false))
+        #expect(meta["escalation"] == .string("recover_side_effect"))
+        #expect(meta["requires_fresh_observation"] == .bool(false))
+        #expect(meta["invalidated_snapshot"] == .string("snapshot-1"))
+
+        let wireResult = PeekabooMCPServer.callToolResult(from: response, toolName: "click")
+        let wireData = try JSONEncoder().encode(wireResult)
+        let wireJSON = try #require(JSONSerialization.jsonObject(with: wireData) as? [String: Any])
+        let wireMeta = try #require(wireJSON["_meta"] as? [String: Any])
+        #expect(wireMeta["state"] as? String == "partial")
+        #expect(wireMeta["escalation"] as? String == "recover_side_effect")
+        #expect(wireMeta["mutation_dispatched"] as? Bool == true)
+        #expect(wireMeta["retry_safe"] as? Bool == false)
+        #expect(wireMeta["requires_fresh_observation"] as? Bool == false)
+    }
+
+    private struct ProjectionExpectation {
+        let state: DesktopActionOutcome.State
+        let dispatched: Bool
+        let retrySafe: Bool
+        let fresh: Bool
+        let escalation: DesktopActionOutcome.Escalation
+    }
+}


### PR DESCRIPTION
## Summary

- serialize `DesktopActionOutcome.Projection` directly into MCP metadata instead of reconstructing effect/dispatch/retry fields locally
- expose the complete bounded canonical outcome vocabulary to external MCP and Agent consumers while continuing to drop untrusted metadata
- remove the incorrect inference that every dispatched failure requires a fresh observation
- preserve partial/recover-side-effect semantics exactly: dispatched and retry-unsafe, but not `observe_before_retry`
- propagate projection-encoding failure through ClickTool instead of silently returning a contradictory envelope

## Compatibility

Existing `effect`, `mutation_dispatched`, `retry_safe`, and `requires_fresh_observation` keys remain. The change adds the canonical state, route, delivery, evidence, dispatch, retry-safety, escalation, refusal, and unit-count fields and makes every compatibility value derive from the validated Foundation outcome.

## Proof

- canonical seven-state MCP wire matrix plus partial-failure regression: passed
- existing Agent tool/MCP bridge: 24 passed
- canonical click integration: passed
- full non-clipboard safe matrix: 881 Core/CLI tests + 86 runtime tests passed
- strict touched-file lint, format, diff hygiene: passed
- P0-P2 autoreview and TruffleHog: clean at 0.97
- post-rebase tree is byte-identical to the reviewed tree

No authorization, target, lane, clipboard, or AppleScript/JXA/OSA behavior changed.
