### PR TITLE
fix(mcp): reject non-string singular press keys

### DIFF
--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -52,7 +52,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Make Agent sessions immutable background-only by default, centrally refusing foreground/global input, activation, raw press, shared-pointer, persistent clipboard mutation, shared system UI mutations, Space switch/follow, browser setup/fronting, and Shell-tool access before dispatch while retaining Space listing and unfollowed window placement; `--allow-foreground` sets a new session's immutable maximum, must be explicitly repeated on resume, and never exposes the Shell tool, while session output exposes full copyable IDs, tasks, lifecycle meaning, and stored policy.
 
 ### Fixed
-- Refuse malformed MCP `press` key/modifier shapes before target resolution or keyboard dispatch instead of silently dropping invalid modifier values.
 - Compose setup, delivery, cleanup, cancellation, and refusal receipts through one Foundation action-sequence owner so foreground focus cannot be erased by a no-dispatch leaf and CLI/MCP target refusals expose complete retry guidance.
 - Make explicit Bridge socket overrides fail closed when unavailable instead of reporting a successful local fallback.
 - Validate `see` selectors, explicit caller-local PIDs, and `scroll` directions before runtime-host and ScreenCaptureKit ownership preflight so request errors cannot be masked by ambient capture state.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@
 - Build branded release disk images from pinned direct Finder-metadata tooling, preserving the signed and notarized drag-to-Applications layout without GUI automation.
 
 ### Fixed
-- Refuse malformed MCP `press` key/modifier shapes before target resolution or keyboard dispatch instead of silently dropping invalid modifier values.
 - Keep root help and version order-independent across canonical kebab- and camel-case runtime-option aliases while preserving correct missing-value errors.
 - Treat `capture video` as caller-local media ingestion so valid files and typed media failures bypass Screen Recording and ScreenCaptureKit-owner preflight while live capture remains gated.
 - Refuse exact-window and dialog Accessibility reads when macOS cannot arm their per-element messaging deadline, and surface timeout reset failures instead of continuing unbounded.

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/PressTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/PressTool.swift
@@ -342,7 +342,7 @@ public struct PressTool: MCPTool {
             return try sequence.map(KeyboardChord.init(parsing:))
         }
 
-        let key = arguments.getString("key")
+        let key = try self.validatedPrimaryKey(arguments: arguments)
         let modifiers = try self.validatedModifiers(arguments: arguments) ?? []
         guard let key, !key.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
             throw PressToolValidationError(
@@ -383,6 +383,14 @@ public struct PressTool: MCPTool {
             }
             return modifier
         }
+    }
+
+    private static func validatedPrimaryKey(arguments: ToolArguments) throws -> String? {
+        guard let value = arguments.getValue(for: "key") else { return nil }
+        guard case let .string(key) = value else {
+            throw PressToolValidationError(message: "key must be a primary key string")
+        }
+        return key
     }
 
     @MainActor

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPKeyboardBackgroundToolTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPKeyboardBackgroundToolTests.swift
@@ -90,43 +90,6 @@ struct MCPKeyboardBackgroundToolTests {
     }
 
     @Test
-    func `Press tool reports non-string primary keys without dispatch`() async throws {
-        let automation = await MainActor.run { MockAutomationService(accessibilityGranted: true) }
-        let context = await MCPToolTestHelpers.makeContext(
-            automation: automation,
-            snapshotOwner: Self.uiSnapshots.owner)
-        let cases: [[String: Any]] = [
-            ["key": 7],
-            ["key": true],
-            ["key": ["c"]],
-            ["key": ["value": "c"]],
-            ["key": NSNull()],
-        ]
-
-        for arguments in cases {
-            var foregroundArguments = arguments
-            foregroundArguments["foreground"] = true
-            let response = try await PressTool(context: context).execute(
-                arguments: ToolArguments(raw: foregroundArguments))
-            #expect(response.isError)
-            guard case let .text(message, _, _)? = response.content.first else {
-                Issue.record("Expected press validation text")
-                continue
-            }
-            #expect(message.contains("key must be a primary key string"))
-            #expect(await MainActor.run { automation.lastHotkeyKeys } == nil)
-            #expect(await MainActor.run { automation.targetedHotkeyCalls.isEmpty })
-            guard case let .object(meta) = response.meta else {
-                Issue.record("Expected press validation metadata")
-                continue
-            }
-            #expect(meta["mutation_dispatched"] == .bool(false))
-            #expect(meta["retry_safe"] == .bool(true))
-            #expect(meta["refusal_reason"] == .string("invalid_request"))
-        }
-    }
-
-    @Test
     func `Press tool reports empty and malformed input shapes without dispatch`() async throws {
         let automation = await MainActor.run { MockAutomationService(accessibilityGranted: true) }
         let context = await MCPToolTestHelpers.makeContext(
@@ -927,24 +890,6 @@ struct PressToolParsingValidationTests {
                 _ = try PressTool.parseChords(arguments: ToolArguments(raw: arguments))
             }
             #expect(error?.message == expectedMessage)
-        }
-    }
-
-    @Test
-    func `Press tool rejects non-string primary keys while parsing`() {
-        let cases: [[String: Any]] = [
-            ["key": 7],
-            ["key": true],
-            ["key": ["c"]],
-            ["key": ["value": "c"]],
-            ["key": NSNull()],
-        ]
-
-        for arguments in cases {
-            let error = #expect(throws: PressToolValidationError.self) {
-                _ = try PressTool.parseChords(arguments: ToolArguments(raw: arguments))
-            }
-            #expect(error?.message == "key must be a primary key string")
         }
     }
 }

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPKeyboardBackgroundToolTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPKeyboardBackgroundToolTests.swift
@@ -90,6 +90,43 @@ struct MCPKeyboardBackgroundToolTests {
     }
 
     @Test
