### PR TITLE
fix: certify exact source provenance

### DIFF
--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -19,7 +19,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Carry canonical desktop-action outcomes through capability-gated Bridge protocol 1.23 requests, preserving exact refused, partial, unverified, and indeterminate failures while older hosts remain conservative after a response is lost.
 - Project canonical desktop-action outcomes into MCP metadata, so partial failures retain recovery-side-effect semantics instead of incorrectly demanding a fresh observation.
-- Embed one canonical 40-hex source commit in clean stamped CLI and macOS app builds, expose it through `--version --json` and Bridge identity receipts, and leave raw unstamped builds explicitly `unknown`.
 - Correct `peekaboo bridge --help` and Bridge docs to describe capability-aware reusable-daemon, Peekaboo.app, on-demand-daemon, and local-fallback routing.
 - Refuse public raw `press` chords before dispatch unless `--foreground` is explicit, with canonical retry-safe refusal metadata and honest unverifiable foreground results.
 - Reject excess positional arguments unless a command declares a variadic tail, while preserving explicit multi-chord `press` sequences.

--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Carry canonical desktop-action outcomes through capability-gated Bridge protocol 1.23 requests, preserving exact refused, partial, unverified, and indeterminate failures while older hosts remain conservative after a response is lost.
 - Project canonical desktop-action outcomes into MCP metadata, so partial failures retain recovery-side-effect semantics instead of incorrectly demanding a fresh observation.
+- Embed one canonical 40-hex source commit in clean stamped CLI and macOS app builds, expose it through `--version --json` and Bridge identity receipts, and leave raw unstamped builds explicitly `unknown`.
 - Correct `peekaboo bridge --help` and Bridge docs to describe capability-aware reusable-daemon, Peekaboo.app, on-demand-daemon, and local-fallback routing.
 - Refuse public raw `press` chords before dispatch unless `--foreground` is explicit, with canonical retry-safe refusal metadata and honest unverifiable foreground results.
 - Reject excess positional arguments unless a command declares a variadic tail, while preserving explicit multi-chord `press` sequences.

