### PR TITLE
fix(mcp): honor cancellation in ShellTool drain and reaper

### DIFF
--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/ShellTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/ShellTool.swift
@@ -16,6 +16,15 @@ public struct ShellTool: MCPTool {
     /// Max time to wait for pipe EOF after the process deadline fires.
     private static let postTimeoutDrainSeconds: TimeInterval = 0.5
 
+    /// Poll interval while waiting for post-timeout pipe EOF.
+    private static let drainPollNanoseconds: UInt64 = 10_000_000
+
+    /// Poll interval for the detached waitpid reaper.
+    private static let reaperPollNanoseconds: UInt64 = 1_000_000_000
+
+    /// Hard ceiling so a detached reaper cannot live forever if waitpid never succeeds.
+    static let backgroundReaperMaxDurationSeconds: TimeInterval = 60
+
     /// Grace period between cooperative and forced process-group termination.
     private static let terminationGraceSeconds: TimeInterval = 0.5
 
@@ -297,29 +306,71 @@ public struct ShellTool: MCPTool {
             return await (outputTask.value, errorTask.value)
         }
 
-        let clock = ContinuousClock()
-        let drainDeadline = clock.now.advanced(by: .seconds(self.postTimeoutDrainSeconds))
-        while clock.now < drainDeadline {
-            if outputReadState.isFinished, errorReadState.isFinished {
-                return await (outputTask.value, errorTask.value)
-            }
-            try? await Task.sleep(nanoseconds: 10_000_000)
-        }
-
-        outputReadState.stop()
-        errorReadState.stop()
+        await self.waitForPostTimeoutDrain(
+            isFinished: { outputReadState.isFinished && errorReadState.isFinished },
+            stop: {
+                outputReadState.stop()
+                errorReadState.stop()
+            },
+            drainSeconds: self.postTimeoutDrainSeconds)
         return await (outputTask.value, errorTask.value)
+    }
+
+    /// Waits for pipe EOF, the drain deadline, or caller cancellation.
+    ///
+    /// Cancellation must stop the readers immediately. Swallowing `CancellationError` from
+    /// `Task.sleep` keeps polling until the deadline and can leave an aborted agent turn
+    /// blocked for the remaining drain window.
+    static func waitForPostTimeoutDrain(
+        isFinished: @escaping @Sendable () -> Bool,
+        stop: @escaping @Sendable () -> Void,
+        drainSeconds: TimeInterval) async
+    {
+        let clock = ContinuousClock()
+        let drainDeadline = clock.now.advanced(by: .seconds(drainSeconds))
+        while clock.now < drainDeadline {
+            if Task.isCancelled {
+                stop()
+                return
+            }
+            if isFinished() {
+                return
+            }
+            do {
+                try await Task.sleep(nanoseconds: self.drainPollNanoseconds)
+            } catch {
+                stop()
+                return
+            }
+        }
+        stop()
     }
 
     private static func startBackgroundReaper(processIdentifier pid: pid_t) {
         Task.detached(priority: .utility) {
-            var waitStatus: Int32 = 0
-            while true {
-                let result = Darwin.waitpid(pid, &waitStatus, WNOHANG)
-                if result == pid || (result == -1 && errno != EINTR) {
-                    return
-                }
-                try? await Task.sleep(nanoseconds: 1_000_000_000)
+            await Self.reapDetachedProcess(
+                processIdentifier: pid,
+                maxDuration: self.backgroundReaperMaxDurationSeconds)
+        }
+    }
+
+    /// Reaps `pid` with WNOHANG until the process exits, waitpid fails, cancellation, or `maxDuration`.
+    static func reapDetachedProcess(processIdentifier pid: pid_t, maxDuration: TimeInterval) async {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: .seconds(maxDuration))
+        var waitStatus: Int32 = 0
+        while clock.now < deadline {
+            if Task.isCancelled {
+                return
+            }
+            let result = Darwin.waitpid(pid, &waitStatus, WNOHANG)
+            if result == pid || (result == -1 && errno != EINTR) {
+                return
+            }
+            do {
+                try await Task.sleep(nanoseconds: self.reaperPollNanoseconds)
+            } catch {
+                return
             }
         }
     }

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPSpecificToolTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPSpecificToolTests.swift
@@ -897,6 +897,63 @@ struct MCPSpecificToolTests {
         let stillAlive = kill(childPid, 0) == 0
         #expect(stillAlive == false)
     }