+    func `Press tool reports non-string primary keys without dispatch`() async throws {
+        let automation = await MainActor.run { MockAutomationService(accessibilityGranted: true) }
+        let context = await MCPToolTestHelpers.makeContext(
+            automation: automation,
+            snapshotOwner: Self.uiSnapshots.owner)
+        let cases: [[String: Any]] = [
+            ["key": 7],
+            ["key": true],
+            ["key": ["c"]],
+            ["key": ["value": "c"]],
+            ["key": NSNull()],
+        ]
+
+        for arguments in cases {
+            var foregroundArguments = arguments
+            foregroundArguments["foreground"] = true
+            let response = try await PressTool(context: context).execute(
+                arguments: ToolArguments(raw: foregroundArguments))
+            #expect(response.isError)
+            guard case let .text(message, _, _)? = response.content.first else {
+                Issue.record("Expected press validation text")
+                continue
+            }
+            #expect(message.contains("key must be a primary key string"))
+            #expect(await MainActor.run { automation.lastHotkeyKeys } == nil)
+            #expect(await MainActor.run { automation.targetedHotkeyCalls.isEmpty })
+            guard case let .object(meta) = response.meta else {
+                Issue.record("Expected press validation metadata")
+                continue
+            }
+            #expect(meta["mutation_dispatched"] == .bool(false))
+            #expect(meta["retry_safe"] == .bool(true))
+            #expect(meta["refusal_reason"] == .string("invalid_request"))
+        }
+    }
+
+    @Test
     func `Press tool reports empty and malformed input shapes without dispatch`() async throws {
         let automation = await MainActor.run { MockAutomationService(accessibilityGranted: true) }
         let context = await MCPToolTestHelpers.makeContext(
@@ -890,6 +927,24 @@ struct PressToolParsingValidationTests {
                 _ = try PressTool.parseChords(arguments: ToolArguments(raw: arguments))
             }
             #expect(error?.message == expectedMessage)
+        }
+    }
+
+    @Test
+    func `Press tool rejects non-string primary keys while parsing`() {
+        let cases: [[String: Any]] = [
+            ["key": 7],
+            ["key": true],
+            ["key": ["c"]],
+            ["key": ["value": "c"]],
+            ["key": NSNull()],
+        ]
+
+        for arguments in cases {
+            let error = #expect(throws: PressToolValidationError.self) {
+                _ = try PressTool.parseChords(arguments: ToolArguments(raw: arguments))
+            }
+            #expect(error?.message == "key must be a primary key string")
         }
     }
 }

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/PeekabooMCPServerTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/PeekabooMCPServerTests.swift
@@ -303,6 +303,53 @@ struct PeekabooMCPServerTests {
 
     @Test
     @MainActor
+    func `press wire rejects non-string primary keys without dispatch`() async throws {
+        let automation = MockAutomationService(accessibilityGranted: true)
+        let context = await MCPToolTestHelpers.makeContext(automation: automation)
+        let session = try await MCPWireSession.connect(context: context)
+        let cases: [Value] = [
+            .int(7),
+            .double(7),
+            .bool(true),
+            .array([.string("c")]),
+            .object(["value": .string("c")]),
+            .null,
+        ]
+
+        do {
+            for key in cases {
+                let request: RequestContext<CallTool.Result> = try await session.client.callTool(
+                    name: "press",
+                    arguments: [
+                        "key": key,
+                        "foreground": .bool(true),
+                    ])
+                let result = try await request.value
+                #expect(result.isError == true)
+                #expect(result.content.contains { content in
+                    guard case let .text(text, _, _) = content else { return false }
+                    return text.contains("key must be a primary key string")
+                })
+
+                let encoded = try JSONEncoder().encode(result)
+                let json = try #require(JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+                let metadata = try #require(json["_meta"] as? [String: Any])
+                #expect(metadata["refusal_reason"] as? String == "invalid_request")
+                #expect(metadata["mutation_dispatched"] as? Bool == false)
+                #expect(metadata["retry_safe"] as? Bool == true)
+                #expect(automation.lastHotkeyKeys == nil)
+                #expect(automation.targetedHotkeyCalls.isEmpty)
+            }
+        } catch {
+            await session.stop()
+            throw error
+        }
+
+        await session.stop()
+    }
+
+    @Test
+    @MainActor
     func `every advertised closed schema rejects unknown properties as invalid params`() async throws {
         let context = await MCPToolTestHelpers.makeContext()
         let session = try await MCPWireSession.connect(context: context)

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/PressToolPrimaryKeyValidationTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/PressToolPrimaryKeyValidationTests.swift
@@ -1,0 +1,65 @@
+import Foundation
+import TachikomaMCP
+import Testing
+@testable import PeekabooAgentRuntime
+@testable import PeekabooCore
+
+@Suite(.serialized)
+struct PressToolPrimaryKeyValidationTests {
+    private static let uiSnapshots = MCPToolUISnapshotStore(owner: MCPToolSnapshotOwner())
+
+    @Test
+    func `Press tool reports non-string primary keys without dispatch`() async throws {
+        let automation = await MainActor.run { MockAutomationService(accessibilityGranted: true) }
+        let context = await MCPToolTestHelpers.makeContext(
+            automation: automation,
+            snapshotOwner: Self.uiSnapshots.owner)
+        let cases: [[String: Any]] = [
+            ["key": 7],
+            ["key": true],
+            ["key": ["c"]],
+            ["key": ["value": "c"]],
+            ["key": NSNull()],
+        ]
+
+        for arguments in cases {
+            var foregroundArguments = arguments
+            foregroundArguments["foreground"] = true
+            let response = try await PressTool(context: context).execute(
+                arguments: ToolArguments(raw: foregroundArguments))
+            #expect(response.isError)
+            guard case let .text(message, _, _)? = response.content.first else {
+                Issue.record("Expected press validation text")
+                continue
+            }
+            #expect(message.contains("key must be a primary key string"))
+            #expect(await MainActor.run { automation.lastHotkeyKeys } == nil)
+            #expect(await MainActor.run { automation.targetedHotkeyCalls.isEmpty })
+            guard case let .object(meta) = response.meta else {
+                Issue.record("Expected press validation metadata")
+                continue
+            }
+            #expect(meta["mutation_dispatched"] == .bool(false))
+            #expect(meta["retry_safe"] == .bool(true))
+            #expect(meta["refusal_reason"] == .string("invalid_request"))
+        }
+    }
+
+    @Test
+    func `Press tool rejects non-string primary keys while parsing`() {
+        let cases: [[String: Any]] = [
+            ["key": 7],
+            ["key": true],
+            ["key": ["c"]],
+            ["key": ["value": "c"]],
+            ["key": NSNull()],
+        ]
+
+        for arguments in cases {
+            let error = #expect(throws: PressToolValidationError.self) {
+                _ = try PressTool.parseChords(arguments: ToolArguments(raw: arguments))
+            }
+            #expect(error?.message == "key must be a primary key string")
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- require the singular MCP `press` form to supply `key` as an actual string before chord parsing
- refuse integer, floating-point, boolean, array, object, and null key values with retry-safe zero-dispatch metadata
- add direct parser, direct execution, and `tools/call` wire regressions
- keep the two changelog files release-owned instead of carrying the duplicate #480 entry

## Root cause

#480 made modifier decoding strict, but the singular primary key still used `ToolArguments.getString`. That helper intentionally converts integer, floating-point, and boolean values to strings. Since a single digit is also a valid keyboard chord, a malformed wire value such as numeric `7` could become a real key press when the caller had explicitly authorized foreground delivery or supplied a valid exact-window receipt.

The public MCP schema advertises `key` as a string, so `PressTool` now validates the raw value before target resolution or keyboard dispatch.

## Proof

- `swift test --package-path Core/PeekabooCore --filter MCPKeyboardBackgroundToolTests --no-parallel` (22 tests)
- `swift test --package-path Core/PeekabooCore --filter PressToolPrimaryKeyValidationTests --no-parallel` (2 tests)
- `swift test --package-path Core/PeekabooCore --filter PeekabooMCPServerTests --no-parallel` (18 tests)
- direct and MCP-wire matrices cover integer, floating-point, boolean, array, object, and null values with `mutation_dispatched:false`, `retry_safe:true`, and `refusal_reason:invalid_request`
- `pnpm run format`
- `pnpm run lint` (29 inherited warnings, 0 serious, no touched-file warning)
- `git diff --check`
- fresh exact-branch autoreview: clean

Follow-up to #480.
