### PR TITLE
feat(scroll): add exact background WebKit wheel routing

### DIFF
--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Add protocol 1.25 exact dialog click/dismiss receipts with unique target planning, raw AX identity revalidation, verified disappearance outcomes, and read-only targeted listing.
+- Add capability-gated exact-window background wheel delivery for opaque WKWebView/Tauri scroll targets, with retry-unsafe unverifiable outcomes and no activation or shared-cursor fallback.
 
 ### Fixed
 - Report exact standard windows with live attached sheets as dialog-active observations, using shared native role evidence without changing the parent window receipt.

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/ScrollCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/ScrollCommand.swift
@@ -170,11 +170,17 @@ RuntimeBackedCommand {
             }
 
         } catch {
-            // ScrollService converts every post-dispatch identity drift into DesktopActionFailure.
-            // A raw stale-snapshot error therefore proves that no scroll unit was emitted.
-            let presentedError: any Error = if let peekabooError = error as? PeekabooError,
-                                               case .snapshotStale = peekabooError {
-                self.preDispatchActionError(for: peekabooError, reason: .targetUnavailable)
+            // ScrollService converts every post-dispatch failure into DesktopActionFailure. Raw
+            // stale/unsupported background errors therefore prove that no scroll unit was emitted.
+            let presentedError: any Error = if let peekabooError = error as? PeekabooError {
+                switch peekabooError {
+                case .snapshotStale:
+                    self.preDispatchActionError(for: peekabooError, reason: .targetUnavailable)
+                case .invalidInput where !self.focusOptions.foreground:
+                    self.preDispatchActionError(for: peekabooError, reason: .operationUnsupported)
+                default:
+                    error
+                }
             } else {
                 error
             }

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/ScrollCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/ScrollCommand.swift
@@ -112,9 +112,14 @@ RuntimeBackedCommand {
             let totalTicks = self.smooth ? self.amount * 10 : self.amount
 
             // Determine scroll location for output
+            let resultDetection: ElementDetectionResult? = if let snapshotId = observation.snapshotId {
+                try await self.services.snapshots.getDetectionResult(snapshotId: snapshotId)
+            } else {
+                nil
+            }
             let scrollResolution: InteractionTargetPointResolution = if let elementId = on {
                 if let snapshotId = observation.snapshotId,
-                   let detectionResult = try await self.services.snapshots.getDetectionResult(snapshotId: snapshotId),
+                   let detectionResult = resultDetection,
                    let element = detectionResult.elements.findById(elementId) {
                     try await InteractionTargetPointResolver.elementCenterResolution(
                         element: element,
@@ -140,6 +145,10 @@ RuntimeBackedCommand {
                 location: ["x": scrollLocation.x, "y": scrollLocation.y],
                 totalTicks: totalTicks,
                 targetPoint: scrollResolution.diagnostics,
+                targetReceipt: ScrollTargetReceipt(
+                    snapshotId: observation.snapshotId,
+                    detectionResult: resultDetection
+                ),
                 executionTime: Date().timeIntervalSince(startTime)
             )
             output(
@@ -218,6 +227,7 @@ struct ScrollResult: Codable {
     let location: [String: Double]
     let totalTicks: Int
     let targetPoint: InteractionTargetPointDiagnostics?
+    let targetReceipt: ScrollTargetReceipt?
     let executionTime: TimeInterval
 
     init(
@@ -226,6 +236,7 @@ struct ScrollResult: Codable {
         location: [String: Double],
         totalTicks: Int,
         targetPoint: InteractionTargetPointDiagnostics? = nil,
+        targetReceipt: ScrollTargetReceipt? = nil,
         executionTime: TimeInterval
     ) {
         self.direction = direction
@@ -233,7 +244,36 @@ struct ScrollResult: Codable {
         self.location = location
         self.totalTicks = totalTicks
         self.targetPoint = targetPoint
+        self.targetReceipt = targetReceipt
         self.executionTime = executionTime
+    }
+}
+
+struct ScrollTargetReceipt: Codable, Equatable {
+    let snapshotId: String
+    let processIdentifier: Int32
+    let processStartIdentityDecimal: String
+    let windowId: Int
+    let windowBounds: CGRect
+
+    init?(snapshotId: String?, detectionResult: ElementDetectionResult?) {
+        guard let snapshotId,
+              let context = detectionResult?.metadata.windowContext,
+              let processIdentifier = context.applicationProcessId,
+              let windowId = context.windowID,
+              let windowBounds = context.windowBounds,
+              let identity = context.windowMutationIdentity,
+              identity.ownerProcessIdentifier == processIdentifier,
+              identity.windowID == windowId,
+              identity.capturedBounds == nil || identity.capturedBounds == windowBounds
+        else {
+            return nil
+        }
+        self.snapshotId = snapshotId
+        self.processIdentifier = processIdentifier
+        self.processStartIdentityDecimal = String(identity.ownerProcessStartIdentity)
+        self.windowId = windowId
+        self.windowBounds = windowBounds
     }
 }
 

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/ScrollCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/ScrollCommand.swift
@@ -161,7 +161,15 @@ RuntimeBackedCommand {
             }
 
         } catch {
-            self.handleError(error)
+            // ScrollService converts every post-dispatch identity drift into DesktopActionFailure.
+            // A raw stale-snapshot error therefore proves that no scroll unit was emitted.
+            let presentedError: any Error = if let peekabooError = error as? PeekabooError,
+                                               case .snapshotStale = peekabooError {
+                self.preDispatchActionError(for: peekabooError, reason: .targetUnavailable)
+            } else {
+                error
+            }
+            self.handleError(presentedError)
             throw ExitCode.failure
         }
     }
@@ -239,9 +247,9 @@ extension ScrollCommand: ParsableCommand {
                 commandName: "scroll",
                 abstract: "Scroll the mouse wheel in any direction",
                 discussion: """
-                    The 'scroll' command scrolls through Accessibility by default so the target
-                    application stays in the background. Add --foreground to focus the target and
-                    allow synthetic mouse-wheel events.
+                    The 'scroll' command keeps a fresh target in the background. It prefers
+                    Accessibility and can use exact-window wheel routing for opaque visible WebKit
+                    surfaces. Add --foreground to focus the target and use the physical pointer.
 
                     EXAMPLES:
                       peekaboo scroll --direction up --amount 10 --on element_42

--- a/Apps/CLI/Tests/CLIAutomationTests/ScrollCommandTests.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/ScrollCommandTests.swift
@@ -318,6 +318,41 @@ struct ScrollCommandResultStructTests {
         #expect(result.location["x"] == 500.0)
         #expect(result.location["y"] == 300.0)
         #expect(result.totalTicks == 5)
+        #expect(result.targetReceipt == nil)
         #expect(result.executionTime == 0.15)
+    }
+
+    @Test
+    func `Scroll exact target receipt preserves generation as decimal text`() throws {
+        let bounds = CGRect(x: 10, y: 20, width: 600, height: 400)
+        let identity = WindowMutationIdentity(
+            windowID: 42,
+            ownerProcessIdentifier: 123,
+            ownerProcessStartIdentity: 9_007_199_254_740_993,
+            capturedBounds: bounds
+        )
+        let result = ElementDetectionResult(
+            snapshotId: "snapshot",
+            screenshotPath: "/tmp/shot.png",
+            elements: DetectedElements(),
+            metadata: DetectionMetadata(
+                detectionTime: 0,
+                elementCount: 0,
+                method: "test",
+                windowContext: WindowContext(
+                    applicationProcessId: 123,
+                    windowID: 42,
+                    windowBounds: bounds,
+                    windowMutationIdentity: identity
+                )
+            )
+        )
+
+        let receipt = try #require(ScrollTargetReceipt(snapshotId: "snapshot", detectionResult: result))
+
+        #expect(receipt.processIdentifier == 123)
+        #expect(receipt.processStartIdentityDecimal == "9007199254740993")
+        #expect(receipt.windowId == 42)
+        #expect(receipt.windowBounds == bounds)
     }
 }

--- a/Apps/CLI/Tests/CLIAutomationTests/ScrollCommandTests.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/ScrollCommandTests.swift
@@ -249,6 +249,40 @@ struct ScrollCommandTests {
         #expect(payload.outcome?.refusalReason == .targetUnavailable)
     }
 
+    @Test
+    func `unsupported background scroll reports canonical retry-safe refusal`() async throws {
+        let snapshotId = "unsupported-scroll-snapshot"
+        let context = await self.makeContext { automation, _ in
+            automation.scrollError = PeekabooError.invalidInput(
+                "Background scroll is unavailable for this target"
+            )
+        }
+        try await context.snapshots.storeDetectionResult(
+            snapshotId: snapshotId,
+            result: Self.detectionResult(snapshotId: snapshotId, element: Self.buttonElement(id: "B1"))
+        )
+
+        let result = try await self.runScroll(
+            arguments: [
+                "--direction", "down",
+                "--on", "B1",
+                "--snapshot", snapshotId,
+                "--json",
+            ],
+            context: context
+        )
+
+        #expect(result.exitStatus != 0)
+        let payloadData = try #require(self.output(from: result).data(using: .utf8))
+        let payload = try JSONDecoder().decode(JSONResponse.self, from: payloadData)
+        #expect(!payload.success)
+        #expect(payload.error?.code == ErrorCode.INVALID_INPUT.rawValue)
+        #expect(payload.outcome?.state == .refused)
+        #expect(payload.outcome?.retrySafety == .safe)
+        #expect(payload.outcome?.dispatchState == DesktopActionOutcome.DispatchState.none)
+        #expect(payload.outcome?.refusalReason == .operationUnsupported)
+    }
+
     // MARK: - Helpers
 
     private func runScroll(

--- a/Apps/CLI/Tests/CLIAutomationTests/ScrollCommandTests.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/ScrollCommandTests.swift
@@ -215,6 +215,40 @@ struct ScrollCommandTests {
         #expect(await self.automationState(context) { $0.scrollCalls }.isEmpty)
     }
 
+    @Test
+    func `stale background scroll reports canonical retry-safe refusal`() async throws {
+        let snapshotId = "stale-scroll-snapshot"
+        let context = await self.makeContext { automation, _ in
+            automation.scrollError = PeekabooError.snapshotStale(
+                "target window owner, process generation, or bounds changed"
+            )
+        }
+        try await context.snapshots.storeDetectionResult(
+            snapshotId: snapshotId,
+            result: Self.detectionResult(snapshotId: snapshotId, element: Self.buttonElement(id: "B1"))
+        )
+
+        let result = try await self.runScroll(
+            arguments: [
+                "--direction", "down",
+                "--on", "B1",
+                "--snapshot", snapshotId,
+                "--json",
+            ],
+            context: context
+        )
+
+        #expect(result.exitStatus != 0)
+        let payloadData = try #require(self.output(from: result).data(using: .utf8))
+        let payload = try JSONDecoder().decode(JSONResponse.self, from: payloadData)
+        #expect(!payload.success)
+        #expect(payload.error?.code == ErrorCode.SNAPSHOT_STALE.rawValue)
+        #expect(payload.outcome?.state == .refused)
+        #expect(payload.outcome?.retrySafety == .safe)
+        #expect(payload.outcome?.dispatchState == DesktopActionOutcome.DispatchState.none)
+        #expect(payload.outcome?.refusalReason == .targetUnavailable)
+    }
+
     // MARK: - Helpers
 
     private func runScroll(

--- a/Apps/CLI/Tests/CLIAutomationTests/Support/TestServices.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/Support/TestServices.swift
@@ -217,6 +217,7 @@ ExactWindowTargetedClickServiceProtocol, ElementActionAutomationServiceProtocol 
     var typeTextCalls: [TypeTextCall] = []
     var typeActionsCalls: [TypeActionsCall] = []
     var scrollCalls: [ScrollCall] = []
+    var scrollError: (any Error)?
     var swipeCalls: [SwipeCall] = []
     var dragCalls: [DragCall] = []
     var moveMouseCalls: [MoveMouseCall] = []
@@ -427,6 +428,9 @@ ExactWindowTargetedClickServiceProtocol, ElementActionAutomationServiceProtocol 
         self.scrollCalls.append(
             ScrollCall(request: request)
         )
+        if let scrollError {
+            throw scrollError
+        }
     }
 
     func setValue(

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 - Add Bridge protocol 1.25 one-shot dialog receipts that uniquely bind an exact process/window, raw dialog or sheet, and semantic AXPress button for background click/dismiss, with read-only targeted listing and canonical postcondition outcomes.
 - Add a background-first native Bridge host runtime for signed macOS apps, with explicit caller allowlists, shared mutation/snapshot state, checked lifecycle, and no Core, provider, browser, daemon, or AppleScript surface.
+- Add capability-gated exact-window background wheel delivery for opaque WKWebView/Tauri scroll targets, preserving the foreground app and physical cursor while refusing hidden, stale, Electron, Chromium, Catalyst, or AX-only routes.
 
 ### Changed
 - Build branded release disk images from pinned direct Finder-metadata tooling, preserving the signed and notarized drag-to-Applications layout without GUI automation.

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/ScrollService.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/ScrollService.swift
@@ -32,6 +32,8 @@ public final class ScrollService {
     private let actionInputDriver: any ActionInputDriving
     private let syntheticInputDriver: any SyntheticInputDriving
     private let automationElementResolver: any AutomationElementResolving
+    private let windowRoutedPointerDriver: WindowRoutedPointerDriver
+    private let backgroundWheelCapability: @MainActor (pid_t) -> Bool
     private let exactWindowIdentityValidator: @Sendable (WindowMutationIdentity, CGRect) -> Bool
     private let processStartIdentityProvider: @Sendable (pid_t) -> UInt64?
     private let desktopOperationExecutor: DesktopOperationExecutor
@@ -58,6 +60,9 @@ public final class ScrollService {
         actionInputDriver: any ActionInputDriving = ActionInputDriver(),
         syntheticInputDriver: any SyntheticInputDriving = SyntheticInputDriver(),
         automationElementResolver: any AutomationElementResolving = AutomationElementResolver(),
+        windowRoutedPointerDriver: WindowRoutedPointerDriver = WindowRoutedPointerDriver(),
+        backgroundWheelCapability: @escaping @MainActor (pid_t) -> Bool =
+            WindowRoutedApplicationClassifier.supportsBackgroundWheelScroll,
         exactWindowIdentityValidator: @escaping @Sendable (WindowMutationIdentity, CGRect) -> Bool =
             SystemIdentityResolver.validateWindowMutationIdentity,
         processStartIdentityProvider: @escaping @Sendable (pid_t) -> UInt64? =
@@ -79,6 +84,8 @@ public final class ScrollService {
         self.actionInputDriver = actionInputDriver
         self.syntheticInputDriver = syntheticInputDriver
         self.automationElementResolver = automationElementResolver
+        self.windowRoutedPointerDriver = windowRoutedPointerDriver
+        self.backgroundWheelCapability = backgroundWheelCapability
         self.exactWindowIdentityValidator = exactWindowIdentityValidator
         self.processStartIdentityProvider = processStartIdentityProvider
         self.desktopOperationExecutor = desktopOperationExecutor
@@ -104,6 +111,7 @@ public final class ScrollService {
         self.logger.debug("\(description, privacy: .public)")
         var bundleIdentifier: String?
         var preparedElement: AutomationElement?
+        var preparedDetectedElement: DetectedElement?
         let strategy: UIInputStrategy = request.foreground ? .synthOnly : .actionOnly
         let captureReceipt: DesktopOperationPlan.CaptureReceipt
         if request.foreground {
@@ -149,7 +157,9 @@ public final class ScrollService {
                             receipt: captureReceipt,
                             processStartIdentityProvider: self.processStartIdentityProvider,
                             exactWindowIdentityValidator: self.exactWindowIdentityValidator)
-                        preparedElement = try self.resolveActionScrollElement(request, in: detectionResult)
+                        let preparedTarget = try self.resolveActionScrollTarget(request, in: detectionResult)
+                        preparedElement = preparedTarget.element
+                        preparedDetectedElement = preparedTarget.detected
                         bundleIdentifier = captureReceipt.bundleIdentifier
                     }
                     await lanePreparation()
@@ -175,10 +185,40 @@ public final class ScrollService {
                         receipt: captureReceipt,
                         processStartIdentityProvider: self.processStartIdentityProvider,
                         exactWindowIdentityValidator: self.exactWindowIdentityValidator)
-                    return try self.actionInputDriver.tryScroll(
-                        element: preparedElement,
-                        direction: request.direction,
-                        pages: Self.actionScrollPages(amount: request.amount, strategy: strategy))
+                    do {
+                        return try self.actionInputDriver.tryScroll(
+                            element: preparedElement,
+                            direction: request.direction,
+                            pages: Self.actionScrollPages(amount: request.amount, strategy: strategy))
+                    } catch let error as ActionInputError {
+                        guard case .unsupported = error,
+                              let preparedDetectedElement,
+                              let exactWindow = captureReceipt.exactWindow,
+                              Self.supportsWindowRoutedWheelTarget(
+                                  preparedDetectedElement,
+                                  screenshotPath: detectionResult.screenshotPath),
+                              self.backgroundWheelCapability(exactWindow.identity.ownerProcessIdentifier),
+                              let targetWindowID = CGWindowID(exactly: exactWindow.identity.windowID)
+                        else {
+                            throw error
+                        }
+                        let point = CGPoint(
+                            x: preparedDetectedElement.bounds.midX,
+                            y: preparedDetectedElement.bounds.midY)
+                        let outcome = try await self.windowRoutedPointerDriver.scroll(
+                            at: point,
+                            direction: request.direction,
+                            ticks: Self.actionScrollPages(amount: request.amount, strategy: strategy),
+                            targetProcessIdentifier: exactWindow.identity.ownerProcessIdentifier,
+                            targetWindowID: targetWindowID,
+                            expectedWindowIdentity: exactWindow.identity,
+                            expectedWindowBounds: exactWindow.bounds)
+                        return UIInputExecutionResult.Action(
+                            outcome: outcome,
+                            actionName: "WindowRoutedWheel",
+                            anchorPoint: point,
+                            elementRole: preparedElement.role)
+                    }
                 },
                 synthesis: DesktopOperationPlan.SynthesisRoute {
                     try await self.performSyntheticScroll(request)
@@ -229,9 +269,24 @@ public final class ScrollService {
             "Retry with foreground enabled to allow synthetic wheel events."
     }
 
-    private func resolveActionScrollElement(
+    nonisolated static func supportsWindowRoutedWheelTarget(
+        _ element: DetectedElement,
+        screenshotPath: String) -> Bool
+    {
+        guard !screenshotPath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              element.bounds.width > 0,
+              element.bounds.height > 0,
+              element.isOCRSemanticEvidence == false
+        else {
+            return false
+        }
+        let role = element.attributes["role"]?.lowercased()
+        return element.type == .group || role == "axgroup" || role == "axwebarea"
+    }
+
+    private func resolveActionScrollTarget(
         _ request: ScrollRequest,
-        in detectionResult: ElementDetectionResult) throws -> AutomationElement
+        in detectionResult: ElementDetectionResult) throws -> (detected: DetectedElement, element: AutomationElement)
     {
         guard let target = request.target?.trimmingCharacters(in: .whitespacesAndNewlines),
               !target.isEmpty
@@ -250,7 +305,7 @@ public final class ScrollService {
             else {
                 throw ActionInputError.unsupported(.missingElement)
             }
-            return element
+            return (detected, element)
         }
         throw NotFoundError.element(target)
     }

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/WindowRoutedApplicationClassifier.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/WindowRoutedApplicationClassifier.swift
@@ -1,0 +1,91 @@
+import AppKit
+import Foundation
+
+enum WindowRoutedApplicationKind: Equatable {
+    case appKit
+    case catalyst
+    case chromium
+    case electron
+    case webKit
+}
+
+/// A narrow runtime gate for process-targeted pointer delivery.
+///
+/// Wheel events are enabled only for visible native applications whose executable imports WebKit.
+/// Electron, Chromium, and Catalyst keep their existing click transport classification but are not
+/// admitted to background wheel delivery because receiver consumption cannot be proven there.
+@MainActor
+enum WindowRoutedApplicationClassifier {
+    private static let chromiumBundlePrefixes = [
+        "com.google.chrome",
+        "org.chromium.chromium",
+        "com.microsoft.edgemac",
+        "com.brave.browser",
+        "com.vivaldi.vivaldi",
+        "company.thebrowser.browser",
+    ]
+    private static let executableProbeLimit = 1_048_576
+    private static let webKitImportMarker = Data("/WebKit.framework/".utf8)
+
+    static func kind(processIdentifier: pid_t) -> WindowRoutedApplicationKind {
+        guard let application = NSRunningApplication(processIdentifier: processIdentifier) else {
+            return .appKit
+        }
+        let info = application.bundleURL.flatMap(Bundle.init(url:))?.infoDictionary ?? [:]
+        let executablePrefix = application.bundleURL
+            .flatMap(Bundle.init(url:))?
+            .executableURL
+            .flatMap(self.executablePrefix)
+        return self.kind(
+            bundleIdentifier: application.bundleIdentifier,
+            principalClass: info["NSPrincipalClass"] as? String,
+            hasElectronAsarIntegrity: info["ElectronAsarIntegrity"] != nil,
+            isCatalyst: info["UIApplicationSceneManifest"] != nil || info["UIDeviceFamily"] != nil,
+            executablePrefix: executablePrefix)
+    }
+
+    static func supportsBackgroundWheelScroll(processIdentifier: pid_t) -> Bool {
+        guard let application = NSRunningApplication(processIdentifier: processIdentifier) else { return false }
+        return self.supportsBackgroundWheelScroll(
+            isHidden: application.isHidden,
+            isTerminated: application.isTerminated,
+            kind: self.kind(processIdentifier: processIdentifier))
+    }
+
+    static func supportsBackgroundWheelScroll(
+        isHidden: Bool,
+        isTerminated: Bool,
+        kind: WindowRoutedApplicationKind) -> Bool
+    {
+        !isHidden && !isTerminated && kind == .webKit
+    }
+
+    static func kind(
+        bundleIdentifier: String?,
+        principalClass: String?,
+        hasElectronAsarIntegrity: Bool,
+        isCatalyst: Bool,
+        executablePrefix: Data?) -> WindowRoutedApplicationKind
+    {
+        let normalizedBundleIdentifier = bundleIdentifier?.lowercased() ?? ""
+        if self.chromiumBundlePrefixes.contains(where: normalizedBundleIdentifier.hasPrefix) {
+            return .chromium
+        }
+        if principalClass?.lowercased().contains("atomapplication") == true || hasElectronAsarIntegrity {
+            return .electron
+        }
+        if isCatalyst {
+            return .catalyst
+        }
+        if executablePrefix?.range(of: self.webKitImportMarker) != nil {
+            return .webKit
+        }
+        return .appKit
+    }
+
+    private static func executablePrefix(_ url: URL) -> Data? {
+        guard let handle = try? FileHandle(forReadingFrom: url) else { return nil }
+        defer { try? handle.close() }
+        return try? handle.read(upToCount: self.executableProbeLimit)
+    }
+}

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/WindowRoutedApplicationClassifier.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/WindowRoutedApplicationClassifier.swift
@@ -45,11 +45,20 @@ enum WindowRoutedApplicationClassifier {
     }
 
     static func supportsBackgroundWheelScroll(processIdentifier: pid_t) -> Bool {
-        guard let application = NSRunningApplication(processIdentifier: processIdentifier) else { return false }
+        guard let application = NSRunningApplication(processIdentifier: processIdentifier),
+              self.applicationIsVisible(application)
+        else {
+            return false
+        }
         return self.supportsBackgroundWheelScroll(
-            isHidden: application.isHidden,
-            isTerminated: application.isTerminated,
+            isHidden: false,
+            isTerminated: false,
             kind: self.kind(processIdentifier: processIdentifier))
+    }
+
+    static func applicationIsVisible(processIdentifier: pid_t) -> Bool {
+        guard let application = NSRunningApplication(processIdentifier: processIdentifier) else { return false }
+        return self.applicationIsVisible(application)
     }
 
     static func supportsBackgroundWheelScroll(
@@ -87,5 +96,9 @@ enum WindowRoutedApplicationClassifier {
         guard let handle = try? FileHandle(forReadingFrom: url) else { return nil }
         defer { try? handle.close() }
         return try? handle.read(upToCount: self.executableProbeLimit)
+    }
+
+    private static func applicationIsVisible(_ application: NSRunningApplication) -> Bool {
+        !application.isHidden && !application.isTerminated
     }
 }

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/WindowRoutedPointerDriver.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/WindowRoutedPointerDriver.swift
@@ -58,6 +58,8 @@ struct WindowRoutedPointerDriver {
     typealias EventPoster = @MainActor (_ event: CGEvent, _ pid: pid_t) -> Void
     typealias SkyLightEventPoster = @MainActor (_ event: CGEvent, _ pid: pid_t) -> Bool
     typealias TransportResolver = @MainActor (_ pid: pid_t) -> WindowRoutedPointerTransport
+    typealias ApplicationVisibilityValidator = @MainActor (_ pid: pid_t) -> Bool
+    typealias WindowVisibilityValidator = @MainActor (_ receipt: RouteReceipt) -> Bool
     typealias Sleeper = @MainActor (_ duration: Duration) async -> Void
 
     private let hasPostEventAccess: () -> Bool
@@ -70,6 +72,8 @@ struct WindowRoutedPointerDriver {
     private let postSkyLight: SkyLightEventPoster
     private let postPublic: EventPoster
     private let resolveTransport: TransportResolver
+    private let applicationIsVisible: ApplicationVisibilityValidator
+    private let windowIsVisible: WindowVisibilityValidator
     private let sleep: Sleeper
     private let clickGroupIdentifier: () -> Int64
 
@@ -84,6 +88,9 @@ struct WindowRoutedPointerDriver {
         postSkyLight: @escaping SkyLightEventPoster = WindowRoutedPointerSPI.postToPid,
         postPublic: @escaping EventPoster = { event, pid in event.postToPid(pid) },
         resolveTransport: @escaping TransportResolver = Self.resolveLiveTransport,
+        applicationIsVisible: @escaping ApplicationVisibilityValidator =
+            WindowRoutedApplicationClassifier.applicationIsVisible,
+        windowIsVisible: @escaping WindowVisibilityValidator = Self.validateLiveWindowVisibility,
         sleep: @escaping Sleeper = { duration in
             // A mouse-down must always be paired with its mouse-up. Detached sleeping makes the
             // short down/up interval non-cancellable; cancellation is observed immediately after
@@ -106,6 +113,8 @@ struct WindowRoutedPointerDriver {
         self.postSkyLight = postSkyLight
         self.postPublic = postPublic
         self.resolveTransport = resolveTransport
+        self.applicationIsVisible = applicationIsVisible
+        self.windowIsVisible = windowIsVisible
         self.sleep = sleep
         self.clickGroupIdentifier = clickGroupIdentifier
     }
@@ -248,10 +257,11 @@ struct WindowRoutedPointerDriver {
         let receipt = try self.resolveRoute(targetProcessIdentifier, targetWindowID, point)
         guard receipt.identity == expectedWindowIdentity,
               receipt.bounds == expectedWindowBounds,
-              receipt.bounds.contains(point)
+              receipt.bounds.contains(point),
+              self.scrollTargetIsVisible(receipt)
         else {
             throw PeekabooError.snapshotStale(
-                "Resolved background wheel route does not match the captured PID, window, bounds, or point")
+                "Resolved background wheel route does not match the visible captured PID, window, bounds, or point")
         }
 
         let transport = self.resolveTransport(targetProcessIdentifier)
@@ -265,10 +275,10 @@ struct WindowRoutedPointerDriver {
                     eventCount: postedEventCount,
                     cause: "The request was cancelled after routed wheel events were emitted")
             }
-            guard self.routeIsCurrent(receipt) else {
+            guard self.scrollRouteIsCurrent(receipt) else {
                 if postedEventCount == 0 {
                     throw PeekabooError.snapshotStale(
-                        "Background wheel target changed owner, process generation, window identity, or bounds")
+                        "Background wheel target changed visibility, owner, process generation, window, or bounds")
                 }
                 throw Self.scrollDispatchFailure(
                     eventCount: postedEventCount,
@@ -306,7 +316,7 @@ struct WindowRoutedPointerDriver {
             }
         }
 
-        guard self.routeIsCurrent(receipt) else {
+        guard self.scrollRouteIsCurrent(receipt) else {
             throw Self.scrollDispatchFailure(
                 eventCount: postedEventCount,
                 cause: "Window-routed wheel events were posted, but final target validation failed")
@@ -319,6 +329,14 @@ struct WindowRoutedPointerDriver {
             delivery: .init(mechanism: .windowTargetedEvents, mode: .background),
             evidence: .deliveryAccepted,
             unitCount: unitCount)
+    }
+
+    private func scrollRouteIsCurrent(_ receipt: RouteReceipt) -> Bool {
+        self.routeIsCurrent(receipt) && self.scrollTargetIsVisible(receipt)
+    }
+
+    private func scrollTargetIsVisible(_ receipt: RouteReceipt) -> Bool {
+        self.applicationIsVisible(receipt.identity.ownerProcessIdentifier) && self.windowIsVisible(receipt)
     }
 
     private func postScrollEvent(
@@ -613,6 +631,22 @@ struct WindowRoutedPointerDriver {
     private static func validateLiveProcessGeneration(_ receipt: RouteReceipt) -> Bool {
         SystemIdentityResolver.processStartIdentity(receipt.identity.ownerProcessIdentifier) ==
             receipt.identity.ownerProcessStartIdentity
+    }
+
+    private static func validateLiveWindowVisibility(_ receipt: RouteReceipt) -> Bool {
+        guard let windowID = CGWindowID(exactly: receipt.identity.windowID),
+              let window = SystemIdentityResolver.windowIdentity(windowID),
+              window.windowID == windowID,
+              window.ownerProcessIdentifier == receipt.identity.ownerProcessIdentifier,
+              window.bounds == receipt.bounds,
+              window.layer == 0,
+              window.isOnScreen,
+              window.alpha > 0,
+              window.bounds.contains(receipt.screenPoint)
+        else {
+            return false
+        }
+        return true
     }
 
     private static func resolveLiveTransport(_ processIdentifier: pid_t) -> WindowRoutedPointerTransport {

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/WindowRoutedPointerDriver.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/WindowRoutedPointerDriver.swift
@@ -51,6 +51,9 @@ struct WindowRoutedPointerDriver {
     typealias EventFactory = @MainActor (
         _ specification: EventSpecification,
         _ screenPoint: CGPoint) -> CGEvent?
+    typealias ScrollEventFactory = @MainActor (
+        _ direction: PeekabooFoundation.ScrollDirection,
+        _ screenPoint: CGPoint) -> CGEvent?
     typealias WindowLocationStamper = @MainActor (_ event: CGEvent, _ windowPoint: CGPoint) -> Bool
     typealias EventPoster = @MainActor (_ event: CGEvent, _ pid: pid_t) -> Void
     typealias SkyLightEventPoster = @MainActor (_ event: CGEvent, _ pid: pid_t) -> Bool
@@ -62,6 +65,7 @@ struct WindowRoutedPointerDriver {
     private let routeIsCurrent: RouteValidator
     private let processGenerationIsCurrent: ProcessGenerationValidator
     private let makeEvent: EventFactory
+    private let makeScrollEvent: ScrollEventFactory
     private let stampWindowLocation: WindowLocationStamper
     private let postSkyLight: SkyLightEventPoster
     private let postPublic: EventPoster
@@ -75,6 +79,7 @@ struct WindowRoutedPointerDriver {
         routeIsCurrent: @escaping RouteValidator = Self.validateLiveRoute,
         processGenerationIsCurrent: @escaping ProcessGenerationValidator = Self.validateLiveProcessGeneration,
         makeEvent: @escaping EventFactory = Self.makeCGEvent,
+        makeScrollEvent: @escaping ScrollEventFactory = Self.makeCGScrollEvent,
         stampWindowLocation: @escaping WindowLocationStamper = WindowRoutedPointerSPI.setWindowLocation,
         postSkyLight: @escaping SkyLightEventPoster = WindowRoutedPointerSPI.postToPid,
         postPublic: @escaping EventPoster = { event, pid in event.postToPid(pid) },
@@ -96,6 +101,7 @@ struct WindowRoutedPointerDriver {
         self.routeIsCurrent = routeIsCurrent
         self.processGenerationIsCurrent = processGenerationIsCurrent
         self.makeEvent = makeEvent
+        self.makeScrollEvent = makeScrollEvent
         self.stampWindowLocation = stampWindowLocation
         self.postSkyLight = postSkyLight
         self.postPublic = postPublic
@@ -218,6 +224,135 @@ struct WindowRoutedPointerDriver {
         return outcome
     }
 
+    /// Posts line-based wheel events to one exact visible background window without cursor movement.
+    ///
+    /// This is intentionally lower-level than an Accessibility scroll action. Callers must first
+    /// capability-gate the target application and retain a fresh exact-window capture receipt.
+    func scroll(
+        at point: CGPoint,
+        direction: PeekabooFoundation.ScrollDirection,
+        ticks: Int,
+        targetProcessIdentifier: pid_t,
+        targetWindowID: CGWindowID,
+        expectedWindowIdentity: WindowMutationIdentity,
+        expectedWindowBounds: CGRect) async throws -> DesktopActionOutcome
+    {
+        guard ticks > 0 else {
+            throw PeekabooError.invalidInput("Window-routed scroll requires at least one tick")
+        }
+        guard self.hasPostEventAccess() else {
+            throw PeekabooError.permissionDeniedEventSynthesizing
+        }
+        try Task.checkCancellation()
+
+        let receipt = try self.resolveRoute(targetProcessIdentifier, targetWindowID, point)
+        guard receipt.identity == expectedWindowIdentity,
+              receipt.bounds == expectedWindowBounds,
+              receipt.bounds.contains(point)
+        else {
+            throw PeekabooError.snapshotStale(
+                "Resolved background wheel route does not match the captured PID, window, bounds, or point")
+        }
+
+        let transport = self.resolveTransport(targetProcessIdentifier)
+        var postedEventCount = 0
+        for tick in 0..<ticks {
+            if Task.isCancelled {
+                if postedEventCount == 0 {
+                    throw CancellationError()
+                }
+                throw Self.scrollDispatchFailure(
+                    eventCount: postedEventCount,
+                    cause: "The request was cancelled after routed wheel events were emitted")
+            }
+            guard self.routeIsCurrent(receipt) else {
+                if postedEventCount == 0 {
+                    throw PeekabooError.snapshotStale(
+                        "Background wheel target changed owner, process generation, window identity, or bounds")
+                }
+                throw Self.scrollDispatchFailure(
+                    eventCount: postedEventCount,
+                    cause: "The exact background wheel route changed during delivery")
+            }
+            guard let event = self.makeScrollEvent(direction, receipt.screenPoint) else {
+                if postedEventCount == 0 {
+                    throw PeekabooError.operationError(message: "Failed to create a window-routed wheel event")
+                }
+                throw Self.scrollDispatchFailure(
+                    eventCount: postedEventCount,
+                    cause: "The next window-routed wheel event could not be constructed")
+            }
+            guard self.stampWindowLocation(event, receipt.windowPoint) else {
+                if postedEventCount == 0 {
+                    throw PeekabooError.serviceUnavailable(
+                        "Window-local wheel routing is unavailable on this macOS build; no scroll was dispatched")
+                }
+                throw Self.scrollDispatchFailure(
+                    eventCount: postedEventCount,
+                    cause: "The next wheel event could not be stamped with its window-local point")
+            }
+
+            Self.stampRoutingFields(
+                on: event,
+                receipt: receipt,
+                clickGroup: self.clickGroupIdentifier())
+            try self.postScrollEvent(
+                event,
+                receipt: receipt,
+                transport: transport,
+                postedEventCount: &postedEventCount)
+            if tick + 1 < ticks {
+                await self.sleep(.milliseconds(12))
+            }
+        }
+
+        guard self.routeIsCurrent(receipt) else {
+            throw Self.scrollDispatchFailure(
+                eventCount: postedEventCount,
+                cause: "Window-routed wheel events were posted, but final target validation failed")
+        }
+        guard let unitCount = DesktopActionOutcome.DispatchUnitCount(postedEventCount) else {
+            throw PeekabooError.operationError(
+                message: "Window-routed wheel delivery completed without posting an event")
+        }
+        return .dispatchedUnverified(
+            delivery: .init(mechanism: .windowTargetedEvents, mode: .background),
+            evidence: .deliveryAccepted,
+            unitCount: unitCount)
+    }
+
+    private func postScrollEvent(
+        _ event: CGEvent,
+        receipt: RouteReceipt,
+        transport: WindowRoutedPointerTransport,
+        postedEventCount: inout Int) throws
+    {
+        switch transport {
+        case .publicCGEvent:
+            self.postPublic(event, receipt.identity.ownerProcessIdentifier)
+        case .skyLight:
+            guard self.postSkyLight(event, receipt.identity.ownerProcessIdentifier) else {
+                let cause = "SkyLight PID wheel routing is unavailable; no global fallback was used"
+                if postedEventCount == 0 {
+                    throw PeekabooError.serviceUnavailable(cause)
+                }
+                throw Self.scrollDispatchFailure(eventCount: postedEventCount, cause: cause)
+            }
+        }
+        postedEventCount += 1
+    }
+
+    private static func scrollDispatchFailure(eventCount: Int, cause: String) -> DesktopActionFailure {
+        let unitCount = DesktopActionOutcome.DispatchUnitCount(eventCount)
+        return .dispatchedUnverified(
+            delivery: .init(mechanism: .windowTargetedEvents, mode: .background),
+            evidence: .deliveryAccepted,
+            unitCount: unitCount,
+            message: "Window-routed wheel outcome is indeterminate; do not retry blindly",
+            hint: "Observe the target before taking another scroll action.",
+            causeDescription: cause)
+    }
+
     private func post(
         _ specification: EventSpecification,
         receipt: RouteReceipt,
@@ -261,16 +396,10 @@ struct WindowRoutedPointerDriver {
                 "Window-local pointer routing is unavailable on this macOS build; no click was dispatched")
         }
 
-        let targetPID = Int64(receipt.identity.ownerProcessIdentifier)
-        let windowID = Int64(receipt.identity.windowID)
-        event.setIntegerValueField(.eventTargetUnixProcessID, value: targetPID)
+        Self.stampRoutingFields(on: event, receipt: receipt, clickGroup: clickGroup)
         Self.setIntegerField(1, clickState: specification.clickState, on: event)
         Self.setIntegerField(3, clickState: specification.buttonNumber, on: event)
         Self.setIntegerField(7, clickState: 3, on: event)
-        Self.setIntegerField(51, clickState: windowID, on: event)
-        Self.setIntegerField(58, clickState: clickGroup, on: event)
-        Self.setIntegerField(91, clickState: windowID, on: event)
-        Self.setIntegerField(92, clickState: windowID, on: event)
 
         // A logical event is posted exactly once. AppKit consumes the public PID route while
         // Chromium/Catalyst require SkyLight's activity-monitor path; broadcasting to both makes
@@ -369,6 +498,20 @@ struct WindowRoutedPointerDriver {
         event.setIntegerValueField(field, value: value)
     }
 
+    private static func stampRoutingFields(
+        on event: CGEvent,
+        receipt: RouteReceipt,
+        clickGroup: Int64)
+    {
+        let targetPID = Int64(receipt.identity.ownerProcessIdentifier)
+        let windowID = Int64(receipt.identity.windowID)
+        event.setIntegerValueField(.eventTargetUnixProcessID, value: targetPID)
+        Self.setIntegerField(51, clickState: windowID, on: event)
+        Self.setIntegerField(58, clickState: clickGroup, on: event)
+        Self.setIntegerField(91, clickState: windowID, on: event)
+        Self.setIntegerField(92, clickState: windowID, on: event)
+    }
+
     private static func checkCancellation(afterPosting eventCount: Int) throws {
         guard Task.isCancelled else { return }
         guard eventCount > 0 else { throw CancellationError() }
@@ -387,6 +530,30 @@ struct WindowRoutedPointerDriver {
             mouseType: specification.type,
             mouseCursorPosition: screenPoint,
             mouseButton: specification.button)
+    }
+
+    private static func makeCGScrollEvent(
+        _ direction: PeekabooFoundation.ScrollDirection,
+        _ screenPoint: CGPoint) -> CGEvent?
+    {
+        let (vertical, horizontal): (Int32, Int32) = switch direction {
+        case .up: (1, 0)
+        case .down: (-1, 0)
+        case .left: (0, 1)
+        case .right: (0, -1)
+        }
+        guard let event = CGEvent(
+            scrollWheelEvent2Source: CGEventSource(stateID: .hidSystemState),
+            units: .line,
+            wheelCount: 2,
+            wheel1: vertical,
+            wheel2: horizontal,
+            wheel3: 0)
+        else {
+            return nil
+        }
+        event.location = screenPoint
+        return event
     }
 
     private static func resolveLiveRoute(
@@ -449,32 +616,12 @@ struct WindowRoutedPointerDriver {
     }
 
     private static func resolveLiveTransport(_ processIdentifier: pid_t) -> WindowRoutedPointerTransport {
-        guard let application = NSRunningApplication(processIdentifier: processIdentifier) else {
-            return .publicCGEvent
+        switch WindowRoutedApplicationClassifier.kind(processIdentifier: processIdentifier) {
+        case .catalyst, .chromium, .electron:
+            .skyLight
+        case .appKit, .webKit:
+            .publicCGEvent
         }
-        let bundleIdentifier = application.bundleIdentifier?.lowercased() ?? ""
-        let chromiumPrefixes = [
-            "com.google.chrome",
-            "org.chromium.chromium",
-            "com.microsoft.edgemac",
-            "com.brave.browser",
-            "com.vivaldi.vivaldi",
-            "company.thebrowser.browser",
-        ]
-        if chromiumPrefixes.contains(where: bundleIdentifier.hasPrefix) {
-            return .skyLight
-        }
-
-        guard let info = application.bundleURL
-            .flatMap(Bundle.init(url:))?
-            .infoDictionary
-        else {
-            return .publicCGEvent
-        }
-        let principalClass = (info["NSPrincipalClass"] as? String)?.lowercased() ?? ""
-        let isElectron = principalClass.contains("atomapplication") || info["ElectronAsarIntegrity"] != nil
-        let isCatalyst = info["UIApplicationSceneManifest"] != nil || info["UIDeviceFamily"] != nil
-        return isElectron || isCatalyst ? .skyLight : .publicCGEvent
     }
 }
 

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ScrollServiceTargetResolutionTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ScrollServiceTargetResolutionTests.swift
@@ -56,6 +56,121 @@ struct ScrollServiceTargetResolutionTests {
 
     @Test
     @MainActor
+    func `unsupported AX group uses exact WebKit wheel route without global synthesis`() async throws {
+        let laneRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("web-scroll-lane-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: laneRoot) }
+        let element = DetectedElement(
+            id: "S1",
+            type: .group,
+            label: "Web content",
+            bounds: CGRect(x: 20, y: 30, width: 300, height: 400),
+            attributes: ["role": "AXGroup"])
+        let detectionResult = Self.exactDetectionResult(element: element)
+        let identity = try #require(detectionResult.metadata.windowContext?.windowMutationIdentity)
+        let bounds = try #require(detectionResult.metadata.windowContext?.windowBounds)
+        let point = CGPoint(x: element.bounds.midX, y: element.bounds.midY)
+        var posted = 0
+        let routedDriver = WindowRoutedPointerDriver(
+            hasPostEventAccess: { true },
+            resolveRoute: { _, _, _ in .init(identity: identity, bounds: bounds, screenPoint: point) },
+            routeIsCurrent: { _ in true },
+            makeScrollEvent: { _, _ in
+                CGEvent(
+                    scrollWheelEvent2Source: nil,
+                    units: .line,
+                    wheelCount: 1,
+                    wheel1: -1,
+                    wheel2: 0,
+                    wheel3: 0)
+            },
+            stampWindowLocation: { _, _ in true },
+            postSkyLight: { _, _ in true },
+            postPublic: { _, _ in posted += 1 },
+            resolveTransport: { _ in .publicCGEvent },
+            sleep: { _ in })
+        let action = ScrollRecordingActionInputDriver(scrollError: .unsupported(.actionUnsupported))
+        let synthetic = ScrollRecordingSyntheticInputDriver()
+        let service = ScrollService(
+            snapshotManager: InMemorySnapshotManager(detectionResult: detectionResult),
+            actionInputDriver: action,
+            syntheticInputDriver: synthetic,
+            automationElementResolver: ScrollFixedAutomationElementResolver(),
+            windowRoutedPointerDriver: routedDriver,
+            backgroundWheelCapability: { _ in true },
+            exactWindowIdentityValidator: { _, _ in true },
+            processStartIdentityProvider: { _ in 11 },
+            desktopOperationExecutor: DesktopOperationExecutor(
+                laneCoordinator: DesktopOperationLaneCoordinator(coordinationRootURL: laneRoot)))
+
+        let result = try await service.scroll(ScrollRequest(
+            direction: .down,
+            amount: 2,
+            target: "S1",
+            snapshotId: "snapshot"))
+
+        #expect(result.path == .action)
+        #expect(result.actionName == "WindowRoutedWheel")
+        #expect(result.outcome.state == .dispatchedUnverified)
+        #expect(result.outcome.delivery == .init(mechanism: .windowTargetedEvents, mode: .background))
+        #expect(result.outcome.dispatchState.unitCount?.rawValue == 2)
+        #expect(result.outcome.retrySafety == .unsafe)
+        #expect(posted == 2)
+        #expect(synthetic.events.isEmpty)
+    }
+
+    @Test
+    @MainActor
+    func `unsupported AX group refuses when application lacks WebKit capability`() async {
+        let laneRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("web-scroll-refusal-lane-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: laneRoot) }
+        let element = DetectedElement(
+            id: "S1",
+            type: .group,
+            label: "Opaque panel",
+            bounds: CGRect(x: 20, y: 30, width: 300, height: 400),
+            attributes: ["role": "AXGroup"])
+        let action = ScrollRecordingActionInputDriver(scrollError: .unsupported(.actionUnsupported))
+        let service = ScrollService(
+            snapshotManager: InMemorySnapshotManager(detectionResult: Self.exactDetectionResult(element: element)),
+            actionInputDriver: action,
+            automationElementResolver: ScrollFixedAutomationElementResolver(),
+            backgroundWheelCapability: { _ in false },
+            exactWindowIdentityValidator: { _, _ in true },
+            processStartIdentityProvider: { _ in 11 },
+            desktopOperationExecutor: DesktopOperationExecutor(
+                laneCoordinator: DesktopOperationLaneCoordinator(coordinationRootURL: laneRoot)))
+
+        do {
+            _ = try await service.scroll(Self.backgroundRequest())
+            Issue.record("Expected foreground-required refusal")
+        } catch let error as PeekabooError {
+            #expect(error.localizedDescription.contains("foreground"))
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+        #expect(action.scrollCalls.count == 1)
+    }
+
+    @Test
+    func `window-routed wheel requires pixel-backed container evidence`() {
+        let element = DetectedElement(
+            id: "S1",
+            type: .group,
+            label: "Web content",
+            bounds: CGRect(x: 20, y: 30, width: 300, height: 400),
+            attributes: ["role": "AXGroup"])
+
+        #expect(ScrollService.supportsWindowRoutedWheelTarget(element, screenshotPath: "/tmp/shot.png"))
+        #expect(!ScrollService.supportsWindowRoutedWheelTarget(element, screenshotPath: ""))
+        #expect(!ScrollService.supportsWindowRoutedWheelTarget(
+            DetectedElement(id: "B1", type: .button, label: "Button", bounds: element.bounds),
+            screenshotPath: "/tmp/shot.png"))
+    }
+
+    @Test
+    @MainActor
     func `action-first missing snapshot fails as stale instead of falling back`() async {
         let service = ScrollService(
             snapshotManager: InMemorySnapshotManager(),
@@ -456,9 +571,14 @@ private final class ScrollRecordingActionInputDriver: ActionInputDriving {
 
     private(set) var scrollCalls: [ScrollCall] = []
     private let afterScroll: @MainActor () -> Void
+    private let scrollError: ActionInputError?
 
-    init(afterScroll: @escaping @MainActor () -> Void = {}) {
+    init(
+        afterScroll: @escaping @MainActor () -> Void = {},
+        scrollError: ActionInputError? = nil)
+    {
         self.afterScroll = afterScroll
+        self.scrollError = scrollError
     }
 
     func tryClick(element _: AutomationElement) throws -> UIInputExecutionResult.Action {
@@ -478,6 +598,9 @@ private final class ScrollRecordingActionInputDriver: ActionInputDriving {
     {
         self.scrollCalls.append(.init(direction: direction, pages: pages))
         self.afterScroll()
+        if let scrollError {
+            throw scrollError
+        }
         return AutomationTestFixtures.uiActionReceipt(actionName: "AXScroll", elementRole: "AXScrollArea")
     }
 

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ScrollServiceTargetResolutionTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ScrollServiceTargetResolutionTests.swift
@@ -88,6 +88,8 @@ struct ScrollServiceTargetResolutionTests {
             postSkyLight: { _, _ in true },
             postPublic: { _, _ in posted += 1 },
             resolveTransport: { _ in .publicCGEvent },
+            applicationIsVisible: { _ in true },
+            windowIsVisible: { _ in true },
             sleep: { _ in })
         let action = ScrollRecordingActionInputDriver(scrollError: .unsupported(.actionUnsupported))
         let synthetic = ScrollRecordingSyntheticInputDriver()

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/WindowRoutedApplicationClassifierTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/WindowRoutedApplicationClassifierTests.swift
@@ -1,0 +1,90 @@
+import Foundation
+import Testing
+@testable import PeekabooAutomationKit
+
+struct WindowRoutedApplicationClassifierTests {
+    @Test
+    @MainActor
+    func `native WebKit import is admitted`() {
+        let prefix = Data("/System/Library/Frameworks/WebKit.framework/Versions/A/WebKit".utf8)
+
+        #expect(WindowRoutedApplicationClassifier.kind(
+            bundleIdentifier: "com.example.TauriLike",
+            principalClass: "NSApplication",
+            hasElectronAsarIntegrity: false,
+            isCatalyst: false,
+            executablePrefix: prefix) == .webKit)
+    }
+
+    @Test(arguments: [
+        ("com.example.Electron", "AtomApplication", false, false),
+        ("com.example.Electron", "NSApplication", true, false),
+    ])
+    @MainActor
+    func `Electron markers override a WebKit-like binary prefix`(
+        bundleIdentifier: String,
+        principalClass: String,
+        hasElectronAsarIntegrity: Bool,
+        isCatalyst: Bool)
+    {
+        let prefix = Data("/System/Library/Frameworks/WebKit.framework/Versions/A/WebKit".utf8)
+
+        #expect(WindowRoutedApplicationClassifier.kind(
+            bundleIdentifier: bundleIdentifier,
+            principalClass: principalClass,
+            hasElectronAsarIntegrity: hasElectronAsarIntegrity,
+            isCatalyst: isCatalyst,
+            executablePrefix: prefix) == .electron)
+    }
+
+    @Test
+    @MainActor
+    func `Chromium and Catalyst remain outside the WebKit wheel capability`() {
+        let prefix = Data("/System/Library/Frameworks/WebKit.framework/Versions/A/WebKit".utf8)
+
+        #expect(WindowRoutedApplicationClassifier.kind(
+            bundleIdentifier: "com.google.Chrome.canary",
+            principalClass: nil,
+            hasElectronAsarIntegrity: false,
+            isCatalyst: false,
+            executablePrefix: prefix) == .chromium)
+        #expect(WindowRoutedApplicationClassifier.kind(
+            bundleIdentifier: "com.example.Catalyst",
+            principalClass: nil,
+            hasElectronAsarIntegrity: false,
+            isCatalyst: true,
+            executablePrefix: prefix) == .catalyst)
+    }
+
+    @Test
+    @MainActor
+    func `ordinary AppKit executable is not admitted`() {
+        #expect(WindowRoutedApplicationClassifier.kind(
+            bundleIdentifier: "com.example.Native",
+            principalClass: "NSApplication",
+            hasElectronAsarIntegrity: false,
+            isCatalyst: false,
+            executablePrefix: Data("AppKit.framework".utf8)) == .appKit)
+    }
+
+    @Test
+    @MainActor
+    func `hidden or terminated WebKit applications are not admitted`() {
+        #expect(WindowRoutedApplicationClassifier.supportsBackgroundWheelScroll(
+            isHidden: false,
+            isTerminated: false,
+            kind: .webKit))
+        #expect(!WindowRoutedApplicationClassifier.supportsBackgroundWheelScroll(
+            isHidden: true,
+            isTerminated: false,
+            kind: .webKit))
+        #expect(!WindowRoutedApplicationClassifier.supportsBackgroundWheelScroll(
+            isHidden: false,
+            isTerminated: true,
+            kind: .webKit))
+        #expect(!WindowRoutedApplicationClassifier.supportsBackgroundWheelScroll(
+            isHidden: false,
+            isTerminated: false,
+            kind: .electron))
+    }
+}

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/WindowRoutedPointerDriverTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/WindowRoutedPointerDriverTests.swift
@@ -21,6 +21,110 @@ struct WindowRoutedPointerDriverTests {
 
     @Test
     @MainActor
+    func `background wheel stamps exact route without pointer primer`() async throws {
+        var directions: [PeekabooFoundation.ScrollDirection] = []
+        var windowPoints: [CGPoint] = []
+        var publicEvents: [CGEvent] = []
+        var clickEventsConstructed = 0
+        var validations = 0
+        let receipt = Self.receipt()
+        let driver = WindowRoutedPointerDriver(
+            hasPostEventAccess: { true },
+            resolveRoute: { _, _, _ in receipt },
+            routeIsCurrent: { _ in validations += 1; return true },
+            makeEvent: { _, _ in clickEventsConstructed += 1; return nil },
+            makeScrollEvent: { direction, point in
+                directions.append(direction)
+                let event = CGEvent(
+                    scrollWheelEvent2Source: nil,
+                    units: .line,
+                    wheelCount: 2,
+                    wheel1: -1,
+                    wheel2: 0,
+                    wheel3: 0)
+                event?.location = point
+                return event
+            },
+            stampWindowLocation: { _, point in windowPoints.append(point); return true },
+            postSkyLight: { _, _ in true },
+            postPublic: { event, _ in publicEvents.append(event) },
+            resolveTransport: { _ in .publicCGEvent },
+            sleep: { _ in },
+            clickGroupIdentifier: { 992 })
+
+        let outcome = try await driver.scroll(
+            at: receipt.screenPoint,
+            direction: .down,
+            ticks: 3,
+            targetProcessIdentifier: receipt.identity.ownerProcessIdentifier,
+            targetWindowID: CGWindowID(receipt.identity.windowID),
+            expectedWindowIdentity: receipt.identity,
+            expectedWindowBounds: receipt.bounds)
+
+        #expect(outcome.state == .dispatchedUnverified)
+        #expect(outcome.delivery == .init(mechanism: .windowTargetedEvents, mode: .background))
+        #expect(outcome.dispatchState.unitCount?.rawValue == 3)
+        #expect(outcome.retrySafety == .unsafe)
+        #expect(directions == [.down, .down, .down])
+        #expect(windowPoints == Array(repeating: receipt.windowPoint, count: 3))
+        #expect(clickEventsConstructed == 0)
+        #expect(publicEvents.count == 3)
+        #expect(validations == 4)
+        for event in publicEvents {
+            #expect(event.getIntegerValueField(.eventTargetUnixProcessID) == 42)
+            #expect(try event.getIntegerValueField(#require(CGEventField(rawValue: 51))) == 7)
+            #expect(try event.getIntegerValueField(#require(CGEventField(rawValue: 58))) == 992)
+        }
+    }
+
+    @Test
+    @MainActor
+    func `background wheel route drift after dispatch is retry unsafe`() async {
+        var validations = 0
+        var posts = 0
+        let receipt = Self.receipt()
+        let driver = WindowRoutedPointerDriver(
+            hasPostEventAccess: { true },
+            resolveRoute: { _, _, _ in receipt },
+            routeIsCurrent: { _ in validations += 1; return validations == 1 },
+            makeScrollEvent: { _, _ in
+                CGEvent(
+                    scrollWheelEvent2Source: nil,
+                    units: .line,
+                    wheelCount: 1,
+                    wheel1: -1,
+                    wheel2: 0,
+                    wheel3: 0)
+            },
+            stampWindowLocation: { _, _ in true },
+            postSkyLight: { _, _ in true },
+            postPublic: { _, _ in posts += 1 },
+            resolveTransport: { _ in .publicCGEvent },
+            sleep: { _ in })
+
+        do {
+            _ = try await driver.scroll(
+                at: receipt.screenPoint,
+                direction: .down,
+                ticks: 3,
+                targetProcessIdentifier: receipt.identity.ownerProcessIdentifier,
+                targetWindowID: CGWindowID(receipt.identity.windowID),
+                expectedWindowIdentity: receipt.identity,
+                expectedWindowBounds: receipt.bounds)
+            Issue.record("Expected post-dispatch route drift")
+        } catch let failure as DesktopActionFailure {
+            #expect(failure.outcome.dispatchState.unitCount?.rawValue == 1)
+            #expect(failure.outcome.retrySafety == .unsafe)
+            #expect(failure.outcome.dispatchState.mutationDispatched)
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+        #expect(posts == 1)
+        #expect(validations == 2)
+    }
+
+    @Test
+    @MainActor
     func `right click stamps exact window route and reports unverifiable dispatch`() async throws {
         var specifications: [WindowRoutedPointerDriver.EventSpecification] = []
         var windowPoints: [CGPoint] = []

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/WindowRoutedPointerDriverTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/WindowRoutedPointerDriverTests.swift
@@ -49,6 +49,8 @@ struct WindowRoutedPointerDriverTests {
             postSkyLight: { _, _ in true },
             postPublic: { event, _ in publicEvents.append(event) },
             resolveTransport: { _ in .publicCGEvent },
+            applicationIsVisible: { _ in true },
+            windowIsVisible: { _ in true },
             sleep: { _ in },
             clickGroupIdentifier: { 992 })
 
@@ -100,6 +102,8 @@ struct WindowRoutedPointerDriverTests {
             postSkyLight: { _, _ in true },
             postPublic: { _, _ in posts += 1 },
             resolveTransport: { _ in .publicCGEvent },
+            applicationIsVisible: { _ in true },
+            windowIsVisible: { _ in true },
             sleep: { _ in })
 
         do {
@@ -121,6 +125,96 @@ struct WindowRoutedPointerDriverTests {
         }
         #expect(posts == 1)
         #expect(validations == 2)
+    }
+
+    @Test
+    @MainActor
+    func `background wheel refuses an initially hidden app before dispatch`() async {
+        var posts = 0
+        let receipt = Self.receipt()
+        let driver = WindowRoutedPointerDriver(
+            hasPostEventAccess: { true },
+            resolveRoute: { _, _, _ in receipt },
+            routeIsCurrent: { _ in true },
+            makeScrollEvent: { _, _ in
+                CGEvent(
+                    scrollWheelEvent2Source: nil,
+                    units: .line,
+                    wheelCount: 1,
+                    wheel1: -1,
+                    wheel2: 0,
+                    wheel3: 0)
+            },
+            stampWindowLocation: { _, _ in true },
+            postSkyLight: { _, _ in true },
+            postPublic: { _, _ in posts += 1 },
+            resolveTransport: { _ in .publicCGEvent },
+            applicationIsVisible: { _ in false },
+            windowIsVisible: { _ in true },
+            sleep: { _ in })
+
+        await #expect(throws: PeekabooError.self) {
+            _ = try await driver.scroll(
+                at: receipt.screenPoint,
+                direction: .down,
+                ticks: 2,
+                targetProcessIdentifier: receipt.identity.ownerProcessIdentifier,
+                targetWindowID: CGWindowID(receipt.identity.windowID),
+                expectedWindowIdentity: receipt.identity,
+                expectedWindowBounds: receipt.bounds)
+        }
+        #expect(posts == 0)
+    }
+
+    @Test
+    @MainActor
+    func `background wheel visibility loss after one tick is retry unsafe`() async {
+        var visibilityChecks = 0
+        var posts = 0
+        let receipt = Self.receipt()
+        let driver = WindowRoutedPointerDriver(
+            hasPostEventAccess: { true },
+            resolveRoute: { _, _, _ in receipt },
+            routeIsCurrent: { _ in true },
+            makeScrollEvent: { _, _ in
+                CGEvent(
+                    scrollWheelEvent2Source: nil,
+                    units: .line,
+                    wheelCount: 1,
+                    wheel1: -1,
+                    wheel2: 0,
+                    wheel3: 0)
+            },
+            stampWindowLocation: { _, _ in true },
+            postSkyLight: { _, _ in true },
+            postPublic: { _, _ in posts += 1 },
+            resolveTransport: { _ in .publicCGEvent },
+            applicationIsVisible: { _ in true },
+            windowIsVisible: { _ in
+                visibilityChecks += 1
+                return visibilityChecks <= 2
+            },
+            sleep: { _ in })
+
+        do {
+            _ = try await driver.scroll(
+                at: receipt.screenPoint,
+                direction: .down,
+                ticks: 3,
+                targetProcessIdentifier: receipt.identity.ownerProcessIdentifier,
+                targetWindowID: CGWindowID(receipt.identity.windowID),
+                expectedWindowIdentity: receipt.identity,
+                expectedWindowBounds: receipt.bounds)
+            Issue.record("Expected post-dispatch visibility loss")
+        } catch let failure as DesktopActionFailure {
+            #expect(failure.outcome.dispatchState.unitCount?.rawValue == 1)
+            #expect(failure.outcome.retrySafety == .unsafe)
+            #expect(failure.outcome.projection.requiresFreshObservation)
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+        #expect(posts == 1)
+        #expect(visibilityChecks == 3)
     }
 
     @Test

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/ScrollTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/ScrollTool.swift
@@ -17,8 +17,9 @@ public struct ScrollTool: MCPTool {
 
     public var description: String {
         """
-        Scrolls a UI target through Accessibility without interrupting the user by default.
-        Set foreground=true to focus the target and allow synthetic wheel events at the pointer.
+        Scrolls a fresh UI target in the background without interrupting the user. Peekaboo prefers
+        Accessibility, then may use exact-window PID-routed wheel events for an opaque visible WebKit target.
+        Set foreground=true to focus the target and allow global wheel events at the pointer.
         \(PeekabooMCPVersion.banner) using openai/gpt-5.6
         and anthropic/claude-opus-5
         """
@@ -31,8 +32,8 @@ public struct ScrollTool: MCPTool {
                     description: "Scroll direction: up (content moves up), down (content moves down), left, or right.",
                     enum: ["up", "down", "left", "right"]),
                 "on": SchemaBuilder.string(
-                    description: "Optional. Element ID to scroll on (from `see` or `inspect_ui`). " +
-                        "If not specified, scrolls at current mouse position."),
+                    description: "Element ID from `see` or `inspect_ui`. Required in background mode; " +
+                        "omit only with foreground=true to scroll at the current physical pointer."),
                 "snapshot": SchemaBuilder.string(
                     description: "Optional. Snapshot ID from `see` or `inspect_ui`. " +
                         "Uses latest snapshot if not specified."),
@@ -46,7 +47,7 @@ public struct ScrollTool: MCPTool {
                     description: "Optional. Use smooth synthetic scrolling; requires foreground=true.",
                     default: false),
                 "foreground": SchemaBuilder.boolean(
-                    description: "Optional. Focus the target and allow synthetic wheel events. Default: false.",
+                    description: "Optional. Focus the target and allow global wheel events. Default: false.",
                     default: false),
             ],
             required: ["direction"])
@@ -118,7 +119,7 @@ public struct ScrollTool: MCPTool {
         }
         guard foreground || elementId != nil else {
             throw ScrollToolValidationError(
-                "Background scroll requires 'on' with an Accessibility-scrollable element; " +
+                "Background scroll requires 'on' from a fresh scrollable or exact-window WebKit snapshot; " +
                     "set foreground=true to scroll at the physical pointer.")
         }
         guard foreground || (!smooth && delay == 0) else {

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -236,7 +236,7 @@ count, `characters_typed` reports that lower bound. Rich/binary and current-clip
 exact-window capability before clipboard mutation or Cmd+V dispatch, then return the normal retry-unsafe
 may-have-pasted result because macOS does not acknowledge receiver consumption.
 
-Pointer tools use an explicit interruption policy. `scroll` is background-safe only when `on` identifies an Accessibility-scrollable element; it never falls back to the shared cursor. Set `foreground: true` for targetless, smooth, or delayed scrolling. `move` and `drag` always manipulate the shared physical cursor, require `foreground: true`, and abort if a requested target cannot be focused. MCP schemas intentionally omit background/auto-focus fields for those global pointer tools.
+Pointer tools use an explicit interruption policy. `scroll` is background-safe only when `on` identifies an Accessibility-scrollable element or a pixel-backed opaque group in a fresh exact-window snapshot of a visible WebKit-linked app. The latter uses PID-routed wheel events, reports an unverifiable retry-unsafe effect, and refuses Electron/Chromium/Catalyst or stale targets instead of falling back to the shared cursor. Set `foreground: true` for targetless, smooth, or delayed scrolling. `move` and `drag` always manipulate the shared physical cursor, require `foreground: true`, and abort if a requested target cannot be focused. MCP schemas intentionally omit background/auto-focus fields for those global pointer tools.
 
 ```json
 {

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -34,7 +34,7 @@ Focus flags tune foreground focus behavior but do not silently change delivery m
 
 All CLI timing flags use the same grammar: bare numbers are milliseconds, and `ms`/`s` suffixes are accepted (`500`, `500ms`, `2s`, `1.5s`).
 
-Pointer delivery is deliberately stricter. A targeted `scroll --on <id>` stays in the background and invokes only the element's Accessibility scroll action; it never falls back to the shared cursor. Targetless, smooth, or delayed wheel input requires `--foreground`. `move`, `drag`, and `click --long-press` manipulate shared physical pointer state, so they also require explicit `--foreground` consent. Their Space/focus modifiers are only valid with that foreground mode; there is no misleading `--no-auto-focus` escape hatch.
+Pointer delivery is deliberately stricter. A targeted `scroll --on <id>` stays in the background and prefers the element's Accessibility scroll action. Opaque groups in a visible WebKit-linked app may use exact PID/window-routed wheel events from a fresh pixel snapshot; that route is retry-unsafe because macOS does not acknowledge the receiver's effect. It never falls back to the shared cursor. Targetless, smooth, or delayed wheel input requires `--foreground`. `move`, `drag`, and `click --long-press` manipulate shared physical pointer state, so they also require explicit `--foreground` consent. Their Space/focus modifiers are only valid with that foreground mode; there is no misleading `--no-auto-focus` escape hatch.
 
 Application menu list/click, dialog list, dialog button click, normal dialog dismissal, window close, and exact minimized-window restore also default to background Accessibility actions. Restore changes only the retained window's `AXMinimized` state. Dialog list never focuses. Dialog keyboard/file flows, forced Escape dismissal, coordinate fallback, and window-close Cmd-W fallback require an explicit `--foreground` (or `foreground: true` in MCP) so these global actions cannot interrupt an unrelated foreground app by accident.
 
@@ -59,7 +59,7 @@ peekaboo type "github.com/openclaw/Peekaboo" --app Safari --foreground && peekab
 | [click](commands/click.md) | mouse clicks, double/triple, right/middle, hold |
 | [type](commands/type.md) | typing strings into targeted fields |
 | [press](commands/press.md) | explicit-foreground individual keys and xdotool-style raw chords |
-| [scroll](commands/scroll.md) | background AX scrolling on a target, or explicit foreground wheel input |
+| [scroll](commands/scroll.md) | background AX/exact-window scrolling on a target, or explicit foreground wheel input |
 | [drag](commands/drag.md) | press, move, release — files, sliders, selections |
 | [move](commands/move.md) | warp the mouse without clicking |
 | [set-value](commands/set-value.md) | write to text fields without typing |
@@ -107,7 +107,7 @@ Three primitives, four lines. The agent does the same thing under the hood — i
 - Always run [`peekaboo see`](commands/see.md) when an element is unreachable. The AX tree refreshes after focus changes; capture again if a click fails.
 - Use [focus](focus.md) and [application-resolving](application-resolving.md) for tricky cases (multiple windows, helper apps, processes that hide on activation).
 - Use `/bin/sleep` between shell-composed actions when a target genuinely needs settling time.
-- Prefer background click, semantic text/value actions, menus, and targeted AX scrolling for routine app-specific input.
+- Prefer background click, semantic text/value actions, menus, and targeted background scrolling for routine app-specific input.
 - Add `--foreground` only when an app needs a focused key window, Space switch, or foreground mouse event.
 
 ## Going further

--- a/docs/commands/scroll.md
+++ b/docs/commands/scroll.md
@@ -7,7 +7,7 @@ read_when:
 
 # `peekaboo scroll`
 
-`scroll` invokes an element's Accessibility scroll action by default, keeping the target app in the background and leaving the shared cursor untouched. Add `--foreground` for targetless, smooth, or delayed synthetic wheel input.
+`scroll` invokes an element's Accessibility scroll action by default, keeping the target app in the background and leaving the shared cursor untouched. When a visible WKWebView/Tauri surface exposes only an opaque container, Peekaboo can instead route line-wheel events to the fresh snapshot's exact PID/window. Add `--foreground` for targetless, smooth, or delayed global wheel input.
 
 ## Key options
 | Flag | Description |
@@ -25,7 +25,8 @@ read_when:
 ## Implementation notes
 - If you pass `--on` without a snapshot, the command automatically looks up `services.snapshots.getMostRecentSnapshot()` so you rarely need to wire IDs manually.
 - If a canonical scroll result requires fresh observation, or no canonical outcome is available, the used snapshot remains readable but cannot drive another mutation. Re-run `peekaboo see`; replaying the old ID returns `SNAPSHOT_STALE` before dispatch.
-- Background scrolling is Accessibility-only. Peekaboo first invokes a directional scroll action, then falls back to a settable descendant `AXScrollBar` used by standard AppKit scroll areas. If neither native path is available, it fails with guidance to retry in foreground rather than silently moving the cursor or scrolling another app.
+- Background scrolling first invokes a directional Accessibility action, then tries a settable descendant `AXScrollBar` used by standard AppKit scroll areas. If an opaque group still cannot scroll, a pixel-backed exact-window snapshot may use native PID-routed wheel events only for a visible, WebKit-linked, non-Electron app. Peekaboo revalidates the captured process generation, window ID, bounds, and point around every tick; it never activates the app, moves the cursor, or falls back to a desktop-global event.
+- macOS does not acknowledge receiver consumption for PID-routed wheel events. A successful routed dispatch therefore reports `effect: "unverifiable"`, `retry_safe: false`, and requires a fresh observation before another scroll. Hidden apps, AX-only snapshots, Electron/Chromium/Catalyst apps, stale receipts, and changed bounds keep the existing pre-dispatch refusal.
 - Foreground mode verifies focus when a target exists, then uses synthetic wheel events. Focus failure aborts before pointer dispatch.
 - JSON output reports target diagnostics for element scrolls and the current pointer position for explicit foreground targetless scrolls.
 - `ScrollRequest` is handed directly to `AutomationServiceBridge.scroll`, so the CLI benefits from the same smooth/step semantics the agent runtime sees.
@@ -43,6 +44,6 @@ peekaboo scroll --direction right --smooth --app Keynote --foreground --space-sw
 ```
 
 ## Troubleshooting
-- Background element scroll needs Accessibility; foreground wheel input needs Event Synthesizing (`peekaboo permissions status`).
+- Background element scroll needs Accessibility. The exact-window WebKit wheel route and foreground wheel input also need Event Synthesizing on the selected execution host (`peekaboo permissions status`).
 - Confirm your process with `peekaboo app list`, its exact window with `peekaboo window list`, and current UI with `peekaboo see` before rerunning.
 - Re-run with `--json` or `--verbose` to surface detailed errors.

--- a/docs/commands/scroll.md
+++ b/docs/commands/scroll.md
@@ -28,7 +28,7 @@ read_when:
 - Background scrolling first invokes a directional Accessibility action, then tries a settable descendant `AXScrollBar` used by standard AppKit scroll areas. If an opaque group still cannot scroll, a pixel-backed exact-window snapshot may use native PID-routed wheel events only for a visible, WebKit-linked, non-Electron app. Peekaboo revalidates the captured process generation, window ID, bounds, and point around every tick; it never activates the app, moves the cursor, or falls back to a desktop-global event.
 - macOS does not acknowledge receiver consumption for PID-routed wheel events. A successful routed dispatch therefore reports `effect: "unverifiable"`, `retry_safe: false`, and requires a fresh observation before another scroll. Hidden apps, AX-only snapshots, Electron/Chromium/Catalyst apps, stale receipts, and changed bounds keep the existing pre-dispatch refusal.
 - Foreground mode verifies focus when a target exists, then uses synthetic wheel events. Focus failure aborts before pointer dispatch.
-- JSON output reports target diagnostics for element scrolls and the current pointer position for explicit foreground targetless scrolls.
+- JSON output reports target diagnostics for element scrolls and the current pointer position for explicit foreground targetless scrolls. When a snapshot carries a complete exact receipt, `targetReceipt` repeats its snapshot ID, PID, decimal process-generation identity, window ID, and bounds so callers can audit the dispatched destination.
 - `ScrollRequest` is handed directly to `AutomationServiceBridge.scroll`, so the CLI benefits from the same smooth/step semantics the agent runtime sees.
 
 ## Examples

--- a/docs/focus.md
+++ b/docs/focus.md
@@ -83,7 +83,7 @@ By default, Peekaboo will:
 
 ## Focus Options
 
-Interaction commands that use foreground delivery support these focus-related options. `click`, `type`, and `paste` default to background delivery when Peekaboo can resolve a target process. Raw `press` always requires `--foreground`. Targeted scroll is background Accessibility-only, while targetless/smooth scroll and all move/drag operations require explicit foreground mode.
+Interaction commands that use foreground delivery support these focus-related options. `click`, `type`, and `paste` default to background delivery when Peekaboo can resolve a target process. Raw `press` always requires `--foreground`. Targeted scroll stays background through Accessibility or a capability-gated exact-window WebKit route, while targetless/smooth scroll and all move/drag operations require explicit foreground mode.
 
 ### `--no-auto-focus`
 Disables automatic focus management (not recommended).
@@ -115,7 +115,7 @@ Use cases:
 
 Currently, typed text and paste use background delivery when `--app`, `--pid`, or supported snapshot process metadata identifies a live process. Raw key chords cannot prove semantic intent or effect and are refused without `--foreground`. Background click can preserve an exact window/element target.
 
-Background delivery is a delivery mode, not a focus mode. It cannot be combined with foreground focus timeout, retry, or Space-switching flags. Background element/query/coordinate clicks and targeted scroll use Accessibility. Keyboard delivery and foreground synthetic pointer operations require Event Synthesizing; `peekaboo permissions request event-synthesizing` requests it for the selected bridge host by default, or for the local CLI with `--no-remote`.
+Background delivery is a delivery mode, not a focus mode. It cannot be combined with foreground focus timeout, retry, or Space-switching flags. Background element/query/coordinate clicks and targeted scroll prefer Accessibility; an opaque WebKit scroll target may use exact PID/window wheel delivery without focus. Keyboard delivery, that WebKit wheel route, and foreground synthetic pointer operations require Event Synthesizing; `peekaboo permissions request event-synthesizing` requests it for the selected bridge host by default, or for the local CLI with `--no-remote`.
 
 ### `--focus-timeout <duration>`
 Sets how long to wait for focus operations (default: `5s`; bare values are milliseconds).

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -25,7 +25,7 @@ If you use a Bridge host, grant permissions to the host reported by `peekaboo pe
 - **macOS 15.0+ (Sequoia)** – core automation APIs depend on Sequoia.
 - **Screen Recording (required)** – enables CGWindow capture and multi-app automation.
 - **Accessibility (required)** – enables window, menu, dialog, and action-based element/query automation.
-- **Event Synthesizing (optional)** – enables background keyboard input and explicitly foreground synthetic pointer input (`click --foreground`, targetless/smooth scroll, move, drag, and swipe). Background clicks use Accessibility.
+- **Event Synthesizing (optional)** – enables background keyboard input, exact-window wheel delivery for opaque WebKit scroll targets, and explicitly foreground synthetic pointer input (`click --foreground`, targetless/smooth scroll, move, drag, and swipe). Background clicks use Accessibility.
 
 For build and runtime version details, see [platform-support.md](platform-support.md).
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -80,7 +80,7 @@ the target app requires focused synthetic input. See [automation.md](automation.
 
 Targeted click and type use background delivery by default, so Safari can receive them without becoming frontmost. Raw `press` requires explicit `--foreground`; prefer semantic actions for background confirmation when one exists.
 
-Targeted `scroll --on <id>` is also background-safe through Accessibility. Targetless/smooth scroll, `move`, and `drag` use the shared physical cursor and require explicit `--foreground`.
+Targeted `scroll --on <id>` is background-safe through Accessibility or, for a fresh exact-window pixel snapshot of a visible WebKit surface, PID-routed wheel events. The latter reports an unverifiable effect and must be observed before retry. Targetless/smooth scroll, `move`, and `drag` use the shared physical cursor and require explicit `--foreground`.
 
 ## 5. Run an agent
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -72,7 +72,7 @@ If you disable the `clipboard` tool via allow/deny filters, the injected DESKTOP
 - **Medium risk** – can manipulate apps or data  
   - `capture`: records retained screen/window/region frames, contact sheets, metadata, and optional MP4 files. Disable it when MCP or agent clients should not persist screen contents.
   - `click`, `type`, and `paste`: can trigger actions in foreground apps or target a background app when a safe receipt is known. Background clicks use Accessibility; background typed delivery requires Event Synthesizing. Raw `press` requires either an exact window/focused-element receipt or explicit `--foreground` consent.
-  - `scroll`: targeted background scrolling is Accessibility-only. Targetless, smooth, and delayed scrolling require explicit foreground mode and Event Synthesizing.
+  - `scroll`: targeted background scrolling prefers Accessibility. A fresh exact-window pixel snapshot may use retry-unsafe PID-routed wheel delivery only for visible WebKit-linked, non-Electron apps; targetless, smooth, and delayed scrolling require explicit foreground mode and Event Synthesizing.
   - `drag`, `move`: manipulate the shared physical cursor, require explicit foreground consent, and need Event Synthesizing.
   - `window`, `app`, `menu_click`, `dock_launch`, `space`: can close apps, move windows, switch spaces.  
   - `permissions`: can prompt/alter macOS permissions flow; disable for locked-down sessions.  

--- a/docs/testing/background-computer-use.md
+++ b/docs/testing/background-computer-use.md
@@ -18,9 +18,10 @@ app/window as the sentinel. It explicitly foreground-launches the controlled fix
 and verifies that exact sentinel window. The monitored phase never activates Calculator or restores a stale foreground
 app after the run. It then exercises fresh, exact PID/window snapshots through
 `see` (including AX-only and screenshot-only modes), `capture live`, click by ID and query, `type`, raw-press refusal, `paste`,
-`set-value`, `action`, and Accessibility-only targeted scroll. Stale snapshots and unsupported named AX actions must
-fail nonzero instead of falling back to foreground synthesis. Targeted scroll must report confirmed Accessibility
-delivery and produce an independent, PID-scoped Playground offset change.
+`set-value`, `action`, and targeted background scroll. Stale snapshots and unsupported named AX actions must
+fail nonzero instead of falling back to foreground synthesis. Standard targeted scroll must report Accessibility
+delivery and produce an independent, PID-scoped Playground offset change; controlled WebKit fixtures may instead
+report exact-window routed, unverifiable delivery and must prove the offset independently before any retry.
 The monitored lifecycle phase also launches distinct TextEdit processes with exact window receipts, establishes a
 non-maximized exact frame, then maximizes and closes that background window. Quit accepts exactly two tuples: confirmed
 success with the target process gone, or `suspected_noop`/`INTERACTION_FAILED` with that target still alive. The harness


### PR DESCRIPTION
## Summary

- preserve Accessibility page actions and settable scroll bars as the first background route, then capability-gate exact-window wheel delivery to visible WebKit-linked applications with opaque container targets from fresh pixel-backed snapshots
- revalidate PID generation, window identity, bounds, and target point around every routed tick; never activate the app, move the shared cursor, or fall back to a desktop-global event
- exclude hidden, Electron, Chromium, Catalyst, AX-only, stale, and unknown targets before dispatch
- report routed delivery honestly as unverifiable, retry-unsafe, and fresh-observation-required, while repeating the exact snapshot/PID/decimal-generation/window/bounds receipt in CLI JSON
- project stale scroll receipts as canonical retry-safe, not-dispatched refusals and update CLI/MCP guidance, permissions, security, testing, and changelogs

## Proof

- `pnpm run format`
- `pnpm run lint` (22 inherited warnings, 0 serious)
- 22 window-routed pointer/classifier tests
- 3 focused ScrollService capability/refusal tests
- 13 ScrollCommand tests
- full `pnpm run test:safe`: release/signing/native-only/consumer/background-certification contracts, 40 Foundation tests, 915 CLI/Core tests, and 92 runtime tests
- source-blind v2 contract: 13/13 assertions passed, including equal-tick down/up restoration, exact target receipt, stable foreground/focus/clipboard/overlay/non-target state, and stale/targetless pre-dispatch refusals
- the original source-blind contract is retained as a useful failed check: it demanded a confirmed effect from event dispatch alone. This PR deliberately rejects that unsafe overclaim and requires independent fresh observation.
- final structured autoreview: no accepted/actionable findings

## Outcome contract

Window-routed wheel success means the exact native event sequence was accepted for dispatch, not that macOS acknowledged the receiver's visual effect. Callers must observe the target before another scroll. A route that changes before the first event is retry-safe; drift after any emitted tick retains the emitted-unit count and is retry-unsafe.
