### PR TITLE
perf(observation): skip redundant exact-target work

### DIFF
--- a/Apps/CLI/Tests/CoreCLITests/SeeCommandTimeoutTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/SeeCommandTimeoutTests.swift
@@ -74,25 +74,28 @@ struct SeeCommandTimeoutTests {
             .appendingPathComponent("peekaboo-local-timeout-\(UUID().uuidString)", isDirectory: true)
         defer { try? FileManager.default.removeItem(at: root) }
         let store = DesktopMutationWatermarkStore(directoryURL: root)
+        let gate = IgnoredCancellationWorkGate()
+        defer { Task { await gate.release() } }
 
-        await #expect(throws: PeekabooError.self) {
+        let operation = Task { @MainActor in
             try await withMainActorCommandTimeout(
                 seconds: 0.01,
                 operationName: "delayed mutation",
                 desktopMutationWatermarkStore: store
             ) {
-                await withCheckedContinuation { continuation in
-                    DispatchQueue.global().asyncAfter(deadline: .now() + 0.1) {
-                        continuation.resume(returning: ())
-                    }
-                }
+                await gate.waitUntilReleased()
             }
+        }
+        await gate.waitUntilStarted()
+        await #expect(throws: PeekabooError.self) {
+            try await operation.value
         }
 
         let firstPendingRead = try #require(store.effectiveWatermark())
         try await Task.sleep(for: .milliseconds(2))
         #expect(try #require(store.effectiveWatermark()) > firstPendingRead)
 
+        await gate.release()
         #expect(try await Self.waitForStableWatermark(store))
     }
 
@@ -105,18 +108,20 @@ struct SeeCommandTimeoutTests {
         let store = DesktopMutationWatermarkStore(directoryURL: root)
         let tracker = InteractionMutationTracker(desktopMutationWatermarkStore: store)
         #expect(try tracker.beginDurableMutation())
+        let gate = IgnoredCancellationWorkGate()
+        defer { Task { await gate.release() } }
 
-        await #expect(throws: CaptureError.self) {
+        let operation = Task { @MainActor in
             try await SeeCommand.withWallClockTimeout(
                 seconds: 0.01,
                 interactionMutationTracker: tracker
             ) {
-                await withCheckedContinuation { continuation in
-                    DispatchQueue.global().asyncAfter(deadline: .now() + 0.1) {
-                        continuation.resume(returning: ())
-                    }
-                }
+                await gate.waitUntilReleased()
             }
+        }
+        await gate.waitUntilStarted()
+        await #expect(throws: CaptureError.self) {
+            try await operation.value
         }
 
         #expect(try tracker.completeDurableMutation(through: Date()) == nil)
@@ -124,6 +129,7 @@ struct SeeCommandTimeoutTests {
         try await Task.sleep(for: .milliseconds(2))
         #expect(try #require(store.effectiveWatermark()) > firstPendingRead)
 
+        await gate.release()
         #expect(try await Self.waitForStableWatermark(store))
     }
 
@@ -145,5 +151,38 @@ struct SeeCommandTimeoutTests {
         } while clock.now < deadline
 
         return false
+    }
+}
+
+private actor IgnoredCancellationWorkGate {
+    private var releaseContinuation: CheckedContinuation<Void, Never>?
+    private var startedContinuations: [CheckedContinuation<Void, Never>] = []
+    private var released = false
+    private var started = false
+
+    func waitUntilReleased() async {
+        self.started = true
+        let startedContinuations = self.startedContinuations
+        self.startedContinuations.removeAll()
+        for continuation in startedContinuations {
+            continuation.resume()
+        }
+        guard !self.released else { return }
+        await withCheckedContinuation { continuation in
+            self.releaseContinuation = continuation
+        }
+    }
+
+    func waitUntilStarted() async {
+        guard !self.started else { return }
+        await withCheckedContinuation { continuation in
+            self.startedContinuations.append(continuation)
+        }
+    }
+
+    func release() {
+        self.released = true
+        self.releaseContinuation?.resume()
+        self.releaseContinuation = nil
     }
 }

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Observation/DesktopObservationService.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Observation/DesktopObservationService.swift
@@ -644,8 +644,13 @@ public final class DesktopObservationService: DesktopObservationActionResultProv
             }
             let capture = Self.normalize(capture: rawCapture, for: target)
             let captureBoundTarget = Self.bindingCaptureReceipt(to: target, capture: capture)
