### PR TITLE
refactor: centralize desktop action composition

### DIFF
--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Wake Bridge hosts on kernel listener readiness instead of polling `accept` every 25 ms, draining queued clients per notification while preserving bounded, descriptor-safe shutdown.
 
 ### Fixed
+- Compose setup, delivery, cleanup, cancellation, and refusal receipts through one Foundation action-sequence owner so foreground focus cannot be erased by a no-dispatch leaf and CLI/MCP target refusals expose complete retry guidance.
 - Make explicit Bridge socket overrides fail closed when unavailable instead of reporting a successful local fallback.
 - Validate `see` selectors, explicit caller-local PIDs, and `scroll` directions before runtime-host and ScreenCaptureKit ownership preflight so request errors cannot be masked by ambient capture state.
 - Consume explicit snapshots for further mutations when a canonical action outcome requires fresh observation or is unavailable, refusing duplicate click/action/set-value/scroll dispatch before it reaches the app while preserving read-only snapshot evidence.

--- a/Apps/CLI/Sources/PeekabooCLI/CLI/Output/JSONOutput.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/CLI/Output/JSONOutput.swift
@@ -87,7 +87,7 @@ struct PreDispatchActionError: LocalizedError, ResultEnvelopeError {
         hint: String?,
         reason: DesktopActionOutcome.RefusalReason
     ) {
-        self.failure = .refused(reason: reason, message: message)
+        self.failure = .preDispatchRefusal(reason: reason, message: message, hint: hint)
         self.code = code
         self.hint = hint
     }
