### PR TITLE
fix(mcp): report invalid press key shapes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,6 @@
 - Treat `capture video` as caller-local media ingestion so valid files and typed media failures bypass Screen Recording and ScreenCaptureKit-owner preflight while live capture remains gated.
 - Refuse exact-window and dialog Accessibility reads when macOS cannot arm their per-element messaging deadline, and surface timeout reset failures instead of continuing unbounded.
 - Treat Finder's role-inapplicable `AXWindow` value failure as sparse descriptor data so normal exact-window combined observations retain usable Accessibility elements, while every other hard AX read and genuinely incomplete window remains fail-closed.
-- Report missing, empty, and malformed MCP `press` key shapes directly instead of inventing a chord named `keys`, while preserving retry-safe zero-dispatch metadata.
 - Refuse exact-window combined observations when Accessibility returns no usable elements, preserving the requested raster and retry-safe `ACCESSIBILITY_INCOMPLETE` semantics across current and legacy Bridge hosts while explicit screenshot-only capture remains successful.
 - Validate request-only `click`, `move`, `type`, and `drag` arguments before runtime-host selection so malformed requests cannot be masked by Bridge availability or trigger unnecessary host startup.
 - Keep concrete interaction snapshots out of ScreenCaptureKit-owner preflight because they cannot refresh or capture, and give omitted/latest snapshot flows an actionable `see --capture-engine classic` recovery.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Treat `capture video` as caller-local media ingestion so valid files and typed media failures bypass Screen Recording and ScreenCaptureKit-owner preflight while live capture remains gated.
 - Refuse exact-window and dialog Accessibility reads when macOS cannot arm their per-element messaging deadline, and surface timeout reset failures instead of continuing unbounded.
 - Treat Finder's role-inapplicable `AXWindow` value failure as sparse descriptor data so normal exact-window combined observations retain usable Accessibility elements, while every other hard AX read and genuinely incomplete window remains fail-closed.
+- Report missing, empty, and malformed MCP `press` key shapes directly instead of inventing a chord named `keys`, while preserving retry-safe zero-dispatch metadata.
 - Refuse exact-window combined observations when Accessibility returns no usable elements, preserving the requested raster and retry-safe `ACCESSIBILITY_INCOMPLETE` semantics across current and legacy Bridge hosts while explicit screenshot-only capture remains successful.
 - Validate request-only `click`, `move`, `type`, and `drag` arguments before runtime-host selection so malformed requests cannot be masked by Bridge availability or trigger unnecessary host startup.
 - Keep concrete interaction snapshots out of ScreenCaptureKit-owner preflight because they cannot refresh or capture, and give omitted/latest snapshot flows an actionable `see --capture-engine classic` recovery.

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/PressTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/PressTool.swift
@@ -330,7 +330,7 @@ public struct PressTool: MCPTool {
     }
 
     static func parseChords(arguments: ToolArguments) throws -> [KeyboardChord] {
-        let sequence = arguments.getStringArray("keys")
+        let sequence = try self.validatedChordSequence(arguments: arguments)
         let key = arguments.getString("key")
         let modifiers = arguments.getStringArray("modifiers") ?? []
 
@@ -338,15 +338,31 @@ public struct PressTool: MCPTool {
             throw KeyboardChordError.invalid("Use either keys or key+modifiers, not both")
         }
         if let sequence {
-            guard !sequence.isEmpty else {
-                throw KeyboardChordError.invalid("keys")
-            }
             return try sequence.map(KeyboardChord.init(parsing:))
         }
         guard let key, !key.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
-            throw KeyboardChordError.invalid("Provide keys or key+modifiers")
+            throw PressToolValidationError(
+                message: "Provide either a non-empty keys array or a non-empty key with optional modifiers")
         }
         return try [KeyboardChord(parsing: (modifiers + [key]).joined(separator: "+"))]
+    }
+
+    private static func validatedChordSequence(arguments: ToolArguments) throws -> [String]? {
+        guard let value = arguments.getValue(for: "keys") else { return nil }
+        guard case let .array(items) = value else {
+            throw PressToolValidationError(message: "keys must be an array of chord strings")
+        }
+        guard !items.isEmpty else {
+            throw PressToolValidationError(message: "keys must contain at least one chord")
+        }
+        return try items.enumerated().map { index, item in
+            guard case let .string(chord) = item,
+                  !chord.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            else {
+                throw PressToolValidationError(message: "keys[\(index)] must be a non-empty chord string")
+            }
+            return chord
+        }
     }
 
     @MainActor

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPKeyboardBackgroundToolTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPKeyboardBackgroundToolTests.swift
@@ -38,6 +38,40 @@ struct MCPKeyboardBackgroundToolTests {
     }
 
     @Test
