### PR TITLE
fix(mcp): reject malformed press modifiers

### DIFF
--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -52,6 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Make Agent sessions immutable background-only by default, centrally refusing foreground/global input, activation, raw press, shared-pointer, persistent clipboard mutation, shared system UI mutations, Space switch/follow, browser setup/fronting, and Shell-tool access before dispatch while retaining Space listing and unfollowed window placement; `--allow-foreground` sets a new session's immutable maximum, must be explicitly repeated on resume, and never exposes the Shell tool, while session output exposes full copyable IDs, tasks, lifecycle meaning, and stored policy.
 
 ### Fixed
+- Refuse malformed MCP `press` key/modifier shapes before target resolution or keyboard dispatch instead of silently dropping invalid modifier values.
 - Compose setup, delivery, cleanup, cancellation, and refusal receipts through one Foundation action-sequence owner so foreground focus cannot be erased by a no-dispatch leaf and CLI/MCP target refusals expose complete retry guidance.
 - Make explicit Bridge socket overrides fail closed when unavailable instead of reporting a successful local fallback.
 - Validate `see` selectors, explicit caller-local PIDs, and `scroll` directions before runtime-host and ScreenCaptureKit ownership preflight so request errors cannot be masked by ambient capture state.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Build branded release disk images from pinned direct Finder-metadata tooling, preserving the signed and notarized drag-to-Applications layout without GUI automation.
 
 ### Fixed
+- Refuse malformed MCP `press` key/modifier shapes before target resolution or keyboard dispatch instead of silently dropping invalid modifier values.
 - Keep root help and version order-independent across canonical kebab- and camel-case runtime-option aliases while preserving correct missing-value errors.
 - Treat `capture video` as caller-local media ingestion so valid files and typed media failures bypass Screen Recording and ScreenCaptureKit-owner preflight while live capture remains gated.
 - Refuse exact-window and dialog Accessibility reads when macOS cannot arm their per-element messaging deadline, and surface timeout reset failures instead of continuing unbounded.

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/PressTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/PressTool.swift
@@ -330,16 +330,20 @@ public struct PressTool: MCPTool {
     }
 
     static func parseChords(arguments: ToolArguments) throws -> [KeyboardChord] {
-        let sequence = try self.validatedChordSequence(arguments: arguments)
-        let key = arguments.getString("key")
-        let modifiers = arguments.getStringArray("modifiers") ?? []
-
-        if sequence != nil, key != nil || !modifiers.isEmpty {
-            throw KeyboardChordError.invalid("Use either keys or key+modifiers, not both")
+        let hasSequence = arguments.getValue(for: "keys") != nil
+        let hasKey = arguments.getValue(for: "key") != nil
+        let hasModifiers = arguments.getValue(for: "modifiers") != nil
+        if hasSequence, hasKey || hasModifiers {
+            throw PressToolValidationError(message: "Use either keys or key+modifiers, not both")
         }
+
+        let sequence = try self.validatedChordSequence(arguments: arguments)
         if let sequence {
             return try sequence.map(KeyboardChord.init(parsing:))
         }
+
+        let key = arguments.getString("key")
+        let modifiers = try self.validatedModifiers(arguments: arguments) ?? []
         guard let key, !key.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
             throw PressToolValidationError(
                 message: "Provide either a non-empty keys array or a non-empty key with optional modifiers")
@@ -362,6 +366,22 @@ public struct PressTool: MCPTool {
                 throw PressToolValidationError(message: "keys[\(index)] must be a non-empty chord string")
             }
             return chord
+        }
+    }
+
+    private static func validatedModifiers(arguments: ToolArguments) throws -> [String]? {
+        guard let value = arguments.getValue(for: "modifiers") else { return nil }
+        guard case let .array(items) = value else {
+            throw PressToolValidationError(message: "modifiers must be an array of modifier strings")
+        }
+        return try items.enumerated().map { index, item in
+            guard case let .string(modifier) = item,
+                  !modifier.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            else {
+                throw PressToolValidationError(
+                    message: "modifiers[\(index)] must be a non-empty modifier string")
+            }
+            return modifier
         }
     }
 
@@ -608,7 +628,7 @@ private struct PressResponseMessageInput {
     let targetFocusCompleted: Bool
 }
 
