### PR TITLE
feat: preserve exact keyboard window targets

### DIFF
--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [4.0.1] - Unreleased
 
 ### Added
+- Add receipt-pinned exact-window background `type`, `paste`, and `press`, with focused-element revalidation and fail-closed app/PID ambiguity handling.
 - Add `see --ocr` for additive host-local Vision text with preserved AX warnings, exact snapshot receipts, logical bounds, confidence, background-only observation, and fail-before-dispatch compatibility with older Bridge hosts.
 - Add `see --roi x,y,width,height` for stateless exact-window crops with fresh snapshot receipts, ROI-local element output, and safe coordinate metadata.
 

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommandServiceBridges.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommandServiceBridges.swift
@@ -182,6 +182,53 @@ enum AutomationServiceBridge {
         }.value
     }
 
+    static func typeActions(
+        automation: any UIAutomationServiceProtocol,
+        request: TypeActionsRequest,
+        target: UIAutomationTarget
+    ) async throws -> UIAutomationActionResult<TypeResult> {
+        switch target {
+        case .foreground:
+            return try await self.typeActions(automation: automation, request: request)
+        case let .process(process):
+            guard let identity = process.identity else {
+                throw PeekabooError.invalidInput(
+                    field: "target",
+                    reason: "Background typing requires a process-generation receipt"
+                )
+            }
+            return try await self.typeActions(
+                automation: automation,
+                request: request,
+                expectedProcessIdentity: identity
+            )
+        case let .exactWindow(exactWindow):
+            let outcomeService = try ExactWindowKeyboardRuntime.requireOutcomeProvider(
+                automation: automation,
+                operation: "Background typing"
+            )
+            guard let focusedElement = exactWindow.focusedElement else {
+                throw PeekabooError.invalidInput(
+                    field: "target",
+                    reason: "Exact-window typing requires a focused-element receipt"
+                )
+            }
+            return try await ExactWindowKeyboardRuntime.validateRouteReceipt(
+                outcomeService.typeActionsWithOutcome(
+                    request.actions,
+                    cadence: request.cadence,
+                    snapshotId: request.snapshotId,
+                    target: ExactWindowKeyboardTarget(
+                        windowIdentity: exactWindow.identity,
+                        windowBounds: exactWindow.bounds,
+                        focusedElement: focusedElement
+                    )
+                ),
+                operation: "Background typing"
+            )
+        }
+    }
+
     static func scroll(
         automation: any UIAutomationServiceProtocol,
         request: ScrollRequest
@@ -259,6 +306,54 @@ enum AutomationServiceBridge {
             try await automation.hotkey(keys: keys, holdDuration: holdDuration)
             return UIAutomationActionResult(payload: (), outcome: nil)
         }.value
+    }
+
+    static func hotkey(
+        automation: any UIAutomationServiceProtocol,
+        keys: String,
+        holdDuration: Int,
+        target: UIAutomationTarget
+    ) async throws -> UIAutomationActionResult<Void> {
+        switch target {
+        case .foreground:
+            return try await self.hotkey(automation: automation, keys: keys, holdDuration: holdDuration)
+        case let .process(process):
+            guard let identity = process.identity else {
+                throw PeekabooError.invalidInput(
+                    field: "target",
+                    reason: "Background hotkeys require a process-generation receipt"
+                )
+            }
+            return try await self.hotkey(
+                automation: automation,
+                keys: keys,
+                holdDuration: holdDuration,
+                expectedProcessIdentity: identity
+            )
+        case let .exactWindow(exactWindow):
+            let outcomeService = try ExactWindowKeyboardRuntime.requireOutcomeProvider(
+                automation: automation,
+                operation: "Background hotkeys"
+            )
+            guard let focusedElement = exactWindow.focusedElement else {
+                throw PeekabooError.invalidInput(
+                    field: "target",
+                    reason: "Exact-window hotkeys require a focused-element receipt"
+                )
+            }
+            return try await ExactWindowKeyboardRuntime.validateRouteReceipt(
+                outcomeService.hotkeyWithOutcome(
+                    keys: keys,
+                    holdDuration: holdDuration,
+                    target: ExactWindowKeyboardTarget(
+                        windowIdentity: exactWindow.identity,
+                        windowBounds: exactWindow.bounds,
+                        focusedElement: focusedElement
+                    )
+                ),
+                operation: "Background hotkeys"
+            )
+        }
     }
 
     static func hotkey(

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/KeyboardDeliverySupport.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/KeyboardDeliverySupport.swift
@@ -9,126 +9,78 @@ enum KeyboardDeliveryMode: String {
 }
 
 enum KeyboardDeliverySupport {
-    static func requireBackgroundProcessIdentity(
+    static func requireBackgroundKeyboardTarget(
         target: InteractionTargetOptions,
         snapshotId: String?,
-        services: any PeekabooServiceProviding
-    ) async throws -> ApplicationProcessIdentity {
-        let resolved = try await self.resolveBackgroundProcess(
+        services: any PeekabooServiceProviding,
+        requiresExplicitExactWindow: Bool = false
+    ) async throws -> UIAutomationTarget {
+        let snapshotTarget: UIAutomationTarget.ExactWindow? = if let snapshotId {
+            try await self.resolveSnapshotTarget(snapshotId: snapshotId, services: services)
+        } else {
+            nil
+        }
+        let selectedWindow = try await self.resolveSelectedWindow(target: target, services: services)
+        let selectedProcessIdentity = try await self.resolveSelectedProcessIdentity(
             target: target,
-            snapshotId: snapshotId,
             services: services
         )
-        let selectedIdentity: ApplicationProcessIdentity
-        switch resolved {
-        case let .pid(processIdentifier):
-            selectedIdentity = try await self.requireCurrentProcessIdentity(
-                processIdentifier: processIdentifier,
-                services: services
-            )
-        case let .application(app, description):
-            selectedIdentity = try self.requireProcessIdentity(app, targetDescription: description)
-        case let .snapshot(processIdentifier, capturedWindowIdentity, snapshotId):
-            return try await self.requireSnapshotProcessIdentity(
-                processIdentifier: processIdentifier,
-                capturedWindowIdentity: capturedWindowIdentity,
-                snapshotId: snapshotId,
-                services: services
-            )
-        }
 
-        if let snapshotId {
-            let snapshot = try await self.resolveSnapshotProcess(snapshotId: snapshotId, services: services)
-            let snapshotIdentity = try await self.requireSnapshotProcessIdentity(
-                processIdentifier: snapshot.processIdentifier,
-                capturedWindowIdentity: snapshot.windowIdentity,
-                snapshotId: snapshotId,
-                services: services
-            )
-            guard snapshotIdentity == selectedIdentity else {
+        let exactWindow: UIAutomationTarget.ExactWindow?
+        switch (snapshotTarget, selectedWindow) {
+        case let (snapshot?, selected?):
+            guard snapshot == selected else {
                 throw ValidationError(
-                    "The selected snapshot belongs to a different process generation. Capture fresh UI state."
+                    "The selected snapshot and window selector identify different exact windows. " +
+                        "Capture fresh UI state."
                 )
             }
-        }
-        return selectedIdentity
-    }
-
-    static func requireBackgroundProcessIdentifier(
-        target: InteractionTargetOptions,
-        snapshotId: String?,
-        services: any PeekabooServiceProviding
-    ) async throws -> pid_t {
-        try await pid_t(self.resolveBackgroundProcess(
-            target: target,
-            snapshotId: snapshotId,
-            services: services
-        ).processIdentifier)
-    }
-
-    private static func resolveBackgroundProcess(
-        target: InteractionTargetOptions,
-        snapshotId: String?,
-        services: any PeekabooServiceProviding
-    ) async throws -> ResolvedBackgroundProcess {
-        if target.windowTitle != nil || target.windowIndex != nil || target.windowId != nil {
-            throw ValidationError(
-                "Background keyboard delivery cannot safely target a specific window. " +
-                    "Use --app/--pid without a window selector, or add --foreground to focus the window first."
-            )
+            exactWindow = snapshot
+        case let (snapshot?, nil):
+            exactWindow = snapshot
+        case let (nil, selected?):
+            exactWindow = selected
+        case (nil, nil):
+            exactWindow = nil
         }
 
-        if let pid = target.pid {
-            guard pid > 0 else {
-                throw ValidationError("--pid must be greater than 0")
-            }
-            return .pid(pid)
-        }
-
-        if let appIdentifier = target.app?.trimmingCharacters(in: .whitespacesAndNewlines),
-           !appIdentifier.isEmpty {
-            let app = try await services.applications.findApplication(identifier: appIdentifier)
-            guard app.processIdentifier > 0 else {
-                throw ValidationError("Could not resolve a running process for --app '\(appIdentifier)'.")
-            }
-            return .application(app, description: "--app '\(appIdentifier)'")
-        }
-
-        if let snapshotId {
-            let snapshot = try await self.resolveSnapshotProcess(snapshotId: snapshotId, services: services)
-            return .snapshot(
-                snapshot.processIdentifier,
-                capturedWindowIdentity: snapshot.windowIdentity,
-                snapshotId: snapshotId
-            )
-        }
-
-        throw PreDispatchActionError(
-            message: "Keyboard input requires --app, --pid, or --snapshot for background delivery.",
-            code: .VALIDATION_ERROR,
-            hint: "Use --foreground for intentional global input.",
-            reason: .invalidRequest
+        let processIdentity = try self.requireConsistentProcessIdentity(
+            selected: selectedProcessIdentity,
+            snapshot: snapshotTarget?.identity.processIdentity,
+            window: selectedWindow?.identity.processIdentity
         )
-    }
+        try await self.requireBackgroundInputEligibility(
+            processIdentity: processIdentity,
+            services: services
+        )
+        let process = try UIAutomationTarget.Process(
+            processIdentifier: processIdentity.processIdentifier,
+            identity: processIdentity
+        )
 
-    private enum ResolvedBackgroundProcess {
-        case pid(Int32)
-        case application(ServiceApplicationInfo, description: String)
-        case snapshot(Int32, capturedWindowIdentity: WindowMutationIdentity, snapshotId: String)
+        if let exactWindow {
+            return try UIAutomationTarget.backgroundKeyboard(
+                process: process,
+                exactWindow: exactWindow
+            )
+        }
 
-        var processIdentifier: Int32 {
-            switch self {
-            case let .pid(processIdentifier), let .snapshot(processIdentifier, _, _):
-                processIdentifier
-            case let .application(app, _):
-                app.processIdentifier
+        let eligibleWindows: [UIAutomationTarget.ExactWindow]
+        if requiresExplicitExactWindow {
+            eligibleWindows = []
+        } else {
+            let windows = try await services.windows.listWindows(
+                target: .application("PID:\(processIdentity.processIdentifier)")
+            )
+            eligibleWindows = try ObservationTargetResolver.captureCandidates(from: windows).map {
+                try UIAutomationTarget.ExactWindow(window: $0)
             }
         }
-    }
-
-    private struct ResolvedSnapshotProcess {
-        let processIdentifier: Int32
-        let windowIdentity: WindowMutationIdentity
+        return try UIAutomationTarget.backgroundKeyboard(
+            process: process,
+            eligibleWindows: eligibleWindows,
+            requiresExplicitExactWindow: requiresExplicitExactWindow
+        )
     }
 
     static func validateForegroundFlags(
@@ -145,83 +97,148 @@ enum KeyboardDeliverySupport {
         }
     }
 
-    private static func requireSnapshotProcessIdentity(
-        processIdentifier: Int32,
-        capturedWindowIdentity: WindowMutationIdentity,
+    private static func resolveSnapshotTarget(
         snapshotId: String,
         services: any PeekabooServiceProviding
-    ) async throws -> ApplicationProcessIdentity {
-        let currentIdentity = try await self.requireCurrentProcessIdentity(
-            processIdentifier: processIdentifier,
-            services: services
-        )
-        let capturedIdentity = ApplicationProcessIdentity(
-            processIdentifier: capturedWindowIdentity.ownerProcessIdentifier,
-            processStartIdentity: capturedWindowIdentity.ownerProcessStartIdentity
-        )
-        guard capturedIdentity.processIdentifier == processIdentifier,
-              capturedIdentity == currentIdentity
+    ) async throws -> UIAutomationTarget.ExactWindow {
+        var processIdentifier: Int32?
+        var windowIdentity: WindowMutationIdentity?
+        var windowBounds: CGRect?
+
+        func merge(
+            process incomingProcess: Int32?,
+            identity incomingIdentity: WindowMutationIdentity?,
+            bounds incomingBounds: CGRect?
+        ) throws {
+            if let incomingProcess {
+                guard processIdentifier.map({ $0 == incomingProcess }) ?? true else {
+                    throw ValidationError("Snapshot '\(snapshotId)' has inconsistent process metadata.")
+                }
+                processIdentifier = incomingProcess
+            }
+            if let incomingIdentity {
+                guard windowIdentity.map({ $0 == incomingIdentity }) ?? true else {
+                    throw ValidationError("Snapshot '\(snapshotId)' has inconsistent window metadata.")
+                }
+                windowIdentity = incomingIdentity
+            }
+            if let incomingBounds {
+                guard windowBounds.map({ $0 == incomingBounds }) ?? true else {
+                    throw ValidationError("Snapshot '\(snapshotId)' has inconsistent window bounds.")
+                }
+                windowBounds = incomingBounds
+            }
+        }
+
+        if let snapshot = try await services.snapshots.getUIAutomationSnapshot(snapshotId: snapshotId) {
+            try merge(
+                process: snapshot.applicationProcessId,
+                identity: snapshot.windowMutationIdentity,
+                bounds: snapshot.windowBounds
+            )
+        }
+        if let detectionResult = try await services.snapshots.getDetectionResult(snapshotId: snapshotId),
+           let context = detectionResult.metadata.windowContext {
+            try merge(
+                process: context.applicationProcessId,
+                identity: context.windowMutationIdentity,
+                bounds: context.windowBounds
+            )
+        }
+
+        guard let processIdentifier, processIdentifier > 0,
+              let windowIdentity,
+              let windowBounds,
+              windowIdentity.ownerProcessIdentifier == processIdentifier,
+              windowIdentity.windowID > 0,
+              windowIdentity.capturedBounds == windowBounds
         else {
             throw ValidationError(
-                "Snapshot '\(snapshotId)' is stale: its target application exited or changed process generation."
+                "Snapshot '\(snapshotId)' has no exact process-generation, window, and bounds receipt. " +
+                    "Capture fresh UI state."
             )
         }
-        return capturedIdentity
+        return try UIAutomationTarget.ExactWindow(identity: windowIdentity, bounds: windowBounds)
     }
 
-    private static func resolveSnapshotProcess(
-        snapshotId: String,
+    private static func resolveSelectedWindow(
+        target: InteractionTargetOptions,
         services: any PeekabooServiceProviding
-    ) async throws -> ResolvedSnapshotProcess {
-        var capturedProcessIdentifier: Int32?
-        var capturedWindowIdentity: WindowMutationIdentity?
-
-        if let snapshot = try await services.snapshots.getUIAutomationSnapshot(snapshotId: snapshotId),
-           let processIdentifier = snapshot.applicationProcessId,
-           processIdentifier > 0 {
-            capturedProcessIdentifier = processIdentifier
-            if let identity = snapshot.windowMutationIdentity {
-                guard identity.ownerProcessIdentifier == processIdentifier else {
-                    throw ValidationError("Snapshot '\(snapshotId)' has inconsistent process metadata.")
-                }
-                capturedWindowIdentity = identity
-            }
+    ) async throws -> UIAutomationTarget.ExactWindow? {
+        guard target.windowId != nil || target.windowTitle != nil || target.windowIndex != nil else {
+            return nil
         }
-
-        if let detectionResult = try await services.snapshots.getDetectionResult(snapshotId: snapshotId),
-           let context = detectionResult.metadata.windowContext,
-           let processIdentifier = context.applicationProcessId,
-           processIdentifier > 0 {
-            if let capturedProcessIdentifier, capturedProcessIdentifier != processIdentifier {
-                throw ValidationError("Snapshot '\(snapshotId)' has inconsistent process metadata.")
-            }
-            capturedProcessIdentifier = processIdentifier
-            if let identity = context.windowMutationIdentity {
-                guard identity.ownerProcessIdentifier == processIdentifier else {
-                    throw ValidationError("Snapshot '\(snapshotId)' has inconsistent process metadata.")
-                }
-                if let existingIdentity = capturedWindowIdentity, existingIdentity != identity {
-                    throw ValidationError("Snapshot '\(snapshotId)' has inconsistent process metadata.")
-                }
-                capturedWindowIdentity = identity
-            }
+        guard let windowTarget = try target.toWindowTarget() else {
+            throw ValidationError("Could not resolve the requested exact window.")
         }
+        let matches = try await services.windows.listWindows(target: windowTarget)
+        guard matches.count == 1, let window = matches.first else {
+            let detail = matches.isEmpty ? "no matching window" : "multiple matching windows"
+            throw ValidationError("Could not resolve one exact background keyboard target: \(detail).")
+        }
+        return try UIAutomationTarget.ExactWindow(window: window)
+    }
 
-        guard let capturedProcessIdentifier else {
-            throw ValidationError(
-                "The selected snapshot does not identify a target process. " +
-                    "Capture a window/app snapshot or add --foreground for intentional global input."
+    private static func resolveSelectedProcessIdentity(
+        target: InteractionTargetOptions,
+        services: any PeekabooServiceProviding
+    ) async throws -> ApplicationProcessIdentity? {
+        if let pid = target.pid {
+            guard pid > 0 else { throw ValidationError("--pid must be greater than 0") }
+            return try await self.requireCurrentProcessIdentity(
+                processIdentifier: pid,
+                services: services
             )
         }
-        guard let capturedWindowIdentity else {
-            throw ValidationError(
-                "The selected snapshot has no capture-time process-generation receipt. Capture fresh UI state."
+        guard let appIdentifier = target.app?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !appIdentifier.isEmpty
+        else { return nil }
+        let app = try await services.applications.findApplication(identifier: appIdentifier)
+        return try self.requireProcessIdentity(app, targetDescription: "--app '\(appIdentifier)'")
+    }
+
+    private static func requireConsistentProcessIdentity(
+        selected: ApplicationProcessIdentity?,
+        snapshot: ApplicationProcessIdentity?,
+        window: ApplicationProcessIdentity?
+    ) throws -> ApplicationProcessIdentity {
+        let identities = [selected, snapshot, window].compactMap(\.self)
+        guard let identity = identities.first else {
+            throw PreDispatchActionError(
+                message: "Keyboard input requires --app, --pid, --window-id, or --snapshot for background delivery.",
+                code: .VALIDATION_ERROR,
+                hint: "Use --foreground for intentional global input.",
+                reason: .invalidRequest
             )
         }
-        return ResolvedSnapshotProcess(
-            processIdentifier: capturedProcessIdentifier,
-            windowIdentity: capturedWindowIdentity
+        guard identities.allSatisfy({ $0 == identity }) else {
+            throw ValidationError(
+                "The selected app, window, and snapshot do not identify the same process generation. " +
+                    "Capture fresh UI state."
+            )
+        }
+        return identity
+    }
+
+    private static func requireBackgroundInputEligibility(
+        processIdentity: ApplicationProcessIdentity,
+        services: any PeekabooServiceProviding
+    ) async throws {
+        let app = try await services.applications.findApplication(
+            identifier: "PID:\(processIdentity.processIdentifier)"
         )
+        guard app.processIdentity == processIdentity else {
+            throw ValidationError(
+                "Target process PID \(processIdentity.processIdentifier) changed identity while " +
+                    "resolving keyboard input."
+            )
+        }
+        guard app.isEligibleForBackgroundInput else {
+            throw ValidationError(
+                "Target process PID \(processIdentity.processIdentifier) cannot receive background input because it " +
+                    "is a prohibited helper or its application metadata is incomplete."
+            )
+        }
     }
 
     private static func requireCurrentProcessIdentity(

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/PasteCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/PasteCommand.swift
@@ -86,10 +86,10 @@ struct PasteCommand: ActionOutputFormattable, ErrorHandlingCommand, OutputFormat
                 request: request
             ) {
                 let expectedPIDIdentity = try self.explicitPIDIdentity()
-                if let targetIdentity = try await self.preDispatchBackgroundProcessIdentity(
+                if let deliveryTarget = try await self.preDispatchBackgroundTarget(
                     expectedPIDIdentity: expectedPIDIdentity
                 ) {
-                    try await self.pasteTextInBackground(text, request: request, targetIdentity: targetIdentity)
+                    try await self.pasteTextInBackground(text, request: request, target: deliveryTarget)
                     return
                 }
             }
@@ -97,10 +97,10 @@ struct PasteCommand: ActionOutputFormattable, ErrorHandlingCommand, OutputFormat
             let expectedPIDIdentity = try self.explicitPIDIdentity()
             let outcome = try await self.withInteractionMutationInvalidation {
                 try await ClipboardPasteTransactionGate.withExclusiveTransaction {
-                    let targetIdentity = try await self.preDispatchBackgroundProcessIdentity(
+                    let deliveryTarget = try await self.preDispatchBackgroundTarget(
                         expectedPIDIdentity: expectedPIDIdentity
                     )
-                    if targetIdentity == nil {
+                    if deliveryTarget == nil {
                         try await ensureFocused(
                             snapshotId: nil,
                             target: self.target,
@@ -110,7 +110,7 @@ struct PasteCommand: ActionOutputFormattable, ErrorHandlingCommand, OutputFormat
                     }
                     return try await self.performClipboardPasteTransaction(
                         request: request,
-                        targetIdentity: targetIdentity
+                        target: deliveryTarget ?? .foreground
                     )
                 }
             }
@@ -135,7 +135,8 @@ struct PasteCommand: ActionOutputFormattable, ErrorHandlingCommand, OutputFormat
                 restoreDelayMs: self.resolvedRestoreDelayMs,
                 deliveryMode: outcome.targetPID == nil ? KeyboardDeliveryMode.foreground.rawValue :
                     KeyboardDeliveryMode.background.rawValue,
-                targetPID: outcome.targetPID.map(Int.init)
+                targetPID: outcome.targetPID.map(Int.init),
+                targetWindowID: outcome.targetWindowID
             )
 
             self.output(
@@ -159,6 +160,9 @@ struct PasteCommand: ActionOutputFormattable, ErrorHandlingCommand, OutputFormat
                 if let targetPID = outcome.targetPID {
                     print("🎯 Mode: background to PID \(targetPID)")
                 }
+                if let targetWindowID = outcome.targetWindowID {
+                    print("🪟 Window: \(targetWindowID)")
+                }
             }
         } catch let error as ClipboardPasteOutcomeError {
             self.handleError(error, customCode: .INTERACTION_FAILED)
@@ -171,9 +175,14 @@ struct PasteCommand: ActionOutputFormattable, ErrorHandlingCommand, OutputFormat
 
     private func performClipboardPasteTransaction(
         request: ClipboardWriteRequest,
-        targetIdentity: ApplicationProcessIdentity?
+        target: UIAutomationTarget
     ) async throws -> ClipboardPasteTransactionOutcome {
-        if targetIdentity != nil {
+        if target.exactWindow != nil {
+            _ = try ExactWindowKeyboardRuntime.requireOutcomeProvider(
+                automation: self.services.automation,
+                operation: "Exact-window paste"
+            )
+        } else if target.processIdentifier != nil {
             guard let automation = self.services.automation as? any TargetedHotkeyServiceProtocol,
                   automation.supportsTargetedHotkeys,
                   automation.supportsProcessGenerationPinnedHotkeys
@@ -233,24 +242,26 @@ struct PasteCommand: ActionOutputFormattable, ErrorHandlingCommand, OutputFormat
             try restoreBeforeDispatchFailure(error)
         }
 
+        let dispatchFailure: DesktopActionFailure?
         let dispatchErrorDescription: String?
         do {
-            if let targetIdentity {
-                _ = try await AutomationServiceBridge.hotkey(
-                    automation: self.services.automation,
-                    keys: "cmd,v",
-                    holdDuration: 50,
-                    expectedProcessIdentity: targetIdentity
-                )
-            } else {
-                _ = try await AutomationServiceBridge.hotkey(
-                    automation: self.services.automation,
-                    keys: "cmd,v",
-                    holdDuration: 50
-                )
-            }
+            let result = try await AutomationServiceBridge.hotkey(
+                automation: self.services.automation,
+                keys: "cmd,v",
+                holdDuration: 50,
+                target: target
+            )
+            try DesktopActionFailure.requireConfirmedIfReported(
+                result.outcome,
+                operation: "Paste hotkey"
+            )
+            dispatchFailure = nil
+            dispatchErrorDescription = nil
+        } catch let failure as DesktopActionFailure {
+            dispatchFailure = failure
             dispatchErrorDescription = nil
         } catch {
+            dispatchFailure = nil
             dispatchErrorDescription = error.localizedDescription
         }
 
@@ -269,22 +280,33 @@ struct PasteCommand: ActionOutputFormattable, ErrorHandlingCommand, OutputFormat
         }
         restorePending = false
 
+        if let dispatchFailure {
+            guard let restoreErrorDescription else { throw dispatchFailure }
+            throw ClipboardPasteOutcomeError(
+                kind: .indeterminate,
+                causeDescription: "\(dispatchFailure.localizedDescription); clipboard restoration also failed: " +
+                    restoreErrorDescription,
+                clipboardRestoreAttempted: true,
+                clipboardRestoreErrorDescription: restoreErrorDescription,
+                targetProcessIdentifier: target.processIdentifier
+            )
+        }
         if dispatchErrorDescription != nil || Task.isCancelled {
             throw ClipboardPasteOutcomeError(
                 kind: .indeterminate,
                 causeDescription: dispatchErrorDescription ?? "The caller cancelled after Cmd+V dispatch began.",
                 clipboardRestoreAttempted: true,
                 clipboardRestoreErrorDescription: restoreErrorDescription,
-                targetProcessIdentifier: targetIdentity?.processIdentifier
+                targetProcessIdentifier: target.processIdentifier
             )
         }
-        if targetIdentity != nil {
+        if target.processIdentifier != nil {
             throw ClipboardPasteOutcomeError(
                 kind: .unverified,
                 causeDescription: "The targeted event API does not acknowledge receiver consumption.",
                 clipboardRestoreAttempted: true,
                 clipboardRestoreErrorDescription: restoreErrorDescription,
-                targetProcessIdentifier: targetIdentity?.processIdentifier
+                targetProcessIdentifier: target.processIdentifier
             )
         }
 
@@ -293,27 +315,32 @@ struct PasteCommand: ActionOutputFormattable, ErrorHandlingCommand, OutputFormat
             previousClipboardPresent: priorClipboard != nil,
             restoreResult: restoreResult,
             restoreErrorDescription: restoreErrorDescription,
-            targetPID: targetIdentity?.processIdentifier
+            targetPID: target.processIdentifier,
+            targetWindowID: target.exactWindow?.identity.windowID
         )
     }
 
     private func pasteTextInBackground(
         _ text: String,
         request: ClipboardWriteRequest,
-        targetIdentity: ApplicationProcessIdentity
+        target: UIAutomationTarget
     ) async throws {
         let setResult = try Self.readResult(for: request)
-        _ = try await self.withInteractionMutationInvalidation {
-            _ = try await AutomationServiceBridge.typeActions(
+        let actionResult = try await self.withInteractionMutationInvalidation {
+            try await AutomationServiceBridge.typeActions(
                 automation: self.services.automation,
                 request: TypeActionsRequest(
                     actions: [.text(text)],
                     cadence: .fixed(milliseconds: 0),
                     snapshotId: nil
                 ),
-                expectedProcessIdentity: targetIdentity
+                target: target
             )
         }
+        try DesktopActionFailure.requireConfirmedIfReported(
+            actionResult.outcome,
+            operation: "Background text paste"
+        )
 
         let result = PasteResult(
             pastedUti: setResult.utiIdentifier,
@@ -326,13 +353,19 @@ struct PasteCommand: ActionOutputFormattable, ErrorHandlingCommand, OutputFormat
             restoreError: nil,
             restoreDelayMs: 0,
             deliveryMode: KeyboardDeliveryMode.background.rawValue,
-            targetPID: Int(targetIdentity.processIdentifier)
+            targetPID: target.processIdentifier.map(Int.init),
+            targetWindowID: target.exactWindow?.identity.windowID
         )
 
-        self.output(result) {
+        self.output(result, outcome: actionResult.outcome) {
             print("✅ Pasted text")
             print("📋 Pasted: \(setResult.utiIdentifier) (\(setResult.data.count) bytes)")
-            print("🎯 Mode: background to PID \(targetIdentity.processIdentifier)")
+            if let processIdentifier = target.processIdentifier {
+                print("🎯 Mode: background to PID \(processIdentifier)")
+            }
+            if let windowID = target.exactWindow?.identity.windowID {
+                print("🪟 Window: \(windowID)")
+            }
         }
     }
 
@@ -397,10 +430,10 @@ struct PasteCommand: ActionOutputFormattable, ErrorHandlingCommand, OutputFormat
     private func pasteCurrentClipboard(expectedPIDIdentity: UInt64?) async throws {
         let outcome = try await self.withInteractionMutationInvalidation {
             try await ClipboardPasteTransactionGate.withExclusiveTransaction {
-                let targetIdentity = try await self.preDispatchBackgroundProcessIdentity(
+                let deliveryTarget = try await self.preDispatchBackgroundTarget(
                     expectedPIDIdentity: expectedPIDIdentity
                 )
-                if targetIdentity == nil {
+                if deliveryTarget == nil {
                     try await ensureFocused(
                         snapshotId: nil,
                         target: self.target,
@@ -410,49 +443,55 @@ struct PasteCommand: ActionOutputFormattable, ErrorHandlingCommand, OutputFormat
                 }
                 let currentClipboard = try self.services.clipboard.get(prefer: nil)
                 try Task.checkCancellation()
+                let dispatchFailure: DesktopActionFailure?
                 let dispatchErrorDescription: String?
                 do {
-                    if let targetIdentity {
-                        _ = try await AutomationServiceBridge.hotkey(
-                            automation: self.services.automation,
-                            keys: "cmd,v",
-                            holdDuration: 50,
-                            expectedProcessIdentity: targetIdentity
-                        )
-                    } else {
-                        _ = try await AutomationServiceBridge.hotkey(
-                            automation: self.services.automation,
-                            keys: "cmd,v",
-                            holdDuration: 50
-                        )
-                    }
+                    let result = try await AutomationServiceBridge.hotkey(
+                        automation: self.services.automation,
+                        keys: "cmd,v",
+                        holdDuration: 50,
+                        target: deliveryTarget ?? .foreground
+                    )
+                    try DesktopActionFailure.requireConfirmedIfReported(
+                        result.outcome,
+                        operation: "Paste hotkey"
+                    )
+                    dispatchFailure = nil
+                    dispatchErrorDescription = nil
+                } catch let failure as DesktopActionFailure {
+                    dispatchFailure = failure
                     dispatchErrorDescription = nil
                 } catch {
+                    dispatchFailure = nil
                     dispatchErrorDescription = error.localizedDescription
                 }
                 await ClipboardPasteTransactionGate.waitForPasteConsumption(
                     milliseconds: self.resolvedRestoreDelayMs
                 )
+                if let dispatchFailure {
+                    throw dispatchFailure
+                }
                 if dispatchErrorDescription != nil || Task.isCancelled {
                     throw ClipboardPasteOutcomeError(
                         kind: .indeterminate,
                         causeDescription: dispatchErrorDescription ??
                             "The caller cancelled after Cmd+V dispatch began.",
                         clipboardRestoreAttempted: false,
-                        targetProcessIdentifier: targetIdentity?.processIdentifier
+                        targetProcessIdentifier: deliveryTarget?.processIdentifier
                     )
                 }
-                if targetIdentity != nil {
+                if deliveryTarget != nil {
                     throw ClipboardPasteOutcomeError(
                         kind: .unverified,
                         causeDescription: "The targeted event API does not acknowledge receiver consumption.",
                         clipboardRestoreAttempted: false,
-                        targetProcessIdentifier: targetIdentity?.processIdentifier
+                        targetProcessIdentifier: deliveryTarget?.processIdentifier
                     )
                 }
                 return CurrentClipboardPasteOutcome(
                     clipboard: currentClipboard,
-                    targetPID: targetIdentity?.processIdentifier
+                    targetPID: deliveryTarget?.processIdentifier,
+                    targetWindowID: deliveryTarget?.exactWindow?.identity.windowID
                 )
             }
         }
@@ -480,7 +519,8 @@ struct PasteCommand: ActionOutputFormattable, ErrorHandlingCommand, OutputFormat
             restoreDelayMs: self.resolvedRestoreDelayMs,
             deliveryMode: outcome.targetPID == nil ? KeyboardDeliveryMode.foreground.rawValue :
                 KeyboardDeliveryMode.background.rawValue,
-            targetPID: outcome.targetPID.map(Int.init)
+            targetPID: outcome.targetPID.map(Int.init),
+            targetWindowID: outcome.targetWindowID
         )
 
         self.output(result) {
@@ -489,6 +529,9 @@ struct PasteCommand: ActionOutputFormattable, ErrorHandlingCommand, OutputFormat
                 print("🎯 Mode: background to PID \(targetPID)")
             } else {
                 print("🎯 Mode: foreground")
+            }
+            if let targetWindowID = outcome.targetWindowID {
+                print("🪟 Window: \(targetWindowID)")
             }
         }
     }
@@ -572,29 +615,21 @@ struct PasteCommand: ActionOutputFormattable, ErrorHandlingCommand, OutputFormat
         return identity
     }
 
-    private func verifiedBackgroundProcessIdentity(
+    private func verifiedBackgroundTarget(
         expectedPIDIdentity: UInt64? = nil
-    ) async throws -> ApplicationProcessIdentity? {
+    ) async throws -> UIAutomationTarget? {
         if self.focusOptions.foreground {
             try self.validateExplicitPIDIdentity(expectedPIDIdentity)
             return nil
         }
 
-        let processIdentity = try await KeyboardDeliverySupport.requireBackgroundProcessIdentity(
+        let plannedTarget = try await KeyboardDeliverySupport.requireBackgroundKeyboardTarget(
             target: self.target,
             snapshotId: nil,
             services: self.services
         )
-        let processIdentifier = processIdentity.processIdentifier
-        let applications = try await self.services.applications.listApplications().data.applications
-        guard let application = applications.first(where: { $0.processIdentifier == processIdentifier }) else {
-            throw ValidationError("Target process PID \(processIdentifier) is no longer running.")
-        }
-        guard application.isEligibleForBackgroundInput else {
-            throw ValidationError(
-                "Target process PID \(processIdentifier) cannot receive background input because it is a " +
-                    "prohibited helper or its application metadata is incomplete."
-            )
+        guard let processIdentifier = plannedTarget.processIdentifier else {
+            throw ValidationError("Background paste requires a resolved target process.")
         }
         if self.target.pid != nil {
             guard let expectedPIDIdentity,
@@ -603,14 +638,38 @@ struct PasteCommand: ActionOutputFormattable, ErrorHandlingCommand, OutputFormat
                 throw ValidationError("Target process PID \(processIdentifier) changed identity while waiting.")
             }
         }
-        return processIdentity
+        if plannedTarget.exactWindow != nil {
+            do {
+                _ = try ExactWindowKeyboardRuntime.requireOutcomeProvider(
+                    automation: self.services.automation,
+                    operation: "Exact-window paste"
+                )
+            } catch {
+                throw PreDispatchActionError(
+                    message: error.localizedDescription,
+                    code: .INTERACTION_FAILED,
+                    hint: "Update the Peekaboo host and retry with a fresh exact-window target.",
+                    reason: .runtimeIncompatible
+                )
+            }
+            guard self.services.automation is any TargetedFocusedElementServiceProtocol else {
+                throw PreDispatchActionError(
+                    message: "This automation host does not support focused exact-window background paste.",
+                    code: .INTERACTION_FAILED,
+                    hint: "Update the Peekaboo host and retry with a fresh exact-window target.",
+                    reason: .runtimeIncompatible
+                )
+            }
+            return try await plannedTarget.pinningCurrentFocusedElement(using: self.services.automation)
+        }
+        return plannedTarget
     }
 
-    private func preDispatchBackgroundProcessIdentity(
+    private func preDispatchBackgroundTarget(
         expectedPIDIdentity: UInt64? = nil
-    ) async throws -> ApplicationProcessIdentity? {
+    ) async throws -> UIAutomationTarget? {
         do {
-            return try await self.verifiedBackgroundProcessIdentity(expectedPIDIdentity: expectedPIDIdentity)
+            return try await self.verifiedBackgroundTarget(expectedPIDIdentity: expectedPIDIdentity)
         } catch is CancellationError {
             throw CancellationError()
         } catch {
@@ -635,11 +694,13 @@ private struct ClipboardPasteTransactionOutcome: Sendable {
     let restoreResult: ClipboardReadResult?
     let restoreErrorDescription: String?
     let targetPID: pid_t?
+    let targetWindowID: Int?
 }
 
 private struct CurrentClipboardPasteOutcome: Sendable {
     let clipboard: ClipboardReadResult?
     let targetPID: pid_t?
+    let targetWindowID: Int?
 }
 
 struct PasteResult: Codable {
@@ -654,6 +715,7 @@ struct PasteResult: Codable {
     let restoreDelayMs: Int
     let deliveryMode: String
     let targetPID: Int?
+    let targetWindowID: Int?
 }
 
 @MainActor
@@ -665,8 +727,8 @@ extension PasteCommand: ParsableCommand {
                 abstract: "Paste current clipboard or set clipboard, paste, and restore",
                 discussion: """
                     With no payload, paste sends Cmd+V using the current clipboard contents.
-                    Background paste requires --app or --pid. Add --foreground for intentional
-                    paste into the current focus or to focus a selected window first.
+                    Background paste requires an exact window selector, or an app/PID with at most
+                    one eligible window. Add --foreground for intentional foreground/global paste.
 
                     This command reduces drift in automation flows by collapsing:
                       1) clipboard set
@@ -682,7 +744,7 @@ extension PasteCommand: ParsableCommand {
                       peekaboo paste --foreground
                       peekaboo paste \"Hello\" --app TextEdit
                       peekaboo paste \"Hello\" --app TextEdit --foreground
-                      peekaboo paste --text \"Hello\" --app TextEdit --window-title \"Untitled\" --foreground
+                      peekaboo paste --text \"Hello\" --app TextEdit --window-title \"Untitled\"
                       peekaboo paste --data-base64 \"$BASE64\" --uti public.rtf --also-text \"fallback\" --app TextEdit
                       peekaboo paste --file-path /tmp/snippet.png --app Notes
                 """,

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/PressCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/PressCommand.swift
@@ -333,6 +333,8 @@ RuntimeOptionsConfigurable {
                 services: self.services,
                 requiresExplicitExactWindow: true
             )
+        } catch is CancellationError {
+            throw CancellationError()
         } catch {
             throw self.preDispatchActionError(for: error, reason: .targetUnavailable)
         }
@@ -368,6 +370,8 @@ RuntimeOptionsConfigurable {
         do {
             let pinnedTarget = try await target.pinningCurrentFocusedElement(using: self.services.automation)
             return PressDeliveryPlan(target: pinnedTarget, foregroundSetupMayHaveMutated: false)
+        } catch is CancellationError {
+            throw CancellationError()
         } catch {
             throw self.preDispatchActionError(for: error, reason: .targetUnavailable)
         }

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/PressCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/PressCommand.swift
@@ -85,19 +85,24 @@ RuntimeOptionsConfigurable {
                 fallbackToLatest: false,
                 snapshots: self.services.snapshots
             )
-            try await observation.validateIfExplicit(using: self.services.snapshots)
+            do {
+                try await observation.validateIfExplicit(using: self.services.snapshots)
+            } catch is CancellationError {
+                throw CancellationError()
+            } catch {
+                try Task.checkCancellation()
+                throw self.preDispatchActionError(for: error, reason: .targetUnavailable)
+            }
 
             self.resolvedRuntime.beginInteractionMutation()
-            try await ensureFocused(
-                snapshotId: observation.focusSnapshotId(for: self.target),
-                target: self.target,
-                options: self.focusOptions,
-                services: self.services
-            )
-
             let parsedChords = try self.parsedChords()
             var completedPresses = 0
             var sequence = DesktopActionSequenceAccumulator()
+            let deliveryPlan = try await self.resolveDeliveryPlan(observation: observation)
+            if deliveryPlan.foregroundSetupMayHaveMutated {
+                sequence.record(.mayHaveDispatched(route: nil, delivery: nil, unitCount: .one))
+            }
+            let deliveryTarget = deliveryPlan.target
 
             for repetition in 0..<self.count {
                 for (index, chord) in parsedChords.indexed() {
@@ -119,7 +124,8 @@ RuntimeOptionsConfigurable {
                         actionResult = try await AutomationServiceBridge.hotkey(
                             automation: self.services.automation,
                             keys: chord.serviceKeys,
-                            holdDuration: self.hold.roundedMilliseconds
+                            holdDuration: self.hold.roundedMilliseconds,
+                            target: deliveryTarget
                         )
                         try DesktopActionFailure.requireConfirmedIfReported(
                             actionResult.outcome,
@@ -138,7 +144,7 @@ RuntimeOptionsConfigurable {
                         throw composed
                     } catch let error as InputDeliveryIndeterminateError {
                         let failure = error.desktopActionFailure(
-                            delivery: Self.foregroundHotkeyDelivery,
+                            delivery: Self.delivery(for: deliveryTarget),
                             route: self.sequenceRoute
                         )
                         let composed = sequence.failure(
@@ -173,7 +179,7 @@ RuntimeOptionsConfigurable {
                     } else {
                         sequence.record(.dispatched(
                             route: self.sequenceRoute,
-                            delivery: Self.foregroundHotkeyDelivery,
+                            delivery: Self.delivery(for: deliveryTarget),
                             unitCount: .one
                         ))
                     }
@@ -207,6 +213,7 @@ RuntimeOptionsConfigurable {
                 parsedChords: parsedChords,
                 completedPresses: completedPresses,
                 sequence: sequence,
+                deliveryTarget: deliveryTarget,
                 startTime: startTime
             )
 
@@ -220,6 +227,7 @@ RuntimeOptionsConfigurable {
         parsedChords: [KeyboardChord],
         completedPresses: Int,
         sequence: DesktopActionSequenceAccumulator,
+        deliveryTarget: UIAutomationTarget,
         startTime: Date
     ) async {
         await InteractionObservationInvalidator.invalidateAfterMutation(
@@ -231,8 +239,11 @@ RuntimeOptionsConfigurable {
             keys: parsedChords.map(\.displayValue),
             totalPresses: completedPresses,
             count: self.count,
-            deliveryMode: KeyboardDeliveryMode.foreground.rawValue,
-            targetPID: nil,
+            deliveryMode: deliveryTarget.processIdentifier == nil
+                ? KeyboardDeliveryMode.foreground.rawValue
+                : KeyboardDeliveryMode.background.rawValue,
+            targetPID: deliveryTarget.processIdentifier.map(Int.init),
+            targetWindowID: deliveryTarget.exactWindow?.identity.windowID,
             executionTime: Date().timeIntervalSince(startTime)
         )
         let actionOutcome = sequence.successResolution().outcome
@@ -246,7 +257,14 @@ RuntimeOptionsConfigurable {
             if self.count > 1 {
                 print("🔢 Repeated: \(self.count) times")
             }
-            print("🎯 Mode: foreground")
+            if let targetPID = deliveryTarget.processIdentifier {
+                print("🎯 Mode: background to PID \(targetPID)")
+            } else {
+                print("🎯 Mode: foreground")
+            }
+            if let targetWindowID = deliveryTarget.exactWindow?.identity.windowID {
+                print("🪟 Window: \(targetWindowID)")
+            }
             print("📊 Total presses: \(completedPresses)")
             if actionOutcome == nil {
                 print("⚠️  Effect: unverifiable; observe the target before continuing")
@@ -271,7 +289,11 @@ RuntimeOptionsConfigurable {
             throw ValidationError("--count must be greater than 0")
         }
         _ = try self.parsedChords()
-        guard self.focusOptions.foreground else {
+        let hasExactSelector = self.target.windowId != nil || self.target.windowTitle != nil ||
+            self.target
+            .windowIndex != nil || !(self.snapshot?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ??
+                true)
+        guard self.focusOptions.foreground || hasExactSelector else {
             throw Self.foregroundConsentRequired
         }
     }
@@ -283,6 +305,71 @@ RuntimeOptionsConfigurable {
             } catch {
                 throw ValidationError(error.localizedDescription)
             }
+        }
+    }
+
+    private func resolveDeliveryPlan(
+        observation: InteractionObservationContext
+    ) async throws -> PressDeliveryPlan {
+        if self.focusOptions.foreground {
+            try await ensureFocused(
+                snapshotId: observation.focusSnapshotId(for: self.target),
+                target: self.target,
+                options: self.focusOptions,
+                services: self.services
+            )
+            return PressDeliveryPlan(
+                target: .foreground,
+                foregroundSetupMayHaveMutated: self.target.hasAnyTarget ||
+                    observation.focusSnapshotId(for: self.target) != nil
+            )
+        }
+
+        let target: UIAutomationTarget
+        do {
+            target = try await KeyboardDeliverySupport.requireBackgroundKeyboardTarget(
+                target: self.target,
+                snapshotId: observation.snapshotId,
+                services: self.services,
+                requiresExplicitExactWindow: true
+            )
+        } catch {
+            throw self.preDispatchActionError(for: error, reason: .targetUnavailable)
+        }
+        guard target.exactWindow != nil else {
+            throw self.preDispatchActionError(
+                for: PeekabooError.invalidInput(
+                    field: "target",
+                    reason: "Background raw key presses require one exact-window receipt"
+                )
+            )
+        }
+        do {
+            _ = try ExactWindowKeyboardRuntime.requireOutcomeProvider(
+                automation: self.services.automation,
+                operation: "Background hotkeys"
+            )
+        } catch {
+            throw PreDispatchActionError(
+                message: error.localizedDescription,
+                code: .INTERACTION_FAILED,
+                hint: "Update the Peekaboo host and retry with a fresh exact-window target.",
+                reason: .runtimeIncompatible
+            )
+        }
+        guard self.services.automation is any TargetedFocusedElementServiceProtocol else {
+            throw PreDispatchActionError(
+                message: "This automation host does not support focused exact-window background hotkeys.",
+                code: .INTERACTION_FAILED,
+                hint: "Update the Peekaboo host and retry with a fresh exact-window target.",
+                reason: .runtimeIncompatible
+            )
+        }
+        do {
+            let pinnedTarget = try await target.pinningCurrentFocusedElement(using: self.services.automation)
+            return PressDeliveryPlan(target: pinnedTarget, foregroundSetupMayHaveMutated: false)
+        } catch {
+            throw self.preDispatchActionError(for: error, reason: .targetUnavailable)
         }
     }
 
@@ -310,10 +397,17 @@ RuntimeOptionsConfigurable {
     }
 
     private static let sequenceObservationHint = "Observe the target before retrying this key sequence."
-    private static let foregroundHotkeyDelivery = DesktopActionOutcome.Delivery(
-        mechanism: .globalEvents,
-        mode: .foreground
-    )
+
+    private static func delivery(for target: UIAutomationTarget) -> DesktopActionOutcome.Delivery {
+        target.exactWindow == nil
+            ? .init(mechanism: .globalEvents, mode: .foreground)
+            : .init(mechanism: .windowTargetedEvents, mode: .background)
+    }
+}
+
+private struct PressDeliveryPlan {
+    let target: UIAutomationTarget
+    let foregroundSetupMayHaveMutated: Bool
 }
 
 struct PressResult: Codable {
@@ -322,6 +416,7 @@ struct PressResult: Codable {
     let count: Int
     let deliveryMode: String
     let targetPID: Int?
+    let targetWindowID: Int?
     let executionTime: TimeInterval
 }
 
@@ -338,13 +433,13 @@ extension PressCommand: ParsableCommand {
                     The 'press' command sends keyboard chords in sequence.
                     Chord syntax matches xdotool key (cmd+shift+t).
 
-                    Raw chords cannot prove their semantic effect on a shared desktop and require
-                    explicit --foreground consent. Use action, menu, window, app, or dialog for
-                    certifiable background intent.
+                    Raw chords require either explicit --foreground consent or a fresh exact-window
+                    receipt whose focused element remains pinned through native background dispatch.
+                    App/PID-only and targetless background press are refused.
 
                     EXAMPLES:
                       peekaboo press cmd+c --app TextEdit --foreground
-                      peekaboo press Return --app TextEdit --foreground
+                      peekaboo press Return --app TextEdit --window-id 1234
                       peekaboo press cmd+shift+4 --foreground
                       peekaboo press ctrl+a Delete --app TextEdit --foreground
 
@@ -362,8 +457,8 @@ extension PressCommand: ParsableCommand {
                       Use --hold to control how long each key is held (default: 50ms)
 
                     TARGETING:
-                      --foreground is required. App, PID, snapshot, and window selectors identify
-                      what Peekaboo focuses before dispatch; they do not authorize raw background input.
+                      Exact window selectors or a fresh exact-window snapshot authorize receipt-pinned
+                      background dispatch. App/PID-only targets require --foreground.
                 """,
 
                 showHelpOnEmptyInvocation: true

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/TypeCommand+Types.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/TypeCommand+Types.swift
@@ -13,6 +13,7 @@ struct TypeCommandResult: Codable {
     let profile: String
     let deliveryMode: String
     let targetPID: Int?
+    let targetWindowID: Int?
 }
 
 struct TypeCommandActionSummary: Codable {

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/TypeCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/TypeCommand.swift
@@ -72,17 +72,33 @@ struct TypeCommand: ActionOutputFormattable, ErrorHandlingCommand, OutputFormatt
         do {
             let actions = try self.buildActions()
             let observation = await self.resolveObservationContext()
-            let targetIdentity: ApplicationProcessIdentity?
             do {
                 try await observation.validateIfExplicit(using: self.services.snapshots)
-                targetIdentity = try await self.backgroundProcessIdentity(snapshotId: observation.snapshotId)
             } catch is CancellationError {
                 throw CancellationError()
             } catch {
                 try Task.checkCancellation()
                 throw self.preDispatchActionError(for: error)
             }
-            let targetPID = targetIdentity?.processIdentifier
+            let backgroundTarget: UIAutomationTarget?
+            do {
+                backgroundTarget = try await self.backgroundKeyboardTarget(snapshotId: observation.snapshotId)
+            } catch is CancellationError {
+                throw CancellationError()
+            } catch {
+                try Task.checkCancellation()
+                throw self.preDispatchActionError(for: error, reason: .targetUnavailable)
+            }
+            let deliveryTarget: UIAutomationTarget
+            do {
+                deliveryTarget = try await self.pinningCurrentFocusedElement(on: backgroundTarget) ?? .foreground
+            } catch is CancellationError {
+                throw CancellationError()
+            } catch {
+                try Task.checkCancellation()
+                throw self.preDispatchActionError(for: error, reason: .targetUnavailable)
+            }
+            let targetPID = deliveryTarget.processIdentifier
             self.resolvedRuntime.beginInteractionMutation()
             var sequence = DesktopActionSequenceAccumulator()
             if targetPID == nil {
@@ -97,7 +113,7 @@ struct TypeCommand: ActionOutputFormattable, ErrorHandlingCommand, OutputFormatt
                 actionResult = try await self.executeTypeActions(
                     actions: actions,
                     snapshotId: observation.snapshotId,
-                    expectedProcessIdentity: targetIdentity
+                    target: deliveryTarget
                 )
                 try DesktopActionFailure.requireConfirmedIfReported(
                     actionResult.outcome,
@@ -112,7 +128,7 @@ struct TypeCommand: ActionOutputFormattable, ErrorHandlingCommand, OutputFormatt
                 await self.invalidateAfterFailedMutation(composed)
                 throw composed
             } catch let error as InputDeliveryIndeterminateError {
-                let delivery = Self.delivery(targetProcessIdentifier: targetPID)
+                let delivery = Self.delivery(for: deliveryTarget)
                 let composed = sequence.failure(
                     combining: error.desktopActionFailure(delivery: delivery, route: self.actionRoute),
                     message: "Typing outcome is indeterminate.",
@@ -141,7 +157,7 @@ struct TypeCommand: ActionOutputFormattable, ErrorHandlingCommand, OutputFormatt
             } else {
                 sequence.record(.dispatched(
                     route: self.actionRoute,
-                    delivery: Self.delivery(targetProcessIdentifier: targetPID),
+                    delivery: Self.delivery(for: deliveryTarget),
                     unitCount: .one
                 ))
             }
@@ -155,7 +171,7 @@ struct TypeCommand: ActionOutputFormattable, ErrorHandlingCommand, OutputFormatt
                 outcome: sequence.successResolution().outcome,
                 actions: actions,
                 startTime: startTime,
-                targetProcessIdentifier: targetPID
+                target: deliveryTarget
             )
         } catch {
             self.handleError(error)
@@ -232,29 +248,43 @@ struct TypeCommand: ActionOutputFormattable, ErrorHandlingCommand, OutputFormatt
     private func executeTypeActions(
         actions: [TypeAction],
         snapshotId: String?,
-        expectedProcessIdentity: ApplicationProcessIdentity?
+        target: UIAutomationTarget
     ) async throws -> UIAutomationActionResult<TypeResult> {
         let request = TypeActionsRequest(actions: actions, cadence: self.typingCadence, snapshotId: snapshotId)
-        if let expectedProcessIdentity {
-            return try await AutomationServiceBridge.typeActions(
-                automation: self.services.automation,
-                request: request,
-                expectedProcessIdentity: expectedProcessIdentity
-            )
-        }
-        return try await AutomationServiceBridge.typeActions(automation: self.services.automation, request: request)
+        return try await AutomationServiceBridge.typeActions(
+            automation: self.services.automation,
+            request: request,
+            target: target
+        )
     }
 
-    private func backgroundProcessIdentity(snapshotId: String?) async throws -> ApplicationProcessIdentity? {
+    private func backgroundKeyboardTarget(snapshotId: String?) async throws -> UIAutomationTarget? {
         guard !self.focusOptions.foreground else {
             return nil
         }
 
-        return try await KeyboardDeliverySupport.requireBackgroundProcessIdentity(
+        return try await KeyboardDeliverySupport.requireBackgroundKeyboardTarget(
             target: self.target,
             snapshotId: snapshotId,
             services: self.services
         )
+    }
+
+    private func pinningCurrentFocusedElement(on target: UIAutomationTarget?) async throws -> UIAutomationTarget? {
+        guard let target, target.exactWindow != nil else { return target }
+        guard let exactService = self.services.automation as? any ExactWindowTargetedKeyboardServiceProtocol,
+              exactService.supportsExactWindowTargetedKeyboard,
+              self.services.automation is any UIAutomationActionOutcomeProviding,
+              self.services.automation is any TargetedFocusedElementServiceProtocol
+        else {
+            throw PreDispatchActionError(
+                message: "This automation host does not support receipt-pinned exact-window background typing.",
+                code: .INTERACTION_FAILED,
+                hint: "Update the Peekaboo host and retry with a fresh exact-window target.",
+                reason: .runtimeIncompatible
+            )
+        }
+        return try await target.pinningCurrentFocusedElement(using: self.services.automation)
     }
 
     private func renderResult(
@@ -262,8 +292,10 @@ struct TypeCommand: ActionOutputFormattable, ErrorHandlingCommand, OutputFormatt
         outcome: DesktopActionOutcome?,
         actions: [TypeAction],
         startTime: Date,
-        targetProcessIdentifier: pid_t?
+        target: UIAutomationTarget
     ) {
+        let targetProcessIdentifier = target.processIdentifier
+        let targetWindowID = target.exactWindow?.identity.windowID
         let specialKeys = max(typeResult.keyPresses - typeResult.totalCharacters, 0)
         let result = TypeCommandResult(
             requestedText: self.resolvedText,
@@ -278,7 +310,8 @@ struct TypeCommand: ActionOutputFormattable, ErrorHandlingCommand, OutputFormatt
             profile: self.resolvedProfile.rawValue,
             deliveryMode: targetProcessIdentifier == nil ? KeyboardDeliveryMode.foreground.rawValue :
                 KeyboardDeliveryMode.background.rawValue,
-            targetPID: targetProcessIdentifier.map(Int.init)
+            targetPID: targetProcessIdentifier.map(Int.init),
+            targetWindowID: targetWindowID
         )
 
         output(result, outcome: outcome) {
@@ -295,6 +328,9 @@ struct TypeCommand: ActionOutputFormattable, ErrorHandlingCommand, OutputFormatt
             }
             if let targetProcessIdentifier {
                 print("🎯 Mode: background to PID \(targetProcessIdentifier)")
+            }
+            if let targetWindowID {
+                print("🪟 Window: \(targetWindowID)")
             }
             print("📊 Total characters: \(typeResult.totalCharacters)")
             switch self.resolvedProfile {
@@ -318,8 +354,11 @@ struct TypeCommand: ActionOutputFormattable, ErrorHandlingCommand, OutputFormatt
         }
     }
 
-    private static func delivery(targetProcessIdentifier: pid_t?) -> DesktopActionOutcome.Delivery {
-        targetProcessIdentifier == nil
+    private static func delivery(for target: UIAutomationTarget) -> DesktopActionOutcome.Delivery {
+        if target.exactWindow != nil {
+            return .init(mechanism: .windowTargetedEvents, mode: .background)
+        }
+        return target.processIdentifier == nil
             ? .init(mechanism: .globalEvents, mode: .foreground)
             : .init(mechanism: .processTargetedEvents, mode: .background)
     }
@@ -403,9 +442,10 @@ extension TypeCommand: ParsableCommand {
 
                     FOCUS MANAGEMENT:
                       Provide --app, --pid, or a snapshot for background delivery.
-                      Window selectors require --foreground because process-targeted events
-                      cannot prove which window owns the focused element. Without a target,
-                      --foreground is required for intentional global keyboard input.
+                      Exact window selectors and fresh snapshots stay pinned through native
+                      dispatch. App/PID-only background typing is accepted only when the process
+                      has at most one eligible window; otherwise add a window selector or snapshot.
+                      Without a target, --foreground is required for intentional global input.
 
                     TYPING CADENCE:
                     Linear typing is the default and uses --delay (0ms by default).

--- a/Apps/CLI/Tests/CLIAutomationTests/PasteCommandTests.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/PasteCommandTests.swift
@@ -594,6 +594,55 @@ struct PasteCommandTests {
 
     @Test
     @MainActor
+    func `Exact window capability refusal happens before clipboard access`() async throws {
+        let pid: Int32 = 2468
+        let bounds = CGRect(x: 20, y: 30, width: 500, height: 400)
+        let clipboard = StubClipboardService()
+        clipboard.current = ClipboardReadResult(
+            utiIdentifier: "public.utf8-plain-text",
+            data: Data("prior".utf8),
+            textPreview: "prior"
+        )
+        let services = TestServicesFactory.makePeekabooServices(
+            applications: StubApplicationService(applications: [ServiceApplicationInfo(
+                processIdentifier: pid,
+                processStartIdentity: 71,
+                bundleIdentifier: "com.apple.TextEdit",
+                name: "TextEdit"
+            )]),
+            windows: StubWindowService(windowsByApp: ["TextEdit": [ServiceWindowInfo(
+                windowID: 901,
+                title: "Untitled",
+                bounds: bounds,
+                mutationIdentity: WindowMutationIdentity(
+                    windowID: 901,
+                    ownerProcessIdentifier: pid,
+                    ownerProcessStartIdentity: 71,
+                    capturedBounds: bounds
+                )
+            )]]),
+            clipboard: clipboard,
+            automation: StubAutomationService()
+        )
+
+        let result = try await InProcessCommandRunner.run(
+            [
+                "paste", "--app", "TextEdit", "--window-id", "901",
+                "--data-base64", "cGF5bG9hZA==", "--uti", "public.data",
+                "--json", "--no-remote",
+            ],
+            services: services
+        )
+
+        #expect(result.exitStatus != 0)
+        #expect(clipboard.getCallCount == 0)
+        #expect(clipboard.saveCallCount == 0)
+        #expect(clipboard.setCallCount == 0)
+        #expect(clipboard.restoreCallCount == 0)
+    }
+
+    @Test
+    @MainActor
     func `Clipboard read failure is not treated as an empty clipboard`() async throws {
         let context = self.makeTransactionGateContext()
         context.clipboard.getError = ClipboardServiceError.writeFailed("simulated read failure")

--- a/Apps/CLI/Tests/CLIAutomationTests/PreDispatchActionEnvelopeTests.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/PreDispatchActionEnvelopeTests.swift
@@ -123,6 +123,12 @@ struct PreDispatchActionEnvelopeTests {
                     .targetUnavailable
                 ),
                 (
+                    "missing explicit press snapshot",
+                    ["press", "return", "--snapshot", "synthetic-missing-snapshot", "--json", "--no-remote"],
+                    .SNAPSHOT_NOT_FOUND,
+                    .targetUnavailable
+                ),
+                (
                     "malformed coordinate click",
                     ["click", "--at", ",", "--json"],
                     .VALIDATION_ERROR,

--- a/Apps/CLI/Tests/CLIAutomationTests/PressCommandTests.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/PressCommandTests.swift
@@ -117,6 +117,68 @@ struct PressCommandTests {
     }
 
     @Test
+    @MainActor
+    func `Exact window press uses receipt-pinned background delivery`() async throws {
+        let pid: Int32 = 4201
+        let bounds = CGRect(x: 20, y: 30, width: 500, height: 400)
+        let applications = StubApplicationService(applications: [ServiceApplicationInfo(
+            processIdentifier: pid,
+            processStartIdentity: 71,
+            bundleIdentifier: "com.example.Editor",
+            name: "Editor"
+        )])
+        let windows = StubWindowService(windowsByApp: ["Editor": [ServiceWindowInfo(
+            windowID: 901,
+            title: "Document",
+            bounds: bounds,
+            mutationIdentity: WindowMutationIdentity(
+                windowID: 901,
+                ownerProcessIdentifier: pid,
+                ownerProcessStartIdentity: 71,
+                capturedBounds: bounds
+            )
+        )]])
+        let automation = OutcomeStubAutomationService()
+        automation.actionOutcome = .confirmedChange(delivery: .init(
+            mechanism: .windowTargetedEvents,
+            mode: .background
+        ))
+        automation.targetedFocusedElement = UIFocusInfo(
+            role: "AXTextArea",
+            title: nil,
+            value: nil,
+            frame: CGRect(x: 40, y: 60, width: 200, height: 100),
+            applicationName: "Editor",
+            bundleIdentifier: "com.example.Editor",
+            processId: Int(pid),
+            windowID: 901,
+            identifier: "editor"
+        )
+        let context = await self.makeContext(
+            automation: automation,
+            applications: applications,
+            windows: windows
+        )
+
+        let result = try await self.runPress(
+            arguments: ["return", "--window-id", "901", "--json"],
+            context: context
+        )
+
+        #expect(result.exitStatus == 0)
+        let call = try #require(automation.exactHotkeyCalls.first)
+        #expect(call.keys == "return")
+        #expect(call.target.windowIdentity.windowID == 901)
+        let payload = try JSONDecoder().decode(
+            CodableJSONResponse<PressResult>.self,
+            from: Data(result.stdout.utf8)
+        )
+        #expect(payload.data.deliveryMode == "background")
+        #expect(payload.data.targetPID == Int(pid))
+        #expect(payload.data.targetWindowID == 901)
+    }
+
+    @Test
     func `Deprecated background alias remains accepted but cannot authorize raw press`() async throws {
         let context = await self.makeContext()
         let result = try await self.runPress(
@@ -203,11 +265,17 @@ struct PressCommandTests {
     }
 
     private func makeContext(
+        automation: StubAutomationService = StubAutomationService(),
         applications: any ApplicationServiceProtocol = StubApplicationService(applications: []),
+        windows: any WindowManagementServiceProtocol = StubWindowService(windowsByApp: [:]),
         configure: (@MainActor (StubAutomationService, StubSnapshotManager) -> Void)? = nil
     ) async -> TestServicesFactory.AutomationTestContext {
         await MainActor.run {
-            let context = TestServicesFactory.makeAutomationTestContext(applications: applications)
+            let context = TestServicesFactory.makeAutomationTestContext(
+                automation: automation,
+                applications: applications,
+                windows: windows
+            )
             configure?(context.automation, context.snapshots)
             return context
         }

--- a/Apps/CLI/Tests/CLIAutomationTests/PressCommandTests.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/PressCommandTests.swift
@@ -179,6 +179,23 @@ struct PressCommandTests {
     }
 
     @Test
+    func `Background target resolution cancellation is not projected as a target refusal`() async throws {
+        let context = await self.makeContext(windows: CancellingPressWindowService())
+
+        let result = try await self.runPress(
+            arguments: ["return", "--window-id", "901", "--json"],
+            context: context
+        )
+
+        #expect(result.exitStatus != 0)
+        let payload = try JSONDecoder().decode(JSONResponse.self, from: Data(result.stdout.utf8))
+        #expect(payload.outcome == nil)
+        #expect(payload.error?.code != ErrorCode.SNAPSHOT_STALE.rawValue)
+        #expect(await self.automationState(context) { $0.hotkeyCalls.isEmpty })
+        #expect(await self.automationState(context) { $0.targetedHotkeyCalls.isEmpty })
+    }
+
+    @Test
     func `Deprecated background alias remains accepted but cannot authorize raw press`() async throws {
         let context = await self.makeContext()
         let result = try await self.runPress(
@@ -305,6 +322,24 @@ struct PressCommandTests {
         await MainActor.run {
             operation(context.automation)
         }
+    }
+}
+
+private actor CancellingPressWindowService: WindowManagementServiceProtocol {
+    func closeWindow(target _: WindowTarget) async throws {}
+    func minimizeWindow(target _: WindowTarget) async throws {}
+    func maximizeWindow(target _: WindowTarget) async throws {}
+    func moveWindow(target _: WindowTarget, to _: CGPoint) async throws {}
+    func resizeWindow(target _: WindowTarget, to _: CGSize) async throws {}
+    func setWindowBounds(target _: WindowTarget, bounds _: CGRect) async throws {}
+    func focusWindow(target _: WindowTarget) async throws {}
+
+    func listWindows(target _: WindowTarget) async throws -> [ServiceWindowInfo] {
+        throw CancellationError()
+    }
+
+    func getFocusedWindow() async throws -> ServiceWindowInfo? {
+        nil
     }
 }
 #endif

--- a/Apps/CLI/Tests/CLIAutomationTests/Support/StubAutomationService+ActionOutcomes.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/Support/StubAutomationService+ActionOutcomes.swift
@@ -1,9 +1,27 @@
+import Foundation
+import PeekabooAutomationKit
 import PeekabooAutomationKitTestSupport
 import PeekabooFoundation
 
 @MainActor
-final class OutcomeStubAutomationService: StubAutomationService, ScriptedUIAutomationActionOutcomeProviding {
+final class OutcomeStubAutomationService: StubAutomationService, ScriptedUIAutomationActionOutcomeProviding,
+ExactWindowTargetedKeyboardServiceProtocol, TargetedFocusedElementServiceProtocol {
+    struct ExactTypeActionsCall {
+        let actions: [TypeAction]
+        let target: ExactWindowKeyboardTarget
+    }
+
+    struct ExactHotkeyCall {
+        let keys: String
+        let target: ExactWindowKeyboardTarget
+    }
+
     let uiAutomationOutcomeScript = UIAutomationOutcomeScript()
+    let supportsExactWindowTargetedKeyboard = true
+    let exactWindowTargetedKeyboardUnavailableReason: String? = nil
+    var exactTypeActionsCalls: [ExactTypeActionsCall] = []
+    var exactHotkeyCalls: [ExactHotkeyCall] = []
+    var targetedFocusedElement: UIFocusInfo?
 
     var actionOutcome: DesktopActionOutcome? {
         didSet {
@@ -21,5 +39,28 @@ final class OutcomeStubAutomationService: StubAutomationService, ScriptedUIAutom
             self.uiAutomationOutcomeScript.append(self.actionOutcome, for: .hotkey)
         }
         self.uiAutomationOutcomeScript.appendFailure(error, for: .hotkey)
+    }
+
+    func typeActions(
+        _ actions: [TypeAction],
+        cadence: TypingCadence,
+        snapshotId: String?,
+        target: ExactWindowKeyboardTarget
+    ) async throws -> TypeResult {
+        self.exactTypeActionsCalls.append(ExactTypeActionsCall(actions: actions, target: target))
+        return try await super.typeActions(actions, cadence: cadence, snapshotId: snapshotId)
+    }
+
+    func hotkey(
+        keys: String,
+        holdDuration _: Int,
+        target: ExactWindowKeyboardTarget
+    ) async throws {
+        self.exactHotkeyCalls.append(ExactHotkeyCall(keys: keys, target: target))
+    }
+
+    func getFocusedElement(targetProcessIdentifier: pid_t) async -> UIFocusInfo? {
+        guard self.targetedFocusedElement?.processId == Int(targetProcessIdentifier) else { return nil }
+        return self.targetedFocusedElement
     }
 }

--- a/Apps/CLI/Tests/CLIAutomationTests/TypeCommandTests.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/TypeCommandTests.swift
@@ -231,6 +231,98 @@ struct TypeCommandTests {
     }
 
     @Test
+    @MainActor
+    func `Type upgrades one eligible app window to exact receipt-pinned delivery`() async throws {
+        let pid: Int32 = 2468
+        let bounds = CGRect(x: 20, y: 30, width: 500, height: 400)
+        let applicationService = StubApplicationService(applications: [ServiceApplicationInfo(
+            processIdentifier: pid,
+            processStartIdentity: 71,
+            bundleIdentifier: "com.apple.TextEdit",
+            name: "TextEdit"
+        )])
+        let windows = StubWindowService(windowsByApp: ["TextEdit": [ServiceWindowInfo(
+            windowID: 901,
+            title: "Untitled",
+            bounds: bounds,
+            mutationIdentity: WindowMutationIdentity(
+                windowID: 901,
+                ownerProcessIdentifier: pid,
+                ownerProcessStartIdentity: 71,
+                capturedBounds: bounds
+            )
+        )]])
+        let automation = OutcomeStubAutomationService()
+        automation.actionOutcome = .confirmedChange(delivery: .init(
+            mechanism: .windowTargetedEvents,
+            mode: .background
+        ))
+        automation.targetedFocusedElement = UIFocusInfo(
+            role: "AXTextArea",
+            title: nil,
+            value: nil,
+            frame: CGRect(x: 40, y: 60, width: 200, height: 100),
+            applicationName: "TextEdit",
+            bundleIdentifier: "com.apple.TextEdit",
+            processId: Int(pid),
+            windowID: 901,
+            identifier: "editor"
+        )
+        let context = await self.makeContext(
+            automation: automation,
+            applications: applicationService,
+            windows: windows
+        )
+
+        let result = try await self.runType(
+            arguments: ["Hello", "--app", "TextEdit", "--json"],
+            context: context
+        )
+
+        #expect(result.exitStatus == 0)
+        let call = try #require(automation.exactTypeActionsCalls.first)
+        #expect(call.target.windowIdentity.windowID == 901)
+        #expect(call.target.focusedElement.identifier == "editor")
+        let payload = try ExternalCommandRunner.decodeJSONResponse(
+            from: result,
+            as: CodableJSONResponse<TypeCommandResult>.self
+        )
+        #expect(payload.data.targetWindowID == 901)
+    }
+
+    @Test
+    @MainActor
+    func `Type refuses ambiguous app windows before any keyboard dispatch`() async throws {
+        let pid: Int32 = 2468
+        let applicationService = StubApplicationService(applications: [ServiceApplicationInfo(
+            processIdentifier: pid,
+            processStartIdentity: 71,
+            bundleIdentifier: "com.apple.TextEdit",
+            name: "TextEdit"
+        )])
+        let windows = StubWindowService(windowsByApp: ["TextEdit": [
+            self.window(windowID: 901, pid: pid, generation: 71),
+            self.window(windowID: 902, pid: pid, generation: 71),
+        ]])
+        let automation = OutcomeStubAutomationService()
+        let context = await self.makeContext(
+            automation: automation,
+            applications: applicationService,
+            windows: windows
+        )
+
+        let result = try await self.runType(
+            arguments: ["Hello", "--app", "TextEdit", "--json"],
+            context: context
+        )
+
+        #expect(result.exitStatus != 0)
+        #expect(automation.exactTypeActionsCalls.isEmpty)
+        #expect(automation.targetedTypeActionsCalls.isEmpty)
+        #expect(result.combinedOutput.contains("multiple eligible windows"))
+    }
+
+    @Test
     func `Type refuses an unpinned background process before delivery`() async throws {
         let app = ServiceApplicationInfo(
             processIdentifier: 2468,
@@ -364,7 +456,7 @@ struct TypeCommandTests {
     }
 
     @Test
-    func `Type background delivery rejects process-wide collapse of window selectors`() async throws {
+    func `Type background delivery refuses an unresolved exact window selector`() async throws {
         let app = ServiceApplicationInfo(
             processIdentifier: 2468,
             processStartIdentity: 71,
@@ -388,7 +480,7 @@ struct TypeCommandTests {
         let payload = try ExternalCommandRunner.decodeJSONResponse(from: result, as: JSONResponse.self)
         #expect(payload.success == false)
         #expect(payload.error?.code == ErrorCode.VALIDATION_ERROR.rawValue)
-        #expect(payload.error?.message.contains("cannot safely target a specific window") == true)
+        #expect(payload.error?.message.contains("no matching window") == true)
         let targetedCalls = await self.automationState(context) { $0.targetedTypeActionsCalls }
         #expect(targetedCalls.isEmpty)
     }
@@ -576,6 +668,25 @@ struct TypeCommandTests {
             configure?(context.automation, context.snapshots)
             return context
         }
+    }
+
+    private func window(
+        windowID: Int,
+        pid: Int32,
+        generation: UInt64
+    ) -> ServiceWindowInfo {
+        let bounds = CGRect(x: windowID * 2, y: 30, width: 500, height: 400)
+        return ServiceWindowInfo(
+            windowID: windowID,
+            title: "Document \(windowID)",
+            bounds: bounds,
+            mutationIdentity: WindowMutationIdentity(
+                windowID: windowID,
+                ownerProcessIdentifier: pid,
+                ownerProcessStartIdentity: generation,
+                capturedBounds: bounds
+            )
+        )
     }
 
     @MainActor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Add receipt-pinned exact-window background `type`, `paste`, and `press`, preserving process generation, window bounds, and focused-element identity while refusing ambiguous app/PID targets and unsafe Agent dialog/shared-UI routes.
 - Restore the root SwiftPM facade for external consumers with four lean library products—Foundation, Protocols, AutomationKit, and Bridge—plus a fresh-consumer build contract that prevents manifest and product drift.
 - Add opt-in host-local Vision OCR to CLI/MCP `see`, preserving incomplete AX evidence, exact snapshot receipts, logical bounds, confidence, background-only observation, and fail-before-dispatch compatibility with older Bridge hosts.
 - Stateless exact-window ROI capture for CLI/MCP `see`, with generation-pinned

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Strategy/UIAutomationTarget.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Strategy/UIAutomationTarget.swift
@@ -79,6 +79,23 @@ public enum UIAutomationTarget: Sendable, Equatable {
             self.focusedElement = focusedElement
         }
 
+        public init(
+            window: ServiceWindowInfo,
+            focusedElement: FocusedElementIdentity? = nil) throws
+        {
+            guard let identity = window.mutationIdentity else {
+                throw PeekabooError.invalidInput(
+                    field: "target",
+                    reason: "The selected window has no process-generation receipt; capture fresh UI state")
+            }
+            try self.init(
+                processIdentifier: identity.ownerProcessIdentifier,
+                windowID: window.windowID,
+                identity: identity,
+                bounds: window.bounds,
+                focusedElement: focusedElement)
+        }
+
         public static func == (lhs: Self, rhs: Self) -> Bool {
             lhs.identity.hasSameStableReceipt(as: rhs.identity) &&
                 lhs.bounds == rhs.bounds &&
@@ -126,6 +143,86 @@ public enum UIAutomationTarget: Sendable, Equatable {
         return target
     }
 
+    /// Select one background keyboard destination without reducing an exact receipt to a process.
+    public static func backgroundKeyboard(
+        process: Process,
+        exactWindow: ExactWindow) throws -> UIAutomationTarget
+    {
+        guard process.identity != nil else {
+            throw PeekabooError.invalidInput(
+                field: "target",
+                reason: "Background keyboard delivery requires a process-generation receipt")
+        }
+        return try UIAutomationTarget.process(process).refined(to: exactWindow)
+    }
+
+    public static func backgroundKeyboard(
+        process: Process,
+        eligibleWindows: [ExactWindow],
+        requiresExplicitExactWindow: Bool = false) throws -> UIAutomationTarget
+    {
+        guard let processIdentity = process.identity else {
+            throw PeekabooError.invalidInput(
+                field: "target",
+                reason: "Background keyboard delivery requires a process-generation receipt")
+        }
+        if requiresExplicitExactWindow {
+            throw PeekabooError.invalidInput(
+                field: "target",
+                reason: "Background raw key presses require an explicit exact-window or snapshot receipt")
+        }
+
+        guard eligibleWindows.allSatisfy({ $0.identity.processIdentity == processIdentity }) else {
+            throw PeekabooError.snapshotStale(
+                "Eligible keyboard windows do not belong to the selected process generation")
+        }
+        let uniqueWindows = eligibleWindows.reduce(into: [ExactWindow]()) { result, candidate in
+            if !result.contains(where: { $0.identity.hasSameStableReceipt(as: candidate.identity) }) {
+                result.append(candidate)
+            }
+        }
+        if uniqueWindows.isEmpty {
+            return .process(process)
+        }
+        guard uniqueWindows.count == 1, let exactWindow = uniqueWindows.first else {
+            throw PeekabooError.invalidInput(
+                field: "target",
+                reason: "The selected process has multiple eligible windows; add a window selector or fresh snapshot")
+        }
+        return try self.backgroundKeyboard(process: process, exactWindow: exactWindow)
+    }
+
+    public func pinningFocusedElement(_ focusedElement: FocusedElementIdentity) throws -> UIAutomationTarget {
+        guard let exactWindow = self.exactWindow else {
+            throw PeekabooError.invalidInput(
+                field: "target",
+                reason: "Focused-element keyboard pinning requires an exact-window receipt")
+        }
+        return try .exactWindow(ExactWindow(
+            identity: exactWindow.identity,
+            bounds: exactWindow.bounds,
+            focusedElement: focusedElement))
+    }
+
+    @MainActor
+    public func pinningCurrentFocusedElement(
+        using automation: any UIAutomationServiceProtocol) async throws -> UIAutomationTarget
+    {
+        guard let exactWindow = self.exactWindow else { return self }
+        guard let focusedElementService = automation as? any TargetedFocusedElementServiceProtocol,
+              let focus = await focusedElementService.getFocusedElement(
+                  targetProcessIdentifier: exactWindow.identity.ownerProcessIdentifier),
+              let focusedElement = FocusedElementIdentity(focus),
+              focusedElement.windowID == exactWindow.identity.windowID,
+              exactWindow.bounds.contains(CGPoint(x: focusedElement.frame.midX, y: focusedElement.frame.midY))
+        else {
+            throw PeekabooError.invalidInput(
+                field: "target",
+                reason: "The exact target window has no provable focused element; capture fresh UI state")
+        }
+        return try self.pinningFocusedElement(focusedElement)
+    }
+
     func refined(to exactWindow: ExactWindow) throws -> UIAutomationTarget {
         if let processIdentifier = self.processIdentifier,
            processIdentifier != exactWindow.identity.ownerProcessIdentifier
@@ -146,5 +243,56 @@ public enum UIAutomationTarget: Sendable, Equatable {
                 "Exact-window receipts refer to different window identities")
         }
         return .exactWindow(exactWindow)
+    }
+}
+
+/// Exact-window keyboard capability and route-receipt validation.
+///
+/// Outcome-state interpretation stays with `DesktopActionFailure` and
+/// `DesktopActionSequenceAccumulator`; this gate only proves that the exact route survived dispatch.
+@MainActor
+public enum ExactWindowKeyboardRuntime {
+    public static func requireOutcomeProvider(
+        automation: any UIAutomationServiceProtocol,
+        operation: String) throws -> any UIAutomationActionOutcomeProviding
+    {
+        guard let exactService = automation as? any ExactWindowTargetedKeyboardServiceProtocol,
+              exactService.supportsExactWindowTargetedKeyboard
+        else {
+            let reason = (automation as? any ExactWindowTargetedKeyboardServiceProtocol)?
+                .exactWindowTargetedKeyboardUnavailableReason
+            throw PeekabooError.serviceUnavailable(
+                reason ?? "\(operation) requires atomic exact-window keyboard delivery")
+        }
+        guard let outcomeProvider = automation as? any UIAutomationActionOutcomeProviding else {
+            throw PeekabooError.serviceUnavailable(
+                "\(operation) requires exact-window typed outcome receipts")
+        }
+        return outcomeProvider
+    }
+
+    public static func validateRouteReceipt<Payload>(
+        _ result: UIAutomationActionResult<Payload>,
+        operation: String) throws -> UIAutomationActionResult<Payload>
+    {
+        guard let outcome = result.outcome else {
+            throw DesktopActionFailure.indeterminate(
+                delivery: .init(mechanism: .windowTargetedEvents, mode: .background),
+                evidence: .completionUnknown,
+                message: "\(operation) returned without its required exact-window route receipt.",
+                hint: "Observe the target before any retry and update the runtime host.")
+        }
+        let expectedDelivery = DesktopActionOutcome.Delivery(
+            mechanism: .windowTargetedEvents,
+            mode: .background)
+        guard !outcome.dispatchState.mutationDispatched || outcome.delivery == expectedDelivery else {
+            throw DesktopActionFailure.indeterminate(
+                route: outcome.route,
+                evidence: .completionUnknown,
+                unitCount: outcome.dispatchState.unitCount,
+                message: "\(operation) returned a contradictory exact-window route receipt.",
+                hint: "Observe the target before any retry and update the runtime host.")
+        }
+        return result
     }
 }

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/UIAutomationTargetTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/UIAutomationTargetTests.swift
@@ -1,5 +1,6 @@
 import CoreGraphics
 import PeekabooAutomationKitTestSupport
+import PeekabooFoundation
 import Testing
 @testable import PeekabooAutomationKit
 
@@ -193,6 +194,79 @@ struct UIAutomationTargetTests {
         let unpinned = try UIAutomationTarget.process(UIAutomationTarget.Process(
             processIdentifier: self.processIdentity.processIdentifier))
         #expect(try unpinned.refined(to: replacement) == .exactWindow(replacement))
+    }
+
+    @Test
+    func `background keyboard upgrades one authoritative window and refuses ambiguity`() throws {
+        let process = try UIAutomationTarget.Process(
+            processIdentifier: self.processIdentity.processIdentifier,
+            identity: self.processIdentity)
+        let first = try self.exactWindowTarget()
+        let secondBounds = CGRect(x: 700, y: 20, width: 640, height: 480)
+        let second = try UIAutomationTarget.ExactWindow(
+            identity: AutomationTestFixtures.windowIdentity(
+                windowID: first.identity.windowID + 1,
+                processIdentity: self.processIdentity,
+                bounds: secondBounds),
+            bounds: secondBounds)
+
+        #expect(try UIAutomationTarget.backgroundKeyboard(
+            process: process,
+            eligibleWindows: [first]) == .exactWindow(first))
+        #expect(try UIAutomationTarget.backgroundKeyboard(
+            process: process,
+            eligibleWindows: []) == .process(process))
+        #expect(throws: (any Error).self) {
+            _ = try UIAutomationTarget.backgroundKeyboard(
+                process: process,
+                eligibleWindows: [first, second])
+        }
+    }
+
+    @Test
+    func `raw background press requires explicit exact evidence`() throws {
+        let process = try UIAutomationTarget.Process(
+            processIdentifier: self.processIdentity.processIdentifier,
+            identity: self.processIdentity)
+        let exact = try self.exactWindowTarget()
+
+        #expect(throws: (any Error).self) {
+            _ = try UIAutomationTarget.backgroundKeyboard(
+                process: process,
+                eligibleWindows: [exact],
+                requiresExplicitExactWindow: true)
+        }
+        #expect(try UIAutomationTarget.backgroundKeyboard(
+            process: process,
+            exactWindow: exact) == .exactWindow(exact))
+    }
+
+    @Test
+    @MainActor
+    func `exact keyboard route validator requires the window targeted background receipt`() throws {
+        let expectedDelivery = DesktopActionOutcome.Delivery(
+            mechanism: .windowTargetedEvents,
+            mode: .background)
+        let confirmed = DesktopActionOutcome.confirmedChange(delivery: expectedDelivery)
+        let accepted = try ExactWindowKeyboardRuntime.validateRouteReceipt(
+            UIAutomationActionResult(payload: 1, outcome: confirmed),
+            operation: "Fixture")
+        #expect(accepted.outcome == confirmed)
+
+        #expect(throws: DesktopActionFailure.self) {
+            _ = try ExactWindowKeyboardRuntime.validateRouteReceipt(
+                UIAutomationActionResult<Int>(payload: 1, outcome: nil),
+                operation: "Fixture")
+        }
+        #expect(throws: DesktopActionFailure.self) {
+            _ = try ExactWindowKeyboardRuntime.validateRouteReceipt(
+                UIAutomationActionResult(
+                    payload: 1,
+                    outcome: .confirmedChange(delivery: .init(
+                        mechanism: .processTargetedEvents,
+                        mode: .background))),
+                operation: "Fixture")
+        }
     }
 
     private func exactWindowTarget(isMinimized: Bool = false) throws -> UIAutomationTarget.ExactWindow {

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/MCPToolContext.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/MCPToolContext.swift
@@ -394,23 +394,24 @@ public struct MCPToolContext: @unchecked Sendable {
 
         guard self.executionPolicy == .backgroundOnly else { return permitted(arguments) }
         let usesSnapshotTarget = ["action", "click", "scroll", "set_value"].contains(toolName) ||
-            (toolName == "type" &&
+            (["type", "press"].contains(toolName) &&
                 (arguments.getValue(for: "on") != nil || arguments.getValue(for: "snapshot") != nil))
         guard usesSnapshotTarget else {
             // BrowserTool mutates DevTools page targets rather than macOS desktop targets. Its policy separately
             // requires background pages and forbids page fronting before dispatch.
-            if toolName == "type" {
+            if ["type", "press"].contains(toolName) {
                 return BackgroundTargetAuthorization(
                     arguments: arguments,
                     rejection: self.executionPolicy.unresolvedTargetRejection(
                         toolName: toolName,
-                        detail: "background Agent typing requires an exact non-dialog snapshot or element target"))
+                        detail: "background Agent keyboard input requires an exact non-dialog snapshot " +
+                            "or element target"))
             }
             return await self.backgroundApplicationTargetAuthorization(
                 toolName: toolName,
                 arguments: arguments)
         }
-        if toolName == "type",
+        if ["type", "press"].contains(toolName),
            ["app", "pid", "window_id", "window_title", "window_index"].contains(where: {
                arguments.getValue(for: $0) != nil
            })
@@ -419,7 +420,7 @@ public struct MCPToolContext: @unchecked Sendable {
                 arguments: arguments,
                 rejection: self.executionPolicy.unresolvedTargetRejection(
                     toolName: toolName,
-                    detail: "snapshot/element typing cannot include competing app, PID, or window selectors"))
+                    detail: "snapshot keyboard input cannot include competing app, PID, or window selectors"))
         }
         let snapshotSelector = Self.strictString(arguments, key: "snapshot")
         let coordinateSelector = Self.strictString(arguments, key: "coordinate_reference")

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/MCPToolExecutionPolicy.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/MCPToolExecutionPolicy.swift
@@ -215,9 +215,26 @@ private enum BackgroundOnlyToolPolicy {
         return nil
     }
 
-    private static func rawPressViolation(_ arguments: ToolArguments) -> Violation {
-        self.explicitForeground(arguments) ?? .sharedDesktop(
-            "public raw press cannot prove background intent or effect and requires foreground consent")
+    private static func rawPressViolation(_ arguments: ToolArguments) -> Violation? {
+        if let violation = self.explicitForeground(arguments) {
+            return violation
+        }
+        let snapshot = arguments.getString("snapshot")?.trimmingCharacters(in: .whitespacesAndNewlines)
+        if snapshot?.isEmpty == false {
+            return nil
+        }
+        if self.hasExactWindowSelector(arguments) {
+            return .sharedDesktop(
+                "a window selector alone cannot prove that raw press targets non-dialog, non-system UI")
+        }
+        return .sharedDesktop(
+            "public raw press requires foreground consent or a fresh exact non-dialog snapshot receipt")
+    }
+
+    private static func hasExactWindowSelector(_ arguments: ToolArguments) -> Bool {
+        arguments.getValue(for: "window_id") != nil ||
+            arguments.getValue(for: "window_title") != nil ||
+            arguments.getValue(for: "window_index") != nil
     }
 
     private static func captureViolation(_ arguments: ToolArguments) -> Violation? {

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/MCPInteractionTarget.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/MCPInteractionTarget.swift
@@ -14,10 +14,16 @@ enum MCPInteractionTargetError: LocalizedError, Equatable {
     case backgroundWindowTargetUnsupported
     case targetProcessNotFound
     case targetProcessIdentityUnavailable
+    case backgroundWindowTargetAmbiguous
+    case backgroundWindowTargetMismatch
+    case backgroundTargetIneligible
 
     var refusalReason: DesktopActionOutcome.RefusalReason {
         switch self {
-        case .targetProcessNotFound:
+        case .targetProcessNotFound,
+             .backgroundWindowTargetAmbiguous,
+             .backgroundWindowTargetMismatch,
+             .backgroundTargetIneligible:
             .targetUnavailable
         case .targetProcessIdentityUnavailable:
             .runtimeIncompatible
@@ -59,6 +65,14 @@ enum MCPInteractionTargetError: LocalizedError, Equatable {
         case .targetProcessIdentityUnavailable:
             "The runtime host could not pin the target to a process generation. " +
                 "Update the host before background input."
+        case .backgroundWindowTargetAmbiguous:
+            "Background keyboard delivery could not resolve one exact window. " +
+                "Add an exact window_id or fresh snapshot."
+        case .backgroundWindowTargetMismatch:
+            "The selected app, window, and snapshot do not identify the same exact process/window receipt."
+        case .backgroundTargetIneligible:
+            "The target cannot receive background input because it is a prohibited helper or its metadata is " +
+                "incomplete."
         }
     }
 }
@@ -288,6 +302,114 @@ struct MCPInteractionTarget {
             throw MCPInteractionTargetError.targetProcessIdentityUnavailable
         }
         return identity
+    }
+
+    func requireBackgroundKeyboardTarget(
+        applications: any ApplicationServiceProtocol,
+        windows: any WindowManagementServiceProtocol,
+        snapshotProcessIdentity: ApplicationProcessIdentity? = nil,
+        snapshotExactWindow: UIAutomationTarget.ExactWindow? = nil,
+        requiresExplicitExactWindow: Bool = false) async throws -> UIAutomationTarget
+    {
+        try self.validate()
+        let selectedWindow: UIAutomationTarget.ExactWindow? = if self.hasWindowSelector {
+            try await self.requireSelectedExactWindow(windows: windows)
+        } else {
+            nil
+        }
+        let exactWindow: UIAutomationTarget.ExactWindow?
+        if let snapshotExactWindow, let selectedWindow {
+            guard snapshotExactWindow == selectedWindow else {
+                throw MCPInteractionTargetError.backgroundWindowTargetMismatch
+            }
+            exactWindow = snapshotExactWindow
+        } else {
+            exactWindow = snapshotExactWindow ?? selectedWindow
+        }
+
+        let selectedProcessIdentity = try await self.selectedProcessIdentity(applications: applications)
+        let identities = [
+            selectedProcessIdentity,
+            snapshotProcessIdentity,
+            snapshotExactWindow?.identity.processIdentity,
+            selectedWindow?.identity.processIdentity,
+        ].compactMap(\.self)
+        guard let processIdentity = identities.first else {
+            throw MCPInteractionTargetError.backgroundTargetRequired
+        }
+        guard identities.allSatisfy({ $0 == processIdentity }) else {
+            throw MCPInteractionTargetError.backgroundWindowTargetMismatch
+        }
+
+        let listedApplications = try await applications.listApplications().data.applications
+        guard let application = listedApplications.first(where: {
+            $0.processIdentifier == processIdentity.processIdentifier
+        }) else {
+            throw MCPInteractionTargetError.targetProcessNotFound
+        }
+        guard application.processIdentity == processIdentity else {
+            throw MCPInteractionTargetError.targetProcessIdentityUnavailable
+        }
+        guard application.isEligibleForBackgroundInput else {
+            throw MCPInteractionTargetError.backgroundTargetIneligible
+        }
+
+        let process = try UIAutomationTarget.Process(
+            processIdentifier: processIdentity.processIdentifier,
+            identity: processIdentity)
+        if let exactWindow {
+            return try UIAutomationTarget.backgroundKeyboard(
+                process: process,
+                exactWindow: exactWindow)
+        }
+
+        let eligibleWindows: [UIAutomationTarget.ExactWindow]
+        if requiresExplicitExactWindow {
+            eligibleWindows = []
+        } else {
+            let listed = try await windows.listWindows(
+                target: .application("PID:\(processIdentity.processIdentifier)"))
+            eligibleWindows = try ObservationTargetResolver.captureCandidates(from: listed).map {
+                try UIAutomationTarget.ExactWindow(window: $0)
+            }
+        }
+        return try UIAutomationTarget.backgroundKeyboard(
+            process: process,
+            eligibleWindows: eligibleWindows,
+            requiresExplicitExactWindow: requiresExplicitExactWindow)
+    }
+
+    private func selectedProcessIdentity(
+        applications: any ApplicationServiceProtocol) async throws -> ApplicationProcessIdentity?
+    {
+        let application: ServiceApplicationInfo
+        if let pid {
+            application = try await applications.findApplication(identifier: "PID:\(pid)")
+            guard application.processIdentifier == pid else {
+                throw MCPInteractionTargetError.targetProcessNotFound
+            }
+        } else if let app = self.app?.trimmingCharacters(in: .whitespacesAndNewlines), !app.isEmpty {
+            application = try await applications.findApplication(identifier: app)
+        } else {
+            return nil
+        }
+        guard let identity = application.processIdentity else {
+            throw MCPInteractionTargetError.targetProcessIdentityUnavailable
+        }
+        return identity
+    }
+
+    private func requireSelectedExactWindow(
+        windows: any WindowManagementServiceProtocol) async throws -> UIAutomationTarget.ExactWindow
+    {
+        guard let windowTarget = try self.toWindowTarget() else {
+            throw MCPInteractionTargetError.backgroundWindowTargetUnsupported
+        }
+        let matches = try await windows.listWindows(target: windowTarget)
+        guard matches.count == 1, let window = matches.first else {
+            throw MCPInteractionTargetError.backgroundWindowTargetAmbiguous
+        }
+        return try UIAutomationTarget.ExactWindow(window: window)
     }
 
     func focusIfRequested(windows: any WindowManagementServiceProtocol, onlyWhenTargeted: Bool) async throws

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/PasteTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/PasteTool.swift
@@ -11,8 +11,6 @@ import UniformTypeIdentifiers
 public struct PasteTool: MCPTool {
     private let logger = os.Logger(subsystem: "boo.peekaboo.mcp", category: "PasteTool")
     private let context: MCPToolContext
-    private let windowIdentityProvider: @Sendable (CGWindowID) -> SystemWindowIdentity?
-    private let windowMutationIdentityProvider: @Sendable (CGWindowID) -> WindowMutationIdentity?
 
     public let name = "paste"
 
@@ -84,24 +82,6 @@ public struct PasteTool: MCPTool {
 
     public init(context: MCPToolContext = .shared) {
         self.context = context
-        self.windowIdentityProvider = SystemIdentityResolver.windowIdentity
-        self.windowMutationIdentityProvider = SystemIdentityResolver.windowMutationIdentity
-    }
-
-    init(
-        context: MCPToolContext,
-        windowIdentityProvider: @escaping @Sendable (CGWindowID) -> SystemWindowIdentity?)
-    {
-        self.context = context
-        self.windowIdentityProvider = windowIdentityProvider
-        self.windowMutationIdentityProvider = { windowID in
-            guard let window = windowIdentityProvider(windowID) else { return nil }
-            return WindowMutationIdentity(
-                windowID: Int(windowID),
-                ownerProcessIdentifier: window.ownerProcessIdentifier,
-                ownerProcessStartIdentity: 1,
-                capturedBounds: window.bounds)
-        }
     }
 
     @MainActor
@@ -126,7 +106,7 @@ public struct PasteTool: MCPTool {
                     target: target,
                     foreground: false,
                     expectedPIDIdentity: expectedPIDIdentity)
-                guard destination.targetPID != nil else {
+                guard destination.processIdentifier != nil else {
                     throw PasteToolError(
                         "Background text paste requires an app or pid target.",
                         refusalReason: .invalidRequest)
@@ -145,7 +125,7 @@ public struct PasteTool: MCPTool {
                         target: target,
                         foreground: foreground,
                         expectedPIDIdentity: expectedPIDIdentity)
-                    if destination.targetPID == nil {
+                    if destination.processIdentifier == nil {
                         _ = try await target.focusIfRequested(windows: self.context.windows)
                     }
                     return try await self.performCurrentClipboardPaste(
@@ -167,7 +147,7 @@ public struct PasteTool: MCPTool {
                     target: target,
                     foreground: foreground,
                     expectedPIDIdentity: expectedPIDIdentity)
-                if destination.targetPID == nil {
+                if destination.processIdentifier == nil {
                     _ = try await target.focusIfRequested(windows: self.context.windows)
                 }
                 return try await self.performClipboardPasteTransaction(
@@ -234,6 +214,11 @@ public struct PasteTool: MCPTool {
             return MCPToolResponseMetadataProjector.preDispatchRefusalResponse(
                 message: error.localizedDescription,
                 reason: error.refusalReason)
+        } catch let failure as DesktopActionFailure {
+            return try await MCPDesktopActionFailureHandler.response(
+                for: failure,
+                uiSnapshots: self.context.uiSnapshots,
+                snapshotID: nil)
         } catch let error as ClipboardPasteOutcomeError {
             self.logger.error("Paste outcome was \(error.kind.rawValue, privacy: .public)")
             return ToolResponse.error(
@@ -263,7 +248,7 @@ public struct PasteTool: MCPTool {
     private func directTextOutcomeResponse(
         _ error: InputDeliveryIndeterminateError,
         requestedCharacterCount: Int,
-        destination: PasteDeliveryDestination) -> ToolResponse
+        destination: UIAutomationTarget) -> ToolResponse
     {
         self.logger.error("Direct text paste outcome was indeterminate")
         return ToolResponse.error(
@@ -281,31 +266,26 @@ public struct PasteTool: MCPTool {
                 "clipboard_restore_error": .null,
                 "requested_characters": .int(requestedCharacterCount),
                 "characters_typed": error.emittedUnitCount.map(Value.int) ?? .null,
-                "target_pid": destination.targetPID.map { .int(Int($0)) } ?? .null,
-                "target_window_id": destination.exactWindow.map { .int($0.windowID) } ?? .null,
+                "target_pid": destination.processIdentifier.map { .int(Int($0)) } ?? .null,
+                "target_window_id": destination.exactWindow.map { .int($0.identity.windowID) } ?? .null,
                 "requires_fresh_observation": .bool(true),
             ]))
     }
 
     @MainActor
-    private func performClipboardPasteTransaction(
-        request: ClipboardWriteRequest,
-        destination: PasteDeliveryDestination,
-        restoreDelayMs: Int) async throws -> ClipboardPasteTransactionOutcome
-    {
-        let exactWindowAutomation: (any ExactWindowTargetedKeyboardServiceProtocol)?
-        let targetedAutomation: (any TargetedHotkeyServiceProtocol)?
+    private func pasteHotkeyRoute(for destination: UIAutomationTarget) throws -> PasteHotkeyRoute {
         if destination.exactWindow != nil {
-            guard let automation = self.context.automation as? any ExactWindowTargetedKeyboardServiceProtocol,
-                  automation.supportsExactWindowTargetedKeyboard
-            else {
+            do {
+                return try .exact(ExactWindowKeyboardRuntime.requireOutcomeProvider(
+                    automation: self.context.automation,
+                    operation: "Exact-window paste"))
+            } catch {
                 throw PasteToolError(
-                    "This automation host does not support atomic exact-window background paste delivery.",
+                    error.localizedDescription,
                     refusalReason: .runtimeIncompatible)
             }
-            exactWindowAutomation = automation
-            targetedAutomation = nil
-        } else if destination.targetPID != nil {
+        }
+        if destination.processIdentifier != nil {
             guard let automation = self.context.automation as? any TargetedHotkeyServiceProtocol,
                   automation.supportsTargetedHotkeys,
                   automation.supportsProcessGenerationPinnedHotkeys
@@ -314,12 +294,56 @@ public struct PasteTool: MCPTool {
                     "This automation host does not support background paste delivery.",
                     refusalReason: .runtimeIncompatible)
             }
-            exactWindowAutomation = nil
-            targetedAutomation = automation
-        } else {
-            exactWindowAutomation = nil
-            targetedAutomation = nil
+            return .process(automation)
         }
+        return .foreground
+    }
+
+    @MainActor
+    private func dispatchPasteHotkey(
+        route: PasteHotkeyRoute,
+        destination: UIAutomationTarget) async throws
+    {
+        switch route {
+        case let .exact(automation):
+            guard let exactWindow = destination.exactWindow,
+                  let focusedElement = exactWindow.focusedElement
+            else {
+                throw PasteToolError("Exact-window paste requires a focused-element receipt.")
+            }
+            let result = try await automation.hotkeyWithOutcome(
+                keys: "cmd,v",
+                holdDuration: 50,
+                target: ExactWindowKeyboardTarget(
+                    windowIdentity: exactWindow.identity,
+                    windowBounds: exactWindow.bounds,
+                    focusedElement: focusedElement))
+            let validated = try ExactWindowKeyboardRuntime.validateRouteReceipt(
+                result,
+                operation: "Exact-window paste")
+            try DesktopActionFailure.requireConfirmedIfReported(
+                validated.outcome,
+                operation: "Paste hotkey")
+        case let .process(automation):
+            guard let processIdentity = destination.processIdentity else {
+                throw PasteToolError("Background paste requires a process-generation receipt.")
+            }
+            try await automation.hotkey(
+                keys: "cmd,v",
+                holdDuration: 50,
+                expectedProcessIdentity: processIdentity)
+        case .foreground:
+            try await self.context.automation.hotkey(keys: "cmd,v", holdDuration: 50)
+        }
+    }
+
+    @MainActor
+    private func performClipboardPasteTransaction(
+        request: ClipboardWriteRequest,
+        destination: UIAutomationTarget,
+        restoreDelayMs: Int) async throws -> ClipboardPasteTransactionOutcome
+    {
+        let hotkeyRoute = try self.pasteHotkeyRoute(for: destination)
 
         try Task.checkCancellation()
         let priorClipboard = try self.context.clipboard.get(prefer: nil)
@@ -377,24 +401,17 @@ public struct PasteTool: MCPTool {
             try restoreBeforeDispatchFailure(error)
         }
 
+        let dispatchFailure: DesktopActionFailure?
         let dispatchErrorDescription: String?
         do {
-            if let exactWindow = destination.exactWindow, let exactWindowAutomation {
-                try await exactWindowAutomation.hotkey(
-                    keys: "cmd,v",
-                    holdDuration: 50,
-                    expectedWindowIdentity: exactWindow.windowIdentity,
-                    expectedWindowBounds: exactWindow.bounds)
-            } else if let processIdentity = destination.processIdentity, let targetedAutomation {
-                try await targetedAutomation.hotkey(
-                    keys: "cmd,v",
-                    holdDuration: 50,
-                    expectedProcessIdentity: processIdentity)
-            } else {
-                try await self.context.automation.hotkey(keys: "cmd,v", holdDuration: 50)
-            }
+            try await self.dispatchPasteHotkey(route: hotkeyRoute, destination: destination)
+            dispatchFailure = nil
+            dispatchErrorDescription = nil
+        } catch let failure as DesktopActionFailure {
+            dispatchFailure = failure
             dispatchErrorDescription = nil
         } catch {
+            dispatchFailure = nil
             dispatchErrorDescription = error.localizedDescription
         }
 
@@ -410,21 +427,31 @@ public struct PasteTool: MCPTool {
         }
         restorePending = false
 
+        if let dispatchFailure {
+            guard let restoreErrorDescription else { throw dispatchFailure }
+            throw ClipboardPasteOutcomeError(
+                kind: .indeterminate,
+                causeDescription: "\(dispatchFailure.localizedDescription); clipboard restoration also failed: " +
+                    restoreErrorDescription,
+                clipboardRestoreAttempted: true,
+                clipboardRestoreErrorDescription: restoreErrorDescription,
+                targetProcessIdentifier: destination.processIdentifier)
+        }
         if dispatchErrorDescription != nil || Task.isCancelled {
             throw ClipboardPasteOutcomeError(
                 kind: .indeterminate,
                 causeDescription: dispatchErrorDescription ?? "The caller cancelled after Cmd+V dispatch began.",
                 clipboardRestoreAttempted: true,
                 clipboardRestoreErrorDescription: restoreErrorDescription,
-                targetProcessIdentifier: destination.targetPID)
+                targetProcessIdentifier: destination.processIdentifier)
         }
-        if destination.targetPID != nil {
+        if destination.processIdentifier != nil {
             throw ClipboardPasteOutcomeError(
                 kind: .unverified,
                 causeDescription: "The targeted event API does not acknowledge receiver consumption.",
                 clipboardRestoreAttempted: true,
                 clipboardRestoreErrorDescription: restoreErrorDescription,
-                targetProcessIdentifier: destination.targetPID)
+                targetProcessIdentifier: destination.processIdentifier)
         }
 
         return ClipboardPasteTransactionOutcome(
@@ -432,85 +459,55 @@ public struct PasteTool: MCPTool {
             previousClipboardPresent: priorClipboard != nil,
             restoreResult: restoreResult,
             restoreErrorDescription: restoreErrorDescription,
-            targetPID: destination.targetPID,
-            targetWindowID: destination.exactWindow?.windowID)
+            targetPID: destination.processIdentifier,
+            targetWindowID: destination.exactWindow?.identity.windowID)
     }
 
     @MainActor
     private func performCurrentClipboardPaste(
-        destination: PasteDeliveryDestination,
+        destination: UIAutomationTarget,
         restoreDelayMs: Int) async throws -> CurrentClipboardPasteOutcome
     {
-        let exactWindowAutomation: (any ExactWindowTargetedKeyboardServiceProtocol)?
-        let targetedAutomation: (any TargetedHotkeyServiceProtocol)?
-        if destination.exactWindow != nil {
-            guard let automation = self.context.automation as? any ExactWindowTargetedKeyboardServiceProtocol,
-                  automation.supportsExactWindowTargetedKeyboard
-            else {
-                throw PasteToolError(
-                    "This automation host does not support atomic exact-window background paste delivery.",
-                    refusalReason: .runtimeIncompatible)
-            }
-            exactWindowAutomation = automation
-            targetedAutomation = nil
-        } else if destination.targetPID != nil {
-            guard let automation = self.context.automation as? any TargetedHotkeyServiceProtocol,
-                  automation.supportsTargetedHotkeys,
-                  automation.supportsProcessGenerationPinnedHotkeys
-            else {
-                throw PasteToolError(
-                    "This automation host does not support background paste delivery.",
-                    refusalReason: .runtimeIncompatible)
-            }
-            exactWindowAutomation = nil
-            targetedAutomation = automation
-        } else {
-            exactWindowAutomation = nil
-            targetedAutomation = nil
-        }
+        let hotkeyRoute = try self.pasteHotkeyRoute(for: destination)
 
         let currentClipboard = try self.context.clipboard.get(prefer: nil)
         try Task.checkCancellation()
+        let dispatchFailure: DesktopActionFailure?
         let dispatchErrorDescription: String?
         do {
-            if let exactWindow = destination.exactWindow, let exactWindowAutomation {
-                try await exactWindowAutomation.hotkey(
-                    keys: "cmd,v",
-                    holdDuration: 50,
-                    expectedWindowIdentity: exactWindow.windowIdentity,
-                    expectedWindowBounds: exactWindow.bounds)
-            } else if let processIdentity = destination.processIdentity, let targetedAutomation {
-                try await targetedAutomation.hotkey(
-                    keys: "cmd,v",
-                    holdDuration: 50,
-                    expectedProcessIdentity: processIdentity)
-            } else {
-                try await self.context.automation.hotkey(keys: "cmd,v", holdDuration: 50)
-            }
+            try await self.dispatchPasteHotkey(route: hotkeyRoute, destination: destination)
+            dispatchFailure = nil
+            dispatchErrorDescription = nil
+        } catch let failure as DesktopActionFailure {
+            dispatchFailure = failure
             dispatchErrorDescription = nil
         } catch {
+            dispatchFailure = nil
             dispatchErrorDescription = error.localizedDescription
         }
 
         await ClipboardPasteTransactionGate.waitForPasteConsumption(milliseconds: restoreDelayMs)
+        if let dispatchFailure {
+            throw dispatchFailure
+        }
         if dispatchErrorDescription != nil || Task.isCancelled {
             throw ClipboardPasteOutcomeError(
                 kind: .indeterminate,
                 causeDescription: dispatchErrorDescription ?? "The caller cancelled after Cmd+V dispatch began.",
                 clipboardRestoreAttempted: false,
-                targetProcessIdentifier: destination.targetPID)
+                targetProcessIdentifier: destination.processIdentifier)
         }
-        if destination.targetPID != nil {
+        if destination.processIdentifier != nil {
             throw ClipboardPasteOutcomeError(
                 kind: .unverified,
                 causeDescription: "The targeted event API does not acknowledge receiver consumption.",
                 clipboardRestoreAttempted: false,
-                targetProcessIdentifier: destination.targetPID)
+                targetProcessIdentifier: destination.processIdentifier)
         }
         return CurrentClipboardPasteOutcome(
             clipboard: currentClipboard,
-            targetPID: destination.targetPID,
-            targetWindowID: destination.exactWindow?.windowID)
+            targetPID: destination.processIdentifier,
+            targetWindowID: destination.exactWindow?.identity.windowID)
     }
 
     @MainActor
@@ -518,29 +515,32 @@ public struct PasteTool: MCPTool {
         text: String,
         request: ClipboardWriteRequest,
         target: MCPInteractionTarget,
-        destination: PasteDeliveryDestination,
+        destination: UIAutomationTarget,
         startedAt: Date) async throws -> ToolResponse
     {
-        guard let targetPID = destination.targetPID else {
+        guard let targetPID = destination.processIdentifier else {
             throw PasteToolError("Background text paste requires a resolved target process.")
         }
-        let typeResult: TypeResult
+        let actionResult: UIAutomationActionResult<TypeResult>
         if let exactWindow = destination.exactWindow {
-            guard let automation = self.context.automation as? any ExactWindowTargetedKeyboardServiceProtocol,
-                  automation.supportsExactWindowTargetedKeyboard
-            else {
-                throw PasteToolError(
-                    "This automation host does not support atomic exact-window background text delivery.",
-                    refusalReason: .runtimeIncompatible)
+            let outcomeAutomation = try ExactWindowKeyboardRuntime.requireOutcomeProvider(
+                automation: self.context.automation,
+                operation: "Exact-window background text delivery")
+            guard let focusedElement = exactWindow.focusedElement else {
+                throw PasteToolError("Exact-window paste requires a focused-element receipt.")
             }
             try Task.checkCancellation()
             do {
-                typeResult = try await automation.typeActions(
-                    [.text(text)],
-                    cadence: .fixed(milliseconds: 0),
-                    snapshotId: nil,
-                    expectedWindowIdentity: exactWindow.windowIdentity,
-                    expectedWindowBounds: exactWindow.bounds)
+                actionResult = try await ExactWindowKeyboardRuntime.validateRouteReceipt(
+                    outcomeAutomation.typeActionsWithOutcome(
+                        [.text(text)],
+                        cadence: .fixed(milliseconds: 0),
+                        snapshotId: nil,
+                        target: ExactWindowKeyboardTarget(
+                            windowIdentity: exactWindow.identity,
+                            windowBounds: exactWindow.bounds,
+                            focusedElement: focusedElement)),
+                    operation: "Exact-window background text delivery")
             } catch let error as InputDeliveryIndeterminateError {
                 return self.directTextOutcomeResponse(
                     Self.pasteDeliveryError(from: error),
@@ -559,11 +559,21 @@ public struct PasteTool: MCPTool {
             }
             try Task.checkCancellation()
             do {
-                typeResult = try await automation.typeActions(
-                    [.text(text)],
-                    cadence: .fixed(milliseconds: 0),
-                    snapshotId: nil,
-                    expectedProcessIdentity: processIdentity)
+                if let outcomeAutomation = automation as? any UIAutomationActionOutcomeProviding {
+                    actionResult = try await outcomeAutomation.typeActionsWithOutcome(
+                        [.text(text)],
+                        cadence: .fixed(milliseconds: 0),
+                        snapshotId: nil,
+                        expectedProcessIdentity: processIdentity)
+                } else {
+                    actionResult = try await UIAutomationActionResult(
+                        payload: automation.typeActions(
+                            [.text(text)],
+                            cadence: .fixed(milliseconds: 0),
+                            snapshotId: nil,
+                            expectedProcessIdentity: processIdentity),
+                        outcome: nil)
+                }
             } catch let error as InputDeliveryIndeterminateError {
                 return self.directTextOutcomeResponse(
                     Self.pasteDeliveryError(from: error),
@@ -571,6 +581,10 @@ public struct PasteTool: MCPTool {
                     destination: destination)
             }
         }
+        try DesktopActionFailure.requireConfirmedIfReported(
+            actionResult.outcome,
+            operation: "Background text paste")
+        let typeResult = actionResult.payload
         if Task.isCancelled {
             return self.directTextOutcomeResponse(
                 InputDeliveryIndeterminateError(
@@ -582,7 +596,7 @@ public struct PasteTool: MCPTool {
         }
         let setResult = try Self.readResult(for: request)
         let executionTime = Date().timeIntervalSince(startedAt)
-        let meta: Value = .object([
+        let metaFields: [String: Value] = [
             "pasted": .object([
                 "uti": .string(setResult.utiIdentifier),
                 "size": .int(setResult.data.count),
@@ -593,20 +607,24 @@ public struct PasteTool: MCPTool {
             "execution_time": .double(executionTime),
             "delivery_mode": .string("background"),
             "target_pid": .int(Int(targetPID)),
-            "target_window_id": destination.exactWindow.map { .int($0.windowID) } ?? .null,
-        ])
+            "target_window_id": destination.exactWindow.map { .int($0.identity.windowID) } ?? .null,
+        ]
         let summary = ToolEventSummary(
             targetApp: target.appIdentifier,
             windowTitle: nil,
             actionDescription: "Paste text",
             notes: setResult.utiIdentifier)
-        return ToolResponse(
+        return try ToolResponse(
             content: [.text(
                 text: "\(AgentDisplayTokens.Status.success) Pasted text in the background " +
                     "in \(String(format: "%.2f", executionTime))s",
                 annotations: nil,
                 _meta: nil)],
-            meta: ToolEventSummary.merge(summary: summary, into: meta))
+            meta: ToolEventSummary.merge(
+                summary: summary,
+                into: MCPToolResponseMetadataProjector.metadata(
+                    merging: metaFields,
+                    outcome: actionResult.outcome)))
     }
 
     private static func pasteDeliveryError(
@@ -666,26 +684,18 @@ public struct PasteTool: MCPTool {
     private func resolveDeliveryDestination(
         target: MCPInteractionTarget,
         foreground: Bool,
-        expectedPIDIdentity: UInt64?) async throws -> PasteDeliveryDestination
+        expectedPIDIdentity: UInt64?) async throws -> UIAutomationTarget
     {
         if foreground {
             try Self.validateExplicitPIDIdentity(target: target, expectedPIDIdentity: expectedPIDIdentity)
             return .foreground
         }
-        if target.hasWindowSelector {
-            return try await self.resolveExactWindowDestination(
-                target: target,
-                expectedPIDIdentity: expectedPIDIdentity)
-        }
-        let processIdentity = try await target.requireBackgroundProcessIdentity(
+        let plannedTarget = try await target.requireBackgroundKeyboardTarget(
             applications: self.context.applications,
             windows: self.context.windows)
-        let processIdentifier = processIdentity.processIdentifier
-        let applications = try await self.context.applications.listApplications().data.applications
-        guard let application = applications.first(where: { $0.processIdentifier == processIdentifier }) else {
-            throw PasteToolError("Target process PID \(processIdentifier) is no longer running.")
+        guard let processIdentifier = plannedTarget.processIdentifier else {
+            throw PasteToolError("Background paste requires a resolved target process.")
         }
-        try application.requireBackgroundInputEligibility()
         if target.pid != nil {
             guard let expectedPIDIdentity,
                   ClipboardPasteTransactionGate.processStartIdentity(processIdentifier) == expectedPIDIdentity
@@ -693,96 +703,22 @@ public struct PasteTool: MCPTool {
                 throw PasteToolError("Target process PID \(processIdentifier) changed identity while waiting.")
             }
         }
-        return .process(processIdentity)
-    }
-
-    @MainActor
-    private func resolveExactWindowDestination(
-        target: MCPInteractionTarget,
-        expectedPIDIdentity: UInt64?) async throws -> PasteDeliveryDestination
-    {
-        try target.validate()
-        guard let windowTarget = try target.toWindowTarget() else {
+        guard plannedTarget.exactWindow != nil else { return plannedTarget }
+        do {
+            _ = try ExactWindowKeyboardRuntime.requireOutcomeProvider(
+                automation: self.context.automation,
+                operation: "Exact-window paste")
+        } catch {
             throw PasteToolError(
-                "Exact-window background paste requires a window selector.",
-                refusalReason: .invalidRequest)
+                error.localizedDescription,
+                refusalReason: .runtimeIncompatible)
         }
-        guard let selectedWindow = try await self.context.windows.listWindows(target: windowTarget).first else {
-            throw PasteToolError("Could not resolve the requested exact window.")
-        }
-        guard selectedWindow.windowID > 0,
-              let windowID = CGWindowID(exactly: selectedWindow.windowID),
-              let identity = self.windowIdentityProvider(windowID)
-        else {
-            throw PasteToolError("Window \(selectedWindow.windowID) is no longer present.")
-        }
-        guard !identity.bounds.isEmpty else {
-            throw PasteToolError("Window \(selectedWindow.windowID) no longer has usable bounds.")
-        }
-
-        let requestedProcessIdentifier = try await self.requestedProcessIdentifier(target: target)
-        if let requestedProcessIdentifier,
-           requestedProcessIdentifier != identity.ownerProcessIdentifier
-        {
+        guard self.context.automation is any TargetedFocusedElementServiceProtocol else {
             throw PasteToolError(
-                "Window \(selectedWindow.windowID) is owned by PID \(identity.ownerProcessIdentifier), not the " +
-                    "requested PID \(requestedProcessIdentifier).")
+                "This automation host does not support focused exact-window background paste.",
+                refusalReason: .runtimeIncompatible)
         }
-
-        let applications = try await self.context.applications.listApplications().data.applications
-        guard let application = applications.first(where: {
-            $0.processIdentifier == identity.ownerProcessIdentifier
-        }) else {
-            throw PasteToolError("Target process PID \(identity.ownerProcessIdentifier) is no longer running.")
-        }
-        try application.requireBackgroundInputEligibility()
-        if target.pid != nil {
-            guard let expectedPIDIdentity,
-                  ClipboardPasteTransactionGate.processStartIdentity(identity.ownerProcessIdentifier) ==
-                  expectedPIDIdentity
-            else {
-                throw PasteToolError(
-                    "Target process PID \(identity.ownerProcessIdentifier) changed identity while waiting.")
-            }
-        }
-
-        return try .exactWindow(PasteExactWindowDestination(
-            processIdentifier: identity.ownerProcessIdentifier,
-            windowID: selectedWindow.windowID,
-            bounds: identity.bounds,
-            windowIdentity: self.requireWindowMutationIdentity(
-                windowID: selectedWindow.windowID,
-                processIdentifier: identity.ownerProcessIdentifier,
-                bounds: identity.bounds)))
-    }
-
-    private func requireWindowMutationIdentity(
-        windowID: Int,
-        processIdentifier: pid_t,
-        bounds: CGRect) throws -> WindowMutationIdentity
-    {
-        guard let cgWindowID = CGWindowID(exactly: windowID),
-              let identity = self.windowMutationIdentityProvider(cgWindowID),
-              identity.ownerProcessIdentifier == processIdentifier,
-              let current = self.windowIdentityProvider(cgWindowID),
-              current.ownerProcessIdentifier == processIdentifier,
-              current.bounds == bounds
-        else {
-            throw PasteToolError("Exact-window identity changed before paste dispatch.")
-        }
-        return identity
-    }
-
-    @MainActor
-    private func requestedProcessIdentifier(target: MCPInteractionTarget) async throws -> pid_t? {
-        if let pid = target.pid {
-            return try Self.checkedProcessIdentifier(pid)
-        }
-        guard let app = target.app?.trimmingCharacters(in: .whitespacesAndNewlines), !app.isEmpty else {
-            return nil
-        }
-        let application = try await self.context.applications.findApplication(identifier: app)
-        return pid_t(application.processIdentifier)
+        return try await plannedTarget.pinningCurrentFocusedElement(using: self.context.automation)
     }
 
     private static func explicitPIDIdentity(target: MCPInteractionTarget) throws -> UInt64? {
@@ -893,45 +829,10 @@ private enum PasteToolPayload: Sendable {
     case explicit(request: ClipboardWriteRequest, text: String?)
 }
 
-private struct PasteExactWindowDestination: Sendable {
-    let processIdentifier: pid_t
-    let windowID: Int
-    let bounds: CGRect
-    let windowIdentity: WindowMutationIdentity
-}
-
-extension ServiceApplicationInfo {
-    fileprivate func requireBackgroundInputEligibility() throws {
-        guard self.isEligibleForBackgroundInput else {
-            throw PasteToolError(
-                "Target process PID \(self.processIdentifier) cannot receive background input because it is a " +
-                    "prohibited helper or its application metadata is incomplete.")
-        }
-    }
-}
-
-private struct PasteDeliveryDestination: Sendable {
-    let targetPID: pid_t?
-    let processIdentity: ApplicationProcessIdentity?
-    let exactWindow: PasteExactWindowDestination?
-
-    static let foreground = PasteDeliveryDestination(targetPID: nil, processIdentity: nil, exactWindow: nil)
-
-    static func process(_ identity: ApplicationProcessIdentity) -> PasteDeliveryDestination {
-        PasteDeliveryDestination(
-            targetPID: identity.processIdentifier,
-            processIdentity: identity,
-            exactWindow: nil)
-    }
-
-    static func exactWindow(_ window: PasteExactWindowDestination) -> PasteDeliveryDestination {
-        PasteDeliveryDestination(
-            targetPID: window.processIdentifier,
-            processIdentity: ApplicationProcessIdentity(
-                processIdentifier: window.processIdentifier,
-                processStartIdentity: window.windowIdentity.ownerProcessStartIdentity),
-            exactWindow: window)
-    }
+private enum PasteHotkeyRoute {
+    case foreground
+    case process(any TargetedHotkeyServiceProtocol)
+    case exact(any UIAutomationActionOutcomeProviding)
 }
 
 private struct ClipboardPasteTransactionOutcome: Sendable {

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/PressTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/PressTool.swift
@@ -370,6 +370,8 @@ public struct PressTool: MCPTool {
                 windows: self.context.windows,
                 snapshotExactWindow: snapshotExactWindow,
                 requiresExplicitExactWindow: true)
+        } catch is CancellationError {
+            throw CancellationError()
         } catch let error as MCPInteractionTargetError {
             throw error
         } catch {
@@ -400,6 +402,8 @@ public struct PressTool: MCPTool {
             let deliveryTarget = try await plannedTarget.pinningCurrentFocusedElement(
                 using: self.context.automation)
             return PressDeliveryPlan(target: deliveryTarget, targetFocusCompleted: false)
+        } catch is CancellationError {
+            throw CancellationError()
         } catch {
             throw PressToolValidationError(
                 message: error.localizedDescription,

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/PressTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/PressTool.swift
@@ -17,10 +17,9 @@ public struct PressTool: MCPTool {
         """
         Presses one or more raw keyboard chords. Use `keys` for an xdotool-style chord sequence such as
         ["cmd+c", "Return"], or use `key` plus `modifiers` for a single chord. The two input shapes are
-        mutually exclusive. Raw chords cannot prove semantic intent or effect on a shared desktop and require
-        foreground=true. For certifiable background automation, use action, menu, window, app, or dialog with an
-        exact target. app and pid are alternatives; provide at most one of window_id, window_title, or window_index,
-        and pair title/index with app or pid.
+        mutually exclusive. Raw chords require foreground=true or an exact window/snapshot receipt whose focused
+        element can be pinned through native background dispatch. App/PID-only and targetless background press are
+        refused. app and pid are alternatives; provide at most one window selector; pair title/index with app or pid.
         \(PeekabooMCPVersion.banner) using openai/gpt-5.6, anthropic/claude-opus-5
         """
     }
@@ -70,8 +69,10 @@ public struct PressTool: MCPTool {
                     .string(description: "Optional window title (substring match) to focus before raw input."),
                 "window_index": SchemaBuilder
                     .integer(description: "Optional window index (0-based); requires app/pid."),
+                "snapshot": SchemaBuilder.string(
+                    description: "Optional fresh exact-window snapshot for receipt-pinned background press."),
                 "foreground": SchemaBuilder.boolean(
-                    description: "Required true. Focus a target or intentionally send OS-global raw keyboard input.",
+                    description: "Focus a target or intentionally send OS-global raw keyboard input.",
                     default: false),
             ],
             required: [])
@@ -97,18 +98,28 @@ public struct PressTool: MCPTool {
                 windowTitle: arguments.getString("window_title"),
                 windowIndex: arguments.validatedInt("window_index"),
                 windowId: arguments.validatedInt("window_id"))
-            guard foreground else {
+            let snapshotID = arguments.getString("snapshot")
+            if foreground, snapshotID?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false {
+                throw PressToolValidationError(
+                    message: "snapshot is only supported for receipt-pinned background press")
+            }
+            guard foreground || target.hasWindowSelector ||
+                snapshotID?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
+            else {
                 return try Self.foregroundConsentRefusal()
             }
             let resolvedWindowTitle = try await target.resolveWindowTitleIfNeeded(windows: self.context.windows)
-            let targetFocusCompleted = try await target.focusIfRequested(
-                windows: self.context.windows,
-                onlyWhenTargeted: true) != nil
+            let deliveryPlan = try await self.resolveDeliveryTarget(
+                foreground: foreground,
+                target: target,
+                snapshotID: snapshotID)
+            let targetFocusCompleted = deliveryPlan.targetFocusCompleted
 
             let startTime = Date()
             let run = try await self.dispatchSequence(
                 chords: chords,
                 parameters: parameters,
+                target: deliveryPlan.target,
                 targetFocusCompleted: targetFocusCompleted)
             let display = chords.map(\.displayValue)
             let elapsed = Date().timeIntervalSince(startTime)
@@ -128,11 +139,13 @@ public struct PressTool: MCPTool {
                 "delay": .int(delay),
                 "hold": .int(hold),
                 "total_presses": .int(run.completedPresses),
-                "target_pid": .null,
+                "target_pid": deliveryPlan.target.processIdentifier.map { .int(Int($0)) } ?? .null,
+                "target_window_id": deliveryPlan.target.exactWindow.map { .int($0.identity.windowID) } ?? .null,
                 "execution_time": .double(elapsed),
             ]
             if !targetFocusCompleted, sequenceResolution.mutationDispatched {
-                baseMeta["delivery_mode"] = .string("foreground")
+                baseMeta["delivery_mode"] = .string(
+                    deliveryPlan.target.processIdentifier == nil ? "foreground" : "background")
             }
             if outcome == nil {
                 if sequenceResolution.mutationDispatched {
@@ -143,7 +156,8 @@ public struct PressTool: MCPTool {
                 baseMeta["requires_fresh_observation"] = .bool(sequenceResolution.requiresFreshObservation)
             }
             if let invalidatedSnapshotID = await self.invalidateSnapshotAfterSuccess(
-                resolution: sequenceResolution)
+                resolution: sequenceResolution,
+                snapshotID: snapshotID)
             {
                 baseMeta["invalidated_snapshot"] = .string(invalidatedSnapshotID)
             }
@@ -162,18 +176,27 @@ public struct PressTool: MCPTool {
         } catch let error as KeyboardChordError {
             return try Self.invalidRequest(error.localizedDescription)
         } catch let error as PressToolValidationError {
-            return try Self.invalidRequest(error.message)
+            return MCPToolResponseMetadataProjector.preDispatchRefusalResponse(
+                message: error.message,
+                reason: error.refusalReason)
         } catch let error as MCPToolArgumentValueError {
             return try Self.invalidRequest(error.localizedDescription)
         } catch let failure as PressSequenceFailure {
             return try await self.failureResponse(
                 failure.failure,
-                compatibility: failure.compatibility)
+                compatibility: failure.compatibility,
+                snapshotID: arguments.getString("snapshot"))
         } catch let failure as DesktopActionFailure {
-            return try await self.failureResponse(failure, compatibility: .none)
+            return try await self.failureResponse(
+                failure,
+                compatibility: .none,
+                snapshotID: arguments.getString("snapshot"))
         } catch let error as InputDeliveryIndeterminateError {
             let failure = error.desktopActionFailure(delivery: nil)
-            return try await self.failureResponse(failure, compatibility: .none)
+            return try await self.failureResponse(
+                failure,
+                compatibility: .none,
+                snapshotID: arguments.getString("snapshot"))
         } catch {
             self.logger.error("Press execution failed: \(error.localizedDescription)")
             return ToolResponse.error(error.localizedDescription)
@@ -184,6 +207,7 @@ public struct PressTool: MCPTool {
     private func dispatchSequence(
         chords: [KeyboardChord],
         parameters: PressExecutionParameters,
+        target: UIAutomationTarget,
         targetFocusCompleted: Bool) async throws -> PressSequenceRun
     {
         var sequence = DesktopActionSequenceAccumulator()
@@ -196,7 +220,10 @@ public struct PressTool: MCPTool {
         do {
             for repetition in 0..<parameters.count {
                 for (index, chord) in chords.enumerated() {
-                    let result = try await self.dispatch(chord: chord, hold: parameters.hold)
+                    let result = try await self.dispatch(
+                        chord: chord,
+                        hold: parameters.hold,
+                        target: target)
                     try DesktopActionFailure.requireConfirmedIfReported(
                         result.outcome,
                         operation: "Raw chord \(chord.displayValue)")
@@ -212,7 +239,7 @@ public struct PressTool: MCPTool {
                         allChordsConfirmedNoChange = false
                         let step = DesktopActionSequenceAccumulator.Step.dispatched(
                             route: .local,
-                            delivery: Self.foregroundHotkeyDelivery,
+                            delivery: Self.delivery(for: target),
                             unitCount: Self.singleDispatchUnit)
                         sequence.record(step)
                         chordSequence.record(step)
@@ -232,7 +259,7 @@ public struct PressTool: MCPTool {
                 chordDisposition: chordSequence.mutationDisposition)
         } catch let error as InputDeliveryIndeterminateError {
             throw Self.sequenceFailure(
-                error.desktopActionFailure(delivery: Self.foregroundHotkeyDelivery),
+                error.desktopActionFailure(delivery: Self.delivery(for: target)),
                 sequence: sequence,
                 completedPresses: completedPresses,
                 chordDisposition: chordSequence.mutationDisposition,
@@ -253,7 +280,29 @@ public struct PressTool: MCPTool {
     }
 
     @MainActor
-    private func dispatch(chord: KeyboardChord, hold: Int) async throws -> UIAutomationActionResult<Void> {
+    private func dispatch(
+        chord: KeyboardChord,
+        hold: Int,
+        target: UIAutomationTarget) async throws -> UIAutomationActionResult<Void>
+    {
+        if let exactWindow = target.exactWindow {
+            let outcomeAutomation = try ExactWindowKeyboardRuntime.requireOutcomeProvider(
+                automation: self.context.automation,
+                operation: "Background hotkeys")
+            guard let focusedElement = exactWindow.focusedElement else {
+                throw PressToolValidationError(
+                    message: "Exact-window background hotkeys require a focused-element receipt.")
+            }
+            return try await ExactWindowKeyboardRuntime.validateRouteReceipt(
+                outcomeAutomation.hotkeyWithOutcome(
+                    keys: chord.serviceKeys,
+                    holdDuration: hold,
+                    target: ExactWindowKeyboardTarget(
+                        windowIdentity: exactWindow.identity,
+                        windowBounds: exactWindow.bounds,
+                        focusedElement: focusedElement)),
+                operation: "Background hotkeys")
+        }
         if let automation = self.context.automation as? any UIAutomationActionOutcomeProviding {
             return try await automation.hotkeyWithOutcome(keys: chord.serviceKeys, holdDuration: hold)
         }
@@ -301,24 +350,109 @@ public struct PressTool: MCPTool {
     }
 
     @MainActor
+    private func resolveDeliveryTarget(
+        foreground: Bool,
+        target: MCPInteractionTarget,
+        snapshotID: String?) async throws -> PressDeliveryPlan
+    {
+        if foreground {
+            let targetFocusCompleted = try await target.focusIfRequested(
+                windows: self.context.windows,
+                onlyWhenTargeted: true) != nil
+            return PressDeliveryPlan(target: .foreground, targetFocusCompleted: targetFocusCompleted)
+        }
+
+        let snapshotExactWindow = try await self.snapshotExactWindow(id: snapshotID)
+        let plannedTarget: UIAutomationTarget
+        do {
+            plannedTarget = try await target.requireBackgroundKeyboardTarget(
+                applications: self.context.applications,
+                windows: self.context.windows,
+                snapshotExactWindow: snapshotExactWindow,
+                requiresExplicitExactWindow: true)
+        } catch let error as MCPInteractionTargetError {
+            throw error
+        } catch {
+            throw PressToolValidationError(
+                message: error.localizedDescription,
+                refusalReason: .targetUnavailable)
+        }
+        guard plannedTarget.exactWindow != nil else {
+            throw PressToolValidationError(
+                message: "Background raw key presses require one exact-window receipt.",
+                refusalReason: .invalidRequest)
+        }
+        do {
+            _ = try ExactWindowKeyboardRuntime.requireOutcomeProvider(
+                automation: self.context.automation,
+                operation: "Background hotkeys")
+        } catch {
+            throw PressToolValidationError(
+                message: error.localizedDescription,
+                refusalReason: .runtimeIncompatible)
+        }
+        guard self.context.automation is any TargetedFocusedElementServiceProtocol else {
+            throw PressToolValidationError(
+                message: "This automation host does not support focused exact-window background hotkeys.",
+                refusalReason: .runtimeIncompatible)
+        }
+        do {
+            let deliveryTarget = try await plannedTarget.pinningCurrentFocusedElement(
+                using: self.context.automation)
+            return PressDeliveryPlan(target: deliveryTarget, targetFocusCompleted: false)
+        } catch {
+            throw PressToolValidationError(
+                message: error.localizedDescription,
+                refusalReason: .targetUnavailable)
+        }
+    }
+
+    private func snapshotExactWindow(id: String?) async throws -> UIAutomationTarget.ExactWindow? {
+        guard let id, !id.isEmpty else { return nil }
+        guard let snapshot = await self.context.uiSnapshots.getSnapshot(id: id),
+              let processIdentifier = snapshot.applicationProcessId,
+              processIdentifier > 0,
+              let windowID = snapshot.windowID,
+              let bounds = snapshot.windowBounds,
+              let identity = snapshot.windowMutationIdentity,
+              identity.ownerProcessIdentifier == processIdentifier,
+              identity.windowID == windowID,
+              identity.capturedBounds == bounds
+        else {
+            throw PressToolValidationError(
+                message: "The selected snapshot has no exact process-generation, window, and bounds receipt.",
+                refusalReason: .targetUnavailable)
+        }
+        return try UIAutomationTarget.ExactWindow(identity: identity, bounds: bounds)
+    }
+
+    private static func delivery(for target: UIAutomationTarget) -> DesktopActionOutcome.Delivery {
+        target.exactWindow == nil
+            ? .init(mechanism: .globalEvents, mode: .foreground)
+            : .init(mechanism: .windowTargetedEvents, mode: .background)
+    }
+
+    @MainActor
     private func invalidateSnapshotAfterSuccess(
-        resolution: DesktopActionSequenceAccumulator.Resolution) async -> String?
+        resolution: DesktopActionSequenceAccumulator.Resolution,
+        snapshotID: String?) async -> String?
     {
         await MCPDesktopActionSnapshotInvalidator.invalidate(
             uiSnapshots: self.context.uiSnapshots,
-            snapshotID: nil,
+            snapshotID: snapshotID,
             mutationDispatched: resolution.mutationDispatched)
     }
 
     @MainActor
     private func failureResponse(
         _ failure: DesktopActionFailure,
-        compatibility: PressFailureCompatibility) async throws -> ToolResponse
+        compatibility: PressFailureCompatibility,
+        snapshotID: String?) async throws -> ToolResponse
     {
         try await MCPDesktopActionFailureHandler.response(
             for: failure,
             uiSnapshots: self.context.uiSnapshots,
-            snapshotID: nil,
+            snapshotID: snapshotID,
             additionalFields: compatibility.fields)
     }
 
@@ -420,9 +554,6 @@ struct PressFailureCompatibility {
 }
 
 extension PressTool {
-    fileprivate static let foregroundHotkeyDelivery = DesktopActionOutcome.Delivery(
-        mechanism: .globalEvents,
-        mode: .foreground)
     fileprivate static let singleDispatchUnit: DesktopActionOutcome.DispatchUnitCount = .one
 }
 
@@ -443,6 +574,11 @@ private struct PressSequenceFailure: Error {
     let compatibility: PressFailureCompatibility
 }
 
+private struct PressDeliveryPlan {
+    let target: UIAutomationTarget
+    let targetFocusCompleted: Bool
+}
+
 private struct PressResponseMessageInput {
     let display: [String]
     let completed: Int
@@ -454,4 +590,13 @@ private struct PressResponseMessageInput {
 
 private struct PressToolValidationError: Error {
     let message: String
+    let refusalReason: DesktopActionOutcome.RefusalReason
+
+    init(
+        message: String,
+        refusalReason: DesktopActionOutcome.RefusalReason = .invalidRequest)
+    {
+        self.message = message
+        self.refusalReason = refusalReason
+    }
 }

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/TypeTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/TypeTool.swift
@@ -15,11 +15,12 @@ public struct TypeTool: MCPTool {
 
     public var description: String {
         """
-        Types text into UI elements or a targeted app process.
+        Types text into UI elements, a targeted app process, or one exact background window.
         Supports human typing (--wpm) or fixed-delay (--delay) pacing. Use `press` for key presses and chords.
         Background delivery requires an element/snapshot/app/pid target. Set `foreground=true` for intentional input
         at the current keyboard focus or when the app must be focused first. app and pid are alternatives; provide at
-        most one window selector, and pair window_title/window_index with app or pid.
+        most one window selector, and pair window_title/window_index with app or pid. A process target with one
+        eligible window is upgraded to exact-window delivery; multiple eligible windows are refused.
         \(PeekabooMCPVersion.banner) using openai/gpt-5.6
         and anthropic/claude-opus-5
         """
@@ -52,11 +53,12 @@ public struct TypeTool: MCPTool {
                     description: "Optional. Target app name/bundle ID, or 'PID:<n>' for background typing."),
                 "pid": SchemaBuilder.integer(
                     description: "Optional. Target process ID for background typing when no element snapshot is used."),
-                "window_id": SchemaBuilder.integer(description: "Optional. Window ID; requires foreground=true."),
+                "window_id": SchemaBuilder.integer(
+                    description: "Optional. Exact background window ID; foreground=true focuses it instead."),
                 "window_title": SchemaBuilder
-                    .string(description: "Optional. Window title (substring match); requires foreground=true."),
+                    .string(description: "Optional. Exact window title substring; must resolve uniquely."),
                 "window_index": SchemaBuilder
-                    .integer(description: "Optional. Window index (0-based); requires app/pid and foreground=true."),
+                    .integer(description: "Optional. Window index (0-based); requires app/pid."),
             ],
             required: [])
     }
@@ -84,15 +86,15 @@ public struct TypeTool: MCPTool {
                 for: failure,
                 uiSnapshots: self.context.uiSnapshots,
                 snapshotID: mutationTracker.snapshotId,
-                additionalFields: mutationTracker.characterCompatibilityFields)
+                additionalFields: mutationTracker.compatibilityFields)
         } catch let error as InputDeliveryIndeterminateError {
+            var additionalFields = mutationTracker.targetFields
+            additionalFields["characters_typed"] = mutationTracker.charactersTyped.map(Value.int) ?? .null
             return try await MCPDesktopActionFailureHandler.response(
                 for: error.desktopActionFailure(delivery: mutationTracker.delivery),
                 uiSnapshots: self.context.uiSnapshots,
                 snapshotID: mutationTracker.snapshotId,
-                additionalFields: [
-                    "characters_typed": mutationTracker.charactersTyped.map(Value.int) ?? .null,
-                ])
+                additionalFields: additionalFields)
         } catch {
             self.logger.error("Type execution failed: \(error)")
             return ToolResponse.error("Failed to type text: \(error.localizedDescription)")
@@ -162,13 +164,19 @@ public struct TypeTool: MCPTool {
             for: request,
             targetContext: targetContext)
 
-        let targetProcessIdentity = try await self.backgroundProcessIdentity(
+        let plannedTarget = try await self.backgroundKeyboardTarget(
             request: request,
             snapshot: snapshotContext)
-        let targetProcessIdentifier = targetProcessIdentity.map { Int($0.processIdentifier) }
+        let targetProcessIdentifier = plannedTarget?.processIdentifier.map(Int.init)
+        let targetWindowID = plannedTarget?.exactWindow?.identity.windowID
         let actions = try self.buildActions(for: request)
         let effectiveSnapshotId = snapshotContext?.id
         mutationTracker.snapshotId = effectiveSnapshotId
+        mutationTracker.targetWindowId = targetWindowID
+        try self.preflightBackgroundType(
+            target: plannedTarget,
+            requiresElementFocus: targetContext != nil,
+            automation: automation)
 
         let focusResult: TypeFocusResult
         do {
@@ -176,7 +184,7 @@ public struct TypeTool: MCPTool {
                 targetContext: targetContext,
                 request: request,
                 automation: automation,
-                targetProcessIdentity: targetProcessIdentity)
+                target: plannedTarget)
         } catch let failure as DesktopActionFailure {
             throw failure
         } catch let error as InputDeliveryIndeterminateError {
@@ -203,13 +211,16 @@ public struct TypeTool: MCPTool {
             if focusResult.completed {
                 try await Task.sleep(nanoseconds: 100_000_000)
             }
-            if let targetProcessIdentity {
+            if let plannedTarget {
+                let deliveryTarget = try await self.pinningCurrentFocusedElement(
+                    on: plannedTarget,
+                    using: automation)
                 typeActionResult = try await self.performBackgroundType(
                     request: BackgroundTypeRequest(
                         actions: actions,
                         cadence: request.cadence,
                         snapshotId: effectiveSnapshotId,
-                        expectedProcessIdentity: targetProcessIdentity),
+                        target: deliveryTarget),
                     automation: automation,
                     mutationTracker: mutationTracker)
             } else {
@@ -283,6 +294,7 @@ public struct TypeTool: MCPTool {
             request: request,
             targetContext: targetContext,
             targetProcessIdentifier: targetProcessIdentifier,
+            targetWindowID: targetWindowID,
             snapshotID: effectiveSnapshotId,
             startedAt: startTime,
             actionResult: typeActionResult,
@@ -316,6 +328,9 @@ public struct TypeTool: MCPTool {
         if let targetProcessIdentifier = input.targetProcessIdentifier {
             baseMetaDict["target_pid"] = .int(targetProcessIdentifier)
         }
+        if let targetWindowID = input.targetWindowID {
+            baseMetaDict["target_window_id"] = .int(targetWindowID)
+        }
         if let invalidatedSnapshotId {
             baseMetaDict["invalidated_snapshot"] = .string(invalidatedSnapshotId)
         }
@@ -343,14 +358,63 @@ public struct TypeTool: MCPTool {
     }
 
     @MainActor
+    private func pinningCurrentFocusedElement(
+        on target: UIAutomationTarget,
+        using automation: any UIAutomationServiceProtocol) async throws -> UIAutomationTarget
+    {
+        guard target.exactWindow != nil else { return target }
+        do {
+            return try await target.pinningCurrentFocusedElement(using: automation)
+        } catch {
+            throw TypeToolValidationError(
+                error.localizedDescription,
+                refusalReason: .targetUnavailable)
+        }
+    }
+
+    @MainActor
+    private func preflightBackgroundType(
+        target: UIAutomationTarget?,
+        requiresElementFocus: Bool,
+        automation: any UIAutomationServiceProtocol) throws
+    {
+        guard target?.exactWindow != nil else { return }
+        do {
+            _ = try ExactWindowKeyboardRuntime.requireOutcomeProvider(
+                automation: automation,
+                operation: "Background typing")
+        } catch {
+            throw TypeToolValidationError(
+                error.localizedDescription,
+                refusalReason: .runtimeIncompatible)
+        }
+        guard automation is any TargetedFocusedElementServiceProtocol else {
+            throw TypeToolValidationError(
+                "This automation host does not support focused exact-window background typing.",
+                refusalReason: .runtimeIncompatible)
+        }
+        guard requiresElementFocus else { return }
+        guard let targetedClick = automation as? any TargetedClickServiceProtocol,
+              targetedClick.supportsTargetedClicks,
+              targetedClick.supportsProcessGenerationPinnedClicks,
+              let exactClick = automation as? any ExactWindowTargetedClickServiceProtocol,
+              exactClick.supportsExactWindowTargetedClicks
+        else {
+            throw TypeToolValidationError(
+                "This automation host does not support exact-window background element focus.",
+                refusalReason: .runtimeIncompatible)
+        }
+    }
+
+    @MainActor
     private func focusIfNeeded(
         targetContext: TargetElementContext?,
         request: TypeRequest,
         automation: any UIAutomationServiceProtocol,
-        targetProcessIdentity: ApplicationProcessIdentity?) async throws -> TypeFocusResult
+        target: UIAutomationTarget?) async throws -> TypeFocusResult
     {
         guard let context = targetContext else {
-            if targetProcessIdentity == nil {
+            if target == nil {
                 let focusedTarget = try await request.target.focusIfRequested(
                     windows: self.context.windows,
                     onlyWhenTargeted: true)
@@ -360,7 +424,7 @@ public struct TypeTool: MCPTool {
         }
 
         let element = context.element
-        if let targetProcessIdentity, !request.foreground {
+        if let target, !request.foreground {
             guard let automation = automation as? any TargetedClickServiceProtocol,
                   automation.supportsTargetedClicks,
                   automation.supportsProcessGenerationPinnedClicks
@@ -369,12 +433,43 @@ public struct TypeTool: MCPTool {
                     "This automation host does not support background element focus.",
                     refusalReason: .runtimeIncompatible)
             }
+            if let exactWindow = target.exactWindow {
+                guard let exactAutomation = automation as? any ExactWindowTargetedClickServiceProtocol,
+                      exactAutomation.supportsExactWindowTargetedClicks
+                else {
+                    throw TypeToolValidationError(
+                        "This automation host does not support exact-window background element focus.",
+                        refusalReason: .runtimeIncompatible)
+                }
+                if let outcomeAutomation = automation as? any UIAutomationActionOutcomeProviding {
+                    let result = try await outcomeAutomation.clickWithOutcome(
+                        target: .elementId(element.id),
+                        clickType: .single,
+                        snapshotId: context.snapshot.id,
+                        expectedWindowIdentity: exactWindow.identity,
+                        expectedWindowBounds: exactWindow.bounds)
+                    try Self.requireConfirmedFocus(result.outcome)
+                    return .completed(outcome: result.outcome)
+                }
+                try await exactAutomation.click(
+                    target: .elementId(element.id),
+                    clickType: .single,
+                    snapshotId: context.snapshot.id,
+                    expectedWindowIdentity: exactWindow.identity,
+                    expectedWindowBounds: exactWindow.bounds)
+                return .completed(outcome: nil)
+            }
+            guard let processIdentity = target.processIdentity else {
+                throw TypeToolValidationError(
+                    "Background element focus has no process-generation receipt.",
+                    refusalReason: .targetUnavailable)
+            }
             if let outcomeAutomation = automation as? any UIAutomationActionOutcomeProviding {
                 let result = try await outcomeAutomation.clickWithOutcome(
                     target: .elementId(element.id),
                     clickType: .single,
                     snapshotId: context.snapshot.id,
-                    expectedProcessIdentity: targetProcessIdentity)
+                    expectedProcessIdentity: processIdentity)
                 try Self.requireConfirmedFocus(result.outcome)
                 return .completed(outcome: result.outcome)
             } else {
@@ -382,7 +477,7 @@ public struct TypeTool: MCPTool {
                     target: .elementId(element.id),
                     clickType: .single,
                     snapshotId: context.snapshot.id,
-                    expectedProcessIdentity: targetProcessIdentity)
+                    expectedProcessIdentity: processIdentity)
                 return .completed(outcome: nil)
             }
         } else if let outcomeAutomation = automation as? any UIAutomationActionOutcomeProviding {
@@ -411,33 +506,33 @@ public struct TypeTool: MCPTool {
         throw failure
     }
 
-    private func backgroundProcessIdentity(
+    private func backgroundKeyboardTarget(
         request: TypeRequest,
-        snapshot: UISnapshot?) async throws -> ApplicationProcessIdentity?
+        snapshot: UISnapshot?) async throws -> UIAutomationTarget?
     {
         guard !request.foreground else { return nil }
 
-        if request.target.hasTarget {
-            let identity = try await request.target.requireBackgroundProcessIdentity(
-                applications: self.context.applications,
-                windows: self.context.windows)
-            if let snapshot {
-                guard let snapshotIdentity = try await self.snapshotProcessIdentity(snapshot) else {
-                    throw TypeToolValidationError(
-                        "The selected snapshot has no capture-time process-generation receipt. " +
-                            "Capture fresh UI state.",
-                        refusalReason: .targetUnavailable)
-                }
-                guard snapshotIdentity == identity else {
-                    throw TypeToolValidationError(
-                        "The selected snapshot belongs to a different process generation. Capture fresh UI state.",
-                        refusalReason: .targetUnavailable)
-                }
-            }
-            return identity
+        let snapshotProcessIdentity = try await self.snapshotProcessIdentity(snapshot)
+        let snapshotExactWindow = try self.snapshotExactWindow(snapshot)
+        if request.target.hasTarget, snapshot != nil, snapshotProcessIdentity == nil {
+            throw TypeToolValidationError(
+                "The selected snapshot has no capture-time process-generation receipt. Capture fresh UI state.",
+                refusalReason: .targetUnavailable)
         }
-        if let identity = try await self.snapshotProcessIdentity(snapshot) {
-            return identity
+        if request.target.hasTarget || snapshotProcessIdentity != nil {
+            do {
+                return try await request.target.requireBackgroundKeyboardTarget(
+                    applications: self.context.applications,
+                    windows: self.context.windows,
+                    snapshotProcessIdentity: snapshotProcessIdentity,
+                    snapshotExactWindow: snapshotExactWindow)
+            } catch let error as MCPInteractionTargetError {
+                throw error
+            } catch {
+                throw TypeToolValidationError(
+                    error.localizedDescription,
+                    refusalReason: .targetUnavailable)
+            }
         }
         if snapshot != nil || request.elementId != nil || request.snapshotId != nil {
             throw TypeToolValidationError(
@@ -455,9 +550,38 @@ public struct TypeTool: MCPTool {
         automation: any UIAutomationServiceProtocol,
         mutationTracker: TypeMutationTracker) async throws -> UIAutomationActionResult<TypeResult>
     {
+        if let exactWindow = request.target.exactWindow {
+            let outcomeAutomation: any UIAutomationActionOutcomeProviding
+            do {
+                outcomeAutomation = try ExactWindowKeyboardRuntime.requireOutcomeProvider(
+                    automation: automation,
+                    operation: "Background typing")
+            } catch {
+                throw TypeToolValidationError(
+                    error.localizedDescription,
+                    refusalReason: .runtimeIncompatible)
+            }
+            guard let focusedElement = exactWindow.focusedElement else {
+                throw TypeToolValidationError(
+                    "Exact-window background typing requires a focused-element receipt.",
+                    refusalReason: .targetUnavailable)
+            }
+            mutationTracker.delivery = .init(mechanism: .windowTargetedEvents, mode: .background)
+            return try await ExactWindowKeyboardRuntime.validateRouteReceipt(
+                outcomeAutomation.typeActionsWithOutcome(
+                    request.actions,
+                    cadence: request.cadence,
+                    snapshotId: request.snapshotId,
+                    target: ExactWindowKeyboardTarget(
+                        windowIdentity: exactWindow.identity,
+                        windowBounds: exactWindow.bounds,
+                        focusedElement: focusedElement)),
+                operation: "Background typing")
+        }
         guard let automation = automation as? any TargetedTypeServiceProtocol,
               automation.supportsTargetedTypeActions,
-              automation.supportsProcessGenerationPinnedTypeActions
+              automation.supportsProcessGenerationPinnedTypeActions,
+              let processIdentity = request.target.processIdentity
         else {
             throw TypeToolValidationError(
                 "This automation host does not support background typing.",
@@ -469,15 +593,34 @@ public struct TypeTool: MCPTool {
                 request.actions,
                 cadence: request.cadence,
                 snapshotId: request.snapshotId,
-                expectedProcessIdentity: request.expectedProcessIdentity)
+                expectedProcessIdentity: processIdentity)
         }
         return try await UIAutomationActionResult(
             payload: automation.typeActions(
                 request.actions,
                 cadence: request.cadence,
                 snapshotId: request.snapshotId,
-                expectedProcessIdentity: request.expectedProcessIdentity),
+                expectedProcessIdentity: processIdentity),
             outcome: nil)
+    }
+
+    private func snapshotExactWindow(_ snapshot: UISnapshot?) throws -> UIAutomationTarget.ExactWindow? {
+        guard let snapshot else { return nil }
+        guard snapshot.windowMutationIdentity != nil else { return nil }
+        guard let processIdentifier = snapshot.applicationProcessId,
+              processIdentifier > 0,
+              let windowID = snapshot.windowID,
+              let bounds = snapshot.windowBounds,
+              let identity = snapshot.windowMutationIdentity,
+              identity.ownerProcessIdentifier == processIdentifier,
+              identity.windowID == windowID,
+              identity.capturedBounds == bounds
+        else {
+            throw TypeToolValidationError(
+                "The selected snapshot has inconsistent process/window metadata.",
+                refusalReason: .targetUnavailable)
+        }
+        return try UIAutomationTarget.ExactWindow(identity: identity, bounds: bounds)
     }
 
     private func snapshotProcessIdentity(_ snapshot: UISnapshot?) async throws -> ApplicationProcessIdentity? {
@@ -547,10 +690,18 @@ private final class TypeMutationTracker {
     var delivery: DesktopActionOutcome.Delivery?
     var charactersTyped: Int?
     var reportsCharactersTyped = false
+    var targetWindowId: Int?
 
-    var characterCompatibilityFields: [String: Value] {
-        guard self.reportsCharactersTyped else { return [:] }
-        return ["characters_typed": self.charactersTyped.map(Value.int) ?? .null]
+    var targetFields: [String: Value] {
+        self.targetWindowId.map { ["target_window_id": .int($0)] } ?? [:]
+    }
+
+    var compatibilityFields: [String: Value] {
+        var fields = self.targetFields
+        if self.reportsCharactersTyped {
+            fields["characters_typed"] = self.charactersTyped.map(Value.int) ?? .null
+        }
+        return fields
     }
 }
 
@@ -569,13 +720,14 @@ private struct BackgroundTypeRequest {
     let actions: [TypeAction]
     let cadence: TypingCadence
     let snapshotId: String?
-    let expectedProcessIdentity: ApplicationProcessIdentity
+    let target: UIAutomationTarget
 }
 
 private struct TypeSuccessInput {
     let request: TypeRequest
     let targetContext: TargetElementContext?
     let targetProcessIdentifier: Int?
+    let targetWindowID: Int?
     let snapshotID: String?
     let startedAt: Date
     let actionResult: UIAutomationActionResult<TypeResult>

--- a/Core/PeekabooCore/Tests/PeekabooAgentRuntimeTests/MCPToolExecutionPolicyTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooAgentRuntimeTests/MCPToolExecutionPolicyTests.swift
@@ -26,6 +26,7 @@ struct MCPToolExecutionPolicyTests {
             .init(tool: "press", arguments: [:]),
             .init(tool: "press", arguments: ["foreground": false]),
             .init(tool: "press", arguments: ["foreground": true]),
+            .init(tool: "press", arguments: ["window_id": 42]),
             .init(tool: "paste", arguments: ["foreground": true]),
             .init(tool: "paste", arguments: ["foreground": false, "window_id": 42]),
             .init(tool: "image", arguments: ["capture_focus": "foreground"]),
@@ -117,6 +118,7 @@ struct MCPToolExecutionPolicyTests {
             .init(tool: "verify_state", arguments: [:]),
             .init(tool: "click", arguments: ["foreground": false]),
             .init(tool: "type", arguments: ["foreground": false]),
+            .init(tool: "press", arguments: ["snapshot": "exact-window"]),
             .init(tool: "action", arguments: ["action": "AXPress"]),
             .init(tool: "set_value", arguments: [:]),
             .init(tool: "image", arguments: [:]),
@@ -316,6 +318,7 @@ struct MCPToolExecutionPolicyTests {
         let snapshots = InMemorySnapshotManager(detectionResult: detectionResult)
         let services = PeekabooServices(snapshotManager: snapshots)
         let context = MCPToolContext(services: services, executionPolicy: .backgroundOnly)
+        let pressCapture = PolicySnapshotArgumentCapture()
 
         let response = try await context.execute(
             tool: ActionTool(context: context),
@@ -324,8 +327,16 @@ struct MCPToolExecutionPolicyTests {
                 "action": "AXPress",
                 "snapshot": snapshotID,
             ]))
+        let pressResponse = try await context.execute(
+            tool: PolicySnapshotProbeTool(name: "press", capture: pressCapture),
+            arguments: ToolArguments(raw: [
+                "keys": ["return"],
+                "snapshot": snapshotID,
+            ]))
 
         #expect(response.isError)
+        #expect(pressResponse.isError)
+        #expect(await pressCapture.callCount == 0)
         guard case let .object(meta)? = response.meta else {
             Issue.record("Missing structured Dock policy refusal metadata")
             return
@@ -430,6 +441,7 @@ struct MCPToolExecutionPolicyTests {
         let toolSnapshot = await UISnapshotManager.shared.createSnapshot(id: snapshotID)
         await toolSnapshot.setTargetMetadata(from: windowContext)
         let capture = PolicySnapshotArgumentCapture()
+        let pressCapture = PolicySnapshotArgumentCapture()
 
         let response = try await context.execute(
             tool: PolicySnapshotProbeTool(name: "click", capture: capture),
@@ -468,6 +480,25 @@ struct MCPToolExecutionPolicyTests {
                 "text": "hello",
                 "app": "TextEdit",
             ]))
+        let exactPressResponse = try await context.execute(
+            tool: PolicySnapshotProbeTool(name: "press", capture: pressCapture),
+            arguments: ToolArguments(raw: [
+                "keys": ["return"],
+                "snapshot": snapshotID,
+            ]))
+        let mixedPressResponse = try await context.execute(
+            tool: PolicySnapshotProbeTool(name: "press", capture: pressCapture),
+            arguments: ToolArguments(raw: [
+                "keys": ["return"],
+                "snapshot": snapshotID,
+                "app": "TextEdit",
+            ]))
+        let windowOnlyPressResponse = try await context.execute(
+            tool: PolicySnapshotProbeTool(name: "press", capture: pressCapture),
+            arguments: ToolArguments(raw: [
+                "keys": ["return"],
+                "window_id": 702,
+            ]))
         try await snapshots.storeDetectionResult(
             snapshotId: snapshotID,
             result: ElementDetectionResult(
@@ -487,6 +518,12 @@ struct MCPToolExecutionPolicyTests {
                 "action": "AXPress",
                 "snapshot": snapshotID,
             ]))
+        let dialogPressResponse = try await context.execute(
+            tool: PolicySnapshotProbeTool(name: "press", capture: pressCapture),
+            arguments: ToolArguments(raw: [
+                "keys": ["return"],
+                "snapshot": snapshotID,
+            ]))
         await UISnapshotManager.shared.removeSnapshot(id: snapshotID)
 
         #expect(response.isError)
@@ -495,7 +532,12 @@ struct MCPToolExecutionPolicyTests {
         #expect(missingReceiptResponse.isError)
         #expect(mixedTypeResponse.isError)
         #expect(processTypeResponse.isError)
+        #expect(!exactPressResponse.isError)
+        #expect(mixedPressResponse.isError)
+        #expect(windowOnlyPressResponse.isError)
         #expect(genericDialogResponse.isError)
+        #expect(dialogPressResponse.isError)
+        #expect(await pressCapture.callCount == 1)
         #expect(await capture.snapshotID == nil)
         guard case let .object(meta)? = response.meta else {
             Issue.record("Missing selector-conflict refusal metadata")
@@ -629,8 +671,10 @@ private actor PolicyInvocationCounter {
 private actor PolicySnapshotArgumentCapture {
     private(set) var snapshotID: String?
     private(set) var coordinateReference: String?
+    private(set) var callCount = 0
 
     func record(snapshotID: String?, coordinateReference: String?) {
+        self.callCount += 1
         self.snapshotID = snapshotID
         self.coordinateReference = coordinateReference
     }

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPExactWindowKeyboardToolTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPExactWindowKeyboardToolTests.swift
@@ -42,6 +42,22 @@ struct MCPExactWindowKeyboardToolTests {
     }
 
     @Test
+    func `Press target resolution cancellation is not projected as a target refusal`() async throws {
+        let fixture = await Self.makeFixture(
+            focusedWindowID: 42,
+            cancelWindowListing: true)
+        let response = try await PressTool(context: fixture.context).execute(arguments: ToolArguments(raw: [
+            "window_id": 42,
+            "keys": ["cmd+l"],
+        ]))
+
+        #expect(response.isError)
+        #expect(response.meta == nil)
+        #expect(await MainActor.run { fixture.automation.exactHotkeyCalls.isEmpty })
+        #expect(await MainActor.run { fixture.automation.lastHotkeyKeys } == nil)
+    }
+
+    @Test
     func `Type app target upgrades one eligible window and refuses ambiguity`() async throws {
         let one = await Self.makeFixture(focusedWindowID: 42)
         let success = try await TypeTool(context: one.context).execute(arguments: ToolArguments(raw: [
@@ -95,6 +111,7 @@ struct MCPExactWindowKeyboardToolTests {
         focusedWindowID: Int?,
         windows: [ServiceWindowInfo] = [Self.keyboardWindow(id: 42, index: 0)],
         backgroundOnly: Bool = false,
+        cancelWindowListing: Bool = false,
         snapshots: (any SnapshotManagerProtocol)? = nil) async
         -> (context: MCPToolContext, automation: ExactKeyboardAutomationService)
     {
@@ -118,7 +135,9 @@ struct MCPExactWindowKeyboardToolTests {
         let context = await MCPToolTestHelpers.makeContext(
             automation: automation,
             applications: applications,
-            windows: ExactKeyboardWindowService(windows: windows),
+            windows: ExactKeyboardWindowService(
+                windows: windows,
+                cancelWindowListing: cancelWindowListing),
             snapshots: snapshots,
             snapshotOwner: Self.uiSnapshots.owner,
             executionPolicy: backgroundOnly ? .backgroundOnly : .unrestricted)
@@ -243,9 +262,11 @@ private final class ExactKeyboardAutomationService: MockAutomationService,
 
 private actor ExactKeyboardWindowService: WindowManagementServiceProtocol {
     let windows: [ServiceWindowInfo]
+    let cancelWindowListing: Bool
 
-    init(windows: [ServiceWindowInfo]) {
+    init(windows: [ServiceWindowInfo], cancelWindowListing: Bool = false) {
         self.windows = windows
+        self.cancelWindowListing = cancelWindowListing
     }
 
     func closeWindow(target _: WindowTarget) async throws {}
@@ -257,7 +278,10 @@ private actor ExactKeyboardWindowService: WindowManagementServiceProtocol {
     func focusWindow(target _: WindowTarget) async throws {}
 
     func listWindows(target: WindowTarget) async throws -> [ServiceWindowInfo] {
-        switch target {
+        if self.cancelWindowListing {
+            throw CancellationError()
+        }
+        return switch target {
         case let .windowId(windowID): self.windows.filter { $0.windowID == windowID }
         case let .title(title), let .applicationAndTitle(_, title):
             self.windows.filter { $0.title.localizedCaseInsensitiveContains(title) }

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPExactWindowKeyboardToolTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPExactWindowKeyboardToolTests.swift
@@ -1,0 +1,272 @@
+import CoreGraphics
+import PeekabooAutomationKit
+import PeekabooAutomationKitTestSupport
+import PeekabooFoundation
+import TachikomaMCP
+import Testing
+@testable import PeekabooAgentRuntime
+@testable import PeekabooCore
+
+@Suite(.serialized)
+struct MCPExactWindowKeyboardToolTests {
+    private static let uiSnapshots = MCPToolUISnapshotStore(owner: MCPToolSnapshotOwner())
+
+    @Test
+    func `Press exact window pins focused element and never uses global delivery`() async throws {
+        let fixture = await Self.makeFixture(focusedWindowID: 42)
+        let response = try await PressTool(context: fixture.context).execute(arguments: ToolArguments(raw: [
+            "window_id": 42,
+            "keys": ["cmd+l"],
+        ]))
+
+        #expect(!response.isError)
+        let call = try #require(await MainActor.run { fixture.automation.exactHotkeyCalls.first })
+        #expect(call.target.windowIdentity.windowID == 42)
+        #expect(call.target.focusedElement.identifier == "editor")
+        #expect(await MainActor.run { fixture.automation.lastHotkeyKeys } == nil)
+        #expect(await MainActor.run { fixture.automation.targetedHotkeyCalls.isEmpty })
+    }
+
+    @Test
+    func `Press exact window refuses focused owner drift without dispatch`() async throws {
+        let fixture = await Self.makeFixture(focusedWindowID: 41)
+        let response = try await PressTool(context: fixture.context).execute(arguments: ToolArguments(raw: [
+            "window_id": 42,
+            "keys": ["cmd+l"],
+        ]))
+
+        #expect(response.isError)
+        #expect(response.meta?.objectValue?["refusal_reason"] == .string("target_unavailable"))
+        #expect(await MainActor.run { fixture.automation.exactHotkeyCalls.isEmpty })
+        #expect(await MainActor.run { fixture.automation.lastHotkeyKeys } == nil)
+    }
+
+    @Test
+    func `Type app target upgrades one eligible window and refuses ambiguity`() async throws {
+        let one = await Self.makeFixture(focusedWindowID: 42)
+        let success = try await TypeTool(context: one.context).execute(arguments: ToolArguments(raw: [
+            "app": "Editor",
+            "text": "hello",
+        ]))
+
+        #expect(!success.isError)
+        let call = try #require(await MainActor.run { one.automation.exactTypeCalls.first })
+        #expect(call.target.windowIdentity.windowID == 42)
+        #expect(call.target.focusedElement.identifier == "editor")
+        #expect(success.meta?.objectValue?["target_window_id"] == .int(42))
+
+        let ambiguous = await Self.makeFixture(
+            focusedWindowID: nil,
+            windows: [Self.keyboardWindow(id: 41, index: 0), Self.keyboardWindow(id: 42, index: 1)])
+        let refusal = try await TypeTool(context: ambiguous.context).execute(arguments: ToolArguments(raw: [
+            "app": "Editor",
+            "text": "hello",
+        ]))
+
+        #expect(refusal.isError)
+        #expect(refusal.meta?.objectValue?["refusal_reason"] == .string("target_unavailable"))
+        #expect(await MainActor.run { ambiguous.automation.exactTypeCalls.isEmpty })
+        #expect(await MainActor.run { ambiguous.automation.targetedTypeActionsCalls.isEmpty })
+    }
+
+    @Test
+    func `Background-only exact snapshot press reaches the exact leaf`() async throws {
+        let snapshot = await Self.makeSnapshot(window: Self.keyboardWindow(id: 42, index: 0))
+        let fixture = await Self.makeFixture(
+            focusedWindowID: 42,
+            backgroundOnly: true,
+            snapshots: InMemorySnapshotManager(detectionResult: snapshot.detectionResult))
+
+        let response = try await fixture.context.execute(
+            tool: PressTool(context: fixture.context),
+            arguments: ToolArguments(raw: [
+                "snapshot": snapshot.id,
+                "keys": ["cmd+l"],
+            ]))
+
+        #expect(!response.isError)
+        let call = try #require(await MainActor.run { fixture.automation.exactHotkeyCalls.first })
+        #expect(call.target.windowIdentity.windowID == 42)
+        #expect(await MainActor.run { fixture.automation.lastHotkeyKeys } == nil)
+        await Self.uiSnapshots.removeSnapshot(id: snapshot.id)
+    }
+
+    private static func makeFixture(
+        focusedWindowID: Int?,
+        windows: [ServiceWindowInfo] = [Self.keyboardWindow(id: 42, index: 0)],
+        backgroundOnly: Bool = false,
+        snapshots: (any SnapshotManagerProtocol)? = nil) async
+        -> (context: MCPToolContext, automation: ExactKeyboardAutomationService)
+    {
+        let automation = await MainActor.run {
+            let service = ExactKeyboardAutomationService(accessibilityGranted: true)
+            service.uiAutomationOutcomeScript.setDefaultOutcome(.confirmedChange(delivery: .init(
+                mechanism: .windowTargetedEvents,
+                mode: .background)))
+            if let focusedWindowID {
+                service.focusedElementsByPID[333] = Self.focusInfo(windowID: focusedWindowID)
+            }
+            return service
+        }
+        let applications = await MainActor.run {
+            MockApplicationService(applications: [AutomationTestFixtures.application(
+                processIdentifier: 333,
+                processStartIdentity: 33,
+                bundleIdentifier: "com.example.editor",
+                name: "Editor")])
+        }
+        let context = await MCPToolTestHelpers.makeContext(
+            automation: automation,
+            applications: applications,
+            windows: ExactKeyboardWindowService(windows: windows),
+            snapshots: snapshots,
+            snapshotOwner: Self.uiSnapshots.owner,
+            executionPolicy: backgroundOnly ? .backgroundOnly : .unrestricted)
+        return (context, automation)
+    }
+
+    private static func keyboardWindow(id: Int, index: Int) -> ServiceWindowInfo {
+        let bounds = CGRect(x: CGFloat(index * 500), y: 0, width: 480, height: 360)
+        return ServiceWindowInfo(
+            windowID: id,
+            title: "Document \(index + 1)",
+            bounds: bounds,
+            index: index,
+            mutationIdentity: WindowMutationIdentity(
+                windowID: id,
+                ownerProcessIdentifier: 333,
+                ownerProcessStartIdentity: 33,
+                capturedBounds: bounds))
+    }
+
+    private static func focusInfo(windowID: Int) -> UIFocusInfo {
+        UIFocusInfo(
+            role: "AXTextField",
+            title: "Editor",
+            value: nil,
+            frame: CGRect(x: 20, y: 20, width: 100, height: 30),
+            applicationName: "Editor",
+            bundleIdentifier: "com.example.editor",
+            processId: 333,
+            windowID: windowID,
+            identifier: "editor")
+    }
+
+    private static func makeSnapshot(window: ServiceWindowInfo) async
+        -> (id: String, detectionResult: ElementDetectionResult)
+    {
+        await self.uiSnapshots.removeAllSnapshots()
+        let snapshot = await self.uiSnapshots.createSnapshot()
+        let snapshotID = await snapshot.id
+        await snapshot.setScreenshot(
+            path: "/tmp/exact-keyboard.png",
+            metadata: CaptureMetadata(
+                size: window.bounds.size,
+                mode: .window,
+                applicationInfo: AutomationTestFixtures.application(
+                    processIdentifier: 333,
+                    processStartIdentity: 33,
+                    bundleIdentifier: "com.example.editor",
+                    name: "Editor"),
+                windowInfo: window))
+        let windowContext = WindowContext(
+            applicationName: "Editor",
+            applicationBundleId: "com.example.editor",
+            applicationProcessId: 333,
+            windowTitle: window.title,
+            windowID: window.windowID,
+            windowBounds: window.bounds,
+            windowMutationIdentity: window.mutationIdentity)
+        return (
+            snapshotID,
+            ElementDetectionResult(
+                snapshotId: snapshotID,
+                screenshotPath: "/tmp/exact-keyboard.png",
+                elements: DetectedElements(),
+                metadata: DetectionMetadata(
+                    detectionTime: 0.01,
+                    elementCount: 0,
+                    method: "test",
+                    windowContext: windowContext)))
+    }
+}
+
+@MainActor
+private final class ExactKeyboardAutomationService: MockAutomationService,
+    ExactWindowTargetedKeyboardServiceProtocol,
+    ScriptedUIAutomationActionOutcomeProviding,
+    TargetedFocusedElementServiceProtocol
+{
+    struct TypeCall {
+        let target: ExactWindowKeyboardTarget
+    }
+
+    struct HotkeyCall {
+        let keys: String
+        let target: ExactWindowKeyboardTarget
+    }
+
+    let supportsExactWindowTargetedKeyboard = true
+    let exactWindowTargetedKeyboardUnavailableReason: String? = nil
+    let uiAutomationOutcomeScript = UIAutomationOutcomeScript()
+    var focusedElementsByPID: [pid_t: UIFocusInfo] = [:]
+    private(set) var exactTypeCalls: [TypeCall] = []
+    private(set) var exactHotkeyCalls: [HotkeyCall] = []
+
+    func getFocusedElement(targetProcessIdentifier: pid_t) async -> UIFocusInfo? {
+        self.focusedElementsByPID[targetProcessIdentifier]
+    }
+
+    func typeActions(
+        _ actions: [TypeAction],
+        cadence _: TypingCadence,
+        snapshotId _: String?,
+        target: ExactWindowKeyboardTarget) async throws -> TypeResult
+    {
+        self.exactTypeCalls.append(TypeCall(target: target))
+        let characterCount = actions.reduce(into: 0) { count, action in
+            if case let .text(text) = action {
+                count += text.count
+            }
+        }
+        return TypeResult(totalCharacters: characterCount, keyPresses: 0)
+    }
+
+    func hotkey(
+        keys: String,
+        holdDuration _: Int,
+        target: ExactWindowKeyboardTarget) async throws
+    {
+        self.exactHotkeyCalls.append(HotkeyCall(keys: keys, target: target))
+    }
+}
+
+private actor ExactKeyboardWindowService: WindowManagementServiceProtocol {
+    let windows: [ServiceWindowInfo]
+
+    init(windows: [ServiceWindowInfo]) {
+        self.windows = windows
+    }
+
+    func closeWindow(target _: WindowTarget) async throws {}
+    func minimizeWindow(target _: WindowTarget) async throws {}
+    func maximizeWindow(target _: WindowTarget) async throws {}
+    func moveWindow(target _: WindowTarget, to _: CGPoint) async throws {}
+    func resizeWindow(target _: WindowTarget, to _: CGSize) async throws {}
+    func setWindowBounds(target _: WindowTarget, bounds _: CGRect) async throws {}
+    func focusWindow(target _: WindowTarget) async throws {}
+
+    func listWindows(target: WindowTarget) async throws -> [ServiceWindowInfo] {
+        switch target {
+        case let .windowId(windowID): self.windows.filter { $0.windowID == windowID }
+        case let .title(title), let .applicationAndTitle(_, title):
+            self.windows.filter { $0.title.localizedCaseInsensitiveContains(title) }
+        case let .index(_, index): self.windows.filter { $0.index == index }
+        case .application, .frontmost: self.windows
+        }
+    }
+
+    func getFocusedWindow() async throws -> ServiceWindowInfo? {
+        self.windows.first
+    }
+}

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPKeyboardBackgroundToolTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPKeyboardBackgroundToolTests.swift
@@ -398,6 +398,11 @@ struct MCPKeyboardBackgroundToolTests {
         }
         let context = await MCPToolTestHelpers.makeContext(
             automation: automation,
+            applications: MockApplicationService(applications: [AutomationTestFixtures.application(
+                processIdentifier: 113,
+                processStartIdentity: 13,
+                bundleIdentifier: "com.example.snapshot",
+                name: "SnapshotApp")]),
             snapshotOwner: Self.uiSnapshots.owner)
         let snapshot = await Self.uiSnapshots.createSnapshot()
         let snapshotId = await snapshot.id
@@ -465,6 +470,11 @@ struct MCPKeyboardBackgroundToolTests {
         }
         let context = await MCPToolTestHelpers.makeContext(
             automation: automation,
+            applications: MockApplicationService(applications: [AutomationTestFixtures.application(
+                processIdentifier: 115,
+                processStartIdentity: 15,
+                bundleIdentifier: "com.example.snapshot",
+                name: "SnapshotApp")]),
             snapshotOwner: Self.uiSnapshots.owner)
         let snapshotId = await self.makeTypingSnapshot(
             processIdentifier: 115,
@@ -501,6 +511,11 @@ struct MCPKeyboardBackgroundToolTests {
         }
         let context = await MCPToolTestHelpers.makeContext(
             automation: automation,
+            applications: MockApplicationService(applications: [AutomationTestFixtures.application(
+                processIdentifier: 114,
+                processStartIdentity: 14,
+                bundleIdentifier: "com.example.snapshot",
+                name: "SnapshotApp")]),
             snapshotOwner: Self.uiSnapshots.owner)
         let snapshotId = await self.makeTypingSnapshot(
             processIdentifier: 114,

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPToolTestHelpers.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPToolTestHelpers.swift
@@ -25,12 +25,19 @@ enum MCPToolTestHelpers {
     {
         await MainActor.run {
             let services = PeekabooServices()
+            let resolvedWindows: any WindowManagementServiceProtocol = if let windows {
+                windows
+            } else if applications != nil {
+                EmptyRecordingWindowService()
+            } else {
+                services.windows
+            }
             let resolvedScreens = screens ?? services.screens
             let resolvedSnapshots = snapshots ?? services.snapshots
             return MCPToolContext(
                 automation: automation ?? services.automation,
                 menu: services.menu,
-                windows: windows ?? services.windows,
+                windows: resolvedWindows,
                 applications: applications ?? services.applications,
                 dialogs: services.dialogs,
                 dock: services.dock,

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/PasteToolExactWindowTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/PasteToolExactWindowTests.swift
@@ -15,12 +15,24 @@ struct PasteToolExactWindowTests {
         windowID: 41,
         title: "First Document",
         bounds: CGRect(x: 10, y: 20, width: 500, height: 400),
-        index: 0)
+        index: 0,
+        mutationIdentity: AutomationTestFixtures.windowIdentity(
+            windowID: 41,
+            processIdentity: AutomationTestFixtures.processIdentity(
+                processIdentifier: 333,
+                processStartIdentity: 33),
+            bounds: CGRect(x: 10, y: 20, width: 500, height: 400)))
     private let secondWindow = ServiceWindowInfo(
         windowID: 42,
         title: "Second Document",
         bounds: CGRect(x: 600, y: 20, width: 500, height: 400),
-        index: 1)
+        index: 1,
+        mutationIdentity: AutomationTestFixtures.windowIdentity(
+            windowID: 42,
+            processIdentity: AutomationTestFixtures.processIdentity(
+                processIdentifier: 333,
+                processStartIdentity: 33),
+            bounds: CGRect(x: 600, y: 20, width: 500, height: 400)))
 
     @Test
     func `Exact title text paste keeps same-process sibling window identity`() async throws {
@@ -88,7 +100,7 @@ struct PasteToolExactWindowTests {
         ]))
 
         #expect(response.isError)
-        #expect(self.responseText(response).contains("atomic exact-window background paste"))
+        #expect(self.responseText(response).contains("requires atomic exact-window keyboard delivery"))
         #expect(await MainActor.run { fixture.clipboard.saveCallCount } == 0)
         #expect(await MainActor.run { fixture.clipboard.setCallCount } == 0)
         #expect(await MainActor.run { fixture.automation.targetedHotkeyCalls.isEmpty })
@@ -106,7 +118,7 @@ struct PasteToolExactWindowTests {
         ]))
 
         #expect(response.isError)
-        #expect(self.responseText(response).contains("atomic exact-window background paste"))
+        #expect(self.responseText(response).contains("requires atomic exact-window keyboard delivery"))
         #expect(await MainActor.run { fixture.clipboard.setCallCount } == 0)
         #expect(await MainActor.run { fixture.automation.targetedHotkeyCalls.isEmpty })
         #expect(await MainActor.run { fixture.automation.lastHotkeyKeys } == nil)
@@ -117,6 +129,7 @@ struct PasteToolExactWindowTests {
     func `Exact window paste refuses an incomplete owner before dispatch`() async throws {
         let application = ServiceApplicationInfo(
             processIdentifier: 333,
+            processStartIdentity: 33,
             bundleIdentifier: nil,
             name: "Incomplete Editor",
             isHiddenKnown: false,
@@ -305,6 +318,7 @@ struct PasteToolExactWindowTests {
     {
         let application = application ?? ServiceApplicationInfo(
             processIdentifier: 333,
+            processStartIdentity: 33,
             bundleIdentifier: "com.example.editor",
             name: "Editor")
         let applications = MockApplicationService(applications: [application])
@@ -329,21 +343,7 @@ struct PasteToolExactWindowTests {
             applications: applications,
             windows: windows,
             clipboard: clipboard)
-        let identities = [self.firstWindow, self.secondWindow].reduce(
-            into: [CGWindowID: SystemWindowIdentity]())
-        { result, window in
-            result[CGWindowID(window.windowID)] = SystemWindowIdentity(
-                windowID: CGWindowID(window.windowID),
-                ownerProcessIdentifier: 333,
-                title: window.title,
-                bounds: window.bounds,
-                layer: 0,
-                alpha: 1,
-                isOnScreen: true,
-                sharingState: .readWrite,
-                applicationName: "Editor")
-        }
-        let tool = PasteTool(context: context) { identities[$0] }
+        let tool = PasteTool(context: context)
         return PasteExactWindowFixture(
             tool: tool,
             automation: automation,
@@ -400,7 +400,9 @@ private struct PasteExactWindowFixture {
 
 @MainActor
 private final class ExactPasteAutomationService: MockAutomationService,
-    ExactWindowTargetedKeyboardServiceProtocol
+    ExactWindowTargetedKeyboardServiceProtocol,
+    ScriptedUIAutomationActionOutcomeProviding,
+    TargetedFocusedElementServiceProtocol
 {
     struct TypeCall {
         let targetProcessIdentifier: pid_t
@@ -417,6 +419,10 @@ private final class ExactPasteAutomationService: MockAutomationService,
 
     let supportsExactWindowTargetedKeyboard = true
     let exactWindowTargetedKeyboardUnavailableReason: String? = nil
+    let uiAutomationOutcomeScript = UIAutomationOutcomeScript(defaultResponse: .outcome(
+        .confirmedChange(delivery: .init(
+            mechanism: .windowTargetedEvents,
+            mode: .background))))
     private(set) var exactTypeCalls: [TypeCall] = []
     private(set) var exactHotkeyCalls: [HotkeyCall] = []
     var typeErrorAfterPrefix: String?
@@ -459,6 +465,45 @@ private final class ExactPasteAutomationService: MockAutomationService,
             targetProcessIdentifier: expectedWindowIdentity.ownerProcessIdentifier,
             targetWindowID: expectedWindowIdentity.windowID,
             expectedWindowBounds: expectedWindowBounds))
+    }
+
+    func typeActions(
+        _ actions: [TypeAction],
+        cadence: TypingCadence,
+        snapshotId: String?,
+        target: ExactWindowKeyboardTarget) async throws -> TypeResult
+    {
+        try await self.typeActions(
+            actions,
+            cadence: cadence,
+            snapshotId: snapshotId,
+            expectedWindowIdentity: target.windowIdentity,
+            expectedWindowBounds: target.windowBounds)
+    }
+
+    func hotkey(
+        keys: String,
+        holdDuration: Int,
+        target: ExactWindowKeyboardTarget) async throws
+    {
+        try await self.hotkey(
+            keys: keys,
+            holdDuration: holdDuration,
+            expectedWindowIdentity: target.windowIdentity,
+            expectedWindowBounds: target.windowBounds)
+    }
+
+    func getFocusedElement(targetProcessIdentifier: pid_t) async -> UIFocusInfo? {
+        UIFocusInfo(
+            role: "AXTextArea",
+            title: nil,
+            value: nil,
+            frame: CGRect(x: 620, y: 50, width: 200, height: 100),
+            applicationName: "Editor",
+            bundleIdentifier: "com.example.editor",
+            processId: Int(targetProcessIdentifier),
+            windowID: 42,
+            identifier: "editor")
     }
 }
 

--- a/docs/commands/paste.md
+++ b/docs/commands/paste.md
@@ -19,15 +19,15 @@ This reduces drift by collapsing multiple CLI steps into one command. Plain text
 | `--data-base64` + `--uti` | Paste raw base64 payload with explicit UTI (e.g. `public.rtf`). |
 | `--also-text` | Optional plain-text companion when pasting binary. |
 | `--restore-delay <duration>` | Delay before restoring the previous clipboard (default `150ms`; bare values are milliseconds). |
-| Target flags | `--app <name>` or `--pid <pid>` for process-targeted background paste. Window selectors require `--foreground`. |
+| Target flags | `--app <name>`, `--pid <pid>`, or an exact window selector for background paste. |
 | `--foreground` | Focus a supplied target or intentionally send foreground/global Cmd+V. |
 | Focus flags | Foreground focus controls (`--space-switch`, `--no-auto-focus`, etc.). |
 
 ## Delivery modes
-- **Background** is the default when Peekaboo can resolve a target process from target flags or snapshot metadata. Plain text is delivered directly without touching the clipboard. Binary/rich content and current-clipboard requests still post process-targeted Cmd+V without activating the app, but macOS provides no receiver-consumption acknowledgement. Peekaboo therefore returns a nonzero, explicit “may have pasted; do not retry” result after the settle/restore transaction instead of claiming success. Observe the target before taking another action.
+- **Background** is the default when Peekaboo can resolve a target. Exact-window routes pin the process generation, window ID/bounds, and focused element. App/PID routes upgrade when one eligible window exists and refuse when several are eligible. Plain text is delivered directly without touching the clipboard. Binary/rich and current-clipboard requests remain receiver-unverifiable and return “may have pasted; do not retry” after cleanup.
 - **Foreground** (`--foreground`) focuses the target first and sends normal/global Cmd+V. Use it for apps that ignore background paste or for flows where focus should visibly move.
 - Without an app/PID target, `paste` fails before mutating the clipboard. Add `--foreground` only when global delivery is intentional.
-- Window selectors are rejected in background mode because process-targeted events cannot prove which window owns the process's focused element.
+- Exact window selectors stay exact through text or Cmd+V dispatch; focus, owner, generation, or bounds drift fails before clipboard access whenever no event has begun. Exact-window remote delivery requires Bridge protocol 1.24.
 - Process-targeted text and Cmd+V delivery retain the resolved app's process-generation receipt. Plain text revalidates before every emitted character, while clipboard-backed paste uses generation-pinned hotkey delivery. A target exit or relaunch never silently retargets the reusable PID. Remote background paste requires Bridge protocol 1.22 or newer.
 - Clipboard-backed transactions are serialized across CLI, daemon, and GUI processes with a private per-user lock under `~/Library/Application Support/Peekaboo`, independent of each process's temporary directory.
 - Target capability checks, cancellation checks, and the prior-clipboard snapshot must all succeed before Peekaboo writes a temporary payload. A read failure is never treated as an empty clipboard; if a write fails after partially changing the pasteboard, Peekaboo restores the exact saved state before returning the error.
@@ -42,7 +42,7 @@ peekaboo paste --foreground
 peekaboo paste "Hello, world" --app TextEdit
 
 # Paste rich text (RTF) into a specific window title
-peekaboo paste --data-base64 "$RTF_B64" --uti public.rtf --also-text "fallback" --app TextEdit --window-title "Untitled" --foreground
+peekaboo paste --data-base64 "$RTF_B64" --uti public.rtf --also-text "fallback" --app TextEdit --window-title "Untitled"
 
 # Paste a PNG into Notes with a confirmed foreground dispatch result
 peekaboo paste --file-path /tmp/snippet.png --app Notes --foreground

--- a/docs/commands/press.md
+++ b/docs/commands/press.md
@@ -7,7 +7,7 @@ read_when:
 
 # `peekaboo press`
 
-`press` sends raw xdotool `key`-style chords such as `cmd+c`, `cmd+shift+t`, and `Return`. Multiple positional chords form a sequence. Raw keys cannot certify semantic intent or effect on a shared desktop, so `--foreground` is required. For background automation, use a semantic `action`, `menu`, `window`, `app`, or `dialog` command with an exact target.
+`press` sends raw xdotool `key`-style chords such as `cmd+c`, `cmd+shift+t`, and `Return`. Multiple positional chords form a sequence. Raw keys require either `--foreground` or an exact window/snapshot receipt whose focused element stays unchanged through native background dispatch.
 
 ## Key options
 | Flag | Description |
@@ -17,18 +17,18 @@ read_when:
 | `--delay <duration>` | Delay between key presses (default `100ms`; bare values are milliseconds). |
 | `--hold <duration>` | Hold duration per key (default `50ms`; bare values are milliseconds). |
 | `--snapshot <id>` | Optional snapshot ID used for validation/focus (no implicit “latest snapshot” lookup). |
-| Target flags | `--app <name>`, `--pid <pid>`, or window selectors identify what to focus before foreground dispatch. |
-| `--foreground` | Required. Focus a supplied target or intentionally send foreground/global key presses. |
+| Target flags | An exact window selector enables receipt-pinned background press; app/PID-only targeting still requires `--foreground`. |
+| `--foreground` | Focus a supplied target or intentionally send foreground/global key presses. |
 | Focus flags | Foreground focus controls; same `FocusCommandOptions` bundle as `click`/`type`. |
 
 ## Delivery mode
-- **Background omission is fail-closed.** Without `--foreground`, `press` returns `effect: refused`, `mutation_dispatched: false`, and `retry_safe: true`. Supplying an app, PID, window, or snapshot does not turn a raw chord into certifiable background intent.
+- **Exact background** accepts only a fresh exact-window selector or snapshot. Peekaboo pins process generation, window ID/bounds, and focused-element identity; missing, ambiguous, or stale receipts refuse before dispatch. App/PID-only and targetless forms retain the canonical retry-safe refusal.
 - **Foreground** (`--foreground`) focuses a supplied target first and sends normal/global key presses. A dispatched chord remains `effect: unverifiable`; run a fresh observation before continuing.
-- Prefer named Accessibility actions and dedicated menu/window/app/dialog operations in background workflows. Peekaboo's internal receipt-pinned keyboard transport remains available to typed composite operations, but public raw `press` does not expose it as successful intent.
+- Prefer named Accessibility actions and dedicated menu/window/app/dialog operations in background workflows. Exact-window `press` exposes the receipt-pinned transport but still reports its semantic effect honestly.
 
 ## Implementation notes
 - Bare keys include Return, Tab, Escape, Delete/Forward Delete, arrows, navigation keys, F1-F12, letters/digits, Space, and standard punctuation. Comma- and space-delimited chord syntax is rejected.
-- Every background raw chord is rejected before dispatch, including app/PID/snapshot and window-targeted forms.
+- Background raw chords never collapse an exact selector to process delivery and never silently foreground. Exact-window remote delivery requires Bridge protocol 1.24.
 - Repetition multiplies the sequence client-side—e.g., `press tab return --count 3 --foreground` becomes six actions—so you get predictable ordering.
 - Results include the literal key list, total presses, repeat count, delivery mode, optional target PID, and elapsed time in both text and JSON modes.
 - The `--hold` flag is passed to the hotkey service for each key press.
@@ -49,6 +49,9 @@ peekaboo press return --app TextEdit --foreground
 
 # Reopen a browser tab with explicit foreground consent
 peekaboo press cmd+shift+t --app Safari --foreground
+
+# Send a chord to one already-focused exact window without activating it
+peekaboo press cmd+l --window-id 12345
 ```
 
 ## Troubleshooting

--- a/docs/commands/type.md
+++ b/docs/commands/type.md
@@ -18,24 +18,24 @@ read_when:
 | `--wpm <80-220>` | Enable human-typing cadence at the chosen words per minute. |
 | `--profile <linear|human>` | Switch between linear (default, honors `--delay`) and human (honors `--wpm`). |
 | `--clear` | Issue Cmd+A, Delete before typing any new text. |
-| Target flags | `--app <name>` or `--pid <pid>` for process-targeted background input. Window selectors require `--foreground`. |
+| Target flags | `--app <name>`, `--pid <pid>`, or an exact window selector for background input. |
 | `--foreground` | Focus a supplied target or intentionally send foreground/global keyboard input. |
 | Focus flags | Foreground focus controls (`--no-auto-focus`, `--space-switch`, etc.). |
 
 ## Delivery modes
-- **Background** is the default when Peekaboo can resolve a target process from target flags or snapshot metadata. It sends process-targeted keyboard events without activating the target app.
+- **Background** is the default when Peekaboo can resolve a target from flags or snapshot metadata. Exact window/snapshot routes pin the process generation, window ID/bounds, and focused element without activating the app. App/PID routes upgrade when one eligible window exists and refuse when several are eligible.
 - **Foreground** (`--foreground`) focuses the target first and sends normal/global keyboard input. Use it for apps or fields that only accept text in the focused key window, or when focus changes are desired.
 - If no target process can be resolved, `type` fails before sending input. Add `--foreground` only when global delivery is intentional.
 
 ## Implementation notes
 - Text may be omitted only when `--clear` is used. Chain a following `press` command for Return, Tab, Escape, or Delete.
 - Escape handling splits literal text and key presses: `"Hello\nWorld"` becomes `text("Hello"), key(.return), text("World")`, so newlines don’t require separate flags.
-- Window selectors are rejected in background mode because process-targeted events cannot prove which window owns the process's focused element. Use `--foreground` to focus that window first.
+- Exact window selectors and fresh exact-window snapshots preserve PID generation, window ID/bounds, and focused-element identity through dispatch. Stale or ambiguous receipts fail before typing.
 - Default profile is `linear`, using no inter-key delay for fast deterministic input. Passing `--wpm` opts into human cadence; `--profile human` uses 140 WPM when `--wpm` is omitted.
 - Background delivery uses process-targeted CoreGraphics keyboard events and requires Event Synthesizing access. Apps that only accept typing in a focused key window may still need `--foreground`.
 - Printable background text is carried as Unicode instead of physical US key positions, so the requested characters remain stable across active keyboard layouts.
-- Background app/PID delivery is pinned to the process generation resolved before dispatch. Peekaboo revalidates the receipt before every character or special action, stops on target exit/relaunch, and reports partial delivery as retry-unsafe. Remote delivery requires Bridge protocol 1.22 or newer.
-- JSON output reports `totalCharacters`, `keyPresses`, delivery mode, optional target PID, and elapsed time; this matches what the agent logs when executing scripted steps.
+- Background app/PID delivery is pinned to the process generation resolved before dispatch. Peekaboo revalidates the receipt before every character or special action, stops on target exit/relaunch, and reports partial delivery as retry-unsafe. Exact-window remote delivery requires Bridge protocol 1.24.
+- JSON output reports `totalCharacters`, `keyPresses`, delivery mode, optional target PID/window ID, and elapsed time; this matches what the agent logs when executing scripted steps.
 
 ## Examples
 ```bash

--- a/docs/security.md
+++ b/docs/security.md
@@ -42,7 +42,7 @@ The policy is checked centrally before lookup, turn-boundary bookkeeping, valida
 by model output or writable session JSON alone. Foreground authorization never exposes the Shell tool: normal Agent
 toolsets omit `shell`, and the execution boundary refuses it under both Agent policies. Foreground UI authority is not
 a process sandbox; a trusted prompt can operate terminal or scripting apps through their UI. Direct standalone CLI and
-MCP tools keep their existing explicit contracts. Background-only Agent sessions refuse raw `press`, persistent
+MCP tools keep their existing explicit contracts. Background-only Agent sessions refuse targetless/process-only raw `press`, persistent
 clipboard writes, dialog mutations, browser setup/fronting, and Space switch/follow while retaining dialog/Space
 listing and unfollowed window placement. Agent typing requires an exact non-dialog snapshot/element; Agent paste is
 refused until its ownership receipt can distinguish both dialogs and sheets. Process-only delivery cannot prove that
@@ -71,7 +71,7 @@ If you disable the `clipboard` tool via allow/deny filters, the injected DESKTOP
   Disable by clearing `PEEKABOO_AI_PROVIDERS`, removing API keys, or adding these names to your deny list when running offline.
 - **Medium risk** – can manipulate apps or data  
   - `capture`: records retained screen/window/region frames, contact sheets, metadata, and optional MP4 files. Disable it when MCP or agent clients should not persist screen contents.
-  - `click`, `type`, and `paste`: can trigger actions in foreground apps or target a background app when a target process is known. Background clicks use Accessibility; background typed delivery requires Event Synthesizing. Raw `press` always requires explicit `--foreground` consent.
+  - `click`, `type`, and `paste`: can trigger actions in foreground apps or target a background app when a safe receipt is known. Background clicks use Accessibility; background typed delivery requires Event Synthesizing. Raw `press` requires either an exact window/focused-element receipt or explicit `--foreground` consent.
   - `scroll`: targeted background scrolling is Accessibility-only. Targetless, smooth, and delayed scrolling require explicit foreground mode and Event Synthesizing.
   - `drag`, `move`: manipulate the shared physical cursor, require explicit foreground consent, and need Event Synthesizing.
   - `window`, `app`, `menu_click`, `dock_launch`, `space`: can close apps, move windows, switch spaces.  

--- a/docs/testing/exact-window-keyboard-contract.md
+++ b/docs/testing/exact-window-keyboard-contract.md
@@ -1,3 +1,10 @@
+---
+summary: 'Source-blind exact-window keyboard behavior contract'
+read_when:
+  - 'changing background type, paste, press, or keyboard target receipts'
+  - 'validating exact-window keyboard behavior without source access'
+---
+
 # Exact-window background keyboard behavior contract
 
 ## User-visible goal

--- a/docs/testing/exact-window-keyboard-contract.md
+++ b/docs/testing/exact-window-keyboard-contract.md
@@ -1,0 +1,49 @@
+# Exact-window background keyboard behavior contract
+
+## User-visible goal
+
+Peekaboo must deliver type, press, and paste to one exact background window without activating it, and must refuse before dispatch whenever that destination or its focused element is ambiguous, stale, or changed.
+
+## Target
+
+- Type: CLI and MCP tools
+- Access: a freshly built `peekaboo` plus mocked CLI/MCP fixtures
+- Allowed fixtures: two same-process windows, exact-window snapshots, focused-element receipts, and mock clipboard services only
+
+## User tasks
+
+1. Type or paste text into one exact window while another window from the same process exists.
+2. Send a raw chord with an exact window/snapshot receipt and no foreground flag.
+3. Attempt app/PID-only typing when multiple eligible windows exist.
+4. Attempt exact-window keyboard delivery after focused-element, window-owner, generation, or bounds drift.
+5. Use explicit foreground input and legacy process-only input where their established contracts still apply.
+
+## Expected observable behavior
+
+- Exact background success reports background delivery plus target PID and window ID, without application activation or global input.
+- Exact routes preserve the focused-element receipt through dispatch.
+- Multiple eligible same-process windows without an exact receipt fail before dispatch and request a window selector or fresh snapshot.
+- Process-only/app-only/targetless raw press remains a retry-safe, not-dispatched refusal.
+- Stale, incomplete, or contradictory receipts fail before any keyboard or clipboard mutation.
+- Plain-text paste does not read, write, clear, save, or restore the clipboard.
+- Clipboard-backed paste tests use only mocks; no validator step reads or mutates the ambient clipboard.
+- Exact Bridge routing uses the existing protocol 1.24 capability surface and never adds a compatibility fallback.
+
+## Anti-cheat probes
+
+- Change only the focused window ID and verify the exact request changes from success to no-dispatch refusal.
+- Add a same-process sibling window and verify app-only type changes from exact success to ambiguity refusal.
+- Remove the exact receipt and verify raw background press refuses rather than silently using process or foreground delivery.
+- Change owner generation/bounds and verify no exact keyboard call is recorded.
+
+## Evidence required
+
+- Structured CLI/MCP responses and recorded mock calls.
+- Focused unit/integration test output for the canonical target planner and all three keyboard tools.
+- Release build and native-only source scan.
+
+## Out of scope
+
+- Reading or mutating the user's ambient clipboard.
+- Claiming that macOS acknowledges the semantic effect of a raw chord or Cmd+V.
+- Broadening targetless/global input or automatically foregrounding an application.


### PR DESCRIPTION
## Summary

- centralize exact/process keyboard destination planning in `UIAutomationTarget`, including process generation, window ID/bounds, and focused-element receipts
- route CLI and MCP type, paste, and press through exact native/Bridge capabilities without foreground or process-wide fallback
- keep raw app/PID/targetless press fail-closed and allow background-only Agent press only from an authoritative exact non-dialog snapshot
- replace MCP Paste's duplicate target structs with the shared target and retain the existing canonical sequence, failure, projection, and snapshot owners

## Safety

- exact keyboard hosts must provide typed action outcomes and a window-targeted background delivery receipt
- ambiguous same-process app/PID targets refuse before dispatch
- exact paste capability/focus preflight completes before clipboard access
- no protocol bump, AppleScript, live UI, foreground input, or ambient clipboard access

## Proof

- `PEEKABOO_INCLUDE_AMBIENT_STATE_TESTS=false pnpm run test:safe`
- `pnpm run lint`
- `pnpm run format:swift`
- focused AutomationKit target tests: 11 passed
- focused MCP exact keyboard/paste/background/policy tests: 59 passed
- focused CLI Type/Press/Paste/refusal suites: 77 passed when run independently
- Release builds: CLI and Core
- fresh SwiftPM consumer contract
- native-only source scan plus Release Mach-O import/string inspection
- isolated source-blind validation against copied CLI/test artifacts
- P0-P2 autoreview: clean, no actionable findings

## Architecture delta

The reconstructed product diff uses 13 production files versus 32 in the frozen prototype and avoids 2,364 lines of production churn while preserving the exact target/receipt behavior. Protocol remains 1.24 and all submodule gitlinks remain unchanged.
