### PR TITLE
fix(config): reject invalid custom-provider URLs instead of crashing

### DIFF
--- a/Apps/CLI/Tests/CoreCLITests/ConfigModelsProviderTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/ConfigModelsProviderTests.swift
@@ -7,6 +7,8 @@ import Testing
 
 @Suite(.tags(.safe), .serialized)
 struct ConfigModelsProviderTests {
+    private static let invalidProviderBaseURL = "https://["
+
     @Test
     func `Saving provider models preserves configured model capabilities`() async throws {
         try await self.withTempConfigDir {
@@ -202,6 +204,91 @@ struct ConfigModelsProviderTests {
         }
     }
 
+    @Test
+    func `OpenAI provider test reports malformed persisted URL as JSON connection failure`() async throws {
+        try await self.withTempConfigDir {
+            try self.seedBrokenProvider(id: "broken-openai", type: .openai)
+
+            var command = ConfigCommand.TestProviderCommand()
+            command.providerId = "broken-openai"
+            let output = try await self.captureStandardOutput {
+                let exitCode = await #expect(throws: ExitCode.self) {
+                    try await command.run(using: self.makeRuntime(jsonOutput: true))
+                }
+                #expect(exitCode == .failure)
+            }
+
+            let response = try JSONDecoder().decode(
+                ProviderConnectionJSONResponse.self,
+                from: Data(output.utf8)
+            )
+            #expect(!response.success)
+            #expect(response.error.code == "CONNECTION_FAILED")
+            #expect(response.error.message.contains("Invalid provider URL"))
+            #expect(response.error.message.contains(Self.invalidProviderBaseURL))
+        }
+    }
+
+    @Test
+    func `Anthropic provider test reports malformed persisted URL as JSON connection failure`() async throws {
+        try await self.withTempConfigDir {
+            try self.seedBrokenProvider(id: "broken-anthropic", type: .anthropic)
+
+            var command = ConfigCommand.TestProviderCommand()
+            command.providerId = "broken-anthropic"
+            let output = try await self.captureStandardOutput {
+                let exitCode = await #expect(throws: ExitCode.self) {
+                    try await command.run(using: self.makeRuntime(jsonOutput: true))
+                }
+                #expect(exitCode == .failure)
+            }
+
+            let response = try JSONDecoder().decode(
+                ProviderConnectionJSONResponse.self,
+                from: Data(output.utf8)
+            )
+            #expect(!response.success)
+            #expect(response.error.code == "CONNECTION_FAILED")
+            #expect(response.error.message.contains("Invalid provider URL"))
+            #expect(response.error.message.contains(Self.invalidProviderBaseURL))
+        }
+    }
+
+    @Test
+    func `OpenAI model discovery reports malformed persisted URL as an ordinary failure`() async throws {
+        try await self.withTempConfigDir {
+            try self.seedBrokenProvider(id: "broken-discover", type: .openai)
+
+            var command = ConfigCommand.ModelsProviderCommand()
+            command.providerId = "broken-discover"
+            command.discover = true
+            let output = try await self.captureStandardOutput {
+                let exitCode = await #expect(throws: ExitCode.self) {
+                    try await command.run(using: self.makeRuntime())
+                }
+                #expect(exitCode == .failure)
+            }
+
+            #expect(output.contains("Failed to discover models"))
+            #expect(output.contains("Invalid provider URL"))
+            #expect(output.contains(Self.invalidProviderBaseURL))
+        }
+    }
+
+    private func seedBrokenProvider(id: String, type: Configuration.CustomProvider.ProviderType) throws {
+        let provider = Configuration.CustomProvider(
+            name: "Broken Provider",
+            type: type,
+            options: .init(baseURL: Self.invalidProviderBaseURL, apiKey: "test-key")
+        )
+        try PeekabooCore.ConfigurationManager.shared.updateConfiguration { configuration in
+            if configuration.customProviders == nil {
+                configuration.customProviders = [:]
+            }
+            configuration.customProviders?[id] = provider
+        }
+    }
+
     private func makeRuntime(jsonOutput: Bool = false) -> CommandRuntime {
         CommandRuntime(
             configuration: .init(verbose: false, jsonOutput: jsonOutput, logLevel: nil),
@@ -281,6 +368,16 @@ private struct ModelsProviderJSONResponse: Decodable {
 private struct ModelsProviderJSONData: Decodable {
     let models: [String]
     let saved: Bool
+}
+
+private struct ProviderConnectionJSONResponse: Decodable {
+    let success: Bool
+    let error: ProviderConnectionJSONError
+}
+
+private struct ProviderConnectionJSONError: Decodable {
+    let code: String
+    let message: String
 }
 
 private final class AcceptedRequestCounter: @unchecked Sendable {

--- a/Core/PeekabooCore/Sources/PeekabooAutomation/Configuration/ConfigurationManager+CustomProviders.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAutomation/Configuration/ConfigurationManager+CustomProviders.swift
@@ -148,7 +148,7 @@ extension ConfigurationManager {
         provider: Configuration.CustomProvider,
         apiKey: String) async throws -> (success: Bool, error: String?)
     {
-        let url = URL(string: "\(provider.options.baseURL)/models")!
+        let url = try self.requiredEndpointURL(provider.options.baseURL, path: "models")
         var request = URLRequest(url: url)
         request.httpMethod = "GET"
         request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
@@ -174,7 +174,7 @@ extension ConfigurationManager {
         provider: Configuration.CustomProvider,
         apiKey: String) async throws -> (success: Bool, error: String?)
     {
-        let url = URL(string: "\(provider.options.baseURL)/messages")!
+        let url = try self.requiredEndpointURL(provider.options.baseURL, path: "messages")
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
@@ -208,11 +208,18 @@ extension ConfigurationManager {
         provider.models?.keys.min() ?? "claude-opus-5"
     }
 
+    private func requiredEndpointURL(_ baseURL: String, path: String) throws -> URL {
+        guard let url = URL(string: "\(baseURL)/\(path)") else {
+            throw ConfigurationValidationError.invalidURL("Invalid provider URL: \(baseURL)/\(path)")
+        }
+        return url
+    }
+
     private func discoverOpenAICompatibleModels(
         provider: Configuration.CustomProvider,
         apiKey: String) async throws -> (models: [String], error: String?)
     {
-        let url = URL(string: "\(provider.options.baseURL)/models")!
+        let url = try self.requiredEndpointURL(provider.options.baseURL, path: "models")
         var request = URLRequest(url: url)
         request.httpMethod = "GET"
         request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")

--- a/Core/PeekabooCore/Tests/PeekabooTests/CustomProviderInvalidURLTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/CustomProviderInvalidURLTests.swift
@@ -1,0 +1,111 @@
+import Darwin
+import Foundation
+import Tachikoma
+import Testing
+@testable import PeekabooAutomation
+@testable import PeekabooCore
+
+@Suite(.serialized)
+struct CustomProviderInvalidURLTests {
+    private let manager = ConfigurationManager.shared
+
+    /// Persisted values can bypass `addCustomProvider` validation. An unterminated IPv6
+    /// authority stays unparseable when an endpoint path is appended.
+    private static let invalidBaseURL = "https://["
+
+    @Test
+    func `testCustomProvider reports invalid OpenAI URL instead of crashing`() async throws {
+        try self.requireUnparseableEndpoint(path: "models")
+        try await withIsolatedConfigurationEnvironment { _ in
+            try self.seedBrokenProvider(id: "broken-openai", type: .openai)
+
+            let result = await self.manager.testCustomProvider(id: "broken-openai")
+
+            #expect(result.success == false)
+            let error = try #require(result.error)
+            #expect(error.contains("Invalid provider URL"))
+        }
+    }
+
+    @Test
+    func `testCustomProvider reports invalid Anthropic URL instead of crashing`() async throws {
+        try self.requireUnparseableEndpoint(path: "messages")
+        try await withIsolatedConfigurationEnvironment { _ in
+            try self.seedBrokenProvider(id: "broken-anthropic", type: .anthropic)
+
+            let result = await self.manager.testCustomProvider(id: "broken-anthropic")
+
+            #expect(result.success == false)
+            let error = try #require(result.error)
+            #expect(error.contains("Invalid provider URL"))
+        }
+    }
+
+    @Test
+    func `discoverModelsForCustomProvider reports invalid URL instead of crashing`() async throws {
+        try self.requireUnparseableEndpoint(path: "models")
+        try await withIsolatedConfigurationEnvironment { _ in
+            try self.seedBrokenProvider(id: "broken-discover", type: .openai)
+
+            let result = await self.manager.discoverModelsForCustomProvider(id: "broken-discover")
+
+            #expect(result.models.isEmpty)
+            let error = try #require(result.error)
+            #expect(error.contains("Invalid provider URL"))
+        }
+    }
+
+    private func requireUnparseableEndpoint(path: String) throws {
+        let candidate = "\(Self.invalidBaseURL)/\(path)"
+        try #require(URL(string: candidate) == nil, "Fixture unexpectedly parsed: \(candidate)")
+    }
+
+    private func seedBrokenProvider(
+        id: String,
+        type: Configuration.CustomProvider.ProviderType) throws
+    {
+        let provider = Configuration.CustomProvider(
+            name: "Broken",
+            type: type,
+            options: .init(baseURL: Self.invalidBaseURL, apiKey: "test-key"))
+        try self.manager.updateConfiguration { configuration in
+            if configuration.customProviders == nil {
+                configuration.customProviders = [:]
+            }
+            configuration.customProviders?[id] = provider
+        }
+    }
+}
+
+private func withIsolatedConfigurationEnvironment(_ body: (URL) async throws -> Void) async throws {
+    let fileManager = FileManager.default
+    let configDir = fileManager.temporaryDirectory
+        .appendingPathComponent("peekaboo-invalid-url-tests-\(UUID().uuidString)", isDirectory: true)
+    try fileManager.createDirectory(at: configDir, withIntermediateDirectories: true)
+
+    let previousConfigDir = getenv("PEEKABOO_CONFIG_DIR").map { String(cString: $0) }
+    let previousDisableMigration = getenv("PEEKABOO_CONFIG_DISABLE_MIGRATION").map { String(cString: $0) }
+    let previousProfileDirectory = TachikomaConfiguration.profileDirectoryName
+
+    setenv("PEEKABOO_CONFIG_DIR", configDir.path, 1)
+    setenv("PEEKABOO_CONFIG_DISABLE_MIGRATION", "1", 1)
+    ConfigurationManager.shared.resetForTesting()
+
+    defer {
+        if let previousConfigDir {
+            setenv("PEEKABOO_CONFIG_DIR", previousConfigDir, 1)
+        } else {
+            unsetenv("PEEKABOO_CONFIG_DIR")
+        }
+        if let previousDisableMigration {
+            setenv("PEEKABOO_CONFIG_DISABLE_MIGRATION", previousDisableMigration, 1)
+        } else {
+            unsetenv("PEEKABOO_CONFIG_DISABLE_MIGRATION")
+        }
+        TachikomaConfiguration.profileDirectoryName = previousProfileDirectory
+        ConfigurationManager.shared.resetForTesting()
+        try? fileManager.removeItem(at: configDir)
+    }
+
+    try await body(configDir)
+}


### PR DESCRIPTION
## What Problem This Solves

`peekaboo config provider test` and model discovery force-unwrap `URL(string: baseURL + "/models")` (and `/messages`). `validate()` already rejects a missing scheme or host via `URLComponents`, but a persisted or hand-edited `baseURL` can still make `URL(string:)` return nil. That path crashed the CLI instead of reporting a connection error.

This showed up with `https://exa mple.com` (space in the host). `URL(string: "https://exa mple.com/models")` is nil. After this change, the same provider returns `CONNECTION_FAILED` / `Invalid provider URL` and the process stays up.

## Evidence

Patched `peekaboo` 4.1.0 on macOS, isolated `PEEKABOO_CONFIG_DIR`, live CLI:

```console
$ swift -e 'import Foundation; print(URL(string: "https://exa mple.com/models") as Any)'
nil

$ PEEKABOO_CONFIG_DIR=/tmp/peekaboo-proof-invalid-url PEEKABOO_CONFIG_DISABLE_MIGRATION=1 \
    peekaboo config provider list
Custom AI Providers:
  [ok] broken (Broken)
     Type: openai
     URL: https://exa mple.com

$ PEEKABOO_CONFIG_DIR=/tmp/peekaboo-proof-invalid-url PEEKABOO_CONFIG_DISABLE_MIGRATION=1 \
    peekaboo config provider test broken
[error] Connection to 'broken' failed: Connection test failed: Invalid provider URL: https://exa mple.com/models

$ PEEKABOO_CONFIG_DIR=/tmp/peekaboo-proof-invalid-url PEEKABOO_CONFIG_DISABLE_MIGRATION=1 \
    peekaboo config provider test broken --json
{
  "success" : false,
  "error" : {
    "message" : "Connection test failed: Invalid provider URL: https:\/\/exa mple.com\/models",
    "code" : "CONNECTION_FAILED"
  },
  "data" : null
}
```

Exit status is 1. The process does not trap / fatalError.

Same class as other Peekaboo fail-closed URL and process-wait hardening (for example [dock wait #303](https://github.com/openclaw/Peekaboo/pull/303)). The force-unwraps date to the configuration-manager split (`aeba4739`, 2026-05-07).

## Real behavior proof

- **Behavior or issue addressed:** Custom-provider test and model discovery crashed on a persisted `baseURL` that `URL(string:)` cannot parse. After the patch they throw `ConfigurationValidationError.invalidURL` and the CLI prints `CONNECTION_FAILED`.
- **Real environment tested:** macOS arm64, Peekaboo 4.1.0 built from this branch at `/tmp/oc-impl-peekaboo-url`, isolated config dir `/tmp/peekaboo-proof-invalid-url`.
- **Exact steps or command run after this patch:**

  Wrote `config.json` with provider `broken`, `baseURL` `https://exa mple.com`, then ran:

  ```
  swift -e 'import Foundation; print(URL(string: "https://exa mple.com/models") as Any)'
  PEEKABOO_CONFIG_DIR=/tmp/peekaboo-proof-invalid-url PEEKABOO_CONFIG_DISABLE_MIGRATION=1 peekaboo config provider list
  PEEKABOO_CONFIG_DIR=/tmp/peekaboo-proof-invalid-url PEEKABOO_CONFIG_DISABLE_MIGRATION=1 peekaboo config provider test broken
  PEEKABOO_CONFIG_DIR=/tmp/peekaboo-proof-invalid-url PEEKABOO_CONFIG_DISABLE_MIGRATION=1 peekaboo config provider test broken --json
  ```

- **Evidence after fix:** terminal output from the patched CLI:

  ```console
  $ swift -e 'import Foundation; print(URL(string: "https://exa mple.com/models") as Any)'
  nil

  $ peekaboo config provider test broken
  [error] Connection to 'broken' failed: Connection test failed: Invalid provider URL: https://exa mple.com/models
  ```

  JSON path returns `code: CONNECTION_FAILED` and the same message. Process exit is 1, not a crash.

- **Observed result after fix:** `URL(string:)` is nil for this host, and the live `peekaboo config provider test` command reports `Invalid provider URL` instead of dying on the force-unwrap.
- **What was not tested:** A live third-party provider that is actually reachable. Anthropic `/messages` uses the same helper; OpenAI `/models` was the CLI path exercised here.
