### PR TITLE
fix(bridge): await socket cleanup on termination

### DIFF
--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/DaemonCommand+Run.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/DaemonCommand+Run.swift
@@ -43,6 +43,12 @@ extension DaemonCommand {
             )
 
             let daemon = PeekabooDaemon(configuration: config)
+            let terminationSignalSource = ProcessTerminationSignalSource { [weak daemon] _ in
+                Task { @MainActor in
+                    _ = await daemon?.requestStop()
+                }
+            }
+            defer { terminationSignalSource.cancel() }
             try await daemon.runUntilStopChecked()
         }
 

--- a/Apps/CLI/Tests/CLIRuntimeTests/ScreenCaptureKitProcessCapabilityRuntimeTests.swift
+++ b/Apps/CLI/Tests/CLIRuntimeTests/ScreenCaptureKitProcessCapabilityRuntimeTests.swift
@@ -11,13 +11,14 @@ struct ScreenCaptureKitProcessCapabilityRuntimeTests {
         let directory = URL(fileURLWithPath: "/tmp/pb-cap-\(identifier)", isDirectory: true)
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: false)
         defer { try? FileManager.default.removeItem(at: directory) }
+        let socketPath = directory.appendingPathComponent("bridge.sock").path
 
         let process = Process()
         process.executableURL = try TestChildProcess.peekabooBinaryURL()
         process.arguments = [
             "daemon", "run",
             "--mode", "manual",
-            "--bridge-socket", directory.appendingPathComponent("bridge.sock").path,
+            "--bridge-socket", socketPath,
         ]
         process.standardOutput = FileHandle.nullDevice
         let standardError = Pipe()
@@ -35,7 +36,10 @@ struct ScreenCaptureKitProcessCapabilityRuntimeTests {
                 $0.processStartIdentity == processStartIdentity
         }))
 
-        Self.stop(process)
+        let exitedAfterSIGTERM = Self.stop(process)
+        #expect(exitedAfterSIGTERM)
+        #expect(!FileManager.default.fileExists(atPath: socketPath))
+        #expect(try Data(contentsOf: URL(fileURLWithPath: "\(socketPath).lock")).isEmpty)
         try ScreenCaptureKitOwnerLease.removeStaleProcessCapabilityMarkers()
     }
 
@@ -63,15 +67,18 @@ struct ScreenCaptureKitProcessCapabilityRuntimeTests {
         throw RuntimeError("Peekaboo marker fixture did not publish its process capability")
     }
 
-    private static func stop(_ process: Process) {
-        guard process.isRunning else { return }
+    @discardableResult
+    private static func stop(_ process: Process) -> Bool {
+        guard process.isRunning else { return true }
         process.terminate()
         for _ in 0..<100 where process.isRunning {
             usleep(10000)
         }
+        let exitedAfterSIGTERM = !process.isRunning
         if process.isRunning {
             kill(process.processIdentifier, SIGKILL)
         }
         process.waitUntilExit()
+        return exitedAfterSIGTERM
     }
 }

--- a/Apps/Mac/Peekaboo/PeekabooApp.swift
+++ b/Apps/Mac/Peekaboo/PeekabooApp.swift
@@ -232,6 +232,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     var windowOpener: ((String) -> Void)?
     private var bridgeHost: PeekabooBridgeHost?
     private var bridgeStartTask: Task<Void, Never>?
+    private let terminationGate = ProcessTerminationGate()
+    private var terminationSignalSource: ProcessTerminationSignalSource?
+    private var didReceiveTerminationSignal = false
     private var didSchedulePermissionsOnboarding = false
 
     // State connections
@@ -271,6 +274,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func applicationDidFinishLaunching(_: Notification) {
+        self.installTerminationSignalSource()
         self.logger.info("Peekaboo launching...")
         NSLog("PeekabooApp: applicationDidFinishLaunching")
 
@@ -387,6 +391,23 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         false // Menu bar app stays running
     }
 
