### PR TITLE
feat(bridge): add embedded native host runtime

### DIFF
--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Core/BridgeCommand+Models.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Core/BridgeCommand+Models.swift
@@ -147,8 +147,7 @@ struct BridgeCandidateErrorReport: Codable, Sendable {
     nonisolated static func bridgeEnvelope(_ envelope: PeekabooBridgeErrorEnvelope) -> BridgeCandidateErrorReport {
         let hint: String? = switch envelope.code {
         case .unauthorizedClient:
-            "Client not signed by an allowed TeamID. For local dev, set " +
-                "PEEKABOO_ALLOW_UNSIGNED_SOCKET_CLIENTS=1 in the host."
+            self.authorizationHint(for: envelope)
         case .decodingFailed:
             "Host returned a non-Bridge response. This commonly means you hit a different socket protocol " +
                 "or the host closed early due to code-sign checks."
@@ -167,6 +166,16 @@ struct BridgeCandidateErrorReport: Codable, Sendable {
             details: envelope.details,
             hint: hint
         )
+    }
+
+    private nonisolated static func authorizationHint(for envelope: PeekabooBridgeErrorEnvelope) -> String {
+        if envelope.message.hasPrefix("Bundle ") {
+            return "Client bundle/signing identifier is not allowlisted for this host. Use the intended signed " +
+                "client or explicitly add its identifier to the host's bundle allowlist; the unsigned-client " +
+                "development override does not bypass bundle authorization."
+        }
+        return "Client is not signed by an allowed TeamID. Use the intended signed client. For local development " +
+            "with a DEBUG host only, set PEEKABOO_ALLOW_UNSIGNED_SOCKET_CLIENTS=1 in the host."
     }
 
     nonisolated static func other(_ error: any Error) -> BridgeCandidateErrorReport {

--- a/Apps/CLI/Tests/CoreCLITests/BridgeStatusReportHintTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/BridgeStatusReportHintTests.swift
@@ -101,6 +101,40 @@ struct BridgeStatusReportHintTests {
     }
 
     @Test
+    func `bundle authorization refusal names the bundle allowlist instead of the team`() throws {
+        let refusal = PeekabooBridgeErrorEnvelope(
+            code: .unauthorizedClient,
+            message: "Bundle boo.peekaboo.boundary-denied is not authorized"
+        )
+
+        let report = BridgeCandidateErrorReport
+            .bridgeEnvelope(refusal)
+        let hint = try #require(report.hint)
+
+        #expect(report.message == refusal.message)
+        #expect(hint.contains("bundle/signing identifier"))
+        #expect(hint.contains("bundle allowlist"))
+        #expect(hint.contains("TeamID") == false)
+        #expect(hint.contains("PEEKABOO_ALLOW_UNSIGNED_SOCKET_CLIENTS") == false)
+    }
+
+    @Test
+    func `team authorization refusal retains the signed-client remediation`() throws {
+        let refusal = PeekabooBridgeErrorEnvelope(
+            code: .unauthorizedClient,
+            message: "Team NOT_ALLOWED is not authorized"
+        )
+
+        let hint = try #require(
+            BridgeCandidateErrorReport.bridgeEnvelope(refusal).hint
+        )
+
+        #expect(hint.contains("allowed TeamID"))
+        #expect(hint.contains("intended signed client"))
+        #expect(hint.contains("DEBUG host only"))
+    }
+
+    @Test
     func `Bridge report preserves host generation build and launch capabilities`() throws {
         let identity = PeekabooBridgeHostIdentity(
             processIdentifier: 4242,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 - Add receipt-pinned exact-window background `type`, `paste`, and `press`, preserving process generation, window bounds, and focused-element identity while refusing ambiguous app/PID targets and unsafe Agent dialog/shared-UI routes.
 - Restore the root SwiftPM facade for external consumers with four lean library products—Foundation, Protocols, AutomationKit, and Bridge—plus a fresh-consumer build contract that prevents manifest and product drift.
+- Add a background-first native Bridge host runtime for signed macOS apps, with explicit caller allowlists, shared mutation/snapshot state, checked lifecycle, and no Core, provider, browser, daemon, or AppleScript surface.
 - Add opt-in host-local Vision OCR to CLI/MCP `see`, preserving incomplete AX evidence, exact snapshot receipts, logical bounds, confidence, background-only observation, and fail-before-dispatch compatibility with older Bridge hosts.
 - Stateless exact-window ROI capture for CLI/MCP `see`, with generation-pinned
   full-window receipts, AX/OCR filtering, snapshot-bound pixel mapping, and

--- a/Core/PeekabooCore/Package.swift
+++ b/Core/PeekabooCore/Package.swift
@@ -91,6 +91,15 @@ let package = Package(
             ],
             path: "Sources/PeekabooBridge",
             swiftSettings: coreTargetSettings),
+        .testTarget(
+            name: "PeekabooBridgeTests",
+            dependencies: [
+                "PeekabooBridge",
+                .product(name: "PeekabooAutomationKit", package: "PeekabooAutomationKit"),
+                .product(name: "PeekabooFoundation", package: "PeekabooFoundation"),
+            ],
+            path: "Tests/PeekabooBridgeTests",
+            swiftSettings: testTargetSettings),
         .target(
             name: "PeekabooBridgeTestSupport",
             dependencies: [

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeBootstrap.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeBootstrap.swift
@@ -3,6 +3,22 @@ import PeekabooAutomationKit
 
 @MainActor
 public enum PeekabooBridgeBootstrap {
+    struct HostConfiguration {
+        let hostKind: PeekabooBridgeHostKind
+        let socketPath: String
+        let allowlistedTeams: Set<String>
+        let allowlistedBundles: Set<String>
+        let daemonControl: (any PeekabooDaemonControlProviding)?
+        let automationActivityObserver: (@Sendable (pid_t) -> Void)?
+        let allowedOperations: Set<PeekabooBridgeOperation>
+        let hostIdentity: PeekabooBridgeHostIdentity?
+        let hostCapabilities: Set<String>
+        let desktopMutationWatermarkStore: DesktopMutationWatermarkStore
+        let maxMessageBytes: Int
+        let requestTimeoutSec: TimeInterval
+        let requestDrainTimeoutSec: TimeInterval
+    }
+
     @discardableResult
     public static func startHost(
         services: any PeekabooBridgeServiceProviding,
@@ -18,23 +34,22 @@ public enum PeekabooBridgeBootstrap {
         maxMessageBytes: Int = 64 * 1024 * 1024,
         requestTimeoutSec: TimeInterval = 10) -> PeekabooBridgeHost
     {
-        let server = PeekabooBridgeServer(
+        let host = self.makeHost(
             services: services,
-            hostKind: hostKind,
-            allowlistedTeams: allowlistedTeams,
-            allowlistedBundles: allowlistedBundles,
-            allowedOperations: allowedOperations,
-            hostIdentity: hostIdentity,
-            hostCapabilities: hostCapabilities,
-            daemonControl: daemonControl,
-            desktopMutationWatermarkStore: DesktopMutationWatermarkStore(),
-            automationActivityObserver: automationActivityObserver)
-        let host = PeekabooBridgeHost(
-            socketPath: socketPath,
-            server: server,
-            maxMessageBytes: maxMessageBytes,
-            allowedTeamIDs: allowlistedTeams,
-            requestTimeoutSec: requestTimeoutSec)
+            configuration: HostConfiguration(
+                hostKind: hostKind,
+                socketPath: socketPath,
+                allowlistedTeams: allowlistedTeams,
+                allowlistedBundles: allowlistedBundles,
+                daemonControl: daemonControl,
+                automationActivityObserver: automationActivityObserver,
+                allowedOperations: allowedOperations,
+                hostIdentity: hostIdentity,
+                hostCapabilities: hostCapabilities,
+                desktopMutationWatermarkStore: DesktopMutationWatermarkStore(),
+                maxMessageBytes: maxMessageBytes,
+                requestTimeoutSec: requestTimeoutSec,
+                requestDrainTimeoutSec: 1.0)).host
         Task {
             await host.start()
         }
@@ -56,24 +71,48 @@ public enum PeekabooBridgeBootstrap {
         maxMessageBytes: Int = 64 * 1024 * 1024,
         requestTimeoutSec: TimeInterval = 10) async throws -> PeekabooBridgeHost
     {
-        let server = PeekabooBridgeServer(
+        let host = self.makeHost(
             services: services,
-            hostKind: hostKind,
-            allowlistedTeams: allowlistedTeams,
-            allowlistedBundles: allowlistedBundles,
-            allowedOperations: allowedOperations,
-            hostIdentity: hostIdentity,
-            hostCapabilities: hostCapabilities,
-            daemonControl: daemonControl,
-            desktopMutationWatermarkStore: DesktopMutationWatermarkStore(),
-            automationActivityObserver: automationActivityObserver)
-        let host = PeekabooBridgeHost(
-            socketPath: socketPath,
-            server: server,
-            maxMessageBytes: maxMessageBytes,
-            allowedTeamIDs: allowlistedTeams,
-            requestTimeoutSec: requestTimeoutSec)
+            configuration: HostConfiguration(
+                hostKind: hostKind,
+                socketPath: socketPath,
+                allowlistedTeams: allowlistedTeams,
+                allowlistedBundles: allowlistedBundles,
+                daemonControl: daemonControl,
+                automationActivityObserver: automationActivityObserver,
+                allowedOperations: allowedOperations,
+                hostIdentity: hostIdentity,
+                hostCapabilities: hostCapabilities,
+                desktopMutationWatermarkStore: DesktopMutationWatermarkStore(),
+                maxMessageBytes: maxMessageBytes,
+                requestTimeoutSec: requestTimeoutSec,
+                requestDrainTimeoutSec: 1.0)).host
         try await host.startChecked()
         return host
+    }
+
+    static func makeHost(
+        services: any PeekabooBridgeServiceProviding,
+        configuration: HostConfiguration) -> (host: PeekabooBridgeHost, capabilities: Set<String>)
+    {
+        let server = PeekabooBridgeServer(
+            services: services,
+            hostKind: configuration.hostKind,
+            allowlistedTeams: configuration.allowlistedTeams,
+            allowlistedBundles: configuration.allowlistedBundles,
+            allowedOperations: configuration.allowedOperations,
+            hostIdentity: configuration.hostIdentity,
+            hostCapabilities: configuration.hostCapabilities,
+            daemonControl: configuration.daemonControl,
+            desktopMutationWatermarkStore: configuration.desktopMutationWatermarkStore,
+            automationActivityObserver: configuration.automationActivityObserver)
+        let host = PeekabooBridgeHost(
+            socketPath: configuration.socketPath,
+            server: server,
+            maxMessageBytes: configuration.maxMessageBytes,
+            allowedTeamIDs: configuration.allowlistedTeams,
+            requestTimeoutSec: configuration.requestTimeoutSec,
+            requestDrainTimeoutSec: configuration.requestDrainTimeoutSec)
+        return (host, server.hostCapabilities)
     }
 }

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeHost.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeHost.swift
@@ -502,6 +502,11 @@ public final actor PeekabooBridgeHost {
         return outcome
     }
 
+    /// Waits for deferred request draining to release the socket lease after `stop()` retained ownership.
+    public func waitUntilFullyStopped() async {
+        await self.ownershipCleanupTask?.value
+    }
+
     private func stopOnce() async -> PeekabooBridgeHostStopOutcome {
         if self.ownershipCleanupTask != nil {
             let snapshot = self.requestTracker.drainSnapshot

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeOperation+Policy.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeOperation+Policy.swift
@@ -1,6 +1,117 @@
 import Foundation
 
 extension PeekabooBridgeOperation {
+    /// Whether Peekaboo's concrete native service retains desktop-lane ownership through its dispatch leaf.
+    ///
+    /// Bridge routing consults this policy together with the service provider's ownership claim. Keeping the
+    /// exhaustive operation list here prevents native host assemblies and request routing from drifting apart.
+    public var nativeServiceOwnsDesktopOperationLane: Bool {
+        switch self {
+        case .click,
+             .type,
+             .typeActions,
+             .targetedTypeActions,
+             .exactWindowTargetedTypeActions,
+             .setValue,
+             .performAction,
+             .scroll,
+             .targetedScroll,
+             .hotkey,
+             .targetedHotkey,
+             .exactWindowTargetedHotkey,
+             .targetedClick,
+             .exactWindowTargetedClick,
+             .swipe,
+             .drag,
+             .moveMouse,
+             .focusWindow,
+             .moveWindow,
+             .resizeWindow,
+             .setWindowBounds,
+             .closeWindow,
+             .backgroundCloseWindow,
+             .minimizeWindow,
+             .restoreWindow,
+             .maximizeWindow,
+             .launchApplication,
+             .launchApplicationWithOptions,
+             .relaunchApplicationWithOptions,
+             .activateApplication,
+             .quitApplication,
+             .hideApplication,
+             .unhideApplication,
+             .hideOtherApplications,
+             .showAllApplications,
+             .clickMenuItem,
+             .clickMenuItemByName,
+             .clickMenuExtra,
+             .clickMenuBarItemNamed,
+             .clickMenuBarItemIndex,
+             .launchDockItem,
+             .rightClickDockItem,
+             .hideDock,
+             .showDock,
+             .dialogFindActive,
+             .dialogClickButton,
+             .backgroundDialogClickButton,
+             .dialogEnterText,
+             .dialogHandleFile,
+             .dialogDismiss,
+             .dialogListElements,
+             .desktopObservation:
+            true
+        case .permissionsStatus,
+             .requestPostEventPermission,
+             .daemonStatus,
+             .daemonStop,
+             .browserStatus,
+             .browserConnect,
+             .browserDisconnect,
+             .browserExecute,
+             .captureScreen,
+             .captureWindow,
+             .captureFrontmost,
+             .captureArea,
+             .detectElements,
+             .inspectAccessibilityTree,
+             .getFocusedElement,
+             .waitForElement,
+             .listWindows,
+             .getFocusedWindow,
+             .listApplications,
+             .findApplication,
+             .getFrontmostApplication,
+             .isApplicationRunning,
+             .listMenus,
+             .listFrontmostMenus,
+             .listMenuExtras,
+             .menuExtraOpenMenuFrame,
+             .listMenuBarItems,
+             .listDockItems,
+             .isDockHidden,
+             .findDockItem,
+             .createSnapshot,
+             .storeDetectionResult,
+             .getDetectionResult,
+             .storeScreenshot,
+             .storeObservationSnapshot,
+             .storeAnnotatedScreenshot,
+             .listSnapshots,
+             .getMostRecentSnapshot,
+             .invalidateImplicitLatestSnapshot,
+             .beginSnapshotMutation,
+             .finishSnapshotMutation,
+             .cleanSnapshot,
+             .cleanSnapshotsOlderThan,
+             .cleanAllSnapshots,
+             ._appleScriptProbe:
+            false
+        }
+    }
+
+    public static let nativeDesktopOperationLaneOperations: Set<PeekabooBridgeOperation> =
+        Set(Self.allCases.filter(\.nativeServiceOwnsDesktopOperationLane))
+
     /// TCC permissions an operation relies on. Used to gate advertisement/handling.
     public var requiredPermissions: Set<PeekabooBridgePermissionKind> {
         switch self {
@@ -163,4 +274,19 @@ extension PeekabooBridgeOperation {
         .cleanSnapshotsOlderThan,
         .cleanAllSnapshots,
     ]
+
+    /// Native operations exposed by an embedded host.
+    ///
+    /// Embedded hosts intentionally do not acquire browser, daemon-control, or interactive permission-prompt
+    /// responsibilities. The containing app remains the owner of those product-specific surfaces.
+    public static let embeddedDefaultAllowlist: Set<PeekabooBridgeOperation> =
+        PeekabooBridgeOperation.remoteDefaultAllowlist.subtracting([
+            .requestPostEventPermission,
+            .daemonStatus,
+            .daemonStop,
+            .browserStatus,
+            .browserConnect,
+            .browserDisconnect,
+            .browserExecute,
+        ])
 }

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeRequest+DesktopMutation.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeRequest+DesktopMutation.swift
@@ -16,62 +16,7 @@ extension PeekabooBridgeRequest {
     /// Native services own these leases after resolving and revalidating their exact target.
     /// Remote callers and the Bridge router must not acquire a second copy of the same lane.
     var nativeLeafOwnsDesktopOperationLane: Bool {
-        switch self {
-        case .click,
-             .type,
-             .typeActions,
-             .targetedTypeActions,
-             .exactWindowTargetedTypeActions,
-             .setValue,
-             .performAction,
-             .scroll,
-             .targetedScroll,
-             .hotkey,
-             .targetedHotkey,
-             .exactWindowTargetedHotkey,
-             .targetedClick,
-             .swipe,
-             .drag,
-             .moveMouse,
-             .focusWindow,
-             .moveWindow,
-             .resizeWindow,
-             .setWindowBounds,
-             .closeWindow,
-             .backgroundCloseWindow,
-             .minimizeWindow,
-             .restoreWindow,
-             .maximizeWindow,
-             .launchApplication,
-             .launchApplicationWithOptions,
-             .relaunchApplicationWithOptions,
-             .activateApplication,
-             .quitApplication,
-             .hideApplication,
-             .unhideApplication,
-             .hideOtherApplications,
-             .showAllApplications,
-             .clickMenuItem,
-             .clickMenuItemByName,
-             .clickMenuExtra,
-             .clickMenuBarItemNamed,
-             .clickMenuBarItemIndex,
-             .launchDockItem,
-             .rightClickDockItem,
-             .hideDock,
-             .showDock,
-             .dialogFindActive,
-             .dialogClickButton,
-             .backgroundDialogClickButton,
-             .dialogEnterText,
-             .dialogHandleFile,
-             .dialogDismiss,
-             .dialogListElements,
-             .desktopObservation:
-            true
-        default:
-            false
-        }
+        self.operation.nativeServiceOwnsDesktopOperationLane
     }
 
     var desktopOperationScope: DesktopOperationScope {

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooEmbeddedBridgeRuntime.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooEmbeddedBridgeRuntime.swift
@@ -1,0 +1,390 @@
+import Foundation
+import PeekabooAutomationKit
+
+/// Native Peekaboo services suitable for embedding in a signed macOS application.
+///
+/// This assembly intentionally excludes agent, browser, provider, configuration, audio, and visualizer state. All
+/// stateful automation services share one snapshot manager, one durable mutation watermark, and the AutomationKit
+/// process-wide desktop lane coordinator.
+@MainActor
+public final class PeekabooEmbeddedBridgeServices: PeekabooBridgeServiceProviding {
+    public static let backgroundFirstInputPolicy = UIInputPolicy(
+        defaultStrategy: .actionFirst,
+        setValue: .actionOnly,
+        performAction: .actionOnly)
+
+    public let permissions: PermissionsService
+    public let screenCapture: any ScreenCaptureServiceProtocol
+    public let automation: any UIAutomationServiceProtocol
+    public let windows: any WindowManagementServiceProtocol
+    public let applications: any ApplicationServiceProtocol
+    public let menu: any MenuServiceProtocol
+    public let dock: any DockServiceProtocol
+    public let dialogs: any DialogServiceProtocol
+    public let snapshots: any SnapshotManagerProtocol
+    public let desktopObservation: any DesktopObservationServiceProtocol
+    public let desktopMutationWatermarkStore: DesktopMutationWatermarkStore
+    public let inputPolicy: UIInputPolicy
+
+    public var supportsScreenCaptureKitProcessOwnership: Bool {
+        true
+    }
+
+    public init(
+        desktopMutationWatermarkStore: DesktopMutationWatermarkStore = DesktopMutationWatermarkStore(),
+        snapshotOptions: InMemorySnapshotManager.Options = .init(copyArtifactsOnStore: true),
+        inputPolicy: UIInputPolicy = PeekabooEmbeddedBridgeServices.backgroundFirstInputPolicy,
+        feedbackClient: any AutomationFeedbackClient = NoopAutomationFeedbackClient())
+    {
+        let logging = LoggingService()
+        let permissions = PermissionsService()
+        let applications = ApplicationService(
+            permissions: permissions,
+            feedbackClient: feedbackClient)
+        let snapshots = InMemorySnapshotManager(
+            options: snapshotOptions,
+            desktopMutationWatermarkStore: desktopMutationWatermarkStore)
+        let screenCapture = ScreenCaptureService(
+            loggingService: logging,
+            feedbackClient: feedbackClient)
+        let automation = UIAutomationService(
+            snapshotManager: snapshots,
+            loggingService: logging,
+            searchPolicy: .balanced,
+            inputPolicy: inputPolicy,
+            feedbackClient: feedbackClient)
+        let windows = WindowManagementService(
+            applicationService: applications,
+            feedbackClient: feedbackClient)
+        let menu = MenuService(
+            applicationService: applications,
+            feedbackClient: feedbackClient)
+        let dock = DockService(feedbackClient: feedbackClient)
+        let dialogs = DialogService(
+            applicationService: applications,
+            feedbackClient: feedbackClient)
+        let screens = ScreenService()
+
+        self.permissions = permissions
+        self.screenCapture = screenCapture
+        self.automation = automation
+        self.windows = windows
+        self.applications = applications
+        self.menu = menu
+        self.dock = dock
+        self.dialogs = dialogs
+        self.snapshots = snapshots
+        self.desktopObservation = DesktopObservationService(
+            screenCapture: screenCapture,
+            automation: automation,
+            applications: applications,
+            menu: menu,
+            screens: screens,
+            snapshotManager: snapshots)
+        self.desktopMutationWatermarkStore = desktopMutationWatermarkStore
+        self.inputPolicy = inputPolicy
+    }
+
+    public func ownsDesktopOperationLane(for operation: PeekabooBridgeOperation) -> Bool {
+        operation.nativeServiceOwnsDesktopOperationLane
+    }
+}
+
+public enum PeekabooEmbeddedBridgeRuntimeError: Error, LocalizedError, Sendable, Equatable {
+    case emptyTeamAllowlist
+    case emptyBundleAllowlist
+
+    public var errorDescription: String? {
+        switch self {
+        case .emptyTeamAllowlist:
+            "An embedded Bridge host requires at least one explicitly allowlisted Team ID"
+        case .emptyBundleAllowlist:
+            "An embedded Bridge host requires at least one explicitly allowlisted bundle identifier"
+        }
+    }
+}
+
+public enum PeekabooEmbeddedBridgeRuntimeState: String, Sendable, Equatable {
+    case stopped
+    case starting
+    case ready
+    case stopping
+}
+
+public struct PeekabooEmbeddedBridgeRuntimeSnapshot: Sendable, Equatable {
+    public let state: PeekabooEmbeddedBridgeRuntimeState
+    public let socketPath: String
+    public let hostCapabilities: Set<String>
+
+    public init(
+        state: PeekabooEmbeddedBridgeRuntimeState,
+        socketPath: String,
+        hostCapabilities: Set<String>)
+    {
+        self.state = state
+        self.socketPath = socketPath
+        self.hostCapabilities = hostCapabilities
+    }
+}
+
+/// Checked lifecycle owner for an embedded native Bridge host.
+///
+/// Start, stop, and restart intents execute in arrival order. A failed start never publishes a host, and successful
+/// stop does not return until any in-flight request has released socket ownership.
+public actor PeekabooEmbeddedBridgeRuntime {
+    struct LifecycleHooks: Sendable {
+        var didEnqueueStart: @Sendable () -> Void = {}
+        var didEnqueueStop: @Sendable () -> Void = {}
+        var didEnqueueRestart: @Sendable () -> Void = {}
+        var willStartHost: @Sendable () async -> Void = {}
+        var willStopHost: @Sendable () async -> Void = {}
+    }
+
+    public struct Configuration: Sendable {
+        public let socketPath: String
+        public let allowlistedTeams: Set<String>
+        public let allowlistedBundles: Set<String>
+        public let allowedOperations: Set<PeekabooBridgeOperation>
+        public let hostKind: PeekabooBridgeHostKind
+        public let hostCapabilities: Set<String>
+        public let maxMessageBytes: Int
+        public let requestTimeoutSeconds: TimeInterval
+        public let requestDrainTimeoutSeconds: TimeInterval
+
+        let screenCaptureKitProcessCapabilityRegistrar: @Sendable () throws -> Void
+
+        public init(
+            socketPath: String,
+            allowlistedTeams: Set<String>,
+            allowlistedBundles: Set<String>,
+            allowedOperations: Set<PeekabooBridgeOperation> = PeekabooBridgeOperation.embeddedDefaultAllowlist,
+            hostKind: PeekabooBridgeHostKind = .helper,
+            hostCapabilities: Set<String> = [PeekabooBridgeHostCapability.backgroundBridgeHost],
+            maxMessageBytes: Int = 64 * 1024 * 1024,
+            requestTimeoutSeconds: TimeInterval = PeekabooBridgeConstants.defaultRequestTimeoutSeconds,
+            requestDrainTimeoutSeconds: TimeInterval = 1.0)
+        {
+            self.init(
+                socketPath: socketPath,
+                allowlistedTeams: allowlistedTeams,
+                allowlistedBundles: allowlistedBundles,
+                allowedOperations: allowedOperations,
+                hostKind: hostKind,
+                hostCapabilities: hostCapabilities,
+                maxMessageBytes: maxMessageBytes,
+                requestTimeoutSeconds: requestTimeoutSeconds,
+                requestDrainTimeoutSeconds: requestDrainTimeoutSeconds,
+                screenCaptureKitProcessCapabilityRegistrar: {
+                    try ScreenCaptureKitOwnerLease.registerCurrentProcessCapability()
+                })
+        }
+
+        init(
+            socketPath: String,
+            allowlistedTeams: Set<String>,
+            allowlistedBundles: Set<String>,
+            allowedOperations: Set<PeekabooBridgeOperation> = PeekabooBridgeOperation.embeddedDefaultAllowlist,
+            hostKind: PeekabooBridgeHostKind = .helper,
+            hostCapabilities: Set<String> = [PeekabooBridgeHostCapability.backgroundBridgeHost],
+            maxMessageBytes: Int = 64 * 1024 * 1024,
+            requestTimeoutSeconds: TimeInterval = PeekabooBridgeConstants.defaultRequestTimeoutSeconds,
+            requestDrainTimeoutSeconds: TimeInterval = 1.0,
+            screenCaptureKitProcessCapabilityRegistrar: @escaping @Sendable () throws -> Void)
+        {
+            self.socketPath = socketPath
+            self.allowlistedTeams = allowlistedTeams
+            self.allowlistedBundles = allowlistedBundles
+            // Callers may narrow the embedded surface, but this native-only runtime cannot acquire browser,
+            // daemon-control, or interactive permission-prompt ownership by configuration accident.
+            self.allowedOperations = allowedOperations.intersection(PeekabooBridgeOperation.embeddedDefaultAllowlist)
+            self.hostKind = hostKind
+            self.hostCapabilities = hostCapabilities.union([PeekabooBridgeHostCapability.backgroundBridgeHost])
+            self.maxMessageBytes = maxMessageBytes
+            self.requestTimeoutSeconds = requestTimeoutSeconds
+            self.requestDrainTimeoutSeconds = requestDrainTimeoutSeconds
+            self.screenCaptureKitProcessCapabilityRegistrar = screenCaptureKitProcessCapabilityRegistrar
+        }
+
+        func validate() throws {
+            guard !self.allowlistedTeams.isEmpty else {
+                throw PeekabooEmbeddedBridgeRuntimeError.emptyTeamAllowlist
+            }
+            guard !self.allowlistedBundles.isEmpty else {
+                throw PeekabooEmbeddedBridgeRuntimeError.emptyBundleAllowlist
+            }
+        }
+    }
+
+    private struct StartedHost: Sendable {
+        let host: PeekabooBridgeHost
+        let capabilities: Set<String>
+    }
+
+    private let configuration: Configuration
+    private let services: PeekabooEmbeddedBridgeServices
+    private let lifecycleHooks: LifecycleHooks
+    private var state: PeekabooEmbeddedBridgeRuntimeState = .stopped
+    private var startedHost: StartedHost?
+    private var lifecycleTail: Task<Void, Never>?
+
+    public init(
+        configuration: Configuration,
+        services: PeekabooEmbeddedBridgeServices)
+    {
+        self.configuration = configuration
+        self.services = services
+        self.lifecycleHooks = LifecycleHooks()
+    }
+
+    init(
+        configuration: Configuration,
+        services: PeekabooEmbeddedBridgeServices,
+        lifecycleHooks: LifecycleHooks)
+    {
+        self.configuration = configuration
+        self.services = services
+        self.lifecycleHooks = lifecycleHooks
+    }
+
+    @MainActor
+    public static func make(
+        configuration: Configuration,
+        desktopMutationWatermarkStore: DesktopMutationWatermarkStore = DesktopMutationWatermarkStore(),
+        snapshotOptions: InMemorySnapshotManager.Options = .init(copyArtifactsOnStore: true),
+        inputPolicy: UIInputPolicy = PeekabooEmbeddedBridgeServices.backgroundFirstInputPolicy,
+        feedbackClient: any AutomationFeedbackClient = NoopAutomationFeedbackClient()) -> Self
+    {
+        Self(
+            configuration: configuration,
+            services: PeekabooEmbeddedBridgeServices(
+                desktopMutationWatermarkStore: desktopMutationWatermarkStore,
+                snapshotOptions: snapshotOptions,
+                inputPolicy: inputPolicy,
+                feedbackClient: feedbackClient))
+    }
+
+    public func snapshot() -> PeekabooEmbeddedBridgeRuntimeSnapshot {
+        PeekabooEmbeddedBridgeRuntimeSnapshot(
+            state: self.state,
+            socketPath: self.configuration.socketPath,
+            hostCapabilities: self.startedHost?.capabilities ?? [])
+    }
+
+    @discardableResult
+    public func startChecked() async throws -> PeekabooEmbeddedBridgeRuntimeSnapshot {
+        let predecessor = self.lifecycleTail
+        let operation = Task<PeekabooEmbeddedBridgeRuntimeSnapshot, any Error> { [self] in
+            await predecessor?.value
+            return try await self.performStart()
+        }
+        self.lifecycleTail = Task {
+            _ = try? await operation.value
+        }
+        self.lifecycleHooks.didEnqueueStart()
+        return try await operation.value
+    }
+
+    public func stopChecked() async {
+        let predecessor = self.lifecycleTail
+        let operation = Task { [self] in
+            await predecessor?.value
+            await self.performStop()
+        }
+        self.lifecycleTail = operation
+        self.lifecycleHooks.didEnqueueStop()
+        await operation.value
+    }
+
+    @discardableResult
+    public func restartChecked() async throws -> PeekabooEmbeddedBridgeRuntimeSnapshot {
+        let predecessor = self.lifecycleTail
+        let operation = Task<PeekabooEmbeddedBridgeRuntimeSnapshot, any Error> { [self] in
+            await predecessor?.value
+            await self.performStop()
+            return try await self.performStart()
+        }
+        self.lifecycleTail = Task {
+            _ = try? await operation.value
+        }
+        self.lifecycleHooks.didEnqueueRestart()
+        return try await operation.value
+    }
+
+    private func performStart() async throws -> PeekabooEmbeddedBridgeRuntimeSnapshot {
+        if let startedHost, self.state == .ready {
+            return self.readySnapshot(for: startedHost)
+        }
+        try self.configuration.validate()
+        self.startedHost = nil
+        self.state = .starting
+        await self.lifecycleHooks.willStartHost()
+        do {
+            let startedHost = try await Self.makeStartedHost(
+                configuration: self.configuration,
+                services: self.services)
+            self.startedHost = startedHost
+            self.state = .ready
+            return self.readySnapshot(for: startedHost)
+        } catch {
+            self.startedHost = nil
+            self.state = .stopped
+            throw error
+        }
+    }
+
+    private func performStop() async {
+        guard let startedHost else {
+            self.state = .stopped
+            return
+        }
+        self.state = .stopping
+        await self.lifecycleHooks.willStopHost()
+        _ = await startedHost.host.stop()
+        await startedHost.host.waitUntilFullyStopped()
+        self.startedHost = nil
+        self.state = .stopped
+    }
+
+    private func readySnapshot(for startedHost: StartedHost) -> PeekabooEmbeddedBridgeRuntimeSnapshot {
+        PeekabooEmbeddedBridgeRuntimeSnapshot(
+            state: .ready,
+            socketPath: self.configuration.socketPath,
+            hostCapabilities: startedHost.capabilities)
+    }
+
+    private nonisolated static func makeStartedHost(
+        configuration: Configuration,
+        services: PeekabooEmbeddedBridgeServices) async throws -> StartedHost
+    {
+        try configuration.screenCaptureKitProcessCapabilityRegistrar()
+
+        let preparedHost = await MainActor.run {
+            PeekabooBridgeBootstrap.makeHost(
+                services: services,
+                configuration: .init(
+                    hostKind: configuration.hostKind,
+                    socketPath: configuration.socketPath,
+                    allowlistedTeams: configuration.allowlistedTeams,
+                    allowlistedBundles: configuration.allowlistedBundles,
+                    daemonControl: nil,
+                    automationActivityObserver: nil,
+                    allowedOperations: configuration.allowedOperations,
+                    hostIdentity: .current(),
+                    hostCapabilities: configuration.hostCapabilities,
+                    desktopMutationWatermarkStore: services.desktopMutationWatermarkStore,
+                    maxMessageBytes: configuration.maxMessageBytes,
+                    requestTimeoutSec: configuration.requestTimeoutSeconds,
+                    requestDrainTimeoutSec: configuration.requestDrainTimeoutSeconds))
+        }
+        let host = preparedHost.host
+
+        do {
+            try await host.startChecked()
+            return StartedHost(host: host, capabilities: preparedHost.capabilities)
+        } catch {
+            _ = await host.stop()
+            await host.waitUntilFullyStopped()
+            throw error
+        }
+    }
+}

--- a/Core/PeekabooCore/Sources/PeekabooCore/Support/PeekabooServices.swift
+++ b/Core/PeekabooCore/Sources/PeekabooCore/Support/PeekabooServices.swift
@@ -215,7 +215,7 @@ public final class PeekabooServices {
 
         // Agent service will be initialized by createShared method
         self.agent = nil
-        self.nativeDesktopOperationLaneOperations = Self.defaultNativeDesktopOperationLaneOperations
+        self.nativeDesktopOperationLaneOperations = PeekabooBridgeOperation.nativeDesktopOperationLaneOperations
 
         self.logger.debug("✨ PeekabooServices initialization complete")
         self.refreshAgentService()
@@ -299,7 +299,7 @@ public final class PeekabooServices {
             configuration: configuration,
             agent: nil,
             screens: screens,
-            nativeDesktopOperationLaneOperations: Self.defaultNativeDesktopOperationLaneOperations)
+            nativeDesktopOperationLaneOperations: PeekabooBridgeOperation.nativeDesktopOperationLaneOperations)
 
         logger.debug("✨ PeekabooServices initialization complete (custom snapshots)")
         self.refreshAgentService()
@@ -418,63 +418,6 @@ extension PeekabooServices: PeekabooBridgeServiceProviding {
     public func ownsDesktopOperationLane(for operation: PeekabooBridgeOperation) -> Bool {
         self.nativeDesktopOperationLaneOperations.contains(operation)
     }
-}
-
-extension PeekabooServices {
-    private static let defaultNativeDesktopOperationLaneOperations: Set<PeekabooBridgeOperation> = [
-        .click,
-        .type,
-        .typeActions,
-        .targetedTypeActions,
-        .exactWindowTargetedTypeActions,
-        .setValue,
-        .performAction,
-        .scroll,
-        .targetedScroll,
-        .hotkey,
-        .targetedHotkey,
-        .exactWindowTargetedHotkey,
-        .targetedClick,
-        .exactWindowTargetedClick,
-        .swipe,
-        .drag,
-        .moveMouse,
-        .focusWindow,
-        .moveWindow,
-        .resizeWindow,
-        .setWindowBounds,
-        .closeWindow,
-        .backgroundCloseWindow,
-        .minimizeWindow,
-        .restoreWindow,
-        .maximizeWindow,
-        .launchApplication,
-        .launchApplicationWithOptions,
-        .relaunchApplicationWithOptions,
-        .activateApplication,
-        .quitApplication,
-        .hideApplication,
-        .unhideApplication,
-        .hideOtherApplications,
-        .showAllApplications,
-        .clickMenuItem,
-        .clickMenuItemByName,
-        .clickMenuExtra,
-        .clickMenuBarItemNamed,
-        .clickMenuBarItemIndex,
-        .launchDockItem,
-        .rightClickDockItem,
-        .hideDock,
-        .showDock,
-        .dialogFindActive,
-        .dialogClickButton,
-        .backgroundDialogClickButton,
-        .dialogEnterText,
-        .dialogHandleFile,
-        .dialogDismiss,
-        .dialogListElements,
-        .desktopObservation,
-    ]
 }
 
 typealias SystemLogger = os.Logger

--- a/Core/PeekabooCore/Tests/PeekabooBridgeTests/PeekabooEmbeddedBridgeRuntimeTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooBridgeTests/PeekabooEmbeddedBridgeRuntimeTests.swift
@@ -1,0 +1,455 @@
+import Darwin
+import Foundation
+import PeekabooAutomationKit
+import Testing
+@testable import PeekabooBridge
+
+@Suite(.serialized)
+struct PeekabooEmbeddedBridgeRuntimeTests {
+    private struct RegistrationFailure: Error {}
+
+    @Test
+    @MainActor
+    func `native assembly defaults to background first and owns every canonical native leaf`() {
+        let services = PeekabooEmbeddedBridgeServices()
+
+        #expect(services.inputPolicy.defaultStrategy == .actionFirst)
+        #expect(services.inputPolicy.strategy(for: .setValue) == .actionOnly)
+        #expect(services.inputPolicy.strategy(for: .performAction) == .actionOnly)
+        #expect(PeekabooBridgeOperation.exactWindowTargetedClick.nativeServiceOwnsDesktopOperationLane)
+        #expect(PeekabooBridgeOperation.nativeDesktopOperationLaneOperations == Set(
+            PeekabooBridgeOperation.allCases.filter(\.nativeServiceOwnsDesktopOperationLane)))
+        #expect(PeekabooBridgeOperation.nativeDesktopOperationLaneOperations.count == 52)
+
+        for operation in PeekabooBridgeOperation.allCases {
+            #expect(services.ownsDesktopOperationLane(for: operation) ==
+                operation.nativeServiceOwnsDesktopOperationLane)
+        }
+    }
+
+    @Test
+    @MainActor
+    func `shared watermark invalidates snapshots across store instances`() async throws {
+        let root = Self.temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let firstStore = DesktopMutationWatermarkStore(directoryURL: root)
+        let secondStore = DesktopMutationWatermarkStore(directoryURL: root)
+        let services = PeekabooEmbeddedBridgeServices(desktopMutationWatermarkStore: firstStore)
+
+        let snapshotID = try await services.snapshots.createSnapshot()
+        #expect(await services.snapshots.getMostRecentSnapshot() == snapshotID)
+
+        let cutoff = Date().addingTimeInterval(1)
+        _ = try secondStore.advance(through: cutoff)
+
+        #expect(await services.snapshots.getMostRecentSnapshot() == nil)
+        #expect(services.snapshots.effectiveImplicitLatestInvalidationWatermark == cutoff)
+    }
+
+    @Test
+    func `embedded allowlist excludes browser daemon and interactive permission ownership`() {
+        let operations = PeekabooBridgeOperation.embeddedDefaultAllowlist
+        #expect(!operations.contains(.browserStatus))
+        #expect(!operations.contains(.browserConnect))
+        #expect(!operations.contains(.browserDisconnect))
+        #expect(!operations.contains(.browserExecute))
+        #expect(!operations.contains(.daemonStatus))
+        #expect(!operations.contains(.daemonStop))
+        #expect(!operations.contains(.requestPostEventPermission))
+        #expect(!operations.contains(._appleScriptProbe))
+        #expect(operations.contains(.desktopObservation))
+        #expect(operations.contains(.exactWindowTargetedClick))
+        #expect(operations.contains(.backgroundDialogClickButton))
+
+        let attemptedBroadening = PeekabooEmbeddedBridgeRuntime.Configuration(
+            socketPath: Self.socketPath(),
+            allowlistedTeams: ["TEAMID"],
+            allowlistedBundles: ["com.example.client"],
+            allowedOperations: [
+                .desktopObservation,
+                .browserExecute,
+                .daemonStop,
+                .requestPostEventPermission,
+                ._appleScriptProbe,
+            ],
+            hostCapabilities: [])
+        #expect(attemptedBroadening.allowedOperations == [.desktopObservation])
+        #expect(attemptedBroadening.hostCapabilities.contains(PeekabooBridgeHostCapability.backgroundBridgeHost))
+    }
+
+    @Test
+    @MainActor
+    func `configuration rejects implicit authorization policy`() async {
+        let services = PeekabooEmbeddedBridgeServices()
+        let noTeams = PeekabooEmbeddedBridgeRuntime(
+            configuration: .init(
+                socketPath: Self.socketPath(),
+                allowlistedTeams: [],
+                allowlistedBundles: ["com.example.client"]),
+            services: services)
+        await #expect(throws: PeekabooEmbeddedBridgeRuntimeError.emptyTeamAllowlist) {
+            try await noTeams.startChecked()
+        }
+
+        let noBundles = PeekabooEmbeddedBridgeRuntime(
+            configuration: .init(
+                socketPath: Self.socketPath(),
+                allowlistedTeams: ["TEAMID"],
+                allowlistedBundles: []),
+            services: services)
+        await #expect(throws: PeekabooEmbeddedBridgeRuntimeError.emptyBundleAllowlist) {
+            try await noBundles.startChecked()
+        }
+    }
+
+    @Test
+    @MainActor
+    func `screen capture capability registration failure leaves no partial host`() async {
+        let socketPath = Self.socketPath()
+        defer { Self.removeSocketArtifacts(socketPath) }
+        let services = PeekabooEmbeddedBridgeServices()
+        let configuration = PeekabooEmbeddedBridgeRuntime.Configuration(
+            socketPath: socketPath,
+            allowlistedTeams: ["TEAMID"],
+            allowlistedBundles: ["com.example.client"],
+            screenCaptureKitProcessCapabilityRegistrar: { throw RegistrationFailure() })
+        let runtime = PeekabooEmbeddedBridgeRuntime(
+            configuration: configuration,
+            services: services)
+
+        await #expect(throws: RegistrationFailure.self) {
+            try await runtime.startChecked()
+        }
+        #expect(await runtime.snapshot().state == .stopped)
+        #expect(!FileManager.default.fileExists(atPath: socketPath))
+    }
+
+    @Test
+    @MainActor
+    func `concurrent lifecycle joins transitions and restart retains current capabilities`() async throws {
+        let socketPath = Self.socketPath()
+        defer { Self.removeSocketArtifacts(socketPath) }
+        let runtime = Self.runtime(socketPath: socketPath)
+
+        async let firstStart = runtime.startChecked()
+        async let secondStart = runtime.startChecked()
+        let (firstSnapshot, secondSnapshot) = try await (firstStart, secondStart)
+        #expect(firstSnapshot == secondSnapshot)
+        #expect(firstSnapshot.state == .ready)
+        #expect(firstSnapshot.hostCapabilities.isSuperset(of: [
+            PeekabooBridgeHostCapability.backgroundBridgeHost,
+            PeekabooBridgeHostCapability.desktopActionOutcomeProjection,
+            PeekabooBridgeHostCapability.desktopObservationOCR,
+            PeekabooBridgeHostCapability.desktopObservationCaptureEngine,
+            PeekabooBridgeHostCapability.screenCaptureKitProcessOwnership,
+            PeekabooBridgeHostCapability.safeBackgroundApplicationLaunchNoOp,
+            PeekabooBridgeHostCapability.processGenerationPinnedApplicationActivation,
+        ]))
+
+        async let firstStop: Void = runtime.stopChecked()
+        async let secondStop: Void = runtime.stopChecked()
+        _ = await (firstStop, secondStop)
+        #expect(await runtime.snapshot().state == .stopped)
+        #expect(!FileManager.default.fileExists(atPath: socketPath))
+
+        let restarted = try await runtime.restartChecked()
+        #expect(restarted.state == .ready)
+        #expect(restarted.hostCapabilities == firstSnapshot.hostCapabilities)
+        await runtime.stopChecked()
+    }
+
+    @Test
+    @MainActor
+    func `failed socket ownership does not disturb the live runtime`() async throws {
+        let socketPath = Self.socketPath()
+        defer { Self.removeSocketArtifacts(socketPath) }
+        let first = Self.runtime(socketPath: socketPath)
+        let second = Self.runtime(socketPath: socketPath)
+
+        _ = try await first.startChecked()
+        await #expect(throws: PeekabooBridgeHostError.self) {
+            try await second.startChecked()
+        }
+        #expect(await first.snapshot().state == .ready)
+        #expect(await second.snapshot().state == .stopped)
+        await first.stopChecked()
+    }
+
+    @Test
+    @MainActor
+    func `later stop wins when it overlaps an earlier start`() async throws {
+        let socketPath = Self.socketPath()
+        defer { Self.removeSocketArtifacts(socketPath) }
+        let registrationEntered = AsyncTestGate()
+        let releaseRegistration = AsyncTestGate()
+        let stopJoinedStart = DispatchSemaphore(value: 0)
+        let runtime = PeekabooEmbeddedBridgeRuntime(
+            configuration: .init(
+                socketPath: socketPath,
+                allowlistedTeams: ["TEAMID"],
+                allowlistedBundles: ["com.example.client"]),
+            services: PeekabooEmbeddedBridgeServices(),
+            lifecycleHooks: .init(
+                didEnqueueStop: { stopJoinedStart.signal() },
+                willStartHost: {
+                    await registrationEntered.open()
+                    await releaseRegistration.wait()
+                }))
+
+        let startTask = Task { try await runtime.startChecked() }
+        await registrationEntered.wait()
+        let stopTask = Task { await runtime.stopChecked() }
+        #expect(await Self.wait(for: stopJoinedStart))
+        await releaseRegistration.open()
+
+        _ = try await startTask.value
+        await stopTask.value
+        #expect(await runtime.snapshot().state == .stopped)
+        #expect(!FileManager.default.fileExists(atPath: socketPath))
+    }
+
+    @Test
+    @MainActor
+    func `later start wins when it overlaps an earlier stop`() async throws {
+        let socketPath = Self.socketPath()
+        defer { Self.removeSocketArtifacts(socketPath) }
+        let stopEntered = AsyncTestGate()
+        let releaseStop = AsyncTestGate()
+        let startEnqueued = DispatchSemaphore(value: 0)
+        let runtime = PeekabooEmbeddedBridgeRuntime(
+            configuration: .init(
+                socketPath: socketPath,
+                allowlistedTeams: ["TEAMID"],
+                allowlistedBundles: ["com.example.client"]),
+            services: PeekabooEmbeddedBridgeServices(),
+            lifecycleHooks: .init(
+                didEnqueueStart: { startEnqueued.signal() },
+                willStopHost: {
+                    await stopEntered.open()
+                    await releaseStop.wait()
+                }))
+        _ = try await runtime.startChecked()
+        #expect(await Self.wait(for: startEnqueued))
+
+        let stopTask = Task { await runtime.stopChecked() }
+        await stopEntered.wait()
+        let startTask = Task { try await runtime.startChecked() }
+        #expect(await Self.wait(for: startEnqueued))
+        await releaseStop.open()
+
+        await stopTask.value
+        _ = try await startTask.value
+        #expect(await runtime.snapshot().state == .ready)
+        #expect(FileManager.default.fileExists(atPath: socketPath))
+
+        await runtime.stopChecked()
+    }
+
+    @Test
+    @MainActor
+    func `later stop wins over an overlapping restart`() async throws {
+        let socketPath = Self.socketPath()
+        defer { Self.removeSocketArtifacts(socketPath) }
+        let stopEntered = AsyncTestGate()
+        let releaseStop = AsyncTestGate()
+        let restartEnqueued = DispatchSemaphore(value: 0)
+        let stopEnqueued = DispatchSemaphore(value: 0)
+        let runtime = PeekabooEmbeddedBridgeRuntime(
+            configuration: .init(
+                socketPath: socketPath,
+                allowlistedTeams: ["TEAMID"],
+                allowlistedBundles: ["com.example.client"]),
+            services: PeekabooEmbeddedBridgeServices(),
+            lifecycleHooks: .init(
+                didEnqueueStop: { stopEnqueued.signal() },
+                didEnqueueRestart: { restartEnqueued.signal() },
+                willStopHost: {
+                    await stopEntered.open()
+                    await releaseStop.wait()
+                }))
+        _ = try await runtime.startChecked()
+
+        let restartTask = Task { try await runtime.restartChecked() }
+        #expect(await Self.wait(for: restartEnqueued))
+        await stopEntered.wait()
+        let stopTask = Task { await runtime.stopChecked() }
+        #expect(await Self.wait(for: stopEnqueued))
+        await releaseStop.open()
+
+        _ = try await restartTask.value
+        await stopTask.value
+        #expect(await runtime.snapshot().state == .stopped)
+        #expect(!FileManager.default.fileExists(atPath: socketPath))
+    }
+
+    @Test
+    @MainActor
+    func `queued stop start stop preserves the latest intent`() async throws {
+        let socketPath = Self.socketPath()
+        defer { Self.removeSocketArtifacts(socketPath) }
+        let stopEntered = AsyncTestGate()
+        let releaseStop = AsyncTestGate()
+        let startEnqueued = DispatchSemaphore(value: 0)
+        let stopEnqueued = DispatchSemaphore(value: 0)
+        let runtime = PeekabooEmbeddedBridgeRuntime(
+            configuration: .init(
+                socketPath: socketPath,
+                allowlistedTeams: ["TEAMID"],
+                allowlistedBundles: ["com.example.client"]),
+            services: PeekabooEmbeddedBridgeServices(),
+            lifecycleHooks: .init(
+                didEnqueueStart: { startEnqueued.signal() },
+                didEnqueueStop: { stopEnqueued.signal() },
+                willStopHost: {
+                    await stopEntered.open()
+                    await releaseStop.wait()
+                }))
+        _ = try await runtime.startChecked()
+        #expect(await Self.wait(for: startEnqueued))
+
+        let firstStop = Task { await runtime.stopChecked() }
+        #expect(await Self.wait(for: stopEnqueued))
+        await stopEntered.wait()
+        let start = Task { try await runtime.startChecked() }
+        #expect(await Self.wait(for: startEnqueued))
+        let finalStop = Task { await runtime.stopChecked() }
+        #expect(await Self.wait(for: stopEnqueued))
+        await releaseStop.open()
+
+        await firstStop.value
+        _ = try await start.value
+        await finalStop.value
+        #expect(await runtime.snapshot().state == .stopped)
+        #expect(!FileManager.default.fileExists(atPath: socketPath))
+    }
+
+    @Test
+    @MainActor
+    func `unauthorized signed peer receives a typed refusal`() async throws {
+        let socketPath = Self.socketPath()
+        defer { Self.removeSocketArtifacts(socketPath) }
+        let runtime = PeekabooEmbeddedBridgeRuntime(
+            configuration: .init(
+                socketPath: socketPath,
+                allowlistedTeams: ["NOT_THE_CURRENT_TEAM"],
+                allowlistedBundles: ["com.example.client"]),
+            services: PeekabooEmbeddedBridgeServices())
+        _ = try await runtime.startChecked()
+        defer { Task { await runtime.stopChecked() } }
+
+        let request = try JSONEncoder.peekabooBridgeEncoder().encode(PeekabooBridgeRequest.permissionsStatus)
+        let responseData = try Self.sendUnixRequest(path: socketPath, request: request)
+        let response = try JSONDecoder.peekabooBridgeDecoder().decode(
+            PeekabooBridgeResponse.self,
+            from: responseData)
+        guard case let .error(error) = response else {
+            Issue.record("Expected an unauthorized error response, got \(response)")
+            return
+        }
+        #expect(error.code == .unauthorizedClient)
+    }
+
+    @MainActor
+    private static func runtime(socketPath: String) -> PeekabooEmbeddedBridgeRuntime {
+        PeekabooEmbeddedBridgeRuntime(
+            configuration: .init(
+                socketPath: socketPath,
+                allowlistedTeams: ["TEAMID"],
+                allowlistedBundles: ["com.example.client"]),
+            services: PeekabooEmbeddedBridgeServices())
+    }
+
+    private static func temporaryDirectory() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("peekaboo-embedded-runtime-tests-\(UUID().uuidString)", isDirectory: true)
+    }
+
+    private static func socketPath() -> String {
+        "/tmp/peekaboo-embedded-runtime-\(UUID().uuidString).sock"
+    }
+
+    private static func removeSocketArtifacts(_ socketPath: String) {
+        try? FileManager.default.removeItem(atPath: socketPath)
+        try? FileManager.default.removeItem(atPath: "\(socketPath).lock")
+    }
+
+    private static func wait(
+        for semaphore: DispatchSemaphore,
+        timeout: DispatchTime = .now() + 2) async -> Bool
+    {
+        await withCheckedContinuation { continuation in
+            DispatchQueue.global().async {
+                continuation.resume(returning: semaphore.wait(timeout: timeout) == .success)
+            }
+        }
+    }
+
+    private static func sendUnixRequest(path: String, request: Data) throws -> Data {
+        let descriptor = socket(AF_UNIX, SOCK_STREAM, 0)
+        guard descriptor >= 0 else { throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO) }
+        defer { close(descriptor) }
+
+        var address = sockaddr_un()
+        address.sun_family = sa_family_t(AF_UNIX)
+        let capacity = MemoryLayout.size(ofValue: address.sun_path)
+        let copied = path.withCString { strlcpy(&address.sun_path.0, $0, capacity) }
+        guard copied < capacity else { throw POSIXError(.ENAMETOOLONG) }
+
+        var localAddress = address
+        let addressLength = socklen_t(MemoryLayout.size(ofValue: localAddress))
+        let result = withUnsafePointer(to: &localAddress) { pointer -> Int32 in
+            Darwin.connect(
+                descriptor,
+                UnsafeRawPointer(pointer).assumingMemoryBound(to: sockaddr.self),
+                addressLength)
+        }
+        guard result == 0 else { throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO) }
+
+        try request.withUnsafeBytes { bytes in
+            guard let baseAddress = bytes.baseAddress else { return }
+            var written = 0
+            while written < request.count {
+                let count = write(descriptor, baseAddress.advanced(by: written), request.count - written)
+                if count > 0 {
+                    written += count
+                } else if count < 0, errno != EINTR {
+                    throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+                }
+            }
+        }
+        _ = shutdown(descriptor, SHUT_WR)
+
+        var response = Data()
+        var buffer = [UInt8](repeating: 0, count: 4096)
+        while true {
+            let count = read(descriptor, &buffer, buffer.count)
+            if count > 0 {
+                response.append(buffer, count: count)
+            } else if count == 0 {
+                return response
+            } else if errno != EINTR {
+                throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+            }
+        }
+    }
+}
+
+private actor AsyncTestGate {
+    private var isOpen = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func wait() async {
+        guard !self.isOpen else { return }
+        await withCheckedContinuation { continuation in
+            self.waiters.append(continuation)
+        }
+    }
+
+    func open() {
+        guard !self.isOpen else { return }
+        self.isOpen = true
+        let waiters = self.waiters
+        self.waiters.removeAll()
+        waiters.forEach { $0.resume() }
+    }
+}

