### PR TITLE
fix: centralize pre-dispatch refusal outcomes

### DIFF
--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Wake Bridge hosts on kernel listener readiness instead of polling `accept` every 25 ms, draining queued clients per notification while preserving bounded, descriptor-safe shutdown.
 
 ### Fixed
+- Report canonical refused, retry-safe, not-dispatched outcomes for pre-dispatch CLI and MCP action validation without attaching desktop semantics to read-only errors or overwriting dispatched receipts.
 - Preserve integer-valued Agent tool data across Codable and Foundation JSON conversion instead of mistaking numeric `0` and `1` for booleans.
 - Carry verified outcomes for receipt-pinned background window close, minimize, restore, maximize, move, resize, and set-bounds through Bridge protocol 1.23 while older hosts remain conservative.
 - Bind each discovered Agent tool to its exact provider and registry generation, recover unchanged bindings after transient discovery failures while refusing ambiguous or stale ownership, and preserve boolean/integer MCP arguments through one typed conversion path.

--- a/Apps/CLI/Sources/PeekabooCLI/CLI/Output/JSONOutput.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/CLI/Output/JSONOutput.swift
@@ -1,12 +1,7 @@
 import Foundation
+import PeekabooFoundation
 
-nonisolated enum ActionEffect: String, Codable, Sendable {
-    case confirmed
-    case partial
-    case unverifiable
-    case suspectedNoop = "suspected_noop"
-    case refused
-}
+typealias ActionEffect = DesktopActionOutcome.Effect
 
 protocol ActionOutputFormattable {
     var defaultEffect: ActionEffect? { get }
@@ -29,6 +24,7 @@ nonisolated protocol ResultEnvelopeError: Error, Sendable {
     var envelopeHint: String? { get }
     var envelopeRetrySafe: Bool? { get }
     var envelopeMutationDispatched: Bool? { get }
+    var envelopeActionFailure: DesktopActionFailure? { get }
 }
 
 extension ResultEnvelopeError {
@@ -43,32 +39,30 @@ extension ResultEnvelopeError {
     nonisolated var envelopeMutationDispatched: Bool? {
         nil
     }
-}
 
-struct ActionRefusalError: LocalizedError, ResultEnvelopeError {
-    let message: String
-    let hint: String?
-
-    nonisolated var errorDescription: String? {
-        self.message
-    }
-
-    nonisolated var envelopeEffect: ActionEffect? {
-        .refused
-    }
-
-    nonisolated var envelopeHint: String? {
-        self.hint
+    nonisolated var envelopeActionFailure: DesktopActionFailure? {
+        nil
     }
 }
 
 struct PreDispatchActionError: LocalizedError, ResultEnvelopeError {
-    let message: String
+    let failure: DesktopActionFailure
     let code: ErrorCode
     let hint: String?
 
+    init(
+        message: String,
+        code: ErrorCode,
+        hint: String?,
+        reason: DesktopActionOutcome.RefusalReason
+    ) {
+        self.failure = .refused(reason: reason, message: message)
+        self.code = code
+        self.hint = hint
+    }
+
     nonisolated var errorDescription: String? {
-        self.message
+        self.failure.message
     }
 
     nonisolated var envelopeCode: ErrorCode? {
@@ -76,24 +70,21 @@ struct PreDispatchActionError: LocalizedError, ResultEnvelopeError {
     }
 
     nonisolated var envelopeEffect: ActionEffect? {
-        .refused
+        self.failure.outcome.effect
     }
 
     nonisolated var envelopeHint: String? {
         self.hint
     }
 
-    nonisolated var envelopeRetrySafe: Bool? {
-        true
-    }
-
-    nonisolated var envelopeMutationDispatched: Bool? {
-        false
+    nonisolated var envelopeActionFailure: DesktopActionFailure? {
+        self.failure
     }
 }
 
 enum ResultEnvelopeContext {
     @TaskLocal static var isActionCommand = false
+    @TaskLocal static var isPreDispatchFailure = false
 }
 
 let jsonEncodingFailureEnvelope =
@@ -103,6 +94,7 @@ let jsonEncodingFailureEnvelope =
 struct ResultEnvelope<Payload> {
     let success: Bool
     var effect: ActionEffect?
+    var outcome: DesktopActionOutcome.Projection?
     let data: Payload
     var messages: [String]?
     var debug_logs: [String] = []
@@ -240,39 +232,89 @@ func outputError(
     effect: ActionEffect? = nil,
     retrySafe: Bool? = nil,
     mutationDispatched: Bool? = nil,
+    actionFailure: DesktopActionFailure? = nil,
     logger: Logger
 ) {
-    let response = ResultEnvelope<Empty?>(
+    let response = makeErrorEnvelope(
+        message: message,
+        code: code,
+        hint: hint,
+        details: details,
+        effect: effect,
+        retrySafe: retrySafe,
+        mutationDispatched: mutationDispatched,
+        actionFailure: actionFailure,
+        debugLogs: logger.getDebugLogs()
+    )
+    outputJSONCodable(response, logger: logger)
+}
+
+func makeErrorEnvelope(
+    message: String,
+    code: ErrorCode,
+    hint: String? = nil,
+    details: String? = nil,
+    effect: ActionEffect? = nil,
+    retrySafe: Bool? = nil,
+    mutationDispatched: Bool? = nil,
+    actionFailure: DesktopActionFailure? = nil,
+    debugLogs: [String] = []
+) -> ResultEnvelope<Empty?> {
+    let suppliedOutcome = actionFailure?.outcome.projection
+    let resolvedEffect = suppliedOutcome?.effect ?? effect ??
+        (ResultEnvelopeContext.isActionCommand ? defaultActionErrorEffect(code) : nil)
+    let resolvedOutcome = suppliedOutcome ?? defaultActionRefusalProjection(effect: resolvedEffect, code: code)
+    return ResultEnvelope(
         success: false,
-        effect: effect ?? (ResultEnvelopeContext.isActionCommand ? defaultActionErrorEffect(code) : nil),
+        effect: resolvedOutcome?.effect ?? resolvedEffect,
+        outcome: resolvedOutcome,
         data: nil,
-        debug_logs: logger.getDebugLogs(),
+        debug_logs: debugLogs,
         error: ErrorInfo(
             message: message,
             code: code,
             hint: hint,
             details: details,
-            retrySafe: retrySafe,
-            mutationDispatched: mutationDispatched
+            retrySafe: resolvedOutcome?.retrySafe ?? retrySafe,
+            mutationDispatched: resolvedOutcome?.mutationDispatched ?? mutationDispatched
         )
     )
-    outputJSONCodable(response, logger: logger)
+}
+
+func defaultActionRefusalProjection(
+    effect: ActionEffect?,
+    code: ErrorCode
+) -> DesktopActionOutcome.Projection? {
+    guard ResultEnvelopeContext.isActionCommand,
+          ResultEnvelopeContext.isPreDispatchFailure,
+          effect == .refused,
+          let reason = defaultActionRefusalReason(code)
+    else {
+        return nil
+    }
+    return DesktopActionOutcome.refused(reason: reason).projection
+}
+
+func defaultActionRefusalReason(_ code: ErrorCode) -> DesktopActionOutcome.RefusalReason? {
+    switch code {
+    case .INVALID_ARGUMENT, .VALIDATION_ERROR, .INVALID_INPUT, .AMBIGUOUS_APP_IDENTIFIER,
+         .NO_POINT_SPECIFIED, .INVALID_COORDINATES:
+        .invalidRequest
+    case .PERMISSION_DENIED, .PERMISSION_ERROR_SCREEN_RECORDING, .PERMISSION_ERROR_ACCESSIBILITY,
+         .PERMISSION_ERROR_EVENT_SYNTHESIZING, .PERMISSION_ERROR_APPLESCRIPT:
+        .permissionDenied
+    case .APP_NOT_FOUND, .WINDOW_NOT_FOUND, .ELEMENT_NOT_FOUND,
+         .APPLICATION_NOT_FOUND, .SESSION_NOT_FOUND, .SNAPSHOT_NOT_FOUND, .SNAPSHOT_STALE,
+         .NO_ACTIVE_DIALOG, .MENU_BAR_NOT_FOUND, .MENU_ITEM_NOT_FOUND, .DOCK_NOT_FOUND,
+         .DOCK_LIST_NOT_FOUND, .DOCK_ITEM_NOT_FOUND, .POSITION_NOT_FOUND:
+        .targetUnavailable
+    default:
+        nil
+    }
 }
 
 func defaultActionErrorEffect(_ code: ErrorCode) -> ActionEffect {
-    switch code {
-    case .INVALID_ARGUMENT, .VALIDATION_ERROR, .INVALID_INPUT,
-         .PERMISSION_DENIED, .PERMISSION_ERROR_SCREEN_RECORDING, .PERMISSION_ERROR_ACCESSIBILITY,
-         .PERMISSION_ERROR_EVENT_SYNTHESIZING, .PERMISSION_ERROR_APPLESCRIPT,
-         .APP_NOT_FOUND, .AMBIGUOUS_APP_IDENTIFIER, .WINDOW_NOT_FOUND, .ELEMENT_NOT_FOUND,
-         .APPLICATION_NOT_FOUND, .SESSION_NOT_FOUND, .SNAPSHOT_NOT_FOUND, .SNAPSHOT_STALE,
-         .NO_POINT_SPECIFIED, .INVALID_COORDINATES, .NO_ACTIVE_DIALOG,
-         .MENU_BAR_NOT_FOUND, .MENU_ITEM_NOT_FOUND, .DOCK_NOT_FOUND, .DOCK_LIST_NOT_FOUND,
-         .DOCK_ITEM_NOT_FOUND, .POSITION_NOT_FOUND:
-        .refused
-    default:
-        .unverifiable
-    }
+    defaultActionRefusalReason(code) == nil ? .unverifiable : .refused
 }
 
 struct Empty: Codable {}

--- a/Apps/CLI/Sources/PeekabooCLI/CLI/Output/JSONOutput.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/CLI/Output/JSONOutput.swift
@@ -45,6 +45,37 @@ extension ResultEnvelopeError {
     }
 }
 
+struct ActionErrorEnvelopeMetadata {
+    let failure: DesktopActionFailure?
+    let effect: ActionEffect?
+    let retrySafe: Bool?
+    let mutationDispatched: Bool?
+}
+
+func actionErrorEnvelopeMetadata(
+    for error: any Error,
+    isActionCommand: Bool
+) -> ActionErrorEnvelopeMetadata {
+    guard isActionCommand else {
+        return ActionErrorEnvelopeMetadata(
+            failure: nil,
+            effect: nil,
+            retrySafe: nil,
+            mutationDispatched: nil
+        )
+    }
+
+    let envelopeError = error as? any ResultEnvelopeError
+    let failure = (error as? DesktopActionFailure) ?? envelopeError?.envelopeActionFailure
+    return ActionErrorEnvelopeMetadata(
+        failure: failure,
+        effect: failure?.outcome.effect ?? envelopeError?.envelopeEffect,
+        retrySafe: failure.map { $0.outcome.retrySafety == .safe } ?? envelopeError?.envelopeRetrySafe,
+        mutationDispatched: failure?.outcome.dispatchState.mutationDispatched ??
+            envelopeError?.envelopeMutationDispatched
+    )
+}
+
 struct PreDispatchActionError: LocalizedError, ResultEnvelopeError {
     let failure: DesktopActionFailure
     let code: ErrorCode

--- a/Apps/CLI/Sources/PeekabooCLI/CLI/Output/JSONOutput.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/CLI/Output/JSONOutput.swift
@@ -77,6 +77,14 @@ struct PreDispatchActionError: LocalizedError, ResultEnvelopeError {
         self.hint
     }
 
+    nonisolated var envelopeRetrySafe: Bool? {
+        self.failure.outcome.retrySafety == .safe
+    }
+
+    nonisolated var envelopeMutationDispatched: Bool? {
+        self.failure.outcome.dispatchState.mutationDispatched
+    }
+
     nonisolated var envelopeActionFailure: DesktopActionFailure? {
         self.failure
     }

--- a/Apps/CLI/Sources/PeekabooCLI/CLI/PeekabooEntryPoint.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/CLI/PeekabooEntryPoint.swift
@@ -82,7 +82,11 @@ private func printGenericError(_ error: any Error, jsonOutput: Bool) {
         .UNKNOWN_ERROR
     }
     let code = envelopeError?.envelopeCode ?? fallbackCode
-    let actionFailure = ResultEnvelopeContext.isActionCommand ? envelopeError?.envelopeActionFailure : nil
+    let actionMetadata = actionErrorEnvelopeMetadata(
+        for: error,
+        isActionCommand: ResultEnvelopeContext.isActionCommand
+    )
+    let actionFailure = actionMetadata.failure
 
     guard jsonOutput else {
         let hint = envelopeError?.envelopeHint.map { " Hint: \($0)" } ?? ""
@@ -92,16 +96,15 @@ private func printGenericError(_ error: any Error, jsonOutput: Bool) {
 
     let logger = Logger.shared
     logger.setJsonOutputMode(true)
-    let isGenericPreDispatchFailure = error is CommanderBindingError || error is CommanderUsageError ||
-        error is Commander.ValidationError
+    let isGenericPreDispatchFailure = isGenericPreDispatchError(error)
     ResultEnvelopeContext.$isPreDispatchFailure.withValue(isGenericPreDispatchFailure) {
         outputError(
             message: error.localizedDescription,
             code: code,
             hint: envelopeError?.envelopeHint,
-            effect: envelopeError?.envelopeEffect,
-            retrySafe: envelopeError?.envelopeRetrySafe,
-            mutationDispatched: envelopeError?.envelopeMutationDispatched,
+            effect: actionMetadata.effect,
+            retrySafe: actionMetadata.retrySafe,
+            mutationDispatched: actionMetadata.mutationDispatched,
             actionFailure: actionFailure,
             logger: logger
         )

--- a/Apps/CLI/Sources/PeekabooCLI/CLI/PeekabooEntryPoint.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/CLI/PeekabooEntryPoint.swift
@@ -67,7 +67,9 @@ private func printCommanderError(_ error: CommanderProgramError, jsonOutput: Boo
 
     let logger = Logger.shared
     logger.setJsonOutputMode(true)
-    outputError(message: message, code: .INVALID_ARGUMENT, logger: logger)
+    ResultEnvelopeContext.$isPreDispatchFailure.withValue(true) {
+        outputError(message: message, code: .INVALID_ARGUMENT, logger: logger)
+    }
 }
 
 private func printGenericError(_ error: any Error, jsonOutput: Bool) {
@@ -80,6 +82,7 @@ private func printGenericError(_ error: any Error, jsonOutput: Bool) {
         .UNKNOWN_ERROR
     }
     let code = envelopeError?.envelopeCode ?? fallbackCode
+    let actionFailure = ResultEnvelopeContext.isActionCommand ? envelopeError?.envelopeActionFailure : nil
 
     guard jsonOutput else {
         let hint = envelopeError?.envelopeHint.map { " Hint: \($0)" } ?? ""
@@ -89,13 +92,18 @@ private func printGenericError(_ error: any Error, jsonOutput: Bool) {
 
     let logger = Logger.shared
     logger.setJsonOutputMode(true)
-    outputError(
-        message: error.localizedDescription,
-        code: code,
-        hint: envelopeError?.envelopeHint,
-        effect: envelopeError?.envelopeEffect,
-        retrySafe: envelopeError?.envelopeRetrySafe,
-        mutationDispatched: envelopeError?.envelopeMutationDispatched,
-        logger: logger
-    )
+    let isGenericPreDispatchFailure = error is CommanderBindingError || error is CommanderUsageError ||
+        error is Commander.ValidationError
+    ResultEnvelopeContext.$isPreDispatchFailure.withValue(isGenericPreDispatchFailure) {
+        outputError(
+            message: error.localizedDescription,
+            code: code,
+            hint: envelopeError?.envelopeHint,
+            effect: envelopeError?.envelopeEffect,
+            retrySafe: envelopeError?.envelopeRetrySafe,
+            mutationDispatched: envelopeError?.envelopeMutationDispatched,
+            actionFailure: actionFailure,
+            logger: logger
+        )
+    }
 }

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommandErrorHandling.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommandErrorHandling.swift
@@ -18,11 +18,8 @@ extension ErrorHandlingCommand {
         if jsonOutput {
             let envelopeError = error as? any ResultEnvelopeError
             let isActionCommand = (self as? any ActionOutputFormattable)?.defaultEffect != nil
-            let actionFailure: DesktopActionFailure? = if isActionCommand {
-                (error as? DesktopActionFailure) ?? envelopeError?.envelopeActionFailure
-            } else {
-                nil
-            }
+            let actionMetadata = actionErrorEnvelopeMetadata(for: error, isActionCommand: isActionCommand)
+            let actionFailure = actionMetadata.failure
             let lifecycleRefusal = applicationLifecycleRefusalProjection(for: error)
             let lifecycleFailure = applicationLifecycleFailureProjection(for: error)
             let errorCode = customCode ?? envelopeError?.envelopeCode ?? self.mapErrorToCode(error)
@@ -37,24 +34,25 @@ extension ErrorHandlingCommand {
             } else {
                 Logger.shared
             }
-            outputError(
-                message: errorMessage(for: error),
-                code: errorCode,
-                hint: envelopeError?.envelopeHint ?? actionFailure?.hint ?? lifecycleFailure?.metadata.hint,
-                details: actionFailure?.causeDescription ?? errorDetails(for: error),
-                effect: actionFailure?.outcome.effect ?? lifecycleFailure?.effect
-                    ?? (lifecycleRefusal != nil ? .refused
-                        : failureReceipt?.mutationDispatched == true
-                        ? .partial
-                        : envelopeError?.envelopeEffect ??
-                        ((self as? any ActionOutputFormattable)?.defaultEffect == nil
-                            ? nil
-                            : defaultActionErrorEffect(errorCode))),
-                retrySafe: failureReceipt?.retrySafe ?? envelopeError?.envelopeRetrySafe,
-                mutationDispatched: failureReceipt?.mutationDispatched ?? envelopeError?.envelopeMutationDispatched,
-                actionFailure: actionFailure,
-                logger: logger
-            )
+            let isPreDispatchFailure = ResultEnvelopeContext.isPreDispatchFailure ||
+                isGenericPreDispatchError(error)
+            ResultEnvelopeContext.$isPreDispatchFailure.withValue(isPreDispatchFailure) {
+                outputError(
+                    message: errorMessage(for: error),
+                    code: errorCode,
+                    hint: envelopeError?.envelopeHint ?? actionFailure?.hint ?? lifecycleFailure?.metadata.hint,
+                    details: actionFailure?.causeDescription ?? errorDetails(for: error),
+                    effect: actionMetadata.effect ?? lifecycleFailure?.effect
+                        ?? (lifecycleRefusal != nil ? .refused
+                            : failureReceipt?.mutationDispatched == true
+                            ? .partial
+                            : isActionCommand ? defaultActionErrorEffect(errorCode) : nil),
+                    retrySafe: failureReceipt?.retrySafe ?? actionMetadata.retrySafe,
+                    mutationDispatched: failureReceipt?.mutationDispatched ?? actionMetadata.mutationDispatched,
+                    actionFailure: actionFailure,
+                    logger: logger
+                )
+            }
         } else {
             let errorMessage: String = if let peekabooError = error as? PeekabooError {
                 peekabooError.errorDescription ?? String(describing: error)
@@ -295,6 +293,10 @@ extension ErrorHandlingCommand {
         guard isIncomplete else { return nil }
         return CaptureFailureReceipt(retrySafe: true, mutationDispatched: false)
     }
+}
+
+func isGenericPreDispatchError(_ error: any Error) -> Bool {
+    error is CommanderBindingError || error is CommanderUsageError || error is Commander.ValidationError
 }
 
 struct CaptureFailureReceipt: Equatable {

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommandErrorHandling.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommandErrorHandling.swift
@@ -17,6 +17,12 @@ extension ErrorHandlingCommand {
     func handleError(_ error: any Error, customCode: ErrorCode? = nil) {
         if jsonOutput {
             let envelopeError = error as? any ResultEnvelopeError
+            let isActionCommand = (self as? any ActionOutputFormattable)?.defaultEffect != nil
+            let actionFailure: DesktopActionFailure? = if isActionCommand {
+                (error as? DesktopActionFailure) ?? envelopeError?.envelopeActionFailure
+            } else {
+                nil
+            }
             let lifecycleRefusal = applicationLifecycleRefusalProjection(for: error)
             let lifecycleFailure = applicationLifecycleFailureProjection(for: error)
             let errorCode = customCode ?? envelopeError?.envelopeCode ?? self.mapErrorToCode(error)
@@ -34,9 +40,9 @@ extension ErrorHandlingCommand {
             outputError(
                 message: errorMessage(for: error),
                 code: errorCode,
-                hint: envelopeError?.envelopeHint ?? lifecycleFailure?.metadata.hint,
-                details: errorDetails(for: error),
-                effect: lifecycleFailure?.effect
+                hint: envelopeError?.envelopeHint ?? actionFailure?.hint ?? lifecycleFailure?.metadata.hint,
+                details: actionFailure?.causeDescription ?? errorDetails(for: error),
+                effect: actionFailure?.outcome.effect ?? lifecycleFailure?.effect
                     ?? (lifecycleRefusal != nil ? .refused
                         : failureReceipt?.mutationDispatched == true
                         ? .partial
@@ -46,6 +52,7 @@ extension ErrorHandlingCommand {
                             : defaultActionErrorEffect(errorCode))),
                 retrySafe: failureReceipt?.retrySafe ?? envelopeError?.envelopeRetrySafe,
                 mutationDispatched: failureReceipt?.mutationDispatched ?? envelopeError?.envelopeMutationDispatched,
+                actionFailure: actionFailure,
                 logger: logger
             )
         } else {
@@ -86,12 +93,12 @@ extension ErrorHandlingCommand {
             errorCode(for: bridgeError)
         case is ApplicationLifecycleRefusalError:
             .INTERACTION_FAILED
+        case is DesktopActionFailure:
+            .INTERACTION_FAILED
         case let failure as ApplicationLifecycleReadOnlyFailureError:
             self.mapPeekabooErrorToCode(failure.underlyingError)
         case let posixError as POSIXError:
             errorCode(for: posixError)
-        case is ActionRefusalError:
-            .VALIDATION_ERROR
         case is CaptureCadenceValidationError:
             .VALIDATION_ERROR
         case is Commander.ValidationError:
@@ -382,7 +389,8 @@ func applicationLifecyclePreDispatchError(
     PreDispatchActionError(
         message: error.userMessage,
         code: .INTERACTION_FAILED,
-        hint: error.hint
+        hint: error.hint,
+        reason: .foregroundConsentRequired
     )
 }
 

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/RuntimeHostResolver+ScreenCaptureKitOwner.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/RuntimeHostResolver+ScreenCaptureKitOwner.swift
@@ -227,7 +227,8 @@ extension RuntimeHostResolver {
         return PreDispatchActionError(
             message: "Peekaboo could not establish safe ScreenCaptureKit process ownership. No capture was dispatched.",
             code: .CAPTURE_FAILED,
-            hint: error.localizedDescription
+            hint: error.localizedDescription,
+            reason: .runtimeIncompatible
         )
     }
 
@@ -247,7 +248,8 @@ extension RuntimeHostResolver {
                 "ScreenCaptureKit ownership. No capture was dispatched.",
             code: .CAPTURE_FAILED,
             hint: "Update and relaunch Peekaboo, or verify and stop that exact host before retrying. " +
-                "Peekaboo will not start a second ScreenCaptureKit owner while it remains live."
+                "Peekaboo will not start a second ScreenCaptureKit owner while it remains live.",
+            reason: .runtimeIncompatible
         )
     }
 
@@ -351,7 +353,12 @@ extension RuntimeHostResolver {
             "Use a Bridge socket served by exactly \(ownerText); otherwise verify and stop that exact owner, " +
                 "or explicitly choose --capture-engine classic."
         }
-        return PreDispatchActionError(message: message, code: .CAPTURE_FAILED, hint: hint)
+        return PreDispatchActionError(
+            message: message,
+            code: .CAPTURE_FAILED,
+            hint: hint,
+            reason: .runtimeIncompatible
+        )
     }
 
     static func ownerRefusal(
@@ -364,7 +371,8 @@ extension RuntimeHostResolver {
                 "ScreenCaptureKit owner (\(ownerText)). No capture was dispatched.",
             code: .CAPTURE_FAILED,
             hint: "Change or remove --bridge-socket to select the exact owner host; otherwise verify and stop " +
-                "\(ownerText), or explicitly choose --capture-engine classic."
+                "\(ownerText), or explicitly choose --capture-engine classic.",
+            reason: .runtimeIncompatible
         )
     }
 
@@ -378,7 +386,8 @@ extension RuntimeHostResolver {
                 "runtime at \(requiredSocket). No capture was dispatched.",
             code: .CAPTURE_FAILED,
             hint: "Stop or upgrade the exact owner before retrying. Peekaboo will not violate process ownership " +
-                "or route stateful snapshot work to a different build."
+                "or route stateful snapshot work to a different build.",
+            reason: .runtimeIncompatible
         )
     }
 

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/ClickCommand+Validation.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/ClickCommand+Validation.swift
@@ -18,7 +18,7 @@ extension ClickCommand {
         }
 
         if let coordString = self.at, Self.parseCoordinates(coordString) == nil {
-            throw ValidationError("Invalid coordinates format. Use: x,y")
+            throw Self.invalidCoordinatesRefusal
         }
 
         if self.global && self.at == nil {

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/ClickCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/ClickCommand.swift
@@ -77,7 +77,7 @@ struct ClickCommand: ActionOutputFormattable, ErrorHandlingCommand, OutputFormat
             // one capture-owned exact-window receipt from a named snapshot.
             if let coordString = at {
                 guard let point = Self.parseCoordinates(coordString) else {
-                    throw ValidationError("Invalid coordinates format. Use: x,y")
+                    throw Self.invalidCoordinatesRefusal
                 }
                 let coordinateSnapshotId = self.snapshot?.trimmingCharacters(in: .whitespacesAndNewlines)
                 let resolvedCoordinates: InteractionCoordinateResolution
@@ -908,9 +908,17 @@ struct ClickCommand: ActionOutputFormattable, ErrorHandlingCommand, OutputFormat
 }
 
 extension ClickCommand {
-    private static let backgroundCoordinateRefusal = ActionRefusalError(
+    private static let backgroundCoordinateRefusal = PreDispatchActionError(
         message: backgroundCoordinateReferenceMessage,
-        hint: "Use --foreground for explicit global input."
+        code: .VALIDATION_ERROR,
+        hint: "Use --foreground for explicit global input.",
+        reason: .invalidRequest
+    )
+    static let invalidCoordinatesRefusal = PreDispatchActionError(
+        message: "Invalid coordinates format. Use: x,y",
+        code: .VALIDATION_ERROR,
+        hint: nil,
+        reason: .invalidRequest
     )
     private static let backgroundCoordinateReferenceMessage =
         "Background coordinate clicks require --snapshot from a fresh see capture of the exact target window. " +

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/DragCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/DragCommand.swift
@@ -195,9 +195,11 @@ struct DragCommand: ActionOutputFormattable, ErrorHandlingCommand, OutputFormatt
             throw ValidationError("Specify only one of --to or --to-app")
         }
         guard self.focusOptions.foreground else {
-            throw ActionRefusalError(
+            throw PreDispatchActionError(
                 message: "drag changes the physical cursor and requires explicit consent.",
-                hint: "Use --foreground to provide explicit consent."
+                code: .VALIDATION_ERROR,
+                hint: "Use --foreground to provide explicit consent.",
+                reason: .foregroundConsentRequired
             )
         }
         guard self.resolvedButton != nil else {

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/KeyboardDeliverySupport.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/KeyboardDeliverySupport.swift
@@ -103,9 +103,11 @@ enum KeyboardDeliverySupport {
             )
         }
 
-        throw ValidationError(
-            "Keyboard input requires --app, --pid, or --snapshot for background delivery. " +
-                "Use --foreground for intentional global input."
+        throw PreDispatchActionError(
+            message: "Keyboard input requires --app, --pid, or --snapshot for background delivery.",
+            code: .VALIDATION_ERROR,
+            hint: "Use --foreground for intentional global input.",
+            reason: .invalidRequest
         )
     }
 

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/MoveCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/MoveCommand.swift
@@ -53,9 +53,11 @@ struct MoveCommand: ActionOutputFormattable, ErrorHandlingCommand, OutputFormatt
             throw ValidationError("Specify exactly one target: --at or --on")
         }
         guard self.focusOptions.foreground else {
-            throw ActionRefusalError(
+            throw PreDispatchActionError(
                 message: "move changes the physical cursor and requires explicit consent.",
-                hint: "Use --foreground to provide explicit consent."
+                code: .VALIDATION_ERROR,
+                hint: "Use --foreground to provide explicit consent.",
+                reason: .foregroundConsentRequired
             )
         }
 

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/PressCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/PressCommand.swift
@@ -11,7 +11,8 @@ RuntimeOptionsConfigurable {
     private static let foregroundConsentRequired = PreDispatchActionError(
         message: RawPressPolicy.foregroundConsentRequiredMessage,
         code: .INTERACTION_FAILED,
-        hint: RawPressPolicy.foregroundConsentRequiredHint
+        hint: RawPressPolicy.foregroundConsentRequiredHint,
+        reason: .foregroundConsentRequired
     )
 
     @Argument(

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/ScrollCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/ScrollCommand.swift
@@ -158,9 +158,11 @@ struct ScrollCommand: ActionOutputFormattable, ErrorHandlingCommand, OutputForma
     private func validateDeliveryMode() throws {
         guard self.focusOptions.foreground else {
             if self.on == nil {
-                throw ActionRefusalError(
+                throw PreDispatchActionError(
                     message: "Background scroll requires --on with an Accessibility-scrollable element.",
-                    hint: "Add --foreground to scroll at the physical pointer."
+                    code: .VALIDATION_ERROR,
+                    hint: "Add --foreground to scroll at the physical pointer.",
+                    reason: .invalidRequest
                 )
             }
             if self.smooth || self.delay.milliseconds > 0 {

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/SetValueCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/SetValueCommand.swift
@@ -2,6 +2,7 @@ import Commander
 import Foundation
 import PeekabooAutomationKit
 import PeekabooCore
+import PeekabooFoundation
 
 @available(macOS 14.0, *)
 @MainActor
@@ -185,8 +186,10 @@ enum ElementActionCommandExecutor {
                     refreshRuntime.beginInteractionMutation(at: startedAt)
                 }
             )
-            try await observation.validateIfExplicit(using: services.snapshots)
-            let actionSnapshotId = try observation.requireSnapshot()
+            let actionSnapshotId = try await self.requireActionSnapshot(
+                observation,
+                snapshots: services.snapshots
+            )
             let startTime = Date()
             runtime.beginInteractionMutation()
             if Self.shouldFocus(target: target, focusOptions: context.focusOptions) {
@@ -232,5 +235,30 @@ enum ElementActionCommandExecutor {
 
     static func shouldAllowWebFocusFallback(focusOptions: FocusCommandOptions) -> Bool {
         focusOptions.foreground && focusOptions.autoFocus
+    }
+
+    private static func requireActionSnapshot(
+        _ observation: InteractionObservationContext,
+        snapshots: any SnapshotManagerProtocol
+    ) async throws -> String {
+        do {
+            try await observation.validateIfExplicit(using: snapshots)
+            return try observation.requireSnapshot()
+        } catch let error as PeekabooError {
+            let code: ErrorCode = switch error {
+            case .snapshotNotFound, .snapshotNotAvailable:
+                .SNAPSHOT_NOT_FOUND
+            case .snapshotStale:
+                .SNAPSHOT_STALE
+            default:
+                throw error
+            }
+            throw PreDispatchActionError(
+                message: error.localizedDescription,
+                code: code,
+                hint: nil,
+                reason: .targetUnavailable
+            )
+        }
     }
 }

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/DockCommand+Launch.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/DockCommand+Launch.swift
@@ -26,9 +26,11 @@ extension DockCommand {
 
             do {
                 guard self.foreground else {
-                    throw ActionRefusalError(
+                    throw PreDispatchActionError(
                         message: "dock launch activates its target and requires explicit foreground consent.",
-                        hint: "Use --foreground to allow the Dock and target application to come forward."
+                        code: .VALIDATION_ERROR,
+                        hint: "Use --foreground to allow the Dock and target application to come forward.",
+                        reason: .foregroundConsentRequired
                     )
                 }
                 self.resolvedRuntime.beginInteractionMutation()

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/DockCommand+RightClick.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/DockCommand+RightClick.swift
@@ -24,9 +24,11 @@ extension DockCommand {
 
             do {
                 guard self.foreground else {
-                    throw ActionRefusalError(
+                    throw PreDispatchActionError(
                         message: "dock right-click opens global Dock UI and requires explicit foreground consent.",
-                        hint: "Use --foreground to allow the Dock context menu to open."
+                        code: .VALIDATION_ERROR,
+                        hint: "Use --foreground to allow the Dock context menu to open.",
+                        reason: .foregroundConsentRequired
                     )
                 }
                 let dockItem = try await DockServiceBridge.findDockItem(dock: self.services.dock, name: self.app)

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/MenuBarCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/MenuBarCommand.swift
@@ -9,14 +9,16 @@ private enum MenuBarClickPreflight {
         message: "Menu bar clicks require --foreground because status items open global UI.",
         code: .VALIDATION_ERROR,
         hint: "Re-run with --foreground only when interrupting the user's menu bar is acceptable. " +
-            "Use 'peekaboo menubar list' for read-only discovery."
+            "Use 'peekaboo menubar list' for read-only discovery.",
+        reason: .foregroundConsentRequired
     )
 
     static func itemNotFound(_ item: String, hint: String) -> PreDispatchActionError {
         PreDispatchActionError(
             message: "Menu bar item not found: \(item)",
             code: .MENU_ITEM_NOT_FOUND,
-            hint: hint
+            hint: hint,
+            reason: .targetUnavailable
         )
     }
 }
@@ -111,7 +113,8 @@ struct MenuBarActionCommand: ErrorHandlingCommand, OutputFormattable, InjectedRu
                 throw PreDispatchActionError(
                     message: "Provide a menu bar item name or use --index.",
                     code: .VALIDATION_ERROR,
-                    hint: "Run 'peekaboo menubar list' to discover available status items."
+                    hint: "Run 'peekaboo menubar list' to discover available status items.",
+                    reason: .invalidRequest
                 )
             }
 
@@ -166,7 +169,8 @@ struct MenuBarActionCommand: ErrorHandlingCommand, OutputFormattable, InjectedRu
                 throw PreDispatchActionError(
                     message: "Provide a menu bar item name or use --index.",
                     code: .VALIDATION_ERROR,
-                    hint: "Run 'peekaboo menubar list' to discover available status items."
+                    hint: "Run 'peekaboo menubar list' to discover available status items.",
+                    reason: .invalidRequest
                 )
             }
             requestedName = name

--- a/Apps/CLI/Tests/CLIAutomationTests/PreDispatchActionEnvelopeTests.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/PreDispatchActionEnvelopeTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import PeekabooFoundation
 import Testing
 @testable import PeekabooCLI
 
@@ -7,6 +8,7 @@ struct PreDispatchActionEnvelopeTests {
     private struct FailureEnvelope: Decodable {
         let success: Bool
         let effect: ActionEffect?
+        let outcome: DesktopActionOutcome.Projection?
         let data: Empty?
         let error: ErrorInfo?
     }
@@ -74,8 +76,65 @@ struct PreDispatchActionEnvelopeTests {
             #expect(envelope.effect == .refused, "Action was not refused for \(testCase.name)")
             #expect(envelope.data == nil)
             #expect(envelope.error?.code == testCase.errorCode.rawValue)
+            Self.expectCanonicalRefusal(envelope, reason: .invalidRequest, name: testCase.name)
             #expect(object["effect"] as? String == ActionEffect.refused.rawValue)
             #expect(object["data"] is NSNull)
+            #expect(result.stderr.isEmpty)
+        }
+    }
+
+    @Test
+    func `source-blind refusal fixtures carry canonical zero-dispatch outcomes`() async throws {
+        let cases: [(name: String, arguments: [String], code: ErrorCode, reason: DesktopActionOutcome.RefusalReason)] =
+            [
+                (
+                    "background coordinate click without receipt",
+                    ["click", "--at", "10,10", "--json"],
+                    .VALIDATION_ERROR,
+                    .invalidRequest
+                ),
+                (
+                    "snapshotless action",
+                    ["action", "AXPress", "--on", "B1", "--json"],
+                    .SNAPSHOT_NOT_FOUND,
+                    .targetUnavailable
+                ),
+                (
+                    "snapshotless set-value",
+                    ["set-value", "hello", "--on", "T1", "--json"],
+                    .SNAPSHOT_NOT_FOUND,
+                    .targetUnavailable
+                ),
+                (
+                    "targetless background scroll",
+                    ["scroll", "--direction", "down", "--json"],
+                    .VALIDATION_ERROR,
+                    .invalidRequest
+                ),
+                (
+                    "targetless background type",
+                    ["type", "hello", "--json"],
+                    .VALIDATION_ERROR,
+                    .invalidRequest
+                ),
+                (
+                    "malformed coordinate click",
+                    ["click", "--at", ",", "--json"],
+                    .VALIDATION_ERROR,
+                    .invalidRequest
+                ),
+            ]
+
+        for testCase in cases {
+            let result = try await InProcessCommandRunner.runShared(
+                testCase.arguments,
+                allowedExitCodes: [1]
+            )
+            let envelope = try JSONDecoder().decode(FailureEnvelope.self, from: Data(result.stdout.utf8))
+
+            #expect(envelope.success == false, "Expected failure for \(testCase.name)")
+            #expect(envelope.error?.code == testCase.code.rawValue)
+            Self.expectCanonicalRefusal(envelope, reason: testCase.reason, name: testCase.name)
             #expect(result.stderr.isEmpty)
         }
     }
@@ -135,8 +194,11 @@ struct PreDispatchActionEnvelopeTests {
 
             #expect(envelope.success == false, "Expected failure for \(testCase.name)")
             #expect(envelope.effect == nil, "Read-only command gained an effect for \(testCase.name)")
+            #expect(envelope.outcome == nil, "Read-only command gained an outcome for \(testCase.name)")
             #expect(envelope.data == nil)
             #expect(envelope.error?.code == testCase.errorCode.rawValue)
+            #expect(envelope.error?.retry_safe == nil)
+            #expect(envelope.error?.mutation_dispatched == nil)
             #expect(object["effect"] == nil, "Read-only command emitted an effect key for \(testCase.name)")
             #expect(object["data"] is NSNull)
             #expect(result.stderr.isEmpty)
@@ -162,5 +224,23 @@ struct PreDispatchActionEnvelopeTests {
         #expect(bindingResult.stderr.hasPrefix("Error: "))
         #expect(!bindingResult.stderr.contains("\"effect\""))
         #expect(!bindingResult.stderr.contains("{"))
+    }
+
+    private static func expectCanonicalRefusal(
+        _ envelope: FailureEnvelope,
+        reason: DesktopActionOutcome.RefusalReason,
+        name: String
+    ) {
+        #expect(envelope.effect == .refused, "Action was not refused for \(name)")
+        #expect(envelope.outcome?.state == .refused, "Missing canonical refusal for \(name)")
+        #expect(envelope.outcome?.refusalReason == reason, "Wrong refusal reason for \(name)")
+        #expect(
+            envelope.outcome?.dispatchState == DesktopActionOutcome.DispatchState.none,
+            "Dispatch was claimed for \(name)"
+        )
+        #expect(envelope.outcome?.retrySafe == true, "Retry was not safe for \(name)")
+        #expect(envelope.outcome?.requiresFreshObservation == false, "Fresh observation was requested for \(name)")
+        #expect(envelope.error?.retry_safe == true, "Legacy retry field disagreed for \(name)")
+        #expect(envelope.error?.mutation_dispatched == false, "Legacy dispatch field disagreed for \(name)")
     }
 }

--- a/Apps/CLI/Tests/CLIAutomationTests/PreDispatchActionEnvelopeTests.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/PreDispatchActionEnvelopeTests.swift
@@ -61,6 +61,13 @@ struct PreDispatchActionEnvelopeTests {
                 ],
                 errorCode: .VALIDATION_ERROR
             ),
+            ValidationCase(
+                name: "drag handler validation",
+                arguments: [
+                    "drag", "--from", "1,1", "--to", "2,2", "--button", "middle", "--foreground", "--json",
+                ],
+                errorCode: .VALIDATION_ERROR
+            ),
         ]
 
         for testCase in cases {

--- a/Apps/CLI/Tests/CoreCLITests/ResultEnvelopeTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/ResultEnvelopeTests.swift
@@ -77,13 +77,16 @@ struct ResultEnvelopeTests {
     }
 
     @Test func `safety refusal carries refused effect and explicit hint`() {
-        let error = ActionRefusalError(
+        let error = PreDispatchActionError(
             message: "Background coordinate clicks require a fresh snapshot.",
-            hint: "Use --foreground for explicit global input."
+            code: .VALIDATION_ERROR,
+            hint: "Use --foreground for explicit global input.",
+            reason: .invalidRequest
         )
 
         #expect(error.envelopeEffect == .refused)
         #expect(error.envelopeHint == "Use --foreground for explicit global input.")
+        #expect(error.envelopeActionFailure?.outcome.refusalReason == .invalidRequest)
     }
 
     @Test func `encoding fallback remains valid JSON`() throws {
@@ -104,6 +107,65 @@ struct ResultEnvelopeTests {
     @Test func `pre-dispatch validation is refused`() {
         #expect(defaultActionErrorEffect(.VALIDATION_ERROR) == .refused)
         #expect(defaultActionErrorEffect(.INTERACTION_FAILED) == .unverifiable)
+        #expect(defaultActionRefusalReason(.AMBIGUOUS_APP_IDENTIFIER) == .invalidRequest)
+    }
+
+    @Test func `action validation derives one canonical zero-dispatch refusal`() {
+        let envelope = ResultEnvelopeContext.$isActionCommand.withValue(true) {
+            ResultEnvelopeContext.$isPreDispatchFailure.withValue(true) {
+                makeErrorEnvelope(message: "Invalid coordinates", code: .VALIDATION_ERROR)
+            }
+        }
+
+        #expect(envelope.effect == .refused)
+        #expect(envelope.outcome?.state == .refused)
+        #expect(envelope.outcome?.refusalReason == .invalidRequest)
+        #expect(envelope.outcome?.retrySafe == true)
+        #expect(envelope.outcome?.mutationDispatched == false)
+        #expect(envelope.outcome?.requiresFreshObservation == false)
+        #expect(envelope.error?.retry_safe == true)
+        #expect(envelope.error?.mutation_dispatched == false)
+    }
+
+    @Test func `stale action target derives a canonical target refusal`() {
+        let envelope = ResultEnvelopeContext.$isActionCommand.withValue(true) {
+            ResultEnvelopeContext.$isPreDispatchFailure.withValue(true) {
+                makeErrorEnvelope(message: "Snapshot is stale", code: .SNAPSHOT_STALE)
+            }
+        }
+
+        #expect(envelope.outcome?.refusalReason == .targetUnavailable)
+        #expect(envelope.outcome?.escalation == .refreshTarget)
+        #expect(envelope.outcome?.requiresFreshObservation == false)
+    }
+
+    @Test func `read-only validation does not acquire an action outcome`() {
+        let envelope = ResultEnvelopeContext.$isActionCommand.withValue(false) {
+            ResultEnvelopeContext.$isPreDispatchFailure.withValue(true) {
+                makeErrorEnvelope(message: "Invalid read request", code: .VALIDATION_ERROR)
+            }
+        }
+
+        #expect(envelope.effect == nil)
+        #expect(envelope.outcome == nil)
+        #expect(envelope.error?.retry_safe == nil)
+        #expect(envelope.error?.mutation_dispatched == nil)
+    }
+
+    @Test func `runtime error code cannot overwrite a dispatched receipt`() {
+        let envelope = ResultEnvelopeContext.$isActionCommand.withValue(true) {
+            makeErrorEnvelope(
+                message: "Validation failed after dispatch",
+                code: .VALIDATION_ERROR,
+                retrySafe: false,
+                mutationDispatched: true
+            )
+        }
+
+        #expect(envelope.effect == .refused)
+        #expect(envelope.outcome == nil)
+        #expect(envelope.error?.retry_safe == false)
+        #expect(envelope.error?.mutation_dispatched == true)
     }
 
     @Test @MainActor func `clipboard reads omit action effect`() {

--- a/Apps/CLI/Tests/CoreCLITests/ResultEnvelopeTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/ResultEnvelopeTests.swift
@@ -86,6 +86,8 @@ struct ResultEnvelopeTests {
 
         #expect(error.envelopeEffect == .refused)
         #expect(error.envelopeHint == "Use --foreground for explicit global input.")
+        #expect(error.envelopeRetrySafe == true)
+        #expect(error.envelopeMutationDispatched == false)
         #expect(error.envelopeActionFailure?.outcome.refusalReason == .invalidRequest)
     }
 

--- a/Apps/CLI/Tests/CoreCLITests/ResultEnvelopeTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/ResultEnvelopeTests.swift
@@ -91,6 +91,27 @@ struct ResultEnvelopeTests {
         #expect(error.envelopeActionFailure?.outcome.refusalReason == .invalidRequest)
     }
 
+    @Test func `action metadata is projected only for action owners`() {
+        let error = PreDispatchActionError(
+            message: "Runtime is incompatible.",
+            code: .CAPTURE_FAILED,
+            hint: "Update the selected host.",
+            reason: .runtimeIncompatible
+        )
+
+        let action = actionErrorEnvelopeMetadata(for: error, isActionCommand: true)
+        #expect(action.failure?.outcome.refusalReason == .runtimeIncompatible)
+        #expect(action.effect == .refused)
+        #expect(action.retrySafe == true)
+        #expect(action.mutationDispatched == false)
+
+        let readOnly = actionErrorEnvelopeMetadata(for: error, isActionCommand: false)
+        #expect(readOnly.failure == nil)
+        #expect(readOnly.effect == nil)
+        #expect(readOnly.retrySafe == nil)
+        #expect(readOnly.mutationDispatched == nil)
+    }
+
     @Test func `encoding fallback remains valid JSON`() throws {
         let fallback = makeJSONEncodingFailureEnvelope(effect: .confirmed)
         let data = try JSONEncoder().encode(fallback)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Wake Bridge hosts on kernel listener readiness instead of polling `accept` every 25 ms, draining queued clients per notification while preserving bounded, descriptor-safe shutdown.
 
 ### Fixed
+- Report canonical refused, retry-safe, not-dispatched outcomes for pre-dispatch CLI and MCP action validation without attaching desktop semantics to read-only errors or overwriting dispatched receipts.
 - Preserve integer-valued Agent tool data across Codable and Foundation JSON conversion instead of mistaking numeric `0` and `1` for booleans.
 - Carry verified outcomes for receipt-pinned background window close, minimize, restore, maximize, move, resize, and set-bounds through Bridge protocol 1.23 while older hosts remain conservative.
 - Bind each discovered Agent tool to its exact provider and registry generation, recover unchanged bindings after transient discovery failures while refusing ambiguous or stale ownership, and preserve boolean/integer MCP arguments through one typed conversion path.

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/MCPToolArgumentValidation.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/MCPToolArgumentValidation.swift
@@ -35,7 +35,11 @@ extension ToolArguments {
 }
 
 enum MCPToolArgumentValidator {
-    static func rejection(tool: any MCPTool, arguments: ToolArguments) -> ToolResponse? {
+    static func rejection(
+        tool: any MCPTool,
+        arguments: ToolArguments,
+        snapshotEffect: MCPToolSnapshotEffect) -> ToolResponse?
+    {
         guard case let .object(schema) = tool.inputSchema,
               case let .object(properties)? = schema["properties"]
         else {
@@ -61,19 +65,28 @@ enum MCPToolArgumentValidator {
             }
             return nil
         } catch let error as MCPToolArgumentValueError {
-            return ToolResponse.error(
-                error.localizedDescription,
-                meta: .object([
-                    "mutation_dispatched": .bool(false),
-                    "retry_safe": .bool(true),
-                ]))
+            return self.rejectionResponse(
+                message: error.localizedDescription,
+                snapshotEffect: snapshotEffect)
         } catch {
-            return ToolResponse.error(
-                "Invalid numeric tool argument: \(error.localizedDescription)",
-                meta: .object([
-                    "mutation_dispatched": .bool(false),
-                    "retry_safe": .bool(true),
-                ]))
+            return self.rejectionResponse(
+                message: "Invalid numeric tool argument: \(error.localizedDescription)",
+                snapshotEffect: snapshotEffect)
+        }
+    }
+
+    private static func rejectionResponse(
+        message: String,
+        snapshotEffect: MCPToolSnapshotEffect) -> ToolResponse
+    {
+        switch snapshotEffect {
+        case .mutation, .mutationProducingFreshObservation:
+            MCPToolResponseMetadataProjector.preDispatchRefusalResponse(
+                message: message,
+                reason: .invalidRequest,
+                additionalFields: ["error_code": .string("VALIDATION_ERROR")])
+        case .none, .freshObservation:
+            ToolResponse.error(message)
         }
     }
 }

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/MCPToolContext.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/MCPToolContext.swift
@@ -207,12 +207,16 @@ public struct MCPToolContext: @unchecked Sendable {
         if let rejection = self.executionPolicy.rejection(toolName: tool.name, arguments: arguments) {
             return rejection
         }
-        if let rejection = MCPToolArgumentValidator.rejection(tool: tool, arguments: arguments) {
+        let effect = MCPToolSnapshotMutationPolicy.effect(toolName: tool.name, arguments: arguments)
+        if let rejection = MCPToolArgumentValidator.rejection(
+            tool: tool,
+            arguments: arguments,
+            snapshotEffect: effect)
+        {
             return rejection
         }
         await self.uiSnapshots.synchronizeImplicitLatestInvalidationWatermark(
             self.snapshots.effectiveImplicitLatestInvalidationWatermark)
-        let effect = MCPToolSnapshotMutationPolicy.effect(toolName: tool.name, arguments: arguments)
         guard effect != .none else {
             try Task.checkCancellation()
             let response = try await tool.execute(arguments: arguments)

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/MCPToolExecutionPolicy.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/MCPToolExecutionPolicy.swift
@@ -1,4 +1,5 @@
 import Foundation
+import PeekabooFoundation
 import Tachikoma
 import TachikomaMCP
 
@@ -15,15 +16,21 @@ public enum MCPToolExecutionPolicy: String, Codable, Sendable {
     static let refusalErrorCode = "AGENT_EXECUTION_POLICY_REFUSAL"
 
     func rejection(toolName: String, arguments: ToolArguments) -> ToolResponse? {
-        let reason: String? = switch self {
+        let refusal: (message: String, reason: DesktopActionOutcome.RefusalReason)? = switch self {
         case .unrestricted:
             nil
         case .backgroundOnly:
-            BackgroundOnlyToolPolicy.violation(toolName: toolName, arguments: arguments)?.reason
+            BackgroundOnlyToolPolicy.violation(toolName: toolName, arguments: arguments).map {
+                ($0.message, $0.refusalReason)
+            }
         case .foregroundAllowed:
-            ForegroundAllowedAgentToolPolicy.refusalReason(toolName: toolName)
+            ForegroundAllowedAgentToolPolicy.refusalMessage(toolName: toolName).map {
+                ($0, .operationUnsupported)
+            }
         }
-        return reason.map { self.refusal(toolName: toolName, reason: $0) }
+        return refusal.map {
+            self.refusal(toolName: toolName, message: $0.message, reason: $0.reason)
+        }
     }
 
     func systemSurfaceRejection(
@@ -47,7 +54,8 @@ public enum MCPToolExecutionPolicy: String, Codable, Sendable {
         }
         return self.refusal(
             toolName: toolName,
-            reason: "the selected target is shared system UI and cannot be mutated in background-only mode")
+            message: "the selected target is shared system UI and cannot be mutated in background-only mode",
+            reason: .foregroundConsentRequired)
     }
 
     func unresolvedTargetRejection(toolName: String, detail: String) -> ToolResponse? {
@@ -56,20 +64,23 @@ public enum MCPToolExecutionPolicy: String, Codable, Sendable {
         }
         return self.refusal(
             toolName: toolName,
-            reason: "the selected mutation target could not be proven background-safe: \(detail)")
+            message: "the selected mutation target could not be proven background-safe: \(detail)",
+            reason: .targetUnavailable)
     }
 
-    private func refusal(toolName: String, reason: String) -> ToolResponse {
-        ToolResponse.error(
-            "Agent session policy refused '\(toolName)' before dispatch because \(reason). " +
+    private func refusal(
+        toolName: String,
+        message: String,
+        reason: DesktopActionOutcome.RefusalReason) -> ToolResponse
+    {
+        MCPToolResponseMetadataProjector.preDispatchRefusalResponse(
+            message: "Agent session policy refused '\(toolName)' before dispatch because \(message). " +
                 "Only a human can authorize a different Agent execution policy.",
-            meta: .object([
-                "effect": .string("refused"),
+            reason: reason,
+            additionalFields: [
                 "error_code": .string(Self.refusalErrorCode),
                 "execution_policy": .string(self.rawValue),
-                "mutation_dispatched": .bool(false),
-                "retry_safe": .bool(true),
-            ]))
+            ])
     }
 
     private static let sharedSystemUIBundleIdentifiers: Set<String> = [
@@ -107,12 +118,21 @@ private enum BackgroundOnlyToolPolicy {
         case sharedDesktop(String)
         case unclassified
 
-        var reason: String {
+        var message: String {
             switch self {
             case let .foregroundRequest(detail): detail
             case let .activation(detail): detail
             case let .sharedDesktop(detail): detail
             case .unclassified: "the tool or action is not classified as background-safe"
+            }
+        }
+
+        var refusalReason: DesktopActionOutcome.RefusalReason {
+            switch self {
+            case .foregroundRequest, .activation, .sharedDesktop:
+                .foregroundConsentRequired
+            case .unclassified:
+                .operationUnsupported
             }
         }
     }
@@ -372,7 +392,7 @@ private enum ForegroundAllowedAgentToolPolicy {
         "set_value", "sleep", "space", "type", "verify_state", "window",
     ]
 
-    static func refusalReason(toolName: String) -> String? {
+    static func refusalMessage(toolName: String) -> String? {
         if toolName == "shell" {
             return "shell execution is a separate privilege and can bypass native UI automation, including through " +
                 "AppleScript, JXA, OSA, or arbitrary subprocesses"

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Server/MCPToolResponseMetadataProjector.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Server/MCPToolResponseMetadataProjector.swift
@@ -93,9 +93,11 @@ enum MCPToolResponseMetadataProjector {
 
     static func errorResponse(
         for failure: DesktopActionFailure,
-        invalidatedSnapshotID: String?) throws -> ToolResponse
+        invalidatedSnapshotID: String?,
+        additionalFields: [String: Value] = [:]) throws -> ToolResponse
     {
-        var fields = try self.fields(for: failure.outcome.projection)
+        var fields = additionalFields
+        try fields.merge(self.fields(for: failure.outcome.projection)) { _, canonical in canonical }
         if let invalidatedSnapshotID {
             fields["invalidated_snapshot"] = .string(invalidatedSnapshotID)
         }
@@ -103,6 +105,23 @@ enum MCPToolResponseMetadataProjector {
         return ToolResponse.error(
             self.message(for: failure),
             meta: .object(fields))
+    }
+
+    static func preDispatchRefusalResponse(
+        message: String,
+        reason: DesktopActionOutcome.RefusalReason,
+        additionalFields: [String: Value] = [:]) -> ToolResponse
+    {
+        let failure = DesktopActionFailure.refused(reason: reason, message: message)
+        do {
+            return try self.errorResponse(
+                for: failure,
+                invalidatedSnapshotID: nil,
+                additionalFields: additionalFields)
+        } catch {
+            let metadata: Value? = additionalFields.isEmpty ? nil : .object(additionalFields)
+            return ToolResponse.error(message, meta: metadata)
+        }
     }
 
     private enum ProjectionError: Error {

--- a/Core/PeekabooCore/Tests/PeekabooAgentRuntimeTests/MCPToolExecutionPolicyTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooAgentRuntimeTests/MCPToolExecutionPolicyTests.swift
@@ -1,5 +1,6 @@
 import MCP
 import PeekabooAutomationKit
+import PeekabooFoundation
 import Tachikoma
 import TachikomaMCP
 import Testing
@@ -94,9 +95,17 @@ struct MCPToolExecutionPolicyTests {
                 continue
             }
             #expect(meta["effect"] == .string("refused"))
+            #expect(meta["state"] == .string("refused"))
+            #expect(meta["dispatch_state"] == .string("none"))
             #expect(meta["mutation_dispatched"] == .bool(false))
             #expect(meta["retry_safe"] == .bool(true))
+            #expect(meta["requires_fresh_observation"] == .bool(false))
             #expect(meta["execution_policy"] == .string("background_only"))
+            let expectedReason: DesktopActionOutcome.RefusalReason =
+                ["agent", "future_desktop_tool"].contains(item.tool)
+                ? .operationUnsupported
+                : .foregroundConsentRequired
+            #expect(meta["refusal_reason"] == .string(expectedReason.rawValue))
         }
     }
 
@@ -186,6 +195,9 @@ struct MCPToolExecutionPolicyTests {
             #expect(meta["mutation_dispatched"] == .bool(false))
             #expect(meta["retry_safe"] == .bool(true))
             #expect(meta["execution_policy"] == .string("foreground_allowed"))
+            #expect(meta["state"] == .string("refused"))
+            #expect(meta["refusal_reason"] == .string("operation_unsupported"))
+            #expect(meta["escalation"] == .string("correct_request"))
         }
 
         #expect(MCPToolExecutionPolicy.foregroundAllowed.rejection(
@@ -226,6 +238,24 @@ struct MCPToolExecutionPolicyTests {
                 applicationBundleIdentifier: bundleIdentifier,
                 applicationName: nil)?.isError == true)
         }
+    }
+
+    @Test
+    func `policy target refusals preserve their canonical recovery reason`() throws {
+        let unresolved = try #require(MCPToolExecutionPolicy.backgroundOnly.unresolvedTargetRejection(
+            toolName: "click",
+            detail: "process generation changed"))
+        let unresolvedMeta = try #require(unresolved.meta?.objectValue)
+        #expect(unresolvedMeta["refusal_reason"] == .string("target_unavailable"))
+        #expect(unresolvedMeta["escalation"] == .string("refresh_target"))
+
+        let systemSurface = try #require(MCPToolExecutionPolicy.backgroundOnly.systemSurfaceRejection(
+            toolName: "action",
+            applicationBundleIdentifier: "com.apple.dock",
+            applicationName: nil))
+        let systemMeta = try #require(systemSurface.meta?.objectValue)
+        #expect(systemMeta["refusal_reason"] == .string("foreground_consent_required"))
+        #expect(systemMeta["escalation"] == .string("correct_request"))
     }
 
     @Test

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPDesktopActionOutcomeProjectionTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPDesktopActionOutcomeProjectionTests.swift
@@ -82,6 +82,25 @@ struct MCPDesktopActionOutcomeProjectionTests {
         #expect(wireMeta["requires_fresh_observation"] as? Bool == false)
     }
 
+    @Test
+    func `pre-dispatch refusal merges presentation metadata around canonical fields`() throws {
+        let response = MCPToolResponseMetadataProjector.preDispatchRefusalResponse(
+            message: "Invalid numeric argument",
+            reason: .invalidRequest,
+            additionalFields: [
+                "error_code": .string("VALIDATION_ERROR"),
+                "retry_safe": .bool(false),
+            ])
+        let meta = try #require(response.meta?.objectValue)
+
+        #expect(meta["error_code"] == .string("VALIDATION_ERROR"))
+        #expect(meta["state"] == .string("refused"))
+        #expect(meta["refusal_reason"] == .string("invalid_request"))
+        #expect(meta["retry_safe"] == .bool(true))
+        #expect(meta["mutation_dispatched"] == .bool(false))
+        #expect(meta["requires_fresh_observation"] == .bool(false))
+    }
+
     private struct ProjectionExpectation {
         let state: DesktopActionOutcome.State
         let dispatched: Bool

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPToolArgumentValidationTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPToolArgumentValidationTests.swift
@@ -1,4 +1,5 @@
 import MCP
+import PeekabooFoundation
 import TachikomaMCP
 import Testing
 @testable import PeekabooAgentRuntime
@@ -6,7 +7,7 @@ import Testing
 @MainActor
 struct MCPToolArgumentValidationTests {
     @Test
-    func `unsafe numeric arguments are refused before tool dispatch`() async throws {
+    func `generic numeric validation probes remain ordinary errors`() async throws {
         let context = await MCPToolTestHelpers.makeContext()
         let counter = MCPNumericDispatchCounter()
         let typeTool = TypeTool(context: context)
@@ -43,12 +44,7 @@ struct MCPToolArgumentValidationTests {
                 arguments: ToolArguments(value: .object([key: value])))
 
             #expect(response.isError, "Expected \(sourceTool.name).\(key) to be rejected")
-            guard case let .object(meta) = response.meta else {
-                Issue.record("Expected refusal metadata for \(sourceTool.name).\(key)")
-                continue
-            }
-            #expect(meta["mutation_dispatched"] == .bool(false))
-            #expect(meta["retry_safe"] == .bool(true))
+            #expect(response.meta == nil, "Generic probe gained desktop-action metadata for \(sourceTool.name).\(key)")
         }
 
         #expect(await counter.value == 0)
@@ -121,11 +117,50 @@ struct MCPToolArgumentValidationTests {
                 tool: tool,
                 arguments: ToolArguments(value: .object(values)))
             #expect(response.isError)
+            let meta = try #require(response.meta?.objectValue)
+            #expect(meta["state"] == .string(DesktopActionOutcome.State.refused.rawValue))
+            #expect(meta["effect"] == .string(DesktopActionOutcome.Effect.refused.rawValue))
+            #expect(meta["refusal_reason"] == .string(DesktopActionOutcome.RefusalReason.invalidRequest.rawValue))
+            #expect(meta["dispatch_state"] == .string("none"))
+            #expect(meta["mutation_dispatched"] == .bool(false))
+            #expect(meta["retry_safe"] == .bool(true))
+            #expect(meta["requires_fresh_observation"] == .bool(false))
+            #expect(meta["error_code"] == .string("VALIDATION_ERROR"))
         }
 
         #expect(automation.lastTypeActions == nil)
         #expect(automation.targetedTypeActionsCalls.isEmpty)
         #expect(automation.scrollRequests.isEmpty)
+    }
+
+    @Test
+    func `invalid read-only numerics omit desktop-action metadata`() async throws {
+        let context = await MCPToolTestHelpers.makeContext()
+        let counter = MCPNumericDispatchCounter()
+        let cases: [(name: String, schema: Value, arguments: [String: Value])] = [
+            (
+                "sleep",
+                SleepTool().inputSchema,
+                ["duration": .double(.infinity)]),
+            (
+                "see",
+                SeeTool(context: context).inputSchema,
+                ["max_depth": .double(1.5)]),
+        ]
+
+        for testCase in cases {
+            let response = try await context.execute(
+                tool: MCPNumericSchemaProbeTool(
+                    name: testCase.name,
+                    inputSchema: testCase.schema,
+                    counter: counter),
+                arguments: ToolArguments(value: .object(testCase.arguments)))
+
+            #expect(response.isError)
+            #expect(response.meta == nil)
+        }
+
+        #expect(await counter.value == 0)
     }
 }
 


### PR DESCRIPTION
## Summary

- make `PreDispatchActionError` carry the canonical Foundation refusal, public code, and hint instead of parallel effect/retry/mutation booleans
- project refused/retry-safe/not-dispatched outcomes once through CLI envelopes and MCP metadata for action-classified validation
- preserve explicit outcomes and dispatched receipts; do not infer pre-dispatch state from runtime error codes
- keep read-only validation errors free of fabricated desktop-action semantics
- delete duplicate `ActionRefusalError`, local action-effect inference, hard-coded CLI booleans, and MCP safety dictionaries

## Behavior proof

- six source-blind CLI refusal cases (C3/C4/C5/C6/C7/C9) now emit canonical outcome plus matching legacy fields
- parser/binder refusal cases and read-only negative controls remain correctly classified
- MCP argument/execution-policy refusals project typed Foundation failures only for mutation tools
- policy/argument refusal returns before owner-scoped snapshot synchronization, mutation gating, invalidation, or leaf dispatch

## Validation

- CLI ResultEnvelope 16/16 + PreDispatchActionEnvelope 4/4
- MCP projection/argument 8/8 + execution policy 10/10
- owner-scoped snapshot integration 41/41
- Release CLI + Core builds
- SwiftFormat: 0/1,309 changed
- strict touched SwiftLint: 0 violations; native-only and diff checks clean
- exact-current P0-P2 review: clean, patch correct at 0.94
- paired changelog review: clean at 0.99

Production delta: +301/-125. Test delta: +235/-9.
