### PR TITLE
fix(cli): validate coordinates before runtime selection

### DIFF
--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Keep normal exact-window Finder `see` usable when the window exposes no semantic AX value, without weakening hard Accessibility-read failures or the typed incomplete-evidence refusal.
 - Refuse exact-window combined `see` results when Accessibility returns no usable elements, including legacy Bridge responses that omit the incomplete-read marker, while preserving the requested raster and explicit `--no-elements` screenshot-only success.
-- Validate `click` and physical-cursor `move` coordinates before runtime-host selection so malformed requests cannot be masked by Bridge availability or trigger unnecessary host startup.
+- Validate request-only `click`, `move`, `type`, and `drag` arguments before runtime-host selection so malformed requests cannot be masked by Bridge availability or trigger unnecessary host startup.
 - Reject unknown and non-object MCP `tools/call` arguments as JSON-RPC invalid params before policy checks or tool dispatch, recursively honoring the closed schemas advertised by `tools/list`.
 - Keep browser CLI calls on one current-build reusable daemon, probe Chrome before reporting connected, require explicit reconnect instead of falling back to another same-channel profile after connection loss, and bind browser typing/key presses to an exact uid in one host-owned sequence.
 - Fail browser uploads closed through a private per-session Chrome MCP temporary root, race-safe regular-file staging, a 100 MiB bound, and child-before-cleanup cancellation without unrestricted path access.

--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Keep normal exact-window Finder `see` usable when the window exposes no semantic AX value, without weakening hard Accessibility-read failures or the typed incomplete-evidence refusal.
 - Refuse exact-window combined `see` results when Accessibility returns no usable elements, including legacy Bridge responses that omit the incomplete-read marker, while preserving the requested raster and explicit `--no-elements` screenshot-only success.
+- Validate `click` and physical-cursor `move` coordinates before runtime-host selection so malformed requests cannot be masked by Bridge availability or trigger unnecessary host startup.
 - Reject unknown and non-object MCP `tools/call` arguments as JSON-RPC invalid params before policy checks or tool dispatch, recursively honoring the closed schemas advertised by `tools/list`.
 - Keep browser CLI calls on one current-build reusable daemon, probe Chrome before reporting connected, require explicit reconnect instead of falling back to another same-channel profile after connection loss, and bind browser typing/key presses to an exact uid in one host-owned sequence.
 - Fail browser uploads closed through a private per-session Chrome MCP temporary root, race-safe regular-file staging, a 100 MiB bound, and child-before-cleanup cancellation without unrestricted path access.

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/ClickCommand+Validation.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/ClickCommand+Validation.swift
@@ -3,7 +3,12 @@ import CoreGraphics
 import Foundation
 import PeekabooCore
 