--- a/docs/bridge-host.md
+++ b/docs/bridge-host.md
@@ -70,6 +70,40 @@ launch remains background-only.
 `peekaboo mcp` never hosts a Bridge listener. When it must run services locally, its in-process daemon is limited to
 the window tracker and other process-local support.
 
+## Embedding a native host
+
+Signed macOS applications can host the native automation surface without linking `PeekabooCore`, Tachikoma, browser
+support, or agent/provider state. The `PeekabooBridge` product exposes a checked runtime with an explicit socket and
+explicit caller-signing policy:
+
+```swift
+import PeekabooBridge
+
+let runtime = await PeekabooEmbeddedBridgeRuntime.make(
+    configuration: .init(
+        socketPath: embeddedBridgeSocketPath,
+        allowlistedTeams: ["YOUR_TEAM_ID"],
+        allowlistedBundles: ["com.example.AutomationClient"]))
+try await runtime.startChecked()
+```
+
+The standard assembly uses one durable desktop-mutation watermark with one in-memory snapshot manager, copies retained
+capture artifacts into manager-owned storage, and defaults action-capable input to accessibility-first background
+delivery. Its allowlist is native-only: browser MCP, daemon control, interactive permission prompts, and the legacy
+AppleScript probe cannot be enabled by configuration. The containing app remains responsible for presenting permission
+UI and choosing an app-specific socket path; embedded hosts never compete for Peekaboo.app's socket by default. The
+runtime always advertises the `backgroundBridgeHost` capability; caller-supplied capabilities are additive and cannot
+remove that routing contract.
+
+Retain the runtime for the full host lifetime. `startChecked()` returns only after the private UNIX listener is ready,
+and `stopChecked()` waits for non-cooperative in-flight requests to release the socket lease. Concurrent start, stop,
+and restart intents execute in arrival order, so a later stop cannot be undone by an older suspended restart. A failed
+signing-capability registration or bind leaves the runtime stopped and does not publish a partial host.
+
+Peekaboo.app and the reusable daemon still use the full `PeekabooServices` registry because they also own agent,
+browser, configuration, audio, and visualizer state. A follow-up can make that registry compose this native bundle once
+those app-only services are injected separately; moving them into the embedded runtime would defeat its lean boundary.
+
 ## Transport
 
 - **UNIX-domain socket**, single request per connection:

