### PR TITLE
fix(automation): fail closed on AX timeout setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Build branded release disk images from pinned direct Finder-metadata tooling, preserving the signed and notarized drag-to-Applications layout without GUI automation.
 
 ### Fixed
+- Refuse exact-window and dialog Accessibility reads when macOS cannot arm their per-element messaging deadline, and surface timeout reset failures instead of continuing unbounded.
 - Refuse exact-window combined observations when Accessibility returns no usable elements, preserving the requested raster and retry-safe `ACCESSIBILITY_INCOMPLETE` semantics across current and legacy Bridge hosts while explicit screenshot-only capture remains successful.
 - Add Bridge protocol 1.26 explicit-reference-only coordinate receipts for exact-window `see --no-elements`, making the documented background coordinate-click workflow consumable without Accessibility traversal or replacing the prior implicit element snapshot while older hosts fail before receipt allocation.
 - Honor cancellation while draining and reaping MCP ShellTool subprocesses so canceled commands cannot linger behind pipe cleanup. Thanks @SebTardif for #454.

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/AXChildWindowMessagingTimeout.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/AXChildWindowMessagingTimeout.swift
@@ -7,15 +7,47 @@ import AXorcist
 enum AXChildWindowMessagingTimeout {
     /// Runs a child-window operation only after macOS accepts the per-element deadline.
     ///
-    /// Unlike the compatibility overloads below, this checked path reports timeout setup
-    /// and reset failures so exact-target callers can refuse instead of running unbounded.
+    /// This compatibility owner keeps Peekaboo's versioned SwiftPM package on AXorcist 0.1.6.
+    /// Delete it after an explicitly authorized AXorcist semantic-version release exposes the
+    /// equivalent checked `Element.withMessagingTimeout` scope.
     @MainActor
-    static func performChecked<Result>(
+    static func performChecked<Value>(
         on window: Element,
         timeout: Float,
-        operation: (Element) throws -> Result) throws -> Result
+        operation: (Element) throws -> Value) throws -> Value
     {
-        try window.withMessagingTimeout(timeout, operation: operation)
+        guard AXChildWindowMessagingTimeoutRegistry.begin(window) else {
+            throw AXChildWindowMessagingTimeoutError.nestedScope
+        }
+        defer { AXChildWindowMessagingTimeoutRegistry.end(window) }
+        return try self.performChecked(
+            timeout: timeout,
+            applyTimeout: { AXUIElementSetMessagingTimeout(window.underlyingElement, $0) },
+            operation: { try operation(window) })
+    }
+
+    static func performChecked<Value>(
+        timeout: Float,
+        applyTimeout: (Float) -> AXError,
+        operation: () throws -> Value) throws -> Value
+    {
+        guard timeout.isFinite, timeout > 0 else {
+            throw AXChildWindowMessagingTimeoutError.invalidTimeout
+        }
+
+        let armResult = applyTimeout(timeout)
+        guard armResult == .success else {
+            throw AXChildWindowMessagingTimeoutError.setupFailure(code: armResult.rawValue)
+        }
+
+        let operationResult: Result<Value, any Error> = Result {
+            try operation()
+        }
+        let resetResult = applyTimeout(0)
+        guard resetResult == .success else {
+            throw AXChildWindowMessagingTimeoutError.resetFailure(code: resetResult.rawValue)
+        }
+        return try operationResult.get()
     }
 
     @MainActor
@@ -50,5 +82,38 @@ enum AXChildWindowMessagingTimeout {
         applyTimeout(timeout)
         defer { applyTimeout(0) }
         return try operation()
+    }
+}
+
+enum AXChildWindowMessagingTimeoutError: Error, Equatable, Sendable {
+    case invalidTimeout
+    case nestedScope
+    case setupFailure(code: Int32)
+    case resetFailure(code: Int32)
+}
+
+@MainActor
+private enum AXChildWindowMessagingTimeoutRegistry {
+    private enum Key: Hashable {
+        case systemWide
+        case element(ObjectIdentifier)
+    }
+
+    private static let systemWideElement = AXUIElementCreateSystemWide()
+    private static var activeElements: Set<Key> = []
+
+    static func begin(_ element: Element) -> Bool {
+        self.activeElements.insert(self.key(for: element)).inserted
+    }
+
+    static func end(_ element: Element) {
+        self.activeElements.remove(self.key(for: element))
+    }
+
+    private static func key(for element: Element) -> Key {
+        if CFEqual(element.underlyingElement, self.systemWideElement) {
+            return .systemWide
+        }
+        return .element(ObjectIdentifier(element.underlyingElement))
     }
 }

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/AXChildWindowMessagingTimeout.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/AXChildWindowMessagingTimeout.swift
@@ -5,6 +5,19 @@ import AXorcist
 /// AX messaging timeouts are per element; setting only the owning application does not bound calls
 /// such as `_AXUIElementGetWindow`, attribute reads, or actions on a returned window element.
 enum AXChildWindowMessagingTimeout {
+    /// Runs a child-window operation only after macOS accepts the per-element deadline.
+    ///
+    /// Unlike the compatibility overloads below, this checked path reports timeout setup
+    /// and reset failures so exact-target callers can refuse instead of running unbounded.
+    @MainActor
+    static func performChecked<Result>(
+        on window: Element,
+        timeout: Float,
+        operation: (Element) throws -> Result) throws -> Result
+    {
+        try window.withMessagingTimeout(timeout, operation: operation)
+    }
+
     @MainActor
     static func perform<Result>(
         on window: Element,

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/DialogService+Resolution.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/DialogService+Resolution.swift
@@ -8,13 +8,13 @@ extension DialogService {
         if let appName, !appName.isEmpty {
             self.logger.debug("Resolving dialog with app hint: \(appName)")
         }
-        if let element = try? self.findDialogElement(withTitle: windowTitle, appName: appName) {
+        if let element = try self.findDialogElementIfAvailable(withTitle: windowTitle, appName: appName) {
             return element
         }
 
         if windowTitle != nil {
             await self.ensureDialogVisibility(windowTitle: windowTitle, appName: appName)
-            if let element = try? self.findDialogElement(withTitle: windowTitle, appName: appName) {
+            if let element = try self.findDialogElementIfAvailable(withTitle: windowTitle, appName: appName) {
                 return element
             }
 
@@ -83,7 +83,7 @@ extension DialogService {
         }
 
         let windowSearchTimeout = self.dialogWindowSearchTimeout(title: title, appName: appName)
-        let windows = self.dialogWindowCandidates(in: focusedApp, title: title, appName: appName)
+        let windows = try self.dialogWindowCandidates(in: focusedApp, title: title, appName: appName)
         self.logger.debug("Checking \(windows.count) windows for dialogs")
 
         for window in windows {
@@ -93,7 +93,10 @@ extension DialogService {
         }
 
         if title != nil {
-            if let globalWindows = systemWide.windows() {
+            if let globalWindows = try systemWide.withMessagingTimeout(
+                windowSearchTimeout,
+                operation: { $0.windows() })
+            {
                 for window in globalWindows {
                     if let candidate = self.resolveDialogCandidate(in: window, matching: title) {
                         return candidate
@@ -105,7 +108,9 @@ extension DialogService {
         if self.scansAllApplicationsForDialogs {
             for app in NSWorkspace.shared.runningApplications {
                 let axApp = AXApp(app).element
-                let appWindows = axApp.windowsWithTimeout(timeout: windowSearchTimeout) ?? []
+                let appWindows = try axApp.withMessagingTimeout(
+                    windowSearchTimeout,
+                    operation: { $0.windows() }) ?? []
                 for window in appWindows {
                     if let candidate = self.resolveDialogCandidate(in: window, matching: title) {
                         return candidate
@@ -125,21 +130,29 @@ extension DialogService {
         title != nil || appName != nil ? self.targetedDialogSearchTimeout : self.activeDialogSearchTimeout
     }
 
-    private func dialogWindowCandidates(in app: Element, title: String?, appName: String?) -> [Element] {
+    private func dialogWindowCandidates(in app: Element, title: String?, appName: String?) throws -> [Element] {
         let timeout = self.dialogWindowSearchTimeout(title: title, appName: appName)
 
         // Without a title, an app-scoped command is still looking for the active dialog, not every dialog-like
         // subtree in the app. Checking focused/main windows keeps "no dialog" responses bounded for Electron/Tauri.
         if appName != nil, title == nil {
-            app.setMessagingTimeout(timeout)
-            defer { app.setMessagingTimeout(0) }
-            return [
-                app.focusedWindow(),
-                app.mainWindow(),
-            ].compactMap(\.self)
+            return try app.withMessagingTimeout(timeout) { boundedApp in
+                [
+                    boundedApp.focusedWindow(),
+                    boundedApp.mainWindow(),
+                ].compactMap(\.self)
+            }
         }
 
-        return app.windowsWithTimeout(timeout: timeout) ?? []
+        return try app.withMessagingTimeout(timeout, operation: { $0.windows() }) ?? []
+    }
+
+    private func findDialogElementIfAvailable(withTitle title: String?, appName: String?) throws -> Element? {
+        do {
+            return try self.findDialogElement(withTitle: title, appName: appName)
+        } catch DialogError.noActiveDialog {
+            return nil
+        }
     }
 
     private func dialogIdentifier(for element: Element) -> String {
@@ -162,7 +175,7 @@ extension DialogService {
             self.logger.debug("Resolving dialog with app hint: \(appName)")
         }
 
-        if let element = try? self.findDialogElement(withTitle: windowTitle, appName: appName) {
+        if let element = try self.findDialogElementIfAvailable(withTitle: windowTitle, appName: appName) {
             return (
                 element: element,
                 dialogIdentifier: self.dialogIdentifier(for: element),
@@ -171,7 +184,7 @@ extension DialogService {
 
         if windowTitle != nil {
             await self.ensureDialogVisibility(windowTitle: windowTitle, appName: appName)
-            if let element = try? self.findDialogElement(withTitle: windowTitle, appName: appName) {
+            if let element = try self.findDialogElementIfAvailable(withTitle: windowTitle, appName: appName) {
                 return (
                     element: element,
                     dialogIdentifier: self.dialogIdentifier(for: element),

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/DialogService+Resolution.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/DialogService+Resolution.swift
@@ -93,8 +93,9 @@ extension DialogService {
         }
 
         if title != nil {
-            if let globalWindows = try systemWide.withMessagingTimeout(
-                windowSearchTimeout,
+            if let globalWindows = try AXChildWindowMessagingTimeout.performChecked(
+                on: systemWide,
+                timeout: windowSearchTimeout,
                 operation: { $0.windows() })
             {
                 for window in globalWindows {
@@ -108,8 +109,9 @@ extension DialogService {
         if self.scansAllApplicationsForDialogs {
             for app in NSWorkspace.shared.runningApplications {
                 let axApp = AXApp(app).element
-                let appWindows = try axApp.withMessagingTimeout(
-                    windowSearchTimeout,
+                let appWindows = try AXChildWindowMessagingTimeout.performChecked(
+                    on: axApp,
+                    timeout: windowSearchTimeout,
                     operation: { $0.windows() }) ?? []
                 for window in appWindows {
                     if let candidate = self.resolveDialogCandidate(in: window, matching: title) {
@@ -136,7 +138,7 @@ extension DialogService {
         // Without a title, an app-scoped command is still looking for the active dialog, not every dialog-like
         // subtree in the app. Checking focused/main windows keeps "no dialog" responses bounded for Electron/Tauri.
         if appName != nil, title == nil {
-            return try app.withMessagingTimeout(timeout) { boundedApp in
+            return try AXChildWindowMessagingTimeout.performChecked(on: app, timeout: timeout) { boundedApp in
                 [
                     boundedApp.focusedWindow(),
                     boundedApp.mainWindow(),
@@ -144,7 +146,10 @@ extension DialogService {
             }
         }
 
-        return try app.withMessagingTimeout(timeout, operation: { $0.windows() }) ?? []
+        return try AXChildWindowMessagingTimeout.performChecked(
+            on: app,
+            timeout: timeout,
+            operation: { $0.windows() }) ?? []
     }
 
     private func findDialogElementIfAvailable(withTitle title: String?, appName: String?) throws -> Element? {

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Utilities/WindowIdentityUtilities.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Utilities/WindowIdentityUtilities.swift
@@ -127,7 +127,11 @@ public final class WindowIdentityService {
         messagingTimeout: Float) -> AXWindowHandle?
     {
         let appElement = Element(AXUIElementCreateApplication(app.processIdentifier))
-        guard let windows = try? appElement.withMessagingTimeout(messagingTimeout, operation: { $0.windows() }) else {
+        guard let windows = try? AXChildWindowMessagingTimeout.performChecked(
+            on: appElement,
+            timeout: messagingTimeout,
+            operation: { $0.windows() })
+        else {
             return nil
         }
         for window in windows {
@@ -151,8 +155,9 @@ public final class WindowIdentityService {
     func focusedWindowID(for app: NSRunningApplication, timeout: TimeInterval) -> CGWindowID? {
         guard timeout > 0 else { return nil }
         let axApp = AXApp(app)
-        guard let focusedWindow = try? axApp.element.withMessagingTimeout(
-            Float(timeout),
+        guard let focusedWindow = try? AXChildWindowMessagingTimeout.performChecked(
+            on: axApp.element,
+            timeout: Float(timeout),
             operation: { _ in axApp.focusedWindow() })
         else {
             return nil

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Utilities/WindowIdentityUtilities.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Utilities/WindowIdentityUtilities.swift
@@ -90,7 +90,7 @@ public final class WindowIdentityService {
     // MARK: - CGWindowID Extraction
 
     func getWindowID(from element: Element, messagingTimeout: Float = 0.25) -> CGWindowID? {
-        AXChildWindowMessagingTimeout.perform(
+        try? AXChildWindowMessagingTimeout.performChecked(
             on: element,
             timeout: messagingTimeout)
         { childWindow in
@@ -127,17 +127,17 @@ public final class WindowIdentityService {
         messagingTimeout: Float) -> AXWindowHandle?
     {
         let appElement = Element(AXUIElementCreateApplication(app.processIdentifier))
-        appElement.setMessagingTimeout(messagingTimeout)
-        defer { appElement.setMessagingTimeout(0) }
-        guard let windows = appElement.windows() else { return nil }
+        guard let windows = try? appElement.withMessagingTimeout(messagingTimeout, operation: { $0.windows() }) else {
+            return nil
+        }
         for window in windows {
-            let matches = AXChildWindowMessagingTimeout.perform(
+            let matches = try? AXChildWindowMessagingTimeout.performChecked(
                 on: window,
                 timeout: messagingTimeout)
             { childWindow in
                 self.resolver.windowID(from: childWindow) == windowID
             }
-            if matches {
+            if matches == true {
                 return AXWindowHandle(app: AXApp(app), element: window)
             }
         }
@@ -151,10 +151,13 @@ public final class WindowIdentityService {
     func focusedWindowID(for app: NSRunningApplication, timeout: TimeInterval) -> CGWindowID? {
         guard timeout > 0 else { return nil }
         let axApp = AXApp(app)
-        axApp.element.setMessagingTimeout(Float(timeout))
-        defer { axApp.element.setMessagingTimeout(0) }
-        guard let focusedWindow = axApp.focusedWindow() else { return nil }
-        return AXChildWindowMessagingTimeout.perform(
+        guard let focusedWindow = try? axApp.element.withMessagingTimeout(
+            Float(timeout),
+            operation: { _ in axApp.focusedWindow() })
+        else {
+            return nil
+        }
+        return try? AXChildWindowMessagingTimeout.performChecked(
             on: focusedWindow,
             timeout: Float(timeout))
         { window in
@@ -169,7 +172,7 @@ public final class WindowIdentityService {
 
         // Compute AX identifier lazily.
         let axIdentifier: String? = if let handle = self.findWindow(byID: windowID, messagingTimeout: 1) {
-            AXChildWindowMessagingTimeout.perform(
+            try? AXChildWindowMessagingTimeout.performChecked(
                 on: handle.element,
                 timeout: 1)
             { window in

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/AXChildWindowMessagingTimeoutTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/AXChildWindowMessagingTimeoutTests.swift
@@ -1,7 +1,69 @@
+import ApplicationServices
+import AXorcist
+import Darwin
 import Testing
 @testable import PeekabooAutomationKit
 
 struct AXChildWindowMessagingTimeoutTests {
+    @Test
+    @MainActor
+    func `checked path refuses the child read when deadline setup fails`() {
+        let invalidApplication = Element(AXUIElementCreateApplication(-1))
+        var readCount = 0
+
+        #expect(throws: AXMessagingTimeoutError.systemFailure(code: AXError.invalidUIElement.rawValue)) {
+            try AXChildWindowMessagingTimeout.performChecked(
+                on: invalidApplication,
+                timeout: 0.25)
+            { _ in
+                readCount += 1
+            }
+        }
+
+        #expect(readCount == 0)
+    }
+
+    @Test
+    @MainActor
+    func `checked optional caller returns nil without dispatching the read`() {
+        let invalidApplication = Element(AXUIElementCreateApplication(-1))
+        var readCount = 0
+
+        let value = try? AXChildWindowMessagingTimeout.performChecked(
+            on: invalidApplication,
+            timeout: 0.25)
+        { _ in
+            readCount += 1
+            return 42
+        }
+
+        #expect(value == nil)
+        #expect(readCount == 0)
+    }
+
+    @Test
+    @MainActor
+    func `checked path releases its scope after error and cancellation`() throws {
+        let application = Element(AXUIElementCreateApplication(getpid()))
+
+        #expect(throws: TimeoutProbeError.self) {
+            try AXChildWindowMessagingTimeout.performChecked(on: application, timeout: 0.25) { _ in
+                throw TimeoutProbeError.failed
+            }
+        }
+        #expect(throws: CancellationError.self) {
+            try AXChildWindowMessagingTimeout.performChecked(on: application, timeout: 0.25) { _ in
+                throw CancellationError()
+            }
+        }
+
+        let value = try AXChildWindowMessagingTimeout.performChecked(
+            on: application,
+            timeout: 0.25,
+            operation: { _ in 42 })
+        #expect(value == 42)
+    }
+
     @Test
     func `exact resolution arms child timeout before an unresponsive ID probe`() {
         let probe = TimeoutProbe()

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/AXChildWindowMessagingTimeoutTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/AXChildWindowMessagingTimeoutTests.swift
@@ -11,7 +11,7 @@ struct AXChildWindowMessagingTimeoutTests {
         let invalidApplication = Element(AXUIElementCreateApplication(-1))
         var readCount = 0
 
-        #expect(throws: AXMessagingTimeoutError.systemFailure(code: AXError.invalidUIElement.rawValue)) {
+        #expect(throws: AXChildWindowMessagingTimeoutError.setupFailure(code: AXError.invalidUIElement.rawValue)) {
             try AXChildWindowMessagingTimeout.performChecked(
                 on: invalidApplication,
                 timeout: 0.25)
@@ -21,6 +21,47 @@ struct AXChildWindowMessagingTimeoutTests {
         }
 
         #expect(readCount == 0)
+    }
+
+    @Test
+    func `checked scope resets after errors and cancellation`() {
+        let probe = TimeoutProbe()
+
+        #expect(throws: TimeoutProbeError.self) {
+            try AXChildWindowMessagingTimeout.performChecked(
+                timeout: 0.25,
+                applyTimeout: probe.applyChecked)
+            {
+                throw TimeoutProbeError.failed
+            }
+        }
+        #expect(throws: CancellationError.self) {
+            try AXChildWindowMessagingTimeout.performChecked(
+                timeout: 0.5,
+                applyTimeout: probe.applyChecked)
+            {
+                throw CancellationError()
+            }
+        }
+
+        #expect(probe.history == [0.25, 0, 0.5, 0])
+    }
+
+    @Test
+    func `checked scope surfaces reset failure`() {
+        var timeoutHistory: [Float] = []
+
+        #expect(throws: AXChildWindowMessagingTimeoutError.resetFailure(code: AXError.failure.rawValue)) {
+            try AXChildWindowMessagingTimeout.performChecked(
+                timeout: 0.25,
+                applyTimeout: { timeout in
+                    timeoutHistory.append(timeout)
+                    return timeout == 0 ? .failure : .success
+                },
+                operation: { 42 })
+        }
+
+        #expect(timeoutHistory == [0.25, 0])
     }
 
     @Test
@@ -62,6 +103,36 @@ struct AXChildWindowMessagingTimeoutTests {
             timeout: 0.25,
             operation: { _ in 42 })
         #expect(value == 42)
+    }
+
+    @Test
+    @MainActor
+    func `equal elements with distinct references keep independent scopes`() throws {
+        let first = Element(AXUIElementCreateApplication(getpid()))
+        let second = Element(AXUIElementCreateApplication(getpid()))
+        #expect(first == second)
+        #expect(ObjectIdentifier(first.underlyingElement) != ObjectIdentifier(second.underlyingElement))
+
+        let value = try AXChildWindowMessagingTimeout.performChecked(on: first, timeout: 0.25) { _ in
+            try AXChildWindowMessagingTimeout.performChecked(on: second, timeout: 0.25) { _ in 42 }
+        }
+        #expect(value == 42)
+    }
+
+    @Test
+    @MainActor
+    func `distinct system-wide references share one scope`() throws {
+        let first = Element(AXUIElementCreateSystemWide())
+        let second = Element(AXUIElementCreateSystemWide())
+        #expect(ObjectIdentifier(first.underlyingElement) != ObjectIdentifier(second.underlyingElement))
+
+        _ = try AXChildWindowMessagingTimeout.performChecked(on: first, timeout: 0.25) { _ in
+            #expect(throws: AXChildWindowMessagingTimeoutError.nestedScope) {
+                try AXChildWindowMessagingTimeout.performChecked(on: second, timeout: 0.25) { _ in
+                    Issue.record("The nested system-wide operation must not run")
+                }
+            }
+        }
     }
 
     @Test
@@ -125,5 +196,10 @@ private final class TimeoutProbe {
     func apply(_ timeout: Float) {
         self.current = timeout
         self.history.append(timeout)
+    }
+
+    func applyChecked(_ timeout: Float) -> AXError {
+        self.apply(timeout)
+        return .success
     }
 }

--- a/scripts/test-swiftpm-consumer.sh
+++ b/scripts/test-swiftpm-consumer.sh
@@ -32,6 +32,15 @@ if (JSON.stringify(actual) !== JSON.stringify([...expected].sort())) {
   console.error(`Public SwiftPM products drifted: expected ${expected.join(", ")}; received ${actual.join(", ")}`);
   process.exit(1);
 }
+
+const expectedAXVersion = "0.1.6";
+const sourceDependencies = manifest.dependencies.flatMap(dependency => dependency.sourceControl ?? []);
+const axorcist = sourceDependencies.find(dependency => dependency.identity === "axorcist");
+const actualAXVersion = axorcist?.requirement?.exact?.[0];
+if (actualAXVersion !== expectedAXVersion) {
+  console.error(`AXorcist version drifted: expected ${expectedAXVersion}; received ${actualAXVersion ?? "none"}`);
+  process.exit(1);
+}
 NODE
 
 package_repo="${fixture_dir}/Peekaboo"
@@ -61,10 +70,14 @@ git -C "${package_repo}" \
   -c user.name='Peekaboo Consumer Contract' \
   -c user.email='consumer-contract@invalid.example' \
   commit -qm 'fixture: exact public package revision'
+git -C "${package_repo}" \
+  -c user.name='Peekaboo Consumer Contract' \
+  -c user.email='consumer-contract@invalid.example' \
+  -c tag.gpgSign=false \
+  tag -am 'fixture: semantic package version' 4.1.1
 
 export PEEKABOO_CONSUMER_PACKAGE_URL="file://${package_repo}"
-export PEEKABOO_CONSUMER_PACKAGE_REVISION
-PEEKABOO_CONSUMER_PACKAGE_REVISION="$(git -C "${package_repo}" rev-parse HEAD)"
+export PEEKABOO_CONSUMER_PACKAGE_VERSION="4.1.1"
 
 consumer_dir="${fixture_dir}/Consumer"
 mkdir -p "${consumer_dir}/Sources/Consumer"
@@ -76,13 +89,13 @@ import Foundation
 import PackageDescription
 
 let packageURL = ProcessInfo.processInfo.environment["PEEKABOO_CONSUMER_PACKAGE_URL"]!
-let packageRevision = ProcessInfo.processInfo.environment["PEEKABOO_CONSUMER_PACKAGE_REVISION"]!
+let packageVersion = ProcessInfo.processInfo.environment["PEEKABOO_CONSUMER_PACKAGE_VERSION"]!
 
 let package = Package(
     name: "PeekabooConsumer",
     platforms: [.macOS(.v14)],
     dependencies: [
-        .package(url: packageURL, revision: packageRevision),
+        .package(url: packageURL, exact: Version(packageVersion)!),
     ],
     targets: [
         .executableTarget(


### PR DESCRIPTION
## Summary

- advance the in-repository AXorcist pin to `137f8b6155c7836b64437165a07aeff0878ddbc7`
- refuse exact-window and dialog AX reads when macOS cannot arm their per-element messaging deadline, surface reset failures, and prevent nested timeout replacement
- key ordinary timeout scopes by concrete `AXUIElement` reference while keeping all system-wide references on one process-global scope
- preserve versioned SwiftPM compatibility with AXorcist 0.1.6 through one temporary checked raw-AX owner, with an explicit deletion boundary after a future authorized AXorcist semantic release
- make the external consumer contract consume a tagged Peekaboo fixture so commit-based dependency drift cannot hide from release validation

## Why

The previous helpers logged `AXUIElementSetMessagingTimeout` failures and still executed the supposedly protected AX read. A refused deadline could therefore become an unbounded background operation. The checked scope makes deadline setup and cleanup part of the result, stops dialog retries and broad fallback after timeout failures, and models the native ownership split between per-reference ordinary elements and the process-global system-wide element.

## Validation

- `pnpm run format`
- `pnpm run lint` (27 existing warnings, 0 serious)
- focused AutomationKit tests: 14 passed
- `pnpm run test:safe`
- clean-HOME tagged Peekaboo 4.1.1 external Release consumer against AXorcist 0.1.6
- root SwiftPM Release build
- structured P0-P2 autoreview clean after fixing semantic-version dependency, fixture tagger identity, ordinary reference identity, and system-wide global identity findings
- AXorcist PRs #39 and #45 landed with exact-head and post-main CI

## Follow-up

After an explicitly authorized AXorcist semantic-version release contains the checked timeout scope, delete the temporary Peekaboo compatibility owner and migrate these callers to the released AXorcist API. This PR does not publish or tag AXorcist.
