### PR TITLE
feat(bridge): preserve successful action outcomes

### DIFF
--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Consolidate accessibility observer registration, exact element/process dispatch, stop, and deinitialization cleanup under one instance-owned registry.
 - Carry canonical desktop-action outcomes through capability-gated Bridge protocol 1.23 requests, preserving exact refused, partial, unverified, and indeterminate failures while older hosts remain conservative after a response is lost.
 - Project canonical desktop-action outcomes into MCP metadata, so partial failures retain recovery-side-effect semantics instead of incorrectly demanding a fresh observation.
+- Preserve successful native outcomes for click, type, type-actions, scroll, hotkey, action, and set-value across projected Bridge requests without changing legacy response payloads.
 - Embed one canonical 40-hex source commit in clean stamped CLI and macOS app builds, expose it through `--version --json` and Bridge identity receipts, and leave raw unstamped builds explicitly `unknown`.
 - Correct `peekaboo bridge --help` and Bridge docs to describe capability-aware reusable-daemon, Peekaboo.app, on-demand-daemon, and local-fallback routing.
 - Refuse public raw `press` chords before dispatch unless `--foreground` is explicit, with canonical retry-safe refusal metadata and honest unverifiable foreground results.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Consolidate accessibility observer registration, exact element/process dispatch, stop, and deinitialization cleanup under one instance-owned registry.
 - Carry canonical desktop-action outcomes through capability-gated Bridge protocol 1.23 requests, preserving exact refused, partial, unverified, and indeterminate failures while older hosts remain conservative after a response is lost.
 - Project canonical desktop-action outcomes into MCP metadata, so partial failures retain recovery-side-effect semantics instead of incorrectly demanding a fresh observation.
+- Preserve successful native outcomes for click, type, type-actions, scroll, hotkey, action, and set-value across projected Bridge requests without changing legacy response payloads.
 - Embed one canonical 40-hex source commit in clean stamped CLI and macOS app builds, expose it through JSON/Bridge identity receipts, and require matching per-case socket/process-generation provenance for background certification while leaving raw unstamped builds explicitly `unknown`.
 - Correct `peekaboo bridge --help` and Bridge docs to describe capability-aware reusable-daemon, Peekaboo.app, on-demand-daemon, and local-fallback routing.
 - Refuse public raw `press` chords before dispatch unless explicit foreground consent is present, keep semantic background alternatives discoverable, and report foreground delivery as unverifiable instead of claiming the intended effect completed.

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Core/Protocols/UIAutomationOperationModels.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Core/Protocols/UIAutomationOperationModels.swift
@@ -237,6 +237,20 @@ public struct TypeResult: Sendable, Codable {
     }
 }
 
+/// Payload returned by an automation action together with its canonical execution outcome.
+///
+/// The outcome is optional so capability implementations backed by an older transport can preserve
+/// their payload without inventing execution evidence. Local automation always supplies it.
+public struct UIAutomationActionResult<Payload: Sendable>: Sendable {
+    public let payload: Payload
+    public let outcome: DesktopActionOutcome?
+
+    public init(payload: Payload, outcome: DesktopActionOutcome?) {
+        self.payload = payload
+        self.outcome = outcome
+    }
+}
+
 /// Value payload for direct accessibility value mutation.
 public enum UIElementValue: Sendable, Codable, Equatable {
     case bool(Bool)

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Core/Protocols/UIAutomationServiceProtocol.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Core/Protocols/UIAutomationServiceProtocol.swift
@@ -147,6 +147,111 @@ extension UIAutomationServiceProtocol {
     }
 }
 