+            let captureBoundResolution = UIAutomationActionResult(
+                payload: captureBoundTarget,
+                outcome: resolution.outcome,
+                targetIdentity: resolution.targetIdentity,
+                selectedLeafEvidence: resolution.selectedLeafEvidence)
             let captureResolution = try Self.composingForegroundCapture(
-                with: resolution,
+                with: captureBoundResolution,
                 target: captureBoundTarget,
                 request: request,
                 requireCompatibleTarget: true)

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Observation/DesktopStateSnapshotProvider.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Observation/DesktopStateSnapshotProvider.swift
@@ -18,6 +18,11 @@ public final class DesktopStateSnapshotProvider: DesktopStateSnapshotProviding {
         case .allScreens, .area, .menubar, .menubarPopover, .screen, .windowID:
             return DesktopStateSnapshot()
 
+        case let .pid(_, window) where window?.isExactID == true:
+            // Exact PID/window observations resolve the live owner and process generation directly from
+            // WindowServer metadata. Older generationless hosts fall back to application discovery in the resolver.
+            return DesktopStateSnapshot()
+
         case .app, .pid:
             return try await self.snapshotWithRunningApplications(frontmost: nil)
 
@@ -34,6 +39,15 @@ public final class DesktopStateSnapshotProvider: DesktopStateSnapshotProviding {
         return DesktopStateSnapshot(
             runningApplications: applications.map(ApplicationIdentity.init),
             frontmostApplication: frontmost.map(ApplicationIdentity.init))
+    }
+}
+
+extension WindowSelection {
+    fileprivate var isExactID: Bool {
+        if case .id = self {
+            return true
+        }
+        return false
     }
 }
 

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Observation/ObservationTargetResolver.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Observation/ObservationTargetResolver.swift
@@ -102,14 +102,18 @@ public final class ObservationTargetResolver: ObservationTargetResolving {
         selection: WindowSelection?,
         snapshot: DesktopStateSnapshot) async throws -> ResolvedObservationTarget
     {
-        let app: ServiceApplicationInfo? = if let snapshotApp = snapshot.runningApplications
-            .first(where: { $0.processIdentifier == pid })
+        if let snapshotApp = snapshot.runningApplications.first(where: { $0.processIdentifier == pid }) {
+            return try await self.resolveApplication(
+                Self.serviceApplicationInfo(from: snapshotApp),
+                selection: selection ?? .automatic)
+        }
+        if case let .id(windowID)? = selection,
+           let exact = try self.resolveExactWindowIfAvailable(windowID, expectedPID: pid)
         {
-            Self.serviceApplicationInfo(from: snapshotApp)
-        } else {
-            try await self.fallbackApplication(pid: pid)
+            return exact
         }
 
+        let app = try await self.fallbackApplication(pid: pid)
         guard let app else {
             throw DesktopObservationError.targetNotFound("pid \(pid)")
         }
@@ -311,6 +315,42 @@ public final class ObservationTargetResolver: ObservationTargetResolving {
                 "window id \(windowID) owned by PID \(app.processIdentifier)")
         }
 
