### PR TITLE
fix(cli): make root early-exit flags order independent

### DIFF
--- a/Apps/CLI/Sources/PeekabooCLI/CLI/CommanderRuntimeRouter.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/CLI/CommanderRuntimeRouter.swift
@@ -126,18 +126,18 @@ enum CommanderRuntimeRouter {
         from tokens: [String],
         descriptors: [CommanderCommandDescriptor]
     ) -> [String] {
-        guard !tokens.isEmpty else { return [] }
-        guard tokens.first?.hasPrefix("-") != true else { return [] }
+        let commandTokens = self.droppingLeadingRuntimeOptions(from: tokens)
+        guard !commandTokens.isEmpty else { return [] }
 
-        for length in stride(from: tokens.count, through: 1, by: -1) {
-            let candidate = Array(tokens.prefix(length))
+        for length in stride(from: commandTokens.count, through: 1, by: -1) {
+            let candidate = Array(commandTokens.prefix(length))
             if self.findDescriptor(in: descriptors, matching: candidate) != nil {
                 return candidate
             }
         }
 
-        // Preserve previous behavior for unknown paths: let printHelp throw with the original tokens.
-        return tokens
+        // Preserve previous behavior for unknown paths after discarding only the leading option prefix.
+        return commandTokens
     }
 
     private static func handleRootEarlyExitRequest(
@@ -148,7 +148,7 @@ enum CommanderRuntimeRouter {
         guard let index = searchable.firstIndex(where: { self.isHelpToken($0) || self.isVersionToken($0) }) else {
             return false
         }
-        guard searchable.prefix(index).allSatisfy({ $0.hasPrefix("-") }) else { return false }
+        guard self.containsOnlyLeadingRuntimeOptions(Array(searchable.prefix(index))) else { return false }
 
         let token = searchable[index]
         if self.isHelpToken(token) {
@@ -163,6 +163,52 @@ enum CommanderRuntimeRouter {
             print(Version.fullVersion)
         }
         return true
+    }
+
+    private static let runtimeValueOptionNames: Set<String> = {
+        let signature = CommandSignature().withPeekabooRuntimeFlags().flattened()
+        return Set(signature.options.flatMap { option in
+            option.names.map { Self.commandLineToken(for: $0) }
+        })
+    }()
+
+    private static func commandLineToken(for name: CommanderName) -> String {
+        switch name {
+        case let .short(value), let .aliasShort(value):
+            "-\(value)"
+        case let .long(value), let .aliasLong(value):
+            "--\(value)"
+        }
+    }
+
+    private static func runtimeOptionConsumesFollowingValue(_ token: String) -> Bool {
+        !token.contains("=") && self.runtimeValueOptionNames.contains(token)
+    }
+
+    private static func containsOnlyLeadingRuntimeOptions(_ tokens: [String]) -> Bool {
+        var index = 0
+        while index < tokens.count {
+            let token = tokens[index]
+            guard token.hasPrefix("-") else { return false }
+            index += 1
+            if self.runtimeOptionConsumesFollowingValue(token) {
+                guard index < tokens.count else { return false }
+                index += 1
+            }
+        }
+        return true
+    }
+
+    private static func droppingLeadingRuntimeOptions(from tokens: [String]) -> [String] {
+        var index = 0
+        while index < tokens.count, tokens[index].hasPrefix("-") {
+            let token = tokens[index]
+            index += 1
+            if self.runtimeOptionConsumesFollowingValue(token), index < tokens.count {
+                index += 1
+            }
+        }
+        return Array(tokens.dropFirst(index))
     }
 
     private static func handleBareInvocation(

--- a/Apps/CLI/Sources/PeekabooCLI/CLI/CommanderRuntimeRouter.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/CLI/CommanderRuntimeRouter.swift
@@ -16,7 +16,7 @@ enum CommanderRuntimeRouter {
             self.printRootHelp(descriptors: descriptors)
             throw ExitCode.success
         }
-        if Self.handleVersionRequest(arguments: trimmedArgs) {
+        if Self.handleRootEarlyExitRequest(arguments: trimmedArgs, descriptors: descriptors) {
             throw ExitCode.success
         }
         if let migrationError = CommanderMigrationAdvisor.commandError(for: trimmedArgs) {
@@ -127,6 +127,7 @@ enum CommanderRuntimeRouter {
         descriptors: [CommanderCommandDescriptor]
     ) -> [String] {
         guard !tokens.isEmpty else { return [] }
+        guard tokens.first?.hasPrefix("-") != true else { return [] }
 
         for length in stride(from: tokens.count, through: 1, by: -1) {
             let candidate = Array(tokens.prefix(length))
@@ -139,11 +140,24 @@ enum CommanderRuntimeRouter {
         return tokens
     }
 
-    private static func handleVersionRequest(arguments: [String]) -> Bool {
-        guard let first = arguments.first else { return false }
-        guard self.isVersionToken(first) else { return false }
+    private static func handleRootEarlyExitRequest(
+        arguments: [String],
+        descriptors: [CommanderCommandDescriptor]
+    ) -> Bool {
+        let searchable = Array(arguments.prefix { $0 != "--" })
+        guard let index = searchable.firstIndex(where: { self.isHelpToken($0) || self.isVersionToken($0) }) else {
+            return false
+        }
+        guard searchable.prefix(index).allSatisfy({ $0.hasPrefix("-") }) else { return false }
+
+        let token = searchable[index]
+        if self.isHelpToken(token) {
+            self.printRootHelp(descriptors: descriptors)
+            return true
+        }
+
         let jsonTokens = Set(["--json", "-j", "--json-output", "--jsonOutput"])
-        if arguments.dropFirst().contains(where: jsonTokens.contains) {
+        if searchable.contains(where: jsonTokens.contains) {
             outputSuccessCodable(data: Version.metadata, logger: .shared)
         } else {
             print(Version.fullVersion)

--- a/Apps/CLI/Tests/CLIRuntimeTests/RootEarlyExitRuntimeTests.swift
+++ b/Apps/CLI/Tests/CLIRuntimeTests/RootEarlyExitRuntimeTests.swift
@@ -41,4 +41,43 @@ struct RootEarlyExitRuntimeTests {
         #expect(result.standardOutput.contains("Usage"))
         #expect(result.standardOutput.contains("Global Runtime Flags"))
     }
+
+    @Test(arguments: [
+        ["--log-level", "debug", "--version"],
+        ["--logLevel=debug", "-V"],
+        ["--bridge-socket", "/tmp/peekaboo-root-help-missing.sock", "--version"],
+        ["--input-strategy", "actionOnly", "--version"],
+    ])
+    func `root version consumes documented runtime option values`(arguments: [String]) async throws {
+        guard TestChildProcess.canLocatePeekabooBinary() else {
+            Issue.record("Build peekaboo before running CLI runtime tests.")
+            return
+        }
+
+        let result = try await TestChildProcess.runPeekaboo(arguments, isolateFromRemoteHosts: false)
+
+        #expect(result.status == .exited(0))
+        #expect(result.standardError.isEmpty)
+        #expect(result.standardOutput.hasPrefix("Peekaboo "))
+        #expect(!result.standardOutput.contains("Bridge"))
+    }
+
+    @Test(arguments: [
+        ["--junk", "click", "--help"],
+        ["--unknown=1", "app", "list", "--help"],
+    ])
+    func `option-leading command help stays command scoped`(arguments: [String]) async throws {
+        guard TestChildProcess.canLocatePeekabooBinary() else {
+            Issue.record("Build peekaboo before running CLI runtime tests.")
+            return
+        }
+
+        let result = try await TestChildProcess.runPeekaboo(arguments, isolateFromRemoteHosts: false)
+
+        #expect(result.status == .exited(0))
+        #expect(result.standardError.isEmpty)
+        #expect(result.standardOutput
+            .contains("Usage\n  peekaboo \(arguments.contains("click") ? "click" : "app list")"))
+        #expect(!result.standardOutput.contains("Core Commands"))
+    }
 }

--- a/Apps/CLI/Tests/CLIRuntimeTests/RootEarlyExitRuntimeTests.swift
+++ b/Apps/CLI/Tests/CLIRuntimeTests/RootEarlyExitRuntimeTests.swift
@@ -1,0 +1,44 @@
+import Foundation
+import Subprocess
+import Testing
+
+struct RootEarlyExitRuntimeTests {
+    @Test
+    func `root version after JSON flag emits the version envelope`() async throws {
+        guard TestChildProcess.canLocatePeekabooBinary() else {
+            Issue.record("Build peekaboo before running CLI runtime tests.")
+            return
+        }
+
+        let result = try await TestChildProcess.runPeekaboo(
+            ["--json", "--version"],
+            isolateFromRemoteHosts: false
+        )
+
+        #expect(result.status == .exited(0))
+        #expect(result.standardError.isEmpty)
+        let object = try JSONSerialization.jsonObject(with: Data(result.standardOutput.utf8))
+        let json = try #require(object as? [String: Any])
+        let data = try #require(json["data"] as? [String: Any])
+        #expect(json["success"] as? Bool == true)
+        #expect((data["current"] as? String)?.hasPrefix("Peekaboo ") == true)
+    }
+
+    @Test(arguments: ["--help", "-h"])
+    func `root help ignores an earlier unknown root option`(helpFlag: String) async throws {
+        guard TestChildProcess.canLocatePeekabooBinary() else {
+            Issue.record("Build peekaboo before running CLI runtime tests.")
+            return
+        }
+
+        let result = try await TestChildProcess.runPeekaboo(
+            ["--junk", helpFlag],
+            isolateFromRemoteHosts: false
+        )
+
+        #expect(result.status == .exited(0))
+        #expect(result.standardError.isEmpty)
+        #expect(result.standardOutput.contains("Usage"))
+        #expect(result.standardOutput.contains("Global Runtime Flags"))
+    }
+}

--- a/Apps/CLI/Tests/CoreCLITests/CommanderRuntimeRouterHelpPathTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/CommanderRuntimeRouterHelpPathTests.swift
@@ -12,6 +12,10 @@ struct CommanderRuntimeRouterHelpPathTests {
         ["peekaboo", "--junk", "--version"],
         ["peekaboo", "--junk", "-V"],
         ["peekaboo", "--json", "--version"],
+        ["peekaboo", "--log-level", "debug", "--version"],
+        ["peekaboo", "--logLevel=debug", "-V"],
+        ["peekaboo", "--bridge-socket", "/tmp/missing.sock", "--help"],
+        ["peekaboo", "--input-strategy", "actionOnly", "-h"],
     ])
     func `root early-exit flags ignore preceding root options`(arguments: [String]) {
         let exitCode = #expect(throws: ExitCode.self) {
@@ -32,6 +36,17 @@ struct CommanderRuntimeRouterHelpPathTests {
     func `help ignores option-like trailing tokens`() {
         let exitCode = #expect(throws: ExitCode.self) {
             _ = try CommanderRuntimeRouter.resolve(argv: ["peekaboo", "help", "app", "quit", "--pid", "123"])
+        }
+        #expect(exitCode == .success)
+    }
+
+    @Test(arguments: [
+        ["peekaboo", "--junk", "click", "--help"],
+        ["peekaboo", "--unknown=1", "app", "list", "--help"],
+    ])
+    func `option-leading command help retains the command path`(arguments: [String]) {
+        let exitCode = #expect(throws: ExitCode.self) {
+            _ = try CommanderRuntimeRouter.resolve(argv: arguments)
         }
         #expect(exitCode == .success)
     }

--- a/Apps/CLI/Tests/CoreCLITests/CommanderRuntimeRouterHelpPathTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/CommanderRuntimeRouterHelpPathTests.swift
@@ -4,6 +4,22 @@ import Testing
 
 @MainActor
 struct CommanderRuntimeRouterHelpPathTests {
+    @Test(arguments: [
+        ["peekaboo", "--junk", "--help"],
+        ["peekaboo", "--junk", "-h"],
+        ["peekaboo", "--json", "--help"],
+        ["peekaboo", "help", "--junk"],
+        ["peekaboo", "--junk", "--version"],
+        ["peekaboo", "--junk", "-V"],
+        ["peekaboo", "--json", "--version"],
+    ])
+    func `root early-exit flags ignore preceding root options`(arguments: [String]) {
+        let exitCode = #expect(throws: ExitCode.self) {
+            _ = try CommanderRuntimeRouter.resolve(argv: arguments)
+        }
+        #expect(exitCode == .success)
+    }
+
     @Test
     func `help resolves longest matching command prefix`() {
         let exitCode = #expect(throws: ExitCode.self) {
@@ -29,5 +45,37 @@ struct CommanderRuntimeRouterHelpPathTests {
         #expect(ObjectIdentifier(resolved.type) == ObjectIdentifier(CaptureActionCommand.self))
         #expect(resolved.parsedValues.positional == ["/bin/echo", "--help"])
         #expect(resolved.parsedValues.options["command"] == nil)
+    }
+
+    @Test
+    func `unknown positional help target remains an error`() {
+        let error = #expect(throws: CommanderProgramError.self) {
+            _ = try CommanderRuntimeRouter.resolve(argv: ["peekaboo", "does-not-exist", "--help"])
+        }
+        #expect(error == .unknownCommand("does-not-exist"))
+    }
+
+    @Test
+    func `early-exit flags after double dash remain ordinary arguments`() {
+        do {
+            _ = try CommanderRuntimeRouter.resolve(argv: ["peekaboo", "--junk", "--", "--help"])
+            Issue.record("Expected an argument error")
+        } catch let exitCode as ExitCode {
+            #expect(exitCode != .success)
+        } catch {
+            // Any ordinary parser error proves the root help short-circuit did not run.
+        }
+    }
+
+    @Test
+    func `leaf version remains an option error`() {
+        do {
+            _ = try CommanderRuntimeRouter.resolve(argv: ["peekaboo", "click", "--version"])
+            Issue.record("Expected an option error")
+        } catch let exitCode as ExitCode {
+            #expect(exitCode != .success)
+        } catch {
+            // Expected: version is a root early-exit flag, not a leaf command option.
+        }
     }
 }


### PR DESCRIPTION
## Summary

- make root help/version early exits independent of preceding root-option order
- consume canonical value-taking runtime options before help/version, including separate and `--name=value` forms
- preserve command-scoped help after unknown option prefixes instead of silently printing root help
- keep positional commands, removed-command migration guidance, leaf `--version`, and the `--` sentinel unchanged
- make `peekaboo --json --version` and valued JSON forms emit the normal version envelope

## Root cause

The router recognized version only when it was the first argument. Help searched anywhere, but treated a leading option as an empty root path. The first repair also treated every non-dash token as a positional command, including values belonging to `--log-level`, `--bridge-socket`, and `--input-strategy`.

The router now derives value-taking runtime option spellings from the canonical Commander signature. A bounded scan consumes only that option prefix before root help/version, never crosses `--`, and stops at a real positional command. Command-help resolution discards only the leading option prefix before matching the longest real command path.

## Behavior

These now succeed without selecting or probing a runtime host:

```text
peekaboo --junk --help
peekaboo --log-level debug --version
peekaboo --logLevel=debug -V
peekaboo --bridge-socket /tmp/missing.sock --version
peekaboo --input-strategy actionOnly --help
peekaboo --log-level debug --json --version
```

`peekaboo --junk click --help` and `peekaboo --unknown=1 app list --help` remain command-scoped. Unknown positional commands, tokens after `--`, and leaf `--version` remain errors.

## Proof

- focused router and real child-process suites pass, including valued options, inline aliases, command-scoped help, JSON output, unknown positional commands, leaf version refusal, and sentinel boundaries
- source-blind final validation: 9/9 clauses and all 16 required probes pass; executable SHA-256 `916e1336669d07dc021326928f51b8d129a287df6b9d880d36849c064b151000`
- `pnpm run format`: clean
- `pnpm run lint`: 27 inherited warnings, 0 serious, none introduced in changed files
- `git diff --check`: clean
- structured autoreview: clean, no accepted/actionable finding

Exact-head hosted CI and ClawSweeper re-review are required before merge. No runtime host, desktop operation, or AppleScript/JXA path is involved.
