### PR TITLE
fix(see): preserve usable Finder accessibility

### DIFF
--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add capability-gated exact-window background wheel delivery for opaque WKWebView/Tauri scroll targets, with retry-unsafe unverifiable outcomes and no activation or shared-cursor fallback.
 
 ### Fixed
+- Keep normal exact-window Finder `see` usable when the window exposes no semantic AX value, without weakening hard Accessibility-read failures or the typed incomplete-evidence refusal.
 - Refuse exact-window combined `see` results when Accessibility returns no usable elements, including legacy Bridge responses that omit the incomplete-read marker, while preserving the requested raster and explicit `--no-elements` screenshot-only success.
 - Reject unknown and non-object MCP `tools/call` arguments as JSON-RPC invalid params before policy checks or tool dispatch, recursively honoring the closed schemas advertised by `tools/list`.
 - Keep browser CLI calls on one current-build reusable daemon, probe Chrome before reporting connected, require explicit reconnect instead of falling back to another same-channel profile after connection loss, and bind browser typing/key presses to an exact uid in one host-owned sequence.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Fixed
 - Refuse exact-window and dialog Accessibility reads when macOS cannot arm their per-element messaging deadline, and surface timeout reset failures instead of continuing unbounded.
+- Treat Finder's role-inapplicable `AXWindow` value failure as sparse descriptor data so normal exact-window combined observations retain usable Accessibility elements, while every other hard AX read and genuinely incomplete window remains fail-closed.
 - Refuse exact-window combined observations when Accessibility returns no usable elements, preserving the requested raster and retry-safe `ACCESSIBILITY_INCOMPLETE` semantics across current and legacy Bridge hosts while explicit screenshot-only capture remains successful.
 - Add Bridge protocol 1.26 explicit-reference-only coordinate receipts for exact-window `see --no-elements`, making the documented background coordinate-click workflow consumable without Accessibility traversal or replacing the prior implicit element snapshot while older hosts fail before receipt allocation.
 - Honor cancellation while draining and reaping MCP ShellTool subprocesses so canceled commands cannot linger behind pipe cleanup. Thanks @SebTardif for #454.

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/DetachedAXObservationWorker.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/DetachedAXObservationWorker.swift
@@ -131,6 +131,14 @@ enum DetachedAXObservationWorker {
         self.descriptorAttributeNames.count
     }
 
+    static var descriptorAttributes: [String] {
+        self.descriptorAttributeNames
+    }
+
+    static func descriptorAttributeIndex(_ name: String) -> Int? {
+        self.descriptorAttributeNames.firstIndex(of: name)
+    }
+
     static var childAttributeCount: Int {
         self.childAttributeNames.count
     }
@@ -138,10 +146,32 @@ enum DetachedAXObservationWorker {
     static func descriptorReadDisposition(error: AXError, values: [Any]?)
         -> DetachedAXMultiAttributeReadDisposition
     {
-        self.multiAttributeReadDisposition(
+        let disposition = self.multiAttributeReadDisposition(
             error: error,
             values: values,
             expectedValueCount: self.descriptorAttributeNames.count)
+        guard disposition == .incomplete,
+              error == .success,
+              let values,
+              values.count == self.descriptorAttributeNames.count
+        else {
+            return disposition
+        }
+
+        let byName = Dictionary(uniqueKeysWithValues: zip(self.descriptorAttributeNames, values))
+        let role = self.stringValue(byName[kAXRoleAttribute])
+        let hasHardFailure = byName.contains { name, value in
+            guard let embeddedError = AXAttributeReadCompletenessPolicy.embeddedError(in: value),
+                  AXAttributeReadCompletenessPolicy.isIncomplete(error: embeddedError)
+            else {
+                return false
+            }
+            // Finder exposes no semantic AXValue on its AXWindow root and reports the absence as
+            // a generic failure rather than attributeUnsupported. The exact window and its tree
+            // remain readable, so this one role-inapplicable value is sparse evidence.
+            return !(name == kAXValueAttribute && role == kAXWindowRole && embeddedError == .failure)
+        }
+        return hasHardFailure ? .incomplete : .values
     }
 
     static func childrenReadDisposition(error: AXError, values: [Any]?)

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/DesktopObservationReceiptRecoveryTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/DesktopObservationReceiptRecoveryTests.swift
@@ -299,8 +299,10 @@ private final class ReceiptRecoveryAutomationService: UIAutomationServiceProtoco
         return ElementDetectionResult(
             snapshotId: snapshotId ?? "generated",
             screenshotPath: "/tmp/fake.png",
-            elements: DetectedElements(),
-            metadata: DetectionMetadata(detectionTime: 0, elementCount: 0, method: "fake"))
+            elements: DetectedElements(buttons: [
+                DetectedElement(id: "B1", type: .button, label: "Fixture", bounds: .zero),
+            ]),
+            metadata: DetectionMetadata(detectionTime: 0, elementCount: 1, method: "fake"))
     }
 
     func click(target _: ClickTarget, clickType _: ClickType, snapshotId _: String?) async throws {}

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/DetachedAXObservationWorkerTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/DetachedAXObservationWorkerTests.swift
@@ -105,6 +105,46 @@ struct DetachedAXObservationWorkerTests {
     }
 
     @Test