+        return Self.resolvedExactWindow(windowID, app: app, metadata: metadata)
+    }
+
+    private func resolveExactWindowIfAvailable(
+        _ windowID: CGWindowID,
+        expectedPID: Int32) throws -> ResolvedObservationTarget?
+    {
+        guard let metadata = self.exactWindowMetadataProvider.metadata(for: windowID) else {
+            return nil
+        }
+        guard metadata.ownerProcessIdentifier == expectedPID else {
+            throw DesktopObservationError.targetNotFound(
+                "window id \(windowID) owned by PID \(expectedPID)")
+        }
+        guard let liveProcessStartIdentity = self.exactWindowMetadataProvider.processStartIdentity(for: expectedPID)
+        else {
+            return nil
+        }
+        guard liveProcessStartIdentity == metadata.ownerProcessStartIdentity else {
+            throw DesktopObservationError.targetNotFound(
+                "live process generation for PID \(expectedPID)")
+        }
+        let app = ServiceApplicationInfo(
+            processIdentifier: expectedPID,
+            processStartIdentity: metadata.ownerProcessStartIdentity,
+            bundleIdentifier: nil,
+            name: metadata.applicationName ?? "PID:\(expectedPID)",
+            windowCount: 1)
+        return Self.resolvedExactWindow(windowID, app: app, metadata: metadata)
+    }
+
+    private static func resolvedExactWindow(
+        _ windowID: CGWindowID,
+        app: ServiceApplicationInfo,
+        metadata: ExactWindowObservationMetadata) -> ResolvedObservationTarget
+    {
         let window = WindowIdentity(
             windowID: Int(windowID),
             title: metadata.title,

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/DesktopObservationServiceTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/DesktopObservationServiceTests.swift
@@ -161,7 +161,7 @@ extension DesktopObservationServiceTests {
         XCTAssertEqual(automation.detectCalls, 0)
     }
 
-    func testReusedPIDAndWindowIDFailBeforeCapture() async throws {
+    func testReusedPIDAndWindowIDFailWhenCaptureReceiptDisagrees() async throws {
         let oldApplication = ServiceApplicationInfo(
             processIdentifier: 123,
             processStartIdentity: 100,
@@ -185,12 +185,51 @@ extension DesktopObservationServiceTests {
             _ = try await service.observe(DesktopObservationRequest(
                 target: .pid(123, window: .id(42)),
                 detection: DesktopDetectionOptions(mode: .none)))
-            XCTFail("Expected reused PID/window ID to fail before capture")
+            XCTFail("Expected reused PID/window ID to fail closed")
         } catch is DesktopObservationError {
             // Expected.
         }
 
-        XCTAssertTrue(capture.operations.isEmpty)
+        XCTAssertEqual(capture.operations, [
+            .windowID(42, .logical1x, .auto),
+            .windowID(42, .logical1x, .auto),
+        ])
+    }
+
+    func testExactPIDObservationBindsCaptureAppMetadataWithoutInventory() async throws {
+        let application = ServiceApplicationInfo(
+            processIdentifier: 123,
+            processStartIdentity: 700,
+            bundleIdentifier: "com.example.fixture",
+            name: "Fixture",
+            windowCount: 1)
+        let window = Self.window(
+            id: 42,
+            title: "Captured",
+            bounds: CGRect(x: 100, y: 100, width: 400, height: 300),
+            mutationIdentity: WindowMutationIdentity(
+                windowID: 42,
+                ownerProcessIdentifier: application.processIdentifier,
+                ownerProcessStartIdentity: 700,
+                capturedBounds: CGRect(x: 100, y: 100, width: 400, height: 300)))
+        let applications = RecordingApplicationService(applications: [application], windows: [window])
+        let service = DesktopObservationService(
+            screenCapture: RecordingScreenCaptureService(
+                result: Self.captureResult(app: application, window: window)),
+            automation: RecordingUIAutomationService(),
+            applications: applications,
+            exactWindowMetadataProvider: StableExactWindowMetadataProvider())
+
+        let result = try await service.observe(DesktopObservationRequest(
+            target: .pid(application.processIdentifier, window: .id(42)),
+            capture: DesktopCaptureOptions(engine: .legacy),
+            detection: DesktopDetectionOptions(mode: .none)))
+
+        XCTAssertEqual(applications.listApplicationsCalls, 0)
+        XCTAssertEqual(result.diagnostics.stateSnapshot?.runningApplicationCount, 0)
+        XCTAssertEqual(result.target.app?.bundleIdentifier, application.bundleIdentifier)
+        XCTAssertEqual(result.target.detectionContext?.applicationBundleId, application.bundleIdentifier)
+        XCTAssertEqual(result.target.app?.processStartIdentity, application.processStartIdentity)
     }
 
     func testGenerationlessRemoteExactObservationStaysReadOnly() async throws {

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ObservationExactWindowResolverTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ObservationExactWindowResolverTests.swift
@@ -4,6 +4,59 @@ import XCTest
 
 @MainActor
 final class ObservationExactWindowResolverTests: XCTestCase {
+    func testExactPIDSkipsRunningApplicationEnumeration() async throws {
+        let app = Self.app(pid: 123)
+        let service = ExactWindowApplicationService(app: app, windows: [])
+        let snapshotProvider = DesktopStateSnapshotProvider(applications: service)
+        let resolver = ObservationTargetResolver(
+            applications: service,
+            exactWindowMetadataProvider: TestExactWindowMetadataProvider { windowID in
+                Self.metadata(windowID: windowID, ownerPID: 123)
+            })
+
+        let target = DesktopObservationTargetRequest.pid(123, window: .id(42))
+        let snapshot = try await snapshotProvider.snapshot(for: target)
+        let resolved = try await resolver.resolve(target, snapshot: snapshot)
+
+        XCTAssertTrue(snapshot.runningApplications.isEmpty)
+        XCTAssertEqual(service.listApplicationsCalls, 0)
+        XCTAssertEqual(service.findApplicationCalls, 0)
+        XCTAssertEqual(service.listWindowsCalls, 0)
+        XCTAssertEqual(resolved.app?.processIdentifier, 123)
+        XCTAssertEqual(resolved.app?.processStartIdentity, 700)
+        XCTAssertEqual(resolved.window?.windowID, 42)
+        XCTAssertEqual(resolved.detectionContext?.windowMutationIdentity?.ownerProcessIdentifier, 123)
+        XCTAssertEqual(resolved.detectionContext?.windowMutationIdentity?.ownerProcessStartIdentity, 700)
+    }
+
+    func testExactPIDWithoutSnapshotFailsClosedForForeignOwnerOrReusedPID() async throws {
+        let app = Self.app(pid: 123)
+        let service = ExactWindowApplicationService(app: app, windows: [])
+        let foreignOwner = ObservationTargetResolver(
+            applications: service,
+            exactWindowMetadataProvider: TestExactWindowMetadataProvider { windowID in
+                Self.metadata(windowID: windowID, ownerPID: 999)
+            })
+        let reusedPID = ObservationTargetResolver(
+            applications: service,
+            exactWindowMetadataProvider: TestExactWindowMetadataProvider(liveProcessStartIdentity: 701) { windowID in
+                Self.metadata(windowID: windowID, ownerPID: 123)
+            })
+
+        for resolver in [foreignOwner, reusedPID] {
+            do {
+                _ = try await resolver.resolve(
+                    .pid(123, window: .id(42)),
+                    snapshot: DesktopStateSnapshot())
+                XCTFail("Expected an unverified exact PID/window receipt to fail")
+            } catch is DesktopObservationError {
+                // Expected.
+            }
+        }
+        XCTAssertEqual(service.listApplicationsCalls, 0)
+        XCTAssertEqual(service.listWindowsCalls, 0)
+    }
+
     func testExactIDUsesCGMetadataWithoutListingAXWindows() async throws {
         let app = Self.app(pid: 123)
         let service = ExactWindowApplicationService(app: app, windows: [Self.serviceWindow(id: 42)])
@@ -243,6 +296,8 @@ private struct TestExactWindowMetadataProvider: ExactWindowMetadataProviding {
 private final class ExactWindowApplicationService: ApplicationServiceProtocol {
     let app: ServiceApplicationInfo
     let windows: [ServiceWindowInfo]
+    var listApplicationsCalls = 0
+    var findApplicationCalls = 0
     var listWindowsCalls = 0
 
     init(app: ServiceApplicationInfo, windows: [ServiceWindowInfo]) {
@@ -251,14 +306,16 @@ private final class ExactWindowApplicationService: ApplicationServiceProtocol {
     }
 
     func listApplications() async throws -> UnifiedToolOutput<ServiceApplicationListData> {
-        UnifiedToolOutput(
+        self.listApplicationsCalls += 1
+        return UnifiedToolOutput(
             data: ServiceApplicationListData(applications: [self.app]),
             summary: .init(brief: "apps", status: .success),
             metadata: .init(duration: 0))
     }
 
     func findApplication(identifier _: String) async throws -> ServiceApplicationInfo {
-        self.app
+        self.findApplicationCalls += 1
+        return self.app
     }
 
     func listWindows(for _: String, timeout _: Float?) async throws -> UnifiedToolOutput<ServiceWindowListData> {

--- a/docs/refactor/desktop-observation.md
+++ b/docs/refactor/desktop-observation.md
@@ -239,6 +239,7 @@ Landed:
 - `peekaboo capture live` now keeps scope resolution, option normalization, output rendering, focus policy, and Commander binding in focused command-support files.
 - `peekaboo capture live` now applies the resolution cap consistently to live frames whose source images lack reusable color-space metadata.
 - `peekaboo see --mode screen --json` now suppresses human screen-summary lines so stdout remains a single JSON document.
+- Exact PID/window observations skip broad application inventory when WindowServer supplies a matching owner and live process-generation receipt; capture metadata then hydrates the bundle identity, while generationless hosts retain the read-only inventory fallback.
 - Screen capture operations now keep ScreenCaptureKit permission probing inside the same serialized transaction as capture work; `peekaboo capture live` now honors `--capture-engine`, and live area capture defaults to the native `screencapture -R` path so it stays fast during concurrent `see` commands.
 - Legacy window capture now tries the private ScreenCaptureKit window-ID lookup behind `screencapture -l <windowID>` before falling back to the system `screencapture` binary and public ScreenCaptureKit enumeration.
 - Legacy window capture fallbacks now live in focused private-ScreenCaptureKit and system-screencapture operator companions; `LegacyScreenCaptureOperator+Support.swift` is back to shared scale/display/configuration helpers.
@@ -880,7 +881,7 @@ These identities must flow through:
 
 ### Request-Scoped Desktop State
 
-Observation should build one request-scoped desktop inventory and pass it through the pipeline.
+Broad observation should build one request-scoped desktop inventory and pass it through the pipeline. An exact PID/window request may instead bind directly to matching WindowServer owner-generation metadata, then require the capture receipt to confirm and hydrate that same target; if generation evidence is unavailable, it falls back to the read-only inventory path.
 
 ```swift
 public struct DesktopStateSnapshot: Sendable {


### PR DESCRIPTION
## Summary

- skip broad running-application enumeration for explicit PID plus window-ID observations when WindowServer proves the requested owner and live process generation
- retain the read-only inventory fallback when exact generation evidence is unavailable, and fail closed on foreign owners or PID reuse
- carry capture-hydrated bundle/window metadata through the landed action-result pipeline while leaving classic capture transaction coordination unchanged
- replace timeout tests' fixed-delay in-flight assumption with an explicit cancellation-ignoring gate, so slow runners cannot observe a legitimately completed barrier as if it were still pending
- document the exact-target exception to request-scoped desktop inventory

## Tests

- `swift test --package-path Core/PeekabooAutomationKit --no-parallel --filter 'ObservationExactWindowResolverTests|DesktopObservationServiceTests|ScreenCaptureFallbackRunnerTests'` (49 passed)
- `swift test --package-path Core/PeekabooAutomationKit --no-parallel` (970 passed)
- repeated both durable-barrier timeout cases 50 times each with Swift Testing repetition (100 passed)
- `pnpm run test:safe`
- `pnpm run format`
- `pnpm run lint` (66 existing warnings, 0 serious)
- `git diff --check origin/main..HEAD`
- autoreview: clean, no accepted/actionable findings

## Signed physical proof

Built the exact source commit `bd95ea5bf8460a441280bcccd95266c4915d7d20` as a Developer ID-signed arm64 CLI. A source-blind validator ran seven alternating background-only TextEdit observation pairs against the same window with classic capture:

- exact `--pid` + `--window-id`: zero enumerated applications; median `state.snapshot` 0.003750 ms and `target.resolve` 0.307750 ms
- broad `--pid`: 139 enumerated applications; median `state.snapshot` 41.174500 ms and `target.resolve` 3.009916 ms
- combined resolution median improved from 43.902625 ms to 0.311375 ms (141x)
- all 14 observations succeeded and resolved window ID 16663
- Finder remained foreground before and after the comparison
- no foreground flag, UI mutation, AppleScript/JXA, or virtualization was used

The final diff contains no capture-gate or fallback-runner change; the earlier experimental bypass remains dropped.
