### PR TITLE
feat(automation): carry verified window outcomes

### DIFF
--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Preserve integer-valued Agent tool data across Codable and Foundation JSON conversion instead of mistaking numeric `0` and `1` for booleans.
+- Carry verified exact-background close, minimize, restore, maximize, move, resize, and set-bounds outcomes through Bridge protocol 1.23 while older hosts remain conservative.
 - Bind each discovered Agent tool to its exact provider and registry generation, recover unchanged bindings after transient discovery failures while refusing ambiguous or stale ownership, and preserve boolean/integer MCP arguments through one typed conversion path.
 - Reject duplicate command, subcommand, option, and flag definitions deterministically instead of trapping or silently selecting one, while keeping daemon `--bridge-socket` on the canonical runtime option.
 - Consolidate accessibility observer registration, exact element/process dispatch, stop, and deinitialization cleanup under one instance-owned registry.

--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Preserve integer-valued Agent tool data across Codable and Foundation JSON conversion instead of mistaking numeric `0` and `1` for booleans.
-- Carry verified exact-background close, minimize, restore, maximize, move, resize, and set-bounds outcomes through Bridge protocol 1.23 while older hosts remain conservative.
+- Carry verified outcomes for receipt-pinned background window close, minimize, restore, maximize, move, resize, and set-bounds through Bridge protocol 1.23 while older hosts remain conservative.
 - Bind each discovered Agent tool to its exact provider and registry generation, recover unchanged bindings after transient discovery failures while refusing ambiguous or stale ownership, and preserve boolean/integer MCP arguments through one typed conversion path.
 - Reject duplicate command, subcommand, option, and flag definitions deterministically instead of trapping or silently selecting one, while keeping daemon `--bridge-socket` on the canonical runtime option.
 - Consolidate accessibility observer registration, exact element/process dispatch, stop, and deinitialization cleanup under one instance-owned registry.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### Fixed
 - Preserve integer-valued Agent tool data across Codable and Foundation JSON conversion instead of mistaking numeric `0` and `1` for booleans.
+- Carry verified exact-background close, minimize, restore, maximize, move, resize, and set-bounds outcomes through Bridge protocol 1.23 while older hosts remain conservative.
 - Bind each discovered Agent tool to its exact provider and registry generation, recover unchanged bindings after transient discovery failures while refusing ambiguous or stale ownership, and preserve boolean/integer MCP arguments through one typed conversion path.
 - Reject duplicate command, subcommand, option, and flag definitions deterministically instead of trapping or silently selecting one, while keeping daemon `--bridge-socket` on the canonical runtime option.
 - Consolidate accessibility observer registration, exact element/process dispatch, stop, and deinitialization cleanup under one instance-owned registry.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 
 ### Fixed
 - Preserve integer-valued Agent tool data across Codable and Foundation JSON conversion instead of mistaking numeric `0` and `1` for booleans.
-- Carry verified exact-background close, minimize, restore, maximize, move, resize, and set-bounds outcomes through Bridge protocol 1.23 while older hosts remain conservative.
+- Carry verified outcomes for receipt-pinned background window close, minimize, restore, maximize, move, resize, and set-bounds through Bridge protocol 1.23 while older hosts remain conservative.
 - Bind each discovered Agent tool to its exact provider and registry generation, recover unchanged bindings after transient discovery failures while refusing ambiguous or stale ownership, and preserve boolean/integer MCP arguments through one typed conversion path.
 - Reject duplicate command, subcommand, option, and flag definitions deterministically instead of trapping or silently selecting one, while keeping daemon `--bridge-socket` on the canonical runtime option.
 - Consolidate accessibility observer registration, exact element/process dispatch, stop, and deinitialization cleanup under one instance-owned registry.

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Core/Protocols/WindowManagementServiceProtocol.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Core/Protocols/WindowManagementServiceProtocol.swift
@@ -150,6 +150,45 @@ extension WindowManagementServiceProtocol {
     }
 }
 
