### PR TITLE
refactor(automation): centralize UI targets and receipts

### DIFF
--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Core/Protocols/ApplicationServiceProtocol.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Core/Protocols/ApplicationServiceProtocol.swift
@@ -457,6 +457,23 @@ public struct WindowMutationIdentity: Sendable, Codable, Equatable {
             capturedBounds: self.capturedBounds,
             isMinimized: isMinimized)
     }
+
+    /// The generation-bound process receipt embedded in this window receipt.
+    public var processIdentity: ApplicationProcessIdentity {
+        ApplicationProcessIdentity(
+            processIdentifier: self.ownerProcessIdentifier,
+            processStartIdentity: self.ownerProcessStartIdentity)
+    }
+
+    /// Compares the stable receipt fields while intentionally ignoring minimized state.
+    ///
+    /// Minimized state is mutable window state, not evidence that a WindowServer identifier or
+    /// owner process generation changed.
+    public func hasSameStableReceipt(as other: WindowMutationIdentity) -> Bool {
+        self.windowID == other.windowID &&
+            self.processIdentity == other.processIdentity &&
+            self.capturedBounds == other.capturedBounds
+    }
 }
 
 public struct ServiceWindowInfo: Sendable, Codable, Equatable {

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/ClickService.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/ClickService.swift
@@ -40,21 +40,17 @@ import PeekabooFoundation
  * - Note: Part of UIAutomationService's specialized service architecture
  * - Since: PeekabooCore 1.0.0
  */
-private struct ExactWindowClickReceipt {
-    let identity: WindowMutationIdentity
-    let bounds: CGRect
-}
-
-private struct ClickMutationReceipt {
-    let processIdentity: ApplicationProcessIdentity?
-    let exactWindow: ExactWindowClickReceipt?
-}
-
 private struct SyntheticClickDestination {
-    let processIdentifier: pid_t?
-    let windowID: CGWindowID?
-    let exactWindowReceipt: ExactWindowClickReceipt?
-    let expectedProcessIdentity: ApplicationProcessIdentity?
+    let captureReceipt: DesktopOperationPlan.CaptureReceipt
+    let validatesProcessIdentity: Bool
+
+    var processIdentifier: pid_t? {
+        self.captureReceipt.processIdentifier
+    }
+
+    var windowID: CGWindowID? {
+        self.captureReceipt.exactWindow.flatMap { CGWindowID(exactly: $0.identity.windowID) }
+    }
 }
 
 private struct ClickExecutionRequest: Sendable {
@@ -156,9 +152,10 @@ public final class ClickService {
         target: ClickTarget,
         clickType: ClickType,
         snapshotId: String?,
-        targetProcessIdentifier: pid_t?,
-        mutationReceipt: ClickMutationReceipt) async throws -> UIInputExecutionResult.Action
+        captureReceipt: DesktopOperationPlan.CaptureReceipt,
+        validatesProcessIdentity: Bool) async throws -> UIInputExecutionResult.Action
     {
+        let targetProcessIdentifier = captureReceipt.processIdentifier
         guard let element = try await self.resolveAutomationElement(
             target: target,
             snapshotId: snapshotId,
@@ -167,8 +164,10 @@ public final class ClickService {
             throw ActionInputError.unsupported(.missingElement)
         }
 
-        try self.requireCurrentProcess(mutationReceipt.processIdentity, afterDispatch: false)
-        try self.requireCurrentExactWindow(mutationReceipt.exactWindow, afterDispatch: false)
+        try self.requireCurrentTarget(
+            captureReceipt,
+            afterDispatch: false,
+            validateProcessIdentity: validatesProcessIdentity)
         switch clickType {
         case .single:
             let valueBefore = element.intAttribute(AXAttributeNames.kAXValueAttribute)
@@ -368,7 +367,7 @@ public final class ClickService {
         snapshotId: String?,
         targetProcessIdentifier: pid_t?,
         requestedTargetWindowID: Int?,
-        exactWindowReceipt: ExactWindowClickReceipt?) async throws -> CGWindowID?
+        captureReceipt: DesktopOperationPlan.CaptureReceipt) async throws -> CGWindowID?
     {
         let requestedCGWindowID = try validatedClickWindowID(requestedTargetWindowID)
         guard let targetProcessIdentifier else { return nil }
@@ -411,10 +410,15 @@ public final class ClickService {
 
         let snapshotWindowID = detectionResult.metadata.windowContext?.windowID
         let snapshotCGWindowID = try validatedClickWindowID(snapshotWindowID)
-        if let exactWindowReceipt {
-            guard detectionResult.metadata.windowContext?.windowMutationIdentity == exactWindowReceipt.identity,
-                  detectionResult.metadata.windowContext?.windowBounds == exactWindowReceipt.bounds
-            else {
+        if captureReceipt.exactWindow != nil {
+            do {
+                try DesktopOperationSnapshotReceiptValidator.validate(
+                    context: detectionResult.metadata.windowContext,
+                    receipt: captureReceipt,
+                    validateCurrentIdentity: false,
+                    processStartIdentityProvider: self.processStartIdentityProvider,
+                    exactWindowIdentityValidator: self.exactWindowIdentityValidator)
+            } catch {
                 throw PeekabooError.snapshotStale(
                     "Exact-window click snapshot receipt or bounds no longer match the dispatch target")
             }
@@ -637,10 +641,8 @@ public final class ClickService {
                 at: candidate,
                 clickType: .single,
                 destination: SyntheticClickDestination(
-                    processIdentifier: nil,
-                    windowID: nil,
-                    exactWindowReceipt: nil,
-                    expectedProcessIdentity: nil))
+                    captureReceipt: DesktopOperationPlan.CaptureReceipt(),
+                    validatesProcessIdentity: false))
             try await Task.sleep(nanoseconds: 60_000_000) // 60ms
 
             if self.isFocusedTextInput(expectedIdentifier: normalizedExpectedIdentifier) {
@@ -798,24 +800,25 @@ public final class ClickService {
     {
         self.logger.debug("Performing \(clickType) click at (\(point.x), \(point.y))")
 
-        try self.requireCurrentProcess(destination.expectedProcessIdentity, afterDispatch: false)
+        try self.requireCurrentTarget(
+            destination.captureReceipt,
+            afterDispatch: false,
+            validateProcessIdentity: destination.validatesProcessIdentity,
+            validateExactWindow: clickType != .longPress)
         switch clickType {
         case .single:
-            try self.requireCurrentExactWindow(destination.exactWindowReceipt, afterDispatch: false)
             return try await self.performSyntheticClick(
                 at: point,
                 button: .left,
                 count: 1,
                 destination: destination)
         case .right:
-            try self.requireCurrentExactWindow(destination.exactWindowReceipt, afterDispatch: false)
             return try await self.performSyntheticClick(
                 at: point,
                 button: .right,
                 count: 1,
                 destination: destination)
         case .double:
-            try self.requireCurrentExactWindow(destination.exactWindowReceipt, afterDispatch: false)
             return try await self.performSyntheticClick(
                 at: point,
                 button: .left,
@@ -840,7 +843,7 @@ public final class ClickService {
         destination: SyntheticClickDestination) async throws -> DesktopActionOutcome
     {
         if let targetProcessIdentifier = destination.processIdentifier {
-            if let exactWindowReceipt = destination.exactWindowReceipt {
+            if let exactWindowReceipt = destination.captureReceipt.exactWindow {
                 try await self.syntheticInputDriver.click(
                     at: point,
                     button: button,
@@ -869,35 +872,11 @@ public final class ClickService {
 }
 
 extension ClickService {
-    fileprivate static func validateExpectedProcessIdentity(
-        _ expectedProcessIdentity: ApplicationProcessIdentity?,
-        targetProcessIdentifier: pid_t?) throws
-    {
-        guard let expectedProcessIdentity else { return }
-        guard targetProcessIdentifier == expectedProcessIdentity.processIdentifier else {
-            throw PeekabooError.invalidInput(
-                "Generation-pinned click identity does not match its target process identifier")
-        }
-    }
-
-    fileprivate static func validateExpectedProcessIdentity(
-        _ expectedProcessIdentity: ApplicationProcessIdentity?,
-        exactWindowReceipt: ExactWindowClickReceipt?) throws
-    {
-        guard let expectedProcessIdentity, let exactWindowReceipt else { return }
-        guard exactWindowReceipt.identity.ownerProcessIdentifier == expectedProcessIdentity.processIdentifier,
-              exactWindowReceipt.identity.ownerProcessStartIdentity == expectedProcessIdentity.processStartIdentity
-        else {
-            throw PeekabooError.snapshotStale(
-                "Exact-window and process-generation click receipts do not match")
-        }
-    }
-
     fileprivate static func exactWindowReceipt(
         targetProcessIdentifier: pid_t?,
         targetWindowID: Int?,
         expectedWindowIdentity: WindowMutationIdentity?,
-        expectedWindowBounds: CGRect?) throws -> ExactWindowClickReceipt?
+        expectedWindowBounds: CGRect?) throws -> DesktopOperationPlan.ExactWindowReceipt?
     {
         guard let targetWindowID else {
             guard expectedWindowIdentity == nil, expectedWindowBounds == nil else {
@@ -915,14 +894,16 @@ extension ClickService {
             throw PeekabooError.snapshotStale(
                 "Exact-window click requires its capture-time process-generation receipt and bounds")
         }
-        return ExactWindowClickReceipt(identity: expectedWindowIdentity, bounds: expectedWindowBounds)
+        return try DesktopOperationPlan.ExactWindowReceipt(
+            identity: expectedWindowIdentity,
+            bounds: expectedWindowBounds)
     }
 
     private func resolvedExactWindowReceipt(
-        _ requested: ExactWindowClickReceipt?,
+        _ requested: DesktopOperationPlan.ExactWindowReceipt?,
         snapshotId: String?,
         targetProcessIdentifier: pid_t?,
-        targetWindowID: CGWindowID?) async throws -> ExactWindowClickReceipt?
+        targetWindowID: CGWindowID?) async throws -> DesktopOperationPlan.ExactWindowReceipt?
     {
         if let requested {
             return requested
@@ -939,33 +920,23 @@ extension ClickService {
             throw PeekabooError.snapshotStale(
                 "Exact-window click snapshot has no capture-time process-generation receipt and bounds")
         }
-        return ExactWindowClickReceipt(identity: identity, bounds: bounds)
+        return try DesktopOperationPlan.ExactWindowReceipt(identity: identity, bounds: bounds)
     }
 
-    private func requireCurrentExactWindow(
-        _ receipt: ExactWindowClickReceipt?,
-        afterDispatch: Bool) throws
+    private func requireCurrentTarget(
+        _ receipt: DesktopOperationPlan.CaptureReceipt,
+        afterDispatch: Bool,
+        validateProcessIdentity: Bool,
+        validateExactWindow: Bool = true) throws
     {
-        guard let receipt else { return }
-        guard self.exactWindowIdentityValidator(receipt.identity, receipt.bounds) else {
-            if afterDispatch {
-                throw InputDeliveryIndeterminateError(
-                    operation: .click,
-                    causeDescription: "The exact window changed before completion validation")
-            }
-            throw PeekabooError.snapshotStale(
-                "Exact-window click identity changed before final dispatch; capture a fresh snapshot")
-        }
-    }
-
-    private func requireCurrentProcess(
-        _ expectedProcessIdentity: ApplicationProcessIdentity?,
-        afterDispatch: Bool) throws
-    {
-        guard let expectedProcessIdentity else { return }
-        guard self.processStartIdentityProvider(expectedProcessIdentity.processIdentifier) ==
-            expectedProcessIdentity.processStartIdentity
-        else {
+        let mismatch = DesktopOperationSnapshotReceiptValidator.currentIdentityMismatch(
+            receipt: receipt,
+            validateProcessIdentity: validateProcessIdentity,
+            validateExactWindow: validateExactWindow,
+            processStartIdentityProvider: self.processStartIdentityProvider,
+            exactWindowIdentityValidator: self.exactWindowIdentityValidator)
+        switch mismatch {
+        case .processGeneration:
             if afterDispatch {
                 throw InputDeliveryIndeterminateError(
                     operation: .click,
@@ -974,6 +945,16 @@ extension ClickService {
             }
             throw PeekabooError.invalidInput(
                 "Background click target process exited or changed process generation before final dispatch")
+        case .exactWindow:
+            if afterDispatch {
+                throw InputDeliveryIndeterminateError(
+                    operation: .click,
+                    causeDescription: "The exact window changed before completion validation")
+            }
+            throw PeekabooError.snapshotStale(
+                "Exact-window click identity changed before final dispatch; capture a fresh snapshot")
+        case nil:
+            return
         }
     }
 }
@@ -1064,9 +1045,6 @@ extension ClickService {
         let targetProcessIdentifier = request.targetProcessIdentifier
         let expectedProcessIdentity = request.expectedProcessIdentity
         self.logger.debug("Click requested - target: \(String(describing: target)), type: \(clickType)")
-        try Self.validateExpectedProcessIdentity(
-            expectedProcessIdentity,
-            targetProcessIdentifier: targetProcessIdentifier)
         if targetProcessIdentifier != nil,
            request.targetWindowID == nil,
            case .coordinates = target
@@ -1080,23 +1058,20 @@ extension ClickService {
             targetWindowID: request.targetWindowID,
             expectedWindowIdentity: request.expectedWindowIdentity,
             expectedWindowBounds: request.expectedWindowBounds)
-        let requestedPlanWindowReceipt = try requestedExactWindowReceipt.map {
-            try DesktopOperationPlan.ExactWindowReceipt(identity: $0.identity, bounds: $0.bounds)
-        }
+        let requestedCaptureReceipt = try DesktopOperationPlan.CaptureReceipt(
+            snapshotID: snapshotID,
+            processIdentifier: targetProcessIdentifier,
+            processIdentity: expectedProcessIdentity,
+            exactWindow: requestedExactWindowReceipt)
         var bundleIdentifier: String?
         var strategy = self.inputPolicy.strategy(for: .click)
-        var exactWindowReceipt: ExactWindowClickReceipt?
-        var mutationReceipt: ClickMutationReceipt?
+        var mutationReceipt: DesktopOperationPlan.CaptureReceipt?
         var syntheticDestination: SyntheticClickDestination?
         do {
             let plan = try DesktopOperationPlan(
                 verb: .click,
                 selector: .click(target),
-                captureReceipt: DesktopOperationPlan.CaptureReceipt(
-                    snapshotID: snapshotID,
-                    processIdentifier: targetProcessIdentifier,
-                    processIdentity: expectedProcessIdentity,
-                    exactWindow: requestedPlanWindowReceipt),
+                captureReceipt: requestedCaptureReceipt,
                 deliveryIntent: targetProcessIdentifier == nil ? .foreground : .background,
                 strategy: strategy,
                 prepare: {
@@ -1110,24 +1085,27 @@ extension ClickService {
                         snapshotId: snapshotID,
                         targetProcessIdentifier: targetProcessIdentifier,
                         requestedTargetWindowID: request.targetWindowID,
-                        exactWindowReceipt: requestedExactWindowReceipt)
-                    exactWindowReceipt = try await self.resolvedExactWindowReceipt(
+                        captureReceipt: requestedCaptureReceipt)
+                    let exactWindowReceipt = try await self.resolvedExactWindowReceipt(
                         requestedExactWindowReceipt,
                         snapshotId: snapshotID,
                         targetProcessIdentifier: targetProcessIdentifier,
                         targetWindowID: exactTargetWindowID)
-                    try Self.validateExpectedProcessIdentity(
-                        expectedProcessIdentity,
-                        exactWindowReceipt: exactWindowReceipt)
-                    try self.requireCurrentProcess(expectedProcessIdentity, afterDispatch: false)
-                    mutationReceipt = ClickMutationReceipt(
+                    let preparedReceipt = try DesktopOperationPlan.CaptureReceipt(
+                        snapshotID: snapshotID,
+                        processIdentifier: targetProcessIdentifier,
                         processIdentity: expectedProcessIdentity,
                         exactWindow: exactWindowReceipt)
+                    let validatesProcessIdentity = expectedProcessIdentity != nil
+                    try self.requireCurrentTarget(
+                        preparedReceipt,
+                        afterDispatch: false,
+                        validateProcessIdentity: validatesProcessIdentity,
+                        validateExactWindow: false)
+                    mutationReceipt = preparedReceipt
                     syntheticDestination = SyntheticClickDestination(
-                        processIdentifier: targetProcessIdentifier,
-                        windowID: exactTargetWindowID,
-                        exactWindowReceipt: exactWindowReceipt,
-                        expectedProcessIdentity: expectedProcessIdentity)
+                        captureReceipt: preparedReceipt,
+                        validatesProcessIdentity: validatesProcessIdentity)
                 },
                 routing: {
                     DesktopOperationPlan.Routing(
@@ -1143,8 +1121,8 @@ extension ClickService {
                             target: target,
                             clickType: clickType,
                             snapshotId: snapshotID,
-                            targetProcessIdentifier: targetProcessIdentifier,
-                            mutationReceipt: mutationReceipt)
+                            captureReceipt: mutationReceipt,
+                            validatesProcessIdentity: expectedProcessIdentity != nil)
                     } catch let error as ActionInputError
                         where strategy == .actionFirst &&
                         targetProcessIdentifier != nil &&
@@ -1165,8 +1143,13 @@ extension ClickService {
                 },
                 postvalidate: { result in
                     do {
-                        try self.requireCurrentProcess(expectedProcessIdentity, afterDispatch: true)
-                        try self.requireCurrentExactWindow(exactWindowReceipt, afterDispatch: true)
+                        guard let mutationReceipt else {
+                            throw PeekabooError.operationError(message: "Click target was not prepared")
+                        }
+                        try self.requireCurrentTarget(
+                            mutationReceipt,
+                            afterDispatch: true,
+                            validateProcessIdentity: expectedProcessIdentity != nil)
                     } catch {
                         throw clickPostDispatchFailure(
                             outcome: result.outcome,

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/ClickService.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/ClickService.swift
@@ -57,11 +57,8 @@ private struct ClickExecutionRequest: Sendable {
     let target: ClickTarget
     let clickType: ClickType
     let snapshotID: String?
-    let targetProcessIdentifier: pid_t?
-    let expectedProcessIdentity: ApplicationProcessIdentity?
-    let targetWindowID: Int?
-    let expectedWindowIdentity: WindowMutationIdentity?
-    let expectedWindowBounds: CGRect?
+    let automationTarget: UIAutomationTarget
+    let validatesProcessIdentity: Bool
     let acquireLane: Bool
     let lanePreparation: @MainActor @Sendable () async -> Void
     let laneCompletion: @MainActor @Sendable (UIInputExecutionResult) async -> Void
@@ -641,7 +638,7 @@ public final class ClickService {
                 at: candidate,
                 clickType: .single,
                 destination: SyntheticClickDestination(
-                    captureReceipt: DesktopOperationPlan.CaptureReceipt(),
+                    captureReceipt: DesktopOperationPlan.CaptureReceipt(target: .foreground),
                     validatesProcessIdentity: false))
             try await Task.sleep(nanoseconds: 60_000_000) // 60ms
 
@@ -872,31 +869,49 @@ public final class ClickService {
 }
 
 extension ClickService {
-    fileprivate static func exactWindowReceipt(
+    fileprivate static func automationTarget(
         targetProcessIdentifier: pid_t?,
+        expectedProcessIdentity: ApplicationProcessIdentity?,
         targetWindowID: Int?,
         expectedWindowIdentity: WindowMutationIdentity?,
-        expectedWindowBounds: CGRect?) throws -> DesktopOperationPlan.ExactWindowReceipt?
+        expectedWindowBounds: CGRect?) throws -> UIAutomationTarget
     {
         guard let targetWindowID else {
             guard expectedWindowIdentity == nil, expectedWindowBounds == nil else {
                 throw PeekabooError.invalidInput(
                     "Exact-window click identity and bounds require a target window ID")
             }
-            return nil
+            if let targetProcessIdentifier {
+                return try .process(UIAutomationTarget.Process(
+                    processIdentifier: targetProcessIdentifier,
+                    identity: expectedProcessIdentity))
+            }
+            if let expectedProcessIdentity {
+                return try .process(UIAutomationTarget.Process(
+                    processIdentifier: expectedProcessIdentity.processIdentifier,
+                    identity: expectedProcessIdentity))
+            }
+            return .foreground
         }
         guard let targetProcessIdentifier,
               let expectedWindowIdentity,
-              let expectedWindowBounds,
-              expectedWindowIdentity.windowID == targetWindowID,
-              expectedWindowIdentity.ownerProcessIdentifier == targetProcessIdentifier
+              let expectedWindowBounds
         else {
             throw PeekabooError.snapshotStale(
                 "Exact-window click requires its capture-time process-generation receipt and bounds")
         }
-        return try DesktopOperationPlan.ExactWindowReceipt(
+        let exactWindow = try UIAutomationTarget.ExactWindow(
+            processIdentifier: targetProcessIdentifier,
+            windowID: targetWindowID,
             identity: expectedWindowIdentity,
             bounds: expectedWindowBounds)
+        if let expectedProcessIdentity,
+           expectedProcessIdentity != expectedWindowIdentity.processIdentity
+        {
+            throw PeekabooError.snapshotStale(
+                "Process and exact-window receipts refer to different process generations")
+        }
+        return .exactWindow(exactWindow)
     }
 
     private func resolvedExactWindowReceipt(
@@ -985,15 +1000,33 @@ extension ClickService {
         expectedWindowIdentity: WindowMutationIdentity? = nil,
         expectedWindowBounds: CGRect? = nil) async throws -> UIInputExecutionResult
     {
-        try await self.executeClick(ClickExecutionRequest(
-            target: target,
-            clickType: clickType,
-            snapshotID: snapshotId,
+        let automationTarget = try Self.automationTarget(
             targetProcessIdentifier: targetProcessIdentifier,
             expectedProcessIdentity: expectedProcessIdentity,
             targetWindowID: targetWindowID,
             expectedWindowIdentity: expectedWindowIdentity,
-            expectedWindowBounds: expectedWindowBounds,
+            expectedWindowBounds: expectedWindowBounds)
+        return try await self.click(
+            target: target,
+            clickType: clickType,
+            snapshotId: snapshotId,
+            automationTarget: automationTarget,
+            validatesProcessIdentity: expectedProcessIdentity != nil)
+    }
+
+    func click(
+        target: ClickTarget,
+        clickType: ClickType,
+        snapshotId: String?,
+        automationTarget: UIAutomationTarget,
+        validatesProcessIdentity: Bool = false) async throws -> UIInputExecutionResult
+    {
+        try await self.executeClick(ClickExecutionRequest(
+            target: target,
+            clickType: clickType,
+            snapshotID: snapshotId,
+            automationTarget: automationTarget,
+            validatesProcessIdentity: validatesProcessIdentity,
             acquireLane: true,
             lanePreparation: {},
             laneCompletion: { _ in }))
@@ -1011,11 +1044,8 @@ extension ClickService {
             target: target,
             clickType: clickType,
             snapshotID: snapshotId,
-            targetProcessIdentifier: nil,
-            expectedProcessIdentity: nil,
-            targetWindowID: nil,
-            expectedWindowIdentity: nil,
-            expectedWindowBounds: nil,
+            automationTarget: .foreground,
+            validatesProcessIdentity: false,
             acquireLane: true,
             lanePreparation: lanePreparation,
             laneCompletion: laneCompletion))
@@ -1028,11 +1058,8 @@ extension ClickService {
             target: target,
             clickType: clickType,
             snapshotID: snapshotId,
-            targetProcessIdentifier: nil,
-            expectedProcessIdentity: nil,
-            targetWindowID: nil,
-            expectedWindowIdentity: nil,
-            expectedWindowBounds: nil,
+            automationTarget: .foreground,
+            validatesProcessIdentity: false,
             acquireLane: false,
             lanePreparation: {},
             laneCompletion: { _ in }))
@@ -1042,27 +1069,21 @@ extension ClickService {
         let target = request.target
         let clickType = request.clickType
         let snapshotID = request.snapshotID
-        let targetProcessIdentifier = request.targetProcessIdentifier
-        let expectedProcessIdentity = request.expectedProcessIdentity
+        let targetProcessIdentifier = request.automationTarget.processIdentifier
+        let validatesProcessIdentity = request.validatesProcessIdentity
         self.logger.debug("Click requested - target: \(String(describing: target)), type: \(clickType)")
         if targetProcessIdentifier != nil,
-           request.targetWindowID == nil,
+           request.automationTarget.exactWindow == nil,
            case .coordinates = target
         {
             throw PeekabooError.invalidInput(
                 "Background coordinate clicks require an exact capture-time window receipt; " +
                     "PID-only coordinate routing is refused")
         }
-        let requestedExactWindowReceipt = try Self.exactWindowReceipt(
-            targetProcessIdentifier: targetProcessIdentifier,
-            targetWindowID: request.targetWindowID,
-            expectedWindowIdentity: request.expectedWindowIdentity,
-            expectedWindowBounds: request.expectedWindowBounds)
-        let requestedCaptureReceipt = try DesktopOperationPlan.CaptureReceipt(
+        let requestedExactWindowReceipt = request.automationTarget.exactWindow
+        let requestedCaptureReceipt = DesktopOperationPlan.CaptureReceipt(
             snapshotID: snapshotID,
-            processIdentifier: targetProcessIdentifier,
-            processIdentity: expectedProcessIdentity,
-            exactWindow: requestedExactWindowReceipt)
+            target: request.automationTarget)
         var bundleIdentifier: String?
         var strategy = self.inputPolicy.strategy(for: .click)
         var mutationReceipt: DesktopOperationPlan.CaptureReceipt?
@@ -1072,7 +1093,6 @@ extension ClickService {
                 verb: .click,
                 selector: .click(target),
                 captureReceipt: requestedCaptureReceipt,
-                deliveryIntent: targetProcessIdentifier == nil ? .foreground : .background,
                 strategy: strategy,
                 prepare: {
                     bundleIdentifier = await self.bundleIdentifier(
@@ -1084,19 +1104,21 @@ extension ClickService {
                         target: target,
                         snapshotId: snapshotID,
                         targetProcessIdentifier: targetProcessIdentifier,
-                        requestedTargetWindowID: request.targetWindowID,
+                        requestedTargetWindowID: requestedExactWindowReceipt?.identity.windowID,
                         captureReceipt: requestedCaptureReceipt)
                     let exactWindowReceipt = try await self.resolvedExactWindowReceipt(
                         requestedExactWindowReceipt,
                         snapshotId: snapshotID,
                         targetProcessIdentifier: targetProcessIdentifier,
                         targetWindowID: exactTargetWindowID)
-                    let preparedReceipt = try DesktopOperationPlan.CaptureReceipt(
+                    let preparedTarget: UIAutomationTarget = if let exactWindowReceipt {
+                        try request.automationTarget.refined(to: exactWindowReceipt)
+                    } else {
+                        request.automationTarget
+                    }
+                    let preparedReceipt = DesktopOperationPlan.CaptureReceipt(
                         snapshotID: snapshotID,
-                        processIdentifier: targetProcessIdentifier,
-                        processIdentity: expectedProcessIdentity,
-                        exactWindow: exactWindowReceipt)
-                    let validatesProcessIdentity = expectedProcessIdentity != nil
+                        target: preparedTarget)
                     try self.requireCurrentTarget(
                         preparedReceipt,
                         afterDispatch: false,
@@ -1122,7 +1144,7 @@ extension ClickService {
                             clickType: clickType,
                             snapshotId: snapshotID,
                             captureReceipt: mutationReceipt,
-                            validatesProcessIdentity: expectedProcessIdentity != nil)
+                            validatesProcessIdentity: validatesProcessIdentity)
                     } catch let error as ActionInputError
                         where strategy == .actionFirst &&
                         targetProcessIdentifier != nil &&
@@ -1149,7 +1171,7 @@ extension ClickService {
                         try self.requireCurrentTarget(
                             mutationReceipt,
                             afterDispatch: true,
-                            validateProcessIdentity: expectedProcessIdentity != nil)
+                            validateProcessIdentity: validatesProcessIdentity)
                     } catch {
                         throw clickPostDispatchFailure(
                             outcome: result.outcome,

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/HotkeyService.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/HotkeyService.swift
@@ -92,8 +92,7 @@ public final class HotkeyService {
         let plan = try DesktopOperationPlan(
             verb: .hotkey,
             selector: .focused,
-            captureReceipt: DesktopOperationPlan.CaptureReceipt(),
-            deliveryIntent: .foreground,
+            captureReceipt: DesktopOperationPlan.CaptureReceipt(target: .foreground),
             strategy: self.inputPolicy.strategy(for: .hotkey),
             prepare: {
                 application = self.frontmostApplicationResolver()
@@ -139,13 +138,34 @@ public final class HotkeyService {
         expectedProcessIdentity: ApplicationProcessIdentity? = nil) async throws
         -> UIInputExecutionResult
     {
+        let automationTarget: UIAutomationTarget = try .process(UIAutomationTarget.Process(
+            processIdentifier: targetProcessIdentifier,
+            identity: expectedProcessIdentity))
+        return try await self.hotkey(
+            keys: keys,
+            holdDuration: holdDuration,
+            automationTarget: automationTarget,
+            deliveryValidator: deliveryValidator)
+    }
+
+    @discardableResult
+    func hotkey(
+        keys: String,
+        holdDuration: Int,
+        automationTarget: UIAutomationTarget,
+        deliveryValidator: (@MainActor @Sendable () async throws -> Void)? = nil) async throws
+        -> UIInputExecutionResult
+    {
+        guard let targetProcessIdentifier = automationTarget.processIdentifier else {
+            throw PeekabooError.invalidInput("Targeted hotkey requires a process target")
+        }
         self.logger.debug(
             "Targeted hotkey requested: '\(keys)', hold: \(holdDuration)ms, pid: \(targetProcessIdentifier)")
 
         try BackgroundHotkeyPolicy.validate(keys: keys)
         let parsedKeys = try self.parsedKeys(keys)
         let targetValidator: @MainActor @Sendable () async throws -> Void = {
-            if let expectedProcessIdentity,
+            if let expectedProcessIdentity = automationTarget.processIdentity,
                self.processStartIdentityProvider(targetProcessIdentifier) !=
                expectedProcessIdentity.processStartIdentity
             {
@@ -159,10 +179,7 @@ public final class HotkeyService {
         let plan = try DesktopOperationPlan(
             verb: .hotkey,
             selector: .focused,
-            captureReceipt: DesktopOperationPlan.CaptureReceipt(
-                processIdentifier: targetProcessIdentifier,
-                processIdentity: expectedProcessIdentity),
-            deliveryIntent: .background,
+            captureReceipt: DesktopOperationPlan.CaptureReceipt(target: automationTarget),
             strategy: self.inputPolicy.strategy(for: .hotkey),
             prepare: {
                 application = self.runningApplicationResolver(targetProcessIdentifier)

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/ScrollService.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/ScrollService.swift
@@ -107,7 +107,9 @@ public final class ScrollService {
         let strategy: UIInputStrategy = request.foreground ? .synthOnly : .actionOnly
         let captureReceipt: DesktopOperationPlan.CaptureReceipt
         if request.foreground {
-            captureReceipt = try DesktopOperationPlan.CaptureReceipt(snapshotID: request.snapshotId)
+            captureReceipt = DesktopOperationPlan.CaptureReceipt(
+                snapshotID: request.snapshotId,
+                target: .foreground)
         } else {
             guard let snapshotID = request.snapshotId,
                   request.target?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
@@ -129,7 +131,6 @@ public final class ScrollService {
                 verb: .scroll,
                 selector: .element(request.target),
                 captureReceipt: captureReceipt,
-                deliveryIntent: request.foreground ? .foreground : .background,
                 strategy: strategy,
                 prepare: {
                     if request.foreground {

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/TypeService.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/TypeService.swift
@@ -145,8 +145,8 @@ public final class TypeService {
             verb: .type,
             selector: .element(target),
             captureReceipt: DesktopOperationPlan.CaptureReceipt(
-                snapshotID: snapshotId),
-            deliveryIntent: .foreground,
+                snapshotID: snapshotId,
+                target: .foreground),
             strategy: self.inputPolicy.strategy(for: .type),
             prepare: {
                 bundleIdentifier = await self.bundleIdentifier(snapshotId: snapshotId)
@@ -309,17 +309,42 @@ public final class TypeService {
         laneCompletion: @escaping @MainActor (TypeActionExecutionSummary) async -> Void = { _ in }) async throws
         -> TypeActionExecutionSummary
     {
+        let automationTarget: UIAutomationTarget = if let targetProcessIdentifier {
+            try .process(UIAutomationTarget.Process(
+                processIdentifier: targetProcessIdentifier,
+                identity: expectedProcessIdentity))
+        } else {
+            .foreground
+        }
+        return try await self.typeActionsTrackingSecureInput(
+            actions,
+            cadence: cadence,
+            snapshotId: snapshotId,
+            automationTarget: automationTarget,
+            deliveryValidator: deliveryValidator,
+            lanePreparation: lanePreparation,
+            laneCompletion: laneCompletion)
+    }
+
+    func typeActionsTrackingSecureInput(
+        _ actions: [TypeAction],
+        cadence: TypingCadence,
+        snapshotId: String?,
+        automationTarget: UIAutomationTarget,
+        deliveryValidator: (@MainActor @Sendable () async throws -> Void)? = nil,
+        lanePreparation: @escaping @MainActor () async -> Void = {},
+        laneCompletion: @escaping @MainActor (TypeActionExecutionSummary) async -> Void = { _ in }) async throws
+        -> TypeActionExecutionSummary
+    {
         var payloadSummary: TypeActionPayloadSummary?
         var summary: TypeActionExecutionSummary?
-        let foreground = targetProcessIdentifier == nil
+        let targetProcessIdentifier = automationTarget.processIdentifier
         let plan = try DesktopOperationPlan(
             verb: .type,
             selector: .focused,
             captureReceipt: DesktopOperationPlan.CaptureReceipt(
                 snapshotID: snapshotId,
-                processIdentifier: targetProcessIdentifier,
-                processIdentity: expectedProcessIdentity),
-            deliveryIntent: foreground ? .foreground : .background,
+                target: automationTarget),
             strategy: targetProcessIdentifier == nil ? self.inputPolicy.strategy(for: .type) : .synthOnly,
             prepare: { await lanePreparation() },
             action: nil,

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/UIAutomationService+ElementActions.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/UIAutomationService+ElementActions.swift
@@ -33,7 +33,6 @@ extension UIAutomationService: ElementActionAutomationServiceProtocol {
             verb: .setValue,
             selector: .element(target),
             captureReceipt: captureReceipt,
-            deliveryIntent: .background,
             strategy: self.inputPolicy.strategy(
                 for: .setValue,
                 bundleIdentifier: captureReceipt.bundleIdentifier),
@@ -122,7 +121,6 @@ extension UIAutomationService: ElementActionAutomationServiceProtocol {
             verb: .performAction,
             selector: .element(target),
             captureReceipt: captureReceipt,
-            deliveryIntent: .background,
             strategy: self.inputPolicy.strategy(
                 for: .performAction,
                 bundleIdentifier: captureReceipt.bundleIdentifier),

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/UIAutomationService+ElementActions.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/UIAutomationService+ElementActions.swift
@@ -256,7 +256,17 @@ extension UIAutomationService: ElementActionAutomationServiceProtocol {
     private func elementMutationCaptureReceipt(snapshotId: String) async throws
         -> DesktopOperationPlan.CaptureReceipt
     {
-        let detectionResult = try? await self.snapshotManager.getDetectionResult(snapshotId: snapshotId)
+        let detectionResult: ElementDetectionResult
+        do {
+            guard let result = try await self.snapshotManager.getDetectionResult(snapshotId: snapshotId) else {
+                throw PeekabooError.snapshotNotFound(snapshotId)
+            }
+            detectionResult = result
+        } catch let error as PeekabooError {
+            throw error
+        } catch {
+            throw PeekabooError.snapshotNotFound(snapshotId)
+        }
         return try DesktopOperationSnapshotReceiptValidator.captureReceipt(
             snapshotID: snapshotId,
             detectionResult: detectionResult,

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/UIAutomationService+Operations.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/UIAutomationService+Operations.swift
@@ -209,12 +209,14 @@ extension UIAutomationService {
         targetProcessIdentifier: pid_t) async throws -> UIAutomationActionResult<Void>
     {
         self.logger.debug("Delegating background click to ClickService")
+        let automationTarget: UIAutomationTarget = try .process(UIAutomationTarget.Process(
+            processIdentifier: targetProcessIdentifier))
         let result = try await self.normalizingSnapshotErrors {
             try await self.clickService.click(
                 target: target,
                 clickType: clickType,
                 snapshotId: snapshotId,
-                targetProcessIdentifier: targetProcessIdentifier)
+                automationTarget: automationTarget)
         }
 
         await self.visualizeClick(
@@ -247,13 +249,16 @@ extension UIAutomationService {
         expectedProcessIdentity: ApplicationProcessIdentity) async throws -> UIAutomationActionResult<Void>
     {
         self.logger.debug("Delegating generation-pinned background click to ClickService")
+        let automationTarget: UIAutomationTarget = try .process(UIAutomationTarget.Process(
+            processIdentifier: expectedProcessIdentity.processIdentifier,
+            identity: expectedProcessIdentity))
         let result = try await self.normalizingSnapshotErrors {
             try await self.clickService.click(
                 target: target,
                 clickType: clickType,
                 snapshotId: snapshotId,
-                targetProcessIdentifier: expectedProcessIdentity.processIdentifier,
-                expectedProcessIdentity: expectedProcessIdentity)
+                automationTarget: automationTarget,
+                validatesProcessIdentity: true)
         }
 
         await self.visualizeClick(
@@ -288,20 +293,17 @@ extension UIAutomationService {
         expectedWindowIdentity: WindowMutationIdentity,
         expectedWindowBounds: CGRect) async throws -> UIAutomationActionResult<Void>
     {
-        let processIdentity = ApplicationProcessIdentity(
-            processIdentifier: expectedWindowIdentity.ownerProcessIdentifier,
-            processStartIdentity: expectedWindowIdentity.ownerProcessStartIdentity)
+        let automationTarget: UIAutomationTarget = try .exactWindow(UIAutomationTarget.ExactWindow(
+            identity: expectedWindowIdentity,
+            bounds: expectedWindowBounds))
         self.logger.debug("Delegating exact-window background click to ClickService")
         let result = try await self.normalizingSnapshotErrors {
             try await self.clickService.click(
                 target: target,
                 clickType: clickType,
                 snapshotId: snapshotId,
-                targetProcessIdentifier: expectedWindowIdentity.ownerProcessIdentifier,
-                expectedProcessIdentity: processIdentity,
-                targetWindowID: expectedWindowIdentity.windowID,
-                expectedWindowIdentity: expectedWindowIdentity,
-                expectedWindowBounds: expectedWindowBounds)
+                automationTarget: automationTarget,
+                validatesProcessIdentity: true)
         }
 
         await self.visualizeClick(

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/UIAutomationService+PointerKeyboardOperations.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/UIAutomationService+PointerKeyboardOperations.swift
@@ -124,10 +124,12 @@ extension UIAutomationService {
         targetProcessIdentifier: pid_t) async throws -> UIAutomationActionResult<Void>
     {
         self.logger.debug("Delegating targeted hotkey to HotkeyService")
+        let automationTarget: UIAutomationTarget = try .process(UIAutomationTarget.Process(
+            processIdentifier: targetProcessIdentifier))
         let result = try await self.hotkeyService.hotkey(
             keys: keys,
             holdDuration: holdDuration,
-            targetProcessIdentifier: targetProcessIdentifier)
+            automationTarget: automationTarget)
 
         await self.visualizeHotkey(keys: keys, targetProcessIdentifier: targetProcessIdentifier)
         return UIAutomationActionResult(payload: (), outcome: result.outcome)
@@ -149,6 +151,9 @@ extension UIAutomationService {
         holdDuration: Int,
         expectedProcessIdentity: ApplicationProcessIdentity) async throws -> UIAutomationActionResult<Void>
     {
+        let automationTarget: UIAutomationTarget = try .process(UIAutomationTarget.Process(
+            processIdentifier: expectedProcessIdentity.processIdentifier,
+            identity: expectedProcessIdentity))
         let validator: @MainActor @Sendable () async throws -> Void = {
             guard self.processStartIdentityProvider(expectedProcessIdentity.processIdentifier) ==
                 expectedProcessIdentity.processStartIdentity
@@ -160,9 +165,8 @@ extension UIAutomationService {
         let result = try await self.hotkeyService.hotkey(
             keys: keys,
             holdDuration: holdDuration,
-            targetProcessIdentifier: expectedProcessIdentity.processIdentifier,
-            deliveryValidator: validator,
-            expectedProcessIdentity: expectedProcessIdentity)
+            automationTarget: automationTarget,
+            deliveryValidator: validator)
         return UIAutomationActionResult(payload: (), outcome: result.outcome)
     }
 
@@ -185,9 +189,9 @@ extension UIAutomationService {
         expectedWindowIdentity: WindowMutationIdentity,
         expectedWindowBounds: CGRect) async throws -> UIAutomationActionResult<Void>
     {
-        let processIdentity = ApplicationProcessIdentity(
-            processIdentifier: expectedWindowIdentity.ownerProcessIdentifier,
-            processStartIdentity: expectedWindowIdentity.ownerProcessStartIdentity)
+        let automationTarget: UIAutomationTarget = try .exactWindow(UIAutomationTarget.ExactWindow(
+            identity: expectedWindowIdentity,
+            bounds: expectedWindowBounds))
         let validator: @MainActor @Sendable () async throws -> Void = {
             try await self.requireExactWindowKeyboardFocus(
                 expectedWindowIdentity: expectedWindowIdentity,
@@ -196,9 +200,8 @@ extension UIAutomationService {
         let result = try await self.hotkeyService.hotkey(
             keys: keys,
             holdDuration: holdDuration,
-            targetProcessIdentifier: expectedWindowIdentity.ownerProcessIdentifier,
-            deliveryValidator: validator,
-            expectedProcessIdentity: processIdentity)
+            automationTarget: automationTarget,
+            deliveryValidator: validator)
         return UIAutomationActionResult(payload: (), outcome: result.outcome)
     }
 
@@ -218,9 +221,10 @@ extension UIAutomationService {
         holdDuration: Int,
         target: ExactWindowKeyboardTarget) async throws -> UIAutomationActionResult<Void>
     {
-        let processIdentity = ApplicationProcessIdentity(
-            processIdentifier: target.windowIdentity.ownerProcessIdentifier,
-            processStartIdentity: target.windowIdentity.ownerProcessStartIdentity)
+        let automationTarget: UIAutomationTarget = try .exactWindow(UIAutomationTarget.ExactWindow(
+            identity: target.windowIdentity,
+            bounds: target.windowBounds,
+            focusedElement: target.focusedElement))
         let validator: @MainActor @Sendable () async throws -> Void = {
             try await self.requireExactWindowKeyboardFocus(
                 expectedWindowIdentity: target.windowIdentity,
@@ -230,9 +234,8 @@ extension UIAutomationService {
         let result = try await self.hotkeyService.hotkey(
             keys: keys,
             holdDuration: holdDuration,
-            targetProcessIdentifier: target.windowIdentity.ownerProcessIdentifier,
-            deliveryValidator: validator,
-            expectedProcessIdentity: processIdentity)
+            automationTarget: automationTarget,
+            deliveryValidator: validator)
         return UIAutomationActionResult(payload: (), outcome: result.outcome)
     }
 

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/UIAutomationService+TypingOperations.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/UIAutomationService+TypingOperations.swift
@@ -143,7 +143,7 @@ extension UIAutomationService {
                 actions,
                 cadence: cadence,
                 snapshotId: snapshotId,
-                targetProcessIdentifier: nil,
+                automationTarget: .foreground,
                 lanePreparation: {
                     visualizerTarget = await self.visualizerTargetWindow(snapshotId: snapshotId)
                 },
@@ -182,9 +182,9 @@ extension UIAutomationService {
         expectedWindowIdentity: WindowMutationIdentity,
         expectedWindowBounds: CGRect) async throws -> UIAutomationActionResult<TypeResult>
     {
-        let processIdentity = ApplicationProcessIdentity(
-            processIdentifier: expectedWindowIdentity.ownerProcessIdentifier,
-            processStartIdentity: expectedWindowIdentity.ownerProcessStartIdentity)
+        let automationTarget: UIAutomationTarget = try .exactWindow(UIAutomationTarget.ExactWindow(
+            identity: expectedWindowIdentity,
+            bounds: expectedWindowBounds))
         let validator: @MainActor @Sendable () async throws -> Void = {
             try await self.requireExactWindowKeyboardFocus(
                 expectedWindowIdentity: expectedWindowIdentity,
@@ -195,9 +195,8 @@ extension UIAutomationService {
                 actions,
                 cadence: cadence,
                 snapshotId: snapshotId,
-                targetProcessIdentifier: expectedWindowIdentity.ownerProcessIdentifier,
-                deliveryValidator: validator,
-                expectedProcessIdentity: processIdentity)
+                automationTarget: automationTarget,
+                deliveryValidator: validator)
         }
         return UIAutomationActionResult(
             payload: summary.result,
@@ -223,9 +222,10 @@ extension UIAutomationService {
         snapshotId: String?,
         target: ExactWindowKeyboardTarget) async throws -> UIAutomationActionResult<TypeResult>
     {
-        let processIdentity = ApplicationProcessIdentity(
-            processIdentifier: target.windowIdentity.ownerProcessIdentifier,
-            processStartIdentity: target.windowIdentity.ownerProcessStartIdentity)
+        let automationTarget: UIAutomationTarget = try .exactWindow(UIAutomationTarget.ExactWindow(
+            identity: target.windowIdentity,
+            bounds: target.windowBounds,
+            focusedElement: target.focusedElement))
         let validator: @MainActor @Sendable () async throws -> Void = {
             try await self.requireExactWindowKeyboardFocus(
                 expectedWindowIdentity: target.windowIdentity,
@@ -237,9 +237,8 @@ extension UIAutomationService {
                 actions,
                 cadence: cadence,
                 snapshotId: snapshotId,
-                targetProcessIdentifier: target.windowIdentity.ownerProcessIdentifier,
-                deliveryValidator: validator,
-                expectedProcessIdentity: processIdentity)
+                automationTarget: automationTarget,
+                deliveryValidator: validator)
         }
         return UIAutomationActionResult(
             payload: summary.result,
@@ -266,12 +265,14 @@ extension UIAutomationService {
         targetProcessIdentifier: pid_t) async throws -> UIAutomationActionResult<TypeResult>
     {
         self.logger.debug("Delegating targeted typeActions to TypeService")
+        let automationTarget: UIAutomationTarget = try .process(UIAutomationTarget.Process(
+            processIdentifier: targetProcessIdentifier))
         let summary = try await self.normalizingSnapshotErrors {
             try await self.typeService.typeActionsTrackingSecureInput(
                 actions,
                 cadence: cadence,
                 snapshotId: snapshotId,
-                targetProcessIdentifier: targetProcessIdentifier)
+                automationTarget: automationTarget)
         }
         await self.visualizeTypeActions(
             actions,
@@ -302,6 +303,9 @@ extension UIAutomationService {
         snapshotId: String?,
         expectedProcessIdentity: ApplicationProcessIdentity) async throws -> UIAutomationActionResult<TypeResult>
     {
+        let automationTarget: UIAutomationTarget = try .process(UIAutomationTarget.Process(
+            processIdentifier: expectedProcessIdentity.processIdentifier,
+            identity: expectedProcessIdentity))
         let validator: @MainActor @Sendable () async throws -> Void = {
             guard self.processStartIdentityProvider(expectedProcessIdentity.processIdentifier) ==
                 expectedProcessIdentity.processStartIdentity
@@ -315,9 +319,8 @@ extension UIAutomationService {
                 actions,
                 cadence: cadence,
                 snapshotId: snapshotId,
-                targetProcessIdentifier: expectedProcessIdentity.processIdentifier,
-                deliveryValidator: validator,
-                expectedProcessIdentity: expectedProcessIdentity)
+                automationTarget: automationTarget,
+                deliveryValidator: validator)
         }
         return UIAutomationActionResult(
             payload: summary.result,

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Strategy/DesktopOperationPlan.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Strategy/DesktopOperationPlan.swift
@@ -31,60 +31,35 @@ struct DesktopOperationPlan {
         }
     }
 
-    struct ExactWindowReceipt: Equatable, Sendable {
-        let identity: WindowMutationIdentity
-        let bounds: CGRect
-
-        init(identity: WindowMutationIdentity, bounds: CGRect) throws {
-            if let capturedBounds = identity.capturedBounds, capturedBounds != bounds {
-                throw PeekabooError.snapshotStale(
-                    "Exact-window receipt bounds do not match the captured window identity")
-            }
-            self.identity = identity
-            self.bounds = bounds
-        }
-    }
+    typealias ExactWindowReceipt = UIAutomationTarget.ExactWindow
 
     struct CaptureReceipt: Equatable, Sendable {
         let snapshotID: String?
         let bundleIdentifier: String?
-        let processIdentifier: pid_t?
-        let processIdentity: ApplicationProcessIdentity?
-        let exactWindow: ExactWindowReceipt?
+        let target: UIAutomationTarget
         let coordinateContext: CaptureCoordinateContext?
+
+        var processIdentifier: pid_t? {
+            self.target.processIdentifier
+        }
+
+        var processIdentity: ApplicationProcessIdentity? {
+            self.target.processIdentity
+        }
+
+        var exactWindow: ExactWindowReceipt? {
+            self.target.exactWindow
+        }
 
         init(
             snapshotID: String? = nil,
             bundleIdentifier: String? = nil,
-            processIdentifier: pid_t? = nil,
-            processIdentity: ApplicationProcessIdentity? = nil,
-            exactWindow: ExactWindowReceipt? = nil,
-            coordinateContext: CaptureCoordinateContext? = nil) throws
+            target: UIAutomationTarget,
+            coordinateContext: CaptureCoordinateContext? = nil)
         {
-            let exactProcessIdentity = exactWindow.map {
-                ApplicationProcessIdentity(
-                    processIdentifier: $0.identity.ownerProcessIdentifier,
-                    processStartIdentity: $0.identity.ownerProcessStartIdentity)
-            }
-            if let processIdentity, let exactProcessIdentity, processIdentity != exactProcessIdentity {
-                throw PeekabooError.snapshotStale(
-                    "Process and exact-window receipts refer to different process generations")
-            }
-            let resolvedProcessIdentity = processIdentity ?? exactProcessIdentity
-            let resolvedProcessIdentifier = processIdentifier ?? resolvedProcessIdentity?.processIdentifier
-            if let resolvedProcessIdentity,
-               let resolvedProcessIdentifier,
-               resolvedProcessIdentity.processIdentifier != resolvedProcessIdentifier
-            {
-                throw PeekabooError.invalidInput(
-                    "Target PID does not match its process-generation receipt")
-            }
-
             self.snapshotID = snapshotID?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
             self.bundleIdentifier = bundleIdentifier
-            self.processIdentifier = resolvedProcessIdentifier
-            self.processIdentity = resolvedProcessIdentity
-            self.exactWindow = exactWindow
+            self.target = target
             self.coordinateContext = coordinateContext
         }
     }
@@ -142,7 +117,6 @@ struct DesktopOperationPlan {
         verb: UIInputVerb,
         selector: Selector,
         captureReceipt: CaptureReceipt,
-        deliveryIntent: DeliveryIntent,
         strategy: UIInputStrategy,
         prepare: @escaping @MainActor () async throws -> Void = {},
         routing: (@MainActor () -> Routing)? = nil,
@@ -153,7 +127,7 @@ struct DesktopOperationPlan {
         finalize: @escaping @MainActor () async -> Void = {}) throws
     {
         let normalizedSelector = try Self.normalized(selector)
-        if deliveryIntent == .background,
+        if captureReceipt.target != .foreground,
            case .coordinates = normalizedSelector,
            captureReceipt.exactWindow == nil
         {
@@ -164,10 +138,8 @@ struct DesktopOperationPlan {
         self.verb = verb
         self.selector = normalizedSelector
         self.captureReceipt = captureReceipt
-        self.deliveryIntent = deliveryIntent
-        self.laneScope = Self.laneScope(
-            deliveryIntent: deliveryIntent,
-            captureReceipt: captureReceipt)
+        self.deliveryIntent = captureReceipt.target == .foreground ? .foreground : .background
+        self.laneScope = Self.laneScope(captureReceipt.target)
         self.prepare = prepare
         self.routing = routing ?? {
             Routing(strategy: strategy, bundleIdentifier: captureReceipt.bundleIdentifier)
@@ -201,11 +173,8 @@ struct DesktopOperationPlan {
         }
     }
 
-    private static func laneScope(
-        deliveryIntent: DeliveryIntent,
-        captureReceipt: CaptureReceipt) -> DesktopOperationScope
-    {
-        guard deliveryIntent == .background, let identity = captureReceipt.processIdentity else {
+    private static func laneScope(_ target: UIAutomationTarget) -> DesktopOperationScope {
+        guard let identity = target.processIdentity else {
             return .global
         }
         // Preserve the shipped process-scoped semantics for exact-window keyboard and pointer input.

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Strategy/DesktopOperationSnapshotReceiptValidator.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Strategy/DesktopOperationSnapshotReceiptValidator.swift
@@ -21,7 +21,8 @@ enum DesktopOperationSnapshotReceiptValidator {
             guard !requireExactWindow else {
                 throw PeekabooError.snapshotStale("background mutation requires a fresh exact-window snapshot")
             }
-            return DesktopOperationPlan.CaptureReceipt(snapshotID: snapshotID, target: .foreground)
+            throw PeekabooError.snapshotStale(
+                "background mutation requires a fresh process-targeted snapshot")
         }
         guard detectionResult.snapshotId == snapshotID else {
             throw PeekabooError.snapshotStale("snapshot identity changed before desktop mutation planning")
@@ -33,10 +34,16 @@ enum DesktopOperationSnapshotReceiptValidator {
                 throw PeekabooError.snapshotStale(
                     "background mutation snapshot has no exact process-generation and window receipt")
             }
-            return DesktopOperationPlan.CaptureReceipt(
+            guard let context = detectionResult.metadata.windowContext,
+                  let processIdentifier = context.applicationProcessId
+            else {
+                throw PeekabooError.snapshotStale(
+                    "background mutation snapshot has no process target")
+            }
+            return try DesktopOperationPlan.CaptureReceipt(
                 snapshotID: snapshotID,
-                bundleIdentifier: detectionResult.metadata.windowContext?.applicationBundleId,
-                target: .foreground,
+                bundleIdentifier: context.applicationBundleId,
+                target: .process(UIAutomationTarget.Process(processIdentifier: processIdentifier)),
                 coordinateContext: detectionResult.metadata.captureCoordinateContext)
         }
         guard let bounds = context.windowBounds,

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Strategy/DesktopOperationSnapshotReceiptValidator.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Strategy/DesktopOperationSnapshotReceiptValidator.swift
@@ -4,6 +4,11 @@ import PeekabooFoundation
 
 /// Builds and revalidates exact snapshot receipts for desktop mutations.
 enum DesktopOperationSnapshotReceiptValidator {
+    enum CurrentIdentityMismatch {
+        case processGeneration
+        case exactWindow
+    }
+
     static func captureReceipt(
         snapshotID: String,
         detectionResult: ElementDetectionResult?,
@@ -74,6 +79,7 @@ enum DesktopOperationSnapshotReceiptValidator {
     static func validate(
         context: WindowContext?,
         receipt: DesktopOperationPlan.CaptureReceipt,
+        validateCurrentIdentity: Bool = true,
         processStartIdentityProvider: @Sendable (pid_t) -> UInt64?,
         exactWindowIdentityValidator: @Sendable (WindowMutationIdentity, CGRect) -> Bool) throws
     {
@@ -88,14 +94,43 @@ enum DesktopOperationSnapshotReceiptValidator {
               context.windowID == expectedWindowIdentity.windowID,
               context.windowBounds == exactWindow.bounds,
               let resolvedWindowIdentity = context.windowMutationIdentity,
-              self.sameIdentity(resolvedWindowIdentity, expectedWindowIdentity),
-              processStartIdentityProvider(expectedProcessIdentity.processIdentifier) ==
-              expectedProcessIdentity.processStartIdentity,
-              exactWindowIdentityValidator(expectedWindowIdentity, exactWindow.bounds)
+              self.sameIdentity(resolvedWindowIdentity, expectedWindowIdentity)
         else {
             throw PeekabooError.snapshotStale(
                 "target window owner, process generation, or bounds changed before desktop mutation dispatch")
         }
+        if validateCurrentIdentity,
+           self.currentIdentityMismatch(
+               receipt: receipt,
+               processStartIdentityProvider: processStartIdentityProvider,
+               exactWindowIdentityValidator: exactWindowIdentityValidator) != nil
+        {
+            throw PeekabooError.snapshotStale(
+                "target window owner, process generation, or bounds changed before desktop mutation dispatch")
+        }
+    }
+
+    static func currentIdentityMismatch(
+        receipt: DesktopOperationPlan.CaptureReceipt,
+        validateProcessIdentity: Bool = true,
+        validateExactWindow: Bool = true,
+        processStartIdentityProvider: @Sendable (pid_t) -> UInt64?,
+        exactWindowIdentityValidator: @Sendable (WindowMutationIdentity, CGRect) -> Bool)
+        -> CurrentIdentityMismatch?
+    {
+        if validateProcessIdentity,
+           let processIdentity = receipt.processIdentity,
+           processStartIdentityProvider(processIdentity.processIdentifier) != processIdentity.processStartIdentity
+        {
+            return .processGeneration
+        }
+        if validateExactWindow,
+           let exactWindow = receipt.exactWindow,
+           !exactWindowIdentityValidator(exactWindow.identity, exactWindow.bounds)
+        {
+            return .exactWindow
+        }
+        return nil
     }
 
     private static func sameIdentity(_ lhs: WindowMutationIdentity, _ rhs: WindowMutationIdentity) -> Bool {

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Strategy/DesktopOperationSnapshotReceiptValidator.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Strategy/DesktopOperationSnapshotReceiptValidator.swift
@@ -21,7 +21,7 @@ enum DesktopOperationSnapshotReceiptValidator {
             guard !requireExactWindow else {
                 throw PeekabooError.snapshotStale("background mutation requires a fresh exact-window snapshot")
             }
-            return try DesktopOperationPlan.CaptureReceipt(snapshotID: snapshotID)
+            return DesktopOperationPlan.CaptureReceipt(snapshotID: snapshotID, target: .foreground)
         }
         guard detectionResult.snapshotId == snapshotID else {
             throw PeekabooError.snapshotStale("snapshot identity changed before desktop mutation planning")
@@ -33,9 +33,10 @@ enum DesktopOperationSnapshotReceiptValidator {
                 throw PeekabooError.snapshotStale(
                     "background mutation snapshot has no exact process-generation and window receipt")
             }
-            return try DesktopOperationPlan.CaptureReceipt(
+            return DesktopOperationPlan.CaptureReceipt(
                 snapshotID: snapshotID,
                 bundleIdentifier: detectionResult.metadata.windowContext?.applicationBundleId,
+                target: .foreground,
                 coordinateContext: detectionResult.metadata.captureCoordinateContext)
         }
         guard let bounds = context.windowBounds,
@@ -48,15 +49,10 @@ enum DesktopOperationSnapshotReceiptValidator {
             throw PeekabooError.snapshotStale(
                 "target window owner, process generation, or bounds changed before desktop mutation")
         }
-        let processIdentity = ApplicationProcessIdentity(
-            processIdentifier: identity.ownerProcessIdentifier,
-            processStartIdentity: identity.ownerProcessStartIdentity)
         return try DesktopOperationPlan.CaptureReceipt(
             snapshotID: snapshotID,
             bundleIdentifier: context.applicationBundleId,
-            processIdentifier: processIdentity.processIdentifier,
-            processIdentity: processIdentity,
-            exactWindow: DesktopOperationPlan.ExactWindowReceipt(identity: identity, bounds: bounds),
+            target: .exactWindow(UIAutomationTarget.ExactWindow(identity: identity, bounds: bounds)),
             coordinateContext: detectionResult.metadata.captureCoordinateContext)
     }
 
@@ -94,7 +90,7 @@ enum DesktopOperationSnapshotReceiptValidator {
               context.windowID == expectedWindowIdentity.windowID,
               context.windowBounds == exactWindow.bounds,
               let resolvedWindowIdentity = context.windowMutationIdentity,
-              self.sameIdentity(resolvedWindowIdentity, expectedWindowIdentity)
+              resolvedWindowIdentity.hasSameStableReceipt(as: expectedWindowIdentity)
         else {
             throw PeekabooError.snapshotStale(
                 "target window owner, process generation, or bounds changed before desktop mutation dispatch")
@@ -131,12 +127,5 @@ enum DesktopOperationSnapshotReceiptValidator {
             return .exactWindow
         }
         return nil
-    }
-
-    private static func sameIdentity(_ lhs: WindowMutationIdentity, _ rhs: WindowMutationIdentity) -> Bool {
-        lhs.windowID == rhs.windowID &&
-            lhs.ownerProcessIdentifier == rhs.ownerProcessIdentifier &&
-            lhs.ownerProcessStartIdentity == rhs.ownerProcessStartIdentity &&
-            lhs.capturedBounds == rhs.capturedBounds
     }
 }

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Strategy/UIAutomationTarget.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Strategy/UIAutomationTarget.swift
@@ -1,0 +1,150 @@
+import CoreGraphics
+import Foundation
+import PeekabooFoundation
+
+/// One validated destination for native UI input.
+///
+/// This is an in-process planning value, not a transport model. Public service overloads adapt
+/// their legacy arguments into this target without changing Bridge or command wire contracts.
+public enum UIAutomationTarget: Sendable, Equatable {
+    /// Input follows the user's current foreground focus.
+    case foreground
+
+    /// Input is routed to a process without requiring one exact window.
+    case process(Process)
+
+    /// Input is pinned to one process generation and exact WindowServer window.
+    case exactWindow(ExactWindow)
+
+    public struct Process: Sendable, Equatable {
+        public let processIdentifier: pid_t
+        public let identity: ApplicationProcessIdentity?
+
+        public init(
+            processIdentifier: pid_t,
+            identity: ApplicationProcessIdentity? = nil) throws
+        {
+            if let identity, identity.processIdentifier != processIdentifier {
+                throw PeekabooError.invalidInput(
+                    "Target PID does not match its process-generation receipt")
+            }
+            self.processIdentifier = processIdentifier
+            self.identity = identity
+        }
+    }
+
+    public struct ExactWindow: Sendable, Equatable {
+        public let identity: WindowMutationIdentity
+        public let bounds: CGRect
+        public let focusedElement: FocusedElementIdentity?
+
+        public init(
+            processIdentifier: pid_t,
+            windowID: Int,
+            identity: WindowMutationIdentity,
+            bounds: CGRect,
+            focusedElement: FocusedElementIdentity? = nil) throws
+        {
+            guard identity.ownerProcessIdentifier == processIdentifier,
+                  identity.windowID == windowID
+            else {
+                throw PeekabooError.snapshotStale(
+                    "Exact-window identifiers do not match the capture-time process-generation receipt")
+            }
+            try self.init(
+                identity: identity,
+                bounds: bounds,
+                focusedElement: focusedElement)
+        }
+
+        public init(
+            identity: WindowMutationIdentity,
+            bounds: CGRect,
+            focusedElement: FocusedElementIdentity? = nil) throws
+        {
+            if let capturedBounds = identity.capturedBounds, capturedBounds != bounds {
+                throw PeekabooError.snapshotStale(
+                    "Exact-window receipt bounds do not match the captured window identity")
+            }
+            if let focusedElement,
+               focusedElement.processIdentifier != identity.ownerProcessIdentifier ||
+               focusedElement.windowID != identity.windowID
+            {
+                throw PeekabooError.invalidInput(
+                    field: "target",
+                    reason: "Focused-element receipt does not belong to the exact target window")
+            }
+            self.identity = identity
+            self.bounds = bounds
+            self.focusedElement = focusedElement
+        }
+
+        public static func == (lhs: Self, rhs: Self) -> Bool {
+            lhs.identity.hasSameStableReceipt(as: rhs.identity) &&
+                lhs.bounds == rhs.bounds &&
+                lhs.focusedElement == rhs.focusedElement
+        }
+    }
+
+    public static func == (lhs: Self, rhs: Self) -> Bool {
+        switch (lhs, rhs) {
+        case (.foreground, .foreground):
+            true
+        case let (.process(lhs), .process(rhs)):
+            lhs == rhs
+        case let (.exactWindow(lhs), .exactWindow(rhs)):
+            lhs == rhs
+        default:
+            false
+        }
+    }
+
+    public var processIdentifier: pid_t? {
+        switch self {
+        case .foreground:
+            nil
+        case let .process(target):
+            target.processIdentifier
+        case let .exactWindow(target):
+            target.identity.ownerProcessIdentifier
+        }
+    }
+
+    public var processIdentity: ApplicationProcessIdentity? {
+        switch self {
+        case .foreground:
+            nil
+        case let .process(target):
+            target.identity
+        case let .exactWindow(target):
+            target.identity.processIdentity
+        }
+    }
+
+    public var exactWindow: ExactWindow? {
+        guard case let .exactWindow(target) = self else { return nil }
+        return target
+    }
+
+    func refined(to exactWindow: ExactWindow) throws -> UIAutomationTarget {
+        if let processIdentifier = self.processIdentifier,
+           processIdentifier != exactWindow.identity.ownerProcessIdentifier
+        {
+            throw PeekabooError.snapshotStale(
+                "Process and exact-window receipts refer to different process generations")
+        }
+        if let processIdentity = self.processIdentity,
+           processIdentity != exactWindow.identity.processIdentity
+        {
+            throw PeekabooError.snapshotStale(
+                "Process and exact-window receipts refer to different process generations")
+        }
+        if let currentExactWindow = self.exactWindow,
+           currentExactWindow != exactWindow
+        {
+            throw PeekabooError.snapshotStale(
+                "Exact-window receipts refer to different window identities")
+        }
+        return .exactWindow(exactWindow)
+    }
+}

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKitTestSupport/AutomationTestFixtures.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKitTestSupport/AutomationTestFixtures.swift
@@ -66,7 +66,7 @@ public enum AutomationTestFixtures {
     public static func windowIdentity(
         windowID: Int = 201,
         processIdentity: ApplicationProcessIdentity = Self.processIdentity(),
-        bounds: CGRect = CGRect(x: 10, y: 20, width: 640, height: 480),
+        bounds: CGRect? = CGRect(x: 10, y: 20, width: 640, height: 480),
         isMinimized: Bool = false) -> WindowMutationIdentity
     {
         WindowMutationIdentity(

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ActionInputDriverTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ActionInputDriverTests.swift
@@ -441,7 +441,11 @@ struct ActionInputDriverTests {
             snapshotId: "snapshot",
             screenshotPath: "/tmp/shot.png",
             elements: DetectedElements(buttons: [detected]),
-            metadata: DetectionMetadata(detectionTime: 0.01, elementCount: 1, method: "test"))
+            metadata: DetectionMetadata(
+                detectionTime: 0.01,
+                elementCount: 1,
+                method: "test",
+                windowContext: WindowContext(applicationProcessId: getpid())))
         let service = UIAutomationService(
             snapshotManager: InMemorySnapshotManager(detectionResult: detectionResult),
             inputPolicy: UIInputPolicy(defaultStrategy: .actionOnly),

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ClickServiceExactWindowTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ClickServiceExactWindowTests.swift
@@ -78,6 +78,109 @@ struct ClickServiceExactWindowTests {
 
     @Test
     @MainActor
+    func `Exact click rejects mismatched process generation before delivery`() async {
+        let bounds = CGRect(x: 0, y: 0, width: 100, height: 100)
+        let identity = WindowMutationIdentity(
+            windowID: 42,
+            ownerProcessIdentifier: getpid(),
+            ownerProcessStartIdentity: 72,
+            capturedBounds: bounds)
+        let synthetic = ClickRecordingSyntheticInputDriver()
+        let service = ClickService(
+            snapshotManager: InMemorySnapshotManager(),
+            inputPolicy: UIInputPolicy(defaultStrategy: .synthOnly),
+            syntheticInputDriver: synthetic,
+            exactWindowIdentityValidator: { _, _ in true },
+            processStartIdentityProvider: { _ in 71 })
+
+        do {
+            _ = try await service.click(
+                target: .coordinates(CGPoint(x: 10, y: 20)),
+                clickType: .single,
+                snapshotId: nil,
+                targetProcessIdentifier: getpid(),
+                expectedProcessIdentity: ApplicationProcessIdentity(
+                    processIdentifier: getpid(),
+                    processStartIdentity: 71),
+                targetWindowID: 42,
+                expectedWindowIdentity: identity,
+                expectedWindowBounds: bounds)
+            Issue.record("Expected mismatched process-generation receipts to fail")
+        } catch let PeekabooError.snapshotStale(reason) {
+            #expect(reason.contains("different process generations"))
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+        #expect(synthetic.events.isEmpty)
+    }
+
+    @Test
+    @MainActor
+    func `Exact click rejects mismatched window identifier before delivery`() async {
+        let bounds = CGRect(x: 0, y: 0, width: 100, height: 100)
+        let identity = WindowMutationIdentity(
+            windowID: 41,
+            ownerProcessIdentifier: getpid(),
+            ownerProcessStartIdentity: 71,
+            capturedBounds: bounds)
+        let synthetic = ClickRecordingSyntheticInputDriver()
+        let service = ClickService(
+            snapshotManager: InMemorySnapshotManager(),
+            inputPolicy: UIInputPolicy(defaultStrategy: .synthOnly),
+            syntheticInputDriver: synthetic)
+
+        do {
+            _ = try await service.click(
+                target: .coordinates(CGPoint(x: 10, y: 20)),
+                clickType: .single,
+                snapshotId: nil,
+                targetProcessIdentifier: getpid(),
+                targetWindowID: 42,
+                expectedWindowIdentity: identity,
+                expectedWindowBounds: bounds)
+            Issue.record("Expected the window identifier mismatch to fail")
+        } catch let PeekabooError.snapshotStale(reason) {
+            #expect(reason.contains("capture-time process-generation receipt"))
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+        #expect(synthetic.events.isEmpty)
+    }
+
+    @Test
+    @MainActor
+    func `Exact click rejects mismatched captured bounds before delivery`() async {
+        let identity = WindowMutationIdentity(
+            windowID: 42,
+            ownerProcessIdentifier: getpid(),
+            ownerProcessStartIdentity: 71,
+            capturedBounds: CGRect(x: 0, y: 0, width: 100, height: 100))
+        let synthetic = ClickRecordingSyntheticInputDriver()
+        let service = ClickService(
+            snapshotManager: InMemorySnapshotManager(),
+            inputPolicy: UIInputPolicy(defaultStrategy: .synthOnly),
+            syntheticInputDriver: synthetic)
+
+        do {
+            _ = try await service.click(
+                target: .coordinates(CGPoint(x: 10, y: 20)),
+                clickType: .single,
+                snapshotId: nil,
+                targetProcessIdentifier: getpid(),
+                targetWindowID: 42,
+                expectedWindowIdentity: identity,
+                expectedWindowBounds: CGRect(x: 0, y: 0, width: 101, height: 100))
+            Issue.record("Expected the captured bounds mismatch to fail")
+        } catch let PeekabooError.snapshotStale(reason) {
+            #expect(reason.contains("bounds do not match"))
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+        #expect(synthetic.events.isEmpty)
+    }
+
+    @Test
+    @MainActor
     func `Exact window identifier must fit CGWindowID`() async {
         let synthetic = ClickRecordingSyntheticInputDriver()
         let service = ClickService(

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ClickServiceExactWindowTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ClickServiceExactWindowTests.swift
@@ -9,6 +9,55 @@ import Testing
 struct ClickServiceExactWindowTests {
     @Test
     @MainActor
+    func `Snapshot refinement cannot replace the caller process generation`() async throws {
+        let pinnedProcess = AutomationTestFixtures.processIdentity(
+            processIdentifier: getpid(),
+            processStartIdentity: 71)
+        let replacementProcess = AutomationTestFixtures.processIdentity(
+            processIdentifier: getpid(),
+            processStartIdentity: 72)
+        let bounds = CGRect(x: 0, y: 0, width: 200, height: 100)
+        let detection = ElementDetectionResult(
+            snapshotId: "snapshot",
+            screenshotPath: "/tmp/shot.png",
+            elements: DetectedElements(buttons: [DetectedElement(
+                id: "B1",
+                type: .button,
+                label: "Button",
+                bounds: CGRect(x: 20, y: 30, width: 100, height: 40))]),
+            metadata: DetectionMetadata(
+                detectionTime: 0,
+                elementCount: 1,
+                method: "test",
+                windowContext: WindowContext(
+                    applicationProcessId: replacementProcess.processIdentifier,
+                    windowID: 42,
+                    windowBounds: bounds,
+                    windowMutationIdentity: AutomationTestFixtures.windowIdentity(
+                        windowID: 42,
+                        processIdentity: replacementProcess,
+                        bounds: bounds))))
+        let synthetic = ClickRecordingSyntheticInputDriver()
+        let service = ClickService(
+            snapshotManager: InMemorySnapshotManager(detectionResult: detection),
+            inputPolicy: UIInputPolicy(defaultStrategy: .synthOnly),
+            syntheticInputDriver: synthetic,
+            exactWindowIdentityValidator: { _, _ in true },
+            processStartIdentityProvider: { _ in replacementProcess.processStartIdentity })
+
+        await #expect(throws: PeekabooError.self) {
+            _ = try await service.click(
+                target: .elementId("B1"),
+                clickType: .single,
+                snapshotId: "snapshot",
+                targetProcessIdentifier: pinnedProcess.processIdentifier,
+                expectedProcessIdentity: pinnedProcess)
+        }
+        #expect(synthetic.events.isEmpty)
+    }
+
+    @Test
+    @MainActor
     func `Background coordinate click preserves exact target window`() async throws {
         let synthetic = ClickRecordingSyntheticInputDriver()
         let identity = WindowMutationIdentity(

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/DesktopOperationExecutorTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/DesktopOperationExecutorTests.swift
@@ -204,7 +204,7 @@ struct DesktopOperationExecutorTests {
         let identity = ApplicationProcessIdentity(processIdentifier: 501, processStartIdentity: 1)
         let plan = try self.makePlan(
             strategy: .synthOnly,
-            receipt: DesktopOperationPlan.CaptureReceipt(processIdentity: identity),
+            receipt: Self.processReceipt(identity),
             action: nil,
             synthesis: .init { Self.synthOutcome })
 
@@ -224,7 +224,7 @@ struct DesktopOperationExecutorTests {
         let identity = ApplicationProcessIdentity(processIdentifier: 501, processStartIdentity: 1)
         let plan = try self.makePlan(
             strategy: .synthOnly,
-            receipt: DesktopOperationPlan.CaptureReceipt(processIdentity: identity),
+            receipt: Self.processReceipt(identity),
             action: nil,
             synthesis: .init {
                 .confirmedChange(delivery: .init(mechanism: .globalEvents, mode: .foreground))
@@ -245,7 +245,7 @@ struct DesktopOperationExecutorTests {
         let identity = ApplicationProcessIdentity(processIdentifier: 501, processStartIdentity: 1)
         let plan = try self.makePlan(
             strategy: .synthOnly,
-            receipt: DesktopOperationPlan.CaptureReceipt(processIdentity: identity),
+            receipt: Self.processReceipt(identity),
             action: nil,
             synthesis: .init {
                 .dispatchedUnverified(
@@ -263,7 +263,7 @@ struct DesktopOperationExecutorTests {
         let identity = ApplicationProcessIdentity(processIdentifier: 501, processStartIdentity: 1)
         let plan = try self.makePlan(
             strategy: .synthOnly,
-            receipt: DesktopOperationPlan.CaptureReceipt(processIdentity: identity),
+            receipt: Self.processReceipt(identity),
             action: nil,
             synthesis: .init {
                 .indeterminate(evidence: .completionUnknown)
@@ -284,7 +284,7 @@ struct DesktopOperationExecutorTests {
         let identity = ApplicationProcessIdentity(processIdentifier: 501, processStartIdentity: 1)
         let plan = try self.makePlan(
             strategy: .synthOnly,
-            receipt: DesktopOperationPlan.CaptureReceipt(processIdentity: identity),
+            receipt: Self.processReceipt(identity),
             action: nil,
             synthesis: .init { .confirmedNoChange() })
 
@@ -345,8 +345,7 @@ struct DesktopOperationExecutorTests {
         let plan = try DesktopOperationPlan(
             verb: .performAction,
             selector: .focused,
-            captureReceipt: DesktopOperationPlan.CaptureReceipt(),
-            deliveryIntent: .foreground,
+            captureReceipt: DesktopOperationPlan.CaptureReceipt(target: .foreground),
             strategy: .actionOnly,
             prepare: { preparedBundle = "com.example.synth-only" },
             routing: {
@@ -747,8 +746,7 @@ struct DesktopOperationExecutorTests {
         try DesktopOperationPlan(
             verb: .click,
             selector: .focused,
-            captureReceipt: receipt ?? DesktopOperationPlan.CaptureReceipt(),
-            deliveryIntent: receipt?.processIdentity == nil ? .foreground : .background,
+            captureReceipt: receipt ?? DesktopOperationPlan.CaptureReceipt(target: .foreground),
             strategy: strategy,
             prepare: prepare,
             action: action,
@@ -763,7 +761,7 @@ struct DesktopOperationExecutorTests {
         probe: OverlapProbe? = nil,
         serialProbe: SerialProbe? = nil) throws -> DesktopOperationPlan
     {
-        let receipt = try DesktopOperationPlan.CaptureReceipt(processIdentity: identity)
+        let receipt = try Self.processReceipt(identity)
         return try self.makePlan(
             strategy: .synthOnly,
             receipt: receipt,
@@ -782,6 +780,15 @@ struct DesktopOperationExecutorTests {
     private static func temporaryRoot() -> URL {
         FileManager.default.temporaryDirectory
             .appendingPathComponent("desktop-operation-executor-\(UUID().uuidString)", isDirectory: true)
+    }
+
+    private static func processReceipt(
+        _ identity: ApplicationProcessIdentity) throws -> DesktopOperationPlan.CaptureReceipt
+    {
+        try DesktopOperationPlan.CaptureReceipt(
+            target: .process(UIAutomationTarget.Process(
+                processIdentifier: identity.processIdentifier,
+                identity: identity)))
     }
 
     private static let actionOutcome = DesktopActionOutcome.dispatchedUnverified(

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/DesktopOperationPlanTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/DesktopOperationPlanTests.swift
@@ -95,6 +95,39 @@ struct DesktopOperationPlanTests {
             exactWindowIdentityValidator: { _, _ in false })
     }
 
+    @Test
+    func `nonexact background receipt retains its process target`() throws {
+        let processIdentifier: pid_t = 321
+        let detectionResult = AutomationTestFixtures.detectionResult(
+            windowContext: WindowContext(
+                applicationBundleId: "com.example.TestApp",
+                applicationProcessId: processIdentifier))
+
+        let receipt = try DesktopOperationSnapshotReceiptValidator.captureReceipt(
+            snapshotID: detectionResult.snapshotId,
+            detectionResult: detectionResult,
+            requireExactWindow: false,
+            processStartIdentityProvider: { _ in nil },
+            exactWindowIdentityValidator: { _, _ in false })
+
+        #expect(try receipt.target == .process(UIAutomationTarget.Process(processIdentifier: processIdentifier)))
+        #expect(receipt.processIdentity == nil)
+    }
+
+    @Test
+    func `nonexact background receipt rejects a missing process target`() {
+        let detectionResult = AutomationTestFixtures.detectionResult()
+
+        #expect(throws: (any Error).self) {
+            _ = try DesktopOperationSnapshotReceiptValidator.captureReceipt(
+                snapshotID: detectionResult.snapshotId,
+                detectionResult: detectionResult,
+                requireExactWindow: false,
+                processStartIdentityProvider: { _ in nil },
+                exactWindowIdentityValidator: { _, _ in false })
+        }
+    }
+
     private func makePlan(
         selector: DesktopOperationPlan.Selector = .focused,
         receipt: DesktopOperationPlan.CaptureReceipt? = nil) throws -> DesktopOperationPlan

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/DesktopOperationPlanTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/DesktopOperationPlanTests.swift
@@ -1,5 +1,6 @@
 import CoreGraphics
 import Foundation
+import PeekabooAutomationKitTestSupport
 import Testing
 @testable import PeekabooAutomationKit
 
@@ -23,28 +24,16 @@ struct DesktopOperationPlanTests {
         #expect(throws: (any Error).self) {
             try self.makePlan(
                 selector: .coordinates(CGPoint(x: 20, y: 30)),
-                intent: .background)
+                receipt: DesktopOperationPlan.CaptureReceipt(
+                    target: .process(UIAutomationTarget.Process(processIdentifier: 321))))
         }
 
         let exact = try Self.exactWindowReceipt()
-        let receipt = try DesktopOperationPlan.CaptureReceipt(exactWindow: exact)
+        let receipt = DesktopOperationPlan.CaptureReceipt(target: .exactWindow(exact))
         let plan = try self.makePlan(
             selector: .coordinates(CGPoint(x: 20, y: 30)),
-            receipt: receipt,
-            intent: .background)
+            receipt: receipt)
         #expect(plan.captureReceipt.exactWindow == exact)
-    }
-
-    @Test
-    func `receipt normalization rejects mismatched process generations`() throws {
-        let exact = try Self.exactWindowReceipt(processStartIdentity: 11)
-        let process = ApplicationProcessIdentity(processIdentifier: 321, processStartIdentity: 12)
-
-        #expect(throws: (any Error).self) {
-            _ = try DesktopOperationPlan.CaptureReceipt(
-                processIdentity: process,
-                exactWindow: exact)
-        }
     }
 
     @Test
@@ -63,39 +52,57 @@ struct DesktopOperationPlanTests {
     }
 
     @Test
-    func `capture receipt rejects process and exact window owner mismatch`() throws {
-        let exact = try Self.exactWindowReceipt()
-        let foreignProcess = ApplicationProcessIdentity(processIdentifier: 322, processStartIdentity: 11)
-
-        #expect(throws: (any Error).self) {
-            _ = try DesktopOperationPlan.CaptureReceipt(
-                processIdentity: foreignProcess,
-                exactWindow: exact)
-        }
-    }
-
-    @Test
-    func `lane scope is derived from intent and stable receipt`() throws {
+    func `lane scope is derived from the validated target`() throws {
         let process = ApplicationProcessIdentity(processIdentifier: 321, processStartIdentity: 11)
-        let receipt = try DesktopOperationPlan.CaptureReceipt(processIdentity: process)
+        let processReceipt = try DesktopOperationPlan.CaptureReceipt(
+            target: .process(UIAutomationTarget.Process(
+                processIdentifier: process.processIdentifier,
+                identity: process)))
 
-        let background = try self.makePlan(receipt: receipt, intent: .background)
-        let foreground = try self.makePlan(receipt: receipt, intent: .foreground)
+        let background = try self.makePlan(receipt: processReceipt)
+        let foreground = try self.makePlan()
 
         #expect(background.laneScope == .process(process))
         #expect(foreground.laneScope == .global)
+        #expect(background.deliveryIntent == .background)
+        #expect(foreground.deliveryIntent == .foreground)
+    }
+
+    @Test
+    func `receipt validation ignores current minimized state`() throws {
+        let processIdentity = AutomationTestFixtures.processIdentity()
+        let bounds = CGRect(x: 1, y: 2, width: 300, height: 200)
+        let capturedIdentity = AutomationTestFixtures.windowIdentity(
+            processIdentity: processIdentity,
+            bounds: bounds,
+            isMinimized: false)
+        let currentIdentity = capturedIdentity.withMinimizedState(true)
+        let receipt = try DesktopOperationPlan.CaptureReceipt(
+            target: .exactWindow(UIAutomationTarget.ExactWindow(
+                identity: capturedIdentity,
+                bounds: bounds)))
+        let context = WindowContext(
+            applicationProcessId: processIdentity.processIdentifier,
+            windowID: capturedIdentity.windowID,
+            windowBounds: bounds,
+            windowMutationIdentity: currentIdentity)
+
+        try DesktopOperationSnapshotReceiptValidator.validate(
+            context: context,
+            receipt: receipt,
+            validateCurrentIdentity: false,
+            processStartIdentityProvider: { _ in nil },
+            exactWindowIdentityValidator: { _, _ in false })
     }
 
     private func makePlan(
         selector: DesktopOperationPlan.Selector = .focused,
-        receipt: DesktopOperationPlan.CaptureReceipt? = nil,
-        intent: DesktopOperationPlan.DeliveryIntent = .foreground) throws -> DesktopOperationPlan
+        receipt: DesktopOperationPlan.CaptureReceipt? = nil) throws -> DesktopOperationPlan
     {
         try DesktopOperationPlan(
             verb: .click,
             selector: selector,
-            captureReceipt: receipt ?? DesktopOperationPlan.CaptureReceipt(),
-            deliveryIntent: intent,
+            captureReceipt: receipt ?? DesktopOperationPlan.CaptureReceipt(target: .foreground),
             strategy: .synthOnly,
             action: nil,
             synthesis: .init { .confirmedNoChange() })

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/UIAutomationActionOutcomeProvidingTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/UIAutomationActionOutcomeProvidingTests.swift
@@ -340,7 +340,8 @@ struct UIAutomationActionOutcomeProvidingTests {
             label: "Value")
         let detection = AutomationTestFixtures.detectionResult(
             snapshotID: "snapshot",
-            elements: DetectedElements(textFields: [detected]))
+            elements: DetectedElements(textFields: [detected]),
+            windowContext: WindowContext(applicationProcessId: getpid()))
         return UIAutomationService(
             snapshotManager: InMemorySnapshotManager(detectionResult: detection),
             inputPolicy: UIInputPolicy(defaultStrategy: .actionOnly),

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/UIAutomationTargetTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/UIAutomationTargetTests.swift
@@ -1,0 +1,216 @@
+import CoreGraphics
+import PeekabooAutomationKitTestSupport
+import Testing
+@testable import PeekabooAutomationKit
+
+struct UIAutomationTargetTests {
+    private let processIdentity = AutomationTestFixtures.processIdentity()
+    private let bounds = CGRect(x: 10, y: 20, width: 640, height: 480)
+
+    @Test
+    func `target cases expose only their validated receipt level`() throws {
+        let unpinned = try UIAutomationTarget.Process(
+            processIdentifier: self.processIdentity.processIdentifier)
+        let pinned = try UIAutomationTarget.Process(
+            processIdentifier: self.processIdentity.processIdentifier,
+            identity: self.processIdentity)
+        let exact = try self.exactWindowTarget()
+
+        #expect(UIAutomationTarget.foreground.processIdentifier == nil)
+        #expect(UIAutomationTarget.foreground.processIdentity == nil)
+        #expect(UIAutomationTarget.foreground.exactWindow == nil)
+
+        #expect(UIAutomationTarget.process(unpinned).processIdentifier == self.processIdentity.processIdentifier)
+        #expect(UIAutomationTarget.process(unpinned).processIdentity == nil)
+        #expect(UIAutomationTarget.process(unpinned).exactWindow == nil)
+
+        #expect(UIAutomationTarget.process(pinned).processIdentity == self.processIdentity)
+        #expect(UIAutomationTarget.exactWindow(exact).processIdentity == self.processIdentity)
+        #expect(UIAutomationTarget.exactWindow(exact).exactWindow == exact)
+    }
+
+    @Test
+    func `process target rejects a receipt for another PID`() {
+        let foreignIdentity = AutomationTestFixtures.processIdentity(
+            processIdentifier: self.processIdentity.processIdentifier + 1)
+
+        #expect(throws: (any Error).self) {
+            _ = try UIAutomationTarget.Process(
+                processIdentifier: self.processIdentity.processIdentifier,
+                identity: foreignIdentity)
+        }
+    }
+
+    @Test
+    func `exact window rejects mismatched embedded bounds`() {
+        let identity = AutomationTestFixtures.windowIdentity(
+            processIdentity: self.processIdentity,
+            bounds: self.bounds)
+
+        #expect(throws: (any Error).self) {
+            _ = try UIAutomationTarget.ExactWindow(
+                identity: identity,
+                bounds: CGRect(x: 10, y: 20, width: 641, height: 480))
+        }
+    }
+
+    @Test
+    func `exact window rejects explicit identifiers that disagree with its receipt`() {
+        let identity = AutomationTestFixtures.windowIdentity(
+            processIdentity: self.processIdentity,
+            bounds: self.bounds)
+
+        #expect(throws: (any Error).self) {
+            _ = try UIAutomationTarget.ExactWindow(
+                processIdentifier: self.processIdentity.processIdentifier + 1,
+                windowID: identity.windowID,
+                identity: identity,
+                bounds: self.bounds)
+        }
+        #expect(throws: (any Error).self) {
+            _ = try UIAutomationTarget.ExactWindow(
+                processIdentifier: self.processIdentity.processIdentifier,
+                windowID: identity.windowID + 1,
+                identity: identity,
+                bounds: self.bounds)
+        }
+    }
+
+    @Test
+    func `exact window rejects focused element from another owner or window`() {
+        let identity = AutomationTestFixtures.windowIdentity(
+            processIdentity: self.processIdentity,
+            bounds: self.bounds)
+        let validFocus = self.focusedElement()
+
+        #expect(throws: (any Error).self) {
+            _ = try UIAutomationTarget.ExactWindow(
+                identity: identity,
+                bounds: self.bounds,
+                focusedElement: FocusedElementIdentity(
+                    processIdentifier: validFocus.processIdentifier + 1,
+                    windowID: validFocus.windowID,
+                    role: validFocus.role,
+                    frame: validFocus.frame))
+        }
+        #expect(throws: (any Error).self) {
+            _ = try UIAutomationTarget.ExactWindow(
+                identity: identity,
+                bounds: self.bounds,
+                focusedElement: FocusedElementIdentity(
+                    processIdentifier: validFocus.processIdentifier,
+                    windowID: validFocus.windowID + 1,
+                    role: validFocus.role,
+                    frame: validFocus.frame))
+        }
+    }
+
+    @Test
+    func `stable receipt comparison ignores minimized state only`() {
+        let base = AutomationTestFixtures.windowIdentity(
+            processIdentity: self.processIdentity,
+            bounds: self.bounds,
+            isMinimized: false)
+        let minimized = base.withMinimizedState(true)
+        let changedWindow = AutomationTestFixtures.windowIdentity(
+            windowID: base.windowID + 1,
+            processIdentity: self.processIdentity,
+            bounds: self.bounds)
+        let changedProcess = AutomationTestFixtures.windowIdentity(
+            processIdentity: AutomationTestFixtures.processIdentity(
+                processIdentifier: self.processIdentity.processIdentifier + 1,
+                processStartIdentity: self.processIdentity.processStartIdentity),
+            bounds: self.bounds)
+        let changedGeneration = AutomationTestFixtures.windowIdentity(
+            processIdentity: AutomationTestFixtures.processIdentity(
+                processIdentifier: self.processIdentity.processIdentifier,
+                processStartIdentity: self.processIdentity.processStartIdentity + 1),
+            bounds: self.bounds)
+        let changedBounds = AutomationTestFixtures.windowIdentity(
+            processIdentity: self.processIdentity,
+            bounds: CGRect(x: 11, y: 20, width: 640, height: 480))
+
+        #expect(base.processIdentity == self.processIdentity)
+        #expect(base.hasSameStableReceipt(as: minimized))
+        #expect(!base.hasSameStableReceipt(as: changedWindow))
+        #expect(!base.hasSameStableReceipt(as: changedProcess))
+        #expect(!base.hasSameStableReceipt(as: changedGeneration))
+        #expect(!base.hasSameStableReceipt(as: changedBounds))
+    }
+
+    @Test
+    func `target equality uses stable receipt and nested sidecars`() throws {
+        let base = try self.exactWindowTarget(isMinimized: false)
+        let minimized = try self.exactWindowTarget(isMinimized: true)
+        let changedBounds = CGRect(x: 11, y: 20, width: 639, height: 480)
+        let changedSidecar = try UIAutomationTarget.ExactWindow(
+            identity: AutomationTestFixtures.windowIdentity(
+                processIdentity: self.processIdentity,
+                bounds: nil),
+            bounds: changedBounds,
+            focusedElement: self.focusedElement())
+        let changedFocus = try UIAutomationTarget.ExactWindow(
+            identity: AutomationTestFixtures.windowIdentity(
+                processIdentity: self.processIdentity,
+                bounds: self.bounds),
+            bounds: self.bounds,
+            focusedElement: FocusedElementIdentity(
+                processIdentifier: self.processIdentity.processIdentifier,
+                windowID: AutomationTestFixtures.windowIdentity().windowID,
+                role: "AXTextField",
+                identifier: "other-field",
+                frame: CGRect(x: 30, y: 40, width: 100, height: 20)))
+
+        #expect(UIAutomationTarget.exactWindow(base) == .exactWindow(minimized))
+        #expect(UIAutomationTarget.exactWindow(base) != .exactWindow(changedSidecar))
+        #expect(UIAutomationTarget.exactWindow(base) != .exactWindow(changedFocus))
+        #expect(try UIAutomationTarget.exactWindow(base) != .process(
+            UIAutomationTarget.Process(
+                processIdentifier: self.processIdentity.processIdentifier,
+                identity: self.processIdentity)))
+        #expect(try UIAutomationTarget.foreground != .process(
+            UIAutomationTarget.Process(processIdentifier: self.processIdentity.processIdentifier)))
+    }
+
+    @Test
+    func `exact window refinement preserves an existing process generation pin`() throws {
+        let pinned = try UIAutomationTarget.process(UIAutomationTarget.Process(
+            processIdentifier: self.processIdentity.processIdentifier,
+            identity: self.processIdentity))
+        let replacementProcess = AutomationTestFixtures.processIdentity(
+            processIdentifier: self.processIdentity.processIdentifier,
+            processStartIdentity: self.processIdentity.processStartIdentity + 1)
+        let replacement = try UIAutomationTarget.ExactWindow(
+            identity: AutomationTestFixtures.windowIdentity(
+                processIdentity: replacementProcess,
+                bounds: self.bounds),
+            bounds: self.bounds)
+
+        #expect(throws: (any Error).self) {
+            _ = try pinned.refined(to: replacement)
+        }
+
+        let unpinned = try UIAutomationTarget.process(UIAutomationTarget.Process(
+            processIdentifier: self.processIdentity.processIdentifier))
+        #expect(try unpinned.refined(to: replacement) == .exactWindow(replacement))
+    }
+
+    private func exactWindowTarget(isMinimized: Bool = false) throws -> UIAutomationTarget.ExactWindow {
+        try UIAutomationTarget.ExactWindow(
+            identity: AutomationTestFixtures.windowIdentity(
+                processIdentity: self.processIdentity,
+                bounds: self.bounds,
+                isMinimized: isMinimized),
+            bounds: self.bounds,
+            focusedElement: self.focusedElement())
+    }
+
+    private func focusedElement() -> FocusedElementIdentity {
+        FocusedElementIdentity(
+            processIdentifier: self.processIdentity.processIdentifier,
+            windowID: AutomationTestFixtures.windowIdentity().windowID,
+            role: "AXTextField",
+            identifier: "editor",
+            frame: CGRect(x: 30, y: 40, width: 100, height: 20))
+    }
+}


### PR DESCRIPTION
## Summary

- replace ClickService's private mutation/window receipt models with the canonical `DesktopOperationPlan.CaptureReceipt`
- introduce one `UIAutomationTarget` owner for process, process-generation, window, identity, bounds, and delivery intent across click/type/hotkey/scroll operations
- centralize live snapshot receipt validation and remove caller-supplied delivery intent
- preserve capture-time process targeting for element actions with incomplete window metadata; fail closed when no background owner exists

## Ownership removed

- five parallel PID/generation/window/identity/bounds fields on click requests
- independent process/exact-window storage in capture receipts
- the separate exact-window receipt model
- duplicate window-identity comparison in the snapshot validator
- inferred foreground delivery from incomplete element-action snapshots

## Safety

- background delivery derives from the validated target
- exact process generation, window identity, and captured bounds remain revalidated around dispatch
- incomplete element targets retain their capture-time PID or refuse before dispatch
- missing explicit snapshots still return `snapshotNotFound`

## Proof

- AutomationKit debug and Release builds
- 202 focused AutomationKit tests across 12 suites
- 10/10 safe CLI background/generation tests, including explicit-app generation overwrite
- SwiftFormat, strict touched SwiftLint, and diff checks: clean
- P0-P2 repair review: clean at 0.97
- final 104 KB full-stack P0-P2 review + TruffleHog: clean at 0.95

Production delta: +511/-280. Test delta: +468/-48.
