### PR TITLE
fix(window): resolve off-Space exact window IDs

### DIFF
--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/System/SystemIdentityResolver.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/System/SystemIdentityResolver.swift
@@ -99,23 +99,41 @@ public enum SystemIdentityResolver {
     /// Resolves one exact window from the current WindowServer catalog without AX traversal.
     public static func windowIdentity(_ windowID: CGWindowID) -> SystemWindowIdentity? {
         guard windowID != kCGNullWindowID else { return nil }
-        if let windows = CGWindowListCopyWindowInfo([.optionIncludingWindow], windowID) as? [[String: Any]],
-           let identity = self.windowIdentity(windowID, in: windows)
-        {
-            return identity
-        }
-
-        // `optionIncludingWindow` can omit a minimized/off-screen window even while `optionAll`
-        // still carries its exact WindowServer ID, owner, and frame. Search the full catalog only
-        // after the fast exact query misses; never fall back to title or bounds matching.
-        guard let windows = CGWindowListCopyWindowInfo(
-            [.optionAll, .excludeDesktopElements],
-            kCGNullWindowID) as? [[String: Any]],
+        guard let windows = self.exactWindowCatalog(
+            windowID,
+            windowListProvider: { options, relativeToWindow in
+                CGWindowListCopyWindowInfo(options, relativeToWindow) as? [[String: Any]]
+            }),
             let identity = self.windowIdentity(windowID, in: windows)
         else {
             return nil
         }
         return identity
+    }
+
+    /// Returns the catalog slice that contains one exact WindowServer ID.
+    ///
+    /// `optionIncludingWindow` can omit a minimized or off-Space window even while `optionAll`
+    /// still carries its exact ID, owner, and frame. The fallback remains ID-only: descriptive
+    /// metadata such as title and bounds is never used to select a different entry.
+    static func exactWindowCatalog(
+        _ windowID: CGWindowID,
+        windowListProvider: (CGWindowListOption, CGWindowID) -> [[String: Any]]?) -> [[String: Any]]?
+    {
+        guard windowID != kCGNullWindowID else { return nil }
+        if let exact = windowListProvider([.optionIncludingWindow], windowID),
+           self.containsWindow(windowID, in: exact)
+        {
+            return exact
+        }
+        guard let all = windowListProvider(
+            [.optionAll, .excludeDesktopElements],
+            kCGNullWindowID),
+            self.containsWindow(windowID, in: all)
+        else {
+            return nil
+        }
+        return all
     }
 
     /// Captures one generation-bound exact-window identity while allowing descriptive metadata
@@ -210,6 +228,15 @@ public enum SystemIdentityResolver {
         windows.first(where: {
             self.intValue($0[kCGWindowNumber as String]) == Int(windowID)
         }).flatMap(self.windowIdentity(from:))
+    }
+
+    private static func containsWindow(
+        _ windowID: CGWindowID,
+        in windows: [[String: Any]]) -> Bool
+    {
+        windows.contains {
+            self.intValue($0[kCGWindowNumber as String]) == Int(windowID)
+        }
     }
 
     /// Resolves the current CoreGraphics owner for one exact window identifier.

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/WindowCGInfoLookup.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/WindowCGInfoLookup.swift
@@ -3,19 +3,37 @@ import Foundation
 
 @MainActor
 struct WindowCGInfoLookup {
-    private let windowIdentityService: WindowIdentityService
+    typealias WindowListProvider = (CGWindowListOption, CGWindowID) -> [[String: Any]]?
 
-    init(windowIdentityService: WindowIdentityService = WindowIdentityService()) {
-        self.windowIdentityService = windowIdentityService
+    private let windowListProvider: WindowListProvider
+    private let processStartIdentityProvider: (pid_t) -> UInt64?
+    private let currentWindowIdentityProvider: (CGWindowID) -> SystemWindowIdentity?
+    private let isMainWindowProvider: (CGWindowID) -> Bool
+
+    init(
+        windowIdentityService: WindowIdentityService = WindowIdentityService(),
+        windowListProvider: @escaping WindowListProvider = { options, relativeToWindow in
+            CGWindowListCopyWindowInfo(options, relativeToWindow) as? [[String: Any]]
+        },
+        processStartIdentityProvider: @escaping (pid_t) -> UInt64? =
+            SystemIdentityResolver.processStartIdentity,
+        currentWindowIdentityProvider: @escaping (CGWindowID) -> SystemWindowIdentity? =
+            SystemIdentityResolver.windowIdentity,
+        isMainWindowProvider: ((CGWindowID) -> Bool)? = nil)
+    {
+        self.windowListProvider = windowListProvider
+        self.processStartIdentityProvider = processStartIdentityProvider
+        self.currentWindowIdentityProvider = currentWindowIdentityProvider
+        self.isMainWindowProvider = isMainWindowProvider ?? windowIdentityService.isTopmostRenderableWindow
     }
 
     func serviceWindowInfo(windowID: Int) -> ServiceWindowInfo? {
         // Exact ID refreshes happen after mutations and snapshot focus; keep them on the CG fast path
         // instead of walking every app's AX window list.
         guard let cgWindowID = CGWindowID(exactly: windowID),
-              let windowList = CGWindowListCopyWindowInfo(
-                  [.optionIncludingWindow, .excludeDesktopElements],
-                  cgWindowID) as? [[String: Any]]
+              let windowList = SystemIdentityResolver.exactWindowCatalog(
+                  cgWindowID,
+                  windowListProvider: self.windowListProvider)
         else {
             return nil
         }
@@ -23,9 +41,9 @@ struct WindowCGInfoLookup {
         return Self.serviceWindowInfo(
             windowID: windowID,
             windowList: windowList,
-            isMainWindowProvider: self.windowIdentityService.isTopmostRenderableWindow,
-            processStartIdentityProvider: SystemIdentityResolver.processStartIdentity,
-            currentWindowIdentityProvider: SystemIdentityResolver.windowIdentity)
+            isMainWindowProvider: self.isMainWindowProvider,
+            processStartIdentityProvider: self.processStartIdentityProvider,
+            currentWindowIdentityProvider: self.currentWindowIdentityProvider)
     }
 
     static func serviceWindowInfo(

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/WindowCGInfoLookupTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/WindowCGInfoLookupTests.swift
@@ -5,6 +5,121 @@ import Testing
 @MainActor
 struct WindowCGInfoLookupTests {
     @Test
+    func `exact lookup resolves an off-Space window from the full catalog without AX window identity`() throws {
+        let bounds = CGRect(x: 10, y: 20, width: 800, height: 600)
+        var queries: [(CGWindowListOption, CGWindowID)] = []
+        var generations = [UInt64(9001), 9001]
+        let lookup = WindowCGInfoLookup(
+            windowListProvider: { options, relativeToWindow in
+                queries.append((options, relativeToWindow))
+                if options.contains(.optionIncludingWindow) {
+                    return []
+                }
+                return [Self.windowDictionary(
+                    windowID: 712,
+                    ownerPID: 41,
+                    bounds: bounds,
+                    isOnScreen: false)]
+            },
+            processStartIdentityProvider: { _ in generations.removeFirst() },
+            currentWindowIdentityProvider: { windowID in
+                SystemWindowIdentity(
+                    windowID: windowID,
+                    ownerProcessIdentifier: 41,
+                    title: "Current metadata",
+                    bounds: bounds,
+                    layer: 0,
+                    alpha: 1,
+                    isOnScreen: false,
+                    sharingState: .readOnly)
+            },
+            isMainWindowProvider: { _ in false })
+
+        let window = try #require(lookup.serviceWindowInfo(windowID: 712))
+
+        #expect(window.windowID == 712)
+        #expect(window.bounds == bounds)
+        #expect(window.isOnScreen == false)
+        #expect(window.mutationIdentity?.ownerProcessStartIdentity == 9001)
+        #expect(queries.count == 2)
+        #expect(queries[0].0.contains(.optionIncludingWindow))
+        #expect(queries[0].1 == 712)
+        #expect(queries[1].0.contains(.optionAll))
+        #expect(queries[1].1 == kCGNullWindowID)
+    }
+
+    @Test
+    func `exact lookup does not widen a missing ID to matching title owner or bounds`() {
+        let bounds = CGRect(x: 10, y: 20, width: 800, height: 600)
+        var currentIdentityRead = false
+        let lookup = WindowCGInfoLookup(
+            windowListProvider: { options, _ in
+                if options.contains(.optionIncludingWindow) {
+                    return []
+                }
+                return [Self.windowDictionary(
+                    windowID: 713,
+                    ownerPID: 41,
+                    bounds: bounds,
+                    isOnScreen: false)]
+            },
+            processStartIdentityProvider: { _ in 9001 },
+            currentWindowIdentityProvider: { windowID in
+                currentIdentityRead = true
+                return SystemWindowIdentity(
+                    windowID: windowID,
+                    ownerProcessIdentifier: 41,
+                    title: "Original metadata",
+                    bounds: bounds,
+                    layer: 0,
+                    alpha: 1,
+                    isOnScreen: false,
+                    sharingState: .readOnly)
+            },
+            isMainWindowProvider: { _ in false })
+
+        #expect(lookup.serviceWindowInfo(windowID: 712) == nil)
+        #expect(!currentIdentityRead)
+    }
+
+    @Test
+    func `exact lookup rejects full-catalog owner drift`() {
+        let window = Self.fullCatalogWindowInfo(
+            dictionaryOwner: 41,
+            currentOwner: 52,
+            dictionaryBounds: CGRect(x: 10, y: 20, width: 800, height: 600),
+            currentBounds: CGRect(x: 10, y: 20, width: 800, height: 600),
+            processGenerations: [9001, 9001])
+
+        #expect(window == nil)
+    }
+
+    @Test
+    func `exact lookup rejects full-catalog PID generation reuse`() {
+        let bounds = CGRect(x: 10, y: 20, width: 800, height: 600)
+        let window = Self.fullCatalogWindowInfo(
+            dictionaryOwner: 41,
+            currentOwner: 41,
+            dictionaryBounds: bounds,
+            currentBounds: bounds,
+            processGenerations: [9001, 9002])
+
+        #expect(window == nil)
+    }
+
+    @Test
+    func `exact lookup rejects full-catalog bounds drift`() {
+        let window = Self.fullCatalogWindowInfo(
+            dictionaryOwner: 41,
+            currentOwner: 41,
+            dictionaryBounds: CGRect(x: 10, y: 20, width: 800, height: 600),
+            currentBounds: CGRect(x: 30, y: 40, width: 640, height: 480),
+            processGenerations: [9001, 9001])
+
+        #expect(window == nil)
+    }
+
+    @Test
     func `exact lookup binds metadata and mutation identity to the dictionary owner`() throws {
         let window = try #require(Self.serviceWindowInfo(
             dictionaryOwner: 41,
@@ -246,5 +361,60 @@ struct WindowCGInfoLookupTests {
                     isOnScreen: true,
                     sharingState: .readOnly)
             })
+    }
+
+    private static func fullCatalogWindowInfo(
+        dictionaryOwner: pid_t,
+        currentOwner: pid_t,
+        dictionaryBounds: CGRect,
+        currentBounds: CGRect,
+        processGenerations: [UInt64]) -> ServiceWindowInfo?
+    {
+        var remainingGenerations = processGenerations
+        let lookup = WindowCGInfoLookup(
+            windowListProvider: { options, _ in
+                if options.contains(.optionIncludingWindow) {
+                    return []
+                }
+                return [Self.windowDictionary(
+                    windowID: 712,
+                    ownerPID: dictionaryOwner,
+                    bounds: dictionaryBounds,
+                    isOnScreen: false)]
+            },
+            processStartIdentityProvider: { _ in
+                guard !remainingGenerations.isEmpty else { return nil }
+                return remainingGenerations.removeFirst()
+            },
+            currentWindowIdentityProvider: { windowID in
+                SystemWindowIdentity(
+                    windowID: windowID,
+                    ownerProcessIdentifier: currentOwner,
+                    title: "Current metadata",
+                    bounds: currentBounds,
+                    layer: 0,
+                    alpha: 1,
+                    isOnScreen: false,
+                    sharingState: .readOnly)
+            },
+            isMainWindowProvider: { _ in false })
+        return lookup.serviceWindowInfo(windowID: 712)
+    }
+
+    private static func windowDictionary(
+        windowID: Int,
+        ownerPID: pid_t,
+        bounds: CGRect,
+        isOnScreen: Bool) -> [String: Any]
+    {
+        [
+            kCGWindowNumber as String: windowID,
+            kCGWindowOwnerPID as String: Int(ownerPID),
+            kCGWindowName as String: "Original metadata",
+            kCGWindowBounds as String: bounds.dictionaryRepresentation,
+            kCGWindowLayer as String: 0,
+            kCGWindowAlpha as String: 1.0,
+            kCGWindowIsOnscreen as String: isOnScreen,
+        ]
     }
 }


### PR DESCRIPTION
## Summary

- centralize exact WindowServer catalog selection so both identity validation and window lookup share the same exact-ID fallback
- recover off-Space/background windows from the full catalog when the targeted query omits them
- keep the fallback fail-closed on exact window ID, owner PID, process generation, and captured bounds

## Root cause

Signed source-blind C8 validation on PR #481 captured a fresh Playground snapshot for PID 91129, window 16684, with a current process generation, exact bounds, and an editable AX element. Immediate background `type --snapshot ... --pid 91129 --window-id 16684 --no-remote` refused before dispatch with `WINDOW_NOT_FOUND`, while immediate native `verify` resolved the same window and exact-snapshot `set-value` succeeded.

The regression was not in #481. Both #481 and its then-current base routed the explicit window selector through `WindowManagementService.windowById`. Its first lookup used only `CGWindowListCopyWindowInfo(.optionIncludingWindow)`, which can omit an off-Space/background window. The fallback then required AX window-number extraction. A live exact WindowServer entry that was available through the full catalog but lacked an AX window number was therefore misreported as absent.

`SystemIdentityResolver` already had the correct ID-only full-catalog fallback for `verify`. This change makes `WindowCGInfoLookup` share that selection path, then preserves its existing second-read owner/generation/bounds validation. It never substitutes a title match, bounds twin, or sibling ID.

## Proof

- `swift test --package-path Core/PeekabooAutomationKit --filter WindowCGInfoLookupTests` — 14 passed
- `swift test --package-path Core/PeekabooAutomationKit --skip-build --no-parallel` — 771 passed
- `pnpm run build:cli`
- `pnpm run format` — 0 files changed
- strict SwiftLint on the three touched files — 0 violations
- full SwiftLint — 31 pre-existing warnings, 0 serious violations
- `git diff --check origin/main..HEAD`
- fresh branch autoreview — clean, no accepted/actionable findings

The adversarial coverage includes off-Space lookup without AX window identity, owner drift, PID-generation reuse, bounds drift, and a same-title/same-owner/same-bounds window with the wrong numeric ID.

## Changelog

No changelog entry: this is a narrow internal follow-up to restore the already-documented background exact-window typing contract. Changelogs remain release-owned.