-private struct PressToolValidationError: Error {
+struct PressToolValidationError: Error {
     let message: String
     let refusalReason: DesktopActionOutcome.RefusalReason
 

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPKeyboardBackgroundToolTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPKeyboardBackgroundToolTests.swift
@@ -24,16 +24,68 @@ struct MCPKeyboardBackgroundToolTests {
             "modifiers": ["command", "shift"],
         ]))
         #expect(single.map(\.serviceKeys) == ["cmd,shift,c"])
+
+        let keyOnly = try PressTool.parseChords(arguments: ToolArguments(raw: [
+            "key": "Return",
+        ]))
+        #expect(keyOnly.map(\.serviceKeys) == ["return"])
+
+        let emptyModifiers = try PressTool.parseChords(arguments: ToolArguments(raw: [
+            "key": "Tab",
+            "modifiers": [],
+        ]))
+        #expect(emptyModifiers.map(\.serviceKeys) == ["tab"])
     }
 
     @Test
     func `Press tool rejects mixed schema shapes`() {
-        #expect(throws: KeyboardChordError.self) {
+        let error = #expect(throws: PressToolValidationError.self) {
             _ = try PressTool.parseChords(arguments: ToolArguments(raw: [
                 "keys": ["cmd+c"],
                 "key": "v",
                 "modifiers": ["cmd"],
             ]))
+        }
+        #expect(error?.message == "Use either keys or key+modifiers, not both")
+    }
+
+    @Test
+    func `Press tool reports malformed modifier shapes without dispatch`() async throws {
+        let automation = await MainActor.run { MockAutomationService(accessibilityGranted: true) }
+        let context = await MCPToolTestHelpers.makeContext(
+            automation: automation,
+            snapshotOwner: Self.uiSnapshots.owner)
+        let cases: [([String: Any], String)] = [
+            (["key": "c", "modifiers": "cmd"], "modifiers must be an array of modifier strings"),
+            (["key": "c", "modifiers": ["cmd": true]], "modifiers must be an array of modifier strings"),
+            (["key": "c", "modifiers": ["cmd", 7]], "modifiers[1] must be a non-empty modifier string"),
+            (["key": "c", "modifiers": ["cmd", "  "]], "modifiers[1] must be a non-empty modifier string"),
+            (
+                ["keys": ["cmd+c"], "modifiers": ["unexpected": true]],
+                "Use either keys or key+modifiers, not both"),
+            (["keys": ["cmd+c"], "modifiers": []], "Use either keys or key+modifiers, not both"),
+        ]
+
+        for (arguments, expectedMessage) in cases {
+            var foregroundArguments = arguments
+            foregroundArguments["foreground"] = true
+            let response = try await PressTool(context: context).execute(
+                arguments: ToolArguments(raw: foregroundArguments))
+            #expect(response.isError)
+            guard case let .text(message, _, _)? = response.content.first else {
+                Issue.record("Expected press validation text")
+                continue
+            }
+            #expect(message.contains(expectedMessage))
+            #expect(await MainActor.run { automation.lastHotkeyKeys } == nil)
+            #expect(await MainActor.run { automation.targetedHotkeyCalls.isEmpty })
+            guard case let .object(meta) = response.meta else {
+                Issue.record("Expected press validation metadata")
+                continue
+            }
+            #expect(meta["mutation_dispatched"] == .bool(false))
+            #expect(meta["retry_safe"] == .bool(true))
+            #expect(meta["refusal_reason"] == .string("invalid_request"))
         }
     }
 
@@ -816,6 +868,29 @@ struct MCPKeyboardBackgroundToolTests {
                 isActionable: true),
         ])
         return snapshotId
