### PR TITLE
feat(browser): pin exact background sessions

### DIFF
--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -9,11 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Add protocol 1.26 explicit-reference-only snapshot publication so exact-window `see --no-elements` can return coordinate receipts without replacing implicit latest element maps, while older hosts fail before allocation.
+- Add `browser connect --browser-url` for an exact loopback DevTools endpoint and expose its pinned browser identity in status metadata through Bridge protocol 1.26.
 - Add protocol 1.25 exact dialog click/dismiss receipts with unique target planning, raw AX identity revalidation, verified disappearance outcomes, and read-only targeted listing.
 - Add capability-gated exact-window background wheel delivery for opaque WKWebView/Tauri scroll targets, with retry-unsafe unverifiable outcomes and no activation or shared-cursor fallback.
 
 ### Fixed
 - Reject unknown and non-object MCP `tools/call` arguments as JSON-RPC invalid params before policy checks or tool dispatch, recursively honoring the closed schemas advertised by `tools/list`.
+- Keep browser CLI calls on one current-build reusable daemon, probe Chrome before reporting connected, require explicit reconnect instead of falling back to another same-channel profile after connection loss, and bind browser typing/key presses to an exact uid in one host-owned sequence.
+- Fail browser uploads closed through a private per-session Chrome MCP temporary root, race-safe regular-file staging, a 100 MiB bound, and child-before-cleanup cancellation without unrestricted path access.
 - Report exact standard windows with live attached sheets as dialog-active observations, using shared native role evidence without changing the parent window receipt.
 - Preserve default automatic capture through an owner-aware Bridge by clamping it to classic-only around an auxiliary legacy ScreenCaptureKit owner, while explicit modern and owner-unaware routes remain fail-closed.
 

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/BridgeCapabilityPolicy.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/BridgeCapabilityPolicy.swift
@@ -541,7 +541,9 @@ enum BridgeCapabilityPolicy {
     }
 
     static func supportsBrowserMCP(for handshake: PeekabooBridgeHandshakeResponse) -> Bool {
-        handshake.negotiatedVersion >= PeekabooBridgeProtocolVersion(major: 1, minor: 4) &&
+        handshake.hostKind == .onDemand &&
+            handshake.negotiatedVersion >= PeekabooBridgeConstants.browserConnectionReceiptVersion &&
+            handshake.hostCapabilities?.contains(PeekabooBridgeHostCapability.browserConnectionReceipts) == true &&
             handshake.supportedOperations.contains(.browserStatus) &&
             handshake.supportedOperations.contains(.browserConnect) &&
             handshake.supportedOperations.contains(.browserDisconnect) &&

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/RuntimeHostResolver.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/RuntimeHostResolver.swift
@@ -602,6 +602,7 @@ enum RuntimeHostResolver {
         }
         return options.requiresScreenCapturePermission ||
             options.requiresInspectAccessibilityTree ||
+            options.requiresBrowserMCP ||
             options.requiresImplicitSnapshotInvalidation ||
             options.usesPerToolSnapshotInvalidation
     }

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/MCP/BrowserCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/MCP/BrowserCommand.swift
@@ -8,6 +8,7 @@ struct BrowserCommand: ErrorHandlingCommand, OutputFormattable, RuntimeOptionsCo
 InjectedRuntimeBackedCommand {
     var action = "status"
     var channel: String?
+    var browserUrl: String?
     var pageId: Int?
     var url: String?
     var navigationType: String?
@@ -130,6 +131,7 @@ InjectedRuntimeBackedCommand {
 
         var arguments: [String: Any] = ["action": normalizedAction]
         self.add(self.channel, as: "channel", to: &arguments)
+        self.add(self.browserUrl, as: "browser_url", to: &arguments)
         self.add(self.pageId, as: "page_id", to: &arguments)
         self.add(self.url, as: "url", to: &arguments)
         self.add(self.navigationType, as: "navigation_type", to: &arguments)
@@ -223,6 +225,11 @@ extension BrowserCommand: CommanderSignatureProviding {
             ],
             options: [
                 .commandOption("channel", help: "Chrome channel", long: "channel"),
+                .commandOption(
+                    "browserUrl",
+                    help: "Exact loopback DevTools HTTP endpoint for connect",
+                    long: "browser-url"
+                ),
                 .commandOption("pageId", help: "Chrome DevTools page ID", long: "page-id"),
                 .commandOption("url", help: "URL for navigate/new-page", long: "url"),
                 .commandOption(
@@ -260,7 +267,11 @@ extension BrowserCommand: CommanderSignatureProviding {
                 .commandOption("requestId", help: "Network request ID", long: "request-id"),
                 .commandOption("requestFilePath", help: "Path for saving a request body", long: "request-file-path"),
                 .commandOption("responseFilePath", help: "Path for saving a response body", long: "response-file-path"),
-                .commandOption("path", help: "Output path for snapshot/screenshot/trace", long: "path"),
+                .commandOption(
+                    "path",
+                    help: "Absolute input file for upload-file; output path for snapshot/screenshot/trace",
+                    long: "path"
+                ),
                 .commandOption("format", help: "Screenshot format: png|jpeg|webp", long: "format"),
                 .commandOption("quality", help: "Screenshot quality for jpeg/webp", long: "quality"),
                 .commandOption("traceAction", help: "Trace action: start|stop|analyze", long: "trace-action"),
@@ -305,6 +316,7 @@ extension BrowserCommand: CommanderBindableCommand {
     mutating func applyCommanderValues(_ values: CommanderBindableValues) throws {
         self.action = values.positionalValue(at: 0) ?? "status"
         self.channel = values.singleOption("channel")
+        self.browserUrl = values.singleOption("browserUrl")
         self.pageId = try values.decodeOption("pageId", as: Int.self)
         self.url = values.singleOption("url")
         self.navigationType = values.singleOption("navigationType")

--- a/Apps/CLI/Tests/CLIRuntimeTests/CommandRuntimeInjectionTests.swift
+++ b/Apps/CLI/Tests/CLIRuntimeTests/CommandRuntimeInjectionTests.swift
@@ -363,10 +363,11 @@ struct CommandRuntimeInjectionTests {
         var options = CommandRuntimeOptions()
         options.requiresBrowserMCP = true
         let supported = BridgeTestFixtures.handshake(
-            negotiatedVersion: PeekabooBridgeProtocolVersion(major: 1, minor: 4),
-            hostKind: .gui,
+            negotiatedVersion: PeekabooBridgeConstants.browserConnectionReceiptVersion,
+            hostKind: .onDemand,
             build: nil,
-            supportedOperations: [.captureScreen, .browserStatus, .browserConnect, .browserDisconnect, .browserExecute]
+            supportedOperations: [.captureScreen, .browserStatus, .browserConnect, .browserDisconnect, .browserExecute],
+            hostCapabilities: [PeekabooBridgeHostCapability.browserConnectionReceipts]
         )
         let older = BridgeTestFixtures.handshake(
             negotiatedVersion: PeekabooBridgeProtocolVersion(major: 1, minor: 3),
@@ -375,18 +376,36 @@ struct CommandRuntimeInjectionTests {
             supportedOperations: [.captureScreen, .browserStatus, .browserConnect, .browserDisconnect, .browserExecute]
         )
         let missingExecute = BridgeTestFixtures.handshake(
-            negotiatedVersion: PeekabooBridgeProtocolVersion(major: 1, minor: 4),
+            negotiatedVersion: PeekabooBridgeConstants.browserConnectionReceiptVersion,
+            hostKind: .onDemand,
+            build: nil,
+            supportedOperations: [.captureScreen, .browserStatus, .browserConnect, .browserDisconnect],
+            hostCapabilities: [PeekabooBridgeHostCapability.browserConnectionReceipts]
+        )
+        let gui = BridgeTestFixtures.handshake(
+            negotiatedVersion: PeekabooBridgeConstants.browserConnectionReceiptVersion,
             hostKind: .gui,
             build: nil,
-            supportedOperations: [.captureScreen, .browserStatus, .browserConnect, .browserDisconnect]
+            supportedOperations: [.captureScreen, .browserStatus, .browserConnect, .browserDisconnect, .browserExecute],
+            hostCapabilities: [PeekabooBridgeHostCapability.browserConnectionReceipts]
+        )
+        let missingReceiptCapability = BridgeTestFixtures.handshake(
+            negotiatedVersion: PeekabooBridgeConstants.browserConnectionReceiptVersion,
+            hostKind: .onDemand,
+            build: nil,
+            supportedOperations: [.captureScreen, .browserStatus, .browserConnect, .browserDisconnect, .browserExecute]
         )
 
         #expect(CommandRuntime.supportsBrowserMCP(for: supported))
         #expect(!CommandRuntime.supportsBrowserMCP(for: older))
         #expect(!CommandRuntime.supportsBrowserMCP(for: missingExecute))
+        #expect(!CommandRuntime.supportsBrowserMCP(for: gui))
+        #expect(!CommandRuntime.supportsBrowserMCP(for: missingReceiptCapability))
         #expect(CommandRuntime.supportsRemoteRequirements(for: supported, options: options))
         #expect(!CommandRuntime.supportsRemoteRequirements(for: older, options: options))
         #expect(!CommandRuntime.supportsRemoteRequirements(for: missingExecute, options: options))
+        #expect(!CommandRuntime.supportsRemoteRequirements(for: gui, options: options))
+        #expect(!CommandRuntime.supportsRemoteRequirements(for: missingReceiptCapability, options: options))
     }
 
     @Test

--- a/Apps/CLI/Tests/CoreCLITests/MCPWrapperCommandBindingTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/MCPWrapperCommandBindingTests.swift
@@ -11,6 +11,7 @@ struct MCPWrapperCommandBindingTests {
             positional: ["navigate"],
             options: [
                 "channel": ["stable"],
+                "browserUrl": ["http://127.0.0.1:9222"],
                 "url": ["https://example.com"],
                 "timeout": ["5000"],
                 "types": ["error,warning", "info"],
@@ -21,6 +22,7 @@ struct MCPWrapperCommandBindingTests {
         let command = try CommanderCLIBinder.instantiateCommand(ofType: BrowserCommand.self, parsedValues: parsed)
         #expect(command.action == "navigate")
         #expect(command.channel == "stable")
+        #expect(command.browserUrl == "http://127.0.0.1:9222")
         #expect(command.url == "https://example.com")
         #expect(command.timeout?.roundedMilliseconds == 5000)
         #expect(command.types == ["error", "warning", "info"])

--- a/Apps/CLI/Tests/CoreCLITests/RuntimeHostResolverTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/RuntimeHostResolverTests.swift
@@ -686,6 +686,8 @@ struct RuntimeHostResolverTests {
         snapshotMutation.requiresImplicitSnapshotInvalidation = true
         var longLivedSnapshotRuntime = CommandRuntimeOptions()
         longLivedSnapshotRuntime.usesPerToolSnapshotInvalidation = true
+        var browserRuntime = CommandRuntimeOptions()
+        browserRuntime.requiresBrowserMCP = true
         var applicationInventory = snapshotProducer
         applicationInventory.requiresHostApplicationInventory = true
         var applicationLaunch = snapshotMutation
@@ -708,6 +710,11 @@ struct RuntimeHostResolverTests {
         ))
         #expect(RuntimeHostResolver.prefersExactBuildScopedHost(
             options: longLivedSnapshotRuntime,
+            explicitSocket: nil,
+            buildScopedDaemonSocketPath: buildScopedSocketPath
+        ))
+        #expect(RuntimeHostResolver.prefersExactBuildScopedHost(
+            options: browserRuntime,
             explicitSocket: nil,
             buildScopedDaemonSocketPath: buildScopedSocketPath
         ))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [4.1.1] - Unreleased
 
 ### Added
+- Add Bridge protocol 1.26 exact browser connection receipts, binding persistent Chrome DevTools MCP sessions to one process generation or validated loopback DevTools browser identity.
 - Add Bridge protocol 1.25 one-shot dialog receipts that uniquely bind an exact process/window, raw dialog or sheet, and semantic AXPress button for background click/dismiss, with read-only targeted listing and canonical postcondition outcomes.
 - Add a background-first native Bridge host runtime for signed macOS apps, with explicit caller allowlists, shared mutation/snapshot state, checked lifecycle, and no Core, provider, browser, daemon, or AppleScript surface.
 - Add capability-gated exact-window background wheel delivery for opaque WKWebView/Tauri scroll targets, preserving the foreground app and physical cursor while refusing hidden, stale, Electron, Chromium, Catalyst, or AX-only routes.
@@ -15,6 +16,8 @@
 - Add Bridge protocol 1.26 explicit-reference-only coordinate receipts for exact-window `see --no-elements`, making the documented background coordinate-click workflow consumable without Accessibility traversal or replacing the prior implicit element snapshot while older hosts fail before receipt allocation.
 - Honor cancellation while draining and reaping MCP ShellTool subprocesses so canceled commands cannot linger behind pipe cleanup. Thanks @SebTardif for #454.
 - Reject unknown and non-object MCP `tools/call` arguments as JSON-RPC invalid params before policy checks or tool dispatch, recursively honoring the closed schemas advertised by `tools/list`.
+- Probe Chrome before reporting browser connection success, reject ambiguous same-channel profiles, preserve structured Bridge failures, never silently rediscover another profile after a session or endpoint is lost, and atomically focus the exact snapshot uid before browser typing or key presses.
+- Stage browser uploads from race-checked, current-user regular files into one private per-session Chrome MCP temporary root, without unrestricted filesystem access, and terminate the exact child before cancellation cleanup.
 - Classify an exact standard window with a live attached sheet as dialog-active during observation, sharing native role evidence with dialog actions while keeping the parent window receipt exact.
 - Report exact ScreenCaptureKit owner PID, process generation, safe build identity, and selected-versus-owner Bridge sockets when available; automatic capture can still use an owner-aware host's classic-only path around an auxiliary legacy owner, while explicit modern and ambiguous legacy ownership remain fail-closed without unsafe process-stop guidance.
 

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/Browser/BrowserMCPDevToolsEndpointResolver.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/Browser/BrowserMCPDevToolsEndpointResolver.swift
@@ -1,0 +1,75 @@
+import Foundation
+
+struct BrowserMCPDevToolsEndpoint: Sendable, Equatable {
+    let browserURL: String
+    let webSocketDebuggerURL: String
+    let browserID: String
+    let browserVersion: String
+    let protocolVersion: String
+}
+
+struct BrowserMCPDevToolsEndpointResolver: Sendable {
+    let resolve: @Sendable (String) async throws -> BrowserMCPDevToolsEndpoint
+
+    static let live = BrowserMCPDevToolsEndpointResolver { rawBrowserURL in
+        let baseURL = try Self.validatedBaseURL(rawBrowserURL)
+        let versionURL = baseURL.appending(path: "json/version")
+        var request = URLRequest(url: versionURL)
+        request.timeoutInterval = 3
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse,
+              (200..<300).contains(httpResponse.statusCode)
+        else {
+            throw BrowserMCPConnectionError.invalidEndpoint("/json/version did not return HTTP success")
+        }
+        guard let object = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let webSocketDebuggerURL = object["webSocketDebuggerUrl"] as? String,
+              let browserVersion = object["Browser"] as? String,
+              let protocolVersion = object["Protocol-Version"] as? String,
+              let webSocketURL = URL(string: webSocketDebuggerURL),
+              ["ws", "wss"].contains(webSocketURL.scheme?.lowercased() ?? ""),
+              Self.isLoopback(webSocketURL.host),
+              webSocketURL.port == baseURL.port,
+              webSocketURL.path.hasPrefix("/devtools/browser/")
+        else {
+            throw BrowserMCPConnectionError
+                .invalidEndpoint("/json/version omitted a matching loopback browser endpoint")
+        }
+        let browserID = String(webSocketURL.path.dropFirst("/devtools/browser/".count))
+        guard !browserID.isEmpty, !browserID.contains("/") else {
+            throw BrowserMCPConnectionError.invalidEndpoint("the DevTools browser identity was malformed")
+        }
+        return BrowserMCPDevToolsEndpoint(
+            browserURL: baseURL.absoluteString,
+            webSocketDebuggerURL: webSocketDebuggerURL,
+            browserID: browserID,
+            browserVersion: browserVersion,
+            protocolVersion: protocolVersion)
+    }
+
+    private static func validatedBaseURL(_ rawValue: String) throws -> URL {
+        guard var components = URLComponents(string: rawValue),
+              components.scheme?.lowercased() == "http",
+              self.isLoopback(components.host),
+              components.port != nil,
+              components.user == nil,
+              components.password == nil,
+              components.query == nil,
+              components.fragment == nil,
+              components.path.isEmpty || components.path == "/"
+        else {
+            throw BrowserMCPConnectionError.invalidEndpoint(
+                "expected http://127.0.0.1:<port>, http://[::1]:<port>, or http://localhost:<port>")
+        }
+        components.path = "/"
+        guard let url = components.url else {
+            throw BrowserMCPConnectionError.invalidEndpoint("the loopback URL could not be canonicalized")
+        }
+        return url
+    }
+
+    private static func isLoopback(_ host: String?) -> Bool {
+        guard let host = host?.lowercased() else { return false }
+        return host == "127.0.0.1" || host == "::1" || host == "localhost"
+    }
+}

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/Browser/BrowserMCPService.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/Browser/BrowserMCPService.swift
@@ -1,26 +1,36 @@
 import AppKit
 import Foundation
 import MCP
+import PeekabooAutomationKit
 import TachikomaMCP
 
 public struct BrowserMCPStatus: Sendable {
     public let isConnected: Bool
     public let toolCount: Int
     public let detectedBrowsers: [DetectedBrowser]
+    public let connectionReceipt: BrowserMCPConnectionReceipt?
     public let error: String?
 
-    public init(isConnected: Bool, toolCount: Int, detectedBrowsers: [DetectedBrowser], error: String? = nil) {
+    public init(
+        isConnected: Bool,
+        toolCount: Int,
+        detectedBrowsers: [DetectedBrowser],
+        connectionReceipt: BrowserMCPConnectionReceipt? = nil,
+        error: String? = nil)
+    {
         self.isConnected = isConnected
         self.toolCount = toolCount
         self.detectedBrowsers = detectedBrowsers
+        self.connectionReceipt = connectionReceipt
         self.error = error
     }
 }
 
-public struct DetectedBrowser: Sendable {
+public struct DetectedBrowser: Sendable, Equatable {
     public let name: String
     public let bundleIdentifier: String
     public let processIdentifier: Int32
+    public let processStartIdentity: UInt64?
     public let version: String?
     public let channel: BrowserMCPChannel
 
@@ -28,18 +38,54 @@ public struct DetectedBrowser: Sendable {
         name: String,
         bundleIdentifier: String,
         processIdentifier: Int32,
+        processStartIdentity: UInt64? = nil,
         version: String?,
         channel: BrowserMCPChannel)
     {
         self.name = name
         self.bundleIdentifier = bundleIdentifier
         self.processIdentifier = processIdentifier
+        self.processStartIdentity = processStartIdentity
         self.version = version
         self.channel = channel
     }
 }
 
-public enum BrowserMCPChannel: String, Sendable, CaseIterable {
+public struct BrowserMCPConnectionReceipt: Sendable, Equatable {
+    public let channel: BrowserMCPChannel?
+    public let processIdentifier: Int32?
+    public let processStartIdentity: UInt64?
+    public let bundleIdentifier: String?
+    public let browserURL: String?
+    public let webSocketDebuggerURL: String?
+    public let devToolsBrowserID: String?
+    public let browserVersion: String?
+    public let protocolVersion: String?
+
+    public init(
+        channel: BrowserMCPChannel? = nil,
+        processIdentifier: Int32? = nil,
+        processStartIdentity: UInt64? = nil,
+        bundleIdentifier: String? = nil,
+        browserURL: String? = nil,
+        webSocketDebuggerURL: String? = nil,
+        devToolsBrowserID: String? = nil,
+        browserVersion: String? = nil,
+        protocolVersion: String? = nil)
+    {
+        self.channel = channel
+        self.processIdentifier = processIdentifier
+        self.processStartIdentity = processStartIdentity
+        self.bundleIdentifier = bundleIdentifier
+        self.browserURL = browserURL
+        self.webSocketDebuggerURL = webSocketDebuggerURL
+        self.devToolsBrowserID = devToolsBrowserID
+        self.browserVersion = browserVersion
+        self.protocolVersion = protocolVersion
+    }
+}
+
+public enum BrowserMCPChannel: String, Sendable, CaseIterable, Codable {
     case stable
     case beta
     case dev
@@ -71,9 +117,44 @@ public protocol BrowserMCPClientProviding: AnyObject, Sendable {
     @MainActor
     func connect(channel: BrowserMCPChannel?) async throws -> BrowserMCPStatus
     @MainActor
+    func connect(channel: BrowserMCPChannel?, browserURL: String?) async throws -> BrowserMCPStatus
+    @MainActor
     func disconnect() async
     @MainActor
     func execute(toolName: String, arguments: [String: Any], channel: BrowserMCPChannel?) async throws -> ToolResponse
+    @MainActor
+    func executeSequence(_ calls: [BrowserMCPMappedCall], channel: BrowserMCPChannel?) async throws -> ToolResponse
+}
+
+extension BrowserMCPClientProviding {
+    @MainActor
+    public func connect(channel: BrowserMCPChannel?, browserURL: String?) async throws -> BrowserMCPStatus {
+        guard browserURL == nil else {
+            throw BrowserMCPConnectionError.explicitEndpointUnsupported
+        }
+        return try await self.connect(channel: channel)
+    }
+
+    @MainActor
+    public func executeSequence(
+        _ calls: [BrowserMCPMappedCall],
+        channel: BrowserMCPChannel?) async throws -> ToolResponse
+    {
+        guard let first = calls.first else {
+            throw BrowserMCPConnectionError.connectionLost("the browser action sequence was empty")
+        }
+        var response = try await self.execute(
+            toolName: first.toolName,
+            arguments: first.arguments,
+            channel: channel)
+        for call in calls.dropFirst() where !response.isError {
+            response = try await self.execute(
+                toolName: call.toolName,
+                arguments: call.arguments,
+                channel: channel)
+        }
+        return response
+    }
 }
 
 public final class BrowserMCPService: BrowserMCPClientProviding, @unchecked Sendable {
@@ -97,7 +178,15 @@ public final class BrowserMCPService: BrowserMCPClientProviding, @unchecked Send
 
     @MainActor
     public func connect(channel: BrowserMCPChannel? = nil) async throws -> BrowserMCPStatus {
-        try await self.resolvedSessionManager().connect(channel: channel)
+        try await self.connect(channel: channel, browserURL: nil)
+    }
+
+    @MainActor
+    public func connect(
+        channel: BrowserMCPChannel? = nil,
+        browserURL: String?) async throws -> BrowserMCPStatus
+    {
+        try await self.resolvedSessionManager().connect(channel: channel, browserURL: browserURL)
     }
 
     @MainActor
@@ -117,8 +206,17 @@ public final class BrowserMCPService: BrowserMCPClientProviding, @unchecked Send
             channel: channel)
     }
 
+    @MainActor
+    public func executeSequence(
+        _ calls: [BrowserMCPMappedCall],
+        channel: BrowserMCPChannel?) async throws -> ToolResponse
+    {
+        try await self.resolvedSessionManager().executeSequence(calls, channel: channel)
+    }
+
     public static func chromeDevToolsConfig(
         channel: BrowserMCPChannel?,
+        webSocketEndpoint: String? = nil,
         environment: [String: String] = ProcessInfo.processInfo.environment) -> MCPServerConfig
     {
         let resolvedChannel = channel ?? .stable
@@ -129,7 +227,10 @@ public final class BrowserMCPService: BrowserMCPClientProviding, @unchecked Send
         ]
         let description: String
 
-        if let browserURL = environment["PEEKABOO_BROWSER_MCP_BROWSER_URL"], !browserURL.isEmpty {
+        if let webSocketEndpoint, !webSocketEndpoint.isEmpty {
+            args.append("--wsEndpoint=\(webSocketEndpoint)")
+            description = "Chrome DevTools automation for an exact browser endpoint"
+        } else if let browserURL = environment["PEEKABOO_BROWSER_MCP_BROWSER_URL"], !browserURL.isEmpty {
             args.append("--browserUrl=\(browserURL)")
             description = "Chrome DevTools automation for \(browserURL)"
         } else if self.environmentFlag("PEEKABOO_BROWSER_MCP_ISOLATED", environment: environment) {
@@ -155,7 +256,7 @@ public final class BrowserMCPService: BrowserMCPClientProviding, @unchecked Send
             args: args,
             enabled: true,
             timeout: 30,
-            autoReconnect: true,
+            autoReconnect: false,
             description: description)
     }
 
@@ -178,6 +279,7 @@ public final class BrowserMCPService: BrowserMCPClientProviding, @unchecked Send
                 name: name,
                 bundleIdentifier: bundleIdentifier,
                 processIdentifier: application.processIdentifier,
+                processStartIdentity: SystemIdentityResolver.processStartIdentity(application.processIdentifier),
                 version: self.version(for: application),
                 channel: inferred)
         }
@@ -211,5 +313,40 @@ public final class BrowserMCPService: BrowserMCPClientProviding, @unchecked Send
             return nil
         }
         return bundle.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
+    }
+}
+
+public enum BrowserMCPConnectionError: LocalizedError, Equatable {
+    case noBrowser(BrowserMCPChannel)
+    case ambiguousBrowsers(BrowserMCPChannel, [Int32])
+    case processIdentityUnavailable(Int32)
+    case explicitEndpointUnsupported
+    case invalidEndpoint(String)
+    case connectionProbeFailed(String)
+    case connectionLost(String)
+    case targetLocked
+
+    public var errorDescription: String? {
+        switch self {
+        case let .noBrowser(channel):
+            "No running \(channel.rawValue) Chrome process is available for an exact browser connection."
+        case let .ambiguousBrowsers(channel, processIdentifiers):
+            "Multiple \(channel.rawValue) Chrome processes are running (PIDs: " +
+                processIdentifiers.sorted().map(String.init).joined(separator: ", ") +
+                "). Refusing channel-only browser discovery; reconnect with one exact loopback browser URL."
+        case let .processIdentityUnavailable(processIdentifier):
+            "Chrome PID \(processIdentifier) has no stable process-generation receipt."
+        case .explicitEndpointUnsupported:
+            "This browser client cannot carry an explicit DevTools endpoint."
+        case let .invalidEndpoint(reason):
+            "Invalid browser_url: \(reason)"
+        case let .connectionProbeFailed(reason):
+            "Chrome DevTools MCP started, but its exact read-only connection probe failed: \(reason)"
+        case let .connectionLost(reason):
+            "The exact browser connection was lost or changed: \(reason). Disconnect and reconnect explicitly."
+        case .targetLocked:
+            "A different browser target is already connected. " +
+                "Disconnect it before selecting another channel or endpoint."
+        }
     }
 }

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/Browser/BrowserMCPSessionManager.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/Browser/BrowserMCPSessionManager.swift
@@ -1,48 +1,157 @@
 import Foundation
 import MCP
+import PeekabooAutomationKit
 import TachikomaMCP
 
 @MainActor
-final class BrowserMCPSessionManager: @unchecked Sendable {
-    private let serverName: String
-    private var manager: TachikomaMCPClientManager
-    private var connectedChannel: BrowserMCPChannel?
+protocol BrowserMCPManaging: AnyObject {
+    func hasServer(name: String) -> Bool
+    func isServerConnected(name: String) async -> Bool
+    func serverToolCount(name: String) async -> Int
+    func addServer(name: String, config: MCPServerConfig) async throws
+    func removeServer(name: String) async
+    func executeTool(serverName: String, toolName: String, arguments: [String: Any]) async throws -> ToolResponse
+}
 
-    init(serverName: String, manager: TachikomaMCPClientManager = TachikomaMCPClientManager()) {
+extension TachikomaMCPClientManager: BrowserMCPManaging {
+    func hasServer(name: String) -> Bool {
+        self.getServerConfig(name: name) != nil
+    }
+
+    func serverToolCount(name: String) async -> Int {
+        await self.getServerTools(name: name).count
+    }
+}
+
+@MainActor
+final class BrowserMCPSessionManager: @unchecked Sendable {
+    typealias BrowserDetector = @MainActor (BrowserMCPChannel?) -> [DetectedBrowser]
+    typealias ProcessIdentityProvider = @Sendable (Int32) -> UInt64?
+
+    private let serverName: String
+    private let manager: any BrowserMCPManaging
+    private let detectedBrowsers: BrowserDetector
+    private let processStartIdentity: ProcessIdentityProvider
+    private let endpointResolver: BrowserMCPDevToolsEndpointResolver
+    private let uploadStager: BrowserMCPUploadStager
+    private let executionGate = MCPToolSnapshotExecutionGate()
+    private var connectionReceipt: BrowserMCPConnectionReceipt?
+    private var uploadWorkspace: BrowserMCPUploadWorkspace?
+    private var activeUploadID: UUID?
+
+    init(
+        serverName: String,
+        manager: any BrowserMCPManaging = TachikomaMCPClientManager(),
+        detectedBrowsers: @escaping BrowserDetector = BrowserMCPService.detectRunningBrowsers,
+        processStartIdentity: @escaping ProcessIdentityProvider = { processIdentifier in
+            SystemIdentityResolver.processStartIdentity(processIdentifier)
+        },
+        endpointResolver: BrowserMCPDevToolsEndpointResolver = .live,
+        uploadStager: BrowserMCPUploadStager = .live)
+    {
         self.serverName = serverName
         self.manager = manager
+        self.detectedBrowsers = detectedBrowsers
+        self.processStartIdentity = processStartIdentity
+        self.endpointResolver = endpointResolver
+        self.uploadStager = uploadStager
     }
 
     func status(channel: BrowserMCPChannel?) async -> BrowserMCPStatus {
-        let browserChannel = self.resolvedChannel(channel)
-        let isConnected = await self.manager.isServerConnected(name: self.serverName)
-        let tools = await self.manager.getServerTools(name: self.serverName)
-        return BrowserMCPStatus(
-            isConnected: isConnected,
-            toolCount: tools.count,
-            detectedBrowsers: BrowserMCPService.detectRunningBrowsers(channel: browserChannel),
-            error: nil)
+        let browsers = self.detectedBrowsers(channel)
+        guard let receipt = self.connectionReceipt else {
+            if await self.manager.isServerConnected(name: self.serverName) || self.manager
+                .hasServer(name: self.serverName)
+            {
+                await self.manager.removeServer(name: self.serverName)
+            }
+            return BrowserMCPStatus(
+                isConnected: false,
+                toolCount: 0,
+                detectedBrowsers: browsers,
+                connectionReceipt: nil)
+        }
+
+        do {
+            try await self.validate(receipt)
+            guard await self.manager.isServerConnected(name: self.serverName) else {
+                throw BrowserMCPConnectionError.connectionLost("the persistent MCP child is no longer connected")
+            }
+            return await BrowserMCPStatus(
+                isConnected: true,
+                toolCount: self.manager.serverToolCount(name: self.serverName),
+                detectedBrowsers: browsers,
+                connectionReceipt: receipt)
+        } catch {
+            await self.clearConnection()
+            return BrowserMCPStatus(
+                isConnected: false,
+                toolCount: 0,
+                detectedBrowsers: browsers,
+                connectionReceipt: nil,
+                error: error.localizedDescription)
+        }
     }
 
-    func connect(channel: BrowserMCPChannel?) async throws -> BrowserMCPStatus {
-        let browserChannel = self.resolvedChannel(channel)
-        let isConnected = await self.manager.isServerConnected(name: self.serverName)
-        if isConnected, self.connectedChannel == browserChannel {
-            return await self.status(channel: browserChannel)
+    func connect(channel: BrowserMCPChannel?, browserURL: String? = nil) async throws -> BrowserMCPStatus {
+        try await self.withExecutionGate {
+            try await self.connectUnlocked(channel: channel, browserURL: browserURL)
+        }
+    }
+
+    private func connectUnlocked(
+        channel: BrowserMCPChannel?,
+        browserURL: String? = nil) async throws -> BrowserMCPStatus
+    {
+        let target = try await self.resolveTarget(channel: channel, browserURL: browserURL)
+        if let existing = self.connectionReceipt {
+            guard existing == target.receipt else {
+                throw BrowserMCPConnectionError.targetLocked
+            }
+            try await self.validate(existing)
+            guard await self.manager.isServerConnected(name: self.serverName) else {
+                await self.clearConnection()
+                throw BrowserMCPConnectionError.connectionLost("the persistent MCP child exited")
+            }
+            return await self.status(channel: channel)
         }
 
-        let config = BrowserMCPService.chromeDevToolsConfig(channel: browserChannel)
-        if self.manager.getServerConfig(name: self.serverName) != nil {
+        if self.manager.hasServer(name: self.serverName) {
             await self.manager.removeServer(name: self.serverName)
         }
-        try await self.manager.addServer(name: self.serverName, config: config)
-        self.connectedChannel = browserChannel
-        return await self.status(channel: browserChannel)
+        do {
+            let uploadWorkspace = try await self.uploadStager.createWorkspace()
+            var config = target.config
+            config.env["TMPDIR"] = uploadWorkspace.rootPath
+            self.uploadWorkspace = uploadWorkspace
+            try await self.manager.addServer(name: self.serverName, config: config)
+            let probe = try await self.manager.executeTool(
+                serverName: self.serverName,
+                toolName: "list_pages",
+                arguments: [:])
+            guard !probe.isError else {
+                throw BrowserMCPConnectionError.connectionProbeFailed(
+                    "Chrome DevTools MCP rejected list_pages")
+            }
+            try await self.validate(target.receipt)
+            self.connectionReceipt = target.receipt
+            return await self.status(channel: channel)
+        } catch let error as BrowserMCPUploadStagingError {
+            await self.clearConnection()
+            throw error
+        } catch let error as BrowserMCPConnectionError {
+            await self.clearConnection()
+            throw error
+        } catch {
+            await self.clearConnection()
+            throw BrowserMCPConnectionError.connectionProbeFailed(error.localizedDescription)
+        }
     }
 
     func disconnect() async {
-        await self.manager.disableServer(name: self.serverName)
-        self.connectedChannel = nil
+        try? await self.withExecutionGate {
+            await self.clearConnection()
+        }
     }
 
     func execute(
@@ -50,19 +159,215 @@ final class BrowserMCPSessionManager: @unchecked Sendable {
         arguments: [String: Any],
         channel: BrowserMCPChannel?) async throws -> ToolResponse
     {
-        if await !self.manager.isServerConnected(name: self.serverName) ||
-            (channel != nil && channel != self.connectedChannel)
-        {
-            _ = try await self.connect(channel: channel)
-        }
-
-        return try await self.manager.executeTool(
-            serverName: self.serverName,
-            toolName: toolName,
-            arguments: arguments)
+        try await self.executeSequence(
+            [BrowserMCPMappedCall(toolName: toolName, arguments: arguments)],
+            channel: channel)
     }
 
-    private func resolvedChannel(_ requestedChannel: BrowserMCPChannel?) -> BrowserMCPChannel {
-        requestedChannel ?? self.connectedChannel ?? BrowserMCPService.preferredChannel()
+    func executeSequence(
+        _ calls: [BrowserMCPMappedCall],
+        channel: BrowserMCPChannel?) async throws -> ToolResponse
+    {
+        try await self.withExecutionGate {
+            try await self.executeSequenceUnlocked(calls, channel: channel)
+        }
+    }
+
+    private func executeSequenceUnlocked(
+        _ calls: [BrowserMCPMappedCall],
+        channel: BrowserMCPChannel?) async throws -> ToolResponse
+    {
+        guard !calls.isEmpty else {
+            throw BrowserMCPConnectionError.connectionLost("the browser action sequence was empty")
+        }
+        if self.connectionReceipt == nil {
+            _ = try await self.connectUnlocked(channel: channel)
+        }
+        guard let receipt = self.connectionReceipt else {
+            throw BrowserMCPConnectionError.connectionLost("no exact connection receipt exists")
+        }
+        if let channel, channel != receipt.channel {
+            throw BrowserMCPConnectionError.targetLocked
+        }
+        try await self.validate(receipt)
+        guard await self.manager.isServerConnected(name: self.serverName) else {
+            await self.clearConnection()
+            throw BrowserMCPConnectionError.connectionLost("the persistent MCP child exited")
+        }
+
+        do {
+            var response: ToolResponse?
+            for call in calls {
+                let current = try await self.execute(call)
+                response = current
+                if current.isError {
+                    break
+                }
+            }
+            try await self.validate(receipt)
+            guard let response else {
+                throw BrowserMCPConnectionError.connectionLost("the browser action sequence returned no response")
+            }
+            return response
+        } catch let error as BrowserMCPUploadStagingError {
+            throw error
+        } catch is CancellationError {
+            await self.clearConnection()
+            throw CancellationError()
+        } catch let error as BrowserMCPConnectionError {
+            await self.clearConnection()
+            throw error
+        } catch {
+            await self.clearConnection()
+            throw BrowserMCPConnectionError.connectionLost(error.localizedDescription)
+        }
+    }
+
+    private func execute(_ call: BrowserMCPMappedCall) async throws -> ToolResponse {
+        guard call.toolName == "upload_file" else {
+            return try await self.manager.executeTool(
+                serverName: self.serverName,
+                toolName: call.toolName,
+                arguments: call.arguments)
+        }
+        guard let sourcePath = call.arguments["filePath"] as? String, !sourcePath.isEmpty else {
+            throw BrowserMCPUploadStagingError.invalidPath("upload_file requires a non-empty filePath string")
+        }
+
+        guard let uploadWorkspace = self.uploadWorkspace else {
+            throw BrowserMCPConnectionError.connectionLost("the browser upload workspace is unavailable")
+        }
+        let stagedUpload = try await self.uploadStager.stage(path: sourcePath, in: uploadWorkspace)
+        try Task.checkCancellation()
+        var stagedArguments = call.arguments
+        stagedArguments["filePath"] = stagedUpload.filePath
+        let uploadID = UUID()
+        self.activeUploadID = uploadID
+        do {
+            let response = try await withTaskCancellationHandler {
+                try Task.checkCancellation()
+                return try await self.manager.executeTool(
+                    serverName: self.serverName,
+                    toolName: call.toolName,
+                    arguments: stagedArguments)
+            } onCancel: { [weak self] in
+                Task { @MainActor in
+                    await self?.cancelUpload(id: uploadID)
+                }
+            }
+            try Task.checkCancellation()
+            if self.activeUploadID == uploadID {
+                self.activeUploadID = nil
+            }
+            uploadWorkspace.retain(stagedUpload)
+            return response
+        } catch {
+            if self.activeUploadID == uploadID {
+                self.activeUploadID = nil
+            }
+            uploadWorkspace.retain(stagedUpload)
+            throw error
+        }
+    }
+
+    private func cancelUpload(id: UUID) async {
+        guard self.activeUploadID == id else { return }
+        self.activeUploadID = nil
+        await self.clearConnection()
+    }
+
+    private func resolveTarget(
+        channel: BrowserMCPChannel?,
+        browserURL: String?) async throws
+        -> (receipt: BrowserMCPConnectionReceipt, config: MCPServerConfig)
+    {
+        if let browserURL {
+            let endpoint = try await self.endpointResolver.resolve(browserURL)
+            let receipt = BrowserMCPConnectionReceipt(
+                channel: channel,
+                browserURL: endpoint.browserURL,
+                webSocketDebuggerURL: endpoint.webSocketDebuggerURL,
+                devToolsBrowserID: endpoint.browserID,
+                browserVersion: endpoint.browserVersion,
+                protocolVersion: endpoint.protocolVersion)
+            return (
+                receipt,
+                BrowserMCPService.chromeDevToolsConfig(
+                    channel: channel,
+                    webSocketEndpoint: endpoint.webSocketDebuggerURL))
+        }
+
+        let resolvedChannel = channel ?? BrowserMCPService.preferredChannel()
+        let candidates = self.detectedBrowsers(resolvedChannel)
+        guard !candidates.isEmpty else {
+            throw BrowserMCPConnectionError.noBrowser(resolvedChannel)
+        }
+        guard candidates.count == 1, let browser = candidates.first else {
+            throw BrowserMCPConnectionError.ambiguousBrowsers(
+                resolvedChannel,
+                candidates.map(\.processIdentifier))
+        }
+        guard let processStartIdentity = browser.processStartIdentity,
+              self.processStartIdentity(browser.processIdentifier) == processStartIdentity
+        else {
+            throw BrowserMCPConnectionError.processIdentityUnavailable(browser.processIdentifier)
+        }
+        let receipt = BrowserMCPConnectionReceipt(
+            channel: resolvedChannel,
+            processIdentifier: browser.processIdentifier,
+            processStartIdentity: processStartIdentity,
+            bundleIdentifier: browser.bundleIdentifier,
+            browserVersion: browser.version)
+        return (receipt, BrowserMCPService.chromeDevToolsConfig(channel: resolvedChannel))
+    }
+
+    private func validate(_ receipt: BrowserMCPConnectionReceipt) async throws {
+        if let browserURL = receipt.browserURL {
+            let endpoint = try await self.endpointResolver.resolve(browserURL)
+            guard endpoint.webSocketDebuggerURL == receipt.webSocketDebuggerURL,
+                  endpoint.browserID == receipt.devToolsBrowserID,
+                  endpoint.browserVersion == receipt.browserVersion,
+                  endpoint.protocolVersion == receipt.protocolVersion
+            else {
+                throw BrowserMCPConnectionError.connectionLost("the DevTools browser endpoint changed identity")
+            }
+        }
+        if let processIdentifier = receipt.processIdentifier,
+           let expectedGeneration = receipt.processStartIdentity
+        {
+            guard self.processStartIdentity(processIdentifier) == expectedGeneration else {
+                throw BrowserMCPConnectionError.connectionLost(
+                    "Chrome PID \(processIdentifier) changed process generation")
+            }
+        }
+    }
+
+    private func clearConnection() async {
+        self.connectionReceipt = nil
+        self.activeUploadID = nil
+        let uploadWorkspace = self.uploadWorkspace
+        self.uploadWorkspace = nil
+        var shouldRemoveServer = self.manager.hasServer(name: self.serverName)
+        if !shouldRemoveServer {
+            shouldRemoveServer = await self.manager.isServerConnected(name: self.serverName)
+        }
+        if shouldRemoveServer {
+            await self.manager.removeServer(name: self.serverName)
+        }
+        uploadWorkspace?.cleanup()
+    }
+
+    private func withExecutionGate<Result>(
+        _ operation: @MainActor () async throws -> Result) async throws -> Result
+    {
+        try await self.executionGate.acquire()
+        do {
+            let result = try await operation()
+            await self.executionGate.release()
+            return result
+        } catch {
+            await self.executionGate.release()
+            throw error
+        }
     }
 }

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/Browser/BrowserMCPUploadStager.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/Browser/BrowserMCPUploadStager.swift
@@ -1,0 +1,396 @@
+import Darwin
+import Foundation
+
+enum BrowserMCPUploadStagingError: LocalizedError, Equatable {
+    case invalidPath(String)
+    case sourceUnavailable(String)
+    case sourceChanged
+    case unsupportedSource(String)
+    case sourceTooLarge(maximumBytes: Int64)
+    case stagingFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case let .invalidPath(reason):
+            "Browser upload path is invalid: \(reason)"
+        case let .sourceUnavailable(reason):
+            "Browser upload source is unavailable: \(reason)"
+        case .sourceChanged:
+            "Browser upload source changed while it was being opened; no file was uploaded."
+        case let .unsupportedSource(reason):
+            "Browser upload source is not allowed: \(reason)"
+        case let .sourceTooLarge(maximumBytes):
+            "Browser upload source exceeds the \(maximumBytes)-byte safety limit."
+        case let .stagingFailed(reason):
+            "Browser upload staging failed: \(reason)"
+        }
+    }
+}
+
+final class BrowserMCPUploadWorkspace: @unchecked Sendable {
+    let rootPath: String
+
+    private let cleanupLock = NSLock()
+    private var cleanedUp = false
+    private var retainedUploads: [BrowserMCPStagedUpload] = []
+    private let cleanupOperation: @Sendable () -> Void
+
+    init(rootPath: String, cleanupOperation: @escaping @Sendable () -> Void) {
+        self.rootPath = rootPath
+        self.cleanupOperation = cleanupOperation
+    }
+
+    func cleanup() {
+        let retainedUploads: [BrowserMCPStagedUpload]? = self.cleanupLock.withLock {
+            guard !self.cleanedUp else { return nil }
+            self.cleanedUp = true
+            defer { self.retainedUploads.removeAll() }
+            return self.retainedUploads
+        }
+        guard let retainedUploads else { return }
+        self.cleanupOperation()
+        retainedUploads.forEach { $0.cleanup() }
+    }
+
+    func retain(_ upload: BrowserMCPStagedUpload) {
+        let retained = self.cleanupLock.withLock {
+            guard !self.cleanedUp else { return false }
+            self.retainedUploads.append(upload)
+            return true
+        }
+        if !retained {
+            upload.cleanup()
+        }
+    }
+
+    deinit {
+        self.cleanup()
+    }
+}
+
+final class BrowserMCPStagedUpload: @unchecked Sendable {
+    let filePath: String
+    let rootPath: String
+
+    private let cleanupLock = NSLock()
+    private var cleanedUp = false
+    private let cleanupOperation: @Sendable () -> Void
+
+    init(filePath: String, rootPath: String, cleanupOperation: @escaping @Sendable () -> Void) {
+        self.filePath = filePath
+        self.rootPath = rootPath
+        self.cleanupOperation = cleanupOperation
+    }
+
+    func cleanup() {
+        let shouldClean = self.cleanupLock.withLock {
+            guard !self.cleanedUp else { return false }
+            self.cleanedUp = true
+            return true
+        }
+        if shouldClean {
+            self.cleanupOperation()
+        }
+    }
+
+    deinit {
+        self.cleanup()
+    }
+}
+
+struct BrowserMCPUploadStager: Sendable {
+    static let maximumFileSize: Int64 = 100 * 1024 * 1024
+
+    typealias SourceInspectionHook = @Sendable (String) throws -> Void
+    typealias CopyProgressHook = @Sendable (Int64) throws -> Void
+
+    private let temporaryDirectory: String
+    private let maximumBytes: Int64
+    private let expectedUserID: uid_t
+    private let sourceInspectionHook: SourceInspectionHook
+    private let copyProgressHook: CopyProgressHook
+
+    static let live = BrowserMCPUploadStager()
+
+    init(
+        temporaryDirectory: String = NSTemporaryDirectory(),
+        maximumBytes: Int64 = Self.maximumFileSize,
+        expectedUserID: uid_t = geteuid(),
+        sourceInspectionHook: @escaping SourceInspectionHook = { _ in },
+        copyProgressHook: @escaping CopyProgressHook = { _ in })
+    {
+        self.temporaryDirectory = temporaryDirectory
+        self.maximumBytes = maximumBytes
+        self.expectedUserID = expectedUserID
+        self.sourceInspectionHook = sourceInspectionHook
+        self.copyProgressHook = copyProgressHook
+    }
+
+    func createWorkspace() async throws -> BrowserMCPUploadWorkspace {
+        let worker = Task.detached {
+            let rootPath = try self.makePrivateDirectory(
+                parentPath: self.temporaryDirectory,
+                nameTemplate: "peekaboo-browser-session.XXXXXX")
+            return BrowserMCPUploadWorkspace(rootPath: rootPath) {
+                Self.removeStagingRoot(rootPath)
+            }
+        }
+        return try await withTaskCancellationHandler {
+            try await worker.value
+        } onCancel: {
+            worker.cancel()
+        }
+    }
+
+    func stage(path: String, in workspace: BrowserMCPUploadWorkspace) async throws -> BrowserMCPStagedUpload {
+        let worker = Task.detached {
+            try self.stageSynchronously(path: path, workspace: workspace)
+        }
+        return try await withTaskCancellationHandler {
+            try await worker.value
+        } onCancel: {
+            worker.cancel()
+        }
+    }
+
+    private func stageSynchronously(
+        path: String,
+        workspace: BrowserMCPUploadWorkspace) throws -> BrowserMCPStagedUpload
+    {
+        try Task.checkCancellation()
+        let fileName = try Self.validatePath(path)
+
+        var inspected = Darwin.stat()
+        guard lstat(path, &inspected) == 0 else {
+            throw BrowserMCPUploadStagingError.sourceUnavailable(Self.errorText(errno))
+        }
+        guard (inspected.st_mode & S_IFMT) != S_IFLNK else {
+            throw BrowserMCPUploadStagingError.unsupportedSource("symbolic links are refused")
+        }
+        guard (inspected.st_mode & S_IFMT) == S_IFREG else {
+            throw BrowserMCPUploadStagingError.unsupportedSource("only regular files can be uploaded")
+        }
+
+        try self.sourceInspectionHook(path)
+        try Task.checkCancellation()
+
+        let sourceDescriptor = open(path, O_RDONLY | O_CLOEXEC | O_NOFOLLOW)
+        guard sourceDescriptor >= 0 else {
+            if errno == ELOOP {
+                throw BrowserMCPUploadStagingError.sourceChanged
+            }
+            throw BrowserMCPUploadStagingError.sourceUnavailable(Self.errorText(errno))
+        }
+        defer { close(sourceDescriptor) }
+
+        var opened = Darwin.stat()
+        guard fstat(sourceDescriptor, &opened) == 0 else {
+            throw BrowserMCPUploadStagingError.sourceUnavailable(Self.errorText(errno))
+        }
+        guard inspected.st_dev == opened.st_dev, inspected.st_ino == opened.st_ino else {
+            throw BrowserMCPUploadStagingError.sourceChanged
+        }
+        guard (opened.st_mode & S_IFMT) == S_IFREG else {
+            throw BrowserMCPUploadStagingError.unsupportedSource("only regular files can be uploaded")
+        }
+        guard opened.st_uid == self.expectedUserID else {
+            throw BrowserMCPUploadStagingError.unsupportedSource("the file is not owned by the current user")
+        }
+        guard opened.st_size >= 0 else {
+            throw BrowserMCPUploadStagingError.unsupportedSource("the file has an invalid size")
+        }
+        guard opened.st_size <= self.maximumBytes else {
+            throw BrowserMCPUploadStagingError.sourceTooLarge(maximumBytes: self.maximumBytes)
+        }
+
+        let rootPath = try self.makePrivateDirectory(
+            parentPath: workspace.rootPath,
+            nameTemplate: "upload.XXXXXX")
+        var stagedSuccessfully = false
+        defer {
+            if !stagedSuccessfully {
+                Self.removeStagingRoot(rootPath)
+            }
+        }
+
+        let rootDescriptor = open(rootPath, O_RDONLY | O_DIRECTORY | O_CLOEXEC | O_NOFOLLOW)
+        guard rootDescriptor >= 0 else {
+            throw BrowserMCPUploadStagingError.stagingFailed(Self.errorText(errno))
+        }
+        defer { close(rootDescriptor) }
+
+        let destinationDescriptor = openat(
+            rootDescriptor,
+            fileName,
+            O_WRONLY | O_CREAT | O_EXCL | O_CLOEXEC | O_NOFOLLOW,
+            mode_t(S_IRUSR | S_IWUSR))
+        guard destinationDescriptor >= 0 else {
+            throw BrowserMCPUploadStagingError.stagingFailed(Self.errorText(errno))
+        }
+        defer { close(destinationDescriptor) }
+
+        try self.copy(
+            sourceDescriptor: sourceDescriptor,
+            destinationDescriptor: destinationDescriptor,
+            expectedSize: opened.st_size)
+        guard fchmod(destinationDescriptor, mode_t(S_IRUSR)) == 0 else {
+            throw BrowserMCPUploadStagingError.stagingFailed(Self.errorText(errno))
+        }
+        guard fsync(destinationDescriptor) == 0 else {
+            throw BrowserMCPUploadStagingError.stagingFailed(Self.errorText(errno))
+        }
+
+        let stagedPath = URL(fileURLWithPath: rootPath, isDirectory: true)
+            .appendingPathComponent(fileName, isDirectory: false)
+            .path
+        stagedSuccessfully = true
+        return BrowserMCPStagedUpload(filePath: stagedPath, rootPath: rootPath) {
+            Self.removeStagingRoot(rootPath)
+        }
+    }
+
+    private func makePrivateDirectory(parentPath: String, nameTemplate: String) throws -> String {
+        try Task.checkCancellation()
+        var directory = Array(URL(fileURLWithPath: parentPath, isDirectory: true)
+            .appendingPathComponent(nameTemplate, isDirectory: true)
+            .path
+            .utf8CString)
+        let created = directory.withUnsafeMutableBufferPointer { buffer in
+            mkdtemp(buffer.baseAddress!)
+        }
+        guard created != nil else {
+            throw BrowserMCPUploadStagingError.stagingFailed(Self.errorText(errno))
+        }
+        let rootPath = directory.withUnsafeBufferPointer { buffer in
+            String(cString: buffer.baseAddress!)
+        }
+        var keepDirectory = false
+        defer {
+            if !keepDirectory {
+                Self.removeStagingRoot(rootPath)
+            }
+        }
+        guard chmod(rootPath, mode_t(S_IRWXU)) == 0 else {
+            throw BrowserMCPUploadStagingError.stagingFailed(Self.errorText(errno))
+        }
+        let canonicalParent = try Self.canonicalPath(parentPath)
+        let canonicalRoot = try Self.canonicalPath(rootPath)
+        guard URL(fileURLWithPath: canonicalRoot).deletingLastPathComponent().path == canonicalParent else {
+            throw BrowserMCPUploadStagingError.stagingFailed("the private directory escaped its parent")
+        }
+
+        var rootInfo = Darwin.stat()
+        guard lstat(canonicalRoot, &rootInfo) == 0,
+              (rootInfo.st_mode & S_IFMT) == S_IFDIR,
+              rootInfo.st_uid == self.expectedUserID,
+              (rootInfo.st_mode & mode_t(0o777)) == mode_t(0o700)
+        else {
+            throw BrowserMCPUploadStagingError.stagingFailed("the private directory ownership or mode is unsafe")
+        }
+        try Task.checkCancellation()
+        keepDirectory = true
+        return canonicalRoot
+    }
+
+    private func copy(
+        sourceDescriptor: Int32,
+        destinationDescriptor: Int32,
+        expectedSize: off_t) throws
+    {
+        var buffer = [UInt8](repeating: 0, count: 256 * 1024)
+        var copied: Int64 = 0
+        while true {
+            try Task.checkCancellation()
+            let readCount = buffer.withUnsafeMutableBytes { bytes in
+                read(sourceDescriptor, bytes.baseAddress, bytes.count)
+            }
+            if readCount == 0 {
+                break
+            }
+            guard readCount > 0 else {
+                if errno == EINTR {
+                    continue
+                }
+                throw BrowserMCPUploadStagingError.stagingFailed(Self.errorText(errno))
+            }
+
+            var written = 0
+            while written < readCount {
+                try Task.checkCancellation()
+                let writeCount = buffer.withUnsafeBytes { bytes in
+                    write(
+                        destinationDescriptor,
+                        bytes.baseAddress?.advanced(by: written),
+                        readCount - written)
+                }
+                guard writeCount > 0 else {
+                    if writeCount < 0, errno == EINTR {
+                        continue
+                    }
+                    throw BrowserMCPUploadStagingError.stagingFailed(Self.errorText(errno))
+                }
+                written += writeCount
+            }
+
+            copied += Int64(readCount)
+            guard copied <= Int64(expectedSize) else {
+                throw BrowserMCPUploadStagingError.sourceChanged
+            }
+            guard copied <= self.maximumBytes else {
+                throw BrowserMCPUploadStagingError.sourceTooLarge(maximumBytes: self.maximumBytes)
+            }
+            try self.copyProgressHook(copied)
+        }
+        guard copied == Int64(expectedSize) else {
+            throw BrowserMCPUploadStagingError.sourceChanged
+        }
+    }
+
+    private static func validatePath(_ path: String) throws -> String {
+        guard !path.isEmpty else {
+            throw BrowserMCPUploadStagingError.invalidPath("the path is empty")
+        }
+        guard path.utf8.count < Int(PATH_MAX) else {
+            throw BrowserMCPUploadStagingError.invalidPath("the path is too long")
+        }
+        guard path.utf8.allSatisfy({ $0 != 0 }) else {
+            throw BrowserMCPUploadStagingError.invalidPath("the path contains a null byte")
+        }
+        guard path.hasPrefix("/") else {
+            throw BrowserMCPUploadStagingError.invalidPath("an absolute path is required")
+        }
+
+        let components = path.split(separator: "/", omittingEmptySubsequences: false)
+        guard !components.contains(where: { $0 == "." || $0 == ".." }) else {
+            throw BrowserMCPUploadStagingError.invalidPath("relative traversal components are refused")
+        }
+        let fileName = URL(fileURLWithPath: path, isDirectory: false).lastPathComponent
+        guard !fileName.isEmpty, fileName != ".", fileName != ".." else {
+            throw BrowserMCPUploadStagingError.invalidPath("the path has no safe file name")
+        }
+        guard fileName.utf8.count <= Int(NAME_MAX) else {
+            throw BrowserMCPUploadStagingError.invalidPath("the file name is too long")
+        }
+        return fileName
+    }
+
+    private static func errorText(_ code: Int32) -> String {
+        String(cString: strerror(code))
+    }
+
+    private static func canonicalPath(_ path: String) throws -> String {
+        var resolved = [CChar](repeating: 0, count: Int(PATH_MAX))
+        guard realpath(path, &resolved) != nil else {
+            throw BrowserMCPUploadStagingError.stagingFailed(Self.errorText(errno))
+        }
+        let bytes = resolved.prefix { $0 != 0 }.map { UInt8(bitPattern: $0) }
+        guard let canonicalPath = String(bytes: bytes, encoding: .utf8) else {
+            throw BrowserMCPUploadStagingError.stagingFailed("the canonical path is not valid UTF-8")
+        }
+        return canonicalPath
+    }
+
+    private static func removeStagingRoot(_ path: String) {
+        try? FileManager.default.removeItem(atPath: path)
+    }
+}

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/BrowserTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/BrowserTool.swift
@@ -32,6 +32,11 @@ public struct BrowserTool: MCPTool {
                     Chrome channel for auto-connect. Defaults to the running Chrome channel, then stable.
                     """,
                     enum: BrowserMCPChannel.allCases.map(\.rawValue)),
+                "browser_url": SchemaBuilder.string(description: """
+                Exact loopback DevTools HTTP endpoint for connect, for example http://127.0.0.1:9222.
+                Peekaboo resolves and pins its browser WebSocket identity. Required when multiple Chrome
+                processes share one channel.
+                """),
                 "page_id": SchemaBuilder.integer(description: """
                 Chrome DevTools page ID. Required for every page-scoped action so concurrent clients cannot
                 redirect one another by changing the shared selected page. Use list_pages to discover IDs.
@@ -40,7 +45,10 @@ public struct BrowserTool: MCPTool {
                 "navigation_type": SchemaBuilder.string(
                     description: "Navigation type for navigate.",
                     enum: ["url", "back", "forward", "reload"]),
-                "uid": SchemaBuilder.string(description: "Element uid from the latest browser snapshot."),
+                "uid": SchemaBuilder.string(description: """
+                Element uid from the latest browser snapshot. Required for element actions, including type and
+                press_key so keyboard input cannot inherit an unrelated focused element.
+                """),
                 "to_uid": SchemaBuilder.string(description: "Drop target uid for drag."),
                 "text": SchemaBuilder.string(description: "Text for type or wait_for."),
                 "value": SchemaBuilder.string(description: "Value for fill."),
@@ -71,7 +79,8 @@ public struct BrowserTool: MCPTool {
                 "request_id": SchemaBuilder.integer(description: "Network request ID for get_network_request."),
                 "request_file_path": SchemaBuilder.string(description: "Path for saving a network request body."),
                 "response_file_path": SchemaBuilder.string(description: "Path for saving a network response body."),
-                "path": SchemaBuilder.string(description: "File path for snapshots, screenshots, or trace output."),
+                "path": SchemaBuilder.string(description: "Absolute input file for upload_file; output path for " +
+                    "snapshots, screenshots, or traces. Uploads accept current-user regular files up to 100 MiB."),
                 "format": SchemaBuilder.string(
                     description: "Screenshot format.",
                     enum: ["png", "jpeg", "webp"]),
@@ -117,13 +126,17 @@ public struct BrowserTool: MCPTool {
         } else {
             channel = nil
         }
+        let browserURL = arguments.getString("browser_url")
+        if browserURL != nil, action != .connect {
+            return ToolResponse.error("browser_url is accepted only by the connect action")
+        }
 
         do {
             switch action {
             case .status:
                 return await self.statusResponse(channel: channel)
             case .connect:
-                let status = try await self.client.connect(channel: channel)
+                let status = try await self.client.connect(channel: channel, browserURL: browserURL)
                 return self.formatStatus(status, headline: "Connected Chrome DevTools MCP")
             case .disconnect:
                 await self.client.disconnect()
@@ -131,15 +144,14 @@ public struct BrowserTool: MCPTool {
             case .call:
                 return try await self.executeRawCall(arguments: arguments, channel: channel)
             default:
-                let call = try BrowserMCPCallMapper.map(action: action, arguments: arguments)
-                return try await self.client.execute(
-                    toolName: call.toolName,
-                    arguments: call.arguments,
-                    channel: channel)
+                let calls = try BrowserMCPCallMapper.mapSequence(action: action, arguments: arguments)
+                return try await self.client.executeSequence(calls, channel: channel)
             }
         } catch let error as BrowserToolError {
             return ToolResponse.error(error.localizedDescription)
         } catch let error as MCPToolArgumentValueError {
+            return ToolResponse.error(error.localizedDescription)
+        } catch let error as BrowserMCPUploadStagingError {
             return ToolResponse.error(error.localizedDescription)
         } catch {
             return ToolResponse.error(Self.permissionHelp(error: error))
@@ -189,6 +201,20 @@ public struct BrowserTool: MCPTool {
             lines.append("Error: \(error)")
         }
 
+        if let receipt = status.connectionReceipt {
+            lines.append("Exact connection:")
+            if let processIdentifier = receipt.processIdentifier,
+               let processStartIdentity = receipt.processStartIdentity
+            {
+                lines.append("- pid=\(processIdentifier) generation=\(processStartIdentity)")
+            }
+            if let browserURL = receipt.browserURL,
+               let browserID = receipt.devToolsBrowserID
+            {
+                lines.append("- endpoint=\(browserURL) browser_id=\(browserID)")
+            }
+        }
+
         if !status.isConnected {
             lines.append("")
             lines.append(contentsOf: Self.permissionInstructions())
@@ -198,12 +224,41 @@ public struct BrowserTool: MCPTool {
     }
 
     private func statusMeta(_ status: BrowserMCPStatus) -> Value {
-        .object([
+        var meta: [String: Value] = [
             "connected": .bool(status.isConnected),
             "tool_count": .int(status.toolCount),
             "browser_count": .int(status.detectedBrowsers.count),
             "channels": .array(status.detectedBrowsers.map { .string($0.channel.rawValue) }),
-        ])
+        ]
+        if let receipt = status.connectionReceipt {
+            var receiptMeta: [String: Value] = [:]
+            if let channel = receipt.channel {
+                receiptMeta["channel"] = .string(channel.rawValue)
+            }
+            if let processIdentifier = receipt.processIdentifier {
+                receiptMeta["pid"] = .int(Int(processIdentifier))
+            }
+            if let processStartIdentity = receipt.processStartIdentity {
+                receiptMeta["process_start_identity_decimal"] = .string(String(processStartIdentity))
+            }
+            if let bundleIdentifier = receipt.bundleIdentifier {
+                receiptMeta["bundle_id"] = .string(bundleIdentifier)
+            }
+            if let browserURL = receipt.browserURL {
+                receiptMeta["browser_url"] = .string(browserURL)
+            }
+            if let browserID = receipt.devToolsBrowserID {
+                receiptMeta["browser_id"] = .string(browserID)
+            }
+            if let browserVersion = receipt.browserVersion {
+                receiptMeta["browser_version"] = .string(browserVersion)
+            }
+            if let protocolVersion = receipt.protocolVersion {
+                receiptMeta["protocol_version"] = .string(protocolVersion)
+            }
+            meta["connection_receipt"] = .object(receiptMeta)
+        }
+        return .object(meta)
     }
 
     private static func permissionHelp(error: any Error) -> String {
@@ -220,6 +275,7 @@ public struct BrowserTool: MCPTool {
             "3. Enable remote debugging for this profile.",
             "4. Run browser { \"action\": \"connect\" }.",
             "5. Accept Chrome's remote debugging permission prompt.",
+            "If multiple Chrome processes share a channel, pass browser_url for one exact loopback DevTools port.",
         ]
     }
 
@@ -303,6 +359,39 @@ public struct BrowserMCPMappedCall {
 
 public enum BrowserMCPCallMapper {
     public static func map(action: BrowserAction, arguments: ToolArguments) throws -> BrowserMCPMappedCall {
+        guard action != .type, action != .pressKey else {
+            throw BrowserToolError.invalidAction("\(action.rawValue) requires an exact atomic call sequence")
+        }
+        return try self.mapSingle(action: action, arguments: arguments)
+    }
+
+    public static func mapSequence(
+        action: BrowserAction,
+        arguments: ToolArguments) throws -> [BrowserMCPMappedCall]
+    {
+        let calls: [BrowserMCPMappedCall] = switch action {
+        case .type, .pressKey:
+            try [
+                BrowserMCPMappedCall(toolName: "click", arguments: [
+                    "uid": self.requiredString("uid", arguments),
+                    "dblClick": false,
+                    "includeSnapshot": false,
+                ]),
+                self.mapSingle(action: action, arguments: arguments),
+            ]
+        default:
+            try [self.mapSingle(action: action, arguments: arguments)]
+        }
+        guard self.requiresPageID(action) else { return calls }
+        let pageID = try self.requiredPageID(arguments)
+        return calls.map { call in
+            var mappedArguments = call.arguments
+            mappedArguments["pageId"] = pageID
+            return BrowserMCPMappedCall(toolName: call.toolName, arguments: mappedArguments)
+        }
+    }
+
+    private static func mapSingle(action: BrowserAction, arguments: ToolArguments) throws -> BrowserMCPMappedCall {
         let call: BrowserMCPMappedCall = switch action {
         case .status, .connect, .disconnect, .call:
             throw BrowserToolError.invalidAction(action.rawValue)

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeBrowserModels.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeBrowserModels.swift
@@ -26,26 +26,67 @@ public struct PeekabooBridgeBrowserStatus: Codable, Sendable, Equatable {
     public let isConnected: Bool
     public let toolCount: Int
     public let detectedBrowsers: [PeekabooBridgeBrowserInfo]
+    public let connectionReceipt: PeekabooBridgeBrowserConnectionReceipt?
     public let error: String?
 
     public init(
         isConnected: Bool,
         toolCount: Int,
         detectedBrowsers: [PeekabooBridgeBrowserInfo],
+        connectionReceipt: PeekabooBridgeBrowserConnectionReceipt? = nil,
         error: String? = nil)
     {
         self.isConnected = isConnected
         self.toolCount = toolCount
         self.detectedBrowsers = detectedBrowsers
+        self.connectionReceipt = connectionReceipt
         self.error = error
+    }
+}
+
+public struct PeekabooBridgeBrowserConnectionReceipt: Codable, Sendable, Equatable {
+    public let channel: String?
+    public let processIdentifier: Int32?
+    public let processStartIdentity: UInt64?
+    public let processStartIdentityDecimal: String?
+    public let bundleIdentifier: String?
+    public let browserURL: String?
+    public let webSocketDebuggerURL: String?
+    public let devToolsBrowserID: String?
+    public let browserVersion: String?
+    public let protocolVersion: String?
+
+    public init(
+        channel: String? = nil,
+        processIdentifier: Int32? = nil,
+        processStartIdentity: UInt64? = nil,
+        bundleIdentifier: String? = nil,
+        browserURL: String? = nil,
+        webSocketDebuggerURL: String? = nil,
+        devToolsBrowserID: String? = nil,
+        browserVersion: String? = nil,
+        protocolVersion: String? = nil)
+    {
+        self.channel = channel
+        self.processIdentifier = processIdentifier
+        self.processStartIdentity = processStartIdentity
+        self.processStartIdentityDecimal = processStartIdentity.map(String.init)
+        self.bundleIdentifier = bundleIdentifier
+        self.browserURL = browserURL
+        self.webSocketDebuggerURL = webSocketDebuggerURL
+        self.devToolsBrowserID = devToolsBrowserID
+        self.browserVersion = browserVersion
+        self.protocolVersion = protocolVersion
     }
 }
 
 public struct PeekabooBridgeBrowserChannelRequest: Codable, Sendable, Equatable {
     public let channel: String?
+    public let browserURL: String?
 
-    public init(channel: String? = nil) {
+    public init(channel: String? = nil, browserURL: String? = nil) {
         self.channel = channel
+        self.browserURL = browserURL
     }
 }
 
@@ -53,6 +94,7 @@ public struct PeekabooBridgeBrowserExecuteRequest: Codable, Sendable, Equatable 
     public let toolName: String
     public let arguments: [String: PeekabooBridgeJSONValue]
     public let channel: String?
+    public let calls: [PeekabooBridgeBrowserToolCall]?
 
     public init(
         toolName: String,
@@ -62,6 +104,28 @@ public struct PeekabooBridgeBrowserExecuteRequest: Codable, Sendable, Equatable 
         self.toolName = toolName
         self.arguments = arguments
         self.channel = channel
+        self.calls = nil
+    }
+
+    public init(calls: [PeekabooBridgeBrowserToolCall], channel: String? = nil) {
+        self.toolName = calls.first?.toolName ?? ""
+        self.arguments = calls.first?.arguments ?? [:]
+        self.channel = channel
+        self.calls = calls
+    }
+
+    public var resolvedCalls: [PeekabooBridgeBrowserToolCall] {
+        self.calls ?? [PeekabooBridgeBrowserToolCall(toolName: self.toolName, arguments: self.arguments)]
+    }
+}
+
+public struct PeekabooBridgeBrowserToolCall: Codable, Sendable, Equatable {
+    public let toolName: String
+    public let arguments: [String: PeekabooBridgeJSONValue]
+
+    public init(toolName: String, arguments: [String: PeekabooBridgeJSONValue]) {
+        self.toolName = toolName
+        self.arguments = arguments
     }
 }
 

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeClient+Browser.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeClient+Browser.swift
@@ -4,16 +4,25 @@ extension PeekabooBridgeClient {
         switch response {
         case let .browserStatus(status):
             return status
+        case let .error(envelope):
+            throw envelope
         default:
             throw PeekabooBridgeErrorEnvelope(code: .invalidRequest, message: "Unexpected browser status response")
         }
     }
 
-    public func browserConnect(channel: String?) async throws -> PeekabooBridgeBrowserStatus {
-        let response = try await self.send(.browserConnect(PeekabooBridgeBrowserChannelRequest(channel: channel)))
+    public func browserConnect(
+        channel: String?,
+        browserURL: String? = nil) async throws -> PeekabooBridgeBrowserStatus
+    {
+        let response = try await self.send(.browserConnect(PeekabooBridgeBrowserChannelRequest(
+            channel: channel,
+            browserURL: browserURL)))
         switch response {
         case let .browserStatus(status):
             return status
+        case let .error(envelope):
+            throw envelope
         default:
             throw PeekabooBridgeErrorEnvelope(code: .invalidRequest, message: "Unexpected browser connect response")
         }
@@ -30,6 +39,8 @@ extension PeekabooBridgeClient {
         switch response {
         case let .browserToolResponse(result):
             return result
+        case let .error(envelope):
+            throw envelope
         default:
             throw PeekabooBridgeErrorEnvelope(code: .invalidRequest, message: "Unexpected browser tool response")
         }

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeConstants.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeConstants.swift
@@ -34,6 +34,10 @@ public enum PeekabooBridgeConstants {
     public static let explicitSnapshotPublicationVersion =
         PeekabooBridgeProtocolVersion(major: 1, minor: 26)
 
+    /// First protocol whose browser connection is probed and pinned to one exact Chrome identity.
+    public static let browserConnectionReceiptVersion =
+        PeekabooBridgeProtocolVersion(major: 1, minor: 26)
+
     /// First protocol with host-retained, one-shot exact dialog/button action receipts.
     public static let receiptPinnedDialogActionVersion =
         PeekabooBridgeProtocolVersion(major: 1, minor: 25)

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeModels.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeModels.swift
@@ -321,6 +321,7 @@ public enum PeekabooBridgeHostCapability {
         "processGenerationPinnedApplicationActivation"
     public static let desktopActionOutcomeProjection = "desktopActionOutcomeProjection"
     public static let explicitSnapshotPublication = "explicitSnapshotPublication"
+    public static let browserConnectionReceipts = "browserConnectionReceipts"
 }
 
 public struct PeekabooBridgeHandshakeResponse: Codable, Sendable {

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer+Handlers.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer+Handlers.swift
@@ -64,7 +64,9 @@ extension PeekabooBridgeServer {
         case let .browserStatus(payload):
             return try await .browserStatus(self.services.browserStatus(channel: payload.channel))
         case let .browserConnect(payload):
-            return try await .browserStatus(self.services.browserConnect(channel: payload.channel))
+            return try await .browserStatus(self.services.browserConnect(
+                channel: payload.channel,
+                browserURL: payload.browserURL))
         case .browserDisconnect:
             try await self.services.browserDisconnect()
             return .ok

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer.swift
@@ -84,6 +84,16 @@ public final class PeekabooBridgeServer {
             hostCapabilities,
             supportedVersions: supportedVersions,
             supportsExplicitSnapshotPublication: services.snapshots.supportsExplicitSnapshotPublication)
+        if supportedVersions.upperBound >= PeekabooBridgeConstants.browserConnectionReceiptVersion,
+           self.allowedOperations.isSuperset(of: [
+               .browserStatus,
+               .browserConnect,
+               .browserDisconnect,
+               .browserExecute,
+           ])
+        {
+            resolvedHostCapabilities.insert(PeekabooBridgeHostCapability.browserConnectionReceipts)
+        }
         let registeredScreenCaptureKitOwnership = services.supportsScreenCaptureKitProcessOwnership &&
             (try? ScreenCaptureKitOwnerLease.registerCurrentProcessCapability()) != nil
         if hostIdentity?.processStartIdentity != nil {

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServiceProviding.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServiceProviding.swift
@@ -25,6 +25,7 @@ public protocol PeekabooBridgeServiceProviding: AnyObject, Sendable {
 
     func browserStatus(channel: String?) async throws -> PeekabooBridgeBrowserStatus
     func browserConnect(channel: String?) async throws -> PeekabooBridgeBrowserStatus
+    func browserConnect(channel: String?, browserURL: String?) async throws -> PeekabooBridgeBrowserStatus
     func browserDisconnect() async throws
     func browserExecute(_ request: PeekabooBridgeBrowserExecuteRequest) async throws
         -> PeekabooBridgeBrowserToolResponse
@@ -54,6 +55,15 @@ extension PeekabooBridgeServiceProviding {
         throw PeekabooBridgeErrorEnvelope(
             code: .operationNotSupported,
             message: "Browser MCP is not supported by this bridge host")
+    }
+
+    public func browserConnect(channel: String?, browserURL: String?) async throws -> PeekabooBridgeBrowserStatus {
+        guard browserURL == nil else {
+            throw PeekabooBridgeErrorEnvelope(
+                code: .operationNotSupported,
+                message: "This bridge host cannot carry an exact browser endpoint")
+        }
+        return try await self.browserConnect(channel: channel)
     }
 
     public func browserDisconnect() async throws {

--- a/Core/PeekabooCore/Sources/PeekabooCore/Support/PeekabooServices+BrowserBridge.swift
+++ b/Core/PeekabooCore/Sources/PeekabooCore/Support/PeekabooServices+BrowserBridge.swift
@@ -12,7 +12,13 @@ extension PeekabooServices {
     }
 
     public func browserConnect(channel: String?) async throws -> PeekabooBridgeBrowserStatus {
-        let status = try await self.browser.connect(channel: channel.flatMap(BrowserMCPChannel.init(rawValue:)))
+        try await self.browserConnect(channel: channel, browserURL: nil)
+    }
+
+    public func browserConnect(channel: String?, browserURL: String?) async throws -> PeekabooBridgeBrowserStatus {
+        let status = try await self.browser.connect(
+            channel: channel.flatMap(BrowserMCPChannel.init(rawValue:)),
+            browserURL: browserURL)
         return Self.bridgeStatus(from: status)
     }
 
@@ -23,9 +29,13 @@ extension PeekabooServices {
     public func browserExecute(_ request: PeekabooBridgeBrowserExecuteRequest) async throws
         -> PeekabooBridgeBrowserToolResponse
     {
-        let response = try await self.browser.execute(
-            toolName: request.toolName,
-            arguments: request.arguments.mapValues { $0.toAny() },
+        let calls = request.resolvedCalls.map { call in
+            BrowserMCPMappedCall(
+                toolName: call.toolName,
+                arguments: call.arguments.mapValues { $0.toAny() })
+        }
+        let response = try await self.browser.executeSequence(
+            calls,
             channel: request.channel.flatMap(BrowserMCPChannel.init(rawValue:)))
         return try Self.bridgeToolResponse(from: response)
     }
@@ -41,6 +51,18 @@ extension PeekabooServices {
                     processIdentifier: $0.processIdentifier,
                     version: $0.version,
                     channel: $0.channel.rawValue)
+            },
+            connectionReceipt: status.connectionReceipt.map {
+                PeekabooBridgeBrowserConnectionReceipt(
+                    channel: $0.channel?.rawValue,
+                    processIdentifier: $0.processIdentifier,
+                    processStartIdentity: $0.processStartIdentity,
+                    bundleIdentifier: $0.bundleIdentifier,
+                    browserURL: $0.browserURL,
+                    webSocketDebuggerURL: $0.webSocketDebuggerURL,
+                    devToolsBrowserID: $0.devToolsBrowserID,
+                    browserVersion: $0.browserVersion,
+                    protocolVersion: $0.protocolVersion)
             },
             error: status.error)
     }

--- a/Core/PeekabooCore/Sources/PeekabooCore/Support/RemoteBrowserMCPClient.swift
+++ b/Core/PeekabooCore/Sources/PeekabooCore/Support/RemoteBrowserMCPClient.swift
@@ -26,7 +26,14 @@ public final class RemoteBrowserMCPClient: BrowserMCPClientProviding, @unchecked
 
     @MainActor
     public func connect(channel: BrowserMCPChannel?) async throws -> BrowserMCPStatus {
-        try await Self.status(from: self.client.browserConnect(channel: channel?.rawValue))
+        try await self.connect(channel: channel, browserURL: nil)
+    }
+
+    @MainActor
+    public func connect(channel: BrowserMCPChannel?, browserURL: String?) async throws -> BrowserMCPStatus {
+        try await Self.status(from: self.client.browserConnect(
+            channel: channel?.rawValue,
+            browserURL: browserURL))
     }
 
     @MainActor
@@ -48,6 +55,22 @@ public final class RemoteBrowserMCPClient: BrowserMCPClientProviding, @unchecked
         return try Self.toolResponse(from: response)
     }
 
+    @MainActor
+    public func executeSequence(
+        _ calls: [BrowserMCPMappedCall],
+        channel: BrowserMCPChannel?) async throws -> ToolResponse
+    {
+        let bridgeCalls = try calls.map { call in
+            try PeekabooBridgeBrowserToolCall(
+                toolName: call.toolName,
+                arguments: call.arguments.mapValues { try PeekabooBridgeJSONValue.fromAny($0) })
+        }
+        let response = try await self.client.browserExecute(PeekabooBridgeBrowserExecuteRequest(
+            calls: bridgeCalls,
+            channel: channel?.rawValue))
+        return try Self.toolResponse(from: response)
+    }
+
     private static func status(from bridgeStatus: PeekabooBridgeBrowserStatus) -> BrowserMCPStatus {
         BrowserMCPStatus(
             isConnected: bridgeStatus.isConnected,
@@ -60,6 +83,18 @@ public final class RemoteBrowserMCPClient: BrowserMCPClientProviding, @unchecked
                     processIdentifier: browser.processIdentifier,
                     version: browser.version,
                     channel: channel)
+            },
+            connectionReceipt: bridgeStatus.connectionReceipt.map { receipt in
+                BrowserMCPConnectionReceipt(
+                    channel: receipt.channel.flatMap(BrowserMCPChannel.init(rawValue:)),
+                    processIdentifier: receipt.processIdentifier,
+                    processStartIdentity: receipt.processStartIdentity,
+                    bundleIdentifier: receipt.bundleIdentifier,
+                    browserURL: receipt.browserURL,
+                    webSocketDebuggerURL: receipt.webSocketDebuggerURL,
+                    devToolsBrowserID: receipt.devToolsBrowserID,
+                    browserVersion: receipt.browserVersion,
+                    protocolVersion: receipt.protocolVersion)
             },
             error: bridgeStatus.error)
     }

--- a/Core/PeekabooCore/Tests/PeekabooAgentRuntimeTests/BrowserMCPSessionManagerTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooAgentRuntimeTests/BrowserMCPSessionManagerTests.swift
@@ -1,0 +1,531 @@
+import Darwin
+import Foundation
+import MCP
+import TachikomaMCP
+import Testing
+@testable import PeekabooAgentRuntime
+
+@MainActor
+struct BrowserMCPSessionManagerTests {
+    @Test
+    func `channel connect refuses ambiguous same-channel processes before spawning MCP`() async {
+        let manager = MockBrowserMCPManager()
+        let browsers = [
+            Self.browser(pid: 41, generation: 1041),
+            Self.browser(pid: 42, generation: 1042),
+        ]
+        let session = Self.session(manager: manager, browsers: browsers)
+
+        await #expect(throws: BrowserMCPConnectionError.ambiguousBrowsers(.stable, [41, 42])) {
+            _ = try await session.connect(channel: .stable)
+        }
+        #expect(manager.addedConfigs.isEmpty)
+        #expect(manager.executedTools.isEmpty)
+    }
+
+    @Test
+    func `connect probes list pages and publishes exact process receipt`() async throws {
+        let manager = MockBrowserMCPManager()
+        let browser = Self.browser(pid: 51, generation: 2051)
+        let session = Self.session(manager: manager, browsers: [browser])
+
+        let status = try await session.connect(channel: .stable)
+
+        #expect(status.isConnected)
+        #expect(status.toolCount == 29)
+        #expect(status.connectionReceipt?.processIdentifier == 51)
+        #expect(status.connectionReceipt?.processStartIdentity == 2051)
+        #expect(manager.executedTools == ["list_pages"])
+        #expect(manager.addedConfigs.count == 1)
+        #expect(manager.addedConfigs[0].autoReconnect == false)
+    }
+
+    @Test
+    func `failed connection probe clears unknown MCP child`() async {
+        let manager = MockBrowserMCPManager()
+        manager.executeError = MockBrowserError.probe
+        let session = Self.session(manager: manager, browsers: [Self.browser(pid: 61, generation: 3061)])
+
+        await #expect(throws: BrowserMCPConnectionError.self) {
+            _ = try await session.connect(channel: .stable)
+        }
+        #expect(manager.removeCount == 1)
+        #expect(!manager.connected)
+        let failedWorkspace = manager.addedConfigs.first?.env["TMPDIR"]
+        #expect(failedWorkspace.map { !FileManager.default.fileExists(atPath: $0) } == true)
+        let status = await session.status(channel: .stable)
+        #expect(!status.isConnected)
+        #expect(status.connectionReceipt == nil)
+    }
+
+    @Test
+    func `lost MCP child refuses without implicit reconnect`() async throws {
+        let manager = MockBrowserMCPManager()
+        let session = Self.session(manager: manager, browsers: [Self.browser(pid: 71, generation: 4071)])
+        _ = try await session.connect(channel: .stable)
+        manager.connected = false
+        manager.executedTools.removeAll()
+
+        await #expect(throws: BrowserMCPConnectionError.self) {
+            _ = try await session.execute(toolName: "take_snapshot", arguments: [:], channel: nil)
+        }
+        #expect(manager.addedConfigs.count == 1)
+        #expect(manager.executedTools.isEmpty)
+        #expect(manager.removeCount == 1)
+    }
+
+    @Test
+    func `process generation drift refuses before browser tool execution`() async throws {
+        let manager = MockBrowserMCPManager()
+        let currentGeneration = GenerationBox(5081)
+        let browser = Self.browser(pid: 81, generation: 5081)
+        let session = BrowserMCPSessionManager(
+            serverName: "test-browser",
+            manager: manager,
+            detectedBrowsers: { _ in [browser] },
+            processStartIdentity: { _ in currentGeneration.get() },
+            endpointResolver: Self.endpointResolver())
+        _ = try await session.connect(channel: .stable)
+        manager.executedTools.removeAll()
+        currentGeneration.set(5082)
+
+        await #expect(throws: BrowserMCPConnectionError.self) {
+            _ = try await session.execute(toolName: "take_snapshot", arguments: [:], channel: nil)
+        }
+        #expect(manager.executedTools.isEmpty)
+    }
+
+    @Test
+    func `exact endpoint is converted to WebSocket target and locked until disconnect`() async throws {
+        let manager = MockBrowserMCPManager()
+        let session = BrowserMCPSessionManager(
+            serverName: "test-browser",
+            manager: manager,
+            detectedBrowsers: { _ in [] },
+            processStartIdentity: { _ in nil },
+            endpointResolver: Self.endpointResolver())
+
+        let status = try await session.connect(
+            channel: .stable,
+            browserURL: "http://127.0.0.1:9222")
+        #expect(status.connectionReceipt?.browserURL == "http://127.0.0.1:9222/")
+        #expect(status.connectionReceipt?.devToolsBrowserID == "browser-a")
+        #expect(manager.addedConfigs[0].args.contains(
+            "--wsEndpoint=ws://127.0.0.1:9222/devtools/browser/browser-a"))
+
+        await #expect(throws: BrowserMCPConnectionError.targetLocked) {
+            _ = try await session.connect(
+                channel: .stable,
+                browserURL: "http://127.0.0.1:9333")
+        }
+    }
+
+    @Test
+    func `endpoint identity replacement refuses before execution`() async throws {
+        let manager = MockBrowserMCPManager()
+        let endpoints = EndpointMap()
+        await endpoints.set("browser-a", port: 9222)
+        let session = BrowserMCPSessionManager(
+            serverName: "test-browser",
+            manager: manager,
+            detectedBrowsers: { _ in [] },
+            processStartIdentity: { _ in nil },
+            endpointResolver: BrowserMCPDevToolsEndpointResolver { url in
+                try await endpoints.resolve(url)
+            })
+        _ = try await session.connect(channel: nil, browserURL: "http://127.0.0.1:9222")
+        manager.executedTools.removeAll()
+        await endpoints.set("browser-b", port: 9222)
+
+        await #expect(throws: BrowserMCPConnectionError.self) {
+            _ = try await session.execute(toolName: "take_snapshot", arguments: [:], channel: nil)
+        }
+        #expect(manager.executedTools.isEmpty)
+    }
+
+    @Test
+    func `atomic browser sequence excludes a concurrent page action`() async throws {
+        let manager = MockBrowserMCPManager()
+        let session = Self.session(manager: manager, browsers: [Self.browser(pid: 91, generation: 6091)])
+        _ = try await session.connect(channel: .stable)
+        manager.executedTools.removeAll()
+        let barrier = SequenceBarrier()
+        manager.executeHandler = { toolName, _ in
+            if toolName == "click" {
+                await barrier.block()
+            }
+            return ToolResponse.text("ok")
+        }
+
+        let sequence = Task { @MainActor in
+            try await session.executeSequence([
+                BrowserMCPMappedCall(toolName: "click", arguments: ["uid": "91_1"]),
+                BrowserMCPMappedCall(toolName: "type_text", arguments: ["text": "value"]),
+            ], channel: nil)
+        }
+        await barrier.waitUntilBlocked()
+        let contender = Task { @MainActor in
+            try await session.execute(toolName: "hover", arguments: ["uid": "91_2"], channel: nil)
+        }
+        await Task.yield()
+        await Task.yield()
+        #expect(manager.executedTools == ["click"])
+
+        await barrier.release()
+        _ = try await sequence.value
+        _ = try await contender.value
+        #expect(manager.executedTools == ["click", "type_text", "hover"])
+    }
+
+    @Test
+    func `connection advertises exact private TMPDIR and retains successful upload until disconnect`() async throws {
+        let fixture = try UploadStagingFixture()
+        defer { fixture.cleanup() }
+        let source = try fixture.write(name: "browser receipt.txt", contents: Data("receipt-value".utf8))
+        let manager = MockBrowserMCPManager()
+        let session = Self.session(
+            manager: manager,
+            browsers: [Self.browser(pid: 101, generation: 7101)],
+            uploadStager: fixture.stager())
+        var stagedPath: String?
+        manager.executeHandler = { toolName, arguments in
+            guard toolName == "upload_file" else { return ToolResponse.text("ok") }
+            let path = try #require(arguments["filePath"] as? String)
+            stagedPath = path
+            #expect(URL(fileURLWithPath: path).lastPathComponent == "browser receipt.txt")
+            #expect(try Data(contentsOf: URL(fileURLWithPath: path)) == Data("receipt-value".utf8))
+            return ToolResponse.text("uploaded")
+        }
+
+        _ = try await session.connect(channel: .stable)
+        let advertisedRoot = try #require(manager.addedConfigs.first?.env["TMPDIR"])
+        #expect(URL(fileURLWithPath: advertisedRoot).deletingLastPathComponent().path ==
+            Self.canonicalPath(fixture.stagingParent.path))
+        #expect(manager.addedConfigs.first?.args.contains("--allowUnrestrictedPaths") == false)
+        manager.executedTools.removeAll()
+        manager.executedArguments.removeAll()
+
+        let response = try await session.execute(
+            toolName: "upload_file",
+            arguments: ["uid": "101_1", "filePath": source.path],
+            channel: .stable)
+
+        #expect(!response.isError)
+        #expect(manager.executedTools == ["upload_file"])
+        let actualStagedPath = try #require(stagedPath)
+        #expect(actualStagedPath.hasPrefix(advertisedRoot + "/upload."))
+        #expect(FileManager.default.fileExists(atPath: actualStagedPath))
+        #expect(FileManager.default.fileExists(atPath: advertisedRoot))
+        await session.disconnect()
+        #expect(!FileManager.default.fileExists(atPath: advertisedRoot))
+    }
+
+    @Test
+    func `invalid upload path is never dispatched and does not discard healthy browser session`() async throws {
+        let fixture = try UploadStagingFixture()
+        defer { fixture.cleanup() }
+        let manager = MockBrowserMCPManager()
+        let session = Self.session(
+            manager: manager,
+            browsers: [Self.browser(pid: 111, generation: 8111)],
+            uploadStager: fixture.stager())
+        _ = try await session.connect(channel: .stable)
+        manager.executedTools.removeAll()
+        let removalsBefore = manager.removeCount
+
+        await #expect(throws: BrowserMCPUploadStagingError.self) {
+            _ = try await session.execute(
+                toolName: "upload_file",
+                arguments: ["uid": "111_1", "filePath": "relative.txt"],
+                channel: .stable)
+        }
+
+        #expect(manager.executedTools.isEmpty)
+        #expect(manager.connected)
+        #expect(manager.removeCount == removalsBefore)
+        #expect(await (session.status(channel: .stable)).isConnected)
+    }
+
+    @Test
+    func `upload tool error retains dispatched transfer in exact browser workspace`() async throws {
+        let fixture = try UploadStagingFixture()
+        defer { fixture.cleanup() }
+        let source = try fixture.write(name: "failure.txt", contents: Data("failure".utf8))
+        let manager = MockBrowserMCPManager()
+        let session = Self.session(
+            manager: manager,
+            browsers: [Self.browser(pid: 121, generation: 9121)],
+            uploadStager: fixture.stager())
+        var stagedPath: String?
+        manager.executeHandler = { toolName, arguments in
+            guard toolName == "upload_file" else { return ToolResponse.text("ok") }
+            stagedPath = arguments["filePath"] as? String
+            return ToolResponse.error("fixture rejected upload")
+        }
+        _ = try await session.connect(channel: .stable)
+        let advertisedRoot = try #require(manager.addedConfigs.first?.env["TMPDIR"])
+
+        let response = try await session.execute(
+            toolName: "upload_file",
+            arguments: ["uid": "121_1", "filePath": source.path],
+            channel: .stable)
+
+        #expect(response.isError)
+        #expect(try FileManager.default.fileExists(atPath: #require(stagedPath)))
+        #expect(FileManager.default.fileExists(atPath: advertisedRoot))
+        #expect(manager.connected)
+    }
+
+    @Test
+    func `caller cancellation removes staged bytes before noncooperative upload returns`() async throws {
+        let fixture = try UploadStagingFixture()
+        defer { fixture.cleanup() }
+        let source = try fixture.write(name: "cancel.txt", contents: Data("cancel".utf8))
+        let manager = MockBrowserMCPManager()
+        let session = Self.session(
+            manager: manager,
+            browsers: [Self.browser(pid: 131, generation: 10131)],
+            uploadStager: fixture.stager())
+        let barrier = SequenceBarrier()
+        var stagedPath: String?
+        var stagedFileExistedWhenChildRemoved = false
+        manager.executeHandler = { toolName, arguments in
+            guard toolName == "upload_file" else { return ToolResponse.text("ok") }
+            stagedPath = arguments["filePath"] as? String
+            await barrier.block()
+            try Task.checkCancellation()
+            return ToolResponse.text("unexpected")
+        }
+        manager.removeHandler = {
+            stagedFileExistedWhenChildRemoved = stagedPath.map {
+                FileManager.default.fileExists(atPath: $0)
+            } ?? false
+        }
+        _ = try await session.connect(channel: .stable)
+        let advertisedRoot = try #require(manager.addedConfigs.first?.env["TMPDIR"])
+
+        let upload = Task { @MainActor in
+            try await session.execute(
+                toolName: "upload_file",
+                arguments: ["uid": "131_1", "filePath": source.path],
+                channel: .stable)
+        }
+        await barrier.waitUntilBlocked()
+        let actualStagedPath = try #require(stagedPath)
+        #expect(FileManager.default.fileExists(atPath: actualStagedPath))
+        upload.cancel()
+        #expect(await Self.waitUntilMissing(advertisedRoot))
+        #expect(stagedFileExistedWhenChildRemoved)
+        #expect(!FileManager.default.fileExists(atPath: actualStagedPath))
+        await barrier.release()
+        await #expect(throws: CancellationError.self) {
+            _ = try await upload.value
+        }
+    }
+
+    @Test
+    func `lost child cleanup removes the advertised browser workspace`() async throws {
+        let fixture = try UploadStagingFixture()
+        defer { fixture.cleanup() }
+        let manager = MockBrowserMCPManager()
+        let session = Self.session(
+            manager: manager,
+            browsers: [Self.browser(pid: 141, generation: 11141)],
+            uploadStager: fixture.stager())
+        _ = try await session.connect(channel: .stable)
+        let advertisedRoot = try #require(manager.addedConfigs.first?.env["TMPDIR"])
+        #expect(FileManager.default.fileExists(atPath: advertisedRoot))
+        manager.connected = false
+
+        let status = await session.status(channel: .stable)
+
+        #expect(!status.isConnected)
+        #expect(!FileManager.default.fileExists(atPath: advertisedRoot))
+    }
+
+    private static func session(
+        manager: MockBrowserMCPManager,
+        browsers: [DetectedBrowser],
+        uploadStager: BrowserMCPUploadStager = .live) -> BrowserMCPSessionManager
+    {
+        let generations = Dictionary(uniqueKeysWithValues: browsers.compactMap { browser in
+            browser.processStartIdentity.map { (browser.processIdentifier, $0) }
+        })
+        return BrowserMCPSessionManager(
+            serverName: "test-browser",
+            manager: manager,
+            detectedBrowsers: { channel in
+                browsers.filter { channel == nil || $0.channel == channel }
+            },
+            processStartIdentity: { generations[$0] },
+            endpointResolver: self.endpointResolver(),
+            uploadStager: uploadStager)
+    }
+
+    private static func browser(pid: Int32, generation: UInt64) -> DetectedBrowser {
+        DetectedBrowser(
+            name: "Google Chrome",
+            bundleIdentifier: "com.google.Chrome",
+            processIdentifier: pid,
+            processStartIdentity: generation,
+            version: "151.0",
+            channel: .stable)
+    }
+
+    private static func endpointResolver() -> BrowserMCPDevToolsEndpointResolver {
+        BrowserMCPDevToolsEndpointResolver { url in
+            guard let port = URL(string: url)?.port else {
+                throw BrowserMCPConnectionError.invalidEndpoint("missing port")
+            }
+            return BrowserMCPDevToolsEndpoint(
+                browserURL: "http://127.0.0.1:\(port)/",
+                webSocketDebuggerURL: "ws://127.0.0.1:\(port)/devtools/browser/browser-a",
+                browserID: "browser-a",
+                browserVersion: "Chrome/151.0",
+                protocolVersion: "1.3")
+        }
+    }
+
+    private static func canonicalPath(_ path: String) -> String {
+        var resolved = [CChar](repeating: 0, count: Int(PATH_MAX))
+        guard realpath(path, &resolved) != nil else { return path }
+        let bytes = resolved.prefix { $0 != 0 }.map { UInt8(bitPattern: $0) }
+        return String(bytes: bytes, encoding: .utf8) ?? path
+    }
+
+    private static func waitUntilMissing(_ path: String) async -> Bool {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: .seconds(2))
+        while FileManager.default.fileExists(atPath: path), clock.now < deadline {
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        return !FileManager.default.fileExists(atPath: path)
+    }
+}
+
+@MainActor
+private final class MockBrowserMCPManager: BrowserMCPManaging {
+    var connected = false
+    var hasConfiguredServer = false
+    var addedConfigs: [MCPServerConfig] = []
+    var executedTools: [String] = []
+    var executedArguments: [[String: Any]] = []
+    var removeCount = 0
+    var executeError: (any Error)?
+    var executeHandler: (@MainActor (String, [String: Any]) async throws -> ToolResponse)?
+    var removeHandler: (@MainActor () async -> Void)?
+
+    func hasServer(name _: String) -> Bool {
+        self.hasConfiguredServer
+    }
+
+    func isServerConnected(name _: String) async -> Bool {
+        self.connected
+    }
+
+    func serverToolCount(name _: String) async -> Int {
+        self.connected ? 29 : 0
+    }
+
+    func addServer(name _: String, config: MCPServerConfig) async throws {
+        self.addedConfigs.append(config)
+        self.hasConfiguredServer = true
+        self.connected = true
+    }
+
+    func removeServer(name _: String) async {
+        await self.removeHandler?()
+        self.removeCount += 1
+        self.hasConfiguredServer = false
+        self.connected = false
+    }
+
+    func executeTool(
+        serverName _: String,
+        toolName: String,
+        arguments: [String: Any]) async throws -> ToolResponse
+    {
+        if let executeError {
+            throw executeError
+        }
+        self.executedTools.append(toolName)
+        self.executedArguments.append(arguments)
+        if let executeHandler {
+            return try await executeHandler(toolName, arguments)
+        }
+        return ToolResponse.text("ok")
+    }
+}
+
+private enum MockBrowserError: Error {
+    case probe
+}
+
+private final class GenerationBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value: UInt64?
+
+    init(_ value: UInt64?) {
+        self.value = value
+    }
+
+    func get() -> UInt64? {
+        self.lock.withLock { self.value }
+    }
+
+    func set(_ value: UInt64?) {
+        self.lock.withLock { self.value = value }
+    }
+}
+
+private actor EndpointMap {
+    private var endpoints: [Int: String] = [:]
+
+    func set(_ browserID: String, port: Int) {
+        self.endpoints[port] = browserID
+    }
+
+    func resolve(_ url: String) throws -> BrowserMCPDevToolsEndpoint {
+        guard let port = URL(string: url)?.port,
+              let browserID = self.endpoints[port]
+        else {
+            throw BrowserMCPConnectionError.invalidEndpoint("unknown endpoint")
+        }
+        return BrowserMCPDevToolsEndpoint(
+            browserURL: "http://127.0.0.1:\(port)/",
+            webSocketDebuggerURL: "ws://127.0.0.1:\(port)/devtools/browser/\(browserID)",
+            browserID: browserID,
+            browserVersion: "Chrome/151.0",
+            protocolVersion: "1.3")
+    }
+}
+
+private actor SequenceBarrier {
+    private var blocked = false
+    private var released = false
+    private var blockedWaiters: [CheckedContinuation<Void, Never>] = []
+    private var releaseWaiters: [CheckedContinuation<Void, Never>] = []
+
+    func block() async {
+        self.blocked = true
+        self.blockedWaiters.forEach { $0.resume() }
+        self.blockedWaiters.removeAll()
+        guard !self.released else { return }
+        await withCheckedContinuation { continuation in
+            self.releaseWaiters.append(continuation)
+        }
+    }
+
+    func waitUntilBlocked() async {
+        guard !self.blocked else { return }
+        await withCheckedContinuation { continuation in
+            self.blockedWaiters.append(continuation)
+        }
+    }
+
+    func release() {
+        self.released = true
+        self.releaseWaiters.forEach { $0.resume() }
+        self.releaseWaiters.removeAll()
+    }
+}

--- a/Core/PeekabooCore/Tests/PeekabooAgentRuntimeTests/BrowserMCPUploadStagerTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooAgentRuntimeTests/BrowserMCPUploadStagerTests.swift
@@ -1,0 +1,238 @@
+import Darwin
+import Foundation
+import Testing
+@testable import PeekabooAgentRuntime
+
+struct BrowserMCPUploadStagerTests {
+    @Test
+    func `staging uses owner-only session and transfer directories and preserves the safe basename`() async throws {
+        let fixture = try UploadStagingFixture()
+        defer { fixture.cleanup() }
+        let source = try fixture.write(name: "invoice upload.txt", contents: Data("fixture-value".utf8))
+        let stager = fixture.stager()
+        let workspace = try await stager.createWorkspace()
+        defer { workspace.cleanup() }
+
+        let staged = try await stager.stage(path: source.path, in: workspace)
+
+        #expect(URL(fileURLWithPath: staged.filePath).lastPathComponent == "invoice upload.txt")
+        #expect(URL(fileURLWithPath: staged.rootPath).deletingLastPathComponent().path == workspace.rootPath)
+        #expect(try Data(contentsOf: URL(fileURLWithPath: staged.filePath)) == Data("fixture-value".utf8))
+        #expect(Self.permissionBits(workspace.rootPath) == 0o700)
+        #expect(Self.permissionBits(staged.rootPath) == 0o700)
+        #expect(Self.permissionBits(staged.filePath) == 0o400)
+
+        staged.cleanup()
+        #expect(!FileManager.default.fileExists(atPath: staged.rootPath))
+        #expect(FileManager.default.fileExists(atPath: workspace.rootPath))
+        workspace.cleanup()
+        #expect(!FileManager.default.fileExists(atPath: workspace.rootPath))
+    }
+
+    @Test
+    func `path policy refuses relative traversal symlink directory and oversized sources`() async throws {
+        let fixture = try UploadStagingFixture()
+        defer { fixture.cleanup() }
+        let source = try fixture.write(name: "source.txt", contents: Data("1234".utf8))
+        let symlink = fixture.root.appendingPathComponent("source-link.txt")
+        try FileManager.default.createSymbolicLink(at: symlink, withDestinationURL: source)
+        let directory = fixture.root.appendingPathComponent("directory", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: false)
+        let workspace = try await fixture.stager().createWorkspace()
+        defer { workspace.cleanup() }
+
+        await #expect(throws: BrowserMCPUploadStagingError.self) {
+            _ = try await fixture.stager().stage(path: "source.txt", in: workspace)
+        }
+        await #expect(throws: BrowserMCPUploadStagingError.self) {
+            _ = try await fixture.stager().stage(
+                path: source.deletingLastPathComponent()
+                    .appendingPathComponent("directory/../source.txt").path,
+                in: workspace)
+        }
+        await #expect(throws: BrowserMCPUploadStagingError.self) {
+            _ = try await fixture.stager().stage(path: symlink.path, in: workspace)
+        }
+        await #expect(throws: BrowserMCPUploadStagingError.self) {
+            _ = try await fixture.stager().stage(path: directory.path, in: workspace)
+        }
+        let exactLimit = try await fixture.stager(maximumBytes: 4).stage(path: source.path, in: workspace)
+        exactLimit.cleanup()
+        await #expect(throws: BrowserMCPUploadStagingError.sourceTooLarge(maximumBytes: 3)) {
+            _ = try await fixture.stager(maximumBytes: 3).stage(path: source.path, in: workspace)
+        }
+        #expect(try Self.transferDirectories(in: workspace.rootPath).isEmpty)
+    }
+
+    @Test
+    func `final symlink swap and regular-file replacement are refused without staging bytes`() async throws {
+        let fixture = try UploadStagingFixture()
+        defer { fixture.cleanup() }
+        let target = try fixture.write(name: "target.txt", contents: Data("do-not-read".utf8))
+
+        let symlinkSource = try fixture.write(name: "symlink-source.txt", contents: Data("original".utf8))
+        let symlinkStager = fixture.stager(sourceInspectionHook: { path in
+            try FileManager.default.removeItem(atPath: path)
+            try FileManager.default.createSymbolicLink(atPath: path, withDestinationPath: target.path)
+        })
+        let symlinkWorkspace = try await symlinkStager.createWorkspace()
+        defer { symlinkWorkspace.cleanup() }
+        await #expect(throws: BrowserMCPUploadStagingError.sourceChanged) {
+            _ = try await symlinkStager.stage(path: symlinkSource.path, in: symlinkWorkspace)
+        }
+        #expect(try Self.transferDirectories(in: symlinkWorkspace.rootPath).isEmpty)
+
+        let replacedSource = try fixture.write(name: "replaced-source.txt", contents: Data("original".utf8))
+        let regularStager = fixture.stager(sourceInspectionHook: { path in
+            try FileManager.default.removeItem(atPath: path)
+            try Data("replacement".utf8).write(to: URL(fileURLWithPath: path), options: .withoutOverwriting)
+        })
+        let regularWorkspace = try await regularStager.createWorkspace()
+        defer { regularWorkspace.cleanup() }
+        await #expect(throws: BrowserMCPUploadStagingError.sourceChanged) {
+            _ = try await regularStager.stage(path: replacedSource.path, in: regularWorkspace)
+        }
+        #expect(try Self.transferDirectories(in: regularWorkspace.rootPath).isEmpty)
+    }
+
+    @Test
+    func `source size drift during copy fails closed and removes transfer directory`() async throws {
+        let fixture = try UploadStagingFixture()
+        defer { fixture.cleanup() }
+        let source = try fixture.write(
+            name: "changing.bin",
+            contents: Data(repeating: 0x41, count: 512 * 1024))
+        let truncated = LockedFlag()
+        let stager = fixture.stager(copyProgressHook: { _ in
+            if truncated.take() {
+                guard truncate(source.path, 0) == 0 else {
+                    throw BrowserMCPUploadStagingError.stagingFailed("test truncate failed")
+                }
+            }
+        })
+        let workspace = try await stager.createWorkspace()
+        defer { workspace.cleanup() }
+
+        await #expect(throws: BrowserMCPUploadStagingError.sourceChanged) {
+            _ = try await stager.stage(path: source.path, in: workspace)
+        }
+        #expect(try Self.transferDirectories(in: workspace.rootPath).isEmpty)
+    }
+
+    @Test
+    func `cancellation during copy removes transfer directory and leaves workspace reusable`() async throws {
+        let fixture = try UploadStagingFixture()
+        defer { fixture.cleanup() }
+        let source = try fixture.write(
+            name: "cancel.bin",
+            contents: Data(repeating: 0x42, count: 512 * 1024))
+        let barrier = UploadCopyBarrier()
+        let stager = fixture.stager(copyProgressHook: { _ in barrier.blockOnce() })
+        let workspace = try await stager.createWorkspace()
+        defer { workspace.cleanup() }
+
+        let task = Task {
+            try await stager.stage(path: source.path, in: workspace)
+        }
+        #expect(await barrier.waitUntilBlocked())
+        task.cancel()
+        barrier.release()
+        await #expect(throws: CancellationError.self) {
+            _ = try await task.value
+        }
+        #expect(try Self.transferDirectories(in: workspace.rootPath).isEmpty)
+
+        let staged = try await fixture.stager().stage(path: source.path, in: workspace)
+        staged.cleanup()
+    }
+
+    private static func permissionBits(_ path: String) -> mode_t? {
+        var info = Darwin.stat()
+        guard lstat(path, &info) == 0 else { return nil }
+        return info.st_mode & mode_t(0o777)
+    }
+
+    private static func transferDirectories(in workspacePath: String) throws -> [String] {
+        try FileManager.default.contentsOfDirectory(atPath: workspacePath)
+            .filter { $0.hasPrefix("upload.") }
+    }
+}
+
+struct UploadStagingFixture {
+    let root: URL
+    let stagingParent: URL
+
+    init() throws {
+        self.root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("peekaboo-upload-stager-tests-\(UUID().uuidString)", isDirectory: true)
+        self.stagingParent = self.root.appendingPathComponent("staging", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: self.stagingParent,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700])
+    }
+
+    func write(name: String, contents: Data) throws -> URL {
+        let url = self.root.appendingPathComponent(name, isDirectory: false)
+        try contents.write(to: url, options: .withoutOverwriting)
+        return url
+    }
+
+    func stager(
+        maximumBytes: Int64 = BrowserMCPUploadStager.maximumFileSize,
+        sourceInspectionHook: @escaping BrowserMCPUploadStager.SourceInspectionHook = { _ in },
+        copyProgressHook: @escaping BrowserMCPUploadStager.CopyProgressHook = { _ in })
+        -> BrowserMCPUploadStager
+    {
+        BrowserMCPUploadStager(
+            temporaryDirectory: self.stagingParent.path,
+            maximumBytes: maximumBytes,
+            sourceInspectionHook: sourceInspectionHook,
+            copyProgressHook: copyProgressHook)
+    }
+
+    func cleanup() {
+        try? FileManager.default.removeItem(at: self.root)
+    }
+}
+
+private final class LockedFlag: @unchecked Sendable {
+    private let lock = NSLock()
+    private var available = true
+
+    func take() -> Bool {
+        self.lock.withLock {
+            defer { self.available = false }
+            return self.available
+        }
+    }
+}
+
+private final class UploadCopyBarrier: @unchecked Sendable {
+    private let lock = NSLock()
+    private let blockedSignal = DispatchSemaphore(value: 0)
+    private let releaseSignal = DispatchSemaphore(value: 0)
+    private var shouldBlock = true
+
+    func blockOnce() {
+        let block = self.lock.withLock {
+            defer { self.shouldBlock = false }
+            return self.shouldBlock
+        }
+        guard block else { return }
+        self.blockedSignal.signal()
+        self.releaseSignal.wait()
+    }
+
+    func waitUntilBlocked() async -> Bool {
+        await withCheckedContinuation { continuation in
+            DispatchQueue.global().async {
+                continuation.resume(returning: self.blockedSignal.wait(timeout: .now() + 2) == .success)
+            }
+        }
+    }
+
+    func release() {
+        self.releaseSignal.signal()
+    }
+}

--- a/Core/PeekabooCore/Tests/PeekabooAgentRuntimeTests/BrowserToolTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooAgentRuntimeTests/BrowserToolTests.swift
@@ -118,6 +118,70 @@ struct BrowserToolTests {
         #expect(foregroundPage.arguments["background"] as? Bool == false)
     }
 
+    @Test(arguments: [
+        BrowserAction.click,
+        .fill,
+        .drag,
+        .hover,
+        .uploadFile,
+        .screenshot,
+    ])
+    func `Browser mapper forwards every declared page selector`(action: BrowserAction) throws {
+        let raw: [String: Any] = switch action {
+        case .click:
+            ["page_id": 17, "uid": "17_1", "double": true, "include_snapshot": true]
+        case .fill:
+            ["page_id": 17, "uid": "17_2", "value": "value", "include_snapshot": true]
+        case .drag:
+            ["page_id": 17, "uid": "17_3", "to_uid": "17_4", "include_snapshot": true]
+        case .hover:
+            ["page_id": 17, "uid": "17_5", "include_snapshot": true]
+        case .uploadFile:
+            ["page_id": 17, "uid": "17_6", "path": "/tmp/fixture", "include_snapshot": true]
+        case .screenshot:
+            ["page_id": 17, "uid": "17_7", "path": "/tmp/fixture.png"]
+        default:
+            [:]
+        }
+
+        let call = try BrowserMCPCallMapper.map(action: action, arguments: ToolArguments(raw: raw))
+        #expect(call.arguments["pageId"] as? Int == 17)
+        #expect(call.arguments["uid"] as? String == raw["uid"] as? String || action == .drag)
+        if action == .drag {
+            #expect(call.arguments["from_uid"] as? String == "17_3")
+            #expect(call.arguments["to_uid"] as? String == "17_4")
+        }
+        if action == .fill {
+            #expect(call.arguments["value"] as? String == "value")
+        }
+        if action == .uploadFile {
+            #expect(call.arguments["filePath"] as? String == "/tmp/fixture")
+        }
+    }
+
+    @Test(arguments: [BrowserAction.type, .pressKey])
+    func `Browser keyboard actions require exact uid and map atomic focus sequence`(action: BrowserAction) throws {
+        let raw: [String: Any] = action == .type
+            ? ["page_id": 21, "uid": "21_8", "text": "typed", "submit_key": "Tab"]
+            : ["page_id": 21, "uid": "21_8", "key": "Enter", "include_snapshot": true]
+        let calls = try BrowserMCPCallMapper.mapSequence(action: action, arguments: ToolArguments(raw: raw))
+
+        #expect(calls.count == 2)
+        #expect(calls[0].toolName == "click")
+        #expect(calls[0].arguments["uid"] as? String == "21_8")
+        #expect(calls[0].arguments["pageId"] as? Int == 21)
+        #expect(calls[1].toolName == (action == .type ? "type_text" : "press_key"))
+        #expect(calls[1].arguments["pageId"] as? Int == 21)
+
+        #expect(throws: (any Error).self) {
+            _ = try BrowserMCPCallMapper.mapSequence(
+                action: action,
+                arguments: ToolArguments(raw: action == .type
+                    ? ["page_id": 21, "text": "typed"]
+                    : ["page_id": 21, "key": "Enter"]))
+        }
+    }
+
     @Test
     func `Browser call mapper preserves MCP-decoded data URLs`() throws {
         let encodedURL: Value = .data(mimeType: "text/html", Data("ALPHA_CONTENT".utf8))
@@ -189,6 +253,79 @@ struct BrowserToolTests {
         #expect(client.executedTools.last?.arguments["pageId"] as? Int == 4)
         #expect(client.executedTools.last?.arguments["uid"] as? String == "7_1")
         #expect(client.executedTools.last?.channel == nil)
+    }
+
+    @Test
+    func `Browser tool sends targeted type as one client-owned sequence`() async throws {
+        let client = MockBrowserMCPClient(status: BrowserMCPStatus(
+            isConnected: true,
+            toolCount: 29,
+            detectedBrowsers: []))
+        let tool = BrowserTool(client: client)
+
+        let response = try await tool.execute(arguments: ToolArguments(raw: [
+            "action": "type",
+            "page_id": 7,
+            "uid": "7_9",
+            "text": "typed",
+        ]))
+
+        #expect(!response.isError)
+        #expect(client.executedSequences.count == 1)
+        #expect(client.executedSequences[0].map(\.toolName) == ["click", "type_text"])
+        #expect(client.executedSequences[0][0].arguments["uid"] as? String == "7_9")
+    }
+
+    @Test
+    func `Browser tool forwards exact endpoint and reports connection receipt`() async throws {
+        let receipt = BrowserMCPConnectionReceipt(
+            browserURL: "http://127.0.0.1:9222/",
+            webSocketDebuggerURL: "ws://127.0.0.1:9222/devtools/browser/browser-a",
+            devToolsBrowserID: "browser-a",
+            browserVersion: "Chrome/151.0",
+            protocolVersion: "1.3")
+        let client = MockBrowserMCPClient(status: BrowserMCPStatus(
+            isConnected: true,
+            toolCount: 29,
+            detectedBrowsers: [],
+            connectionReceipt: receipt))
+        let tool = BrowserTool(client: client)
+
+        let response = try await tool.execute(arguments: ToolArguments(raw: [
+            "action": "connect",
+            "browser_url": "http://127.0.0.1:9222",
+        ]))
+
+        #expect(!response.isError)
+        #expect(client.connectedBrowserURLs == ["http://127.0.0.1:9222"])
+        #expect(Self.text(from: response).contains("browser_id=browser-a"))
+        guard case let .object(meta) = response.meta else {
+            Issue.record("Expected browser status metadata")
+            return
+        }
+        guard case let .object(receiptMeta) = meta["connection_receipt"] else {
+            Issue.record("Expected exact connection receipt")
+            return
+        }
+        #expect(receiptMeta["browser_id"] == .string("browser-a"))
+    }
+
+    @Test
+    func `Browser tool rejects endpoint on non-connect action`() async throws {
+        let client = MockBrowserMCPClient(status: BrowserMCPStatus(
+            isConnected: false,
+            toolCount: 0,
+            detectedBrowsers: []))
+        let tool = BrowserTool(client: client)
+
+        let response = try await tool.execute(arguments: ToolArguments(raw: [
+            "action": "list_pages",
+            "browser_url": "http://127.0.0.1:9222",
+        ]))
+
+        #expect(response.isError)
+        #expect(Self.text(from: response) == "browser_url is accepted only by the connect action")
+        #expect(client.executedTools.isEmpty)
     }
 
     @Test
@@ -427,8 +564,10 @@ private final class MockBrowserMCPClient: BrowserMCPClientProviding, @unchecked 
 
     var status: BrowserMCPStatus
     var connectedChannels: [BrowserMCPChannel?] = []
+    var connectedBrowserURLs: [String?] = []
     var disconnected = false
     var executedTools: [ExecutedTool] = []
+    var executedSequences: [[ExecutedTool]] = []
 
     init(status: BrowserMCPStatus) {
         self.status = status
@@ -443,6 +582,12 @@ private final class MockBrowserMCPClient: BrowserMCPClientProviding, @unchecked 
         return self.status
     }
 
+    func connect(channel: BrowserMCPChannel?, browserURL: String?) async throws -> BrowserMCPStatus {
+        self.connectedChannels.append(channel)
+        self.connectedBrowserURLs.append(browserURL)
+        return self.status
+    }
+
     func disconnect() async {
         self.disconnected = true
     }
@@ -454,5 +599,17 @@ private final class MockBrowserMCPClient: BrowserMCPClientProviding, @unchecked 
     {
         self.executedTools.append(ExecutedTool(toolName: toolName, arguments: arguments, channel: channel))
         return ToolResponse.text("called \(toolName)")
+    }
+
+    func executeSequence(
+        _ calls: [BrowserMCPMappedCall],
+        channel: BrowserMCPChannel?) async throws -> ToolResponse
+    {
+        let sequence = calls.map { call in
+            ExecutedTool(toolName: call.toolName, arguments: call.arguments, channel: channel)
+        }
+        self.executedSequences.append(sequence)
+        self.executedTools.append(contentsOf: sequence)
+        return ToolResponse.text("called \(calls.last?.toolName ?? "none")")
     }
 }

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeActionOutcomeProjectionTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeActionOutcomeProjectionTests.swift
@@ -565,8 +565,8 @@ struct PeekabooBridgeActionOutcomeProjectionTests {
     }
 
     @Test
-    func `current protocol 1 25 preserves projection capability introduced at 1 23`() {
-        let currentVersion = PeekabooBridgeProtocolVersion(major: 1, minor: 25)
+    func `current protocol 1 26 preserves projection capability introduced at 1 23`() {
+        let currentVersion = PeekabooBridgeProtocolVersion(major: 1, minor: 26)
         let projectionVersion = PeekabooBridgeProtocolVersion(major: 1, minor: 23)
 
         #expect(PeekabooBridgeConstants.protocolVersion == currentVersion)

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeBrowserClientTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeBrowserClientTests.swift
@@ -1,0 +1,39 @@
+import PeekabooBridgeTestSupport
+import Testing
+@testable import PeekabooBridge
+
+struct PeekabooBridgeBrowserClientTests {
+    @Test(arguments: ["status", "connect", "execute"])
+    func `browser client preserves structured Bridge errors`(operation: String) async throws {
+        let expected = PeekabooBridgeErrorEnvelope(
+            code: .operationNotSupported,
+            message: "browser backend unavailable",
+            details: "npx is not available to this host")
+        let peer = try ScriptedBridgePeer(steps: [.respond(.error(expected))])
+        let client = PeekabooBridgeClient(socketPath: peer.socketPath, requestTimeoutSec: 1)
+
+        do {
+            switch operation {
+            case "status":
+                _ = try await client.browserStatus(channel: "stable")
+            case "connect":
+                _ = try await client.browserConnect(
+                    channel: "stable",
+                    browserURL: "http://127.0.0.1:9222")
+            case "execute":
+                _ = try await client.browserExecute(.init(
+                    toolName: "list_pages",
+                    arguments: [:],
+                    channel: "stable"))
+            default:
+                Issue.record("Unknown test operation")
+            }
+            Issue.record("Expected the structured browser error")
+        } catch let envelope as PeekabooBridgeErrorEnvelope {
+            #expect(envelope.code == expected.code)
+            #expect(envelope.message == expected.message)
+            #expect(envelope.details == expected.details)
+        }
+        await peer.waitUntilFinished()
+    }
+}

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeCapabilityTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeCapabilityTests.swift
@@ -222,6 +222,60 @@ struct PeekabooBridgeCapabilityTests {
         #expect(requests == [request])
     }
 
+    @Test
+    func `current daemon advertises exact browser connection receipts`() async throws {
+        let browserOperations: Set<PeekabooBridgeOperation> = [
+            .browserStatus,
+            .browserConnect,
+            .browserDisconnect,
+            .browserExecute,
+        ]
+        let legacyVersion = PeekabooBridgeProtocolVersion(major: 1, minor: 25)
+        let legacyRange = PeekabooBridgeConstants.minimumProtocolVersion...legacyVersion
+        let current = await MainActor.run {
+            PeekabooBridgeServer(
+                services: StubServices(),
+                hostKind: .onDemand,
+                allowlistedTeams: [],
+                allowlistedBundles: [],
+                allowedOperations: browserOperations)
+        }
+        let legacy = await MainActor.run {
+            PeekabooBridgeServer(
+                services: StubServices(),
+                hostKind: .onDemand,
+                allowlistedTeams: [],
+                allowlistedBundles: [],
+                supportedVersions: legacyRange,
+                allowedOperations: browserOperations)
+        }
+
+        let currentHandshake = try await self.handshake(server: current, hostKind: .onDemand)
+        #expect(currentHandshake.hostCapabilities?.contains(
+            PeekabooBridgeHostCapability.browserConnectionReceipts) == true)
+
+        let legacyRequest = PeekabooBridgeRequest.handshake(.init(
+            protocolVersion: PeekabooBridgeProtocolVersion(major: 1, minor: 25),
+            client: .init(
+                bundleIdentifier: "dev.peeka.legacy-browser",
+                teamIdentifier: "TEAMID",
+                processIdentifier: getpid(),
+                hostname: Host.current().name),
+            requestedHostKind: .onDemand))
+        let legacyData = try await legacy.decodeAndHandle(
+            JSONEncoder.peekabooBridgeEncoder().encode(legacyRequest),
+            peer: nil)
+        let legacyResponse = try JSONDecoder.peekabooBridgeDecoder().decode(
+            PeekabooBridgeResponse.self,
+            from: legacyData)
+        guard case let .handshake(legacyHandshake) = legacyResponse else {
+            Issue.record("Expected legacy handshake")
+            return
+        }
+        #expect(legacyHandshake.hostCapabilities?.contains(
+            PeekabooBridgeHostCapability.browserConnectionReceipts) != true)
+    }
+
     private func handshake(
         server: PeekabooBridgeServer,
         hostKind: PeekabooBridgeHostKind) async throws -> PeekabooBridgeHandshakeResponse

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeOperationRoutingTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeOperationRoutingTests.swift
@@ -146,7 +146,7 @@ struct PeekabooBridgeOperationRoutingTests {
             services: services,
             allowlistedTeams: [],
             allowlistedBundles: [],
-            allowedOperations: [.browserStatus, .browserExecute])
+            allowedOperations: [.browserStatus, .browserConnect, .browserExecute])
 
         let statusRequest = PeekabooBridgeRequest.browserStatus(.init(channel: "stable"))
         let statusData = try JSONEncoder.peekabooBridgeEncoder().encode(statusRequest)