+/// Additive capability for exact-window mutations that can report their canonical execution outcome.
+///
+/// Existing protocol methods remain the compatibility surface. The outcome is optional so a remote
+/// implementation negotiated with an older host can preserve the successful legacy operation without
+/// inventing verification evidence.
+public protocol WindowManagementActionOutcomeProviding: WindowManagementServiceProtocol {
+    /// Close the exact window through the background-only Accessibility route.
+    func closeWindowWithOutcome(
+        target: WindowTarget,
+        expectedIdentity: WindowMutationIdentity) async throws -> DesktopActionOutcome?
+
+    func minimizeWindowWithOutcome(
+        target: WindowTarget,
+        expectedIdentity: WindowMutationIdentity) async throws -> DesktopActionOutcome?
+
+    func restoreWindowWithOutcome(
+        target: WindowTarget,
+        expectedIdentity: WindowMutationIdentity) async throws -> DesktopActionOutcome?
+
+    func maximizeWindowWithOutcome(
+        target: WindowTarget,
+        expectedIdentity: WindowMutationIdentity) async throws -> DesktopActionOutcome?
+
+    func moveWindowWithOutcome(
+        target: WindowTarget,
+        expectedIdentity: WindowMutationIdentity,
+        to position: CGPoint) async throws -> DesktopActionOutcome?
+
+    func resizeWindowWithOutcome(
+        target: WindowTarget,
+        expectedIdentity: WindowMutationIdentity,
+        to size: CGSize) async throws -> DesktopActionOutcome?
+
+    func setWindowBoundsWithOutcome(
+        target: WindowTarget,
+        expectedIdentity: WindowMutationIdentity,
+        bounds: CGRect) async throws -> DesktopActionOutcome?
+}
+
 /// Options for targeting a window
 public enum WindowTarget: Sendable, CustomStringConvertible, Codable {
     /// Target by application name or bundle ID

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/WindowManagementActionOutcome.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/WindowManagementActionOutcome.swift
@@ -1,0 +1,179 @@
+import CoreGraphics
+import Foundation
+import PeekabooFoundation
+
+struct WindowGeometryDispatchAcceptance: Equatable {
+    let positionAccepted: Bool
+    let sizeAccepted: Bool
+
+    var dispatchCount: Int {
+        (self.positionAccepted ? 1 : 0) + (self.sizeAccepted ? 1 : 0)
+    }
+}
+
+enum WindowManagementActionOutcome {
+    static let backgroundActionDelivery = DesktopActionOutcome.Delivery(
+        mechanism: .accessibilityAction,
+        mode: .background)
+    static let backgroundValueDelivery = DesktopActionOutcome.Delivery(
+        mechanism: .accessibilityValue,
+        mode: .background)
+
+    static func confirmedChange(
+        delivery: DesktopActionOutcome.Delivery,
+        dispatchCount: Int) -> DesktopActionOutcome
+    {
+        .confirmedChange(
+            delivery: delivery,
+            unitCount: self.dispatchUnitCount(dispatchCount))
+    }
+
+    static var confirmedNoChange: DesktopActionOutcome {
+        .confirmedNoChange()
+    }
+
+    @MainActor
+    static func perform(
+        action: String,
+        operation: @MainActor () async throws -> DesktopActionOutcome) async throws -> DesktopActionOutcome?
+    {
+        do {
+            return try await operation()
+        } catch let failure as DesktopActionFailure {
+            throw failure
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch {
+            throw self.refused(action: action, error: error)
+        }
+    }
+
+    static func refused(
+        action: String,
+        error: any Error) -> DesktopActionFailure
+    {
+        let reason = self.refusalReason(for: error)
+        return .refused(
+            reason: reason,
+            message: error.localizedDescription,
+            hint: self.refusalHint(reason: reason, action: action),
+            causeDescription: String(describing: error))
+    }
+
+    static func suspectedNoop(
+        action: String,
+        delivery: DesktopActionOutcome.Delivery,
+        dispatchCount: Int,
+        cause: (any Error)? = nil) -> DesktopActionFailure
+    {
+        .suspectedNoop(
+            delivery: delivery,
+            unitCount: self.dispatchUnitCount(dispatchCount),
+            message: "The \(action) request was accepted, but the exact window remained in its prior state",
+            hint: "Refresh the exact window receipt before retrying.",
+            causeDescription: cause.map { String(describing: $0) })
+    }
+
+    static func dispatchedUnverified(
+        action: String,
+        delivery: DesktopActionOutcome.Delivery,
+        dispatchCount: Int,
+        cause: any Error) -> DesktopActionFailure
+    {
+        .dispatchedUnverified(
+            delivery: delivery,
+            evidence: .deliveryAccepted,
+            unitCount: self.dispatchUnitCount(dispatchCount),
+            message: "The \(action) request was accepted, but its exact result could not be verified",
+            hint: "Observe the exact window before retrying.",
+            causeDescription: String(describing: cause))
+    }
+
+    static func refusalReason(for error: any Error) -> DesktopActionOutcome.RefusalReason {
+        if let error = error as? PeekabooError {
+            switch error {
+            case .permissionDeniedScreenRecording, .permissionDeniedAccessibility,
+                 .permissionDeniedEventSynthesizing, .permissionDenied:
+                return .permissionDenied
+            case .invalidCoordinates, .invalidInput, .ambiguousAppIdentifier:
+                return .invalidRequest
+            case .appNotFound, .windowNotFound, .notFound, .commandFailed:
+                return .targetUnavailable
+            case .serviceUnavailable, .notImplemented:
+                return .runtimeIncompatible
+            default:
+                return .operationUnsupported
+            }
+        }
+        if let error = error as? any StandardizedError {
+            switch error.code {
+            case .screenRecordingPermissionDenied, .accessibilityPermissionDenied,
+                 .eventSynthesizingPermissionDenied:
+                return .permissionDenied
+            case .applicationNotFound, .windowNotFound:
+                return .targetUnavailable
+            case .invalidInput, .invalidCoordinates, .invalidWindowIndex, .ambiguousAppIdentifier:
+                return .invalidRequest
+            default:
+                return .operationUnsupported
+            }
+        }
+        return .operationUnsupported
+    }
+
+    private static func refusalHint(
+        reason: DesktopActionOutcome.RefusalReason,
+        action: String) -> String
+    {
+        switch reason {
+        case .permissionDenied:
+            "Grant Accessibility permission before retrying \(action)."
+        case .targetUnavailable:
+            "Refresh the exact window receipt before retrying."
+        case .runtimeIncompatible:
+            "Update the runtime host before retrying."
+        case .invalidRequest:
+            "Correct the window target or mutation receipt before retrying."
+        case .foregroundConsentRequired:
+            "Retry only with explicit foreground consent."
+        case .operationUnsupported:
+            "Use a window and host that support \(action)."
+        }
+    }
+
+    private static func dispatchUnitCount(_ value: Int) -> DesktopActionOutcome.DispatchUnitCount {
+        guard let count = DesktopActionOutcome.DispatchUnitCount(value) else {
+            preconditionFailure("Window mutation dispatch counts must be positive")
+        }
+        return count
+    }
+}
+
+@MainActor
+extension WindowManagementService {
+    func geometryVerificationFailure(
+        action: String,
+        expectedIdentity: WindowMutationIdentity,
+        dispatchCount: Int,
+        cause: any Error) -> DesktopActionFailure
+    {
+        let current = self.windowIdentityService.getWindowServerInfo(
+            windowID: CGWindowID(expectedIdentity.windowID))
+        if let current,
+           current.ownerPID == expectedIdentity.ownerProcessIdentifier,
+           SystemIdentityResolver.validateWindowMutationOwnerGeneration(expectedIdentity),
+           current.bounds == expectedIdentity.capturedBounds
+        {
+            return WindowManagementActionOutcome.suspectedNoop(
+                action: action,
+                delivery: WindowManagementActionOutcome.backgroundValueDelivery,
+                dispatchCount: dispatchCount,
+                cause: cause)
+        }
+        return WindowManagementActionOutcome.dispatchedUnverified(
+            action: action,
+            delivery: WindowManagementActionOutcome.backgroundValueDelivery,
+            dispatchCount: dispatchCount,
+            cause: cause)
+    }
+}

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/WindowManagementService+GeometryOperations.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/WindowManagementService+GeometryOperations.swift
@@ -17,24 +17,49 @@ extension WindowManagementService {
         expectedIdentity: WindowMutationIdentity,
         to position: CGPoint) async throws
     {
-        try await self.operationLaneCoordinator.run(scope: .window(expectedIdentity), access: .write) {
-            try self.validatePinnedWindowMutation(target: target, expectedIdentity: expectedIdentity)
-            guard let capturedBounds = expectedIdentity.capturedBounds else {
-                throw PeekabooError.commandFailed("Window mutation receipt lacks capture-time bounds")
-            }
-            let window = try await self.element(for: target)
-            try self.validatePinnedWindowMutation(target: target, expectedIdentity: expectedIdentity)
-            try self.validatePinnedWindowElement(window, expectedIdentity: expectedIdentity)
-            let success = window.moveWindow(to: position)
+        _ = try await self.moveWindowWithOutcome(
+            target: target,
+            expectedIdentity: expectedIdentity,
+            to: position)
+    }
 
-            if !success {
-                throw OperationError.interactionFailed(
-                    action: "move window",
-                    reason: "Window move operation failed")
+    public func moveWindowWithOutcome(
+        target: WindowTarget,
+        expectedIdentity: WindowMutationIdentity,
+        to position: CGPoint) async throws -> DesktopActionOutcome?
+    {
+        try await WindowManagementActionOutcome.perform(action: "move window") {
+            try await self.operationLaneCoordinator.run(scope: .window(expectedIdentity), access: .write) {
+                try self.validatePinnedWindowMutation(target: target, expectedIdentity: expectedIdentity)
+                guard let capturedBounds = expectedIdentity.capturedBounds else {
+                    throw PeekabooError.commandFailed("Window mutation receipt lacks capture-time bounds")
+                }
+                let window = try await self.element(for: target)
+                try self.validatePinnedWindowMutation(target: target, expectedIdentity: expectedIdentity)
+                try self.validatePinnedWindowElement(window, expectedIdentity: expectedIdentity)
+                guard capturedBounds.origin != position else {
+                    return WindowManagementActionOutcome.confirmedNoChange
+                }
+                guard window.moveWindow(to: position) else {
+                    throw OperationError.interactionFailed(
+                        action: "move window",
+                        reason: "Window move operation failed")
+                }
+                do {
+                    _ = try await self.waitForRepinnedWindowMutation(
+                        expectedIdentity,
+                        expectedBounds: CGRect(origin: position, size: capturedBounds.size))
+                } catch {
+                    throw self.geometryVerificationFailure(
+                        action: "move window",
+                        expectedIdentity: expectedIdentity,
+                        dispatchCount: 1,
+                        cause: error)
+                }
+                return WindowManagementActionOutcome.confirmedChange(
+                    delivery: WindowManagementActionOutcome.backgroundValueDelivery,
+                    dispatchCount: 1)
             }
-            _ = try await self.waitForRepinnedWindowMutation(
-                expectedIdentity,
-                expectedBounds: CGRect(origin: position, size: capturedBounds.size))
         }
     }
 
@@ -51,31 +76,58 @@ extension WindowManagementService {
         expectedIdentity: WindowMutationIdentity,
         to size: CGSize) async throws
     {
-        try await self.operationLaneCoordinator.run(scope: .window(expectedIdentity), access: .write) {
-            try self.validatePinnedWindowMutation(target: target, expectedIdentity: expectedIdentity)
-            guard let capturedBounds = expectedIdentity.capturedBounds else {
-                throw PeekabooError.commandFailed("Window mutation receipt lacks capture-time bounds")
+        _ = try await self.resizeWindowWithOutcome(
+            target: target,
+            expectedIdentity: expectedIdentity,
+            to: size)
+    }
+
+    public func resizeWindowWithOutcome(
+        target: WindowTarget,
+        expectedIdentity: WindowMutationIdentity,
+        to size: CGSize) async throws -> DesktopActionOutcome?
+    {
+        try await WindowManagementActionOutcome.perform(action: "resize window") {
+            try await self.operationLaneCoordinator.run(scope: .window(expectedIdentity), access: .write) {
+                try self.validatePinnedWindowMutation(target: target, expectedIdentity: expectedIdentity)
+                guard let capturedBounds = expectedIdentity.capturedBounds else {
+                    throw PeekabooError.commandFailed("Window mutation receipt lacks capture-time bounds")
+                }
+                let resizeDescription = "target=\(target), size=(width: \(size.width), height: \(size.height))"
+                self.logger.info("Starting resize window operation: \(resizeDescription)")
+                let startTime = Date()
+
+                let window = try await self.element(for: target)
+                try self.validatePinnedWindowMutation(target: target, expectedIdentity: expectedIdentity)
+                try self.validatePinnedWindowElement(window, expectedIdentity: expectedIdentity)
+                guard capturedBounds.size != size else {
+                    return WindowManagementActionOutcome.confirmedNoChange
+                }
+                let success = window.resizeWindow(to: size)
+
+                let elapsed = Date().timeIntervalSince(startTime)
+                self.logger.info("Resize window operation completed in \(elapsed)s")
+
+                guard success else {
+                    throw OperationError.interactionFailed(
+                        action: "resize window",
+                        reason: "Window resize operation failed")
+                }
+                do {
+                    _ = try await self.waitForRepinnedWindowMutation(
+                        expectedIdentity,
+                        expectedBounds: CGRect(origin: capturedBounds.origin, size: size))
+                } catch {
+                    throw self.geometryVerificationFailure(
+                        action: "resize window",
+                        expectedIdentity: expectedIdentity,
+                        dispatchCount: 1,
+                        cause: error)
+                }
+                return WindowManagementActionOutcome.confirmedChange(
+                    delivery: WindowManagementActionOutcome.backgroundValueDelivery,
+                    dispatchCount: 1)
             }
-            let resizeDescription = "target=\(target), size=(width: \(size.width), height: \(size.height))"
-            self.logger.info("Starting resize window operation: \(resizeDescription)")
-            let startTime = Date()
-
-            let window = try await self.element(for: target)
-            try self.validatePinnedWindowMutation(target: target, expectedIdentity: expectedIdentity)
-            try self.validatePinnedWindowElement(window, expectedIdentity: expectedIdentity)
-            let success = window.resizeWindow(to: size)
-
-            let elapsed = Date().timeIntervalSince(startTime)
-            self.logger.info("Resize window operation completed in \(elapsed)s")
-
-            if !success {
-                throw OperationError.interactionFailed(
-                    action: "resize window",
-                    reason: "Window resize operation failed")
-            }
-            _ = try await self.waitForRepinnedWindowMutation(
-                expectedIdentity,
-                expectedBounds: CGRect(origin: capturedBounds.origin, size: size))
         }
     }
 
@@ -92,19 +144,48 @@ extension WindowManagementService {
         expectedIdentity: WindowMutationIdentity,
         bounds: CGRect) async throws
     {
-        try await self.operationLaneCoordinator.run(scope: .window(expectedIdentity), access: .write) {
-            try self.validatePinnedWindowMutation(target: target, expectedIdentity: expectedIdentity)
-            let window = try await self.element(for: target)
-            try self.validatePinnedWindowMutation(target: target, expectedIdentity: expectedIdentity)
-            try self.validatePinnedWindowElement(window, expectedIdentity: expectedIdentity)
-            let success = window.setWindowBounds(bounds)
+        _ = try await self.setWindowBoundsWithOutcome(
+            target: target,
+            expectedIdentity: expectedIdentity,
+            bounds: bounds)
+    }
 
-            if !success {
-                throw OperationError.interactionFailed(
-                    action: "set window bounds",
-                    reason: "Window bounds operation failed")
+    public func setWindowBoundsWithOutcome(
+        target: WindowTarget,
+        expectedIdentity: WindowMutationIdentity,
+        bounds: CGRect) async throws -> DesktopActionOutcome?
+    {
+        try await WindowManagementActionOutcome.perform(action: "set window bounds") {
+            try await self.operationLaneCoordinator.run(scope: .window(expectedIdentity), access: .write) {
+                try self.validatePinnedWindowMutation(target: target, expectedIdentity: expectedIdentity)
+                let window = try await self.element(for: target)
+                try self.validatePinnedWindowMutation(target: target, expectedIdentity: expectedIdentity)
+                try self.validatePinnedWindowElement(window, expectedIdentity: expectedIdentity)
+                guard expectedIdentity.capturedBounds != bounds else {
+                    return WindowManagementActionOutcome.confirmedNoChange
+                }
+                let dispatch = WindowGeometryDispatchAcceptance(
+                    positionAccepted: window.setPosition(bounds.origin) == .success,
+                    sizeAccepted: window.setSize(bounds.size) == .success)
+                let dispatchCount = dispatch.dispatchCount
+                guard dispatchCount > 0 else {
+                    throw OperationError.interactionFailed(
+                        action: "set window bounds",
+                        reason: "Window bounds operation failed")
+                }
+                do {
+                    _ = try await self.waitForRepinnedWindowMutation(expectedIdentity, expectedBounds: bounds)
+                } catch {
+                    throw self.geometryVerificationFailure(
+                        action: "set window bounds",
+                        expectedIdentity: expectedIdentity,
+                        dispatchCount: dispatchCount,
+                        cause: error)
+                }
+                return WindowManagementActionOutcome.confirmedChange(
+                    delivery: WindowManagementActionOutcome.backgroundValueDelivery,
+                    dispatchCount: dispatchCount)
             }
-            _ = try await self.waitForRepinnedWindowMutation(expectedIdentity, expectedBounds: bounds)
         }
     }
 }

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/WindowManagementService+StateOperations.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/WindowManagementService+StateOperations.swift
@@ -24,8 +24,13 @@ extension WindowManagementService {
         expectedIdentity: WindowMutationIdentity,
         allowForegroundFallback: Bool) async throws
     {
-        let operationScope: DesktopOperationScope = allowForegroundFallback ? .global : .window(expectedIdentity)
-        try await self.operationLaneCoordinator.run(scope: operationScope, access: .write) {
+        if !allowForegroundFallback {
+            _ = try await self.closeWindowWithOutcome(
+                target: target,
+                expectedIdentity: expectedIdentity)
+            return
+        }
+        try await self.operationLaneCoordinator.run(scope: .global, access: .write) {
             try self.validatePinnedWindowMutation(target: target, expectedIdentity: expectedIdentity)
             let trackedWindowID = expectedIdentity.windowID
             try Task.checkCancellation()
@@ -38,18 +43,9 @@ extension WindowManagementService {
             else {
                 throw PeekabooError.windowNotFound(criteria: "windowId \(trackedWindowID)")
             }
-            if minimizedCloseRequiresForegroundFallback(isMinimized: expectedIdentity.isMinimized == true),
-               !allowForegroundFallback
-            {
-                throw OperationError.interactionFailed(
-                    action: "close window",
-                    reason: "A minimized window cannot be closed with a verified background-only route; " +
-                        "run `peekaboo window restore` for the same exact target first, or retry with --foreground")
-            }
-
             let backgroundAttempt: PinnedWindowCloseAttemptResult
             if expectedIdentity.isMinimized == true {
-                backgroundAttempt = PinnedWindowCloseAttemptResult(dispatched: false, disappeared: false)
+                backgroundAttempt = PinnedWindowCloseAttemptResult(dispatchCount: 0, disappeared: false)
             } else {
                 do {
                     backgroundAttempt = try await self.attemptPinnedBackgroundClose(expectedIdentity)
@@ -58,23 +54,6 @@ extension WindowManagementService {
                 }
             }
             try Task.checkCancellation()
-
-            if !allowForegroundFallback {
-                do {
-                    try validateBackgroundCloseOutcome(
-                        dispatchSucceeded: backgroundAttempt.dispatched,
-                        disappeared: backgroundAttempt.disappeared)
-                } catch {
-                    if shouldRestoreMinimizedWindowAfterCloseFailure(
-                        wasMinimized: expectedIdentity.isMinimized == true,
-                        closeCompleted: false)
-                    {
-                        _ = try? await self.restorePinnedMinimizedWindow(expectedIdentity)
-                    }
-                    throw error
-                }
-                return
-            }
 
             if backgroundAttempt.disappeared {
                 return
@@ -138,27 +117,98 @@ extension WindowManagementService {
         }
     }
 
+    public func closeWindowWithOutcome(
+        target: WindowTarget,
+        expectedIdentity: WindowMutationIdentity) async throws -> DesktopActionOutcome?
+    {
+        try await WindowManagementActionOutcome.perform(action: "close window") {
+            try await self.operationLaneCoordinator.run(scope: .window(expectedIdentity), access: .write) {
+                try self.validatePinnedWindowMutation(target: target, expectedIdentity: expectedIdentity)
+                let trackedWindowID = expectedIdentity.windowID
+                try Task.checkCancellation()
+                let windowServerInfo = self.windowIdentityService
+                    .getWindowServerInfo(windowID: CGWindowID(trackedWindowID))
+                guard hasSufficientMetadataForPinnedClose(
+                    hasWindowServerMetadata: windowServerInfo != nil,
+                    expectedMinimized: expectedIdentity.isMinimized == true)
+                else {
+                    throw PeekabooError.windowNotFound(criteria: "windowId \(trackedWindowID)")
+                }
+                if minimizedCloseRequiresForegroundFallback(isMinimized: expectedIdentity.isMinimized == true) {
+                    throw DesktopActionFailure.refused(
+                        reason: .foregroundConsentRequired,
+                        message: "A minimized window cannot be closed with a verified background-only route",
+                        hint: "Restore the same exact window first, or retry with explicit foreground consent.")
+                }
+
+                let attempt = try await self.attemptPinnedBackgroundClose(expectedIdentity)
+                guard attempt.dispatched else {
+                    throw OperationError.interactionFailed(
+                        action: "close window",
+                        reason: "Window close operation failed")
+                }
+                guard attempt.disappeared else {
+                    throw WindowManagementActionOutcome.suspectedNoop(
+                        action: "close window",
+                        delivery: WindowManagementActionOutcome.backgroundActionDelivery,
+                        dispatchCount: attempt.dispatchCount)
+                }
+                return WindowManagementActionOutcome.confirmedChange(
+                    delivery: WindowManagementActionOutcome.backgroundActionDelivery,
+                    dispatchCount: attempt.dispatchCount)
+            }
+        }
+    }
+
     public func minimizeWindow(target: WindowTarget) async throws {
         let pinned = try await self.pinnedWindowMutation(for: target)
         try await self.minimizeWindow(target: pinned.target, expectedIdentity: pinned.identity)
     }
 
     public func minimizeWindow(target: WindowTarget, expectedIdentity: WindowMutationIdentity) async throws {
-        try await self.operationLaneCoordinator.run(scope: .window(expectedIdentity), access: .write) {
-            try self.validatePinnedWindowMutation(target: target, expectedIdentity: expectedIdentity)
-            let window = try await self.element(for: target)
-            try self.validatePinnedWindowMutation(target: target, expectedIdentity: expectedIdentity)
-            try self.validatePinnedWindowElement(window, expectedIdentity: expectedIdentity)
-            let success = window.minimizeWindow()
+        _ = try await self.minimizeWindowWithOutcome(target: target, expectedIdentity: expectedIdentity)
+    }
 
-            if !success {
-                throw OperationError.interactionFailed(
-                    action: "minimize window",
-                    reason: "Window minimize operation failed")
-            }
-            guard try await self.waitForPinnedWindowMinimized(window, expectedIdentity: expectedIdentity) else {
-                throw PeekabooError.commandFailed(
-                    "Window \(expectedIdentity.windowID) did not reach verified minimized state")
+    public func minimizeWindowWithOutcome(
+        target: WindowTarget,
+        expectedIdentity: WindowMutationIdentity) async throws -> DesktopActionOutcome?
+    {
+        try await WindowManagementActionOutcome.perform(action: "minimize window") {
+            try await self.operationLaneCoordinator.run(scope: .window(expectedIdentity), access: .write) {
+                try self.validatePinnedWindowMutation(target: target, expectedIdentity: expectedIdentity)
+                let window = try await self.element(for: target)
+                try self.validatePinnedWindowMutation(target: target, expectedIdentity: expectedIdentity)
+                try self.validatePinnedWindowElement(window, expectedIdentity: expectedIdentity)
+                if window.isMinimized() == true {
+                    return WindowManagementActionOutcome.confirmedNoChange
+                }
+                guard window.setMinimized(true) == .success else {
+                    throw OperationError.interactionFailed(
+                        action: "minimize window",
+                        reason: "Window minimize operation failed")
+                }
+                do {
+                    guard try await self.waitForPinnedWindowMinimized(
+                        window,
+                        expectedIdentity: expectedIdentity)
+                    else {
+                        throw WindowManagementActionOutcome.suspectedNoop(
+                            action: "minimize window",
+                            delivery: WindowManagementActionOutcome.backgroundValueDelivery,
+                            dispatchCount: 1)
+                    }
+                } catch let failure as DesktopActionFailure {
+                    throw failure
+                } catch {
+                    throw WindowManagementActionOutcome.dispatchedUnverified(
+                        action: "minimize window",
+                        delivery: WindowManagementActionOutcome.backgroundValueDelivery,
+                        dispatchCount: 1,
+                        cause: error)
+                }
+                return WindowManagementActionOutcome.confirmedChange(
+                    delivery: WindowManagementActionOutcome.backgroundValueDelivery,
+                    dispatchCount: 1)
             }
         }
     }
@@ -169,32 +219,81 @@ extension WindowManagementService {
     }
 
     public func restoreWindow(target: WindowTarget, expectedIdentity: WindowMutationIdentity) async throws {
-        try await self.operationLaneCoordinator.run(scope: .window(expectedIdentity), access: .write) {
-            try self.validatePinnedWindowMutation(target: target, expectedIdentity: expectedIdentity)
-            if expectedIdentity.isMinimized == true {
-                try await self.restorePinnedMinimizedWindow(expectedIdentity)
-                return
-            }
-            let window = try await self.element(for: target)
-            try self.validatePinnedWindowMutation(target: target, expectedIdentity: expectedIdentity)
-            try self.validatePinnedWindowElement(window, expectedIdentity: expectedIdentity)
+        _ = try await self.restoreWindowWithOutcome(target: target, expectedIdentity: expectedIdentity)
+    }
 
-            if window.isMinimized() == false {
-                guard SystemIdentityResolver.validateWindowMutationIdentity(expectedIdentity) else {
-                    throw PeekabooError.commandFailed(
-                        "Window \(expectedIdentity.windowID) changed identity before restore completion")
+    public func restoreWindowWithOutcome(
+        target: WindowTarget,
+        expectedIdentity: WindowMutationIdentity) async throws -> DesktopActionOutcome?
+    {
+        try await WindowManagementActionOutcome.perform(action: "restore window") {
+            try await self.operationLaneCoordinator.run(scope: .window(expectedIdentity), access: .write) {
+                try self.validatePinnedWindowMutation(target: target, expectedIdentity: expectedIdentity)
+                if expectedIdentity.isMinimized == true {
+                    var dispatchAccepted = false
+                    do {
+                        _ = try await completePinnedMinimizedWindowRestore(
+                            expectedIdentity: expectedIdentity,
+                            dispatch: {
+                                dispatchAccepted = await BoundedBackgroundWindowAX.dispatchMinimizedRestore(
+                                    expectedIdentity: expectedIdentity)
+                                return dispatchAccepted
+                            },
+                            repin: { identity, expectedBounds in
+                                try await self.waitForRepinnedWindowMutation(
+                                    identity,
+                                    expectedBounds: expectedBounds)
+                            })
+                    } catch let failure as DesktopActionFailure {
+                        throw failure
+                    } catch {
+                        guard dispatchAccepted else { throw error }
+                        throw WindowManagementActionOutcome.dispatchedUnverified(
+                            action: "restore window",
+                            delivery: WindowManagementActionOutcome.backgroundValueDelivery,
+                            dispatchCount: 1,
+                            cause: error)
+                    }
+                    return WindowManagementActionOutcome.confirmedChange(
+                        delivery: WindowManagementActionOutcome.backgroundValueDelivery,
+                        dispatchCount: 1)
                 }
-                return
-            }
+                let window = try await self.element(for: target)
+                try self.validatePinnedWindowMutation(target: target, expectedIdentity: expectedIdentity)
+                try self.validatePinnedWindowElement(window, expectedIdentity: expectedIdentity)
 
-            guard window.unminimizeWindow() else {
-                throw OperationError.interactionFailed(
-                    action: "restore window",
-                    reason: "Window restore operation failed")
-            }
-            guard try await self.waitForPinnedWindowRestored(window, expectedIdentity: expectedIdentity) else {
-                throw PeekabooError.commandFailed(
-                    "Window \(expectedIdentity.windowID) did not reach verified restored state")
+                if window.isMinimized() == false {
+                    guard SystemIdentityResolver.validateWindowMutationIdentity(expectedIdentity) else {
+                        throw PeekabooError.commandFailed(
+                            "Window \(expectedIdentity.windowID) changed identity before restore completion")
+                    }
+                    return WindowManagementActionOutcome.confirmedNoChange
+                }
+
+                guard window.unminimizeWindow() else {
+                    throw OperationError.interactionFailed(
+                        action: "restore window",
+                        reason: "Window restore operation failed")
+                }
+                do {
+                    guard try await self.waitForPinnedWindowRestored(window, expectedIdentity: expectedIdentity) else {
+                        throw WindowManagementActionOutcome.suspectedNoop(
+                            action: "restore window",
+                            delivery: WindowManagementActionOutcome.backgroundValueDelivery,
+                            dispatchCount: 1)
+                    }
+                } catch let failure as DesktopActionFailure {
+                    throw failure
+                } catch {
+                    throw WindowManagementActionOutcome.dispatchedUnverified(
+                        action: "restore window",
+                        delivery: WindowManagementActionOutcome.backgroundValueDelivery,
+                        dispatchCount: 1,
+                        cause: error)
+                }
+                return WindowManagementActionOutcome.confirmedChange(
+                    delivery: WindowManagementActionOutcome.backgroundValueDelivery,
+                    dispatchCount: 1)
             }
         }
     }
@@ -216,45 +315,87 @@ extension WindowManagementService {
     }
 
     public func maximizeWindow(target: WindowTarget, expectedIdentity: WindowMutationIdentity) async throws {
-        try await self.operationLaneCoordinator.run(scope: .window(expectedIdentity), access: .write) {
-            try self.validatePinnedWindowMutation(target: target, expectedIdentity: expectedIdentity)
-            guard let windowInfo = try await self.listWindows(target: target).first else {
-                throw PeekabooError.windowNotFound(criteria: "No exact window identity was available for maximize")
-            }
-            try self.validatePinnedWindowMutation(target: target, expectedIdentity: expectedIdentity)
-            let desiredBounds = try self.maximizedBounds(for: windowInfo.bounds)
+        _ = try await self.maximizeWindowWithOutcome(target: target, expectedIdentity: expectedIdentity)
+    }
 
-            if Self.windowBoundsMatch(windowInfo.bounds, desiredBounds, tolerance: 4) {
-                return
-            }
+    public func maximizeWindowWithOutcome(
+        target: WindowTarget,
+        expectedIdentity: WindowMutationIdentity) async throws -> DesktopActionOutcome?
+    {
+        try await WindowManagementActionOutcome.perform(action: "maximize window") {
+            try await self.operationLaneCoordinator.run(scope: .window(expectedIdentity), access: .write) {
+                try self.validatePinnedWindowMutation(target: target, expectedIdentity: expectedIdentity)
+                guard let windowInfo = try await self.listWindows(target: target).first else {
+                    throw PeekabooError.windowNotFound(
+                        criteria: "No exact window identity was available for maximize")
+                }
+                try self.validatePinnedWindowMutation(target: target, expectedIdentity: expectedIdentity)
+                let desiredBounds = try self.maximizedBounds(for: windowInfo.bounds)
 
-            guard self.windowIdentityService
-                .getWindowServerInfo(windowID: CGWindowID(windowInfo.windowID)) != nil
-            else {
-                throw PeekabooError.windowNotFound(criteria: "windowId \(windowInfo.windowID)")
-            }
-            let success = await BoundedBackgroundWindowAX.setBounds(
-                expectedIdentity: expectedIdentity,
-                bounds: desiredBounds)
+                if Self.windowBoundsMatch(windowInfo.bounds, desiredBounds, tolerance: 4) {
+                    return WindowManagementActionOutcome.confirmedNoChange
+                }
 
-            if !success {
-                throw OperationError.interactionFailed(
-                    action: "maximize window",
-                    reason: "The bounded background geometry request failed")
-            }
+                guard self.windowIdentityService
+                    .getWindowServerInfo(windowID: CGWindowID(windowInfo.windowID)) != nil
+                else {
+                    throw PeekabooError.windowNotFound(criteria: "windowId \(windowInfo.windowID)")
+                }
+                let dispatch = await BoundedBackgroundWindowAX.setBounds(
+                    expectedIdentity: expectedIdentity,
+                    bounds: desiredBounds)
+                guard dispatch.dispatchCount > 0 else {
+                    throw OperationError.interactionFailed(
+                        action: "maximize window",
+                        reason: "The bounded background geometry request failed before dispatch")
+                }
+                guard dispatch.identityRemainedPinned else {
+                    throw WindowManagementActionOutcome.dispatchedUnverified(
+                        action: "maximize window",
+                        delivery: WindowManagementActionOutcome.backgroundValueDelivery,
+                        dispatchCount: dispatch.dispatchCount,
+                        cause: PeekabooError.commandFailed(
+                            "Window identity changed during bounded background geometry dispatch"))
+                }
 
-            guard try await self.waitForWindowBounds(
-                windowID: windowInfo.windowID,
-                expectedIdentity: expectedIdentity,
-                expected: desiredBounds,
-                timeoutSeconds: 2)
-            else {
-                let achieved = self.windowIdentityService
-                    .getWindowServerInfo(windowID: CGWindowID(windowInfo.windowID))?.bounds
-                throw OperationError.interactionFailed(
-                    action: "maximize window",
-                    reason: "The window did not reach the target screen's visible bounds within 2 seconds " +
-                        "(requested: \(desiredBounds), achieved: \(String(describing: achieved)))")
+                do {
+                    guard try await self.waitForWindowBounds(
+                        windowID: windowInfo.windowID,
+                        expectedIdentity: expectedIdentity,
+                        expected: desiredBounds,
+                        timeoutSeconds: 2)
+                    else {
+                        let achieved = self.windowIdentityService
+                            .getWindowServerInfo(windowID: CGWindowID(windowInfo.windowID))?.bounds
+                        let cause = OperationError.interactionFailed(
+                            action: "maximize window",
+                            reason: "The window did not reach the target screen's visible bounds within 2 seconds " +
+                                "(requested: \(desiredBounds), achieved: \(String(describing: achieved)))")
+                        if Self.windowBoundsMatch(windowInfo.bounds, achieved ?? .null, tolerance: 4) {
+                            throw WindowManagementActionOutcome.suspectedNoop(
+                                action: "maximize window",
+                                delivery: WindowManagementActionOutcome.backgroundValueDelivery,
+                                dispatchCount: dispatch.dispatchCount,
+                                cause: cause)
+                        }
+                        throw WindowManagementActionOutcome.dispatchedUnverified(
+                            action: "maximize window",
+                            delivery: WindowManagementActionOutcome.backgroundValueDelivery,
+                            dispatchCount: dispatch.dispatchCount,
+                            cause: cause)
+                    }
+                } catch let failure as DesktopActionFailure {
+                    throw failure
+                } catch {
+                    throw WindowManagementActionOutcome.dispatchedUnverified(
+                        action: "maximize window",
+                        delivery: WindowManagementActionOutcome.backgroundValueDelivery,
+                        dispatchCount: dispatch.dispatchCount,
+                        cause: error)
+                }
+                return WindowManagementActionOutcome.confirmedChange(
+                    delivery: WindowManagementActionOutcome.backgroundValueDelivery,
+                    dispatchCount: dispatch.dispatchCount)
             }
         }
     }
@@ -354,11 +495,24 @@ extension WindowManagementService {
             expectedIdentity: expectedIdentity,
             action: .windowClose)
         if primaryDispatched {
-            switch try await self.verifyPinnedWindowClose(expectedIdentity) {
-            case .succeeded:
-                return PinnedWindowCloseAttemptResult(dispatched: true, disappeared: true)
-            case .pending, .retryClose, .unverifiable:
-                break
+            do {
+                switch try await pinnedWindowCloseAttemptDisposition(
+                    for: self.verifyPinnedWindowClose(expectedIdentity))
+                {
+                case .disappeared:
+                    return PinnedWindowCloseAttemptResult(dispatchCount: 1, disappeared: true)
+                case .remained:
+                    break
+                case .unverifiable:
+                    throw PeekabooError.commandFailed(
+                        "The exact window close result could not be verified")
+                }
+            } catch {
+                throw WindowManagementActionOutcome.dispatchedUnverified(
+                    action: "close window",
+                    delivery: WindowManagementActionOutcome.backgroundActionDelivery,
+                    dispatchCount: 1,
+                    cause: error)
             }
         }
 
@@ -366,15 +520,28 @@ extension WindowManagementService {
         let fallbackDispatched = await BoundedBackgroundWindowAX.dispatchClose(
             expectedIdentity: expectedIdentity,
             action: .closeButton)
-        let anyDispatched = primaryDispatched || fallbackDispatched
-        guard anyDispatched else {
-            return PinnedWindowCloseAttemptResult(dispatched: false, disappeared: false)
+        let dispatchCount = (primaryDispatched ? 1 : 0) + (fallbackDispatched ? 1 : 0)
+        guard dispatchCount > 0 else {
+            return PinnedWindowCloseAttemptResult(dispatchCount: 0, disappeared: false)
         }
 
-        let fallbackDecision = try await self.verifyPinnedWindowClose(expectedIdentity)
-        return PinnedWindowCloseAttemptResult(
-            dispatched: true,
-            disappeared: fallbackDecision == .succeeded)
+        do {
+            let disposition = try await pinnedWindowCloseAttemptDisposition(
+                for: self.verifyPinnedWindowClose(expectedIdentity))
+            guard disposition != .unverifiable else {
+                throw PeekabooError.commandFailed(
+                    "The exact window close result could not be verified")
+            }
+            return PinnedWindowCloseAttemptResult(
+                dispatchCount: dispatchCount,
+                disappeared: disposition == .disappeared)
+        } catch {
+            throw WindowManagementActionOutcome.dispatchedUnverified(
+                action: "close window",
+                delivery: WindowManagementActionOutcome.backgroundActionDelivery,
+                dispatchCount: dispatchCount,
+                cause: error)
+        }
     }
 
     private func verifyPinnedWindowClose(
@@ -589,6 +756,25 @@ enum PinnedWindowCloseVerificationDecision: Equatable {
     case unverifiable
 }
 
+enum PinnedWindowCloseAttemptDisposition: Equatable {
+    case disappeared
+    case remained
+    case unverifiable
+}
+
+func pinnedWindowCloseAttemptDisposition(
+    for decision: PinnedWindowCloseVerificationDecision) -> PinnedWindowCloseAttemptDisposition
+{
+    switch decision {
+    case .succeeded:
+        .disappeared
+    case .retryClose:
+        .remained
+    case .pending, .unverifiable:
+        .unverifiable
+    }
+}
+
 struct PinnedWindowCloseVerification {
     private let successHorizon: Duration
     private let disappearanceStability: Duration
@@ -737,8 +923,12 @@ func withMinimizedWindowFailureRecovery<T>(
 }
 
 private struct PinnedWindowCloseAttemptResult {
-    let dispatched: Bool
+    let dispatchCount: Int
     let disappeared: Bool
+
+    var dispatched: Bool {
+        self.dispatchCount > 0
+    }
 }
 
 func hasSufficientMetadataForPinnedClose(
@@ -941,6 +1131,21 @@ func backgroundGeometryDispatchRemainsPinned(
         candidateWindowID == expectedIdentity.windowID
 }
 
+private struct BackgroundWindowGeometryDispatchResult {
+    let acceptance: WindowGeometryDispatchAcceptance
+    let identityRemainedPinned: Bool
+
+    static let notDispatched = Self(
+        acceptance: WindowGeometryDispatchAcceptance(
+            positionAccepted: false,
+            sizeAccepted: false),
+        identityRemainedPinned: false)
+
+    var dispatchCount: Int {
+        self.acceptance.dispatchCount
+    }
+}
+
 extension CGRect {
     fileprivate var area: CGFloat {
         guard !self.isNull, !self.isInfinite else { return 0 }
@@ -1092,7 +1297,10 @@ private enum BoundedBackgroundWindowAX {
         }.value
     }
 
-    static func setBounds(expectedIdentity: WindowMutationIdentity, bounds: CGRect) async -> Bool {
+    static func setBounds(
+        expectedIdentity: WindowMutationIdentity,
+        bounds: CGRect) async -> BackgroundWindowGeometryDispatchResult
+    {
         await Task.detached(priority: .userInitiated) {
             guard SystemIdentityResolver.validateWindowMutationIdentity(expectedIdentity),
                   let capturedBounds = expectedIdentity.capturedBounds,
@@ -1101,7 +1309,7 @@ private enum BoundedBackgroundWindowAX {
                       windowID: windowID,
                       ownerPID: expectedIdentity.ownerProcessIdentifier)
             else {
-                return false
+                return .notDispatched
             }
             return AXChildWindowMessagingTimeout.perform(
                 on: rawWindow,
@@ -1110,7 +1318,7 @@ private enum BoundedBackgroundWindowAX {
                 guard SystemIdentityResolver.validateWindowMutationOwnerGeneration(expectedIdentity),
                       self.bounds(of: childWindow) == capturedBounds
                 else {
-                    return false
+                    return .notDispatched
                 }
 
                 var origin = bounds.origin
@@ -1118,7 +1326,7 @@ private enum BoundedBackgroundWindowAX {
                 guard let originValue = AXValueCreate(.cgPoint, &origin),
                       let sizeValue = AXValueCreate(.cgSize, &size)
                 else {
-                    return false
+                    return .notDispatched
                 }
 
                 let positionResult = AXUIElementSetAttributeValue(
@@ -1133,13 +1341,17 @@ private enum BoundedBackgroundWindowAX {
                 let windowIDResult = AXWindowIDResolver.copyWindowID(
                     childWindow,
                     into: &candidateWindowID)
-                return backgroundGeometryDispatchRemainsPinned(
-                    expectedIdentity: expectedIdentity,
-                    positionSetSucceeded: positionResult == .success,
-                    sizeSetSucceeded: sizeResult == .success,
-                    liveProcessStartIdentity: SystemIdentityResolver.processStartIdentity(
-                        expectedIdentity.ownerProcessIdentifier),
-                    candidateWindowID: windowIDResult == .success ? Int(candidateWindowID) : nil)
+                let positionAccepted = positionResult == .success
+                let sizeAccepted = sizeResult == .success
+                let liveProcessStartIdentity = SystemIdentityResolver.processStartIdentity(
+                    expectedIdentity.ownerProcessIdentifier)
+                let resolvedCandidateWindowID = windowIDResult == .success ? Int(candidateWindowID) : nil
+                return BackgroundWindowGeometryDispatchResult(
+                    acceptance: WindowGeometryDispatchAcceptance(
+                        positionAccepted: positionAccepted,
+                        sizeAccepted: sizeAccepted),
+                    identityRemainedPinned: liveProcessStartIdentity == expectedIdentity.ownerProcessStartIdentity &&
+                        resolvedCandidateWindowID == expectedIdentity.windowID)
             }
         }.value
     }

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/WindowManagementService.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/WindowManagementService.swift
@@ -37,7 +37,7 @@ import PeekabooFoundation
  * - Since: PeekabooCore 1.0.0
  */
 @MainActor
-public final class WindowManagementService: WindowManagementServiceProtocol {
+public final class WindowManagementService: WindowManagementServiceProtocol, WindowManagementActionOutcomeProviding {
     let applicationService: any ApplicationServiceProtocol
     let windowIdentityService = WindowIdentityService()
     let cgInfoLookup: WindowCGInfoLookup

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/WindowManagementServiceProtocolTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/WindowManagementServiceProtocolTests.swift
@@ -1,9 +1,90 @@
 import CoreGraphics
+import PeekabooAutomationKitTestSupport
 import PeekabooFoundation
 import Testing
 @testable import PeekabooAutomationKit
 
 struct WindowManagementServiceProtocolTests {
+    @Test
+    func `additive carrier preserves canonical outcomes and legacy nil without changing witnesses`() async throws {
+        let service = OutcomeWindowManagementService()
+        let identity = AutomationTestFixtures.windowIdentity()
+        let target = WindowTarget.windowId(identity.windowID)
+        let outcomes = AutomationTestFixtures.canonicalActionOutcomes.map(Optional.some) + [nil]
+
+        for (index, outcome) in outcomes.enumerated() {
+            await service.setOutcome(outcome)
+            let carried = switch index % 7 {
+            case 0:
+                try await service.closeWindowWithOutcome(target: target, expectedIdentity: identity)
+            case 1:
+                try await service.minimizeWindowWithOutcome(target: target, expectedIdentity: identity)
+            case 2:
+                try await service.restoreWindowWithOutcome(target: target, expectedIdentity: identity)
+            case 3:
+                try await service.maximizeWindowWithOutcome(target: target, expectedIdentity: identity)
+            case 4:
+                try await service.moveWindowWithOutcome(target: target, expectedIdentity: identity, to: .zero)
+            case 5:
+                try await service.resizeWindowWithOutcome(target: target, expectedIdentity: identity, to: .zero)
+            default:
+                try await service.setWindowBoundsWithOutcome(
+                    target: target,
+                    expectedIdentity: identity,
+                    bounds: .zero)
+            }
+            #expect(carried == outcome)
+        }
+
+        let legacy: any WindowManagementServiceProtocol = LegacyOnlyWindowManagementService()
+        #expect((legacy as? any WindowManagementActionOutcomeProviding) == nil)
+    }
+
+    @Test
+    func `window refusal classification preserves permission target request and runtime causes`() {
+        #expect(WindowManagementActionOutcome.refusalReason(
+            for: PeekabooError.permissionDeniedAccessibility) == .permissionDenied)
+        #expect(WindowManagementActionOutcome.refusalReason(
+            for: PeekabooError.windowNotFound(criteria: "fixture")) == .targetUnavailable)
+        #expect(WindowManagementActionOutcome.refusalReason(
+            for: PeekabooError.invalidInput("fixture")) == .invalidRequest)
+        #expect(WindowManagementActionOutcome.refusalReason(
+            for: PeekabooError.serviceUnavailable("fixture")) == .runtimeIncompatible)
+        #expect(WindowManagementActionOutcome.refusalReason(
+            for: PeekabooError.operationError(message: "fixture")) == .operationUnsupported)
+    }
+
+    @Test
+    func `post AX verification failure reports accepted delivery without claiming work is still running`() {
+        let failure = WindowManagementActionOutcome.dispatchedUnverified(
+            action: "move window",
+            delivery: WindowManagementActionOutcome.backgroundValueDelivery,
+            dispatchCount: 1,
+            cause: PeekabooError.timeout("fixture"))
+
+        #expect(failure.outcome.state == .dispatchedUnverified)
+        #expect(failure.outcome.evidence == .deliveryAccepted)
+        #expect(failure.outcome.delivery == .init(mechanism: .accessibilityValue, mode: .background))
+    }
+
+    @Test(arguments: [
+        (positionAccepted: false, sizeAccepted: false, expectedCount: 0),
+        (positionAccepted: true, sizeAccepted: false, expectedCount: 1),
+        (positionAccepted: false, sizeAccepted: true, expectedCount: 1),
+        (positionAccepted: true, sizeAccepted: true, expectedCount: 2),
+    ])
+    func `geometry dispatch counts zero partial and complete AX acceptance`(
+        positionAccepted: Bool,
+        sizeAccepted: Bool,
+        expectedCount: Int)
+    {
+        let acceptance = WindowGeometryDispatchAcceptance(
+            positionAccepted: positionAccepted,
+            sizeAccepted: sizeAccepted)
+
+        #expect(acceptance.dispatchCount == expectedCount)
+    }
+
     @Test
     func `identity defaults fail closed without dispatching legacy numeric overloads`() async {
         let double = LegacyOnlyWindowManagementService()
@@ -37,6 +118,81 @@ struct WindowManagementServiceProtocolTests {
         }
 
         #expect(await double.legacyDispatchCount == 0)
+    }
+}
+
+private actor OutcomeWindowManagementService: WindowManagementActionOutcomeProviding {
+    private var outcome: DesktopActionOutcome?
+
+    func setOutcome(_ outcome: DesktopActionOutcome?) {
+        self.outcome = outcome
+    }
+
+    func closeWindowWithOutcome(
+        target _: WindowTarget,
+        expectedIdentity _: WindowMutationIdentity) async throws -> DesktopActionOutcome?
+    {
+        self.outcome
+    }
+
+    func minimizeWindowWithOutcome(
+        target _: WindowTarget,
+        expectedIdentity _: WindowMutationIdentity) async throws -> DesktopActionOutcome?
+    {
+        self.outcome
+    }
+
+    func restoreWindowWithOutcome(
+        target _: WindowTarget,
+        expectedIdentity _: WindowMutationIdentity) async throws -> DesktopActionOutcome?
+    {
+        self.outcome
+    }
+
+    func maximizeWindowWithOutcome(
+        target _: WindowTarget,
+        expectedIdentity _: WindowMutationIdentity) async throws -> DesktopActionOutcome?
+    {
+        self.outcome
+    }
+
+    func moveWindowWithOutcome(
+        target _: WindowTarget,
+        expectedIdentity _: WindowMutationIdentity,
+        to _: CGPoint) async throws -> DesktopActionOutcome?
+    {
+        self.outcome
+    }
+
+    func resizeWindowWithOutcome(
+        target _: WindowTarget,
+        expectedIdentity _: WindowMutationIdentity,
+        to _: CGSize) async throws -> DesktopActionOutcome?
+    {
+        self.outcome
+    }
+
+    func setWindowBoundsWithOutcome(
+        target _: WindowTarget,
+        expectedIdentity _: WindowMutationIdentity,
+        bounds _: CGRect) async throws -> DesktopActionOutcome?
+    {
+        self.outcome
+    }
+
+    func closeWindow(target _: WindowTarget) async throws {}
+    func minimizeWindow(target _: WindowTarget) async throws {}
+    func maximizeWindow(target _: WindowTarget) async throws {}
+    func moveWindow(target _: WindowTarget, to _: CGPoint) async throws {}
+    func resizeWindow(target _: WindowTarget, to _: CGSize) async throws {}
+    func setWindowBounds(target _: WindowTarget, bounds _: CGRect) async throws {}
+    func focusWindow(target _: WindowTarget) async throws {}
+    func listWindows(target _: WindowTarget) async throws -> [ServiceWindowInfo] {
+        []
+    }
+
+    func getFocusedWindow() async throws -> ServiceWindowInfo? {
+        nil
     }
 }
 

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/WindowStateMutationPolicyTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/WindowStateMutationPolicyTests.swift
@@ -512,6 +512,14 @@ struct WindowStateMutationPolicyTests {
     }
 
     @Test
+    func `close outcome keeps unavailable verification distinct from observed no op`() {
+        #expect(pinnedWindowCloseAttemptDisposition(for: .succeeded) == .disappeared)
+        #expect(pinnedWindowCloseAttemptDisposition(for: .retryClose) == .remained)
+        #expect(pinnedWindowCloseAttemptDisposition(for: .pending) == .unverifiable)
+        #expect(pinnedWindowCloseAttemptDisposition(for: .unverifiable) == .unverifiable)
+    }
+
+    @Test
     func `background close succeeds only after exact disappearance`() throws {
         try validateBackgroundCloseOutcome(dispatchSucceeded: true, disappeared: true)
     }

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeClient+WindowsApplications.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeClient+WindowsApplications.swift
@@ -33,7 +33,18 @@ extension PeekabooBridgeClient {
         expectedIdentity: WindowMutationIdentity,
         to position: CGPoint) async throws
     {
-        try await self.sendExpectOK(.moveWindow(PeekabooBridgeWindowMoveRequest(
+        _ = try await self.moveWindowWithOutcome(
+            target: target,
+            expectedIdentity: expectedIdentity,
+            to: position)
+    }
+
+    public func moveWindowWithOutcome(
+        target: WindowTarget,
+        expectedIdentity: WindowMutationIdentity,
+        to position: CGPoint) async throws -> DesktopActionOutcome?
+    {
+        try await self.sendExpectOKCarryingActionOutcome(.moveWindow(PeekabooBridgeWindowMoveRequest(
             target: target,
             expectedIdentity: expectedIdentity,
             position: position)))
@@ -49,7 +60,18 @@ extension PeekabooBridgeClient {
         expectedIdentity: WindowMutationIdentity,
         to size: CGSize) async throws
     {
-        try await self.sendExpectOK(.resizeWindow(PeekabooBridgeWindowResizeRequest(
+        _ = try await self.resizeWindowWithOutcome(
+            target: target,
+            expectedIdentity: expectedIdentity,
+            to: size)
+    }
+
+    public func resizeWindowWithOutcome(
+        target: WindowTarget,
+        expectedIdentity: WindowMutationIdentity,
+        to size: CGSize) async throws -> DesktopActionOutcome?
+    {
+        try await self.sendExpectOKCarryingActionOutcome(.resizeWindow(PeekabooBridgeWindowResizeRequest(
             target: target,
             expectedIdentity: expectedIdentity,
             size: size)))
@@ -68,7 +90,18 @@ extension PeekabooBridgeClient {
         expectedIdentity: WindowMutationIdentity,
         bounds: CGRect) async throws
     {
-        try await self.sendExpectOK(.setWindowBounds(PeekabooBridgeWindowBoundsRequest(
+        _ = try await self.setWindowBoundsWithOutcome(
+            target: target,
+            expectedIdentity: expectedIdentity,
+            bounds: bounds)
+    }
+
+    public func setWindowBoundsWithOutcome(
+        target: WindowTarget,
+        expectedIdentity: WindowMutationIdentity,
+        bounds: CGRect) async throws -> DesktopActionOutcome?
+    {
+        try await self.sendExpectOKCarryingActionOutcome(.setWindowBounds(PeekabooBridgeWindowBoundsRequest(
             target: target,
             expectedIdentity: expectedIdentity,
             bounds: bounds)))
@@ -97,8 +130,19 @@ extension PeekabooBridgeClient {
         if allowForegroundFallback {
             try await self.sendExpectOK(.closeWindow(request))
         } else {
-            try await self.sendExpectOK(.backgroundCloseWindow(request))
+            _ = try await self.closeWindowWithOutcome(
+                target: target,
+                expectedIdentity: expectedIdentity)
         }
+    }
+
+    public func closeWindowWithOutcome(
+        target: WindowTarget,
+        expectedIdentity: WindowMutationIdentity) async throws -> DesktopActionOutcome?
+    {
+        try await self.sendExpectOKCarryingActionOutcome(.backgroundCloseWindow(.init(
+            target: target,
+            expectedIdentity: expectedIdentity)))
     }
 
     public func minimizeWindow(target: WindowTarget) async throws {
@@ -107,7 +151,14 @@ extension PeekabooBridgeClient {
     }
 
     public func minimizeWindow(target: WindowTarget, expectedIdentity: WindowMutationIdentity) async throws {
-        try await self.sendExpectOK(.minimizeWindow(PeekabooBridgeWindowTargetRequest(
+        _ = try await self.minimizeWindowWithOutcome(target: target, expectedIdentity: expectedIdentity)
+    }
+
+    public func minimizeWindowWithOutcome(
+        target: WindowTarget,
+        expectedIdentity: WindowMutationIdentity) async throws -> DesktopActionOutcome?
+    {
+        try await self.sendExpectOKCarryingActionOutcome(.minimizeWindow(PeekabooBridgeWindowTargetRequest(
             target: target,
             expectedIdentity: expectedIdentity)))
     }
@@ -118,7 +169,14 @@ extension PeekabooBridgeClient {
     }
 
     public func restoreWindow(target: WindowTarget, expectedIdentity: WindowMutationIdentity) async throws {
-        try await self.sendExpectOK(.restoreWindow(PeekabooBridgeWindowTargetRequest(
+        _ = try await self.restoreWindowWithOutcome(target: target, expectedIdentity: expectedIdentity)
+    }
+
+    public func restoreWindowWithOutcome(
+        target: WindowTarget,
+        expectedIdentity: WindowMutationIdentity) async throws -> DesktopActionOutcome?
+    {
+        try await self.sendExpectOKCarryingActionOutcome(.restoreWindow(PeekabooBridgeWindowTargetRequest(
             target: target,
             expectedIdentity: expectedIdentity)))
     }
@@ -129,7 +187,14 @@ extension PeekabooBridgeClient {
     }
 
     public func maximizeWindow(target: WindowTarget, expectedIdentity: WindowMutationIdentity) async throws {
-        try await self.sendExpectOK(.maximizeWindow(PeekabooBridgeWindowTargetRequest(
+        _ = try await self.maximizeWindowWithOutcome(target: target, expectedIdentity: expectedIdentity)
+    }
+
+    public func maximizeWindowWithOutcome(
+        target: WindowTarget,
+        expectedIdentity: WindowMutationIdentity) async throws -> DesktopActionOutcome?
+    {
+        try await self.sendExpectOKCarryingActionOutcome(.maximizeWindow(PeekabooBridgeWindowTargetRequest(
             target: target,
             expectedIdentity: expectedIdentity)))
     }

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer+Handlers.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer+Handlers.swift
@@ -28,7 +28,7 @@ extension PeekabooBridgeServer {
         case .listWindows, .focusWindow, .moveWindow, .resizeWindow, .setWindowBounds, .closeWindow,
              .backgroundCloseWindow,
              .minimizeWindow, .restoreWindow, .maximizeWindow, .getFocusedWindow:
-            return try await .init(response: self.handleWindowRequest(request))
+            return try await self.handleWindowRequest(request)
         case .listApplications, .findApplication, .getFrontmostApplication, .isApplicationRunning,
              .launchApplication, .launchApplicationWithOptions, .relaunchApplicationWithOptions,
              .activateApplication, .quitApplication,
@@ -713,77 +713,141 @@ extension PeekabooBridgeServer {
         return .init(response: .ok)
     }
 
-    private func handleWindowRequest(_ request: PeekabooBridgeRequest) async throws -> PeekabooBridgeResponse {
+    private func handleWindowRequest(_ request: PeekabooBridgeRequest) async throws -> PeekabooBridgeHandledResponse {
         switch request {
         case let .listWindows(payload):
             let result = try await self.services.windows.listWindows(target: payload.target)
-            return .windows(result)
+            return .init(response: .windows(result))
         case let .focusWindow(payload):
             try await self.services.windows.focusWindow(target: payload.target)
-            return .ok
+            return .init(response: .ok)
         case let .moveWindow(payload):
             let identity = try Self.requireWindowMutationReceipt(payload.expectedIdentity, operation: .moveWindow)
-            try await self.services.windows.moveWindow(
-                target: payload.target,
-                expectedIdentity: identity,
-                to: payload.position)
-            return .ok
+            return try await self.handleWindowAction(
+                withOutcome: { service in
+                    try await service.moveWindowWithOutcome(
+                        target: payload.target,
+                        expectedIdentity: identity,
+                        to: payload.position)
+                },
+                legacy: {
+                    try await self.services.windows.moveWindow(
+                        target: payload.target,
+                        expectedIdentity: identity,
+                        to: payload.position)
+                })
         case let .resizeWindow(payload):
             let identity = try Self.requireWindowMutationReceipt(payload.expectedIdentity, operation: .resizeWindow)
-            try await self.services.windows.resizeWindow(
-                target: payload.target,
-                expectedIdentity: identity,
-                to: payload.size)
-            return .ok
+            return try await self.handleWindowAction(
+                withOutcome: { service in
+                    try await service.resizeWindowWithOutcome(
+                        target: payload.target,
+                        expectedIdentity: identity,
+                        to: payload.size)
+                },
+                legacy: {
+                    try await self.services.windows.resizeWindow(
+                        target: payload.target,
+                        expectedIdentity: identity,
+                        to: payload.size)
+                })
         case let .setWindowBounds(payload):
             let identity = try Self.requireWindowMutationReceipt(
                 payload.expectedIdentity,
                 operation: .setWindowBounds)
-            try await self.services.windows.setWindowBounds(
-                target: payload.target,
-                expectedIdentity: identity,
-                bounds: payload.bounds)
-            return .ok
+            return try await self.handleWindowAction(
+                withOutcome: { service in
+                    try await service.setWindowBoundsWithOutcome(
+                        target: payload.target,
+                        expectedIdentity: identity,
+                        bounds: payload.bounds)
+                },
+                legacy: {
+                    try await self.services.windows.setWindowBounds(
+                        target: payload.target,
+                        expectedIdentity: identity,
+                        bounds: payload.bounds)
+                })
         case let .closeWindow(payload):
             let identity = try Self.requireWindowMutationReceipt(payload.expectedIdentity, operation: .closeWindow)
             try await self.services.windows.closeWindow(
                 target: payload.target,
                 expectedIdentity: identity,
                 allowForegroundFallback: true)
-            return .ok
+            return .init(response: .ok)
         case let .backgroundCloseWindow(payload):
             let identity = try Self.requireWindowMutationReceipt(
                 payload.expectedIdentity,
                 operation: .backgroundCloseWindow)
-            try await self.services.windows.closeWindow(
-                target: payload.target,
-                expectedIdentity: identity,
-                allowForegroundFallback: false)
-            return .ok
+            return try await self.handleWindowAction(
+                withOutcome: { service in
+                    try await service.closeWindowWithOutcome(
+                        target: payload.target,
+                        expectedIdentity: identity)
+                },
+                legacy: {
+                    try await self.services.windows.closeWindow(
+                        target: payload.target,
+                        expectedIdentity: identity,
+                        allowForegroundFallback: false)
+                })
         case let .minimizeWindow(payload):
             let identity = try Self.requireWindowMutationReceipt(payload.expectedIdentity, operation: .minimizeWindow)
-            try await self.services.windows.minimizeWindow(
-                target: payload.target,
-                expectedIdentity: identity)
-            return .ok
+            return try await self.handleWindowAction(
+                withOutcome: { service in
+                    try await service.minimizeWindowWithOutcome(
+                        target: payload.target,
+                        expectedIdentity: identity)
+                },
+                legacy: {
+                    try await self.services.windows.minimizeWindow(
+                        target: payload.target,
+                        expectedIdentity: identity)
+                })
         case let .restoreWindow(payload):
             let identity = try Self.requireWindowMutationReceipt(payload.expectedIdentity, operation: .restoreWindow)
-            try await self.services.windows.restoreWindow(
-                target: payload.target,
-                expectedIdentity: identity)
-            return .ok
+            return try await self.handleWindowAction(
+                withOutcome: { service in
+                    try await service.restoreWindowWithOutcome(
+                        target: payload.target,
+                        expectedIdentity: identity)
+                },
+                legacy: {
+                    try await self.services.windows.restoreWindow(
+                        target: payload.target,
+                        expectedIdentity: identity)
+                })
         case let .maximizeWindow(payload):
             let identity = try Self.requireWindowMutationReceipt(payload.expectedIdentity, operation: .maximizeWindow)
-            try await self.services.windows.maximizeWindow(
-                target: payload.target,
-                expectedIdentity: identity)
-            return .ok
+            return try await self.handleWindowAction(
+                withOutcome: { service in
+                    try await service.maximizeWindowWithOutcome(
+                        target: payload.target,
+                        expectedIdentity: identity)
+                },
+                legacy: {
+                    try await self.services.windows.maximizeWindow(
+                        target: payload.target,
+                        expectedIdentity: identity)
+                })
         case .getFocusedWindow:
             let window = try await self.services.windows.getFocusedWindow()
-            return .window(window)
+            return .init(response: .window(window))
         default:
             throw Self.invalidRequest(for: request)
         }
+    }
+
+    private func handleWindowAction(
+        withOutcome: (any WindowManagementActionOutcomeProviding) async throws -> DesktopActionOutcome?,
+        legacy: () async throws -> Void) async throws -> PeekabooBridgeHandledResponse
+    {
+        guard let service = self.services.windows as? any WindowManagementActionOutcomeProviding else {
+            try await legacy()
+            return .init(response: .ok)
+        }
+        let outcome = try await withOutcome(service)
+        return .init(response: .ok, outcome: outcome)
     }
 
     private static func requireWindowMutationReceipt(

--- a/Core/PeekabooCore/Sources/PeekabooCore/Support/RemoteWindowManagementService.swift
+++ b/Core/PeekabooCore/Sources/PeekabooCore/Support/RemoteWindowManagementService.swift
@@ -6,7 +6,9 @@ import PeekabooBridge
 import PeekabooFoundation
 
 @MainActor
-public final class RemoteWindowManagementService: WindowManagementServiceProtocol {
+public final class RemoteWindowManagementService: WindowManagementServiceProtocol,
+    WindowManagementActionOutcomeProviding
+{
     private let client: PeekabooBridgeClient
     private let supportsBackgroundClose: Bool
     private nonisolated let supportsPinnedWindowMutations: Bool
@@ -55,6 +57,22 @@ public final class RemoteWindowManagementService: WindowManagementServiceProtoco
             allowForegroundFallback: allowForegroundFallback)
     }
 
+    public func closeWindowWithOutcome(
+        target: WindowTarget,
+        expectedIdentity: WindowMutationIdentity) async throws -> DesktopActionOutcome?
+    {
+        try self.requirePinnedWindowMutationSupport()
+        guard self.supportsBackgroundClose else {
+            throw PeekabooBridgeErrorEnvelope(
+                code: .operationNotSupported,
+                message: "Remote host does not support AX-only background window close; " +
+                    "update the host or use --no-remote")
+        }
+        return try await self.client.closeWindowWithOutcome(
+            target: target,
+            expectedIdentity: expectedIdentity)
+    }
+
     public func minimizeWindow(target: WindowTarget) async throws {
         try self.requirePinnedWindowMutationSupport()
         let pinned = try await self.client.resolvedPinnedWindowMutation(target: target)
@@ -62,8 +80,15 @@ public final class RemoteWindowManagementService: WindowManagementServiceProtoco
     }
 
     public func minimizeWindow(target: WindowTarget, expectedIdentity: WindowMutationIdentity) async throws {
+        _ = try await self.minimizeWindowWithOutcome(target: target, expectedIdentity: expectedIdentity)
+    }
+
+    public func minimizeWindowWithOutcome(
+        target: WindowTarget,
+        expectedIdentity: WindowMutationIdentity) async throws -> DesktopActionOutcome?
+    {
         try self.requirePinnedWindowMutationSupport()
-        try await self.client.minimizeWindow(target: target, expectedIdentity: expectedIdentity)
+        return try await self.client.minimizeWindowWithOutcome(target: target, expectedIdentity: expectedIdentity)
     }
 
     public func restoreWindow(target: WindowTarget) async throws {
@@ -73,8 +98,15 @@ public final class RemoteWindowManagementService: WindowManagementServiceProtoco
     }
 
     public func restoreWindow(target: WindowTarget, expectedIdentity: WindowMutationIdentity) async throws {
+        _ = try await self.restoreWindowWithOutcome(target: target, expectedIdentity: expectedIdentity)
+    }
+
+    public func restoreWindowWithOutcome(
+        target: WindowTarget,
+        expectedIdentity: WindowMutationIdentity) async throws -> DesktopActionOutcome?
+    {
         try self.requireWindowRestoreSupport()
-        try await self.client.restoreWindow(target: target, expectedIdentity: expectedIdentity)
+        return try await self.client.restoreWindowWithOutcome(target: target, expectedIdentity: expectedIdentity)
     }
 
     public func maximizeWindow(target: WindowTarget) async throws {
@@ -84,8 +116,15 @@ public final class RemoteWindowManagementService: WindowManagementServiceProtoco
     }
 
     public func maximizeWindow(target: WindowTarget, expectedIdentity: WindowMutationIdentity) async throws {
+        _ = try await self.maximizeWindowWithOutcome(target: target, expectedIdentity: expectedIdentity)
+    }
+
+    public func maximizeWindowWithOutcome(
+        target: WindowTarget,
+        expectedIdentity: WindowMutationIdentity) async throws -> DesktopActionOutcome?
+    {
         try self.requirePinnedWindowMutationSupport()
-        try await self.client.maximizeWindow(target: target, expectedIdentity: expectedIdentity)
+        return try await self.client.maximizeWindowWithOutcome(target: target, expectedIdentity: expectedIdentity)
     }
 
     public func moveWindow(target: WindowTarget, to position: CGPoint) async throws {
@@ -102,8 +141,22 @@ public final class RemoteWindowManagementService: WindowManagementServiceProtoco
         expectedIdentity: WindowMutationIdentity,
         to position: CGPoint) async throws
     {
+        _ = try await self.moveWindowWithOutcome(
+            target: target,
+            expectedIdentity: expectedIdentity,
+            to: position)
+    }
+
+    public func moveWindowWithOutcome(
+        target: WindowTarget,
+        expectedIdentity: WindowMutationIdentity,
+        to position: CGPoint) async throws -> DesktopActionOutcome?
+    {
         try self.requirePinnedWindowMutationSupport()
-        try await self.client.moveWindow(target: target, expectedIdentity: expectedIdentity, to: position)
+        return try await self.client.moveWindowWithOutcome(
+            target: target,
+            expectedIdentity: expectedIdentity,
+            to: position)
     }
 
     public func resizeWindow(target: WindowTarget, to size: CGSize) async throws {
@@ -120,8 +173,22 @@ public final class RemoteWindowManagementService: WindowManagementServiceProtoco
         expectedIdentity: WindowMutationIdentity,
         to size: CGSize) async throws
     {
+        _ = try await self.resizeWindowWithOutcome(
+            target: target,
+            expectedIdentity: expectedIdentity,
+            to: size)
+    }
+
+    public func resizeWindowWithOutcome(
+        target: WindowTarget,
+        expectedIdentity: WindowMutationIdentity,
+        to size: CGSize) async throws -> DesktopActionOutcome?
+    {
         try self.requirePinnedWindowMutationSupport()
-        try await self.client.resizeWindow(target: target, expectedIdentity: expectedIdentity, to: size)
+        return try await self.client.resizeWindowWithOutcome(
+            target: target,
+            expectedIdentity: expectedIdentity,
+            to: size)
     }
 
     public func setWindowBounds(target: WindowTarget, bounds: CGRect) async throws {
@@ -138,8 +205,19 @@ public final class RemoteWindowManagementService: WindowManagementServiceProtoco
         expectedIdentity: WindowMutationIdentity,
         bounds: CGRect) async throws
     {
+        _ = try await self.setWindowBoundsWithOutcome(
+            target: target,
+            expectedIdentity: expectedIdentity,
+            bounds: bounds)
+    }
+
+    public func setWindowBoundsWithOutcome(
+        target: WindowTarget,
+        expectedIdentity: WindowMutationIdentity,
+        bounds: CGRect) async throws -> DesktopActionOutcome?
+    {
         try self.requirePinnedWindowMutationSupport()
-        try await self.client.setWindowBounds(
+        return try await self.client.setWindowBoundsWithOutcome(
             target: target,
             expectedIdentity: expectedIdentity,
             bounds: bounds)

--- a/Core/PeekabooCore/Tests/PeekabooTests/RemoteWindowManagementServiceTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/RemoteWindowManagementServiceTests.swift
@@ -1,6 +1,8 @@
 import CoreGraphics
 import Foundation
 import PeekabooAutomationKit
+import PeekabooAutomationKitTestSupport
+import PeekabooFoundation
 import Testing
 @testable import PeekabooBridge
 @testable import PeekabooCore
@@ -13,6 +15,101 @@ struct RemoteWindowManagementServiceTests {
         ownerProcessIdentifier: 420,
         ownerProcessStartIdentity: 9001,
         capturedBounds: CGRect(x: 0, y: 0, width: 100, height: 100))
+
+    @Test
+    func `capable remote preserves every window mutation outcome through protocol 1 23`() async throws {
+        let socketPath = "/tmp/peekaboo-remote-window-outcome-\(UUID().uuidString).sock"
+        let expected = AutomationTestFixtures.canonicalActionOutcomes[0]
+        let windows = RemoteWindowMutationFixture(identity: self.identity, actionOutcome: expected)
+        let server = PeekabooBridgeServer(
+            services: StubServices(windows: windows),
+            allowlistedTeams: [],
+            allowlistedBundles: [],
+            allowedOperations: Self.allowedOperations,
+            windowOwnerProcessIdentifierProvider: { _ in 420 },
+            windowBoundsProvider: { _ in CGRect(x: 0, y: 0, width: 100, height: 100) },
+            processStartIdentityProvider: { _ in 9001 })
+        let host = PeekabooBridgeHost(
+            socketPath: socketPath,
+            server: server,
+            allowedTeamIDs: [],
+            requestTimeoutSec: 2)
+        try await host.startChecked()
+        defer { Task { await host.stop() } }
+
+        let client = PeekabooBridgeClient(socketPath: socketPath, requestTimeoutSec: 2)
+        _ = try await client.handshake(client: Self.clientIdentity)
+        let remote = RemoteWindowManagementService(
+            client: client,
+            supportsBackgroundClose: true,
+            supportsPinnedWindowMutations: true,
+            supportsWindowRestore: true)
+        let target = WindowTarget.windowId(self.identity.windowID)
+        let outcomes = try await [
+            remote.closeWindowWithOutcome(target: target, expectedIdentity: self.identity),
+            remote.minimizeWindowWithOutcome(target: target, expectedIdentity: self.identity),
+            remote.restoreWindowWithOutcome(target: target, expectedIdentity: self.identity),
+            remote.maximizeWindowWithOutcome(target: target, expectedIdentity: self.identity),
+            remote.moveWindowWithOutcome(target: target, expectedIdentity: self.identity, to: .zero),
+            remote.resizeWindowWithOutcome(target: target, expectedIdentity: self.identity, to: .zero),
+            remote.setWindowBoundsWithOutcome(target: target, expectedIdentity: self.identity, bounds: .zero),
+        ]
+
+        #expect(outcomes.allSatisfy { $0 == expected.routed(to: .bridge) })
+        for expectedOutcome in AutomationTestFixtures.canonicalActionOutcomes {
+            await windows.setActionOutcome(expectedOutcome)
+            let carried = try await remote.moveWindowWithOutcome(
+                target: target,
+                expectedIdentity: self.identity,
+                to: CGPoint(x: 12, y: 34))
+            #expect(carried == expectedOutcome.routed(to: .bridge))
+        }
+        await windows.setActionOutcome(nil)
+        #expect(try await remote.moveWindowWithOutcome(
+            target: target,
+            expectedIdentity: self.identity,
+            to: CGPoint(x: 56, y: 78)) == nil)
+        await host.stop()
+    }
+
+    @Test
+    func `legacy negotiated remote returns nil instead of fabricating window outcomes`() async throws {
+        let socketPath = "/tmp/peekaboo-remote-window-outcome-legacy-\(UUID().uuidString).sock"
+        let legacyVersion = PeekabooBridgeProtocolVersion(major: 1, minor: 22)
+        let windows = RemoteWindowMutationFixture(
+            identity: self.identity,
+            actionOutcome: AutomationTestFixtures.canonicalActionOutcomes[0])
+        let server = PeekabooBridgeServer(
+            services: StubServices(windows: windows),
+            allowlistedTeams: [],
+            allowlistedBundles: [],
+            supportedVersions: legacyVersion...legacyVersion,
+            allowedOperations: Self.allowedOperations,
+            windowOwnerProcessIdentifierProvider: { _ in 420 },
+            windowBoundsProvider: { _ in CGRect(x: 0, y: 0, width: 100, height: 100) },
+            processStartIdentityProvider: { _ in 9001 })
+        let host = PeekabooBridgeHost(
+            socketPath: socketPath,
+            server: server,
+            allowedTeamIDs: [],
+            requestTimeoutSec: 2)
+        try await host.startChecked()
+        defer { Task { await host.stop() } }
+
+        let client = PeekabooBridgeClient(socketPath: socketPath, requestTimeoutSec: 2)
+        _ = try await client.handshake(client: Self.clientIdentity, protocolVersion: legacyVersion)
+        let remote = RemoteWindowManagementService(
+            client: client,
+            supportsPinnedWindowMutations: true)
+        let outcome = try await remote.moveWindowWithOutcome(
+            target: .windowId(self.identity.windowID),
+            expectedIdentity: self.identity,
+            to: CGPoint(x: 12, y: 34))
+
+        #expect(outcome == nil)
+        #expect(await windows.pinnedMutations.map(\.operation) == ["move"])
+        await host.stop()
+    }
 
     @Test
     func `legacy mutation overloads resolve and dispatch pinned identities`() async throws {
@@ -201,6 +298,12 @@ struct RemoteWindowManagementServiceTests {
         .maximizeWindow,
     ]
 
+    private static let clientIdentity = PeekabooBridgeClientIdentity(
+        bundleIdentifier: "dev.peekaboo.window-outcome-tests",
+        teamIdentifier: nil,
+        processIdentifier: getpid(),
+        hostname: nil)
+
     private static func waitForConnectionCount(
         _ expectedCount: Int,
         host: PeekabooBridgeHost) async throws
@@ -224,8 +327,9 @@ private struct RecordedRemoteWindowMutation: Equatable {
     let identity: WindowMutationIdentity
 }
 
-private actor RemoteWindowMutationFixture: WindowManagementServiceProtocol {
+private actor RemoteWindowMutationFixture: WindowManagementActionOutcomeProviding {
     let identity: WindowMutationIdentity
+    private var actionOutcome: DesktopActionOutcome?
     private let blocksFirstLegacyMove: Bool
     private var didBlockLegacyMove = false
     private var legacyMutationStarted = false
@@ -236,9 +340,18 @@ private actor RemoteWindowMutationFixture: WindowManagementServiceProtocol {
     private(set) var pinnedMutations: [RecordedRemoteWindowMutation] = []
     private(set) var focusedTargets: [String] = []
 
-    init(identity: WindowMutationIdentity, blocksFirstLegacyMove: Bool = false) {
+    init(
+        identity: WindowMutationIdentity,
+        blocksFirstLegacyMove: Bool = false,
+        actionOutcome: DesktopActionOutcome? = nil)
+    {
         self.identity = identity
         self.blocksFirstLegacyMove = blocksFirstLegacyMove
+        self.actionOutcome = actionOutcome
+    }
+
+    func setActionOutcome(_ outcome: DesktopActionOutcome?) {
+        self.actionOutcome = outcome
     }
 
     func closeWindow(target: WindowTarget) async throws {
@@ -260,12 +373,28 @@ private actor RemoteWindowMutationFixture: WindowManagementServiceProtocol {
             identity: expectedIdentity)
     }
 
+    func closeWindowWithOutcome(
+        target: WindowTarget,
+        expectedIdentity: WindowMutationIdentity) async throws -> DesktopActionOutcome?
+    {
+        self.record("background-close", target: target, identity: expectedIdentity)
+        return self.actionOutcome
+    }
+
     func minimizeWindow(target: WindowTarget) async throws {
         self.legacyMutations.append("minimize:\(target)")
     }
 
     func minimizeWindow(target: WindowTarget, expectedIdentity: WindowMutationIdentity) async throws {
         self.record("minimize", target: target, identity: expectedIdentity)
+    }
+
+    func minimizeWindowWithOutcome(
+        target: WindowTarget,
+        expectedIdentity: WindowMutationIdentity) async throws -> DesktopActionOutcome?
+    {
+        self.record("minimize", target: target, identity: expectedIdentity)
+        return self.actionOutcome
     }
 
     func restoreWindow(target: WindowTarget) async throws {
@@ -276,12 +405,28 @@ private actor RemoteWindowMutationFixture: WindowManagementServiceProtocol {
         self.record("restore", target: target, identity: expectedIdentity)
     }
 
+    func restoreWindowWithOutcome(
+        target: WindowTarget,
+        expectedIdentity: WindowMutationIdentity) async throws -> DesktopActionOutcome?
+    {
+        self.record("restore", target: target, identity: expectedIdentity)
+        return self.actionOutcome
+    }
+
     func maximizeWindow(target: WindowTarget) async throws {
         self.legacyMutations.append("maximize:\(target)")
     }
 
     func maximizeWindow(target: WindowTarget, expectedIdentity: WindowMutationIdentity) async throws {
         self.record("maximize", target: target, identity: expectedIdentity)
+    }
+
+    func maximizeWindowWithOutcome(
+        target: WindowTarget,
+        expectedIdentity: WindowMutationIdentity) async throws -> DesktopActionOutcome?
+    {
+        self.record("maximize", target: target, identity: expectedIdentity)
+        return self.actionOutcome
     }
 
     func moveWindow(target: WindowTarget, to _: CGPoint) async throws {
@@ -308,6 +453,15 @@ private actor RemoteWindowMutationFixture: WindowManagementServiceProtocol {
         await withCheckedContinuation { self.releaseContinuation = $0 }
     }
 
+    func moveWindowWithOutcome(
+        target: WindowTarget,
+        expectedIdentity: WindowMutationIdentity,
+        to position: CGPoint) async throws -> DesktopActionOutcome?
+    {
+        try await self.moveWindow(target: target, expectedIdentity: expectedIdentity, to: position)
+        return self.actionOutcome
+    }
+
     func resizeWindow(target: WindowTarget, to _: CGSize) async throws {
         self.legacyMutations.append("resize:\(target)")
     }
@@ -320,6 +474,15 @@ private actor RemoteWindowMutationFixture: WindowManagementServiceProtocol {
         self.record("resize", target: target, identity: expectedIdentity)
     }
 
+    func resizeWindowWithOutcome(
+        target: WindowTarget,
+        expectedIdentity: WindowMutationIdentity,
+        to _: CGSize) async throws -> DesktopActionOutcome?
+    {
+        self.record("resize", target: target, identity: expectedIdentity)
+        return self.actionOutcome
+    }
+
     func setWindowBounds(target: WindowTarget, bounds _: CGRect) async throws {
         self.legacyMutations.append("set-bounds:\(target)")
     }
@@ -330,6 +493,15 @@ private actor RemoteWindowMutationFixture: WindowManagementServiceProtocol {
         bounds _: CGRect) async throws
     {
         self.record("set-bounds", target: target, identity: expectedIdentity)
+    }
+
+    func setWindowBoundsWithOutcome(
+        target: WindowTarget,
+        expectedIdentity: WindowMutationIdentity,
+        bounds _: CGRect) async throws -> DesktopActionOutcome?
+    {
+        self.record("set-bounds", target: target, identity: expectedIdentity)
+        return self.actionOutcome
     }
 
     func focusWindow(target: WindowTarget) async throws {


### PR DESCRIPTION
## Summary

- add an opt-in `WindowManagementActionOutcomeProviding` carrier for exact background window mutations
- preserve verified close, minimize, restore, maximize, move, resize, and set-bounds outcomes through Bridge protocol 1.23 and `RemoteWindowManagementService`
- report honest confirmed, no-op, refused, suspected-noop, or delivery-accepted-unverified state from the existing generation/window/bounds checks
- count the actual zero/one/two AX writes performed by set-bounds
- keep protocol 1.22, legacy services, foreground close, and focus operations on their unchanged payloads with no fabricated outcome

## Proof

- AutomationKit window outcome/policy suites: 55/55
- Bridge + Remote outcome suites: 30/30
- full ambient-disabled safe gate: Foundation 26, CLI/Core 885, runtime 88, plus provenance/release/native/certification policies
- Debug and Release builds
- SwiftFormat: 0/1,307 changed
- strict touched SwiftLint: 0 violations; repository baseline 22 warnings/0 serious
- P0-P2 review found/fixed unverifiable close mislabeled as suspected-noop; final review clean
- paired changelog review: clean at 0.99

Production delta: +944/-226. Test delta: +338/-2.
