### PR TITLE
fix(cli): preserve root exits for runtime aliases

### DIFF
--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add capability-gated exact-window background wheel delivery for opaque WKWebView/Tauri scroll targets, with retry-unsafe unverifiable outcomes and no activation or shared-cursor fallback.
 
 ### Fixed
+- Keep root help and version order-independent across canonical kebab- and camel-case runtime-option aliases while preserving correct missing-value errors.
 - Treat `capture video` as caller-local media ingestion so valid files and typed media failures bypass Screen Recording and ScreenCaptureKit-owner preflight while live capture remains gated.
 - Keep normal exact-window Finder `see` usable when the window exposes no semantic AX value, without weakening hard Accessibility-read failures or the typed incomplete-evidence refusal.
 - Project dialog input and forced Escape through canonical unverified outcomes and exact PID/generation/window receipts so retained-value evidence, driver cancellation, legacy Bridge PID targets, and concurrent-controller races cannot be reported as confirmed effects.

--- a/Apps/CLI/Sources/PeekabooCLI/CLI/CommanderMigrationAdvisor.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/CLI/CommanderMigrationAdvisor.swift
@@ -10,10 +10,13 @@ struct CommanderUsageError: LocalizedError, Equatable {
 }
 
 enum CommanderMigrationAdvisor {
-    private static let runtimeFlags = Set([
-        "--json", "-j", "--json-output", "--jsonOutput",
-        "--verbose", "-v", "--log-level", "--no-remote", "--bridge-socket", "--input-strategy",
-    ])
+    private static let runtimeFlags: Set<String> = {
+        let signature = CommandSignature().withPeekabooRuntimeFlags().flattened()
+        return Set(
+            signature.options.flatMap { $0.names.map(\.commandLineToken) } +
+                signature.flags.flatMap { $0.names.map(\.commandLineToken) }
+        )
+    }()
 
     private static let removedRootReplacements: [String: String] = [
         "hotkey": "peekaboo press",

--- a/Apps/CLI/Sources/PeekabooCLI/CLI/CommanderRuntimeRouter.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/CLI/CommanderRuntimeRouter.swift
@@ -168,18 +168,9 @@ enum CommanderRuntimeRouter {
     private static let runtimeValueOptionNames: Set<String> = {
         let signature = CommandSignature().withPeekabooRuntimeFlags().flattened()
         return Set(signature.options.flatMap { option in
-            option.names.map { Self.commandLineToken(for: $0) }
+            option.names.map(\.commandLineToken)
         })
     }()
-
-    private static func commandLineToken(for name: CommanderName) -> String {
-        switch name {
-        case let .short(value), let .aliasShort(value):
-            "-\(value)"
-        case let .long(value), let .aliasLong(value):
-            "--\(value)"
-        }
-    }
 
     private static func runtimeOptionConsumesFollowingValue(_ token: String) -> Bool {
         !token.contains("=") && self.runtimeValueOptionNames.contains(token)

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommandSignature+PeekabooRuntime.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommandSignature+PeekabooRuntime.swift
@@ -41,3 +41,14 @@ extension CommandSignature {
         )
     }
 }
+
+extension CommanderName {
+    var commandLineToken: String {
+        switch self {
+        case let .short(value), let .aliasShort(value):
+            "-\(value)"
+        case let .long(value), let .aliasLong(value):
+            "--\(value)"
+        }
+    }
+}

--- a/Apps/CLI/Tests/CLIRuntimeTests/RootEarlyExitRuntimeTests.swift
+++ b/Apps/CLI/Tests/CLIRuntimeTests/RootEarlyExitRuntimeTests.swift
@@ -64,6 +64,7 @@ struct RootEarlyExitRuntimeTests {
 
     @Test(arguments: [
         ["--junk", "click", "--help"],
+        ["--junk", "app", "--help"],
         ["--unknown=1", "app", "list", "--help"],
     ])
     func `option-leading command help stays command scoped`(arguments: [String]) async throws {
@@ -76,8 +77,49 @@ struct RootEarlyExitRuntimeTests {
 
         #expect(result.status == .exited(0))
         #expect(result.standardError.isEmpty)
-        #expect(result.standardOutput
-            .contains("Usage\n  peekaboo \(arguments.contains("click") ? "click" : "app list")"))
+        let expectedPath = if arguments.contains("click") {
+            "click"
+        } else if arguments.contains("list") {
+            "app list"
+        } else {
+            "app"
+        }
+        #expect(result.standardOutput.contains("Usage\n  peekaboo \(expectedPath)"))
         #expect(!result.standardOutput.contains("Core Commands"))
+    }
+
+    @Test(arguments: [
+        ["--log-level", "--help"],
+        ["--logLevel", "--help"],
+        ["--bridge-socket", "--help"],
+        ["--bridgeSocket", "--help"],
+        ["--input-strategy", "--help"],
+        ["--inputStrategy", "--help"],
+    ])
+    func `missing runtime option value does not become root help`(arguments: [String]) async throws {
+        guard TestChildProcess.canLocatePeekabooBinary() else {
+            Issue.record("Build peekaboo before running CLI runtime tests.")
+            return
+        }
+
+        let result = try await TestChildProcess.runPeekaboo(arguments, isolateFromRemoteHosts: false)
+
+        #expect(result.status == .exited(1))
+        #expect(result.standardOutput.isEmpty)
+        #expect(result.standardError.contains("Runtime flags must follow the leaf command"))
+    }
+
+    @Test(arguments: ["--log-level=--help", "--logLevel=--help"])
+    func `attached help token remains a runtime option value`(argument: String) async throws {
+        guard TestChildProcess.canLocatePeekabooBinary() else {
+            Issue.record("Build peekaboo before running CLI runtime tests.")
+            return
+        }
+
+        let result = try await TestChildProcess.runPeekaboo([argument], isolateFromRemoteHosts: false)
+
+        #expect(result.status == .exited(1))
+        #expect(result.standardOutput.isEmpty)
+        #expect(result.standardError.contains("Unknown command '\(argument)'"))
     }
 }

--- a/Apps/CLI/Tests/CoreCLITests/CommanderRuntimeRouterHelpPathTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/CommanderRuntimeRouterHelpPathTests.swift
@@ -42,6 +42,7 @@ struct CommanderRuntimeRouterHelpPathTests {
 
     @Test(arguments: [
         ["peekaboo", "--junk", "click", "--help"],
+        ["peekaboo", "--junk", "app", "--help"],
         ["peekaboo", "--unknown=1", "app", "list", "--help"],
     ])
     func `option-leading command help retains the command path`(arguments: [String]) {
@@ -62,12 +63,41 @@ struct CommanderRuntimeRouterHelpPathTests {
         #expect(resolved.parsedValues.options["command"] == nil)
     }
 
-    @Test
-    func `unknown positional help target remains an error`() {
+    @Test(arguments: [
+        ["peekaboo", "does-not-exist", "--help"],
+        ["peekaboo", "--junk", "does-not-exist", "--help"],
+    ])
+    func `unknown positional help target remains an error`(arguments: [String]) {
         let error = #expect(throws: CommanderProgramError.self) {
-            _ = try CommanderRuntimeRouter.resolve(argv: ["peekaboo", "does-not-exist", "--help"])
+            _ = try CommanderRuntimeRouter.resolve(argv: arguments)
         }
         #expect(error == .unknownCommand("does-not-exist"))
+    }
+
+    @Test(arguments: [
+        ["peekaboo", "--log-level", "--help"],
+        ["peekaboo", "--logLevel", "--help"],
+        ["peekaboo", "--bridge-socket", "--help"],
+        ["peekaboo", "--bridgeSocket", "--help"],
+        ["peekaboo", "--input-strategy", "--help"],
+        ["peekaboo", "--inputStrategy", "--help"],
+    ])
+    func `missing runtime option value does not become root help`(arguments: [String]) {
+        let error = #expect(throws: CommanderUsageError.self) {
+            _ = try CommanderRuntimeRouter.resolve(argv: arguments)
+        }
+        #expect(error?.message.contains("Runtime flags must follow the leaf command") == true)
+    }
+
+    @Test(arguments: [
+        ["peekaboo", "--log-level=--help"],
+        ["peekaboo", "--logLevel=--help"],
+    ])
+    func `attached help token remains a runtime option value`(arguments: [String]) {
+        let error = #expect(throws: CommanderProgramError.self) {
+            _ = try CommanderRuntimeRouter.resolve(argv: arguments)
+        }
+        #expect(error == .unknownCommand(arguments[1]))
     }
 
     @Test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Build branded release disk images from pinned direct Finder-metadata tooling, preserving the signed and notarized drag-to-Applications layout without GUI automation.
 
 ### Fixed
+- Keep root help and version order-independent across canonical kebab- and camel-case runtime-option aliases while preserving correct missing-value errors.
 - Treat `capture video` as caller-local media ingestion so valid files and typed media failures bypass Screen Recording and ScreenCaptureKit-owner preflight while live capture remains gated.
 - Refuse exact-window and dialog Accessibility reads when macOS cannot arm their per-element messaging deadline, and surface timeout reset failures instead of continuing unbounded.
 - Treat Finder's role-inapplicable `AXWindow` value failure as sparse descriptor data so normal exact-window combined observations retain usable Accessibility elements, while every other hard AX read and genuinely incomplete window remains fail-closed.


### PR DESCRIPTION
## Summary

- Follow up on #471 by deriving root help/version runtime-option aliases from the shared canonical command signature, including kebab- and camel-case forms.
- Keep separated runtime options with missing values on the usage-error path instead of treating the following help token as root help.
- Keep attached help-like option values as values rather than early-exit flags.

## Tests

- Focused router suite: 10 tests
- Child-process suite: 6 tests
- Direct reproduction matrix: 16/16
- `pnpm run format`, `pnpm run lint`, and diff validation
- `pnpm run test:safe`
- Clean P0-P2 autoreview