@@ -159,6 +159,20 @@ struct PeekabooBridgeOperationRoutingTests {
         #expect(status.isConnected)
         #expect(status.toolCount == 1)
         #expect(services.lastBrowserStatusChannel == "stable")
+        #expect(status.connectionReceipt?.processIdentifier == 42)
+        #expect(status.connectionReceipt?.processStartIdentityDecimal == "10042")
+
+        let connectRequest = PeekabooBridgeRequest.browserConnect(.init(
+            channel: "stable",
+            browserURL: "http://127.0.0.1:9222"))
+        let connectData = try JSONEncoder.peekabooBridgeEncoder().encode(connectRequest)
+        let connectResponse = try await self.decode(server.decodeAndHandle(connectData, peer: nil))
+        guard case .browserStatus = connectResponse else {
+            Issue.record("Expected browserStatus connect response, got \(connectResponse)")
+            return
+        }
+        #expect(services.lastBrowserConnectTarget?.channel == "stable")
+        #expect(services.lastBrowserConnectTarget?.browserURL == "http://127.0.0.1:9222")
 
         let executeRequest = PeekabooBridgeRequest.browserExecute(.init(
             toolName: "list_pages",
@@ -174,6 +188,14 @@ struct PeekabooBridgeOperationRoutingTests {
         #expect(toolResponse.isError == false)
         #expect(services.lastBrowserExecute?.toolName == "list_pages")
         #expect(services.lastBrowserExecute?.channel == "canary")
+
+        let sequenceRequest = PeekabooBridgeRequest.browserExecute(.init(calls: [
+            .init(toolName: "click", arguments: ["uid": .string("2_1")]),
+            .init(toolName: "type_text", arguments: ["text": .string("value")]),
+        ], channel: "stable"))
+        let sequenceData = try JSONEncoder.peekabooBridgeEncoder().encode(sequenceRequest)
+        _ = try await self.decode(server.decodeAndHandle(sequenceData, peer: nil))
+        #expect(services.lastBrowserExecute?.resolvedCalls.map(\.toolName) == ["click", "type_text"])
     }
 
     private static func mutatingObservationRequest(snapshotID: String) -> DesktopObservationRequest {

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeTests.swift
@@ -1859,6 +1859,7 @@ final class StubServices: PeekabooBridgeServiceProviding {
     let desktopObservation: any DesktopObservationServiceProtocol
     let permissions: PermissionsService = .init()
     var lastBrowserStatusChannel: String?
+    var lastBrowserConnectTarget: (channel: String?, browserURL: String?)?
     var lastBrowserExecute: PeekabooBridgeBrowserExecuteRequest?
 
     init(
@@ -1889,7 +1890,18 @@ final class StubServices: PeekabooBridgeServiceProviding {
                     processIdentifier: 42,
                     version: "144.0",
                     channel: "stable"),
-            ])
+            ],
+            connectionReceipt: PeekabooBridgeBrowserConnectionReceipt(
+                channel: "stable",
+                processIdentifier: 42,
+                processStartIdentity: 10042,
+                bundleIdentifier: "com.google.Chrome",
+                browserVersion: "144.0"))
+    }
+
+    func browserConnect(channel: String?, browserURL: String?) async throws -> PeekabooBridgeBrowserStatus {
+        self.lastBrowserConnectTarget = (channel, browserURL)
+        return try await self.browserStatus(channel: channel)
     }
 
     func browserExecute(_ request: PeekabooBridgeBrowserExecuteRequest) async throws

--- a/docs/bridge-host.md
+++ b/docs/bridge-host.md
@@ -132,6 +132,8 @@ Protocol `1.3` adds element action operations:
 - `performAction` for named accessibility action invocation.
 
 Protocol `1.4` adds browser MCP operations for persistent Chrome DevTools MCP sessions.
+Protocol `1.26` makes those sessions fail closed: connection success requires a read-only page probe and an exact
+process-generation or loopback DevTools-browser receipt, and later calls cannot silently rediscover another profile.
 
 Protocol `1.5` adds `desktopObservation`, used by daemon-backed `image` and `see` paths. The host performs target resolution, capture, optional detection, and file writes, then returns lightweight metadata instead of embedding screenshot bytes in the Bridge response.
 

--- a/docs/browser-mcp.md
+++ b/docs/browser-mcp.md
@@ -51,7 +51,25 @@ For deterministic local tests or custom Chrome endpoints:
 - `PEEKABOO_BROWSER_MCP_HEADLESS=1` makes that launched browser headless.
 - `PEEKABOO_BROWSER_MCP_BROWSER_URL=http://127.0.0.1:9222` connects to an explicit debuggable Chrome endpoint instead of auto-connect.
 
+The CLI exposes the safer request-carried equivalent:
+
+```bash
+peekaboo browser connect --browser-url http://127.0.0.1:9222 --json
+```
+
+Only loopback HTTP endpoints are accepted. Peekaboo resolves `/json/version`, pins the returned browser WebSocket
+identity, probes `list_pages` before reporting connected, and revalidates that identity before every later tool call.
+When multiple Chrome processes share one channel, channel-only connection refuses and requires this exact endpoint.
+
 The tool can expose page content, cookies/session-backed data visible to the page, console messages, network requests, screenshots, and traces to the active agent/MCP client. Do not enable it for browser profiles containing sensitive data unless that exposure is acceptable.
+
+Browser uploads are host-owned. Peekaboo gives each Chrome DevTools MCP child one private owner-only temporary root and
+does not pass `--allowUnrestrictedPaths`. Every mapped or raw `upload_file` call is intercepted before dispatch: the
+source must be an absolute, current-user-owned regular file no larger than 100 MiB, opened without following a final
+symlink, and copied from that checked descriptor into a read-only transfer directory under the child root. The copy is
+kept for the exact browser session because Chrome can read an attached file after the upload tool returns; it is removed
+only after the MCP child terminates on disconnect, connection loss, endpoint drift, or cancellation. External upload
+authorization remains the caller's responsibility.
 
 ## Persistence
 
@@ -60,7 +78,14 @@ Browser MCP state is owned by `BrowserMCPService` through `BrowserMCPSessionMana
 - In a local MCP process, the browser tool uses the `BrowserMCPService` from `MCPToolContext`.
 - In daemon-backed mode, `RemotePeekabooServices` forwards browser status/connect/execute calls over the Bridge socket.
 - The daemon owns the `chrome-devtools-mcp` child process and per-page snapshot UID state.
-- Browser page actions auto-connect through the same session manager. If a call names a different Chrome channel than the active session, the manager reconnects to that channel before forwarding the action.
+- Separate CLI invocations require the same current-build reusable daemon. Peekaboo.app and older Bridge hosts are not
+  eligible for browser session routing because they cannot attest the exact persistent connection receipt.
+- A first page action may connect only when exactly one process exists for the selected channel. Once connected, the
+  channel/process generation or explicit DevTools identity remains locked until `disconnect`.
+- Child-process loss, PID reuse, endpoint restart, or an attempted retarget fails closed with reconnect guidance. Peekaboo
+  never silently rediscovers another same-channel profile.
+- Active upload cancellation terminates the exact MCP child before deleting its private transfer root; an operation ID
+  prevents delayed cancellation cleanup from terminating a newer browser session.
 - Peekaboo enables Chrome DevTools MCP's page-ID routing. Every page-scoped action requires `page_id` and is
   routed directly to that page instead of relying on the process-global selected page. The upstream MCP server
   serializes calls with its FIFO tool mutex, so concurrent agents cannot redirect one another between selection
@@ -104,6 +129,9 @@ Start page work with `list_pages` or `new_page`, retain the returned page ID, an
 page-scoped action. `select_page` and `new_page` stay in the background by default. Use `bring_to_front: true` or
 `background: false` only when foreground interaction is intentional.
 
+`type` and `press_key` also require a fresh snapshot `uid`. Peekaboo holds one browser execution gate while it
+focuses that exact uid and sends the keyboard operation; concurrent page work cannot interleave between those leaves.
+
 ## Examples
 
 CLI:
@@ -111,6 +139,7 @@ CLI:
 ```bash
 peekaboo browser status --json
 peekaboo browser connect --channel stable
+peekaboo browser connect --browser-url http://127.0.0.1:9222
 peekaboo browser new-page --url https://example.com
 peekaboo browser navigate --page-id 2 --url https://example.com/docs
 peekaboo browser snapshot --page-id 2 --path /tmp/page.txt

--- a/docs/commands/browser.md
+++ b/docs/commands/browser.md
@@ -14,8 +14,23 @@ The action is positional and defaults to `status`.
 ```bash
 peekaboo browser status --json
 peekaboo browser connect --channel stable
+peekaboo browser connect --browser-url http://127.0.0.1:9222
 peekaboo browser new-page --url https://example.com
 peekaboo browser snapshot --page-id 2 --path /tmp/page.txt
 ```
 
 Use `peekaboo browser --help` for the complete action-specific option set. Page-scoped automation should retain the returned page ID and pass `--page-id` on later calls so concurrent browser work cannot redirect it.
+
+Browser state is owned by one current-build reusable daemon across CLI invocations. Channel connection requires exactly
+one running browser process. When more than one process shares a channel, use `--browser-url` with one loopback DevTools
+HTTP endpoint. Connection output includes the exact PID/process generation or DevTools browser identity receipt. If the
+daemon, Chrome generation, or endpoint changes, later calls fail and require an explicit reconnect.
+
+Browser `type` and `press-key` require `--uid` from a fresh snapshot. Peekaboo focuses that exact page element and sends
+the keyboard operation as one daemon-owned sequence rather than inheriting whichever control another caller focused.
+
+`browser upload-file` requires `--page-id`, a fresh file-input `--uid`, and an absolute `--path` to a current-user
+regular file no larger than 100 MiB. Peekaboo never grants Chrome DevTools MCP unrestricted filesystem access. The daemon
+copies the already-open source into its private browser-session temporary root, preserves only the source basename, and
+retains that read-only copy until disconnect so delayed page reads and form submission remain valid. Symlinks,
+directories, special files, traversal paths, ownership changes, and size or identity races fail before browser dispatch.


### PR DESCRIPTION
## Summary

- bind every browser session to one exact Chrome process generation or validated loopback DevTools browser identity, probe `list_pages` before reporting success, and require explicit reconnect after target or child loss
- route browser CLI work through one current-build reusable daemon, carry exact receipts and structured failures over Bridge protocol 1.26, and keep explicit snapshot publication as an additive capability on the shared protocol version
- make page targeting concurrency-safe, including host-owned exact-UID focus plus type/press sequences and batched Bridge calls
- fail browser uploads closed through one private per-session Chrome MCP `TMPDIR`: race-check and stream current-user regular files up to 100 MiB, preserve only the basename, retain delayed-read semantics, and tear down the exact child before cancellation cleanup
- document `--browser-url`, upload policy, persistent session ownership, and reconnect behavior

## Proof

- `pnpm run test:safe`
- `pnpm run lint` (0 serious violations) and `pnpm run lint:docs`
- browser mapper/session/upload suites: 44 tests passed
- Bridge browser client and receipt capability suites: 13 tests passed
- CLI runtime, host selection, and command binding suites: 27 + 39 tests passed
- pinned Chrome DevTools MCP routing contract: 32 page-scoped, 35 page-targeted, 16 global, and 1 blocked selected-page tool
- source-blind disposable-Chrome acceptance on the exact signed head: exact endpoint receipt and 29 tools; background type/press targeting; delayed `FileReader`; real multipart filename/body/hash equality; relative and symlink refusal; wrong/stale-ref refusal; simultaneous cross-page isolation; foreground, clipboard, overlay, source-file, and cleanup invariants all passed
- final structured autoreview: clean, no actionable findings

The source-blind run used only a fresh localhost fixture, private Chrome profile, task-owned daemon/socket, and Foundation-signed CLI. It did not attach to or mutate the user's existing Chrome profile.
