### PR TITLE
fix(menu): bound menubar helper wait so a wedged helper cannot hang list

### DIFF
--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/MenuService+MenuExtraWindows.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/MenuService+MenuExtraWindows.swift
@@ -217,8 +217,12 @@ extension MenuService {
     }
 
     /// Invoke the LSUIElement helper (if built) to enumerate menu bar windows from a GUI context.
-    func getMenuBarItemsViaHelper(displayBounds: [CGRect]) -> [MenuExtraInfo]? {
-        let helperPath = [
+    func getMenuBarItemsViaHelper(
+        displayBounds: [CGRect],
+        helperPath: String? = nil,
+        timeoutSeconds: TimeInterval = 15) -> [MenuExtraInfo]?
+    {
+        let resolvedHelperPath = helperPath ?? [
             FileManager.default.currentDirectoryPath,
             "Helpers",
             "MenuBarHelper",
@@ -228,12 +232,12 @@ extension MenuService {
             "MacOS",
             "menubar-helper",
         ].joined(separator: "/")
-        guard FileManager.default.isExecutableFile(atPath: helperPath) else {
+        guard FileManager.default.isExecutableFile(atPath: resolvedHelperPath) else {
             return nil
         }
 
         let process = Process()
-        process.launchPath = helperPath
+        process.launchPath = resolvedHelperPath
 
         let pipe = Pipe()
         process.standardOutput = pipe
@@ -244,7 +248,14 @@ extension MenuService {
             return nil
         }
 
-        process.waitUntilExit()
+        // Same bounded wait as dock helpers. waitUntilExit() hangs forever if the
+        // helper wedges, and peekaboo menubar list prefers this path when present.
+        do {
+            try DockService.waitForProcessExit(process, timeoutSeconds: timeoutSeconds)
+        } catch {
+            self.logger.debug("Menubar helper wait failed: \(error.localizedDescription)")
+            return nil
+        }
         let data = pipe.fileHandleForReading.readDataToEndOfFile()
         guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
               let ids = json["window_ids"] as? [UInt32]

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/MenuBarHelperProcessWaitTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/MenuBarHelperProcessWaitTests.swift
@@ -8,12 +8,13 @@ struct MenuBarHelperProcessWaitTests {
     func `wedged menubar helper does not block menu listing`() throws {
         let helper = try Self.writeExecutableHelper(
             contents: "#!/bin/sh\nexec /bin/sleep 3\n")
+        defer { helper.remove() }
         let service = MenuService()
         let startedAt = Date()
 
         let items = service.getMenuBarItemsViaHelper(
             displayBounds: [],
-            helperPath: helper.path,
+            helperPath: helper.executableURL.path,
             timeoutSeconds: 0.05)
 
         #expect(items == nil)
@@ -24,25 +25,40 @@ struct MenuBarHelperProcessWaitTests {
     func `successful menubar helper still returns parsed extras`() throws {
         let helper = try Self.writeExecutableHelper(
             contents: "#!/bin/sh\nprintf '%s\\n' '{\"window_ids\":[]}'\n")
+        defer { helper.remove() }
         let service = MenuService()
 
         let items = service.getMenuBarItemsViaHelper(
             displayBounds: [],
-            helperPath: helper.path,
+            helperPath: helper.executableURL.path,
             timeoutSeconds: 2)
 
         #expect(items?.isEmpty == true)
     }
 
-    private static func writeExecutableHelper(contents: String) throws -> URL {
+    private static func writeExecutableHelper(contents: String) throws -> TemporaryHelper {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("peekaboo-menubar-helper-\(UUID().uuidString)", isDirectory: true)
-        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
-        let helper = directory.appendingPathComponent("menubar-helper")
-        try contents.write(to: helper, atomically: true, encoding: .utf8)
-        try FileManager.default.setAttributes(
-            [.posixPermissions: 0o755],
-            ofItemAtPath: helper.path)
-        return helper
+        do {
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+            let executableURL = directory.appendingPathComponent("menubar-helper")
+            try contents.write(to: executableURL, atomically: true, encoding: .utf8)
+            try FileManager.default.setAttributes(
+                [.posixPermissions: 0o755],
+                ofItemAtPath: executableURL.path)
+            return TemporaryHelper(directoryURL: directory, executableURL: executableURL)
+        } catch {
+            try? FileManager.default.removeItem(at: directory)
+            throw error
+        }
+    }
+
+    private struct TemporaryHelper {
+        let directoryURL: URL
+        let executableURL: URL
+
+        func remove() {
+            try? FileManager.default.removeItem(at: self.directoryURL)
+        }
     }
 }

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/MenuBarHelperProcessWaitTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/MenuBarHelperProcessWaitTests.swift
@@ -1,0 +1,48 @@
+import Foundation
+import Testing
+@testable import PeekabooAutomationKit
+
+@MainActor
+struct MenuBarHelperProcessWaitTests {
+    @Test
+    func `wedged menubar helper does not block menu listing`() throws {
+        let helper = try Self.writeExecutableHelper(
+            contents: "#!/bin/sh\nexec /bin/sleep 3\n")
+        let service = MenuService()
+        let startedAt = Date()
+
+        let items = service.getMenuBarItemsViaHelper(
+            displayBounds: [],
+            helperPath: helper.path,
+            timeoutSeconds: 0.05)
+
+        #expect(items == nil)
+        #expect(Date().timeIntervalSince(startedAt) < 2)
+    }
+
+    @Test
+    func `successful menubar helper still returns parsed extras`() throws {
+        let helper = try Self.writeExecutableHelper(
+            contents: "#!/bin/sh\nprintf '%s\\n' '{\"window_ids\":[]}'\n")
+        let service = MenuService()
+
+        let items = service.getMenuBarItemsViaHelper(
+            displayBounds: [],
+            helperPath: helper.path,
+            timeoutSeconds: 2)
+
+        #expect(items?.isEmpty == true)
+    }
+
+    private static func writeExecutableHelper(contents: String) throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("peekaboo-menubar-helper-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let helper = directory.appendingPathComponent("menubar-helper")
+        try contents.write(to: helper, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755],
+            ofItemAtPath: helper.path)
+        return helper
+    }
+}


### PR DESCRIPTION
## What Problem This Solves

`peekaboo menubar list` prefers an optional LSUIElement helper when it is present on disk. That helper was waited on with Foundation `waitUntilExit()`, which has no deadline. If the helper wedges, menu listing (CLI and MCP) never returns. The same Process wait already has a bounded helper for dock commands; menubar listing did not use it.

## Why This Change Was Made

Reuse `DockService.waitForProcessExit` (15s default, then TERM and SIGKILL) so a wedged helper fails closed and listing falls back to the existing CGS / `CGWindowList` path. That is the same fallback used when the helper is missing or fails to launch.

## User Impact

`peekaboo menubar list` returns within the wait budget even when `Helpers/MenuBarHelper/.../menubar-helper` is present and stuck. Successful helpers are unchanged.

## Evidence

Production `MenuService.getMenuBarItemsViaHelper` against a real `/bin/sleep` helper (same `Process` launch path as the CLI).

Before (unbounded `waitUntilExit()`):

```console
$ swift test --package-path Core/PeekabooAutomationKit --filter "wedged menubar helper"
✘ Test "wedged menubar helper does not block menu listing" recorded an issue
  Expectation failed: (Date().timeIntervalSince(startedAt) → 3.2349870204925537) < (2 → 2.0)
✘ Test "wedged menubar helper does not block menu listing" failed after 3.438 seconds
```

After (bounded `DockService.waitForProcessExit`, 0.05s budget):

```console
$ swift test --package-path Core/PeekabooAutomationKit --filter "MenuBarHelperProcessWaitTests|DockProcessWaitTests"
✔ Test "successful menubar helper still returns parsed extras" passed after 0.105 seconds.
✔ Test "wedged menubar helper does not block menu listing" passed after 0.157 seconds.
✔ Test run with 4 tests in 2 suites passed after 1.113 seconds.
```

## Real behavior proof

Behavior addressed: A wedged menubar helper no longer blocks menu listing. `getMenuBarItemsViaHelper` returns nil after the wait budget and the caller uses CGS fallback.
Real environment tested: macOS 26, arm64, Swift 6.3.3, Peekaboo worktree at `/tmp/peekaboo-menubar-wait` on `14b3e5ec` plus this patch. Live child was `/bin/sleep`, not a fake wait.
Exact steps or command run after this patch:

```
swift test --package-path Core/PeekabooAutomationKit --filter MenuBarHelperProcessWaitTests
```

Evidence after fix: terminal output copied below.

```console
$ swift test --package-path Core/PeekabooAutomationKit --filter MenuBarHelperProcessWaitTests
✔ Test "successful menubar helper still returns parsed extras" passed after 0.105 seconds.
✔ Test "wedged menubar helper does not block menu listing" passed after 0.157 seconds.
```

Unfixed `waitUntilExit()` on the same sleep helper took 3.23s (the child duration). After the patch the same helper returns in 0.16s and listing continues.
Observed result after fix: Wedged helper is reaped inside the wait budget. Empty JSON helpers still parse to an empty extra list.
What was not tested: A signed Ice-style MenubarHelper.app on a machine with Accessibility granted through the full `peekaboo menubar list` permission path. That CLI path refused `listMenuBarItems` here for missing permissions before the helper wait.

## Related

- Same wait helper: [#303](https://github.com/openclaw/Peekaboo/pull/303) (dock `waitUntilExit`)
- Same hang class: [#215](https://github.com/openclaw/Peekaboo/pull/215), [#298](https://github.com/openclaw/Peekaboo/pull/298), [#454](https://github.com/openclaw/Peekaboo/pull/454)
- Wait introduced in [`95afdfd90`](https://github.com/openclaw/Peekaboo/commit/95afdfd90d7920d025c235aa9fbb631386d1990a) (2026-05-07, Peter Steinberger, menu extra split)