+    func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
+        self.logger.info("Deferring application termination until Bridge ownership is released")
+        switch self.terminationGate.begin(
+            shutdown: { [weak self] in
+                await self?.stopBridgeHostForTermination()
+            },
+            reply: { shouldTerminate in
+                sender.reply(toApplicationShouldTerminate: shouldTerminate)
+            })
+        {
+        case .terminateNow:
+            return .terminateNow
+        case .terminateLater:
+            return .terminateLater
+        }
+    }
+
     func applicationShouldHandleReopen(_: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
         guard !self.launchPolicy.isBackgroundBridgeHost || flag else { return false }
         // Reopen fires for dock clicks and for `open`/relaunch attempts while
@@ -403,14 +424,36 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func applicationWillTerminate(_: Notification) {
+        self.terminationSignalSource?.cancel()
+        self.terminationSignalSource = nil
         self.statusBarController?.removeStatusItem()
         self.statusBarController = nil
-        self.bridgeStartTask?.cancel()
+    }
+
+    private func installTerminationSignalSource() {
+        guard self.terminationSignalSource == nil else { return }
+        self.terminationSignalSource = ProcessTerminationSignalSource(signals: [SIGTERM]) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                guard let self, !self.didReceiveTerminationSignal else { return }
+                self.didReceiveTerminationSignal = true
+                self.logger.info("Received SIGTERM; releasing Bridge ownership before process exit")
+                await self.stopBridgeHostForTermination()
+                Darwin.exit(EXIT_SUCCESS)
+            }
+        }
+    }
+
+    private func stopBridgeHostForTermination() async {
+        let bridgeStartTask = self.bridgeStartTask
+        bridgeStartTask?.cancel()
+        await bridgeStartTask?.value
         self.bridgeStartTask = nil
 
-        if let bridgeHost = self.bridgeHost {
-            Task { await bridgeHost.stop() }
-        }
+        guard let bridgeHost = self.bridgeHost else { return }
+        _ = await bridgeHost.stop()
+        await bridgeHost.waitUntilFullyStopped()
+        self.bridgeHost = nil
+        self.logger.info("Bridge ownership released; application termination may continue")
     }
 
     // MARK: - Window Management

--- a/Core/PeekabooCore/Sources/PeekabooCore/ProcessTerminationSignalSource.swift
+++ b/Core/PeekabooCore/Sources/PeekabooCore/ProcessTerminationSignalSource.swift
@@ -1,0 +1,93 @@
+import Darwin
+import Dispatch
+import Foundation
+
+public enum ProcessTerminationDecision: Sendable, Equatable {
+    case terminateNow
+    case terminateLater
+}
+
+/// Joins repeated process-termination requests and replies only after asynchronous shutdown completes.
+@MainActor
+public final class ProcessTerminationGate {
+    public typealias Shutdown = @MainActor @Sendable () async -> Void
+    public typealias Reply = @MainActor @Sendable (Bool) -> Void
+
+    private var shutdownTask: Task<Void, Never>?
+    private var didComplete = false
+
+    public init() {}
+
+    public func begin(
+        shutdown: @escaping Shutdown,
+        reply: @escaping Reply) -> ProcessTerminationDecision
+    {
+        if self.didComplete {
+            return .terminateNow
+        }
+        if self.shutdownTask != nil {
+            return .terminateLater
+        }
+
+        self.shutdownTask = Task { [weak self] in
+            await shutdown()
+            guard let self else { return }
+            self.didComplete = true
+            self.shutdownTask = nil
+            reply(true)
+        }
+        return .terminateLater
+    }
+}
+
+/// Converts process-termination signals into ordinary callbacks owned by an executable's lifecycle layer.
+///
+/// This type intentionally does not know about Bridge hosts or process exit. A GUI app or daemon can use the
+/// callback to begin its own asynchronous shutdown and keep the process alive until that shutdown completes.
+public final class ProcessTerminationSignalSource: @unchecked Sendable {
+    private let lock = NSLock()
+    private let queue = DispatchQueue(label: "boo.peekaboo.process-termination-signals")
+    private nonisolated(unsafe) var sources: [any DispatchSourceSignal] = []
+    private nonisolated(unsafe) var previousHandlers: [(Int32, sig_t?)] = []
+    private nonisolated(unsafe) var cancelled = false
+
+    public nonisolated init(
+        signals: [Int32] = [SIGINT, SIGTERM],
+        onSignal: @escaping @Sendable (Int32) -> Void)
+    {
+        for signalNumber in signals {
+            self.previousHandlers.append((signalNumber, Darwin.signal(signalNumber, SIG_IGN)))
+            let source = DispatchSource.makeSignalSource(signal: signalNumber, queue: self.queue)
+            source.setEventHandler {
+                onSignal(signalNumber)
+            }
+            source.activate()
+            self.sources.append(source)
+        }
+    }
+
+    public nonisolated func cancel() {
+        self.lock.lock()
+        guard !self.cancelled else {
+            self.lock.unlock()
+            return
+        }
+        self.cancelled = true
+        let sources = self.sources
+        let previousHandlers = self.previousHandlers
+        self.sources.removeAll()
+        self.previousHandlers.removeAll()
+        self.lock.unlock()
+
+        for source in sources {
+            source.cancel()
+        }
+        for (signalNumber, previousHandler) in previousHandlers {
+            Darwin.signal(signalNumber, previousHandler)
+        }
+    }
+
+    deinit {
+        self.cancel()
+    }
+}

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeHostOwnershipTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeHostOwnershipTests.swift
@@ -332,6 +332,28 @@ struct PeekabooBridgeHostOwnershipTests {
     }
 
     @Test