-extension ClickCommand {
+extension ClickCommand: PreRuntimeValidatingCommand {
+    func validateBeforeRuntime() throws {
+        var command = self
+        try command.validate()
+    }
+
     mutating func validate() throws {
         try self.target.validate()
         self.query = Self.nonEmptyClickSelector(self.query)

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/DragCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/DragCommand.swift
@@ -260,6 +260,13 @@ struct DragCommand: ActionOutputFormattable, ErrorHandlingCommand, OutputFormatt
 
 // MARK: - Conformances
 
+extension DragCommand: PreRuntimeValidatingCommand {
+    func validateBeforeRuntime() throws {
+        var command = self
+        try command.validateInputs()
+    }
+}
+
 @MainActor
 extension DragCommand: ParsableCommand {
     nonisolated(unsafe) static var commandDescription: CommandDescription {

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/MoveCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/MoveCommand.swift
@@ -238,3 +238,10 @@ struct MoveCommand: ActionOutputFormattable, ErrorHandlingCommand, OutputFormatt
         return "\(roleDescription): \(label)"
     }
 }
+
+extension MoveCommand: PreRuntimeValidatingCommand {
+    func validateBeforeRuntime() throws {
+        var command = self
+        try command.validate()
+    }
+}

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/TypeCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/TypeCommand.swift
@@ -405,6 +405,14 @@ extension TypeCommand: CommanderBindableCommand {
 
 // MARK: - Conformances
 
+extension TypeCommand: PreRuntimeValidatingCommand {
+    func validateBeforeRuntime() throws {
+        var command = self
+        try command.validate()
+        _ = try command.buildActions()
+    }
+}
+
 @MainActor
 extension TypeCommand: ParsableCommand {
     nonisolated(unsafe) static var commandDescription: CommandDescription {

--- a/Apps/CLI/Tests/CLIRuntimeTests/BridgeStatusCLITests.swift
+++ b/Apps/CLI/Tests/CLIRuntimeTests/BridgeStatusCLITests.swift
@@ -3,8 +3,32 @@ import Subprocess
 import Testing
 
 struct BridgeStatusCLITests {
-    @Test(arguments: ["click", "move"])
-    func `malformed coordinates fail before explicit Bridge resolution`(command: String) async throws {
+    struct MalformedRequestCase: Sendable {
+        let arguments: [String]
+        let expectedMessage: String
+    }
+
+    @Test(arguments: [
+        MalformedRequestCase(
+            arguments: ["click", "--at", "not-a-coordinate"],
+            expectedMessage: "Invalid coordinates format. Use: x,y"
+        ),
+        MalformedRequestCase(
+            arguments: ["move", "--at", "not-a-coordinate", "--foreground"],
+            expectedMessage: "Invalid coordinates format. Use: x,y"
+        ),
+        MalformedRequestCase(
+            arguments: ["type", "--profile", "human"],
+            expectedMessage: "No input specified. Provide text or use --clear."
+        ),
+        MalformedRequestCase(
+            arguments: [
+                "drag", "--from", "source_id", "--to", "target_id", "--button", "middle", "--foreground",
+            ],
+            expectedMessage: "--button must be either 'left' or 'right'"
+        ),
+    ])
+    func `malformed requests fail before explicit Bridge resolution`(testCase: MalformedRequestCase) async throws {
         guard TestChildProcess.canLocatePeekabooBinary() else {
             Issue.record("Build peekaboo before running CLI runtime tests.")
             return
@@ -12,10 +36,7 @@ struct BridgeStatusCLITests {
 
         let socketPath = FileManager.default.temporaryDirectory
             .appendingPathComponent("peekaboo-missing-bridge-\(UUID().uuidString).sock").path
-        var arguments = [command, "--at", "not-a-coordinate"]
-        if command == "move" {
-            arguments.append("--foreground")
-        }
+        var arguments = testCase.arguments
         arguments += ["--bridge-socket", socketPath, "--json"]
 
         let result = try await TestChildProcess.runPeekaboo(
@@ -33,7 +54,7 @@ struct BridgeStatusCLITests {
         #expect(json["success"] as? Bool == false)
         #expect(json["effect"] as? String == "refused")
         #expect(error["code"] as? String == "VALIDATION_ERROR")
-        #expect(error["message"] as? String == "Invalid coordinates format. Use: x,y")
+        #expect(error["message"] as? String == testCase.expectedMessage)
         #expect(error["mutation_dispatched"] as? Bool == false)
         #expect(error["retry_safe"] as? Bool == true)
         #expect(outcome["dispatch_state"] as? String == "none")

--- a/Apps/CLI/Tests/CLIRuntimeTests/BridgeStatusCLITests.swift
+++ b/Apps/CLI/Tests/CLIRuntimeTests/BridgeStatusCLITests.swift
@@ -3,6 +3,46 @@ import Subprocess
 import Testing
 
 struct BridgeStatusCLITests {
+    @Test(arguments: ["click", "move"])
+    func `malformed coordinates fail before explicit Bridge resolution`(command: String) async throws {
+        guard TestChildProcess.canLocatePeekabooBinary() else {
+            Issue.record("Build peekaboo before running CLI runtime tests.")
+            return
+        }
+
+        let socketPath = FileManager.default.temporaryDirectory
+            .appendingPathComponent("peekaboo-missing-bridge-\(UUID().uuidString).sock").path
+        var arguments = [command, "--at", "not-a-coordinate"]
+        if command == "move" {
+            arguments.append("--foreground")
+        }
+        arguments += ["--bridge-socket", socketPath, "--json"]
+
+        let result = try await TestChildProcess.runPeekaboo(
+            arguments,
+            isolateFromRemoteHosts: false
+        )
+
+        #expect(result.status == .exited(1))
+        #expect(result.standardError.isEmpty)
+
+        let object = try JSONSerialization.jsonObject(with: Data(result.standardOutput.utf8))
+        let json = try #require(object as? [String: Any])
+        let error = try #require(json["error"] as? [String: Any])
+        let outcome = try #require(json["outcome"] as? [String: Any])
+        #expect(json["success"] as? Bool == false)
+        #expect(json["effect"] as? String == "refused")
+        #expect(error["code"] as? String == "VALIDATION_ERROR")
+        #expect(error["message"] as? String == "Invalid coordinates format. Use: x,y")
+        #expect(error["mutation_dispatched"] as? Bool == false)
+        #expect(error["retry_safe"] as? Bool == true)
+        #expect(outcome["dispatch_state"] as? String == "none")
+        #expect(outcome["state"] as? String == "refused")
+        #expect(!result.standardOutput.contains("BRIDGE_UNAVAILABLE"))
+        #expect(!result.standardOutput.contains(socketPath))
+        #expect(!result.standardOutput.contains("Runtime host:"))
+    }
+
     @Test
     func `explicit missing Bridge socket fails without local fallback`() async throws {
         guard TestChildProcess.canLocatePeekabooBinary() else {

--- a/Apps/CLI/Tests/CoreCLITests/PreRuntimeSemanticValidationTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/PreRuntimeSemanticValidationTests.swift
@@ -39,6 +39,17 @@ struct PreRuntimeSemanticValidationTests {
             ],
             expectedMessage: "Invalid coordinates format. Use: x,y"
         ),
+        Case(
+            arguments: ["peekaboo", "type", "--profile", "human", "--no-remote", "--json"],
+            expectedMessage: "No input specified. Provide text or use --clear."
+        ),
+        Case(
+            arguments: [
+                "peekaboo", "drag", "--from", "source_id", "--to", "target_id", "--button", "middle",
+                "--foreground", "--no-remote", "--json",
+            ],
+            expectedMessage: "--button must be either 'left' or 'right'"
+        ),
     ])
     func `request semantics validate through the pre-runtime hook`(_ testCase: Case) throws {
         let resolved = try CommanderRuntimeRouter.resolve(argv: testCase.arguments)
@@ -69,6 +80,22 @@ struct PreRuntimeSemanticValidationTests {
             try validator.validateBeforeRuntime()
         }
         #expect(error?.localizedDescription == "Invalid coordinates format. Use: x,y")
+    }
+
+    @Test
+    func `drag element selectors remain valid before runtime selection`() throws {
+        let resolved = try CommanderRuntimeRouter.resolve(argv: [
+            "peekaboo", "drag", "--from", "row_1", "--to", "row_5", "--foreground", "--json",
+        ])
+        let command = try CommanderCLIBinder.instantiateCommand(
+            type: resolved.type,
+            parsedValues: resolved.parsedValues
+        )
+        let validator = try #require(command as? any PreRuntimeValidatingCommand)
+
+        #expect(throws: Never.self) {
+            try validator.validateBeforeRuntime()
+        }
     }
 
     @Test

--- a/Apps/CLI/Tests/CoreCLITests/PreRuntimeSemanticValidationTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/PreRuntimeSemanticValidationTests.swift
@@ -33,6 +33,12 @@ struct PreRuntimeSemanticValidationTests {
             ],
             expectedMessage: "Invalid direction. Use: up, down, left, or right"
         ),
+        Case(
+            arguments: [
+                "peekaboo", "move", "--at", "not-a-coordinate", "--foreground", "--no-remote", "--json",
+            ],
+            expectedMessage: "Invalid coordinates format. Use: x,y"
+        ),
     ])
     func `request semantics validate through the pre-runtime hook`(_ testCase: Case) throws {
         let resolved = try CommanderRuntimeRouter.resolve(argv: testCase.arguments)
@@ -46,6 +52,23 @@ struct PreRuntimeSemanticValidationTests {
             try validator.validateBeforeRuntime()
         }
         #expect(error?.localizedDescription == testCase.expectedMessage)
+    }
+
+    @Test
+    func `click coordinates validate before runtime selection`() throws {
+        let resolved = try CommanderRuntimeRouter.resolve(argv: [
+            "peekaboo", "click", "--at", "not-a-coordinate", "--json",
+        ])
+        let command = try CommanderCLIBinder.instantiateCommand(
+            type: resolved.type,
+            parsedValues: resolved.parsedValues
+        )
+        let validator = try #require(command as? any PreRuntimeValidatingCommand)
+
+        let error = #expect(throws: PreDispatchActionError.self) {
+            try validator.validateBeforeRuntime()
+        }
+        #expect(error?.localizedDescription == "Invalid coordinates format. Use: x,y")
     }
 
     @Test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 - Refuse exact-window and dialog Accessibility reads when macOS cannot arm their per-element messaging deadline, and surface timeout reset failures instead of continuing unbounded.
 - Treat Finder's role-inapplicable `AXWindow` value failure as sparse descriptor data so normal exact-window combined observations retain usable Accessibility elements, while every other hard AX read and genuinely incomplete window remains fail-closed.
 - Refuse exact-window combined observations when Accessibility returns no usable elements, preserving the requested raster and retry-safe `ACCESSIBILITY_INCOMPLETE` semantics across current and legacy Bridge hosts while explicit screenshot-only capture remains successful.
-- Validate `click` and physical-cursor `move` coordinates before runtime-host selection so malformed requests cannot be masked by Bridge availability or trigger unnecessary host startup.
+- Validate request-only `click`, `move`, `type`, and `drag` arguments before runtime-host selection so malformed requests cannot be masked by Bridge availability or trigger unnecessary host startup.
 - Add Bridge protocol 1.26 explicit-reference-only coordinate receipts for exact-window `see --no-elements`, making the documented background coordinate-click workflow consumable without Accessibility traversal or replacing the prior implicit element snapshot while older hosts fail before receipt allocation.
 - Honor cancellation while draining and reaping MCP ShellTool subprocesses so canceled commands cannot linger behind pipe cleanup. Thanks @SebTardif for #454.
 - Reject unknown and non-object MCP `tools/call` arguments as JSON-RPC invalid params before policy checks or tool dispatch, recursively honoring the closed schemas advertised by `tools/list`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Refuse exact-window and dialog Accessibility reads when macOS cannot arm their per-element messaging deadline, and surface timeout reset failures instead of continuing unbounded.
 - Treat Finder's role-inapplicable `AXWindow` value failure as sparse descriptor data so normal exact-window combined observations retain usable Accessibility elements, while every other hard AX read and genuinely incomplete window remains fail-closed.
 - Refuse exact-window combined observations when Accessibility returns no usable elements, preserving the requested raster and retry-safe `ACCESSIBILITY_INCOMPLETE` semantics across current and legacy Bridge hosts while explicit screenshot-only capture remains successful.
+- Validate `click` and physical-cursor `move` coordinates before runtime-host selection so malformed requests cannot be masked by Bridge availability or trigger unnecessary host startup.
 - Add Bridge protocol 1.26 explicit-reference-only coordinate receipts for exact-window `see --no-elements`, making the documented background coordinate-click workflow consumable without Accessibility traversal or replacing the prior implicit element snapshot while older hosts fail before receipt allocation.
 - Honor cancellation while draining and reaping MCP ShellTool subprocesses so canceled commands cannot linger behind pipe cleanup. Thanks @SebTardif for #454.
 - Reject unknown and non-object MCP `tools/call` arguments as JSON-RPC invalid params before policy checks or tool dispatch, recursively honoring the closed schemas advertised by `tools/list`.


### PR DESCRIPTION
## Summary

- validate `click --at` request grammar before runtime-host selection
- apply the same preflight to physical-cursor `move --at`, which had the identical ordering defect
- preserve the existing command validation as the single owner by validating a copy before runtime creation and validating the executing value defensively inside `run`
- keep malformed requests canonical: refused, retry-safe, and not dispatched, with no Bridge probe, daemon startup, or runtime-host log

## Root cause

`CommanderRuntimeExecutor` runs request-only validation before runtime selection only for commands conforming to `PreRuntimeValidatingCommand`. Click and move validated coordinates inside `run(using:)`, after `CommandRuntime.makeDefaultAsync` had already selected or probed a host.

As a result, this request reported `BRIDGE_UNAVAILABLE` instead of the malformed coordinate:

```bash
peekaboo click --at not-a-coordinate \
  --bridge-socket /tmp/definitely-missing.sock --json
```

Implicit routing eventually returned the coordinate error, but only after selecting/logging a daemon. `move --at` behaved the same when explicit foreground consent was supplied. Drag is intentionally unchanged because a non-coordinate `--from`/`--to` value can be an element ID.

## Proof

- built CLI proof for click and move with missing explicit sockets: both return `VALIDATION_ERROR: Invalid coordinates format. Use: x,y`, `effect=refused`, `dispatch_state=none`, `mutation_dispatched=false`, `retry_safe=true`, empty debug logs, and no socket path or `BRIDGE_UNAVAILABLE`
- focused pre-runtime and child-process suites passed: 8 tests, including both exact missing-socket cases
- `pnpm run format`: clean
- `pnpm run lint`: 0 serious; 22 existing warnings
- `pnpm run test:safe`: release/native-only/SwiftPM/browser/background-certification gates plus 40 Foundation, 918 CLI/Core, and 93 runtime tests passed
- autoreview: clean, no accepted/actionable findings; patch correct at 0.99 confidence

No AppleScript/JXA path is added or used.
