### PR TITLE
feat(input): close background input gaps

### DIFF
--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Core/Protocols/UIAutomationServiceProtocol.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Core/Protocols/UIAutomationServiceProtocol.swift
@@ -519,3 +519,42 @@ public protocol ElementActionAutomationServiceProtocol: UIAutomationServiceProto
     func setValue(target: String, value: UIElementValue, snapshotId: String?) async throws -> ElementActionResult
     func performAction(target: String, actionName: String, snapshotId: String?) async throws -> ElementActionResult
 }
+
+/// Additive capability for exact-window background input that must remain held across an await or call boundary.
+///
+/// These routes neither activate the target nor move the shared cursor. Pointer holds are owned by an opaque token and
+/// automatically released after a bounded idle period. Held keys are bounded to ten seconds and use the same
+/// cancellation-safe key-up cleanup as targeted hotkeys.
+@MainActor
+public protocol BackgroundInputServiceProtocol: UIAutomationServiceProtocol {
+    func mouseDown(
+        at point: CGPoint,
+        button: PointerButton,
+        expectedWindowIdentity: WindowMutationIdentity,
+        expectedWindowBounds: CGRect) async throws -> BackgroundPointerHoldToken
+
+    func mouseDownWithOutcome(
+        at point: CGPoint,
+        button: PointerButton,
+        expectedWindowIdentity: WindowMutationIdentity,
+        expectedWindowBounds: CGRect) async throws -> UIAutomationActionResult<BackgroundPointerHoldToken>
+
+    func mouseUpWithOutcome(
+        hold: BackgroundPointerHoldToken) async throws -> UIAutomationActionResult<Void>
+
+    func mouseUp(hold: BackgroundPointerHoldToken) async throws
+
+    func releaseHeldInput() async
+
+    func holdKeyWithOutcome(
+        keys: String,
+        durationMilliseconds: Int,
+        target: ExactWindowKeyboardTarget) async throws -> UIAutomationActionResult<Void>
+
+    func holdKey(
+        keys: String,
+        durationMilliseconds: Int,
+        target: ExactWindowKeyboardTarget) async throws
+
+    func getCursorPosition() -> CGPoint?
+}

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/BackgroundInputDriver.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/BackgroundInputDriver.swift
@@ -9,8 +9,8 @@ import PeekabooFoundation
 /// Background input that targets a process directly without focusing it or moving the cursor.
 ///
 /// Keyboard input is delivered as pid-routed CGEvents. Single left clicks prefer accessibility