+    }
+}
+
+struct PressToolParsingValidationTests {
+    @Test
+    func `Press tool rejects malformed modifier shapes while parsing`() {
+        let cases: [([String: Any], String)] = [
+            (["key": "c", "modifiers": "cmd"], "modifiers must be an array of modifier strings"),
+            (["key": "c", "modifiers": ["cmd": true]], "modifiers must be an array of modifier strings"),
+            (["key": "c", "modifiers": ["cmd", 7]], "modifiers[1] must be a non-empty modifier string"),
+            (["key": "c", "modifiers": ["cmd", "  "]], "modifiers[1] must be a non-empty modifier string"),
+            (
+                ["keys": ["cmd+c"], "modifiers": ["unexpected": true]],
+                "Use either keys or key+modifiers, not both"),
+            (["keys": ["cmd+c"], "modifiers": []], "Use either keys or key+modifiers, not both"),
+        ]
+
+        for (arguments, expectedMessage) in cases {
+            let error = #expect(throws: PressToolValidationError.self) {
+                _ = try PressTool.parseChords(arguments: ToolArguments(raw: arguments))
+            }
+            #expect(error?.message == expectedMessage)
+        }
     }
 }
 

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/PeekabooMCPServerTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/PeekabooMCPServerTests.swift
@@ -242,6 +242,67 @@ struct PeekabooMCPServerTests {
 
     @Test
     @MainActor
+    func `press wire rejects malformed modifier shapes without dispatch`() async throws {
+        let automation = MockAutomationService(accessibilityGranted: true)
+        let context = await MCPToolTestHelpers.makeContext(automation: automation)
+        let session = try await MCPWireSession.connect(context: context)
+        let cases: [([String: Value], String)] = [
+            (
+                ["key": .string("c"), "modifiers": .string("cmd")],
+                "modifiers must be an array of modifier strings"),
+            (
+                ["key": .string("c"), "modifiers": .object(["cmd": .bool(true)])],
+                "modifiers must be an array of modifier strings"),
+            (
+                ["key": .string("c"), "modifiers": .array([.string("cmd"), .int(7)])],
+                "modifiers[1] must be a non-empty modifier string"),
+            (
+                ["key": .string("c"), "modifiers": .array([.string("cmd"), .string("  ")])],
+                "modifiers[1] must be a non-empty modifier string"),
+            (
+                [
+                    "keys": .array([.string("cmd+c")]),
+                    "modifiers": .object(["unexpected": .bool(true)]),
+                ],
+                "Use either keys or key+modifiers, not both"),
+            (
+                ["keys": .array([.string("cmd+c")]), "modifiers": .array([])],
+                "Use either keys or key+modifiers, not both"),
+        ]
+
+        do {
+            for (arguments, expectedMessage) in cases {
+                var foregroundArguments = arguments
+                foregroundArguments["foreground"] = .bool(true)
+                let request: RequestContext<CallTool.Result> = try await session.client.callTool(
+                    name: "press",
+                    arguments: foregroundArguments)
+                let result = try await request.value
+                #expect(result.isError == true)
+                #expect(result.content.contains { content in
+                    guard case let .text(text, _, _) = content else { return false }
+                    return text.contains(expectedMessage)
+                })
+
+                let encoded = try JSONEncoder().encode(result)
+                let json = try #require(JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+                let metadata = try #require(json["_meta"] as? [String: Any])
+                #expect(metadata["refusal_reason"] as? String == "invalid_request")
+                #expect(metadata["mutation_dispatched"] as? Bool == false)
+                #expect(metadata["retry_safe"] as? Bool == true)
+                #expect(automation.lastHotkeyKeys == nil)
+                #expect(automation.targetedHotkeyCalls.isEmpty)
+            }
+        } catch {
+            await session.stop()
+            throw error
+        }
+
+        await session.stop()
+    }
+
+    @Test
+    @MainActor
     func `every advertised closed schema rejects unknown properties as invalid params`() async throws {
         let context = await MCPToolTestHelpers.makeContext()
         let session = try await MCPWireSession.connect(context: context)


### PR DESCRIPTION
## Summary

Follow-up to #472. `PressTool` still extracted `modifiers` with a lossy string-array helper, so malformed values could be dropped and a different chord could be dispatched.

- detect raw `keys`, `key`, and `modifiers` field presence before selecting the input shape
- require supplied modifiers to be an array of non-empty strings while preserving every element and its order
- keep recognized modifier-name validation in `KeyboardChord`
- refuse malformed and mixed shapes before target resolution or keyboard delivery
- add direct parsing, mock-backed zero-dispatch, and MCP wire regressions

## Tests

- `swift test --package-path Core/PeekabooCore --filter MCPKeyboardBackgroundToolTests --no-parallel` (22 tests)
- `swift test --package-path Core/PeekabooCore --filter PeekabooMCPServerTests --no-parallel` (17 tests)
- source-blind built-server MCP probes for all malformed shapes and valid key/sequence forms
- `pnpm run test:safe`
- `pnpm run format`
- `pnpm run lint`
- `git diff --check`
- fresh P0-P2 branch autoreview: clean
