### PR TITLE
fix(mcp): reject undeclared tool arguments

### DIFF
--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add protocol 1.25 exact dialog click/dismiss receipts with unique target planning, raw AX identity revalidation, verified disappearance outcomes, and read-only targeted listing.
 
 ### Fixed
+- Reject unknown and non-object MCP `tools/call` arguments as JSON-RPC invalid params before policy checks or tool dispatch, recursively honoring the closed schemas advertised by `tools/list`.
 - Report exact standard windows with live attached sheets as dialog-active observations, using shared native role evidence without changing the parent window receipt.
 - Preserve default automatic capture through an owner-aware Bridge by clamping it to classic-only around an auxiliary legacy ScreenCaptureKit owner, while explicit modern and owner-unaware routes remain fail-closed.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Fixed
 
+- Reject unknown and non-object MCP `tools/call` arguments as JSON-RPC invalid params before policy checks or tool dispatch, recursively honoring the closed schemas advertised by `tools/list`.
 - Classify an exact standard window with a live attached sheet as dialog-active during observation, sharing native role evidence with dialog actions while keeping the parent window receipt exact.
 - Report exact ScreenCaptureKit owner PID, process generation, safe build identity, and selected-versus-owner Bridge sockets when available; automatic capture can still use an owner-aware host's classic-only path around an auxiliary legacy owner, while explicit modern and ambiguous legacy ownership remain fail-closed without unsafe process-stop guidance.
 

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/MCPToolArgumentValidation.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/MCPToolArgumentValidation.swift
@@ -16,6 +16,18 @@ struct MCPToolArgumentValueError: LocalizedError, Sendable, Equatable {
     }
 }
 
