### PR TITLE
refactor(targeting): centralize selector and receipt adapters

### DIFF
--- a/Apps/CLI/Sources/PeekabooCLI/Commands/AI/SeeCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/AI/SeeCommand.swift
@@ -439,13 +439,18 @@ struct SeeCommand: ApplicationResolvable, ErrorHandlingCommand, PreRuntimeValida
     }
 
     func validateInteractionTargetSelectors() throws {
-        try InteractionTargetSelectorValidator.validateCLI(
-            hasApplication: self.app != nil,
-            hasProcessIdentifier: self.pid != nil,
-            hasWindowID: self.windowId != nil,
-            hasWindowTitle: self.windowTitle != nil,
-            hasWindowIndex: self.windowIndex != nil
-        )
+        do {
+            try InteractionTargetSelector(
+                applicationIdentifier: self.app,
+                processIdentifier: self.pid.map(Int.init),
+                windowID: self.windowId,
+                windowTitle: self.windowTitle,
+                windowIndex: self.windowIndex
+            )
+            .validate(policy: .interaction)
+        } catch let error as InteractionTargetSelector.ValidationError {
+            throw InteractionTargetOptions.validationError(for: error)
+        }
     }
 
     private func runPixelOnlyCapture() async throws {

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/ClickCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/ClickCommand.swift
@@ -997,54 +997,42 @@ extension ClickCommand {
     private func backgroundClickSnapshotProcessIdentity(snapshotId: String?) async throws
     -> ApplicationProcessIdentity? {
         guard let snapshotId else { return nil }
-        var snapshotProcessIdentifier: Int32?
-        var snapshotProcessIdentity: ApplicationProcessIdentity?
+        var evidence: [DesktopTargetIdentity.Evidence] = []
+        var hasProcessIdentifier = false
         if let snapshot = try? await self.services.snapshots.getUIAutomationSnapshot(snapshotId: snapshotId),
            let processIdentifier = snapshot.applicationProcessId {
-            snapshotProcessIdentifier = processIdentifier
-            if let identity = snapshot.windowMutationIdentity {
-                guard identity.ownerProcessIdentifier == processIdentifier else {
-                    throw ValidationError("Snapshot '\(snapshotId)' has inconsistent process metadata.")
-                }
-                snapshotProcessIdentity = ApplicationProcessIdentity(
-                    processIdentifier: identity.ownerProcessIdentifier,
-                    processStartIdentity: identity.ownerProcessStartIdentity
-                )
-            }
+            hasProcessIdentifier = true
+            evidence.append(.init(
+                processIdentifier: processIdentifier,
+                processIdentity: snapshot.windowMutationIdentity?.processIdentity
+            ))
         }
         if let detection = try? await self.services.snapshots.getDetectionResult(snapshotId: snapshotId),
            let context = detection.metadata.windowContext,
            let processIdentifier = context.applicationProcessId {
-            if let snapshotProcessIdentifier, snapshotProcessIdentifier != processIdentifier {
-                throw ValidationError("Snapshot '\(snapshotId)' has inconsistent process metadata.")
-            }
-            snapshotProcessIdentifier = processIdentifier
-            if let identity = context.windowMutationIdentity {
-                guard identity.ownerProcessIdentifier == processIdentifier else {
-                    throw ValidationError("Snapshot '\(snapshotId)' has inconsistent process metadata.")
-                }
-                let detectionIdentity = ApplicationProcessIdentity(
-                    processIdentifier: identity.ownerProcessIdentifier,
-                    processStartIdentity: identity.ownerProcessStartIdentity
-                )
-                if let existingIdentity = snapshotProcessIdentity, existingIdentity != detectionIdentity {
-                    throw ValidationError("Snapshot '\(snapshotId)' has inconsistent process metadata.")
-                }
-                snapshotProcessIdentity = detectionIdentity
-            }
+            hasProcessIdentifier = true
+            evidence.append(.init(
+                processIdentifier: processIdentifier,
+                processIdentity: context.windowMutationIdentity?.processIdentity
+            ))
         }
-        guard snapshotProcessIdentifier != nil else {
+        guard hasProcessIdentifier else {
             throw ValidationError(
                 "Snapshot '\(snapshotId)' does not identify a target process. Run see again before clicking."
             )
         }
-        guard let snapshotProcessIdentity else {
+        do {
+            return try SnapshotTargetReceipt(snapshotID: snapshotId, evidence: evidence)
+                .requireIdentity().processIdentity
+        } catch DesktopTargetIdentityError.missingProcessGeneration,
+            DesktopTargetIdentityError.incompleteExactWindow {
             throw ValidationError(
                 "Snapshot '\(snapshotId)' has no capture-time process-generation receipt. " +
                     "Run see again before clicking."
             )
+        } catch {
+            throw ValidationError("Snapshot '\(snapshotId)' has inconsistent process metadata.")
         }
-        return snapshotProcessIdentity
     }
 
     private func currentProcessIdentity(identifier: String) async throws -> ApplicationProcessIdentity {
@@ -1063,16 +1051,32 @@ extension ClickCommand {
     ) async throws -> InteractionCoordinateResolution {
         guard let detection = try await self.services.snapshots.getDetectionResult(snapshotId: snapshotId),
               !detection.screenshotPath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
-              let captured = detection.metadata.windowContext,
-              let processIdentifier = captured.applicationProcessId,
-              let windowID = captured.windowID,
-              let capturedBounds = captured.windowBounds,
-              let capturedIdentity = captured.windowMutationIdentity,
-              capturedIdentity.windowID == windowID,
-              capturedIdentity.ownerProcessIdentifier == processIdentifier
+              let captured = detection.metadata.windowContext
         else {
             throw ValidationError(Self.backgroundCoordinateReferenceMessage)
         }
+        let coordinateAuthority: SnapshotTargetReceipt.CoordinateAuthority
+        do {
+            coordinateAuthority = try SnapshotTargetReceipt(
+                snapshotID: snapshotId,
+                evidence: [.init(
+                    processIdentifier: captured.applicationProcessId,
+                    windowID: captured.windowID,
+                    windowIdentity: captured.windowMutationIdentity,
+                    windowBounds: captured.windowBounds
+                )],
+                applicationBundleIdentifier: captured.applicationBundleId,
+                applicationName: captured.applicationName,
+                coordinateContext: detection.metadata.captureCoordinateContext
+            )
+            .requireCoordinateAuthority()
+        } catch {
+            throw ValidationError(Self.backgroundCoordinateReferenceMessage)
+        }
+        let capturedIdentity = coordinateAuthority.target.identity
+        let processIdentifier = capturedIdentity.ownerProcessIdentifier
+        let windowID = capturedIdentity.windowID
+        let capturedBounds = coordinateAuthority.target.bounds
 
         if let requestedPID = self.target.pid, requestedPID != processIdentifier {
             throw ValidationError(
@@ -1145,12 +1149,33 @@ extension ClickCommand {
               let expectedIdentity = window.mutationIdentity,
               expectedIdentity.windowID == window.windowID,
               expectedIdentity.ownerProcessIdentifier == resolution.targetProcessIdentifier,
-              window.bounds.contains(resolution.screenPoint),
-              let detection = try await self.services.snapshots.getDetectionResult(snapshotId: snapshotId),
-              let captured = detection.metadata.windowContext,
-              captured.windowID == window.windowID,
-              captured.windowBounds == window.bounds,
-              captured.windowMutationIdentity == expectedIdentity
+              window.bounds.contains(resolution.screenPoint)
+        else {
+            throw ValidationError(Self.backgroundCoordinateReferenceMessage)
+        }
+        guard let detection = try await self.services.snapshots.getDetectionResult(snapshotId: snapshotId),
+              let captured = detection.metadata.windowContext
+        else {
+            throw ValidationError(Self.backgroundCoordinateReferenceMessage)
+        }
+        let authority: SnapshotTargetReceipt.CoordinateAuthority
+        do {
+            authority = try SnapshotTargetReceipt(
+                snapshotID: snapshotId,
+                evidence: [.init(
+                    processIdentifier: captured.applicationProcessId,
+                    windowID: captured.windowID,
+                    windowIdentity: captured.windowMutationIdentity,
+                    windowBounds: captured.windowBounds
+                )],
+                coordinateContext: detection.metadata.captureCoordinateContext
+            )
+            .requireCoordinateAuthority()
+        } catch {
+            throw ValidationError(Self.backgroundCoordinateReferenceMessage)
+        }
+        guard authority.target.identity.hasSameStableReceipt(as: expectedIdentity),
+              authority.target.bounds == window.bounds
         else {
             throw ValidationError(Self.backgroundCoordinateReferenceMessage)
         }

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/KeyboardDeliverySupport.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/KeyboardDeliverySupport.swift
@@ -101,64 +101,40 @@ enum KeyboardDeliverySupport {
         snapshotId: String,
         services: any PeekabooServiceProviding
     ) async throws -> UIAutomationTarget.ExactWindow {
-        var processIdentifier: Int32?
-        var windowIdentity: WindowMutationIdentity?
-        var windowBounds: CGRect?
-
-        func merge(
-            process incomingProcess: Int32?,
-            identity incomingIdentity: WindowMutationIdentity?,
-            bounds incomingBounds: CGRect?
-        ) throws {
-            if let incomingProcess {
-                guard processIdentifier.map({ $0 == incomingProcess }) ?? true else {
-                    throw ValidationError("Snapshot '\(snapshotId)' has inconsistent process metadata.")
-                }
-                processIdentifier = incomingProcess
-            }
-            if let incomingIdentity {
-                guard windowIdentity.map({ $0 == incomingIdentity }) ?? true else {
-                    throw ValidationError("Snapshot '\(snapshotId)' has inconsistent window metadata.")
-                }
-                windowIdentity = incomingIdentity
-            }
-            if let incomingBounds {
-                guard windowBounds.map({ $0 == incomingBounds }) ?? true else {
-                    throw ValidationError("Snapshot '\(snapshotId)' has inconsistent window bounds.")
-                }
-                windowBounds = incomingBounds
-            }
-        }
-
+        var evidence: [DesktopTargetIdentity.Evidence] = []
         if let snapshot = try await services.snapshots.getUIAutomationSnapshot(snapshotId: snapshotId) {
-            try merge(
-                process: snapshot.applicationProcessId,
-                identity: snapshot.windowMutationIdentity,
-                bounds: snapshot.windowBounds
-            )
+            evidence.append(.init(
+                processIdentifier: snapshot.applicationProcessId,
+                windowID: snapshot.windowID.map(Int.init),
+                windowIdentity: snapshot.windowMutationIdentity,
+                windowBounds: snapshot.windowBounds
+            ))
         }
         if let detectionResult = try await services.snapshots.getDetectionResult(snapshotId: snapshotId),
            let context = detectionResult.metadata.windowContext {
-            try merge(
-                process: context.applicationProcessId,
-                identity: context.windowMutationIdentity,
-                bounds: context.windowBounds
-            )
+            evidence.append(.init(
+                processIdentifier: context.applicationProcessId,
+                windowID: context.windowID,
+                windowIdentity: context.windowMutationIdentity,
+                windowBounds: context.windowBounds
+            ))
         }
 
-        guard let processIdentifier, processIdentifier > 0,
-              let windowIdentity,
-              let windowBounds,
-              windowIdentity.ownerProcessIdentifier == processIdentifier,
-              windowIdentity.windowID > 0,
-              windowIdentity.capturedBounds == windowBounds
-        else {
+        do {
+            let receipt = try SnapshotTargetReceipt(snapshotID: snapshotId, evidence: evidence)
+            guard let exactWindow = try receipt.requireIdentity().exactWindow else {
+                throw DesktopTargetIdentityError.incompleteExactWindow
+            }
+            return exactWindow
+        } catch DesktopTargetIdentityError.missingProcessGeneration,
+            DesktopTargetIdentityError.incompleteExactWindow {
             throw ValidationError(
                 "Snapshot '\(snapshotId)' has no exact process-generation, window, and bounds receipt. " +
                     "Capture fresh UI state."
             )
+        } catch {
+            throw ValidationError("Snapshot '\(snapshotId)' has inconsistent process/window metadata.")
         }
-        return try UIAutomationTarget.ExactWindow(identity: windowIdentity, bounds: windowBounds)
     }
 
     private static func resolveSelectedWindow(
@@ -202,19 +178,25 @@ enum KeyboardDeliverySupport {
         snapshot: ApplicationProcessIdentity?,
         window: ApplicationProcessIdentity?
     ) throws -> ApplicationProcessIdentity {
-        let identities = [selected, snapshot, window].compactMap(\.self)
-        guard let identity = identities.first else {
+        let identities = try [selected, snapshot, window].map { identity throws -> DesktopTargetIdentity? in
+            guard let identity else { return nil }
+            return try DesktopTargetIdentity(processIdentity: identity)
+        }
+        let targetIdentity: DesktopTargetIdentity?
+        do {
+            targetIdentity = try DesktopTargetPlanning.DesktopTargetIdentityCoalescer.coalesce(identities)
+        } catch {
+            throw ValidationError(
+                "The selected app, window, and snapshot do not identify the same process generation. " +
+                    "Capture fresh UI state."
+            )
+        }
+        guard let identity = targetIdentity?.processIdentity else {
             throw PreDispatchActionError(
                 message: "Keyboard input requires --app, --pid, --window-id, or --snapshot for background delivery.",
                 code: .VALIDATION_ERROR,
                 hint: "Use --foreground for intentional global input.",
                 reason: .invalidRequest
-            )
-        }
-        guard identities.allSatisfy({ $0 == identity }) else {
-            throw ValidationError(
-                "The selected app, window, and snapshot do not identify the same process generation. " +
-                    "Capture fresh UI state."
             )
         }
         return identity

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/KeyboardDeliverySupport.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/KeyboardDeliverySupport.swift
@@ -152,7 +152,14 @@ enum KeyboardDeliverySupport {
             let detail = matches.isEmpty ? "no matching window" : "multiple matching windows"
             throw ValidationError("Could not resolve one exact background keyboard target: \(detail).")
         }
-        return try UIAutomationTarget.ExactWindow(window: window)
+        do {
+            return try DesktopTargetPlanning.DesktopTargetIdentityCoalescer.exactWindow(from: window)
+        } catch {
+            throw ValidationError(
+                "The selected window has no valid process-generation, window ID, and capture-bounds receipt. " +
+                    "Capture fresh UI state."
+            )
+        }
     }
 
     private static func resolveSelectedProcessIdentity(

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Shared/InteractionTargetOptions.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Shared/InteractionTargetOptions.swift
@@ -29,17 +29,25 @@ struct InteractionTargetOptions: CommanderParsable, ApplicationResolvable {
     init() {}
 
     var hasAnyTarget: Bool {
-        self.app != nil || self.pid != nil || self.windowTitle != nil || self.windowIndex != nil || self.windowId != nil
+        self.selector.hasAnyInput
+    }
+
+    var selector: InteractionTargetSelector {
+        InteractionTargetSelector(
+            applicationIdentifier: self.app,
+            processIdentifier: self.pid.map(Int.init),
+            windowID: self.windowId,
+            windowTitle: self.windowTitle,
+            windowIndex: self.windowIndex
+        )
     }
 
     func validateSelectorCombination() throws {
-        try InteractionTargetSelectorValidator.validateCLI(
-            hasApplication: self.app != nil,
-            hasProcessIdentifier: self.pid != nil,
-            hasWindowID: self.windowId != nil,
-            hasWindowTitle: self.windowTitle != nil,
-            hasWindowIndex: self.windowIndex != nil
-        )
+        do {
+            try self.selector.validate(policy: .interaction)
+        } catch let error as InteractionTargetSelector.ValidationError {
+            throw Self.validationError(for: error)
+        }
     }
 
     func validate() throws {
@@ -109,24 +117,18 @@ struct InteractionTargetOptions: CommanderParsable, ApplicationResolvable {
 
     func toWindowTarget() throws -> WindowTarget? {
         try self.validate()
-        if let windowId {
-            return .windowId(windowId)
+        switch try self.selector.normalizedWindowSelector(policy: .interaction) {
+        case let .id(windowID):
+            return .windowId(windowID)
+        case let .title(title):
+            guard let appIdentifier = try self.resolveApplicationIdentifierOptional() else { return nil }
+            return .applicationAndTitle(app: appIdentifier, title: title)
+        case let .index(index):
+            guard let appIdentifier = try self.resolveApplicationIdentifierOptional() else { return nil }
+            return .index(app: appIdentifier, index: index)
+        case nil:
+            return try self.resolveApplicationIdentifierOptional().map(WindowTarget.application)
         }
-
-        guard let appIdentifier = try self.resolveApplicationIdentifierOptional() else {
-            return nil
-        }
-
-        if let windowTitle = self.windowTitle?.trimmingCharacters(in: .whitespacesAndNewlines),
-           !windowTitle.isEmpty {
-            return .applicationAndTitle(app: appIdentifier, title: windowTitle)
-        }
-
-        if let windowIndex {
-            return .index(app: appIdentifier, index: windowIndex)
-        }
-
-        return .application(appIdentifier)
     }
 
     func dialogTargetSelector() throws -> DialogTargetSelector {
@@ -139,34 +141,32 @@ struct InteractionTargetOptions: CommanderParsable, ApplicationResolvable {
             windowIndex: self.windowIndex
         )
     }
-}
 
-extension InteractionTargetSelectorValidator {
-    static func validateCLI(
-        hasApplication: Bool,
-        hasProcessIdentifier: Bool,
-        hasWindowID: Bool,
-        hasWindowTitle: Bool,
-        hasWindowIndex: Bool
-    ) throws {
-        do {
-            try self.validate(
-                hasApplication: hasApplication,
-                hasProcessIdentifier: hasProcessIdentifier,
-                hasWindowID: hasWindowID,
-                hasWindowTitle: hasWindowTitle,
-                hasWindowIndex: hasWindowIndex
-            )
-        } catch let error as InteractionTargetSelectorValidationError {
-            let message = switch error {
-            case .applicationAndProcessIdentifier:
-                "Use either --app or --pid, not both."
-            case .multipleWindowSelectors:
-                "Use only one of --window-id, --window-title, or --window-index."
-            case .windowSelectorRequiresApplication:
-                "--window-title and --window-index require --app or --pid."
-            }
-            throw ValidationError(message)
+    static func validationError(
+        for error: InteractionTargetSelector.ValidationError
+    ) -> Commander.ValidationError {
+        let message = switch error {
+        case .applicationAndProcessIdentifier,
+             .conflictingProcessIdentifiers,
+             .invalidApplicationProcessIdentifier:
+            "Use either --app or --pid, not both."
+        case .multipleWindowSelectors:
+            "Use only one of --window-id, --window-title, or --window-index."
+        case .windowSelectorRequiresApplication:
+            "--window-title and --window-index require --app or --pid."
+        case .invalidProcessIdentifier:
+            "--pid must be greater than 0"
+        case .invalidWindowID:
+            "--window-id must be between 1 and \(UInt32.max)"
+        case .invalidWindowIndex:
+            "--window-index must be 0 or greater"
+        case .missingTarget:
+            "Target is required"
+        case .emptyApplication:
+            "--app must not be empty"
+        case .emptyWindowTitle:
+            "--window-title must not be empty"
         }
+        return Commander.ValidationError(message)
     }
 }

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Shared/SnapshotMutationCoordinator.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Shared/SnapshotMutationCoordinator.swift
@@ -32,6 +32,16 @@ enum SnapshotMutationCoordinator {
         let value: Value
         do {
             value = try await operation()
+        } catch let error as SnapshotTargetReceiptPreDispatchError {
+            // Receipt-shape planning is complete before any action/synthesis route can dispatch.
+            // Release this lease without changing conservative handling for live drift or unknown errors.
+            try? await snapshots.finishSnapshotMutation(lease, requiresFreshObservation: false)
+            throw PreDispatchActionError(
+                message: error.localizedDescription,
+                code: .SNAPSHOT_STALE,
+                hint: "Run 'peekaboo see' again and use a complete exact-window snapshot.",
+                reason: .targetUnavailable
+            )
         } catch let failure as DesktopActionFailure {
             // A typed failure says whether dispatch occurred. If lease finalization itself fails, the
             // still-present pending receipt remains the safer state and the original action failure

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/WindowCommand+Support.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/WindowCommand+Support.swift
@@ -43,18 +43,42 @@ struct WindowIdentificationOptions: CommanderParsable, ApplicationResolvable {
         self.windowIndex = try container.decodeIfPresent(Int.self, forKey: .windowIndex)
     }
 
+    var selector: InteractionTargetSelector {
+        InteractionTargetSelector(
+            applicationIdentifier: self.app,
+            processIdentifier: self.pid.map(Int.init),
+            windowID: self.windowId,
+            windowTitle: self.windowTitle,
+            windowIndex: self.windowIndex
+        )
+    }
+
     func validate(allowMissingTarget: Bool = false) throws {
-        if let windowId = self.windowId, windowId <= 0 {
-            throw ValidationError("--window-id must be greater than 0")
-        }
-
-        // Ensure we have some way to identify the window
-        if self.app == nil, self.pid == nil, self.windowId == nil, !allowMissingTarget {
-            throw ValidationError("Either --app, --pid, or --window-id must be specified")
-        }
-
-        if let index = self.windowIndex, index < 0 {
-            throw ValidationError("--window-index must be 0 or greater")
+        do {
+            try self.selector.validate(policy: .windowCLI(allowMissingTarget: allowMissingTarget))
+        } catch let error as InteractionTargetSelector.ValidationError {
+            switch error {
+            case .invalidWindowID:
+                throw ValidationError("--window-id must be greater than 0")
+            case .missingTarget:
+                throw ValidationError("Either --app, --pid, or --window-id must be specified")
+            case .invalidWindowIndex:
+                throw ValidationError("--window-index must be 0 or greater")
+            case let .conflictingProcessIdentifiers(applicationPID, explicitPID):
+                throw PeekabooError.invalidInput(
+                    "Conflicting PIDs: --app specifies PID \(applicationPID) but --pid is \(explicitPID)"
+                )
+            case .invalidApplicationProcessIdentifier:
+                throw PeekabooError.invalidInput("Invalid PID format in --app: '\(self.app ?? "")'")
+            case .applicationAndProcessIdentifier:
+                throw PeekabooError.invalidInput("Provide the application either with --app or --pid, not both")
+            case .multipleWindowSelectors,
+                 .windowSelectorRequiresApplication,
+                 .invalidProcessIdentifier,
+                 .emptyApplication,
+                 .emptyWindowTitle:
+                preconditionFailure("Window CLI policy does not emit \(error)")
+            }
         }
     }
 

--- a/Apps/CLI/Tests/CLIAutomationTests/SnapshotReceiptPreDispatchCommandTests.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/SnapshotReceiptPreDispatchCommandTests.swift
@@ -1,0 +1,128 @@
+import CoreGraphics
+import Foundation
+import PeekabooAutomationKitTestSupport
+import PeekabooCore
+import Testing
+@testable import PeekabooCLI
+
+@Suite(.serialized)
+@MainActor
+struct SnapshotReceiptPreDispatchCommandTests {
+    @Test
+    func `incomplete exact receipt refusals release the snapshot lease across action commands`() async throws {
+        let snapshots = StubSnapshotManager()
+        let snapshotID = try await Self.storeIncompleteExactWindowElementSnapshot(in: snapshots)
+        let automation = UIAutomationService(snapshotManager: snapshots)
+        let services = TestServicesFactory.makePeekabooServices(
+            snapshots: snapshots,
+            automation: automation
+        )
+        let actionArguments = [
+            ["set-value", "updated", "--on", "E1"],
+            ["action", "AXPress", "--on", "B1"],
+            ["scroll", "--direction", "down", "--amount", "1", "--on", "B1"],
+            ["click", "--on", "B1"],
+        ]
+
+        for _ in 0..<2 {
+            for arguments in actionArguments {
+                let result = try await InProcessCommandRunner.run(
+                    arguments + ["--snapshot", snapshotID, "--no-remote", "--json"],
+                    services: services
+                )
+                let object = try Self.jsonObject(result.stdout)
+                let outcome = try #require(object["outcome"] as? [String: Any])
+                let error = try #require(object["error"] as? [String: Any])
+
+                #expect(result.exitStatus == 1, "Expected receipt refusal for \(arguments[0])")
+                #expect(error["code"] as? String == ErrorCode.SNAPSHOT_STALE.rawValue)
+                #expect((error["message"] as? String)?.contains("incomplete") == true)
+                #expect((error["message"] as? String)?.contains("immutable captured bounds") == true)
+                #expect(error["retry_safe"] as? Bool == true)
+                #expect(error["mutation_dispatched"] as? Bool == false)
+                #expect(outcome["state"] as? String == "refused")
+                #expect(outcome["dispatch_state"] as? String == "none")
+                #expect(outcome["requires_fresh_observation"] as? Bool == false)
+                #expect(!result.combinedOutput.contains("already drove a mutation"))
+            }
+        }
+
+        let typeResult = try await InProcessCommandRunner.run(
+            ["type", "hello", "--snapshot", snapshotID, "--no-remote", "--json"],
+            services: services
+        )
+        let typeObject = try Self.jsonObject(typeResult.stdout)
+        let typeError = try #require(typeObject["error"] as? [String: Any])
+        #expect(typeResult.exitStatus == 1)
+        #expect(typeError["code"] as? String == ErrorCode.VALIDATION_ERROR.rawValue)
+        #expect(typeResult.combinedOutput.contains("no exact process-generation, window, and bounds receipt"))
+        #expect(!typeResult.combinedOutput.contains("already drove a mutation"))
+
+        let humanResult = try await InProcessCommandRunner.run(
+            ["set-value", "updated", "--on", "E1", "--snapshot", snapshotID, "--no-remote"],
+            services: services
+        )
+        #expect(humanResult.exitStatus == 1)
+        #expect(humanResult.combinedOutput.contains("Snapshot target receipt is incomplete"))
+        #expect(humanResult.combinedOutput.contains("immutable captured bounds"))
+        #expect(humanResult.combinedOutput.contains("complete exact-window snapshot"))
+        #expect(!humanResult.combinedOutput.contains("already drove a mutation"))
+
+        let lease = try await snapshots.beginSnapshotMutation(snapshotId: snapshotID)
+        try await snapshots.finishSnapshotMutation(lease, requiresFreshObservation: false)
+    }
+
+    private static func storeIncompleteExactWindowElementSnapshot(
+        in snapshots: StubSnapshotManager
+    ) async throws -> String {
+        let snapshotID = try await snapshots.createSnapshot()
+        let process = AutomationTestFixtures.processIdentity(
+            processIdentifier: getpid(),
+            processStartIdentity: 71
+        )
+        let bounds = CGRect(x: 100, y: 100, width: 500, height: 400)
+        let identity = AutomationTestFixtures.windowIdentity(
+            windowID: 42,
+            processIdentity: process,
+            bounds: nil
+        )
+        let button = AutomationTestFixtures.detectedElement(
+            id: "B1",
+            type: .button,
+            label: "Button",
+            bounds: CGRect(x: 120, y: 140, width: 100, height: 40),
+            isEnabled: true,
+            attributes: ["role": "AXButton"]
+        )
+        let textField = AutomationTestFixtures.detectedElement(
+            id: "E1",
+            type: .textField,
+            label: "Value",
+            bounds: CGRect(x: 120, y: 200, width: 200, height: 30),
+            isEnabled: true,
+            attributes: ["role": "AXTextField"]
+        )
+        try await snapshots.storeDetectionResult(
+            snapshotId: snapshotID,
+            result: AutomationTestFixtures.detectionResult(
+                snapshotID: snapshotID,
+                screenshotPath: "/tmp/incomplete-exact-window.png",
+                elements: DetectedElements(
+                    buttons: [button],
+                    textFields: [textField]
+                ),
+                windowContext: WindowContext(
+                    applicationProcessId: process.processIdentifier,
+                    windowID: identity.windowID,
+                    windowBounds: bounds,
+                    windowMutationIdentity: identity
+                )
+            )
+        )
+        return snapshotID
+    }
+
+    private static func jsonObject(_ output: String) throws -> [String: Any] {
+        try #require(JSONSerialization.jsonObject(with: Data(output.utf8)) as? [String: Any])
+    }
+}

--- a/Apps/CLI/Tests/CLIAutomationTests/TargetedInteractionDefaultDeliveryTests.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/TargetedInteractionDefaultDeliveryTests.swift
@@ -1,3 +1,4 @@
+import Commander
 import CoreGraphics
 import Foundation
 import PeekabooCore
@@ -115,7 +116,7 @@ struct TargetedInteractionDefaultDeliveryTests {
     }
 
     @Test
-    func `background keyboard delivery rejects window selectors instead of collapsing to pid`() async throws {
+    func `unresolved background window selectors refuse instead of collapsing to pid`() async throws {
         let app = ServiceApplicationInfo(
             processIdentifier: 2468,
             bundleIdentifier: "com.apple.TextEdit",
@@ -134,7 +135,7 @@ struct TargetedInteractionDefaultDeliveryTests {
         ] {
             let result = try await InProcessCommandRunner.run(arguments + ["--no-remote"], services: services)
             #expect(result.exitStatus != 0, "Expected unsafe window targeting to fail: \(arguments)")
-            #expect(result.combinedOutput.contains("cannot safely target a specific window"))
+            #expect(result.combinedOutput.contains("no matching window"))
         }
         let press = try await InProcessCommandRunner.run(
             [
@@ -143,7 +144,7 @@ struct TargetedInteractionDefaultDeliveryTests {
             services: services
         )
         #expect(press.exitStatus != 0)
-        #expect(press.combinedOutput.contains("require explicit foreground consent"))
+        #expect(press.combinedOutput.contains("no matching window"))
 
         #expect(automation.targetedTypeActionsCalls.isEmpty)
         #expect(automation.targetedHotkeyCalls.isEmpty)
@@ -152,7 +153,7 @@ struct TargetedInteractionDefaultDeliveryTests {
     }
 
     @Test
-    func `snapshot process receipt keeps type pid routed while raw press refuses`() async throws {
+    func `snapshot exact-window evidence without captured bounds refuses keyboard delivery`() async throws {
         let app = ServiceApplicationInfo(
             processIdentifier: 2468,
             processStartIdentity: 7,
@@ -193,18 +194,75 @@ struct TargetedInteractionDefaultDeliveryTests {
             ["type", "hello", "--snapshot", snapshotId, "--no-auto-focus", "--no-remote"],
             services: context.services
         )
-        #expect(type.exitStatus == 0)
+        #expect(type.exitStatus != 0)
         let press = try await InProcessCommandRunner.run(
             ["press", "return", "--snapshot", snapshotId, "--no-auto-focus", "--no-remote"],
             services: context.services
         )
         #expect(press.exitStatus != 0)
-        #expect(press.combinedOutput.contains("require explicit foreground consent"))
+        #expect(press.combinedOutput.contains("no exact process-generation, window, and bounds receipt"))
 
-        #expect(context.automation.targetedTypeActionsCalls.count == 1)
-        #expect(context.automation.targetedTypeActionsCalls.allSatisfy { $0.targetProcessIdentifier == 2468 })
+        #expect(context.automation.targetedTypeActionsCalls.isEmpty)
         #expect(context.automation.targetedHotkeyCalls.isEmpty)
         #expect(context.automation.hotkeyCalls.isEmpty)
+    }
+
+    @Test
+    func `CLI keyboard receipt adapter accepts only complete immutable exact-window evidence`() async throws {
+        let processIdentifier: pid_t = 2468
+        let processStartIdentity: UInt64 = 7
+        let bounds = CGRect(x: 10, y: 20, width: 640, height: 480)
+        let application = ServiceApplicationInfo(
+            processIdentifier: processIdentifier,
+            processStartIdentity: processStartIdentity,
+            bundleIdentifier: "com.apple.TextEdit",
+            name: "TextEdit"
+        )
+        let context = TestServicesFactory.makeAutomationTestContext(
+            applications: StubApplicationService(applications: [application])
+        )
+        let malformedReceipts: [(windowID: Int, capturedBounds: CGRect?)] = [
+            (42, nil),
+            (42, bounds.offsetBy(dx: 1, dy: 0)),
+            (0, bounds),
+            (Int(UInt32.max) + 1, bounds),
+        ]
+
+        for malformed in malformedReceipts {
+            let snapshotID = try await self.storeKeyboardSnapshot(
+                in: context.services,
+                processIdentifier: processIdentifier,
+                processStartIdentity: processStartIdentity,
+                windowID: malformed.windowID,
+                windowBounds: bounds,
+                capturedBounds: malformed.capturedBounds
+            )
+
+            await #expect(throws: ValidationError.self) {
+                _ = try await KeyboardDeliverySupport.requireBackgroundKeyboardTarget(
+                    target: InteractionTargetOptions(),
+                    snapshotId: snapshotID,
+                    services: context.services
+                )
+            }
+        }
+
+        let validSnapshotID = try await self.storeKeyboardSnapshot(
+            in: context.services,
+            processIdentifier: processIdentifier,
+            processStartIdentity: processStartIdentity,
+            windowID: 42,
+            windowBounds: bounds,
+            capturedBounds: bounds
+        )
+        let target = try await KeyboardDeliverySupport.requireBackgroundKeyboardTarget(
+            target: InteractionTargetOptions(),
+            snapshotId: validSnapshotID,
+            services: context.services
+        )
+        #expect(target.exactWindow?.identity.windowID == 42)
+        #expect(target.exactWindow?.identity.capturedBounds == bounds)
+        #expect(target.exactWindow?.bounds == bounds)
     }
 
     @Test
@@ -219,6 +277,7 @@ struct TargetedInteractionDefaultDeliveryTests {
             applications: StubApplicationService(applications: [app])
         )
         let snapshotId = try await context.snapshots.createSnapshot()
+        let bounds = CGRect(x: 10, y: 20, width: 640, height: 480)
         try await context.snapshots.storeDetectionResult(
             snapshotId: snapshotId,
             result: ElementDetectionResult(
@@ -234,10 +293,12 @@ struct TargetedInteractionDefaultDeliveryTests {
                         applicationBundleId: "com.apple.TextEdit",
                         applicationProcessId: 2468,
                         windowID: 42,
+                        windowBounds: bounds,
                         windowMutationIdentity: WindowMutationIdentity(
                             windowID: 42,
                             ownerProcessIdentifier: 2468,
-                            ownerProcessStartIdentity: 7
+                            ownerProcessStartIdentity: 7,
+                            capturedBounds: bounds
                         )
                     )
                 )
@@ -253,7 +314,7 @@ struct TargetedInteractionDefaultDeliveryTests {
         )
 
         #expect(result.exitStatus != 0)
-        #expect(result.combinedOutput.contains("changed process generation"))
+        #expect(result.combinedOutput.contains("do not identify the same process generation"))
         #expect(context.automation.targetedTypeActionsCalls.isEmpty)
     }
 
@@ -285,13 +346,13 @@ struct TargetedInteractionDefaultDeliveryTests {
             services: context.services
         )
         #expect(type.exitStatus != 0)
-        #expect(type.combinedOutput.contains("no capture-time process-generation receipt"))
+        #expect(type.combinedOutput.contains("no exact process-generation, window, and bounds receipt"))
         let press = try await InProcessCommandRunner.run(
             ["press", "return", "--snapshot", snapshotId, "--no-auto-focus", "--no-remote"],
             services: context.services
         )
         #expect(press.exitStatus != 0)
-        #expect(press.combinedOutput.contains("require explicit foreground consent"))
+        #expect(press.combinedOutput.contains("no exact process-generation, window, and bounds receipt"))
 
         #expect(context.automation.targetedTypeActionsCalls.isEmpty)
         #expect(context.automation.targetedHotkeyCalls.isEmpty)
@@ -319,7 +380,7 @@ struct TargetedInteractionDefaultDeliveryTests {
         )
 
         #expect(result.exitStatus != 0)
-        #expect(result.combinedOutput.contains("does not identify a target process"))
+        #expect(result.combinedOutput.contains("no exact process-generation, window, and bounds receipt"))
         #expect(context.automation.typeActionsCalls.isEmpty)
         #expect(context.automation.targetedTypeActionsCalls.isEmpty)
     }
@@ -350,6 +411,11 @@ struct TargetedInteractionDefaultDeliveryTests {
         )
         let services = TestServicesFactory.makePeekabooServices(
             applications: applications,
+            clipboard: clipboard,
+            automation: automation
+        )
+        let clickServices = TestServicesFactory.makePeekabooServices(
+            applications: applications,
             windows: StubWindowService(windowsByApp: [app.name: [window]]),
             clipboard: clipboard,
             automation: automation
@@ -359,7 +425,7 @@ struct TargetedInteractionDefaultDeliveryTests {
         try await self.assertPressDefaultsToRefusal(services: services, automation: automation)
         try await self.assertPasteDefaultsToBackground(services: services, automation: automation)
         try await self.assertClickDefaultsToBackground(
-            services: services,
+            services: clickServices,
             automation: automation,
             targetWindow: window
         )
@@ -456,6 +522,15 @@ struct TargetedInteractionDefaultDeliveryTests {
                         windowID: targetWindow.windowID,
                         windowBounds: targetWindow.bounds,
                         windowMutationIdentity: targetWindow.mutationIdentity
+                    ),
+                    truncationInfo: nil,
+                    captureCoordinateContext: CaptureCoordinateContext(
+                        metadata: CaptureMetadata(
+                            size: targetWindow.bounds.size,
+                            mode: .window,
+                            windowInfo: targetWindow
+                        ),
+                        referenceID: snapshotId
                     )
                 )
             )
@@ -468,7 +543,7 @@ struct TargetedInteractionDefaultDeliveryTests {
             services: services
         )
 
-        #expect(result.exitStatus == 0)
+        #expect(result.exitStatus == 0, "Unexpected click refusal: \(result.combinedOutput)")
         let call = try #require(automation.targetedClickCalls.last)
         #expect(call.targetProcessIdentifier == 2468)
         #expect(call.targetWindowID == targetWindow.windowID)
@@ -483,6 +558,46 @@ struct TargetedInteractionDefaultDeliveryTests {
             as: CodableJSONResponse<ClickDeliveryPayload>.self
         )
         #expect(payload.data.deliveryMode == "background")
+    }
+
+    private func storeKeyboardSnapshot(
+        in services: PeekabooServices,
+        processIdentifier: pid_t,
+        processStartIdentity: UInt64,
+        windowID: Int,
+        windowBounds: CGRect,
+        capturedBounds: CGRect?
+    ) async throws -> String {
+        let snapshotID = try await services.snapshots.createSnapshot()
+        let identity = WindowMutationIdentity(
+            windowID: windowID,
+            ownerProcessIdentifier: processIdentifier,
+            ownerProcessStartIdentity: processStartIdentity,
+            capturedBounds: capturedBounds
+        )
+        try await services.snapshots.storeDetectionResult(
+            snapshotId: snapshotID,
+            result: ElementDetectionResult(
+                snapshotId: snapshotID,
+                screenshotPath: "/tmp/keyboard-receipt.png",
+                elements: DetectedElements(),
+                metadata: DetectionMetadata(
+                    detectionTime: 0,
+                    elementCount: 0,
+                    method: "stub",
+                    windowContext: WindowContext(
+                        applicationName: "TextEdit",
+                        applicationBundleId: "com.apple.TextEdit",
+                        applicationProcessId: processIdentifier,
+                        windowTitle: "Document",
+                        windowID: windowID,
+                        windowBounds: windowBounds,
+                        windowMutationIdentity: identity
+                    )
+                )
+            )
+        )
+        return snapshotID
     }
 }
 

--- a/Apps/CLI/Tests/CoreCLITests/WindowTargetCreationTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/WindowTargetCreationTests.swift
@@ -5,6 +5,32 @@ import Testing
 
 struct WindowTargetCreationTests {
     @Test
+    func `window CLI syntax preserves matching redundant PID channels`() throws {
+        var options = WindowIdentificationOptions()
+        options.app = "PID:12345"
+        options.pid = 12345
+
+        try options.validate()
+        #expect(try options.selector.normalizedApplicationTarget(policy: .windowCLI()) == "PID:12345")
+    }
+
+    @Test
+    func `window CLI syntax preserves conflicting PID error`() {
+        var options = WindowIdentificationOptions()
+        options.app = "PID:12345"
+        options.pid = 54321
+
+        do {
+            try options.validate()
+            Issue.record("Expected conflicting PID validation error")
+        } catch {
+            #expect(error.localizedDescription.contains("Conflicting PIDs"))
+            #expect(error.localizedDescription.contains("12345"))
+            #expect(error.localizedDescription.contains("54321"))
+        }
+    }
+
+    @Test
     func `app + windowTitle creates .applicationAndTitle`() throws {
         var options = WindowIdentificationOptions()
         options.app = "Safari"

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Core/Protocols/DialogOperationModels.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Core/Protocols/DialogOperationModels.swift
@@ -19,12 +19,23 @@ public struct DialogTargetSelector: Sendable, Codable, Equatable {
         windowTitle: String? = nil,
         windowIndex: Int? = nil) throws
     {
-        self.applicationIdentifier = Self.normalized(applicationIdentifier)
+        let selector = InteractionTargetSelector(
+            applicationIdentifier: applicationIdentifier,
+            processIdentifier: processIdentifier.map(Int.init),
+            windowID: windowID,
+            windowTitle: windowTitle,
+            windowIndex: windowIndex)
+        do {
+            try selector.validate(policy: .dialogOwnerRequired)
+        } catch let error as InteractionTargetSelector.ValidationError {
+            throw PeekabooError.invalidInput(Self.validationMessage(for: error))
+        }
+
+        self.applicationIdentifier = selector.normalizedApplicationIdentifier
         self.processIdentifier = processIdentifier
         self.windowID = windowID
-        self.windowTitle = Self.normalized(windowTitle)
+        self.windowTitle = selector.normalizedWindowTitle
         self.windowIndex = windowIndex
-        try self.validate(originalApplication: applicationIdentifier, originalWindowTitle: windowTitle)
     }
 
     public var hasTarget: Bool {
@@ -54,45 +65,40 @@ public struct DialogTargetSelector: Sendable, Codable, Equatable {
             windowIndex: container.decodeIfPresent(Int.self, forKey: .windowIndex))
     }
 
-    private func validate(originalApplication: String?, originalWindowTitle: String?) throws {
-        if originalApplication != nil, self.applicationIdentifier == nil {
-            throw PeekabooError.invalidInput("Dialog target application must not be empty")
-        }
-        if originalWindowTitle != nil, self.windowTitle == nil {
-            throw PeekabooError.invalidInput("Dialog target window title must not be empty")
-        }
-        do {
-            try InteractionTargetSelectorValidator.validate(
-                hasApplication: self.applicationIdentifier != nil,
-                hasProcessIdentifier: self.processIdentifier != nil,
-                hasWindowID: self.windowID != nil,
-                hasWindowTitle: self.windowTitle != nil,
-                hasWindowIndex: self.windowIndex != nil)
-        } catch let error as InteractionTargetSelectorValidationError {
-            let reason = switch error {
-            case .applicationAndProcessIdentifier:
-                "Dialog app and PID selectors are mutually exclusive"
-            case .multipleWindowSelectors:
-                "Dialog window ID, title, and index selectors are mutually exclusive"
-            case .windowSelectorRequiresApplication:
-                "Dialog window title and index selectors require an app or PID"
-            }
-            throw PeekabooError.invalidInput(reason)
-        }
-        if let processIdentifier, processIdentifier <= 0 {
-            throw PeekabooError.invalidInput("Dialog target PID must be positive")
-        }
-        if let windowID, windowID <= 0 || UInt32(exactly: windowID) == nil {
-            throw PeekabooError.invalidInput("Dialog target window ID must be between 1 and \(UInt32.max)")
-        }
-        if let windowIndex, windowIndex < 0 {
-            throw PeekabooError.invalidInput("Dialog target window index must be 0 or greater")
-        }
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(self.applicationIdentifier, forKey: .applicationIdentifier)
+        try container.encodeIfPresent(self.processIdentifier, forKey: .processIdentifier)
+        try container.encodeIfPresent(self.windowID, forKey: .windowID)
+        try container.encodeIfPresent(self.windowTitle, forKey: .windowTitle)
+        try container.encodeIfPresent(self.windowIndex, forKey: .windowIndex)
     }
 
-    private static func normalized(_ value: String?) -> String? {
-        guard let value = value?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty else { return nil }
-        return value
+    private static func validationMessage(
+        for error: InteractionTargetSelector.ValidationError) -> String
+    {
+        switch error {
+        case .emptyApplication:
+            "Dialog target application must not be empty"
+        case .emptyWindowTitle:
+            "Dialog target window title must not be empty"
+        case .applicationAndProcessIdentifier,
+             .conflictingProcessIdentifiers,
+             .invalidApplicationProcessIdentifier:
+            "Dialog app and PID selectors are mutually exclusive"
+        case .multipleWindowSelectors:
+            "Dialog window ID, title, and index selectors are mutually exclusive"
+        case .windowSelectorRequiresApplication:
+            "Dialog window title and index selectors require an app or PID"
+        case .invalidProcessIdentifier:
+            "Dialog target PID must be positive"
+        case .invalidWindowID:
+            "Dialog target window ID must be between 1 and \(UInt32.max)"
+        case .invalidWindowIndex:
+            "Dialog target window index must be 0 or greater"
+        case .missingTarget:
+            "Dialog target is required"
+        }
     }
 }
 

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/ClickService.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/ClickService.swift
@@ -926,16 +926,31 @@ extension ClickService {
         guard let targetWindowID, let targetProcessIdentifier else { return nil }
         guard let snapshotId,
               let detection = try? await self.snapshotManager.getDetectionResult(snapshotId: snapshotId),
-              let context = detection.metadata.windowContext,
-              let identity = context.windowMutationIdentity,
-              let bounds = context.windowBounds,
-              identity.windowID == Int(targetWindowID),
-              identity.ownerProcessIdentifier == targetProcessIdentifier
+              let context = detection.metadata.windowContext
         else {
             throw PeekabooError.snapshotStale(
                 "Exact-window click snapshot has no capture-time process-generation receipt and bounds")
         }
-        return try DesktopOperationPlan.ExactWindowReceipt(identity: identity, bounds: bounds)
+        do {
+            let receipt = try SnapshotTargetReceipt(
+                snapshotID: snapshotId,
+                evidence: [
+                    .init(
+                        processIdentifier: targetProcessIdentifier,
+                        windowID: Int(targetWindowID)),
+                    .init(
+                        processIdentifier: context.applicationProcessId,
+                        windowID: context.windowID,
+                        windowIdentity: context.windowMutationIdentity,
+                        windowBounds: context.windowBounds),
+                ])
+            guard let exactWindow = try receipt.requireIdentity().exactWindow else {
+                throw DesktopTargetIdentityError.incompleteExactWindow
+            }
+            return exactWindow
+        } catch let error as DesktopTargetIdentityError {
+            throw SnapshotTargetReceiptPreDispatchError(error)
+        }
     }
 
     private func requireCurrentTarget(

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Strategy/DesktopOperationPlan.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Strategy/DesktopOperationPlan.swift
@@ -62,6 +62,15 @@ struct DesktopOperationPlan {
             self.target = target
             self.coordinateContext = coordinateContext
         }
+
+        init(snapshotReceipt: SnapshotTargetReceipt) throws {
+            let identity = try snapshotReceipt.requireIdentity()
+            self.init(
+                snapshotID: snapshotReceipt.snapshotID,
+                bundleIdentifier: snapshotReceipt.applicationBundleIdentifier,
+                target: identity.target,
+                coordinateContext: snapshotReceipt.coordinateContext)
+        }
     }
 
     enum DeliveryIntent: Equatable, Sendable {

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Strategy/DesktopOperationSnapshotReceiptValidator.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Strategy/DesktopOperationSnapshotReceiptValidator.swift
@@ -56,11 +56,16 @@ enum DesktopOperationSnapshotReceiptValidator {
             throw PeekabooError.snapshotStale(
                 "target window owner, process generation, or bounds changed before desktop mutation")
         }
-        return try DesktopOperationPlan.CaptureReceipt(
+        return try DesktopOperationPlan.CaptureReceipt(snapshotReceipt: SnapshotTargetReceipt(
             snapshotID: snapshotID,
-            bundleIdentifier: context.applicationBundleId,
-            target: .exactWindow(UIAutomationTarget.ExactWindow(identity: identity, bounds: bounds)),
-            coordinateContext: detectionResult.metadata.captureCoordinateContext)
+            evidence: [.init(
+                processIdentifier: context.applicationProcessId,
+                windowID: context.windowID,
+                windowIdentity: identity,
+                windowBounds: bounds)],
+            applicationBundleIdentifier: context.applicationBundleId,
+            applicationName: context.applicationName,
+            coordinateContext: detectionResult.metadata.captureCoordinateContext))
     }
 
     static func validate(

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Strategy/DesktopOperationSnapshotReceiptValidator.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Strategy/DesktopOperationSnapshotReceiptValidator.swift
@@ -46,26 +46,30 @@ enum DesktopOperationSnapshotReceiptValidator {
                 target: .process(UIAutomationTarget.Process(processIdentifier: processIdentifier)),
                 coordinateContext: detectionResult.metadata.captureCoordinateContext)
         }
-        guard let bounds = context.windowBounds,
-              context.applicationProcessId == identity.ownerProcessIdentifier,
-              context.windowID == identity.windowID,
-              identity.capturedBounds == bounds,
-              processStartIdentityProvider(identity.ownerProcessIdentifier) == identity.ownerProcessStartIdentity,
-              exactWindowIdentityValidator(identity, bounds)
+        let captureReceipt: DesktopOperationPlan.CaptureReceipt
+        do {
+            captureReceipt = try DesktopOperationPlan.CaptureReceipt(snapshotReceipt: SnapshotTargetReceipt(
+                snapshotID: snapshotID,
+                evidence: [.init(
+                    processIdentifier: context.applicationProcessId,
+                    windowID: context.windowID,
+                    windowIdentity: identity,
+                    windowBounds: context.windowBounds)],
+                applicationBundleIdentifier: context.applicationBundleId,
+                applicationName: context.applicationName,
+                coordinateContext: detectionResult.metadata.captureCoordinateContext))
+        } catch let error as DesktopTargetIdentityError {
+            throw SnapshotTargetReceiptPreDispatchError(error)
+        }
+        guard let exactWindow = captureReceipt.exactWindow,
+              processStartIdentityProvider(exactWindow.identity.ownerProcessIdentifier) ==
+              exactWindow.identity.ownerProcessStartIdentity,
+              exactWindowIdentityValidator(exactWindow.identity, exactWindow.bounds)
         else {
             throw PeekabooError.snapshotStale(
                 "target window owner, process generation, or bounds changed before desktop mutation")
         }
-        return try DesktopOperationPlan.CaptureReceipt(snapshotReceipt: SnapshotTargetReceipt(
-            snapshotID: snapshotID,
-            evidence: [.init(
-                processIdentifier: context.applicationProcessId,
-                windowID: context.windowID,
-                windowIdentity: identity,
-                windowBounds: bounds)],
-            applicationBundleIdentifier: context.applicationBundleId,
-            applicationName: context.applicationName,
-            coordinateContext: detectionResult.metadata.captureCoordinateContext))
+        return captureReceipt
     }
 
     static func validate(

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Strategy/DesktopTargetPlanning.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Strategy/DesktopTargetPlanning.swift
@@ -89,6 +89,7 @@ public struct DesktopTargetIdentity: Equatable, Sendable {
 
 public enum DesktopTargetIdentityError: LocalizedError, Equatable, Sendable {
     case invalidProcessIdentifier
+    case invalidWindowIdentifier
     case contradictoryProcessIdentifier
     case contradictoryProcessGeneration
     case contradictoryWindowIdentifier
@@ -107,6 +108,8 @@ public enum DesktopTargetIdentityError: LocalizedError, Equatable, Sendable {
         switch self {
         case .invalidProcessIdentifier:
             "Target PID must be positive."
+        case .invalidWindowIdentifier:
+            "Target window ID must be between 1 and \(UInt32.max)."
         case .contradictoryProcessIdentifier:
             "Target receipt sources identify different processes."
         case .contradictoryProcessGeneration:
@@ -241,6 +244,22 @@ public struct SnapshotTargetReceipt: Equatable, Sendable {
 /// Namespace for pure target-planning components. Mutation planners are added by the follow-up slice.
 public enum DesktopTargetPlanning {
     public enum DesktopTargetIdentityCoalescer {
+        public static func exactWindow(
+            from window: ServiceWindowInfo) throws -> UIAutomationTarget.ExactWindow
+        {
+            guard let identity = try self.resolve([
+                .init(
+                    windowID: window.windowID,
+                    windowIdentity: window.mutationIdentity,
+                    windowBounds: window.bounds),
+            ]),
+                let exactWindow = identity.exactWindow
+            else {
+                throw DesktopTargetIdentityError.incompleteExactWindow
+            }
+            return exactWindow
+        }
+
         public static func coalesce(
             _ identities: [DesktopTargetIdentity?]) throws -> DesktopTargetIdentity?
         {
@@ -269,6 +288,9 @@ public enum DesktopTargetPlanning {
                 try self.merge(fragment.processIdentity, into: &processIdentity) {
                     .contradictoryProcessGeneration
                 }
+                if let incomingWindowID = fragment.windowID {
+                    try self.requireValidWindowIdentifier(incomingWindowID)
+                }
                 try self.merge(fragment.windowID, into: &windowID) {
                     .contradictoryWindowIdentifier
                 }
@@ -279,6 +301,7 @@ public enum DesktopTargetPlanning {
                     .contradictoryFocusedElement
                 }
                 if let incomingWindowIdentity = fragment.windowIdentity {
+                    try self.requireValidWindowIdentifier(incomingWindowIdentity.windowID)
                     if let currentWindowIdentity = windowIdentity,
                        !currentWindowIdentity.hasSameStableReceipt(as: incomingWindowIdentity)
                     {
@@ -310,12 +333,6 @@ public enum DesktopTargetPlanning {
                 if let windowID, windowID != windowIdentity.windowID {
                     throw DesktopTargetIdentityError.contradictoryWindowIdentifier
                 }
-                if let capturedBounds = windowIdentity.capturedBounds,
-                   let windowBounds,
-                   capturedBounds != windowBounds
-                {
-                    throw DesktopTargetIdentityError.contradictoryWindowBounds
-                }
                 processIdentifier = windowIdentity.ownerProcessIdentifier
                 processIdentity = windowIdentity.processIdentity
                 windowID = windowIdentity.windowID
@@ -333,11 +350,18 @@ public enum DesktopTargetPlanning {
             guard hasWindowEvidence else {
                 return try DesktopTargetIdentity(processIdentity: resolvedProcessIdentity)
             }
-            guard let windowIdentity, let windowID, let windowBounds else {
+            guard let windowIdentity,
+                  let windowID,
+                  let windowBounds,
+                  let capturedBounds = windowIdentity.capturedBounds
+            else {
                 throw DesktopTargetIdentityError.incompleteExactWindow
             }
             guard windowIdentity.windowID == windowID else {
                 throw DesktopTargetIdentityError.contradictoryWindowIdentifier
+            }
+            guard capturedBounds == windowBounds else {
+                throw DesktopTargetIdentityError.contradictoryWindowBounds
             }
             let exactWindow = try UIAutomationTarget.ExactWindow(
                 processIdentifier: resolvedProcessIdentity.processIdentifier,
@@ -365,6 +389,12 @@ public enum DesktopTargetPlanning {
                 throw conflict()
             }
             current = current ?? incoming
+        }
+
+        private static func requireValidWindowIdentifier(_ windowID: Int) throws {
+            guard windowID > 0, UInt32(exactly: windowID) != nil else {
+                throw DesktopTargetIdentityError.invalidWindowIdentifier
+            }
         }
     }
 }

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Strategy/DesktopTargetPlanning.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Strategy/DesktopTargetPlanning.swift
@@ -1,0 +1,370 @@
+import CoreGraphics
+import Foundation
+import PeekabooFoundation
+
+/// Canonical stable identity for a process or exact window target.
+///
+/// Snapshot lifecycle and coordinate authority intentionally live in `SnapshotTargetReceipt`.
+public struct DesktopTargetIdentity: Equatable, Sendable {
+    public struct Evidence: Equatable, Sendable {
+        public let processIdentifier: Int32?
+        public let processIdentity: ApplicationProcessIdentity?
+        public let windowID: Int?
+        public let windowIdentity: WindowMutationIdentity?
+        public let windowBounds: CGRect?
+        public let focusedElement: FocusedElementIdentity?
+
+        public init(
+            processIdentifier: Int32? = nil,
+            processIdentity: ApplicationProcessIdentity? = nil,
+            windowID: Int? = nil,
+            windowIdentity: WindowMutationIdentity? = nil,
+            windowBounds: CGRect? = nil,
+            focusedElement: FocusedElementIdentity? = nil)
+        {
+            self.processIdentifier = processIdentifier
+            self.processIdentity = processIdentity
+            self.windowID = windowID
+            self.windowIdentity = windowIdentity
+            self.windowBounds = windowBounds
+            self.focusedElement = focusedElement
+        }
+
+        public init(target: DesktopTargetIdentity) {
+            switch target.target {
+            case .foreground:
+                preconditionFailure("DesktopTargetIdentity cannot contain a foreground target")
+            case let .process(process):
+                self.init(
+                    processIdentifier: process.processIdentifier,
+                    processIdentity: process.identity)
+            case let .exactWindow(window):
+                self.init(
+                    processIdentifier: window.identity.ownerProcessIdentifier,
+                    processIdentity: window.identity.processIdentity,
+                    windowID: window.identity.windowID,
+                    windowIdentity: window.identity,
+                    windowBounds: window.bounds,
+                    focusedElement: window.focusedElement)
+            }
+        }
+    }
+
+    public let target: UIAutomationTarget
+
+    public var processIdentity: ApplicationProcessIdentity {
+        guard let processIdentity = self.target.processIdentity else {
+            preconditionFailure("A stable desktop target always contains a process identity")
+        }
+        return processIdentity
+    }
+
+    public var exactWindow: UIAutomationTarget.ExactWindow? {
+        self.target.exactWindow
+    }
+
+    public init(processIdentity: ApplicationProcessIdentity) throws {
+        guard processIdentity.processIdentifier > 0 else {
+            throw DesktopTargetIdentityError.invalidProcessIdentifier
+        }
+        self.target = try .process(UIAutomationTarget.Process(
+            processIdentifier: processIdentity.processIdentifier,
+            identity: processIdentity))
+    }
+
+    public init(exactWindow: UIAutomationTarget.ExactWindow) {
+        self.target = .exactWindow(exactWindow)
+    }
+
+    public func coalescing(_ other: DesktopTargetIdentity) throws -> DesktopTargetIdentity {
+        guard let result = try DesktopTargetPlanning.DesktopTargetIdentityCoalescer.resolve([
+            Evidence(target: self),
+            Evidence(target: other),
+        ]) else {
+            preconditionFailure("Coalescing two stable targets cannot produce missing evidence")
+        }
+        return result
+    }
+}
+
+public enum DesktopTargetIdentityError: LocalizedError, Equatable, Sendable {
+    case invalidProcessIdentifier
+    case contradictoryProcessIdentifier
+    case contradictoryProcessGeneration
+    case contradictoryWindowIdentifier
+    case contradictoryWindowIdentity
+    case contradictoryWindowBounds
+    case contradictoryFocusedElement
+    case missingProcessGeneration
+    case incompleteExactWindow
+    case invalidatedSnapshotReceipt
+    case invalidSnapshotIdentifier
+    case coordinateReferenceMismatch
+    case coordinateWindowMismatch
+    case coordinateBoundsMismatch
+
+    public var errorDescription: String? {
+        switch self {
+        case .invalidProcessIdentifier:
+            "Target PID must be positive."
+        case .contradictoryProcessIdentifier:
+            "Target receipt sources identify different processes."
+        case .contradictoryProcessGeneration:
+            "Target receipt sources identify different process generations."
+        case .contradictoryWindowIdentifier:
+            "Target receipt sources identify different windows."
+        case .contradictoryWindowIdentity:
+            "Target receipt sources contain contradictory exact-window identities."
+        case .contradictoryWindowBounds:
+            "Target receipt sources contain contradictory exact-window bounds."
+        case .contradictoryFocusedElement:
+            "Target receipt sources contain contradictory focused-element identities."
+        case .missingProcessGeneration:
+            "Target receipt has no process-generation identity."
+        case .incompleteExactWindow:
+            "Target receipt has incomplete exact-window identity or bounds evidence."
+        case .invalidatedSnapshotReceipt:
+            "Snapshot target receipt was invalidated by contradictory or removed metadata."
+        case .invalidSnapshotIdentifier:
+            "Snapshot identifier must not be empty."
+        case .coordinateReferenceMismatch:
+            "Capture coordinate reference does not identify the selected snapshot."
+        case .coordinateWindowMismatch:
+            "Capture coordinate metadata identifies a different exact window."
+        case .coordinateBoundsMismatch:
+            "Capture coordinate source bounds do not match the exact-window receipt."
+        }
+    }
+}
+
+/// Snapshot lifecycle plus optional stable target identity. Coordinate authority is admitted separately.
+public struct SnapshotTargetReceipt: Equatable, Sendable {
+    public enum TargetEvidence: Equatable, Sendable {
+        case missing
+        case available(DesktopTargetIdentity)
+        case invalidated
+    }
+
+    public struct CoordinateAuthority: Equatable, Sendable {
+        public let snapshotID: String
+        public let target: UIAutomationTarget.ExactWindow
+        public let sourceBounds: CGRect
+        public let context: CaptureCoordinateContext
+
+        public init(
+            snapshotID: String,
+            target: UIAutomationTarget.ExactWindow,
+            sourceBounds: CGRect,
+            context: CaptureCoordinateContext)
+        {
+            self.snapshotID = snapshotID
+            self.target = target
+            self.sourceBounds = sourceBounds
+            self.context = context
+        }
+    }
+
+    public let snapshotID: String
+    public let targetEvidence: TargetEvidence
+    public let applicationBundleIdentifier: String?
+    public let applicationName: String?
+    public let coordinateContext: CaptureCoordinateContext?
+
+    public init(
+        snapshotID: String,
+        evidence: [DesktopTargetIdentity.Evidence],
+        targetReceiptInvalidated: Bool = false,
+        applicationBundleIdentifier: String? = nil,
+        applicationName: String? = nil,
+        coordinateContext: CaptureCoordinateContext? = nil) throws
+    {
+        guard !snapshotID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw DesktopTargetIdentityError.invalidSnapshotIdentifier
+        }
+        self.snapshotID = snapshotID
+        if targetReceiptInvalidated {
+            self.targetEvidence = .invalidated
+        } else if let identity = try DesktopTargetPlanning.DesktopTargetIdentityCoalescer.resolve(evidence) {
+            self.targetEvidence = .available(identity)
+        } else {
+            self.targetEvidence = .missing
+        }
+        self.applicationBundleIdentifier = applicationBundleIdentifier
+        self.applicationName = applicationName
+        self.coordinateContext = coordinateContext
+    }
+
+    public var identity: DesktopTargetIdentity? {
+        guard case let .available(identity) = self.targetEvidence else { return nil }
+        return identity
+    }
+
+    public func requireIdentity() throws -> DesktopTargetIdentity {
+        switch self.targetEvidence {
+        case .missing:
+            throw DesktopTargetIdentityError.missingProcessGeneration
+        case let .available(identity):
+            return identity
+        case .invalidated:
+            throw DesktopTargetIdentityError.invalidatedSnapshotReceipt
+        }
+    }
+
+    public func requireCoordinateAuthority() throws -> CoordinateAuthority {
+        let identity = try self.requireIdentity()
+        guard let exactWindow = identity.exactWindow else {
+            throw DesktopTargetIdentityError.incompleteExactWindow
+        }
+        guard let context = self.coordinateContext,
+              context.referenceID == self.snapshotID
+        else {
+            throw DesktopTargetIdentityError.coordinateReferenceMismatch
+        }
+        guard let coordinateWindow = context.window,
+              coordinateWindow.windowID == exactWindow.identity.windowID
+        else {
+            throw DesktopTargetIdentityError.coordinateWindowMismatch
+        }
+        guard let sourceBounds = context.viewport?.sourceLogicalBounds ?? context.logicalBounds,
+              sourceBounds == exactWindow.bounds
+        else {
+            throw DesktopTargetIdentityError.coordinateBoundsMismatch
+        }
+        return CoordinateAuthority(
+            snapshotID: self.snapshotID,
+            target: exactWindow,
+            sourceBounds: sourceBounds,
+            context: context)
+    }
+}
+
+/// Namespace for pure target-planning components. Mutation planners are added by the follow-up slice.
+public enum DesktopTargetPlanning {
+    public enum DesktopTargetIdentityCoalescer {
+        public static func coalesce(
+            _ identities: [DesktopTargetIdentity?]) throws -> DesktopTargetIdentity?
+        {
+            try self.resolve(identities.compactMap { $0.map(DesktopTargetIdentity.Evidence.init(target:)) })
+        }
+
+        public static func resolve(
+            _ evidence: [DesktopTargetIdentity.Evidence]) throws -> DesktopTargetIdentity?
+        {
+            var processIdentifier: Int32?
+            var processIdentity: ApplicationProcessIdentity?
+            var windowID: Int?
+            var windowIdentity: WindowMutationIdentity?
+            var windowBounds: CGRect?
+            var focusedElement: FocusedElementIdentity?
+            var hasAnyEvidence = false
+
+            for fragment in evidence {
+                hasAnyEvidence = hasAnyEvidence || fragment.processIdentifier != nil ||
+                    fragment.processIdentity != nil || fragment.windowID != nil || fragment.windowIdentity != nil ||
+                    fragment.windowBounds != nil || fragment.focusedElement != nil
+
+                try self.merge(fragment.processIdentifier, into: &processIdentifier) {
+                    .contradictoryProcessIdentifier
+                }
+                try self.merge(fragment.processIdentity, into: &processIdentity) {
+                    .contradictoryProcessGeneration
+                }
+                try self.merge(fragment.windowID, into: &windowID) {
+                    .contradictoryWindowIdentifier
+                }
+                try self.merge(fragment.windowBounds, into: &windowBounds) {
+                    .contradictoryWindowBounds
+                }
+                try self.merge(fragment.focusedElement, into: &focusedElement) {
+                    .contradictoryFocusedElement
+                }
+                if let incomingWindowIdentity = fragment.windowIdentity {
+                    if let currentWindowIdentity = windowIdentity,
+                       !currentWindowIdentity.hasSameStableReceipt(as: incomingWindowIdentity)
+                    {
+                        throw DesktopTargetIdentityError.contradictoryWindowIdentity
+                    }
+                    windowIdentity = windowIdentity ?? incomingWindowIdentity
+                }
+            }
+
+            guard hasAnyEvidence else { return nil }
+
+            if let processIdentity {
+                if let processIdentifier, processIdentifier != processIdentity.processIdentifier {
+                    throw DesktopTargetIdentityError.contradictoryProcessIdentifier
+                }
+                processIdentifier = processIdentity.processIdentifier
+            }
+            if let windowIdentity {
+                if let processIdentifier,
+                   processIdentifier != windowIdentity.ownerProcessIdentifier
+                {
+                    throw DesktopTargetIdentityError.contradictoryProcessIdentifier
+                }
+                if let processIdentity,
+                   processIdentity != windowIdentity.processIdentity
+                {
+                    throw DesktopTargetIdentityError.contradictoryProcessGeneration
+                }
+                if let windowID, windowID != windowIdentity.windowID {
+                    throw DesktopTargetIdentityError.contradictoryWindowIdentifier
+                }
+                if let capturedBounds = windowIdentity.capturedBounds,
+                   let windowBounds,
+                   capturedBounds != windowBounds
+                {
+                    throw DesktopTargetIdentityError.contradictoryWindowBounds
+                }
+                processIdentifier = windowIdentity.ownerProcessIdentifier
+                processIdentity = windowIdentity.processIdentity
+                windowID = windowIdentity.windowID
+            }
+
+            guard let resolvedProcessIdentity = processIdentity else {
+                throw DesktopTargetIdentityError.missingProcessGeneration
+            }
+            guard resolvedProcessIdentity.processIdentifier > 0 else {
+                throw DesktopTargetIdentityError.invalidProcessIdentifier
+            }
+
+            let hasWindowEvidence = windowID != nil || windowIdentity != nil || windowBounds != nil ||
+                focusedElement != nil
+            guard hasWindowEvidence else {
+                return try DesktopTargetIdentity(processIdentity: resolvedProcessIdentity)
+            }
+            guard let windowIdentity, let windowID, let windowBounds else {
+                throw DesktopTargetIdentityError.incompleteExactWindow
+            }
+            guard windowIdentity.windowID == windowID else {
+                throw DesktopTargetIdentityError.contradictoryWindowIdentifier
+            }
+            let exactWindow = try UIAutomationTarget.ExactWindow(
+                processIdentifier: resolvedProcessIdentity.processIdentifier,
+                windowID: windowID,
+                identity: windowIdentity,
+                bounds: windowBounds,
+                focusedElement: focusedElement)
+            let process = try UIAutomationTarget.Process(
+                processIdentifier: resolvedProcessIdentity.processIdentifier,
+                identity: resolvedProcessIdentity)
+            let refined = try UIAutomationTarget.process(process).refined(to: exactWindow)
+            guard let refinedWindow = refined.exactWindow else {
+                preconditionFailure("Exact-window refinement must retain the exact target")
+            }
+            return DesktopTargetIdentity(exactWindow: refinedWindow)
+        }
+
+        private static func merge<Value: Equatable>(
+            _ incoming: Value?,
+            into current: inout Value?,
+            conflict: () -> DesktopTargetIdentityError) throws
+        {
+            guard let incoming else { return }
+            if let current, current != incoming {
+                throw conflict()
+            }
+            current = current ?? incoming
+        }
+    }
+}

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Strategy/DesktopTargetPlanning.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Strategy/DesktopTargetPlanning.swift
@@ -140,6 +140,29 @@ public enum DesktopTargetIdentityError: LocalizedError, Equatable, Sendable {
     }
 }
 
+/// A structural snapshot-receipt refusal proven before desktop mutation dispatch.
+///
+/// Only receipt-planning owners construct this wrapper. Callers may therefore release a mutation
+/// lease for this error without weakening fail-closed handling for live drift or post-dispatch failures.
+public struct SnapshotTargetReceiptPreDispatchError: LocalizedError, Equatable, Sendable {
+    public let receiptError: DesktopTargetIdentityError
+
+    init(_ receiptError: DesktopTargetIdentityError) {
+        self.receiptError = receiptError
+    }
+
+    public var errorDescription: String? {
+        switch self.receiptError {
+        case .incompleteExactWindow:
+            "Snapshot target receipt is incomplete: exact-window identity and immutable captured bounds are required."
+        case .missingProcessGeneration:
+            "Snapshot target receipt has no capture-time process-generation receipt."
+        default:
+            "Snapshot target receipt is invalid: \(self.receiptError.localizedDescription)"
+        }
+    }
+}
+
 /// Snapshot lifecycle plus optional stable target identity. Coordinate authority is admitted separately.
 public struct SnapshotTargetReceipt: Equatable, Sendable {
     public enum TargetEvidence: Equatable, Sendable {

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKitTestSupport/AutomationTestFixtures.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKitTestSupport/AutomationTestFixtures.swift
@@ -100,6 +100,36 @@ public enum AutomationTestFixtures {
                 : nil)
     }
 
+    public static func focusedElement(
+        processIdentity: ApplicationProcessIdentity = Self.processIdentity(),
+        windowID: Int = 201,
+        role: String = "AXTextField",
+        identifier: String? = "editor",
+        frame: CGRect = CGRect(x: 30, y: 40, width: 200, height: 32)) -> FocusedElementIdentity
+    {
+        FocusedElementIdentity(
+            processIdentifier: processIdentity.processIdentifier,
+            windowID: windowID,
+            role: role,
+            identifier: identifier,
+            frame: frame)
+    }
+
+    public static func captureCoordinateContext(
+        snapshotID: String = "snapshot-1",
+        window: ServiceWindowInfo = Self.window(),
+        deliveredImageSize: CGSize? = nil,
+        viewport: CaptureViewport? = nil) -> CaptureCoordinateContext
+    {
+        CaptureCoordinateContext(
+            metadata: CaptureMetadata(
+                size: deliveredImageSize ?? window.bounds.size,
+                mode: .window,
+                windowInfo: window,
+                viewport: viewport),
+            referenceID: snapshotID)
+    }
+
     public static func detectedElement(
         id: String = "element-1",
         type: ElementType = .textField,

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ClickServiceExactWindowTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ClickServiceExactWindowTests.swift
@@ -58,6 +58,53 @@ struct ClickServiceExactWindowTests {
 
     @Test
     @MainActor
+    func `Snapshot refinement reports incomplete immutable bounds before delivery`() async throws {
+        let process = AutomationTestFixtures.processIdentity(
+            processIdentifier: getpid(),
+            processStartIdentity: 71)
+        let bounds = CGRect(x: 0, y: 0, width: 200, height: 100)
+        let identity = AutomationTestFixtures.windowIdentity(
+            windowID: 42,
+            processIdentity: process,
+            bounds: nil)
+        let detection = AutomationTestFixtures.detectionResult(
+            snapshotID: "incomplete",
+            elements: DetectedElements(buttons: [AutomationTestFixtures.detectedElement(
+                id: "B1",
+                type: .button,
+                label: "Button")]),
+            windowContext: WindowContext(
+                applicationProcessId: process.processIdentifier,
+                windowID: identity.windowID,
+                windowBounds: bounds,
+                windowMutationIdentity: identity))
+        let synthetic = ClickRecordingSyntheticInputDriver()
+        let service = ClickService(
+            snapshotManager: InMemorySnapshotManager(detectionResult: detection),
+            inputPolicy: UIInputPolicy(defaultStrategy: .synthOnly),
+            syntheticInputDriver: synthetic,
+            exactWindowIdentityValidator: { _, _ in
+                Issue.record("Incomplete click receipt reached live window validation")
+                return false
+            },
+            processStartIdentityProvider: { _ in process.processStartIdentity })
+
+        let error = await #expect(throws: SnapshotTargetReceiptPreDispatchError.self) {
+            _ = try await service.click(
+                target: .elementId("B1"),
+                clickType: .single,
+                snapshotId: detection.snapshotId,
+                targetProcessIdentifier: process.processIdentifier,
+                expectedProcessIdentity: process)
+        }
+
+        #expect(error?.receiptError == .incompleteExactWindow)
+        #expect(error?.localizedDescription.contains("immutable captured bounds") == true)
+        #expect(synthetic.events.isEmpty)
+    }
+
+    @Test
+    @MainActor
     func `Background coordinate click preserves exact target window`() async throws {
         let synthetic = ClickRecordingSyntheticInputDriver()
         let identity = WindowMutationIdentity(

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/DesktopOperationPlanTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/DesktopOperationPlanTests.swift
@@ -1,6 +1,7 @@
 import CoreGraphics
 import Foundation
 import PeekabooAutomationKitTestSupport
+import PeekabooFoundation
 import Testing
 @testable import PeekabooAutomationKit
 
@@ -125,6 +126,94 @@ struct DesktopOperationPlanTests {
                 requireExactWindow: false,
                 processStartIdentityProvider: { _ in nil },
                 exactWindowIdentityValidator: { _, _ in false })
+        }
+    }
+
+    @Test
+    func `capture receipt classifies incomplete immutable window evidence before live validation`() throws {
+        let process = AutomationTestFixtures.processIdentity()
+        let bounds = CGRect(x: 1, y: 2, width: 300, height: 200)
+        let identity = AutomationTestFixtures.windowIdentity(
+            processIdentity: process,
+            bounds: nil)
+        let detectionResult = AutomationTestFixtures.detectionResult(
+            windowContext: WindowContext(
+                applicationProcessId: process.processIdentifier,
+                windowID: identity.windowID,
+                windowBounds: bounds,
+                windowMutationIdentity: identity))
+
+        let error = #expect(throws: SnapshotTargetReceiptPreDispatchError.self) {
+            _ = try DesktopOperationSnapshotReceiptValidator.captureReceipt(
+                snapshotID: detectionResult.snapshotId,
+                detectionResult: detectionResult,
+                requireExactWindow: true,
+                processStartIdentityProvider: { _ in
+                    Issue.record("Incomplete receipt reached live process validation")
+                    return nil
+                },
+                exactWindowIdentityValidator: { _, _ in
+                    Issue.record("Incomplete receipt reached live window validation")
+                    return false
+                })
+        }
+
+        #expect(error?.receiptError == .incompleteExactWindow)
+        #expect(error?.localizedDescription.contains("immutable captured bounds") == true)
+    }
+
+    @Test
+    func `capture receipt keeps structural bounds conflict distinct from live drift`() throws {
+        let process = AutomationTestFixtures.processIdentity()
+        let capturedBounds = CGRect(x: 1, y: 2, width: 300, height: 200)
+        let identity = AutomationTestFixtures.windowIdentity(
+            processIdentity: process,
+            bounds: capturedBounds)
+        let detectionResult = AutomationTestFixtures.detectionResult(
+            windowContext: WindowContext(
+                applicationProcessId: process.processIdentifier,
+                windowID: identity.windowID,
+                windowBounds: capturedBounds.offsetBy(dx: 1, dy: 0),
+                windowMutationIdentity: identity))
+
+        let error = #expect(throws: SnapshotTargetReceiptPreDispatchError.self) {
+            _ = try DesktopOperationSnapshotReceiptValidator.captureReceipt(
+                snapshotID: detectionResult.snapshotId,
+                detectionResult: detectionResult,
+                requireExactWindow: true,
+                processStartIdentityProvider: { _ in process.processStartIdentity },
+                exactWindowIdentityValidator: { _, _ in true })
+        }
+
+        #expect(error?.receiptError == .contradictoryWindowBounds)
+    }
+
+    @Test
+    func `capture receipt preserves live process drift as stale snapshot`() throws {
+        let process = AutomationTestFixtures.processIdentity()
+        let bounds = CGRect(x: 1, y: 2, width: 300, height: 200)
+        let identity = AutomationTestFixtures.windowIdentity(
+            processIdentity: process,
+            bounds: bounds)
+        let detectionResult = AutomationTestFixtures.detectionResult(
+            windowContext: WindowContext(
+                applicationProcessId: process.processIdentifier,
+                windowID: identity.windowID,
+                windowBounds: bounds,
+                windowMutationIdentity: identity))
+
+        do {
+            _ = try DesktopOperationSnapshotReceiptValidator.captureReceipt(
+                snapshotID: detectionResult.snapshotId,
+                detectionResult: detectionResult,
+                requireExactWindow: true,
+                processStartIdentityProvider: { _ in process.processStartIdentity + 1 },
+                exactWindowIdentityValidator: { _, _ in true })
+            Issue.record("Expected live process drift to remain a stale-snapshot failure")
+        } catch let PeekabooError.snapshotStale(reason) {
+            #expect(reason.contains("process generation"))
+        } catch {
+            Issue.record("Unexpected error: \(error)")
         }
     }
 

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/DesktopTargetPlanningTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/DesktopTargetPlanningTests.swift
@@ -1,0 +1,185 @@
+import CoreGraphics
+import PeekabooAutomationKitTestSupport
+import Testing
+@testable import PeekabooAutomationKit
+
+struct DesktopTargetPlanningTests {
+    @Test
+    func `process and exact-window evidence coalesce into the more specific stable target`() throws {
+        let process = AutomationTestFixtures.processIdentity()
+        let window = AutomationTestFixtures.windowIdentity(processIdentity: process)
+
+        let resolved = try DesktopTargetPlanning.DesktopTargetIdentityCoalescer.resolve([
+            .init(processIdentifier: process.processIdentifier, processIdentity: process),
+            .init(
+                windowID: window.windowID,
+                windowIdentity: window,
+                windowBounds: window.capturedBounds),
+        ])
+        let identity = try #require(resolved)
+
+        #expect(identity.processIdentity == process)
+        #expect(identity.exactWindow?.identity.hasSameStableReceipt(as: window) == true)
+    }
+
+    @Test
+    func `stable window coalescing ignores minimized state`() throws {
+        let bounds = CGRect(x: 10, y: 20, width: 640, height: 480)
+        let visible = AutomationTestFixtures.windowIdentity(bounds: bounds, isMinimized: false)
+        let minimized = visible.withMinimizedState(true)
+
+        let resolved = try DesktopTargetPlanning.DesktopTargetIdentityCoalescer.resolve([
+            .init(windowIdentity: visible, windowBounds: bounds),
+            .init(windowIdentity: minimized, windowBounds: bounds),
+        ])
+        let identity = try #require(resolved)
+
+        #expect(identity.exactWindow?.identity.hasSameStableReceipt(as: minimized) == true)
+    }
+
+    @Test
+    func `coalescer refuses every stable identity contradiction`() {
+        let process = AutomationTestFixtures.processIdentity()
+        let otherGeneration = AutomationTestFixtures.processIdentity(processStartIdentity: 1002)
+        let bounds = CGRect(x: 10, y: 20, width: 640, height: 480)
+        let window = AutomationTestFixtures.windowIdentity(processIdentity: process, bounds: bounds)
+
+        #expect(throws: DesktopTargetIdentityError.contradictoryProcessGeneration) {
+            _ = try DesktopTargetPlanning.DesktopTargetIdentityCoalescer.resolve([
+                .init(processIdentity: process),
+                .init(processIdentity: otherGeneration),
+            ])
+        }
+        #expect(throws: DesktopTargetIdentityError.contradictoryWindowIdentifier) {
+            _ = try DesktopTargetPlanning.DesktopTargetIdentityCoalescer.resolve([
+                .init(windowID: window.windowID, windowIdentity: window, windowBounds: bounds),
+                .init(windowID: window.windowID + 1),
+            ])
+        }
+        #expect(throws: DesktopTargetIdentityError.contradictoryWindowBounds) {
+            _ = try DesktopTargetPlanning.DesktopTargetIdentityCoalescer.resolve([
+                .init(windowIdentity: window, windowBounds: bounds),
+                .init(windowBounds: bounds.offsetBy(dx: 1, dy: 0)),
+            ])
+        }
+    }
+
+    @Test
+    func `two supplied focused-element receipts must agree`() throws {
+        let bounds = CGRect(x: 10, y: 20, width: 640, height: 480)
+        let window = AutomationTestFixtures.windowIdentity(bounds: bounds)
+        let focused = AutomationTestFixtures.focusedElement()
+        let changedFocus = AutomationTestFixtures.focusedElement(identifier: "other")
+
+        let resolved = try DesktopTargetPlanning.DesktopTargetIdentityCoalescer.resolve([
+            .init(windowIdentity: window, windowBounds: bounds, focusedElement: focused),
+            .init(windowIdentity: window, windowBounds: bounds, focusedElement: focused),
+        ])
+        let identity = try #require(resolved)
+        #expect(identity.exactWindow?.focusedElement == focused)
+
+        #expect(throws: DesktopTargetIdentityError.contradictoryFocusedElement) {
+            _ = try DesktopTargetPlanning.DesktopTargetIdentityCoalescer.resolve([
+                .init(windowIdentity: window, windowBounds: bounds, focusedElement: focused),
+                .init(windowIdentity: window, windowBounds: bounds, focusedElement: changedFocus),
+            ])
+        }
+    }
+
+    @Test
+    func `missing generation and incomplete exact-window evidence remain distinct`() throws {
+        #expect(throws: DesktopTargetIdentityError.missingProcessGeneration) {
+            _ = try DesktopTargetPlanning.DesktopTargetIdentityCoalescer.resolve([
+                .init(processIdentifier: 101),
+            ])
+        }
+        #expect(throws: DesktopTargetIdentityError.incompleteExactWindow) {
+            _ = try DesktopTargetPlanning.DesktopTargetIdentityCoalescer.resolve([
+                .init(
+                    processIdentity: AutomationTestFixtures.processIdentity(),
+                    windowID: 201),
+            ])
+        }
+        #expect(try DesktopTargetPlanning.DesktopTargetIdentityCoalescer.resolve([]) == nil)
+    }
+
+    @Test
+    func `snapshot receipt preserves sticky invalidation instead of treating it as missing`() throws {
+        let receipt = try SnapshotTargetReceipt(
+            snapshotID: "snapshot-1",
+            evidence: [.init(processIdentity: AutomationTestFixtures.processIdentity())],
+            targetReceiptInvalidated: true)
+
+        #expect(receipt.targetEvidence == .invalidated)
+        #expect(throws: DesktopTargetIdentityError.invalidatedSnapshotReceipt) {
+            _ = try receipt.requireIdentity()
+        }
+    }
+
+    @Test
+    func `coordinate authority requires snapshot window and source-bounds agreement`() throws {
+        let snapshotID = "snapshot-1"
+        let window = AutomationTestFixtures.window()
+        let identity = try #require(window.mutationIdentity)
+        let receipt = try SnapshotTargetReceipt(
+            snapshotID: snapshotID,
+            evidence: [.init(
+                processIdentifier: identity.ownerProcessIdentifier,
+                windowID: window.windowID,
+                windowIdentity: identity,
+                windowBounds: window.bounds)],
+            coordinateContext: AutomationTestFixtures.captureCoordinateContext(
+                snapshotID: snapshotID,
+                window: window))
+
+        let authority = try receipt.requireCoordinateAuthority()
+        #expect(authority.snapshotID == snapshotID)
+        #expect(authority.target.identity.hasSameStableReceipt(as: identity))
+        #expect(authority.sourceBounds == window.bounds)
+
+        let wrongReference = try SnapshotTargetReceipt(
+            snapshotID: snapshotID,
+            evidence: [.init(windowIdentity: identity, windowBounds: window.bounds)],
+            coordinateContext: AutomationTestFixtures.captureCoordinateContext(
+                snapshotID: "other-snapshot",
+                window: window))
+        #expect(throws: DesktopTargetIdentityError.coordinateReferenceMismatch) {
+            _ = try wrongReference.requireCoordinateAuthority()
+        }
+
+        let wrongWindow = AutomationTestFixtures.window(windowID: window.windowID + 1)
+        let wrongWindowContext = try SnapshotTargetReceipt(
+            snapshotID: snapshotID,
+            evidence: [.init(windowIdentity: identity, windowBounds: window.bounds)],
+            coordinateContext: AutomationTestFixtures.captureCoordinateContext(
+                snapshotID: snapshotID,
+                window: wrongWindow))
+        #expect(throws: DesktopTargetIdentityError.coordinateWindowMismatch) {
+            _ = try wrongWindowContext.requireCoordinateAuthority()
+        }
+    }
+
+    @Test
+    func `ROI coordinate authority uses full source bounds rather than cropped logical bounds`() throws {
+        let snapshotID = "snapshot-roi"
+        let window = AutomationTestFixtures.window()
+        let identity = try #require(window.mutationIdentity)
+        let roi = CGRect(x: 110, y: 120, width: 200, height: 100)
+        let viewport = CaptureViewport(
+            sourceLogicalBounds: window.bounds,
+            requestedWindowRelativeBounds: CGRect(x: 100, y: 100, width: 200, height: 100),
+            deliveredWindowRelativeBounds: CGRect(x: 100, y: 100, width: 200, height: 100),
+            logicalBounds: roi,
+            sourceImageSize: window.bounds.size)
+        let receipt = try SnapshotTargetReceipt(
+            snapshotID: snapshotID,
+            evidence: [.init(windowIdentity: identity, windowBounds: window.bounds)],
+            coordinateContext: AutomationTestFixtures.captureCoordinateContext(
+                snapshotID: snapshotID,
+                window: window,
+                deliveredImageSize: roi.size,
+                viewport: viewport))
+
+        #expect(try receipt.requireCoordinateAuthority().sourceBounds == window.bounds)
+    }
+}

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/DesktopTargetPlanningTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/DesktopTargetPlanningTests.swift
@@ -23,6 +23,58 @@ struct DesktopTargetPlanningTests {
     }
 
     @Test
+    func `exact-window evidence requires immutable captured bounds`() {
+        let bounds = CGRect(x: 10, y: 20, width: 640, height: 480)
+        let missingCapturedBounds = AutomationTestFixtures.windowIdentity(bounds: nil)
+
+        #expect(throws: DesktopTargetIdentityError.incompleteExactWindow) {
+            _ = try DesktopTargetPlanning.DesktopTargetIdentityCoalescer.resolve([
+                .init(
+                    windowID: missingCapturedBounds.windowID,
+                    windowIdentity: missingCapturedBounds,
+                    windowBounds: bounds),
+            ])
+        }
+    }
+
+    @Test
+    func `exact-window evidence requires external bounds to equal immutable captured bounds`() {
+        let bounds = CGRect(x: 10, y: 20, width: 640, height: 480)
+        let window = AutomationTestFixtures.windowIdentity(bounds: bounds)
+
+        #expect(throws: DesktopTargetIdentityError.contradictoryWindowBounds) {
+            _ = try DesktopTargetPlanning.DesktopTargetIdentityCoalescer.resolve([
+                .init(
+                    windowID: window.windowID,
+                    windowIdentity: window,
+                    windowBounds: bounds.offsetBy(dx: 1, dy: 0)),
+            ])
+        }
+    }
+
+    @Test(arguments: [0, -1, Int(UInt32.max) + 1])
+    func `exact-window evidence rejects invalid window identifiers`(_ windowID: Int) {
+        let bounds = CGRect(x: 10, y: 20, width: 640, height: 480)
+        let window = AutomationTestFixtures.windowIdentity(windowID: windowID, bounds: bounds)
+
+        #expect(throws: DesktopTargetIdentityError.invalidWindowIdentifier) {
+            _ = try DesktopTargetPlanning.DesktopTargetIdentityCoalescer.resolve([
+                .init(windowID: windowID, windowIdentity: window, windowBounds: bounds),
+            ])
+        }
+    }
+
+    @Test
+    func `service-window adapter accepts only a complete valid exact-window receipt`() throws {
+        let window = AutomationTestFixtures.window()
+
+        let exactWindow = try DesktopTargetPlanning.DesktopTargetIdentityCoalescer.exactWindow(from: window)
+
+        #expect(exactWindow.identity == window.mutationIdentity)
+        #expect(exactWindow.bounds == window.bounds)
+    }
+
+    @Test
     func `stable window coalescing ignores minimized state`() throws {
         let bounds = CGRect(x: 10, y: 20, width: 640, height: 480)
         let visible = AutomationTestFixtures.windowIdentity(bounds: bounds, isMinimized: false)

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/DialogPreparedActionStoreTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/DialogPreparedActionStoreTests.swift
@@ -4,12 +4,47 @@ import CoreGraphics
 import Darwin
 import Foundation
 import PeekabooFoundation
+import PeekabooFoundationTestSupport
 import Testing
 @testable import PeekabooAutomationKit
 
 @MainActor
 @Suite("Prepared dialog action receipts")
 struct DialogPreparedActionStoreTests {
+    @Test(arguments: InteractionTargetSelectorFixtures.validCases)
+    func `dialog adapter accepts the canonical valid selector matrix`(
+        _ selectors: InteractionTargetSelectorCase) throws
+    {
+        _ = try Self.selector(selectors)
+    }
+
+    @Test(arguments: InteractionTargetSelectorFixtures.applicationAndProcessIdentifierCases)
+    func `dialog adapter refuses canonical app and PID conflicts`(
+        _ selectors: InteractionTargetSelectorCase)
+    {
+        #expect(throws: (any Error).self) {
+            _ = try Self.selector(selectors)
+        }
+    }
+
+    @Test(arguments: InteractionTargetSelectorFixtures.multipleWindowSelectorCases)
+    func `dialog adapter refuses the canonical multiple-window matrix`(
+        _ selectors: InteractionTargetSelectorCase)
+    {
+        #expect(throws: (any Error).self) {
+            _ = try Self.selector(selectors)
+        }
+    }
+
+    @Test(arguments: InteractionTargetSelectorFixtures.windowSelectorRequiresApplicationCases)
+    func `dialog adapter refuses ownerless relative-window syntax`(
+        _ selectors: InteractionTargetSelectorCase)
+    {
+        #expect(throws: (any Error).self) {
+            _ = try Self.selector(selectors)
+        }
+    }
+
     @Test
     func `selector preserves owner and window constraints and rejects conflicts`() throws {
         let selector = try DialogTargetSelector(
@@ -29,6 +64,29 @@ struct DialogPreparedActionStoreTests {
         #expect(throws: (any Error).self) {
             try DialogTargetSelector(processIdentifier: 42, windowID: 700, windowIndex: 0)
         }
+    }
+
+    @Test
+    func `selector manual coding preserves existing keys and normalized values`() throws {
+        let selector = try DialogTargetSelector(
+            applicationIdentifier: "  TextEdit  ",
+            windowTitle: "  Save  ")
+        let data = try JSONEncoder().encode(selector)
+        let object = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+
+        #expect(Set(object.keys) == ["applicationIdentifier", "windowTitle"])
+        #expect(object["applicationIdentifier"] as? String == "TextEdit")
+        #expect(object["windowTitle"] as? String == "Save")
+        #expect(try JSONDecoder().decode(DialogTargetSelector.self, from: data) == selector)
+    }
+
+    private static func selector(_ selectors: InteractionTargetSelectorCase) throws -> DialogTargetSelector {
+        try DialogTargetSelector(
+            applicationIdentifier: selectors.hasApplication ? "TextEdit" : nil,
+            processIdentifier: selectors.hasProcessIdentifier ? 42 : nil,
+            windowID: selectors.hasWindowID ? 700 : nil,
+            windowTitle: selectors.hasWindowTitle ? "Save" : nil,
+            windowIndex: selectors.hasWindowIndex ? 2 : nil)
     }
 
     @Test

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ScrollServiceTargetResolutionTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ScrollServiceTargetResolutionTests.swift
@@ -405,9 +405,10 @@ struct ScrollServiceTargetResolutionTests {
             exactWindowIdentityValidator: { _, _ in true },
             processStartIdentityProvider: { _ in 11 })
 
-        await #expect(throws: PeekabooError.self) {
+        let error = await #expect(throws: SnapshotTargetReceiptPreDispatchError.self) {
             _ = try await service.scroll(Self.backgroundRequest())
         }
+        #expect(error?.receiptError == .contradictoryWindowBounds)
         #expect(action.scrollCalls.isEmpty)
     }
 

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/MCPToolContext.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/MCPToolContext.swift
@@ -665,17 +665,17 @@ public struct MCPToolContext: @unchecked Sendable {
     }
 
     private static func sameTarget(_ snapshot: UISnapshot, _ context: WindowContext) -> Bool {
-        guard let processIdentifier = context.applicationProcessId,
-              snapshot.applicationProcessId == processIdentifier,
-              let windowID = context.windowID,
-              snapshot.windowID == windowID,
-              let bounds = context.windowBounds,
-              snapshot.windowBounds == bounds,
-              let identity = context.windowMutationIdentity,
-              snapshot.windowMutationIdentity == identity,
-              identity.windowID == windowID,
-              identity.ownerProcessIdentifier == processIdentifier,
-              identity.capturedBounds == bounds
+        guard let snapshotIdentity = try? snapshot.targetReceipt().requireIdentity(),
+              let snapshotExactWindow = snapshotIdentity.exactWindow,
+              let contextIdentity = try? DesktopTargetPlanning.DesktopTargetIdentityCoalescer.resolve([
+                  .init(
+                      processIdentifier: context.applicationProcessId,
+                      windowID: context.windowID,
+                      windowIdentity: context.windowMutationIdentity,
+                      windowBounds: context.windowBounds),
+              ]),
+              let contextExactWindow = contextIdentity.exactWindow,
+              snapshotExactWindow == contextExactWindow
         else {
             return false
         }

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/MCPInteractionTarget.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/MCPInteractionTarget.swift
@@ -422,7 +422,11 @@ struct MCPInteractionTarget {
         guard matches.count == 1, let window = matches.first else {
             throw MCPInteractionTargetError.backgroundWindowTargetAmbiguous
         }
-        return try UIAutomationTarget.ExactWindow(window: window)
+        do {
+            return try DesktopTargetPlanning.DesktopTargetIdentityCoalescer.exactWindow(from: window)
+        } catch {
+            throw MCPInteractionTargetError.backgroundWindowTargetMismatch
+        }
     }
 
     func focusIfRequested(windows: any WindowManagementServiceProtocol, onlyWhenTargeted: Bool) async throws

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/MCPInteractionTarget.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/MCPInteractionTarget.swift
@@ -106,15 +106,19 @@ struct MCPInteractionTarget {
         return self.app
     }
 
+    var selector: InteractionTargetSelector {
+        InteractionTargetSelector(
+            applicationIdentifier: self.app,
+            processIdentifier: self.pid,
+            windowID: self.windowId,
+            windowTitle: self.windowTitle,
+            windowIndex: self.windowIndex)
+    }
+
     func validate() throws {
         do {
-            try InteractionTargetSelectorValidator.validate(
-                hasApplication: self.app != nil,
-                hasProcessIdentifier: self.pid != nil,
-                hasWindowID: self.windowId != nil,
-                hasWindowTitle: self.windowTitle != nil,
-                hasWindowIndex: self.windowIndex != nil)
-        } catch let error as InteractionTargetSelectorValidationError {
+            try self.selector.validate(policy: .interaction)
+        } catch let error as InteractionTargetSelector.ValidationError {
             switch error {
             case .applicationAndProcessIdentifier:
                 throw MCPInteractionTargetError.applicationAndProcessIdentifier
@@ -122,6 +126,18 @@ struct MCPInteractionTarget {
                 throw MCPInteractionTargetError.multipleWindowSelectors
             case .windowSelectorRequiresApplication:
                 throw MCPInteractionTargetError.windowSelectorRequiresApp
+            case .invalidProcessIdentifier:
+                throw MCPInteractionTargetError.invalidProcessIdentifier
+            case .invalidWindowID:
+                throw MCPInteractionTargetError.invalidWindowId
+            case .invalidWindowIndex:
+                throw MCPInteractionTargetError.invalidWindowIndex
+            case .conflictingProcessIdentifiers,
+                 .invalidApplicationProcessIdentifier,
+                 .missingTarget,
+                 .emptyApplication,
+                 .emptyWindowTitle:
+                preconditionFailure("Interaction policy does not emit \(error)")
             }
         }
 
@@ -140,27 +156,19 @@ struct MCPInteractionTarget {
 
     func toWindowTarget() throws -> WindowTarget? {
         try self.validate()
-
-        if let windowId {
-            return .windowId(windowId)
-        }
-
-        if let title = self.windowTitle?.trimmingCharacters(in: .whitespacesAndNewlines), !title.isEmpty {
+        switch try self.selector.normalizedWindowSelector(policy: .interaction) {
+        case let .id(windowID):
+            return .windowId(windowID)
+        case let .title(title):
             if let appId = self.appIdentifier, !appId.isEmpty {
                 return .applicationAndTitle(app: appId, title: title)
             }
             return .title(title)
+        case let .index(index):
+            return .index(app: self.appIdentifier ?? "", index: index)
+        case nil:
+            return self.appIdentifier.flatMap { $0.isEmpty ? nil : .application($0) }
         }
-
-        if let windowIndex {
-            return .index(app: self.appIdentifier ?? "", index: windowIndex)
-        }
-
-        if let appId = self.appIdentifier, !appId.isEmpty {
-            return .application(appId)
-        }
-
-        return nil
     }
 
     func focusIfRequested(windows: any WindowManagementServiceProtocol) async throws -> WindowTarget? {
@@ -243,16 +251,12 @@ struct MCPInteractionTarget {
     }
 
     var hasTarget: Bool {
-        self.pid != nil ||
-            !(self.app?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ?? true) ||
-            self.windowId != nil ||
-            self.windowIndex != nil ||
-            !(self.windowTitle?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ?? true)
+        self.pid != nil || self.selector.normalizedApplicationIdentifier != nil || self.windowId != nil ||
+            self.windowIndex != nil || self.selector.normalizedWindowTitle != nil
     }
 
     var hasWindowSelector: Bool {
-        self.windowId != nil || self.windowIndex != nil ||
-            !(self.windowTitle?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ?? true)
+        self.windowId != nil || self.windowIndex != nil || self.selector.normalizedWindowTitle != nil
     }
 
     func requireBackgroundProcessIdentifier(
@@ -328,17 +332,26 @@ struct MCPInteractionTarget {
         }
 
         let selectedProcessIdentity = try await self.selectedProcessIdentity(applications: applications)
-        let identities = [
-            selectedProcessIdentity,
-            snapshotProcessIdentity,
-            snapshotExactWindow?.identity.processIdentity,
-            selectedWindow?.identity.processIdentity,
-        ].compactMap(\.self)
-        guard let processIdentity = identities.first else {
-            throw MCPInteractionTargetError.backgroundTargetRequired
-        }
-        guard identities.allSatisfy({ $0 == processIdentity }) else {
+        let stableIdentities: [DesktopTargetIdentity?]
+        do {
+            stableIdentities = try [selectedProcessIdentity, snapshotProcessIdentity].map { identity in
+                guard let identity else { return nil }
+                return try DesktopTargetIdentity(processIdentity: identity)
+            } + [
+                snapshotExactWindow.map(DesktopTargetIdentity.init(exactWindow:)),
+                selectedWindow.map(DesktopTargetIdentity.init(exactWindow:)),
+            ]
+        } catch {
             throw MCPInteractionTargetError.backgroundWindowTargetMismatch
+        }
+        let stableIdentity: DesktopTargetIdentity?
+        do {
+            stableIdentity = try DesktopTargetPlanning.DesktopTargetIdentityCoalescer.coalesce(stableIdentities)
+        } catch {
+            throw MCPInteractionTargetError.backgroundWindowTargetMismatch
+        }
+        guard let processIdentity = stableIdentity?.processIdentity else {
+            throw MCPInteractionTargetError.backgroundTargetRequired
         }
 
         let listedApplications = try await applications.listApplications().data.applications

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/PressTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/PressTool.swift
@@ -457,21 +457,21 @@ public struct PressTool: MCPTool {
 
     private func snapshotExactWindow(id: String?) async throws -> UIAutomationTarget.ExactWindow? {
         guard let id, !id.isEmpty else { return nil }
-        guard let snapshot = await self.context.uiSnapshots.getSnapshot(id: id),
-              let processIdentifier = snapshot.applicationProcessId,
-              processIdentifier > 0,
-              let windowID = snapshot.windowID,
-              let bounds = snapshot.windowBounds,
-              let identity = snapshot.windowMutationIdentity,
-              identity.ownerProcessIdentifier == processIdentifier,
-              identity.windowID == windowID,
-              identity.capturedBounds == bounds
-        else {
+        guard let snapshot = await self.context.uiSnapshots.getSnapshot(id: id) else {
             throw PressToolValidationError(
                 message: "The selected snapshot has no exact process-generation, window, and bounds receipt.",
                 refusalReason: .targetUnavailable)
         }
-        return try UIAutomationTarget.ExactWindow(identity: identity, bounds: bounds)
+        do {
+            guard let exactWindow = try snapshot.targetReceipt().requireIdentity().exactWindow else {
+                throw DesktopTargetIdentityError.incompleteExactWindow
+            }
+            return exactWindow
+        } catch {
+            throw PressToolValidationError(
+                message: "The selected snapshot has no exact process-generation, window, and bounds receipt.",
+                refusalReason: .targetUnavailable)
+        }
     }
 
     private static func delivery(for target: UIAutomationTarget) -> DesktopActionOutcome.Delivery {

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/TypeTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/TypeTool.swift
@@ -607,39 +607,35 @@ public struct TypeTool: MCPTool {
     private func snapshotExactWindow(_ snapshot: UISnapshot?) throws -> UIAutomationTarget.ExactWindow? {
         guard let snapshot else { return nil }
         guard snapshot.windowMutationIdentity != nil else { return nil }
-        guard let processIdentifier = snapshot.applicationProcessId,
-              processIdentifier > 0,
-              let windowID = snapshot.windowID,
-              let bounds = snapshot.windowBounds,
-              let identity = snapshot.windowMutationIdentity,
-              identity.ownerProcessIdentifier == processIdentifier,
-              identity.windowID == windowID,
-              identity.capturedBounds == bounds
-        else {
+        do {
+            guard let exactWindow = try snapshot.targetReceipt().requireIdentity().exactWindow else {
+                throw DesktopTargetIdentityError.incompleteExactWindow
+            }
+            return exactWindow
+        } catch {
             throw TypeToolValidationError(
                 "The selected snapshot has inconsistent process/window metadata.",
                 refusalReason: .targetUnavailable)
         }
-        return try UIAutomationTarget.ExactWindow(identity: identity, bounds: bounds)
     }
 
     private func snapshotProcessIdentity(_ snapshot: UISnapshot?) async throws -> ApplicationProcessIdentity? {
         guard let snapshot, let processIdentifier = snapshot.applicationProcessId, processIdentifier > 0 else {
             return nil
         }
-        if let windowIdentity = snapshot.windowMutationIdentity,
-           windowIdentity.ownerProcessIdentifier != processIdentifier
+        do {
+            return try snapshot.targetReceipt().requireIdentity().processIdentity
+        } catch DesktopTargetIdentityError.missingProcessGeneration,
+            DesktopTargetIdentityError.incompleteExactWindow
         {
+            throw TypeToolValidationError(
+                "The selected snapshot has no capture-time process-generation receipt. Capture fresh UI state.",
+                refusalReason: .targetUnavailable)
+        } catch {
             throw TypeToolValidationError(
                 "The selected snapshot has inconsistent process metadata.",
                 refusalReason: .targetUnavailable)
         }
-        if let identity = snapshot.applicationProcessIdentity {
-            return identity
-        }
-        throw TypeToolValidationError(
-            "The selected snapshot has no capture-time process-generation receipt. Capture fresh UI state.",
-            refusalReason: .targetUnavailable)
     }
 
     @MainActor

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/UISnapshotStore.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/UISnapshotStore.swift
@@ -242,6 +242,43 @@ actor UISnapshot {
     nonisolated var windowMutationIdentity: WindowMutationIdentity? {
         self.targetCache.withLock { $0.targetReceiptInvalidated ? nil : $0.windowMutationIdentity }
     }
+
+    nonisolated var targetReceiptInvalidated: Bool {
+        self.targetCache.withLock { $0.targetReceiptInvalidated }
+    }
+
+    /// Atomically projects the store's sticky receipt state into the canonical snapshot adapter.
+    nonisolated func targetReceipt() throws -> SnapshotTargetReceipt {
+        let cached = self.targetCache.withLock { cache in
+            (
+                applicationName: cache.applicationName,
+                processIdentifier: cache.applicationProcessId,
+                processStartIdentity: cache.applicationProcessStartIdentity,
+                windowID: cache.windowID,
+                windowBounds: cache.windowBounds,
+                windowIdentity: cache.windowMutationIdentity,
+                invalidated: cache.targetReceiptInvalidated)
+        }
+        let processIdentity: ApplicationProcessIdentity? = if let processIdentifier = cached.processIdentifier,
+                                                              let processStartIdentity = cached.processStartIdentity
+        {
+            ApplicationProcessIdentity(
+                processIdentifier: processIdentifier,
+                processStartIdentity: processStartIdentity)
+        } else {
+            nil
+        }
+        return try SnapshotTargetReceipt(
+            snapshotID: self.id,
+            evidence: [.init(
+                processIdentifier: cached.processIdentifier,
+                processIdentity: processIdentity,
+                windowID: cached.windowIdentity == nil ? nil : cached.windowID,
+                windowIdentity: cached.windowIdentity,
+                windowBounds: cached.windowIdentity == nil ? nil : cached.windowBounds)],
+            targetReceiptInvalidated: cached.invalidated,
+            applicationName: cached.applicationName)
+    }
 }
 
 /// Logical owner of one MCP/Agent snapshot history inside this process.

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/WindowTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/WindowTool.swift
@@ -278,23 +278,30 @@ public struct WindowTool: MCPTool {
     // MARK: - Helper Methods
 
     private func createWindowTarget(app: String?, title: String?, index: Int?, windowId: Int?) throws -> WindowTarget {
-        if let windowId {
+        let selector = InteractionTargetSelector(
+            applicationIdentifier: app,
+            windowID: windowId,
+            windowTitle: title,
+            windowIndex: index)
+        try selector.validate(policy: .windowGlobalTitleAllowed)
+
+        if let windowId = selector.windowID {
             return .windowId(windowId)
         }
 
-        if let app, let title {
+        if let app = selector.applicationIdentifier, let title = selector.windowTitle {
             return .applicationAndTitle(app: app, title: title)
         }
 
-        if let app, let index {
+        if let app = selector.applicationIdentifier, let index = selector.windowIndex {
             return .index(app: app, index: index)
         }
 
-        if let app {
+        if let app = selector.applicationIdentifier {
             return .application(app)
         }
 
-        if let title {
+        if let title = selector.windowTitle {
             return .title(title)
         }
 

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPInteractionTargetTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPInteractionTargetTests.swift
@@ -1,4 +1,7 @@
+import CoreGraphics
 import PeekabooAutomation
+import PeekabooAutomationKit
+import PeekabooAutomationKitTestSupport
 import PeekabooFoundationTestSupport
 import TachikomaMCP
 import Testing
@@ -50,6 +53,67 @@ struct MCPInteractionTargetTests {
                 applications: context.applications,
                 windows: context.windows)
         }
+    }
+
+    @MainActor
+    @Test
+    func `background keyboard window adapter enforces complete immutable receipts`() async throws {
+        let processIdentity = AutomationTestFixtures.processIdentity(
+            processIdentifier: 4242,
+            processStartIdentity: 71)
+        let bounds = CGRect(x: 10, y: 20, width: 640, height: 480)
+        let applications = MockApplicationService(applications: [AutomationTestFixtures.application(
+            processIdentifier: processIdentity.processIdentifier,
+            processStartIdentity: processIdentity.processStartIdentity,
+            bundleIdentifier: "com.example.editor",
+            name: "Editor")])
+        let target = try Self.makeTarget(Selectors(
+            app: "Editor",
+            pid: nil,
+            windowTitle: nil,
+            windowIndex: nil,
+            windowID: 42))
+        let malformedWindows = [
+            Self.window(
+                windowID: 42,
+                processIdentity: processIdentity,
+                bounds: bounds,
+                capturedBounds: nil),
+            Self.window(
+                windowID: 42,
+                processIdentity: processIdentity,
+                bounds: bounds,
+                capturedBounds: bounds.offsetBy(dx: 1, dy: 0)),
+            Self.window(
+                windowID: 0,
+                processIdentity: processIdentity,
+                bounds: bounds,
+                capturedBounds: bounds),
+            Self.window(
+                windowID: Int(UInt32.max) + 1,
+                processIdentity: processIdentity,
+                bounds: bounds,
+                capturedBounds: bounds),
+        ]
+
+        for window in malformedWindows {
+            await #expect(throws: MCPInteractionTargetError.backgroundWindowTargetMismatch) {
+                _ = try await target.requireBackgroundKeyboardTarget(
+                    applications: applications,
+                    windows: ReceiptWindowService(window: window))
+            }
+        }
+
+        let valid = Self.window(
+            windowID: 42,
+            processIdentity: processIdentity,
+            bounds: bounds,
+            capturedBounds: bounds)
+        let resolved = try await target.requireBackgroundKeyboardTarget(
+            applications: applications,
+            windows: ReceiptWindowService(window: valid))
+        #expect(resolved.exactWindow?.identity == valid.mutationIdentity)
+        #expect(resolved.exactWindow?.bounds == bounds)
     }
 
     enum InvalidConsumerFixture: CaseIterable, Sendable {
@@ -232,5 +296,45 @@ struct MCPInteractionTargetTests {
             windowTitle: selectors.hasWindowTitle ? "Main" : nil,
             windowIndex: selectors.hasWindowIndex ? 2 : nil,
             windowID: selectors.hasWindowID ? 7 : nil))
+    }
+
+    private static func window(
+        windowID: Int,
+        processIdentity: ApplicationProcessIdentity,
+        bounds: CGRect,
+        capturedBounds: CGRect?) -> ServiceWindowInfo
+    {
+        ServiceWindowInfo(
+            windowID: windowID,
+            title: "Document",
+            bounds: bounds,
+            mutationIdentity: WindowMutationIdentity(
+                windowID: windowID,
+                ownerProcessIdentifier: processIdentity.processIdentifier,
+                ownerProcessStartIdentity: processIdentity.processStartIdentity,
+                capturedBounds: capturedBounds))
+    }
+}
+
+private actor ReceiptWindowService: WindowManagementServiceProtocol {
+    let window: ServiceWindowInfo
+
+    init(window: ServiceWindowInfo) {
+        self.window = window
+    }
+
+    func closeWindow(target _: WindowTarget) async throws {}
+    func minimizeWindow(target _: WindowTarget) async throws {}
+    func maximizeWindow(target _: WindowTarget) async throws {}
+    func moveWindow(target _: WindowTarget, to _: CGPoint) async throws {}
+    func resizeWindow(target _: WindowTarget, to _: CGSize) async throws {}
+    func setWindowBounds(target _: WindowTarget, bounds _: CGRect) async throws {}
+    func focusWindow(target _: WindowTarget) async throws {}
+    func listWindows(target _: WindowTarget) async throws -> [ServiceWindowInfo] {
+        [self.window]
+    }
+
+    func getFocusedWindow() async throws -> ServiceWindowInfo? {
+        nil
     }
 }

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPKeyboardBackgroundToolTests+Receipts.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPKeyboardBackgroundToolTests+Receipts.swift
@@ -1,0 +1,96 @@
+import CoreGraphics
+import PeekabooAutomationKit
+import PeekabooAutomationKitTestSupport
+import TachikomaMCP
+import Testing
+@testable import PeekabooAgentRuntime
+@testable import PeekabooCore
+
+private let keyboardReceiptSnapshots = MCPToolUISnapshotStore(owner: MCPToolSnapshotOwner())
+
+extension MCPKeyboardBackgroundToolTests {
+    @Test
+    func `Press and Type refuse malformed exact-window snapshot receipts before dispatch`() async throws {
+        await keyboardReceiptSnapshots.removeAllSnapshots()
+        let processIdentifier: pid_t = 447
+        let processStartIdentity: UInt64 = 47
+        let bounds = CGRect(x: 10, y: 20, width: 640, height: 480)
+        let automation = await MainActor.run { MockAutomationService(accessibilityGranted: true) }
+        let applications = await MainActor.run {
+            MockApplicationService(applications: [AutomationTestFixtures.application(
+                processIdentifier: processIdentifier,
+                processStartIdentity: processStartIdentity,
+                bundleIdentifier: "com.example.receipt",
+                name: "ReceiptApp")])
+        }
+        let context = await MCPToolTestHelpers.makeContext(
+            automation: automation,
+            applications: applications,
+            snapshotOwner: keyboardReceiptSnapshots.owner)
+        let invalidReceipts: [(name: String, windowID: Int, capturedBounds: CGRect?)] = [
+            ("missing captured bounds", 42, nil),
+            ("mismatched captured bounds", 42, bounds.offsetBy(dx: 1, dy: 0)),
+            ("zero window ID", 0, bounds),
+            ("out-of-range window ID", Int(UInt32.max) + 1, bounds),
+        ]
+
+        for invalid in invalidReceipts {
+            let snapshotID = await self.makeExactWindowSnapshot(
+                processIdentifier: processIdentifier,
+                processStartIdentity: processStartIdentity,
+                windowID: invalid.windowID,
+                windowBounds: bounds,
+                capturedBounds: invalid.capturedBounds)
+
+            let pressResponse = try await PressTool(context: context).execute(arguments: ToolArguments(raw: [
+                "snapshot": snapshotID,
+                "keys": ["cmd+l"],
+            ]))
+            let typeResponse = try await TypeTool(context: context).execute(arguments: ToolArguments(raw: [
+                "snapshot": snapshotID,
+                "text": "hello",
+            ]))
+
+            #expect(pressResponse.isError, "Press accepted \(invalid.name)")
+            #expect(typeResponse.isError, "Type accepted \(invalid.name)")
+        }
+
+        #expect(await MainActor.run { automation.lastHotkeyKeys } == nil)
+        #expect(await MainActor.run { automation.lastTypeActions } == nil)
+        #expect(await MainActor.run { automation.targetedHotkeyCalls.isEmpty })
+        #expect(await MainActor.run { automation.targetedTypeActionsCalls.isEmpty })
+    }
+
+    private func makeExactWindowSnapshot(
+        processIdentifier: pid_t,
+        processStartIdentity: UInt64,
+        windowID: Int,
+        windowBounds: CGRect,
+        capturedBounds: CGRect?) async -> String
+    {
+        let snapshot = await keyboardReceiptSnapshots.createSnapshot()
+        let snapshotID = await snapshot.id
+        let application = AutomationTestFixtures.application(
+            processIdentifier: processIdentifier,
+            processStartIdentity: processStartIdentity,
+            bundleIdentifier: "com.example.receipt",
+            name: "ReceiptApp")
+        let window = ServiceWindowInfo(
+            windowID: windowID,
+            title: "Receipt Window",
+            bounds: windowBounds,
+            mutationIdentity: WindowMutationIdentity(
+                windowID: windowID,
+                ownerProcessIdentifier: processIdentifier,
+                ownerProcessStartIdentity: processStartIdentity,
+                capturedBounds: capturedBounds))
+        await snapshot.setScreenshot(
+            path: "/tmp/receipt-\(snapshotID).png",
+            metadata: CaptureMetadata(
+                size: windowBounds.size,
+                mode: .window,
+                applicationInfo: application,
+                windowInfo: window))
+        return snapshotID
+    }
+}

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/UISnapshotStoreConcurrencyTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/UISnapshotStoreConcurrencyTests.swift
@@ -184,7 +184,7 @@ struct UISnapshotStoreConcurrencyTests {
     }
 
     @Test
-    func `conflicting detection generation permanently invalidates snapshot receipt`() async {
+    func `conflicting detection generation permanently invalidates snapshot receipt`() async throws {
         let snapshot = UISnapshot()
         await snapshot.setScreenshot(
             path: "/tmp/screenshot.png",
@@ -210,6 +210,8 @@ struct UISnapshotStoreConcurrencyTests {
         await snapshot.setTargetMetadata(from: conflictingContext)
         #expect(snapshot.applicationProcessIdentity == nil)
         #expect(snapshot.windowMutationIdentity == nil)
+        #expect(snapshot.targetReceiptInvalidated)
+        #expect(try snapshot.targetReceipt().targetEvidence == .invalidated)
 
         await snapshot.setTargetMetadata(from: conflictingContext)
         #expect(snapshot.applicationProcessIdentity == nil)
@@ -227,6 +229,7 @@ struct UISnapshotStoreConcurrencyTests {
                     name: "Editor")))
         #expect(snapshot.applicationProcessIdentity == nil)
         #expect(snapshot.windowMutationIdentity == nil)
+        #expect(try snapshot.targetReceipt().targetEvidence == .invalidated)
     }
 
     @Test

--- a/Core/PeekabooFoundation/Sources/PeekabooFoundation/InteractionTargetSelector.swift
+++ b/Core/PeekabooFoundation/Sources/PeekabooFoundation/InteractionTargetSelector.swift
@@ -1,0 +1,284 @@
+import Foundation
+
+/// Parser-neutral syntax for one application/window target.
+///
+/// The raw optional strings intentionally preserve whether a caller supplied an empty value. Surface
+/// adapters keep their shipped error wording while sharing normalization and combination rules here.
+public struct InteractionTargetSelector: Equatable, Sendable {
+    public enum WindowSelector: Equatable, Sendable {
+        case id(Int)
+        case title(String)
+        case index(Int)
+    }
+
+    public enum Policy: Equatable, Sendable {
+        /// CLI and MCP interaction grammar.
+        case interaction
+        /// Dialog grammar, including its existing nonempty-string requirements.
+        case dialogOwnerRequired
+        /// MCP Window compatibility grammar, where a title may be global and legacy selector precedence remains.
+        case windowGlobalTitleAllowed
+        /// CLI Window compatibility grammar, including redundant `--app PID:n --pid n` support.
+        case windowCLI(allowMissingTarget: Bool = false)
+        /// Strict syntax for mutation planners. Selection and dispatch are deliberately outside this value.
+        case mutationSafe
+    }
+
+    public enum ValidationError: Error, Equatable, Sendable {
+        case applicationAndProcessIdentifier
+        case conflictingProcessIdentifiers(application: Int32, explicit: Int32)
+        case invalidApplicationProcessIdentifier
+        case multipleWindowSelectors
+        case windowSelectorRequiresApplication
+        case missingTarget
+        case emptyApplication
+        case emptyWindowTitle
+        case invalidProcessIdentifier
+        case invalidWindowID
+        case invalidWindowIndex
+    }
+
+    /// Original application channel, before whitespace normalization.
+    public let applicationIdentifier: String?
+    /// Original PID channel. `Int` retains out-of-range input until policy validation.
+    public let rawProcessIdentifier: Int?
+    /// Original window-id channel.
+    public let windowID: Int?
+    /// Original title channel, before whitespace normalization.
+    public let windowTitle: String?
+    /// Original index channel.
+    public let windowIndex: Int?
+
+    public init(
+        applicationIdentifier: String? = nil,
+        processIdentifier: Int? = nil,
+        windowID: Int? = nil,
+        windowTitle: String? = nil,
+        windowIndex: Int? = nil)
+    {
+        self.applicationIdentifier = applicationIdentifier
+        self.rawProcessIdentifier = processIdentifier
+        self.windowID = windowID
+        self.windowTitle = windowTitle
+        self.windowIndex = windowIndex
+    }
+
+    public var normalizedApplicationIdentifier: String? {
+        Self.normalized(self.applicationIdentifier)
+    }
+
+    public var processIdentifier: Int32? {
+        self.rawProcessIdentifier.flatMap(Int32.init(exactly:))
+    }
+
+    public var normalizedWindowTitle: String? {
+        Self.normalized(self.windowTitle)
+    }
+
+    public var hasAnyInput: Bool {
+        self.applicationIdentifier != nil || self.rawProcessIdentifier != nil || self.windowID != nil ||
+            self.windowTitle != nil || self.windowIndex != nil
+    }
+
+    public var hasOwnerInput: Bool {
+        self.applicationIdentifier != nil || self.rawProcessIdentifier != nil
+    }
+
+    public var hasWindowInput: Bool {
+        self.windowID != nil || self.windowTitle != nil || self.windowIndex != nil
+    }
+
+    /// Returns the normalized selector using the shipped precedence for the requested surface.
+    /// Policies that require exclusivity validate before returning.
+    public func normalizedWindowSelector(policy: Policy) throws -> WindowSelector? {
+        try self.validate(policy: policy)
+        if let windowID = self.windowID {
+            return .id(windowID)
+        }
+        if let title = self.normalizedWindowTitle {
+            return .title(title)
+        }
+        if let windowIndex = self.windowIndex {
+            return .index(windowIndex)
+        }
+        return nil
+    }
+
+    /// Resolves only the selector syntax. It does not look up or select an application.
+    public func normalizedApplicationTarget(policy: Policy) throws -> String? {
+        try self.validate(policy: policy)
+        switch (self.applicationIdentifier, self.rawProcessIdentifier) {
+        case (nil, nil):
+            return nil
+        case (_?, nil):
+            return self.normalizedApplicationIdentifier
+        case (nil, let processIdentifier?):
+            guard let pid = Int32(exactly: processIdentifier) else {
+                throw ValidationError.invalidProcessIdentifier
+            }
+            return "PID:\(pid)"
+        case let (application?, processIdentifier?):
+            guard case .windowCLI = policy else {
+                throw ValidationError.applicationAndProcessIdentifier
+            }
+            guard let explicitPID = Int32(exactly: processIdentifier), explicitPID > 0 else {
+                throw ValidationError.invalidProcessIdentifier
+            }
+            guard let applicationPID = Self.pid(fromApplicationIdentifier: application) else {
+                if Self.looksLikePIDIdentifier(application) {
+                    throw ValidationError.invalidApplicationProcessIdentifier
+                }
+                throw ValidationError.applicationAndProcessIdentifier
+            }
+            guard applicationPID == explicitPID else {
+                throw ValidationError.conflictingProcessIdentifiers(
+                    application: applicationPID,
+                    explicit: explicitPID)
+            }
+            return self.normalizedApplicationIdentifier
+        }
+    }
+
+    public func validate(policy: Policy) throws {
+        switch policy {
+        case .interaction:
+            try self.validateInteractionGrammar(allowsGlobalTitle: false, rejectsEmptyStrings: false)
+
+        case .dialogOwnerRequired:
+            try self.validateInteractionGrammar(allowsGlobalTitle: false, rejectsEmptyStrings: true)
+            try self.validateNumericRanges()
+
+        case .windowGlobalTitleAllowed:
+            // Preserve the shipped MCP Window selector precedence in slice 1. Strict mutation syntax
+            // is admitted only by `.mutationSafe` in the follow-up planning slice.
+            break
+
+        case let .windowCLI(allowMissingTarget):
+            if !allowMissingTarget,
+               self.applicationIdentifier == nil,
+               self.rawProcessIdentifier == nil,
+               self.windowID == nil
+            {
+                throw ValidationError.missingTarget
+            }
+            if let windowID = self.windowID, windowID <= 0 {
+                throw ValidationError.invalidWindowID
+            }
+            if let windowIndex = self.windowIndex, windowIndex < 0 {
+                throw ValidationError.invalidWindowIndex
+            }
+            if self.applicationIdentifier != nil, self.rawProcessIdentifier != nil {
+                _ = try self.normalizedApplicationTargetForWindowCLI()
+            }
+
+        case .mutationSafe:
+            try self.validateInteractionGrammar(
+                allowsGlobalTitle: false,
+                rejectsEmptyStrings: true)
+            try self.validateNumericRanges()
+        }
+    }
+
+    private func validateInteractionGrammar(
+        allowsGlobalTitle: Bool,
+        rejectsEmptyStrings: Bool) throws
+    {
+        if rejectsEmptyStrings {
+            if self.applicationIdentifier != nil, self.normalizedApplicationIdentifier == nil {
+                throw ValidationError.emptyApplication
+            }
+            if self.windowTitle != nil, self.normalizedWindowTitle == nil {
+                throw ValidationError.emptyWindowTitle
+            }
+        }
+
+        do {
+            try InteractionTargetSelectorValidator.validate(
+                hasApplication: self.applicationIdentifier != nil,
+                hasProcessIdentifier: self.rawProcessIdentifier != nil,
+                hasWindowID: self.windowID != nil,
+                hasWindowTitle: allowsGlobalTitle ? false : self.windowTitle != nil,
+                hasWindowIndex: self.windowIndex != nil)
+        } catch let error as InteractionTargetSelectorValidationError {
+            switch error {
+            case .applicationAndProcessIdentifier:
+                throw ValidationError.applicationAndProcessIdentifier
+            case .multipleWindowSelectors:
+                throw ValidationError.multipleWindowSelectors
+            case .windowSelectorRequiresApplication:
+                throw ValidationError.windowSelectorRequiresApplication
+            }
+        }
+
+        if allowsGlobalTitle {
+            let windowSelectorCount = [self.windowID != nil, self.windowTitle != nil, self.windowIndex != nil]
+                .count(where: { $0 })
+            if windowSelectorCount > 1 {
+                throw ValidationError.multipleWindowSelectors
+            }
+        }
+    }
+
+    private func validateNumericRanges() throws {
+        if let processIdentifier = self.rawProcessIdentifier,
+           processIdentifier <= 0 || Int32(exactly: processIdentifier) == nil
+        {
+            throw ValidationError.invalidProcessIdentifier
+        }
+        if let windowID,
+           windowID <= 0 || UInt32(exactly: windowID) == nil
+        {
+            throw ValidationError.invalidWindowID
+        }
+        if let windowIndex, windowIndex < 0 {
+            throw ValidationError.invalidWindowIndex
+        }
+    }
+
+    private func normalizedApplicationTargetForWindowCLI() throws -> String? {
+        switch (self.applicationIdentifier, self.rawProcessIdentifier) {
+        case (nil, nil):
+            return nil
+        case (let application?, nil):
+            return application
+        case (nil, let processIdentifier?):
+            if let pid = Int32(exactly: processIdentifier) {
+                return "PID:\(pid)"
+            } else {
+                throw ValidationError.invalidProcessIdentifier
+            }
+        case let (application?, processIdentifier?):
+            guard let explicitPID = Int32(exactly: processIdentifier) else {
+                throw ValidationError.invalidProcessIdentifier
+            }
+            guard let applicationPID = Self.pid(fromApplicationIdentifier: application) else {
+                if Self.looksLikePIDIdentifier(application) {
+                    throw ValidationError.invalidApplicationProcessIdentifier
+                }
+                throw ValidationError.applicationAndProcessIdentifier
+            }
+            guard applicationPID == explicitPID else {
+                throw ValidationError.conflictingProcessIdentifiers(
+                    application: applicationPID,
+                    explicit: explicitPID)
+            }
+            return application
+        }
+    }
+
+    private static func normalized(_ value: String?) -> String? {
+        guard let value = value?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty else {
+            return nil
+        }
+        return value
+    }
+
+    private static func looksLikePIDIdentifier(_ value: String) -> Bool {
+        value.hasPrefix("PID:")
+    }
+
+    private static func pid(fromApplicationIdentifier value: String) -> Int32? {
+        guard value.hasPrefix("PID:") else { return nil }
+        return Int32(value.dropFirst("PID:".count))
+    }
+}

--- a/Core/PeekabooFoundation/Tests/PeekabooFoundationTests/InteractionTargetSelectorValidationTests.swift
+++ b/Core/PeekabooFoundation/Tests/PeekabooFoundationTests/InteractionTargetSelectorValidationTests.swift
@@ -41,4 +41,98 @@ struct InteractionTargetSelectorValidationTests {
             hasWindowTitle: selectors.hasWindowTitle,
             hasWindowIndex: selectors.hasWindowIndex)
     }
+
+    @Test
+    func `canonical syntax retains raw channels while exposing normalized values`() throws {
+        let selector = InteractionTargetSelector(
+            applicationIdentifier: "  Preview  ",
+            windowTitle: "  Main  ")
+
+        #expect(selector.applicationIdentifier == "  Preview  ")
+        #expect(selector.windowTitle == "  Main  ")
+        #expect(selector.normalizedApplicationIdentifier == "Preview")
+        #expect(selector.normalizedWindowTitle == "Main")
+        #expect(try selector.normalizedApplicationTarget(policy: .interaction) == "Preview")
+        #expect(try selector.normalizedWindowSelector(policy: .interaction) == .title("Main"))
+    }
+
+    @Test
+    func `canonical syntax distinguishes absent and supplied empty strings`() {
+        let absent = InteractionTargetSelector()
+        let suppliedEmpty = InteractionTargetSelector(applicationIdentifier: "  ")
+
+        #expect(absent.applicationIdentifier == nil)
+        #expect(!absent.hasAnyInput)
+        #expect(suppliedEmpty.applicationIdentifier != nil)
+        #expect(suppliedEmpty.normalizedApplicationIdentifier == nil)
+        #expect(suppliedEmpty.hasAnyInput)
+        #expect(throws: InteractionTargetSelector.ValidationError.emptyApplication) {
+            try suppliedEmpty.validate(policy: .dialogOwnerRequired)
+        }
+        #expect(throws: Never.self) {
+            try suppliedEmpty.validate(policy: .interaction)
+        }
+    }
+
+    @Test
+    func `canonical mutation-safe policy validates numeric ranges`() {
+        #expect(throws: InteractionTargetSelector.ValidationError.invalidProcessIdentifier) {
+            try InteractionTargetSelector(processIdentifier: 0).validate(policy: .mutationSafe)
+        }
+        #expect(throws: InteractionTargetSelector.ValidationError.invalidProcessIdentifier) {
+            try InteractionTargetSelector(processIdentifier: Int(Int32.max) + 1).validate(policy: .mutationSafe)
+        }
+        #expect(throws: InteractionTargetSelector.ValidationError.invalidWindowID) {
+            try InteractionTargetSelector(windowID: Int(UInt32.max) + 1).validate(policy: .mutationSafe)
+        }
+        #expect(throws: InteractionTargetSelector.ValidationError.invalidWindowIndex) {
+            try InteractionTargetSelector(applicationIdentifier: "Preview", windowIndex: -1)
+                .validate(policy: .mutationSafe)
+        }
+    }
+
+    @Test
+    func `window policies preserve their distinct shipped grammars`() throws {
+        let globalTitle = InteractionTargetSelector(windowTitle: "Document")
+        #expect(throws: InteractionTargetSelector.ValidationError.windowSelectorRequiresApplication) {
+            try globalTitle.validate(policy: .interaction)
+        }
+        #expect(try globalTitle.normalizedWindowSelector(policy: .windowGlobalTitleAllowed) == .title("Document"))
+
+        let redundantPID = InteractionTargetSelector(
+            applicationIdentifier: "PID:42",
+            processIdentifier: 42)
+        #expect(try redundantPID.normalizedApplicationTarget(policy: .windowCLI()) == "PID:42")
+        #expect(throws: InteractionTargetSelector.ValidationError.applicationAndProcessIdentifier) {
+            try redundantPID.validate(policy: .interaction)
+        }
+
+        let conflictingPID = InteractionTargetSelector(
+            applicationIdentifier: "PID:41",
+            processIdentifier: 42)
+        #expect(throws: InteractionTargetSelector.ValidationError.conflictingProcessIdentifiers(
+            application: 41,
+            explicit: 42))
+        {
+            try conflictingPID.validate(policy: .windowCLI())
+        }
+    }
+
+    @Test
+    func `strict policy rejects ambiguous and empty selector syntax`() {
+        #expect(throws: InteractionTargetSelector.ValidationError.windowSelectorRequiresApplication) {
+            try InteractionTargetSelector(windowTitle: "Main").validate(policy: .mutationSafe)
+        }
+        #expect(throws: InteractionTargetSelector.ValidationError.multipleWindowSelectors) {
+            try InteractionTargetSelector(
+                applicationIdentifier: "Preview",
+                windowID: 7,
+                windowTitle: "Main")
+                .validate(policy: .mutationSafe)
+        }
+        #expect(throws: InteractionTargetSelector.ValidationError.emptyWindowTitle) {
+            try InteractionTargetSelector(applicationIdentifier: "Preview", windowTitle: " ")
+                .validate(policy: .mutationSafe)
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- introduce one parser-neutral `InteractionTargetSelector` in Foundation for app, PID, window ID/title/index, snapshot, and coordinate intent
- centralize stable process/window/snapshot identity coalescing in AutomationKit instead of rebuilding receipts independently in CLI, MCP, dialogs, keyboard, click, and window adapters
- route CLI and MCP selector surfaces through the shared validator while preserving existing flags, keys, errors, and candidate-selection behavior
- fail closed unless exact-window evidence carries a positive UInt32-valid window ID and immutable captured bounds that exactly match the external bounds
- distinguish deterministic receipt-shape refusals from live drift, release snapshot mutation leases only for the typed pre-dispatch case, and report the missing immutable evidence directly

## Root cause

The same target syntax and receipt merge policy had grown independently across CLI options, MCP arguments, dialog prepared actions, snapshot stores, keyboard delivery, click routing, and window tools. Those copies could disagree on conflicts, relative-window ownership, or whether an incomplete window identity was safe enough to dispatch.

The first physical-host upgrade run also exposed a result-semantics edge: malformed immutable receipt evidence was discovered only after the CLI reserved the snapshot for mutation. The untyped error path correctly refused dispatch but conservatively retained the lease, so a later command saw only a generic stale-snapshot result.

This slice gives syntax normalization to Foundation and stable identity/receipt coalescing to AutomationKit. A dedicated receipt-planning error can only be created by pre-dispatch planning owners; the CLI releases a lease for that marker and preserves conservative handling for live drift, generic stale errors, and every possible post-dispatch failure.

## Safety properties

- app and PID selectors remain mutually exclusive
- title/index selectors still require an application owner and all window selectors remain exclusive
- exact-window receipts require a positive UInt32-valid ID, matching PID/process generation, non-nil immutable captured bounds, and exact bounds agreement
- separate bounds cannot fill a missing receipt field
- conflicting snapshot/process/window evidence refuses instead of choosing one source
- CLI/MCP selected-window adapters, Press, Type, keyboard delivery, dialogs, and window tools use the same coalescer
- malformed immutable receipt evidence returns `SNAPSHOT_STALE`, `effect: refused`, `retry_safe: true`, and `mutation_dispatched: false` without consuming the snapshot lease
- live target drift and post-dispatch ambiguity retain their existing retry-unsafe/fresh-observation behavior
- current dialog protocol 1.28 wire keys, MCP capture-refusal wiring, Action/SetValue preflight, strict Press key/modifier validation, exact WindowServer catalog fallback, and awaited Bridge termination cleanup are preserved

## Proof

- focused restack matrix: 265 tests
  - Foundation selector policy: 9
  - AutomationKit target/receipt planning, click, scroll, dialogs, and exact WindowServer lookup: 83
  - CLI repeated-receipt and keyboard adapters: 12
  - Core MCP, strict Press parsing, snapshot store, termination, and host ownership: 74
  - protocol 1.28 dialog wire compatibility: 6
  - MCP/Agent capture-preflight context: 13
  - CLI pre-runtime, capture-owner, dialog capability, and window adapters: 67
  - current CLI process capability: 1
- repeated one malformed snapshot twice through `set-value`, `action`, targeted `scroll`, and `click`; every attempt returned the same explicit retry-safe pre-dispatch refusal, Type retained its existing validation error, and the lease remained reusable
- full `pnpm run test:safe`: pass, including 55 Foundation, 946 CLI/Core, and 99 runtime tests plus native-only, release, background-certification, and SwiftPM-consumer gates
- SwiftFormat, docs lint, `git diff --check`, and zero changelog diff: clean
- SwiftLint: 30 existing warnings, 0 serious
- range-diff: all three rebased commits are semantic equivalents in the same order
- fresh whole-branch autoreview: clean, no accepted/actionable finding

## Signed upgrade validation status

The Foundation-signed physical-host run on exact head `216364c32adb0ac1ab4ce95f38e7c4abf2f688e4` passed **14 of 15 clauses**. All #481-specific upgrade-recovery behavior now passes:

- C5 missing immutable bounds returns the explicit typed `SNAPSHOT_STALE` refusal, a verbatim retry returns the same result instead of a consumed/busy snapshot, and no dispatch occurs
- C6 invalid window ID remains a precise retry-safe pre-dispatch refusal
- C15 clean task-owned GUI shutdown removes the exact private socket while leaving the unrelated installed app untouched
- selector conflicts, MCP conflict projection, ambient foreground/clipboard stability, exact snapshot cleanup, and generation-pinned process cleanup all pass

The sole failure is C8, a baseline inactive-window per-element focus-receipt limitation in unchanged code. Exact-window observation and native background `AXPress` succeeded, but the subsequent exact background Type correctly refused because the target window had no provable focused-element receipt. A direct semantic-click addendum likewise could not prove native `AXFocused` acceptance without introducing a prohibited alternate focus mechanism. A focused baseline follow-up is active; this PR does **not** claim full signed certification.

Private source-blind reports (text paths only; not uploaded):

- `/private/tmp/pb481.yvRO36/reports/report.{md,json}`
- `/private/tmp/pb481c8.beLyaP/reports/report.{md,json}`

For comparison, the old-head run at `8c35e9455514131e7040bc8bbfba44867a2f7b77` passed 12 of 15 clauses. Its three findings now have explicit owners and current-head evidence:

| Old-head finding | Repair |
|---|---|
| Missing-bounds `set-value` collapsed to generic `SNAPSHOT_STALE` and masked the receipt diagnostic | This PR's typed receipt-planning and lease-release follow-up, now at `216364c32adb0ac1ab4ce95f38e7c4abf2f688e4` |
| Fresh exact-window background Type returned `WINDOW_NOT_FOUND` | Exact-ID full WindowServer catalog fallback landed independently in #483 |
| Clean task-owned GUI shutdown left its private socket pathname | Awaited executable-owner shutdown landed independently in #484 |

Exact-head hosted CI and a fresh ClawSweeper review are also required before merge.

No changelog file is changed.