+
+    @Test(.timeLimit(.minutes(1)))
+    func `Shell tool post-timeout drain stops promptly when the caller is cancelled`() async {
+        let stopped = LockedFlag()
+        let task = Task {
+            await ShellTool.waitForPostTimeoutDrain(
+                isFinished: { false },
+                stop: { stopped.set() },
+                drainSeconds: 5)
+        }
+        try? await Task.sleep(nanoseconds: 20_000_000)
+        let cancelledAt = ContinuousClock.now
+        task.cancel()
+        await task.value
+        #expect(cancelledAt.duration(to: .now) < .seconds(1))
+        #expect(stopped.value)
+    }
+
+    @Test(.timeLimit(.minutes(1)))
+    func `Shell tool background reaper exits when cancelled`() async throws {
+        let child = Process()
+        child.executableURL = URL(fileURLWithPath: "/bin/sleep")
+        child.arguments = ["30"]
+        try child.run()
+        defer {
+            child.terminate()
+            child.waitUntilExit()
+        }
+
+        let task = Task {
+            await ShellTool.reapDetachedProcess(
+                processIdentifier: child.processIdentifier,
+                maxDuration: 30)
+        }
+        try await Task.sleep(nanoseconds: 20_000_000)
+        let cancelledAt = ContinuousClock.now
+        task.cancel()
+        await task.value
+        #expect(cancelledAt.duration(to: .now) < .seconds(1))
+    }
+}
+
+private final class LockedFlag: @unchecked Sendable {
+    private let lock = NSLock()
+    private var stored = false
+
+    var value: Bool {
+        self.lock.lock()
+        defer { self.lock.unlock() }
+        return self.stored
+    }
+
+    func set() {
+        self.lock.lock()
+        self.stored = true
+        self.lock.unlock()
+    }
 }
 
 @MainActor


### PR DESCRIPTION
## What Problem This Solves

After a shell command times out, ShellTool still polls for leftover pipe data. That poll used `try? await Task.sleep`, so a cancelled agent turn discarded `CancellationError` and kept looping until the drain deadline. The detached waitpid reaper had the same `try?` sleep inside `while true`, so a PID that never reaped left a permanent background task.

This is the leftover of the same cancel-swallow class as #311 / #304 / #270, in the timeout path added after #298.

## Evidence

Red (unfixed `try?` loops, cancel after 20ms):

```console
$ swift test --package-path Core/PeekabooCore --filter "post-timeout drain|background reaper" --no-parallel
✘ Test "Shell tool post-timeout drain stops promptly when the caller is cancelled"
  Expectation failed: (cancelledAt.duration(to: .now) -> 4.979514166 seconds) < 1.0 seconds
✘ Test "Shell tool background reaper exits when cancelled"
  Expectation failed: (cancelledAt.duration(to: .now) -> 29.979060875 seconds) < 1.0 seconds
```

Green (this branch, same commands):

```console
$ swift test --package-path Core/PeekabooCore --filter "Shell tool" --no-parallel
✔ Test "Shell tool post-timeout drain stops promptly when the caller is cancelled" passed after 0.020 seconds.
✔ Test "Shell tool background reaper exits when cancelled" passed after 0.021 seconds.
✔ Test run with 13 tests in 4 suites passed after 7.041 seconds.
```

## Real behavior proof

Behavior addressed: Cancelled post-timeout pipe drain stops readers immediately instead of spinning until the deadline; the detached waitpid reaper honors cancel and is capped at 60s instead of looping forever.
Real environment tested: macOS 15 arm64, Swift Testing 1902, PeekabooCore built from this branch at `/tmp/peekaboo-shell-cancel` (upstream/main `4dc20053` + this commit).
Exact steps or command run after this patch: Built PeekabooCore from `/tmp/peekaboo-shell-cancel`, then ran the focused ShellTool cancel and timeout filters on that package.
Evidence after fix: terminal output copied below.

```console
✔ Test "Shell tool post-timeout drain stops promptly when the caller is cancelled" passed after 0.020 seconds.
✔ Test "Shell tool background reaper exits when cancelled" passed after 0.021 seconds.
✔ Test "Shell tool times out hung commands instead of blocking forever" passed after 1.504 seconds.
✔ Test "Shell tool timeout bounds drain when a descendant holds stdout" passed after 1.518 seconds.
```

Observed result after fix: Cancel returns in about 20ms (was 5s drain / 30s reaper). Hung-command timeout and descendant-stdout drain still complete in about 1.5s.
What was not tested: Live MCP agent turn abort against a hung interactive shell on a signed Peekaboo.app build.

## Change

- `waitForPostTimeoutDrain`: `try await` sleep; on cancel, stop pipe readers and return so `execute()` can still report the timeout response.
- `reapDetachedProcess`: cancel-aware sleep and a 60s ceiling (production reaper is still fire-and-forget `Task.detached`).
- Regression coverage in `MCPSpecificToolTests`.

## Origin

The `try?` drain/reaper sleeps landed in [`4f143d40`](https://github.com/openclaw/Peekaboo/commit/4f143d40) (2026-08-01, steipete, "isolate timed-out shell process groups"), 12 days before this PR, on top of #298.

## Related

- Sibling cancel-honor: #311, #304, #270, #267
- Timeout bound: #298
