### PR TITLE
fix(cli): preserve classic-first automatic capture

### DIFF
--- a/Apps/CLI/Sources/PeekabooCLI/Commands/AI/SeeCommand+ObservationRequest.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/AI/SeeCommand+ObservationRequest.swift
@@ -192,7 +192,10 @@ extension SeeCommand {
     }
 
     private var observationCaptureEnginePreference: CaptureEnginePreference {
-        ObservationCommandSupport.captureEnginePreference(
+        if let safetyOverride = self.runtime?.captureEngineSafetyOverride {
+            return safetyOverride
+        }
+        return ObservationCommandSupport.captureEnginePreference(
             cliValue: self.captureEngine,
             configuredValue: self.configuredCaptureEnginePreference
         )

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/AI/SeeCommand+PixelObservationRequest.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/AI/SeeCommand+PixelObservationRequest.swift
@@ -79,7 +79,10 @@ extension SeeCommand {
     }
 
     private var pixelObservationCaptureEnginePreference: CaptureEnginePreference {
-        ObservationCommandSupport.captureEnginePreference(
+        if let safetyOverride = self.runtime?.captureEngineSafetyOverride {
+            return safetyOverride
+        }
+        return ObservationCommandSupport.captureEnginePreference(
             cliValue: self.captureEngine,
             configuredValue: self.configuredCaptureEnginePreference
         )

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommandRuntime.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommandRuntime.swift
@@ -156,6 +156,7 @@ struct CommandRuntime {
     let hostDescription: String
     let selectedRemoteSocketPath: String?
     let selectedRemoteHostProcessIdentifier: pid_t?
+    let captureEngineSafetyOverride: CaptureEnginePreference?
     let snapshotInvalidationRemoteSocketPaths: [String]
     let applicationRelaunchAllowed: Bool
     let requiredHostFailure: String?
@@ -178,6 +179,7 @@ struct CommandRuntime {
         hostDescription: String = "local (in-process)",
         selectedRemoteSocketPath: String? = nil,
         selectedRemoteHostProcessIdentifier: pid_t? = nil,
+        captureEngineSafetyOverride: CaptureEnginePreference? = nil,
         snapshotInvalidationRemoteSocketPaths: [String] = [],
         applicationRelaunchAllowed: Bool = true,
         requiredHostFailure: String? = nil,
@@ -191,6 +193,7 @@ struct CommandRuntime {
         self.hostDescription = hostDescription
         self.selectedRemoteSocketPath = selectedRemoteSocketPath
         self.selectedRemoteHostProcessIdentifier = selectedRemoteHostProcessIdentifier
+        self.captureEngineSafetyOverride = captureEngineSafetyOverride
         self.snapshotInvalidationRemoteSocketPaths = snapshotInvalidationRemoteSocketPaths
         self.applicationRelaunchAllowed = applicationRelaunchAllowed
         self.requiredHostFailure = requiredHostFailure
@@ -269,6 +272,7 @@ extension CommandRuntime {
             hostDescription: resolution.hostDescription,
             selectedRemoteSocketPath: resolution.selectedRemoteSocketPath,
             selectedRemoteHostProcessIdentifier: resolution.selectedRemoteHostProcessIdentifier,
+            captureEngineSafetyOverride: resolution.captureEngineSafetyOverride,
             snapshotInvalidationRemoteSocketPaths: resolution.snapshotInvalidationRemoteSocketPaths,
             applicationRelaunchAllowed: resolution.applicationRelaunchAllowed,
             requiredHostFailure: resolution.requiredHostFailure

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/RuntimeHostResolver+Resolution.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/RuntimeHostResolver+Resolution.swift
@@ -1,0 +1,16 @@
+import Darwin
+import PeekabooAutomationKit
+import PeekabooCore
+
+extension RuntimeHostResolver {
+    struct Resolution {
+        let services: any PeekabooServiceProviding
+        let hostDescription: String
+        let selectedRemoteSocketPath: String?
+        let selectedRemoteHostProcessIdentifier: pid_t?
+        let snapshotInvalidationRemoteSocketPaths: [String]
+        let applicationRelaunchAllowed: Bool
+        let requiredHostFailure: String?
+        var captureEngineSafetyOverride: CaptureEnginePreference?
+    }
+}

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/RuntimeHostResolver+ScreenCaptureKitOwner.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/RuntimeHostResolver+ScreenCaptureKitOwner.swift
@@ -149,6 +149,12 @@ extension RuntimeHostResolver {
         let buildIdentity: String?
     }
 
+    enum ScreenCaptureKitSafetyDisposition {
+        case refuse
+        case deferLocalRuntime
+        case routeAutomaticCapture
+    }
+
     static func requiresCallerLocalModernOwnerClaim(
         options: CommandRuntimeOptions,
         environment: [String: String]
@@ -183,6 +189,48 @@ extension RuntimeHostResolver {
         return options.requiresScreenCapturePermission &&
             options.transportsCaptureEnginePreference &&
             preference != .legacy
+    }
+
+    static func canRouteAutomaticCaptureAroundAuxiliaryOwnerUnawareHost(
+        _ host: ScreenCaptureKitOwnerUnawareHost,
+        plan: RemoteCandidatePlan,
+        options: CommandRuntimeOptions,
+        environment: [String: String]
+    ) -> Bool {
+        guard self.captureEnginePreferenceForOwnership(options: options, environment: environment) == .auto,
+              options.requiresScreenCapturePermission,
+              options.transportsCaptureEnginePreference,
+              options.requiresScreenCaptureKitOwnerCapability
+        else {
+            return false
+        }
+
+        let hostPath = NSString(string: host.socketPath).standardizingPath
+        return !plan.candidates.contains {
+            NSString(string: $0.socketPath).standardizingPath == hostPath
+        }
+    }
+
+    static func screenCaptureKitSafetyDisposition(
+        for host: ScreenCaptureKitOwnerUnawareHost,
+        plan: RemoteCandidatePlan,
+        options: CommandRuntimeOptions,
+        environment: [String: String]
+    ) -> ScreenCaptureKitSafetyDisposition {
+        if options.usesPerToolSnapshotInvalidation,
+           !options.requiresScreenCapturePermission,
+           plan.explicitSocket == nil {
+            return .deferLocalRuntime
+        }
+        if self.canRouteAutomaticCaptureAroundAuxiliaryOwnerUnawareHost(
+            host,
+            plan: plan,
+            options: options,
+            environment: environment
+        ) {
+            return .routeAutomaticCapture
+        }
+        return .refuse
     }
 
     static func screenCaptureKitHostMatchesOwner(

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/RuntimeHostResolver+ScreenCaptureKitOwner.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/RuntimeHostResolver+ScreenCaptureKitOwner.swift
@@ -24,7 +24,8 @@ extension RuntimeHostResolver {
         ImplicitRemoteCandidate,
         PeekabooBridgeClientIdentity
     ) async throws -> PeekabooBridgeHandshakeResponse
-    typealias ScreenCaptureKitExternalHostInspector = @MainActor @Sendable (String) -> Bool
+    typealias ScreenCaptureKitExternalHostInspector = @MainActor @Sendable (String) ->
+        ScreenCaptureKitExternalHostPresence
 
     struct Dependencies {
         let makeLocalServices: LocalServiceFactory
@@ -79,7 +80,8 @@ extension RuntimeHostResolver {
                 ScreenCaptureKitOwnerLease.registerPotentialUncoordinatedHost(
                     socketPath: host.socketPath,
                     processIdentifier: host.processIdentifier,
-                    processStartIdentity: host.processStartIdentity
+                    processStartIdentity: host.processStartIdentity,
+                    buildIdentity: host.buildIdentity
                 )
             }
         )
@@ -101,6 +103,50 @@ extension RuntimeHostResolver {
         let socketPath: String
         let processIdentifier: pid_t?
         let processStartIdentity: UInt64?
+        let buildIdentity: String?
+
+        init(
+            socketPath: String,
+            processIdentifier: pid_t?,
+            processStartIdentity: UInt64?,
+            buildIdentity: String? = nil
+        ) {
+            self.socketPath = socketPath
+            self.processIdentifier = processIdentifier
+            self.processStartIdentity = processStartIdentity
+            self.buildIdentity = buildIdentity
+        }
+    }
+
+    enum ScreenCaptureKitExternalHostPresence: Equatable {
+        case absent
+        case present(
+            processIdentifier: pid_t?,
+            processStartIdentity: UInt64?,
+            buildIdentity: String?
+        )
+
+        var identity: (
+            processIdentifier: pid_t?,
+            processStartIdentity: UInt64?,
+            buildIdentity: String?
+        )? {
+            switch self {
+            case .absent:
+                nil
+            case let .present(processIdentifier, processStartIdentity, buildIdentity):
+                (processIdentifier, processStartIdentity, buildIdentity)
+            }
+        }
+    }
+
+    struct ScreenCaptureKitExternalApplication: Equatable {
+        let bundleIdentifier: String?
+        let bundleName: String?
+        let localizedName: String?
+        let processIdentifier: pid_t
+        let isTerminated: Bool
+        let buildIdentity: String?
     }
 
     static func requiresCallerLocalModernOwnerClaim(
@@ -218,11 +264,28 @@ extension RuntimeHostResolver {
 
     static func ownerRefusal(
         error: any Error,
-        callerLocal: Bool
+        callerLocal: Bool,
+        selectedSocket: String? = nil
     ) -> PreDispatchActionError {
-        if let leaseError = error as? ScreenCaptureKitOwnerLease.LeaseError,
-           case let .ownedByAnotherProcess(_, receipt) = leaseError {
-            return self.ownerRefusal(owner: receipt, callerLocal: callerLocal)
+        if let leaseError = error as? ScreenCaptureKitOwnerLease.LeaseError {
+            switch leaseError {
+            case let .ownedByAnotherProcess(_, receipt):
+                return self.ownerRefusal(owner: receipt, callerLocal: callerLocal)
+            case let .uncoordinatedHosts(hosts):
+                if let host = hosts.first {
+                    return self.ownerCapabilityRefusal(
+                        host: ScreenCaptureKitOwnerUnawareHost(
+                            socketPath: host.socketPath,
+                            processIdentifier: host.processIdentifier,
+                            processStartIdentity: host.processStartIdentity,
+                            buildIdentity: host.buildIdentity
+                        ),
+                        selectedSocket: selectedSocket
+                    )
+                }
+            default:
+                break
+            }
         }
         return PreDispatchActionError(
             message: "Peekaboo could not establish safe ScreenCaptureKit process ownership. No capture was dispatched.",
@@ -233,22 +296,46 @@ extension RuntimeHostResolver {
     }
 
     static func ownerCapabilityRefusal(
-        host: ScreenCaptureKitOwnerUnawareHost
+        host: ScreenCaptureKitOwnerUnawareHost,
+        selectedSocket: String?
     ) -> PreDispatchActionError {
-        let identity = if let processIdentifier = host.processIdentifier,
-                          let processStartIdentity = host.processStartIdentity {
-            "PID \(processIdentifier), generation \(processStartIdentity)"
+        let ownerSocket = NSString(string: host.socketPath).standardizingPath
+        let selectedSocket = selectedSocket.map { NSString(string: $0).standardizingPath }
+        let selectedSocketText = selectedSocket ?? "automatic resolution"
+        let buildText = self.safeDiagnosticBuildIdentity(host.buildIdentity).map { ", build \($0)" } ?? ""
+        let hasExactProcessIdentity = host.processIdentifier != nil && host.processStartIdentity != nil
+        let identityText: String
+        let message: String
+        if let processIdentifier = host.processIdentifier,
+           let processStartIdentity = host.processStartIdentity {
+            identityText = "PID \(processIdentifier), generation \(processStartIdentity)\(buildText)"
+            message = "Bridge host \(identityText) at owner socket \(ownerSocket) predates safe " +
+                "process-lifetime ScreenCaptureKit ownership. Selected socket: \(selectedSocketText). " +
+                "No capture was dispatched."
         } else if let processIdentifier = host.processIdentifier {
-            "PID \(processIdentifier)"
+            identityText = "PID \(processIdentifier)\(buildText)"
+            message = "Bridge host \(identityText) at owner socket \(ownerSocket) may predate safe " +
+                "process-lifetime ScreenCaptureKit ownership, but its exact process-start identity is unavailable. " +
+                "Selected socket: \(selectedSocketText). No capture was dispatched."
         } else {
-            "an unknown process generation"
+            identityText = "unknown process identity\(buildText)"
+            message = "A live Bridge host at owner socket \(ownerSocket) may predate safe process-lifetime " +
+                "ScreenCaptureKit ownership, but its exact PID and process-start identity are unavailable" +
+                "\(buildText). Selected socket: \(selectedSocketText). No capture was dispatched."
+        }
+        let hint = if hasExactProcessIdentity {
+            "Update or relaunch the host at owner socket \(ownerSocket). If stopping it is necessary, first " +
+                "revalidate and stop exactly \(identityText); never use the socket path alone. Alternatively, " +
+                "explicitly choose --capture-engine classic."
+        } else {
+            "Update or relaunch the app configured for owner socket \(ownerSocket), or explicitly choose " +
+                "--capture-engine classic. Do not stop any process based on this refusal: the exact PID and " +
+                "process-start identity are unavailable."
         }
         return PreDispatchActionError(
-            message: "Bridge host \(identity) via \(host.socketPath) predates safe process-lifetime " +
-                "ScreenCaptureKit ownership. No capture was dispatched.",
+            message: message,
             code: .CAPTURE_FAILED,
-            hint: "Update and relaunch Peekaboo, or verify and stop that exact host before retrying. " +
-                "Peekaboo will not start a second ScreenCaptureKit owner while it remains live.",
+            hint: hint,
             reason: .runtimeIncompatible
         )
     }
@@ -260,8 +347,8 @@ extension RuntimeHostResolver {
             try await PeekabooBridgeClient(socketPath: candidate.socketPath)
                 .handshake(client: identity, requestedHost: nil)
         },
-        externalHostIsRunning: @escaping ScreenCaptureKitExternalHostInspector = {
-            RuntimeHostResolver.isKnownExternalHostProcessRunning(socketPath: $0)
+        externalHostPresence: @escaping ScreenCaptureKitExternalHostInspector = {
+            RuntimeHostResolver.knownExternalHostPresence(socketPath: $0)
         }
     ) async throws -> ScreenCaptureKitOwnerUnawareHost? {
         for candidate in candidates {
@@ -276,14 +363,17 @@ extension RuntimeHostResolver {
                 if Task.isCancelled {
                     throw CancellationError()
                 }
+                let presence = externalHostPresence(candidate.socketPath)
                 if self.isDefinitiveScreenCaptureKitSocketAbsence(error),
-                   !externalHostIsRunning(candidate.socketPath) {
+                   presence == .absent {
                     continue
                 }
+                let knownIdentity = presence.identity
                 return ScreenCaptureKitOwnerUnawareHost(
                     socketPath: candidate.socketPath,
-                    processIdentifier: nil,
-                    processStartIdentity: nil
+                    processIdentifier: knownIdentity?.processIdentifier,
+                    processStartIdentity: knownIdentity?.processStartIdentity,
+                    buildIdentity: knownIdentity?.buildIdentity
                 )
             }
             guard !BridgeCapabilityPolicy.supportsScreenCaptureKitProcessOwnership(for: response),
@@ -292,10 +382,20 @@ extension RuntimeHostResolver {
             else {
                 continue
             }
+            let externalIdentity = externalHostPresence(candidate.socketPath).identity
+            let handshakeProcessIdentifier = response.hostIdentity?.processIdentifier
+            let processIdentifier = handshakeProcessIdentifier ?? externalIdentity?.processIdentifier
+            let externalIdentityMatches = handshakeProcessIdentifier == nil ||
+                handshakeProcessIdentifier == externalIdentity?.processIdentifier
+            let processStartIdentity = response.hostIdentity?.processStartIdentity ?? {
+                guard externalIdentityMatches else { return nil }
+                return externalIdentity?.processStartIdentity
+            }()
             return ScreenCaptureKitOwnerUnawareHost(
                 socketPath: candidate.socketPath,
-                processIdentifier: response.hostIdentity?.processIdentifier,
-                processStartIdentity: response.hostIdentity?.processStartIdentity
+                processIdentifier: processIdentifier,
+                processStartIdentity: processStartIdentity,
+                buildIdentity: response.build ?? (externalIdentityMatches ? externalIdentity?.buildIdentity : nil)
             )
         }
         return nil
@@ -313,24 +413,102 @@ extension RuntimeHostResolver {
         return code == .ENOENT || code == .ECONNREFUSED || code == .ENAMETOOLONG
     }
 
-    private static func isKnownExternalHostProcessRunning(socketPath: String) -> Bool {
+    private static func knownExternalHostPresence(socketPath: String) -> ScreenCaptureKitExternalHostPresence {
+        let applications = NSWorkspace.shared.runningApplications.map { application in
+            ScreenCaptureKitExternalApplication(
+                bundleIdentifier: application.bundleIdentifier,
+                bundleName: application.bundleURL?.deletingPathExtension().lastPathComponent,
+                localizedName: application.localizedName,
+                processIdentifier: application.processIdentifier,
+                isTerminated: application.isTerminated,
+                buildIdentity: self.externalHostBuildIdentity(application)
+            )
+        }
+        return self.knownExternalHostPresence(
+            socketPath: socketPath,
+            applications: applications,
+            processStartIdentity: SystemIdentityResolver.processStartIdentity
+        )
+    }
+
+    static func knownExternalHostPresence(
+        socketPath: String,
+        applications: [ScreenCaptureKitExternalApplication],
+        processStartIdentity: (pid_t) -> UInt64?
+    ) -> ScreenCaptureKitExternalHostPresence {
         let standardizedPath = NSString(string: socketPath).standardizingPath
         let identityFragments: [String]
+        let exactBundleIdentifiers: Set<String>
         if standardizedPath == NSString(string: PeekabooBridgeConstants.claudeSocketPath).standardizingPath {
             identityFragments = ["anthropic.claude", "claude"]
+            exactBundleIdentifiers = ["com.anthropic.claudefordesktop"]
         } else if standardizedPath == NSString(string: PeekabooBridgeConstants.clawdbotSocketPath).standardizingPath {
             identityFragments = ["clawdbot", "openclaw"]
+            exactBundleIdentifiers = [
+                "com.clawdis.mac",
+                "com.clawdis.mac.debug",
+                "com.clawdbot.mac",
+                "com.clawdbot.mac.debug",
+                "bot.molt.mac",
+                "bot.molt.mac.debug",
+                "ai.openclaw.mac",
+                "ai.openclaw.mac.debug",
+            ]
         } else {
-            return false
+            return .absent
         }
 
-        return NSWorkspace.shared.runningApplications.contains { application in
+        let broadMatches = applications.filter { application in
             let values = [
                 application.bundleIdentifier?.lowercased(),
-                application.bundleURL?.deletingPathExtension().lastPathComponent.lowercased(),
+                application.bundleName?.lowercased(),
                 application.localizedName?.lowercased(),
             ].compactMap(\.self)
             return identityFragments.contains { fragment in values.contains(where: { $0.contains(fragment) }) }
+        }
+        guard !broadMatches.isEmpty else { return .absent }
+
+        let exactMatches = applications.filter { application in
+            guard let bundleIdentifier = application.bundleIdentifier?.lowercased() else { return false }
+            return exactBundleIdentifiers.contains(bundleIdentifier)
+        }
+        guard exactMatches.count == 1,
+              let application = exactMatches.first,
+              !application.isTerminated,
+              application.processIdentifier > 0
+        else {
+            return .present(processIdentifier: nil, processStartIdentity: nil, buildIdentity: nil)
+        }
+
+        let processIdentifier = application.processIdentifier
+        guard let firstGeneration = processStartIdentity(processIdentifier),
+              !application.isTerminated,
+              processStartIdentity(processIdentifier) == firstGeneration
+        else {
+            return .present(processIdentifier: nil, processStartIdentity: nil, buildIdentity: nil)
+        }
+        return .present(
+            processIdentifier: processIdentifier,
+            processStartIdentity: firstGeneration,
+            buildIdentity: application.buildIdentity
+        )
+    }
+
+    private static func externalHostBuildIdentity(_ application: NSRunningApplication) -> String? {
+        guard let bundleURL = application.bundleURL,
+              let information = Bundle(url: bundleURL)?.infoDictionary
+        else { return nil }
+        let shortVersion = information["CFBundleShortVersionString"] as? String
+        let buildVersion = information["CFBundleVersion"] as? String
+        switch (shortVersion, buildVersion) {
+        case let (shortVersion?, buildVersion?) where shortVersion != buildVersion:
+            return "\(shortVersion) (\(buildVersion))"
+        case let (shortVersion?, _):
+            return shortVersion
+        case let (_, buildVersion?):
+            return buildVersion
+        default:
+            return nil
         }
     }
 
@@ -338,13 +516,15 @@ extension RuntimeHostResolver {
         owner: ScreenCaptureKitOwnerLease.OwnerReceipt,
         callerLocal: Bool
     ) -> PreDispatchActionError {
-        let ownerText = "PID \(owner.processIdentifier), generation \(owner.processStartIdentity)"
+        let ownerText = self.ownerDescription(owner)
         let message = if callerLocal {
             "Caller-local ScreenCaptureKit is already owned by another Peekaboo process (\(ownerText)). " +
+                "Selected route: caller-local; owner socket: unavailable in the process ownership receipt. " +
                 "No capture was dispatched."
         } else {
             "ScreenCaptureKit is owned by another Peekaboo process (\(ownerText)), but no compatible " +
-                "Bridge host for that exact process generation is available. No capture was dispatched."
+                "Bridge host for that exact process generation is available. Selected socket: automatic " +
+                "resolution; owner socket: unavailable in the process ownership receipt. No capture was dispatched."
         }
         let hint = if callerLocal {
             "Retry without --no-remote to use the selected owner host; otherwise verify and stop exactly " +
@@ -365,10 +545,11 @@ extension RuntimeHostResolver {
         owner: ScreenCaptureKitOwnerLease.OwnerReceipt,
         explicitSocket: String
     ) -> PreDispatchActionError {
-        let ownerText = "PID \(owner.processIdentifier), generation \(owner.processStartIdentity)"
+        let ownerText = self.ownerDescription(owner)
+        let selectedSocket = NSString(string: explicitSocket).standardizingPath
         return PreDispatchActionError(
-            message: "The explicitly selected Bridge socket \(explicitSocket) is not served by the " +
-                "ScreenCaptureKit owner (\(ownerText)). No capture was dispatched.",
+            message: "Selected socket: \(selectedSocket). The ScreenCaptureKit owner is \(ownerText), but its " +
+                "owner socket is unavailable in the process ownership receipt. No capture was dispatched.",
             code: .CAPTURE_FAILED,
             hint: "Change or remove --bridge-socket to select the exact owner host; otherwise verify and stop " +
                 "\(ownerText), or explicitly choose --capture-engine classic.",
@@ -380,15 +561,45 @@ extension RuntimeHostResolver {
         owner: ScreenCaptureKitOwnerLease.OwnerReceipt,
         requiredSocket: String
     ) -> PreDispatchActionError {
-        let ownerText = "PID \(owner.processIdentifier), generation \(owner.processStartIdentity)"
+        let ownerText = self.ownerDescription(owner)
+        let selectedSocket = NSString(string: requiredSocket).standardizingPath
         return PreDispatchActionError(
-            message: "ScreenCaptureKit owner \(ownerText) does not serve the current stateful build-scoped " +
-                "runtime at \(requiredSocket). No capture was dispatched.",
+            message: "ScreenCaptureKit owner \(ownerText) does not serve selected socket \(selectedSocket); " +
+                "the owner socket is unavailable in the process ownership receipt. No capture was dispatched.",
             code: .CAPTURE_FAILED,
             hint: "Stop or upgrade the exact owner before retrying. Peekaboo will not violate process ownership " +
                 "or route stateful snapshot work to a different build.",
             reason: .runtimeIncompatible
         )
+    }
+
+    private static func ownerDescription(_ owner: ScreenCaptureKitOwnerLease.OwnerReceipt) -> String {
+        let base = "PID \(owner.processIdentifier), generation \(owner.processStartIdentity)"
+        if let buildIdentity = self.safeDiagnosticBuildIdentity(owner.buildIdentity) {
+            return "\(base), build \(buildIdentity)"
+        }
+        if let codeSignatureHash = self.safeDiagnosticBuildIdentity(owner.codeSignatureHash) {
+            return "\(base), build CDHash \(codeSignatureHash)"
+        }
+        return base
+    }
+
+    /// Build strings cross a process boundary. Keep useful version/hash evidence while refusing
+    /// paths, control characters, shell metacharacters, and unbounded host-provided text.
+    private static func safeDiagnosticBuildIdentity(_ rawValue: String?) -> String? {
+        guard let value = rawValue?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !value.isEmpty,
+              value.utf8.count <= 128
+        else { return nil }
+        let permittedPunctuation = Set(" ._:+-()[]".unicodeScalars.map(\.value))
+        guard value.unicodeScalars.allSatisfy({ scalar in
+            let codePoint = scalar.value
+            return (codePoint >= 48 && codePoint <= 57) ||
+                (codePoint >= 65 && codePoint <= 90) ||
+                (codePoint >= 97 && codePoint <= 122) ||
+                permittedPunctuation.contains(codePoint)
+        }) else { return nil }
+        return value
     }
 
     static func captureEnginePreferenceForOwnership(

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/RuntimeHostResolver.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/RuntimeHostResolver.swift
@@ -7,16 +7,6 @@ import PeekabooCore
 
 @MainActor
 enum RuntimeHostResolver {
-    struct Resolution {
-        let services: any PeekabooServiceProviding
-        let hostDescription: String
-        let selectedRemoteSocketPath: String?
-        let selectedRemoteHostProcessIdentifier: pid_t?
-        let snapshotInvalidationRemoteSocketPaths: [String]
-        let applicationRelaunchAllowed: Bool
-        let requiredHostFailure: String?
-    }
-
     struct ImplicitRemoteCandidate: Equatable {
         let socketPath: String
         let requireReusableDaemon: Bool
@@ -61,6 +51,7 @@ enum RuntimeHostResolver {
         dependencies: Dependencies
     ) async throws -> Resolution {
         var deferredScreenCaptureKitSafetyBlocker = false
+        var captureEngineSafetyOverride: CaptureEnginePreference?
         if self.requiresCallerLocalModernOwnerClaim(options: options, environment: environment) {
             do {
                 if let owner = try dependencies.inspectScreenCaptureKitOwner(),
@@ -92,8 +83,9 @@ enum RuntimeHostResolver {
                 case .refuse: throw self.ownerCapabilityRefusal(host: oldHost, selectedSocket: plan.explicitSocket)
                 case .deferLocalRuntime: deferredScreenCaptureKitSafetyBlocker = true
                 case .routeAutomaticCapture:
-                    // Auto is classic-first. The selected host still refuses any later SCK fallback.
-                    break
+                    // The blocker tombstone belongs to this caller process. Clamp the transported
+                    // request so a different Bridge process cannot fall back from classic to SCK.
+                    captureEngineSafetyOverride = .legacy
                 }
             }
         } else {
@@ -120,7 +112,8 @@ enum RuntimeHostResolver {
                 selectedRemoteHostProcessIdentifier: nil,
                 snapshotInvalidationRemoteSocketPaths: [],
                 applicationRelaunchAllowed: true,
-                requiredHostFailure: nil
+                requiredHostFailure: nil,
+                captureEngineSafetyOverride: captureEngineSafetyOverride
             )
         }
 
@@ -148,7 +141,8 @@ enum RuntimeHostResolver {
                 selectedRemoteHostProcessIdentifier: nil,
                 snapshotInvalidationRemoteSocketPaths: snapshotInvalidationRemoteSocketPaths,
                 applicationRelaunchAllowed: true,
-                requiredHostFailure: nil
+                requiredHostFailure: nil,
+                captureEngineSafetyOverride: captureEngineSafetyOverride
             )
         }
 
@@ -178,7 +172,8 @@ enum RuntimeHostResolver {
                 selectedRemoteHostProcessIdentifier: nil,
                 snapshotInvalidationRemoteSocketPaths: localSnapshotInvalidationPaths,
                 applicationRelaunchAllowed: true,
-                requiredHostFailure: nil
+                requiredHostFailure: nil,
+                captureEngineSafetyOverride: captureEngineSafetyOverride
             )
         }
 
@@ -189,7 +184,7 @@ enum RuntimeHostResolver {
             hostname: Host.current().name
         )
 
-        return try await self.resolveRemoteRouting(context: RemoteResolutionContext(
+        var resolution = try await self.resolveRemoteRouting(context: RemoteResolutionContext(
             options: options,
             environment: environment,
             candidatePlan: candidatePlan,
@@ -200,6 +195,8 @@ enum RuntimeHostResolver {
             inspectScreenCaptureKitSafety: dependencies.inspectScreenCaptureKitSafety,
             recordScreenCaptureKitSafetyBlocker: dependencies.recordScreenCaptureKitSafetyBlocker
         ))
+        resolution.captureEngineSafetyOverride = captureEngineSafetyOverride
+        return resolution
     }
 
     private static func resolveRemoteRouting(

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/RuntimeHostResolver.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/RuntimeHostResolver.swift
@@ -70,7 +70,7 @@ enum RuntimeHostResolver {
             } catch let error as PreDispatchActionError {
                 throw error
             } catch {
-                throw self.ownerRefusal(error: error, callerLocal: true)
+                throw self.ownerRefusal(error: error, callerLocal: true, selectedSocket: options.bridgeSocketPath)
             }
         }
         let safetyPlan: RemoteCandidatePlan?
@@ -90,7 +90,7 @@ enum RuntimeHostResolver {
                     !options.requiresScreenCapturePermission &&
                     plan.explicitSocket == nil
                 guard dynamicLocalDeferral else {
-                    throw self.ownerCapabilityRefusal(host: oldHost)
+                    throw self.ownerCapabilityRefusal(host: oldHost, selectedSocket: plan.explicitSocket)
                 }
                 deferredScreenCaptureKitSafetyBlocker = true
             }
@@ -101,7 +101,7 @@ enum RuntimeHostResolver {
             do {
                 _ = try dependencies.claimScreenCaptureKitOwner()
             } catch {
-                throw self.ownerRefusal(error: error, callerLocal: true)
+                throw self.ownerRefusal(error: error, callerLocal: true, selectedSocket: safetyPlan?.explicitSocket)
             }
         }
 
@@ -155,7 +155,8 @@ enum RuntimeHostResolver {
             do {
                 preferredScreenCaptureKitOwner = try dependencies.inspectScreenCaptureKitOwner()
             } catch {
-                throw self.ownerRefusal(error: error, callerLocal: false)
+                let selectedSocket = candidatePlan.explicitSocket
+                throw self.ownerRefusal(error: error, callerLocal: false, selectedSocket: selectedSocket)
             }
         } else {
             preferredScreenCaptureKitOwner = nil
@@ -232,7 +233,7 @@ enum RuntimeHostResolver {
                candidatePlan.candidates
            ) {
             context.recordScreenCaptureKitSafetyBlocker(oldHost)
-            throw self.ownerCapabilityRefusal(host: oldHost)
+            throw self.ownerCapabilityRefusal(host: oldHost, selectedSocket: explicitSocket)
         }
 
         if let preferredScreenCaptureKitOwner = context.preferredScreenCaptureKitOwner {

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/RuntimeHostResolver.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/RuntimeHostResolver.swift
@@ -86,13 +86,15 @@ enum RuntimeHostResolver {
                 // discovered old host therefore blocks every later SCK leaf even if another old
                 // host appears, disappears, or reuses the same socket before the runtime restarts.
                 dependencies.recordScreenCaptureKitSafetyBlocker(oldHost)
-                let dynamicLocalDeferral = options.usesPerToolSnapshotInvalidation &&
-                    !options.requiresScreenCapturePermission &&
-                    plan.explicitSocket == nil
-                guard dynamicLocalDeferral else {
-                    throw self.ownerCapabilityRefusal(host: oldHost, selectedSocket: plan.explicitSocket)
+                switch self.screenCaptureKitSafetyDisposition(
+                    for: oldHost, plan: plan, options: options, environment: environment
+                ) {
+                case .refuse: throw self.ownerCapabilityRefusal(host: oldHost, selectedSocket: plan.explicitSocket)
+                case .deferLocalRuntime: deferredScreenCaptureKitSafetyBlocker = true
+                case .routeAutomaticCapture:
+                    // Auto is classic-first. The selected host still refuses any later SCK fallback.
+                    break
                 }
-                deferredScreenCaptureKitSafetyBlocker = true
             }
         } else {
             safetyPlan = nil

--- a/Apps/CLI/Tests/CoreCLITests/ObservationPolicyDefaultsTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/ObservationPolicyDefaultsTests.swift
@@ -1,4 +1,5 @@
 import Commander
+import Foundation
 import PeekabooCore
 import Testing
 @testable import PeekabooCLI
@@ -40,6 +41,22 @@ struct ObservationPolicyDefaultsTests {
 
         #expect(try classic.makeObservationRequest(target: .frontmost).capture.engine == .legacy)
         #expect(try modern.makeObservationRequest(target: .frontmost).capture.engine == .modern)
+    }
+
+    @Test
+    func `See safety override clamps transported auto requests to classic`() throws {
+        var command = try SeeCommand.parse(["--capture-engine", "auto"])
+        command.runtime = CommandRuntime(
+            configuration: .init(verbose: false, jsonOutput: false, logLevel: nil),
+            services: PeekabooServices(),
+            captureEngineSafetyOverride: .legacy
+        )
+
+        #expect(try command.makeObservationRequest(target: .frontmost).capture.engine == .legacy)
+        #expect(command.makePixelObservationRequest(
+            target: .frontmost,
+            outputURL: FileManager.default.temporaryDirectory.appendingPathComponent("capture.png")
+        ).capture.engine == .legacy)
     }
 
     @Test

--- a/Apps/CLI/Tests/CoreCLITests/ScreenCaptureKitOwnerRuntimeTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/ScreenCaptureKitOwnerRuntimeTests.swift
@@ -265,6 +265,99 @@ struct ScreenCaptureKitOwnerRuntimeTests {
     }
 
     @Test
+    func `automatic capture routes to an owner-aware host around an auxiliary legacy SCK blocker`() async throws {
+        let selectedSocket = "/tmp/peekaboo-auto-classic-first-\(UUID().uuidString).sock"
+        let ownerAwareHost = try await Self.startHost(
+            socketPath: selectedSocket,
+            processIdentifier: 3131,
+            processStartIdentity: 4141,
+            codeSignatureHash: "current-build"
+        )
+        defer { Task { await ownerAwareHost.stop() } }
+
+        var options = Self.captureOptions(engine: "auto")
+        options.bridgeSocketPath = selectedSocket
+        options.autoStartDaemon = false
+        let auxiliaryBlocker = RuntimeHostResolver.ScreenCaptureKitOwnerUnawareHost(
+            socketPath: PeekabooBridgeConstants.claudeSocketPath,
+            processIdentifier: 5151,
+            processStartIdentity: 6161,
+            buildIdentity: "legacy-build"
+        )
+        var recordedBlockers: [RuntimeHostResolver.ScreenCaptureKitOwnerUnawareHost] = []
+        var localFactoryCalls = 0
+
+        let resolution = try await RuntimeHostResolver.resolveServices(
+            options: options,
+            environment: [:],
+            configurationInput: nil,
+            dependencies: .init(
+                makeLocalServices: { _ in
+                    localFactoryCalls += 1
+                    return PeekabooServices()
+                },
+                claimScreenCaptureKitOwner: { Self.ownerReceipt() },
+                inspectScreenCaptureKitOwner: { nil },
+                inspectScreenCaptureKitSafety: { _, _, _ in auxiliaryBlocker },
+                recordScreenCaptureKitSafetyBlocker: { recordedBlockers.append($0) }
+            )
+        )
+
+        #expect(resolution.selectedRemoteSocketPath == selectedSocket)
+        #expect(recordedBlockers == [auxiliaryBlocker])
+        #expect(localFactoryCalls == 0)
+        await ownerAwareHost.stop()
+    }
+
+    @Test
+    func `explicit modern capture still refuses an auxiliary legacy SCK blocker`() async throws {
+        let selectedSocket = "/tmp/peekaboo-modern-auxiliary-blocker-\(UUID().uuidString).sock"
+        let ownerAwareHost = try await Self.startHost(
+            socketPath: selectedSocket,
+            processIdentifier: 3131,
+            processStartIdentity: 4141,
+            codeSignatureHash: "current-build"
+        )
+        defer { Task { await ownerAwareHost.stop() } }
+
+        var options = Self.captureOptions(engine: "modern")
+        options.bridgeSocketPath = selectedSocket
+        options.autoStartDaemon = false
+        let auxiliaryBlocker = RuntimeHostResolver.ScreenCaptureKitOwnerUnawareHost(
+            socketPath: PeekabooBridgeConstants.claudeSocketPath,
+            processIdentifier: 5151,
+            processStartIdentity: 6161,
+            buildIdentity: "legacy-build"
+        )
+        var recordedBlockers: [RuntimeHostResolver.ScreenCaptureKitOwnerUnawareHost] = []
+        var localFactoryCalls = 0
+
+        let error = await #expect(throws: PreDispatchActionError.self) {
+            _ = try await RuntimeHostResolver.resolveServices(
+                options: options,
+                environment: [:],
+                configurationInput: nil,
+                dependencies: .init(
+                    makeLocalServices: { _ in
+                        localFactoryCalls += 1
+                        return PeekabooServices()
+                    },
+                    claimScreenCaptureKitOwner: { Self.ownerReceipt() },
+                    inspectScreenCaptureKitOwner: { nil },
+                    inspectScreenCaptureKitSafety: { _, _, _ in auxiliaryBlocker },
+                    recordScreenCaptureKitSafetyBlocker: { recordedBlockers.append($0) }
+                )
+            )
+        }
+
+        #expect(error?.code == .CAPTURE_FAILED)
+        #expect(error?.localizedDescription.contains("legacy-build") == true)
+        #expect(recordedBlockers == [auxiliaryBlocker])
+        #expect(localFactoryCalls == 0)
+        await ownerAwareHost.stop()
+    }
+
+    @Test
     func `known legacy owner diagnostics distinguish selected and owner sockets`() {
         let ownerSocket = "/tmp/legacy-owner.sock"
         let selectedSocket = "/tmp/selected-current.sock"

--- a/Apps/CLI/Tests/CoreCLITests/ScreenCaptureKitOwnerRuntimeTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/ScreenCaptureKitOwnerRuntimeTests.swift
@@ -232,7 +232,8 @@ struct ScreenCaptureKitOwnerRuntimeTests {
                         RuntimeHostResolver.ScreenCaptureKitOwnerUnawareHost(
                             socketPath: explicitSocket,
                             processIdentifier: 3131,
-                            processStartIdentity: 4141
+                            processStartIdentity: 4141,
+                            buildIdentity: "4.0.0 (4000099)"
                         )
                     },
                     recordScreenCaptureKitSafetyBlocker: { blocker in
@@ -247,16 +248,106 @@ struct ScreenCaptureKitOwnerRuntimeTests {
         #expect(error?.envelopeRetrySafe == true)
         #expect(error?.envelopeMutationDispatched == false)
         #expect(error?.localizedDescription.contains("PID 3131, generation 4141") == true)
+        #expect(error?.localizedDescription.contains("build 4.0.0 (4000099)") == true)
         #expect(error?.localizedDescription.contains(explicitSocket) == true)
-        #expect(error?.hint?.contains("will not start a second ScreenCaptureKit owner") == true)
+        #expect(error?.localizedDescription.contains("Selected socket: \(explicitSocket)") == true)
+        #expect(error?.hint?.contains("revalidate and stop exactly PID 3131, generation 4141") == true)
+        #expect(error?.hint?.contains("never use the socket path alone") == true)
         #expect(inspectCalls == 0)
         #expect(recordedBlockers == [RuntimeHostResolver.ScreenCaptureKitOwnerUnawareHost(
             socketPath: explicitSocket,
             processIdentifier: 3131,
-            processStartIdentity: 4141
+            processStartIdentity: 4141,
+            buildIdentity: "4.0.0 (4000099)"
         )])
         #expect(localFactoryCalls == 0)
         await oldHost.stop()
+    }
+
+    @Test
+    func `known legacy owner diagnostics distinguish selected and owner sockets`() {
+        let ownerSocket = "/tmp/legacy-owner.sock"
+        let selectedSocket = "/tmp/selected-current.sock"
+        let error = RuntimeHostResolver.ownerCapabilityRefusal(
+            host: .init(
+                socketPath: ownerSocket,
+                processIdentifier: 3131,
+                processStartIdentity: 4141,
+                buildIdentity: "4.0.0 (4000099)"
+            ),
+            selectedSocket: selectedSocket
+        )
+
+        #expect(error.code == .CAPTURE_FAILED)
+        #expect(error.envelopeMutationDispatched == false)
+        #expect(error.localizedDescription.contains("PID 3131, generation 4141") == true)
+        #expect(error.localizedDescription.contains("build 4.0.0 (4000099)") == true)
+        #expect(error.localizedDescription.contains("owner socket \(ownerSocket)") == true)
+        #expect(error.localizedDescription.contains("Selected socket: \(selectedSocket)") == true)
+        #expect(error.hint?.contains("stop exactly PID 3131, generation 4141") == true)
+        #expect(error.hint?.contains("never use the socket path alone") == true)
+    }
+
+    @Test
+    func `unknown legacy owner diagnostics refuse unsafe stop guidance and redact hostile build`() {
+        let ownerSocket = "/tmp/legacy-unknown.sock"
+        let selectedSocket = "/tmp/selected-current.sock"
+        let hostileBuild = "4.0.0\n/private/user/$TOKEN"
+        let error = RuntimeHostResolver.ownerCapabilityRefusal(
+            host: .init(
+                socketPath: ownerSocket,
+                processIdentifier: nil,
+                processStartIdentity: nil,
+                buildIdentity: hostileBuild
+            ),
+            selectedSocket: selectedSocket
+        )
+
+        #expect(error.localizedDescription.contains("exact PID and process-start identity are unavailable") == true)
+        #expect(error.localizedDescription.contains("owner socket \(ownerSocket)") == true)
+        #expect(error.localizedDescription.contains("Selected socket: \(selectedSocket)") == true)
+        #expect(!error.localizedDescription.contains(hostileBuild))
+        #expect(!error.localizedDescription.contains("/private/user"))
+        #expect(error.hint?.contains("Do not stop any process") == true)
+        #expect(error.hint?.contains("stop exactly") == false)
+    }
+
+    @Test
+    func `PID-only legacy owner remains ambiguous and non-actionable`() {
+        let error = RuntimeHostResolver.ownerCapabilityRefusal(
+            host: .init(
+                socketPath: "/tmp/legacy-partial.sock",
+                processIdentifier: 3131,
+                processStartIdentity: nil,
+                buildIdentity: "4.0.0"
+            ),
+            selectedSocket: nil
+        )
+
+        #expect(error.localizedDescription.contains("PID 3131, build 4.0.0") == true)
+        #expect(error.localizedDescription.contains("exact process-start identity is unavailable") == true)
+        #expect(error.localizedDescription.contains("Selected socket: automatic resolution") == true)
+        #expect(error.hint?.contains("Do not stop any process") == true)
+    }
+
+    @Test
+    func `deferred legacy owner record retains build and safe socket diagnostics`() {
+        let host = ScreenCaptureKitOwnerLease.UncoordinatedHost(
+            socketPath: "/tmp/deferred-owner.sock",
+            processIdentifier: 3131,
+            processStartIdentity: 4141,
+            buildIdentity: "4.0.0 (4000099)"
+        )
+        let error = RuntimeHostResolver.ownerRefusal(
+            error: ScreenCaptureKitOwnerLease.LeaseError.uncoordinatedHosts([host]),
+            callerLocal: true,
+            selectedSocket: "/tmp/selected-current.sock"
+        )
+
+        #expect(error.localizedDescription.contains("PID 3131, generation 4141") == true)
+        #expect(error.localizedDescription.contains("build 4.0.0 (4000099)") == true)
+        #expect(error.localizedDescription.contains("owner socket /tmp/deferred-owner.sock") == true)
+        #expect(error.localizedDescription.contains("Selected socket: /tmp/selected-current.sock") == true)
     }
 
     @Test
@@ -707,6 +798,68 @@ extension ScreenCaptureKitOwnerRuntimeTests {
     }
 
     @Test
+    func `external host diagnostics attribute only one exact main application`() {
+        let exactClaude = RuntimeHostResolver.ScreenCaptureKitExternalApplication(
+            bundleIdentifier: "com.anthropic.claudefordesktop",
+            bundleName: "Claude",
+            localizedName: "Claude",
+            processIdentifier: 3131,
+            isTerminated: false,
+            buildIdentity: "4.0.0 (4000099)"
+        )
+        let helper = RuntimeHostResolver.ScreenCaptureKitExternalApplication(
+            bundleIdentifier: "com.anthropic.claudefordesktop.helper",
+            bundleName: "Claude Helper",
+            localizedName: "Claude Helper",
+            processIdentifier: 3232,
+            isTerminated: false,
+            buildIdentity: "4.0.0 (4000099)"
+        )
+        let similarlyNamed = RuntimeHostResolver.ScreenCaptureKitExternalApplication(
+            bundleIdentifier: "com.example.claude.integration",
+            bundleName: "Claude Integration",
+            localizedName: "Claude Integration",
+            processIdentifier: 3333,
+            isTerminated: false,
+            buildIdentity: "fixture"
+        )
+        let generation: (pid_t) -> UInt64? = { processIdentifier in
+            processIdentifier == 3131 ? 4141 : 5151
+        }
+
+        let exact = RuntimeHostResolver.knownExternalHostPresence(
+            socketPath: PeekabooBridgeConstants.claudeSocketPath,
+            applications: [exactClaude, helper],
+            processStartIdentity: generation
+        )
+        #expect(exact == .present(
+            processIdentifier: 3131,
+            processStartIdentity: 4141,
+            buildIdentity: "4.0.0 (4000099)"
+        ))
+
+        for ambiguousApplications in [[helper], [similarlyNamed], [exactClaude, exactClaude]] {
+            let ambiguous = RuntimeHostResolver.knownExternalHostPresence(
+                socketPath: PeekabooBridgeConstants.claudeSocketPath,
+                applications: ambiguousApplications,
+                processStartIdentity: generation
+            )
+            #expect(ambiguous == .present(
+                processIdentifier: nil,
+                processStartIdentity: nil,
+                buildIdentity: nil
+            ))
+        }
+
+        let absent = RuntimeHostResolver.knownExternalHostPresence(
+            socketPath: PeekabooBridgeConstants.claudeSocketPath,
+            applications: [],
+            processStartIdentity: generation
+        )
+        #expect(absent == .absent)
+    }
+
+    @Test
     func `old-host safety skips only definitive socket and process absence`() async throws {
         let candidate = RuntimeHostResolver.ImplicitRemoteCandidate(
             socketPath: "/tmp/fixture.sock",
@@ -725,7 +878,7 @@ extension ScreenCaptureKitOwnerRuntimeTests {
                 candidates: [candidate],
                 identity: identity,
                 handshake: { _, _ in throw POSIXError(code) },
-                externalHostIsRunning: { _ in false }
+                externalHostPresence: { _ in .absent }
             )
             #expect(result == nil)
         }
@@ -734,7 +887,7 @@ extension ScreenCaptureKitOwnerRuntimeTests {
             candidates: [candidate],
             identity: identity,
             handshake: { _, _ in throw POSIXError(.ETIMEDOUT) },
-            externalHostIsRunning: { _ in false }
+            externalHostPresence: { _ in .absent }
         )
         #expect(timeout == RuntimeHostResolver.ScreenCaptureKitOwnerUnawareHost(
             socketPath: candidate.socketPath,
@@ -748,7 +901,7 @@ extension ScreenCaptureKitOwnerRuntimeTests {
             handshake: { _, _ in
                 throw PeekabooBridgeErrorEnvelope(code: .unauthorizedClient, message: "fixture")
             },
-            externalHostIsRunning: { _ in false }
+            externalHostPresence: { _ in .absent }
         )
         #expect(unauthorized == timeout)
 
@@ -756,7 +909,9 @@ extension ScreenCaptureKitOwnerRuntimeTests {
             candidates: [candidate],
             identity: identity,
             handshake: { _, _ in throw POSIXError(.ENOENT) },
-            externalHostIsRunning: { _ in true }
+            externalHostPresence: { _ in
+                .present(processIdentifier: nil, processStartIdentity: nil, buildIdentity: nil)
+            }
         )
         #expect(liveExternalProcess == timeout)
 
@@ -764,7 +919,7 @@ extension ScreenCaptureKitOwnerRuntimeTests {
             candidates: [candidate],
             identity: identity,
             handshake: { _, _ in throw POSIXError(.ECONNREFUSED) },
-            externalHostIsRunning: { _ in false }
+            externalHostPresence: { _ in .absent }
         )
         #expect(explicitUnknownSocket == nil)
 
@@ -787,7 +942,7 @@ extension ScreenCaptureKitOwnerRuntimeTests {
                         processStartIdentity: 9001
                     )
                 },
-                externalHostIsRunning: { _ in false }
+                externalHostPresence: { _ in .absent }
             )
         #expect(validExplicitWithAbsentAuxiliary == nil)
 
@@ -796,7 +951,9 @@ extension ScreenCaptureKitOwnerRuntimeTests {
                 candidates: [candidate],
                 identity: identity,
                 handshake: { _, _ in throw CancellationError() },
-                externalHostIsRunning: { _ in true }
+                externalHostPresence: { _ in
+                    .present(processIdentifier: nil, processStartIdentity: nil, buildIdentity: nil)
+                }
             )
         }
 
@@ -812,7 +969,9 @@ extension ScreenCaptureKitOwnerRuntimeTests {
                         hostCapabilities: []
                     )
                 },
-                externalHostIsRunning: { _ in true }
+                externalHostPresence: { _ in
+                    .present(processIdentifier: nil, processStartIdentity: nil, buildIdentity: nil)
+                }
             )
         }
         try await Task.sleep(for: .milliseconds(1))
@@ -820,6 +979,121 @@ extension ScreenCaptureKitOwnerRuntimeTests {
         await #expect(throws: CancellationError.self) {
             _ = try await uncooperativeHandshake.value
         }
+    }
+
+    @Test
+    func `old-host safety retains handshake and exact external owner diagnostics`() async throws {
+        let candidate = RuntimeHostResolver.ImplicitRemoteCandidate(
+            socketPath: "/tmp/fixture-owner.sock",
+            requireReusableDaemon: false,
+            requiredHostKind: nil,
+            requiresValidatedHistoricalDaemon: false
+        )
+        let identity = PeekabooBridgeClientIdentity(
+            bundleIdentifier: "boo.peekaboo.test.client",
+            teamIdentifier: nil,
+            processIdentifier: getpid()
+        )
+
+        let handshakeOwner = try await RuntimeHostResolver.firstScreenCaptureKitOwnerUnawareHost(
+            candidates: [candidate],
+            identity: identity,
+            handshake: { _, _ in
+                Self.handshake(
+                    processIdentifier: 3131,
+                    processStartIdentity: 4141,
+                    hostCapabilities: [],
+                    build: "4.0.0 (4000099)"
+                )
+            },
+            externalHostPresence: { _ in .absent }
+        )
+        #expect(handshakeOwner == .init(
+            socketPath: candidate.socketPath,
+            processIdentifier: 3131,
+            processStartIdentity: 4141,
+            buildIdentity: "4.0.0 (4000099)"
+        ))
+
+        let unreachableOwner = try await RuntimeHostResolver.firstScreenCaptureKitOwnerUnawareHost(
+            candidates: [candidate],
+            identity: identity,
+            handshake: { _, _ in throw POSIXError(.ETIMEDOUT) },
+            externalHostPresence: { _ in
+                .present(
+                    processIdentifier: 5151,
+                    processStartIdentity: 6161,
+                    buildIdentity: "3.9.2 (3920)"
+                )
+            }
+        )
+        #expect(unreachableOwner == .init(
+            socketPath: candidate.socketPath,
+            processIdentifier: 5151,
+            processStartIdentity: 6161,
+            buildIdentity: "3.9.2 (3920)"
+        ))
+    }
+
+    @Test
+    func `legacy handshake enriches only a matching external PID`() async throws {
+        let candidate = RuntimeHostResolver.ImplicitRemoteCandidate(
+            socketPath: "/tmp/fixture-owner.sock",
+            requireReusableDaemon: false,
+            requiredHostKind: nil,
+            requiresValidatedHistoricalDaemon: false
+        )
+        let identity = PeekabooBridgeClientIdentity(
+            bundleIdentifier: "boo.peekaboo.test.client",
+            teamIdentifier: nil,
+            processIdentifier: getpid()
+        )
+        let partialHandshake: RuntimeHostResolver.ScreenCaptureKitHandshake = { _, _ in
+            Self.handshake(
+                processIdentifier: 3131,
+                processStartIdentity: nil,
+                hostCapabilities: [],
+                build: nil
+            )
+        }
+
+        let matching = try await RuntimeHostResolver.firstScreenCaptureKitOwnerUnawareHost(
+            candidates: [candidate],
+            identity: identity,
+            handshake: partialHandshake,
+            externalHostPresence: { _ in
+                .present(
+                    processIdentifier: 3131,
+                    processStartIdentity: 4141,
+                    buildIdentity: "4.0.0"
+                )
+            }
+        )
+        #expect(matching == .init(
+            socketPath: candidate.socketPath,
+            processIdentifier: 3131,
+            processStartIdentity: 4141,
+            buildIdentity: "4.0.0"
+        ))
+
+        let mismatched = try await RuntimeHostResolver.firstScreenCaptureKitOwnerUnawareHost(
+            candidates: [candidate],
+            identity: identity,
+            handshake: partialHandshake,
+            externalHostPresence: { _ in
+                .present(
+                    processIdentifier: 9191,
+                    processStartIdentity: 9292,
+                    buildIdentity: "unrelated-build"
+                )
+            }
+        )
+        #expect(mismatched == .init(
+            socketPath: candidate.socketPath,
+            processIdentifier: 3131,
+            processStartIdentity: nil,
+            buildIdentity: nil
+        ))
     }
 
     @Test
@@ -970,18 +1244,19 @@ extension ScreenCaptureKitOwnerRuntimeTests {
 
     private static func handshake(
         processIdentifier: pid_t,
-        processStartIdentity: UInt64,
+        processStartIdentity: UInt64?,
         hostCapabilities: [String] = [
             PeekabooBridgeHostCapability.hostGenerationIdentity,
             PeekabooBridgeHostCapability.codeSignatureBuildIdentity,
             PeekabooBridgeHostCapability.screenCaptureKitProcessOwnership,
         ],
-        codeSignatureHash: String = "owner-build"
+        codeSignatureHash: String = "owner-build",
+        build: String? = nil
     ) -> PeekabooBridgeHandshakeResponse {
         BridgeTestFixtures.handshake(
             negotiatedVersion: PeekabooBridgeConstants.protocolVersion,
             hostKind: .onDemand,
-            build: nil,
+            build: build,
             supportedOperations: [.captureScreen, .desktopObservation],
             permissions: PermissionsStatus(
                 screenRecording: true,

--- a/Apps/CLI/Tests/CoreCLITests/ScreenCaptureKitOwnerRuntimeTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/ScreenCaptureKitOwnerRuntimeTests.swift
@@ -304,6 +304,7 @@ struct ScreenCaptureKitOwnerRuntimeTests {
         )
 
         #expect(resolution.selectedRemoteSocketPath == selectedSocket)
+        #expect(resolution.captureEngineSafetyOverride == .legacy)
         #expect(recordedBlockers == [auxiliaryBlocker])
         #expect(localFactoryCalls == 0)
         await ownerAwareHost.stop()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Changed
 - Build branded release disk images from pinned direct Finder-metadata tooling, preserving the signed and notarized drag-to-Applications layout without GUI automation.
 
+### Fixed
+- Report exact ScreenCaptureKit owner PID, process generation, safe build identity, and selected-versus-owner Bridge sockets when available, while keeping ambiguous legacy owners fail-closed without unsafe process-stop guidance.
+
 ## [4.1.0] - 2026-08-13
 
 ### Highlights

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Build branded release disk images from pinned direct Finder-metadata tooling, preserving the signed and notarized drag-to-Applications layout without GUI automation.
 
 ### Fixed
-- Report exact ScreenCaptureKit owner PID, process generation, safe build identity, and selected-versus-owner Bridge sockets when available; automatic capture can still use an owner-aware host's classic-first path around an auxiliary legacy owner, while explicit modern and ambiguous legacy ownership remain fail-closed without unsafe process-stop guidance.
+- Report exact ScreenCaptureKit owner PID, process generation, safe build identity, and selected-versus-owner Bridge sockets when available; automatic capture can still use an owner-aware host's classic-only path around an auxiliary legacy owner, while explicit modern and ambiguous legacy ownership remain fail-closed without unsafe process-stop guidance.
 
 ## [4.1.0] - 2026-08-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Build branded release disk images from pinned direct Finder-metadata tooling, preserving the signed and notarized drag-to-Applications layout without GUI automation.
 
 ### Fixed
-- Report exact ScreenCaptureKit owner PID, process generation, safe build identity, and selected-versus-owner Bridge sockets when available, while keeping ambiguous legacy owners fail-closed without unsafe process-stop guidance.
+- Report exact ScreenCaptureKit owner PID, process generation, safe build identity, and selected-versus-owner Bridge sockets when available; automatic capture can still use an owner-aware host's classic-first path around an auxiliary legacy owner, while explicit modern and ambiguous legacy ownership remain fail-closed without unsafe process-stop guidance.
 
 ## [4.1.0] - 2026-08-13
 

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/ScreenCaptureKitOwnerLease.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/ScreenCaptureKitOwnerLease.swift
@@ -101,15 +101,18 @@ public final class ScreenCaptureKitOwnerLease: Sendable {
         public let socketPath: String
         public let processIdentifier: pid_t?
         public let processStartIdentity: UInt64?
+        public let buildIdentity: String?
 
         public init(
             socketPath: String,
             processIdentifier: pid_t?,
-            processStartIdentity: UInt64?)
+            processStartIdentity: UInt64?,
+            buildIdentity: String? = nil)
         {
             self.socketPath = socketPath
             self.processIdentifier = processIdentifier
             self.processStartIdentity = processStartIdentity
+            self.buildIdentity = buildIdentity
         }
     }
 
@@ -172,7 +175,8 @@ public final class ScreenCaptureKitOwnerLease: Sendable {
                     }
                     return $0.socketPath
                 }.joined(separator: ", ") +
-                    ". Update or stop those hosts, then restart this process before retrying SCK"
+                    ". Update or relaunch those hosts, then restart this process before retrying SCK. " +
+                    "Do not stop a process unless its exact PID and process generation are known and revalidated"
             }
         }
     }
@@ -304,14 +308,16 @@ public final class ScreenCaptureKitOwnerLease: Sendable {
     public static func registerPotentialUncoordinatedHost(
         socketPath: String,
         processIdentifier: pid_t?,
-        processStartIdentity: UInt64?)
+        processStartIdentity: UInt64?,
+        buildIdentity: String? = nil)
     {
         let standardizedPath = NSString(string: socketPath).standardizingPath
         guard !standardizedPath.isEmpty else { return }
         let host = UncoordinatedHost(
             socketPath: standardizedPath,
             processIdentifier: processIdentifier,
-            processStartIdentity: processStartIdentity)
+            processStartIdentity: processStartIdentity,
+            buildIdentity: buildIdentity)
         self.registryLock.withLock {
             self.registeredUncoordinatedHostsBySocket[standardizedPath] = host
         }


### PR DESCRIPTION
## Summary

- make ScreenCaptureKit ownership refusals identify the safe exact PID, process generation, build, owner socket, and selected socket when available
- keep ambiguous legacy owners fail-closed without telling users to stop an unverified process
- let automatic capture reach an owner-aware selected host when a different legacy host blocks ScreenCaptureKit, while clamping that transported request to classic-only so the remote process cannot fall back to ScreenCaptureKit
- keep explicit modern and owner-unaware selected hosts fail-closed before dispatch

## Why

With ordinary Claude Desktop running, Peekaboo 4.1.0 refused default automatic capture before it could try CoreGraphics, even though explicit classic capture succeeded. The auxiliary legacy host should block an unsafe ScreenCaptureKit fallback, not a safe classic capture on a different owner-aware host. Because the legacy-host tombstone belongs to the caller process, the chosen capture engine must cross the Bridge boundary as classic-only rather than relying on the remote host to know about caller-local state.

## Verification

- `pnpm run format`
- `pnpm run lint` (22 inherited warnings, 0 serious; changed files clean)
- `pnpm run lint:docs`
- `swift test --package-path Apps/CLI --filter 'ScreenCaptureKitOwnerRuntimeTests|ObservationPolicyDefaultsTests'` (36 passed)
- `pnpm run test:safe` (40 Foundation, 912 CLI/Core, 92 runtime; release/install/consumer/certification contracts passed)
- whole-branch and post-fix Autoreview clean

## Exact-head live proof

Exact head `5296631783db61e2113b9143ab52f991a8cacee6` was built as a Developer ID-signed CLI with matching embedded source provenance. With Claude Desktop running, a fresh exact TextEdit window was captured through the selected owner-aware Bridge using default automatic capture.

- capture engine: `CGWindowList`
- capture span: 147 ms
- logical window: 603 by 505 points
- output: 1206 by 1010 pixels
- decoded pixel statistics: mean 33.61, standard deviation 15.31, extrema 0 through 255
- local visual inspection confirmed the TextEdit title bar, toolbar, ruler, document canvas, and scrollbars; the artifact is not blank
- Finder remained foreground before and after the capture

The same signed commit was then run with explicit modern capture against the same fresh exact window. It refused before dispatch, reported the exact legacy Claude host PID, process generation, safe build identity, and owner socket, preserved Finder as foreground, and created no output image.