-/// actions. Pixel right- and double-clicks use a PID/window-routed event sequence carrying an
-/// explicit window-local point; they never use the desktop-global event tap.
+/// actions. Pixel middle/right and multi-clicks use a PID/window-routed event sequence carrying
+/// an explicit window-local point; they never use the desktop-global event tap.
 enum BackgroundInputDriver {
     private static let logger = Logger(subsystem: "boo.peekaboo.core", category: "BackgroundInputDriver")
 
@@ -908,12 +908,6 @@ extension BackgroundInputDriver {
     requested PID and point. Capture or select a specific window, or use --foreground explicitly.
     """
 
-    static let middleClickUnsupportedMessage = """
-    Background middle-click is not supported: accessibility has no middle-button action and \
-    pid-targeted mouse events cannot be positioned. Re-run with --foreground to send a real \
-    middle-click.
-    """
-
     static let unverifiedPressMessage = """
     The accessibility press did not complete, so Peekaboo cannot verify that the click was delivered. \
     Re-run with --foreground --input-strategy synthOnly to focus the app and send a real mouse click.
@@ -971,10 +965,6 @@ extension BackgroundInputDriver {
                 "Background coordinate clicks require an exact capture-time window receipt; " +
                     "PID-only coordinate routing is refused")
         }
-        guard button != .middle else {
-            throw PeekabooError.serviceUnavailable(self.middleClickUnsupportedMessage)
-        }
-
         let resolvedWindowID = try self.resolveTargetWindowID(
             at: point,
             targetProcessIdentifier: targetProcessIdentifier,
@@ -994,7 +984,7 @@ extension BackgroundInputDriver {
             }
         }
 
-        if count == 2 || button == .right {
+        if count > 1 || button != .left {
             guard let resolvedWindowID else {
                 throw PeekabooError.serviceUnavailable(self.unprovenWindowRouteMessage)
             }
@@ -1008,7 +998,7 @@ extension BackgroundInputDriver {
                 expectedWindowBounds: expectedWindowBounds)
         }
         guard count == 1 else {
-            throw PeekabooError.invalidInput("Background click count must be 1 or 2")
+            throw PeekabooError.invalidInput("Background click count must be between 1 and 3")
         }
         guard AXIsProcessTrusted() else {
             throw PeekabooError.permissionDeniedAccessibility

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/BackgroundInputHoldCoordinator.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/BackgroundInputHoldCoordinator.swift
@@ -1,0 +1,138 @@
+import AXorcist
+import CoreGraphics
+import Foundation
+import PeekabooFoundation
+
+/// Owns split routed pointer input until an explicit release or the bounded watchdog fires.
+///
+/// The watchdog task retains this coordinator, so deallocating the embedding automation service
+/// cannot abandon a posted mouse-down while the process remains alive.
+@MainActor
+final class BackgroundInputHoldCoordinator {
+    typealias Sleeper = @MainActor @Sendable (Duration) async throws -> Void
+
+    private struct HeldPointer {
+        let token: BackgroundPointerHoldToken
+        let route: WindowRoutedPointerDriver.HeldButtonRoute
+    }
+
+    static let defaultIdleTimeout: Duration = .seconds(30)
+
+    private let driver: WindowRoutedPointerDriver
+    private let idleTimeout: Duration
+    private let sleep: Sleeper
+    private var heldPointer: HeldPointer?
+    private var watchdog: Task<Void, Never>?
+
+    init(
+        driver: WindowRoutedPointerDriver = WindowRoutedPointerDriver(),
+        idleTimeout: Duration = BackgroundInputHoldCoordinator.defaultIdleTimeout,
+        sleep: @escaping Sleeper = { duration in try await Task.sleep(for: duration) })
+    {
+        self.driver = driver
+        self.idleTimeout = idleTimeout
+        self.sleep = sleep
+    }
+
+    func mouseDown(
+        at point: CGPoint,
+        button: PointerButton,
+        expectedWindowIdentity: WindowMutationIdentity,
+        expectedWindowBounds: CGRect) async throws -> UIAutomationActionResult<BackgroundPointerHoldToken>
+    {
+        guard self.heldPointer == nil else {
+            throw PeekabooError.invalidInput("A background pointer button is already held by this automation service")
+        }
+        guard let windowID = CGWindowID(exactly: expectedWindowIdentity.windowID) else {
+            throw PeekabooError.invalidInput("Background pointer target window ID is out of range")
+        }
+
+        let dispatch = try await self.driver.mouseDown(
+            at: point,
+            button: Self.mouseButton(button),
+            targetProcessIdentifier: expectedWindowIdentity.ownerProcessIdentifier,
+            targetWindowID: windowID,
+            expectedWindowIdentity: expectedWindowIdentity,
+            expectedWindowBounds: expectedWindowBounds)
+        let token = BackgroundPointerHoldToken()
+        self.heldPointer = HeldPointer(token: token, route: dispatch.route)
+        self.armWatchdog(for: token)
+        return UIAutomationActionResult(payload: token, outcome: dispatch.outcome)
+    }
+
+    func mouseUp(hold token: BackgroundPointerHoldToken) throws -> UIAutomationActionResult<Void> {
+        guard let heldPointer = self.heldPointer else {
+            throw PeekabooError.invalidInput("No background pointer button is held by this automation service")
+        }
+        guard heldPointer.token == token else {
+            throw PeekabooError.invalidInput("Background pointer hold token does not own the held button")
+        }
+
+        do {
+            let outcome = try self.driver.mouseUp(heldPointer.route)
+            self.clearHeldPointer()
+            return UIAutomationActionResult(payload: (), outcome: outcome)
+        } catch {
+            if self.driver.originalProcessGenerationIsCurrent(for: heldPointer.route) {
+                self.armWatchdog(for: token)
+            } else {
+                self.clearHeldPointer()
+            }
+            throw error
+        }
+    }
+
+    func releaseHeldInput() {
+        guard let heldPointer = self.heldPointer else {
+            self.clearHeldPointer()
+            return
+        }
+        do {
+            _ = try self.driver.mouseUp(heldPointer.route)
+            self.clearHeldPointer()
+        } catch {
+            if self.driver.originalProcessGenerationIsCurrent(for: heldPointer.route) {
+                self.armWatchdog(for: heldPointer.token)
+            } else {
+                self.clearHeldPointer()
+            }
+        }
+    }
+
+    private func armWatchdog(for token: BackgroundPointerHoldToken) {
+        self.watchdog?.cancel()
+        self.watchdog = Task { [self] in
+            do {
+                try await self.sleep(self.idleTimeout)
+            } catch {
+                return
+            }
+            guard self.heldPointer?.token == token else { return }
+            self.releaseHeldInput()
+        }
+    }
+
+    private func clearHeldPointer() {
+        self.watchdog?.cancel()
+        self.watchdog = nil
+        self.heldPointer = nil
+    }
+
+    private static func mouseButton(_ button: PointerButton) -> MouseButton {
+        switch button {
+        case .left: .left
+        case .right: .right
+        case .middle: .middle
+        }
+    }
+
+    #if DEBUG
+    var heldTokenForTesting: BackgroundPointerHoldToken? {
+        self.heldPointer?.token
+    }
+
+    var watchdogIsArmedForTesting: Bool {
+        self.watchdog != nil
+    }
+    #endif
+}

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/ClickService.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/ClickService.swift
@@ -191,7 +191,7 @@ public final class ClickService {
             return result
         case .right:
             return try await self.actionInputDriver.tryRightClick(element: element)
-        case .double:
+        case .middle, .double, .triple:
             throw ActionInputError.unsupported(.actionUnsupported)
         case .longPress:
             throw ActionInputError.unsupported(.actionUnsupported)
@@ -815,11 +815,23 @@ public final class ClickService {
                 button: .right,
                 count: 1,
                 destination: destination)
+        case .middle:
+            return try await self.performSyntheticClick(
+                at: point,
+                button: .middle,
+                count: 1,
+                destination: destination)
         case .double:
             return try await self.performSyntheticClick(
                 at: point,
                 button: .left,
                 count: 2,
+                destination: destination)
+        case .triple:
+            return try await self.performSyntheticClick(
+                at: point,
+                button: .left,
+                count: 3,
                 destination: destination)
         case .longPress:
             guard destination.processIdentifier == nil else {

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/UIAutomationService+BackgroundInput.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/UIAutomationService+BackgroundInput.swift
@@ -1,0 +1,82 @@
+import CoreGraphics
+import Foundation
+import PeekabooFoundation
+
+extension UIAutomationService {
+    public func mouseDown(
+        at point: CGPoint,
+        button: PointerButton = .left,
+        expectedWindowIdentity: WindowMutationIdentity,
+        expectedWindowBounds: CGRect) async throws -> BackgroundPointerHoldToken
+    {
+        try await self.mouseDownWithOutcome(
+            at: point,
+            button: button,
+            expectedWindowIdentity: expectedWindowIdentity,
+            expectedWindowBounds: expectedWindowBounds).payload
+    }
+
+    public func mouseDownWithOutcome(
+        at point: CGPoint,
+        button: PointerButton = .left,
+        expectedWindowIdentity: WindowMutationIdentity,
+        expectedWindowBounds: CGRect) async throws -> UIAutomationActionResult<BackgroundPointerHoldToken>
+    {
+        try await self.operationLaneCoordinator.run(scope: .window(expectedWindowIdentity), access: .write) {
+            try await self.backgroundInputHoldCoordinator.mouseDown(
+                at: point,
+                button: button,
+                expectedWindowIdentity: expectedWindowIdentity,
+                expectedWindowBounds: expectedWindowBounds)
+        }
+    }
+
+    public func mouseUpWithOutcome(
+        hold: BackgroundPointerHoldToken) async throws -> UIAutomationActionResult<Void>
+    {
+        try await self.operationLaneCoordinator.run(scope: .global, access: .write) {
+            try self.backgroundInputHoldCoordinator.mouseUp(hold: hold)
+        }
+    }
+
+    public func mouseUp(hold: BackgroundPointerHoldToken) async throws {
+        _ = try await self.mouseUpWithOutcome(hold: hold)
+    }
+
+    /// Immediately releases any split pointer input owned by this service. This is idempotent and
+    /// should be called when an embedding host loses its caller or lifecycle authority.
+    public func releaseHeldInput() async {
+        self.backgroundInputHoldCoordinator.releaseHeldInput()
+    }
+
+    /// Holds one exact-window background chord for a bounded duration and always posts key-up on
+    /// cancellation or failure after key-down.
+    public func holdKeyWithOutcome(
+        keys: String,
+        durationMilliseconds: Int,
+        target: ExactWindowKeyboardTarget) async throws -> UIAutomationActionResult<Void>
+    {
+        guard (1...10000).contains(durationMilliseconds) else {
+            throw PeekabooError.invalidInput("Background key hold duration must be between 1 and 10000 milliseconds")
+        }
+        return try await self.hotkeyWithOutcome(
+            keys: keys,
+            holdDuration: durationMilliseconds,
+            target: target)
+    }
+
+    public func holdKey(
+        keys: String,
+        durationMilliseconds: Int,
+        target: ExactWindowKeyboardTarget) async throws
+    {
+        _ = try await self.holdKeyWithOutcome(
+            keys: keys,
+            durationMilliseconds: durationMilliseconds,
+            target: target)
+    }
+
+    public func getCursorPosition() -> CGPoint? {
+        self.currentMouseLocation()
+    }
+}

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/UIAutomationService+Operations.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/UIAutomationService+Operations.swift
@@ -112,6 +112,7 @@ extension UIAutomationService {
      * - `.double`: Double-click for opening/selecting
      * - `.right`: Right-click for context menus
      * - `.middle`: Middle-click (wheel button)
+     * - `.triple`: Triple-click for paragraph selection and app-specific actions
      *
      * ## Visual Feedback
      * When visualizer is connected, shows:

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/UIAutomationService.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/UIAutomationService.swift
@@ -47,7 +47,8 @@ struct HotkeyServiceFactoryContext {
 @MainActor
 public final class UIAutomationService: TargetedHotkeyServiceProtocol, TargetedTypeServiceProtocol,
     ExactWindowTargetedClickServiceProtocol, TargetedFocusedElementServiceProtocol,
-    ExactWindowTargetedKeyboardServiceProtocol, UIAutomationActionOutcomeProviding
+    ExactWindowTargetedKeyboardServiceProtocol, UIAutomationActionOutcomeProviding,
+    BackgroundInputServiceProtocol
 {
     public let supportsProcessGenerationPinnedHotkeys = true
     public let supportsProcessGenerationPinnedTypeActions = true
@@ -77,6 +78,7 @@ public final class UIAutomationService: TargetedHotkeyServiceProtocol, TargetedT
     let processStartIdentityProvider: @Sendable (pid_t) -> UInt64?
     let operationLaneCoordinator: DesktopOperationLaneCoordinator
     let desktopOperationExecutor: DesktopOperationExecutor
+    let backgroundInputHoldCoordinator: BackgroundInputHoldCoordinator
 
     // Search constraints to prevent unbounded AX traversals
     var searchLimits: UIAutomationSearchLimits
@@ -182,6 +184,7 @@ public final class UIAutomationService: TargetedHotkeyServiceProtocol, TargetedT
         self.operationLaneCoordinator = operationLaneCoordinator
         let executor = desktopOperationExecutor ?? DesktopOperationExecutor(laneCoordinator: operationLaneCoordinator)
         self.desktopOperationExecutor = executor
+        self.backgroundInputHoldCoordinator = BackgroundInputHoldCoordinator()
 
         // Initialize specialized services
         let elementDetectionService = ElementDetectionService(snapshotManager: manager)

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/WindowRoutedPointerDriver.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/WindowRoutedPointerDriver.swift
@@ -36,6 +36,13 @@ struct WindowRoutedPointerDriver {
         let buttonNumber: Int64
     }
 
+    struct HeldButtonRoute {
+        let receipt: RouteReceipt
+        let clickGroup: Int64
+        let transport: WindowRoutedPointerTransport
+        let button: MouseButton
+    }
+
     private struct DispatchContext {
         let receipt: RouteReceipt
         let clickGroup: Int64
@@ -128,12 +135,8 @@ struct WindowRoutedPointerDriver {
         expectedWindowIdentity: WindowMutationIdentity? = nil,
         expectedWindowBounds: CGRect? = nil) async throws -> DesktopActionOutcome
     {
-        guard button == .left || button == .right else {
-            throw PeekabooError.serviceUnavailable(
-                "Window-routed background pointer delivery supports left and right buttons only")
-        }
-        guard (1...2).contains(count) else {
-            throw PeekabooError.invalidInput("Window-routed click count must be 1 or 2")
+        guard (1...3).contains(count) else {
+            throw PeekabooError.invalidInput("Window-routed click count must be between 1 and 3")
         }
         guard self.hasPostEventAccess() else {
             throw PeekabooError.permissionDeniedEventSynthesizing
@@ -170,16 +173,8 @@ struct WindowRoutedPointerDriver {
         for pairIndex in 0..<count {
             try Self.checkCancellation(afterPosting: postedEventCount)
             let clickState = Int64(pairIndex + 1)
-            let down = EventSpecification(
-                type: button == .right ? .rightMouseDown : .leftMouseDown,
-                button: button == .right ? .right : .left,
-                clickState: clickState,
-                buttonNumber: button == .right ? 1 : 0)
-            let up = EventSpecification(
-                type: button == .right ? .rightMouseUp : .leftMouseUp,
-                button: button == .right ? .right : .left,
-                clickState: clickState,
-                buttonNumber: button == .right ? 1 : 0)
+            let down = Self.buttonEventSpecification(button: button, down: true, clickState: clickState)
+            let up = Self.buttonEventSpecification(button: button, down: false, clickState: clickState)
 
             try self.post(
                 down,
@@ -231,6 +226,89 @@ struct WindowRoutedPointerDriver {
                 causeDescription: error.localizedDescription)
         }
         return outcome
+    }
+
+    /// Posts a routed mouse-down and returns the exact route needed for its eventual release.
+    ///
+    /// The caller owns the returned route until `mouseUp` succeeds. Any failure after the down
+    /// event is posted releases it to the original process generation before returning.
+    func mouseDown(
+        at point: CGPoint,
+        button: MouseButton,
+        targetProcessIdentifier: pid_t,
+        targetWindowID: CGWindowID,
+        expectedWindowIdentity: WindowMutationIdentity,
+        expectedWindowBounds: CGRect) async throws -> (route: HeldButtonRoute, outcome: DesktopActionOutcome)
+    {
+        guard self.hasPostEventAccess() else {
+            throw PeekabooError.permissionDeniedEventSynthesizing
+        }
+        try Task.checkCancellation()
+
+        let receipt = try self.resolveRoute(targetProcessIdentifier, targetWindowID, point)
+        guard receipt.identity == expectedWindowIdentity,
+              receipt.bounds == expectedWindowBounds,
+              receipt.bounds.contains(point)
+        else {
+            throw PeekabooError.snapshotStale(
+                "Resolved background pointer hold does not match the captured PID, window, bounds, or point")
+        }
+
+        let route = HeldButtonRoute(
+            receipt: receipt,
+            clickGroup: self.clickGroupIdentifier(),
+            transport: self.resolveTransport(targetProcessIdentifier),
+            button: button)
+        var postedEventCount = 0
+        let primer = EventSpecification(type: .mouseMoved, button: .left, clickState: 0, buttonNumber: 0)
+        try self.post(
+            primer,
+            receipt: receipt,
+            clickGroup: route.clickGroup,
+            transport: route.transport,
+            postedEventCount: &postedEventCount)
+        await self.sleep(.milliseconds(12))
+        try Self.checkCancellation(afterPosting: postedEventCount)
+
+        let down = Self.buttonEventSpecification(button: button, down: true, clickState: 1)
+        let up = Self.buttonEventSpecification(button: button, down: false, clickState: 1)
+        try self.post(
+            down,
+            receipt: receipt,
+            clickGroup: route.clickGroup,
+            transport: route.transport,
+            postedEventCount: &postedEventCount)
+        do {
+            try Self.checkCancellation(afterPosting: postedEventCount)
+            try self.requireCurrentRoute(receipt, afterPosting: postedEventCount)
+        } catch {
+            try self.releaseAfterInterruptedDown(
+                up,
+                context: DispatchContext(
+                    receipt: receipt,
+                    clickGroup: route.clickGroup,
+                    transport: route.transport),
+                postedEventCount: &postedEventCount,
+                cause: error)
+        }
+        return try (route, Self.pointerOutcome(eventCount: postedEventCount))
+    }
+
+    /// Releases a previously returned held-button route without requiring the window to remain
+    /// stationary. Cleanup is restricted to the original live process generation.
+    func mouseUp(_ route: HeldButtonRoute) throws -> DesktopActionOutcome {
+        var postedEventCount = 0
+        try self.postRelease(
+            Self.buttonEventSpecification(button: route.button, down: false, clickState: 1),
+            receipt: route.receipt,
+            clickGroup: route.clickGroup,
+            transport: route.transport,
+            postedEventCount: &postedEventCount)
+        return try Self.pointerOutcome(eventCount: postedEventCount)
+    }
+
+    func originalProcessGenerationIsCurrent(for route: HeldButtonRoute) -> Bool {
+        self.processGenerationIsCurrent(route.receipt)
     }
 
     /// Posts line-based wheel events to one exact visible background window without cursor movement.
@@ -514,6 +592,44 @@ struct WindowRoutedPointerDriver {
     private static func setIntegerField(_ rawField: UInt32, clickState value: Int64, on event: CGEvent) {
         guard let field = CGEventField(rawValue: rawField) else { return }
         event.setIntegerValueField(field, value: value)
+    }
+
+    private static func buttonEventSpecification(
+        button: MouseButton,
+        down: Bool,
+        clickState: Int64) -> EventSpecification
+    {
+        switch button {
+        case .left:
+            EventSpecification(
+                type: down ? .leftMouseDown : .leftMouseUp,
+                button: .left,
+                clickState: clickState,
+                buttonNumber: 0)
+        case .right:
+            EventSpecification(
+                type: down ? .rightMouseDown : .rightMouseUp,
+                button: .right,
+                clickState: clickState,
+                buttonNumber: 1)
+        case .middle:
+            EventSpecification(
+                type: down ? .otherMouseDown : .otherMouseUp,
+                button: .center,
+                clickState: clickState,
+                buttonNumber: 2)
+        }
+    }
+
+    private static func pointerOutcome(eventCount: Int) throws -> DesktopActionOutcome {
+        guard let unitCount = DesktopActionOutcome.DispatchUnitCount(eventCount) else {
+            throw PeekabooError.operationError(
+                message: "Window-routed pointer delivery completed without posting an event")
+        }
+        return .dispatchedUnverified(
+            delivery: .init(mechanism: .windowTargetedEvents, mode: .background),
+            evidence: .deliveryAccepted,
+            unitCount: unitCount)
     }
 
     private static func stampRoutingFields(

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/BackgroundInputDriverPositionalTargetTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/BackgroundInputDriverPositionalTargetTests.swift
@@ -312,9 +312,8 @@ struct BackgroundInputDriverPositionalTargetTests {
     }
 
     @Test
-    func `unproven route and middle click messages point to foreground`() {
+    func `unproven route message points to foreground`() {
         #expect(BackgroundInputDriver.unprovenWindowRouteMessage.contains("--foreground"))
-        #expect(BackgroundInputDriver.middleClickUnsupportedMessage.contains("--foreground"))
     }
 
     @Test

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/BackgroundInputHoldCoordinatorTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/BackgroundInputHoldCoordinatorTests.swift
@@ -1,0 +1,110 @@
+import AXorcist
+import CoreGraphics
+import Foundation
+import PeekabooFoundation
+import Testing
+@testable import PeekabooAutomationKit
+
+@Suite(.serialized)
+struct BackgroundInputHoldCoordinatorTests {
+    @Test
+    @MainActor
+    func `watchdog retains coordinator and releases when owner disappears`() async throws {
+        var postedTypes: [CGEventType] = []
+        var sleeperContinuation: CheckedContinuation<Void, Never>?
+        let receipt = Self.receipt()
+        let driver = WindowRoutedPointerDriver(
+            hasPostEventAccess: { true },
+            resolveRoute: { _, _, _ in receipt },
+            routeIsCurrent: { _ in true },
+            processGenerationIsCurrent: { _ in true },
+            makeEvent: { specification, point in
+                CGEvent(
+                    mouseEventSource: nil,
+                    mouseType: specification.type,
+                    mouseCursorPosition: point,
+                    mouseButton: specification.button)
+            },
+            stampWindowLocation: { _, _ in true },
+            postSkyLight: { _, _ in true },
+            postPublic: { event, _ in postedTypes.append(event.type) },
+            resolveTransport: { _ in .publicCGEvent },
+            sleep: { _ in })
+        var coordinator: BackgroundInputHoldCoordinator? = BackgroundInputHoldCoordinator(
+            driver: driver,
+            idleTimeout: .seconds(1),
+            sleep: { _ in
+                await withCheckedContinuation { continuation in
+                    sleeperContinuation = continuation
+                }
+            })
+        weak let retainedCoordinator = coordinator
+
+        _ = try await coordinator?.mouseDown(
+            at: receipt.screenPoint,
+            button: .left,
+            expectedWindowIdentity: receipt.identity,
+            expectedWindowBounds: receipt.bounds)
+        while sleeperContinuation == nil {
+            await Task.yield()
+        }
+        coordinator = nil
+        #expect(retainedCoordinator != nil)
+
+        sleeperContinuation?.resume()
+        while retainedCoordinator != nil {
+            await Task.yield()
+        }
+
+        #expect(postedTypes == [.mouseMoved, .leftMouseDown, .leftMouseUp])
+    }
+
+    @Test
+    @MainActor
+    func `only the owning token can release a held pointer`() async throws {
+        var postedTypes: [CGEventType] = []
+        let receipt = Self.receipt()
+        let driver = WindowRoutedPointerDriver(
+            hasPostEventAccess: { true },
+            resolveRoute: { _, _, _ in receipt },
+            routeIsCurrent: { _ in true },
+            processGenerationIsCurrent: { _ in true },
+            makeEvent: { specification, point in
+                CGEvent(
+                    mouseEventSource: nil,
+                    mouseType: specification.type,
+                    mouseCursorPosition: point,
+                    mouseButton: specification.button)
+            },
+            stampWindowLocation: { _, _ in true },
+            postSkyLight: { _, _ in true },
+            postPublic: { event, _ in postedTypes.append(event.type) },
+            resolveTransport: { _ in .publicCGEvent },
+            sleep: { _ in })
+        let coordinator = BackgroundInputHoldCoordinator(driver: driver)
+
+        let down = try await coordinator.mouseDown(
+            at: receipt.screenPoint,
+            button: .left,
+            expectedWindowIdentity: receipt.identity,
+            expectedWindowBounds: receipt.bounds)
+        #expect(throws: PeekabooError.self) {
+            _ = try coordinator.mouseUp(hold: BackgroundPointerHoldToken())
+        }
+        #expect(coordinator.heldTokenForTesting == down.payload)
+
+        _ = try coordinator.mouseUp(hold: down.payload)
+        #expect(coordinator.heldTokenForTesting == nil)
+        #expect(postedTypes == [.mouseMoved, .leftMouseDown, .leftMouseUp])
+    }
+
+    private static func receipt() -> WindowRoutedPointerDriver.RouteReceipt {
+        WindowRoutedPointerDriver.RouteReceipt(
+            identity: WindowMutationIdentity(
+                windowID: 7,
+                ownerProcessIdentifier: 42,
+                ownerProcessStartIdentity: 9001),
+            bounds: CGRect(x: 100, y: 200, width: 400, height: 300),
+            screenPoint: CGPoint(x: 120, y: 230))
+    }
+}

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/HotkeyServiceTargetingTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/HotkeyServiceTargetingTests.swift
@@ -257,6 +257,28 @@ struct HotkeyServiceTargetingTests {
         #expect(postedEvents.allSatisfy { $0.pid == getpid() })
     }
 
+    @Test func `cancelling a held targeted key releases the key and modifiers`() async {
+        var postedEvents: [CGEventType] = []
+        let service = HotkeyService(
+            inputPolicy: UIInputPolicy(defaultStrategy: .synthOnly),
+            postEventAccessEvaluator: { true },
+            eventPoster: { event, _ in postedEvents.append(event.type) })
+        let task = Task { @MainActor in
+            try await service.hotkey(
+                keys: "cmd,s",
+                holdDuration: 10000,
+                targetProcessIdentifier: getpid())
+        }
+
+        while postedEvents.count < 2 {
+            await Task.yield()
+        }
+        task.cancel()
+        _ = try? await task.value
+
+        #expect(postedEvents == [.flagsChanged, .keyDown, .keyUp, .flagsChanged])
+    }
+
     @Test func `exact window validator failure before modifiers posts no events`() async throws {
         var validationCount = 0
         var postedEventCount = 0

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/WindowRoutedPointerDriverTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/WindowRoutedPointerDriverTests.swift
@@ -284,6 +284,100 @@ struct WindowRoutedPointerDriverTests {
 
     @Test
     @MainActor
+    func `middle and triple clicks use routed button events`() async throws {
+        let cases: [(MouseButton, Int, [CGEventType], [Int64])] = [
+            (.middle, 1, [.mouseMoved, .otherMouseDown, .otherMouseUp], [0, 2, 2]),
+            (
+                .left,
+                3,
+                [
+                    .mouseMoved,
+                    .leftMouseDown,
+                    .leftMouseUp,
+                    .leftMouseDown,
+                    .leftMouseUp,
+                    .leftMouseDown,
+                    .leftMouseUp,
+                ],
+                [0, 0, 0, 0, 0, 0, 0]),
+        ]
+
+        for (button, count, expectedTypes, expectedButtonNumbers) in cases {
+            var specifications: [WindowRoutedPointerDriver.EventSpecification] = []
+            let receipt = Self.receipt()
+            let driver = WindowRoutedPointerDriver(
+                hasPostEventAccess: { true },
+                resolveRoute: { _, _, _ in receipt },
+                routeIsCurrent: { _ in true },
+                makeEvent: { specification, point in
+                    specifications.append(specification)
+                    return CGEvent(
+                        mouseEventSource: nil,
+                        mouseType: specification.type,
+                        mouseCursorPosition: point,
+                        mouseButton: specification.button)
+                },
+                stampWindowLocation: { _, _ in true },
+                postSkyLight: { _, _ in true },
+                postPublic: { _, _ in },
+                resolveTransport: { _ in .publicCGEvent },
+                sleep: { _ in })
+
+            let outcome = try await driver.click(
+                at: receipt.screenPoint,
+                button: button,
+                count: count,
+                targetProcessIdentifier: receipt.identity.ownerProcessIdentifier,
+                targetWindowID: CGWindowID(receipt.identity.windowID))
+
+            #expect(specifications.map(\.type) == expectedTypes)
+            #expect(specifications.map(\.buttonNumber) == expectedButtonNumbers)
+            #expect(outcome.dispatchState.unitCount?.rawValue == expectedTypes.count)
+        }
+    }
+
+    @Test
+    @MainActor
+    func `split mouse down and up retain the exact routed destination`() async throws {
+        var specifications: [WindowRoutedPointerDriver.EventSpecification] = []
+        var processGenerationChecks = 0
+        let receipt = Self.receipt()
+        let driver = WindowRoutedPointerDriver(
+            hasPostEventAccess: { true },
+            resolveRoute: { _, _, _ in receipt },
+            routeIsCurrent: { _ in true },
+            processGenerationIsCurrent: { _ in processGenerationChecks += 1; return true },
+            makeEvent: { specification, point in
+                specifications.append(specification)
+                return CGEvent(
+                    mouseEventSource: nil,
+                    mouseType: specification.type,
+                    mouseCursorPosition: point,
+                    mouseButton: specification.button)
+            },
+            stampWindowLocation: { _, _ in true },
+            postSkyLight: { _, _ in true },
+            postPublic: { _, _ in },
+            resolveTransport: { _ in .publicCGEvent },
+            sleep: { _ in })
+
+        let down = try await driver.mouseDown(
+            at: receipt.screenPoint,
+            button: .left,
+            targetProcessIdentifier: receipt.identity.ownerProcessIdentifier,
+            targetWindowID: CGWindowID(receipt.identity.windowID),
+            expectedWindowIdentity: receipt.identity,
+            expectedWindowBounds: receipt.bounds)
+        let up = try driver.mouseUp(down.route)
+
+        #expect(specifications.map(\.type) == [.mouseMoved, .leftMouseDown, .leftMouseUp])
+        #expect(down.outcome.dispatchState.unitCount?.rawValue == 2)
+        #expect(up.dispatchState.unitCount?.rawValue == 1)
+        #expect(processGenerationChecks == 1)
+    }
+
+    @Test
+    @MainActor
     func `final route drift retains exact dispatched event evidence`() async {
         var validations = 0
         var posted = 0

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/ClickTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/ClickTool.swift
@@ -15,7 +15,7 @@ public struct ClickTool: MCPTool {
 
     public var description: String {
         """
-        Clicks on UI elements or coordinates.
+        Clicks on UI elements or coordinates, including middle and triple clicks.
         Supports element queries, specific IDs from `see` or `inspect_ui`, or raw coordinates.
         Background delivery is the default. Background coordinates require a nonempty snapshot or coordinate_reference
         from a fresh exact-window `see`; pid alone is never a safe coordinate target. Set `foreground` to true only for
@@ -72,6 +72,12 @@ public struct ClickTool: MCPTool {
                     default: false),
                 "right": SchemaBuilder.boolean(
                     description: "Optional. Right-click (secondary click) instead of left-click.",
+                    default: false),
+                "middle": SchemaBuilder.boolean(
+                    description: "Optional. Middle-click instead of left-click.",
+                    default: false),
+                "triple": SchemaBuilder.boolean(
+                    description: "Optional. Triple-click instead of single click.",
                     default: false),
                 "foreground": SchemaBuilder.boolean(
                     description: "Use foreground/shared-pointer delivery. Background delivery is the default.",
@@ -749,7 +755,13 @@ private struct ClickRequest {
         self.coordinateReference = coordinateReference
         let isDouble = arguments.getBool("double") ?? false
         let isRight = arguments.getBool("right") ?? false
-        self.intent = ClickIntent(double: isDouble, right: isRight)
+        let isMiddle = arguments.getBool("middle") ?? false
+        let isTriple = arguments.getBool("triple") ?? false
+        self.intent = try ClickIntent(
+            double: isDouble,
+            right: isRight,
+            middle: isMiddle,
+            triple: isTriple)
         let foreground = arguments.getBool("foreground") ?? false
         self.deliveryMode = if foreground || arguments.getBool("background") == false {
             .foreground
@@ -865,10 +877,19 @@ private struct ClickIntent {
     let automationType: ClickType
     let displayVerb: String
 
-    init(double: Bool, right: Bool) {
+    init(double: Bool, right: Bool, middle: Bool, triple: Bool) throws {
+        guard [double, right, middle, triple].filter(\.self).count <= 1 else {
+            throw ClickToolError("Choose at most one of double, right, middle, or triple.")
+        }
         if right {
             self.automationType = .right
             self.displayVerb = "Right-clicked"
+        } else if middle {
+            self.automationType = .middle
+            self.displayVerb = "Middle-clicked"
+        } else if triple {
+            self.automationType = .triple
+            self.displayVerb = "Triple-clicked"
         } else if double {
             self.automationType = .double
             self.displayVerb = "Double-clicked"

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgePayloads.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgePayloads.swift
@@ -262,7 +262,7 @@ public struct PeekabooBridgeTargetedClickRequest: Codable, Sendable {
 
     public static func requiresPostEventPermission(target: ClickTarget, clickType: ClickType) -> Bool {
         switch (target, clickType) {
-        case (.coordinates, _), (_, .double), (_, .longPress):
+        case (.coordinates, _), (_, .middle), (_, .double), (_, .triple), (_, .longPress):
             true
         case (_, .single), (_, .right):
             false

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPInteractionToolExecutionTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPInteractionToolExecutionTests.swift
@@ -147,6 +147,25 @@ extension MCPToolExecutionTests {
     }
 
     @Test
+    func `Click tool forwards middle and triple variants`() async throws {
+        let automation = await MainActor.run { MockAutomationService(accessibilityGranted: true) }
+        let context = await MCPToolTestHelpers.makeLegacyContext(automation: automation)
+        let tool = ClickTool(context: context)
+
+        let variants: [(String, ClickType)] = [("middle", .middle), ("triple", .triple)]
+        for (flag, expected) in variants {
+            let response = try await tool.execute(arguments: ToolArguments(raw: [
+                "coords": "10,20",
+                "foreground": true,
+                flag: true,
+            ]))
+
+            #expect(response.isError == false)
+            #expect(await MainActor.run { automation.clickCalls.last?.clickType } == expected)
+        }
+    }
+
+    @Test
     func `Click tool invalidates snapshot after indeterminate delivery`() async throws {
         await UISnapshotManager.shared.removeAllSnapshots()
         let automation = await MainActor.run {
@@ -297,6 +316,8 @@ extension MCPToolExecutionTests {
             ["query": "OK", "coords": "10,20", "foreground": true],
             ["on": "B1", "query": "OK", "coords": "10,20", "foreground": true],
             ["on": " ", "query": " "],
+            ["coords": "10,20", "foreground": true, "middle": true, "triple": true],
+            ["coords": "10,20", "foreground": true, "right": true, "double": true],
         ]
 
         for arguments in invalidArguments {

--- a/Core/PeekabooFoundation/Sources/PeekabooFoundation/BasicTypes.swift
+++ b/Core/PeekabooFoundation/Sources/PeekabooFoundation/BasicTypes.swift
@@ -31,8 +31,26 @@ public enum ElementType: String, Sendable, Codable {
 public enum ClickType: String, Sendable, Codable {
     case single
     case right
+    case middle
     case double
+    case triple
     case longPress
+}
+
+/// Mouse button used by split background pointer holds.
+public enum PointerButton: String, Sendable, Equatable, Codable {
+    case left
+    case right
+    case middle
+}
+
+/// Opaque ownership token returned by a successful background mouse-down.
+public struct BackgroundPointerHoldToken: Sendable, Equatable, Hashable, Codable {
+    public let id: UUID
+
+    public init(id: UUID = UUID()) {
+        self.id = id
+    }
 }
 
 // MARK: - Scroll & Swipe
@@ -232,7 +250,9 @@ extension ClickType: CustomStringConvertible {
         switch self {
         case .single: "single"
         case .right: "right"
+        case .middle: "middle"
         case .double: "double"
+        case .triple: "triple"
         case .longPress: "long press"
         }
     }

--- a/scripts/test-background-computer-use.sh
+++ b/scripts/test-background-computer-use.sh
@@ -169,14 +169,14 @@ read_launch_process_receipt() {
     [[ -n "$result_file" && -s "$result_file" ]] || return 1
     receipt="$(jq -er '
         .data as $data |
-        if ($data | has("pid")) and ($data | has("process_start_identity")) and
-           (($data | has("new_pid")) | not) and (($data | has("new_process_start_identity")) | not)
-        then [$data.pid, $data.process_start_identity]
-        elif ($data | has("new_pid")) and ($data | has("new_process_start_identity")) and
-             (($data | has("pid")) | not) and (($data | has("process_start_identity")) | not)
-        then [$data.new_pid, $data.new_process_start_identity]
-        else empty
-        end as $receipt |
+        (if ($data | has("pid")) and ($data | has("process_start_identity")) and
+            (($data | has("new_pid")) | not) and (($data | has("new_process_start_identity")) | not)
+         then [$data.pid, $data.process_start_identity]
+         elif ($data | has("new_pid")) and ($data | has("new_process_start_identity")) and
+              (($data | has("pid")) | not) and (($data | has("process_start_identity")) | not)
+         then [$data.new_pid, $data.new_process_start_identity]
+         else empty
+         end) as $receipt |
         $receipt[0] as $pid |
         $receipt[1] as $identity |
         select(


### PR DESCRIPTION
## Why

OpenClaw's native macOS `computer.act` v2 provider in openclaw/openclaw#123801 uses
PeekabooAutomationKit for exact-window background input. It currently has to omit background
middle/triple click, split mouse down/up, and a named held-key capability because the public kit
does not expose those operations.

## What changed

- Extend the existing AX-first / exact-window routed click path with background middle-click and
  triple-click. Middle clicks use routed `otherMouseDown`/`otherMouseUp` events; triple clicks use
  three routed left-button pairs with the expected click-state sequence.
- Add `BackgroundInputServiceProtocol` and concrete `UIAutomationService` methods for token-owned
  `mouseDown`/`mouseUp`, bounded `holdKey`, explicit held-input cleanup, and `getCursorPosition`.
- Keep split pointer input bound to the captured window/process generation. It uses the same
  window-local stamping and PID transport as existing background clicks, never activates the app,
  never posts through the desktop-global event tap, and never warps the physical cursor.
- Make held input fail-safe: key cancellation always posts key-up/modifier-up, split pointer holds
  have an owning token plus a 30-second watchdog, and embedding hosts can call `releaseHeldInput()`
  immediately on disconnect or lifecycle revocation. The watchdog retains the cleanup owner if the
  embedding service disappears.
- Surface middle/triple variants through the MCP `click` schema and reject mutually conflicting
  click variants before dispatch.

The branch also fixes a pre-existing jq grouping error in the background-certification harness
that prevented the repository's own safe suite from reaching its Swift tests.

## Background guarantees

- Exact capture-time PID, process generation, window ID, bounds, and point are validated before
  pointer dispatch.
- Cleanup mouse-up is sent only to the original live process generation; it is never retargeted to
  a recycled PID.
- No foreground fallback is used when private/public PID routing is unavailable.
- Cursor position is read-only, and all new background pointer paths preserve the shared cursor.

## Proof

- `pnpm run build:cli` — passed
- `pnpm run lint` — passed (existing warning baseline, 0 serious violations)
- `pnpm run format` — passed, final run formatted 0 files
- `swift test --package-path Core/PeekabooAutomationKit --filter 'WindowRoutedPointerDriverTests|BackgroundInputHoldCoordinatorTests|HotkeyServiceTargetingTests'` — 49 tests passed
- `swift test --package-path Core/PeekabooCore --filter 'Click tool forwards middle and triple variants'` — passed
- `swift test --package-path Core/PeekabooCore --skip-build --filter 'Click tool refuses empty or conflicting target shapes before dispatch or invalidation'` — passed
- `pnpm run test:background-certification` — 36 certification/overlap tests passed
- `pnpm run test:safe` — passed end to end
- `autoreview --mode local` — clean; no accepted/actionable findings, secret scan clean
- Source-blind public-surface validation — external SwiftPM consumer compiled the new API; MCP schema and two pre-dispatch conflict probes passed

No changelog entry is included per the work order.