+    func `Press tool reports empty and malformed input shapes without dispatch`() async throws {
+        let automation = await MainActor.run { MockAutomationService(accessibilityGranted: true) }
+        let context = await MCPToolTestHelpers.makeContext(
+            automation: automation,
+            snapshotOwner: Self.uiSnapshots.owner)
+        let cases: [([String: Any], String)] = [
+            ([:], "Provide either a non-empty keys array or a non-empty key with optional modifiers"),
+            (["keys": []], "keys must contain at least one chord"),
+            (["key": ""], "Provide either a non-empty keys array or a non-empty key with optional modifiers"),
+            (["keys": ""], "keys must be an array of chord strings"),
+            (["keys": [""]], "keys[0] must be a non-empty chord string"),
+        ]
+
+        for (arguments, expectedMessage) in cases {
+            let response = try await PressTool(context: context).execute(arguments: ToolArguments(raw: arguments))
+            #expect(response.isError)
+            guard case let .text(message, _, _)? = response.content.first else {
+                Issue.record("Expected press validation text")
+                continue
+            }
+            #expect(message.contains(expectedMessage))
+            #expect(await MainActor.run { automation.lastHotkeyKeys } == nil)
+            #expect(await MainActor.run { automation.targetedHotkeyCalls.isEmpty })
+            guard case let .object(meta) = response.meta else {
+                Issue.record("Expected press validation metadata")
+                continue
+            }
+            #expect(meta["mutation_dispatched"] == .bool(false))
+            #expect(meta["retry_safe"] == .bool(true))
+            #expect(meta["refusal_reason"] == .string("invalid_request"))
+        }
+    }
+
+    @Test
     func `Keyboard tools reject targetless input instead of injecting globally`() async throws {
         let automation = await MainActor.run { MockAutomationService(accessibilityGranted: true) }
         let context = await MCPToolTestHelpers.makeContext(

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/PeekabooMCPServerTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/PeekabooMCPServerTests.swift
@@ -215,6 +215,33 @@ struct PeekabooMCPServerTests {
 
     @Test
     @MainActor
+    func `press wire reports an empty chord sequence without dispatch`() async throws {
+        let automation = MockAutomationService(accessibilityGranted: true)
+        let context = await MCPToolTestHelpers.makeContext(automation: automation)
+        let session = try await MCPWireSession.connect(context: context)
+
+        do {
+            let request: RequestContext<CallTool.Result> = try await session.client.callTool(
+                name: "press",
+                arguments: ["keys": .array([])])
+            let result = try await request.value
+            #expect(result.isError == true)
+            #expect(result.content.contains { content in
+                guard case let .text(text, _, _) = content else { return false }
+                return text.contains("keys must contain at least one chord")
+            })
+            #expect(automation.lastHotkeyKeys == nil)
+            #expect(automation.targetedHotkeyCalls.isEmpty)
+        } catch {
+            await session.stop()
+            throw error
+        }
+
+        await session.stop()
+    }
+
+    @Test
+    @MainActor
     func `every advertised closed schema rejects unknown properties as invalid params`() async throws {
         let context = await MCPToolTestHelpers.makeContext()
         let session = try await MCPWireSession.connect(context: context)


### PR DESCRIPTION
## Summary

- report missing, empty, non-array, blank, and malformed MCP press key shapes directly
- preserve retry-safe zero-dispatch metadata and avoid keyboard delivery for every validation failure
- keep valid array and single-key forms on the existing explicit-foreground consent boundary
- add direct-tool and tools/call wire regressions; no AppleScript/JXA path is involved

## Root cause

The press tool previously defaulted a missing `keys` argument to the literal chord name `keys`. Empty and wrongly typed arrays also fell through to generic parsing, producing confusing errors that did not identify the request shape. The tool now validates the two intentional schema forms before chord parsing and returns precise indexed errors with conservative refusal metadata.

## Proof

- exact rebased focused run: 36/36 tests across `MCPKeyboardBackgroundToolTests` and `PeekabooMCPServerTests`
- final source-blind MCP stdin/stdout validation: all 6 clauses and anti-cheat probes pass; executable SHA-256 `8f6e2d20f0272b68d4545bbfcc9e77b04c5cb47ecee4f7a7fd92f5ed4ab0985a`
- missing, empty, non-array, empty-string, whitespace-only, and invalid-chord probes all report `mutation_dispatched:false`, `retry_safe:true`, and `refusal_reason:invalid_request`
- valid array and single-key forms reach `foreground_consent_required` without dispatch
- `pnpm run format`: clean
- `pnpm run lint:docs`: clean
- `pnpm run lint`: 29 inherited warnings, 0 serious, none introduced in changed files
- `git diff --check`: clean
- structured autoreview: clean, no accepted/actionable finding

Exact-head hosted CI and ClawSweeper re-review are required before merge.