+    func `only a window value failure is sparse in an otherwise usable descriptor`() throws {
+        let valueIndex = try #require(DetachedAXObservationWorker.descriptorAttributeIndex(kAXValueAttribute))
+        var values = try Self.usableDescriptorValues(role: kAXWindowRole)
+        values[valueIndex] = try Self.errorValue(.failure)
+
+        #expect(DetachedAXObservationWorker.descriptorReadDisposition(
+            error: .success,
+            values: values) == .values)
+
+        for role in [kAXButtonRole, kAXTextFieldRole, kAXGroupRole] {
+            var controlValues = try Self.usableDescriptorValues(role: role)
+            controlValues[valueIndex] = try Self.errorValue(.failure)
+            #expect(DetachedAXObservationWorker.descriptorReadDisposition(
+                error: .success,
+                values: controlValues) == .incomplete)
+        }
+
+        for attribute in DetachedAXObservationWorker.descriptorAttributes where attribute != kAXValueAttribute {
+            var failedValues = try Self.usableDescriptorValues(role: kAXWindowRole)
+            let index = try #require(DetachedAXObservationWorker.descriptorAttributeIndex(attribute))
+            failedValues[index] = try Self.errorValue(.failure)
+            #expect(DetachedAXObservationWorker.descriptorReadDisposition(
+                error: .success,
+                values: failedValues) == .incomplete)
+        }
+
+        for error in [AXError.cannotComplete, .invalidUIElement, .apiDisabled] {
+            var failedValues = try Self.usableDescriptorValues(role: kAXWindowRole)
+            failedValues[valueIndex] = try Self.errorValue(error)
+            #expect(DetachedAXObservationWorker.descriptorReadDisposition(
+                error: .success,
+                values: failedValues) == .incomplete)
+        }
+
+        #expect(DetachedAXObservationWorker.descriptorReadDisposition(
+            error: .failure,
+            values: values) == .incomplete)
+    }
+
+    @Test
     func `embedded children read failure is not mistaken for an absent child list`() throws {
         var values = [Any](
             repeating: NSNull(),
@@ -306,6 +346,22 @@ struct DetachedAXObservationWorkerTests {
             appIsActive: false,
             traversalBudget: AXTraversalBudget(),
             timing: DetachedAXObservationTiming(hardTimeoutSeconds: 1))
+    }
+
+    private static func usableDescriptorValues(role: String) throws -> [Any] {
+        var position = CGPoint(x: 10, y: 20)
+        var size = CGSize(width: 800, height: 600)
+        var values = [Any](
+            repeating: NSNull(),
+            count: DetachedAXObservationWorker.descriptorAttributeCount)
+        let positionIndex = try #require(
+            DetachedAXObservationWorker.descriptorAttributeIndex(kAXPositionAttribute))
+        let sizeIndex = try #require(DetachedAXObservationWorker.descriptorAttributeIndex(kAXSizeAttribute))
+        let roleIndex = try #require(DetachedAXObservationWorker.descriptorAttributeIndex(kAXRoleAttribute))
+        values[positionIndex] = try #require(AXValueCreate(.cgPoint, &position))
+        values[sizeIndex] = try #require(AXValueCreate(.cgSize, &size))
+        values[roleIndex] = role
+        return values
     }
 
     private static func errorValue(_ error: AXError) throws -> AXValue {


### PR DESCRIPTION
## Summary

- Keep normal exact-window Finder combined observations usable when the `AXWindow` root reports its role-inapplicable `AXValue` as a generic Accessibility failure.
- Treat only the outer-success, full-descriptor `AXWindow` plus `AXValue` plus `.failure` combination as sparse evidence; every other role, attribute, hard embedded error, batch failure, and shape mismatch remains fail-closed.
- Update the receipt-recovery fixture to return usable evidence under the current exact-window observation policy, with regression and changelog coverage.

## Proof

- `swift test --package-path Core/PeekabooAutomationKit --filter 'DetachedAXObservationWorkerTests|DesktopObservationReceiptRecoveryTests'` — 22 detached-worker and 4 receipt-recovery tests pass.
- `pnpm run test:safe` — 50 Foundation, 918 CLI/Core, and 92 runtime tests pass, including release, native-only, SwiftPM consumer, restart, and background-certification gates.
- `pnpm run format`, `pnpm run lint`, `pnpm run lint:docs`, touched-file strict SwiftLint, diff checks, TruffleHog, and P0–P2 autoreview pass.
- A Foundation-signed source-blind run returned 74 usable elements and the real 1840×928 raster for a task-owned normal Finder window. The separate 64×64 Finder negative still returned retry-safe `ACCESSIBILITY_INCOMPLETE`, preserved its 128×128 raster, and published no element snapshot. Foreground and clipboard digests stayed unchanged; no AppleScript, JXA, global input, or shared-cursor operation was used.