--- a/Apps/CLI/Sources/PeekabooCLI/CLI/CommanderRuntimeRouter.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/CLI/CommanderRuntimeRouter.swift
@@ -142,7 +142,12 @@ enum CommanderRuntimeRouter {
     private static func handleVersionRequest(arguments: [String]) -> Bool {
         guard let first = arguments.first else { return false }
         guard self.isVersionToken(first) else { return false }
-        print(Version.fullVersion)
+        let jsonTokens = Set(["--json", "-j", "--json-output", "--jsonOutput"])
+        if arguments.dropFirst().contains(where: jsonTokens.contains) {
+            outputSuccessCodable(data: Version.metadata, logger: .shared)
+        } else {
+            print(Version.fullVersion)
+        }
         return true
     }
 

--- a/Apps/CLI/Sources/PeekabooCLI/CLI/Utilities/BuildStalenessChecker.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/CLI/Utilities/BuildStalenessChecker.swift
@@ -1,4 +1,5 @@
 import Foundation
+import PeekabooFoundation
 
 /// Check if the CLI binary is stale compared to the current git state.
 /// Only runs in debug builds when git config 'peekaboo.check-build-staleness' is true.
@@ -118,9 +119,8 @@ private func findGitConfigPath(startingAt path: String) -> String? {
 
 /// Check if the embedded git commit differs from the current git commit
 private func checkGitCommitStaleness() {
-    // Get embedded commit from build (strip -dirty suffix if present). Raw SwiftPM
-    // builds intentionally omit provenance, so avoid spawning Git for them.
-    let embeddedCommit = Version.gitCommit.replacingOccurrences(of: "-dirty", with: "")
+    // Raw SwiftPM builds intentionally omit exact provenance, so avoid spawning Git for them.
+    let embeddedCommit = Version.sourceCommit
     guard shouldCheckGitCommitStaleness(embeddedCommit: embeddedCommit) else {
         return
     }
@@ -128,7 +128,7 @@ private func checkGitCommitStaleness() {
     // Get current git commit hash
     let gitProcess = Process()
     gitProcess.executableURL = URL(fileURLWithPath: "/usr/bin/git")
-    gitProcess.arguments = ["rev-parse", "--short", "HEAD"]
+    gitProcess.arguments = ["rev-parse", "HEAD"]
 
     let gitPipe = Pipe()
     gitProcess.standardOutput = gitPipe
@@ -162,8 +162,7 @@ private func checkGitCommitStaleness() {
 }
 
 func shouldCheckGitCommitStaleness(embeddedCommit: String) -> Bool {
-    let commit = embeddedCommit.trimmingCharacters(in: .whitespacesAndNewlines)
-    return !commit.isEmpty && commit != "unknown"
+    SourceProvenance.exactCommit(embeddedCommit) != nil
 }
 
 /// Check if any tracked files have been modified after the build time

--- a/Apps/CLI/Sources/PeekabooCLI/Version.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Version.swift
@@ -1,10 +1,13 @@
 import Foundation
+import PeekabooFoundation
 
 enum Version {
     private static let values = VersionMetadata.resolve()
 
+    static let metadata = values
     static let current = values.current
     static let gitCommit = values.gitCommit
+    static let sourceCommit = values.sourceCommit
     static let gitCommitDate = values.gitCommitDate
     static let gitBranch = values.gitBranch
     static let buildDate = values.buildDate
@@ -15,9 +18,10 @@ enum Version {
 }
 
 enum VersionMetadata {
-    struct Values: Equatable, Sendable {
+    struct Values: Codable, Equatable, Sendable {
         let current: String
         let gitCommit: String
+        let sourceCommit: String
         let gitCommitDate: String
         let gitBranch: String
         let buildDate: String
@@ -31,6 +35,7 @@ enum VersionMetadata {
         return Values(
             current: "Peekaboo 0.0.0",
             gitCommit: "unknown",
+            sourceCommit: SourceProvenance.unknownCommit,
             gitCommitDate: "unknown",
             gitBranch: "unknown",
             buildDate: "unknown"
@@ -50,6 +55,7 @@ enum VersionMetadata {
         return Values(
             current: display,
             gitCommit: self.metadataValue(info["PeekabooGitCommit"]),
+            sourceCommit: SourceProvenance.normalizedCommit(info["PeekabooSourceCommit"] as? String),
             gitCommitDate: self.metadataValue(info["PeekabooGitCommitDate"]),
             gitBranch: self.metadataValue(info["PeekabooGitBranch"]),
             buildDate: self.metadataValue(info["PeekabooBuildDate"])

--- a/Apps/CLI/Sources/Resources/Info.plist
+++ b/Apps/CLI/Sources/Resources/Info.plist
@@ -22,5 +22,7 @@
 	<string>Peekaboo needs screen recording permission to capture screenshots and analyze window content.</string>
 	<key>PeekabooVersionDisplayString</key>
 	<string>Peekaboo 4.0.0</string>
+	<key>PeekabooSourceCommit</key>
+	<string>unknown</string>
 </dict>
 </plist>

--- a/Apps/CLI/Tests/CLIRuntimeTests/CLIRuntimeSmokeTests.swift
+++ b/Apps/CLI/Tests/CLIRuntimeTests/CLIRuntimeSmokeTests.swift
@@ -83,7 +83,7 @@ struct CLIRuntimeSmokeTests {
         let script = """
         #!/bin/sh
         case "$*" in
-          "rev-parse --short HEAD") echo "\(identity)-commit" ;;
+          "rev-parse HEAD") echo "\(identity)-commit" ;;
           "status --porcelain") exit 0 ;;
           "show -s --format=%ci HEAD") echo "2026-01-01 00:00:00 +0000" ;;
           "rev-parse --abbrev-ref HEAD") echo "\(identity)-branch" ;;
@@ -92,6 +92,28 @@ struct CLIRuntimeSmokeTests {
         """
         try Data(script.utf8).write(to: url, options: .atomic)
         try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: url.path)
+    }
+
+    @Test
+    func `version JSON exposes one explicit source commit`() async throws {
+        guard Self.ensureLocalRuntimeAvailable() else { return }
+        let result = try await TestChildProcess.runPeekaboo(["--version", "--json"])
+
+        #expect(result.status == .exited(0))
+        #expect(result.standardError.isEmpty)
+        let object = try #require(
+            JSONSerialization.jsonObject(with: Data(result.standardOutput.utf8)) as? [String: Any]
+        )
+        let data = try #require(object["data"] as? [String: Any])
+        let sourceCommit = try #require(data["sourceCommit"] as? String)
+        if ProcessInfo.processInfo.environment["PEEKABOO_CLI_BINARY"] == nil {
+            #expect(sourceCommit == "unknown")
+        } else {
+            #expect(sourceCommit == "unknown" || sourceCommit.range(
+                of: #"^[0-9a-f]{40}$"#,
+                options: .regularExpression
+            ) != nil)
+        }
     }
 
     @Test

--- a/Apps/CLI/Tests/CoreCLITests/BridgeStatusReportHintTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/BridgeStatusReportHintTests.swift
@@ -108,7 +108,8 @@ struct BridgeStatusReportHintTests {
             bundleIdentifier: "boo.peekaboo.mac",
             bundleShortVersion: "4.0.0",
             bundleVersion: "400",
-            codeSignatureHash: "abcdef"
+            codeSignatureHash: "abcdef",
+            sourceCommit: "0123456789abcdef0123456789abcdef01234567"
         )
         let handshake = BridgeTestFixtures.handshake(
             negotiatedVersion: PeekabooBridgeProtocolVersion(major: 1, minor: 21),
@@ -129,6 +130,8 @@ struct BridgeStatusReportHintTests {
             JSONSerialization.jsonObject(with: JSONEncoder().encode(report)) as? [String: Any]
         )
         #expect((object["hostIdentity"] as? [String: Any])?["processIdentifier"] as? Int == 4242)
+        #expect((object["hostIdentity"] as? [String: Any])?["sourceCommit"] as? String ==
+            "0123456789abcdef0123456789abcdef01234567")
         #expect(object["hostCapabilities"] as? [String] == [PeekabooBridgeHostCapability.backgroundBridgeHost])
     }
 }

--- a/Apps/CLI/Tests/CoreCLITests/UtilityTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/UtilityTests.swift
@@ -110,6 +110,7 @@ struct UtilityTests {
             #expect(values == VersionMetadata.Values(
                 current: "Peekaboo 4.2.0-beta.1",
                 gitCommit: "unknown",
+                sourceCommit: "unknown",
                 gitCommitDate: "unknown",
                 gitBranch: "unknown",
                 buildDate: "unknown"
@@ -122,6 +123,7 @@ struct UtilityTests {
                 "CFBundleShortVersionString": "4.2.0",
                 "PeekabooVersionDisplayString": "Peekaboo 4.2.0",
                 "PeekabooGitCommit": "abc1234-dirty",
+                "PeekabooSourceCommit": "0123456789abcdef0123456789abcdef01234567",
                 "PeekabooGitCommitDate": "2026-08-10 12:34:56 -0700",
                 "PeekabooGitBranch": "release/4.2.0",
                 "PeekabooBuildDate": "2026-08-10T19:35:00Z",
@@ -130,6 +132,7 @@ struct UtilityTests {
             #expect(values == VersionMetadata.Values(
                 current: "Peekaboo 4.2.0",
                 gitCommit: "abc1234-dirty",
+                sourceCommit: "0123456789abcdef0123456789abcdef01234567",
                 gitCommitDate: "2026-08-10 12:34:56 -0700",
                 gitBranch: "release/4.2.0",
                 buildDate: "2026-08-10T19:35:00Z"
@@ -141,6 +144,7 @@ struct UtilityTests {
             let expected = VersionMetadata.Values(
                 current: "Peekaboo 0.0.0",
                 gitCommit: "unknown",
+                sourceCommit: "unknown",
                 gitCommitDate: "unknown",
                 gitBranch: "unknown",
                 buildDate: "unknown"
@@ -148,6 +152,20 @@ struct UtilityTests {
 
             #expect(VersionMetadata.resolve(infoDictionary: nil) == expected)
             #expect(VersionMetadata.resolve(infoDictionary: ["CFBundleShortVersionString": "   "]) == expected)
+        }
+
+        @Test(arguments: [
+            "abc1234",
+            "0123456789abcdef0123456789abcdef0123456g",
+            "0123456789abcdef0123456789abcdef01234567-dirty",
+        ])
+        func `Malformed embedded source commits stay unknown`(_ sourceCommit: String) {
+            let values = VersionMetadata.resolve(infoDictionary: [
+                "CFBundleShortVersionString": "4.2.0",
+                "PeekabooSourceCommit": sourceCommit,
+            ])
+
+            #expect(values.sourceCommit == "unknown")
         }
     }
 
@@ -194,13 +212,16 @@ struct UtilityTests {
     @Suite(.tags(.safe))
     struct BuildStalenessCheckerTests {
         @Test(arguments: ["", "   ", "unknown"])
-        func `Missing embedded commits skip Git staleness checks`(commit: String) {
+        func `Missing source commits skip Git staleness checks`(commit: String) {
             #expect(!shouldCheckGitCommitStaleness(embeddedCommit: commit))
         }
 
         @Test
-        func `Embedded commit enables Git staleness checks`() {
-            #expect(shouldCheckGitCommitStaleness(embeddedCommit: "abc1234"))
+        func `Only canonical source commits enable Git staleness checks`() {
+            #expect(shouldCheckGitCommitStaleness(
+                embeddedCommit: "0123456789abcdef0123456789abcdef01234567"
+            ))
+            #expect(!shouldCheckGitCommitStaleness(embeddedCommit: "abc1234"))
         }
 
         @Test

--- a/Apps/Mac/Peekaboo.xcodeproj/project.pbxproj
+++ b/Apps/Mac/Peekaboo.xcodeproj/project.pbxproj
@@ -320,6 +320,7 @@
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
 				MARKETING_VERSION = 4.0.0;
+				PEEKABOO_SOURCE_COMMIT = unknown;
 				PRODUCT_BUNDLE_IDENTIFIER = boo.peekaboo.mac.debug;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -360,6 +361,7 @@
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
 				MARKETING_VERSION = 4.0.0;
+				PEEKABOO_SOURCE_COMMIT = unknown;
 				PRODUCT_BUNDLE_IDENTIFIER = boo.peekaboo.mac;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;

--- a/Apps/Mac/Peekaboo/Info.plist
+++ b/Apps/Mac/Peekaboo/Info.plist
@@ -50,6 +50,8 @@
 	</dict>
 	<key>NSScreenCaptureUsageDescription</key>
 	<string>Peekaboo needs screen recording permission to capture screenshots and analyze your screen content.</string>
+	<key>PeekabooSourceCommit</key>
+	<string>$(PEEKABOO_SOURCE_COMMIT)</string>
 	<key>SUEnableAutomaticChecks</key>
 	<true/>
 	<key>SUFeedURL</key>

--- a/Apps/Playground/scripts/peekaboo-perf.sh
+++ b/Apps/Playground/scripts/peekaboo-perf.sh
@@ -395,7 +395,7 @@ summary = {
     "environment": {
         "platform": platform.platform(),
         "python": platform.python_version(),
-        "git_commit": git_value(["rev-parse", "--short", "HEAD"]),
+        "git_commit": git_value(["rev-parse", "HEAD"]),
     },
 }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 ### Fixed
 - Carry canonical desktop-action outcomes through capability-gated Bridge protocol 1.23 requests, preserving exact refused, partial, unverified, and indeterminate failures while older hosts remain conservative after a response is lost.
 - Project canonical desktop-action outcomes into MCP metadata, so partial failures retain recovery-side-effect semantics instead of incorrectly demanding a fresh observation.
+- Embed one canonical 40-hex source commit in clean stamped CLI and macOS app builds, expose it through JSON/Bridge identity receipts, and require matching per-case socket/process-generation provenance for background certification while leaving raw unstamped builds explicitly `unknown`.
 - Correct `peekaboo bridge --help` and Bridge docs to describe capability-aware reusable-daemon, Peekaboo.app, on-demand-daemon, and local-fallback routing.
 - Refuse public raw `press` chords before dispatch unless explicit foreground consent is present, keep semantic background alternatives discoverable, and report foreground delivery as unverifiable instead of claiming the intended effect completed.
 - Reject excess positional arguments unless a command declares a variadic tail, while preserving explicit multi-chord `press` sequences.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,6 @@
 ### Fixed
 - Carry canonical desktop-action outcomes through capability-gated Bridge protocol 1.23 requests, preserving exact refused, partial, unverified, and indeterminate failures while older hosts remain conservative after a response is lost.
 - Project canonical desktop-action outcomes into MCP metadata, so partial failures retain recovery-side-effect semantics instead of incorrectly demanding a fresh observation.
-- Embed one canonical 40-hex source commit in clean stamped CLI and macOS app builds, expose it through JSON/Bridge identity receipts, and require matching per-case socket/process-generation provenance for background certification while leaving raw unstamped builds explicitly `unknown`.
 - Correct `peekaboo bridge --help` and Bridge docs to describe capability-aware reusable-daemon, Peekaboo.app, on-demand-daemon, and local-fallback routing.
 - Refuse public raw `press` chords before dispatch unless explicit foreground consent is present, keep semantic background alternatives discoverable, and report foreground delivery as unverifiable instead of claiming the intended effect completed.
 - Reject excess positional arguments unless a command declares a variadic tail, while preserving explicit multi-chord `press` sequences.

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeHostIdentity.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeHostIdentity.swift
@@ -1,6 +1,7 @@
 import Darwin
 import Foundation
 import PeekabooAutomationKit
+import PeekabooFoundation
 import Security
 
 extension PeekabooBridgeHostIdentity {
@@ -17,7 +18,8 @@ extension PeekabooBridgeHostIdentity {
             bundleIdentifier: bundle.bundleIdentifier,
             bundleShortVersion: info?["CFBundleShortVersionString"] as? String,
             bundleVersion: info?["CFBundleVersion"] as? String,
-            codeSignatureHash: Self.currentCodeSignatureHash())
+            codeSignatureHash: Self.currentCodeSignatureHash(),
+            sourceCommit: SourceProvenance.exactCommit(info?["PeekabooSourceCommit"] as? String))
     }
 
     private static func currentCodeSignatureHash() -> String? {

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeModels.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeModels.swift
@@ -268,6 +268,8 @@ public struct PeekabooBridgeHostIdentity: Codable, Sendable, Equatable {
     public let bundleShortVersion: String?
     public let bundleVersion: String?
     public let codeSignatureHash: String?
+    /// Canonical 40-hex source revision embedded by a stamped build.
+    public let sourceCommit: String?
 
     public init(
         processIdentifier: pid_t,
@@ -275,7 +277,8 @@ public struct PeekabooBridgeHostIdentity: Codable, Sendable, Equatable {
         bundleIdentifier: String?,
         bundleShortVersion: String?,
         bundleVersion: String?,
-        codeSignatureHash: String?)
+        codeSignatureHash: String?,
+        sourceCommit: String? = nil)
     {
         self.processIdentifier = processIdentifier
         self.processStartIdentity = processStartIdentity
@@ -284,6 +287,7 @@ public struct PeekabooBridgeHostIdentity: Codable, Sendable, Equatable {
         self.bundleShortVersion = bundleShortVersion
         self.bundleVersion = bundleVersion
         self.codeSignatureHash = codeSignatureHash
+        self.sourceCommit = sourceCommit
     }
 }
 

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeHostIdentityTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeHostIdentityTests.swift
@@ -34,11 +34,13 @@ struct PeekabooBridgeHostIdentityTests {
             bundleIdentifier: "boo.peekaboo.mac",
             bundleShortVersion: "4.0.0",
             bundleVersion: "400",
-            codeSignatureHash: "abcdef")
+            codeSignatureHash: "abcdef",
+            sourceCommit: "0123456789abcdef0123456789abcdef01234567")
 
         let data = try JSONEncoder.peekabooBridgeEncoder().encode(identity)
         let object = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
         #expect(object["processStartIdentityDecimal"] as? String == String(generation))
+        #expect(object["sourceCommit"] as? String == "0123456789abcdef0123456789abcdef01234567")
         #expect(try JSONDecoder.peekabooBridgeDecoder().decode(
             PeekabooBridgeHostIdentity.self,
             from: data).processStartIdentityDecimal == String(generation))
@@ -62,6 +64,7 @@ struct PeekabooBridgeHostIdentityTests {
             from: data)
         #expect(identity.processStartIdentity == 9_876_543)
         #expect(identity.processStartIdentityDecimal == nil)
+        #expect(identity.sourceCommit == nil)
     }
 
     @Test
@@ -92,7 +95,8 @@ struct PeekabooBridgeHostIdentityTests {
             bundleIdentifier: "boo.peekaboo.mac",
             bundleShortVersion: "4.0.0",
             bundleVersion: "400",
-            codeSignatureHash: "abcdef")
+            codeSignatureHash: "abcdef",
+            sourceCommit: "0123456789abcdef0123456789abcdef01234567")
         let server = await MainActor.run {
             PeekabooBridgeServer(
                 services: PeekabooServices(),

--- a/Core/PeekabooFoundation/Sources/PeekabooFoundation/SourceProvenance.swift
+++ b/Core/PeekabooFoundation/Sources/PeekabooFoundation/SourceProvenance.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+/// Canonical validation for immutable source-revision receipts embedded at build time.
+public enum SourceProvenance {
+    public static let unknownCommit = "unknown"
+
+    /// Returns a canonical full Git object name only when the stamp is exactly 40 lowercase hex characters.
+    public static func exactCommit(_ value: String?) -> String? {
+        guard let value else { return nil }
+        let bytes = value.utf8
+        guard bytes.count == 40,
+              bytes.allSatisfy({ byte in
+                  (48...57).contains(byte) || (97...102).contains(byte)
+              })
+        else { return nil }
+        return value
+    }
+
+    public static func normalizedCommit(_ value: String?) -> String {
+        self.exactCommit(value) ?? self.unknownCommit
+    }
+}

--- a/Core/PeekabooFoundation/Tests/PeekabooFoundationTests/SourceProvenanceTests.swift
+++ b/Core/PeekabooFoundation/Tests/PeekabooFoundationTests/SourceProvenanceTests.swift
@@ -1,0 +1,27 @@
+import Testing
+@testable import PeekabooFoundation
+
+struct SourceProvenanceTests {
+    private let exact = "0123456789abcdef0123456789abcdef01234567"
+
+    @Test
+    func `exact commit accepts one canonical full object name`() {
+        #expect(SourceProvenance.exactCommit(self.exact) == self.exact)
+        #expect(SourceProvenance.normalizedCommit(self.exact) == self.exact)
+    }
+
+    @Test(arguments: [
+        nil,
+        "",
+        "unknown",
+        "0123456789abcdef0123456789abcdef0123456",
+        "0123456789abcdef0123456789abcdef012345678",
+        "0123456789ABCDEF0123456789ABCDEF01234567",
+        "0123456789abcdef0123456789abcdef0123456g",
+        "0123456789abcdef0123456789abcdef01234567-dirty",
+    ] as [String?])
+    func `malformed source stamps remain explicitly unknown`(_ value: String?) {
+        #expect(SourceProvenance.exactCommit(value) == nil)
+        #expect(SourceProvenance.normalizedCommit(value) == "unknown")
+    }
+}

--- a/docs/install.md
+++ b/docs/install.md
@@ -50,8 +50,11 @@ pnpm run build:swift:all   # universal release
 ```
 
 The output binary lives under `Apps/CLI/.build/...`. See [building.md](building.md) for signing and notarization.
-Raw SwiftPM/debug builds use stable `unknown` placeholders for Git and build-time metadata. Use the repository's
-stamped debug or release build scripts when `peekaboo --version` must include immutable commit and build-date provenance.
+Raw SwiftPM and manual unstamped Xcode builds use stable `unknown` placeholders for source and build-time metadata.
+Use the repository's stamped debug or release build scripts from a clean checkout when `peekaboo --version --json`
+must include immutable provenance; stamped builds refuse dirty or unverifiable source trees.
+`peekaboo --version --json` exposes the canonical 40-hex `sourceCommit`; background certification requires it and
+pins one exact Bridge socket for remote execution, requiring that host to advertise the same source commit.
 
 ## Verify
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -51,8 +51,9 @@ pnpm run build:swift:all   # universal release
 
 The output binary lives under `Apps/CLI/.build/...`. See [building.md](building.md) for signing and notarization.
 Raw SwiftPM and manual unstamped Xcode builds use stable `unknown` placeholders for source and build-time metadata.
-Use the repository's stamped debug or release build scripts from a clean checkout when `peekaboo --version --json`
-must include immutable provenance; stamped builds refuse dirty or unverifiable source trees.
+Use the repository's debug or release build scripts from a clean checkout when `peekaboo --version --json` must
+include immutable provenance. Dirty or unverifiable debug builds remain available but report `sourceCommit: unknown`;
+release builds and debug builds with `PEEKABOO_REQUIRE_SOURCE_PROVENANCE=1` refuse that source state.
 `peekaboo --version --json` exposes the canonical 40-hex `sourceCommit`; background certification requires it and
 pins one exact Bridge socket for remote execution, requiring that host to advertise the same source commit.
 

--- a/docs/testing/background-computer-use.md
+++ b/docs/testing/background-computer-use.md
@@ -32,6 +32,12 @@ post-launch PID to mint ownership or issues a separate unpinned quit that could 
 the target process and intentionally do not claim sibling-window isolation. Fixture windows open through background
 semantic menu actions rather than uncertified raw shortcuts.
 The harness invokes the current CLI directly; it does not use AppleScript or a command runner.
+Certification requires a stamped CLI whose `--version --json` output contains one canonical 40-hex `sourceCommit`.
+Remote certification pins every command to one exact Bridge socket and requires its additive host-identity receipt to
+expose the same source commit. Raw SwiftPM and manual unstamped Xcode builds report `unknown` and are intentionally
+refused for certification. The validated certification report records both stamps and rejects missing or mismatched
+provenance when artifacts are replayed. Every monitored case brackets its command with exact socket, PID, and
+process-generation attestations; a restarted or rebound Bridge host invalidates that case.
 
 Every background case starts only after the 10 ms monitor completes its first sample and publishes a sequence
 heartbeat. After the command and its restoration checks finish, the case waits for that sequence to advance again; an

--- a/docs/testing/background-computer-use.md
+++ b/docs/testing/background-computer-use.md
@@ -13,9 +13,10 @@ Run the source-controlled harness from the repository root:
 scripts/test-background-computer-use.sh
 ```
 
-It builds the Playground fixture, signs it with the OpenClaw Foundation Developer ID, launches it without activation,
-and samples the app that is already frontmost as the per-row sentinel. It never activates Calculator or restores a
-stale foreground app after the run. It then exercises fresh, exact PID/window snapshots through
+It builds the Playground fixture, signs it with the OpenClaw Foundation Developer ID, and samples the already-frontmost
+app/window as the sentinel. It explicitly foreground-launches the controlled fixture before monitoring, then restores
+and verifies that exact sentinel window. The monitored phase never activates Calculator or restores a stale foreground
+app after the run. It then exercises fresh, exact PID/window snapshots through
 `see` (including AX-only and screenshot-only modes), `capture live`, click by ID and query, `type`, raw-press refusal, `paste`,
 `set-value`, `action`, and Accessibility-only targeted scroll. Stale snapshots and unsupported named AX actions must
 fail nonzero instead of falling back to foreground synthesis. Targeted scroll must report confirmed Accessibility

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test:safe": "pnpm run test:ambient-state-policy && scripts/test-source-provenance.sh && scripts/test-release-signing-policy.sh && scripts/test-swift-runtime-libraries.sh && scripts/test-create-release-dmg.sh && scripts/test-restart-peekaboo.sh && node scripts/test-update-appcast-entry.mjs && node --no-warnings scripts/test-chrome-devtools-mcp-contract.mjs && pnpm run test:release-preflight && pnpm run test:background-certification && swift test --package-path Core/PeekabooFoundation && PEEKABOO_INCLUDE_AMBIENT_STATE_TESTS=false swift test --package-path Apps/CLI -Xswiftc -DPEEKABOO_SKIP_AUTOMATION --no-parallel",
     "test:ambient-state-policy": "node --test tests/ambient-state-test-policy.test.mjs",
     "test:release-preflight": "node --test tests/release-preflight-contract.test.mjs",
-    "test:background-certification": "node --test tests/background-computer-use-report.test.mjs",
+    "test:background-certification": "scripts/test-background-certification.sh",
     "test:automation": "PEEKABOO_INCLUDE_AUTOMATION_TESTS=true swift test --package-path Apps/CLI --no-parallel",
     "test:automation:read": "RUN_AUTOMATION_READ=true PEEKABOO_INCLUDE_AUTOMATION_TESTS=true swift test --package-path Apps/CLI --no-parallel",
     "test:automation:input": "PEEKABOO_INCLUDE_AUTOMATION_TESTS=true PEEKABOO_RUN_INPUT_AUTOMATION_TESTS=true swift test --package-path Core/PeekabooCore --no-parallel",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "app:restart": "./scripts/restart-peekaboo.sh",
     "app:install-companion": "./scripts/restart-peekaboo.sh --deployment",
     "build": "pnpm run build:cli",
-    "test:safe": "pnpm run test:ambient-state-policy && scripts/test-release-signing-policy.sh && scripts/test-swift-runtime-libraries.sh && scripts/test-create-release-dmg.sh && scripts/test-restart-peekaboo.sh && node scripts/test-update-appcast-entry.mjs && node --no-warnings scripts/test-chrome-devtools-mcp-contract.mjs && pnpm run test:release-preflight && pnpm run test:background-certification && PEEKABOO_INCLUDE_AMBIENT_STATE_TESTS=false swift test --package-path Apps/CLI -Xswiftc -DPEEKABOO_SKIP_AUTOMATION --no-parallel",
+    "test:safe": "pnpm run test:ambient-state-policy && scripts/test-source-provenance.sh && scripts/test-release-signing-policy.sh && scripts/test-swift-runtime-libraries.sh && scripts/test-create-release-dmg.sh && scripts/test-restart-peekaboo.sh && node scripts/test-update-appcast-entry.mjs && node --no-warnings scripts/test-chrome-devtools-mcp-contract.mjs && pnpm run test:release-preflight && pnpm run test:background-certification && swift test --package-path Core/PeekabooFoundation && PEEKABOO_INCLUDE_AMBIENT_STATE_TESTS=false swift test --package-path Apps/CLI -Xswiftc -DPEEKABOO_SKIP_AUTOMATION --no-parallel",
     "test:ambient-state-policy": "node --test tests/ambient-state-test-policy.test.mjs",
     "test:release-preflight": "node --test tests/release-preflight-contract.test.mjs",
     "test:background-certification": "node --test tests/background-computer-use-report.test.mjs",

--- a/scripts/build-mac-debug.sh
+++ b/scripts/build-mac-debug.sh
@@ -6,7 +6,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 # shellcheck source=scripts/source-provenance.sh
 source "$PROJECT_ROOT/scripts/source-provenance.sh"
-if ! SOURCE_COMMIT="$(peekaboo_require_source_commit "$PROJECT_ROOT")"; then
+if ! SOURCE_COMMIT="$(peekaboo_debug_source_commit "$PROJECT_ROOT")"; then
     exit 1
 fi
 
@@ -104,7 +104,8 @@ xcodebuild \
 BUILD_EXIT_CODE=${PIPESTATUS[0]}
 
 if [ $BUILD_EXIT_CODE -eq 0 ]; then
-    if ! peekaboo_verify_source_commit "$PROJECT_ROOT" "$SOURCE_COMMIT"; then
+    if peekaboo_is_exact_source_commit "$SOURCE_COMMIT" && \
+       ! peekaboo_verify_source_commit "$PROJECT_ROOT" "$SOURCE_COMMIT"; then
         exit 1
     fi
     echo -e "${GREEN}✅ Build successful${NC}"

--- a/scripts/build-mac-debug.sh
+++ b/scripts/build-mac-debug.sh
@@ -4,6 +4,11 @@ set -o pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=scripts/source-provenance.sh
+source "$PROJECT_ROOT/scripts/source-provenance.sh"
+if ! SOURCE_COMMIT="$(peekaboo_require_source_commit "$PROJECT_ROOT")"; then
+    exit 1
+fi
 
 # Colors for output
 RED='\033[0;31m'
@@ -92,12 +97,16 @@ xcodebuild \
     -destination "$DESTINATION" \
     build \
     ONLY_ACTIVE_ARCH=YES \
+    PEEKABOO_SOURCE_COMMIT="$SOURCE_COMMIT" \
     "${SIGNING_SETTINGS[@]}" \
     2>&1 | pipe_build_output
 
 BUILD_EXIT_CODE=${PIPESTATUS[0]}
 
 if [ $BUILD_EXIT_CODE -eq 0 ]; then
+    if ! peekaboo_verify_source_commit "$PROJECT_ROOT" "$SOURCE_COMMIT"; then
+        exit 1
+    fi
     echo -e "${GREEN}✅ Build successful${NC}"
     
     # Find and report the app location

--- a/scripts/build-swift-arm.sh
+++ b/scripts/build-swift-arm.sh
@@ -4,6 +4,8 @@ set -o pipefail
 
 PROJECT_ROOT=$(cd "$(dirname "$0")/.." && pwd)
 SWIFT_PROJECT_PATH="$PROJECT_ROOT/Apps/CLI"
+# shellcheck source=scripts/source-provenance.sh
+source "$PROJECT_ROOT/scripts/source-provenance.sh"
 FINAL_BINARY_NAME="peekaboo"
 FINAL_BINARY_PATH="$PROJECT_ROOT/$FINAL_BINARY_NAME"
 SIGN_IDENTITY="${MAC_RELEASE_CODESIGN_IDENTITY:-${SIGN_IDENTITY:-}}"
@@ -100,7 +102,8 @@ generate_info_plist() {
     set_plist_value "$output" "CFBundleShortVersionString" "$VERSION"
     set_plist_value "$output" "CFBundleVersion" "$VERSION"
     set_plist_value "$output" "PeekabooVersionDisplayString" "$display"
-    set_plist_value "$output" "PeekabooGitCommit" "$GIT_COMMIT$GIT_DIRTY"
+    set_plist_value "$output" "PeekabooGitCommit" "$GIT_COMMIT_SHORT$GIT_DIRTY"
+    set_plist_value "$output" "PeekabooSourceCommit" "$SOURCE_COMMIT"
     set_plist_value "$output" "PeekabooGitCommitDate" "$GIT_COMMIT_DATE"
     set_plist_value "$output" "PeekabooGitBranch" "$GIT_BRANCH"
     set_plist_value "$output" "PeekabooBuildDate" "$BUILD_DATE"
@@ -126,8 +129,10 @@ echo "📦 Reading version from version.json..."
 VERSION=$(node -p "require('$PROJECT_ROOT/version.json').version")
 echo "Version: $VERSION"
 
-# Get git information
-GIT_COMMIT=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+# Get git information. Keep the historical short value for human display while
+# certification consumes the separate immutable full source commit.
+SOURCE_COMMIT=$(peekaboo_require_source_commit "$PROJECT_ROOT")
+GIT_COMMIT_SHORT=$(peekaboo_short_source_commit "$SOURCE_COMMIT")
 GIT_COMMIT_DATE=$(git show -s --format=%ci HEAD 2>/dev/null || echo "unknown")
 GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
 GIT_DIRTY=$(git diff --quiet && git diff --cached --quiet || echo "-dirty")
@@ -144,6 +149,7 @@ echo "🏗️ Building for arm64 (Apple Silicon) only..."
 ARM64_BUILD_BINARY=$(bash "$PROJECT_ROOT/scripts/resolve-swift-binary-path.sh" \
     "$SWIFT_PROJECT_PATH" arm64 release "$FINAL_BINARY_NAME")
 cp "$ARM64_BUILD_BINARY" "$FINAL_BINARY_PATH.tmp"
+peekaboo_verify_source_commit "$PROJECT_ROOT" "$SOURCE_COMMIT"
 echo "✅ arm64 build complete"
 
 echo "🤏 Stripping symbols for further size reduction..."

--- a/scripts/build-swift-debug.sh
+++ b/scripts/build-swift-debug.sh
@@ -118,11 +118,12 @@ VERSION=$(node -p "require('$PROJECT_ROOT/version.json').version" 2>/dev/null ||
 
 # Get git information. Keep the historical short value for human display while
 # certification consumes the separate immutable full source commit.
-SOURCE_COMMIT=$(peekaboo_require_source_commit "$PROJECT_ROOT")
-GIT_COMMIT_SHORT=$(peekaboo_short_source_commit "$SOURCE_COMMIT")
+SOURCE_COMMIT=$(peekaboo_debug_source_commit "$PROJECT_ROOT")
+HUMAN_SOURCE_COMMIT=$(peekaboo_source_commit_from_repo "$PROJECT_ROOT")
+GIT_COMMIT_SHORT=$(peekaboo_short_source_commit "$HUMAN_SOURCE_COMMIT")
 GIT_COMMIT_DATE=$(git show -s --format=%ci HEAD 2>/dev/null || echo "unknown")
 GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
-GIT_DIRTY=$(git diff --quiet && git diff --cached --quiet || echo "-dirty")
+GIT_DIRTY=$(peekaboo_source_dirty_suffix "$PROJECT_ROOT")
 BUILD_DATE=$(date -Iseconds)
 
 echo "🧾 Embedding version metadata in Info.plist..."
@@ -138,7 +139,9 @@ fi
     cd "$SWIFT_PROJECT_PATH"
     swift build 2>&1 | pipe_build_output
 )
-peekaboo_verify_source_commit "$PROJECT_ROOT" "$SOURCE_COMMIT"
+if peekaboo_is_exact_source_commit "$SOURCE_COMMIT"; then
+    peekaboo_verify_source_commit "$PROJECT_ROOT" "$SOURCE_COMMIT"
+fi
 
 echo "🔏 Code signing the debug binary..."
 PROJECT_NAME="peekaboo"

--- a/scripts/build-swift-debug.sh
+++ b/scripts/build-swift-debug.sh
@@ -4,6 +4,8 @@ set -o pipefail
 
 PROJECT_ROOT=$(cd "$(dirname "$0")/.." && pwd)
 SWIFT_PROJECT_PATH="$PROJECT_ROOT/Apps/CLI"
+# shellcheck source=scripts/source-provenance.sh
+source "$PROJECT_ROOT/scripts/source-provenance.sh"
 SIGN_IDENTITY="${SIGN_IDENTITY:-}"
 CODESIGN_TIMESTAMP="${CODESIGN_TIMESTAMP:-auto}"
 
@@ -89,7 +91,8 @@ generate_info_plist() {
     set_plist_value "$output" "CFBundleShortVersionString" "$VERSION"
     set_plist_value "$output" "CFBundleVersion" "$VERSION"
     set_plist_value "$output" "PeekabooVersionDisplayString" "$display"
-    set_plist_value "$output" "PeekabooGitCommit" "$GIT_COMMIT$GIT_DIRTY"
+    set_plist_value "$output" "PeekabooGitCommit" "$GIT_COMMIT_SHORT$GIT_DIRTY"
+    set_plist_value "$output" "PeekabooSourceCommit" "$SOURCE_COMMIT"
     set_plist_value "$output" "PeekabooGitCommitDate" "$GIT_COMMIT_DATE"
     set_plist_value "$output" "PeekabooGitBranch" "$GIT_BRANCH"
     set_plist_value "$output" "PeekabooBuildDate" "$BUILD_DATE"
@@ -113,8 +116,10 @@ fi
 echo "📦 Reading version from version.json..."
 VERSION=$(node -p "require('$PROJECT_ROOT/version.json').version" 2>/dev/null || echo "3.0.0-dev")
 
-# Get git information
-GIT_COMMIT=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+# Get git information. Keep the historical short value for human display while
+# certification consumes the separate immutable full source commit.
+SOURCE_COMMIT=$(peekaboo_require_source_commit "$PROJECT_ROOT")
+GIT_COMMIT_SHORT=$(peekaboo_short_source_commit "$SOURCE_COMMIT")
 GIT_COMMIT_DATE=$(git show -s --format=%ci HEAD 2>/dev/null || echo "unknown")
 GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
 GIT_DIRTY=$(git diff --quiet && git diff --cached --quiet || echo "-dirty")
@@ -133,6 +138,7 @@ fi
     cd "$SWIFT_PROJECT_PATH"
     swift build 2>&1 | pipe_build_output
 )
+peekaboo_verify_source_commit "$PROJECT_ROOT" "$SOURCE_COMMIT"
 
 echo "🔏 Code signing the debug binary..."
 PROJECT_NAME="peekaboo"

--- a/scripts/build-swift-universal.sh
+++ b/scripts/build-swift-universal.sh
@@ -4,6 +4,8 @@ set -o pipefail
 
 PROJECT_ROOT=$(cd "$(dirname "$0")/.." && pwd)
 SWIFT_PROJECT_PATH="$PROJECT_ROOT/Apps/CLI"
+# shellcheck source=scripts/source-provenance.sh
+source "$PROJECT_ROOT/scripts/source-provenance.sh"
 FINAL_BINARY_NAME="peekaboo"
 FINAL_BINARY_PATH="$PROJECT_ROOT/$FINAL_BINARY_NAME"
 SIGN_IDENTITY="${MAC_RELEASE_CODESIGN_IDENTITY:-${SIGN_IDENTITY:-}}"
@@ -108,7 +110,8 @@ generate_info_plist() {
     set_plist_value "$output" "CFBundleShortVersionString" "$VERSION"
     set_plist_value "$output" "CFBundleVersion" "$VERSION"
     set_plist_value "$output" "PeekabooVersionDisplayString" "$display"
-    set_plist_value "$output" "PeekabooGitCommit" "$GIT_COMMIT$GIT_DIRTY"
+    set_plist_value "$output" "PeekabooGitCommit" "$GIT_COMMIT_SHORT$GIT_DIRTY"
+    set_plist_value "$output" "PeekabooSourceCommit" "$SOURCE_COMMIT"
     set_plist_value "$output" "PeekabooGitCommitDate" "$GIT_COMMIT_DATE"
     set_plist_value "$output" "PeekabooGitBranch" "$GIT_BRANCH"
     set_plist_value "$output" "PeekabooBuildDate" "$BUILD_DATE"
@@ -129,8 +132,10 @@ echo "📦 Reading version from version.json..."
 VERSION=$(node -p "require('$PROJECT_ROOT/version.json').version")
 echo "Version: $VERSION"
 
-# Get git information
-GIT_COMMIT=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+# Get git information. Keep the historical short value for human display while
+# certification consumes the separate immutable full source commit.
+SOURCE_COMMIT=$(peekaboo_require_source_commit "$PROJECT_ROOT")
+GIT_COMMIT_SHORT=$(peekaboo_short_source_commit "$SOURCE_COMMIT")
 GIT_COMMIT_DATE=$(git show -s --format=%ci HEAD 2>/dev/null || echo "unknown")
 GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
 GIT_DIRTY=$(git diff --quiet && git diff --cached --quiet || echo "-dirty")
@@ -157,6 +162,7 @@ echo "🏗️ Building for x86_64 (Intel)..."
 X86_64_BUILD_BINARY=$(bash "$PROJECT_ROOT/scripts/resolve-swift-binary-path.sh" \
     "$SWIFT_PROJECT_PATH" x86_64 release "$FINAL_BINARY_NAME")
 cp "$X86_64_BUILD_BINARY" "$X86_64_BINARY_TEMP"
+peekaboo_verify_source_commit "$PROJECT_ROOT" "$SOURCE_COMMIT"
 echo "✅ x86_64 build complete: $X86_64_BINARY_TEMP"
 
 echo "🔗 Creating universal binary..."

--- a/scripts/release-binaries.sh
+++ b/scripts/release-binaries.sh
@@ -16,6 +16,8 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 # shellcheck source=scripts/native-only-policy.sh
 source "$SCRIPT_DIR/native-only-policy.sh"
+# shellcheck source=scripts/source-provenance.sh
+source "$SCRIPT_DIR/source-provenance.sh"
 BUILD_DIR="$PROJECT_ROOT/build"
 RELEASE_DIR="${RELEASE_DIR:-$BUILD_DIR/release}"
 MAC_RELEASE_MANIFEST="${MAC_RELEASE_MANIFEST:-$PROJECT_ROOT/.mac-release.env}"
@@ -80,6 +82,8 @@ verify_binary_artifact() {
     local binary_path="$1"
     local label="$2"
     local version_output
+    local provenance_json
+    local source_commit
     local binary_size
     local lipo_output
     local authority
@@ -125,6 +129,13 @@ verify_binary_artifact() {
     if printf '%s\n' "$version_output" | grep -Fq 'unknown'; then
         fail "$label has incomplete version provenance: $version_output"
     fi
+    provenance_json=$("$binary_path" --version --json)
+    source_commit=$(PROVENANCE_JSON="$provenance_json" node -e '
+        const parsed = JSON.parse(process.env.PROVENANCE_JSON);
+        process.stdout.write(parsed?.data?.sourceCommit ?? "");
+    ')
+    peekaboo_is_exact_source_commit "$source_commit" ||
+        fail "$label has no exact source commit in version JSON"
 }
 
 notarize_cli_binary() {

--- a/scripts/release-macos-app.sh
+++ b/scripts/release-macos-app.sh
@@ -8,7 +8,7 @@ ROOT="${ROOT:-$ROOT_DIR}"
 ROOT="$(cd "$ROOT" && pwd)"
 # shellcheck source=scripts/source-provenance.sh
 source "$ROOT/scripts/source-provenance.sh"
-SOURCE_COMMIT="$(peekaboo_require_source_commit "$ROOT")"
+SOURCE_COMMIT=""
 MAC_RELEASE_MANIFEST="${MAC_RELEASE_MANIFEST:-$ROOT/.mac-release.env}"
 MAC_RELEASE_MANIFEST_LOADED=false
 if [[ -f "$MAC_RELEASE_MANIFEST" ]]; then
@@ -228,6 +228,10 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+if [[ -z "$VERIFY_ONLY_ZIP" ]]; then
+  SOURCE_COMMIT="$(peekaboo_require_source_commit "$ROOT")"
+fi
+
 if [[ "$DRY_RUN" == true ]]; then
   NOTARIZE=false
   UPDATE_APPCAST=false
@@ -300,6 +304,7 @@ bundle_executable_name() {
 
 verify_app_payload() {
   local app_path="$1"
+  local provenance_status=0
   local source_commit
   local executable_name
   executable_name="$(bundle_executable_name "$app_path")"
@@ -316,12 +321,16 @@ verify_app_payload() {
 
   source_commit="$(/usr/libexec/PlistBuddy -c 'Print :PeekabooSourceCommit' \
     "$app_path/Contents/Info.plist" 2>/dev/null || true)"
-  peekaboo_verify_source_commit "$ROOT" "$SOURCE_COMMIT" ||
-    fail "Release root changed or became dirty while building: $ROOT"
-  peekaboo_is_exact_source_commit "$source_commit" ||
-    fail "App has no exact 40-hex source commit: $app_path"
-  [[ "$source_commit" == "$SOURCE_COMMIT" ]] ||
-    fail "App source commit does not match the release root: $app_path"
+  peekaboo_validate_artifact_source_commit "$ROOT" "$source_commit" "$SOURCE_COMMIT" ||
+    provenance_status=$?
+  case "$provenance_status" in
+    0) ;;
+    2) fail "App has no exact 40-hex source commit: $app_path" ;;
+    3) fail "Release expected source commit is invalid: $SOURCE_COMMIT" ;;
+    4) fail "Release root changed or became dirty while building: $ROOT" ;;
+    5) fail "App source commit does not match the release root: $app_path" ;;
+    *) fail "App source provenance validation failed: $app_path" ;;
+  esac
 
   "$ROOT_DIR/scripts/verify-native-only-app.sh" --app "$app_path"
 

--- a/scripts/release-macos-app.sh
+++ b/scripts/release-macos-app.sh
@@ -7,7 +7,7 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 ROOT="${ROOT:-$ROOT_DIR}"
 ROOT="$(cd "$ROOT" && pwd)"
 # shellcheck source=scripts/source-provenance.sh
-source "$ROOT_DIR/scripts/source-provenance.sh"
+source "$ROOT/scripts/source-provenance.sh"
 SOURCE_COMMIT="$(peekaboo_require_source_commit "$ROOT")"
 MAC_RELEASE_MANIFEST="${MAC_RELEASE_MANIFEST:-$ROOT/.mac-release.env}"
 MAC_RELEASE_MANIFEST_LOADED=false

--- a/scripts/release-macos-app.sh
+++ b/scripts/release-macos-app.sh
@@ -5,10 +5,14 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 ROOT="${ROOT:-$ROOT_DIR}"
-MAC_RELEASE_MANIFEST="${MAC_RELEASE_MANIFEST:-$ROOT_DIR/.mac-release.env}"
+ROOT="$(cd "$ROOT" && pwd)"
+# shellcheck source=scripts/source-provenance.sh
+source "$ROOT_DIR/scripts/source-provenance.sh"
+SOURCE_COMMIT="$(peekaboo_require_source_commit "$ROOT")"
+MAC_RELEASE_MANIFEST="${MAC_RELEASE_MANIFEST:-$ROOT/.mac-release.env}"
 MAC_RELEASE_MANIFEST_LOADED=false
 if [[ -f "$MAC_RELEASE_MANIFEST" ]]; then
-  pushd "$ROOT_DIR" >/dev/null
+  pushd "$ROOT" >/dev/null
   # shellcheck source=/Users/steipete/Projects/Peekaboo/.mac-release.env
   source "$MAC_RELEASE_MANIFEST"
   popd >/dev/null
@@ -17,7 +21,7 @@ fi
 MAC_RELEASE_HELPER_LOADED=false
 for candidate in \
   "${MAC_RELEASE_LIB:-}" \
-  "$ROOT_DIR/../agent-scripts/skills/release-mac-app/scripts/lib/mac_release.sh" \
+  "$ROOT/../agent-scripts/skills/release-mac-app/scripts/lib/mac_release.sh" \
   "$HOME/Projects/agent-scripts/skills/release-mac-app/scripts/lib/mac_release.sh"; do
   if [[ -n "$candidate" && -f "$candidate" ]]; then
     # shellcheck source=/Users/steipete/Projects/agent-scripts/skills/release-mac-app/scripts/lib/mac_release.sh
@@ -83,15 +87,15 @@ version_to_build_number() {
   printf '%d\n' $((((10#$major * 100 + 10#$minor) * 100 + 10#$patch) * 100 + 10#$suffix))
 }
 
-MARKETING_VERSION="${MARKETING_VERSION:-$(node -p "require('$ROOT_DIR/package.json').version")}"
+MARKETING_VERSION="${MARKETING_VERSION:-$(node -p "require('$ROOT/package.json').version")}"
 BUILD_NUMBER="${BUILD_NUMBER:-$(version_to_build_number "$MARKETING_VERSION")}"
 
-WORKSPACE="${WORKSPACE:-$ROOT_DIR/Apps/Peekaboo.xcworkspace}"
+WORKSPACE="${WORKSPACE:-$ROOT/Apps/Peekaboo.xcworkspace}"
 SCHEME="${SCHEME:-Peekaboo}"
 CONFIGURATION="${CONFIGURATION:-Release}"
 DESTINATION="${DESTINATION:-platform=macOS,arch=arm64}"
 DERIVED_DATA_PATH="${DERIVED_DATA_PATH:-/tmp/peekaboo-macos-app-release}"
-RELEASE_DIR="${RELEASE_DIR:-$ROOT_DIR/release}"
+RELEASE_DIR="${RELEASE_DIR:-$ROOT/release}"
 APP_NAME="${APP_NAME:-${MAC_RELEASE_APP_NAME:-Peekaboo}}"
 EXPECTED_SIGN_IDENTITY="Developer ID Application: OpenClaw Foundation (FWJYW4S8P8)"
 EXPECTED_TEAM_ID="FWJYW4S8P8"
@@ -99,11 +103,11 @@ EXPECTED_SIGN_REQUIREMENT="anchor apple generic and certificate leaf[subject.OU]
 SIGN_IDENTITY="${MAC_RELEASE_CODESIGN_IDENTITY:-${SIGN_IDENTITY:-$EXPECTED_SIGN_IDENTITY}}"
 NOTARYTOOL_PROFILE="${NOTARYTOOL_PROFILE:-${NOTARYTOOL_KEYCHAIN_PROFILE:-}}"
 APPCAST="${APPCAST:-${MAC_RELEASE_APPCAST:-appcast.xml}}"
-APPCAST_PATH="${APPCAST_PATH:-$ROOT_DIR/$APPCAST}"
+APPCAST_PATH="${APPCAST_PATH:-$ROOT/$APPCAST}"
 MINIMUM_SYSTEM_VERSION="${MINIMUM_SYSTEM_VERSION:-15.0}"
 REPOSITORY_SLUG="${REPOSITORY_SLUG:-${MAC_RELEASE_REPO:-openclaw/Peekaboo}}"
-ENTITLEMENTS_PATH="${ENTITLEMENTS_PATH:-$ROOT_DIR/Apps/Mac/Peekaboo/Peekaboo.entitlements}"
-DMG_BACKGROUND="${DMG_BACKGROUND:-$ROOT_DIR/assets/dmg-background.png}"
+ENTITLEMENTS_PATH="${ENTITLEMENTS_PATH:-$ROOT/Apps/Mac/Peekaboo/Peekaboo.entitlements}"
+DMG_BACKGROUND="${DMG_BACKGROUND:-$ROOT/assets/dmg-background.png}"
 
 VERSION="${VERSION:-$MARKETING_VERSION}"
 TAG="v${VERSION}"
@@ -296,6 +300,7 @@ bundle_executable_name() {
 
 verify_app_payload() {
   local app_path="$1"
+  local source_commit
   local executable_name
   executable_name="$(bundle_executable_name "$app_path")"
   local executable_path="$app_path/Contents/MacOS/$executable_name"
@@ -308,6 +313,15 @@ verify_app_payload() {
 
   file "$executable_path" | grep -q 'Mach-O' ||
     fail "Main executable is not a Mach-O binary: $executable_path"
+
+  source_commit="$(/usr/libexec/PlistBuddy -c 'Print :PeekabooSourceCommit' \
+    "$app_path/Contents/Info.plist" 2>/dev/null || true)"
+  peekaboo_verify_source_commit "$ROOT" "$SOURCE_COMMIT" ||
+    fail "Release root changed or became dirty while building: $ROOT"
+  peekaboo_is_exact_source_commit "$source_commit" ||
+    fail "App has no exact 40-hex source commit: $app_path"
+  [[ "$source_commit" == "$SOURCE_COMMIT" ]] ||
+    fail "App source commit does not match the release root: $app_path"
 
   "$ROOT_DIR/scripts/verify-native-only-app.sh" --app "$app_path"
 
@@ -432,6 +446,7 @@ else
     -quiet \
     MARKETING_VERSION="$VERSION" \
     CURRENT_PROJECT_VERSION="$BUILD_NUMBER" \
+    PEEKABOO_SOURCE_COMMIT="$SOURCE_COMMIT" \
     CODE_SIGNING_ALLOWED=NO \
     build
 fi

--- a/scripts/source-provenance.sh
+++ b/scripts/source-provenance.sh
@@ -70,6 +70,20 @@ peekaboo_verify_source_commit() {
   fi
 }
 
+# Validates an embedded artifact stamp independently for verify-only workflows,
+# or against the still-clean build checkout when an expected commit is supplied.
+peekaboo_validate_artifact_source_commit() {
+  local repository_root="${1:?repository root required}"
+  local artifact_commit="${2:-}"
+  local expected_commit="${3:-}"
+
+  peekaboo_is_exact_source_commit "$artifact_commit" || return 2
+  [[ -z "$expected_commit" ]] && return 0
+  peekaboo_is_exact_source_commit "$expected_commit" || return 3
+  peekaboo_verify_source_commit "$repository_root" "$expected_commit" || return 4
+  [[ "$artifact_commit" == "$expected_commit" ]] || return 5
+}
+
 peekaboo_source_dirty_suffix() {
   local repository_root="${1:?repository root required}"
   local checkout_status

--- a/scripts/source-provenance.sh
+++ b/scripts/source-provenance.sh
@@ -36,6 +36,28 @@ peekaboo_require_source_commit() {
   printf '%s\n' "$commit"
 }
 
+peekaboo_debug_source_commit() {
+  local repository_root="${1:?repository root required}"
+  local require_provenance="${PEEKABOO_REQUIRE_SOURCE_PROVENANCE:-0}"
+  local commit
+  case "$require_provenance" in
+    0|false|no|off|'') ;;
+    1|true|yes|on)
+      peekaboo_require_source_commit "$repository_root"
+      return
+      ;;
+    *)
+      printf 'Invalid PEEKABOO_REQUIRE_SOURCE_PROVENANCE value: %s\n' "$require_provenance" >&2
+      return 1
+      ;;
+  esac
+  if commit="$(peekaboo_require_source_commit "$repository_root" 2>/dev/null)"; then
+    printf '%s\n' "$commit"
+  else
+    printf '%s\n' unknown
+  fi
+}
+
 peekaboo_verify_source_commit() {
   local repository_root="${1:?repository root required}"
   local expected_commit="${2:?expected source commit required}"
@@ -45,6 +67,16 @@ peekaboo_verify_source_commit() {
     printf 'Source commit changed during the build: expected %s, found %s\n' \
       "$expected_commit" "$current_commit" >&2
     return 1
+  fi
+}
+
+peekaboo_source_dirty_suffix() {
+  local repository_root="${1:?repository root required}"
+  local checkout_status
+  if ! checkout_status="$(git -C "$repository_root" status \
+    --porcelain=v1 --untracked-files=all --ignore-submodules=none 2>/dev/null)" || \
+     [[ -n "$checkout_status" ]]; then
+    printf '%s\n' -dirty
   fi
 }
 

--- a/scripts/source-provenance.sh
+++ b/scripts/source-provenance.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+peekaboo_is_exact_source_commit() {
+  [[ "${1:-}" =~ ^[0-9a-f]{40}$ ]]
+}
+
+peekaboo_source_commit_from_repo() {
+  local repository_root="${1:?repository root required}"
+  local commit
+  commit="$(git -C "$repository_root" rev-parse HEAD 2>/dev/null || true)"
+  if peekaboo_is_exact_source_commit "$commit"; then
+    printf '%s\n' "$commit"
+  else
+    printf '%s\n' unknown
+  fi
+}
+
+peekaboo_require_source_commit() {
+  local repository_root="${1:?repository root required}"
+  local commit
+  local checkout_status
+  commit="$(peekaboo_source_commit_from_repo "$repository_root")"
+  if ! peekaboo_is_exact_source_commit "$commit"; then
+    printf 'Unable to resolve an exact source commit from %s\n' "$repository_root" >&2
+    return 1
+  fi
+  if ! checkout_status="$(git -C "$repository_root" status \
+    --porcelain=v1 --untracked-files=all --ignore-submodules=none 2>/dev/null)"; then
+    printf 'Unable to verify checkout cleanliness: %s\n' "$repository_root" >&2
+    return 1
+  fi
+  if [[ -n "$checkout_status" ]]; then
+    printf 'Refusing to stamp a source commit for a dirty checkout: %s\n' "$repository_root" >&2
+    return 1
+  fi
+  printf '%s\n' "$commit"
+}
+
+peekaboo_verify_source_commit() {
+  local repository_root="${1:?repository root required}"
+  local expected_commit="${2:?expected source commit required}"
+  local current_commit
+  current_commit="$(peekaboo_require_source_commit "$repository_root")" || return 1
+  if [[ "$current_commit" != "$expected_commit" ]]; then
+    printf 'Source commit changed during the build: expected %s, found %s\n' \
+      "$expected_commit" "$current_commit" >&2
+    return 1
+  fi
+}
+
+peekaboo_short_source_commit() {
+  local commit="${1:-}"
+  if peekaboo_is_exact_source_commit "$commit"; then
+    printf '%.9s\n' "$commit"
+  else
+    printf '%s\n' unknown
+  fi
+}

--- a/scripts/test-background-certification.sh
+++ b/scripts/test-background-certification.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ARTIFACT_ROOT="$(mktemp -d /tmp/peekaboo-background-certification.XXXXXX)"
+trap 'rm -rf "$ARTIFACT_ROOT"' EXIT
+
+"$ROOT_DIR/scripts/test-background-computer-use.sh" \
+  --self-test \
+  --bridge-socket "$ARTIFACT_ROOT/explicit-bridge.sock" \
+  --artifacts "$ARTIFACT_ROOT/harness"
+node --test "$ROOT_DIR/tests/background-computer-use-report.test.mjs"

--- a/scripts/test-background-computer-use.sh
+++ b/scripts/test-background-computer-use.sh
@@ -402,6 +402,33 @@ contamination_retry_allowed() {
     ' "$CERTIFICATION_CATALOG" >/dev/null
 }
 
+read_pinned_bridge_receipt() {
+    local status_file="${1:?Bridge status file required}"
+    jq -cer --arg socketPath "$BRIDGE_SOCKET" '
+        .data.selected |
+        select(.source == "remote" and .socketPath == $socketPath) |
+        . as $selected |
+        .handshake.hostIdentity as $identity |
+        select($identity != null) |
+        {
+            pid: $identity.processIdentifier,
+            startIdentity: (
+                $identity.processStartIdentityDecimal //
+                ($identity.processStartIdentity | tostring)
+            ),
+            socketPath: $selected.socketPath,
+            sourceCommit: $identity.sourceCommit
+        } |
+        select(
+            (.pid | type) == "number" and .pid > 0 and
+            (.startIdentity | type) == "string" and
+            (.startIdentity | test("^[0-9]+$")) and
+            (.sourceCommit | type) == "string" and
+            (.sourceCommit | test("^[0-9a-f]{40}$"))
+        )
+    ' "$status_file"
+}
+
 if $SELF_TEST_ONLY; then
     "$PROBE_BIN" process-identity --pid "$$" \
         --output "$ARTIFACT_ROOT/probe-process-identity.json"
@@ -411,6 +438,29 @@ if $SELF_TEST_ONLY; then
     same_process_generation 7 7
     if same_process_generation 7 8 || same_process_generation "" 7; then
         echo "Process-generation cleanup guard self-test failed." >&2
+        exit 1
+    fi
+    BRIDGE_RECEIPT_SELF_TEST="$ARTIFACT_ROOT/bridge-receipt-self-test.json"
+    jq -n \
+        --arg socketPath "$BRIDGE_SOCKET" \
+        '{
+            data: {selected: {
+                source: "remote",
+                socketPath: $socketPath,
+                handshake: {hostIdentity: {
+                    processIdentifier: 4242,
+                    processStartIdentityDecimal: "987654321",
+                    sourceCommit: "0123456789abcdef0123456789abcdef01234567"
+                }}
+            }}
+        }' > "$BRIDGE_RECEIPT_SELF_TEST"
+    read_pinned_bridge_receipt "$BRIDGE_RECEIPT_SELF_TEST" >/dev/null
+    jq --arg mismatchedSocket "${BRIDGE_SOCKET}.rerouted" \
+        '.data.selected.socketPath = $mismatchedSocket' \
+        "$BRIDGE_RECEIPT_SELF_TEST" > "$BRIDGE_RECEIPT_SELF_TEST.tmp"
+    mv "$BRIDGE_RECEIPT_SELF_TEST.tmp" "$BRIDGE_RECEIPT_SELF_TEST"
+    if read_pinned_bridge_receipt "$BRIDGE_RECEIPT_SELF_TEST" >/dev/null 2>&1; then
+        echo "Pinned Bridge receipt accepted a rerouted socket." >&2
         exit 1
     fi
     if [[ "$(certification_command_identity app launch TextEdit)" != "app launch" ]] || \
@@ -618,31 +668,6 @@ pb() {
     else
         "$PEEKABOO_BIN" "$@" --bridge-socket "$BRIDGE_SOCKET"
     fi
-}
-
-read_pinned_bridge_receipt() {
-    local status_file="${1:?Bridge status file required}"
-    jq -cer --arg socketPath "$BRIDGE_SOCKET" '
-        .data.selected |
-        select(.source == "remote") |
-        .handshake.hostIdentity as $identity |
-        select($identity != null) |
-        {
-            pid: $identity.processIdentifier,
-            startIdentity: (
-                $identity.processStartIdentityDecimal //
-                ($identity.processStartIdentity | tostring)
-            ),
-            socketPath: $socketPath,
-            sourceCommit: $identity.sourceCommit
-        } |
-        select(
-            (.pid | type) == "number" and .pid > 0 and
-            (.startIdentity | type) == "string" and test("^[0-9]+$") and
-            (.sourceCommit | type) == "string" and
-            (.sourceCommit | test("^[0-9a-f]{40}$"))
-        )
-    ' "$status_file"
 }
 
 if $NO_REMOTE; then
@@ -2045,6 +2070,7 @@ jq -s \
     --arg cliSourceCommit "$PEEKABOO_SOURCE_COMMIT" \
     --arg eventProducerSource "$EVENT_PRODUCER_SOURCE" \
     --arg eventProducerSourceCommit "$EVENT_PRODUCER_SOURCE_COMMIT" \
+    --arg requestedBridgeSocket "$BRIDGE_SOCKET" \
     --argjson remoteHost "$REMOTE_EVENT_PRODUCER_JSON" \
     '{
         probe_canary: ($probe[0].success == true),
@@ -2052,6 +2078,9 @@ jq -s \
             cli_source_commit: $cliSourceCommit,
             event_producer_source: $eventProducerSource,
             event_producer_source_commit: $eventProducerSourceCommit,
+            requested_bridge_socket: (
+                if $eventProducerSource == "remote" then $requestedBridgeSocket else null end
+            ),
             remote_host: $remoteHost
         },
         cases: .

--- a/scripts/test-background-computer-use.sh
+++ b/scripts/test-background-computer-use.sh
@@ -15,6 +15,7 @@ SKIP_PLAYGROUND_BUILD=false
 RUN_FOREGROUND_PHASE=false
 SELF_TEST_ONLY=false
 NO_REMOTE=false
+BRIDGE_SOCKET="${PEEKABOO_CERTIFICATION_BRIDGE_SOCKET:-${PEEKABOO_BRIDGE_SOCKET:-}}"
 
 usage() {
     cat <<'EOF'
@@ -31,6 +32,8 @@ Options:
   --skip-playground-build    Require --playground-app and skip xcodebuild
   --foreground-phase        Also run explicit physical-pointer tests
   --no-remote               Force the exact CLI process to use its local TCC grants
+  --bridge-socket PATH      Pin every remote command to one exact Bridge host
+                            (default: Peekaboo.app's bridge.sock)
   --sentinel-bundle-id ID   Require this app to already be frontmost (default: current app)
   --self-test               Compile and self-test the invariant probe only
   -h, --help                Show this help
@@ -63,6 +66,10 @@ while [[ $# -gt 0 ]]; do
             NO_REMOTE=true
             shift
             ;;
+        --bridge-socket)
+            BRIDGE_SOCKET="$2"
+            shift 2
+            ;;
         --sentinel-bundle-id)
             SENTINEL_BUNDLE_ID="$2"
             shift 2
@@ -82,6 +89,10 @@ while [[ $# -gt 0 ]]; do
             ;;
     esac
 done
+
+if ! $NO_REMOTE && [[ -z "$BRIDGE_SOCKET" ]]; then
+    BRIDGE_SOCKET="$HOME/Library/Application Support/Peekaboo/bridge.sock"
+fi
 
 if [[ "$(uname -s)" != "Darwin" ]]; then
     echo "This harness requires macOS." >&2
@@ -605,8 +616,33 @@ pb() {
     if $NO_REMOTE; then
         "$PEEKABOO_BIN" "$@" --no-remote
     else
-        "$PEEKABOO_BIN" "$@"
+        "$PEEKABOO_BIN" "$@" --bridge-socket "$BRIDGE_SOCKET"
     fi
+}
+
+read_pinned_bridge_receipt() {
+    local status_file="${1:?Bridge status file required}"
+    jq -cer --arg socketPath "$BRIDGE_SOCKET" '
+        .data.selected |
+        select(.source == "remote") |
+        .handshake.hostIdentity as $identity |
+        select($identity != null) |
+        {
+            pid: $identity.processIdentifier,
+            startIdentity: (
+                $identity.processStartIdentityDecimal //
+                ($identity.processStartIdentity | tostring)
+            ),
+            socketPath: $socketPath,
+            sourceCommit: $identity.sourceCommit
+        } |
+        select(
+            (.pid | type) == "number" and .pid > 0 and
+            (.startIdentity | type) == "string" and test("^[0-9]+$") and
+            (.sourceCommit | type) == "string" and
+            (.sourceCommit | test("^[0-9a-f]{40}$"))
+        )
+    ' "$status_file"
 }
 
 if $NO_REMOTE; then
@@ -619,6 +655,15 @@ if $NO_REMOTE; then
 fi
 
 pb --version > "$ARTIFACT_ROOT/peekaboo-version.txt"
+pb --version --json > "$ARTIFACT_ROOT/peekaboo-provenance.json"
+PEEKABOO_SOURCE_COMMIT="$(jq -er '
+    select(.success == true) |
+    .data.sourceCommit |
+    select(type == "string" and test("^[0-9a-f]{40}$"))
+' "$ARTIFACT_ROOT/peekaboo-provenance.json")" || {
+    echo "Background certification requires a stamped CLI with one exact 40-hex source commit." >&2
+    exit 2
+}
 pb permissions status --json > "$ARTIFACT_ROOT/permissions.json"
 if ! jq -e '
     .success == true and
@@ -628,31 +673,23 @@ if ! jq -e '
     exit 2
 fi
 
+EVENT_PRODUCER_SOURCE=local
+EVENT_PRODUCER_SOURCE_COMMIT="$PEEKABOO_SOURCE_COMMIT"
 REMOTE_EVENT_PRODUCER_JSON=null
 if ! $NO_REMOTE; then
     pb bridge status --verbose --json > "$ARTIFACT_ROOT/bridge-event-producer.json"
-    SELECTED_BRIDGE_SOURCE="$(jq -r '.data.selected.source // empty' \
-        "$ARTIFACT_ROOT/bridge-event-producer.json")"
-    if [[ "$SELECTED_BRIDGE_SOURCE" == "remote" ]]; then
-        REMOTE_EVENT_PRODUCER_JSON="$(jq -cer '
-            .data.selected.handshake.hostIdentity as $identity |
-            select($identity != null) |
-            {
-                pid: $identity.processIdentifier,
-                startIdentity: (
-                    $identity.processStartIdentityDecimal //
-                    ($identity.processStartIdentity | tostring)
-                )
-            } |
-            select(
-                (.pid | type) == "number" and .pid > 0 and
-                (.startIdentity | type) == "string" and test("^[0-9]+$")
-            )
-        ' "$ARTIFACT_ROOT/bridge-event-producer.json")" || {
-            echo "Selected Bridge host lacks an exact event-producer process receipt." >&2
-            exit 2
-        }
+    REMOTE_EVENT_PRODUCER_JSON="$(read_pinned_bridge_receipt \
+        "$ARTIFACT_ROOT/bridge-event-producer.json")" || {
+        echo "Pinned Bridge host lacks an exact event-producer source receipt." >&2
+        exit 2
+    }
+    BRIDGE_SOURCE_COMMIT="$(jq -er '.sourceCommit' <<<"$REMOTE_EVENT_PRODUCER_JSON")"
+    if [[ "$BRIDGE_SOURCE_COMMIT" != "$PEEKABOO_SOURCE_COMMIT" ]]; then
+        echo "CLI and pinned Bridge host were built from different source commits." >&2
+        exit 2
     fi
+    EVENT_PRODUCER_SOURCE=remote
+    EVENT_PRODUCER_SOURCE_COMMIT="$BRIDGE_SOURCE_COMMIT"
 fi
 
 build_playground() {
@@ -751,12 +788,30 @@ cleanup() {
 }
 trap cleanup EXIT INT TERM
 
+"$PROBE_BIN" sample --output "$ARTIFACT_ROOT/sentinel.json"
+SENTINEL_PID="$(jq -r '.frontmostPID // empty' "$ARTIFACT_ROOT/sentinel.json")"
+SENTINEL_WINDOW_ID="$(jq -r '.frontmostWindowID // empty' "$ARTIFACT_ROOT/sentinel.json")"
+SENTINEL_OBSERVED_BUNDLE_ID="$(jq -r '.frontmostBundleIdentifier // empty' \
+    "$ARTIFACT_ROOT/sentinel.json")"
+if [[ -z "$SENTINEL_PID" || -z "$SENTINEL_WINDOW_ID" ]]; then
+    echo "A foreground sentinel window is required for background certification." >&2
+    exit 1
+fi
+if [[ "$SENTINEL_OBSERVED_BUNDLE_ID" == "$PLAYGROUND_BUNDLE_ID" ]]; then
+    echo "A non-Playground foreground sentinel window is required for certification." >&2
+    exit 1
+fi
+if [[ -n "$SENTINEL_BUNDLE_ID" && "$SENTINEL_OBSERVED_BUNDLE_ID" != "$SENTINEL_BUNDLE_ID" ]]; then
+    echo "Required sentinel $SENTINEL_BUNDLE_ID is not already frontmost; refusing to activate it." >&2
+    exit 1
+fi
+
 if "$PROBE_BIN" find-app --bundle-id "$PLAYGROUND_BUNDLE_ID" >/dev/null 2>&1; then
     pb app quit --app "$PLAYGROUND_BUNDLE_ID" --json \
         > "$ARTIFACT_ROOT/playground-quit-existing.json" || true
 fi
 
-pb app launch "$PLAYGROUND_APP" --wait-ready --json \
+pb app launch "$PLAYGROUND_APP" --wait-ready --foreground --json \
     > "$ARTIFACT_ROOT/playground-launch.json"
 if ! read_launch_process_receipt "$ARTIFACT_ROOT/playground-launch.json" || \
    ! refresh_playground_process_receipt \
@@ -769,18 +824,15 @@ if ! kill -0 "$PLAYGROUND_PID" 2>/dev/null; then
     exit 1
 fi
 
-"$PROBE_BIN" sample --output "$ARTIFACT_ROOT/sentinel.json"
-SENTINEL_PID="$(jq -r '.frontmostPID // empty' "$ARTIFACT_ROOT/sentinel.json")"
-SENTINEL_WINDOW_ID="$(jq -r '.frontmostWindowID // empty' "$ARTIFACT_ROOT/sentinel.json")"
-SENTINEL_OBSERVED_BUNDLE_ID="$(jq -r '.frontmostBundleIdentifier // empty' \
-    "$ARTIFACT_ROOT/sentinel.json")"
-if [[ -z "$SENTINEL_PID" || -z "$SENTINEL_WINDOW_ID" ]] || \
-   [[ "$SENTINEL_PID" == "$PLAYGROUND_PID" ]]; then
-    echo "A non-Playground foreground window is required for background certification." >&2
-    exit 1
-fi
-if [[ -n "$SENTINEL_BUNDLE_ID" && "$SENTINEL_OBSERVED_BUNDLE_ID" != "$SENTINEL_BUNDLE_ID" ]]; then
-    echo "Required sentinel $SENTINEL_BUNDLE_ID is not already frontmost; refusing to activate it." >&2
+pb window focus --pid "$SENTINEL_PID" --window-id "$SENTINEL_WINDOW_ID" --verify --json \
+    > "$ARTIFACT_ROOT/sentinel-restore.json"
+"$PROBE_BIN" sample --output "$ARTIFACT_ROOT/sentinel-restored.json"
+if ! jq -e \
+    --argjson pid "$SENTINEL_PID" \
+    --argjson windowID "$SENTINEL_WINDOW_ID" \
+    '.frontmostPID == $pid and .frontmostWindowID == $windowID' \
+    "$ARTIFACT_ROOT/sentinel-restored.json" >/dev/null; then
+    echo "Foreground fixture launch did not restore the exact sentinel window." >&2
     exit 1
 fi
 
@@ -900,6 +952,8 @@ run_case() {
     local exit_file="$case_dir/exit-code.txt"
     local summary="$case_dir/summary.json"
     local failed=false
+    local case_remote_receipt=null
+    local event_producer_stable=true
     local observed_command=""
     local observed_phase=""
     local monitor_progress=true
@@ -1073,6 +1127,34 @@ run_case() {
         return 1
     fi
 
+    if ! $NO_REMOTE; then
+        pb bridge status --verbose --json > "$case_dir/bridge-before.json"
+        case_remote_receipt="$(read_pinned_bridge_receipt "$case_dir/bridge-before.json")" || {
+            abort_current_monitor
+            if [[ -n "$stale_window_id" ]]; then
+                restore_stale_window_bounds \
+                    "$case_dir/bridge-attestation-restore" \
+                    "$stale_window_id" "$stale_pid" \
+                    "$stale_original_x" "$stale_original_y" \
+                    "$stale_original_width" "$stale_original_height" || true
+            fi
+            record_failure "$name could not attest the pinned Bridge host before dispatch"
+            return 1
+        }
+        if [[ "$case_remote_receipt" != "$REMOTE_EVENT_PRODUCER_JSON" ]]; then
+            abort_current_monitor
+            if [[ -n "$stale_window_id" ]]; then
+                restore_stale_window_bounds \
+                    "$case_dir/bridge-generation-restore" \
+                    "$stale_window_id" "$stale_pid" \
+                    "$stale_original_x" "$stale_original_y" \
+                    "$stale_original_width" "$stale_original_height" || true
+            fi
+            record_failure "$name observed a changed pinned Bridge generation before dispatch"
+            return 1
+        fi
+    fi
+
     local command_gate="$case_dir/command.ready"
     (
         while [[ ! -f "$command_gate" ]]; do
@@ -1081,7 +1163,7 @@ run_case() {
         if $NO_REMOTE; then
             exec "$PEEKABOO_BIN" "$@" --json --no-remote
         else
-            exec "$PEEKABOO_BIN" "$@" --json
+            exec "$PEEKABOO_BIN" "$@" --json --bridge-socket "$BRIDGE_SOCKET"
         fi
     ) > "$result" 2> "$stderr_file" &
     local command_pid=$!
@@ -1106,7 +1188,7 @@ run_case() {
         --argjson revision "$command_pid" \
         --argjson pid "$command_pid" \
         --arg startIdentity "$command_start_identity" \
-        --argjson remote "$REMOTE_EVENT_PRODUCER_JSON" '
+        --argjson remote "$case_remote_receipt" '
         {
             revision: $revision,
             producers: (
@@ -1175,6 +1257,17 @@ run_case() {
     printf '%s\n' complete > "$phase.tmp"
     mv "$phase.tmp" "$phase"
     printf '%s\n' "$command_exit" > "$exit_file"
+
+    if ! $NO_REMOTE; then
+        local post_command_receipt=""
+        if ! pb bridge status --verbose --json > "$case_dir/bridge-after.json" ||
+           ! post_command_receipt="$(read_pinned_bridge_receipt "$case_dir/bridge-after.json")" ||
+           [[ "$post_command_receipt" != "$case_remote_receipt" ]]; then
+            event_producer_stable=false
+            record_failure "$name could not retain one pinned Bridge generation across dispatch"
+            failed=true
+        fi
+    fi
 
     if [[ -n "$setup_window_id" ]]; then
         set +e
@@ -1318,6 +1411,8 @@ run_case() {
         --argjson nonmaximizedPrecondition "$nonmaximized_precondition" \
         --argjson snapshotWindowDrift "$snapshot_window_drift" \
         --argjson targetWindowRestored "$target_window_restored" \
+        --argjson eventProducer "$case_remote_receipt" \
+        --argjson eventProducerStable "$event_producer_stable" \
         '{
             id: $id,
             surface: $surface,
@@ -1329,6 +1424,8 @@ run_case() {
             effect: $effect,
             delivery_mode: $deliveryMode,
             error_code: $errorCode,
+            event_producer: $eventProducer,
+            event_producer_stable: $eventProducerStable,
             invariants: $invariants,
             evidence: {
                 result_contract: $resultContract,
@@ -1936,28 +2033,29 @@ if $RUN_FOREGROUND_PHASE; then
     pb move --at "$ORIGINAL_CURSOR" --foreground --json \
         > "$FOREGROUND_DIR/restore-cursor.json"
 
-    # Relaunching the controlled fixture resets any visual/scroll state from this explicit phase.
-    pb app relaunch --pid "$PLAYGROUND_PID" --wait-until-ready --json \
-        > "$FOREGROUND_DIR/reset-playground.json"
-    if ! read_launch_process_receipt "$FOREGROUND_DIR/reset-playground.json" || \
-       ! refresh_playground_process_receipt \
-           "$LAUNCH_RECEIPT_PID" "$LAUNCH_RECEIPT_PROCESS_START_IDENTITY"; then
-        echo "Playground relaunch did not return a process-generation receipt." >&2
-        exit 1
-    fi
-    if ! kill -0 "$PLAYGROUND_PID" 2>/dev/null; then
-        echo "Playground relaunch receipt names a process that is no longer running." >&2
-        exit 1
-    fi
-    pb app switch --to "PID:$SENTINEL_PID" --verify --json \
+    pb window focus --pid "$SENTINEL_PID" --window-id "$SENTINEL_WINDOW_ID" --verify --json \
         > "$FOREGROUND_DIR/restore-sentinel.json"
 fi
 
 OBSERVED_CERTIFICATION="$ARTIFACT_ROOT/certification-observed.json"
 CERTIFICATION_RESULT="$ARTIFACT_ROOT/certification.json"
 case_summaries=("$ARTIFACT_ROOT"/cases/*/summary.json)
-jq -s --slurpfile probe "$ARTIFACT_ROOT/probe-self-test.json" \
-    '{probe_canary: ($probe[0].success == true), cases: .}' \
+jq -s \
+    --slurpfile probe "$ARTIFACT_ROOT/probe-self-test.json" \
+    --arg cliSourceCommit "$PEEKABOO_SOURCE_COMMIT" \
+    --arg eventProducerSource "$EVENT_PRODUCER_SOURCE" \
+    --arg eventProducerSourceCommit "$EVENT_PRODUCER_SOURCE_COMMIT" \
+    --argjson remoteHost "$REMOTE_EVENT_PRODUCER_JSON" \
+    '{
+        probe_canary: ($probe[0].success == true),
+        provenance: {
+            cli_source_commit: $cliSourceCommit,
+            event_producer_source: $eventProducerSource,
+            event_producer_source_commit: $eventProducerSourceCommit,
+            remote_host: $remoteHost
+        },
+        cases: .
+    }' \
     "${case_summaries[@]}" > "$OBSERVED_CERTIFICATION"
 set +e
 node "$CERTIFICATION_REPORTER" \
@@ -1973,6 +2071,7 @@ fi
 CASE_COUNT="$(find "$ARTIFACT_ROOT/cases" -name summary.json -type f | wc -l | tr -d ' ')"
 jq -n \
     --arg peekaboo "$(head -n 1 "$ARTIFACT_ROOT/peekaboo-version.txt")" \
+    --arg sourceCommit "$PEEKABOO_SOURCE_COMMIT" \
     --arg playgroundBundle "$PLAYGROUND_BUNDLE_ID" \
     --argjson playgroundPID "$PLAYGROUND_PID" \
     --argjson sentinelPID "$SENTINEL_PID" \
@@ -1984,6 +2083,7 @@ jq -n \
     '{
         success: ($failures == 0),
         peekaboo: $peekaboo,
+        source_commit: $sourceCommit,
         playground: {bundle_id: $playgroundBundle, pid: $playgroundPID},
         sentinel: {pid: $sentinelPID, window_id: $sentinelWindowID},
         cases: $cases,

--- a/scripts/test-extracted-cli-artifact.sh
+++ b/scripts/test-extracted-cli-artifact.sh
@@ -2,6 +2,8 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+# shellcheck source=scripts/source-provenance.sh
+source "$ROOT_DIR/scripts/source-provenance.sh"
 VERSION=$(node -p "require('$ROOT_DIR/package.json').version")
 ARTIFACT_DIR=$(mktemp -d /tmp/peekaboo-extracted-artifact.XXXXXX)
 trap 'rm -rf "$ARTIFACT_DIR"' EXIT
@@ -40,5 +42,14 @@ if printf '%s\n' "$VERSION_OUTPUT_1" | grep -Fq "unknown"; then
     echo "Extracted release CLI is missing embedded build metadata" >&2
     exit 1
 fi
+PROVENANCE_JSON=$("$EXTRACTED_DIR/peekaboo" --version --json)
+PROVENANCE_COMMIT=$(node -e '
+  const input = require("fs").readFileSync(0, "utf8");
+  process.stdout.write(JSON.parse(input).data.sourceCommit ?? "");
+' <<<"$PROVENANCE_JSON")
+peekaboo_is_exact_source_commit "$PROVENANCE_COMMIT" || {
+    echo "Extracted release CLI has no exact source commit in version JSON" >&2
+    exit 1
+}
 
 echo "test-extracted-cli-artifact: ok"

--- a/scripts/test-restart-peekaboo.sh
+++ b/scripts/test-restart-peekaboo.sh
@@ -776,6 +776,16 @@ fi
 # reject the app and Swift-package resource targets before compilation.
 build_signing_dir="${TEST_DIR}/build-signing"
 mkdir -p "${build_signing_dir}/bin"
+build_signing_source="${build_signing_dir}/source"
+mkdir -p "${build_signing_source}/scripts" "${build_signing_source}/Apps/Peekaboo.xcworkspace"
+: >"${build_signing_source}/Apps/Peekaboo.xcworkspace/contents.xcworkspacedata"
+cp "${ROOT_DIR}/scripts/build-mac-debug.sh" "${build_signing_source}/scripts/build-mac-debug.sh"
+cp "${ROOT_DIR}/scripts/source-provenance.sh" "${build_signing_source}/scripts/source-provenance.sh"
+git -C "${build_signing_source}" init -q
+git -C "${build_signing_source}" add scripts Apps
+git -C "${build_signing_source}" \
+  -c user.name=Peekaboo -c user.email=peekaboo@example.invalid \
+  commit -q -m fixture
 cat >"${build_signing_dir}/bin/xcodebuild" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
@@ -790,7 +800,7 @@ env \
   DERIVED_DATA_PATH="${build_signing_dir}/DerivedData" \
   DEBUG_CODE_SIGN_IDENTITY='Developer ID Application: Test (TESTTEAM)' \
   DEBUG_DEVELOPMENT_TEAM=TESTTEAM \
-  "${ROOT_DIR}/scripts/build-mac-debug.sh" >/dev/null
+  "${build_signing_source}/scripts/build-mac-debug.sh" >/dev/null
 grep -Fxq 'CODE_SIGN_STYLE=Manual' "${build_signing_dir}/developer-id-args" || \
   fail 'Developer ID build did not request manual signing'
 if grep -Fxq 'CODE_SIGN_STYLE=Automatic' "${build_signing_dir}/developer-id-args"; then
@@ -804,7 +814,7 @@ env \
   DERIVED_DATA_PATH="${build_signing_dir}/DerivedData" \
   DEBUG_CODE_SIGN_IDENTITY='Apple Development' \
   DEBUG_DEVELOPMENT_TEAM=TESTTEAM \
-  "${ROOT_DIR}/scripts/build-mac-debug.sh" >/dev/null
+  "${build_signing_source}/scripts/build-mac-debug.sh" >/dev/null
 grep -Fxq 'CODE_SIGN_STYLE=Automatic' "${build_signing_dir}/development-args" || \
   fail 'Apple Development build did not retain automatic signing'
 

--- a/scripts/test-restart-peekaboo.sh
+++ b/scripts/test-restart-peekaboo.sh
@@ -786,6 +786,7 @@ git -C "${build_signing_source}" add scripts Apps
 git -C "${build_signing_source}" \
   -c user.name=Peekaboo -c user.email=peekaboo@example.invalid \
   commit -q -m fixture
+build_signing_commit="$(git -C "${build_signing_source}" rev-parse HEAD)"
 cat >"${build_signing_dir}/bin/xcodebuild" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
@@ -803,6 +804,9 @@ env \
   "${build_signing_source}/scripts/build-mac-debug.sh" >/dev/null
 grep -Fxq 'CODE_SIGN_STYLE=Manual' "${build_signing_dir}/developer-id-args" || \
   fail 'Developer ID build did not request manual signing'
+grep -Fxq "PEEKABOO_SOURCE_COMMIT=${build_signing_commit}" \
+  "${build_signing_dir}/developer-id-args" || \
+  fail 'Clean debug app build did not stamp its exact source commit'
 if grep -Fxq 'CODE_SIGN_STYLE=Automatic' "${build_signing_dir}/developer-id-args"; then
   fail 'Developer ID build still requested automatic signing'
 fi
@@ -817,6 +821,33 @@ env \
   "${build_signing_source}/scripts/build-mac-debug.sh" >/dev/null
 grep -Fxq 'CODE_SIGN_STYLE=Automatic' "${build_signing_dir}/development-args" || \
   fail 'Apple Development build did not retain automatic signing'
+
+touch "${build_signing_source}/untracked-build-input"
+env \
+  PATH="${build_signing_dir}/bin:/usr/bin:/bin" \
+  PEEKABOO_TEST_XCODEBUILD_ARGS="${build_signing_dir}/dirty-args" \
+  CONFIGURATION=Debug \
+  DERIVED_DATA_PATH="${build_signing_dir}/DerivedData" \
+  DEBUG_CODE_SIGN_IDENTITY='Apple Development' \
+  DEBUG_DEVELOPMENT_TEAM=TESTTEAM \
+  "${build_signing_source}/scripts/build-mac-debug.sh" >/dev/null
+grep -Fxq 'PEEKABOO_SOURCE_COMMIT=unknown' "${build_signing_dir}/dirty-args" || \
+  fail 'Dirty debug app build did not remain explicitly unstamped'
+
+rm -f "${build_signing_dir}/strict-dirty-args"
+if env \
+  PATH="${build_signing_dir}/bin:/usr/bin:/bin" \
+  PEEKABOO_TEST_XCODEBUILD_ARGS="${build_signing_dir}/strict-dirty-args" \
+  PEEKABOO_REQUIRE_SOURCE_PROVENANCE=1 \
+  CONFIGURATION=Debug \
+  DERIVED_DATA_PATH="${build_signing_dir}/DerivedData" \
+  DEBUG_CODE_SIGN_IDENTITY='Apple Development' \
+  DEBUG_DEVELOPMENT_TEAM=TESTTEAM \
+  "${build_signing_source}/scripts/build-mac-debug.sh" >/dev/null 2>&1; then
+  fail 'Strict dirty debug app build unexpectedly succeeded'
+fi
+[[ ! -e "${build_signing_dir}/strict-dirty-args" ]] || \
+  fail 'Strict dirty debug app build reached xcodebuild before refusing'
 
 # The public package default delegates to the contributor Debug path without injecting any
 # Foundation or organization-owned signing identity.

--- a/scripts/test-source-provenance.sh
+++ b/scripts/test-source-provenance.sh
@@ -10,6 +10,8 @@ EXPECTED_COMMIT="$(git -C "$ROOT_DIR" rev-parse HEAD)"
 
 PROVENANCE_TEST_REPOSITORY="$(mktemp -d /tmp/peekaboo-source-test.XXXXXX)"
 [[ "$(peekaboo_source_commit_from_repo "$PROVENANCE_TEST_REPOSITORY")" == unknown ]]
+[[ "$(peekaboo_debug_source_commit "$PROVENANCE_TEST_REPOSITORY")" == unknown ]]
+[[ "$(peekaboo_source_dirty_suffix "$PROVENANCE_TEST_REPOSITORY")" == -dirty ]]
 if peekaboo_require_source_commit "$PROVENANCE_TEST_REPOSITORY" >/dev/null 2>&1; then
   echo "stamped source resolution unexpectedly accepted a non-repository" >&2
   exit 1
@@ -20,12 +22,23 @@ git -C "$PROVENANCE_TEST_REPOSITORY" \
   commit -q --allow-empty -m initial
 TEST_COMMIT="$(git -C "$PROVENANCE_TEST_REPOSITORY" rev-parse HEAD)"
 [[ "$(peekaboo_require_source_commit "$PROVENANCE_TEST_REPOSITORY")" == "$TEST_COMMIT" ]]
+[[ "$(peekaboo_debug_source_commit "$PROVENANCE_TEST_REPOSITORY")" == "$TEST_COMMIT" ]]
+[[ -z "$(peekaboo_source_dirty_suffix "$PROVENANCE_TEST_REPOSITORY")" ]]
+[[ "$(PEEKABOO_REQUIRE_SOURCE_PROVENANCE=1 \
+  peekaboo_debug_source_commit "$PROVENANCE_TEST_REPOSITORY")" == "$TEST_COMMIT" ]]
 mv "$PROVENANCE_TEST_REPOSITORY/.git/index" "$PROVENANCE_TEST_REPOSITORY/.git/index.saved"
 mkdir "$PROVENANCE_TEST_REPOSITORY/.git/index"
 if peekaboo_require_source_commit "$PROVENANCE_TEST_REPOSITORY" >/dev/null 2>&1; then
   echo "stamped source resolution ignored a Git status failure" >&2
   exit 1
 fi
+[[ "$(peekaboo_debug_source_commit "$PROVENANCE_TEST_REPOSITORY")" == unknown ]]
+if PEEKABOO_REQUIRE_SOURCE_PROVENANCE=1 \
+  peekaboo_debug_source_commit "$PROVENANCE_TEST_REPOSITORY" >/dev/null 2>&1; then
+  echo "strict debug source resolution ignored a Git status failure" >&2
+  exit 1
+fi
+[[ "$(peekaboo_source_dirty_suffix "$PROVENANCE_TEST_REPOSITORY")" == -dirty ]]
 rmdir "$PROVENANCE_TEST_REPOSITORY/.git/index"
 mv "$PROVENANCE_TEST_REPOSITORY/.git/index.saved" "$PROVENANCE_TEST_REPOSITORY/.git/index"
 touch "$PROVENANCE_TEST_REPOSITORY/untracked-build-input"
@@ -33,6 +46,13 @@ if peekaboo_require_source_commit "$PROVENANCE_TEST_REPOSITORY" >/dev/null 2>&1;
   echo "stamped source resolution unexpectedly accepted a dirty repository" >&2
   exit 1
 fi
+[[ "$(peekaboo_debug_source_commit "$PROVENANCE_TEST_REPOSITORY")" == unknown ]]
+if PEEKABOO_REQUIRE_SOURCE_PROVENANCE=1 \
+  peekaboo_debug_source_commit "$PROVENANCE_TEST_REPOSITORY" >/dev/null 2>&1; then
+  echo "strict debug source resolution unexpectedly accepted a dirty repository" >&2
+  exit 1
+fi
+[[ "$(peekaboo_source_dirty_suffix "$PROVENANCE_TEST_REPOSITORY")" == -dirty ]]
 rm -rf "$PROVENANCE_TEST_REPOSITORY"
 
 for malformed in \
@@ -47,7 +67,6 @@ for malformed in \
 done
 
 for build_script in \
-  "$ROOT_DIR/scripts/build-swift-debug.sh" \
   "$ROOT_DIR/scripts/build-swift-arm.sh" \
   "$ROOT_DIR/scripts/build-swift-universal.sh"; do
   rg -Fq 'PeekabooSourceCommit' "$build_script"
@@ -59,12 +78,19 @@ for build_script in \
   fi
 done
 
+rg -Fq 'peekaboo_debug_source_commit' "$ROOT_DIR/scripts/build-swift-debug.sh"
+rg -Fq 'peekaboo_source_commit_from_repo' "$ROOT_DIR/scripts/build-swift-debug.sh"
+rg -Fq 'peekaboo_source_dirty_suffix' "$ROOT_DIR/scripts/build-swift-debug.sh"
+rg -Fq 'peekaboo_verify_source_commit' "$ROOT_DIR/scripts/build-swift-debug.sh"
+
 rg -Fq '<key>PeekabooSourceCommit</key>' "$ROOT_DIR/Apps/CLI/Sources/Resources/Info.plist"
 rg -Fq '<string>unknown</string>' "$ROOT_DIR/Apps/CLI/Sources/Resources/Info.plist"
 rg -Fq '<string>$(PEEKABOO_SOURCE_COMMIT)</string>' "$ROOT_DIR/Apps/Mac/Peekaboo/Info.plist"
 rg -Fq 'PEEKABOO_SOURCE_COMMIT = unknown;' "$ROOT_DIR/Apps/Mac/Peekaboo.xcodeproj/project.pbxproj"
 rg -Fq 'PEEKABOO_SOURCE_COMMIT="$SOURCE_COMMIT"' "$ROOT_DIR/scripts/build-mac-debug.sh"
+rg -Fq 'peekaboo_debug_source_commit' "$ROOT_DIR/scripts/build-mac-debug.sh"
 rg -Fq 'PEEKABOO_SOURCE_COMMIT="$SOURCE_COMMIT"' "$ROOT_DIR/scripts/release-macos-app.sh"
+rg -Fq 'source "$ROOT/scripts/source-provenance.sh"' "$ROOT_DIR/scripts/release-macos-app.sh"
 rg -Fq 'SOURCE_COMMIT="$(peekaboo_require_source_commit "$ROOT")"' \
   "$ROOT_DIR/scripts/release-macos-app.sh"
 rg -Fq 'App has no exact 40-hex source commit' "$ROOT_DIR/scripts/release-macos-app.sh"

--- a/scripts/test-source-provenance.sh
+++ b/scripts/test-source-provenance.sh
@@ -99,7 +99,11 @@ rg -Fq 'sourceCommit' "$ROOT_DIR/scripts/test-background-computer-use.sh"
 rg -Fq 'source_commit' "$ROOT_DIR/scripts/test-background-computer-use.sh"
 rg -Fq 'bridge-before.json' "$ROOT_DIR/scripts/test-background-computer-use.sh"
 rg -Fq 'bridge-after.json' "$ROOT_DIR/scripts/test-background-computer-use.sh"
+rg -Fq '.socketPath == $socketPath' "$ROOT_DIR/scripts/test-background-computer-use.sh"
+rg -Fq 'requested_bridge_socket' "$ROOT_DIR/scripts/test-background-computer-use.sh"
 rg -Fq 'event_producer_stable' "$ROOT_DIR/scripts/test-background-computer-use.sh"
+rg -Fq -- '--bridge-socket "$ARTIFACT_ROOT/explicit-bridge.sock"' \
+  "$ROOT_DIR/scripts/test-background-certification.sh"
 rg -Fq 'exec "$PEEKABOO_BIN" "$@" --json --no-remote' \
   "$ROOT_DIR/scripts/test-background-computer-use.sh"
 rg -Fq 'exec "$PEEKABOO_BIN" "$@" --json --bridge-socket "$BRIDGE_SOCKET"' \

--- a/scripts/test-source-provenance.sh
+++ b/scripts/test-source-provenance.sh
@@ -21,11 +21,27 @@ git -C "$PROVENANCE_TEST_REPOSITORY" \
   -c user.name=Peekaboo -c user.email=peekaboo@example.invalid \
   commit -q --allow-empty -m initial
 TEST_COMMIT="$(git -C "$PROVENANCE_TEST_REPOSITORY" rev-parse HEAD)"
+HISTORICAL_COMMIT=0123456789abcdef0123456789abcdef01234567
 [[ "$(peekaboo_require_source_commit "$PROVENANCE_TEST_REPOSITORY")" == "$TEST_COMMIT" ]]
 [[ "$(peekaboo_debug_source_commit "$PROVENANCE_TEST_REPOSITORY")" == "$TEST_COMMIT" ]]
 [[ -z "$(peekaboo_source_dirty_suffix "$PROVENANCE_TEST_REPOSITORY")" ]]
 [[ "$(PEEKABOO_REQUIRE_SOURCE_PROVENANCE=1 \
   peekaboo_debug_source_commit "$PROVENANCE_TEST_REPOSITORY")" == "$TEST_COMMIT" ]]
+peekaboo_validate_artifact_source_commit "$PROVENANCE_TEST_REPOSITORY" "$TEST_COMMIT" "$TEST_COMMIT"
+peekaboo_validate_artifact_source_commit "$PROVENANCE_TEST_REPOSITORY" "$HISTORICAL_COMMIT" ""
+if peekaboo_validate_artifact_source_commit \
+  "$PROVENANCE_TEST_REPOSITORY" "$HISTORICAL_COMMIT" "$TEST_COMMIT"; then
+  echo "current-checkout validation unexpectedly accepted a historical artifact" >&2
+  exit 1
+else
+  [[ "$?" -eq 5 ]]
+fi
+if peekaboo_validate_artifact_source_commit "$PROVENANCE_TEST_REPOSITORY" unknown ""; then
+  echo "verify-only validation unexpectedly accepted an unstamped artifact" >&2
+  exit 1
+else
+  [[ "$?" -eq 2 ]]
+fi
 mv "$PROVENANCE_TEST_REPOSITORY/.git/index" "$PROVENANCE_TEST_REPOSITORY/.git/index.saved"
 mkdir "$PROVENANCE_TEST_REPOSITORY/.git/index"
 if peekaboo_require_source_commit "$PROVENANCE_TEST_REPOSITORY" >/dev/null 2>&1; then
@@ -53,6 +69,14 @@ if PEEKABOO_REQUIRE_SOURCE_PROVENANCE=1 \
   exit 1
 fi
 [[ "$(peekaboo_source_dirty_suffix "$PROVENANCE_TEST_REPOSITORY")" == -dirty ]]
+peekaboo_validate_artifact_source_commit "$PROVENANCE_TEST_REPOSITORY" "$HISTORICAL_COMMIT" ""
+if peekaboo_validate_artifact_source_commit \
+  "$PROVENANCE_TEST_REPOSITORY" "$TEST_COMMIT" "$TEST_COMMIT" >/dev/null 2>&1; then
+  echo "current-checkout validation unexpectedly accepted a dirty repository" >&2
+  exit 1
+else
+  [[ "$?" -eq 4 ]]
+fi
 rm -rf "$PROVENANCE_TEST_REPOSITORY"
 
 for malformed in \
@@ -93,6 +117,9 @@ rg -Fq 'PEEKABOO_SOURCE_COMMIT="$SOURCE_COMMIT"' "$ROOT_DIR/scripts/release-maco
 rg -Fq 'source "$ROOT/scripts/source-provenance.sh"' "$ROOT_DIR/scripts/release-macos-app.sh"
 rg -Fq 'SOURCE_COMMIT="$(peekaboo_require_source_commit "$ROOT")"' \
   "$ROOT_DIR/scripts/release-macos-app.sh"
+rg -Fq 'SOURCE_COMMIT=""' "$ROOT_DIR/scripts/release-macos-app.sh"
+rg -Fq 'if [[ -z "$VERIFY_ONLY_ZIP" ]]; then' "$ROOT_DIR/scripts/release-macos-app.sh"
+rg -Fq 'peekaboo_validate_artifact_source_commit' "$ROOT_DIR/scripts/release-macos-app.sh"
 rg -Fq 'App has no exact 40-hex source commit' "$ROOT_DIR/scripts/release-macos-app.sh"
 rg -Fq 'App source commit does not match the release root' "$ROOT_DIR/scripts/release-macos-app.sh"
 rg -Fq 'sourceCommit' "$ROOT_DIR/scripts/test-background-computer-use.sh"

--- a/scripts/test-source-provenance.sh
+++ b/scripts/test-source-provenance.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+source "$ROOT_DIR/scripts/source-provenance.sh"
+
+EXPECTED_COMMIT="$(git -C "$ROOT_DIR" rev-parse HEAD)"
+[[ "$(peekaboo_source_commit_from_repo "$ROOT_DIR")" == "$EXPECTED_COMMIT" ]]
+[[ "$(peekaboo_short_source_commit "$EXPECTED_COMMIT")" == "${EXPECTED_COMMIT:0:9}" ]]
+
+PROVENANCE_TEST_REPOSITORY="$(mktemp -d /tmp/peekaboo-source-test.XXXXXX)"
+[[ "$(peekaboo_source_commit_from_repo "$PROVENANCE_TEST_REPOSITORY")" == unknown ]]
+if peekaboo_require_source_commit "$PROVENANCE_TEST_REPOSITORY" >/dev/null 2>&1; then
+  echo "stamped source resolution unexpectedly accepted a non-repository" >&2
+  exit 1
+fi
+git -C "$PROVENANCE_TEST_REPOSITORY" init -q
+git -C "$PROVENANCE_TEST_REPOSITORY" \
+  -c user.name=Peekaboo -c user.email=peekaboo@example.invalid \
+  commit -q --allow-empty -m initial
+TEST_COMMIT="$(git -C "$PROVENANCE_TEST_REPOSITORY" rev-parse HEAD)"
+[[ "$(peekaboo_require_source_commit "$PROVENANCE_TEST_REPOSITORY")" == "$TEST_COMMIT" ]]
+mv "$PROVENANCE_TEST_REPOSITORY/.git/index" "$PROVENANCE_TEST_REPOSITORY/.git/index.saved"
+mkdir "$PROVENANCE_TEST_REPOSITORY/.git/index"
+if peekaboo_require_source_commit "$PROVENANCE_TEST_REPOSITORY" >/dev/null 2>&1; then
+  echo "stamped source resolution ignored a Git status failure" >&2
+  exit 1
+fi
+rmdir "$PROVENANCE_TEST_REPOSITORY/.git/index"
+mv "$PROVENANCE_TEST_REPOSITORY/.git/index.saved" "$PROVENANCE_TEST_REPOSITORY/.git/index"
+touch "$PROVENANCE_TEST_REPOSITORY/untracked-build-input"
+if peekaboo_require_source_commit "$PROVENANCE_TEST_REPOSITORY" >/dev/null 2>&1; then
+  echo "stamped source resolution unexpectedly accepted a dirty repository" >&2
+  exit 1
+fi
+rm -rf "$PROVENANCE_TEST_REPOSITORY"
+
+for malformed in \
+  '' unknown abc1234 \
+  0123456789abcdef0123456789abcdef0123456g \
+  0123456789ABCDEF0123456789ABCDEF01234567 \
+  0123456789abcdef0123456789abcdef01234567-dirty; do
+  if peekaboo_is_exact_source_commit "$malformed"; then
+    echo "unexpected valid source commit: $malformed" >&2
+    exit 1
+  fi
+done
+
+for build_script in \
+  "$ROOT_DIR/scripts/build-swift-debug.sh" \
+  "$ROOT_DIR/scripts/build-swift-arm.sh" \
+  "$ROOT_DIR/scripts/build-swift-universal.sh"; do
+  rg -Fq 'PeekabooSourceCommit' "$build_script"
+  rg -Fq 'peekaboo_require_source_commit' "$build_script"
+  rg -Fq 'peekaboo_verify_source_commit' "$build_script"
+  if rg -q 'rev-parse[[:space:]]+--short' "$build_script"; then
+    echo "short-only source commit stamping remains in $build_script" >&2
+    exit 1
+  fi
+done
+
+rg -Fq '<key>PeekabooSourceCommit</key>' "$ROOT_DIR/Apps/CLI/Sources/Resources/Info.plist"
+rg -Fq '<string>unknown</string>' "$ROOT_DIR/Apps/CLI/Sources/Resources/Info.plist"
+rg -Fq '<string>$(PEEKABOO_SOURCE_COMMIT)</string>' "$ROOT_DIR/Apps/Mac/Peekaboo/Info.plist"
+rg -Fq 'PEEKABOO_SOURCE_COMMIT = unknown;' "$ROOT_DIR/Apps/Mac/Peekaboo.xcodeproj/project.pbxproj"
+rg -Fq 'PEEKABOO_SOURCE_COMMIT="$SOURCE_COMMIT"' "$ROOT_DIR/scripts/build-mac-debug.sh"
+rg -Fq 'PEEKABOO_SOURCE_COMMIT="$SOURCE_COMMIT"' "$ROOT_DIR/scripts/release-macos-app.sh"
+rg -Fq 'SOURCE_COMMIT="$(peekaboo_require_source_commit "$ROOT")"' \
+  "$ROOT_DIR/scripts/release-macos-app.sh"
+rg -Fq 'App has no exact 40-hex source commit' "$ROOT_DIR/scripts/release-macos-app.sh"
+rg -Fq 'App source commit does not match the release root' "$ROOT_DIR/scripts/release-macos-app.sh"
+rg -Fq 'sourceCommit' "$ROOT_DIR/scripts/test-background-computer-use.sh"
+rg -Fq 'source_commit' "$ROOT_DIR/scripts/test-background-computer-use.sh"
+rg -Fq 'bridge-before.json' "$ROOT_DIR/scripts/test-background-computer-use.sh"
+rg -Fq 'bridge-after.json' "$ROOT_DIR/scripts/test-background-computer-use.sh"
+rg -Fq 'event_producer_stable' "$ROOT_DIR/scripts/test-background-computer-use.sh"
+rg -Fq 'exec "$PEEKABOO_BIN" "$@" --json --no-remote' \
+  "$ROOT_DIR/scripts/test-background-computer-use.sh"
+rg -Fq 'exec "$PEEKABOO_BIN" "$@" --json --bridge-socket "$BRIDGE_SOCKET"' \
+  "$ROOT_DIR/scripts/test-background-computer-use.sh"
+
+echo "test-source-provenance: ok"

--- a/scripts/validate-background-computer-use-report.mjs
+++ b/scripts/validate-background-computer-use-report.mjs
@@ -95,6 +95,100 @@ function matchesAllowedOutcome(outcome, observed) {
     && observed.error_code === outcome.error_code;
 }
 
+const exactSourceCommit = /^[0-9a-f]{40}$/;
+
+function isExactSourceCommit(value) {
+  return typeof value === "string" && value.length === 40 && exactSourceCommit.test(value);
+}
+
+function isExactRemoteHostReceipt(receipt) {
+  const keys = receipt && typeof receipt === "object" && !Array.isArray(receipt)
+    ? Object.keys(receipt).sort()
+    : [];
+  const expectedKeys = ["pid", "socketPath", "sourceCommit", "startIdentity"];
+  return keys.length === expectedKeys.length
+    && keys.every((key, index) => key === expectedKeys[index])
+    && Number.isSafeInteger(receipt.pid)
+    && receipt.pid > 0
+    && typeof receipt.startIdentity === "string"
+    && receipt.startIdentity.length > 0
+    && receipt.startIdentity[0] !== "0"
+    && [...receipt.startIdentity].every((character) => character >= "0" && character <= "9")
+    && typeof receipt.socketPath === "string"
+    && path.isAbsolute(receipt.socketPath)
+    && !["\0", "\r", "\n"].some((character) => receipt.socketPath.includes(character))
+    && isExactSourceCommit(receipt.sourceCommit);
+}
+
+function sameRemoteHostReceipt(left, right) {
+  return isExactRemoteHostReceipt(left)
+    && isExactRemoteHostReceipt(right)
+    && left.pid === right.pid
+    && left.startIdentity === right.startIdentity
+    && left.socketPath === right.socketPath
+    && left.sourceCommit === right.sourceCommit;
+}
+
+function validateProvenance(report, failures) {
+  const provenance = report?.provenance;
+  const keys = provenance && typeof provenance === "object" && !Array.isArray(provenance)
+    ? Object.keys(provenance).sort()
+    : [];
+  const expectedKeys = [
+    "cli_source_commit",
+    "event_producer_source",
+    "event_producer_source_commit",
+    "remote_host",
+  ];
+  if (keys.length !== expectedKeys.length
+      || keys.some((key, index) => key !== expectedKeys[index])) {
+    failures.push(failure(
+      "certification",
+      "provenance_schema",
+      "Provenance must be a closed CLI/event-producer source receipt",
+    ));
+    return;
+  }
+  if (!isExactSourceCommit(provenance.cli_source_commit)
+      || !isExactSourceCommit(provenance.event_producer_source_commit)) {
+    failures.push(failure(
+      "certification",
+      "source_commit",
+      "CLI and event-producer source commits must be canonical 40-hex values",
+    ));
+  }
+  if (!["local", "remote"].includes(provenance.event_producer_source)) {
+    failures.push(failure(
+      "certification",
+      "event_producer_source",
+      "Event-producer source must be local or remote",
+    ));
+  }
+  if (provenance.cli_source_commit !== provenance.event_producer_source_commit) {
+    failures.push(failure(
+      "certification",
+      "source_commit_mismatch",
+      "CLI and event-producer source commits differ",
+    ));
+  }
+  if (provenance.event_producer_source === "remote") {
+    if (!isExactRemoteHostReceipt(provenance.remote_host)
+        || provenance.remote_host.sourceCommit !== provenance.event_producer_source_commit) {
+      failures.push(failure(
+        "certification",
+        "remote_host_receipt",
+        "Remote certification requires one exact socket and process-generation source receipt",
+      ));
+    }
+  } else if (provenance.event_producer_source === "local" && provenance.remote_host !== null) {
+    failures.push(failure(
+      "certification",
+      "remote_host_receipt",
+      "Local certification must not claim a remote host receipt",
+    ));
+  }
+}
+
 export function validateCertification(catalog, report) {
   const failures = validateCatalog(catalog);
   if (failures.length > 0) {
@@ -110,6 +204,7 @@ export function validateCertification(catalog, report) {
   if (report?.probe_canary !== true) {
     failures.push(failure("certification", "canary", "Invariant probe self-test did not pass"));
   }
+  validateProvenance(report, failures);
 
   const observedCases = Array.isArray(report?.cases) ? report.cases : [];
   const catalogById = new Map(catalog.cases.map((entry) => [entry.id, entry]));
@@ -131,6 +226,24 @@ export function validateCertification(catalog, report) {
     if (!observed) {
       failures.push(failure(expected.id, "missing_case", `Required case '${expected.id}' is missing`));
       continue;
+    }
+    const provenance = report?.provenance;
+    const eventProducerMatches = provenance?.event_producer_source === "remote"
+      ? sameRemoteHostReceipt(observed.event_producer, provenance.remote_host)
+      : provenance?.event_producer_source === "local" && observed.event_producer === null;
+    if (!eventProducerMatches) {
+      failures.push(failure(
+        expected.id,
+        "event_producer_receipt",
+        "Case event producer does not match the certification provenance receipt",
+      ));
+    }
+    if (observed.event_producer_stable !== true) {
+      failures.push(failure(
+        expected.id,
+        "event_producer_stability",
+        "Case did not retain one event-producer generation across dispatch",
+      ));
     }
     for (const field of ["surface", "command", "phase"]) {
       if (observed[field] !== expected[field]) {
@@ -268,12 +381,24 @@ export function makePassingReport(catalog) {
       effect: selectedOutcome?.effect ?? entry.expected_effect ?? null,
       delivery_mode: entry.expected_delivery ?? null,
       error_code: selectedOutcome?.error_code ?? entry.expected_error_code ?? null,
+      event_producer: null,
+      event_producer_stable: true,
       invariants,
       evidence,
       oracles,
     };
   });
-  return { probe_canary: true, cases };
+  const sourceCommit = "0123456789abcdef0123456789abcdef01234567";
+  return {
+    probe_canary: true,
+    provenance: {
+      cli_source_commit: sourceCommit,
+      event_producer_source: "local",
+      event_producer_source_commit: sourceCommit,
+      remote_host: null,
+    },
+    cases,
+  };
 }
 
 function parseArguments(argv) {

--- a/scripts/validate-background-computer-use-report.mjs
+++ b/scripts/validate-background-computer-use-report.mjs
@@ -101,6 +101,12 @@ function isExactSourceCommit(value) {
   return typeof value === "string" && value.length === 40 && exactSourceCommit.test(value);
 }
 
+function isExactSocketPath(value) {
+  return typeof value === "string"
+    && path.isAbsolute(value)
+    && !["\0", "\r", "\n"].some((character) => value.includes(character));
+}
+
 function isExactRemoteHostReceipt(receipt) {
   const keys = receipt && typeof receipt === "object" && !Array.isArray(receipt)
     ? Object.keys(receipt).sort()
@@ -114,9 +120,7 @@ function isExactRemoteHostReceipt(receipt) {
     && receipt.startIdentity.length > 0
     && receipt.startIdentity[0] !== "0"
     && [...receipt.startIdentity].every((character) => character >= "0" && character <= "9")
-    && typeof receipt.socketPath === "string"
-    && path.isAbsolute(receipt.socketPath)
-    && !["\0", "\r", "\n"].some((character) => receipt.socketPath.includes(character))
+    && isExactSocketPath(receipt.socketPath)
     && isExactSourceCommit(receipt.sourceCommit);
 }
 
@@ -139,6 +143,7 @@ function validateProvenance(report, failures) {
     "event_producer_source",
     "event_producer_source_commit",
     "remote_host",
+    "requested_bridge_socket",
   ];
   if (keys.length !== expectedKeys.length
       || keys.some((key, index) => key !== expectedKeys[index])) {
@@ -180,7 +185,16 @@ function validateProvenance(report, failures) {
         "Remote certification requires one exact socket and process-generation source receipt",
       ));
     }
-  } else if (provenance.event_producer_source === "local" && provenance.remote_host !== null) {
+    if (!isExactSocketPath(provenance.requested_bridge_socket)
+        || provenance.remote_host?.socketPath !== provenance.requested_bridge_socket) {
+      failures.push(failure(
+        "certification",
+        "bridge_socket_mismatch",
+        "Remote host receipt does not match the exact requested Bridge socket",
+      ));
+    }
+  } else if (provenance.event_producer_source === "local"
+      && (provenance.remote_host !== null || provenance.requested_bridge_socket !== null)) {
     failures.push(failure(
       "certification",
       "remote_host_receipt",
@@ -395,6 +409,7 @@ export function makePassingReport(catalog) {
       cli_source_commit: sourceCommit,
       event_producer_source: "local",
       event_producer_source_commit: sourceCommit,
+      requested_bridge_socket: null,
       remote_host: null,
     },
     cases,

--- a/tests/background-computer-use-report.test.mjs
+++ b/tests/background-computer-use-report.test.mjs
@@ -31,6 +31,22 @@ function invariantByName(caseResult, name) {
   return entry;
 }
 
+function makeRemoteReport() {
+  const report = makePassingReport(catalog);
+  const receipt = {
+    pid: 4242,
+    startIdentity: "987654321",
+    socketPath: "/tmp/peekaboo-certification/bridge.sock",
+    sourceCommit: report.provenance.cli_source_commit,
+  };
+  report.provenance.event_producer_source = "remote";
+  report.provenance.remote_host = receipt;
+  for (const caseResult of report.cases) {
+    caseResult.event_producer = structuredClone(receipt);
+  }
+  return report;
+}
+
 test("passing report covers the complete 34-case catalog", () => {
   const report = makePassingReport(catalog);
   const result = validateCertification(catalog, report);
@@ -169,6 +185,41 @@ test("probe canary and invariant violations are unsuppressible", () => {
   assert.equal(result.success, false);
   assert.ok(rules(result).has("canary"));
   assert.ok(rules(result).has("violated_invariant"));
+});
+
+test("source provenance is exact closed and identical across the event producer", () => {
+  const missing = makePassingReport(catalog);
+  delete missing.provenance;
+  assert.ok(rules(validateCertification(catalog, missing)).has("provenance_schema"));
+
+  const malformed = makePassingReport(catalog);
+  malformed.provenance.cli_source_commit = "unknown";
+  assert.ok(rules(validateCertification(catalog, malformed)).has("source_commit"));
+
+  const terminated = makePassingReport(catalog);
+  terminated.provenance.cli_source_commit += "\n";
+  terminated.provenance.event_producer_source_commit += "\n";
+  assert.ok(rules(validateCertification(catalog, terminated)).has("source_commit"));
+
+  const mismatch = makePassingReport(catalog);
+  mismatch.provenance.event_producer_source = "remote";
+  mismatch.provenance.event_producer_source_commit =
+    "fedcba9876543210fedcba9876543210fedcba98";
+  assert.ok(rules(validateCertification(catalog, mismatch)).has("source_commit_mismatch"));
+
+  const receiptlessRemote = makePassingReport(catalog);
+  receiptlessRemote.provenance.event_producer_source = "remote";
+  assert.ok(rules(validateCertification(catalog, receiptlessRemote)).has("remote_host_receipt"));
+
+  const remote = makeRemoteReport();
+  assert.equal(validateCertification(catalog, remote).success, true);
+
+  caseById(remote, "see-text").event_producer.pid += 1;
+  assert.ok(rules(validateCertification(catalog, remote)).has("event_producer_receipt"));
+
+  const unstable = makeRemoteReport();
+  caseById(unstable, "see-text").event_producer_stable = false;
+  assert.ok(rules(validateCertification(catalog, unstable)).has("event_producer_stability"));
 });
 
 test("catalog invariants are required nonempty and unique", () => {

--- a/tests/background-computer-use-report.test.mjs
+++ b/tests/background-computer-use-report.test.mjs
@@ -40,6 +40,7 @@ function makeRemoteReport() {
     sourceCommit: report.provenance.cli_source_commit,
   };
   report.provenance.event_producer_source = "remote";
+  report.provenance.requested_bridge_socket = receipt.socketPath;
   report.provenance.remote_host = receipt;
   for (const caseResult of report.cases) {
     caseResult.event_producer = structuredClone(receipt);
@@ -213,6 +214,10 @@ test("source provenance is exact closed and identical across the event producer"
 
   const remote = makeRemoteReport();
   assert.equal(validateCertification(catalog, remote).success, true);
+
+  const rerouted = makeRemoteReport();
+  rerouted.provenance.requested_bridge_socket = "/tmp/different-bridge.sock";
+  assert.ok(rules(validateCertification(catalog, rerouted)).has("bridge_socket_mismatch"));
 
   caseById(remote, "see-text").event_producer.pid += 1;
   assert.ok(rules(validateCertification(catalog, remote)).has("event_producer_receipt"));


### PR DESCRIPTION
## Summary

- stamp CLI and app artifacts with an exact 40-hex source revision while preserving the existing human-readable short version output
- make release and strict builds refuse dirty or unverifiable source, while debug builds report unknown provenance instead of making a false claim
- bind background certification to the exact CLI source and, for remote execution, the requested Bridge socket, PID, process generation, and Bridge source revision
- restore the exact pre-certification sentinel window after the opt-in foreground phase

## Proof

- `pnpm run test:safe` (882 CoreCLI tests, 88 runtime tests, and 26 Foundation tests)
- `pnpm run test:background-certification` (18/18)
- `pnpm run lint`
- `pnpm run format`
- documentation, Bash, ShellCheck, native-only, source-provenance, release-signing, and restart contracts
- arm64 Release CLI built and signed with OpenClaw Foundation Team FWJYW4S8P8; embedded source revision matched `a07567becfc883c043b7816323bd10d7cafa53b3`
- default and explicit non-default Bridge socket certification self-tests passed
- landed ambient-state policy preserved; the full safe matrix explicitly skipped the live clipboard smoke test
- P0-P2 autoreview clean at 0.86 on the rebased exact head
- historical `--verify-only` artifacts validate their own canonical stamp without being compared to the verifier checkout; build/skip-build modes remain checkout-pinned

## Documentation

- updated install and background-computer-use certification documentation
- added one-line changelog entries in both release-note surfaces