--- a/scripts/test-swiftpm-consumer.sh
+++ b/scripts/test-swiftpm-consumer.sh
@@ -113,6 +113,16 @@ let failure = DesktopActionFailure.refused(
     reason: .targetUnavailable,
     message: "Consumer contract probe")
 precondition(!pendingReservationDisposition(for: failure))
+
+@MainActor
+func makeEmbeddedRuntime() -> PeekabooEmbeddedBridgeRuntime {
+    PeekabooEmbeddedBridgeRuntime.make(configuration: .init(
+        socketPath: "/tmp/peekaboo-consumer-contract.sock",
+        allowlistedTeams: ["TEAMID"],
+        allowlistedBundles: ["com.example.PeekabooConsumer"]))
+}
+
+_ = makeEmbeddedRuntime
 EOF
 
 swift package --package-path "${consumer_dir}" resolve


### PR DESCRIPTION
## Summary

- expose a checked `PeekabooEmbeddedBridgeRuntime` for signed macOS apps without linking PeekabooCore, provider, browser, daemon, or agent state
- centralize native desktop-lane ownership and assemble shared snapshot, mutation-watermark, and background-first input services at the Bridge boundary
- require explicit caller Team ID and bundle allowlists, and prevent configuration from broadening the embedded surface to browser, daemon-control, interactive-permission, or AppleScript operations
- serialize start, stop, and restart intents and retain socket ownership until deferred request draining completes
- report bundle/signing-identifier authorization failures with bundle-specific safe remediation instead of blaming the caller's Team ID

## Verification

- `swift test --package-path Core/PeekabooCore --filter PeekabooEmbeddedBridgeRuntimeTests` — 12 tests passed
- `swift test --package-path Apps/CLI --filter BridgeStatusReportHintTests` — 5 tests passed
- `./scripts/test-swiftpm-consumer.sh` — fresh external production consumer build passed
- [Foundation-signed allowed/denied exact-socket proof and maintainer owner decision](https://github.com/openclaw/Peekaboo/pull/457#issuecomment-5288683594)
- `git diff --check origin/main...HEAD`
- structured P0–P2 autoreview of the feature and follow-up diagnostic increment — clean, no accepted or actionable findings

Exact reviewed head: `351fbcabda23aad962b4fc60bd78e1e61a703dd5`