+struct MCPToolArgumentSchemaError: LocalizedError, Sendable, Equatable {
+    let path: String
+    let properties: [String]
+
+    var errorDescription: String? {
+        let noun = self.properties.count == 1 ? "property" : "properties"
+        let names = self.properties.prefix(8).map { String(reflecting: $0) }.joined(separator: ", ")
+        let remainder = self.properties.count > 8 ? " and \(self.properties.count - 8) more" : ""
+        return "Unknown \(noun) \(names)\(remainder) at \(self.path)."
+    }
+}
+
 extension ToolArguments {
     func validatedInt(_ key: String) throws -> Int? {
         guard self.getValue(for: key) != nil else { return nil }
@@ -35,18 +47,27 @@ extension ToolArguments {
 }
 
 enum MCPToolArgumentValidator {
+    static func validateClosedProperties(tool: any MCPTool, arguments: ToolArguments) throws {
+        try self.validateClosedProperties(
+            value: arguments.rawValue,
+            schema: tool.inputSchema,
+            path: "$")
+    }
+
     static func rejection(
         tool: any MCPTool,
         arguments: ToolArguments,
         snapshotEffect: MCPToolSnapshotEffect) -> ToolResponse?
     {
-        guard case let .object(schema) = tool.inputSchema,
-              case let .object(properties)? = schema["properties"]
-        else {
-            return nil
-        }
-
         do {
+            try self.validateClosedProperties(tool: tool, arguments: arguments)
+
+            guard case let .object(schema) = tool.inputSchema,
+                  case let .object(properties)? = schema["properties"]
+            else {
+                return nil
+            }
+
             for key in properties.keys.sorted() where arguments.getValue(for: key) != nil {
                 guard case let .object(property)? = properties[key],
                       case let .string(type)? = property["type"]
@@ -64,15 +85,132 @@ enum MCPToolArgumentValidator {
                 }
             }
             return nil
+        } catch let error as MCPToolArgumentSchemaError {
+            return self.rejectionResponse(
+                message: error.localizedDescription,
+                snapshotEffect: snapshotEffect)
         } catch let error as MCPToolArgumentValueError {
             return self.rejectionResponse(
                 message: error.localizedDescription,
                 snapshotEffect: snapshotEffect)
         } catch {
             return self.rejectionResponse(
-                message: "Invalid numeric tool argument: \(error.localizedDescription)",
+                message: "Invalid tool argument: \(error.localizedDescription)",
                 snapshotEffect: snapshotEffect)
         }
+    }
+
+    private static func validateClosedProperties(
+        value: Value,
+        schema: Value,
+        path: String) throws
+    {
+        guard case let .object(schemaFields) = schema else { return }
+
+        if case let .object(argumentFields) = value {
+            let propertySchemas = schemaFields["properties"]?.objectValue ?? [:]
+            if schemaFields["additionalProperties"] == .bool(false) {
+                let unknown = argumentFields.keys.filter { propertySchemas[$0] == nil }.sorted()
+                guard unknown.isEmpty else {
+                    throw MCPToolArgumentSchemaError(path: path, properties: unknown)
+                }
+            }
+
+            for key in argumentFields.keys.sorted() {
+                guard let propertySchema = propertySchemas[key], let propertyValue = argumentFields[key] else {
+                    continue
+                }
+                try self.validateClosedProperties(
+                    value: propertyValue,
+                    schema: propertySchema,
+                    path: self.appending(key, to: path))
+            }
+        } else if case let .array(items) = value,
+                  let itemSchema = schemaFields["items"]
+        {
+            for (index, item) in items.enumerated() {
+                try self.validateClosedProperties(
+                    value: item,
+                    schema: itemSchema,
+                    path: "\(path)[\(index)]")
+            }
+        }
+
+        if case let .array(allOf)? = schemaFields["allOf"] {
+            for alternative in allOf {
+                try self.validateClosedProperties(value: value, schema: alternative, path: path)
+            }
+        }
+        for keyword in ["oneOf", "anyOf"] {
+            guard case let .array(alternatives)? = schemaFields[keyword] else { continue }
+            try self.validateAtLeastOneAlternative(
+                value: value,
+                alternatives: alternatives,
+                path: path)
+        }
+    }
+
+    private static func validateAtLeastOneAlternative(
+        value: Value,
+        alternatives: [Value],
+        path: String) throws
+    {
+        let candidates = self.discriminatorMatches(value: value, alternatives: alternatives)
+        var firstError: MCPToolArgumentSchemaError?
+        for alternative in candidates {
+            do {
+                try self.validateClosedProperties(value: value, schema: alternative, path: path)
+                return
+            } catch let error as MCPToolArgumentSchemaError {
+                firstError = firstError ?? error
+            }
+        }
+        if let firstError {
+            throw firstError
+        }
+    }
+
+    private static func discriminatorMatches(value: Value, alternatives: [Value]) -> [Value] {
+        guard case let .object(argumentFields) = value else { return alternatives }
+
+        let scored = alternatives.map { alternative -> (Value, Int, Bool) in
+            guard case let .object(schemaFields) = alternative,
+                  case let .object(properties)? = schemaFields["properties"]
+            else {
+                return (alternative, 0, false)
+            }
+
+            var matches = 0
+            for (key, propertySchema) in properties {
+                guard let argumentValue = argumentFields[key],
+                      case let .object(propertyFields) = propertySchema
+                else {
+                    continue
+                }
+                if let constant = propertyFields["const"] {
+                    guard argumentValue == constant else { return (alternative, 0, true) }
+                    matches += 1
+                }
+                if case let .array(allowed)? = propertyFields["enum"] {
+                    guard allowed.contains(argumentValue) else { return (alternative, 0, true) }
+                    matches += 1
+                }
+            }
+            return (alternative, matches, false)
+        }
+        let maximumScore = scored.map(\.1).max() ?? 0
+        guard maximumScore > 0 else {
+            let nonConflicting = scored.filter { !$0.2 }.map(\.0)
+            return nonConflicting.isEmpty ? alternatives : nonConflicting
+        }
+        return scored.filter { $0.1 == maximumScore && !$0.2 }.map(\.0)
+    }
+
+    private static func appending(_ key: String, to path: String) -> String {
+        let isIdentifier = !key.isEmpty && key.allSatisfy { character in
+            character == "_" || character.isLetter || character.isNumber
+        }
+        return isIdentifier ? "\(path).\(key)" : "\(path)[\(String(reflecting: key))]"
     }
 
     private static func rejectionResponse(

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Server/PeekabooMCPServer.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Server/PeekabooMCPServer.swift
@@ -21,6 +21,37 @@ public enum TransportType: CustomStringConvertible, Sendable {
 
 /// Peekaboo MCP Server implementation
 public actor PeekabooMCPServer {
+    private enum StrictCallTool: MCP.Method {
+        typealias Parameters = Value
+        typealias Result = CallTool.Result
+
+        static let name = CallTool.name
+    }
+
+    private struct ToolCallRequest {
+        let name: String
+        let arguments: [String: Value]
+
+        init(params: Value) throws {
+            guard case let .object(fields) = params else {
+                throw MCP.MCPError.invalidParams("tools/call params must be an object")
+            }
+            guard case let .string(name)? = fields["name"], !name.isEmpty else {
+                throw MCP.MCPError.invalidParams("tools/call requires a nonempty string name")
+            }
+            self.name = name
+
+            switch fields["arguments"] {
+            case nil:
+                self.arguments = [:]
+            case let .object(arguments):
+                self.arguments = arguments
+            default:
+                throw MCP.MCPError.invalidParams("Tool '\(name)' arguments must be an object")
+            }
+        }
+    }
+
     private let server: Server
     private let toolRegistry: MCPToolRegistry
     private let logger: os.Logger
@@ -72,21 +103,29 @@ public actor PeekabooMCPServer {
         }
 
         // Tool call handler
-        await self.server.withMethodHandler(CallTool.self) { [weak self] params in
+        await self.server.withMethodHandler(StrictCallTool.self) { [weak self] params in
             guard let self else {
                 throw MCP.MCPError.methodNotFound("Server deallocated")
             }
 
-            guard let tool = await self.toolRegistry.tool(named: params.name) else {
-                throw MCP.MCPError.invalidParams("Tool '\(params.name)' not found")
+            let request = try ToolCallRequest(params: params)
+
+            guard let tool = await self.toolRegistry.tool(named: request.name) else {
+                throw MCP.MCPError.invalidParams("Tool '\(request.name)' not found")
             }
 
-            let arguments = ToolArguments(value: .object(params.arguments ?? [:]))
+            let arguments = ToolArguments(value: .object(request.arguments))
+            do {
+                try MCPToolArgumentValidator.validateClosedProperties(tool: tool, arguments: arguments)
+            } catch let error as MCPToolArgumentSchemaError {
+                throw MCP.MCPError.invalidParams(
+                    "Invalid arguments for tool '\(request.name)': \(error.localizedDescription)")
+            }
 
             // Execute tool on main thread
             let response = try await self.toolContext.execute(tool: tool, arguments: arguments)
 
-            return Self.callToolResult(from: response, toolName: params.name)
+            return Self.callToolResult(from: response, toolName: request.name)
         }
 
         // Resources list handler (empty for now, but prevents inspector errors)

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPToolArgumentValidationTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPToolArgumentValidationTests.swift
@@ -162,6 +162,136 @@ struct MCPToolArgumentValidationTests {
 
         #expect(await counter.value == 0)
     }
+
+    @Test
+    func `every closed catalog schema rejects unknown top-level properties before dispatch`() async throws {
+        let context = await MCPToolTestHelpers.makeContext()
+        let counter = MCPUnknownPropertyDispatchCounter()
+        let tools = MCPToolCatalog.unfilteredTools(context: context)
+        let probeValues: [Value] = [
+            .bool(true),
+            .string("unexpected"),
+            .int(17),
+            .array([.string("nested")]),
+            .object(["nested": .bool(false)]),
+        ]
+
+        #expect(tools.count == 26)
+        for (index, sourceTool) in tools.enumerated() {
+            guard case let .object(schema) = sourceTool.inputSchema else {
+                Issue.record("Expected \(sourceTool.name) to advertise an object schema")
+                continue
+            }
+            #expect(schema["additionalProperties"] == .bool(false))
+
+            let unknownKey = "__unexpected_\(index)"
+            let response = try await context.execute(
+                tool: MCPUnknownPropertySchemaProbeTool(
+                    name: sourceTool.name,
+                    inputSchema: sourceTool.inputSchema,
+                    counter: counter),
+                arguments: ToolArguments(value: .object([
+                    unknownKey: probeValues[index % probeValues.count],
+                ])))
+
+            #expect(response.isError, "Expected \(sourceTool.name) to reject \(unknownKey)")
+        }
+
+        #expect(await counter.value == 0)
+    }
+
+    @Test
+    func `closed nested schemas reject unknown properties and accept declared properties`() async throws {
+        let context = await MCPToolTestHelpers.makeContext()
+        let counter = MCPUnknownPropertyDispatchCounter()
+        let cases: [(name: String, schema: Value, invalid: [String: Value], valid: [String: Value])] = [
+            (
+                "analyze",
+                AnalyzeTool().inputSchema,
+                [
+                    "question": .string("What is shown?"),
+                    "provider_config": .object(["bogus": .bool(true)]),
+                ],
+                [
+                    "question": .string("What is shown?"),
+                    "provider_config": .object(["type": .string("auto")]),
+                ]),
+            (
+                "verify_state",
+                VerifyStateTool(context: context).inputSchema,
+                [
+                    "predicates": .array([.object([
+                        "kind": .string("window_exists"),
+                        "expected": .bool(true),
+                        "bogus": .int(1),
+                    ])]),
+                ],
+                [
+                    "predicates": .array([.object([
+                        "kind": .string("window_exists"),
+                        "expected": .bool(true),
+                    ])]),
+                ]),
+            (
+                "verify_state",
+                VerifyStateTool(context: context).inputSchema,
+                [
+                    "predicates": .array([.object([
+                        "kind": .string("element_exists"),
+                        "selector": .object([
+                            "identifier": .string("save-button"),
+                            "bogus": .string("nested"),
+                        ]),
+                        "expected": .bool(true),
+                    ])]),
+                ],
+                [
+                    "predicates": .array([.object([
+                        "kind": .string("element_exists"),
+                        "selector": .object(["identifier": .string("save-button")]),
+                        "expected": .bool(true),
+                    ])]),
+                ]),
+        ]
+
+        for testCase in cases {
+            let probe = MCPUnknownPropertySchemaProbeTool(
+                name: testCase.name,
+                inputSchema: testCase.schema,
+                counter: counter)
+            let rejected = try await context.execute(
+                tool: probe,
+                arguments: ToolArguments(value: .object(testCase.invalid)))
+            #expect(rejected.isError)
+
+            let accepted = try await context.execute(
+                tool: probe,
+                arguments: ToolArguments(value: .object(testCase.valid)))
+            #expect(!accepted.isError)
+        }
+
+        #expect(await counter.value == cases.count)
+    }
+}
+
+private actor MCPUnknownPropertyDispatchCounter {
+    private(set) var value = 0
+
+    func increment() {
+        self.value += 1
+    }
+}
+
+private struct MCPUnknownPropertySchemaProbeTool: MCPTool {
+    let name: String
+    let description = "Unknown-property schema validation probe"
+    let inputSchema: Value
+    let counter: MCPUnknownPropertyDispatchCounter
+
+    func execute(arguments _: ToolArguments) async throws -> ToolResponse {
+        await self.counter.increment()
+        return .text("dispatched")
+    }
 }
 
 private actor MCPNumericDispatchCounter {

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPToolSnapshotMutationTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPToolSnapshotMutationTests.swift
@@ -915,7 +915,7 @@ private struct StubMCPTool: MCPTool {
     }
 
     var inputSchema: Value {
-        SchemaBuilder.object(properties: [:], required: [])
+        SchemaBuilder.object(properties: [:], required: [], additionalProperties: true)
     }
 
     init(

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/PeekabooMCPServerTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/PeekabooMCPServerTests.swift
@@ -108,7 +108,7 @@ struct PeekabooMCPServerTests {
     @MainActor
     func `click wire schema requires an exclusive target and a background coordinate receipt`() async throws {
         let context = await MCPToolTestHelpers.makeContext()
-        let session = try await ClickMCPWireSession.connect(context: context)
+        let session = try await MCPWireSession.connect(context: context)
 
         do {
             let (tools, _) = try await session.client.listTools()
@@ -182,7 +182,7 @@ struct PeekabooMCPServerTests {
     func `click wire refuses mixed target routes before dispatch`() async throws {
         let automation = MockAutomationService(accessibilityGranted: true)
         let context = await MCPToolTestHelpers.makeContext(automation: automation)
-        let session = try await ClickMCPWireSession.connect(context: context)
+        let session = try await MCPWireSession.connect(context: context)
         let invalidArguments: [[String: Value]] = [
             ["on": .string("B1"), "query": .string("Save")],
             ["on": .string("B1"), "coords": .string("10,20"), "foreground": .bool(true)],
@@ -208,6 +208,136 @@ struct PeekabooMCPServerTests {
         } catch {
             await session.stop()
             throw error
+        }
+
+        await session.stop()
+    }
+
+    @Test
+    @MainActor
+    func `every advertised closed schema rejects unknown properties as invalid params`() async throws {
+        let context = await MCPToolTestHelpers.makeContext()
+        let session = try await MCPWireSession.connect(context: context)
+        let probeValues: [Value] = [
+            .bool(true),
+            .string("unexpected"),
+            .int(17),
+            .array([.string("nested")]),
+            .object(["nested": .bool(false)]),
+        ]
+
+        do {
+            let (tools, _) = try await session.client.listTools()
+            #expect(tools.count == 26)
+
+            for (index, tool) in tools.sorted(by: { $0.name < $1.name }).enumerated() {
+                guard case let .object(schema) = tool.inputSchema else {
+                    Issue.record("Expected \(tool.name) to advertise an object schema")
+                    continue
+                }
+                #expect(schema["additionalProperties"] == .bool(false))
+
+                let unknownKey = "__unexpected_\(index)"
+                let detail = await Self.invalidParamsDetail(
+                    session: session,
+                    params: .object([
+                        "name": .string(tool.name),
+                        "arguments": .object([
+                            unknownKey: probeValues[index % probeValues.count],
+                        ]),
+                    ]))
+                #expect(detail?.contains(tool.name) == true)
+                #expect(detail?.contains(unknownKey) == true)
+            }
+        } catch {
+            await session.stop()
+            throw error
+        }
+
+        await session.stop()
+    }
+
+    @Test
+    @MainActor
+    func `wire decoder rejects non-object tool calls and preserves omitted arguments`() async throws {
+        let context = await MCPToolTestHelpers.makeContext()
+        let session = try await MCPWireSession.connect(context: context)
+
+        do {
+            for params: Value in [.null, .array([]), .string("permissions"), .bool(true)] {
+                let detail = await Self.invalidParamsDetail(session: session, params: params)
+                #expect(detail?.contains("params must be an object") == true)
+            }
+
+            for arguments: Value in [.null, .array([]), .string("bogus"), .bool(true), .int(1)] {
+                let detail = await Self.invalidParamsDetail(
+                    session: session,
+                    params: .object([
+                        "name": .string("permissions"),
+                        "arguments": arguments,
+                    ]))
+                #expect(detail?.contains("arguments must be an object") == true)
+            }
+
+            let result = try await session.callRaw(params: .object([
+                "name": .string("permissions"),
+            ]))
+            #expect(result.isError != true)
+        } catch {
+            await session.stop()
+            throw error
+        }
+
+        await session.stop()
+    }
+
+    @Test
+    @MainActor
+    func `wire decoder enforces nested closed schemas before dispatch`() async throws {
+        let context = await MCPToolTestHelpers.makeContext()
+        let session = try await MCPWireSession.connect(context: context)
+        let cases: [(name: String, arguments: [String: Value], path: String)] = [
+            (
+                "analyze",
+                [
+                    "question": .string("What is shown?"),
+                    "provider_config": .object(["bogus": .bool(true)]),
+                ],
+                "$.provider_config"),
+            (
+                "verify_state",
+                [
+                    "predicates": .array([.object([
+                        "kind": .string("window_exists"),
+                        "expected": .bool(true),
+                        "bogus": .string("nested"),
+                    ])]),
+                ],
+                "$.predicates[0]"),
+            (
+                "verify_state",
+                [
+                    "predicates": .array([.object([
+                        "kind": .string("element_exists"),
+                        "selector": .object([
+                            "identifier": .string("save-button"),
+                            "bogus": .int(9),
+                        ]),
+                        "expected": .bool(true),
+                    ])]),
+                ],
+                "$.predicates[0].selector"),
+        ]
+
+        for testCase in cases {
+            let detail = await Self.invalidParamsDetail(
+                session: session,
+                params: .object([
+                    "name": .string(testCase.name),
+                    "arguments": .object(testCase.arguments),
+                ]))
+            #expect(detail?.contains(testCase.path) == true)
+            #expect(detail?.contains("bogus") == true)
         }
 
         await session.stop()
@@ -308,6 +438,24 @@ struct PeekabooMCPServerTests {
         }
     }
 
+    private static func invalidParamsDetail(session: MCPWireSession, params: Value) async -> String? {
+        do {
+            _ = try await session.callRaw(params: params)
+            Issue.record("Expected tools/call to fail with invalid params")
+            return nil
+        } catch let error as MCP.MCPError {
+            #expect(error.code == -32602)
+            guard case let .invalidParams(detail) = error else {
+                Issue.record("Expected invalidParams, got \(error)")
+                return nil
+            }
+            return detail
+        } catch {
+            Issue.record("Expected MCPError.invalidParams, got \(error)")
+            return nil
+        }
+    }
+
     @Test
     @MainActor
     func `default server context inherits the installed agent execution gate`() async throws {
@@ -362,7 +510,7 @@ struct PeekabooMCPServerTests {
     }
 }
 
-private struct ClickMCPWireSession {
+private struct MCPWireSession {
     let client: Client
     let server: PeekabooMCPServer
 
@@ -385,6 +533,19 @@ private struct ClickMCPWireSession {
         await self.client.disconnect()
         await self.server.stopForTesting()
     }
+
+    func callRaw(params: Value) async throws -> CallTool.Result {
+        let request = RawCallTool.request(params)
+        let context: RequestContext<CallTool.Result> = try await self.client.send(request)
+        return try await context.value
+    }
+}
+
+private enum RawCallTool: MCP.Method {
+    typealias Parameters = Value
+    typealias Result = CallTool.Result
+
+    static let name = CallTool.name
 }
 
 @MainActor


### PR DESCRIPTION
## Summary

- decode `tools/call` parameters as raw MCP values so malformed/non-object arguments fail as JSON-RPC `-32602` instead of SDK `-32603`
- recursively enforce every `additionalProperties: false` boundary advertised by each tool schema before policy evaluation or tool dispatch
- share the closed-schema validator with direct and Agent-wrapped MCP tool execution while preserving declared optional fields and defaults
- cover all 26 catalog tools plus nested objects, arrays, discriminated `oneOf` branches, malformed calls, and valid omitted arguments

## Proof

- `swift test --filter 'MCPToolArgumentValidationTests|PeekabooMCPServerTests|MCPToolSnapshotMutationTests'` (49 tests)
- `pnpm run build:cli`
- `pnpm run format` (0 files changed)
- `pnpm run lint` (0 serious violations)
- source-blind stdio JSON-RPC replay against the built CLI: 26/26 schemas closed, 14/14 invalid/valid anti-cheat probes passed
- structured autoreview clean with no accepted/actionable findings

## Documentation

- added 4.1.1 changelog entries to the root and CLI changelogs