@@ -321,7 +321,12 @@ func makeErrorEnvelope(
     let suppliedOutcome = actionFailure?.outcome.projection
     let resolvedEffect = suppliedOutcome?.effect ?? effect ??
         (ResultEnvelopeContext.isActionCommand ? defaultActionErrorEffect(code) : nil)
-    let resolvedOutcome = suppliedOutcome ?? defaultActionRefusalProjection(effect: resolvedEffect, code: code)
+    let resolvedOutcome = suppliedOutcome ?? defaultActionRefusalProjection(
+        effect: resolvedEffect,
+        code: code,
+        retrySafe: retrySafe,
+        mutationDispatched: mutationDispatched
+    )
     return ResultEnvelope(
         success: false,
         effect: resolvedOutcome?.effect ?? resolvedEffect,
@@ -341,16 +346,24 @@ func makeErrorEnvelope(
 
 func defaultActionRefusalProjection(
     effect: ActionEffect?,
-    code: ErrorCode
+    code: ErrorCode,
+    retrySafe: Bool? = nil,
+    mutationDispatched: Bool? = nil
 ) -> DesktopActionOutcome.Projection? {
     guard ResultEnvelopeContext.isActionCommand,
-          ResultEnvelopeContext.isPreDispatchFailure,
           effect == .refused,
           let reason = defaultActionRefusalReason(code)
     else {
         return nil
     }
-    return DesktopActionOutcome.refused(reason: reason).projection
+    if ResultEnvelopeContext.isPreDispatchFailure {
+        return DesktopActionOutcome.preDispatchRefusalProjection(reason: reason)
+    }
+    return DesktopActionOutcome.preDispatchRefusalProjection(
+        reason: reason,
+        legacyRetrySafe: retrySafe,
+        legacyMutationDispatched: mutationDispatched
+    )
 }
 
 func defaultActionRefusalReason(_ code: ErrorCode) -> DesktopActionOutcome.RefusalReason? {

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommandErrorHandling.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommandErrorHandling.swift
@@ -12,78 +12,24 @@ protocol ErrorHandlingCommand {
     var jsonOutput: Bool { get }
 }
 
-/// Canonical composition for a multi-call action whose prefix has already dispatched.
-///
-/// Individual commands own their user-facing wording, but they must not independently infer
-/// dispatch counts or downgrade an uncertain leaf into a contradictory retry-safe result.
-enum ActionSequenceFailureComposer {
-    struct IndeterminateContext {
-        let route: DesktopActionOutcome.Route
-        let delivery: DesktopActionOutcome.Delivery
-        let message: String
-        let hint: String
-        let causeDescription: String
-    }
-
-    static func combining(
-        completedUnitCount: Int,
-        leafFailure: DesktopActionFailure,
-        delivery: DesktopActionOutcome.Delivery,
-        message: String,
-        indeterminateHint: String
-    ) -> DesktopActionFailure {
-        let cumulativeCount: DesktopActionOutcome.DispatchUnitCount? = switch leafFailure.outcome.dispatchState {
-        case .none:
-            DesktopActionOutcome.DispatchUnitCount(completedUnitCount)
-        case let .dispatched(unitCount), let .mayHaveDispatched(unitCount):
-            unitCount.flatMap { DesktopActionOutcome.DispatchUnitCount(completedUnitCount + $0.rawValue) }
-        }
-
-        if leafFailure.outcome.state == .partial {
-            return .partial(
-                route: leafFailure.outcome.route,
-                delivery: delivery,
-                unitCount: cumulativeCount,
-                message: message,
-                hint: leafFailure.hint,
-                causeDescription: leafFailure.causeDescription
-            )
-        }
-
-        let evidence: DesktopActionOutcome.IndeterminateEvidence = switch leafFailure.outcome.evidence {
-        case .responseLost:
-            .responseLost
-        default:
-            .completionUnknown
-        }
-        return .indeterminate(
-            route: leafFailure.outcome.route,
-            delivery: delivery,
-            evidence: evidence,
-            unitCount: cumulativeCount,
-            message: message,
-            hint: indeterminateHint,
-            causeDescription: leafFailure.causeDescription
-        )
-    }
-
-    static func indeterminate(
-        knownDispatchedUnitCount: Int?,
-        context: IndeterminateContext
-    ) -> DesktopActionFailure {
-        .indeterminate(
-            route: context.route,
-            delivery: context.delivery,
-            evidence: .completionUnknown,
-            unitCount: knownDispatchedUnitCount.flatMap { DesktopActionOutcome.DispatchUnitCount($0) },
-            message: context.message,
-            hint: context.hint,
-            causeDescription: context.causeDescription
-        )
-    }
-}
-
 extension ErrorHandlingCommand {
+    func preDispatchActionError(
+        for error: any Error,
+        reason explicitReason: DesktopActionOutcome.RefusalReason? = nil
+    ) -> PreDispatchActionError {
+        if let error = error as? PreDispatchActionError {
+            return error
+        }
+        let code = self.mapErrorToCode(error)
+        let presentation = splitErrorHint(from: errorMessage(for: error))
+        return PreDispatchActionError(
+            message: presentation.message,
+            code: code,
+            hint: (error as? any ResultEnvelopeError)?.envelopeHint ?? presentation.hint,
+            reason: explicitReason ?? defaultActionRefusalReason(code) ?? .targetUnavailable
+        )
+    }
+
     /// Handle errors with appropriate output format
     func handleError(_ error: any Error, customCode: ErrorCode? = nil) {
         if jsonOutput {

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/PasteCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/PasteCommand.swift
@@ -86,7 +86,7 @@ struct PasteCommand: ActionOutputFormattable, ErrorHandlingCommand, OutputFormat
                 request: request
             ) {
                 let expectedPIDIdentity = try self.explicitPIDIdentity()
-                if let targetIdentity = try await self.verifiedBackgroundProcessIdentity(
+                if let targetIdentity = try await self.preDispatchBackgroundProcessIdentity(
                     expectedPIDIdentity: expectedPIDIdentity
                 ) {
                     try await self.pasteTextInBackground(text, request: request, targetIdentity: targetIdentity)
@@ -97,7 +97,7 @@ struct PasteCommand: ActionOutputFormattable, ErrorHandlingCommand, OutputFormat
             let expectedPIDIdentity = try self.explicitPIDIdentity()
             let outcome = try await self.withInteractionMutationInvalidation {
                 try await ClipboardPasteTransactionGate.withExclusiveTransaction {
-                    let targetIdentity = try await self.verifiedBackgroundProcessIdentity(
+                    let targetIdentity = try await self.preDispatchBackgroundProcessIdentity(
                         expectedPIDIdentity: expectedPIDIdentity
                     )
                     if targetIdentity == nil {
@@ -397,7 +397,7 @@ struct PasteCommand: ActionOutputFormattable, ErrorHandlingCommand, OutputFormat
     private func pasteCurrentClipboard(expectedPIDIdentity: UInt64?) async throws {
         let outcome = try await self.withInteractionMutationInvalidation {
             try await ClipboardPasteTransactionGate.withExclusiveTransaction {
-                let targetIdentity = try await self.verifiedBackgroundProcessIdentity(
+                let targetIdentity = try await self.preDispatchBackgroundProcessIdentity(
                     expectedPIDIdentity: expectedPIDIdentity
                 )
                 if targetIdentity == nil {
@@ -564,7 +564,10 @@ struct PasteCommand: ActionOutputFormattable, ErrorHandlingCommand, OutputFormat
     private func explicitPIDIdentity() throws -> UInt64? {
         guard let pid = self.target.pid else { return nil }
         guard let identity = ClipboardPasteTransactionGate.processStartIdentity(pid_t(pid)) else {
-            throw ValidationError("Could not verify process identity for --pid \(pid).")
+            throw self.preDispatchActionError(
+                for: ValidationError("Could not verify process identity for --pid \(pid)."),
+                reason: .targetUnavailable
+            )
         }
         return identity
     }
@@ -601,6 +604,19 @@ struct PasteCommand: ActionOutputFormattable, ErrorHandlingCommand, OutputFormat
             }
         }
         return processIdentity
+    }
+
+    private func preDispatchBackgroundProcessIdentity(
+        expectedPIDIdentity: UInt64? = nil
+    ) async throws -> ApplicationProcessIdentity? {
+        do {
+            return try await self.verifiedBackgroundProcessIdentity(expectedPIDIdentity: expectedPIDIdentity)
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch {
+            try Task.checkCancellation()
+            throw self.preDispatchActionError(for: error, reason: .targetUnavailable)
+        }
     }
 
     private func validateExplicitPIDIdentity(_ expectedPIDIdentity: UInt64?) throws {

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/PressCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/PressCommand.swift
@@ -97,22 +97,22 @@ RuntimeOptionsConfigurable {
 
             let parsedChords = try self.parsedChords()
             var completedPresses = 0
-            var actionOutcomes: [DesktopActionOutcome] = []
+            var sequence = DesktopActionSequenceAccumulator()
 
             for repetition in 0..<self.count {
                 for (index, chord) in parsedChords.indexed() {
                     do {
                         try Task.checkCancellation()
                     } catch {
-                        guard completedPresses > 0 else { throw error }
-                        throw ActionSequenceFailureComposer.indeterminate(
-                            knownDispatchedUnitCount: completedPresses,
-                            context: self.indeterminateSequenceContext(
-                                completedPresses: completedPresses,
-                                actionOutcomes: actionOutcomes,
-                                causeDescription: error.localizedDescription
-                            )
+                        guard let failure = sequence.cancellationFailure(
+                            fallbackRoute: self.sequenceRoute,
+                            message: Self.indeterminateSequenceMessage(completedPresses: completedPresses),
+                            hint: Self.sequenceObservationHint,
+                            causeDescription: error.localizedDescription
                         )
+                        else { throw error }
+                        await self.invalidateAfterFailedMutation(failure)
+                        throw failure
                     }
                     let actionResult: UIAutomationActionResult<Void>
                     do {
@@ -121,41 +121,61 @@ RuntimeOptionsConfigurable {
                             keys: chord.serviceKeys,
                             holdDuration: self.hold.roundedMilliseconds
                         )
+                        try DesktopActionFailure.requireConfirmedIfReported(
+                            actionResult.outcome,
+                            operation: "Raw chord \(chord.displayValue)"
+                        )
                     } catch let failure as DesktopActionFailure {
-                        guard completedPresses > 0 else { throw failure }
-                        throw ActionSequenceFailureComposer.combining(
-                            completedUnitCount: completedPresses,
-                            leafFailure: failure,
-                            delivery: Self.foregroundHotkeyDelivery,
+                        let composed = sequence.failure(
+                            combining: failure,
                             message: Self.sequenceFailureMessage(
                                 completedPresses: completedPresses,
                                 detail: failure.message
                             ),
-                            indeterminateHint: Self.sequenceObservationHint
+                            hint: Self.sequenceObservationHint
                         )
+                        await self.invalidateAfterFailedMutation(composed)
+                        throw composed
                     } catch let error as InputDeliveryIndeterminateError {
-                        guard completedPresses > 0 else { throw error }
-                        throw ActionSequenceFailureComposer.indeterminate(
-                            knownDispatchedUnitCount: error.emittedUnitCount.map { completedPresses + $0 },
-                            context: self.indeterminateSequenceContext(
-                                completedPresses: completedPresses,
-                                actionOutcomes: actionOutcomes,
-                                causeDescription: error.causeDescription ?? error.localizedDescription
-                            )
+                        let failure = error.desktopActionFailure(
+                            delivery: Self.foregroundHotkeyDelivery,
+                            route: self.sequenceRoute
                         )
+                        let composed = sequence.failure(
+                            combining: failure,
+                            message: Self.indeterminateSequenceMessage(completedPresses: completedPresses),
+                            hint: Self.sequenceObservationHint,
+                            causeDescription: error.causeDescription ?? error.localizedDescription
+                        )
+                        await self.invalidateAfterFailedMutation(composed)
+                        throw composed
                     } catch {
-                        guard completedPresses > 0 else { throw error }
-                        throw ActionSequenceFailureComposer.indeterminate(
-                            knownDispatchedUnitCount: nil,
-                            context: self.indeterminateSequenceContext(
-                                completedPresses: completedPresses,
-                                actionOutcomes: actionOutcomes,
-                                causeDescription: error.localizedDescription
-                            )
+                        guard sequence.mutationDisposition.mutationDispatched else { throw error }
+                        let leaf = DesktopActionFailure.preDispatchRefusal(
+                            route: self.sequenceRoute,
+                            reason: .operationUnsupported,
+                            message: error.localizedDescription
                         )
+                        let composed = sequence.failure(
+                            combining: leaf,
+                            message: Self.indeterminateSequenceMessage(completedPresses: completedPresses),
+                            hint: Self.sequenceObservationHint,
+                            causeDescription: error.localizedDescription
+                        )
+                        await self.invalidateAfterFailedMutation(composed)
+                        throw composed
                     }
                     if let outcome = actionResult.outcome {
-                        actionOutcomes.append(outcome)
+                        sequence.record(.reportedOutcome(
+                            outcome,
+                            defaultDispatchedUnitCount: .one
+                        ))
+                    } else {
+                        sequence.record(.dispatched(
+                            route: self.sequenceRoute,
+                            delivery: Self.foregroundHotkeyDelivery,
+                            unitCount: .one
+                        ))
                     }
                     completedPresses += 1
 
@@ -170,58 +190,68 @@ RuntimeOptionsConfigurable {
                             try await Task.sleep(for: .seconds(self.delay.seconds))
                         }
                     } catch {
-                        throw ActionSequenceFailureComposer.indeterminate(
-                            knownDispatchedUnitCount: completedPresses,
-                            context: self.indeterminateSequenceContext(
-                                completedPresses: completedPresses,
-                                actionOutcomes: actionOutcomes,
-                                causeDescription: error.localizedDescription
-                            )
+                        guard let failure = sequence.cancellationFailure(
+                            fallbackRoute: self.sequenceRoute,
+                            message: Self.indeterminateSequenceMessage(completedPresses: completedPresses),
+                            hint: Self.sequenceObservationHint,
+                            causeDescription: error.localizedDescription
                         )
+                        else { throw error }
+                        await self.invalidateAfterFailedMutation(failure)
+                        throw failure
                     }
                 }
             }
 
-            await InteractionObservationInvalidator.invalidateAfterMutation(
-                targets: self.resolvedRuntime.interactionMutationTargets,
-                logger: self.logger,
-                reason: "press"
+            await self.finishSuccess(
+                parsedChords: parsedChords,
+                completedPresses: completedPresses,
+                sequence: sequence,
+                startTime: startTime
             )
-
-            // Output results
-            let pressResult = PressResult(
-                keys: parsedChords.map(\.displayValue),
-                totalPresses: completedPresses,
-                count: self.count,
-                deliveryMode: KeyboardDeliveryMode.foreground.rawValue,
-                targetPID: nil,
-                executionTime: Date().timeIntervalSince(startTime)
-            )
-
-            // A leaf receipt describes one hotkey call, not a CLI sequence. Keep a successful
-            // multi-call sequence on the legacy effect-only contract until the leaf owns batching.
-            let actionOutcome = completedPresses == 1 && actionOutcomes.count == 1 ? actionOutcomes[0] : nil
-            output(pressResult, effect: .unverifiable, outcome: actionOutcome) {
-                if let actionOutcome {
-                    print(ActionOutcomeHumanRenderer.statusLine(for: actionOutcome, operation: "Key press"))
-                } else {
-                    print("✅ Key press dispatched")
-                }
-                print("🔑 Chords: \(parsedChords.map(\.displayValue).joined(separator: " → "))")
-                if self.count > 1 {
-                    print("🔢 Repeated: \(self.count) times")
-                }
-                print("🎯 Mode: foreground")
-                print("📊 Total presses: \(completedPresses)")
-                if actionOutcome == nil {
-                    print("⚠️  Effect: unverifiable; observe the target before continuing")
-                }
-                print("⏱️  Completed in \(String(format: "%.2f", Date().timeIntervalSince(startTime)))s")
-            }
 
         } catch {
             self.handleError(error)
             throw ExitCode.failure
+        }
+    }
+
+    private func finishSuccess(
+        parsedChords: [KeyboardChord],
+        completedPresses: Int,
+        sequence: DesktopActionSequenceAccumulator,
+        startTime: Date
+    ) async {
+        await InteractionObservationInvalidator.invalidateAfterMutation(
+            targets: self.resolvedRuntime.interactionMutationTargets,
+            logger: self.logger,
+            reason: "press"
+        )
+        let pressResult = PressResult(
+            keys: parsedChords.map(\.displayValue),
+            totalPresses: completedPresses,
+            count: self.count,
+            deliveryMode: KeyboardDeliveryMode.foreground.rawValue,
+            targetPID: nil,
+            executionTime: Date().timeIntervalSince(startTime)
+        )
+        let actionOutcome = sequence.successResolution().outcome
+        self.output(pressResult, effect: .unverifiable, outcome: actionOutcome) {
+            if let actionOutcome {
+                print(ActionOutcomeHumanRenderer.statusLine(for: actionOutcome, operation: "Key press"))
+            } else {
+                print("✅ Key press dispatched")
+            }
+            print("🔑 Chords: \(parsedChords.map(\.displayValue).joined(separator: " → "))")
+            if self.count > 1 {
+                print("🔢 Repeated: \(self.count) times")
+            }
+            print("🎯 Mode: foreground")
+            print("📊 Total presses: \(completedPresses)")
+            if actionOutcome == nil {
+                print("⚠️  Effect: unverifiable; observe the target before continuing")
+            }
+            print("⏱️  Completed in \(String(format: "%.2f", Date().timeIntervalSince(startTime)))s")
         }
     }
 
@@ -266,21 +296,16 @@ RuntimeOptionsConfigurable {
             (completedPresses == 1 ? "" : "es")
     }
 
-    private func sequenceRoute(actionOutcomes: [DesktopActionOutcome]) -> DesktopActionOutcome.Route {
-        actionOutcomes.last?.route ?? (self.services.automation is RemoteUIAutomationService ? .bridge : .local)
+    private var sequenceRoute: DesktopActionOutcome.Route {
+        self.services.automation is RemoteUIAutomationService ? .bridge : .local
     }
 
-    private func indeterminateSequenceContext(
-        completedPresses: Int,
-        actionOutcomes: [DesktopActionOutcome],
-        causeDescription: String
-    ) -> ActionSequenceFailureComposer.IndeterminateContext {
-        .init(
-            route: self.sequenceRoute(actionOutcomes: actionOutcomes),
-            delivery: Self.foregroundHotkeyDelivery,
-            message: Self.indeterminateSequenceMessage(completedPresses: completedPresses),
-            hint: Self.sequenceObservationHint,
-            causeDescription: causeDescription
+    private func invalidateAfterFailedMutation(_ failure: DesktopActionFailure) async {
+        guard failure.outcome.dispatchState.mutationDispatched else { return }
+        await InteractionObservationInvalidator.invalidateAfterMutation(
+            targets: self.resolvedRuntime.interactionMutationTargets,
+            logger: self.logger,
+            reason: "press failure"
         )
     }
 

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/TypeCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/TypeCommand.swift
@@ -72,18 +72,79 @@ struct TypeCommand: ActionOutputFormattable, ErrorHandlingCommand, OutputFormatt
         do {
             let actions = try self.buildActions()
             let observation = await self.resolveObservationContext()
-            try await observation.validateIfExplicit(using: self.services.snapshots)
-            let targetIdentity = try await self.backgroundProcessIdentity(snapshotId: observation.snapshotId)
+            let targetIdentity: ApplicationProcessIdentity?
+            do {
+                try await observation.validateIfExplicit(using: self.services.snapshots)
+                targetIdentity = try await self.backgroundProcessIdentity(snapshotId: observation.snapshotId)
+            } catch is CancellationError {
+                throw CancellationError()
+            } catch {
+                try Task.checkCancellation()
+                throw self.preDispatchActionError(for: error)
+            }
             let targetPID = targetIdentity?.processIdentifier
             self.resolvedRuntime.beginInteractionMutation()
+            var sequence = DesktopActionSequenceAccumulator()
             if targetPID == nil {
                 try await self.focusIfNeeded(snapshotId: observation.focusSnapshotId(for: self.target))
+                if self.focusOptions.autoFocus,
+                   self.target.hasAnyTarget || observation.focusSnapshotId(for: self.target) != nil {
+                    sequence.record(.mayHaveDispatched(route: nil, delivery: nil, unitCount: .one))
+                }
             }
-            let actionResult = try await self.executeTypeActions(
-                actions: actions,
-                snapshotId: observation.snapshotId,
-                expectedProcessIdentity: targetIdentity
-            )
+            let actionResult: UIAutomationActionResult<TypeResult>
+            do {
+                actionResult = try await self.executeTypeActions(
+                    actions: actions,
+                    snapshotId: observation.snapshotId,
+                    expectedProcessIdentity: targetIdentity
+                )
+                try DesktopActionFailure.requireConfirmedIfReported(
+                    actionResult.outcome,
+                    operation: "Typing"
+                )
+            } catch let failure as DesktopActionFailure {
+                let composed = sequence.failure(
+                    combining: failure,
+                    message: "Typing failed after foreground setup may have changed focus.",
+                    hint: "Observe the target before deciding whether to retry typing."
+                )
+                await self.invalidateAfterFailedMutation(composed)
+                throw composed
+            } catch let error as InputDeliveryIndeterminateError {
+                let delivery = Self.delivery(targetProcessIdentifier: targetPID)
+                let composed = sequence.failure(
+                    combining: error.desktopActionFailure(delivery: delivery, route: self.actionRoute),
+                    message: "Typing outcome is indeterminate.",
+                    hint: "Observe the target before deciding whether to retry typing.",
+                    causeDescription: error.causeDescription ?? error.localizedDescription
+                )
+                await self.invalidateAfterFailedMutation(composed)
+                throw composed
+            } catch {
+                guard sequence.mutationDisposition.mutationDispatched else { throw error }
+                let composed = sequence.failure(
+                    combining: .preDispatchRefusal(
+                        route: self.actionRoute,
+                        reason: .operationUnsupported,
+                        message: error.localizedDescription
+                    ),
+                    message: "Typing failed after foreground setup may have changed focus.",
+                    hint: "Observe the target before deciding whether to retry typing.",
+                    causeDescription: error.localizedDescription
+                )
+                await self.invalidateAfterFailedMutation(composed)
+                throw composed
+            }
+            if let outcome = actionResult.outcome {
+                sequence.record(.reportedOutcome(outcome, defaultDispatchedUnitCount: .one))
+            } else {
+                sequence.record(.dispatched(
+                    route: self.actionRoute,
+                    delivery: Self.delivery(targetProcessIdentifier: targetPID),
+                    unitCount: .one
+                ))
+            }
             await InteractionObservationInvalidator.invalidateAfterMutation(
                 targets: self.resolvedRuntime.interactionMutationTargets,
                 logger: self.logger,
@@ -91,7 +152,7 @@ struct TypeCommand: ActionOutputFormattable, ErrorHandlingCommand, OutputFormatt
             )
             self.renderResult(
                 actionResult.payload,
-                outcome: actionResult.outcome,
+                outcome: sequence.successResolution().outcome,
                 actions: actions,
                 startTime: startTime,
                 targetProcessIdentifier: targetPID
@@ -255,6 +316,25 @@ struct TypeCommand: ActionOutputFormattable, ErrorHandlingCommand, OutputFormatt
         case .clear:
             TypeCommandActionSummary(kind: "clear", value: nil)
         }
+    }
+
+    private static func delivery(targetProcessIdentifier: pid_t?) -> DesktopActionOutcome.Delivery {
+        targetProcessIdentifier == nil
+            ? .init(mechanism: .globalEvents, mode: .foreground)
+            : .init(mechanism: .processTargetedEvents, mode: .background)
+    }
+
+    private func invalidateAfterFailedMutation(_ failure: DesktopActionFailure) async {
+        guard failure.outcome.dispatchState.mutationDispatched else { return }
+        await InteractionObservationInvalidator.invalidateAfterMutation(
+            targets: self.resolvedRuntime.interactionMutationTargets,
+            logger: self.logger,
+            reason: "type failure"
+        )
+    }
+
+    private var actionRoute: DesktopActionOutcome.Route {
+        self.services.automation is RemoteUIAutomationService ? .bridge : .local
     }
 }
 

--- a/Apps/CLI/Tests/CLIAutomationTests/ActionOutcomeCommandTests.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/ActionOutcomeCommandTests.swift
@@ -253,11 +253,10 @@ struct ActionOutcomeCommandTests {
     }
 
     @Test
-    func `successful multi press keeps legacy effect and omits singular outcome`() async throws {
+    func `successful multi press publishes one canonical aggregate`() async throws {
         let context = Self.makeContext()
-        context.automation.actionOutcome = .dispatchedUnverified(
-            delivery: .init(mechanism: .globalEvents, mode: .foreground),
-            evidence: .deliveryAccepted
+        context.automation.actionOutcome = .confirmedChange(
+            delivery: .init(mechanism: .globalEvents, mode: .foreground)
         )
 
         let result = try await InProcessCommandRunner.run(
@@ -267,17 +266,18 @@ struct ActionOutcomeCommandTests {
         let object = try Self.jsonObject(result.stdout)
 
         #expect(result.exitStatus == 0)
-        #expect(object["effect"] as? String == "unverifiable")
-        #expect(object["outcome"] == nil)
+        let projection = try #require(object["outcome"] as? [String: Any])
+        #expect(object["effect"] as? String == "confirmed")
+        #expect(projection["state"] as? String == "confirmed_change")
+        #expect(projection["dispatched_unit_count"] as? Int == 2)
         #expect(context.automation.hotkeyCalls.count == 2)
     }
 
     @Test
     func `mid sequence partial failure publishes cumulative canonical projection`() async throws {
         let context = Self.makeContext()
-        context.automation.actionOutcome = .dispatchedUnverified(
-            delivery: .init(mechanism: .globalEvents, mode: .foreground),
-            evidence: .deliveryAccepted
+        context.automation.actionOutcome = .confirmedChange(
+            delivery: .init(mechanism: .globalEvents, mode: .foreground)
         )
         let leafFailure = DesktopActionFailure.partial(
             delivery: .init(mechanism: .globalEvents, mode: .foreground),
@@ -308,9 +308,8 @@ struct ActionOutcomeCommandTests {
     @Test
     func `mid sequence partial failure preserves unknown leaf unit count`() async throws {
         let context = Self.makeContext()
-        context.automation.actionOutcome = .dispatchedUnverified(
-            delivery: .init(mechanism: .globalEvents, mode: .foreground),
-            evidence: .deliveryAccepted
+        context.automation.actionOutcome = .confirmedChange(
+            delivery: .init(mechanism: .globalEvents, mode: .foreground)
         )
         let leafFailure = DesktopActionFailure.partial(
             delivery: .init(mechanism: .globalEvents, mode: .foreground),
@@ -334,9 +333,8 @@ struct ActionOutcomeCommandTests {
     @Test
     func `mid sequence indeterminate failure adds completed and leaf units`() async throws {
         let context = Self.makeContext()
-        context.automation.actionOutcome = .dispatchedUnverified(
-            delivery: .init(mechanism: .globalEvents, mode: .foreground),
-            evidence: .deliveryAccepted
+        context.automation.actionOutcome = .confirmedChange(
+            delivery: .init(mechanism: .globalEvents, mode: .foreground)
         )
         let leafFailure = InputDeliveryIndeterminateError(
             operation: .hotkey,
@@ -360,7 +358,7 @@ struct ActionOutcomeCommandTests {
     }
 
     @Test
-    func `first unbacked indeterminate failure preserves legacy omission`() async throws {
+    func `first indeterminate failure publishes canonical retry guidance`() async throws {
         let context = Self.makeContext()
         let leafFailure = InputDeliveryIndeterminateError(
             operation: .hotkey,
@@ -375,20 +373,40 @@ struct ActionOutcomeCommandTests {
         )
         let object = try Self.jsonObject(result.stdout)
         let error = try #require(object["error"] as? [String: Any])
+        let projection = try #require(object["outcome"] as? [String: Any])
 
         #expect(result.exitStatus == 1)
         #expect(object["effect"] as? String == "unverifiable")
-        #expect(object["outcome"] == nil)
-        #expect(error["mutation_dispatched"] == nil)
-        #expect(error["retry_safe"] == nil)
+        #expect(projection["state"] as? String == "indeterminate")
+        #expect(projection["dispatched_unit_count"] == nil)
+        #expect(error["mutation_dispatched"] as? Bool == true)
+        #expect(error["retry_safe"] as? Bool == false)
+    }
+
+    @Test
+    func `returned dispatched press failure invalidates prior observations`() async throws {
+        let context = Self.makeContext()
+        context.automation.actionOutcome = .dispatchedUnverified(
+            delivery: .init(mechanism: .globalEvents, mode: .foreground),
+            evidence: .deliveryAccepted
+        )
+        _ = try await context.snapshots.createSnapshot()
+
+        let result = try await InProcessCommandRunner.run(
+            ["press", "cmd+a", "--foreground", "--json", "--no-remote"],
+            services: context.services
+        )
+
+        #expect(result.exitStatus == 1)
+        #expect(context.snapshots.invalidationCutoffs.count == 1)
+        #expect(await context.snapshots.getMostRecentSnapshot() == nil)
     }
 
     @Test
     func `later indeterminate failure keeps aggregate count unknown when leaf count is unknown`() async throws {
         let context = Self.makeContext()
-        context.automation.actionOutcome = .dispatchedUnverified(
-            delivery: .init(mechanism: .globalEvents, mode: .foreground),
-            evidence: .deliveryAccepted
+        context.automation.actionOutcome = .confirmedChange(
+            delivery: .init(mechanism: .globalEvents, mode: .foreground)
         )
         let leafFailure = InputDeliveryIndeterminateError(
             operation: .hotkey,
@@ -411,17 +429,19 @@ struct ActionOutcomeCommandTests {
     }
 
     @Test
-    func `between call failure projection preserves exact completed count`() {
-        let failure = ActionSequenceFailureComposer.indeterminate(
-            knownDispatchedUnitCount: 1,
-            context: .init(
-                route: .bridge,
-                delivery: .init(mechanism: .globalEvents, mode: .foreground),
-                message: "Key sequence outcome is indeterminate after 1 completed press",
-                hint: "Observe the target before retrying this key sequence.",
-                causeDescription: "Cancelled between chords"
-            )
-        )
+    func `between call failure projection preserves exact completed count`() throws {
+        var sequence = DesktopActionSequenceAccumulator()
+        sequence.record(.dispatched(
+            route: .bridge,
+            delivery: .init(mechanism: .globalEvents, mode: .foreground),
+            unitCount: DesktopActionOutcome.DispatchUnitCount(1)
+        ))
+        let failure = try #require(sequence.cancellationFailure(
+            fallbackRoute: .local,
+            message: "Key sequence outcome is indeterminate after 1 completed press",
+            hint: "Observe the target before retrying this key sequence.",
+            causeDescription: "Cancelled between chords"
+        ))
         let projection = failure.outcome.projection
 
         #expect(projection.state == .indeterminate)
@@ -433,6 +453,12 @@ struct ActionOutcomeCommandTests {
 
     @Test
     func `sequence composition preserves canonical response loss evidence and route`() {
+        var sequence = DesktopActionSequenceAccumulator()
+        sequence.record(.dispatched(
+            route: .bridge,
+            delivery: .init(mechanism: .globalEvents, mode: .foreground),
+            unitCount: DesktopActionOutcome.DispatchUnitCount(1)
+        ))
         let leafFailure = DesktopActionFailure.indeterminate(
             route: .bridge,
             delivery: .init(mechanism: .globalEvents, mode: .foreground),
@@ -440,12 +466,10 @@ struct ActionOutcomeCommandTests {
             unitCount: DesktopActionOutcome.DispatchUnitCount(2),
             message: "Bridge response was lost"
         )
-        let failure = ActionSequenceFailureComposer.combining(
-            completedUnitCount: 1,
-            leafFailure: leafFailure,
-            delivery: .init(mechanism: .globalEvents, mode: .foreground),
+        let failure = sequence.failure(
+            combining: leafFailure,
             message: "Key sequence stopped after 1 completed press",
-            indeterminateHint: "Observe before retrying"
+            hint: "Observe before retrying"
         )
         let projection = failure.outcome.projection
 

--- a/Apps/CLI/Tests/CLIAutomationTests/PasteCommandInventoryEligibilityTests.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/PasteCommandInventoryEligibilityTests.swift
@@ -1,4 +1,5 @@
 import PeekabooAutomationKitTestSupport
+import PeekabooFoundation
 import Testing
 @testable import PeekabooCLI
 @testable import PeekabooCore
@@ -48,6 +49,8 @@ struct PasteCommandInventoryEligibilityTests {
 
             #expect(result.exitStatus != 0)
             #expect(result.stdout.contains("cannot receive background input"))
+            let envelope = try ActionEnvelopeTestProbe.decode(result.stdout)
+            ActionEnvelopeTestAssertions.expectCanonicalRefusal(reason: .targetUnavailable, in: envelope)
             #expect(automation.targetedTypeActionsCalls.isEmpty)
             #expect(automation.targetedHotkeyCalls.isEmpty)
             #expect(automation.hotkeyCalls.isEmpty)

--- a/Apps/CLI/Tests/CLIAutomationTests/PreDispatchActionEnvelopeTests.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/PreDispatchActionEnvelopeTests.swift
@@ -117,6 +117,12 @@ struct PreDispatchActionEnvelopeTests {
                     .invalidRequest
                 ),
                 (
+                    "missing explicit type snapshot",
+                    ["type", "hello", "--snapshot", "synthetic-missing-snapshot", "--json", "--no-remote"],
+                    .SNAPSHOT_NOT_FOUND,
+                    .targetUnavailable
+                ),
+                (
                     "malformed coordinate click",
                     ["click", "--at", ",", "--json"],
                     .VALIDATION_ERROR,

--- a/Apps/CLI/Tests/CLIAutomationTests/TypeCommandTests.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/TypeCommandTests.swift
@@ -213,7 +213,6 @@ struct TypeCommandTests {
             arguments: ["Hello", "--app", "TextEdit", "--json"],
             context: context
         )
-
         #expect(result.exitStatus == 0)
         let targetedCall = try #require(await self.automationState(context) { $0.targetedTypeActionsCalls.first })
         #expect(targetedCall.targetProcessIdentifier == 2468)
@@ -282,6 +281,86 @@ struct TypeCommandTests {
         )
         #expect(payload.data.deliveryMode == "foreground")
         #expect(payload.data.targetPID == nil)
+    }
+
+    @Test
+    func `Foreground setup suppresses a no-dispatch typing leaf`() async throws {
+        let windows = await MainActor.run { StubWindowService(windowsByApp: [:]) }
+        let automation = await MainActor.run {
+            let automation = OutcomeStubAutomationService()
+            automation.actionOutcome = .confirmedNoChange()
+            return automation
+        }
+        let context = await self.makeContext(automation: automation, windows: windows)
+
+        let result = try await self.runType(
+            arguments: ["Hello", "--window-id", "777", "--foreground", "--json"],
+            context: context
+        )
+        let object = try #require(
+            JSONSerialization.jsonObject(with: Data(result.stdout.utf8)) as? [String: Any]
+        )
+
+        #expect(result.exitStatus == 0)
+        #expect(object["effect"] as? String == "unverifiable")
+        #expect(object["outcome"] == nil)
+        let focusCalls = await MainActor.run { windows.focusCalls }
+        #expect(!focusCalls.isEmpty)
+    }
+
+    @Test
+    func `Foreground setup makes a refused typing leaf indeterminate`() async throws {
+        let windows = await MainActor.run { StubWindowService(windowsByApp: [:]) }
+        let automation = await MainActor.run {
+            let automation = OutcomeStubAutomationService()
+            automation.actionOutcome = .refused(reason: .permissionDenied)
+            return automation
+        }
+        let context = await self.makeContext(automation: automation, windows: windows)
+
+        let result = try await self.runType(
+            arguments: ["Hello", "--window-id", "777", "--foreground", "--json"],
+            context: context
+        )
+        let object = try #require(
+            JSONSerialization.jsonObject(with: Data(result.stdout.utf8)) as? [String: Any]
+        )
+        let outcome = try #require(object["outcome"] as? [String: Any])
+        let error = try #require(object["error"] as? [String: Any])
+
+        #expect(result.exitStatus == 1)
+        #expect(outcome["state"] as? String == "indeterminate")
+        #expect(outcome["dispatch_state"] as? String == "may_have_dispatched")
+        #expect(outcome["mutation_dispatched"] as? Bool == true)
+        #expect(outcome["retry_safe"] as? Bool == false)
+        #expect(outcome["requires_fresh_observation"] as? Bool == true)
+        #expect(error["mutation_dispatched"] as? Bool == true)
+        let focusCalls = await MainActor.run { windows.focusCalls }
+        #expect(!focusCalls.isEmpty)
+    }
+
+    @Test
+    func `Returned dispatched typing failure invalidates prior observations`() async throws {
+        let windows = await MainActor.run { StubWindowService(windowsByApp: [:]) }
+        let automation = await MainActor.run {
+            let automation = OutcomeStubAutomationService()
+            automation.actionOutcome = .dispatchedUnverified(
+                delivery: .init(mechanism: .globalEvents, mode: .foreground),
+                evidence: .deliveryAccepted
+            )
+            return automation
+        }
+        let context = await self.makeContext(automation: automation, windows: windows)
+        _ = try await context.snapshots.createSnapshot()
+
+        let result = try await self.runType(
+            arguments: ["Hello", "--window-id", "777", "--foreground", "--json"],
+            context: context
+        )
+
+        #expect(result.exitStatus == 1)
+        #expect(context.snapshots.invalidationCutoffs.count == 1)
+        #expect(await context.snapshots.getMostRecentSnapshot() == nil)
     }
 
     @Test
@@ -483,12 +562,17 @@ struct TypeCommandTests {
 
     @MainActor
     private func makeContext(
+        automation: StubAutomationService = StubAutomationService(),
         applications: any ApplicationServiceProtocol = StubApplicationService(applications: []),
         windows: any WindowManagementServiceProtocol = StubWindowService(windowsByApp: [:]),
         configure: ((StubAutomationService, StubSnapshotManager) -> Void)? = nil
     ) async -> TestServicesFactory.AutomationTestContext {
         await MainActor.run {
-            let context = TestServicesFactory.makeAutomationTestContext(applications: applications, windows: windows)
+            let context = TestServicesFactory.makeAutomationTestContext(
+                automation: automation,
+                applications: applications,
+                windows: windows
+            )
             configure?(context.automation, context.snapshots)
             return context
         }

--- a/Apps/CLI/Tests/CoreCLITests/ResultEnvelopeTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/ResultEnvelopeTests.swift
@@ -235,6 +235,49 @@ struct ResultEnvelopeTests {
         #expect(envelope.error?.mutation_dispatched == false)
     }
 
+    @Test func `definitive legacy no-dispatch receipt derives one canonical refusal`() {
+        let envelope = ResultEnvelopeContext.$isActionCommand.withValue(true) {
+            makeErrorEnvelope(
+                message: "The exact target has no provable focused element.",
+                code: .INVALID_INPUT,
+                effect: .refused,
+                retrySafe: true,
+                mutationDispatched: false
+            )
+        }
+
+        #expect(envelope.effect == .refused)
+        #expect(envelope.outcome?.state == .refused)
+        #expect(envelope.outcome?.refusalReason == .invalidRequest)
+        #expect(envelope.outcome?.dispatchState == DesktopActionOutcome.DispatchState.none)
+        #expect(envelope.outcome?.retrySafety == .safe)
+        #expect(envelope.outcome?.requiresFreshObservation == false)
+        #expect(envelope.error?.retry_safe == true)
+        #expect(envelope.error?.mutation_dispatched == false)
+    }
+
+    @Test func `incomplete legacy receipts never invent canonical action evidence`() {
+        let receipts: [(retrySafe: Bool?, mutationDispatched: Bool?)] = [
+            (nil, nil),
+            (true, nil),
+            (nil, false),
+            (false, false),
+            (true, true),
+        ]
+        for receipt in receipts {
+            let envelope = ResultEnvelopeContext.$isActionCommand.withValue(true) {
+                makeErrorEnvelope(
+                    message: "Fixture failure.",
+                    code: .INVALID_INPUT,
+                    effect: .refused,
+                    retrySafe: receipt.retrySafe,
+                    mutationDispatched: receipt.mutationDispatched
+                )
+            }
+            #expect(envelope.outcome == nil)
+        }
+    }
+
     @Test func `stale action target derives a canonical target refusal`() {
         let envelope = ResultEnvelopeContext.$isActionCommand.withValue(true) {
             ResultEnvelopeContext.$isPreDispatchFailure.withValue(true) {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Wake Bridge hosts on kernel listener readiness instead of polling `accept` every 25 ms, draining queued clients per notification while preserving bounded, descriptor-safe shutdown.
 
 ### Fixed
+- Compose setup, delivery, cleanup, cancellation, and refusal receipts through one Foundation action-sequence owner so foreground focus cannot be erased by a no-dispatch leaf and CLI/MCP target refusals expose complete retry guidance.
 - Make explicit Bridge socket overrides fail closed when unavailable instead of reporting a successful local fallback.
 - Validate `see` selectors, explicit caller-local PIDs, and `scroll` directions before runtime-host and ScreenCaptureKit ownership preflight so request errors cannot be masked by ambient capture state.
 - Consume explicit snapshots for further mutations when a canonical action outcome requires fresh observation or is unavailable, refusing duplicate click/action/set-value/scroll dispatch before it reaches the app while preserving read-only snapshot evidence.

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Server/MCPDesktopActionFailureHandler.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Server/MCPDesktopActionFailureHandler.swift
@@ -3,19 +3,6 @@ import PeekabooFoundation
 import TachikomaMCP
 
 enum MCPDesktopActionFailureHandler {
-    static func requireConfirmed(
-        _ outcome: DesktopActionOutcome?,
-        operation: String) throws
-    {
-        guard let outcome,
-              let failure = DesktopActionFailure(
-                  outcome: outcome,
-                  message: "\(operation) did not return a confirmed outcome.",
-                  hint: "Follow the canonical escalation metadata before deciding whether to retry.")
-        else { return }
-        throw failure
-    }
-
     @MainActor
     static func response(
         for failure: DesktopActionFailure,

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Server/MCPToolResponseMetadataProjector.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Server/MCPToolResponseMetadataProjector.swift
@@ -140,7 +140,7 @@ enum MCPToolResponseMetadataProjector {
         reason: DesktopActionOutcome.RefusalReason,
         additionalFields: [String: Value] = [:]) -> ToolResponse
     {
-        let failure = DesktopActionFailure.refused(reason: reason, message: message)
+        let failure = DesktopActionFailure.preDispatchRefusal(reason: reason, message: message)
         do {
             return try self.errorResponse(
                 for: failure,

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/ActionTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/ActionTool.swift
@@ -66,7 +66,7 @@ public struct ActionTool: MCPTool {
                         snapshotId: effectiveSnapshotId),
                     outcome: nil)
             }
-            try MCPDesktopActionFailureHandler.requireConfirmed(
+            try DesktopActionFailure.requireConfirmedIfReported(
                 actionResult.outcome,
                 operation: "Action")
             let invalidatedSnapshotId = await MCPDesktopActionSnapshotInvalidator.invalidate(

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/ClickTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/ClickTool.swift
@@ -161,7 +161,7 @@ public struct ClickTool: MCPTool {
                 intent: request.intent,
                 deliveryMode: request.deliveryMode,
                 targetProcessIdentity: effectiveTargetProcessIdentity)
-            try MCPDesktopActionFailureHandler.requireConfirmed(
+            try DesktopActionFailure.requireConfirmedIfReported(
                 outcome,
                 operation: "Click")
 

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/PasteTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/PasteTool.swift
@@ -3,6 +3,7 @@ import Foundation
 import MCP
 import os.log
 import PeekabooAutomation
+import PeekabooFoundation
 import TachikomaMCP
 import UniformTypeIdentifiers
 
@@ -126,7 +127,9 @@ public struct PasteTool: MCPTool {
                     foreground: false,
                     expectedPIDIdentity: expectedPIDIdentity)
                 guard destination.targetPID != nil else {
-                    throw PasteToolError("Background text paste requires an app or pid target.")
+                    throw PasteToolError(
+                        "Background text paste requires an app or pid target.",
+                        refusalReason: .invalidRequest)
                 }
                 return try await self.performBackgroundTextPaste(
                     text: text,
@@ -157,7 +160,7 @@ public struct PasteTool: MCPTool {
             }
 
             guard case let .explicit(request, _) = payload else {
-                throw PasteToolError("Invalid paste payload.")
+                throw PasteToolError("Invalid paste payload.", refusalReason: .invalidRequest)
             }
             let outcome = try await ClipboardPasteTransactionGate.withExclusiveTransaction {
                 let destination = try await self.resolveDeliveryDestination(
@@ -228,7 +231,9 @@ public struct PasteTool: MCPTool {
                 content: [.text(text: message, annotations: nil, _meta: nil)],
                 meta: ToolEventSummary.merge(summary: summary, into: meta))
         } catch let error as MCPInteractionTargetError {
-            return ToolResponse.error(error.localizedDescription)
+            return MCPToolResponseMetadataProjector.preDispatchRefusalResponse(
+                message: error.localizedDescription,
+                reason: error.refusalReason)
         } catch let error as ClipboardPasteOutcomeError {
             self.logger.error("Paste outcome was \(error.kind.rawValue, privacy: .public)")
             return ToolResponse.error(
@@ -246,7 +251,9 @@ public struct PasteTool: MCPTool {
                     "requires_fresh_observation": .bool(true),
                 ]))
         } catch let error as PasteToolError {
-            return ToolResponse.error(error.message)
+            return MCPToolResponseMetadataProjector.preDispatchRefusalResponse(
+                message: error.message,
+                reason: error.refusalReason)
         } catch {
             self.logger.error("Paste failed: \(error.localizedDescription)")
             return ToolResponse.error("Paste failed: \(error.localizedDescription)")
@@ -293,7 +300,8 @@ public struct PasteTool: MCPTool {
                   automation.supportsExactWindowTargetedKeyboard
             else {
                 throw PasteToolError(
-                    "This automation host does not support atomic exact-window background paste delivery.")
+                    "This automation host does not support atomic exact-window background paste delivery.",
+                    refusalReason: .runtimeIncompatible)
             }
             exactWindowAutomation = automation
             targetedAutomation = nil
@@ -302,7 +310,9 @@ public struct PasteTool: MCPTool {
                   automation.supportsTargetedHotkeys,
                   automation.supportsProcessGenerationPinnedHotkeys
             else {
-                throw PasteToolError("This automation host does not support background paste delivery.")
+                throw PasteToolError(
+                    "This automation host does not support background paste delivery.",
+                    refusalReason: .runtimeIncompatible)
             }
             exactWindowAutomation = nil
             targetedAutomation = automation
@@ -438,7 +448,8 @@ public struct PasteTool: MCPTool {
                   automation.supportsExactWindowTargetedKeyboard
             else {
                 throw PasteToolError(
-                    "This automation host does not support atomic exact-window background paste delivery.")
+                    "This automation host does not support atomic exact-window background paste delivery.",
+                    refusalReason: .runtimeIncompatible)
             }
             exactWindowAutomation = automation
             targetedAutomation = nil
@@ -447,7 +458,9 @@ public struct PasteTool: MCPTool {
                   automation.supportsTargetedHotkeys,
                   automation.supportsProcessGenerationPinnedHotkeys
             else {
-                throw PasteToolError("This automation host does not support background paste delivery.")
+                throw PasteToolError(
+                    "This automation host does not support background paste delivery.",
+                    refusalReason: .runtimeIncompatible)
             }
             exactWindowAutomation = nil
             targetedAutomation = automation
@@ -517,7 +530,8 @@ public struct PasteTool: MCPTool {
                   automation.supportsExactWindowTargetedKeyboard
             else {
                 throw PasteToolError(
-                    "This automation host does not support atomic exact-window background text delivery.")
+                    "This automation host does not support atomic exact-window background text delivery.",
+                    refusalReason: .runtimeIncompatible)
             }
             try Task.checkCancellation()
             do {
@@ -539,7 +553,9 @@ public struct PasteTool: MCPTool {
                   automation.supportsProcessGenerationPinnedTypeActions,
                   let processIdentity = destination.processIdentity
             else {
-                throw PasteToolError("This automation host does not support background text delivery.")
+                throw PasteToolError(
+                    "This automation host does not support background text delivery.",
+                    refusalReason: .runtimeIncompatible)
             }
             try Task.checkCancellation()
             do {
@@ -646,26 +662,6 @@ public struct PasteTool: MCPTool {
             meta: ToolEventSummary.merge(summary: summary, into: meta))
     }
 
-    private static func readResult(for request: ClipboardWriteRequest) throws -> ClipboardReadResult {
-        guard let primary = request.representations.first else {
-            throw ClipboardServiceError.writeFailed("No representations provided.")
-        }
-        let textPreview: String? = if let text = request.alsoText {
-            String(text.prefix(80))
-        } else if primary.utiIdentifier == UTType.plainText.identifier ||
-            primary.utiIdentifier == UTType.utf8PlainText.identifier,
-            let string = String(data: primary.data, encoding: .utf8)
-        {
-            String(string.prefix(80))
-        } else {
-            nil
-        }
-        return ClipboardReadResult(
-            utiIdentifier: primary.utiIdentifier,
-            data: primary.data,
-            textPreview: textPreview)
-    }
-
     @MainActor
     private func resolveDeliveryDestination(
         target: MCPInteractionTarget,
@@ -707,7 +703,9 @@ public struct PasteTool: MCPTool {
     {
         try target.validate()
         guard let windowTarget = try target.toWindowTarget() else {
-            throw PasteToolError("Exact-window background paste requires a window selector.")
+            throw PasteToolError(
+                "Exact-window background paste requires a window selector.",
+                refusalReason: .invalidRequest)
         }
         guard let selectedWindow = try await self.context.windows.listWindows(target: windowTarget).first else {
             throw PasteToolError("Could not resolve the requested exact window.")
@@ -859,6 +857,26 @@ public struct PasteTool: MCPTool {
 }
 
 extension PasteTool {
+    fileprivate static func readResult(for request: ClipboardWriteRequest) throws -> ClipboardReadResult {
+        guard let primary = request.representations.first else {
+            throw ClipboardServiceError.writeFailed("No representations provided.")
+        }
+        let textPreview: String? = if let text = request.alsoText {
+            String(text.prefix(80))
+        } else if primary.utiIdentifier == UTType.plainText.identifier ||
+            primary.utiIdentifier == UTType.utf8PlainText.identifier,
+            let string = String(data: primary.data, encoding: .utf8)
+        {
+            String(string.prefix(80))
+        } else {
+            nil
+        }
+        return ClipboardReadResult(
+            utiIdentifier: primary.utiIdentifier,
+            data: primary.data,
+            textPreview: textPreview)
+    }
+
     fileprivate static func backgroundPlainText(from request: ClipboardWriteRequest) -> String? {
         guard let primary = request.representations.first,
               primary.utiIdentifier == UTType.plainText.identifier ||
@@ -933,7 +951,13 @@ private struct CurrentClipboardPasteOutcome: Sendable {
 
 private struct PasteToolError: Error {
     let message: String
-    init(_ message: String) {
+    let refusalReason: DesktopActionOutcome.RefusalReason
+
+    init(
+        _ message: String,
+        refusalReason: DesktopActionOutcome.RefusalReason = .targetUnavailable)
+    {
         self.message = message
+        self.refusalReason = refusalReason
     }
 }

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/PressTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/PressTool.swift
@@ -83,9 +83,6 @@ public struct PressTool: MCPTool {
 
     @MainActor
     public func execute(arguments: ToolArguments) async throws -> ToolResponse {
-        var targetFocusCompleted = false
-        var progress = PressSequenceProgress()
-        var failureCompatibility = PressFailureCompatibility.none
         do {
             let chords = try Self.parseChords(arguments: arguments)
             let parameters = try Self.executionParameters(arguments: arguments)
@@ -104,111 +101,49 @@ public struct PressTool: MCPTool {
                 return try Self.foregroundConsentRefusal()
             }
             let resolvedWindowTitle = try await target.resolveWindowTitleIfNeeded(windows: self.context.windows)
-            targetFocusCompleted = try await target.focusIfRequested(
+            let targetFocusCompleted = try await target.focusIfRequested(
                 windows: self.context.windows,
                 onlyWhenTargeted: true) != nil
 
             let startTime = Date()
-            var singleOutcome: DesktopActionOutcome?
-            do {
-                for repetition in 0..<count {
-                    for (index, chord) in chords.enumerated() {
-                        if let outcomeAutomation = self.context.automation as? any UIAutomationActionOutcomeProviding {
-                            let result = try await outcomeAutomation.hotkeyWithOutcome(
-                                keys: chord.serviceKeys,
-                                holdDuration: hold)
-                            if let outcome = result.outcome,
-                               let failure = DesktopActionFailure(
-                                   outcome: outcome,
-                                   message: "Raw chord \(chord.displayValue) did not return a confirmed outcome.",
-                                   hint: "Follow the canonical escalation metadata before deciding whether to retry.")
-                            {
-                                throw failure
-                            }
-                            singleOutcome = progress.completedCalls == 0 ? result.outcome : nil
-                            progress.record(outcome: result.outcome)
-                        } else {
-                            try await self.context.automation.hotkey(keys: chord.serviceKeys, holdDuration: hold)
-                            singleOutcome = nil
-                            progress.record(outcome: nil)
-                        }
-                        let isLast = repetition == count - 1 && index == chords.count - 1
-                        if delay > 0, !isLast {
-                            try await Task.sleep(nanoseconds: UInt64(delay) * 1_000_000)
-                        }
-                    }
-                }
-            } catch let failure as DesktopActionFailure {
-                failureCompatibility = PressFailureCompatibility(
-                    progress: progress,
-                    leafFailure: failure)
-                throw Self.aggregateSequenceFailure(
-                    failure,
-                    progress: progress,
-                    setupFocusCompleted: targetFocusCompleted)
-            } catch let error as InputDeliveryIndeterminateError {
-                let failure = error.desktopActionFailure(
-                    delivery: .init(mechanism: .globalEvents, mode: .foreground))
-                failureCompatibility = PressFailureCompatibility(
-                    progress: progress,
-                    leafFailure: failure)
-                throw Self.aggregateSequenceFailure(
-                    failure,
-                    progress: progress,
-                    setupFocusCompleted: targetFocusCompleted)
-            } catch {
-                guard progress.dispatchedUnitCount > 0 || targetFocusCompleted else { throw error }
-                let failure = DesktopActionFailure.refused(
-                    reason: .operationUnsupported,
-                    message: error.localizedDescription)
-                failureCompatibility = PressFailureCompatibility(
-                    progress: progress,
-                    leafFailure: failure)
-                throw Self.aggregateSequenceFailure(
-                    failure,
-                    progress: progress,
-                    setupFocusCompleted: targetFocusCompleted)
-            }
-
+            let run = try await self.dispatchSequence(
+                chords: chords,
+                parameters: parameters,
+                targetFocusCompleted: targetFocusCompleted)
             let display = chords.map(\.displayValue)
             let elapsed = Date().timeIntervalSince(startTime)
-            // A sequence has no canonical aggregate contract. Publishing its last leaf receipt would erase
-            // earlier states, so preserve the shipped safety fields until Foundation owns batch composition.
-            let outcome = if progress.completedCalls == 1 && !targetFocusCompleted {
-                singleOutcome
-            } else {
-                progress.aggregateSuccess(setupFocusCompleted: targetFocusCompleted)
-            }
-            let message = Self.responseMessage(
+            let sequenceResolution = run.resolution
+            let outcome = sequenceResolution.outcome
+            let message = Self.responseMessage(PressResponseMessageInput(
                 display: display,
-                completed: progress.completedCalls,
+                completed: run.completedPresses,
                 elapsed: elapsed,
                 outcome: outcome,
                 confirmedNoChangeWithoutAggregate: outcome == nil &&
-                    progress.allConfirmedNoChange,
-                targetFocusCompleted: targetFocusCompleted)
+                    run.allChordsConfirmedNoChange,
+                targetFocusCompleted: targetFocusCompleted))
             var baseMeta: [String: Value] = [
                 "keys": .array(display.map(Value.string)),
                 "count": .int(count),
                 "delay": .int(delay),
                 "hold": .int(hold),
-                "total_presses": .int(progress.completedCalls),
+                "total_presses": .int(run.completedPresses),
                 "target_pid": .null,
                 "execution_time": .double(elapsed),
             ]
-            if !targetFocusCompleted, progress.dispatchedUnitCount > 0 {
+            if !targetFocusCompleted, sequenceResolution.mutationDispatched {
                 baseMeta["delivery_mode"] = .string("foreground")
             }
-            if outcome == nil, progress.dispatchedUnitCount > 0 || targetFocusCompleted {
-                baseMeta["effect"] = .string("unverifiable")
-                baseMeta["mutation_dispatched"] = .bool(true)
-                baseMeta["retry_safe"] = .bool(false)
-                baseMeta["requires_fresh_observation"] = .bool(true)
+            if outcome == nil {
+                if sequenceResolution.mutationDispatched {
+                    baseMeta["effect"] = .string(DesktopActionOutcome.Effect.unverifiable.rawValue)
+                }
+                baseMeta["mutation_dispatched"] = .bool(sequenceResolution.mutationDispatched)
+                baseMeta["retry_safe"] = .bool(sequenceResolution.retrySafe)
+                baseMeta["requires_fresh_observation"] = .bool(sequenceResolution.requiresFreshObservation)
             }
             if let invalidatedSnapshotID = await self.invalidateSnapshotAfterSuccess(
-                outcome: outcome,
-                progress: progress,
-                targetFocusCompleted: targetFocusCompleted)
+                resolution: sequenceResolution)
             {
                 baseMeta["invalidated_snapshot"] = .string(invalidatedSnapshotID)
             }
@@ -230,15 +165,119 @@ public struct PressTool: MCPTool {
             return try Self.invalidRequest(error.message)
         } catch let error as MCPToolArgumentValueError {
             return try Self.invalidRequest(error.localizedDescription)
+        } catch let failure as PressSequenceFailure {
+            return try await self.failureResponse(
+                failure.failure,
+                compatibility: failure.compatibility)
         } catch let failure as DesktopActionFailure {
-            return try await self.failureResponse(failure, compatibility: failureCompatibility)
+            return try await self.failureResponse(failure, compatibility: .none)
         } catch let error as InputDeliveryIndeterminateError {
             let failure = error.desktopActionFailure(delivery: nil)
-            return try await self.failureResponse(failure, compatibility: failureCompatibility)
+            return try await self.failureResponse(failure, compatibility: .none)
         } catch {
             self.logger.error("Press execution failed: \(error.localizedDescription)")
             return ToolResponse.error(error.localizedDescription)
         }
+    }
+
+    @MainActor
+    private func dispatchSequence(
+        chords: [KeyboardChord],
+        parameters: PressExecutionParameters,
+        targetFocusCompleted: Bool) async throws -> PressSequenceRun
+    {
+        var sequence = DesktopActionSequenceAccumulator()
+        if targetFocusCompleted {
+            sequence.record(.dispatched(route: nil, delivery: nil, unitCount: Self.singleDispatchUnit))
+        }
+        var chordSequence = DesktopActionSequenceAccumulator()
+        var completedPresses = 0
+        var allChordsConfirmedNoChange = true
+        do {
+            for repetition in 0..<parameters.count {
+                for (index, chord) in chords.enumerated() {
+                    let result = try await self.dispatch(chord: chord, hold: parameters.hold)
+                    try DesktopActionFailure.requireConfirmedIfReported(
+                        result.outcome,
+                        operation: "Raw chord \(chord.displayValue)")
+                    if let outcome = result.outcome {
+                        allChordsConfirmedNoChange = allChordsConfirmedNoChange &&
+                            outcome.state == .confirmedNoChange
+                        let step = DesktopActionSequenceAccumulator.Step.reportedOutcome(
+                            outcome,
+                            defaultDispatchedUnitCount: .one)
+                        sequence.record(step)
+                        chordSequence.record(step)
+                    } else {
+                        allChordsConfirmedNoChange = false
+                        let step = DesktopActionSequenceAccumulator.Step.dispatched(
+                            route: .local,
+                            delivery: Self.foregroundHotkeyDelivery,
+                            unitCount: Self.singleDispatchUnit)
+                        sequence.record(step)
+                        chordSequence.record(step)
+                    }
+                    completedPresses += 1
+                    let isLast = repetition == parameters.count - 1 && index == chords.count - 1
+                    if parameters.delay > 0, !isLast {
+                        try await Task.sleep(nanoseconds: UInt64(parameters.delay) * 1_000_000)
+                    }
+                }
+            }
+        } catch let failure as DesktopActionFailure {
+            throw Self.sequenceFailure(
+                failure,
+                sequence: sequence,
+                completedPresses: completedPresses,
+                chordDisposition: chordSequence.mutationDisposition)
+        } catch let error as InputDeliveryIndeterminateError {
+            throw Self.sequenceFailure(
+                error.desktopActionFailure(delivery: Self.foregroundHotkeyDelivery),
+                sequence: sequence,
+                completedPresses: completedPresses,
+                chordDisposition: chordSequence.mutationDisposition,
+                causeDescription: error.causeDescription ?? error.localizedDescription)
+        } catch {
+            guard sequence.mutationDisposition.mutationDispatched else { throw error }
+            throw Self.sequenceFailure(
+                .preDispatchRefusal(reason: .operationUnsupported, message: error.localizedDescription),
+                sequence: sequence,
+                completedPresses: completedPresses,
+                chordDisposition: chordSequence.mutationDisposition,
+                causeDescription: error.localizedDescription)
+        }
+        return PressSequenceRun(
+            resolution: sequence.successResolution(),
+            completedPresses: completedPresses,
+            allChordsConfirmedNoChange: allChordsConfirmedNoChange)
+    }
+
+    @MainActor
+    private func dispatch(chord: KeyboardChord, hold: Int) async throws -> UIAutomationActionResult<Void> {
+        if let automation = self.context.automation as? any UIAutomationActionOutcomeProviding {
+            return try await automation.hotkeyWithOutcome(keys: chord.serviceKeys, holdDuration: hold)
+        }
+        try await self.context.automation.hotkey(keys: chord.serviceKeys, holdDuration: hold)
+        return UIAutomationActionResult(payload: (), outcome: nil)
+    }
+
+    private static func sequenceFailure(
+        _ leafFailure: DesktopActionFailure,
+        sequence: DesktopActionSequenceAccumulator,
+        completedPresses: Int,
+        chordDisposition: DesktopActionMutationDisposition,
+        causeDescription: String? = nil) -> PressSequenceFailure
+    {
+        let failure = sequence.failure(
+            combining: leafFailure,
+            message: "Press sequence stopped after \(completedPresses) completed action unit(s).",
+            hint: "Observe the target before deciding whether to continue the sequence.",
+            causeDescription: causeDescription)
+        return PressSequenceFailure(
+            failure: failure,
+            compatibility: PressFailureCompatibility(
+                prefixDisposition: chordDisposition,
+                leafFailure: leafFailure))
     }
 
     static func parseChords(arguments: ToolArguments) throws -> [KeyboardChord] {
@@ -263,16 +302,12 @@ public struct PressTool: MCPTool {
 
     @MainActor
     private func invalidateSnapshotAfterSuccess(
-        outcome: DesktopActionOutcome?,
-        progress: PressSequenceProgress,
-        targetFocusCompleted: Bool) async -> String?
+        resolution: DesktopActionSequenceAccumulator.Resolution) async -> String?
     {
-        let mutationDispatched = outcome?.dispatchState.mutationDispatched ??
-            (progress.dispatchedUnitCount > 0 || targetFocusCompleted)
-        return await MCPDesktopActionSnapshotInvalidator.invalidate(
+        await MCPDesktopActionSnapshotInvalidator.invalidate(
             uiSnapshots: self.context.uiSnapshots,
             snapshotID: nil,
-            mutationDispatched: mutationDispatched)
+            mutationDispatched: resolution.mutationDispatched)
     }
 
     @MainActor
@@ -310,19 +345,12 @@ public struct PressTool: MCPTool {
         return parameters
     }
 
-    private static func responseMessage(
-        display: [String],
-        completed: Int,
-        elapsed: TimeInterval,
-        outcome: DesktopActionOutcome?,
-        confirmedNoChangeWithoutAggregate: Bool,
-        targetFocusCompleted: Bool) -> String
-    {
-        let sequence = display.joined(separator: " → ")
-        let duration = String(format: "%.2f", elapsed)
-        guard let outcome else {
-            if confirmedNoChangeWithoutAggregate {
-                if targetFocusCompleted {
+    private static func responseMessage(_ input: PressResponseMessageInput) -> String {
+        let sequence = input.display.joined(separator: " → ")
+        let duration = String(format: "%.2f", input.elapsed)
+        guard let outcome = input.outcome else {
+            if input.confirmedNoChangeWithoutAggregate {
+                if input.targetFocusCompleted {
                     return "\(AgentDisplayTokens.Status.warning) Completed \(sequence); " +
                         "all chords confirmed no change. The setup-focus effect is unverifiable; " +
                         "observe before continuing. Completed in \(duration)s"
@@ -331,7 +359,7 @@ public struct PressTool: MCPTool {
                     "all chords confirmed no change in \(duration)s"
             }
             return "\(AgentDisplayTokens.Status.success) Dispatched \(sequence) " +
-                "(\(completed) raw chord\(completed == 1 ? "" : "s")); effect is unverifiable. " +
+                "(\(input.completed) raw chord\(input.completed == 1 ? "" : "s")); effect is unverifiable. " +
                 "Observe before continuing. Completed in \(duration)s"
         }
         return switch outcome.state {
@@ -355,67 +383,6 @@ public struct PressTool: MCPTool {
         }
     }
 
-    static func aggregateSequenceFailure(
-        _ failure: DesktopActionFailure,
-        progress: PressSequenceProgress,
-        setupFocusCompleted: Bool) -> DesktopActionFailure
-    {
-        let completedUnits = progress.dispatchedUnitCount + (setupFocusCompleted ? 1 : 0)
-        guard completedUnits > 0 else { return failure }
-        let failedUnits: Int? = if let count = failure.outcome.dispatchState.unitCount?.rawValue {
-            count
-        } else if failure.outcome.dispatchState.mutationDispatched {
-            nil
-        } else {
-            0
-        }
-        let unitCount = failedUnits.flatMap { DesktopActionOutcome.DispatchUnitCount(completedUnits + $0) }
-        var deliveryIsKnown = !setupFocusCompleted && progress.deliveryIsHomogeneous
-        var delivery = progress.homogeneousDelivery
-        let failureDispatched = failure.outcome.dispatchState.mutationDispatched
-        var routeIsHomogeneous = !setupFocusCompleted && progress.routeIsHomogeneous
-        var aggregateRoute = failure.outcome.route
-        if failureDispatched {
-            if let priorRoute = progress.homogeneousRoute, priorRoute != failure.outcome.route {
-                routeIsHomogeneous = false
-            }
-            if let failureDelivery = failure.outcome.delivery {
-                if progress.dispatchedUnitCount == 0 {
-                    delivery = failureDelivery
-                } else if delivery != failureDelivery {
-                    deliveryIsKnown = false
-                }
-            } else {
-                deliveryIsKnown = false
-            }
-        } else if progress.dispatchedUnitCount > 0,
-                  routeIsHomogeneous,
-                  let priorRoute = progress.homogeneousRoute
-        {
-            aggregateRoute = priorRoute
-        }
-        if !deliveryIsKnown || !routeIsHomogeneous {
-            delivery = nil
-        }
-        if failure.outcome.state == .partial, let delivery, routeIsHomogeneous {
-            return .partial(
-                route: aggregateRoute,
-                delivery: delivery,
-                unitCount: unitCount,
-                message: failure.message,
-                hint: failure.hint,
-                causeDescription: failure.causeDescription)
-        }
-        return .indeterminate(
-            route: aggregateRoute,
-            delivery: delivery,
-            evidence: .completionUnknown,
-            unitCount: unitCount,
-            message: "Press sequence stopped after \(completedUnits) dispatched setup/action unit(s).",
-            hint: "Observe the target before deciding whether to continue the sequence.",
-            causeDescription: failure.localizedDescription)
-    }
-
     private static func foregroundConsentRefusal() throws -> ToolResponse {
         MCPToolResponseMetadataProjector.preDispatchRefusalResponse(
             message: RawPressPolicy.foregroundConsentRequiredMessage,
@@ -427,101 +394,16 @@ public struct PressTool: MCPTool {
     }
 }
 
-struct PressSequenceProgress {
-    private(set) var completedCalls = 0
-    private(set) var dispatchedUnitCount = 0
-    private(set) var homogeneousRoute: DesktopActionOutcome.Route?
-    private(set) var homogeneousDelivery: DesktopActionOutcome.Delivery?
-    private(set) var routeIsHomogeneous = true
-    private(set) var deliveryIsHomogeneous = true
-    private(set) var allOutcomesProvided = true
-    private(set) var allConfirmedNoChange = true
-    private(set) var outcomeRoute: DesktopActionOutcome.Route?
-    private(set) var outcomeRouteIsHomogeneous = true
-
-    mutating func record(outcome: DesktopActionOutcome?) {
-        self.completedCalls += 1
-        guard let outcome else {
-            self.allOutcomesProvided = false
-            self.allConfirmedNoChange = false
-            return self.recordLegacyDispatch()
-        }
-        if outcome.state != .confirmedNoChange {
-            self.allConfirmedNoChange = false
-        }
-        if let outcomeRoute, outcomeRoute != outcome.route {
-            self.outcomeRouteIsHomogeneous = false
-        } else if self.outcomeRoute == nil {
-            self.outcomeRoute = outcome.route
-        }
-        guard outcome.dispatchState.mutationDispatched else { return }
-
-        let unitCount = outcome.dispatchState.unitCount?.rawValue ?? 1
-        self.dispatchedUnitCount += unitCount
-        let route = outcome.route
-        guard let delivery = outcome.delivery else {
-            self.deliveryIsHomogeneous = false
-            return
-        }
-        if let homogeneousRoute, homogeneousRoute != route {
-            self.routeIsHomogeneous = false
-        } else if self.homogeneousRoute == nil {
-            self.homogeneousRoute = route
-        }
-        if let homogeneousDelivery, homogeneousDelivery != delivery {
-            self.deliveryIsHomogeneous = false
-        } else if self.homogeneousDelivery == nil {
-            self.homogeneousDelivery = delivery
-        }
-    }
-
-    func aggregateSuccess(setupFocusCompleted: Bool) -> DesktopActionOutcome? {
-        guard !setupFocusCompleted,
-              self.completedCalls > 0,
-              self.allOutcomesProvided
-        else { return nil }
-        guard self.dispatchedUnitCount > 0 else {
-            guard self.outcomeRouteIsHomogeneous, let outcomeRoute else { return nil }
-            return .confirmedNoChange(route: outcomeRoute)
-        }
-        guard self.routeIsHomogeneous,
-              let homogeneousRoute,
-              self.deliveryIsHomogeneous,
-              let delivery = self.homogeneousDelivery
-        else { return nil }
-        return .confirmedChange(
-            route: homogeneousRoute,
-            delivery: delivery,
-            unitCount: DesktopActionOutcome.DispatchUnitCount(self.dispatchedUnitCount))
-    }
-
-    private mutating func recordLegacyDispatch() {
-        self.dispatchedUnitCount += 1
-        let route = DesktopActionOutcome.Route.local
-        let delivery = DesktopActionOutcome.Delivery(mechanism: .globalEvents, mode: .foreground)
-        if let homogeneousRoute, homogeneousRoute != route {
-            self.routeIsHomogeneous = false
-        } else if self.homogeneousRoute == nil {
-            self.homogeneousRoute = route
-        }
-        if let homogeneousDelivery, homogeneousDelivery != delivery {
-            self.deliveryIsHomogeneous = false
-        } else if self.homogeneousDelivery == nil {
-            self.homogeneousDelivery = delivery
-        }
-    }
-}
-
 struct PressFailureCompatibility {
     static let none = PressFailureCompatibility(reportsEmittedUnits: false, emittedUnits: nil)
 
     let reportsEmittedUnits: Bool
     let emittedUnits: Int?
 
-    init(progress: PressSequenceProgress, leafFailure: DesktopActionFailure) {
+    init(prefixDisposition: DesktopActionMutationDisposition, leafFailure: DesktopActionFailure) {
         let leafDispatched = leafFailure.outcome.dispatchState.mutationDispatched
-        self.reportsEmittedUnits = progress.dispatchedUnitCount > 0 || leafDispatched
-        let knownUnits = progress.dispatchedUnitCount +
+        self.reportsEmittedUnits = prefixDisposition.mutationDispatched || leafDispatched
+        let knownUnits = (prefixDisposition.unitCount?.rawValue ?? 0) +
             (leafFailure.outcome.dispatchState.unitCount?.rawValue ?? 0)
         self.emittedUnits = knownUnits > 0 ? knownUnits : nil
     }
@@ -537,10 +419,37 @@ struct PressFailureCompatibility {
     }
 }
 
+extension PressTool {
+    fileprivate static let foregroundHotkeyDelivery = DesktopActionOutcome.Delivery(
+        mechanism: .globalEvents,
+        mode: .foreground)
+    fileprivate static let singleDispatchUnit: DesktopActionOutcome.DispatchUnitCount = .one
+}
+
 private struct PressExecutionParameters {
     let count: Int
     let delay: Int
     let hold: Int
+}
+
+private struct PressSequenceRun {
+    let resolution: DesktopActionSequenceAccumulator.Resolution
+    let completedPresses: Int
+    let allChordsConfirmedNoChange: Bool
+}
+
+private struct PressSequenceFailure: Error {
+    let failure: DesktopActionFailure
+    let compatibility: PressFailureCompatibility
+}
+
+private struct PressResponseMessageInput {
+    let display: [String]
+    let completed: Int
+    let elapsed: TimeInterval
+    let outcome: DesktopActionOutcome?
+    let confirmedNoChangeWithoutAggregate: Bool
+    let targetFocusCompleted: Bool
 }
 
 private struct PressToolValidationError: Error {

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/PressTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/PressTool.swift
@@ -270,7 +270,7 @@ public struct PressTool: MCPTool {
     {
         let failure = sequence.failure(
             combining: leafFailure,
-            message: "Press sequence stopped after \(completedPresses) completed action unit(s).",
+            message: "Press sequence stopped after \(completedPresses) completed press(es).",
             hint: "Observe the target before deciding whether to continue the sequence.",
             causeDescription: causeDescription)
         return PressSequenceFailure(

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/ScrollTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/ScrollTool.swift
@@ -164,7 +164,7 @@ public struct ScrollTool: MCPTool {
                     payload: automation.scroll(serviceRequest),
                     outcome: nil)
             }
-            try MCPDesktopActionFailureHandler.requireConfirmed(
+            try DesktopActionFailure.requireConfirmedIfReported(
                 actionResult.outcome,
                 operation: "Scroll")
         } catch let failure as DesktopActionFailure {

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/SetValueTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/SetValueTool.swift
@@ -74,7 +74,7 @@ public struct SetValueTool: MCPTool {
                         snapshotId: effectiveSnapshotId),
                     outcome: nil)
             }
-            try MCPDesktopActionFailureHandler.requireConfirmed(
+            try DesktopActionFailure.requireConfirmedIfReported(
                 actionResult.outcome,
                 operation: "Set value")
             let invalidatedSnapshotId = await MCPDesktopActionSnapshotInvalidator.invalidate(

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/TypeTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/TypeTool.swift
@@ -83,7 +83,8 @@ public struct TypeTool: MCPTool {
             return try await MCPDesktopActionFailureHandler.response(
                 for: failure,
                 uiSnapshots: self.context.uiSnapshots,
-                snapshotID: mutationTracker.snapshotId)
+                snapshotID: mutationTracker.snapshotId,
+                additionalFields: mutationTracker.characterCompatibilityFields)
         } catch let error as InputDeliveryIndeterminateError {
             return try await MCPDesktopActionFailureHandler.response(
                 for: error.desktopActionFailure(delivery: mutationTracker.delivery),
@@ -185,7 +186,19 @@ public struct TypeTool: MCPTool {
                 causeDescription: error.causeDescription ?? error.localizedDescription)
         }
 
+        var sequence = DesktopActionSequenceAccumulator()
+        if focusResult.completed {
+            if let outcome = focusResult.outcome {
+                sequence.record(.reportedOutcome(
+                    outcome,
+                    defaultDispatchedUnitCount: .one))
+            } else {
+                sequence.record(.dispatched(route: nil, delivery: nil, unitCount: Self.singleDispatchUnit))
+            }
+        }
+
         let typeActionResult: UIAutomationActionResult<TypeResult>
+        mutationTracker.reportsCharactersTyped = true
         do {
             if focusResult.completed {
                 try await Task.sleep(nanoseconds: 100_000_000)
@@ -216,67 +229,107 @@ public struct TypeTool: MCPTool {
                 }
             }
         } catch let failure as DesktopActionFailure {
-            throw Self.aggregateTypingFailure(failure, after: focusResult)
+            throw sequence.failure(
+                combining: failure,
+                message: "Typing failed after its element focus action completed.",
+                hint: "Observe the target before deciding whether to retry typing.")
         } catch let error as InputDeliveryIndeterminateError {
             mutationTracker.charactersTyped = error.emittedUnitCount
-            if focusResult.dispatchedUnitCount > 0 {
+            if sequence.mutationDisposition.mutationDispatched {
                 mutationTracker.delivery = nil
             }
-            throw Self.aggregateIndeterminateTypingError(error, after: focusResult)
+            let failure = error.desktopActionFailure(delivery: mutationTracker.delivery)
+            throw sequence.failure(
+                combining: failure,
+                message: "Typing failed after its element focus action completed.",
+                hint: "Observe the target before deciding whether to retry typing.",
+                causeDescription: error.causeDescription ?? error.localizedDescription)
         } catch {
-            guard focusResult.dispatchedUnitCount > 0 else { throw error }
+            guard sequence.mutationDisposition.mutationDispatched else { throw error }
             mutationTracker.delivery = nil
-            throw InputDeliveryIndeterminateError(
-                operation: .type,
-                emittedUnitCount: focusResult.dispatchedUnitCount,
+            let leaf = DesktopActionFailure.preDispatchRefusal(
+                reason: .operationUnsupported,
+                message: error.localizedDescription)
+            throw sequence.failure(
+                combining: leaf,
+                message: "Typing failed after its element focus action completed.",
+                hint: "Observe the target before deciding whether to retry typing.",
                 causeDescription: error.localizedDescription)
         }
 
-        if let outcome = typeActionResult.outcome,
-           let failure = DesktopActionFailure(
-               outcome: outcome,
-               message: "Typing did not return a confirmed outcome.",
-               hint: "Follow the canonical escalation metadata before deciding whether to retry.")
-        {
-            throw Self.aggregateTypingFailure(failure, after: focusResult)
+        do {
+            try DesktopActionFailure.requireConfirmedIfReported(
+                typeActionResult.outcome,
+                operation: "Typing")
+        } catch let failure as DesktopActionFailure {
+            throw sequence.failure(
+                combining: failure,
+                message: "Typing failed after its element focus action completed.",
+                hint: "Observe the target before deciding whether to retry typing.")
         }
 
-        let responseOutcome = Self.aggregateTypingSuccess(
-            typeActionResult.outcome,
-            after: focusResult)
-        let mutationDispatched = focusResult.dispatchedUnitCount > 0 ||
-            (typeActionResult.outcome?.dispatchState.mutationDispatched ?? true)
+        if let outcome = typeActionResult.outcome {
+            sequence.record(.reportedOutcome(
+                outcome,
+                defaultDispatchedUnitCount: .one))
+        } else {
+            sequence.record(.dispatched(
+                route: nil,
+                delivery: mutationTracker.delivery,
+                unitCount: Self.singleDispatchUnit))
+        }
+        let sequenceResolution = sequence.successResolution()
+        return try await self.successResponse(TypeSuccessInput(
+            request: request,
+            targetContext: targetContext,
+            targetProcessIdentifier: targetProcessIdentifier,
+            snapshotID: effectiveSnapshotId,
+            startedAt: startTime,
+            actionResult: typeActionResult,
+            focusCompleted: focusResult.completed,
+            sequenceResolution: sequenceResolution))
+    }
+
+    @MainActor
+    private func successResponse(_ input: TypeSuccessInput) async throws -> ToolResponse {
+        let responseOutcome = input.sequenceResolution.outcome
         let invalidatedSnapshotId = await MCPDesktopActionSnapshotInvalidator.invalidate(
             uiSnapshots: self.context.uiSnapshots,
-            snapshotID: effectiveSnapshotId,
-            mutationDispatched: mutationDispatched)
-        let executionTime = Date().timeIntervalSince(startTime)
-        let typingDispatched = typeActionResult.outcome?.dispatchState.mutationDispatched ?? true
-        let charactersTyped = typingDispatched ? typeActionResult.payload.totalCharacters : 0
+            snapshotID: input.snapshotID,
+            mutationDispatched: input.sequenceResolution.mutationDispatched)
+        let executionTime = Date().timeIntervalSince(input.startedAt)
+        let typingDispatched = input.actionResult.outcome?.dispatchState.mutationDispatched ?? true
+        let charactersTyped = typingDispatched ? input.actionResult.payload.totalCharacters : 0
         let message = self.buildSummary(
-            request: request,
+            request: input.request,
             executionTime: executionTime,
-            result: typeActionResult.payload,
+            result: input.actionResult.payload,
             typingDispatched: typingDispatched)
         var baseMetaDict: [String: Value] = [
             "execution_time": .double(executionTime),
             "characters_typed": .double(Double(charactersTyped)),
         ]
-        if !focusResult.completed {
-            baseMetaDict["delivery_mode"] = .string(targetProcessIdentifier == nil ? "foreground" : "background")
+        if !input.focusCompleted {
+            baseMetaDict["delivery_mode"] = .string(
+                input.targetProcessIdentifier == nil ? "foreground" : "background")
         }
-        if let targetProcessIdentifier {
+        if let targetProcessIdentifier = input.targetProcessIdentifier {
             baseMetaDict["target_pid"] = .int(targetProcessIdentifier)
         }
         if let invalidatedSnapshotId {
             baseMetaDict["invalidated_snapshot"] = .string(invalidatedSnapshotId)
         }
-        if focusResult.completed, responseOutcome == nil, mutationDispatched {
-            baseMetaDict["requires_fresh_observation"] = .bool(true)
+        if responseOutcome == nil {
+            baseMetaDict["mutation_dispatched"] = .bool(input.sequenceResolution.mutationDispatched)
+            baseMetaDict["retry_safe"] = .bool(input.sequenceResolution.retrySafe)
+            baseMetaDict["requires_fresh_observation"] = .bool(input.sequenceResolution.requiresFreshObservation)
+            if input.sequenceResolution.mutationDispatched {
+                baseMetaDict["effect"] = .string(DesktopActionOutcome.Effect.unverifiable.rawValue)
+            }
         }
         let summary = self.buildEventSummary(
-            request: request,
-            targetContext: targetContext,
+            request: input.request,
+            targetContext: input.targetContext,
             typingDispatched: typingDispatched)
         let mergedMeta = try ToolEventSummary.merge(
             summary: summary,
@@ -356,97 +409,6 @@ public struct TypeTool: MCPTool {
             hint: "Observe the target before deciding whether to retry typing.")
         else { return }
         throw failure
-    }
-
-    static func aggregateTypingFailure(
-        _ failure: DesktopActionFailure,
-        after focusResult: TypeFocusResult) -> DesktopActionFailure
-    {
-        let focusUnits = focusResult.dispatchedUnitCount
-        guard focusUnits > 0 else { return failure }
-        let leafUnits: Int? = if let count = failure.outcome.dispatchState.unitCount?.rawValue {
-            count
-        } else if failure.outcome.dispatchState.mutationDispatched {
-            nil
-        } else {
-            0
-        }
-        let unitCount = leafUnits.flatMap { DesktopActionOutcome.DispatchUnitCount(focusUnits + $0) }
-        let aggregateRoute = failure.outcome.dispatchState.mutationDispatched
-            ? failure.outcome.route
-            : focusResult.outcome?.route ?? failure.outcome.route
-        if failure.outcome.state == .partial,
-           let delivery = failure.outcome.delivery,
-           focusResult.outcome?.delivery == delivery,
-           focusResult.outcome?.route == failure.outcome.route
-        {
-            return .partial(
-                route: failure.outcome.route,
-                delivery: delivery,
-                unitCount: unitCount,
-                message: failure.message,
-                hint: failure.hint,
-                causeDescription: failure.causeDescription)
-        }
-        return .indeterminate(
-            route: aggregateRoute,
-            delivery: nil,
-            evidence: .completionUnknown,
-            unitCount: unitCount,
-            message: "Typing failed after its element focus action completed.",
-            hint: "Observe the target before deciding whether to retry typing.",
-            causeDescription: failure.localizedDescription)
-    }
-
-    static func aggregateTypingSuccess(
-        _ outcome: DesktopActionOutcome?,
-        after focusResult: TypeFocusResult) -> DesktopActionOutcome?
-    {
-        guard focusResult.completed else { return outcome }
-        let focusUnits = focusResult.dispatchedUnitCount
-        guard focusUnits > 0 else {
-            if let focusOutcome = focusResult.outcome,
-               let outcome,
-               !outcome.dispatchState.mutationDispatched,
-               focusOutcome.route != outcome.route
-            {
-                return nil
-            }
-            return outcome
-        }
-        guard let focusOutcome = focusResult.outcome,
-              let outcome,
-              focusOutcome.isConfirmed,
-              outcome.isConfirmed
-        else { return nil }
-        guard outcome.dispatchState.mutationDispatched else { return focusOutcome }
-        guard focusOutcome.route == outcome.route,
-              let delivery = focusOutcome.delivery,
-              outcome.delivery == delivery
-        else { return nil }
-
-        let leafUnits = outcome.dispatchState.unitCount?.rawValue
-            ?? (outcome.dispatchState.mutationDispatched ? 1 : 0)
-        return .confirmedChange(
-            route: outcome.route,
-            delivery: delivery,
-            unitCount: DesktopActionOutcome.DispatchUnitCount(focusUnits + leafUnits))
-    }
-
-    static func aggregateIndeterminateTypingError(
-        _ error: InputDeliveryIndeterminateError,
-        after focusResult: TypeFocusResult) -> InputDeliveryIndeterminateError
-    {
-        let focusUnits = focusResult.dispatchedUnitCount
-        let emittedUnitCount = if focusUnits > 0 {
-            error.emittedUnitCount.map { focusUnits + $0 }
-        } else {
-            error.emittedUnitCount
-        }
-        return InputDeliveryIndeterminateError(
-            operation: .type,
-            emittedUnitCount: emittedUnitCount,
-            causeDescription: error.causeDescription ?? error.localizedDescription)
     }
 
     private func backgroundProcessIdentity(
@@ -575,11 +537,21 @@ public struct TypeTool: MCPTool {
     }
 }
 
+extension TypeTool {
+    fileprivate static let singleDispatchUnit: DesktopActionOutcome.DispatchUnitCount = .one
+}
+
 @MainActor
 private final class TypeMutationTracker {
     var snapshotId: String?
     var delivery: DesktopActionOutcome.Delivery?
     var charactersTyped: Int?
+    var reportsCharactersTyped = false
+
+    var characterCompatibilityFields: [String: Value] {
+        guard self.reportsCharactersTyped else { return [:] }
+        return ["characters_typed": self.charactersTyped.map(Value.int) ?? .null]
+    }
 }
 
 struct TypeFocusResult {
@@ -591,13 +563,6 @@ struct TypeFocusResult {
     static func completed(outcome: DesktopActionOutcome?) -> Self {
         Self(completed: true, outcome: outcome)
     }
-
-    var dispatchedUnitCount: Int {
-        guard self.completed else { return 0 }
-        guard let outcome else { return 1 }
-        guard outcome.dispatchState.mutationDispatched else { return 0 }
-        return outcome.dispatchState.unitCount?.rawValue ?? 1
-    }
 }
 
 private struct BackgroundTypeRequest {
@@ -605,4 +570,15 @@ private struct BackgroundTypeRequest {
     let cadence: TypingCadence
     let snapshotId: String?
     let expectedProcessIdentity: ApplicationProcessIdentity
+}
+
+private struct TypeSuccessInput {
+    let request: TypeRequest
+    let targetContext: TargetElementContext?
+    let targetProcessIdentifier: Int?
+    let snapshotID: String?
+    let startedAt: Date
+    let actionResult: UIAutomationActionResult<TypeResult>
+    let focusCompleted: Bool
+    let sequenceResolution: DesktopActionSequenceAccumulator.Resolution
 }

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPCompositeActionOutcomeTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPCompositeActionOutcomeTests.swift
@@ -131,4 +131,29 @@ struct MCPCompositeActionOutcomeTests {
         #expect(response.meta?.objectValue?["state"] == .string("indeterminate"))
         #expect(response.meta?.objectValue?["emitted_units"] == .int(2))
     }
+
+    @Test
+    @MainActor
+    func `press failure message distinguishes completed presses from setup focus`() async throws {
+        let automation = StubAutomationService()
+        automation.actionOutcome = .refused(reason: .permissionDenied)
+        let context = await MCPToolTestHelpers.makeContext(
+            automation: automation,
+            windows: EmptyRecordingWindowService())
+
+        let response = try await PressTool(context: context).execute(arguments: ToolArguments(raw: [
+            "keys": ["cmd+a"],
+            "app": "Example",
+            "foreground": true,
+        ]))
+
+        #expect(response.isError)
+        guard case let .text(text, _, _) = response.content.first else {
+            Issue.record("Expected text response")
+            return
+        }
+        #expect(text.contains("0 completed press(es)"))
+        #expect(!text.contains("completed action unit"))
+        #expect(response.meta?.objectValue?["dispatched_unit_count"] == .int(1))
+    }
 }

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPCompositeActionOutcomeTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPCompositeActionOutcomeTests.swift
@@ -28,71 +28,6 @@ struct MCPCompositeActionOutcomeTests {
     }
 
     @Test
-    func `press compatibility excludes setup focus from emitted units`() {
-        let leafFailure = DesktopActionFailure.indeterminate(
-            delivery: .init(mechanism: .globalEvents, mode: .foreground),
-            evidence: .completionUnknown,
-            unitCount: DesktopActionOutcome.DispatchUnitCount(2),
-            message: "Chord completion unknown")
-        let aggregate = PressTool.aggregateSequenceFailure(
-            leafFailure,
-            progress: PressSequenceProgress(),
-            setupFocusCompleted: true)
-        let compatibility = PressFailureCompatibility(
-            progress: PressSequenceProgress(),
-            leafFailure: leafFailure)
-
-        #expect(aggregate.outcome.dispatchState.unitCount?.rawValue == 3)
-        #expect(compatibility.fields["emitted_units"] == .int(2))
-    }
-
-    @Test
-    func `press compatibility preserves known prior units when the failing count is unknown`() {
-        var progress = PressSequenceProgress()
-        progress.record(outcome: .confirmedChange(
-            delivery: .init(mechanism: .globalEvents, mode: .foreground)))
-        let failure = DesktopActionFailure.indeterminate(
-            delivery: nil,
-            evidence: .completionUnknown,
-            unitCount: nil,
-            message: "Chord completion unknown")
-
-        let compatibility = PressFailureCompatibility(
-            progress: progress,
-            leafFailure: failure)
-
-        #expect(compatibility.fields["emitted_units"] == .int(1))
-    }
-
-    @Test
-    func `press compatibility preserves an unknown first leaf emitted count`() {
-        let failure = DesktopActionFailure.indeterminate(
-            delivery: nil,
-            evidence: .completionUnknown,
-            unitCount: nil,
-            message: "Chord completion unknown")
-
-        let compatibility = PressFailureCompatibility(
-            progress: PressSequenceProgress(),
-            leafFailure: failure)
-
-        #expect(compatibility.fields["emitted_units"] == .null)
-    }
-
-    @Test
-    func `press compatibility omits setup-only dispatch from emitted units`() {
-        let failure = DesktopActionFailure.refused(
-            reason: .permissionDenied,
-            message: "Chord was refused")
-
-        let compatibility = PressFailureCompatibility(
-            progress: PressSequenceProgress(),
-            leafFailure: failure)
-
-        #expect(compatibility.fields.isEmpty)
-    }
-
-    @Test
     @MainActor
     func `successful dispatched press invalidates the session implicit snapshot`() async throws {
         let automation = StubAutomationService()
@@ -158,163 +93,42 @@ struct MCPCompositeActionOutcomeTests {
     }
 
     @Test
-    func `confirmed no change press does not fabricate dispatch before refusal`() {
-        var progress = PressSequenceProgress()
-        progress.record(outcome: .confirmedNoChange())
-        let leafFailure = DesktopActionFailure.refused(
-            reason: .permissionDenied,
-            message: "Second chord was refused")
+    @MainActor
+    func `confirmed no change prefix does not fabricate legacy emitted units`() async throws {
+        let automation = StubAutomationService()
+        automation.uiAutomationOutcomeScript.append(.confirmedNoChange(), for: .hotkey)
+        automation.uiAutomationOutcomeScript.append(.refused(reason: .permissionDenied), for: .hotkey)
+        let context = await MCPToolTestHelpers.makeContext(automation: automation)
 
-        let aggregate = PressTool.aggregateSequenceFailure(
-            leafFailure,
-            progress: progress,
-            setupFocusCompleted: false)
+        let response = try await PressTool(context: context).execute(arguments: ToolArguments(raw: [
+            "keys": ["cmd+a", "cmd+c"],
+            "foreground": true,
+        ]))
 
-        #expect(aggregate == leafFailure)
-        #expect(aggregate.outcome.state == .refused)
-        #expect(aggregate.outcome.dispatchState.mutationDispatched == false)
+        #expect(response.isError)
+        #expect(response.meta?.objectValue?["state"] == .string("refused"))
+        #expect(response.meta?.objectValue?["emitted_units"] == nil)
     }
 
     @Test
-    func `non dispatched leaf does not erase prior homogeneous route and delivery`() {
-        let delivery = DesktopActionOutcome.Delivery(
-            mechanism: .globalEvents,
-            mode: .foreground)
-        var progress = PressSequenceProgress()
-        progress.record(outcome: .confirmedChange(
-            route: .bridge,
-            delivery: delivery))
-        let leafFailure = DesktopActionFailure.refused(
-            route: .local,
-            reason: .permissionDenied,
-            message: "Second chord was refused")
+    @MainActor
+    func `canonical prefix count drives legacy emitted units`() async throws {
+        let automation = StubAutomationService()
+        automation.uiAutomationOutcomeScript.append(
+            .confirmedChange(
+                delivery: .init(mechanism: .globalEvents, mode: .foreground),
+                unitCount: DesktopActionOutcome.DispatchUnitCount(2)),
+            for: .hotkey)
+        automation.uiAutomationOutcomeScript.append(.refused(reason: .permissionDenied), for: .hotkey)
+        let context = await MCPToolTestHelpers.makeContext(automation: automation)
 
-        let aggregate = PressTool.aggregateSequenceFailure(
-            leafFailure,
-            progress: progress,
-            setupFocusCompleted: false)
+        let response = try await PressTool(context: context).execute(arguments: ToolArguments(raw: [
+            "keys": ["cmd+a", "cmd+c"],
+            "foreground": true,
+        ]))
 
-        #expect(aggregate.outcome.state == .indeterminate)
-        #expect(aggregate.outcome.route == .bridge)
-        #expect(aggregate.outcome.delivery == delivery)
-        #expect(aggregate.outcome.dispatchState.unitCount?.rawValue == 1)
-    }
-
-    @Test
-    func `no change press route does not erase dispatched route`() {
-        let delivery = DesktopActionOutcome.Delivery(
-            mechanism: .globalEvents,
-            mode: .foreground)
-        var progress = PressSequenceProgress()
-        progress.record(outcome: .confirmedNoChange(route: .bridge))
-        progress.record(outcome: .confirmedChange(
-            route: .local,
-            delivery: delivery))
-
-        let aggregate = progress.aggregateSuccess(setupFocusCompleted: false)
-
-        #expect(aggregate?.state == .confirmedChange)
-        #expect(aggregate?.route == .local)
-        #expect(aggregate?.delivery == delivery)
-        #expect(aggregate?.dispatchState.unitCount?.rawValue == 1)
-    }
-
-    @Test
-    func `no change typing leaf preserves dispatched focus outcome`() {
-        let focus = DesktopActionOutcome.confirmedChange(
-            route: .bridge,
-            delivery: .init(mechanism: .accessibilityAction, mode: .background))
-
-        let aggregate = TypeTool.aggregateTypingSuccess(
-            .confirmedNoChange(route: .local),
-            after: TypeFocusResult(completed: true, outcome: focus))
-
-        #expect(aggregate == focus)
-    }
-
-    @Test
-    func `heterogeneous all no change typing has no aggregate route`() {
-        let aggregate = TypeTool.aggregateTypingSuccess(
-            .confirmedNoChange(route: .local),
-            after: TypeFocusResult(
-                completed: true,
-                outcome: .confirmedNoChange(route: .bridge)))
-
-        #expect(aggregate == nil)
-    }
-
-    @Test
-    func `predispatch typing refusal retains dispatched focus route`() {
-        let focus = DesktopActionOutcome.confirmedChange(
-            route: .bridge,
-            delivery: .init(mechanism: .accessibilityAction, mode: .background))
-        let refusal = DesktopActionFailure.refused(
-            route: .local,
-            reason: .permissionDenied,
-            message: "Typing was refused")
-
-        let aggregate = TypeTool.aggregateTypingFailure(
-            refusal,
-            after: TypeFocusResult(completed: true, outcome: focus))
-
-        #expect(aggregate.outcome.state == .indeterminate)
-        #expect(aggregate.outcome.route == .bridge)
-        #expect(aggregate.outcome.delivery == nil)
-    }
-
-    @Test
-    func `unknown typing units remain unknown after dispatched focus`() {
-        let focus = DesktopActionOutcome.confirmedChange(
-            delivery: .init(mechanism: .accessibilityAction, mode: .background))
-        let error = InputDeliveryIndeterminateError(
-            operation: .type,
-            emittedUnitCount: nil,
-            causeDescription: "completion unknown")
-
-        let aggregate = TypeTool.aggregateIndeterminateTypingError(
-            error,
-            after: TypeFocusResult(completed: true, outcome: focus))
-
-        #expect(aggregate.emittedUnitCount == nil)
-    }
-
-    @Test
-    func `unknown failed press units remain unknown after prior dispatch`() {
-        let delivery = DesktopActionOutcome.Delivery(
-            mechanism: .globalEvents,
-            mode: .foreground)
-        var progress = PressSequenceProgress()
-        progress.record(outcome: .confirmedChange(delivery: delivery))
-        let failure = DesktopActionFailure.indeterminate(
-            delivery: delivery,
-            evidence: .completionUnknown,
-            unitCount: nil,
-            message: "Chord completion unknown")
-
-        let aggregate = PressTool.aggregateSequenceFailure(
-            failure,
-            progress: progress,
-            setupFocusCompleted: false)
-
-        #expect(aggregate.outcome.dispatchState.unitCount == nil)
-    }
-
-    @Test
-    func `unknown failed typing units remain unknown after focus`() {
-        let delivery = DesktopActionOutcome.Delivery(
-            mechanism: .processTargetedEvents,
-            mode: .background)
-        let focus = DesktopActionOutcome.confirmedChange(delivery: delivery)
-        let failure = DesktopActionFailure.indeterminate(
-            delivery: delivery,
-            evidence: .completionUnknown,
-            unitCount: nil,
-            message: "Typing completion unknown")
-
-        let aggregate = TypeTool.aggregateTypingFailure(
-            failure,
-            after: TypeFocusResult(completed: true, outcome: focus))
-
-        #expect(aggregate.outcome.dispatchState.unitCount == nil)
+        #expect(response.isError)
+        #expect(response.meta?.objectValue?["state"] == .string("indeterminate"))
+        #expect(response.meta?.objectValue?["emitted_units"] == .int(2))
     }
 }

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPDesktopActionOutcomeProjectionTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPDesktopActionOutcomeProjectionTests.swift
@@ -381,7 +381,9 @@ extension MCPDesktopActionOutcomeProjectionTests {
         #expect(!text.contains("Dispatched"))
         #expect(!text.contains("unverifiable"))
         #expect(meta["delivery_mode"] == nil)
-        #expect(meta["mutation_dispatched"] == nil)
+        #expect(meta["mutation_dispatched"] == .bool(false))
+        #expect(meta["retry_safe"] == .bool(true))
+        #expect(meta["requires_fresh_observation"] == .bool(false))
         #expect(meta["invalidated_snapshot"] == nil)
     }
 
@@ -418,7 +420,7 @@ extension MCPDesktopActionOutcomeProjectionTests {
 
     @Test
     @MainActor
-    func `multi chord legacy success preserves conservative safety metadata`() async throws {
+    func `multi chord legacy success publishes canonical unverified aggregate`() async throws {
         let automation = MockAutomationService(accessibilityGranted: true)
         let context = await MCPToolTestHelpers.makeContext(automation: automation)
 
@@ -430,10 +432,11 @@ extension MCPDesktopActionOutcomeProjectionTests {
         #expect(!response.isError)
         let meta = try #require(response.meta?.objectValue)
         #expect(meta["total_presses"] == .int(2))
-        #expect(meta["state"] == nil)
+        #expect(meta["state"] == .string("dispatched_unverified"))
         #expect(meta["effect"] == .string("unverifiable"))
         #expect(meta["mutation_dispatched"] == .bool(true))
         #expect(meta["requires_fresh_observation"] == .bool(true))
+        #expect(meta["dispatched_unit_count"] == .int(2))
     }
 
     @Test
@@ -464,17 +467,16 @@ extension MCPDesktopActionOutcomeProjectionTests {
 
     @Test
     func `multi chord leaf failure preserves cumulative canonical partial semantics`() throws {
-        var progress = PressSequenceProgress()
-        progress.record(outcome: .confirmedChange(
-            delivery: .init(mechanism: .globalEvents, mode: .foreground)))
+        var sequence = DesktopActionSequenceAccumulator()
+        sequence.record(
+            .reportedOutcome(
+                .confirmedChange(delivery: .init(mechanism: .globalEvents, mode: .foreground)),
+                defaultDispatchedUnitCount: .one))
         let leafFailure = DesktopActionFailure.partial(
             delivery: .init(mechanism: .globalEvents, mode: .foreground),
             unitCount: DesktopActionOutcome.DispatchUnitCount(1),
             message: "Second chord completed but cleanup failed")
-        let aggregate = PressTool.aggregateSequenceFailure(
-            leafFailure,
-            progress: progress,
-            setupFocusCompleted: false)
+        let aggregate = sequence.failure(combining: leafFailure, message: leafFailure.message)
         let response = try MCPToolResponseMetadataProjector.errorResponse(
             for: aggregate,
             invalidatedSnapshotID: nil)
@@ -490,14 +492,16 @@ extension MCPDesktopActionOutcomeProjectionTests {
 
     @Test
     func `press includes completed target focus before first chord refusal`() {
+        var sequence = DesktopActionSequenceAccumulator()
+        sequence.record(.dispatched(
+            route: nil,
+            delivery: nil,
+            unitCount: DesktopActionOutcome.DispatchUnitCount(1)))
         let leafFailure = DesktopActionFailure.refused(
             reason: .permissionDenied,
             message: "Hotkey was refused")
 
-        let aggregate = PressTool.aggregateSequenceFailure(
-            leafFailure,
-            progress: PressSequenceProgress(),
-            setupFocusCompleted: true)
+        let aggregate = sequence.failure(combining: leafFailure, message: leafFailure.message)
 
         #expect(aggregate.outcome.state == .indeterminate)
         #expect(aggregate.outcome.delivery == nil)
@@ -508,15 +512,17 @@ extension MCPDesktopActionOutcomeProjectionTests {
 
     @Test
     func `press does not assign a partial leaf delivery to completed target focus`() {
+        var sequence = DesktopActionSequenceAccumulator()
+        sequence.record(.dispatched(
+            route: nil,
+            delivery: nil,
+            unitCount: DesktopActionOutcome.DispatchUnitCount(1)))
         let leafFailure = DesktopActionFailure.partial(
             delivery: .init(mechanism: .globalEvents, mode: .foreground),
             unitCount: DesktopActionOutcome.DispatchUnitCount(1),
             message: "Chord completed but cleanup failed")
 
-        let aggregate = PressTool.aggregateSequenceFailure(
-            leafFailure,
-            progress: PressSequenceProgress(),
-            setupFocusCompleted: true)
+        let aggregate = sequence.failure(combining: leafFailure, message: leafFailure.message)
 
         #expect(aggregate.outcome.state == .indeterminate)
         #expect(aggregate.outcome.delivery == nil)
@@ -674,13 +680,16 @@ extension MCPDesktopActionOutcomeProjectionTests {
 
     @Test
     func `type conservatively counts a receiptless completed focus before refusal`() {
+        var sequence = DesktopActionSequenceAccumulator()
+        sequence.record(.dispatched(
+            route: nil,
+            delivery: nil,
+            unitCount: DesktopActionOutcome.DispatchUnitCount(1)))
         let leafFailure = DesktopActionFailure.refused(
             reason: .permissionDenied,
             message: "Typing was refused")
 
-        let aggregate = TypeTool.aggregateTypingFailure(
-            leafFailure,
-            after: TypeFocusResult(completed: true, outcome: nil))
+        let aggregate = sequence.failure(combining: leafFailure, message: leafFailure.message)
 
         #expect(aggregate.outcome.state == .indeterminate)
         #expect(aggregate.outcome.dispatchState.unitCount?.rawValue == 1)
@@ -697,9 +706,9 @@ extension MCPDesktopActionOutcomeProjectionTests {
             unitCount: DesktopActionOutcome.DispatchUnitCount(2),
             message: "Typing completed but cleanup failed")
 
-        let aggregate = TypeTool.aggregateTypingFailure(
-            leafFailure,
-            after: TypeFocusResult(completed: true, outcome: focusOutcome))
+        var sequence = DesktopActionSequenceAccumulator()
+        sequence.record(.reportedOutcome(focusOutcome, defaultDispatchedUnitCount: .one))
+        let aggregate = sequence.failure(combining: leafFailure, message: leafFailure.message)
 
         #expect(aggregate.outcome.state == .indeterminate)
         #expect(aggregate.outcome.dispatchState.unitCount?.rawValue == 3)
@@ -719,9 +728,9 @@ extension MCPDesktopActionOutcomeProjectionTests {
             unitCount: DesktopActionOutcome.DispatchUnitCount(2),
             message: "Typing completed but cleanup failed")
 
-        let aggregate = TypeTool.aggregateTypingFailure(
-            leafFailure,
-            after: TypeFocusResult(completed: true, outcome: focusOutcome))
+        var sequence = DesktopActionSequenceAccumulator()
+        sequence.record(.reportedOutcome(focusOutcome, defaultDispatchedUnitCount: .one))
+        let aggregate = sequence.failure(combining: leafFailure, message: leafFailure.message)
 
         #expect(aggregate.outcome.state == .partial)
         #expect(aggregate.outcome.dispatchState.unitCount?.rawValue == 3)
@@ -744,9 +753,9 @@ extension MCPDesktopActionOutcomeProjectionTests {
             unitCount: DesktopActionOutcome.DispatchUnitCount(1),
             message: "Typing completed but cleanup failed")
 
-        let aggregate = TypeTool.aggregateTypingFailure(
-            leafFailure,
-            after: TypeFocusResult(completed: true, outcome: focusOutcome))
+        var sequence = DesktopActionSequenceAccumulator()
+        sequence.record(.reportedOutcome(focusOutcome, defaultDispatchedUnitCount: .one))
+        let aggregate = sequence.failure(combining: leafFailure, message: leafFailure.message)
 
         #expect(aggregate.outcome.state == .indeterminate)
         #expect(aggregate.outcome.route == .bridge)
@@ -757,10 +766,10 @@ extension MCPDesktopActionOutcomeProjectionTests {
     @Test
     func `type preserves confirmed no change when no composite unit dispatched`() {
         let outcome = DesktopActionOutcome.confirmedNoChange()
-
-        let aggregate = TypeTool.aggregateTypingSuccess(
-            outcome,
-            after: TypeFocusResult(completed: true, outcome: .confirmedNoChange()))
+        var sequence = DesktopActionSequenceAccumulator()
+        sequence.record(.outcome(.confirmedNoChange()))
+        sequence.record(.outcome(outcome))
+        let aggregate = sequence.successResolution().outcome
 
         #expect(aggregate == outcome)
         #expect(aggregate?.state == .confirmedNoChange)
@@ -876,7 +885,9 @@ extension MCPDesktopActionOutcomeProjectionTests {
         #expect(!response.isError)
         let meta = try #require(response.meta?.objectValue)
         #expect(meta["state"] == nil)
-        #expect(meta["effect"] == nil)
+        #expect(meta["effect"] == .string("unverifiable"))
+        #expect(meta["mutation_dispatched"] == .bool(true))
+        #expect(meta["retry_safe"] == .bool(false))
         #expect(meta["delivery_mechanism"] == nil)
         #expect(meta["delivery_mode"] == nil)
         #expect(meta["requires_fresh_observation"] == .bool(true))

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPInteractionTargetTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPInteractionTargetTests.swift
@@ -209,6 +209,11 @@ struct MCPInteractionTargetTests {
             }
             #expect(text.contains(fixture.message))
         }
+        for response in responses.prefix(3) {
+            try MCPToolTestHelpers.expectCanonicalOutcomeMetadata(
+                .refused(reason: .invalidRequest),
+                in: response)
+        }
     }
 
     private static func makeTarget(_ selectors: Selectors) throws -> MCPInteractionTarget {

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/PasteToolTransactionGateTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/PasteToolTransactionGateTests.swift
@@ -143,6 +143,9 @@ struct PasteToolTransactionGateTests {
 
             #expect(response.isError)
             #expect(self.responseText(response).contains("cannot receive background input"))
+            try MCPToolTestHelpers.expectCanonicalOutcomeMetadata(
+                .refused(reason: .targetUnavailable),
+                in: response)
             #expect(await MainActor.run { automation.targetedTypeActionsCalls.isEmpty })
             #expect(await MainActor.run { automation.targetedHotkeyCalls.isEmpty })
             #expect(await MainActor.run { clipboard.getCallCount } == 0)

--- a/Core/PeekabooFoundation/Sources/PeekabooFoundation/DesktopActionOutcome+Projection.swift
+++ b/Core/PeekabooFoundation/Sources/PeekabooFoundation/DesktopActionOutcome+Projection.swift
@@ -134,4 +134,24 @@ extension DesktopActionOutcome {
     public var projection: Projection {
         Projection(outcome: self)
     }
+
+    /// Canonical flat projection for a refusal before any mutation dispatch.
+    public static func preDispatchRefusalProjection(
+        route: Route = .local,
+        reason: RefusalReason) -> Projection
+    {
+        refused(route: route, reason: reason).projection
+    }
+
+    /// Upgrades paired legacy compatibility fields only when they prove zero dispatch.
+    /// Either field on its own is insufficient evidence for the canonical state machine.
+    public static func preDispatchRefusalProjection(
+        route: Route = .local,
+        reason: RefusalReason,
+        legacyRetrySafe: Bool?,
+        legacyMutationDispatched: Bool?) -> Projection?
+    {
+        guard legacyRetrySafe == true, legacyMutationDispatched == false else { return nil }
+        return self.preDispatchRefusalProjection(route: route, reason: reason)
+    }
 }

--- a/Core/PeekabooFoundation/Sources/PeekabooFoundation/DesktopActionOutcome.swift
+++ b/Core/PeekabooFoundation/Sources/PeekabooFoundation/DesktopActionOutcome.swift
@@ -93,6 +93,8 @@ public struct DesktopActionOutcome: Codable, Equatable, Sendable {
     }
 
     public struct DispatchUnitCount: Codable, Equatable, Hashable, RawRepresentable, Sendable {
+        public static let one = Self(validatedRawValue: 1)
+
         public let rawValue: Int
 
         public init?(_ value: Int) {
@@ -118,6 +120,10 @@ public struct DesktopActionOutcome: Codable, Equatable, Sendable {
         public func encode(to encoder: any Encoder) throws {
             var container = encoder.singleValueContainer()
             try container.encode(self.rawValue)
+        }
+
+        private init(validatedRawValue: Int) {
+            self.rawValue = validatedRawValue
         }
     }
 
@@ -617,6 +623,38 @@ public struct DesktopActionFailure: Codable, Equatable, LocalizedError, Sendable
             message: message,
             hint: hint,
             causeDescription: causeDescription)
+    }
+
+    /// Constructs the canonical, retry-safe projection for a refusal before any mutation dispatch.
+    public static func preDispatchRefusal(
+        route: DesktopActionOutcome.Route = .local,
+        reason: DesktopActionOutcome.RefusalReason,
+        message: String,
+        hint: String? = nil,
+        causeDescription: String? = nil) -> DesktopActionFailure
+    {
+        .refused(
+            route: route,
+            reason: reason,
+            message: message,
+            hint: hint,
+            causeDescription: causeDescription)
+    }
+
+    /// Fails a step only when its implementation reported a non-confirmed canonical outcome.
+    /// Legacy implementations that report no outcome retain their existing compatibility behavior.
+    public static func requireConfirmedIfReported(
+        _ outcome: DesktopActionOutcome?,
+        operation: String,
+        hint: String = "Follow the canonical escalation metadata before deciding whether to retry.") throws
+    {
+        guard let outcome,
+              let failure = Self(
+                  outcome: outcome,
+                  message: "\(operation) did not return a confirmed outcome.",
+                  hint: hint)
+        else { return }
+        throw failure
     }
 
     public static func indeterminate(

--- a/Core/PeekabooFoundation/Sources/PeekabooFoundation/DesktopActionSequenceAccumulator.swift
+++ b/Core/PeekabooFoundation/Sources/PeekabooFoundation/DesktopActionSequenceAccumulator.swift
@@ -1,0 +1,327 @@
+/// What a composite desktop action knows about mutation dispatch independent of its semantic outcome.
+///
+/// This deliberately distinguishes a definite dispatch from a possible dispatch. The compatibility
+/// `mutation_dispatched` boolean collapses both to `true`, but composition must retain the distinction
+/// so cancellation and response-loss paths cannot become retry-safe by accident.
+public enum DesktopActionMutationDisposition: Equatable, Sendable {
+    case none
+    case definite(unitCount: DesktopActionOutcome.DispatchUnitCount?)
+    case possible(unitCount: DesktopActionOutcome.DispatchUnitCount?)
+
+    public init(dispatchState: DesktopActionOutcome.DispatchState) {
+        switch dispatchState {
+        case .none:
+            self = .none
+        case let .dispatched(unitCount):
+            self = .definite(unitCount: unitCount)
+        case let .mayHaveDispatched(unitCount):
+            self = .possible(unitCount: unitCount)
+        }
+    }
+
+    public var mutationDispatched: Bool {
+        self != .none
+    }
+
+    public var unitCount: DesktopActionOutcome.DispatchUnitCount? {
+        switch self {
+        case .none:
+            nil
+        case let .definite(unitCount), let .possible(unitCount):
+            unitCount
+        }
+    }
+}
+
+/// Canonical, presentation-neutral composition of setup, leaf-delivery, and cleanup action phases.
+///
+/// Callers must state receiptless dispatch explicitly. A missing outcome is never silently interpreted:
+/// a successfully returned legacy action is `.dispatched`, while an interrupted or otherwise uncertain
+/// phase is `.mayHaveDispatched`.
+public struct DesktopActionSequenceAccumulator: Sendable {
+    public enum Step: Sendable {
+        case outcome(DesktopActionOutcome)
+        case reportedOutcome(
+            DesktopActionOutcome,
+            defaultDispatchedUnitCount: DesktopActionOutcome.DispatchUnitCount)
+        case dispatched(
+            route: DesktopActionOutcome.Route?,
+            delivery: DesktopActionOutcome.Delivery?,
+            unitCount: DesktopActionOutcome.DispatchUnitCount?)
+        case mayHaveDispatched(
+            route: DesktopActionOutcome.Route?,
+            delivery: DesktopActionOutcome.Delivery?,
+            unitCount: DesktopActionOutcome.DispatchUnitCount?)
+    }
+
+    public struct Resolution: Sendable {
+        public let outcome: DesktopActionOutcome?
+        public let mutationDisposition: DesktopActionMutationDisposition
+
+        public var mutationDispatched: Bool {
+            self.mutationDisposition.mutationDispatched
+        }
+
+        public var retrySafety: DesktopActionOutcome.RetrySafety {
+            self.outcome?.retrySafety ?? (self.mutationDisposition == .none ? .safe : .unsafe)
+        }
+
+        public var retrySafe: Bool {
+            self.retrySafety == .safe
+        }
+
+        public var requiresFreshObservation: Bool {
+            self.outcome?.projection.requiresFreshObservation ?? self.mutationDisposition.mutationDispatched
+        }
+    }
+
+    public private(set) var completedStepCount = 0
+    public private(set) var mutationDisposition: DesktopActionMutationDisposition = .none
+    private var allStepsReported = true
+    private var allReportedOutcomesAreConfirmedNoChange = true
+
+    private var allReportedOutcomesAreConfirmed = true
+    private var singleReportedOutcome: DesktopActionOutcome?
+    private var dispatchedRoute = HomogeneousValue<DesktopActionOutcome.Route>()
+    private var dispatchedDelivery = HomogeneousValue<DesktopActionOutcome.Delivery>()
+    private var noDispatchRoute = HomogeneousValue<DesktopActionOutcome.Route>()
+
+    public init() {}
+
+    public mutating func record(_ step: Step) {
+        self.completedStepCount += 1
+        switch step {
+        case let .outcome(outcome):
+            self.recordReportedOutcome(outcome)
+        case let .reportedOutcome(outcome, defaultUnitCount):
+            self.recordReportedOutcome(outcome, defaultDispatchedUnitCount: defaultUnitCount)
+        case let .dispatched(route, delivery, unitCount):
+            self.recordReceiptlessMutation(
+                disposition: .definite(unitCount: unitCount),
+                route: route,
+                delivery: delivery)
+        case let .mayHaveDispatched(route, delivery, unitCount):
+            self.recordReceiptlessMutation(
+                disposition: .possible(unitCount: unitCount),
+                route: route,
+                delivery: delivery)
+        }
+    }
+
+    /// Resolves a successfully completed sequence without inventing route or delivery fields.
+    ///
+    /// Mixed or receiptless phases can leave `outcome` nil. The returned mutation disposition still
+    /// supplies the authoritative retry/fresh-observation compatibility semantics.
+    public func successResolution() -> Resolution {
+        if self.completedStepCount == 1,
+           let outcome = self.singleReportedOutcome,
+           outcome.isConfirmed
+        {
+            return Resolution(
+                outcome: outcome,
+                mutationDisposition: self.mutationDisposition)
+        }
+        let outcome: DesktopActionOutcome? = switch self.mutationDisposition {
+        case .none:
+            if self.completedStepCount > 0,
+               self.allStepsReported,
+               self.allReportedOutcomesAreConfirmedNoChange,
+               let route = self.noDispatchRoute.value
+            {
+                .confirmedNoChange(route: route)
+            } else {
+                nil
+            }
+        case let .definite(unitCount):
+            if self.allStepsReported,
+               self.allReportedOutcomesAreConfirmed,
+               let route = self.dispatchedRoute.value,
+               let delivery = self.dispatchedDelivery.value
+            {
+                .confirmedChange(route: route, delivery: delivery, unitCount: unitCount)
+            } else if let route = self.dispatchedRoute.value,
+                      let delivery = self.dispatchedDelivery.value
+            {
+                .dispatchedUnverified(
+                    route: route,
+                    delivery: delivery,
+                    evidence: .deliveryAccepted,
+                    unitCount: unitCount)
+            } else {
+                nil
+            }
+        case let .possible(unitCount):
+            if let route = self.dispatchedRoute.value {
+                .indeterminate(
+                    route: route,
+                    delivery: self.dispatchedDelivery.value,
+                    evidence: .completionUnknown,
+                    unitCount: unitCount)
+            } else {
+                nil
+            }
+        }
+        return Resolution(
+            outcome: outcome,
+            mutationDisposition: self.mutationDisposition)
+    }
+
+    /// Composes a failed leaf with every phase that completed before it.
+    ///
+    /// A leaf refusal/no-change receipt survives only while the prefix proves no mutation. Once the
+    /// prefix dispatched or may have dispatched, the composite becomes partial (only for one fully
+    /// homogeneous partial route) or indeterminate and retry-unsafe.
+    public func failure(
+        combining leafFailure: DesktopActionFailure,
+        message: String,
+        hint: String? = nil,
+        causeDescription: String? = nil) -> DesktopActionFailure
+    {
+        guard self.mutationDisposition == .none else {
+            var aggregate = self
+            aggregate.record(.outcome(leafFailure.outcome))
+            let route = aggregate.dispatchedRoute.value ?? leafFailure.outcome.route
+            let unitCount = aggregate.mutationDisposition.unitCount
+
+            if leafFailure.outcome.state == .partial,
+               case .definite = aggregate.mutationDisposition,
+               aggregate.dispatchedRoute.value != nil,
+               let delivery = aggregate.dispatchedDelivery.value
+            {
+                return .partial(
+                    route: route,
+                    delivery: delivery,
+                    unitCount: unitCount,
+                    message: message,
+                    hint: hint ?? leafFailure.hint,
+                    causeDescription: causeDescription ?? leafFailure.causeDescription)
+            }
+
+            let evidence: DesktopActionOutcome.IndeterminateEvidence =
+                leafFailure.outcome.evidence == .responseLost ? .responseLost : .completionUnknown
+            return .indeterminate(
+                route: route,
+                delivery: aggregate.dispatchedRoute.value == nil ? nil : aggregate.dispatchedDelivery.value,
+                evidence: evidence,
+                unitCount: unitCount,
+                message: message,
+                hint: hint ?? leafFailure.hint,
+                causeDescription: causeDescription ?? leafFailure.localizedDescription)
+        }
+        return leafFailure
+    }
+
+    /// Returns a canonical cancellation failure only after mutation became possible.
+    /// Pre-dispatch cancellation remains ordinary cancellation and returns nil.
+    public func cancellationFailure(
+        fallbackRoute: DesktopActionOutcome.Route,
+        message: String,
+        hint: String,
+        causeDescription: String) -> DesktopActionFailure?
+    {
+        guard self.mutationDisposition.mutationDispatched else { return nil }
+        return .indeterminate(
+            route: self.dispatchedRoute.value ?? fallbackRoute,
+            delivery: self.dispatchedRoute.value == nil ? nil : self.dispatchedDelivery.value,
+            evidence: .completionUnknown,
+            unitCount: self.mutationDisposition.unitCount,
+            message: message,
+            hint: hint,
+            causeDescription: causeDescription)
+    }
+
+    private mutating func recordReportedOutcome(
+        _ outcome: DesktopActionOutcome,
+        defaultDispatchedUnitCount: DesktopActionOutcome.DispatchUnitCount? = nil)
+    {
+        if self.completedStepCount == 1 {
+            self.singleReportedOutcome = outcome
+        } else {
+            self.singleReportedOutcome = nil
+        }
+        self.allReportedOutcomesAreConfirmed = self.allReportedOutcomesAreConfirmed && outcome.isConfirmed
+        self.allReportedOutcomesAreConfirmedNoChange = self.allReportedOutcomesAreConfirmedNoChange &&
+            outcome.state == .confirmedNoChange
+        let disposition: DesktopActionMutationDisposition = switch outcome.dispatchState {
+        case .none:
+            .none
+        case let .dispatched(unitCount):
+            .definite(unitCount: unitCount ?? defaultDispatchedUnitCount)
+        case let .mayHaveDispatched(unitCount):
+            .possible(unitCount: unitCount)
+        }
+        if disposition == .none {
+            self.noDispatchRoute.record(outcome.route)
+        } else {
+            self.dispatchedRoute.record(outcome.route)
+            self.dispatchedDelivery.record(outcome.delivery)
+        }
+        self.mutationDisposition = Self.combined(self.mutationDisposition, disposition)
+    }
+
+    private mutating func recordReceiptlessMutation(
+        disposition: DesktopActionMutationDisposition,
+        route: DesktopActionOutcome.Route?,
+        delivery: DesktopActionOutcome.Delivery?)
+    {
+        self.singleReportedOutcome = nil
+        self.allStepsReported = false
+        self.allReportedOutcomesAreConfirmed = false
+        self.allReportedOutcomesAreConfirmedNoChange = false
+        self.dispatchedRoute.record(route)
+        self.dispatchedDelivery.record(delivery)
+        self.mutationDisposition = Self.combined(self.mutationDisposition, disposition)
+    }
+
+    private static func combined(
+        _ lhs: DesktopActionMutationDisposition,
+        _ rhs: DesktopActionMutationDisposition) -> DesktopActionMutationDisposition
+    {
+        let unitCount = Self.combinedUnitCount(lhs, rhs)
+        switch (lhs, rhs) {
+        case (.none, .none):
+            return .none
+        case (.possible, _), (_, .possible):
+            return .possible(unitCount: unitCount)
+        case (.definite, _), (_, .definite):
+            return .definite(unitCount: unitCount)
+        }
+    }
+
+    private static func combinedUnitCount(
+        _ lhs: DesktopActionMutationDisposition,
+        _ rhs: DesktopActionMutationDisposition) -> DesktopActionOutcome.DispatchUnitCount?
+    {
+        switch (lhs, rhs) {
+        case (.none, .none):
+            return nil
+        case let (.none, value), let (value, .none):
+            return value.unitCount
+        default:
+            guard let lhsCount = lhs.unitCount?.rawValue,
+                  let rhsCount = rhs.unitCount?.rawValue
+            else { return nil }
+            return DesktopActionOutcome.DispatchUnitCount(lhsCount + rhsCount)
+        }
+    }
+}
+
+private struct HomogeneousValue<Value: Equatable & Sendable>: Sendable {
+    private(set) var value: Value?
+    private var isAvailable = true
+
+    mutating func record(_ value: Value?) {
+        guard self.isAvailable else { return }
+        guard let value else {
+            self.value = nil
+            self.isAvailable = false
+            return
+        }
+        if let existing = self.value, existing != value {
+            self.value = nil
+            self.isAvailable = false
+        } else {
+            self.value = value
+        }
+    }
+}

--- a/Core/PeekabooFoundation/Sources/PeekabooFoundation/DesktopActionSequenceAccumulator.swift
+++ b/Core/PeekabooFoundation/Sources/PeekabooFoundation/DesktopActionSequenceAccumulator.swift
@@ -206,7 +206,7 @@ public struct DesktopActionSequenceAccumulator: Sendable {
                 unitCount: unitCount,
                 message: message,
                 hint: hint ?? leafFailure.hint,
-                causeDescription: causeDescription ?? leafFailure.localizedDescription)
+                causeDescription: causeDescription ?? leafFailure.causeDescription)
         }
         return leafFailure
     }

--- a/Core/PeekabooFoundation/Tests/PeekabooFoundationTests/DesktopActionSequenceAccumulatorTests.swift
+++ b/Core/PeekabooFoundation/Tests/PeekabooFoundationTests/DesktopActionSequenceAccumulatorTests.swift
@@ -135,7 +135,8 @@ struct DesktopActionSequenceAccumulatorTests {
     func `leaf refusal is preserved only while the whole composite has no dispatch`() throws {
         let refusal = DesktopActionFailure.preDispatchRefusal(
             reason: .targetUnavailable,
-            message: "Target drifted")
+            message: "Target drifted",
+            causeDescription: "The pinned window generation changed")
 
         var noDispatch = DesktopActionSequenceAccumulator()
         noDispatch.record(.outcome(.confirmedNoChange(route: .bridge)))
@@ -154,6 +155,7 @@ struct DesktopActionSequenceAccumulatorTests {
         #expect(try composed.outcome.dispatchState == .mayHaveDispatched(unitCount: self.units(1)))
         #expect(composed.outcome.retrySafety == .unsafe)
         #expect(composed.outcome.projection.requiresFreshObservation)
+        #expect(composed.causeDescription == "The pinned window generation changed")
     }
 
     @Test

--- a/Core/PeekabooFoundation/Tests/PeekabooFoundationTests/DesktopActionSequenceAccumulatorTests.swift
+++ b/Core/PeekabooFoundation/Tests/PeekabooFoundationTests/DesktopActionSequenceAccumulatorTests.swift
@@ -1,0 +1,322 @@
+import Foundation
+import PeekabooFoundation
+import Testing
+
+struct DesktopActionSequenceAccumulatorTests {
+    private let localBackground = DesktopActionOutcome.Delivery(
+        mechanism: .processTargetedEvents,
+        mode: .background)
+    private let localForeground = DesktopActionOutcome.Delivery(
+        mechanism: .globalEvents,
+        mode: .foreground)
+
+    @Test
+    func `mutation disposition preserves none definite and possible dispatch`() throws {
+        let two = try self.units(2)
+        let three = try self.units(3)
+
+        #expect(DesktopActionMutationDisposition(dispatchState: .none) == .none)
+        #expect(
+            DesktopActionMutationDisposition(dispatchState: .dispatched(unitCount: two)) ==
+                .definite(unitCount: two))
+        #expect(
+            DesktopActionMutationDisposition(dispatchState: .mayHaveDispatched(unitCount: three)) ==
+                .possible(unitCount: three))
+
+        #expect(!DesktopActionMutationDisposition.none.mutationDispatched)
+        #expect(DesktopActionMutationDisposition.possible(unitCount: nil).mutationDispatched)
+    }
+
+    @Test
+    func `homogeneous confirmed sequence composes exact units`() throws {
+        var sequence = DesktopActionSequenceAccumulator()
+        try sequence.record(.outcome(.confirmedChange(
+            delivery: self.localBackground,
+            unitCount: self.units(2))))
+        sequence.record(.outcome(.confirmedNoChange()))
+        try sequence.record(.outcome(.confirmedChange(
+            delivery: self.localBackground,
+            unitCount: self.units(3))))
+
+        let resolution = sequence.successResolution()
+        #expect(try resolution.outcome == .confirmedChange(
+            delivery: self.localBackground,
+            unitCount: self.units(5)))
+        #expect(try resolution.mutationDisposition == .definite(unitCount: self.units(5)))
+        #expect(!resolution.retrySafe)
+        #expect(!resolution.requiresFreshObservation)
+    }
+
+    @Test
+    func `single reported leaf preserves its exact canonical receipt`() {
+        let leaf = DesktopActionOutcome.confirmedChange(delivery: self.localForeground)
+        var sequence = DesktopActionSequenceAccumulator()
+        sequence.record(.reportedOutcome(leaf, defaultDispatchedUnitCount: .one))
+
+        #expect(sequence.mutationDisposition == .definite(unitCount: .one))
+        #expect(sequence.successResolution().outcome == leaf)
+    }
+
+    @Test
+    func `all no-dispatch phases preserve confirmed no-change only with one route`() {
+        var homogeneous = DesktopActionSequenceAccumulator()
+        homogeneous.record(.outcome(.confirmedNoChange(route: .bridge)))
+        homogeneous.record(.outcome(.confirmedNoChange(route: .bridge)))
+        #expect(homogeneous.successResolution().outcome == .confirmedNoChange(route: .bridge))
+
+        var mixed = homogeneous
+        mixed.record(.outcome(.confirmedNoChange(route: .local)))
+        let mixedResolution = mixed.successResolution()
+        #expect(mixedResolution.outcome == nil)
+        #expect(mixedResolution.mutationDisposition == .none)
+        #expect(mixedResolution.retrySafe)
+        #expect(!mixedResolution.requiresFreshObservation)
+    }
+
+    @Test
+    func `receiptless definite and possible phases never fabricate delivery`() throws {
+        var known = DesktopActionSequenceAccumulator()
+        try known.record(.dispatched(
+            route: .local,
+            delivery: self.localForeground,
+            unitCount: self.units(1)))
+        let knownResolution = known.successResolution()
+        #expect(try knownResolution.outcome == .dispatchedUnverified(
+            delivery: self.localForeground,
+            evidence: .deliveryAccepted,
+            unitCount: self.units(1)))
+        #expect(knownResolution.requiresFreshObservation)
+        #expect(!knownResolution.retrySafe)
+
+        var unknown = DesktopActionSequenceAccumulator()
+        try unknown.record(.mayHaveDispatched(route: nil, delivery: nil, unitCount: self.units(1)))
+        let unknownResolution = unknown.successResolution()
+        #expect(unknownResolution.outcome == nil)
+        #expect(try unknownResolution.mutationDisposition == .possible(unitCount: self.units(1)))
+        #expect(unknownResolution.requiresFreshObservation)
+        #expect(!unknownResolution.retrySafe)
+    }
+
+    @Test
+    func `unknown unit count stays unknown across otherwise exact phases`() throws {
+        var sequence = DesktopActionSequenceAccumulator()
+        try sequence.record(.dispatched(route: .local, delivery: self.localBackground, unitCount: self.units(2)))
+        sequence.record(.dispatched(route: .local, delivery: self.localBackground, unitCount: nil))
+
+        #expect(sequence.mutationDisposition == .definite(unitCount: nil))
+        #expect(sequence.successResolution().outcome == .dispatchedUnverified(
+            delivery: self.localBackground,
+            evidence: .deliveryAccepted,
+            unitCount: nil))
+    }
+
+    @Test
+    func `mixed route or delivery keeps disposition but suppresses a false aggregate`() throws {
+        var mixedRoute = DesktopActionSequenceAccumulator()
+        try mixedRoute.record(.outcome(.confirmedChange(
+            route: .local,
+            delivery: self.localBackground,
+            unitCount: self.units(1))))
+        try mixedRoute.record(.outcome(.confirmedChange(
+            route: .bridge,
+            delivery: self.localBackground,
+            unitCount: self.units(1))))
+        #expect(mixedRoute.successResolution().outcome == nil)
+        #expect(try mixedRoute.mutationDisposition == .definite(unitCount: self.units(2)))
+
+        var mixedDelivery = DesktopActionSequenceAccumulator()
+        mixedDelivery.record(.outcome(.confirmedChange(delivery: self.localBackground)))
+        mixedDelivery.record(.outcome(.confirmedChange(delivery: self.localForeground)))
+        #expect(mixedDelivery.successResolution().outcome == nil)
+        #expect(mixedDelivery.successResolution().requiresFreshObservation)
+    }
+
+    @Test
+    func `leaf refusal is preserved only while the whole composite has no dispatch`() throws {
+        let refusal = DesktopActionFailure.preDispatchRefusal(
+            reason: .targetUnavailable,
+            message: "Target drifted")
+
+        var noDispatch = DesktopActionSequenceAccumulator()
+        noDispatch.record(.outcome(.confirmedNoChange(route: .bridge)))
+        #expect(noDispatch.failure(combining: refusal, message: "Composite failed") == refusal)
+
+        var dispatched = noDispatch
+        try dispatched.record(.dispatched(
+            route: .local,
+            delivery: self.localForeground,
+            unitCount: self.units(1)))
+        let composed = dispatched.failure(
+            combining: refusal,
+            message: "Composite failed",
+            hint: "Observe before retrying")
+        #expect(composed.outcome.state == .indeterminate)
+        #expect(try composed.outcome.dispatchState == .mayHaveDispatched(unitCount: self.units(1)))
+        #expect(composed.outcome.retrySafety == .unsafe)
+        #expect(composed.outcome.projection.requiresFreshObservation)
+    }
+
+    @Test
+    func `foreground setup cannot be erased by a no-dispatch leaf`() throws {
+        var sequence = DesktopActionSequenceAccumulator()
+        try sequence.record(.mayHaveDispatched(route: nil, delivery: nil, unitCount: self.units(1)))
+        let refusal = DesktopActionFailure.preDispatchRefusal(
+            reason: .runtimeIncompatible,
+            message: "Leaf refused")
+
+        let composed = sequence.failure(
+            combining: refusal,
+            message: "Typing failed after setup focus",
+            hint: "Observe before retrying")
+        #expect(composed.outcome.state == .indeterminate)
+        #expect(try composed.outcome.dispatchState == .mayHaveDispatched(unitCount: self.units(1)))
+        #expect(composed.outcome.delivery == nil)
+        #expect(composed.outcome.retrySafety == .unsafe)
+        #expect(composed.outcome.projection.requiresFreshObservation)
+    }
+
+    @Test
+    func `homogeneous partial failure retains delivery while contradictions do not`() throws {
+        var homogeneous = DesktopActionSequenceAccumulator()
+        try homogeneous.record(.outcome(.confirmedChange(
+            route: .bridge,
+            delivery: self.localBackground,
+            unitCount: self.units(2))))
+        let partial = try DesktopActionFailure.partial(
+            route: .bridge,
+            delivery: self.localBackground,
+            unitCount: self.units(1),
+            message: "Cleanup failed")
+        let retained = homogeneous.failure(combining: partial, message: "Composite cleanup failed")
+        #expect(try retained.outcome == .partial(
+            route: .bridge,
+            delivery: self.localBackground,
+            unitCount: self.units(3)))
+
+        var mixed = homogeneous
+        try mixed.record(.outcome(.confirmedChange(
+            route: .local,
+            delivery: self.localForeground,
+            unitCount: self.units(1))))
+        let suppressed = mixed.failure(combining: partial, message: "Composite cleanup failed")
+        #expect(suppressed.outcome.state == .indeterminate)
+        #expect(suppressed.outcome.delivery == nil)
+        #expect(try suppressed.outcome.dispatchState == .mayHaveDispatched(unitCount: self.units(4)))
+    }
+
+    @Test
+    func `response loss evidence and cancellation remain retry unsafe`() throws {
+        var sequence = DesktopActionSequenceAccumulator()
+        #expect(sequence.cancellationFailure(
+            fallbackRoute: .local,
+            message: "Cancelled",
+            hint: "Retry",
+            causeDescription: "cancelled") == nil)
+
+        try sequence.record(.outcome(.confirmedChange(
+            route: .bridge,
+            delivery: self.localBackground,
+            unitCount: self.units(2))))
+        let responseLost = DesktopActionFailure.indeterminate(
+            route: .bridge,
+            delivery: self.localBackground,
+            evidence: .responseLost,
+            message: "Response lost")
+        let composed = sequence.failure(combining: responseLost, message: "Composite response lost")
+        #expect(composed.outcome.evidence == .responseLost)
+        #expect(composed.outcome.retrySafety == .unsafe)
+
+        let cancellation = try #require(sequence.cancellationFailure(
+            fallbackRoute: .local,
+            message: "Cancelled after dispatch",
+            hint: "Observe before retrying",
+            causeDescription: "cancelled"))
+        #expect(cancellation.outcome.route == .bridge)
+        #expect(cancellation.outcome.delivery == self.localBackground)
+        #expect(try cancellation.outcome.dispatchState == .mayHaveDispatched(unitCount: self.units(2)))
+        #expect(cancellation.outcome.projection.requiresFreshObservation)
+
+        var unknownRoute = DesktopActionSequenceAccumulator()
+        unknownRoute.record(.dispatched(
+            route: nil,
+            delivery: self.localForeground,
+            unitCount: .one))
+        let conservative = try #require(unknownRoute.cancellationFailure(
+            fallbackRoute: .local,
+            message: "Cancelled",
+            hint: "Observe before retrying",
+            causeDescription: "cancelled"))
+        #expect(conservative.outcome.delivery == nil)
+    }
+
+    @Test
+    func `require confirmed if reported accepts legacy and rejects every non-confirmed state`() throws {
+        try DesktopActionFailure.requireConfirmedIfReported(nil, operation: "Legacy action")
+        try DesktopActionFailure.requireConfirmedIfReported(
+            .confirmedNoChange(),
+            operation: "No-change action")
+        try DesktopActionFailure.requireConfirmedIfReported(
+            .confirmedChange(delivery: self.localBackground),
+            operation: "Confirmed action")
+
+        let nonConfirmed: [DesktopActionOutcome] = [
+            .partial(delivery: self.localBackground),
+            .dispatchedUnverified(delivery: self.localBackground, evidence: .deliveryAccepted),
+            .suspectedNoop(delivery: self.localBackground),
+            .refused(reason: .invalidRequest),
+            .indeterminate(evidence: .completionUnknown),
+        ]
+        for outcome in nonConfirmed {
+            #expect(throws: DesktopActionFailure.self) {
+                try DesktopActionFailure.requireConfirmedIfReported(outcome, operation: "Fixture")
+            }
+        }
+    }
+
+    @Test
+    func `target and pinning refusals share the complete canonical projection`() {
+        for reason in [
+            DesktopActionOutcome.RefusalReason.invalidRequest,
+            .targetUnavailable,
+            .runtimeIncompatible,
+            .permissionDenied,
+            .foregroundConsentRequired,
+        ] {
+            let failure = DesktopActionFailure.preDispatchRefusal(reason: reason, message: "Refused")
+            let projection = DesktopActionOutcome.preDispatchRefusalProjection(reason: reason)
+            #expect(failure.outcome.projection == projection)
+            #expect(projection.state == .refused)
+            #expect(projection.dispatchState == .none)
+            #expect(!projection.mutationDispatched)
+            #expect(projection.retrySafe)
+            #expect(!projection.requiresFreshObservation)
+            #expect(projection.refusalReason == reason)
+        }
+    }
+
+    @Test
+    func `legacy refusal projection requires the complete zero-dispatch receipt`() {
+        let expected = DesktopActionOutcome.preDispatchRefusalProjection(reason: .targetUnavailable)
+        #expect(DesktopActionOutcome.preDispatchRefusalProjection(
+            reason: .targetUnavailable,
+            legacyRetrySafe: true,
+            legacyMutationDispatched: false) == expected)
+
+        for receipt in [
+            (retrySafe: nil, mutationDispatched: nil),
+            (retrySafe: true, mutationDispatched: nil),
+            (retrySafe: nil, mutationDispatched: false),
+            (retrySafe: false, mutationDispatched: false),
+            (retrySafe: true, mutationDispatched: true),
+        ] as [(retrySafe: Bool?, mutationDispatched: Bool?)] {
+            #expect(DesktopActionOutcome.preDispatchRefusalProjection(
+                reason: .targetUnavailable,
+                legacyRetrySafe: receipt.retrySafe,
+                legacyMutationDispatched: receipt.mutationDispatched) == nil)
+        }
+    }
+
+    private func units(_ value: Int) throws -> DesktopActionOutcome.DispatchUnitCount {
+        try #require(DesktopActionOutcome.DispatchUnitCount(value))
+    }
+}


### PR DESCRIPTION
## Summary

- add a Foundation-owned action-sequence accumulator for setup, leaf delivery, cleanup, cancellation, and refusal phases
- migrate CLI and MCP press/type receipt composition to the shared owner and make paste planning failures use canonical fail-closed refusals
- preserve prior dispatch, route, cancellation, retry, and observation semantics when later phases report no change or fail
- replace duplicated surface-level composition matrices with canonical Foundation fixtures and focused CLI/MCP regressions

## Why

Keyboard actions can contain more than one mutation phase. A foreground focus phase may dispatch before the key or text leaf reports no change or a refusal. Separate CLI and MCP composers could erase that earlier mutation, publish stale observation receipts, or provide incomplete retry guidance. This moves the semantic decision into one typed Foundation owner and leaves each transport responsible only for projection.

## Proof

- `pnpm run test:safe` — 40 Foundation, 900 CLI/Core, and 92 AgentRuntime tests passed; SwiftPM consumer, release-preflight, 34-case certification, and native-only gates passed
- release builds passed for PeekabooFoundation, PeekabooAgentRuntime, and the CLI
- strict SwiftLint over touched Swift files: 0 violations
- final P0-P2 autoreview: clean, no actionable findings
- source-blind exact-artifact validation: 4 passed, 0 failed, 0 blocked; all six refusal cases run twice emitted one stable canonical JSON document, exited 1, and wrote zero stderr

Exact validated Release CLI SHA-256: `ab7d3ceb76e778a192888d127340bcc18876dbbb1128227e19fb78c2d37c3d8f`

## Documentation

- updated both CLI and repository changelogs