+/// Additive capability for callers that need the canonical result of a successful automation action.
+///
+/// Existing protocol methods remain the compatibility surface. A caller can opt into this capability
+/// without requiring older or transport-backed automation services to fabricate outcome evidence.
+@MainActor
+public protocol UIAutomationActionOutcomeProviding: UIAutomationServiceProtocol {
+    func clickWithOutcome(
+        target: ClickTarget,
+        clickType: ClickType,
+        snapshotId: String?) async throws -> UIAutomationActionResult<Void>
+
+    func clickWithOutcome(
+        target: ClickTarget,
+        clickType: ClickType,
+        snapshotId: String?,
+        targetProcessIdentifier: pid_t) async throws -> UIAutomationActionResult<Void>
+
+    func clickWithOutcome(
+        target: ClickTarget,
+        clickType: ClickType,
+        snapshotId: String?,
+        expectedProcessIdentity: ApplicationProcessIdentity) async throws -> UIAutomationActionResult<Void>
+
+    func clickWithOutcome(
+        target: ClickTarget,
+        clickType: ClickType,
+        snapshotId: String?,
+        expectedWindowIdentity: WindowMutationIdentity,
+        expectedWindowBounds: CGRect) async throws -> UIAutomationActionResult<Void>
+
+    func typeWithOutcome(
+        text: String,
+        target: String?,
+        clearExisting: Bool,
+        typingDelay: Int,
+        snapshotId: String?) async throws -> UIAutomationActionResult<Void>
+
+    func typeActionsWithOutcome(
+        _ actions: [TypeAction],
+        cadence: TypingCadence,
+        snapshotId: String?) async throws -> UIAutomationActionResult<TypeResult>
+
+    func typeActionsWithOutcome(
+        _ actions: [TypeAction],
+        cadence: TypingCadence,
+        snapshotId: String?,
+        targetProcessIdentifier: pid_t) async throws -> UIAutomationActionResult<TypeResult>
+
+    func typeActionsWithOutcome(
+        _ actions: [TypeAction],
+        cadence: TypingCadence,
+        snapshotId: String?,
+        expectedProcessIdentity: ApplicationProcessIdentity) async throws -> UIAutomationActionResult<TypeResult>
+
+    func typeActionsWithOutcome(
+        _ actions: [TypeAction],
+        cadence: TypingCadence,
+        snapshotId: String?,
+        expectedWindowIdentity: WindowMutationIdentity,
+        expectedWindowBounds: CGRect) async throws -> UIAutomationActionResult<TypeResult>
+
+    func typeActionsWithOutcome(
+        _ actions: [TypeAction],
+        cadence: TypingCadence,
+        snapshotId: String?,
+        target: ExactWindowKeyboardTarget) async throws -> UIAutomationActionResult<TypeResult>
+
+    func scrollWithOutcome(_ request: ScrollRequest) async throws -> UIAutomationActionResult<Void>
+
+    func hotkeyWithOutcome(
+        keys: String,
+        holdDuration: Int) async throws -> UIAutomationActionResult<Void>
+
+    func hotkeyWithOutcome(
+        keys: String,
+        holdDuration: Int,
+        targetProcessIdentifier: pid_t) async throws -> UIAutomationActionResult<Void>
+
+    func hotkeyWithOutcome(
+        keys: String,
+        holdDuration: Int,
+        expectedProcessIdentity: ApplicationProcessIdentity) async throws -> UIAutomationActionResult<Void>
+
+    func hotkeyWithOutcome(
+        keys: String,
+        holdDuration: Int,
+        expectedWindowIdentity: WindowMutationIdentity,
+        expectedWindowBounds: CGRect) async throws -> UIAutomationActionResult<Void>
+
+    func hotkeyWithOutcome(
+        keys: String,
+        holdDuration: Int,
+        target: ExactWindowKeyboardTarget) async throws -> UIAutomationActionResult<Void>
+
+    func setValueWithOutcome(
+        target: String,
+        value: UIElementValue,
+        snapshotId: String?) async throws -> UIAutomationActionResult<ElementActionResult>
+
+    func performActionWithOutcome(
+        target: String,
+        actionName: String,
+        snapshotId: String?) async throws -> UIAutomationActionResult<ElementActionResult>
+}
+
 /// Optional capability for querying the focused element of a specific background application.
 /// A system-wide focus query reports the user's foreground app and is not a valid substitute.
 @MainActor

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/TypeService.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/TypeService.swift
@@ -15,6 +15,12 @@ public final class TypeService {
 
     struct TypeActionExecutionSummary {
         let result: TypeResult
+        let executionResult: UIInputExecutionResult
+        let typedIntoSecureField: Bool
+    }
+
+    private struct TypeActionPayloadSummary {
+        let result: TypeResult
         let typedIntoSecureField: Bool
     }
 
@@ -303,6 +309,7 @@ public final class TypeService {
         laneCompletion: @escaping @MainActor (TypeActionExecutionSummary) async -> Void = { _ in }) async throws
         -> TypeActionExecutionSummary
     {
+        var payloadSummary: TypeActionPayloadSummary?
         var summary: TypeActionExecutionSummary?
         let foreground = targetProcessIdentifier == nil
         let plan = try DesktopOperationPlan(
@@ -317,7 +324,7 @@ public final class TypeService {
             prepare: { await lanePreparation() },
             action: nil,
             synthesis: DesktopOperationPlan.SynthesisRoute {
-                summary = try await self.performSyntheticTypeActions(
+                payloadSummary = try await self.performSyntheticTypeActions(
                     actions,
                     cadence: cadence,
                     snapshotId: snapshotId,
@@ -329,11 +336,16 @@ public final class TypeService {
                         mode: targetProcessIdentifier == nil ? .foreground : .background),
                     evidence: .deliveryAccepted)
             },
-            success: { _ in
-                guard let summary else {
+            success: { executionResult in
+                guard let payloadSummary else {
                     return
                 }
-                await laneCompletion(summary)
+                let completedSummary = TypeActionExecutionSummary(
+                    result: payloadSummary.result,
+                    executionResult: executionResult,
+                    typedIntoSecureField: payloadSummary.typedIntoSecureField)
+                summary = completedSummary
+                await laneCompletion(completedSummary)
             },
             finalize: self.operationFinalizer)
         _ = try await self.desktopOperationExecutor.execute(plan)
@@ -350,7 +362,7 @@ public final class TypeService {
         snapshotId _: String?,
         targetProcessIdentifier: pid_t?,
         deliveryValidator: (@MainActor @Sendable () async throws -> Void)?) async throws
-        -> TypeActionExecutionSummary
+        -> TypeActionPayloadSummary
     {
         var totalChars = 0
         var keyPresses = 0
@@ -441,7 +453,7 @@ public final class TypeService {
                 emittedUnitCount: emittedUnitCount)
         }
 
-        return TypeActionExecutionSummary(
+        return TypeActionPayloadSummary(
             result: TypeResult(
                 totalCharacters: totalChars,
                 keyPresses: keyPresses),

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/UIAutomationService+ElementActions.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/UIAutomationService+ElementActions.swift
@@ -13,6 +13,17 @@ extension UIAutomationService: ElementActionAutomationServiceProtocol {
         value: UIElementValue,
         snapshotId: String?) async throws -> ElementActionResult
     {
+        try await self.setValueWithOutcome(
+            target: target,
+            value: value,
+            snapshotId: snapshotId).payload
+    }
+
+    public func setValueWithOutcome(
+        target: String,
+        value: UIElementValue,
+        snapshotId: String?) async throws -> UIAutomationActionResult<ElementActionResult>
+    {
         let requiredSnapshotId = try Self.requireElementActionSnapshotID(snapshotId)
         let captureReceipt = try await self.elementMutationCaptureReceipt(snapshotId: requiredSnapshotId)
         var resolved: ResolvedElementMutationTarget?
@@ -30,8 +41,7 @@ extension UIAutomationService: ElementActionAutomationServiceProtocol {
                 let target = try await self.resolveActionTarget(target, snapshotId: requiredSnapshotId)
                 try self.validateElementMutationTarget(target.windowContext, receipt: captureReceipt)
                 resolved = target
-                oldValue = self.safeValueDescription(target.element.value)
-                    ?? target.element.selectedValue.map(String.init)
+                oldValue = self.elementMutationValueReader(target.element)
             },
             routing: {
                 let bundleIdentifier = resolved?.bundleIdentifier ?? captureReceipt.bundleIdentifier
@@ -60,8 +70,7 @@ extension UIAutomationService: ElementActionAutomationServiceProtocol {
                 guard let resolved else {
                     throw PeekabooError.operationError(message: "Element mutation target was not prepared")
                 }
-                newValue = self.safeValueDescription(resolved.element.value)
-                    ?? resolved.element.selectedValue.map(String.init)
+                newValue = self.elementMutationValueReader(resolved.element)
                 guard newValue != nil else {
                     throw DesktopActionFailure.indeterminate(
                         delivery: result.outcome.delivery,
@@ -80,18 +89,31 @@ extension UIAutomationService: ElementActionAutomationServiceProtocol {
             throw PeekabooError.operationError(message: "Element value result was not captured")
         }
 
-        return ElementActionResult(
-            target: resolved.description,
-            actionName: result.actionName,
-            anchorPoint: result.anchorPoint,
-            oldValue: oldValue,
-            newValue: newValue)
+        return UIAutomationActionResult(
+            payload: ElementActionResult(
+                target: resolved.description,
+                actionName: result.actionName,
+                anchorPoint: result.anchorPoint,
+                oldValue: oldValue,
+                newValue: newValue),
+            outcome: result.outcome)
     }
 
     public func performAction(
         target: String,
         actionName: String,
         snapshotId: String?) async throws -> ElementActionResult
+    {
+        try await self.performActionWithOutcome(
+            target: target,
+            actionName: actionName,
+            snapshotId: snapshotId).payload
+    }
+
+    public func performActionWithOutcome(
+        target: String,
+        actionName: String,
+        snapshotId: String?) async throws -> UIAutomationActionResult<ElementActionResult>
     {
         let requiredSnapshotId = try Self.requireElementActionSnapshotID(snapshotId)
         let captureReceipt = try await self.elementMutationCaptureReceipt(snapshotId: requiredSnapshotId)
@@ -147,10 +169,12 @@ extension UIAutomationService: ElementActionAutomationServiceProtocol {
             throw PeekabooError.operationError(message: "Element action target was not prepared")
         }
 
-        return ElementActionResult(
-            target: resolved.description,
-            actionName: result.actionName,
-            anchorPoint: result.anchorPoint)
+        return UIAutomationActionResult(
+            payload: ElementActionResult(
+                target: resolved.description,
+                actionName: result.actionName,
+                anchorPoint: result.anchorPoint),
+            outcome: result.outcome)
     }
 
     private func resolveActionTarget(_ target: String, snapshotId: String) async throws
@@ -275,7 +299,7 @@ extension UIAutomationService: ElementActionAutomationServiceProtocol {
         "Cannot set value on \(target): \(reason)"
     }
 
-    private func safeValueDescription(_ value: Any?) -> String? {
+    static func safeValueDescription(_ value: Any?) -> String? {
         switch value {
         case let value as String:
             value

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/UIAutomationService+Operations.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/UIAutomationService+Operations.swift
@@ -152,10 +152,21 @@ extension UIAutomationService {
      * - Note: Visual feedback is automatically shown if visualizer is connected
      */
     public func click(target: ClickTarget, clickType: ClickType, snapshotId: String?) async throws {
+        _ = try await self.clickWithOutcome(
+            target: target,
+            clickType: clickType,
+            snapshotId: snapshotId)
+    }
+
+    public func clickWithOutcome(
+        target: ClickTarget,
+        clickType: ClickType,
+        snapshotId: String?) async throws -> UIAutomationActionResult<Void>
+    {
         self.logger.debug("Delegating click to ClickService")
         var fallbackPoint: CGPoint?
         var visualizerTarget: VisualizerTargetWindow?
-        _ = try await self.normalizingSnapshotErrors {
+        let result = try await self.normalizingSnapshotErrors {
             try await self.clickService.clickWithLanePreparation(
                 target: target,
                 clickType: clickType,
@@ -175,6 +186,7 @@ extension UIAutomationService {
                         visualizerTarget: visualizerTarget)
                 })
         }
+        return UIAutomationActionResult(payload: (), outcome: result.outcome)
     }
 
     public func click(
@@ -182,6 +194,19 @@ extension UIAutomationService {
         clickType: ClickType,
         snapshotId: String?,
         targetProcessIdentifier: pid_t) async throws
+    {
+        _ = try await self.clickWithOutcome(
+            target: target,
+            clickType: clickType,
+            snapshotId: snapshotId,
+            targetProcessIdentifier: targetProcessIdentifier)
+    }
+
+    public func clickWithOutcome(
+        target: ClickTarget,
+        clickType: ClickType,
+        snapshotId: String?,
+        targetProcessIdentifier: pid_t) async throws -> UIAutomationActionResult<Void>
     {
         self.logger.debug("Delegating background click to ClickService")
         let result = try await self.normalizingSnapshotErrors {
@@ -198,6 +223,8 @@ extension UIAutomationService {
             clickType: clickType,
             snapshotId: snapshotId,
             targetProcessIdentifier: targetProcessIdentifier)
+
+        return UIAutomationActionResult(payload: (), outcome: result.outcome)
     }
 
     public func click(
@@ -205,6 +232,19 @@ extension UIAutomationService {
         clickType: ClickType,
         snapshotId: String?,
         expectedProcessIdentity: ApplicationProcessIdentity) async throws
+    {
+        _ = try await self.clickWithOutcome(
+            target: target,
+            clickType: clickType,
+            snapshotId: snapshotId,
+            expectedProcessIdentity: expectedProcessIdentity)
+    }
+
+    public func clickWithOutcome(
+        target: ClickTarget,
+        clickType: ClickType,
+        snapshotId: String?,
+        expectedProcessIdentity: ApplicationProcessIdentity) async throws -> UIAutomationActionResult<Void>
     {
         self.logger.debug("Delegating generation-pinned background click to ClickService")
         let result = try await self.normalizingSnapshotErrors {
@@ -222,6 +262,8 @@ extension UIAutomationService {
             clickType: clickType,
             snapshotId: snapshotId,
             targetProcessIdentifier: expectedProcessIdentity.processIdentifier)
+
+        return UIAutomationActionResult(payload: (), outcome: result.outcome)
     }
 
     public func click(
@@ -230,6 +272,21 @@ extension UIAutomationService {
         snapshotId: String?,
         expectedWindowIdentity: WindowMutationIdentity,
         expectedWindowBounds: CGRect) async throws
+    {
+        _ = try await self.clickWithOutcome(
+            target: target,
+            clickType: clickType,
+            snapshotId: snapshotId,
+            expectedWindowIdentity: expectedWindowIdentity,
+            expectedWindowBounds: expectedWindowBounds)
+    }
+
+    public func clickWithOutcome(
+        target: ClickTarget,
+        clickType: ClickType,
+        snapshotId: String?,
+        expectedWindowIdentity: WindowMutationIdentity,
+        expectedWindowBounds: CGRect) async throws -> UIAutomationActionResult<Void>
     {
         let processIdentity = ApplicationProcessIdentity(
             processIdentifier: expectedWindowIdentity.ownerProcessIdentifier,
@@ -253,6 +310,8 @@ extension UIAutomationService {
             clickType: clickType,
             snapshotId: snapshotId,
             targetProcessIdentifier: expectedWindowIdentity.ownerProcessIdentifier)
+
+        return UIAutomationActionResult(payload: (), outcome: result.outcome)
     }
 
     /// Background delivery must remain invisible to the foreground user. Visualizer windows are

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/UIAutomationService+PointerKeyboardOperations.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/UIAutomationService+PointerKeyboardOperations.swift
@@ -19,9 +19,13 @@ extension UIAutomationService {
      * ```
      */
     public func scroll(_ request: ScrollRequest) async throws {
+        _ = try await self.scrollWithOutcome(request)
+    }
+
+    public func scrollWithOutcome(_ request: ScrollRequest) async throws -> UIAutomationActionResult<Void> {
         self.logger.debug("Delegating scroll to ScrollService")
         var visualizerTarget: VisualizerTargetWindow?
-        _ = try await self.normalizingSnapshotErrors {
+        let result = try await self.normalizingSnapshotErrors {
             try await self.scrollService.scrollWithLanePreparation(
                 request,
                 lanePreparation: {
@@ -34,6 +38,7 @@ extension UIAutomationService {
                         visualizerTarget: visualizerTarget)
                 })
         }
+        return UIAutomationActionResult(payload: (), outcome: result.outcome)
     }
 
     /// Background scrolls are AX actions scoped to a snapshot element and never emit foreground feedback.
@@ -82,9 +87,16 @@ extension UIAutomationService {
      * ```
      */
     public func hotkey(keys: String, holdDuration: Int) async throws {
+        _ = try await self.hotkeyWithOutcome(keys: keys, holdDuration: holdDuration)
+    }
+
+    public func hotkeyWithOutcome(
+        keys: String,
+        holdDuration: Int) async throws -> UIAutomationActionResult<Void>
+    {
         self.logger.debug("Delegating hotkey to HotkeyService")
         var visualizerTarget: VisualizerTargetWindow?
-        _ = try await self.hotkeyService.hotkeyWithLanePreparation(
+        let result = try await self.hotkeyService.hotkeyWithLanePreparation(
             keys: keys,
             holdDuration: holdDuration,
             lanePreparation: {
@@ -96,22 +108,46 @@ extension UIAutomationService {
                     targetProcessIdentifier: nil,
                     visualizerTarget: visualizerTarget)
             })
+        return UIAutomationActionResult(payload: (), outcome: result.outcome)
     }
 
     public func hotkey(keys: String, holdDuration: Int, targetProcessIdentifier: pid_t) async throws {
+        _ = try await self.hotkeyWithOutcome(
+            keys: keys,
+            holdDuration: holdDuration,
+            targetProcessIdentifier: targetProcessIdentifier)
+    }
+
+    public func hotkeyWithOutcome(
+        keys: String,
+        holdDuration: Int,
+        targetProcessIdentifier: pid_t) async throws -> UIAutomationActionResult<Void>
+    {
         self.logger.debug("Delegating targeted hotkey to HotkeyService")
-        _ = try await self.hotkeyService.hotkey(
+        let result = try await self.hotkeyService.hotkey(
             keys: keys,
             holdDuration: holdDuration,
             targetProcessIdentifier: targetProcessIdentifier)
 
         await self.visualizeHotkey(keys: keys, targetProcessIdentifier: targetProcessIdentifier)
+        return UIAutomationActionResult(payload: (), outcome: result.outcome)
     }
 
     public func hotkey(
         keys: String,
         holdDuration: Int,
         expectedProcessIdentity: ApplicationProcessIdentity) async throws
+    {
+        _ = try await self.hotkeyWithOutcome(
+            keys: keys,
+            holdDuration: holdDuration,
+            expectedProcessIdentity: expectedProcessIdentity)
+    }
+
+    public func hotkeyWithOutcome(
+        keys: String,
+        holdDuration: Int,
+        expectedProcessIdentity: ApplicationProcessIdentity) async throws -> UIAutomationActionResult<Void>
     {
         let validator: @MainActor @Sendable () async throws -> Void = {
             guard self.processStartIdentityProvider(expectedProcessIdentity.processIdentifier) ==
@@ -121,12 +157,13 @@ extension UIAutomationService {
                     "Background hotkey target process exited or changed process generation")
             }
         }
-        _ = try await self.hotkeyService.hotkey(
+        let result = try await self.hotkeyService.hotkey(
             keys: keys,
             holdDuration: holdDuration,
             targetProcessIdentifier: expectedProcessIdentity.processIdentifier,
             deliveryValidator: validator,
             expectedProcessIdentity: expectedProcessIdentity)
+        return UIAutomationActionResult(payload: (), outcome: result.outcome)
     }
 
     public func hotkey(
@@ -134,6 +171,19 @@ extension UIAutomationService {
         holdDuration: Int,
         expectedWindowIdentity: WindowMutationIdentity,
         expectedWindowBounds: CGRect) async throws
+    {
+        _ = try await self.hotkeyWithOutcome(
+            keys: keys,
+            holdDuration: holdDuration,
+            expectedWindowIdentity: expectedWindowIdentity,
+            expectedWindowBounds: expectedWindowBounds)
+    }
+
+    public func hotkeyWithOutcome(
+        keys: String,
+        holdDuration: Int,
+        expectedWindowIdentity: WindowMutationIdentity,
+        expectedWindowBounds: CGRect) async throws -> UIAutomationActionResult<Void>
     {
         let processIdentity = ApplicationProcessIdentity(
             processIdentifier: expectedWindowIdentity.ownerProcessIdentifier,
@@ -143,18 +193,30 @@ extension UIAutomationService {
                 expectedWindowIdentity: expectedWindowIdentity,
                 expectedWindowBounds: expectedWindowBounds)
         }
-        _ = try await self.hotkeyService.hotkey(
+        let result = try await self.hotkeyService.hotkey(
             keys: keys,
             holdDuration: holdDuration,
             targetProcessIdentifier: expectedWindowIdentity.ownerProcessIdentifier,
             deliveryValidator: validator,
             expectedProcessIdentity: processIdentity)
+        return UIAutomationActionResult(payload: (), outcome: result.outcome)
     }
 
     public func hotkey(
         keys: String,
         holdDuration: Int,
         target: ExactWindowKeyboardTarget) async throws
+    {
+        _ = try await self.hotkeyWithOutcome(
+            keys: keys,
+            holdDuration: holdDuration,
+            target: target)
+    }
+
+    public func hotkeyWithOutcome(
+        keys: String,
+        holdDuration: Int,
+        target: ExactWindowKeyboardTarget) async throws -> UIAutomationActionResult<Void>
     {
         let processIdentity = ApplicationProcessIdentity(
             processIdentifier: target.windowIdentity.ownerProcessIdentifier,
@@ -165,12 +227,13 @@ extension UIAutomationService {
                 expectedWindowBounds: target.windowBounds,
                 expectedFocusedElement: target.focusedElement)
         }
-        _ = try await self.hotkeyService.hotkey(
+        let result = try await self.hotkeyService.hotkey(
             keys: keys,
             holdDuration: holdDuration,
             targetProcessIdentifier: target.windowIdentity.ownerProcessIdentifier,
             deliveryValidator: validator,
             expectedProcessIdentity: processIdentity)
+        return UIAutomationActionResult(payload: (), outcome: result.outcome)
     }
 
     /// PID-routed hotkeys are background operations and never emit foreground feedback.

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/UIAutomationService+TypingOperations.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/UIAutomationService+TypingOperations.swift
@@ -82,9 +82,24 @@ extension UIAutomationService {
         typingDelay: Int,
         snapshotId: String?) async throws
     {
+        _ = try await self.typeWithOutcome(
+            text: text,
+            target: target,
+            clearExisting: clearExisting,
+            typingDelay: typingDelay,
+            snapshotId: snapshotId)
+    }
+
+    public func typeWithOutcome(
+        text: String,
+        target: String?,
+        clearExisting: Bool,
+        typingDelay: Int,
+        snapshotId: String?) async throws -> UIAutomationActionResult<Void>
+    {
         self.logger.debug("Delegating type to TypeService")
         var visualizerTarget: VisualizerTargetWindow?
-        _ = try await self.normalizingSnapshotErrors {
+        let summary = try await self.normalizingSnapshotErrors {
             try await self.typeService.typeTrackingSecureInput(
                 text: text,
                 target: target,
@@ -102,12 +117,24 @@ extension UIAutomationService {
                         visualizerTarget: visualizerTarget)
                 })
         }
+        return UIAutomationActionResult(payload: (), outcome: summary.result.outcome)
     }
 
     public func typeActions(
         _ actions: [TypeAction],
         cadence: TypingCadence,
         snapshotId: String?) async throws -> TypeResult
+    {
+        try await self.typeActionsWithOutcome(
+            actions,
+            cadence: cadence,
+            snapshotId: snapshotId).payload
+    }
+
+    public func typeActionsWithOutcome(
+        _ actions: [TypeAction],
+        cadence: TypingCadence,
+        snapshotId: String?) async throws -> UIAutomationActionResult<TypeResult>
     {
         self.logger.debug("Delegating typeActions to TypeService")
         var visualizerTarget: VisualizerTargetWindow?
@@ -128,7 +155,9 @@ extension UIAutomationService {
                         visualizerTarget: visualizerTarget)
                 })
         }
-        return summary.result
+        return UIAutomationActionResult(
+            payload: summary.result,
+            outcome: summary.executionResult.outcome)
     }
 
     public func typeActions(
@@ -137,6 +166,21 @@ extension UIAutomationService {
         snapshotId: String?,
         expectedWindowIdentity: WindowMutationIdentity,
         expectedWindowBounds: CGRect) async throws -> TypeResult
+    {
+        try await self.typeActionsWithOutcome(
+            actions,
+            cadence: cadence,
+            snapshotId: snapshotId,
+            expectedWindowIdentity: expectedWindowIdentity,
+            expectedWindowBounds: expectedWindowBounds).payload
+    }
+
+    public func typeActionsWithOutcome(
+        _ actions: [TypeAction],
+        cadence: TypingCadence,
+        snapshotId: String?,
+        expectedWindowIdentity: WindowMutationIdentity,
+        expectedWindowBounds: CGRect) async throws -> UIAutomationActionResult<TypeResult>
     {
         let processIdentity = ApplicationProcessIdentity(
             processIdentifier: expectedWindowIdentity.ownerProcessIdentifier,
@@ -155,7 +199,9 @@ extension UIAutomationService {
                 deliveryValidator: validator,
                 expectedProcessIdentity: processIdentity)
         }
-        return summary.result
+        return UIAutomationActionResult(
+            payload: summary.result,
+            outcome: summary.executionResult.outcome)
     }
 
     public func typeActions(
@@ -163,6 +209,19 @@ extension UIAutomationService {
         cadence: TypingCadence,
         snapshotId: String?,
         target: ExactWindowKeyboardTarget) async throws -> TypeResult
+    {
+        try await self.typeActionsWithOutcome(
+            actions,
+            cadence: cadence,
+            snapshotId: snapshotId,
+            target: target).payload
+    }
+
+    public func typeActionsWithOutcome(
+        _ actions: [TypeAction],
+        cadence: TypingCadence,
+        snapshotId: String?,
+        target: ExactWindowKeyboardTarget) async throws -> UIAutomationActionResult<TypeResult>
     {
         let processIdentity = ApplicationProcessIdentity(
             processIdentifier: target.windowIdentity.ownerProcessIdentifier,
@@ -182,7 +241,9 @@ extension UIAutomationService {
                 deliveryValidator: validator,
                 expectedProcessIdentity: processIdentity)
         }
-        return summary.result
+        return UIAutomationActionResult(
+            payload: summary.result,
+            outcome: summary.executionResult.outcome)
     }
 
     public func typeActions(
@@ -190,6 +251,19 @@ extension UIAutomationService {
         cadence: TypingCadence,
         snapshotId: String?,
         targetProcessIdentifier: pid_t) async throws -> TypeResult
+    {
+        try await self.typeActionsWithOutcome(
+            actions,
+            cadence: cadence,
+            snapshotId: snapshotId,
+            targetProcessIdentifier: targetProcessIdentifier).payload
+    }
+
+    public func typeActionsWithOutcome(
+        _ actions: [TypeAction],
+        cadence: TypingCadence,
+        snapshotId: String?,
+        targetProcessIdentifier: pid_t) async throws -> UIAutomationActionResult<TypeResult>
     {
         self.logger.debug("Delegating targeted typeActions to TypeService")
         let summary = try await self.normalizingSnapshotErrors {
@@ -204,7 +278,9 @@ extension UIAutomationService {
             cadence: cadence,
             typedIntoSecureField: summary.typedIntoSecureField,
             targetProcessIdentifier: targetProcessIdentifier)
-        return summary.result
+        return UIAutomationActionResult(
+            payload: summary.result,
+            outcome: summary.executionResult.outcome)
     }
 
     public func typeActions(
@@ -212,6 +288,19 @@ extension UIAutomationService {
         cadence: TypingCadence,
         snapshotId: String?,
         expectedProcessIdentity: ApplicationProcessIdentity) async throws -> TypeResult
+    {
+        try await self.typeActionsWithOutcome(
+            actions,
+            cadence: cadence,
+            snapshotId: snapshotId,
+            expectedProcessIdentity: expectedProcessIdentity).payload
+    }
+
+    public func typeActionsWithOutcome(
+        _ actions: [TypeAction],
+        cadence: TypingCadence,
+        snapshotId: String?,
+        expectedProcessIdentity: ApplicationProcessIdentity) async throws -> UIAutomationActionResult<TypeResult>
     {
         let validator: @MainActor @Sendable () async throws -> Void = {
             guard self.processStartIdentityProvider(expectedProcessIdentity.processIdentifier) ==
@@ -230,7 +319,9 @@ extension UIAutomationService {
                 deliveryValidator: validator,
                 expectedProcessIdentity: expectedProcessIdentity)
         }
-        return summary.result
+        return UIAutomationActionResult(
+            payload: summary.result,
+            outcome: summary.executionResult.outcome)
     }
 
     // MARK: - Typing Visualization Helpers

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/UIAutomationService.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/UIAutomationService.swift
@@ -47,7 +47,7 @@ struct HotkeyServiceFactoryContext {
 @MainActor
 public final class UIAutomationService: TargetedHotkeyServiceProtocol, TargetedTypeServiceProtocol,
     ExactWindowTargetedClickServiceProtocol, TargetedFocusedElementServiceProtocol,
-    ExactWindowTargetedKeyboardServiceProtocol
+    ExactWindowTargetedKeyboardServiceProtocol, UIAutomationActionOutcomeProviding
 {
     public let supportsProcessGenerationPinnedHotkeys = true
     public let supportsProcessGenerationPinnedTypeActions = true
@@ -71,6 +71,7 @@ public final class UIAutomationService: TargetedHotkeyServiceProtocol, TargetedT
     let actionInputDriver: any ActionInputDriving
     let syntheticInputDriver: any SyntheticInputDriving
     let automationElementResolver: any AutomationElementResolving
+    let elementMutationValueReader: @MainActor @Sendable (AutomationElement) -> String?
     let exactWindowFocusReader: @Sendable (pid_t) -> ExactWindowFocusSnapshot?
     let exactWindowIdentityValidator: @Sendable (WindowMutationIdentity, CGRect) -> Bool
     let processStartIdentityProvider: @Sendable (pid_t) -> UInt64?
@@ -147,6 +148,7 @@ public final class UIAutomationService: TargetedHotkeyServiceProtocol, TargetedT
         actionInputDriver: any ActionInputDriving,
         syntheticInputDriver: any SyntheticInputDriving = SyntheticInputDriver(),
         automationElementResolver: any AutomationElementResolving,
+        elementMutationValueReader: (@MainActor @Sendable (AutomationElement) -> String?)? = nil,
         hotkeyServiceFactory: ((HotkeyServiceFactoryContext) -> HotkeyService)? = nil,
         feedbackClient: any AutomationFeedbackClient = NoopAutomationFeedbackClient(),
         exactWindowFocusReader: @escaping @Sendable (pid_t) -> ExactWindowFocusSnapshot? =
@@ -169,6 +171,10 @@ public final class UIAutomationService: TargetedHotkeyServiceProtocol, TargetedT
         self.actionInputDriver = actionInputDriver
         self.syntheticInputDriver = syntheticInputDriver
         self.automationElementResolver = automationElementResolver
+        self.elementMutationValueReader = elementMutationValueReader ?? { element in
+            Self.safeValueDescription(element.value)
+                ?? element.selectedValue.map(String.init)
+        }
         self.feedbackClient = feedbackClient
         self.exactWindowFocusReader = exactWindowFocusReader
         self.exactWindowIdentityValidator = exactWindowIdentityValidator

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKitTestSupport/AutomationTestFixtures.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKitTestSupport/AutomationTestFixtures.swift
@@ -5,6 +5,38 @@ import PeekabooFoundation
 
 /// Canonical deterministic builders for automation tests.
 public enum AutomationTestFixtures {
+    /// One valid outcome for every canonical desktop-action state.
+    public static var canonicalActionOutcomes: [DesktopActionOutcome] {
+        let backgroundAccessibilityAction = DesktopActionOutcome.Delivery(
+            mechanism: .accessibilityAction,
+            mode: .background)
+        let backgroundTargetedEvents = DesktopActionOutcome.Delivery(
+            mechanism: .processTargetedEvents,
+            mode: .background)
+
+        return [
+            .confirmedChange(
+                delivery: backgroundAccessibilityAction,
+                unitCount: self.dispatchUnitCount(1)),
+            .confirmedNoChange(),
+            .partial(
+                delivery: backgroundAccessibilityAction,
+                unitCount: self.dispatchUnitCount(2)),
+            .dispatchedUnverified(
+                delivery: backgroundTargetedEvents,
+                evidence: .operationStillRunning,
+                unitCount: self.dispatchUnitCount(3)),
+            .suspectedNoop(
+                delivery: backgroundAccessibilityAction,
+                unitCount: self.dispatchUnitCount(1)),
+            .refused(reason: .permissionDenied),
+            .indeterminate(
+                delivery: backgroundTargetedEvents,
+                evidence: .responseLost,
+                unitCount: self.dispatchUnitCount(2)),
+        ]
+    }
+
     public static func uiActionReceipt(
         outcome: DesktopActionOutcome = .dispatchedUnverified(
             delivery: DesktopActionOutcome.Delivery(
@@ -219,5 +251,12 @@ public enum AutomationTestFixtures {
             windowBounds: window.bounds,
             windowMutationIdentity: window.mutationIdentity,
             windowID: CGWindowID(window.windowID))
+    }
+
+    private static func dispatchUnitCount(_ value: Int) -> DesktopActionOutcome.DispatchUnitCount {
+        guard let unitCount = DesktopActionOutcome.DispatchUnitCount(value) else {
+            preconditionFailure("Automation fixture dispatch counts must be positive")
+        }
+        return unitCount
     }
 }

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/UIAutomationActionOutcomeProvidingTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/UIAutomationActionOutcomeProvidingTests.swift
@@ -1,0 +1,588 @@
+import AppKit
+import struct AXorcist.Element
+import enum AXorcist.MouseButton
+import enum AXorcist.SpecialKey
+import CoreGraphics
+import Foundation
+import PeekabooAutomationKitTestSupport
+import struct PeekabooFoundation.DesktopActionOutcome
+import enum PeekabooFoundation.ScrollDirection
+import enum PeekabooFoundation.TypeAction
+import Testing
+@testable import PeekabooAutomationKit
+
+@Suite(.serialized)
+@MainActor
+struct UIAutomationActionOutcomeProvidingTests {
+    @Test
+    func `carrier preserves every canonical outcome and the legacy missing-outcome case`() {
+        let outcomes = AutomationTestFixtures.canonicalActionOutcomes
+
+        #expect(outcomes.map(\.state) == [
+            .confirmedChange,
+            .confirmedNoChange,
+            .partial,
+            .dispatchedUnverified,
+            .suspectedNoop,
+            .refused,
+            .indeterminate,
+        ])
+        for (index, outcome) in outcomes.enumerated() {
+            let result = UIAutomationActionResult(payload: index, outcome: outcome)
+            #expect(result.payload == index)
+            #expect(result.outcome == outcome)
+        }
+
+        let legacy = UIAutomationActionResult(payload: "legacy", outcome: nil)
+        #expect(legacy.payload == "legacy")
+        #expect(legacy.outcome == nil)
+    }
+
+    @Test
+    func `click result returns the exact driver outcome and legacy adapter repeats the same dispatch`() async throws {
+        let expected = Self.outcome(mechanism: .globalEvents, mode: .foreground)
+        let synthetic = OutcomeSyntheticInputDriver(clickOutcome: expected)
+        let service = self.makeSynthesisService(synthetic: synthetic)
+
+        let result = try await service.clickWithOutcome(
+            target: .coordinates(CGPoint(x: 20, y: 30)),
+            clickType: .single,
+            snapshotId: nil)
+        try await service.click(
+            target: .coordinates(CGPoint(x: 20, y: 30)),
+            clickType: .single,
+            snapshotId: nil)
+
+        #expect(result.outcome == expected)
+        #expect(synthetic.clickCount == 2)
+    }
+
+    @Test
+    func `type result returns the executor outcome and legacy adapter preserves execution`() async throws {
+        let synthetic = OutcomeSyntheticInputDriver(clickOutcome: Self.foregroundOutcome)
+        let service = self.makeSynthesisService(synthetic: synthetic)
+
+        let result = try await service.typeWithOutcome(
+            text: "a",
+            target: nil,
+            clearExisting: false,
+            typingDelay: 0,
+            snapshotId: nil)
+        try await service.type(
+            text: "a",
+            target: nil,
+            clearExisting: false,
+            typingDelay: 0,
+            snapshotId: nil)
+
+        #expect(result.outcome == Self.foregroundOutcome)
+        #expect(synthetic.typedTexts == ["a", "a"])
+    }
+
+    @Test
+    func `type actions retain the outer executor result and legacy payload parity`() async throws {
+        let actions: [TypeAction] = [.text("bc"), .key(.return)]
+        let synthetic = OutcomeSyntheticInputDriver(clickOutcome: Self.foregroundOutcome)
+        let service = self.makeSynthesisService(synthetic: synthetic)
+
+        let result = try await service.typeActionsWithOutcome(
+            actions,
+            cadence: .fixed(milliseconds: 0),
+            snapshotId: nil)
+        let legacy = try await service.typeActions(
+            actions,
+            cadence: .fixed(milliseconds: 0),
+            snapshotId: nil)
+
+        #expect(result.outcome == Self.foregroundOutcome)
+        #expect(result.payload.totalCharacters == 2)
+        #expect(result.payload.keyPresses == 3)
+        #expect(legacy.totalCharacters == result.payload.totalCharacters)
+        #expect(legacy.keyPresses == result.payload.keyPresses)
+
+        let typeService = TypeService(
+            inputPolicy: UIInputPolicy(defaultStrategy: .synthOnly),
+            syntheticInputDriver: synthetic,
+            randomSource: SystemTypingCadenceRandomSource())
+        var completionOutcome: DesktopActionOutcome?
+        let summary = try await typeService.typeActionsTrackingSecureInput(
+            [],
+            cadence: .fixed(milliseconds: 0),
+            snapshotId: nil,
+            targetProcessIdentifier: nil,
+            laneCompletion: { completionOutcome = $0.executionResult.outcome })
+
+        #expect(summary.executionResult.outcome == Self.foregroundOutcome)
+        #expect(completionOutcome == summary.executionResult.outcome)
+    }
+
+    @Test
+    func `scroll result returns the executor outcome and legacy adapter repeats the same input`() async throws {
+        let synthetic = OutcomeSyntheticInputDriver(clickOutcome: Self.foregroundOutcome)
+        let service = self.makeSynthesisService(synthetic: synthetic)
+        let request = ScrollRequest(
+            direction: .down,
+            amount: 1,
+            smooth: false,
+            delay: 0,
+            foreground: true)
+
+        let result = try await service.scrollWithOutcome(request)
+        try await service.scroll(request)
+
+        #expect(result.outcome == Self.foregroundOutcome)
+        #expect(synthetic.scrollCount == 2)
+    }
+
+    @Test
+    func `hotkey result returns the exact action outcome and legacy adapter repeats the same chord`() async throws {
+        let expected = Self.outcome(mechanism: .globalEvents, mode: .foreground)
+        let actionDriver = OutcomeActionInputDriver(outcome: expected)
+        let service = self.makeHotkeyService(actionDriver: actionDriver)
+
+        let result = try await service.hotkeyWithOutcome(keys: "cmd,k", holdDuration: 0)
+        try await service.hotkey(keys: "cmd,k", holdDuration: 0)
+
+        #expect(result.outcome == expected)
+        #expect(actionDriver.hotkeyCount == 2)
+    }
+
+    @Test
+    func `set value result preserves payload and exact outcome with legacy payload parity`() async throws {
+        let expected = Self.outcome(mechanism: .accessibilityValue, mode: .background)
+        let resultDriver = OutcomeActionInputDriver(outcome: expected, storedValue: "old")
+        let legacyDriver = OutcomeActionInputDriver(outcome: expected, storedValue: "old")
+        let resultService = self.makeElementActionService(actionDriver: resultDriver)
+        let legacyService = self.makeElementActionService(actionDriver: legacyDriver)
+
+        let result = try await resultService.setValueWithOutcome(
+            target: "E1",
+            value: .string("new"),
+            snapshotId: "snapshot")
+        let legacy = try await legacyService.setValue(
+            target: "E1",
+            value: .string("new"),
+            snapshotId: "snapshot")
+
+        #expect(result.outcome == expected)
+        #expect(result.payload == legacy)
+        #expect(result.payload.oldValue == "old")
+        #expect(result.payload.newValue == "new")
+        #expect(resultDriver.setValueCount == 1)
+        #expect(legacyDriver.setValueCount == 1)
+    }
+
+    @Test
+    func `perform action result preserves payload and exact outcome with legacy payload parity`() async throws {
+        let expected = Self.outcome(mechanism: .accessibilityAction, mode: .background)
+        let resultDriver = OutcomeActionInputDriver(outcome: expected)
+        let legacyDriver = OutcomeActionInputDriver(outcome: expected)
+        let resultService = self.makeElementActionService(actionDriver: resultDriver)
+        let legacyService = self.makeElementActionService(actionDriver: legacyDriver)
+
+        let result = try await resultService.performActionWithOutcome(
+            target: "E1",
+            actionName: "AXPress",
+            snapshotId: "snapshot")
+        let legacy = try await legacyService.performAction(
+            target: "E1",
+            actionName: "AXPress",
+            snapshotId: "snapshot")
+
+        #expect(result.outcome == expected)
+        #expect(result.payload == legacy)
+        #expect(resultDriver.performActionCount == 1)
+        #expect(legacyDriver.performActionCount == 1)
+    }
+
+    @Test
+    func `targeted result overloads return exact background executor outcomes`() async throws {
+        let generation: UInt64 = 71
+        let processIdentity = ApplicationProcessIdentity(
+            processIdentifier: getpid(),
+            processStartIdentity: generation)
+        let bounds = CGRect(x: 100, y: 100, width: 500, height: 400)
+        let windowIdentity = WindowMutationIdentity(
+            windowID: 307,
+            ownerProcessIdentifier: getpid(),
+            ownerProcessStartIdentity: generation,
+            capturedBounds: bounds)
+        let focused = FocusedElementIdentity(
+            processIdentifier: getpid(),
+            windowID: windowIdentity.windowID,
+            role: "AXTextField",
+            title: "Editor",
+            identifier: "editor",
+            frame: CGRect(x: 150, y: 150, width: 200, height: 30))
+        let exactTarget = ExactWindowKeyboardTarget(
+            windowIdentity: windowIdentity,
+            windowBounds: bounds,
+            focusedElement: focused)
+        let expectedClick = Self.outcome(mechanism: .windowTargetedEvents, mode: .background)
+        let synthetic = OutcomeSyntheticInputDriver(clickOutcome: expectedClick)
+        let service = self.makeTargetedService(
+            synthetic: synthetic,
+            generation: generation,
+            windowIdentity: windowIdentity,
+            focused: focused)
+        let clickTarget = ClickTarget.elementId("B1")
+
+        let clickResults = try await WindowMovementTrackingProviderScope.withProvider(
+            TargetedWindowTracker(
+                windowID: CGWindowID(windowIdentity.windowID),
+                bounds: bounds,
+                processIdentifier: getpid()))
+        {
+            let pidClick = try await service.clickWithOutcome(
+                target: clickTarget,
+                clickType: .single,
+                snapshotId: "targeted",
+                targetProcessIdentifier: getpid())
+            let processClick = try await service.clickWithOutcome(
+                target: clickTarget,
+                clickType: .single,
+                snapshotId: "targeted",
+                expectedProcessIdentity: processIdentity)
+            let windowClick = try await service.clickWithOutcome(
+                target: clickTarget,
+                clickType: .single,
+                snapshotId: "targeted",
+                expectedWindowIdentity: windowIdentity,
+                expectedWindowBounds: bounds)
+            return [pidClick, processClick, windowClick]
+        }
+
+        for result in clickResults {
+            #expect(result.outcome == expectedClick)
+        }
+
+        let pidType = try await service.typeActionsWithOutcome(
+            [],
+            cadence: .fixed(milliseconds: 0),
+            snapshotId: nil,
+            targetProcessIdentifier: getpid())
+        let processType = try await service.typeActionsWithOutcome(
+            [],
+            cadence: .fixed(milliseconds: 0),
+            snapshotId: nil,
+            expectedProcessIdentity: processIdentity)
+        let windowType = try await service.typeActionsWithOutcome(
+            [],
+            cadence: .fixed(milliseconds: 0),
+            snapshotId: nil,
+            expectedWindowIdentity: windowIdentity,
+            expectedWindowBounds: bounds)
+        let focusedType = try await service.typeActionsWithOutcome(
+            [],
+            cadence: .fixed(milliseconds: 0),
+            snapshotId: nil,
+            target: exactTarget)
+
+        for result in [pidType, processType, windowType, focusedType] {
+            #expect(result.outcome == Self.backgroundOutcome)
+            #expect(result.payload.totalCharacters == 0)
+            #expect(result.payload.keyPresses == 0)
+        }
+
+        let pidHotkey = try await service.hotkeyWithOutcome(
+            keys: "cmd,shift,l",
+            holdDuration: 0,
+            targetProcessIdentifier: getpid())
+        let processHotkey = try await service.hotkeyWithOutcome(
+            keys: "cmd,shift,l",
+            holdDuration: 0,
+            expectedProcessIdentity: processIdentity)
+        let windowHotkey = try await service.hotkeyWithOutcome(
+            keys: "cmd,shift,l",
+            holdDuration: 0,
+            expectedWindowIdentity: windowIdentity,
+            expectedWindowBounds: bounds)
+        let focusedHotkey = try await service.hotkeyWithOutcome(
+            keys: "cmd,shift,l",
+            holdDuration: 0,
+            target: exactTarget)
+
+        for result in [pidHotkey, processHotkey, windowHotkey, focusedHotkey] {
+            #expect(result.outcome == Self.backgroundOutcome)
+        }
+    }
+
+    private func makeSynthesisService(synthetic: OutcomeSyntheticInputDriver) -> UIAutomationService {
+        UIAutomationService(
+            inputPolicy: UIInputPolicy(defaultStrategy: .synthOnly),
+            actionInputDriver: OutcomeActionInputDriver(outcome: Self.foregroundOutcome),
+            syntheticInputDriver: synthetic,
+            automationElementResolver: FixedOutcomeAutomationElementResolver())
+    }
+
+    private func makeHotkeyService(actionDriver: OutcomeActionInputDriver) -> UIAutomationService {
+        UIAutomationService(
+            inputPolicy: UIInputPolicy(defaultStrategy: .actionOnly),
+            actionInputDriver: actionDriver,
+            automationElementResolver: FixedOutcomeAutomationElementResolver(),
+            hotkeyServiceFactory: { context in
+                HotkeyService(
+                    inputPolicy: UIInputPolicy(defaultStrategy: .actionOnly),
+                    actionInputDriver: actionDriver,
+                    frontmostApplicationResolver: {
+                        NSRunningApplication(processIdentifier: getpid())
+                    },
+                    processStartIdentityProvider: context.processStartIdentityProvider,
+                    desktopOperationExecutor: context.desktopOperationExecutor,
+                    operationFinalizer: context.operationFinalizer)
+            })
+    }
+
+    private func makeElementActionService(actionDriver: OutcomeActionInputDriver) -> UIAutomationService {
+        let detected = AutomationTestFixtures.detectedElement(
+            id: "E1",
+            type: .textField,
+            label: "Value")
+        let detection = AutomationTestFixtures.detectionResult(
+            snapshotID: "snapshot",
+            elements: DetectedElements(textFields: [detected]))
+        return UIAutomationService(
+            snapshotManager: InMemorySnapshotManager(detectionResult: detection),
+            inputPolicy: UIInputPolicy(defaultStrategy: .actionOnly),
+            actionInputDriver: actionDriver,
+            automationElementResolver: FixedOutcomeAutomationElementResolver(),
+            elementMutationValueReader: { _ in actionDriver.storedValue })
+    }
+
+    private func makeTargetedService(
+        synthetic: OutcomeSyntheticInputDriver,
+        generation: UInt64,
+        windowIdentity: WindowMutationIdentity,
+        focused: FocusedElementIdentity) -> UIAutomationService
+    {
+        let detected = AutomationTestFixtures.detectedElement(
+            id: "B1",
+            type: .button,
+            label: "Button",
+            bounds: focused.frame)
+        let context = WindowContext(
+            applicationName: "Test App",
+            applicationBundleId: "com.example.TestApp",
+            applicationProcessId: windowIdentity.ownerProcessIdentifier,
+            windowTitle: "Test Window",
+            windowID: windowIdentity.windowID,
+            windowBounds: windowIdentity.capturedBounds,
+            windowMutationIdentity: windowIdentity)
+        let detection = AutomationTestFixtures.detectionResult(
+            snapshotID: "targeted",
+            elements: DetectedElements(buttons: [detected]),
+            windowContext: context)
+        return UIAutomationService(
+            snapshotManager: InMemorySnapshotManager(detectionResult: detection),
+            inputPolicy: UIInputPolicy(defaultStrategy: .synthOnly),
+            actionInputDriver: OutcomeActionInputDriver(outcome: Self.backgroundOutcome),
+            syntheticInputDriver: synthetic,
+            automationElementResolver: FixedOutcomeAutomationElementResolver(),
+            hotkeyServiceFactory: { context in
+                HotkeyService(
+                    inputPolicy: UIInputPolicy(defaultStrategy: .synthOnly),
+                    postEventAccessEvaluator: { true },
+                    eventPoster: { _, _ in },
+                    runningApplicationResolver: {
+                        NSRunningApplication(processIdentifier: $0)
+                    },
+                    processStartIdentityProvider: context.processStartIdentityProvider,
+                    desktopOperationExecutor: context.desktopOperationExecutor,
+                    operationFinalizer: context.operationFinalizer)
+            },
+            exactWindowFocusReader: { _ in
+                ExactWindowFocusSnapshot(
+                    processIdentifier: focused.processIdentifier,
+                    windowID: focused.windowID,
+                    frame: focused.frame,
+                    role: focused.role,
+                    title: focused.title,
+                    identifier: focused.identifier)
+            },
+            exactWindowIdentityValidator: { identity, bounds in
+                identity == windowIdentity && bounds == windowIdentity.capturedBounds
+            },
+            processStartIdentityProvider: { _ in generation })
+    }
+
+    private static var foregroundOutcome: DesktopActionOutcome {
+        .dispatchedUnverified(
+            delivery: .init(mechanism: .globalEvents, mode: .foreground),
+            evidence: .deliveryAccepted)
+    }
+
+    private static var backgroundOutcome: DesktopActionOutcome {
+        .dispatchedUnverified(
+            delivery: .init(mechanism: .processTargetedEvents, mode: .background),
+            evidence: .deliveryAccepted)
+    }
+
+    private static func outcome(
+        mechanism: DesktopActionOutcome.Delivery.Mechanism,
+        mode: DesktopActionOutcome.Delivery.Mode) -> DesktopActionOutcome
+    {
+        .confirmedChange(
+            delivery: .init(mechanism: mechanism, mode: mode),
+            unitCount: DesktopActionOutcome.DispatchUnitCount(1))
+    }
+}
+
+@MainActor
+private final class OutcomeSyntheticInputDriver: SyntheticInputDriving {
+    private let clickOutcome: DesktopActionOutcome
+    private(set) var clickCount = 0
+    private(set) var scrollCount = 0
+    private(set) var typedTexts: [String] = []
+
+    init(clickOutcome: DesktopActionOutcome) {
+        self.clickOutcome = clickOutcome
+    }
+
+    func click(at _: CGPoint, button _: MouseButton, count _: Int) throws -> DesktopActionOutcome {
+        self.clickCount += 1
+        return self.clickOutcome
+    }
+
+    func click(
+        at _: CGPoint,
+        button _: MouseButton,
+        count _: Int,
+        targetProcessIdentifier _: pid_t) async throws -> DesktopActionOutcome
+    {
+        self.clickCount += 1
+        return self.clickOutcome
+    }
+
+    func click(
+        at _: CGPoint,
+        button _: MouseButton,
+        count _: Int,
+        targetProcessIdentifier _: pid_t,
+        targetWindowID _: CGWindowID?) async throws -> DesktopActionOutcome
+    {
+        self.clickCount += 1
+        return self.clickOutcome
+    }
+
+    func move(to _: CGPoint) throws {}
+
+    func currentLocation() -> CGPoint? {
+        CGPoint(x: 10, y: 10)
+    }
+
+    func pressHold(at _: CGPoint, button _: MouseButton, duration _: TimeInterval) async throws {}
+
+    func scroll(deltaX _: Double, deltaY _: Double, at _: CGPoint?) throws {
+        self.scrollCount += 1
+    }
+
+    func type(_ text: String, delayPerCharacter _: TimeInterval) throws {
+        self.typedTexts.append(text)
+    }
+
+    func tapKey(_: SpecialKey, modifiers _: CGEventFlags) throws {}
+
+    func hotkey(keys _: [String], holdDuration _: TimeInterval) throws {}
+}
+
+@MainActor
+private final class OutcomeActionInputDriver: ActionInputDriving {
+    private let outcome: DesktopActionOutcome
+    private(set) var hotkeyCount = 0
+    private(set) var setValueCount = 0
+    private(set) var performActionCount = 0
+    private(set) var storedValue: String?
+
+    init(outcome: DesktopActionOutcome, storedValue: String? = nil) {
+        self.outcome = outcome
+        self.storedValue = storedValue
+    }
+
+    func tryClick(element _: AutomationElement) throws -> UIInputExecutionResult.Action {
+        UIInputExecutionResult.Action(outcome: self.outcome)
+    }
+
+    func tryRightClick(element _: any AutomationElementRepresenting) async throws
+        -> UIInputExecutionResult.Action
+    {
+        UIInputExecutionResult.Action(outcome: self.outcome)
+    }
+
+    func tryScroll(
+        element _: AutomationElement,
+        direction _: ScrollDirection,
+        pages _: Int) throws -> UIInputExecutionResult.Action
+    {
+        UIInputExecutionResult.Action(outcome: self.outcome)
+    }
+
+    func trySetText(element _: AutomationElement, text _: String, replace _: Bool) throws
+        -> UIInputExecutionResult.Action
+    {
+        UIInputExecutionResult.Action(outcome: self.outcome)
+    }
+
+    func tryHotkey(application _: NSRunningApplication, keys _: [String]) throws
+        -> UIInputExecutionResult.Action
+    {
+        self.hotkeyCount += 1
+        return UIInputExecutionResult.Action(outcome: self.outcome)
+    }
+
+    func trySetValue(element _: AutomationElement, value: UIElementValue) throws
+        -> UIInputExecutionResult.Action
+    {
+        self.setValueCount += 1
+        self.storedValue = value.displayString
+        return UIInputExecutionResult.Action(
+            outcome: self.outcome,
+            actionName: "AXSetValue")
+    }
+
+    func tryPerformAction(element _: AutomationElement, actionName: String) throws
+        -> UIInputExecutionResult.Action
+    {
+        self.performActionCount += 1
+        return UIInputExecutionResult.Action(
+            outcome: self.outcome,
+            actionName: actionName)
+    }
+}
+
+@MainActor
+private struct FixedOutcomeAutomationElementResolver: AutomationElementResolving {
+    private let element = AutomationElement(Element(AXUIElementCreateApplication(getpid())))
+
+    func resolve(detectedElement _: DetectedElement, windowContext _: WindowContext?) -> AutomationElement? {
+        self.element
+    }
+
+    func resolve(query _: String, windowContext _: WindowContext?, requireTextInput _: Bool) -> AutomationElement? {
+        self.element
+    }
+}
+
+private final class TargetedWindowTracker: WindowTrackingProviding, @unchecked Sendable {
+    private let windowID: CGWindowID
+    private let bounds: CGRect
+    private let processIdentifier: pid_t
+
+    init(windowID: CGWindowID, bounds: CGRect, processIdentifier: pid_t) {
+        self.windowID = windowID
+        self.bounds = bounds
+        self.processIdentifier = processIdentifier
+    }
+
+    @MainActor
+    func windowBounds(for windowID: CGWindowID) -> CGRect? {
+        windowID == self.windowID ? self.bounds : nil
+    }
+
+    @MainActor
+    func windowOwnerProcessIdentifier(for windowID: CGWindowID) -> pid_t? {
+        windowID == self.windowID ? self.processIdentifier : nil
+    }
+
+    @MainActor
+    func refreshWindow(for _: CGWindowID) {}
+}

--- a/Core/PeekabooCore/Package.swift
+++ b/Core/PeekabooCore/Package.swift
@@ -96,6 +96,7 @@ let package = Package(
             dependencies: [
                 .target(name: "PeekabooBridge"),
                 .product(name: "PeekabooAutomationKit", package: "PeekabooAutomationKit"),
+                .product(name: "PeekabooAutomationKitTestSupport", package: "PeekabooAutomationKit"),
                 .product(name: "PeekabooFoundation", package: "PeekabooFoundation"),
             ],
             path: "Sources/PeekabooBridgeTestSupport",

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeClient+ActionOutcomes.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeClient+ActionOutcomes.swift
@@ -1,0 +1,317 @@
+import Foundation
+import PeekabooAutomationKit
+import PeekabooFoundation
+
+extension PeekabooBridgeClient {
+    public func clickWithOutcome(
+        target: ClickTarget,
+        clickType: ClickType,
+        snapshotId: String?) async throws -> UIAutomationActionResult<Void>
+    {
+        try await self.actionResult(
+            for: .click(.init(target: target, clickType: clickType, snapshotId: snapshotId)),
+            expectedResponse: "click")
+        { response in
+            guard case .ok = response else { return nil }
+            return ()
+        }
+    }
+
+    public func clickWithOutcome(
+        target: ClickTarget,
+        clickType: ClickType,
+        snapshotId: String?,
+        targetProcessIdentifier: pid_t) async throws -> UIAutomationActionResult<Void>
+    {
+        try await self.actionResult(
+            for: .targetedClick(.init(
+                target: target,
+                clickType: clickType,
+                snapshotId: snapshotId,
+                targetProcessIdentifier: Int32(targetProcessIdentifier))),
+            expectedResponse: "targeted click")
+        { response in
+            guard case .ok = response else { return nil }
+            return ()
+        }
+    }
+
+    public func clickWithOutcome(
+        target: ClickTarget,
+        clickType: ClickType,
+        snapshotId: String?,
+        expectedProcessIdentity: ApplicationProcessIdentity) async throws -> UIAutomationActionResult<Void>
+    {
+        try await self.actionResult(
+            for: .targetedClick(.init(
+                target: target,
+                clickType: clickType,
+                snapshotId: snapshotId,
+                targetProcessIdentifier: expectedProcessIdentity.processIdentifier,
+                expectedProcessIdentity: expectedProcessIdentity)),
+            expectedResponse: "generation-pinned click")
+        { response in
+            guard case .ok = response else { return nil }
+            return ()
+        }
+    }
+
+    public func clickWithOutcome(
+        target: ClickTarget,
+        clickType: ClickType,
+        snapshotId: String?,
+        expectedWindowIdentity: WindowMutationIdentity,
+        expectedWindowBounds: CGRect) async throws -> UIAutomationActionResult<Void>
+    {
+        try await self.actionResult(
+            for: .targetedClick(.init(
+                target: target,
+                clickType: clickType,
+                snapshotId: snapshotId,
+                targetProcessIdentifier: expectedWindowIdentity.ownerProcessIdentifier,
+                targetWindowID: expectedWindowIdentity.windowID,
+                expectedWindowIdentity: expectedWindowIdentity,
+                expectedWindowBounds: expectedWindowBounds)),
+            expectedResponse: "exact-window click")
+        { response in
+            guard case .ok = response else { return nil }
+            return ()
+        }
+    }
+
+    public func typeWithOutcome(
+        text: String,
+        target: String?,
+        clearExisting: Bool,
+        typingDelay: Int,
+        snapshotId: String?) async throws -> UIAutomationActionResult<Void>
+    {
+        try await self.actionResult(
+            for: .type(.init(
+                text: text,
+                target: target,
+                clearExisting: clearExisting,
+                typingDelay: typingDelay,
+                snapshotId: snapshotId)),
+            expectedResponse: "type")
+        { response in
+            guard case .ok = response else { return nil }
+            return ()
+        }
+    }
+
+    public func typeActionsWithOutcome(
+        _ actions: [TypeAction],
+        cadence: TypingCadence,
+        snapshotId: String?) async throws -> UIAutomationActionResult<TypeResult>
+    {
+        try await self.typeActionResult(for: .typeActions(.init(
+            actions: actions,
+            cadence: cadence,
+            snapshotId: snapshotId)))
+    }
+
+    public func typeActionsWithOutcome(
+        _ actions: [TypeAction],
+        cadence: TypingCadence,
+        snapshotId: String?,
+        targetProcessIdentifier: pid_t) async throws -> UIAutomationActionResult<TypeResult>
+    {
+        try await self.typeActionResult(for: .targetedTypeActions(.init(
+            actions: actions,
+            cadence: cadence,
+            snapshotId: snapshotId,
+            targetProcessIdentifier: Int32(targetProcessIdentifier))))
+    }
+
+    public func typeActionsWithOutcome(
+        _ actions: [TypeAction],
+        cadence: TypingCadence,
+        snapshotId: String?,
+        expectedProcessIdentity: ApplicationProcessIdentity) async throws -> UIAutomationActionResult<TypeResult>
+    {
+        try await self.typeActionResult(for: .targetedTypeActions(.init(
+            actions: actions,
+            cadence: cadence,
+            snapshotId: snapshotId,
+            targetProcessIdentifier: expectedProcessIdentity.processIdentifier,
+            expectedProcessIdentity: expectedProcessIdentity)))
+    }
+
+    public func typeActionsWithOutcome(
+        _ actions: [TypeAction],
+        cadence: TypingCadence,
+        snapshotId: String?,
+        expectedWindowIdentity: WindowMutationIdentity,
+        expectedWindowBounds: CGRect) async throws -> UIAutomationActionResult<TypeResult>
+    {
+        try await self.typeActionResult(for: .exactWindowTargetedTypeActions(.init(
+            actions: actions,
+            cadence: cadence,
+            snapshotId: snapshotId,
+            expectedWindowIdentity: expectedWindowIdentity,
+            expectedWindowBounds: expectedWindowBounds,
+            expectedFocusedElement: nil)))
+    }
+
+    public func typeActionsWithOutcome(
+        _ actions: [TypeAction],
+        cadence: TypingCadence,
+        snapshotId: String?,
+        target: ExactWindowKeyboardTarget) async throws -> UIAutomationActionResult<TypeResult>
+    {
+        try await self.typeActionResult(for: .exactWindowTargetedTypeActions(.init(
+            actions: actions,
+            cadence: cadence,
+            snapshotId: snapshotId,
+            expectedWindowIdentity: target.windowIdentity,
+            expectedWindowBounds: target.windowBounds,
+            expectedFocusedElement: target.focusedElement)))
+    }
+
+    public func scrollWithOutcome(
+        _ request: ScrollRequest) async throws -> UIAutomationActionResult<Void>
+    {
+        let payload = PeekabooBridgeScrollRequest(request: request)
+        return try await self.actionResult(
+            for: request.foreground ? .scroll(payload) : .targetedScroll(payload),
+            expectedResponse: "scroll")
+        { response in
+            guard case .ok = response else { return nil }
+            return ()
+        }
+    }
+
+    public func hotkeyWithOutcome(
+        keys: String,
+        holdDuration: Int) async throws -> UIAutomationActionResult<Void>
+    {
+        try await self.voidActionResult(
+            for: .hotkey(.init(keys: keys, holdDuration: holdDuration)),
+            expectedResponse: "hotkey")
+    }
+
+    public func hotkeyWithOutcome(
+        keys: String,
+        holdDuration: Int,
+        targetProcessIdentifier: pid_t) async throws -> UIAutomationActionResult<Void>
+    {
+        try await self.voidActionResult(
+            for: .targetedHotkey(.init(
+                keys: keys,
+                holdDuration: holdDuration,
+                targetProcessIdentifier: Int32(targetProcessIdentifier))),
+            expectedResponse: "targeted hotkey")
+    }
+
+    public func hotkeyWithOutcome(
+        keys: String,
+        holdDuration: Int,
+        expectedProcessIdentity: ApplicationProcessIdentity) async throws -> UIAutomationActionResult<Void>
+    {
+        try await self.voidActionResult(
+            for: .targetedHotkey(.init(
+                keys: keys,
+                holdDuration: holdDuration,
+                targetProcessIdentifier: expectedProcessIdentity.processIdentifier,
+                expectedProcessIdentity: expectedProcessIdentity)),
+            expectedResponse: "generation-pinned hotkey")
+    }
+
+    public func hotkeyWithOutcome(
+        keys: String,
+        holdDuration: Int,
+        expectedWindowIdentity: WindowMutationIdentity,
+        expectedWindowBounds: CGRect) async throws -> UIAutomationActionResult<Void>
+    {
+        try await self.voidActionResult(
+            for: .exactWindowTargetedHotkey(.init(
+                keys: keys,
+                holdDuration: holdDuration,
+                expectedWindowIdentity: expectedWindowIdentity,
+                expectedWindowBounds: expectedWindowBounds,
+                expectedFocusedElement: nil)),
+            expectedResponse: "exact-window hotkey")
+    }
+
+    public func hotkeyWithOutcome(
+        keys: String,
+        holdDuration: Int,
+        target: ExactWindowKeyboardTarget) async throws -> UIAutomationActionResult<Void>
+    {
+        try await self.voidActionResult(
+            for: .exactWindowTargetedHotkey(.init(
+                keys: keys,
+                holdDuration: holdDuration,
+                expectedWindowIdentity: target.windowIdentity,
+                expectedWindowBounds: target.windowBounds,
+                expectedFocusedElement: target.focusedElement)),
+            expectedResponse: "focused exact-window hotkey")
+    }
+
+    public func setValueWithOutcome(
+        target: String,
+        value: UIElementValue,
+        snapshotId: String?) async throws -> UIAutomationActionResult<ElementActionResult>
+    {
+        try await self.actionResult(
+            for: .setValue(.init(target: target, value: value, snapshotId: snapshotId)),
+            expectedResponse: "setValue")
+        { response in
+            guard case let .elementActionResult(result) = response else { return nil }
+            return result
+        }
+    }
+
+    public func performActionWithOutcome(
+        target: String,
+        actionName: String,
+        snapshotId: String?) async throws -> UIAutomationActionResult<ElementActionResult>
+    {
+        try await self.actionResult(
+            for: .performAction(.init(target: target, actionName: actionName, snapshotId: snapshotId)),
+            expectedResponse: "performAction")
+        { response in
+            guard case let .elementActionResult(result) = response else { return nil }
+            return result
+        }
+    }
+
+    private func typeActionResult(
+        for request: PeekabooBridgeRequest) async throws -> UIAutomationActionResult<TypeResult>
+    {
+        try await self.actionResult(for: request, expectedResponse: "type actions") { response in
+            guard case let .typeResult(result) = response else { return nil }
+            return result
+        }
+    }
+
+    private func voidActionResult(
+        for request: PeekabooBridgeRequest,
+        expectedResponse: String) async throws -> UIAutomationActionResult<Void>
+    {
+        try await self.actionResult(for: request, expectedResponse: expectedResponse) { response in
+            guard case .ok = response else { return nil }
+            return ()
+        }
+    }
+
+    private func actionResult<Payload: Sendable>(
+        for request: PeekabooBridgeRequest,
+        expectedResponse: String,
+        extract: (PeekabooBridgeResponse) -> Payload?) async throws -> UIAutomationActionResult<Payload>
+    {
+        let reply = try await self.sendCarryingActionOutcome(request)
+        if case let .error(envelope) = reply.response {
+            throw envelope
+        }
+        guard let payload = extract(reply.response) else {
+            throw PeekabooBridgeErrorEnvelope(
+                code: .invalidRequest,
+                message: "Unexpected \(expectedResponse) response")
+        }
+        return UIAutomationActionResult(
+            payload: payload,
+            outcome: reply.outcome?.outcome)
+    }
+}

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeClient+Interaction.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeClient+Interaction.swift
@@ -6,8 +6,7 @@ import PeekabooFoundation
 
 extension PeekabooBridgeClient {
     public func click(target: ClickTarget, clickType: ClickType, snapshotId: String?) async throws {
-        let payload = PeekabooBridgeClickRequest(target: target, clickType: clickType, snapshotId: snapshotId)
-        try await self.sendExpectOK(.click(payload))
+        _ = try await self.clickWithOutcome(target: target, clickType: clickType, snapshotId: snapshotId)
     }
 
     public func type(
@@ -17,13 +16,12 @@ extension PeekabooBridgeClient {
         typingDelay: Int,
         snapshotId: String?) async throws
     {
-        let payload = PeekabooBridgeTypeRequest(
+        _ = try await self.typeWithOutcome(
             text: text,
             target: target,
             clearExisting: clearExisting,
             typingDelay: typingDelay,
             snapshotId: snapshotId)
-        try await self.sendExpectOK(.type(payload))
     }
 
     public func typeActions(
@@ -31,16 +29,7 @@ extension PeekabooBridgeClient {
         cadence: TypingCadence,
         snapshotId: String?) async throws -> TypeResult
     {
-        let payload = PeekabooBridgeTypeActionsRequest(actions: actions, cadence: cadence, snapshotId: snapshotId)
-        let response = try await self.send(.typeActions(payload))
-        switch response {
-        case let .typeResult(result):
-            return result
-        case let .error(envelope):
-            throw envelope
-        default:
-            throw PeekabooBridgeErrorEnvelope(code: .invalidRequest, message: "Unexpected typeActions response")
-        }
+        try await self.typeActionsWithOutcome(actions, cadence: cadence, snapshotId: snapshotId).payload
     }
 
     public func typeActions(
@@ -49,23 +38,11 @@ extension PeekabooBridgeClient {
         snapshotId: String?,
         expectedProcessIdentity: ApplicationProcessIdentity) async throws -> TypeResult
     {
-        let payload = PeekabooBridgeTargetedTypeActionsRequest(
-            actions: actions,
+        try await self.typeActionsWithOutcome(
+            actions,
             cadence: cadence,
             snapshotId: snapshotId,
-            targetProcessIdentifier: expectedProcessIdentity.processIdentifier,
-            expectedProcessIdentity: expectedProcessIdentity)
-        let response = try await self.send(.targetedTypeActions(payload))
-        switch response {
-        case let .typeResult(result):
-            return result
-        case let .error(envelope):
-            throw envelope
-        default:
-            throw PeekabooBridgeErrorEnvelope(
-                code: .invalidRequest,
-                message: "Unexpected targetedTypeActions response")
-        }
+            expectedProcessIdentity: expectedProcessIdentity).payload
     }
 
     public func typeActions(
@@ -75,24 +52,12 @@ extension PeekabooBridgeClient {
         expectedWindowIdentity: WindowMutationIdentity,
         expectedWindowBounds: CGRect) async throws -> TypeResult
     {
-        let payload = PeekabooBridgeExactWindowTypeActionsRequest(
-            actions: actions,
+        try await self.typeActionsWithOutcome(
+            actions,
             cadence: cadence,
             snapshotId: snapshotId,
             expectedWindowIdentity: expectedWindowIdentity,
-            expectedWindowBounds: expectedWindowBounds,
-            expectedFocusedElement: nil)
-        let response = try await self.send(.exactWindowTargetedTypeActions(payload))
-        switch response {
-        case let .typeResult(result):
-            return result
-        case let .error(envelope):
-            throw envelope
-        default:
-            throw PeekabooBridgeErrorEnvelope(
-                code: .invalidRequest,
-                message: "Unexpected exactWindowTargetedTypeActions response")
-        }
+            expectedWindowBounds: expectedWindowBounds).payload
     }
 
     public func typeActions(
@@ -101,23 +66,11 @@ extension PeekabooBridgeClient {
         snapshotId: String?,
         target: ExactWindowKeyboardTarget) async throws -> TypeResult
     {
-        let payload = PeekabooBridgeExactWindowTypeActionsRequest(
-            actions: actions,
+        try await self.typeActionsWithOutcome(
+            actions,
             cadence: cadence,
             snapshotId: snapshotId,
-            expectedWindowIdentity: target.windowIdentity,
-            expectedWindowBounds: target.windowBounds,
-            expectedFocusedElement: target.focusedElement)
-        let response = try await self.send(.exactWindowTargetedTypeActions(payload))
-        guard case let .typeResult(result) = response else {
-            if case let .error(envelope) = response {
-                throw envelope
-            }
-            throw PeekabooBridgeErrorEnvelope(
-                code: .invalidRequest,
-                message: "Unexpected exactWindowTargetedTypeActions response")
-        }
-        return result
+            target: target).payload
     }
 
     public func getFocusedElement(targetProcessIdentifier: pid_t) async throws -> UIFocusInfo? {
@@ -141,22 +94,11 @@ extension PeekabooBridgeClient {
         snapshotId: String?,
         targetProcessIdentifier: pid_t) async throws -> TypeResult
     {
-        let payload = PeekabooBridgeTargetedTypeActionsRequest(
-            actions: actions,
+        try await self.typeActionsWithOutcome(
+            actions,
             cadence: cadence,
             snapshotId: snapshotId,
-            targetProcessIdentifier: Int32(targetProcessIdentifier))
-        let response = try await self.send(.targetedTypeActions(payload))
-        switch response {
-        case let .typeResult(result):
-            return result
-        case let .error(envelope):
-            throw envelope
-        default:
-            throw PeekabooBridgeErrorEnvelope(
-                code: .invalidRequest,
-                message: "Unexpected targetedTypeActions response")
-        }
+            targetProcessIdentifier: targetProcessIdentifier).payload
     }
 
     public func setValue(
@@ -164,51 +106,31 @@ extension PeekabooBridgeClient {
         value: UIElementValue,
         snapshotId: String?) async throws -> ElementActionResult
     {
-        let payload = PeekabooBridgeSetValueRequest(target: target, value: value, snapshotId: snapshotId)
-        let response = try await self.send(.setValue(payload))
-        switch response {
-        case let .elementActionResult(result):
-            return result
-        case let .error(envelope):
-            throw envelope
-        default:
-            throw PeekabooBridgeErrorEnvelope(code: .invalidRequest, message: "Unexpected setValue response")
-        }
+        try await self.setValueWithOutcome(target: target, value: value, snapshotId: snapshotId).payload
     }
 
     public func performAction(target: String, actionName: String, snapshotId: String?) async throws
         -> ElementActionResult
     {
-        let payload = PeekabooBridgePerformActionRequest(
+        try await self.performActionWithOutcome(
             target: target,
             actionName: actionName,
-            snapshotId: snapshotId)
-        let response = try await self.send(.performAction(payload))
-        switch response {
-        case let .elementActionResult(result):
-            return result
-        case let .error(envelope):
-            throw envelope
-        default:
-            throw PeekabooBridgeErrorEnvelope(code: .invalidRequest, message: "Unexpected performAction response")
-        }
+            snapshotId: snapshotId).payload
     }
 
     public func scroll(_ request: ScrollRequest) async throws {
-        let payload = PeekabooBridgeScrollRequest(request: request)
-        try await self.sendExpectOK(request.foreground ? .scroll(payload) : .targetedScroll(payload))
+        _ = try await self.scrollWithOutcome(request)
     }
 
     public func hotkey(keys: String, holdDuration: Int) async throws {
-        try await self.sendExpectOK(.hotkey(PeekabooBridgeHotkeyRequest(keys: keys, holdDuration: holdDuration)))
+        _ = try await self.hotkeyWithOutcome(keys: keys, holdDuration: holdDuration)
     }
 
     public func hotkey(keys: String, holdDuration: Int, targetProcessIdentifier: pid_t) async throws {
-        try await self.sendExpectOK(
-            .targetedHotkey(PeekabooBridgeTargetedHotkeyRequest(
-                keys: keys,
-                holdDuration: holdDuration,
-                targetProcessIdentifier: Int32(targetProcessIdentifier))))
+        _ = try await self.hotkeyWithOutcome(
+            keys: keys,
+            holdDuration: holdDuration,
+            targetProcessIdentifier: targetProcessIdentifier)
     }
 
     public func hotkey(
@@ -216,12 +138,10 @@ extension PeekabooBridgeClient {
         holdDuration: Int,
         expectedProcessIdentity: ApplicationProcessIdentity) async throws
     {
-        try await self.sendExpectOK(
-            .targetedHotkey(PeekabooBridgeTargetedHotkeyRequest(
-                keys: keys,
-                holdDuration: holdDuration,
-                targetProcessIdentifier: expectedProcessIdentity.processIdentifier,
-                expectedProcessIdentity: expectedProcessIdentity)))
+        _ = try await self.hotkeyWithOutcome(
+            keys: keys,
+            holdDuration: holdDuration,
+            expectedProcessIdentity: expectedProcessIdentity)
     }
 
     public func hotkey(
@@ -230,12 +150,11 @@ extension PeekabooBridgeClient {
         expectedWindowIdentity: WindowMutationIdentity,
         expectedWindowBounds: CGRect) async throws
     {
-        try await self.sendExpectOK(.exactWindowTargetedHotkey(.init(
+        _ = try await self.hotkeyWithOutcome(
             keys: keys,
             holdDuration: holdDuration,
             expectedWindowIdentity: expectedWindowIdentity,
-            expectedWindowBounds: expectedWindowBounds,
-            expectedFocusedElement: nil)))
+            expectedWindowBounds: expectedWindowBounds)
     }
 
     public func hotkey(
@@ -243,12 +162,10 @@ extension PeekabooBridgeClient {
         holdDuration: Int,
         target: ExactWindowKeyboardTarget) async throws
     {
-        try await self.sendExpectOK(.exactWindowTargetedHotkey(.init(
+        _ = try await self.hotkeyWithOutcome(
             keys: keys,
             holdDuration: holdDuration,
-            expectedWindowIdentity: target.windowIdentity,
-            expectedWindowBounds: target.windowBounds,
-            expectedFocusedElement: target.focusedElement)))
+            target: target)
     }
 
     public func click(
@@ -257,12 +174,11 @@ extension PeekabooBridgeClient {
         snapshotId: String?,
         targetProcessIdentifier: pid_t) async throws
     {
-        try await self.sendExpectOK(
-            .targetedClick(PeekabooBridgeTargetedClickRequest(
-                target: target,
-                clickType: clickType,
-                snapshotId: snapshotId,
-                targetProcessIdentifier: Int32(targetProcessIdentifier))))
+        _ = try await self.clickWithOutcome(
+            target: target,
+            clickType: clickType,
+            snapshotId: snapshotId,
+            targetProcessIdentifier: targetProcessIdentifier)
     }
 
     public func click(
@@ -271,13 +187,11 @@ extension PeekabooBridgeClient {
         snapshotId: String?,
         expectedProcessIdentity: ApplicationProcessIdentity) async throws
     {
-        try await self.sendExpectOK(
-            .targetedClick(PeekabooBridgeTargetedClickRequest(
-                target: target,
-                clickType: clickType,
-                snapshotId: snapshotId,
-                targetProcessIdentifier: expectedProcessIdentity.processIdentifier,
-                expectedProcessIdentity: expectedProcessIdentity)))
+        _ = try await self.clickWithOutcome(
+            target: target,
+            clickType: clickType,
+            snapshotId: snapshotId,
+            expectedProcessIdentity: expectedProcessIdentity)
     }
 
     public func click(
@@ -287,15 +201,12 @@ extension PeekabooBridgeClient {
         expectedWindowIdentity: WindowMutationIdentity,
         expectedWindowBounds: CGRect) async throws
     {
-        try await self.sendExpectOK(
-            .targetedClick(PeekabooBridgeTargetedClickRequest(
-                target: target,
-                clickType: clickType,
-                snapshotId: snapshotId,
-                targetProcessIdentifier: expectedWindowIdentity.ownerProcessIdentifier,
-                targetWindowID: expectedWindowIdentity.windowID,
-                expectedWindowIdentity: expectedWindowIdentity,
-                expectedWindowBounds: expectedWindowBounds)))
+        _ = try await self.clickWithOutcome(
+            target: target,
+            clickType: clickType,
+            snapshotId: snapshotId,
+            expectedWindowIdentity: expectedWindowIdentity,
+            expectedWindowBounds: expectedWindowBounds)
     }
 
     public func swipe(

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeClient+Transport.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeClient+Transport.swift
@@ -7,6 +7,13 @@ extension PeekabooBridgeClient {
         _ request: PeekabooBridgeRequest,
         timeoutSec: TimeInterval? = nil) async throws -> PeekabooBridgeResponse
     {
+        try await self.sendCarryingActionOutcome(request, timeoutSec: timeoutSec).response
+    }
+
+    func sendCarryingActionOutcome(
+        _ request: PeekabooBridgeRequest,
+        timeoutSec: TimeInterval? = nil) async throws -> PeekabooBridgeTransportReply
+    {
         let explicitlyProjected = if case .projectedAction = request {
             true
         } else {
@@ -84,10 +91,11 @@ extension PeekabooBridgeClient {
                 operation: op,
                 causeDescription: "Bridge response decoding failed: \(error)")
         }
-        let response = try Self.unwrapResponse(
+        let reply = try Self.unwrapResponse(
             wireResponse,
             expectsProjectedResponse: expectsProjectedResponse,
             request: request)
+        let response = reply.response
         if case let .error(envelope) = response,
            request.mayMutateDesktop
         {
@@ -101,13 +109,13 @@ extension PeekabooBridgeClient {
         let duration = Date().timeIntervalSince(start)
         self.logger.debug(
             "bridge \(op.rawValue, privacy: .public) completed in \(duration, format: .fixed(precision: 3))s")
-        return response
+        return reply
     }
 
     private nonisolated static func unwrapResponse(
         _ response: PeekabooBridgeResponse,
         expectsProjectedResponse: Bool,
-        request: PeekabooBridgeRequest) throws -> PeekabooBridgeResponse
+        request: PeekabooBridgeRequest) throws -> PeekabooBridgeTransportReply
     {
         if expectsProjectedResponse {
             guard case let .projectedAction(payload) = response else {
@@ -127,10 +135,14 @@ extension PeekabooBridgeClient {
                     operation: request.operation,
                     causeDescription: "Bridge action response and error envelope carried contradictory outcomes")
             }
-            return payload.response
+            return PeekabooBridgeTransportReply(
+                response: payload.response,
+                outcome: payload.outcome)
         }
 
-        guard case .projectedAction = response else { return response }
+        guard case .projectedAction = response else {
+            return PeekabooBridgeTransportReply(response: response, outcome: nil)
+        }
         if request.mayMutateDesktop {
             throw self.responseLostFailure(
                 operation: request.operation,
@@ -149,6 +161,21 @@ extension PeekabooBridgeClient {
         switch response {
         case .ok:
             return
+        case let .error(envelope):
+            throw envelope
+        default:
+            throw PeekabooBridgeErrorEnvelope(code: .invalidRequest, message: "Unexpected response for void request")
+        }
+    }
+
+    func sendExpectOKCarryingActionOutcome(
+        _ request: PeekabooBridgeRequest,
+        timeoutSec: TimeInterval? = nil) async throws -> DesktopActionOutcome?
+    {
+        let reply = try await self.sendCarryingActionOutcome(request, timeoutSec: timeoutSec)
+        switch reply.response {
+        case .ok:
+            return reply.outcome?.outcome
         case let .error(envelope):
             throw envelope
         default:
@@ -255,6 +282,11 @@ extension PeekabooBridgeClient {
             hint: "Observe the target before retrying this operation.",
             causeDescription: envelope.details)
     }
+}
+
+struct PeekabooBridgeTransportReply: Sendable {
+    let response: PeekabooBridgeResponse
+    let outcome: DesktopActionOutcome.Projection?
 }
 
 private struct PeekabooBridgeResponseReadFailure: Error {

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeHandledResponse.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeHandledResponse.swift
@@ -1,0 +1,19 @@
+import PeekabooFoundation
+
+/// One internal Bridge response plus the canonical action outcome erased by the legacy wire case.
+struct PeekabooBridgeHandledResponse: Sendable {
+    let response: PeekabooBridgeResponse
+    let outcome: DesktopActionOutcome?
+
+    init(
+        response: PeekabooBridgeResponse,
+        outcome: DesktopActionOutcome? = nil)
+    {
+        self.response = response
+        self.outcome = outcome
+    }
+
+    func replacingResponse(_ response: PeekabooBridgeResponse) -> Self {
+        Self(response: response, outcome: self.outcome)
+    }
+}

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer+Handlers.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer+Handlers.swift
@@ -8,48 +8,48 @@ extension PeekabooBridgeServer {
     func handleAuthorized(
         _ request: PeekabooBridgeRequest,
         peer: PeekabooBridgePeer?,
-        permissions: PermissionsStatus) async throws -> PeekabooBridgeResponse
+        permissions: PermissionsStatus) async throws -> PeekabooBridgeHandledResponse
     {
         switch request.operation {
         case .permissionsStatus, .requestPostEventPermission, .daemonStatus, .daemonStop:
-            try await self.handleCoreRequest(request, peer: peer, permissions: permissions)
+            return try await .init(response: self.handleCoreRequest(request, peer: peer, permissions: permissions))
         case .browserStatus, .browserConnect, .browserDisconnect, .browserExecute:
-            try await self.handleBrowserRequest(request)
+            return try await .init(response: self.handleBrowserRequest(request))
         case .captureScreen, .captureWindow, .captureFrontmost, .captureArea:
-            try await self.handleCaptureRequest(request)
+            return try await .init(response: self.handleCaptureRequest(request))
         case .desktopObservation:
-            try await self.handleDesktopObservationRequest(request)
+            return try await .init(response: self.handleDesktopObservationRequest(request))
         case .detectElements, .inspectAccessibilityTree, .getFocusedElement, .click, .type, .typeActions,
              .targetedTypeActions, .exactWindowTargetedTypeActions,
              .setValue, .performAction, .scroll, .targetedScroll, .hotkey, .targetedHotkey,
              .exactWindowTargetedHotkey, .targetedClick,
              .exactWindowTargetedClick, .swipe, .drag, .moveMouse, .waitForElement:
-            try await self.handleAutomationRequest(request)
+            return try await self.handleAutomationRequest(request)
         case .listWindows, .focusWindow, .moveWindow, .resizeWindow, .setWindowBounds, .closeWindow,
              .backgroundCloseWindow,
              .minimizeWindow, .restoreWindow, .maximizeWindow, .getFocusedWindow:
-            try await self.handleWindowRequest(request)
+            return try await .init(response: self.handleWindowRequest(request))
         case .listApplications, .findApplication, .getFrontmostApplication, .isApplicationRunning,
              .launchApplication, .launchApplicationWithOptions, .relaunchApplicationWithOptions,
              .activateApplication, .quitApplication,
              .hideApplication, .unhideApplication, .hideOtherApplications, .showAllApplications:
-            try await self.handleApplicationRequest(request)
+            return try await .init(response: self.handleApplicationRequest(request))
         case .listMenus, .listFrontmostMenus, .clickMenuItem, .clickMenuItemByName, .listMenuExtras,
              .clickMenuExtra, .menuExtraOpenMenuFrame, .listMenuBarItems, .clickMenuBarItemNamed,
              .clickMenuBarItemIndex:
-            try await self.handleMenuRequest(request)
+            return try await .init(response: self.handleMenuRequest(request))
         case .listDockItems, .launchDockItem, .rightClickDockItem, .hideDock, .showDock, .isDockHidden,
              .findDockItem:
-            try await self.handleDockRequest(request)
+            return try await .init(response: self.handleDockRequest(request))
         case .dialogFindActive, .dialogClickButton, .backgroundDialogClickButton, .dialogEnterText,
              .dialogHandleFile, .dialogDismiss,
              .dialogListElements:
-            try await self.handleDialogRequest(request)
+            return try await .init(response: self.handleDialogRequest(request))
         case .createSnapshot, .storeDetectionResult, .getDetectionResult, .storeScreenshot,
              .storeObservationSnapshot, .storeAnnotatedScreenshot, .listSnapshots, .getMostRecentSnapshot,
              .cleanSnapshot,
              .invalidateImplicitLatestSnapshot, .cleanSnapshotsOlderThan, .cleanAllSnapshots:
-            try await self.handleSnapshotRequest(request)
+            return try await .init(response: self.handleSnapshotRequest(request))
         case ._appleScriptProbe:
             throw PeekabooBridgeErrorEnvelope(
                 code: .operationNotSupported,
@@ -176,18 +176,20 @@ extension PeekabooBridgeServer {
         }
     }
 
-    private func handleAutomationRequest(_ request: PeekabooBridgeRequest) async throws -> PeekabooBridgeResponse {
+    private func handleAutomationRequest(
+        _ request: PeekabooBridgeRequest) async throws -> PeekabooBridgeHandledResponse
+    {
         switch request {
         case let .detectElements(payload):
             let result = try await self.services.automation.detectElements(
                 in: payload.imageData,
                 snapshotId: payload.snapshotId,
                 windowContext: payload.windowContext)
-            return .elementDetection(result)
+            return .init(response: .elementDetection(result))
         case let .inspectAccessibilityTree(payload):
             let result = try await self.services.automation.inspectAccessibilityTree(
                 windowContext: payload.windowContext)
-            return .elementDetection(result)
+            return .init(response: .elementDetection(result))
         case let .getFocusedElement(payload):
             guard let automation = self.services.automation as? any TargetedFocusedElementServiceProtocol else {
                 throw PeekabooBridgeErrorEnvelope(
@@ -196,61 +198,79 @@ extension PeekabooBridgeServer {
             }
             let focusedElement = await automation.getFocusedElement(
                 targetProcessIdentifier: pid_t(payload.targetProcessIdentifier))
-            return .focusedElement(focusedElement)
+            return .init(response: .focusedElement(focusedElement))
         case let .click(payload):
-            try await self.services.automation.click(
-                target: payload.target,
-                clickType: payload.clickType,
-                snapshotId: payload.snapshotId)
-            return .ok
+            return try await self.handleAutomationAction(
+                withOutcome: { service in
+                    try await service.clickWithOutcome(
+                        target: payload.target,
+                        clickType: payload.clickType,
+                        snapshotId: payload.snapshotId)
+                },
+                legacy: {
+                    try await self.services.automation.click(
+                        target: payload.target,
+                        clickType: payload.clickType,
+                        snapshotId: payload.snapshotId)
+                    return ()
+                },
+                response: { _ in .ok })
         case let .type(payload):
-            try await self.services.automation.type(
-                text: payload.text,
-                target: payload.target,
-                clearExisting: payload.clearExisting,
-                typingDelay: payload.typingDelay,
-                snapshotId: payload.snapshotId)
-            return .ok
+            return try await self.handleAutomationAction(
+                withOutcome: { service in
+                    try await service.typeWithOutcome(
+                        text: payload.text,
+                        target: payload.target,
+                        clearExisting: payload.clearExisting,
+                        typingDelay: payload.typingDelay,
+                        snapshotId: payload.snapshotId)
+                },
+                legacy: {
+                    try await self.services.automation.type(
+                        text: payload.text,
+                        target: payload.target,
+                        clearExisting: payload.clearExisting,
+                        typingDelay: payload.typingDelay,
+                        snapshotId: payload.snapshotId)
+                    return ()
+                },
+                response: { _ in .ok })
         case let .typeActions(payload):
-            let result = try await self.services.automation.typeActions(
-                payload.actions,
-                cadence: payload.cadence,
-                snapshotId: payload.snapshotId)
-            return .typeResult(result)
+            return try await self.handleAutomationAction(
+                withOutcome: { service in
+                    try await service.typeActionsWithOutcome(
+                        payload.actions,
+                        cadence: payload.cadence,
+                        snapshotId: payload.snapshotId)
+                },
+                legacy: {
+                    try await self.services.automation.typeActions(
+                        payload.actions,
+                        cadence: payload.cadence,
+                        snapshotId: payload.snapshotId)
+                },
+                response: PeekabooBridgeResponse.typeResult)
         case .targetedTypeActions, .exactWindowTargetedTypeActions, .targetedHotkey,
              .exactWindowTargetedHotkey, .targetedClick:
             return try await self.handleTargetedAutomationRequest(request)
-        case let .setValue(payload):
-            guard let automation = self.services.automation as? any ElementActionAutomationServiceProtocol else {
-                throw PeekabooBridgeErrorEnvelope(
-                    code: .operationNotSupported,
-                    message: "setValue is not supported by this bridge host")
-            }
-            let result = try await automation.setValue(
-                target: payload.target,
-                value: payload.value,
-                snapshotId: payload.snapshotId)
-            return .elementActionResult(result)
-        case let .performAction(payload):
-            guard let automation = self.services.automation as? any ElementActionAutomationServiceProtocol else {
-                throw PeekabooBridgeErrorEnvelope(
-                    code: .operationNotSupported,
-                    message: "performAction is not supported by this bridge host")
-            }
-            let result = try await automation.performAction(
-                target: payload.target,
-                actionName: payload.actionName,
-                snapshotId: payload.snapshotId)
-            return .elementActionResult(result)
+        case .setValue, .performAction:
+            return try await self.handleElementActionRequest(request)
         case let .scroll(payload):
-            try await self.services.automation.scroll(payload.request)
-            return .ok
+            return try await self.handleScroll(payload.request)
         case let .targetedScroll(payload):
-            try await self.services.automation.scroll(payload.request)
-            return .ok
+            return try await self.handleScroll(payload.request)
         case let .hotkey(payload):
-            try await self.services.automation.hotkey(keys: payload.keys, holdDuration: payload.holdDuration)
-            return .ok
+            return try await self.handleAutomationAction(
+                withOutcome: { service in
+                    try await service.hotkeyWithOutcome(keys: payload.keys, holdDuration: payload.holdDuration)
+                },
+                legacy: {
+                    try await self.services.automation.hotkey(
+                        keys: payload.keys,
+                        holdDuration: payload.holdDuration)
+                    return ()
+                },
+                response: { _ in .ok })
         case let .swipe(payload):
             try await self.services.automation.swipe(
                 from: payload.from,
@@ -258,30 +278,100 @@ extension PeekabooBridgeServer {
                 duration: payload.duration,
                 steps: payload.steps,
                 profile: payload.profile)
-            return .ok
+            return .init(response: .ok)
         case let .drag(payload):
             try await self.services.automation.drag(payload.automationRequest)
-            return .ok
+            return .init(response: .ok)
         case let .moveMouse(payload):
             try await self.services.automation.moveMouse(
                 to: payload.to,
                 duration: payload.duration,
                 steps: payload.steps,
                 profile: payload.profile)
-            return .ok
+            return .init(response: .ok)
         case let .waitForElement(payload):
             let result = try await self.services.automation.waitForElement(
                 target: payload.target,
                 timeout: payload.timeout,
                 snapshotId: payload.snapshotId)
-            return .waitResult(result)
+            return .init(response: .waitResult(result))
+        default:
+            throw Self.invalidRequest(for: request)
+        }
+    }
+
+    private func handleScroll(_ request: ScrollRequest) async throws -> PeekabooBridgeHandledResponse {
+        try await self.handleAutomationAction(
+            withOutcome: { service in
+                try await service.scrollWithOutcome(request)
+            },
+            legacy: {
+                try await self.services.automation.scroll(request)
+                return ()
+            },
+            response: { _ in .ok })
+    }
+
+    private func handleAutomationAction<Payload: Sendable>(
+        withOutcome: (any UIAutomationActionOutcomeProviding) async throws -> UIAutomationActionResult<Payload>,
+        legacy: () async throws -> Payload,
+        response: (Payload) -> PeekabooBridgeResponse) async throws -> PeekabooBridgeHandledResponse
+    {
+        guard let service = self.services.automation as? any UIAutomationActionOutcomeProviding else {
+            let payload = try await legacy()
+            return .init(response: response(payload))
+        }
+        let result = try await withOutcome(service)
+        return .init(response: response(result.payload), outcome: result.outcome)
+    }
+
+    private func handleElementActionRequest(_ request: PeekabooBridgeRequest) async throws
+        -> PeekabooBridgeHandledResponse
+    {
+        guard let automation = self.services.automation as? any ElementActionAutomationServiceProtocol else {
+            throw PeekabooBridgeErrorEnvelope(
+                code: .operationNotSupported,
+                message: "Element actions are not supported by this bridge host")
+        }
+
+        switch request {
+        case let .setValue(payload):
+            return try await self.handleAutomationAction(
+                withOutcome: { service in
+                    try await service.setValueWithOutcome(
+                        target: payload.target,
+                        value: payload.value,
+                        snapshotId: payload.snapshotId)
+                },
+                legacy: {
+                    try await automation.setValue(
+                        target: payload.target,
+                        value: payload.value,
+                        snapshotId: payload.snapshotId)
+                },
+                response: PeekabooBridgeResponse.elementActionResult)
+        case let .performAction(payload):
+            return try await self.handleAutomationAction(
+                withOutcome: { service in
+                    try await service.performActionWithOutcome(
+                        target: payload.target,
+                        actionName: payload.actionName,
+                        snapshotId: payload.snapshotId)
+                },
+                legacy: {
+                    try await automation.performAction(
+                        target: payload.target,
+                        actionName: payload.actionName,
+                        snapshotId: payload.snapshotId)
+                },
+                response: PeekabooBridgeResponse.elementActionResult)
         default:
             throw Self.invalidRequest(for: request)
         }
     }
 
     private func handleTargetedAutomationRequest(_ request: PeekabooBridgeRequest) async throws
-        -> PeekabooBridgeResponse
+        -> PeekabooBridgeHandledResponse
     {
         switch request {
         case let .targetedTypeActions(payload):
@@ -294,126 +384,210 @@ extension PeekabooBridgeServer {
                     message: "Background typing is not supported by this bridge host")
             }
 
-            return try await .typeResult(self.handleTargetedTypeActions(payload, service: targetedTypeService))
+            return try await self.handleTargetedTypeActions(payload, service: targetedTypeService)
         case let .exactWindowTargetedTypeActions(payload):
-            guard let service = self.services.automation as? any ExactWindowTargetedKeyboardServiceProtocol,
-                  service.supportsExactWindowTargetedKeyboard
-            else {
-                throw PeekabooBridgeErrorEnvelope(
-                    code: .operationNotSupported,
-                    message: "Atomic exact-window background typing is not supported by this bridge host")
-            }
-            self.automationActivityObserver?(pid_t(payload.expectedWindowIdentity.ownerProcessIdentifier))
-            let result = if let expectedFocusedElement = payload.expectedFocusedElement {
-                try await service.typeActions(
-                    payload.actions,
-                    cadence: payload.cadence,
-                    snapshotId: payload.snapshotId,
-                    target: ExactWindowKeyboardTarget(
-                        windowIdentity: payload.expectedWindowIdentity,
-                        windowBounds: payload.expectedWindowBounds,
-                        focusedElement: expectedFocusedElement))
-            } else {
-                try await service.typeActions(
-                    payload.actions,
-                    cadence: payload.cadence,
-                    snapshotId: payload.snapshotId,
-                    expectedWindowIdentity: payload.expectedWindowIdentity,
-                    expectedWindowBounds: payload.expectedWindowBounds)
-            }
-            return .typeResult(result)
+            return try await self.handleExactWindowTargetedTypeActions(payload)
         case let .targetedHotkey(payload):
             return try await self.handleTargetedHotkey(payload)
         case let .exactWindowTargetedHotkey(payload):
-            guard let service = self.services.automation as? any ExactWindowTargetedKeyboardServiceProtocol,
-                  service.supportsExactWindowTargetedKeyboard
-            else {
-                throw PeekabooBridgeErrorEnvelope(
-                    code: .operationNotSupported,
-                    message: "Atomic exact-window background hotkeys are not supported by this bridge host")
-            }
-            self.automationActivityObserver?(pid_t(payload.expectedWindowIdentity.ownerProcessIdentifier))
-            if let expectedFocusedElement = payload.expectedFocusedElement {
-                try await service.hotkey(
-                    keys: payload.keys,
-                    holdDuration: payload.holdDuration,
-                    target: ExactWindowKeyboardTarget(
-                        windowIdentity: payload.expectedWindowIdentity,
-                        windowBounds: payload.expectedWindowBounds,
-                        focusedElement: expectedFocusedElement))
-            } else {
-                try await service.hotkey(
-                    keys: payload.keys,
-                    holdDuration: payload.holdDuration,
-                    expectedWindowIdentity: payload.expectedWindowIdentity,
-                    expectedWindowBounds: payload.expectedWindowBounds)
-            }
-            return .ok
+            return try await self.handleExactWindowTargetedHotkey(payload)
         case let .targetedClick(payload):
-            guard
-                let targetedClickService = self.services.automation as? any TargetedClickServiceProtocol,
-                targetedClickService.supportsTargetedClicks
-            else {
-                throw PeekabooBridgeErrorEnvelope(
-                    code: .operationNotSupported,
-                    message: "Background clicks are not supported by this bridge host")
-            }
-
-            if case .coordinates = payload.target, payload.targetWindowID == nil {
-                throw PeekabooBridgeErrorEnvelope(
-                    code: .invalidRequest,
-                    message: "Background coordinate clicks require an exact capture-time window identity and bounds; " +
-                        "PID-only coordinates are refused")
-            }
-
-            if let targetWindowID = payload.targetWindowID {
-                guard payload.expectedProcessIdentity == nil else {
-                    throw PeekabooBridgeErrorEnvelope(
-                        code: .invalidRequest,
-                        message: "Exact-window clicks cannot also supply a process-only identity")
-                }
-                guard let exactWindowService = targetedClickService as? any ExactWindowTargetedClickServiceProtocol
-                else {
-                    throw PeekabooBridgeErrorEnvelope(
-                        code: .operationNotSupported,
-                        message: "Exact-window background clicks are not supported by this bridge host")
-                }
-                guard let expectedIdentity = payload.expectedWindowIdentity,
-                      let expectedBounds = payload.expectedWindowBounds,
-                      expectedIdentity.windowID == targetWindowID,
-                      expectedIdentity.ownerProcessIdentifier == payload.targetProcessIdentifier
-                else {
-                    throw PeekabooBridgeErrorEnvelope(
-                        code: .invalidRequest,
-                        message: "Exact-window click requires a matching process-generation identity and bounds")
-                }
-                self.automationActivityObserver?(pid_t(payload.targetProcessIdentifier))
-                try await exactWindowService.click(
-                    target: payload.target,
-                    clickType: payload.clickType,
-                    snapshotId: payload.snapshotId,
-                    expectedWindowIdentity: expectedIdentity,
-                    expectedWindowBounds: expectedBounds)
-            } else {
-                try await self.handleProcessTargetedClick(payload, service: targetedClickService)
-            }
-            return .ok
+            return try await self.handleTargetedClick(payload)
         default:
             throw Self.invalidRequest(for: request)
         }
     }
 
+    private func handleExactWindowTargetedTypeActions(
+        _ payload: PeekabooBridgeExactWindowTypeActionsRequest) async throws
+        -> PeekabooBridgeHandledResponse
+    {
+        guard let service = self.services.automation as? any ExactWindowTargetedKeyboardServiceProtocol,
+              service.supportsExactWindowTargetedKeyboard
+        else {
+            throw PeekabooBridgeErrorEnvelope(
+                code: .operationNotSupported,
+                message: "Atomic exact-window background typing is not supported by this bridge host")
+        }
+        self.automationActivityObserver?(pid_t(payload.expectedWindowIdentity.ownerProcessIdentifier))
+        if let outcomeService = self.services.automation as? any UIAutomationActionOutcomeProviding {
+            let result = if let expectedFocusedElement = payload.expectedFocusedElement {
+                try await outcomeService.typeActionsWithOutcome(
+                    payload.actions,
+                    cadence: payload.cadence,
+                    snapshotId: payload.snapshotId,
+                    target: ExactWindowKeyboardTarget(
+                        windowIdentity: payload.expectedWindowIdentity,
+                        windowBounds: payload.expectedWindowBounds,
+                        focusedElement: expectedFocusedElement))
+            } else {
+                try await outcomeService.typeActionsWithOutcome(
+                    payload.actions,
+                    cadence: payload.cadence,
+                    snapshotId: payload.snapshotId,
+                    expectedWindowIdentity: payload.expectedWindowIdentity,
+                    expectedWindowBounds: payload.expectedWindowBounds)
+            }
+            return .init(response: .typeResult(result.payload), outcome: result.outcome)
+        }
+        let result = if let expectedFocusedElement = payload.expectedFocusedElement {
+            try await service.typeActions(
+                payload.actions,
+                cadence: payload.cadence,
+                snapshotId: payload.snapshotId,
+                target: ExactWindowKeyboardTarget(
+                    windowIdentity: payload.expectedWindowIdentity,
+                    windowBounds: payload.expectedWindowBounds,
+                    focusedElement: expectedFocusedElement))
+        } else {
+            try await service.typeActions(
+                payload.actions,
+                cadence: payload.cadence,
+                snapshotId: payload.snapshotId,
+                expectedWindowIdentity: payload.expectedWindowIdentity,
+                expectedWindowBounds: payload.expectedWindowBounds)
+        }
+        return .init(response: .typeResult(result))
+    }
+
+    private func handleExactWindowTargetedHotkey(
+        _ payload: PeekabooBridgeExactWindowHotkeyRequest) async throws
+        -> PeekabooBridgeHandledResponse
+    {
+        guard let service = self.services.automation as? any ExactWindowTargetedKeyboardServiceProtocol,
+              service.supportsExactWindowTargetedKeyboard
+        else {
+            throw PeekabooBridgeErrorEnvelope(
+                code: .operationNotSupported,
+                message: "Atomic exact-window background hotkeys are not supported by this bridge host")
+        }
+        self.automationActivityObserver?(pid_t(payload.expectedWindowIdentity.ownerProcessIdentifier))
+        if let outcomeService = self.services.automation as? any UIAutomationActionOutcomeProviding {
+            let result = if let expectedFocusedElement = payload.expectedFocusedElement {
+                try await outcomeService.hotkeyWithOutcome(
+                    keys: payload.keys,
+                    holdDuration: payload.holdDuration,
+                    target: ExactWindowKeyboardTarget(
+                        windowIdentity: payload.expectedWindowIdentity,
+                        windowBounds: payload.expectedWindowBounds,
+                        focusedElement: expectedFocusedElement))
+            } else {
+                try await outcomeService.hotkeyWithOutcome(
+                    keys: payload.keys,
+                    holdDuration: payload.holdDuration,
+                    expectedWindowIdentity: payload.expectedWindowIdentity,
+                    expectedWindowBounds: payload.expectedWindowBounds)
+            }
+            return .init(response: .ok, outcome: result.outcome)
+        }
+        if let expectedFocusedElement = payload.expectedFocusedElement {
+            try await service.hotkey(
+                keys: payload.keys,
+                holdDuration: payload.holdDuration,
+                target: ExactWindowKeyboardTarget(
+                    windowIdentity: payload.expectedWindowIdentity,
+                    windowBounds: payload.expectedWindowBounds,
+                    focusedElement: expectedFocusedElement))
+        } else {
+            try await service.hotkey(
+                keys: payload.keys,
+                holdDuration: payload.holdDuration,
+                expectedWindowIdentity: payload.expectedWindowIdentity,
+                expectedWindowBounds: payload.expectedWindowBounds)
+        }
+        return .init(response: .ok)
+    }
+
+    private func handleTargetedClick(_ payload: PeekabooBridgeTargetedClickRequest) async throws
+        -> PeekabooBridgeHandledResponse
+    {
+        guard
+            let targetedClickService = self.services.automation as? any TargetedClickServiceProtocol,
+            targetedClickService.supportsTargetedClicks
+        else {
+            throw PeekabooBridgeErrorEnvelope(
+                code: .operationNotSupported,
+                message: "Background clicks are not supported by this bridge host")
+        }
+        if case .coordinates = payload.target, payload.targetWindowID == nil {
+            throw PeekabooBridgeErrorEnvelope(
+                code: .invalidRequest,
+                message: "Background coordinate clicks require an exact capture-time window identity and bounds; " +
+                    "PID-only coordinates are refused")
+        }
+        guard let targetWindowID = payload.targetWindowID else {
+            let outcome = try await self.handleProcessTargetedClick(payload, service: targetedClickService)
+            return .init(response: .ok, outcome: outcome)
+        }
+        return try await self.handleExactWindowTargetedClick(
+            payload,
+            targetWindowID: targetWindowID,
+            service: targetedClickService)
+    }
+
+    private func handleExactWindowTargetedClick(
+        _ payload: PeekabooBridgeTargetedClickRequest,
+        targetWindowID: Int,
+        service: any TargetedClickServiceProtocol) async throws -> PeekabooBridgeHandledResponse
+    {
+        guard payload.expectedProcessIdentity == nil else {
+            throw PeekabooBridgeErrorEnvelope(
+                code: .invalidRequest,
+                message: "Exact-window clicks cannot also supply a process-only identity")
+        }
+        guard let exactWindowService = service as? any ExactWindowTargetedClickServiceProtocol else {
+            throw PeekabooBridgeErrorEnvelope(
+                code: .operationNotSupported,
+                message: "Exact-window background clicks are not supported by this bridge host")
+        }
+        guard let expectedIdentity = payload.expectedWindowIdentity,
+              let expectedBounds = payload.expectedWindowBounds,
+              expectedIdentity.windowID == targetWindowID,
+              expectedIdentity.ownerProcessIdentifier == payload.targetProcessIdentifier
+        else {
+            throw PeekabooBridgeErrorEnvelope(
+                code: .invalidRequest,
+                message: "Exact-window click requires a matching process-generation identity and bounds")
+        }
+        self.automationActivityObserver?(pid_t(payload.targetProcessIdentifier))
+        guard let outcomeService = self.services.automation as? any UIAutomationActionOutcomeProviding else {
+            try await exactWindowService.click(
+                target: payload.target,
+                clickType: payload.clickType,
+                snapshotId: payload.snapshotId,
+                expectedWindowIdentity: expectedIdentity,
+                expectedWindowBounds: expectedBounds)
+            return .init(response: .ok)
+        }
+        let result = try await outcomeService.clickWithOutcome(
+            target: payload.target,
+            clickType: payload.clickType,
+            snapshotId: payload.snapshotId,
+            expectedWindowIdentity: expectedIdentity,
+            expectedWindowBounds: expectedBounds)
+        return .init(response: .ok, outcome: result.outcome)
+    }
+
     private func handleTargetedTypeActions(
         _ payload: PeekabooBridgeTargetedTypeActionsRequest,
-        service: any TargetedTypeServiceProtocol) async throws -> TypeResult
+        service: any TargetedTypeServiceProtocol) async throws -> PeekabooBridgeHandledResponse
     {
         self.automationActivityObserver?(pid_t(payload.targetProcessIdentifier))
         guard let expectedIdentity = payload.expectedProcessIdentity else {
-            return try await service.typeActions(
+            if let outcomeService = self.services.automation as? any UIAutomationActionOutcomeProviding {
+                let result = try await outcomeService.typeActionsWithOutcome(
+                    payload.actions,
+                    cadence: payload.cadence,
+                    snapshotId: payload.snapshotId,
+                    targetProcessIdentifier: pid_t(payload.targetProcessIdentifier))
+                return .init(response: .typeResult(result.payload), outcome: result.outcome)
+            }
+            let result = try await service.typeActions(
                 payload.actions,
                 cadence: payload.cadence,
                 snapshotId: payload.snapshotId,
                 targetProcessIdentifier: pid_t(payload.targetProcessIdentifier))
+            return .init(response: .typeResult(result))
         }
         guard expectedIdentity.processIdentifier == payload.targetProcessIdentifier else {
             throw PeekabooBridgeErrorEnvelope(
@@ -425,25 +599,42 @@ extension PeekabooBridgeServer {
                 code: .operationNotSupported,
                 message: "Process-generation-pinned background typing is not supported by this bridge host")
         }
-        return try await service.typeActions(
+        if let outcomeService = self.services.automation as? any UIAutomationActionOutcomeProviding {
+            let result = try await outcomeService.typeActionsWithOutcome(
+                payload.actions,
+                cadence: payload.cadence,
+                snapshotId: payload.snapshotId,
+                expectedProcessIdentity: expectedIdentity)
+            return .init(response: .typeResult(result.payload), outcome: result.outcome)
+        }
+        let result = try await service.typeActions(
             payload.actions,
             cadence: payload.cadence,
             snapshotId: payload.snapshotId,
             expectedProcessIdentity: expectedIdentity)
+        return .init(response: .typeResult(result))
     }
 
     private func handleProcessTargetedClick(
         _ payload: PeekabooBridgeTargetedClickRequest,
-        service: any TargetedClickServiceProtocol) async throws
+        service: any TargetedClickServiceProtocol) async throws -> DesktopActionOutcome?
     {
         self.automationActivityObserver?(pid_t(payload.targetProcessIdentifier))
         guard let expectedIdentity = payload.expectedProcessIdentity else {
+            if let outcomeService = self.services.automation as? any UIAutomationActionOutcomeProviding {
+                let result = try await outcomeService.clickWithOutcome(
+                    target: payload.target,
+                    clickType: payload.clickType,
+                    snapshotId: payload.snapshotId,
+                    targetProcessIdentifier: pid_t(payload.targetProcessIdentifier))
+                return result.outcome
+            }
             try await service.click(
                 target: payload.target,
                 clickType: payload.clickType,
                 snapshotId: payload.snapshotId,
                 targetProcessIdentifier: pid_t(payload.targetProcessIdentifier))
-            return
+            return nil
         }
         guard expectedIdentity.processIdentifier == payload.targetProcessIdentifier else {
             throw PeekabooBridgeErrorEnvelope(
@@ -455,15 +646,24 @@ extension PeekabooBridgeServer {
                 code: .operationNotSupported,
                 message: "Process-generation-pinned background clicks are not supported by this bridge host")
         }
+        if let outcomeService = self.services.automation as? any UIAutomationActionOutcomeProviding {
+            let result = try await outcomeService.clickWithOutcome(
+                target: payload.target,
+                clickType: payload.clickType,
+                snapshotId: payload.snapshotId,
+                expectedProcessIdentity: expectedIdentity)
+            return result.outcome
+        }
         try await service.click(
             target: payload.target,
             clickType: payload.clickType,
             snapshotId: payload.snapshotId,
             expectedProcessIdentity: expectedIdentity)
+        return nil
     }
 
     private func handleTargetedHotkey(
-        _ payload: PeekabooBridgeTargetedHotkeyRequest) async throws -> PeekabooBridgeResponse
+        _ payload: PeekabooBridgeTargetedHotkeyRequest) async throws -> PeekabooBridgeHandledResponse
     {
         guard
             let service = self.services.automation as? any TargetedHotkeyServiceProtocol,
@@ -486,17 +686,31 @@ extension PeekabooBridgeServer {
                     code: .operationNotSupported,
                     message: "Process-generation-pinned background hotkeys are not supported by this bridge host")
             }
+            if let outcomeService = self.services.automation as? any UIAutomationActionOutcomeProviding {
+                let result = try await outcomeService.hotkeyWithOutcome(
+                    keys: payload.keys,
+                    holdDuration: payload.holdDuration,
+                    expectedProcessIdentity: expectedIdentity)
+                return .init(response: .ok, outcome: result.outcome)
+            }
             try await service.hotkey(
                 keys: payload.keys,
                 holdDuration: payload.holdDuration,
                 expectedProcessIdentity: expectedIdentity)
         } else {
+            if let outcomeService = self.services.automation as? any UIAutomationActionOutcomeProviding {
+                let result = try await outcomeService.hotkeyWithOutcome(
+                    keys: payload.keys,
+                    holdDuration: payload.holdDuration,
+                    targetProcessIdentifier: pid_t(payload.targetProcessIdentifier))
+                return .init(response: .ok, outcome: result.outcome)
+            }
             try await service.hotkey(
                 keys: payload.keys,
                 holdDuration: payload.holdDuration,
                 targetProcessIdentifier: pid_t(payload.targetProcessIdentifier))
         }
-        return .ok
+        return .init(response: .ok)
     }
 
     private func handleWindowRequest(_ request: PeekabooBridgeRequest) async throws -> PeekabooBridgeResponse {

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer.swift
@@ -151,8 +151,8 @@ public final class PeekabooBridgeServer {
             if case let .projectedAction(payload) = request {
                 return await self.handleProjectedAction(payload, peer: peer)
             }
-            let response = try await self.route(request, peer: peer)
-            return try self.encoder.encode(response)
+            let handled = try await self.route(request, peer: peer)
+            return try self.encoder.encode(handled.response)
         } catch let envelope as PeekabooBridgeErrorEnvelope {
             self.logger.error("bridge request failed: \(envelope.message, privacy: .public)")
             return PeekabooBridgeResponse.encodeError(envelope.legacyCompatible, using: self.encoder)
@@ -178,10 +178,10 @@ public final class PeekabooBridgeServer {
     {
         do {
             let request = try payload.validatedRequest()
-            let response = try await self.route(request, peer: peer)
+            let handled = try await self.route(request, peer: peer)
             return try self.encoder.encode(PeekabooBridgeResponse.projectedAction(.init(
-                response: response,
-                outcome: Self.actionOutcome(in: response))))
+                response: handled.response,
+                outcome: handled.outcome?.routed(to: .bridge).projection)))
         } catch let envelope as PeekabooBridgeErrorEnvelope {
             self.logger.error("projected bridge request failed: \(envelope.message, privacy: .public)")
             return self.encodeProjectedError(envelope)
@@ -209,19 +209,9 @@ public final class PeekabooBridgeServer {
         return data
     }
 
-    private static func actionOutcome(
-        in response: PeekabooBridgeResponse) -> DesktopActionOutcome.Projection?
-    {
-        switch response {
-        case let .error(envelope): envelope.actionOutcome
-        case let .projectedAction(payload): payload.outcome
-        default: nil
-        }
-    }
-
     private func route(
         _ request: PeekabooBridgeRequest,
-        peer: PeekabooBridgePeer?) async throws -> PeekabooBridgeResponse
+        peer: PeekabooBridgePeer?) async throws -> PeekabooBridgeHandledResponse
     {
         try self.validatePeerAuthorization(peer)
         try PeekabooBridgeRequestContext.checkRequestIsActive()
@@ -556,7 +546,7 @@ public final class PeekabooBridgeServer {
     private func handleAuthorizedWithDesktopMutationBarrier(
         _ request: PeekabooBridgeRequest,
         peer: PeekabooBridgePeer?,
-        permissions: PermissionsStatus) async throws -> PeekabooBridgeResponse
+        permissions: PermissionsStatus) async throws -> PeekabooBridgeHandledResponse
     {
         let nativeLeafOwnsLane = request.nativeLeafOwnsDesktopOperationLane &&
             self.services.ownsDesktopOperationLane(for: request.operation)
@@ -592,7 +582,7 @@ public final class PeekabooBridgeServer {
     private func handleAuthorizedWithOwnedDesktopOperationLane(
         _ request: PeekabooBridgeRequest,
         peer: PeekabooBridgePeer?,
-        permissions: PermissionsStatus) async throws -> PeekabooBridgeResponse
+        permissions: PermissionsStatus) async throws -> PeekabooBridgeHandledResponse
     {
         guard request.mayMutateDesktop else {
             return try await self.handleAuthorized(request, peer: peer, permissions: permissions)
@@ -631,7 +621,7 @@ public final class PeekabooBridgeServer {
             throw error
         }
 
-        let response: PeekabooBridgeResponse?
+        let response: PeekabooBridgeHandledResponse?
         let operationError: (any Error)?
         do {
             response = try await self.handleAuthorized(request, peer: peer, permissions: permissions)
@@ -641,12 +631,12 @@ public final class PeekabooBridgeServer {
             operationError = error
         }
 
-        let completedResponse: PeekabooBridgeResponse?
+        let completedLegacyResponse: PeekabooBridgeResponse?
         do {
-            completedResponse = try await self.completeDesktopMutation(
+            completedLegacyResponse = try await self.completeDesktopMutation(
                 mutation,
                 request: request,
-                response: response,
+                response: response?.response,
                 store: desktopMutationWatermarkStore)
         } catch {
             throw error
@@ -655,12 +645,12 @@ public final class PeekabooBridgeServer {
         if let operationError {
             throw operationError
         }
-        guard let completedResponse = completedResponse ?? response else {
+        guard let response else {
             throw PeekabooBridgeErrorEnvelope(
                 code: .internalError,
                 message: "Desktop operation returned neither a response nor an error")
         }
-        return completedResponse
+        return completedLegacyResponse.map(response.replacingResponse) ?? response
     }
 
     private func validatePinnedWindowMutation(_ request: PeekabooBridgeRequest) throws {

--- a/Core/PeekabooCore/Sources/PeekabooBridgeTestSupport/BridgeTestFixtures.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridgeTestSupport/BridgeTestFixtures.swift
@@ -1,4 +1,5 @@
 import PeekabooAutomationKit
+import PeekabooAutomationKitTestSupport
 import PeekabooBridge
 import PeekabooFoundation
 
@@ -6,31 +7,7 @@ import PeekabooFoundation
 public enum BridgeTestFixtures {
     /// One valid outcome for every canonical desktop-action state.
     public static var canonicalActionOutcomes: [DesktopActionOutcome] {
-        let backgroundAccessibilityAction = DesktopActionOutcome.Delivery(
-            mechanism: .accessibilityAction,
-            mode: .background)
-        let backgroundTargetedEvents = DesktopActionOutcome.Delivery(
-            mechanism: .processTargetedEvents,
-            mode: .background)
-        let oneUnit = self.dispatchUnitCount(1)
-        let twoUnits = self.dispatchUnitCount(2)
-        let threeUnits = self.dispatchUnitCount(3)
-
-        return [
-            .confirmedChange(delivery: backgroundAccessibilityAction, unitCount: oneUnit),
-            .confirmedNoChange(),
-            .partial(delivery: backgroundAccessibilityAction, unitCount: twoUnits),
-            .dispatchedUnverified(
-                delivery: backgroundTargetedEvents,
-                evidence: .operationStillRunning,
-                unitCount: threeUnits),
-            .suspectedNoop(delivery: backgroundAccessibilityAction, unitCount: oneUnit),
-            .refused(reason: .permissionDenied),
-            .indeterminate(
-                delivery: backgroundTargetedEvents,
-                evidence: .responseLost,
-                unitCount: twoUnits),
-        ]
+        AutomationTestFixtures.canonicalActionOutcomes
     }
 
     /// Builds one internally coherent handshake while keeping protocol versions explicit at every call site.
@@ -97,12 +74,5 @@ public enum BridgeTestFixtures {
             permission: permission,
             kind: kind,
             context: context))
-    }
-
-    private static func dispatchUnitCount(_ value: Int) -> DesktopActionOutcome.DispatchUnitCount {
-        guard let unitCount = DesktopActionOutcome.DispatchUnitCount(value) else {
-            preconditionFailure("Bridge fixture dispatch counts must be positive")
-        }
-        return unitCount
     }
 }

--- a/Core/PeekabooCore/Sources/PeekabooCore/Support/RemoteUIAutomationService+ActionOutcomes.swift
+++ b/Core/PeekabooCore/Sources/PeekabooCore/Support/RemoteUIAutomationService+ActionOutcomes.swift
@@ -1,0 +1,334 @@
+import CoreGraphics
+import Darwin
+import PeekabooAutomationKit
+import PeekabooBridge
+import PeekabooFoundation
+
+extension RemoteUIAutomationService: UIAutomationActionOutcomeProviding {
+    public func clickWithOutcome(
+        target: ClickTarget,
+        clickType: ClickType,
+        snapshotId: String?) async throws -> UIAutomationActionResult<Void>
+    {
+        try await self.remoteAction(snapshotId: snapshotId) {
+            try await self.client.clickWithOutcome(
+                target: target,
+                clickType: clickType,
+                snapshotId: snapshotId)
+        }
+    }
+
+    public func clickWithOutcome(
+        target: ClickTarget,
+        clickType: ClickType,
+        snapshotId: String?,
+        targetProcessIdentifier: pid_t) async throws -> UIAutomationActionResult<Void>
+    {
+        try self.requireTargetedClicks()
+        return try await self.remoteAction(snapshotId: snapshotId) {
+            try await self.client.clickWithOutcome(
+                target: target,
+                clickType: clickType,
+                snapshotId: snapshotId,
+                targetProcessIdentifier: targetProcessIdentifier)
+        }
+    }
+
+    public func clickWithOutcome(
+        target: ClickTarget,
+        clickType: ClickType,
+        snapshotId: String?,
+        expectedProcessIdentity: ApplicationProcessIdentity) async throws -> UIAutomationActionResult<Void>
+    {
+        guard self.supportsProcessGenerationPinnedClicks else {
+            throw PeekabooError.serviceUnavailable(
+                "Remote bridge host does not support process-generation-pinned background clicks; update the host")
+        }
+        return try await self.remoteAction(snapshotId: snapshotId) {
+            try await self.client.clickWithOutcome(
+                target: target,
+                clickType: clickType,
+                snapshotId: snapshotId,
+                expectedProcessIdentity: expectedProcessIdentity)
+        }
+    }
+
+    public func clickWithOutcome(
+        target: ClickTarget,
+        clickType: ClickType,
+        snapshotId: String?,
+        expectedWindowIdentity: WindowMutationIdentity,
+        expectedWindowBounds: CGRect) async throws -> UIAutomationActionResult<Void>
+    {
+        guard self.supportsExactWindowTargetedClicks else {
+            throw PeekabooError.serviceUnavailable(
+                "Remote bridge host does not support exact-window background clicks")
+        }
+        try self.requireTargetedClicks()
+        return try await self.remoteAction(snapshotId: snapshotId) {
+            try await self.client.clickWithOutcome(
+                target: target,
+                clickType: clickType,
+                snapshotId: snapshotId,
+                expectedWindowIdentity: expectedWindowIdentity,
+                expectedWindowBounds: expectedWindowBounds)
+        }
+    }
+
+    public func typeWithOutcome(
+        text: String,
+        target: String?,
+        clearExisting: Bool,
+        typingDelay: Int,
+        snapshotId: String?) async throws -> UIAutomationActionResult<Void>
+    {
+        try await self.remoteAction(snapshotId: snapshotId) {
+            try await self.client.typeWithOutcome(
+                text: text,
+                target: target,
+                clearExisting: clearExisting,
+                typingDelay: typingDelay,
+                snapshotId: snapshotId)
+        }
+    }
+
+    public func typeActionsWithOutcome(
+        _ actions: [TypeAction],
+        cadence: TypingCadence,
+        snapshotId: String?) async throws -> UIAutomationActionResult<TypeResult>
+    {
+        try await self.remoteAction(snapshotId: snapshotId) {
+            try await self.client.typeActionsWithOutcome(
+                actions,
+                cadence: cadence,
+                snapshotId: snapshotId)
+        }
+    }
+
+    public func typeActionsWithOutcome(
+        _ actions: [TypeAction],
+        cadence: TypingCadence,
+        snapshotId: String?,
+        targetProcessIdentifier: pid_t) async throws -> UIAutomationActionResult<TypeResult>
+    {
+        try self.requireTargetedTypeActions()
+        return try await self.remoteAction(snapshotId: snapshotId) {
+            try await self.client.typeActionsWithOutcome(
+                actions,
+                cadence: cadence,
+                snapshotId: snapshotId,
+                targetProcessIdentifier: targetProcessIdentifier)
+        }
+    }
+
+    public func typeActionsWithOutcome(
+        _ actions: [TypeAction],
+        cadence: TypingCadence,
+        snapshotId: String?,
+        expectedProcessIdentity: ApplicationProcessIdentity) async throws -> UIAutomationActionResult<TypeResult>
+    {
+        guard self.supportsProcessGenerationPinnedTypeActions else {
+            throw PeekabooError.serviceUnavailable(
+                "Remote bridge host does not support process-generation-pinned background typing; update the host")
+        }
+        return try await self.remoteAction(snapshotId: snapshotId) {
+            try await self.client.typeActionsWithOutcome(
+                actions,
+                cadence: cadence,
+                snapshotId: snapshotId,
+                expectedProcessIdentity: expectedProcessIdentity)
+        }
+    }
+
+    public func typeActionsWithOutcome(
+        _ actions: [TypeAction],
+        cadence: TypingCadence,
+        snapshotId: String?,
+        expectedWindowIdentity: WindowMutationIdentity,
+        expectedWindowBounds: CGRect) async throws -> UIAutomationActionResult<TypeResult>
+    {
+        try self.requireExactWindowKeyboard()
+        return try await self.remoteAction(snapshotId: snapshotId) {
+            try await self.client.typeActionsWithOutcome(
+                actions,
+                cadence: cadence,
+                snapshotId: snapshotId,
+                expectedWindowIdentity: expectedWindowIdentity,
+                expectedWindowBounds: expectedWindowBounds)
+        }
+    }
+
+    public func typeActionsWithOutcome(
+        _ actions: [TypeAction],
+        cadence: TypingCadence,
+        snapshotId: String?,
+        target: ExactWindowKeyboardTarget) async throws -> UIAutomationActionResult<TypeResult>
+    {
+        try self.requireExactWindowKeyboard()
+        return try await self.remoteAction(snapshotId: snapshotId) {
+            try await self.client.typeActionsWithOutcome(
+                actions,
+                cadence: cadence,
+                snapshotId: snapshotId,
+                target: target)
+        }
+    }
+
+    public func scrollWithOutcome(_ request: ScrollRequest) async throws -> UIAutomationActionResult<Void> {
+        if !request.foreground, !self.supportsTargetedScroll {
+            throw PeekabooError.serviceUnavailable(
+                "Remote bridge host does not support background-safe targeted scroll; relaunch or update Peekaboo.")
+        }
+        return try await self.remoteAction(snapshotId: request.snapshotId) {
+            try await self.client.scrollWithOutcome(request)
+        }
+    }
+
+    public func hotkeyWithOutcome(
+        keys: String,
+        holdDuration: Int) async throws -> UIAutomationActionResult<Void>
+    {
+        try await self.remoteAction(snapshotId: nil) {
+            try await self.client.hotkeyWithOutcome(keys: keys, holdDuration: holdDuration)
+        }
+    }
+
+    public func hotkeyWithOutcome(
+        keys: String,
+        holdDuration: Int,
+        targetProcessIdentifier: pid_t) async throws -> UIAutomationActionResult<Void>
+    {
+        try self.requireTargetedHotkeys()
+        return try await self.remoteAction(snapshotId: nil) {
+            try await self.client.hotkeyWithOutcome(
+                keys: keys,
+                holdDuration: holdDuration,
+                targetProcessIdentifier: targetProcessIdentifier)
+        }
+    }
+
+    public func hotkeyWithOutcome(
+        keys: String,
+        holdDuration: Int,
+        expectedProcessIdentity: ApplicationProcessIdentity) async throws -> UIAutomationActionResult<Void>
+    {
+        guard self.supportsProcessGenerationPinnedHotkeys else {
+            throw PeekabooError.serviceUnavailable(
+                "Remote bridge host does not support process-generation-pinned background hotkeys; " +
+                    "use --no-remote or update the host")
+        }
+        return try await self.remoteAction(snapshotId: nil) {
+            try await self.client.hotkeyWithOutcome(
+                keys: keys,
+                holdDuration: holdDuration,
+                expectedProcessIdentity: expectedProcessIdentity)
+        }
+    }
+
+    public func hotkeyWithOutcome(
+        keys: String,
+        holdDuration: Int,
+        expectedWindowIdentity: WindowMutationIdentity,
+        expectedWindowBounds: CGRect) async throws -> UIAutomationActionResult<Void>
+    {
+        try self.requireExactWindowKeyboard()
+        return try await self.remoteAction(snapshotId: nil) {
+            try await self.client.hotkeyWithOutcome(
+                keys: keys,
+                holdDuration: holdDuration,
+                expectedWindowIdentity: expectedWindowIdentity,
+                expectedWindowBounds: expectedWindowBounds)
+        }
+    }
+
+    public func hotkeyWithOutcome(
+        keys: String,
+        holdDuration: Int,
+        target: ExactWindowKeyboardTarget) async throws -> UIAutomationActionResult<Void>
+    {
+        try self.requireExactWindowKeyboard()
+        return try await self.remoteAction(snapshotId: nil) {
+            try await self.client.hotkeyWithOutcome(keys: keys, holdDuration: holdDuration, target: target)
+        }
+    }
+
+    public func setValueWithOutcome(
+        target: String,
+        value: UIElementValue,
+        snapshotId: String?) async throws -> UIAutomationActionResult<ElementActionResult>
+    {
+        try await self.remoteAction(snapshotId: snapshotId) {
+            try await self.client.setValueWithOutcome(target: target, value: value, snapshotId: snapshotId)
+        }
+    }
+
+    public func performActionWithOutcome(
+        target: String,
+        actionName: String,
+        snapshotId: String?) async throws -> UIAutomationActionResult<ElementActionResult>
+    {
+        try await self.remoteAction(snapshotId: snapshotId) {
+            try await self.client.performActionWithOutcome(
+                target: target,
+                actionName: actionName,
+                snapshotId: snapshotId)
+        }
+    }
+
+    private func remoteAction<Payload: Sendable>(
+        snapshotId: String?,
+        operation: () async throws -> UIAutomationActionResult<Payload>) async throws
+        -> UIAutomationActionResult<Payload>
+    {
+        do {
+            return try await operation()
+        } catch let envelope as PeekabooBridgeErrorEnvelope {
+            throw Self.automationError(for: envelope, snapshotId: snapshotId)
+        }
+    }
+
+    private func requireTargetedClicks() throws {
+        guard self.supportsTargetedClicks else {
+            throw Self.unavailableError(
+                reason: self.targetedClickUnavailableReason,
+                requiresEventSynthesizingPermission: self.targetedClickRequiresEventSynthesizingPermission,
+                fallback: "Remote bridge host does not support background clicks; use --no-remote or update the host")
+        }
+    }
+
+    private func requireTargetedTypeActions() throws {
+        guard self.supportsTargetedTypeActions else {
+            throw Self.unavailableError(
+                reason: self.targetedTypeUnavailableReason,
+                requiresEventSynthesizingPermission: self.targetedTypeRequiresEventSynthesizingPermission,
+                fallback: "Remote bridge host does not support background typing; use --no-remote or update the host")
+        }
+    }
+
+    private func requireTargetedHotkeys() throws {
+        guard self.supportsTargetedHotkeys else {
+            throw Self.unavailableError(
+                reason: self.targetedHotkeyUnavailableReason,
+                requiresEventSynthesizingPermission: self.targetedHotkeyRequiresEventSynthesizingPermission,
+                fallback: "Remote bridge host does not support background hotkeys; use --no-remote or update the host")
+        }
+    }
+
+    private func requireExactWindowKeyboard() throws {
+        guard self.supportsExactWindowTargetedKeyboard else {
+            throw PeekabooError.serviceUnavailable(
+                self.exactWindowTargetedKeyboardUnavailableReason ??
+                    "Atomic exact-window background keyboard delivery is unavailable")
+        }
+    }
+
+    private static func unavailableError(
+        reason: String?,
+        requiresEventSynthesizingPermission: Bool,
+        fallback: String) -> PeekabooError
+    {
+        requiresEventSynthesizingPermission
+            ? .permissionDeniedEventSynthesizing
+            : .serviceUnavailable(reason ?? fallback)
+    }
+}

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeActionOutcomeProjectionTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeActionOutcomeProjectionTests.swift
@@ -6,6 +6,7 @@ import PeekabooBridgeTestSupport
 import PeekabooFoundation
 import Testing
 @testable import PeekabooBridge
+@testable import PeekabooCore
 
 struct PeekabooBridgeActionOutcomeProjectionTests {
     @Test
@@ -193,6 +194,121 @@ struct PeekabooBridgeActionOutcomeProjectionTests {
         #expect(projectedError.message == failure.message)
         #expect(projectedError.actionFailureHint == failure.hint)
         #expect(projectedError.actionFailureCauseDescription == failure.causeDescription)
+    }
+
+    @Test
+    @MainActor
+    func `current server preserves every successful canonical outcome behind legacy responses`() async throws {
+        let services = StubServices()
+        let server = PeekabooBridgeServer(
+            services: services,
+            allowlistedTeams: [],
+            allowlistedBundles: [],
+            hostIdentity: nil,
+            permissionStatusEvaluator: { _ in Self.grantedPermissions })
+
+        for outcome in BridgeTestFixtures.canonicalActionOutcomes {
+            services.automationStub.actionOutcome = outcome
+            let legacy = try await Self.send(Self.clickRequest, to: server)
+            guard case .ok = legacy else {
+                Issue.record("Expected unchanged legacy click response for \(outcome.state.rawValue)")
+                continue
+            }
+
+            let projected = try await Self.send(
+                .projectedAction(.init(request: Self.clickRequest)),
+                to: server)
+            guard case let .projectedAction(payload) = projected,
+                  case .ok = payload.response
+            else {
+                Issue.record("Expected projected click response for \(outcome.state.rawValue)")
+                continue
+            }
+            #expect(payload.outcome == outcome.routed(to: .bridge).projection)
+        }
+    }
+
+    @Test
+    @MainActor
+    func `all backed automation families retain their native success outcome`() async throws {
+        let services = StubServices()
+        let server = PeekabooBridgeServer(
+            services: services,
+            allowlistedTeams: [],
+            allowlistedBundles: [],
+            hostIdentity: nil)
+        let expected = DesktopActionOutcome.confirmedChange(
+            delivery: .init(mechanism: .accessibilityAction, mode: .background))
+        services.automationStub.actionOutcome = expected
+        let requests: [PeekabooBridgeRequest] = [
+            Self.clickRequest,
+            .type(.init(
+                text: "x",
+                target: nil,
+                clearExisting: false,
+                typingDelay: 0,
+                snapshotId: nil)),
+            .typeActions(.init(
+                actions: [.text("x")],
+                cadence: .fixed(milliseconds: 0),
+                snapshotId: nil)),
+            .scroll(.init(request: .init(
+                direction: .down,
+                amount: 1,
+                foreground: true))),
+            .hotkey(.init(keys: "cmd,a", holdDuration: 0)),
+            .setValue(.init(target: "B1", value: .string("x"), snapshotId: "snapshot")),
+            .performAction(.init(target: "B1", actionName: "AXPress", snapshotId: "snapshot")),
+        ]
+
+        for request in requests {
+            let handled = try await server.handleAuthorized(
+                request,
+                peer: nil,
+                permissions: Self.grantedPermissions)
+            #expect(handled.outcome == expected, "Missing native outcome for \(request.operation.rawValue)")
+        }
+    }
+
+    @Test
+    func `remote automation preserves current outcomes and legacy absence`() async throws {
+        let currentOutcome = DesktopActionOutcome.confirmedChange(
+            route: .bridge,
+            delivery: .init(mechanism: .accessibilityAction, mode: .background))
+        let currentHandshake = BridgeTestFixtures.handshake(
+            negotiatedVersion: PeekabooBridgeConstants.protocolVersion,
+            supportedOperations: [.click],
+            hostCapabilities: [PeekabooBridgeHostCapability.desktopActionOutcomeProjection])
+        let currentPeer = try NegotiatedProjectionBridgePeer(responses: [
+            .handshake(currentHandshake),
+            .projectedAction(.init(response: .ok, outcome: currentOutcome.projection)),
+        ])
+        let currentClient = PeekabooBridgeClient(socketPath: currentPeer.socketPath, requestTimeoutSec: 1)
+        _ = try await currentClient.handshake(client: Self.clientIdentity)
+        let currentRemote = await MainActor.run { RemoteUIAutomationService(client: currentClient) }
+        let currentResult = try await currentRemote.clickWithOutcome(
+            target: .coordinates(.zero),
+            clickType: .single,
+            snapshotId: nil)
+        #expect(currentResult.outcome == currentOutcome)
+        await currentPeer.waitUntilFinished()
+
+        let previousHandshake = BridgeTestFixtures.handshake(
+            negotiatedVersion: .init(major: 1, minor: 22),
+            supportedOperations: [.click])
+        let previousPeer = try NegotiatedProjectionBridgePeer(responses: [
+            .handshake(previousHandshake),
+            .ok,
+        ])
+        let previousClient = PeekabooBridgeClient(socketPath: previousPeer.socketPath, requestTimeoutSec: 1)
+        _ = try await previousClient.handshake(client: Self.clientIdentity)
+        let previousRemote = await MainActor.run { RemoteUIAutomationService(client: previousClient) }
+        let previousResult = try await previousRemote.clickWithOutcome(
+            target: .coordinates(.zero),
+            clickType: .single,
+            snapshotId: nil)
+        #expect(previousResult.outcome == nil)
+        await previousPeer.waitUntilFinished()
     }
 
     @Test
@@ -554,6 +670,11 @@ struct PeekabooBridgeActionOutcomeProjectionTests {
         processIdentifier: getpid(),
         hostname: nil)
 
+    private static let grantedPermissions = PermissionsStatus(
+        screenRecording: true,
+        accessibility: true,
+        postEvent: true)
+
     private static let legacyClickRequestData = Data(
         #"{"click":{"_0":{"clickType":"single","target":{"kind":"coordinates","x":17,"y":29}}}}"#.utf8)
 
@@ -672,6 +793,222 @@ struct PeekabooBridgeActionOutcomeProjectionTests {
         let mutationDispatched: Bool
         let retrySafe: Bool
         let requiresFreshObservation: Bool
+    }
+}
+
+extension StubAutomationService: UIAutomationActionOutcomeProviding {
+    func clickWithOutcome(
+        target: ClickTarget,
+        clickType: ClickType,
+        snapshotId: String?) async throws -> UIAutomationActionResult<Void>
+    {
+        try await self.click(target: target, clickType: clickType, snapshotId: snapshotId)
+        return self.actionResult(())
+    }
+
+    func clickWithOutcome(
+        target: ClickTarget,
+        clickType: ClickType,
+        snapshotId: String?,
+        targetProcessIdentifier: pid_t) async throws -> UIAutomationActionResult<Void>
+    {
+        try await self.click(
+            target: target,
+            clickType: clickType,
+            snapshotId: snapshotId,
+            targetProcessIdentifier: targetProcessIdentifier)
+        return self.actionResult(())
+    }
+
+    func clickWithOutcome(
+        target: ClickTarget,
+        clickType: ClickType,
+        snapshotId: String?,
+        expectedProcessIdentity: ApplicationProcessIdentity) async throws -> UIAutomationActionResult<Void>
+    {
+        try await self.click(
+            target: target,
+            clickType: clickType,
+            snapshotId: snapshotId,
+            expectedProcessIdentity: expectedProcessIdentity)
+        return self.actionResult(())
+    }
+
+    func clickWithOutcome(
+        target: ClickTarget,
+        clickType: ClickType,
+        snapshotId: String?,
+        expectedWindowIdentity: WindowMutationIdentity,
+        expectedWindowBounds: CGRect) async throws -> UIAutomationActionResult<Void>
+    {
+        try await self.click(
+            target: target,
+            clickType: clickType,
+            snapshotId: snapshotId,
+            expectedWindowIdentity: expectedWindowIdentity,
+            expectedWindowBounds: expectedWindowBounds)
+        return self.actionResult(())
+    }
+
+    func typeWithOutcome(
+        text: String,
+        target: String?,
+        clearExisting: Bool,
+        typingDelay: Int,
+        snapshotId: String?) async throws -> UIAutomationActionResult<Void>
+    {
+        try await self.type(
+            text: text,
+            target: target,
+            clearExisting: clearExisting,
+            typingDelay: typingDelay,
+            snapshotId: snapshotId)
+        return self.actionResult(())
+    }
+
+    func typeActionsWithOutcome(
+        _ actions: [TypeAction],
+        cadence: TypingCadence,
+        snapshotId: String?) async throws -> UIAutomationActionResult<TypeResult>
+    {
+        try await self.actionResult(self.typeActions(actions, cadence: cadence, snapshotId: snapshotId))
+    }
+
+    func typeActionsWithOutcome(
+        _ actions: [TypeAction],
+        cadence: TypingCadence,
+        snapshotId: String?,
+        targetProcessIdentifier: pid_t) async throws -> UIAutomationActionResult<TypeResult>
+    {
+        try await self.actionResult(self.typeActions(
+            actions,
+            cadence: cadence,
+            snapshotId: snapshotId,
+            targetProcessIdentifier: targetProcessIdentifier))
+    }
+
+    func typeActionsWithOutcome(
+        _ actions: [TypeAction],
+        cadence: TypingCadence,
+        snapshotId: String?,
+        expectedProcessIdentity: ApplicationProcessIdentity) async throws -> UIAutomationActionResult<TypeResult>
+    {
+        try await self.actionResult(self.typeActions(
+            actions,
+            cadence: cadence,
+            snapshotId: snapshotId,
+            expectedProcessIdentity: expectedProcessIdentity))
+    }
+
+    func typeActionsWithOutcome(
+        _ actions: [TypeAction],
+        cadence: TypingCadence,
+        snapshotId: String?,
+        expectedWindowIdentity: WindowMutationIdentity,
+        expectedWindowBounds: CGRect) async throws -> UIAutomationActionResult<TypeResult>
+    {
+        try await self.actionResult(self.typeActions(
+            actions,
+            cadence: cadence,
+            snapshotId: snapshotId,
+            expectedWindowIdentity: expectedWindowIdentity,
+            expectedWindowBounds: expectedWindowBounds))
+    }
+
+    func typeActionsWithOutcome(
+        _ actions: [TypeAction],
+        cadence: TypingCadence,
+        snapshotId: String?,
+        target: ExactWindowKeyboardTarget) async throws -> UIAutomationActionResult<TypeResult>
+    {
+        try await self.actionResult(self.typeActions(
+            actions,
+            cadence: cadence,
+            snapshotId: snapshotId,
+            target: target))
+    }
+
+    func scrollWithOutcome(_ request: ScrollRequest) async throws -> UIAutomationActionResult<Void> {
+        try await self.scroll(request)
+        return self.actionResult(())
+    }
+
+    func hotkeyWithOutcome(
+        keys: String,
+        holdDuration: Int) async throws -> UIAutomationActionResult<Void>
+    {
+        try await self.hotkey(keys: keys, holdDuration: holdDuration)
+        return self.actionResult(())
+    }
+
+    func hotkeyWithOutcome(
+        keys: String,
+        holdDuration: Int,
+        targetProcessIdentifier: pid_t) async throws -> UIAutomationActionResult<Void>
+    {
+        try await self.hotkey(
+            keys: keys,
+            holdDuration: holdDuration,
+            targetProcessIdentifier: targetProcessIdentifier)
+        return self.actionResult(())
+    }
+
+    func hotkeyWithOutcome(
+        keys: String,
+        holdDuration: Int,
+        expectedProcessIdentity: ApplicationProcessIdentity) async throws -> UIAutomationActionResult<Void>
+    {
+        try await self.hotkey(
+            keys: keys,
+            holdDuration: holdDuration,
+            expectedProcessIdentity: expectedProcessIdentity)
+        return self.actionResult(())
+    }
+
+    func hotkeyWithOutcome(
+        keys: String,
+        holdDuration: Int,
+        expectedWindowIdentity: WindowMutationIdentity,
+        expectedWindowBounds: CGRect) async throws -> UIAutomationActionResult<Void>
+    {
+        try await self.hotkey(
+            keys: keys,
+            holdDuration: holdDuration,
+            expectedWindowIdentity: expectedWindowIdentity,
+            expectedWindowBounds: expectedWindowBounds)
+        return self.actionResult(())
+    }
+
+    func hotkeyWithOutcome(
+        keys: String,
+        holdDuration: Int,
+        target: ExactWindowKeyboardTarget) async throws -> UIAutomationActionResult<Void>
+    {
+        try await self.hotkey(keys: keys, holdDuration: holdDuration, target: target)
+        return self.actionResult(())
+    }
+
+    func setValueWithOutcome(
+        target: String,
+        value: UIElementValue,
+        snapshotId: String?) async throws -> UIAutomationActionResult<ElementActionResult>
+    {
+        try await self.actionResult(self.setValue(target: target, value: value, snapshotId: snapshotId))
+    }
+
+    func performActionWithOutcome(
+        target: String,
+        actionName: String,
+        snapshotId: String?) async throws -> UIAutomationActionResult<ElementActionResult>
+    {
+        try await self.actionResult(self.performAction(
+            target: target,
+            actionName: actionName,
+            snapshotId: snapshotId))
+    }
+
+    private func actionResult<Payload: Sendable>(_ payload: Payload) -> UIAutomationActionResult<Payload> {
+        UIAutomationActionResult(payload: payload, outcome: self.actionOutcome)
     }
 }
 

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeTests.swift
@@ -2090,6 +2090,9 @@ final class StubAutomationService: TargetedHotkeyServiceProtocol, TargetedTypeSe
     var exactTypeError: (any Error)?
     var exactHotkeyError: (any Error)?
     var targetedClickError: (any Error)?
+    var actionOutcome = DesktopActionOutcome.dispatchedUnverified(
+        delivery: .init(mechanism: .accessibilityAction, mode: .background),
+        evidence: .deliveryAccepted)
     var exactKeyboardDelayNanoseconds: UInt64 = 0
     var recordsExactKeyboardEvents = false
     private(set) var exactKeyboardEvents: [String] = []


### PR DESCRIPTION
## Summary

- add one additive `UIAutomationActionOutcomeProviding` carrier so result-bearing automation paths expose their canonical native outcome without changing existing protocol witnesses
- preserve successful click, type, type-action, scroll, hotkey, set-value, and named-action outcomes across protocol 1.23 projected Bridge requests
- keep legacy response payloads and older hosts conservative, centralize Bridge outcome dispatch, and make AutomationKit test support the shared owner of the seven canonical outcome fixtures

## Safety and compatibility

- protocol 1.22 and legacy-only services continue returning the unchanged legacy response with no fabricated outcome
- current projected requests validate the carried outcome before exposing it
- no foreground policy, clipboard path, or AppleScript surface changes

## Proof

- `PEEKABOO_INCLUDE_AMBIENT_STATE_TESTS=false pnpm run test:safe` (885 CLI/Core + 88 runtime; clipboard case explicitly skipped)
- `UIAutomationActionOutcomeProvidingTests` (9/9)
- Bridge projection, transport, and core suites (81/81)
- Release builds for `PeekabooBridge` and `PeekabooCore`
- `pnpm run format` (0/1,304 files changed)
- `pnpm run lint` (22 existing warnings, 0 serious across 1,288 files)
- P0-P2 autoreview and TruffleHog: clean