+    func `clean stop removes the exact owned socket and clears its lease identity`() async throws {
+        let socketPath = Self.socketPath()
+        defer { Self.removeSocketArtifacts(socketPath) }
+
+        let host = await Self.makeHost(socketPath: socketPath)
+        try await host.startChecked()
+
+        var socketInfo = stat()
+        #expect(lstat(socketPath, &socketInfo) == 0)
+        #expect(socketInfo.st_mode & mode_t(S_IFMT) == mode_t(S_IFSOCK))
+        #expect(socketInfo.st_mode & mode_t(0o777) == mode_t(S_IRUSR | S_IWUSR))
+        let markerBefore = try Data(contentsOf: URL(fileURLWithPath: "\(socketPath).lock"))
+        #expect(!markerBefore.isEmpty)
+
+        #expect(await host.stop() == .stopped)
+        await host.waitUntilFullyStopped()
+
+        #expect(!FileManager.default.fileExists(atPath: socketPath))
+        #expect(try Data(contentsOf: URL(fileURLWithPath: "\(socketPath).lock")).isEmpty)
+    }
+
+    @Test
     func `stopping an old host preserves a replacement socket`() async throws {
         let socketPath = Self.socketPath()
         defer { Self.removeSocketArtifacts(socketPath) }

--- a/Core/PeekabooCore/Tests/PeekabooTests/ProcessTerminationGateTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/ProcessTerminationGateTests.swift
@@ -1,0 +1,55 @@
+import Testing
+@testable import PeekabooCore
+
+@Suite(.serialized)
+struct ProcessTerminationGateTests {
+    @Test
+    @MainActor
+    func `termination remains deferred until asynchronous shutdown completes`() async {
+        let gate = ProcessTerminationGate()
+        let entered = TerminationTestGate()
+        let release = TerminationTestGate()
+        var replies: [Bool] = []
+
+        let first = gate.begin(
+            shutdown: {
+                await entered.open()
+                await release.wait()
+            },
+            reply: { replies.append($0) })
+        let second = gate.begin(
+            shutdown: { Issue.record("Concurrent termination must join the existing shutdown") },
+            reply: { _ in Issue.record("Concurrent termination must not install another reply") })
+
+        #expect(first == .terminateLater)
+        #expect(second == .terminateLater)
+        await entered.wait()
+        #expect(replies.isEmpty)
+
+        await release.open()
+        for _ in 0..<100 where replies.isEmpty {
+            await Task.yield()
+        }
+        #expect(replies == [true])
+        #expect(gate.begin(shutdown: {}, reply: { _ in }) == .terminateNow)
+    }
+}
+
+private actor TerminationTestGate {
+    private var isOpen = false
+    private var continuations: [CheckedContinuation<Void, Never>] = []
+
+    func open() {
+        self.isOpen = true
+        let continuations = self.continuations
+        self.continuations.removeAll()
+        continuations.forEach { $0.resume() }
+    }
+
+    func wait() async {
+        guard !self.isOpen else { return }
+        await withCheckedContinuation { continuation in
+            self.continuations.append(continuation)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- convert GUI and reusable-daemon termination signals into lifecycle-owned asynchronous shutdown
- defer ordinary AppKit termination until the Bridge listener has fully released its socket ownership
- keep `PeekabooBridgeHost` as the sole socket unlink owner, preserving its lease and device/inode replacement-race checks

## Root cause

`applicationWillTerminate` launched `bridgeHost.stop()` in an unstructured task and immediately returned. Process exit could therefore destroy the task before the listener removed its socket. Raw `SIGTERM` likewise had no path that kept the GUI process alive while asynchronous Bridge shutdown completed.

## Proof

- `swift test --package-path Core/PeekabooCore --no-parallel --filter 'PeekabooBridgeHostOwnershipTests|ProcessTerminationGateTests'` — 26 passed
- `swift test --package-path Apps/CLI --no-parallel --filter ScreenCaptureKitProcessCapabilityRuntimeTests` — real private custom-socket daemon received `SIGTERM`, exited within grace, removed its socket, and emptied its lease marker
- `xcodebuild -workspace Apps/Peekaboo.xcworkspace -scheme Peekaboo -configuration Debug -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build` — passed
- `pnpm run format` — no changes
- `pnpm run lint` — 29 inherited warnings, 0 serious
- branch autoreview against exact `origin/main` — clean, no accepted/actionable findings

Physical-host validation of the identical lifecycle diff before the conflict-free #482 restack used a freshly timestamped OpenClaw Foundation-signed private Peekaboo app and isolated `CFFIXED_USER_HOME`:

- mode-0600 Bridge socket existed with a nonempty exact lease marker before termination
- real `SIGTERM` exited 0, removed the socket, and emptied the marker
- exact installed user-owned Peekaboo process remained unchanged
- `SIGKILL` intentionally left a stale socket; the next listener atomically published a different inode, and its later `SIGTERM` removed only that replacement

Exact-head source/build/test/review proof above is green. A bounded exact-head re-sign exhausted eight attempts against Apple's currently unavailable TSA; no untimestamped artifact was launched or accepted as proof.

No AppleScript, JXA, virtualization, VNC, TCC mutation, installed-app replacement, or changelog change is involved.
