### PR TITLE
refactor(automation): centralize mutation target planning

### DIFF
--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add authenticated `bridge receipt validate` for fail-closed, agent-readable verification of private protocol 1.29 bundles against the exact live listener that produced them.
 
+### Fixed
+- Make application and window inventories report omitted or identity-incomplete rows as partial, while keeping complete AX-only window listings usable without Screen Recording.
+
 ## [4.2.0] - 2026-08-16
 
 ### Added
@@ -22,7 +25,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Complete the Bridge 1.29 receipt-session handshake before daemon status or stop control, validate explicit move snapshots before focus setup, and preserve actionable quit recovery over generic escalation guidance.
-- Make application and window inventories report omitted or identity-incomplete rows as partial, while keeping complete AX-only window listings usable without Screen Recording.
 - Require explicit foreground consent for Space switching and followed window moves across CLI and MCP, and compose their native move/switch receipts without synthesizing success or dispatch counts.
 - Establish and verify a window's destination Space before removing prior memberships, and retain its exact generation-bound identity through Space-aware focus.
 - Let later exact maximize readbacks supersede transient poll errors while preserving cancellation and identity contradictions, and route idempotent no-change receipts by the actual execution host.

--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Complete the Bridge 1.29 receipt-session handshake before daemon status or stop control, validate explicit move snapshots before focus setup, and preserve actionable quit recovery over generic escalation guidance.
+- Make application and window inventories report omitted or identity-incomplete rows as partial, while keeping complete AX-only window listings usable without Screen Recording.
 - Require explicit foreground consent for Space switching and followed window moves across CLI and MCP, and compose their native move/switch receipts without synthesizing success or dispatch counts.
 - Establish and verify a window's destination Space before removing prior memberships, and retain its exact generation-bound identity through Space-aware focus.
 - Let later exact maximize readbacks supersede transient poll errors while preserving cancellation and identity contradictions, and route idempotent no-change receipts by the actual execution host.

--- a/Apps/CLI/Tests/CoreCLITests/WindowListDeduplicationTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/WindowListDeduplicationTests.swift
@@ -134,10 +134,10 @@ struct WindowListDeduplicationTests {
     }
 
     @Test
-    func `Bounds fallback title is consumed once so identical frames are not all relabeled`() {
+    func `Bounds fallback refuses one descriptor shared by identical frames`() {
         // Two untitled CG windows share an identical frame (stacked/maximized). A single AX
-        // descriptor without a resolvable CGWindowID matches that frame. It must relabel exactly one
-        // window; the other stays untitled rather than borrowing the same title and mislabeling.
+        // descriptor without a resolvable CGWindowID matches both. Neither identity is unique, so
+        // both windows stay untitled and the descriptor remains visibly unmaterialized.
         let frame = CGRect(x: 0, y: 0, width: 1440, height: 900)
         let cgWindows = [
             Self.window(id: 11, title: "", index: 0, bounds: frame),
@@ -145,14 +145,18 @@ struct WindowListDeduplicationTests {
         ]
         let axDescriptors = [Self.descriptor(id: nil, title: "Document", bounds: frame)]
 
-        let merged = WindowEnumerationContext.mergeWindows(cgWindows: cgWindows, axDescriptors: axDescriptors)
+        let merged = WindowEnumerationContext.mergeWindowInventory(
+            cgWindows: cgWindows,
+            axDescriptors: axDescriptors
+        )
 
-        #expect(merged.map(\.windowID) == [11, 12])
-        #expect(merged.map(\.title) == ["Document", ""])
+        #expect(merged.windows.map(\.windowID) == [11, 12])
+        #expect(merged.windows.map(\.title) == ["", ""])
+        #expect(merged.unmaterializedAXDescriptorCount == 1)
     }
 
     @Test
-    func `Bounds fallback assigns distinct titles to identically framed windows in order`() {
+    func `Bounds fallback refuses order-dependent pairing for identical frames`() {
         let frame = CGRect(x: 0, y: 0, width: 1440, height: 900)
         let cgWindows = [
             Self.window(id: 11, title: "", index: 0, bounds: frame),
@@ -163,10 +167,14 @@ struct WindowListDeduplicationTests {
             Self.descriptor(id: nil, title: "Second", bounds: frame),
         ]
 
-        let merged = WindowEnumerationContext.mergeWindows(cgWindows: cgWindows, axDescriptors: axDescriptors)
+        let merged = WindowEnumerationContext.mergeWindowInventory(
+            cgWindows: cgWindows,
+            axDescriptors: axDescriptors
+        )
 
-        #expect(merged.map(\.windowID) == [11, 12])
-        #expect(merged.map(\.title) == ["First", "Second"])
+        #expect(merged.windows.map(\.windowID) == [11, 12])
+        #expect(merged.windows.map(\.title) == ["", ""])
+        #expect(merged.unmaterializedAXDescriptorCount == 2)
     }
 
     @Test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 ### Fixed
 - Keep Finder layout metadata on the DMG volume instead of the signed app bundle, preserving strict mounted-payload code verification without losing the branded drag-to-Applications layout.
 - Complete the Bridge 1.29 receipt-session handshake before daemon status or stop control, validate explicit move snapshots before focus setup, and preserve actionable quit recovery over generic escalation guidance.
+- Make application and window inventories report omitted or identity-incomplete rows as partial, while keeping complete AX-only window listings usable without Screen Recording.
 - Require explicit foreground consent for Space switching and followed window moves across CLI and MCP, and compose their native move/switch receipts without synthesizing success or dispatch counts.
 - Establish and verify a window's destination Space before removing prior memberships, and retain its exact generation-bound identity through Space-aware focus.
 - Let later exact maximize readbacks supersede transient poll errors while preserving cancellation and identity contradictions, and route idempotent no-change receipts by the actual execution host.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Added
 - Add authenticated `peekaboo bridge receipt validate` for fail-closed, agent-readable verification of private protocol 1.29 bundles against the exact live listener that produced them.
 
+### Fixed
+- Make application and window inventories report omitted or identity-incomplete rows as partial, while keeping complete AX-only window listings usable without Screen Recording.
+
 ## [4.2.0] - 2026-08-16
 
 ### Added
@@ -21,7 +24,6 @@
 ### Fixed
 - Keep Finder layout metadata on the DMG volume instead of the signed app bundle, preserving strict mounted-payload code verification without losing the branded drag-to-Applications layout.
 - Complete the Bridge 1.29 receipt-session handshake before daemon status or stop control, validate explicit move snapshots before focus setup, and preserve actionable quit recovery over generic escalation guidance.
-- Make application and window inventories report omitted or identity-incomplete rows as partial, while keeping complete AX-only window listings usable without Screen Recording.
 - Require explicit foreground consent for Space switching and followed window moves across CLI and MCP, and compose their native move/switch receipts without synthesizing success or dispatch counts.
 - Establish and verify a window's destination Space before removing prior memberships, and retain its exact generation-bound identity through Space-aware focus.
 - Let later exact maximize readbacks supersede transient poll errors while preserving cancellation and identity contradictions, and route idempotent no-change receipts by the actual execution host.

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Core/Protocols/ApplicationServiceProtocol.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Core/Protocols/ApplicationServiceProtocol.swift
@@ -382,6 +382,32 @@ public protocol ApplicationServiceProtocol: Sendable {
     func showAllApplications() async throws
 }
 
+/// Additive catalog capability for exact mutation target selection.
+///
+/// The inventory covers process identity and exact application membership. Optional window or
+/// presentation metadata must not make an otherwise complete application catalog look incomplete.
+public protocol ApplicationMutationInventoryProviding: ApplicationServiceProtocol {
+    func applicationMutationInventory() async throws
+        -> DesktopTargetPlanning.Inventory<ServiceApplicationInfo>
+}
+
+extension ApplicationServiceProtocol {
+    /// Returns application rows together with explicit completeness evidence.
+    ///
+    /// Legacy conformers expose rows only. Mutation planners therefore treat their broad catalog as
+    /// partial while still allowing a direct exact-PID lookup through `findApplication`.
+    public func mutationApplicationInventory() async throws
+        -> DesktopTargetPlanning.Inventory<ServiceApplicationInfo>
+    {
+        if let provider = self as? any ApplicationMutationInventoryProviding {
+            return try await provider.applicationMutationInventory()
+        }
+        return try await .partial(
+            self.listApplications().data.applications,
+            warnings: ["Application mutation inventory completeness was not reported by this service."])
+    }
+}
+
 /// Additive capability for application mutations that return the shared action-result carrier.
 ///
 /// Requirement names intentionally differ from the public `*Result` adapters below. Keeping the

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Core/Protocols/WindowManagementServiceProtocol.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Core/Protocols/WindowManagementServiceProtocol.swift
@@ -88,6 +88,21 @@ public protocol WindowManagementServiceProtocol: Sendable {
 }
 
 extension WindowManagementServiceProtocol {
+    /// Returns window rows together with explicit completeness evidence.
+    ///
+    /// Legacy conformers expose rows only, so broad selectors cannot infer uniqueness from them. An
+    /// exact window-ID lookup may still use those rows as direct identity proof.
+    public func mutationInventory(
+        target: WindowTarget) async throws -> DesktopTargetPlanning.Inventory<ServiceWindowInfo>
+    {
+        if let provider = self as? any WindowMutationInventoryProviding {
+            return try await provider.windowMutationInventory(target: target)
+        }
+        return try await .partial(
+            self.listWindows(target: target),
+            warnings: ["Window mutation inventory completeness was not reported by this service."])
+    }
+
     public func requireWindowMutationResultProvider(operation: String) throws {
         guard self is any WindowManagementActionResultProviding ||
             self is any WindowManagementActionOutcomeProviding
@@ -159,6 +174,12 @@ extension WindowManagementServiceProtocol {
         PeekabooError.serviceUnavailable(
             "This window service does not support process-generation-pinned mutations; update the runtime host")
     }
+}
+
+/// Additive inventory capability for mutation planners that must prove catalog completeness.
+public protocol WindowMutationInventoryProviding: WindowManagementServiceProtocol {
+    func windowMutationInventory(
+        target: WindowTarget) async throws -> DesktopTargetPlanning.Inventory<ServiceWindowInfo>
 }
 
 /// Additive capability for exact-window mutations that can report their canonical execution outcome.
@@ -513,7 +534,7 @@ extension WindowManagementServiceProtocol {
 }
 
 /// Options for targeting a window
-public enum WindowTarget: Sendable, CustomStringConvertible, Codable {
+public enum WindowTarget: Sendable, CustomStringConvertible, Codable, Equatable, Hashable {
     /// Target by application name or bundle ID
     case application(String)
 

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Observation/WindowSelectorResolutionProof.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Observation/WindowSelectorResolutionProof.swift
@@ -73,9 +73,9 @@ public enum WindowSelectorResolutionProof {
     {
         switch selection {
         case .automatic:
-            guard ObservationTargetResolver.bestWindow(from: candidates)?.windowID == selected.windowID else {
-                return nil
-            }
+            // Automatic is a provenance label shared by capture and dialog callers with different
+            // route-specific rankers. The mutation planner therefore never emits an automatic proof;
+            // it retains the exact selected identity and revalidates that target directly instead.
             return (.automaticWindowRank, 1)
         case let .index(index):
             let explicit = candidates.filter { $0.index == index }

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Observation/WindowSelectorResolutionProof.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Observation/WindowSelectorResolutionProof.swift
@@ -73,6 +73,9 @@ public enum WindowSelectorResolutionProof {
     {
         switch selection {
         case .automatic:
+            guard ObservationTargetResolver.bestWindow(from: candidates)?.windowID == selected.windowID else {
+                return nil
+            }
             return (.automaticWindowRank, 1)
         case let .index(index):
             let explicit = candidates.filter { $0.index == index }

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/System/ApplicationService+Discovery.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/System/ApplicationService+Discovery.swift
@@ -54,6 +54,11 @@ extension ApplicationService {
                     "Application PID \(processIdentifier) changed process generation during inventory and was omitted.")
                 continue
             }
+            guard !candidate.name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                warnings.append(
+                    "Application PID \(processIdentifier) metadata lacked a usable name and was omitted.")
+                continue
+            }
             let activationPolicy: ServiceApplicationActivationPolicy = if !candidate.allowsFuzzyMatching {
                 .prohibited
             } else if candidate.isRegularApplication {

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/System/ApplicationService+Discovery.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/System/ApplicationService+Discovery.swift
@@ -212,7 +212,7 @@ extension ApplicationService {
                     "appsWithWindows": appsWithWindows.count,
                     "totalWindows": totalWindows,
                     "incompleteApplications":
-                        applications.count(where: { !($0.metadataWarnings ?? []).isEmpty }) + omissionWarnings.count,
+                        applications.count(where: { !($0.metadataWarnings ?? []).isEmpty }),
                     "omittedApplications": omissionWarnings.count,
                 ],
                 highlights: highlights),

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/System/ApplicationService+Discovery.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/System/ApplicationService+Discovery.swift
@@ -26,6 +26,56 @@ private struct ApplicationInventoryRead: Sendable {
 
 @MainActor
 extension ApplicationService {
+    public func applicationMutationInventory() async throws
+        -> DesktopTargetPlanning.Inventory<ServiceApplicationInfo>
+    {
+        let processIdentifiers = Array(Set(self.runningApplicationProcessIdentifiersProvider()))
+            .filter { $0 > 0 }
+            .sorted()
+        var applications: [ServiceApplicationInfo] = []
+        var warnings: [String] = []
+        for processIdentifier in processIdentifiers {
+            guard let generation = self.processStartIdentityProvider(processIdentifier),
+                  generation > 0
+            else {
+                warnings.append(
+                    "Application PID \(processIdentifier) lacked process-generation identity and was omitted.")
+                continue
+            }
+            guard let candidate = self.applicationMutationCandidateProvider(processIdentifier) else {
+                warnings.append(
+                    "Application PID \(processIdentifier) metadata was unavailable and was omitted.")
+                continue
+            }
+            guard candidate.processIdentifier == processIdentifier,
+                  self.processStartIdentityProvider(processIdentifier) == generation
+            else {
+                warnings.append(
+                    "Application PID \(processIdentifier) changed process generation during inventory and was omitted.")
+                continue
+            }
+            let activationPolicy: ServiceApplicationActivationPolicy = if !candidate.allowsFuzzyMatching {
+                .prohibited
+            } else if candidate.isRegularApplication {
+                .regular
+            } else {
+                .accessory
+            }
+            applications.append(ServiceApplicationInfo(
+                processIdentifier: processIdentifier,
+                processStartIdentity: generation,
+                bundleIdentifier: candidate.bundleIdentifier,
+                name: candidate.name,
+                bundlePath: candidate.bundlePath,
+                executablePath: candidate.executablePath,
+                activationPolicy: activationPolicy))
+        }
+        return DesktopTargetPlanning.Inventory(
+            items: applications,
+            completeness: warnings.isEmpty ? .complete : .partial,
+            warnings: warnings)
+    }
+
     public func listApplications() async throws -> UnifiedToolOutput<ServiceApplicationListData> {
         let startTime = Date()
         self.logger.info("Listing all running applications")
@@ -111,19 +161,29 @@ extension ApplicationService {
         }
         try Task.checkCancellation()
 
-        let applications = reads.compactMap { read -> ServiceApplicationInfo? in
+        var applications: [ServiceApplicationInfo] = []
+        var omissionWarnings: [String] = []
+        for read in reads {
             if let expectedGeneration = read.candidate.processStartIdentity,
                self.processStartIdentityProvider(read.candidate.processIdentifier) != expectedGeneration
             {
-                return nil
+                omissionWarnings.append(
+                    "Application PID \(read.candidate.processIdentifier) changed process generation during inventory " +
+                        "and was omitted.")
+                continue
             }
-            return self.applicationInfo(from: read)
-        }.sorted { app1, app2 -> Bool in
+            if let application = self.applicationInfo(from: read) {
+                applications.append(application)
+            } else {
+                omissionWarnings.append(Self.applicationOmissionWarning(read))
+            }
+        }
+        applications.sort { app1, app2 -> Bool in
             app1.name == app2.name
                 ? app1.processIdentifier < app2.processIdentifier
                 : app1.name < app2.name
         }
-        let warnings = Self.uniqueWarnings(in: applications)
+        let warnings = Array(Set(Self.uniqueWarnings(in: applications) + omissionWarnings)).sorted()
 
         self.logger.info("Returning \(applications.count) applications")
 
@@ -151,7 +211,9 @@ extension ApplicationService {
                     "applications": applications.count,
                     "appsWithWindows": appsWithWindows.count,
                     "totalWindows": totalWindows,
-                    "incompleteApplications": applications.count(where: { !($0.metadataWarnings ?? []).isEmpty }),
+                    "incompleteApplications":
+                        applications.count(where: { !($0.metadataWarnings ?? []).isEmpty }) + omissionWarnings.count,
+                    "omittedApplications": omissionWarnings.count,
                 ],
                 highlights: highlights),
             metadata: UnifiedToolOutput.Metadata(
@@ -166,6 +228,10 @@ extension ApplicationService {
         var warnings: [String] = candidate.windowCatalogAvailable
             ? []
             : ["Window inventory was unavailable for PID \(candidate.processIdentifier)"]
+        if candidate.processStartIdentity == nil {
+            warnings.append(
+                "Process-generation identity was unavailable for PID \(candidate.processIdentifier)")
+        }
 
         switch read.outcome {
         case let .metadata(metadata):
@@ -249,6 +315,21 @@ extension ApplicationService {
             for warning in application.metadataWarnings ?? [] where !result.contains(warning) {
                 result.append(warning)
             }
+        }
+    }
+
+    private static func applicationOmissionWarning(_ read: ApplicationInventoryRead) -> String {
+        let pid = read.candidate.processIdentifier
+        guard read.candidate.processStartIdentity != nil else {
+            return "Application PID \(pid) lacked process-generation identity and was omitted."
+        }
+        switch read.outcome {
+        case .processChanged:
+            return "Application PID \(pid) changed process generation during metadata discovery and was omitted."
+        case let .metadata(metadata) where metadata.name?.isEmpty != false:
+            return "Application PID \(pid) metadata lacked a usable name and was omitted."
+        default:
+            return "Application PID \(pid) could not be represented in the inventory and was omitted."
         }
     }
 

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/System/ApplicationService+WindowListing.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/System/ApplicationService+WindowListing.swift
@@ -126,30 +126,54 @@ extension ApplicationService {
         guard let windowList = CGWindowListCopyWindowInfo(options, kCGNullWindowID) as? [[String: Any]] else {
             return nil
         }
+        let candidates = windowList.compactMap(Self.windowIDInferenceCandidate)
+        return Self.uniqueMatchingWindowID(pid: pid, title: title, bounds: bounds, candidates: candidates)
+    }
 
-        for windowInfo in windowList {
-            guard let ownerPID = windowInfo[kCGWindowOwnerPID as String] as? pid_t,
-                  ownerPID == pid,
-                  let windowTitle = windowInfo[kCGWindowName as String] as? String,
-                  windowTitle == title,
-                  let boundsDict = windowInfo[kCGWindowBounds as String] as? [String: Any],
-                  let x = boundsDict["X"] as? CGFloat,
-                  let y = boundsDict["Y"] as? CGFloat,
-                  let width = boundsDict["Width"] as? CGFloat,
-                  let height = boundsDict["Height"] as? CGFloat
-            else {
-                continue
-            }
-            let candidateBounds = CGRect(x: x, y: y, width: width, height: height)
-            let matchesBounds = abs(candidateBounds.origin.x - bounds.origin.x) < 5 &&
-                abs(candidateBounds.origin.y - bounds.origin.y) < 5 &&
-                abs(candidateBounds.size.width - bounds.size.width) < 5 &&
-                abs(candidateBounds.size.height - bounds.size.height) < 5
-            if matchesBounds, let windowNumber = windowInfo[kCGWindowNumber as String] as? Int {
-                return windowNumber
-            }
+    struct WindowIDInferenceCandidate: Equatable, Sendable {
+        let windowID: Int
+        let ownerProcessIdentifier: pid_t
+        let title: String
+        let bounds: CGRect
+    }
+
+    static func uniqueMatchingWindowID(
+        pid: pid_t,
+        title: String,
+        bounds: CGRect,
+        candidates: [WindowIDInferenceCandidate]) -> Int?
+    {
+        let matches = candidates.filter { candidate in
+            candidate.ownerProcessIdentifier == pid &&
+                candidate.title == title &&
+                abs(candidate.bounds.origin.x - bounds.origin.x) < 5 &&
+                abs(candidate.bounds.origin.y - bounds.origin.y) < 5 &&
+                abs(candidate.bounds.size.width - bounds.size.width) < 5 &&
+                abs(candidate.bounds.size.height - bounds.size.height) < 5
         }
-        return nil
+        guard matches.count == 1 else { return nil }
+        return matches[0].windowID
+    }
+
+    private static func windowIDInferenceCandidate(
+        _ windowInfo: [String: Any]) -> WindowIDInferenceCandidate?
+    {
+        guard let ownerPID = windowInfo[kCGWindowOwnerPID as String] as? pid_t,
+              let windowTitle = windowInfo[kCGWindowName as String] as? String,
+              let boundsDict = windowInfo[kCGWindowBounds as String] as? [String: Any],
+              let x = boundsDict["X"] as? CGFloat,
+              let y = boundsDict["Y"] as? CGFloat,
+              let width = boundsDict["Width"] as? CGFloat,
+              let height = boundsDict["Height"] as? CGFloat,
+              let windowNumber = windowInfo[kCGWindowNumber as String] as? Int
+        else {
+            return nil
+        }
+        return WindowIDInferenceCandidate(
+            windowID: windowNumber,
+            ownerProcessIdentifier: ownerPID,
+            title: windowTitle,
+            bounds: CGRect(x: x, y: y, width: width, height: height))
     }
 
     private func spaceInfo(for windowID: CGWindowID) -> (spaceID: UInt64?, spaceName: String?) {
@@ -170,7 +194,8 @@ extension ApplicationService {
         windows: [ServiceWindowInfo],
         app: ServiceApplicationInfo,
         startTime: Date,
-        warnings: [String]) -> UnifiedToolOutput<ServiceWindowListData>
+        warnings: [String],
+        additionalHints: [String] = []) -> UnifiedToolOutput<ServiceWindowListData>
     {
         let normalizedWindows = ApplicationService.normalizeWindowIndices(windows)
         let processedCount = normalizedWindows.count
@@ -208,6 +233,6 @@ extension ApplicationService {
             metadata: UnifiedToolOutput.Metadata(
                 duration: Date().timeIntervalSince(startTime),
                 warnings: warnings,
-                hints: ["Use window title or index to target specific window"]))
+                hints: ["Use window title or index to target specific window"] + additionalHints))
     }
 }

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/System/ApplicationService.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/System/ApplicationService.swift
@@ -42,8 +42,8 @@ import PeekabooFoundation
  * - Since: PeekabooCore 1.0.0
  */
 @MainActor
-public final class ApplicationService: ApplicationServiceProtocol, ApplicationServiceActionResultProviding,
-    ApplicationServiceTargetedActionResultProviding
+public final class ApplicationService: ApplicationServiceProtocol, ApplicationMutationInventoryProviding,
+    ApplicationServiceActionResultProviding, ApplicationServiceTargetedActionResultProviding
 {
     public let supportsApplicationLaunchOptions = true
     public let supportsSafeBackgroundApplicationLaunchNoOp = true
@@ -107,6 +107,8 @@ public final class ApplicationService: ApplicationServiceProtocol, ApplicationSe
         _ configuration: NSWorkspace.OpenConfiguration) async throws -> NSRunningApplication
     typealias RunningApplicationsForURLProvider = @MainActor (_ applicationURL: URL) -> [NSRunningApplication]
     typealias ApplicationSelectorCandidatesProvider = @MainActor () -> [ApplicationIdentifierMatcher.Candidate]
+    typealias ApplicationMutationCandidateProvider = @MainActor (_ processIdentifier: pid_t)
+        -> ApplicationIdentifierMatcher.Candidate?
     typealias RelaunchTargetResolver = @MainActor (_ identifier: String) async throws -> ServiceApplicationInfo
     typealias RelaunchQuitHandler = @MainActor (_ request: ApplicationQuitRequest) async throws
         -> ApplicationQuitAttempt
@@ -146,6 +148,7 @@ public final class ApplicationService: ApplicationServiceProtocol, ApplicationSe
     let defaultApplicationOpenHandler: DefaultApplicationOpenHandler
     let runningApplicationsForURLProvider: RunningApplicationsForURLProvider
     let applicationSelectorCandidatesProvider: ApplicationSelectorCandidatesProvider
+    let applicationMutationCandidateProvider: ApplicationMutationCandidateProvider
     let relaunchTargetResolver: RelaunchTargetResolver?
     let relaunchQuitHandler: RelaunchQuitHandler?
     let relaunchRunningHandler: RelaunchRunningHandler?
@@ -227,6 +230,12 @@ public final class ApplicationService: ApplicationServiceProtocol, ApplicationSe
                 .filter { !$0.isTerminated }
                 .map(ApplicationService.identifierCandidate)
         },
+        applicationMutationCandidateProvider: @escaping ApplicationMutationCandidateProvider = { pid in
+            guard let application = NSRunningApplication(processIdentifier: pid), !application.isTerminated else {
+                return nil
+            }
+            return ApplicationService.identifierCandidate(application)
+        },
         relaunchTargetResolver: RelaunchTargetResolver? = nil,
         relaunchQuitHandler: RelaunchQuitHandler? = nil,
         relaunchRunningHandler: RelaunchRunningHandler? = nil,
@@ -291,6 +300,7 @@ public final class ApplicationService: ApplicationServiceProtocol, ApplicationSe
         self.defaultApplicationOpenHandler = defaultApplicationOpenHandler
         self.runningApplicationsForURLProvider = runningApplicationsForURLProvider
         self.applicationSelectorCandidatesProvider = applicationSelectorCandidatesProvider
+        self.applicationMutationCandidateProvider = applicationMutationCandidateProvider
         self.relaunchTargetResolver = relaunchTargetResolver
         self.relaunchQuitHandler = relaunchQuitHandler
         self.relaunchRunningHandler = relaunchRunningHandler

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/System/ApplicationWindowEnumerationContext.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/System/ApplicationWindowEnumerationContext.swift
@@ -431,9 +431,12 @@ struct WindowEnumerationContext {
         var axDescriptorByID: [Int: AXWindowDescriptor] = [:]
         let cgWindowIDs = Set(cgWindows.map(\.windowID))
         var coveredDescriptorIndices = Set<Int>()
+        var claimedDescriptorWindowIDs = Set<Int>()
         for (index, descriptor) in axDescriptors.enumerated() {
             guard let id = descriptor.windowID else { continue }
-            if cgWindowIDs.contains(id) || descriptor.standaloneInfo != nil {
+            if cgWindowIDs.contains(id) || descriptor.standaloneInfo != nil,
+               claimedDescriptorWindowIDs.insert(id).inserted
+            {
                 coveredDescriptorIndices.insert(index)
             }
             if axDescriptorByID[id] == nil {

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/System/ApplicationWindowEnumerationContext.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/System/ApplicationWindowEnumerationContext.swift
@@ -471,7 +471,28 @@ struct WindowEnumerationContext {
             let descriptor = axDescriptors[index]
             return descriptor.windowID == nil && !descriptor.title.isEmpty && descriptor.bounds != nil
         }
-        var consumedFallbacks = Set<Int>()
+        var fallbackDescriptorIndicesByCGWindowID: [Int: [Int]] = [:]
+        for descriptorIndex in boundsFallbackIndices {
+            let descriptor = axDescriptors[descriptorIndex]
+            guard let bounds = descriptor.bounds else { continue }
+            let candidateWindowIDs = Set(cgWindows.compactMap { window -> Int? in
+                guard window.title.isEmpty,
+                      !claimedExactCGWindowIDs.contains(window.windowID),
+                      Self.boundsMatch(bounds, window.bounds),
+                      !Self.boundsOwnedByOtherWindow(
+                          title: descriptor.title,
+                          bounds: bounds,
+                          excluding: window.windowID,
+                          in: cgWindows)
+                else { return nil }
+                return window.windowID
+            })
+            guard candidateWindowIDs.count == 1, let windowID = candidateWindowIDs.first else { continue }
+            fallbackDescriptorIndicesByCGWindowID[windowID, default: []].append(descriptorIndex)
+        }
+        let uniqueFallbackDescriptorByCGWindowID = fallbackDescriptorIndicesByCGWindowID.compactMapValues {
+            $0.count == 1 ? $0[0] : nil
+        }
 
         var merged: [ServiceWindowInfo] = []
         merged.reserveCapacity(cgWindows.count + axDescriptors.count)
@@ -493,21 +514,7 @@ struct WindowEnumerationContext {
                 continue
             }
 
-            if let descriptorIndex = boundsFallbackIndices.first(where: { index in
-                guard !consumedFallbacks.contains(index), let bounds = axDescriptors[index].bounds else {
-                    return false
-                }
-                guard !claimedExactCGWindowIDs.contains(cgWindow.windowID) else { return false }
-                guard Self.boundsMatch(bounds, cgWindow.bounds) else { return false }
-                // Do not hijack: if this AX title+frame already belongs to a different CG window, that
-                // window is the real owner, so leave this untitled entry alone.
-                return !Self.boundsOwnedByOtherWindow(
-                    title: axDescriptors[index].title,
-                    bounds: bounds,
-                    excluding: cgWindow.windowID,
-                    in: cgWindows)
-            }) {
-                consumedFallbacks.insert(descriptorIndex)
+            if let descriptorIndex = uniqueFallbackDescriptorByCGWindowID[cgWindow.windowID] {
                 coveredDescriptorIndices.insert(descriptorIndex)
                 merged.append(enrichedWindow.withTitle(axDescriptors[descriptorIndex].title))
                 continue

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/System/ApplicationWindowEnumerationContext.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/System/ApplicationWindowEnumerationContext.swift
@@ -494,6 +494,7 @@ struct WindowEnumerationContext {
                 guard !consumedFallbacks.contains(index), let bounds = axDescriptors[index].bounds else {
                     return false
                 }
+                guard !claimedExactCGWindowIDs.contains(cgWindow.windowID) else { return false }
                 guard Self.boundsMatch(bounds, cgWindow.bounds) else { return false }
                 // Do not hijack: if this AX title+frame already belongs to a different CG window, that
                 // window is the real owner, so leave this untitled entry alone.

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/System/ApplicationWindowEnumerationContext.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/System/ApplicationWindowEnumerationContext.swift
@@ -11,6 +11,12 @@ struct WindowEnumerationContext {
 
     struct CGSnapshot {
         let windows: [ServiceWindowInfo]
+        let omittedOwnerRowCount: Int
+
+        init(windows: [ServiceWindowInfo], omittedOwnerRowCount: Int = 0) {
+            self.windows = windows
+            self.omittedOwnerRowCount = omittedOwnerRowCount
+        }
     }
 
     /// MainActor-owned descriptor used by the existing CG/AX merge contract. Detached workers return
@@ -144,6 +150,8 @@ struct WindowEnumerationContext {
 
         var windowIndex = 0
         var windows: [ServiceWindowInfo] = []
+        var ownerRowCount = 0
+        var omittedOwnerRowCount = 0
         let screenService = ScreenService()
         let spaceService = SpaceManagementService()
 
@@ -153,6 +161,7 @@ struct WindowEnumerationContext {
             else {
                 continue
             }
+            ownerRowCount += 1
 
             guard let windowInfo = self.snapshotWindowInfo(
                 from: windowInfo,
@@ -160,6 +169,7 @@ struct WindowEnumerationContext {
                 screenService: screenService,
                 spaceService: spaceService)
             else {
+                omittedOwnerRowCount += 1
                 continue
             }
 
@@ -172,12 +182,12 @@ struct WindowEnumerationContext {
             windowIndex += 1
         }
 
-        guard !windows.isEmpty else {
+        guard ownerRowCount > 0 else {
             return nil
         }
 
         self.logger.debug("CGWindowList found \(windows.count) windows for \(self.app.name)")
-        return CGSnapshot(windows: windows)
+        return CGSnapshot(windows: windows, omittedOwnerRowCount: omittedOwnerRowCount)
     }
 
     private func snapshotWindowInfo(
@@ -289,7 +299,7 @@ struct WindowEnumerationContext {
             axResult: axResult,
             cgWindowIDs: Set(snapshot.windows.map(\.windowID)))
 
-        let merged = Self.mergeWindows(cgWindows: snapshot.windows, axDescriptors: descriptors)
+        let merge = Self.mergeWindowInventory(cgWindows: snapshot.windows, axDescriptors: descriptors)
 
         if axResult.timedOut {
             warnings.append("Window enumeration timed out after \(self.axTimeout)s, results may be incomplete")
@@ -302,9 +312,19 @@ struct WindowEnumerationContext {
                 "Accessibility reported \(axResult.reportedWindowCount) windows; " +
                     "enriched \(descriptors.count) before the bounded deadline")
         }
+        if snapshot.omittedOwnerRowCount > 0 {
+            warnings.append(
+                "CoreGraphics omitted \(snapshot.omittedOwnerRowCount) owner window " +
+                    "row\(snapshot.omittedOwnerRowCount == 1 ? "" : "s") without complete identity evidence")
+        }
+        if merge.unmaterializedAXDescriptorCount > 0 {
+            warnings.append(
+                "Accessibility omitted \(merge.unmaterializedAXDescriptorCount) unmatched window " +
+                    "row\(merge.unmaterializedAXDescriptorCount == 1 ? "" : "s") without stable identity")
+        }
 
         return self.service.buildWindowListOutput(
-            windows: merged,
+            windows: merge.windows,
             app: self.app,
             startTime: self.startTime,
             warnings: warnings)
@@ -389,21 +409,55 @@ struct WindowEnumerationContext {
     /// Every decision uses only reliable signals — an exact `CGWindowID`, or a CG-snapshot
     /// title+bounds — never a synthesized ID, so same-titled windows keep distinct positions and
     /// `--window-index` stays aligned with the printed list.
+    struct WindowMergeResult: Sendable {
+        let windows: [ServiceWindowInfo]
+        let unmaterializedAXDescriptorCount: Int
+    }
+
     nonisolated static func mergeWindows(
         cgWindows: [ServiceWindowInfo],
         axDescriptors: [AXWindowDescriptor]) -> [ServiceWindowInfo]
+    {
+        self.mergeWindowInventory(cgWindows: cgWindows, axDescriptors: axDescriptors).windows
+    }
+
+    nonisolated static func mergeWindowInventory(
+        cgWindows: [ServiceWindowInfo],
+        axDescriptors: [AXWindowDescriptor]) -> WindowMergeResult
     {
         // Exact CGWindowID → title is one-to-one (CG windows are deduplicated by ID): an unambiguous
         // enrichment source for the untitled CG window carrying that id.
         var axTitleByID: [Int: String] = [:]
         var axDescriptorByID: [Int: AXWindowDescriptor] = [:]
-        for descriptor in axDescriptors {
+        let cgWindowIDs = Set(cgWindows.map(\.windowID))
+        var coveredDescriptorIndices = Set<Int>()
+        for (index, descriptor) in axDescriptors.enumerated() {
             guard let id = descriptor.windowID else { continue }
+            if cgWindowIDs.contains(id) || descriptor.standaloneInfo != nil {
+                coveredDescriptorIndices.insert(index)
+            }
             if axDescriptorByID[id] == nil {
                 axDescriptorByID[id] = descriptor
             }
             if !descriptor.title.isEmpty, axTitleByID[id] == nil {
                 axTitleByID[id] = descriptor.title
+            }
+        }
+        var claimedExactCGWindowIDs = Set(axDescriptors.compactMap { descriptor -> Int? in
+            guard let windowID = descriptor.windowID, cgWindowIDs.contains(windowID) else { return nil }
+            return windowID
+        })
+        for (index, descriptor) in axDescriptors.enumerated()
+            where descriptor.windowID == nil && !descriptor.title.isEmpty
+        {
+            guard let bounds = descriptor.bounds else { continue }
+            let exactRows = cgWindows.filter {
+                !claimedExactCGWindowIDs.contains($0.windowID) &&
+                    $0.title == descriptor.title && Self.boundsMatch($0.bounds, bounds)
+            }
+            if exactRows.count == 1, let matched = exactRows.first {
+                claimedExactCGWindowIDs.insert(matched.windowID)
+                coveredDescriptorIndices.insert(index)
             }
         }
 
@@ -450,6 +504,7 @@ struct WindowEnumerationContext {
                     in: cgWindows)
             }) {
                 consumedFallbacks.insert(descriptorIndex)
+                coveredDescriptorIndices.insert(descriptorIndex)
                 merged.append(enrichedWindow.withTitle(axDescriptors[descriptorIndex].title))
                 continue
             }
@@ -458,14 +513,17 @@ struct WindowEnumerationContext {
         }
 
         // Append AX-only windows that resolved to a reliable CGWindowID absent from the CG snapshot.
-        for descriptor in axDescriptors {
+        for (index, descriptor) in axDescriptors.enumerated() {
             guard let info = descriptor.standaloneInfo, seenWindowIDs.insert(info.windowID).inserted else {
                 continue
             }
+            coveredDescriptorIndices.insert(index)
             merged.append(info)
         }
 
-        return merged
+        return WindowMergeResult(
+            windows: merged,
+            unmaterializedAXDescriptorCount: axDescriptors.count - coveredDescriptorIndices.count)
     }
 
     /// Whether a titled CG window other than `windowID` already claims this AX title at these bounds,
@@ -508,6 +566,7 @@ struct WindowEnumerationContext {
         var warnings: [String] = []
         let descriptors = self.materializeStandaloneWindows(axResult: axResult, cgWindowIDs: [])
         let windowInfos = descriptors.compactMap(\.standaloneInfo)
+        let unmaterializedDescriptorCount = descriptors.count - windowInfos.count
 
         if axResult.timedOut {
             warnings.append("Window enumeration timed out, results may be incomplete")
@@ -519,16 +578,22 @@ struct WindowEnumerationContext {
             warnings.append(
                 "Only processed \(descriptors.count) of \(axResult.reportedWindowCount) accessible windows")
         }
-
-        if !self.hasScreenRecording {
-            warnings.append("Screen recording permission not granted - window listing may be slower")
+        if unmaterializedDescriptorCount > 0 {
+            warnings.append(
+                "Accessibility omitted \(unmaterializedDescriptorCount) window " +
+                    "row\(unmaterializedDescriptorCount == 1 ? "" : "s") without stable window identity")
         }
+
+        let additionalHints = self.hasScreenRecording
+            ? []
+            : ["Screen recording permission not granted - window listing may be slower"]
 
         return self.service.buildWindowListOutput(
             windows: windowInfos,
             app: self.app,
             startTime: self.startTime,
-            warnings: warnings)
+            warnings: warnings,
+            additionalHints: additionalHints)
     }
 }
 

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/WindowManagementService+Listing.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/WindowManagementService+Listing.swift
@@ -6,6 +6,26 @@ import PeekabooFoundation
 
 @MainActor
 extension WindowManagementService {
+    public func windowMutationInventory(
+        target: WindowTarget) async throws -> DesktopTargetPlanning.Inventory<ServiceWindowInfo>
+    {
+        switch target {
+        case let .application(appIdentifier):
+            return try await self.inventoryForApplication(appIdentifier)
+        case let .applicationAndTitle(appIdentifier, _), let .index(appIdentifier, _):
+            return try await self.inventoryForApplication(appIdentifier)
+        case let .windowId(id):
+            return try await .complete(self.windowById(id))
+        case .title:
+            return try await .partial(
+                self.listWindows(target: target),
+                warnings: ["Global title lookup spans independently bounded application inventories."])
+        case .frontmost:
+            let application = try await self.applicationService.getFrontmostApplication()
+            return try await self.inventoryForApplication("PID:\(application.processIdentifier)")
+        }
+    }
+
     public func listWindows(target: WindowTarget) async throws -> [ServiceWindowInfo] {
         switch target {
         case let .application(appIdentifier):
@@ -34,6 +54,13 @@ extension WindowManagementService {
         case let .windowId(id):
             return try await self.windowById(id)
         }
+    }
+
+    private func inventoryForApplication(
+        _ identifier: String) async throws -> DesktopTargetPlanning.Inventory<ServiceWindowInfo>
+    {
+        let output = try await self.applicationService.listWindows(for: identifier, timeout: nil)
+        return .windowOutput(output)
     }
 
     public func getFocusedWindow() async throws -> ServiceWindowInfo? {

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/WindowManagementService+Resolution.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/WindowManagementService+Resolution.swift
@@ -338,7 +338,14 @@ extension ServiceWindowInfo {
             isOnScreen: isMinimized ? false : self.isOnScreen,
             sharingState: self.sharingState,
             isExcludedFromWindowsMenu: self.isExcludedFromWindowsMenu,
-            mutationIdentity: self.mutationIdentity?.withMinimizedState(isMinimized))
+            mutationIdentity: self.mutationIdentity.map { identity in
+                WindowMutationIdentity(
+                    windowID: identity.windowID,
+                    ownerProcessIdentifier: identity.ownerProcessIdentifier,
+                    ownerProcessStartIdentity: identity.ownerProcessStartIdentity,
+                    capturedBounds: bounds,
+                    isMinimized: isMinimized)
+            })
     }
 }
 

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/WindowManagementService.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/WindowManagementService.swift
@@ -38,6 +38,7 @@ import PeekabooFoundation
  */
 @MainActor
 public final class WindowManagementService: WindowManagementServiceProtocol,
+    WindowMutationInventoryProviding,
     WindowManagementActionOutcomeProviding,
     WindowManagementActionResultProviding,
     WindowManagementPinnedFocusActionResultProviding

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Strategy/DesktopTargetPlanning+Candidates.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Strategy/DesktopTargetPlanning+Candidates.swift
@@ -453,7 +453,7 @@ extension DesktopTargetPlanning {
                 (!lhs.isMinimized, !rhs.isMinimized),
                 (!lhs.isOffScreen, !rhs.isOffScreen),
                 (lhs.isOnScreen, rhs.isOnScreen),
-                (lhs.layer == 0, rhs.layer == 0),
+                (lhs.windowLevel == 0, rhs.windowLevel == 0),
                 (!lhs.title.isEmpty, !rhs.title.isEmpty),
             ])
             for (left, right) in preferences where left != right {

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Strategy/DesktopTargetPlanning+Candidates.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Strategy/DesktopTargetPlanning+Candidates.swift
@@ -1,0 +1,522 @@
+import CoreGraphics
+import Foundation
+import PeekabooFoundation
+
+public enum DesktopTargetPlanningError: LocalizedError, Equatable, Sendable {
+    case invalidSelector(InteractionTargetSelector.ValidationError)
+    case missingApplicationTarget
+    case applicationNotFound(identifier: String, candidatePIDs: [Int32])
+    case ambiguousApplication(identifier: String, candidatePIDs: [Int32])
+    case unsupportedApplicationIdentifier(identifier: String, candidatePIDs: [Int32])
+    case missingProcessIdentity(processIdentifier: Int32)
+    case invalidProcessIdentity(processIdentifier: Int32, processStartIdentity: UInt64)
+    case staleApplication(expected: ApplicationProcessIdentity)
+    case incompleteApplicationInventory(identifier: String, warnings: [String])
+    case applicationInventoryUnavailable(identifier: String)
+    case windowNotFound(selector: String, candidateWindowIDs: [Int])
+    case ambiguousWindow(selector: String, candidateWindowIDs: [Int])
+    case conflictingWindowEntries(windowID: Int)
+    case missingWindowIdentity(windowID: Int)
+    case incompleteWindowIdentity(windowID: Int)
+    case windowOwnerMismatch(windowID: Int, expected: ApplicationProcessIdentity)
+    case staleWindow(expected: WindowMutationIdentity)
+    case incompleteWindowInventory(selector: String, warnings: [String])
+    case windowInventoryUnavailable(selector: String)
+    case invalidWindowInventory(selector: String, reason: String)
+    case unsupportedGlobalWindowTitle
+    case unsupportedFrontmostTarget
+
+    public var errorDescription: String? {
+        switch self {
+        case let .invalidSelector(error):
+            Self.selectorMessage(error)
+        case .missingApplicationTarget:
+            "A mutation-safe application target is required."
+        case let .applicationNotFound(identifier, candidatePIDs):
+            Self.candidateMessage(
+                "No running application exactly matched '\(identifier)'.",
+                pids: candidatePIDs)
+        case let .ambiguousApplication(identifier, candidatePIDs):
+            Self.candidateMessage(
+                "Application target '\(identifier)' matched more than one running process.",
+                pids: candidatePIDs)
+        case let .unsupportedApplicationIdentifier(identifier, candidatePIDs):
+            Self.candidateMessage(
+                "Application target '\(identifier)' is only an executable-name or fuzzy match, which is not " +
+                    "allowed for mutation.",
+                pids: candidatePIDs)
+        case let .missingProcessIdentity(processIdentifier):
+            "Application PID \(processIdentifier) did not include a process-generation receipt."
+        case let .invalidProcessIdentity(processIdentifier, processStartIdentity):
+            "Application identity PID \(processIdentifier), generation \(processStartIdentity) is invalid."
+        case let .staleApplication(expected):
+            "Application PID \(expected.processIdentifier) disappeared or changed process generation."
+        case let .incompleteApplicationInventory(identifier, warnings):
+            Self.inventoryMessage(
+                "Application inventory was incomplete while resolving '\(identifier)'.",
+                warnings: warnings)
+        case let .applicationInventoryUnavailable(identifier):
+            "Application inventory was unavailable while resolving '\(identifier)'."
+        case let .windowNotFound(selector, candidateWindowIDs):
+            Self.windowCandidateMessage("No window matched \(selector).", windowIDs: candidateWindowIDs)
+        case let .ambiguousWindow(selector, candidateWindowIDs):
+            Self.windowCandidateMessage(
+                "Window target \(selector) matched more than one window.",
+                windowIDs: candidateWindowIDs)
+        case let .conflictingWindowEntries(windowID):
+            "Window inventory contained contradictory receipts for window \(windowID)."
+        case let .missingWindowIdentity(windowID):
+            "Window \(windowID) did not include a process-generation mutation receipt."
+        case let .incompleteWindowIdentity(windowID):
+            "Window \(windowID) did not include complete ID, owner-generation, and bounds evidence."
+        case let .windowOwnerMismatch(windowID, expected):
+            "Window \(windowID) is not owned by selected application PID \(expected.processIdentifier) " +
+                "and its exact process generation."
+        case let .staleWindow(expected):
+            "Window \(expected.windowID) disappeared or changed ID, owner generation, or bounds."
+        case let .incompleteWindowInventory(selector, warnings):
+            Self.inventoryMessage(
+                "Window inventory was incomplete while resolving \(selector).",
+                warnings: warnings)
+        case let .windowInventoryUnavailable(selector):
+            "Window inventory was unavailable while resolving \(selector)."
+        case let .invalidWindowInventory(selector, reason):
+            "Window inventory was invalid while resolving \(selector): \(reason)"
+        case .unsupportedGlobalWindowTitle:
+            "Window title and index mutations require an application or PID owner."
+        case .unsupportedFrontmostTarget:
+            "This planner does not permit an implicit frontmost mutation target."
+        }
+    }
+
+    public var refusalReason: DesktopActionOutcome.RefusalReason {
+        switch self {
+        case .invalidSelector, .missingApplicationTarget, .unsupportedGlobalWindowTitle, .unsupportedFrontmostTarget:
+            .invalidRequest
+        default:
+            .targetUnavailable
+        }
+    }
+
+    public var hint: String {
+        switch self {
+        case .invalidSelector, .missingApplicationTarget, .unsupportedGlobalWindowTitle, .unsupportedFrontmostTarget:
+            "Correct the target selector before retrying."
+        case .ambiguousApplication, .unsupportedApplicationIdentifier:
+            "Choose one exact PID from a fresh application inventory."
+        case .ambiguousWindow:
+            "Choose one exact window ID from a fresh window inventory."
+        default:
+            "Refresh the target inventory and retry with its exact PID, process generation, and window ID."
+        }
+    }
+
+    public var desktopActionFailure: DesktopActionFailure {
+        .preDispatchRefusal(
+            reason: self.refusalReason,
+            message: self.localizedDescription,
+            hint: self.hint)
+    }
+
+    private static func selectorMessage(_ error: InteractionTargetSelector.ValidationError) -> String {
+        switch error {
+        case .applicationAndProcessIdentifier:
+            "Provide an application either by identifier or PID, not both."
+        case let .conflictingProcessIdentifiers(application, explicit):
+            "Application PID \(application) conflicts with explicit PID \(explicit)."
+        case .invalidApplicationProcessIdentifier:
+            "The application PID selector is invalid."
+        case .multipleWindowSelectors:
+            "Provide only one of window ID, title, or index."
+        case .windowSelectorRequiresApplication:
+            "Window title and index mutations require an application or PID owner."
+        case .missingTarget:
+            "A mutation target is required."
+        case .emptyApplication:
+            "Application must not be empty."
+        case .emptyWindowTitle:
+            "Window title must not be empty."
+        case .invalidProcessIdentifier:
+            "PID must be a positive 32-bit integer."
+        case .invalidWindowID:
+            "Window ID must be a positive 32-bit integer."
+        case .invalidWindowIndex:
+            "Window index must be zero or greater."
+        }
+    }
+
+    private static func candidateMessage(_ message: String, pids: [Int32]) -> String {
+        guard !pids.isEmpty else { return message + " Use an exact PID target." }
+        return message + " Candidate PIDs: " + pids.map(String.init).joined(separator: ", ") + "."
+    }
+
+    private static func windowCandidateMessage(_ message: String, windowIDs: [Int]) -> String {
+        guard !windowIDs.isEmpty else { return message + " Use an exact window ID." }
+        return message + " Candidate window IDs: " + windowIDs.map(String.init).joined(separator: ", ") + "."
+    }
+
+    private static func inventoryMessage(_ message: String, warnings: [String]) -> String {
+        guard !warnings.isEmpty else { return message }
+        return message + " " + warnings.joined(separator: "; ")
+    }
+}
+
+extension DesktopTargetPlanning {
+    /// Inventory rows plus the provider's completeness evidence.
+    ///
+    /// Mutation planners must not infer uniqueness from a partial catalog. Exact PID and window-ID
+    /// selectors can bypass a partial catalog only when their provider performed a direct lookup.
+    public struct Inventory<Element: Codable & Equatable & Sendable>: Codable, Equatable, Sendable {
+        public enum Completeness: String, Codable, Equatable, Sendable {
+            case complete
+            case partial
+        }
+
+        public let items: [Element]
+        public let completeness: Completeness
+        public let warnings: [String]
+
+        public init(
+            items: [Element],
+            completeness: Completeness,
+            warnings: [String] = [])
+        {
+            self.items = items
+            self.completeness = completeness
+            self.warnings = warnings
+        }
+
+        public static func complete(_ items: [Element]) -> Self {
+            Self(items: items, completeness: .complete)
+        }
+
+        public static func partial(_ items: [Element], warnings: [String]) -> Self {
+            Self(items: items, completeness: .partial, warnings: warnings)
+        }
+
+        public var isComplete: Bool {
+            self.completeness == .complete && self.warnings.isEmpty
+        }
+    }
+
+    struct ApplicationSelection: Equatable, Sendable {
+        let index: Int
+        let resolution: ApplicationIdentifierMatcher.Resolution
+    }
+
+    enum ApplicationMutationSelector {
+        static func normalizedIdentifier(_ rawIdentifier: String) throws -> String {
+            let identifier = ApplicationIdentifierMatcher.normalized(rawIdentifier)
+            guard !identifier.isEmpty else {
+                throw DesktopTargetPlanningError.invalidSelector(.emptyApplication)
+            }
+            if identifier.uppercased().hasPrefix("PID:") {
+                guard let pid = Int32(identifier.dropFirst(4)), pid > 0 else {
+                    throw DesktopTargetPlanningError.invalidSelector(.invalidApplicationProcessIdentifier)
+                }
+            }
+            return identifier
+        }
+
+        static func select(
+            identifier: String,
+            applications: [ServiceApplicationInfo]) throws -> ApplicationSelection
+        {
+            let identifier = try self.normalizedIdentifier(identifier)
+
+            let candidates = applications.map(ApplicationIdentifierMatcher.Candidate.init)
+            let resolution: ApplicationIdentifierMatcher.Resolution?
+            do {
+                resolution = try ApplicationIdentifierMatcher.resolution(
+                    for: identifier,
+                    in: candidates)
+            } catch {
+                throw DesktopTargetPlanningError.applicationInventoryUnavailable(identifier: identifier)
+            }
+            guard let resolution else {
+                throw DesktopTargetPlanningError.applicationNotFound(identifier: identifier, candidatePIDs: [])
+            }
+            let matchingPIDs = candidates.enumerated().compactMap { index, candidate -> Int32? in
+                guard ApplicationIdentifierMatcher.matchKind(for: candidate, identifier: identifier) ==
+                    resolution.matchKind
+                else { return nil }
+                return candidates[index].processIdentifier
+            }
+            let candidatePIDs = Array(Set(matchingPIDs)).sorted()
+
+            switch resolution.matchKind {
+            case .processIdentifier:
+                break
+            case .bundleIdentifier:
+                break
+            case .exactName:
+                break
+            case .bundlePath, .exactExecutable, .fuzzyNameOrExecutable:
+                throw DesktopTargetPlanningError.unsupportedApplicationIdentifier(
+                    identifier: identifier,
+                    candidatePIDs: candidatePIDs)
+            case .windowID, .windowIndex, .exactWindowTitle, .partialWindowTitle, .automaticWindowRank:
+                throw DesktopTargetPlanningError.applicationInventoryUnavailable(identifier: identifier)
+            }
+            guard !resolution.hasWinningTie else {
+                throw DesktopTargetPlanningError.ambiguousApplication(
+                    identifier: identifier,
+                    candidatePIDs: candidatePIDs)
+            }
+            return ApplicationSelection(index: resolution.index, resolution: resolution)
+        }
+    }
+
+    public enum WindowMutationIntent: Equatable, Sendable {
+        case general
+        case restore
+    }
+
+    public enum WindowSelectionPolicy: Equatable, Sendable {
+        case explicit
+        case preferredMutationWindow(WindowMutationIntent)
+    }
+
+    public enum WindowMutationSelection: Equatable, Sendable {
+        case automatic
+        case id(Int)
+        case title(String)
+        case index(Int)
+    }
+
+    public enum WindowCandidateSelector {
+        public static func select(
+            candidates: [ServiceWindowInfo],
+            selector: InteractionTargetSelector.WindowSelector?,
+            policy: WindowSelectionPolicy,
+            expectedOwner: ApplicationProcessIdentity? = nil) throws -> ServiceWindowInfo
+        {
+            let canonical = try self.canonicalizedCandidates(candidates)
+            let selected: ServiceWindowInfo
+            switch selector {
+            case let .id(windowID):
+                selected = try self.selectUniqueID(
+                    windowID,
+                    from: canonical,
+                    selector: "window ID \(windowID)")
+            case let .title(title):
+                selected = try self.selectTitle(title, from: canonical)
+            case let .index(index):
+                selected = try self.selectIndex(index, from: canonical)
+            case nil:
+                guard case let .preferredMutationWindow(intent) = policy else {
+                    throw DesktopTargetPlanningError.windowNotFound(
+                        selector: "an explicit window selector",
+                        candidateWindowIDs: self.windowIDs(canonical))
+                }
+                guard let best = canonical.min(by: { lhs, rhs in
+                    self.isPreferredMutationWindow(lhs, rhs, intent: intent)
+                }) else {
+                    throw DesktopTargetPlanningError.windowNotFound(
+                        selector: "the application's best window",
+                        candidateWindowIDs: self.windowIDs(canonical))
+                }
+                selected = best
+            }
+            try self.validate(selected, expectedOwner: expectedOwner)
+            return selected
+        }
+
+        private static func selectTitle(
+            _ title: String,
+            from candidates: [ServiceWindowInfo]) throws -> ServiceWindowInfo
+        {
+            let exact = candidates.filter {
+                $0.title.compare(title, options: .caseInsensitive) == .orderedSame
+            }
+            if !exact.isEmpty {
+                return try self.selectOneWindowID(exact, selector: "title '\(title)'")
+            }
+            let partial = candidates.filter { $0.title.localizedCaseInsensitiveContains(title) }
+            return try self.selectOneWindowID(partial, selector: "title containing '\(title)'")
+        }
+
+        private static func selectIndex(
+            _ index: Int,
+            from candidates: [ServiceWindowInfo]) throws -> ServiceWindowInfo
+        {
+            let normalizedMatches = candidates.filter { $0.index == index }
+            if !normalizedMatches.isEmpty {
+                return try self.selectOneWindowID(normalizedMatches, selector: "index \(index)")
+            }
+            throw DesktopTargetPlanningError.windowNotFound(
+                selector: "index \(index)",
+                candidateWindowIDs: self.windowIDs(candidates))
+        }
+
+        private static func selectOneWindowID(
+            _ candidates: [ServiceWindowInfo],
+            selector: String) throws -> ServiceWindowInfo
+        {
+            let ids = self.windowIDs(candidates)
+            guard let id = ids.first else {
+                throw DesktopTargetPlanningError.windowNotFound(selector: selector, candidateWindowIDs: [])
+            }
+            guard ids.count == 1 else {
+                throw DesktopTargetPlanningError.ambiguousWindow(
+                    selector: selector,
+                    candidateWindowIDs: ids)
+            }
+            return try self.selectUniqueID(id, from: candidates, selector: selector)
+        }
+
+        private static func selectUniqueID(
+            _ windowID: Int,
+            from candidates: [ServiceWindowInfo],
+            selector: String) throws -> ServiceWindowInfo
+        {
+            let matches = candidates.filter { $0.windowID == windowID }
+            guard !matches.isEmpty else {
+                throw DesktopTargetPlanningError.windowNotFound(
+                    selector: selector,
+                    candidateWindowIDs: self.windowIDs(candidates))
+            }
+            return try self.canonical(matches)
+        }
+
+        static func canonicalizedCandidates(_ candidates: [ServiceWindowInfo]) throws -> [ServiceWindowInfo] {
+            let grouped = Dictionary(grouping: candidates, by: \.windowID)
+            return try grouped.keys.sorted().map { windowID in
+                guard let group = grouped[windowID] else {
+                    preconditionFailure("Grouped window inventory lost window \(windowID)")
+                }
+                return try self.canonical(group)
+            }
+        }
+
+        private static func canonical(_ candidates: [ServiceWindowInfo]) throws -> ServiceWindowInfo {
+            guard let windowID = candidates.first?.windowID,
+                  candidates.allSatisfy({ $0.windowID == windowID })
+            else {
+                preconditionFailure("Window canonicalization requires one window ID")
+            }
+            let identities = candidates.compactMap(\.mutationIdentity)
+            if identities.count != candidates.count, !identities.isEmpty {
+                throw DesktopTargetPlanningError.conflictingWindowEntries(windowID: windowID)
+            }
+            if candidates.count > 1,
+               let firstIdentity = identities.first,
+               candidates.contains(where: { candidate in
+                   guard let identity = candidate.mutationIdentity else { return true }
+                   return !identity.hasSameStableReceipt(as: firstIdentity) ||
+                       identity.windowID != candidate.windowID ||
+                       identity.capturedBounds != candidate.bounds
+               })
+            {
+                throw DesktopTargetPlanningError.conflictingWindowEntries(windowID: windowID)
+            }
+            if let first = candidates.first,
+               candidates.contains(where: { $0.title != first.title || $0.index != first.index })
+            {
+                throw DesktopTargetPlanningError.conflictingWindowEntries(windowID: windowID)
+            }
+            return candidates.sorted(by: self.isPreferredCanonicalWindow)[0]
+        }
+
+        private static func isPreferredCanonicalWindow(
+            _ lhs: ServiceWindowInfo,
+            _ rhs: ServiceWindowInfo) -> Bool
+        {
+            if (lhs.mutationIdentity != nil) != (rhs.mutationIdentity != nil) {
+                return lhs.mutationIdentity != nil
+            }
+            if lhs.isMinimized != rhs.isMinimized {
+                return !lhs.isMinimized
+            }
+            if lhs.index != rhs.index {
+                return lhs.index < rhs.index
+            }
+            if lhs.title != rhs.title {
+                return lhs.title < rhs.title
+            }
+            return lhs.windowID < rhs.windowID
+        }
+
+        private static func isPreferredMutationWindow(
+            _ lhs: ServiceWindowInfo,
+            _ rhs: ServiceWindowInfo,
+            intent: WindowMutationIntent) -> Bool
+        {
+            var preferences: [(Bool, Bool)] = []
+            if intent == .restore {
+                preferences.append((lhs.isMinimized, rhs.isMinimized))
+            }
+            preferences.append(contentsOf: [
+                (lhs.isKeyWindow == true, rhs.isKeyWindow == true),
+                (lhs.isMainWindow, rhs.isMainWindow),
+                (lhs.isFrontmost == true, rhs.isFrontmost == true),
+                (!lhs.isMinimized, !rhs.isMinimized),
+                (!lhs.isOffScreen, !rhs.isOffScreen),
+                (lhs.isOnScreen, rhs.isOnScreen),
+                (lhs.layer == 0, rhs.layer == 0),
+                (!lhs.title.isEmpty, !rhs.title.isEmpty),
+            ])
+            for (left, right) in preferences where left != right {
+                return left
+            }
+            let leftArea = lhs.bounds.width * lhs.bounds.height
+            let rightArea = rhs.bounds.width * rhs.bounds.height
+            if leftArea != rightArea {
+                return leftArea > rightArea
+            }
+            if lhs.index != rhs.index {
+                return lhs.index < rhs.index
+            }
+            return lhs.windowID < rhs.windowID
+        }
+
+        static func validate(
+            _ window: ServiceWindowInfo,
+            expectedOwner: ApplicationProcessIdentity?) throws
+        {
+            guard let identity = window.mutationIdentity else {
+                throw DesktopTargetPlanningError.missingWindowIdentity(windowID: window.windowID)
+            }
+            guard window.windowID > 0,
+                  CGWindowID(exactly: window.windowID) != nil,
+                  identity.windowID == window.windowID,
+                  CGWindowID(exactly: identity.windowID) != nil,
+                  identity.ownerProcessIdentifier > 0,
+                  identity.ownerProcessStartIdentity > 0,
+                  let capturedBounds = identity.capturedBounds,
+                  capturedBounds == window.bounds
+            else {
+                throw DesktopTargetPlanningError.incompleteWindowIdentity(windowID: window.windowID)
+            }
+            if let expectedOwner, identity.processIdentity != expectedOwner {
+                throw DesktopTargetPlanningError.windowOwnerMismatch(
+                    windowID: window.windowID,
+                    expected: expectedOwner)
+            }
+        }
+
+        private static func windowIDs(_ candidates: [ServiceWindowInfo]) -> [Int] {
+            Array(Set(candidates.map(\.windowID))).sorted()
+        }
+    }
+}
+
+extension DesktopTargetPlanning.Inventory where Element == ServiceWindowInfo {
+    public static func windowOutput(_ output: UnifiedToolOutput<ServiceWindowListData>) -> Self {
+        var warnings = output.metadata.warnings
+        for window in output.data.windows {
+            do {
+                try DesktopTargetPlanning.WindowCandidateSelector.validate(window, expectedOwner: nil)
+            } catch {
+                warnings.append(error.localizedDescription)
+            }
+        }
+        warnings = Array(Set(warnings)).sorted()
+        return Self(
+            items: output.data.windows,
+            completeness: output.summary.status == .success && warnings.isEmpty
+                ? .complete
+                : .partial,
+            warnings: warnings)
+    }
+}

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Strategy/DesktopTargetPlanning+MutationPlanners.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Strategy/DesktopTargetPlanning+MutationPlanners.swift
@@ -376,11 +376,19 @@ extension DesktopTargetPlanning {
                     selector: selectorDescription,
                     warnings: inventory.warnings)
             }
-            let selected = try WindowCandidateSelector.select(
-                candidates: inventory.items,
-                selector: windowSelector,
-                policy: windowSelector == nil ? automaticSelection : .explicit,
-                expectedOwner: owner?.processIdentity)
+            let selected: ServiceWindowInfo
+            do {
+                selected = try WindowCandidateSelector.select(
+                    candidates: inventory.items,
+                    selector: windowSelector,
+                    policy: windowSelector == nil ? automaticSelection : .explicit,
+                    expectedOwner: owner?.processIdentity)
+            } catch {
+                if let owner {
+                    _ = try await self.applications.revalidate(owner)
+                }
+                throw error
+            }
             guard let selectedIdentity = selected.mutationIdentity else {
                 throw DesktopTargetPlanningError.missingWindowIdentity(windowID: selected.windowID)
             }

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Strategy/DesktopTargetPlanning+MutationPlanners.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Strategy/DesktopTargetPlanning+MutationPlanners.swift
@@ -12,6 +12,12 @@ extension DesktopTargetPlanning {
             "PID:\(self.processIdentity.processIdentifier)"
         }
 
+        public var expectedTargetIdentity: DesktopTargetIdentity {
+            get throws {
+                try DesktopTargetIdentity(processIdentity: self.processIdentity)
+            }
+        }
+
         init(
             application: ServiceApplicationInfo,
             processIdentity: ApplicationProcessIdentity,
@@ -260,6 +266,17 @@ extension DesktopTargetPlanning {
             .windowId(self.identity.windowID)
         }
 
+        public var expectedTargetIdentity: DesktopTargetIdentity {
+            get throws {
+                guard let bounds = self.identity.capturedBounds else {
+                    throw DesktopTargetPlanningError.incompleteWindowIdentity(windowID: self.identity.windowID)
+                }
+                return try DesktopTargetIdentity(exactWindow: UIAutomationTarget.ExactWindow(
+                    identity: self.identity,
+                    bounds: bounds))
+            }
+        }
+
         init(
             selectionWindow: ServiceWindowInfo,
             identity: WindowMutationIdentity,
@@ -340,6 +357,7 @@ extension DesktopTargetPlanning {
             let selectorDescription = Self.selectorDescription(windowSelector)
             let inventory = try await self.windowInventory(
                 target: inventoryTarget,
+                expectedOwner: owner?.processIdentity,
                 directSelectorDescription: {
                     if case .id = windowSelector {
                         return selectorDescription
@@ -442,11 +460,13 @@ extension DesktopTargetPlanning {
             } catch let error as DesktopTargetPlanningError {
                 throw error
             } catch let error as PeekabooError {
-                guard case .windowNotFound = error else {
+                switch error {
+                case .windowNotFound, .appNotFound, .snapshotStale:
+                    throw DesktopTargetPlanningError.staleWindow(expected: plan.identity)
+                default:
                     throw DesktopTargetPlanningError.windowInventoryUnavailable(
                         selector: Self.targetDescription(plan.target))
                 }
-                throw DesktopTargetPlanningError.staleWindow(expected: plan.identity)
             } catch {
                 throw DesktopTargetPlanningError.windowInventoryUnavailable(
                     selector: Self.targetDescription(plan.target))
@@ -491,6 +511,7 @@ extension DesktopTargetPlanning {
                 revalidateBeforeReturn: false)
             let inventory = try await self.windowInventory(
                 target: .application(owner.target),
+                expectedOwner: owner.processIdentity,
                 directSelectorDescription: nil)
             guard inventory.isComplete else {
                 throw DesktopTargetPlanningError.incompleteWindowInventory(
@@ -586,6 +607,7 @@ extension DesktopTargetPlanning {
 
         private func windowInventory(
             target: WindowTarget,
+            expectedOwner: ApplicationProcessIdentity?,
             directSelectorDescription: String?) async throws -> Inventory<ServiceWindowInfo>
         {
             do {
@@ -601,6 +623,14 @@ extension DesktopTargetPlanning {
                     throw DesktopTargetPlanningError.windowNotFound(
                         selector: directSelectorDescription,
                         candidateWindowIDs: [])
+                }
+                if let expectedOwner {
+                    switch error {
+                    case .appNotFound, .snapshotStale:
+                        throw DesktopTargetPlanningError.staleApplication(expected: expectedOwner)
+                    default:
+                        break
+                    }
                 }
                 throw DesktopTargetPlanningError.windowInventoryUnavailable(
                     selector: Self.targetDescription(target))

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Strategy/DesktopTargetPlanning+MutationPlanners.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Strategy/DesktopTargetPlanning+MutationPlanners.swift
@@ -1,0 +1,624 @@
+import CoreGraphics
+import Foundation
+import PeekabooFoundation
+
+extension DesktopTargetPlanning {
+    public struct ApplicationMutationPlan: Equatable, Sendable {
+        public let application: ServiceApplicationInfo
+        public let processIdentity: ApplicationProcessIdentity
+        public let selectorProof: SelectorResolutionProof
+
+        public var target: String {
+            "PID:\(self.processIdentity.processIdentifier)"
+        }
+
+        init(
+            application: ServiceApplicationInfo,
+            processIdentity: ApplicationProcessIdentity,
+            selectorProof: SelectorResolutionProof)
+        {
+            self.application = application
+            self.processIdentity = processIdentity
+            self.selectorProof = selectorProof
+        }
+    }
+
+    @MainActor
+    public struct ApplicationMutationPlanner {
+        public typealias InventoryProvider =
+            @MainActor @Sendable () async throws -> Inventory<ServiceApplicationInfo>
+        public typealias FrontmostProvider = @MainActor @Sendable () async throws -> ServiceApplicationInfo
+        public typealias ExactIdentifierProvider =
+            @MainActor @Sendable (_ identifier: String) async throws -> ServiceApplicationInfo
+
+        private let inventoryProvider: InventoryProvider
+        private let frontmostProvider: FrontmostProvider?
+        private let exactIdentifierProvider: ExactIdentifierProvider?
+
+        public init(applications: any ApplicationServiceProtocol) {
+            self.inventoryProvider = {
+                try await applications.mutationApplicationInventory()
+            }
+            self.frontmostProvider = {
+                try await applications.getFrontmostApplication()
+            }
+            self.exactIdentifierProvider = { identifier in
+                try await applications.findApplication(identifier: identifier)
+            }
+        }
+
+        public init(
+            inventoryProvider: @escaping InventoryProvider,
+            frontmostProvider: FrontmostProvider? = nil,
+            exactIdentifierProvider: ExactIdentifierProvider? = nil)
+        {
+            self.inventoryProvider = inventoryProvider
+            self.frontmostProvider = frontmostProvider
+            self.exactIdentifierProvider = exactIdentifierProvider
+        }
+
+        func plan(
+            selector: InteractionTargetSelector,
+            expectedIdentity: ApplicationProcessIdentity? = nil) async throws -> ApplicationMutationPlan
+        {
+            try await self.resolve(
+                selector: selector,
+                expectedIdentity: expectedIdentity,
+                revalidateBeforeReturn: true)
+        }
+
+        public func plan(
+            identifier: String,
+            expectedIdentity: ApplicationProcessIdentity? = nil) async throws -> ApplicationMutationPlan
+        {
+            try await self.plan(
+                selector: InteractionTargetSelector(applicationIdentifier: identifier),
+                expectedIdentity: expectedIdentity)
+        }
+
+        public func plan(
+            processIdentifier: Int32,
+            expectedIdentity: ApplicationProcessIdentity? = nil) async throws -> ApplicationMutationPlan
+        {
+            try await self.plan(
+                selector: InteractionTargetSelector(processIdentifier: Int(processIdentifier)),
+                expectedIdentity: expectedIdentity)
+        }
+
+        public func revalidate(_ plan: ApplicationMutationPlan) async throws -> ApplicationMutationPlan {
+            let originalIdentifier = plan.selectorProof.normalizedSelector
+            let inventory: Inventory<ServiceApplicationInfo> = if let exactIdentifierProvider {
+                try await .complete([self.exactApplication(
+                    identifier: plan.target,
+                    staleIdentity: plan.processIdentity,
+                    provider: exactIdentifierProvider)])
+            } else {
+                try await self.applicationInventory(identifier: plan.target)
+            }
+            guard inventory.isComplete else {
+                throw DesktopTargetPlanningError.incompleteApplicationInventory(
+                    identifier: plan.target,
+                    warnings: inventory.warnings)
+            }
+            let selection: ApplicationSelection
+            do {
+                selection = try ApplicationMutationSelector.select(
+                    identifier: plan.target,
+                    applications: inventory.items)
+            } catch let error as DesktopTargetPlanningError {
+                if case .applicationNotFound = error {
+                    throw DesktopTargetPlanningError.staleApplication(expected: plan.processIdentity)
+                }
+                throw error
+            }
+            let application = inventory.items[selection.index]
+            let identity = try Self.validatedIdentity(application)
+            guard identity == plan.processIdentity,
+                  plan.selectorProof.applicationMismatch(
+                      identifier: originalIdentifier,
+                      selectedCandidate: ApplicationIdentifierMatcher.Candidate(application),
+                      processIdentity: identity) == nil
+            else {
+                throw DesktopTargetPlanningError.staleApplication(expected: plan.processIdentity)
+            }
+            return ApplicationMutationPlan(
+                application: application,
+                processIdentity: identity,
+                selectorProof: plan.selectorProof)
+        }
+
+        func resolve(
+            selector: InteractionTargetSelector,
+            expectedIdentity: ApplicationProcessIdentity?,
+            revalidateBeforeReturn: Bool) async throws -> ApplicationMutationPlan
+        {
+            do {
+                try selector.validate(policy: .mutationSafe)
+            } catch let error as InteractionTargetSelector.ValidationError {
+                throw DesktopTargetPlanningError.invalidSelector(error)
+            }
+            guard selector.hasOwnerInput else {
+                throw DesktopTargetPlanningError.missingApplicationTarget
+            }
+            let normalizedTarget = try selector.normalizedApplicationTarget(policy: .mutationSafe).map {
+                try ApplicationMutationSelector.normalizedIdentifier($0)
+            }
+            let isExactPID = normalizedTarget?.uppercased().hasPrefix("PID:") == true
+            let inventory: Inventory<ServiceApplicationInfo> = if let normalizedTarget,
+                                                                  isExactPID,
+                                                                  let exactIdentifierProvider
+            {
+                try await .complete([self.exactApplication(
+                    identifier: normalizedTarget,
+                    staleIdentity: expectedIdentity,
+                    provider: exactIdentifierProvider)])
+            } else {
+                try await self.applicationInventory(identifier: normalizedTarget ?? "application target")
+            }
+            guard inventory.isComplete else {
+                throw DesktopTargetPlanningError.incompleteApplicationInventory(
+                    identifier: normalizedTarget ?? "application target",
+                    warnings: inventory.warnings)
+            }
+            guard let normalizedTarget else {
+                throw DesktopTargetPlanningError.missingApplicationTarget
+            }
+            let selection = try ApplicationMutationSelector.select(
+                identifier: normalizedTarget,
+                applications: inventory.items)
+            let application = inventory.items[selection.index]
+            let processIdentity = try Self.validatedIdentity(application)
+            if let expectedIdentity, processIdentity != expectedIdentity {
+                throw DesktopTargetPlanningError.staleApplication(expected: expectedIdentity)
+            }
+            let plan = ApplicationMutationPlan(
+                application: application,
+                processIdentity: processIdentity,
+                selectorProof: selection.resolution.proof(selectedProcessIdentity: processIdentity))
+            return if revalidateBeforeReturn {
+                try await self.revalidate(plan)
+            } else {
+                plan
+            }
+        }
+
+        func frontmost() async throws -> ServiceApplicationInfo {
+            guard let frontmostProvider else {
+                throw DesktopTargetPlanningError.unsupportedFrontmostTarget
+            }
+            return try await frontmostProvider()
+        }
+
+        private func exactApplication(
+            identifier: String,
+            staleIdentity: ApplicationProcessIdentity?,
+            provider: ExactIdentifierProvider) async throws -> ServiceApplicationInfo
+        {
+            do {
+                return try await provider(identifier)
+            } catch is CancellationError {
+                throw CancellationError()
+            } catch let failure as DesktopActionFailure {
+                throw failure
+            } catch let error as DesktopTargetPlanningError {
+                throw error
+            } catch let error as PeekabooError {
+                guard case .appNotFound = error else {
+                    throw DesktopTargetPlanningError.applicationInventoryUnavailable(identifier: identifier)
+                }
+                if let staleIdentity {
+                    throw DesktopTargetPlanningError.staleApplication(expected: staleIdentity)
+                }
+                throw DesktopTargetPlanningError.applicationNotFound(
+                    identifier: identifier,
+                    candidatePIDs: [])
+            } catch {
+                throw DesktopTargetPlanningError.applicationInventoryUnavailable(identifier: identifier)
+            }
+        }
+
+        private func applicationInventory(
+            identifier: String) async throws -> Inventory<ServiceApplicationInfo>
+        {
+            do {
+                return try await self.inventoryProvider()
+            } catch is CancellationError {
+                throw CancellationError()
+            } catch let failure as DesktopActionFailure {
+                throw failure
+            } catch let error as DesktopTargetPlanningError {
+                throw error
+            } catch {
+                throw DesktopTargetPlanningError.applicationInventoryUnavailable(identifier: identifier)
+            }
+        }
+
+        static func validatedIdentity(
+            _ application: ServiceApplicationInfo) throws -> ApplicationProcessIdentity
+        {
+            guard let identity = application.processIdentity else {
+                throw DesktopTargetPlanningError.missingProcessIdentity(
+                    processIdentifier: application.processIdentifier)
+            }
+            guard identity.processIdentifier > 0, identity.processStartIdentity > 0 else {
+                throw DesktopTargetPlanningError.invalidProcessIdentity(
+                    processIdentifier: identity.processIdentifier,
+                    processStartIdentity: identity.processStartIdentity)
+            }
+            return identity
+        }
+    }
+
+    public struct WindowMutationPlan: Equatable, Sendable {
+        public let selectionWindow: ServiceWindowInfo
+        public let identity: WindowMutationIdentity
+        public let owner: ApplicationMutationPlan
+        public let selection: WindowMutationSelection
+        public let selectorProof: SelectorResolutionProof?
+
+        public var target: WindowTarget {
+            .windowId(self.identity.windowID)
+        }
+
+        init(
+            selectionWindow: ServiceWindowInfo,
+            identity: WindowMutationIdentity,
+            owner: ApplicationMutationPlan,
+            selection: WindowMutationSelection,
+            selectorProof: SelectorResolutionProof?)
+        {
+            self.selectionWindow = selectionWindow
+            self.identity = identity
+            self.owner = owner
+            self.selection = selection
+            self.selectorProof = selectorProof
+        }
+    }
+
+    @MainActor
+    public struct WindowMutationPlanner {
+        public typealias WindowInventoryProvider =
+            @MainActor @Sendable (_ target: WindowTarget) async throws -> Inventory<ServiceWindowInfo>
+
+        private let applications: ApplicationMutationPlanner
+        private let windowInventoryProvider: WindowInventoryProvider
+
+        public init(
+            applications: any ApplicationServiceProtocol,
+            windows: any WindowManagementServiceProtocol)
+        {
+            self.applications = ApplicationMutationPlanner(applications: applications)
+            self.windowInventoryProvider = { target in
+                try await windows.mutationInventory(target: target)
+            }
+        }
+
+        public init(
+            applicationPlanner: ApplicationMutationPlanner,
+            windowInventoryProvider: @escaping WindowInventoryProvider)
+        {
+            self.applications = applicationPlanner
+            self.windowInventoryProvider = windowInventoryProvider
+        }
+
+        public func plan(
+            selector: InteractionTargetSelector,
+            automaticSelection: WindowSelectionPolicy = .preferredMutationWindow(.general)) async throws
+            -> WindowMutationPlan
+        {
+            do {
+                try selector.validate(policy: .mutationSafe)
+            } catch let error as InteractionTargetSelector.ValidationError {
+                throw DesktopTargetPlanningError.invalidSelector(error)
+            }
+            let windowSelector: InteractionTargetSelector.WindowSelector?
+            do {
+                windowSelector = try selector.normalizedWindowSelector(policy: .mutationSafe)
+            } catch let error as InteractionTargetSelector.ValidationError {
+                throw DesktopTargetPlanningError.invalidSelector(error)
+            }
+
+            var owner: ApplicationMutationPlan?
+            if selector.hasOwnerInput {
+                owner = try await self.applications.resolve(
+                    selector: selector,
+                    expectedIdentity: nil,
+                    revalidateBeforeReturn: false)
+            }
+
+            let inventoryTarget: WindowTarget
+            switch windowSelector {
+            case let .id(windowID):
+                inventoryTarget = .windowId(windowID)
+            case .title, .index, nil:
+                guard let owner else {
+                    throw DesktopTargetPlanningError.missingApplicationTarget
+                }
+                inventoryTarget = .application(owner.target)
+            }
+
+            let selectorDescription = Self.selectorDescription(windowSelector)
+            let inventory = try await self.windowInventory(
+                target: inventoryTarget,
+                directSelectorDescription: {
+                    if case .id = windowSelector {
+                        return selectorDescription
+                    }
+                    return nil
+                }())
+            let isDirectWindowIDLookup = if case .id = windowSelector,
+                                            case .windowId = inventoryTarget
+            {
+                true
+            } else {
+                false
+            }
+            guard inventory.isComplete || isDirectWindowIDLookup else {
+                throw DesktopTargetPlanningError.incompleteWindowInventory(
+                    selector: selectorDescription,
+                    warnings: inventory.warnings)
+            }
+            let selected = try WindowCandidateSelector.select(
+                candidates: inventory.items,
+                selector: windowSelector,
+                policy: windowSelector == nil ? automaticSelection : .explicit,
+                expectedOwner: owner?.processIdentity)
+            guard let selectedIdentity = selected.mutationIdentity else {
+                throw DesktopTargetPlanningError.missingWindowIdentity(windowID: selected.windowID)
+            }
+
+            if owner == nil {
+                owner = try await self.applications.resolve(
+                    selector: InteractionTargetSelector(
+                        processIdentifier: Int(selectedIdentity.ownerProcessIdentifier)),
+                    expectedIdentity: selectedIdentity.processIdentity,
+                    revalidateBeforeReturn: false)
+            }
+            guard let owner else {
+                preconditionFailure("Window planning must resolve an owner")
+            }
+            let revalidatedOwner = try await self.applications.revalidate(owner)
+            guard selectedIdentity.processIdentity == revalidatedOwner.processIdentity else {
+                throw DesktopTargetPlanningError.windowOwnerMismatch(
+                    windowID: selected.windowID,
+                    expected: revalidatedOwner.processIdentity)
+            }
+            let selection = Self.windowSelection(for: windowSelector)
+            let selectorProof = try Self.selectorProof(
+                selection: selection,
+                candidates: inventory.items,
+                selected: selected,
+                processIdentity: revalidatedOwner.processIdentity)
+
+            return WindowMutationPlan(
+                selectionWindow: selected,
+                identity: selectedIdentity,
+                owner: revalidatedOwner,
+                selection: selection,
+                selectorProof: selectorProof)
+        }
+
+        public func plan(
+            target: WindowTarget,
+            automaticSelection: WindowSelectionPolicy = .preferredMutationWindow(.general)) async throws
+            -> WindowMutationPlan
+        {
+            switch target {
+            case let .application(application):
+                return try await self.plan(
+                    selector: InteractionTargetSelector(applicationIdentifier: application),
+                    automaticSelection: automaticSelection)
+            case .title:
+                throw DesktopTargetPlanningError.unsupportedGlobalWindowTitle
+            case let .index(application, index):
+                return try await self.plan(
+                    selector: InteractionTargetSelector(
+                        applicationIdentifier: application,
+                        windowIndex: index),
+                    automaticSelection: automaticSelection)
+            case let .applicationAndTitle(application, title):
+                return try await self.plan(
+                    selector: InteractionTargetSelector(
+                        applicationIdentifier: application,
+                        windowTitle: title),
+                    automaticSelection: automaticSelection)
+            case let .windowId(windowID):
+                return try await self.plan(
+                    selector: InteractionTargetSelector(windowID: windowID),
+                    automaticSelection: automaticSelection)
+            case .frontmost:
+                return try await self.planFrontmost(automaticSelection: automaticSelection)
+            }
+        }
+
+        public func revalidate(_ plan: WindowMutationPlan) async throws -> WindowMutationPlan {
+            let inventory: Inventory<ServiceWindowInfo>
+            do {
+                inventory = try await self.windowInventoryProvider(plan.target)
+            } catch is CancellationError {
+                throw CancellationError()
+            } catch let failure as DesktopActionFailure {
+                throw failure
+            } catch let error as DesktopTargetPlanningError {
+                throw error
+            } catch let error as PeekabooError {
+                guard case .windowNotFound = error else {
+                    throw DesktopTargetPlanningError.windowInventoryUnavailable(
+                        selector: Self.targetDescription(plan.target))
+                }
+                throw DesktopTargetPlanningError.staleWindow(expected: plan.identity)
+            } catch {
+                throw DesktopTargetPlanningError.windowInventoryUnavailable(
+                    selector: Self.targetDescription(plan.target))
+            }
+            let selected: ServiceWindowInfo
+            do {
+                selected = try WindowCandidateSelector.select(
+                    candidates: inventory.items,
+                    selector: .id(plan.identity.windowID),
+                    policy: .explicit,
+                    expectedOwner: plan.owner.processIdentity)
+            } catch let error as DesktopTargetPlanningError {
+                switch error {
+                case .windowNotFound, .windowOwnerMismatch:
+                    throw DesktopTargetPlanningError.staleWindow(expected: plan.identity)
+                default:
+                    throw error
+                }
+            }
+            guard let identity = selected.mutationIdentity,
+                  identity.hasSameStableReceipt(as: plan.identity)
+            else {
+                throw DesktopTargetPlanningError.staleWindow(expected: plan.identity)
+            }
+            let owner = try await self.applications.revalidate(plan.owner)
+            return WindowMutationPlan(
+                selectionWindow: plan.selectionWindow,
+                identity: identity,
+                owner: owner,
+                selection: plan.selection,
+                selectorProof: plan.selectorProof)
+        }
+
+        private func planFrontmost(
+            automaticSelection: WindowSelectionPolicy) async throws -> WindowMutationPlan
+        {
+            let frontmost = try await self.applications.frontmost()
+            let identity = try ApplicationMutationPlanner.validatedIdentity(frontmost)
+            let owner = try await self.applications.resolve(
+                selector: InteractionTargetSelector(processIdentifier: Int(frontmost.processIdentifier)),
+                expectedIdentity: identity,
+                revalidateBeforeReturn: false)
+            let inventory = try await self.windowInventory(
+                target: .application(owner.target),
+                directSelectorDescription: nil)
+            guard inventory.isComplete else {
+                throw DesktopTargetPlanningError.incompleteWindowInventory(
+                    selector: "the frontmost application's best window",
+                    warnings: inventory.warnings)
+            }
+            let selected = try WindowCandidateSelector.select(
+                candidates: inventory.items,
+                selector: nil,
+                policy: automaticSelection,
+                expectedOwner: identity)
+            guard let selectedIdentity = selected.mutationIdentity else {
+                throw DesktopTargetPlanningError.missingWindowIdentity(windowID: selected.windowID)
+            }
+            let revalidatedOwner = try await self.applications.revalidate(owner)
+            let selection = WindowMutationSelection.automatic
+            return WindowMutationPlan(
+                selectionWindow: selected,
+                identity: selectedIdentity,
+                owner: revalidatedOwner,
+                selection: selection,
+                selectorProof: nil)
+        }
+
+        private static func selectorProof(
+            selection: WindowMutationSelection,
+            candidates: [ServiceWindowInfo],
+            selected: ServiceWindowInfo,
+            processIdentity: ApplicationProcessIdentity) throws -> SelectorResolutionProof?
+        {
+            let proofSelection: WindowSelection
+            switch selection {
+            case .automatic:
+                return nil
+            case let .id(windowID):
+                proofSelection = .id(CGWindowID(windowID))
+            case let .title(title):
+                proofSelection = .title(title)
+            case let .index(index):
+                proofSelection = .index(index)
+            }
+            do {
+                return try WindowSelectorResolutionProof.make(
+                    selection: proofSelection,
+                    candidates: WindowCandidateSelector.canonicalizedCandidates(candidates),
+                    selected: selected,
+                    processIdentity: processIdentity)
+            } catch let error as WindowSelectorResolutionProof.ResolutionError {
+                throw DesktopTargetPlanningError.invalidWindowInventory(
+                    selector: Self.selectorDescription(selection),
+                    reason: String(describing: error))
+            } catch {
+                throw DesktopTargetPlanningError.invalidWindowInventory(
+                    selector: Self.selectorDescription(selection),
+                    reason: "candidate evidence could not be encoded")
+            }
+        }
+
+        private static func windowSelection(
+            for selector: InteractionTargetSelector.WindowSelector?) -> WindowMutationSelection
+        {
+            switch selector {
+            case let .id(windowID): .id(windowID)
+            case let .title(title): .title(title)
+            case let .index(index): .index(index)
+            case nil: .automatic
+            }
+        }
+
+        private static func selectorDescription(
+            _ selector: InteractionTargetSelector.WindowSelector?) -> String
+        {
+            switch selector {
+            case let .id(windowID):
+                "window ID \(windowID)"
+            case let .title(title):
+                "window title '\(title)'"
+            case let .index(index):
+                "window index \(index)"
+            case nil:
+                "the application's best window"
+            }
+        }
+
+        private static func selectorDescription(_ selection: WindowMutationSelection) -> String {
+            switch selection {
+            case let .id(windowID): "window ID \(windowID)"
+            case let .title(title): "window title '\(title)'"
+            case let .index(index): "window index \(index)"
+            case .automatic: "the application's preferred mutation window"
+            }
+        }
+
+        private func windowInventory(
+            target: WindowTarget,
+            directSelectorDescription: String?) async throws -> Inventory<ServiceWindowInfo>
+        {
+            do {
+                return try await self.windowInventoryProvider(target)
+            } catch is CancellationError {
+                throw CancellationError()
+            } catch let failure as DesktopActionFailure {
+                throw failure
+            } catch let error as DesktopTargetPlanningError {
+                throw error
+            } catch let error as PeekabooError {
+                if case .windowNotFound = error, let directSelectorDescription {
+                    throw DesktopTargetPlanningError.windowNotFound(
+                        selector: directSelectorDescription,
+                        candidateWindowIDs: [])
+                }
+                throw DesktopTargetPlanningError.windowInventoryUnavailable(
+                    selector: Self.targetDescription(target))
+            } catch {
+                throw DesktopTargetPlanningError.windowInventoryUnavailable(
+                    selector: Self.targetDescription(target))
+            }
+        }
+
+        private static func targetDescription(_ target: WindowTarget) -> String {
+            switch target {
+            case let .application(application): "application '\(application)'"
+            case let .title(title): "window title '\(title)'"
+            case let .index(application, index): "window index \(index) for '\(application)'"
+            case let .applicationAndTitle(application, title): "window title '\(title)' for '\(application)'"
+            case let .windowId(windowID): "window ID \(windowID)"
+            case .frontmost: "frontmost window"
+            }
+        }
+    }
+}

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKitTestSupport/AutomationTestFixtures.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKitTestSupport/AutomationTestFixtures.swift
@@ -70,6 +70,21 @@ public enum AutomationTestFixtures {
             activationPolicy: activationPolicy)
     }
 
+    public static func duplicateApplications() -> [ServiceApplicationInfo] {
+        [
+            self.application(
+                processIdentifier: 101,
+                processStartIdentity: 1001,
+                bundleIdentifier: "com.example.Shared",
+                name: "Shared App"),
+            self.application(
+                processIdentifier: 202,
+                processStartIdentity: 2002,
+                bundleIdentifier: "com.example.Shared",
+                name: "Shared App"),
+        ]
+    }
+
     public static func window(
         windowID: Int = 201,
         title: String = "Test Window",
@@ -98,6 +113,27 @@ public enum AutomationTestFixtures {
                     bounds: bounds,
                     isMinimized: isMinimized)
                 : nil)
+    }
+
+    public static func duplicateTitleWindows(
+        processIdentity: ApplicationProcessIdentity = Self.processIdentity()) -> [ServiceWindowInfo]
+    {
+        [
+            self.window(
+                windowID: 201,
+                title: "Shared Document",
+                processIdentity: processIdentity,
+                index: 0),
+            self.window(
+                windowID: 202,
+                title: "Shared Document Copy",
+                processIdentity: processIdentity,
+                index: 1),
+        ]
+    }
+
+    public static func wrongGenerationApplication() -> ServiceApplicationInfo {
+        self.application(processStartIdentity: 9999)
     }
 
     public static func focusedElement(
@@ -249,5 +285,25 @@ public enum AutomationTestFixtures {
             windowBounds: window.bounds,
             windowMutationIdentity: window.mutationIdentity,
             windowID: CGWindowID(window.windowID))
+    }
+}
+
+/// Small lock-backed cell for deterministic `@Sendable` test providers.
+public final class AutomationTestLockedValue<Value: Sendable>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storedValue: Value
+
+    public init(_ value: Value) {
+        self.storedValue = value
+    }
+
+    public var value: Value {
+        get { self.lock.withLock { self.storedValue } }
+        set { self.lock.withLock { self.storedValue = newValue } }
+    }
+
+    @discardableResult
+    public func withValue<Result>(_ body: (inout Value) throws -> Result) rethrows -> Result {
+        try self.lock.withLock { try body(&self.storedValue) }
     }
 }

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ApplicationInventoryTimeoutTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ApplicationInventoryTimeoutTests.swift
@@ -147,6 +147,31 @@ struct ApplicationInventoryTimeoutTests {
 
     @Test
     @MainActor
+    func `mutation inventory omits a live process without a usable selector name`() async throws {
+        let namedPID: pid_t = 40008
+        let unnamedPID: pid_t = 40009
+        let service = ApplicationService(
+            applicationOpenHandler: { _, _, _ in throw ApplicationInventoryFixtureError.unused },
+            applicationMutationCandidateProvider: { pid in
+                ApplicationIdentifierMatcher.Candidate(
+                    processIdentifier: pid,
+                    bundleIdentifier: "com.example.\(pid)",
+                    name: pid == unnamedPID ? "  \n" : "Named App")
+            },
+            processStartIdentityProvider: { pid in UInt64(pid) + 100 },
+            runningApplicationProcessIdentifiersProvider: { [namedPID, unnamedPID] })
+
+        let inventory = try await service.applicationMutationInventory()
+
+        #expect(inventory.items.map(\.processIdentifier) == [namedPID])
+        #expect(!inventory.isComplete)
+        #expect(inventory.warnings == [
+            "Application PID \(unnamedPID) metadata lacked a usable name and was omitted.",
+        ])
+    }
+
+    @Test
+    @MainActor
     func `one timed out process returns truthful partial inventory without dropping other apps`() async throws {
         let healthyPID: pid_t = 41001
         let poisonedPID: pid_t = 41002

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ApplicationInventoryTimeoutTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ApplicationInventoryTimeoutTests.swift
@@ -1,11 +1,148 @@
 import CoreGraphics
 import Foundation
+import PeekabooAutomationKitTestSupport
 import PeekabooFoundation
 import Testing
 @testable import PeekabooAutomationKit
 
 @Suite(.serialized)
 struct ApplicationInventoryTimeoutTests {
+    @Test
+    @MainActor
+    func `omitted and identity-incomplete live processes make inventory partial`() async throws {
+        let changedPID: pid_t = 40001
+        let missingIdentityPID: pid_t = 40002
+        let changedGeneration = AutomationTestLockedValue<UInt64>(70)
+        let service = ApplicationService(
+            applicationOpenHandler: { _, _, _ in throw ApplicationInventoryFixtureError.unused },
+            processStartIdentityProvider: { pid in
+                pid == changedPID ? changedGeneration.value : nil
+            },
+            runningApplicationProcessIdentifiersProvider: { [changedPID, missingIdentityPID] },
+            applicationWindowCatalogProvider: { [] },
+            applicationMetadataProvider: { pid, _, _ in
+                if pid == changedPID {
+                    changedGeneration.value = 71
+                }
+                return Self.metadata(name: "App \(pid)")
+            })
+
+        let output = try await service.listApplications()
+
+        #expect(output.data.applications.map(\.processIdentifier) == [missingIdentityPID])
+        #expect(output.summary.status == .partial)
+        #expect(output.summary.counts["omittedApplications"] == 1)
+        #expect(output.metadata.warnings.contains { $0.contains("changed process generation") })
+        #expect(output.metadata.warnings.contains { $0.contains("Process-generation identity was unavailable") })
+    }
+
+    @Test
+    @MainActor
+    func `metadata without a usable name records an omitted inventory row`() async throws {
+        let pid: pid_t = 40003
+        let service = ApplicationService(
+            applicationOpenHandler: { _, _, _ in throw ApplicationInventoryFixtureError.unused },
+            processStartIdentityProvider: { _ in 73 },
+            runningApplicationProcessIdentifiersProvider: { [pid] },
+            applicationWindowCatalogProvider: { [] },
+            applicationMetadataProvider: { _, _, _ in
+                DetachedApplicationMetadata(
+                    bundleIdentifier: "com.example.unnamed",
+                    name: nil,
+                    bundlePath: nil,
+                    isHidden: false,
+                    activationPolicy: .regular,
+                    isFinishedLaunching: true)
+            })
+
+        let output = try await service.listApplications()
+
+        #expect(output.data.applications.isEmpty)
+        #expect(output.summary.status == .partial)
+        #expect(output.summary.counts["omittedApplications"] == 1)
+        #expect(output.metadata.warnings == ["Application PID \(pid) metadata lacked a usable name and was omitted."])
+    }
+
+    @Test
+    @MainActor
+    func `mutation inventory uses only selector fields and skips presentation enrichment`() async throws {
+        let pid: pid_t = 40004
+        let application = ServiceApplicationInfo(
+            processIdentifier: pid,
+            processStartIdentity: 74,
+            bundleIdentifier: "com.example.fixture",
+            name: "Editor")
+        var windowCatalogReadCount = 0
+        let metadataReadCount = AutomationTestLockedValue(0)
+        let service = ApplicationService(
+            applicationOpenHandler: { _, _, _ in throw ApplicationInventoryFixtureError.unused },
+            applicationMutationCandidateProvider: { _ in
+                ApplicationIdentifierMatcher.Candidate(
+                    processIdentifier: pid,
+                    bundleIdentifier: "com.example.fixture",
+                    name: "Editor",
+                    isRegularApplication: true)
+            },
+            processStartIdentityProvider: { _ in 74 },
+            runningApplicationProcessIdentifiersProvider: { [pid] },
+            applicationWindowCatalogProvider: {
+                windowCatalogReadCount += 1
+                return nil
+            },
+            applicationMetadataProvider: { _, _, _ in
+                metadataReadCount.withValue { $0 += 1 }
+                return Self.metadata(name: "Editor")
+            })
+        let planner = DesktopTargetPlanning.ApplicationMutationPlanner(
+            inventoryProvider: { try await service.applicationMutationInventory() },
+            exactIdentifierProvider: { _ in application })
+
+        let byName = try await planner.plan(identifier: "Editor")
+        let byBundle = try await planner.plan(identifier: "com.example.fixture")
+
+        #expect(byName.processIdentity == application.processIdentity)
+        #expect(byBundle.processIdentity == application.processIdentity)
+        #expect(windowCatalogReadCount == 0)
+        #expect(metadataReadCount.value == 0)
+    }
+
+    @Test
+    @MainActor
+    func `mutation inventory reports missing and drifting process generations as partial`() async throws {
+        let stablePID: pid_t = 40005
+        let missingPID: pid_t = 40006
+        let driftingPID: pid_t = 40007
+        var driftingReads = 0
+        let service = ApplicationService(
+            applicationOpenHandler: { _, _, _ in throw ApplicationInventoryFixtureError.unused },
+            applicationMutationCandidateProvider: { pid in
+                ApplicationIdentifierMatcher.Candidate(
+                    processIdentifier: pid,
+                    bundleIdentifier: "com.example.\(pid)",
+                    name: "App \(pid)")
+            },
+            processStartIdentityProvider: { pid -> UInt64? in
+                switch pid {
+                case stablePID: return 75
+                case missingPID: return nil
+                case driftingPID:
+                    driftingReads += 1
+                    return driftingReads == 1 ? 76 : 77
+                default: return nil
+                }
+            },
+            runningApplicationProcessIdentifiersProvider: { [stablePID, missingPID, driftingPID] })
+
+        let inventory = try await service.applicationMutationInventory()
+
+        #expect(inventory.items.map(\.processIdentifier) == [stablePID])
+        #expect(!inventory.isComplete)
+        #expect(inventory.warnings == [
+            "Application PID \(missingPID) lacked process-generation identity and was omitted.",
+            "Application PID \(driftingPID) changed process generation during inventory and was omitted.",
+        ])
+    }
+
     @Test
     @MainActor
     func `one timed out process returns truthful partial inventory without dropping other apps`() async throws {

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ApplicationInventoryTimeoutTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ApplicationInventoryTimeoutTests.swift
@@ -31,6 +31,7 @@ struct ApplicationInventoryTimeoutTests {
 
         #expect(output.data.applications.map(\.processIdentifier) == [missingIdentityPID])
         #expect(output.summary.status == .partial)
+        #expect(output.summary.counts["incompleteApplications"] == 1)
         #expect(output.summary.counts["omittedApplications"] == 1)
         #expect(output.metadata.warnings.contains { $0.contains("changed process generation") })
         #expect(output.metadata.warnings.contains { $0.contains("Process-generation identity was unavailable") })
@@ -59,6 +60,7 @@ struct ApplicationInventoryTimeoutTests {
 
         #expect(output.data.applications.isEmpty)
         #expect(output.summary.status == .partial)
+        #expect(output.summary.counts["incompleteApplications"] == 0)
         #expect(output.summary.counts["omittedApplications"] == 1)
         #expect(output.metadata.warnings == ["Application PID \(pid) metadata lacked a usable name and was omitted."])
     }

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ApplicationMutationPlannerTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ApplicationMutationPlannerTests.swift
@@ -1,0 +1,256 @@
+import PeekabooAutomationKitTestSupport
+import PeekabooFoundation
+import Testing
+@testable import PeekabooAutomationKit
+
+@MainActor
+struct ApplicationMutationPlannerTests {
+    @Test
+    func `malformed PID selectors refuse before direct provider lookup`() async {
+        var directReadCount = 0
+        let planner = DesktopTargetPlanning.ApplicationMutationPlanner(
+            inventoryProvider: { .complete([]) },
+            exactIdentifierProvider: { _ in
+                directReadCount += 1
+                return AutomationTestFixtures.application()
+            })
+
+        for identifier in ["PID:0", "PID:-1", "PID:999999999999", "PID:not-a-number"] {
+            await #expect(throws: DesktopTargetPlanningError.invalidSelector(
+                .invalidApplicationProcessIdentifier))
+            {
+                _ = try await planner.plan(identifier: identifier)
+            }
+        }
+        #expect(directReadCount == 0)
+    }
+
+    @Test
+    func `planner refuses nonpositive process identities from inventory and direct proof`() async {
+        let invalidPID = AutomationTestFixtures.application(processIdentifier: 0, processStartIdentity: 1)
+        let namePlanner = DesktopTargetPlanning.ApplicationMutationPlanner(
+            inventoryProvider: { .complete([invalidPID]) })
+        await #expect(throws: DesktopTargetPlanningError.invalidProcessIdentity(
+            processIdentifier: 0,
+            processStartIdentity: 1))
+        {
+            _ = try await namePlanner.plan(identifier: "Test App")
+        }
+
+        let invalidGeneration = AutomationTestFixtures.application(
+            processIdentifier: 101,
+            processStartIdentity: 0)
+        let pidPlanner = DesktopTargetPlanning.ApplicationMutationPlanner(
+            inventoryProvider: { .complete([]) },
+            exactIdentifierProvider: { _ in invalidGeneration })
+        await #expect(throws: DesktopTargetPlanningError.invalidProcessIdentity(
+            processIdentifier: 101,
+            processStartIdentity: 0))
+        {
+            _ = try await pidPlanner.plan(identifier: "PID:101")
+        }
+    }
+
+    @Test
+    func `partial inventory never proves unique name or bundle selection`() async {
+        let application = AutomationTestFixtures.application()
+        let planner = DesktopTargetPlanning.ApplicationMutationPlanner(
+            inventoryProvider: {
+                .partial([application], warnings: ["one application timed out"])
+            })
+
+        await #expect(throws: DesktopTargetPlanningError.incompleteApplicationInventory(
+            identifier: "Test App",
+            warnings: ["one application timed out"]))
+        {
+            _ = try await planner.plan(identifier: "Test App")
+        }
+    }
+
+    @Test
+    func `exact PID uses direct proof when broad inventory is partial`() async throws {
+        let application = AutomationTestFixtures.application()
+        var broadReadCount = 0
+        var directReadCount = 0
+        let planner = DesktopTargetPlanning.ApplicationMutationPlanner(
+            inventoryProvider: {
+                broadReadCount += 1
+                return .partial([], warnings: ["catalog incomplete"])
+            },
+            exactIdentifierProvider: { _ in
+                directReadCount += 1
+                return application
+            })
+
+        let plan = try await planner.plan(identifier: "PID:101")
+
+        #expect(plan.processIdentity == application.processIdentity)
+        #expect(broadReadCount == 0)
+        #expect(directReadCount == 2)
+    }
+
+    @Test
+    func `exact provider transport failures stay unavailable instead of impersonating target loss`() async throws {
+        let application = AutomationTestFixtures.application()
+        let shouldFail = AutomationTestLockedValue(true)
+        let planner = DesktopTargetPlanning.ApplicationMutationPlanner(
+            inventoryProvider: { .complete([]) },
+            exactIdentifierProvider: { _ in
+                if shouldFail.value {
+                    throw PeekabooError.commandFailed("raw provider failure")
+                }
+                return application
+            })
+
+        await #expect(throws: DesktopTargetPlanningError.applicationInventoryUnavailable(
+            identifier: "PID:101"))
+        {
+            _ = try await planner.plan(identifier: "PID:101")
+        }
+
+        shouldFail.value = false
+        let plan = try await planner.plan(identifier: "PID:101")
+        shouldFail.value = true
+        await #expect(throws: DesktopTargetPlanningError.applicationInventoryUnavailable(identifier: "PID:101")) {
+            _ = try await planner.revalidate(plan)
+        }
+    }
+
+    @Test
+    func `exact provider absence becomes not found initially and stale after selection`() async throws {
+        let application = AutomationTestFixtures.application()
+        let isMissing = AutomationTestLockedValue(true)
+        let planner = DesktopTargetPlanning.ApplicationMutationPlanner(
+            inventoryProvider: { .complete([]) },
+            exactIdentifierProvider: { identifier in
+                guard !isMissing.value else { throw PeekabooError.appNotFound(identifier) }
+                return application
+            })
+
+        await #expect(throws: DesktopTargetPlanningError.applicationNotFound(
+            identifier: "PID:101",
+            candidatePIDs: []))
+        {
+            _ = try await planner.plan(identifier: "PID:101")
+        }
+
+        isMissing.value = false
+        let plan = try await planner.plan(identifier: "PID:101")
+        isMissing.value = true
+        await #expect(throws: DesktopTargetPlanningError.staleApplication(expected: plan.processIdentity)) {
+            _ = try await planner.revalidate(plan)
+        }
+    }
+
+    @Test
+    func `raw broad inventory errors become canonical unavailable errors`() async {
+        let planner = DesktopTargetPlanning.ApplicationMutationPlanner(
+            inventoryProvider: { throw PeekabooError.timeout("raw inventory timeout") })
+
+        await #expect(throws: DesktopTargetPlanningError.applicationInventoryUnavailable(
+            identifier: "Test App"))
+        {
+            _ = try await planner.plan(identifier: "Test App")
+        }
+    }
+
+    @Test
+    func `planner returns exact canonical PID and revalidates generation`() async throws {
+        let application = AutomationTestFixtures.application()
+        let spy = ApplicationPlannerInventorySpy(inventories: [[application], [application]])
+        let planner = DesktopTargetPlanning.ApplicationMutationPlanner(
+            inventoryProvider: { try .complete(spy.next()) })
+
+        let plan = try await planner.plan(identifier: "Test App")
+
+        #expect(plan.application == application)
+        #expect(plan.target == "PID:101")
+        #expect(plan.processIdentity == application.processIdentity)
+        #expect(plan.selectorProof.scope == .application)
+        #expect(plan.selectorProof.normalizedSelector == "Test App")
+        #expect(plan.selectorProof.matchKind == .exactName)
+        #expect(plan.selectorProof.selectedProcessIdentity == application.processIdentity)
+        #expect(!plan.selectorProof.hasWinningTie)
+        #expect(spy.readCount == 2)
+    }
+
+    @Test
+    func `planner refuses process-generation drift before returning`() async throws {
+        let original = AutomationTestFixtures.application()
+        let changed = AutomationTestFixtures.wrongGenerationApplication()
+        let spy = ApplicationPlannerInventorySpy(inventories: [[original], [changed]])
+        let planner = DesktopTargetPlanning.ApplicationMutationPlanner(
+            inventoryProvider: { try .complete(spy.next()) })
+        let identity = try #require(original.processIdentity)
+
+        await #expect(throws: DesktopTargetPlanningError.staleApplication(expected: identity)) {
+            _ = try await planner.plan(identifier: "Test App")
+        }
+    }
+
+    @Test
+    func `empty exact revalidation becomes stale after a successful selection`() async throws {
+        let application = AutomationTestFixtures.application()
+        let spy = ApplicationPlannerInventorySpy(inventories: [[application], [application], []])
+        let planner = DesktopTargetPlanning.ApplicationMutationPlanner(
+            inventoryProvider: { try .complete(spy.next()) })
+        let plan = try await planner.plan(identifier: "Test App")
+
+        await #expect(throws: DesktopTargetPlanningError.staleApplication(expected: plan.processIdentity)) {
+            _ = try await planner.revalidate(plan)
+        }
+    }
+
+    @Test
+    func `exact revalidation rejects selector metadata rebound onto the same PID generation`() async throws {
+        let selected = AutomationTestFixtures.application(name: "Selected App")
+        let rebound = AutomationTestFixtures.application(
+            bundleIdentifier: "com.example.Rebound",
+            name: "Rebound App")
+        let current = AutomationTestLockedValue(selected)
+        let planner = DesktopTargetPlanning.ApplicationMutationPlanner(
+            inventoryProvider: { .complete([selected]) },
+            exactIdentifierProvider: { _ in current.value })
+
+        let plan = try await planner.plan(identifier: "Selected App")
+        current.value = rebound
+
+        await #expect(throws: DesktopTargetPlanningError.staleApplication(expected: plan.processIdentity)) {
+            _ = try await planner.revalidate(plan)
+        }
+    }
+
+    @Test
+    func `remote inventory without executable data never delegates to legacy lookup`() async {
+        let application = AutomationTestFixtures.application(name: "OpenClaw Desktop Test")
+        let spy = ApplicationPlannerInventorySpy(inventories: [[application]])
+        let planner = DesktopTargetPlanning.ApplicationMutationPlanner(
+            inventoryProvider: { try .complete(spy.next()) })
+
+        await #expect(throws: DesktopTargetPlanningError.applicationNotFound(
+            identifier: "openclaw-desktop",
+            candidatePIDs: []))
+        {
+            _ = try await planner.plan(identifier: "openclaw-desktop")
+        }
+        #expect(spy.readCount == 1)
+    }
+}
+
+@MainActor
+private final class ApplicationPlannerInventorySpy {
+    private var inventories: [[ServiceApplicationInfo]]
+    private(set) var readCount = 0
+
+    init(inventories: [[ServiceApplicationInfo]]) {
+        self.inventories = inventories
+    }
+
+    func next() throws -> [ServiceApplicationInfo] {
+        guard self.readCount < self.inventories.count else {
+            throw PeekabooError.commandFailed("Unexpected application inventory read")
+        }
+        defer { self.readCount += 1 }
+        return self.inventories[self.readCount]
+    }
+}

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ApplicationMutationPlannerTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ApplicationMutationPlannerTests.swift
@@ -166,6 +166,7 @@ struct ApplicationMutationPlannerTests {
         #expect(plan.application == application)
         #expect(plan.target == "PID:101")
         #expect(plan.processIdentity == application.processIdentity)
+        #expect(try plan.expectedTargetIdentity == DesktopTargetIdentity(processIdentity: plan.processIdentity))
         #expect(plan.selectorProof.scope == .application)
         #expect(plan.selectorProof.normalizedSelector == "Test App")
         #expect(plan.selectorProof.matchKind == .exactName)

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ApplicationMutationSelectorTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ApplicationMutationSelectorTests.swift
@@ -1,0 +1,90 @@
+import PeekabooAutomationKitTestSupport
+import PeekabooFoundation
+import Testing
+@testable import PeekabooAutomationKit
+
+struct ApplicationMutationSelectorTests {
+    @Test
+    func `mutation selection admits exact PID bundle and localized name through the canonical grammar`() throws {
+        let application = AutomationTestFixtures.application()
+
+        #expect(try self.select("PID:101", from: [application]).resolution.matchKind == .processIdentifier)
+        #expect(try self.select("com.example.TestApp", from: [application]).resolution.matchKind == .bundleIdentifier)
+        #expect(try self.select("test app", from: [application]).resolution.matchKind == .exactName)
+    }
+
+    @Test
+    func `duplicate exact applications refuse with stable sorted PID guidance`() {
+        let applications = AutomationTestFixtures.duplicateApplications()
+        let expected = DesktopTargetPlanningError.ambiguousApplication(
+            identifier: "com.example.Shared",
+            candidatePIDs: [101, 202])
+
+        #expect(throws: expected) {
+            _ = try self.select("com.example.Shared", from: applications)
+        }
+        #expect(throws: expected) {
+            _ = try self.select("com.example.Shared", from: applications.reversed())
+        }
+    }
+
+    @Test
+    func `path executable and fuzzy selectors retain read compatibility but cannot authorize mutation`() throws {
+        let application = ServiceApplicationInfo(
+            processIdentifier: 101,
+            processStartIdentity: 1001,
+            bundleIdentifier: "com.example.OpenClaw",
+            name: "OpenClaw Desktop Test",
+            bundlePath: "/Applications/OpenClaw Desktop Test.app",
+            executablePath: "/Applications/OpenClaw Desktop Test.app/Contents/MacOS/openclaw-desktop")
+        let candidate = ApplicationIdentifierMatcher.Candidate(application)
+        let selectors = [
+            "/Applications/OpenClaw Desktop Test.app",
+            "openclaw-desktop",
+            "OpenClaw",
+        ]
+
+        for selector in selectors {
+            #expect(ApplicationIdentifierMatcher.matches(candidate, identifier: selector))
+            #expect(throws: DesktopTargetPlanningError.unsupportedApplicationIdentifier(
+                identifier: selector,
+                candidatePIDs: [101]))
+            {
+                _ = try self.select(selector, from: [application])
+            }
+        }
+    }
+
+    @Test
+    func `empty malformed and oversized inventories fail closed`() {
+        let application = AutomationTestFixtures.application()
+
+        #expect(throws: DesktopTargetPlanningError.invalidSelector(.emptyApplication)) {
+            _ = try self.select("  ", from: [application])
+        }
+        #expect(throws: DesktopTargetPlanningError.invalidSelector(.invalidApplicationProcessIdentifier)) {
+            _ = try self.select("PID:0", from: [application])
+        }
+
+        let oversized = (0...ApplicationIdentifierMatcher.maximumProofCandidateCount).map { index in
+            AutomationTestFixtures.application(
+                processIdentifier: Int32(index + 1),
+                processStartIdentity: UInt64(index + 1),
+                bundleIdentifier: "com.example.\(index)",
+                name: "Fixture \(index)")
+        }
+        #expect(throws: DesktopTargetPlanningError.applicationInventoryUnavailable(identifier: "Fixture")) {
+            _ = try self.select("Fixture", from: oversized)
+        }
+    }
+
+    private func select(
+        _ identifier: String,
+        from applications: some Sequence<ServiceApplicationInfo>) throws
+        -> DesktopTargetPlanning.ApplicationSelection
+    {
+        try DesktopTargetPlanning.ApplicationMutationSelector.select(
+            identifier: identifier,
+            applications: Array(applications))
+    }
+}

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/WindowCandidateSelectorTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/WindowCandidateSelectorTests.swift
@@ -118,6 +118,28 @@ struct WindowCandidateSelectorTests {
     }
 
     @Test
+    func `automatic mutation ranking prefers normal window level`() throws {
+        let bounds = CGRect(x: 10, y: 20, width: 640, height: 480)
+        let normal = ServiceWindowInfo(
+            windowID: 305,
+            title: "Normal",
+            bounds: bounds,
+            windowLevel: 0,
+            mutationIdentity: AutomationTestFixtures.windowIdentity(windowID: 305, bounds: bounds))
+        let elevated = ServiceWindowInfo(
+            windowID: 306,
+            title: "Elevated",
+            bounds: bounds,
+            windowLevel: 10,
+            mutationIdentity: AutomationTestFixtures.windowIdentity(windowID: 306, bounds: bounds))
+
+        #expect(try DesktopTargetPlanning.WindowCandidateSelector.select(
+            candidates: [elevated, normal],
+            selector: nil,
+            policy: .preferredMutationWindow(.general)).windowID == normal.windowID)
+    }
+
+    @Test
     func `identity validation refuses missing bounds wrong IDs and wrong owners`() {
         let process = AutomationTestFixtures.processIdentity()
         let missing = AutomationTestFixtures.window(includesMutationIdentity: false)

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/WindowCandidateSelectorTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/WindowCandidateSelectorTests.swift
@@ -1,0 +1,235 @@
+import CoreGraphics
+import PeekabooAutomationKitTestSupport
+import PeekabooFoundation
+import Testing
+@testable import PeekabooAutomationKit
+
+struct WindowCandidateSelectorTests {
+    @Test
+    func `unique exact title wins before partial while duplicate exact refuses deterministically`() throws {
+        let windows = AutomationTestFixtures.duplicateTitleWindows()
+        let selected = try DesktopTargetPlanning.WindowCandidateSelector.select(
+            candidates: windows,
+            selector: .title("Shared Document"),
+            policy: .explicit)
+        #expect(selected.windowID == 201)
+
+        let duplicate = AutomationTestFixtures.window(windowID: 203, title: "shared document", index: 2)
+        let candidates = windows + [duplicate]
+        let expected = DesktopTargetPlanningError.ambiguousWindow(
+            selector: "title 'Shared Document'",
+            candidateWindowIDs: [201, 203])
+        #expect(throws: expected) {
+            _ = try DesktopTargetPlanning.WindowCandidateSelector.select(
+                candidates: candidates,
+                selector: .title("Shared Document"),
+                policy: .explicit)
+        }
+        #expect(throws: expected) {
+            _ = try DesktopTargetPlanning.WindowCandidateSelector.select(
+                candidates: candidates.reversed(),
+                selector: .title("Shared Document"),
+                policy: .explicit)
+        }
+    }
+
+    @Test
+    func `multiple partial titles refuse with sorted candidate IDs`() {
+        let windows = Array(AutomationTestFixtures.duplicateTitleWindows().reversed())
+        #expect(throws: DesktopTargetPlanningError.ambiguousWindow(
+            selector: "title containing 'Shared'",
+            candidateWindowIDs: [201, 202]))
+        {
+            _ = try DesktopTargetPlanning.WindowCandidateSelector.select(
+                candidates: windows,
+                selector: .title("Shared"),
+                policy: .explicit)
+        }
+    }
+
+    @Test
+    func `normalized index is authoritative and never falls back to inventory position`() throws {
+        let first = AutomationTestFixtures.window(windowID: 201, index: 4)
+        let second = AutomationTestFixtures.window(windowID: 202, index: 7)
+
+        #expect(try DesktopTargetPlanning.WindowCandidateSelector.select(
+            candidates: [first, second],
+            selector: .index(7),
+            policy: .explicit).windowID == 202)
+        #expect(throws: DesktopTargetPlanningError.self) {
+            _ = try DesktopTargetPlanning.WindowCandidateSelector.select(
+                candidates: [first, second],
+                selector: .index(0),
+                policy: .explicit)
+        }
+    }
+
+    @Test
+    func `automatic selection requires an explicit mutation policy`() throws {
+        let windows = AutomationTestFixtures.duplicateTitleWindows()
+        #expect(throws: DesktopTargetPlanningError.self) {
+            _ = try DesktopTargetPlanning.WindowCandidateSelector.select(
+                candidates: windows,
+                selector: nil,
+                policy: .explicit)
+        }
+        #expect(try DesktopTargetPlanning.WindowCandidateSelector.select(
+            candidates: windows,
+            selector: nil,
+            policy: .preferredMutationWindow(.general)).windowID == 201)
+    }
+
+    @Test
+    func `automatic mutation selection retains minimized and offscreen exact windows`() throws {
+        let minimized = AutomationTestFixtures.window(
+            windowID: 301,
+            title: "Minimized",
+            isMinimized: true)
+        let offscreenBounds = CGRect(x: -2000, y: 100, width: 640, height: 480)
+        let offscreen = ServiceWindowInfo(
+            windowID: 302,
+            title: "Offscreen",
+            bounds: offscreenBounds,
+            isOffScreen: true,
+            isOnScreen: false,
+            mutationIdentity: AutomationTestFixtures.windowIdentity(
+                windowID: 302,
+                bounds: offscreenBounds))
+
+        #expect(try DesktopTargetPlanning.WindowCandidateSelector.select(
+            candidates: [minimized],
+            selector: nil,
+            policy: .preferredMutationWindow(.general)).windowID == minimized.windowID)
+        #expect(try DesktopTargetPlanning.WindowCandidateSelector.select(
+            candidates: [offscreen],
+            selector: nil,
+            policy: .preferredMutationWindow(.general)).windowID == offscreen.windowID)
+    }
+
+    @Test
+    func `restore intent prefers a minimized window over a visible sibling`() throws {
+        let visible = AutomationTestFixtures.window(windowID: 303, title: "Visible", isMinimized: false)
+        let minimized = AutomationTestFixtures.window(windowID: 304, title: "Minimized", isMinimized: true)
+
+        #expect(try DesktopTargetPlanning.WindowCandidateSelector.select(
+            candidates: [visible, minimized],
+            selector: nil,
+            policy: .preferredMutationWindow(.restore)).windowID == minimized.windowID)
+    }
+
+    @Test
+    func `identity validation refuses missing bounds wrong IDs and wrong owners`() {
+        let process = AutomationTestFixtures.processIdentity()
+        let missing = AutomationTestFixtures.window(includesMutationIdentity: false)
+        #expect(throws: DesktopTargetPlanningError.missingWindowIdentity(windowID: missing.windowID)) {
+            _ = try DesktopTargetPlanning.WindowCandidateSelector.select(
+                candidates: [missing],
+                selector: .id(missing.windowID),
+                policy: .explicit)
+        }
+
+        let noBounds = ServiceWindowInfo(
+            windowID: 201,
+            title: "No Bounds Receipt",
+            bounds: CGRect(x: 1, y: 2, width: 3, height: 4),
+            mutationIdentity: AutomationTestFixtures.windowIdentity(bounds: nil))
+        #expect(throws: DesktopTargetPlanningError.incompleteWindowIdentity(windowID: 201)) {
+            _ = try DesktopTargetPlanning.WindowCandidateSelector.select(
+                candidates: [noBounds],
+                selector: .id(201),
+                policy: .explicit)
+        }
+
+        let window = AutomationTestFixtures.window(processIdentity: process)
+        let other = AutomationTestFixtures.processIdentity(processIdentifier: 202, processStartIdentity: 2002)
+        #expect(throws: DesktopTargetPlanningError.windowOwnerMismatch(windowID: 201, expected: other)) {
+            _ = try DesktopTargetPlanning.WindowCandidateSelector.select(
+                candidates: [window],
+                selector: .id(201),
+                policy: .explicit,
+                expectedOwner: other)
+        }
+    }
+
+    @Test
+    func `duplicate rows with the same stable receipt coalesce across minimized state`() throws {
+        let visible = AutomationTestFixtures.window(isMinimized: false)
+        let minimized = AutomationTestFixtures.window(isMinimized: true)
+        let selected = try DesktopTargetPlanning.WindowCandidateSelector.select(
+            candidates: [minimized, visible],
+            selector: .id(visible.windowID),
+            policy: .explicit)
+        #expect(!selected.isMinimized)
+    }
+
+    @Test
+    func `conflicting duplicate titles refuse before title filtering independent of row order`() {
+        let matching = AutomationTestFixtures.window(title: "Target Document")
+        let conflicting = AutomationTestFixtures.window(title: "Different Document")
+        let expected = DesktopTargetPlanningError.conflictingWindowEntries(windowID: matching.windowID)
+
+        for candidates in [[matching, conflicting], [conflicting, matching]] {
+            #expect(throws: expected) {
+                _ = try DesktopTargetPlanning.WindowCandidateSelector.select(
+                    candidates: candidates,
+                    selector: .title(matching.title),
+                    policy: .explicit)
+            }
+        }
+    }
+
+    @Test
+    func `conflicting duplicate indices refuse before index filtering independent of row order`() {
+        let matching = AutomationTestFixtures.window(index: 3)
+        let conflicting = AutomationTestFixtures.window(index: 7)
+        let expected = DesktopTargetPlanningError.conflictingWindowEntries(windowID: matching.windowID)
+
+        for candidates in [[matching, conflicting], [conflicting, matching]] {
+            #expect(throws: expected) {
+                _ = try DesktopTargetPlanning.WindowCandidateSelector.select(
+                    candidates: candidates,
+                    selector: .index(matching.index),
+                    policy: .explicit)
+            }
+        }
+    }
+
+    @Test
+    func `title and index refuse window IDs outside the WindowServer range`() {
+        let oversizedID = Int(UInt32.max) + 1
+        let oversized = AutomationTestFixtures.window(windowID: oversizedID, title: "Oversized", index: 3)
+
+        for selector: InteractionTargetSelector.WindowSelector in [.title("Oversized"), .index(3)] {
+            #expect(throws: DesktopTargetPlanningError.incompleteWindowIdentity(windowID: oversizedID)) {
+                _ = try DesktopTargetPlanning.WindowCandidateSelector.select(
+                    candidates: [oversized],
+                    selector: selector,
+                    policy: .explicit)
+            }
+        }
+    }
+
+    @Test
+    func `duplicate rows refuse missing receipts and external bounds conflicts`() {
+        let valid = AutomationTestFixtures.window()
+        let missing = AutomationTestFixtures.window(includesMutationIdentity: false)
+        #expect(throws: DesktopTargetPlanningError.conflictingWindowEntries(windowID: valid.windowID)) {
+            _ = try DesktopTargetPlanning.WindowCandidateSelector.select(
+                candidates: [valid, missing],
+                selector: .id(valid.windowID),
+                policy: .explicit)
+        }
+
+        let mismatchedBounds = ServiceWindowInfo(
+            windowID: valid.windowID,
+            title: valid.title,
+            bounds: valid.bounds.offsetBy(dx: 1, dy: 0),
+            mutationIdentity: valid.mutationIdentity)
+        #expect(throws: DesktopTargetPlanningError.conflictingWindowEntries(windowID: valid.windowID)) {
+            _ = try DesktopTargetPlanning.WindowCandidateSelector.select(
+                candidates: [valid, mismatchedBounds],
+                selector: .id(valid.windowID),
+                policy: .explicit)
+        }
+    }
+}

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/WindowEnumerationTimeoutTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/WindowEnumerationTimeoutTests.swift
@@ -9,6 +9,170 @@ import Testing
 @MainActor
 struct WindowEnumerationTimeoutTests {
     @Test
+    func `AX rows without stable window identity make an AX-only inventory partial`() async throws {
+        let identity = ApplicationProcessIdentity(processIdentifier: 40, processStartIdentity: 5)
+        let service = Self.makeService { _ in identity.processStartIdentity }
+        let context = WindowEnumerationContext(
+            service: service,
+            app: Self.application(identity: identity),
+            startTime: Date(),
+            axTimeout: 0.05,
+            hasScreenRecording: true,
+            logger: Self.logger,
+            processIdentity: identity,
+            cgSnapshotProvider: { nil },
+            applicationRunningProvider: { true },
+            axEnumerator: { _, _ in
+                DetachedAXWindowEnumerationResult(
+                    descriptors: [DetachedAXWindowDescriptor(
+                        windowID: nil,
+                        title: "Unidentified",
+                        bounds: CGRect(x: 10, y: 20, width: 800, height: 600))],
+                    focusedWindowID: nil,
+                    timedOut: false,
+                    incomplete: false,
+                    reportedWindowCount: 1)
+            })
+
+        let output = try await context.run()
+        let inventory: DesktopTargetPlanning.Inventory<ServiceWindowInfo> = .windowOutput(output)
+
+        #expect(output.data.windows.isEmpty)
+        #expect(output.summary.status == .partial)
+        #expect(output.metadata.warnings == [
+            "Accessibility omitted 1 window row without stable window identity",
+        ])
+        #expect(!inventory.isComplete)
+    }
+
+    @Test
+    func `missing screen recording notice does not poison complete AX selector inventory`() {
+        let identity = ApplicationProcessIdentity(processIdentifier: 39, processStartIdentity: 4)
+        let service = Self.makeService { _ in identity.processStartIdentity }
+        let window = ServiceWindowInfo(
+            windowID: 331,
+            title: "AX Window",
+            bounds: CGRect(x: 10, y: 20, width: 800, height: 600),
+            mutationIdentity: WindowMutationIdentity(
+                windowID: 331,
+                ownerProcessIdentifier: identity.processIdentifier,
+                ownerProcessStartIdentity: identity.processStartIdentity,
+                capturedBounds: CGRect(x: 10, y: 20, width: 800, height: 600)))
+        let output = service.buildWindowListOutput(
+            windows: [window],
+            app: Self.application(identity: identity),
+            startTime: Date(),
+            warnings: [],
+            additionalHints: ["Screen recording permission not granted - window listing may be slower"])
+        let inventory: DesktopTargetPlanning.Inventory<ServiceWindowInfo> = .windowOutput(output)
+
+        #expect(output.summary.status == .success)
+        #expect(output.metadata.warnings.isEmpty)
+        #expect(output.metadata.hints.contains(
+            "Screen recording permission not granted - window listing may be slower"))
+        #expect(inventory.isComplete)
+        #expect(inventory.warnings.isEmpty)
+        #expect(inventory.items.map(\.windowID) == [331])
+    }
+
+    @Test
+    func `successful presentation output with incomplete row identity remains partial for mutation`() {
+        let identity = ApplicationProcessIdentity(processIdentifier: 37, processStartIdentity: 2)
+        let service = Self.makeService { _ in identity.processStartIdentity }
+        let incomplete = ServiceWindowInfo(
+            windowID: 329,
+            title: "Incomplete",
+            bounds: CGRect(x: 10, y: 20, width: 800, height: 600))
+        let output = service.buildWindowListOutput(
+            windows: [incomplete],
+            app: Self.application(identity: identity),
+            startTime: Date(),
+            warnings: [])
+
+        let inventory: DesktopTargetPlanning.Inventory<ServiceWindowInfo> = .windowOutput(output)
+
+        #expect(output.summary.status == .success)
+        #expect(!inventory.isComplete)
+        #expect(inventory.warnings == [
+            "Window 329 did not include a process-generation mutation receipt.",
+        ])
+    }
+
+    @Test
+    func `unmaterialized CoreGraphics owner rows make inventory partial`() async throws {
+        let identity = ApplicationProcessIdentity(processIdentifier: 41, processStartIdentity: 6)
+        let service = Self.makeService { _ in identity.processStartIdentity }
+        let cgWindow = ServiceWindowInfo(
+            windowID: 332,
+            title: "CG Window",
+            bounds: CGRect(x: 10, y: 20, width: 800, height: 600))
+        let context = WindowEnumerationContext(
+            service: service,
+            app: Self.application(identity: identity),
+            startTime: Date(),
+            axTimeout: 0.05,
+            hasScreenRecording: true,
+            logger: Self.logger,
+            processIdentity: identity,
+            cgSnapshotProvider: { .init(windows: [cgWindow], omittedOwnerRowCount: 1) },
+            applicationRunningProvider: { true },
+            axEnumerator: { _, _ in
+                DetachedAXWindowEnumerationResult(
+                    descriptors: [],
+                    focusedWindowID: nil,
+                    timedOut: false,
+                    incomplete: false,
+                    reportedWindowCount: 0)
+            })
+
+        let output = try await context.run()
+
+        #expect(output.summary.status == .partial)
+        #expect(output.metadata.warnings == [
+            "CoreGraphics omitted 1 owner window row without complete identity evidence",
+        ])
+    }
+
+    @Test
+    func `unmatched AX rows without stable identity make hybrid inventory partial`() async throws {
+        let identity = ApplicationProcessIdentity(processIdentifier: 38, processStartIdentity: 3)
+        let service = Self.makeService { _ in identity.processStartIdentity }
+        let cgWindow = ServiceWindowInfo(
+            windowID: 330,
+            title: "CG Window",
+            bounds: CGRect(x: 10, y: 20, width: 800, height: 600))
+        let context = WindowEnumerationContext(
+            service: service,
+            app: Self.application(identity: identity),
+            startTime: Date(),
+            axTimeout: 0.05,
+            hasScreenRecording: true,
+            logger: Self.logger,
+            processIdentity: identity,
+            cgSnapshotProvider: { .init(windows: [cgWindow]) },
+            applicationRunningProvider: { true },
+            axEnumerator: { _, _ in
+                DetachedAXWindowEnumerationResult(
+                    descriptors: [DetachedAXWindowDescriptor(
+                        windowID: nil,
+                        title: "Unmatched AX Window",
+                        bounds: CGRect(x: 1200, y: 20, width: 500, height: 400))],
+                    focusedWindowID: nil,
+                    timedOut: false,
+                    incomplete: false,
+                    reportedWindowCount: 1)
+            })
+
+        let output = try await context.run()
+
+        #expect(output.data.windows.map(\.windowID) == [cgWindow.windowID])
+        #expect(output.summary.status == .partial)
+        #expect(output.metadata.warnings == [
+            "Accessibility omitted 1 unmatched window row without stable identity",
+        ])
+    }
+
+    @Test
     func `CG inventory survives an AX hard timeout as partial output`() async throws {
         let identity = ApplicationProcessIdentity(processIdentifier: 42, processStartIdentity: 7)
         let service = Self.makeService { _ in identity.processStartIdentity }

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/WindowListIndexNormalizationTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/WindowListIndexNormalizationTests.swift
@@ -63,6 +63,37 @@ struct WindowListIndexNormalizationTests {
     }
 
     @Test
+    func `missing AX ID inference requires one unique CG sibling`() {
+        let bounds = CGRect(x: 10, y: 20, width: 640, height: 480)
+        let first = ApplicationService.WindowIDInferenceCandidate(
+            windowID: 111,
+            ownerProcessIdentifier: 42,
+            title: "Duplicate",
+            bounds: bounds)
+        let second = ApplicationService.WindowIDInferenceCandidate(
+            windowID: 222,
+            ownerProcessIdentifier: 42,
+            title: "Duplicate",
+            bounds: bounds)
+
+        #expect(ApplicationService.uniqueMatchingWindowID(
+            pid: 42,
+            title: "Duplicate",
+            bounds: bounds,
+            candidates: [first]) == 111)
+        #expect(ApplicationService.uniqueMatchingWindowID(
+            pid: 42,
+            title: "Duplicate",
+            bounds: bounds,
+            candidates: [first, second]) == nil)
+        #expect(ApplicationService.uniqueMatchingWindowID(
+            pid: 42,
+            title: "Duplicate",
+            bounds: bounds,
+            candidates: [second, first]) == nil)
+    }
+
+    @Test
     func `hybrid merge restores a missing CG receipt from exact AX ownership`() throws {
         let cgWindow = ServiceWindowInfo(
             windowID: 333,
@@ -125,5 +156,64 @@ struct WindowListIndexNormalizationTests {
         #expect(window.windowID == 444)
         #expect(window.isMinimized)
         #expect(window.mutationIdentity == receipt)
+    }
+
+    @Test
+    func `matching titled CG row accounts for an AX descriptor without window ID`() {
+        let bounds = CGRect(x: 40, y: 50, width: 700, height: 500)
+        let cgWindow = ServiceWindowInfo(windowID: 445, title: "Fixture", bounds: bounds)
+        let descriptor = WindowEnumerationContext.AXWindowDescriptor(
+            windowID: nil,
+            title: cgWindow.title,
+            bounds: bounds,
+            standaloneInfo: nil)
+
+        let merged = WindowEnumerationContext.mergeWindowInventory(
+            cgWindows: [cgWindow],
+            axDescriptors: [descriptor])
+
+        #expect(merged.windows == [cgWindow])
+        #expect(merged.unmaterializedAXDescriptorCount == 0)
+    }
+
+    @Test
+    func `one titled CG row cannot account for two AX descriptors without IDs`() {
+        let bounds = CGRect(x: 40, y: 50, width: 700, height: 500)
+        let cgWindow = ServiceWindowInfo(windowID: 446, title: "Fixture", bounds: bounds)
+        let descriptor = WindowEnumerationContext.AXWindowDescriptor(
+            windowID: nil,
+            title: cgWindow.title,
+            bounds: bounds,
+            standaloneInfo: nil)
+
+        let merged = WindowEnumerationContext.mergeWindowInventory(
+            cgWindows: [cgWindow],
+            axDescriptors: [descriptor, descriptor])
+
+        #expect(merged.windows == [cgWindow])
+        #expect(merged.unmaterializedAXDescriptorCount == 1)
+    }
+
+    @Test
+    func `exact ID and unidentified AX rows cannot both claim one CG window`() {
+        let bounds = CGRect(x: 40, y: 50, width: 700, height: 500)
+        let cgWindow = ServiceWindowInfo(windowID: 447, title: "Fixture", bounds: bounds)
+        let exact = WindowEnumerationContext.AXWindowDescriptor(
+            windowID: cgWindow.windowID,
+            title: cgWindow.title,
+            bounds: bounds,
+            standaloneInfo: nil)
+        let unidentified = WindowEnumerationContext.AXWindowDescriptor(
+            windowID: nil,
+            title: cgWindow.title,
+            bounds: bounds,
+            standaloneInfo: nil)
+
+        let merged = WindowEnumerationContext.mergeWindowInventory(
+            cgWindows: [cgWindow],
+            axDescriptors: [exact, unidentified])
+
+        #expect(merged.windows == [cgWindow])
+        #expect(merged.unmaterializedAXDescriptorCount == 1)
     }
 }

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/WindowListIndexNormalizationTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/WindowListIndexNormalizationTests.swift
@@ -177,6 +177,47 @@ struct WindowListIndexNormalizationTests {
     }
 
     @Test
+    func `one untitled CG row can borrow one unique AX title`() {
+        let bounds = CGRect(x: 40, y: 50, width: 700, height: 500)
+        let cgWindow = ServiceWindowInfo(windowID: 450, title: "", bounds: bounds)
+        let descriptor = WindowEnumerationContext.AXWindowDescriptor(
+            windowID: nil,
+            title: "Fixture",
+            bounds: bounds,
+            standaloneInfo: nil)
+
+        let merged = WindowEnumerationContext.mergeWindowInventory(
+            cgWindows: [cgWindow],
+            axDescriptors: [descriptor])
+
+        #expect(merged.windows.map(\.title) == ["Fixture"])
+        #expect(merged.unmaterializedAXDescriptorCount == 0)
+    }
+
+    @Test
+    func `overlapping untitled CG rows do not consume ambiguous AX descriptors`() {
+        let bounds = CGRect(x: 40, y: 50, width: 700, height: 500)
+        let cgWindows = [
+            ServiceWindowInfo(windowID: 451, title: "", bounds: bounds),
+            ServiceWindowInfo(windowID: 452, title: "", bounds: bounds),
+        ]
+        let descriptors = ["First", "Second"].map {
+            WindowEnumerationContext.AXWindowDescriptor(
+                windowID: nil,
+                title: $0,
+                bounds: bounds,
+                standaloneInfo: nil)
+        }
+
+        let merged = WindowEnumerationContext.mergeWindowInventory(
+            cgWindows: cgWindows,
+            axDescriptors: descriptors)
+
+        #expect(merged.windows.map(\.title) == ["", ""])
+        #expect(merged.unmaterializedAXDescriptorCount == 2)
+    }
+
+    @Test
     func `one titled CG row cannot account for two AX descriptors without IDs`() {
         let bounds = CGRect(x: 40, y: 50, width: 700, height: 500)
         let cgWindow = ServiceWindowInfo(windowID: 446, title: "Fixture", bounds: bounds)

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/WindowListIndexNormalizationTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/WindowListIndexNormalizationTests.swift
@@ -216,4 +216,27 @@ struct WindowListIndexNormalizationTests {
         #expect(merged.windows == [cgWindow])
         #expect(merged.unmaterializedAXDescriptorCount == 1)
     }
+
+    @Test
+    func `unidentified AX title cannot relabel a CG window already claimed by an exact ID row`() {
+        let bounds = CGRect(x: 40, y: 50, width: 700, height: 500)
+        let cgWindow = ServiceWindowInfo(windowID: 448, title: "", bounds: bounds)
+        let exact = WindowEnumerationContext.AXWindowDescriptor(
+            windowID: cgWindow.windowID,
+            title: "",
+            bounds: bounds,
+            standaloneInfo: nil)
+        let unidentified = WindowEnumerationContext.AXWindowDescriptor(
+            windowID: nil,
+            title: "Borrowed title",
+            bounds: bounds,
+            standaloneInfo: nil)
+
+        let merged = WindowEnumerationContext.mergeWindowInventory(
+            cgWindows: [cgWindow],
+            axDescriptors: [exact, unidentified])
+
+        #expect(merged.windows == [cgWindow])
+        #expect(merged.unmaterializedAXDescriptorCount == 1)
+    }
 }

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/WindowListIndexNormalizationTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/WindowListIndexNormalizationTests.swift
@@ -195,6 +195,24 @@ struct WindowListIndexNormalizationTests {
     }
 
     @Test
+    func `one exact CG ID cannot account for two AX descriptors`() {
+        let bounds = CGRect(x: 40, y: 50, width: 700, height: 500)
+        let cgWindow = ServiceWindowInfo(windowID: 449, title: "Fixture", bounds: bounds)
+        let descriptor = WindowEnumerationContext.AXWindowDescriptor(
+            windowID: cgWindow.windowID,
+            title: cgWindow.title,
+            bounds: bounds,
+            standaloneInfo: nil)
+
+        let merged = WindowEnumerationContext.mergeWindowInventory(
+            cgWindows: [cgWindow],
+            axDescriptors: [descriptor, descriptor])
+
+        #expect(merged.windows == [cgWindow])
+        #expect(merged.unmaterializedAXDescriptorCount == 1)
+    }
+
+    @Test
     func `exact ID and unidentified AX rows cannot both claim one CG window`() {
         let bounds = CGRect(x: 40, y: 50, width: 700, height: 500)
         let cgWindow = ServiceWindowInfo(windowID: 447, title: "Fixture", bounds: bounds)

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/WindowMutationPlannerTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/WindowMutationPlannerTests.swift
@@ -58,6 +58,34 @@ struct WindowMutationPlannerTests {
     }
 
     @Test
+    func `AX-refreshed offscreen exact window plans and revalidates coherent bounds`() async throws {
+        let application = AutomationTestFixtures.application()
+        let original = AutomationTestFixtures.window(
+            bounds: CGRect(x: -2000, y: 100, width: 640, height: 480),
+            isMinimized: false)
+        let refreshedBounds = CGRect(x: 30, y: 40, width: 900, height: 700)
+        let refreshed = original.withExactAXState(
+            title: "Refreshed Fixture",
+            bounds: refreshedBounds,
+            isMinimized: true)
+        let applications = DesktopTargetPlanning.ApplicationMutationPlanner(
+            inventoryProvider: { .complete([application]) })
+        let planner = DesktopTargetPlanning.WindowMutationPlanner(
+            applicationPlanner: applications,
+            windowInventoryProvider: { target in
+                #expect(target == .windowId(refreshed.windowID))
+                return .complete([refreshed])
+            })
+
+        let plan = try await planner.plan(selector: InteractionTargetSelector(windowID: refreshed.windowID))
+        let revalidated = try await planner.revalidate(plan)
+
+        #expect(plan.identity.capturedBounds == refreshedBounds)
+        #expect(plan.identity.isMinimized == true)
+        #expect(revalidated.identity == plan.identity)
+    }
+
+    @Test
     func `window provider transport failures stay unavailable instead of impersonating target loss`() async throws {
         let application = AutomationTestFixtures.application()
         let window = AutomationTestFixtures.window()

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/WindowMutationPlannerTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/WindowMutationPlannerTests.swift
@@ -1,0 +1,346 @@
+import CoreGraphics
+import PeekabooAutomationKitTestSupport
+import PeekabooFoundation
+import Testing
+@testable import PeekabooAutomationKit
+
+@MainActor
+struct WindowMutationPlannerTests {
+    @Test
+    func `partial window inventory refuses title and index uniqueness`() async {
+        let application = AutomationTestFixtures.application()
+        let window = AutomationTestFixtures.window()
+        let applications = DesktopTargetPlanning.ApplicationMutationPlanner(
+            inventoryProvider: { .complete([application]) })
+        let planner = DesktopTargetPlanning.WindowMutationPlanner(
+            applicationPlanner: applications,
+            windowInventoryProvider: { _ in
+                .partial([window], warnings: ["AX enumeration timed out"])
+            })
+
+        await #expect(throws: DesktopTargetPlanningError.incompleteWindowInventory(
+            selector: "window title 'Test Window'",
+            warnings: ["AX enumeration timed out"]))
+        {
+            _ = try await planner.plan(selector: InteractionTargetSelector(
+                applicationIdentifier: "Test App",
+                windowTitle: "Test Window"))
+        }
+        await #expect(throws: DesktopTargetPlanningError.incompleteWindowInventory(
+            selector: "window index 0",
+            warnings: ["AX enumeration timed out"]))
+        {
+            _ = try await planner.plan(selector: InteractionTargetSelector(
+                applicationIdentifier: "Test App",
+                windowIndex: 0))
+        }
+    }
+
+    @Test
+    func `exact window ID can use a partial direct lookup`() async throws {
+        let application = AutomationTestFixtures.application()
+        let window = AutomationTestFixtures.window()
+        let applications = DesktopTargetPlanning.ApplicationMutationPlanner(
+            inventoryProvider: { .complete([application]) })
+        let planner = DesktopTargetPlanning.WindowMutationPlanner(
+            applicationPlanner: applications,
+            windowInventoryProvider: { target in
+                #expect(target == .windowId(window.windowID))
+                return .partial([window], warnings: ["broad catalog unavailable"])
+            })
+
+        let plan = try await planner.plan(selector: InteractionTargetSelector(windowID: window.windowID))
+
+        #expect(plan.identity == window.mutationIdentity)
+    }
+
+    @Test
+    func `window provider transport failures stay unavailable instead of impersonating target loss`() async throws {
+        let application = AutomationTestFixtures.application()
+        let window = AutomationTestFixtures.window()
+        let shouldFail = AutomationTestLockedValue(true)
+        let applications = DesktopTargetPlanning.ApplicationMutationPlanner(
+            inventoryProvider: { .complete([application]) })
+        let planner = DesktopTargetPlanning.WindowMutationPlanner(
+            applicationPlanner: applications,
+            windowInventoryProvider: { _ in
+                if shouldFail.value {
+                    throw PeekabooError.timeout("raw window timeout")
+                }
+                return .complete([window])
+            })
+
+        await #expect(throws: DesktopTargetPlanningError.windowInventoryUnavailable(
+            selector: "window ID 201"))
+        {
+            _ = try await planner.plan(selector: InteractionTargetSelector(windowID: 201))
+        }
+
+        shouldFail.value = false
+        let plan = try await planner.plan(selector: InteractionTargetSelector(windowID: 201))
+        shouldFail.value = true
+        await #expect(throws: DesktopTargetPlanningError.windowInventoryUnavailable(selector: "window ID 201")) {
+            _ = try await planner.revalidate(plan)
+        }
+    }
+
+    @Test
+    func `exact window absence becomes not found initially and stale after selection`() async throws {
+        let application = AutomationTestFixtures.application()
+        let window = AutomationTestFixtures.window()
+        let isMissing = AutomationTestLockedValue(true)
+        let applications = DesktopTargetPlanning.ApplicationMutationPlanner(
+            inventoryProvider: { .complete([application]) })
+        let planner = DesktopTargetPlanning.WindowMutationPlanner(
+            applicationPlanner: applications,
+            windowInventoryProvider: { _ in
+                guard !isMissing.value else { throw PeekabooError.windowNotFound(criteria: "fixture") }
+                return .complete([window])
+            })
+
+        await #expect(throws: DesktopTargetPlanningError.windowNotFound(
+            selector: "window ID 201",
+            candidateWindowIDs: []))
+        {
+            _ = try await planner.plan(selector: InteractionTargetSelector(windowID: 201))
+        }
+
+        isMissing.value = false
+        let plan = try await planner.plan(selector: InteractionTargetSelector(windowID: 201))
+        isMissing.value = true
+        await #expect(throws: DesktopTargetPlanningError.staleWindow(expected: plan.identity)) {
+            _ = try await planner.revalidate(plan)
+        }
+    }
+
+    @Test
+    func `raw broad window inventory errors become canonical unavailable errors`() async {
+        let application = AutomationTestFixtures.application()
+        let applications = DesktopTargetPlanning.ApplicationMutationPlanner(
+            inventoryProvider: { .complete([application]) })
+        let planner = DesktopTargetPlanning.WindowMutationPlanner(
+            applicationPlanner: applications,
+            windowInventoryProvider: { _ in throw PeekabooError.timeout("raw window timeout") })
+
+        await #expect(throws: DesktopTargetPlanningError.windowInventoryUnavailable(
+            selector: "application 'PID:101'"))
+        {
+            _ = try await planner.plan(selector: InteractionTargetSelector(
+                applicationIdentifier: "Test App",
+                windowTitle: "Test Window"))
+        }
+    }
+
+    @Test
+    func `nonfinite unrelated candidate evidence becomes a canonical invalid inventory`() async {
+        let application = AutomationTestFixtures.application()
+        let selected = AutomationTestFixtures.window(title: "Target")
+        let invalid = ServiceWindowInfo(
+            windowID: 202,
+            title: "Unrelated",
+            bounds: CGRect(x: CGFloat.nan, y: 0, width: 640, height: 480))
+        let spy = WindowPlannerInventorySpy(
+            applicationInventories: [[application], [application]],
+            windows: [.application("PID:101"): [selected, invalid]])
+
+        await #expect(throws: DesktopTargetPlanningError.invalidWindowInventory(
+            selector: "window title 'Target'",
+            reason: "candidate evidence could not be encoded"))
+        {
+            _ = try await spy.planner().plan(selector: InteractionTargetSelector(
+                applicationIdentifier: "Test App",
+                windowTitle: "Target"))
+        }
+    }
+
+    @Test
+    func `relative selector lists only by canonical exact PID and returns exact target`() async throws {
+        let application = AutomationTestFixtures.application()
+        let window = AutomationTestFixtures.window()
+        let spy = WindowPlannerInventorySpy(
+            applicationInventories: [[application], [application]],
+            windows: [.application("PID:101"): [window]])
+        let planner = spy.planner()
+
+        let plan = try await planner.plan(selector: InteractionTargetSelector(
+            applicationIdentifier: "Test App",
+            windowTitle: "Test Window"))
+
+        #expect(plan.target == .windowId(201))
+        #expect(plan.selectionWindow == window)
+        #expect(plan.identity == window.mutationIdentity)
+        #expect(plan.owner.selectorProof.matchKind == .exactName)
+        let proof = try #require(plan.selectorProof)
+        #expect(proof.scope == .window)
+        #expect(proof.matchKind == .exactWindowTitle)
+        #expect(proof.selectedWindowIdentity == window.mutationIdentity)
+        #expect(!proof.hasWinningTie)
+        #expect(spy.requestedWindowTargets == [.application("PID:101")])
+        #expect(spy.mutationCallCount == 0)
+    }
+
+    @Test
+    func `exact ID alone derives owner while a wrong explicit owner refuses`() async throws {
+        let application = AutomationTestFixtures.application()
+        let window = AutomationTestFixtures.window()
+        let exactSpy = WindowPlannerInventorySpy(
+            applicationInventories: [[application], [application]],
+            windows: [.windowId(201): [window]])
+        let exactPlan = try await exactSpy.planner().plan(
+            selector: InteractionTargetSelector(windowID: 201))
+        #expect(exactPlan.owner.processIdentity == application.processIdentity)
+
+        let other = AutomationTestFixtures.application(
+            processIdentifier: 202,
+            processStartIdentity: 2002,
+            bundleIdentifier: "com.example.Other",
+            name: "Other")
+        let wrongOwnerSpy = WindowPlannerInventorySpy(
+            applicationInventories: [[other]],
+            windows: [.windowId(201): [window]])
+        await #expect(throws: try DesktopTargetPlanningError.windowOwnerMismatch(
+            windowID: 201,
+            expected: #require(other.processIdentity)))
+        {
+            _ = try await wrongOwnerSpy.planner().plan(selector: InteractionTargetSelector(
+                applicationIdentifier: "Other",
+                windowID: 201))
+        }
+    }
+
+    @Test
+    func `owner drift after window inventory refuses pre-dispatch`() async throws {
+        let original = AutomationTestFixtures.application()
+        let changed = AutomationTestFixtures.wrongGenerationApplication()
+        let window = AutomationTestFixtures.window()
+        let spy = WindowPlannerInventorySpy(
+            applicationInventories: [[original], [changed]],
+            windows: [.application("PID:101"): [window]])
+
+        await #expect(throws: try DesktopTargetPlanningError.staleApplication(
+            expected: #require(original.processIdentity)))
+        {
+            _ = try await spy.planner().plan(selector: InteractionTargetSelector(
+                applicationIdentifier: "Test App",
+                windowIndex: 0))
+        }
+        #expect(spy.mutationCallCount == 0)
+    }
+
+    @Test
+    func `plan revalidation refuses moved bounds`() async throws {
+        let application = AutomationTestFixtures.application()
+        let original = AutomationTestFixtures.window()
+        let moved = AutomationTestFixtures.window(
+            bounds: original.bounds.offsetBy(dx: 1, dy: 0))
+        let spy = WindowPlannerInventorySpy(
+            applicationInventories: [[application], [application], [application]],
+            windows: [.windowId(201): [original]])
+        let planner = spy.planner()
+        let plan = try await planner.plan(selector: InteractionTargetSelector(windowID: 201))
+        spy.windows[.windowId(201)] = [moved]
+
+        await #expect(throws: DesktopTargetPlanningError.staleWindow(expected: plan.identity)) {
+            _ = try await planner.revalidate(plan)
+        }
+    }
+
+    @Test
+    func `revalidation reports a replacement owner as stale`() async throws {
+        let application = AutomationTestFixtures.application()
+        let original = AutomationTestFixtures.window()
+        let replacementOwner = AutomationTestFixtures.processIdentity(
+            processIdentifier: 202,
+            processStartIdentity: 2002)
+        let replacement = AutomationTestFixtures.window(processIdentity: replacementOwner)
+        let spy = WindowPlannerInventorySpy(
+            applicationInventories: [[application], [application]],
+            windows: [.windowId(201): [original]])
+        let planner = spy.planner()
+        let plan = try await planner.plan(selector: InteractionTargetSelector(windowID: 201))
+        spy.windows[.windowId(201)] = [replacement]
+
+        await #expect(throws: DesktopTargetPlanningError.staleWindow(expected: plan.identity)) {
+            _ = try await planner.revalidate(plan)
+        }
+    }
+
+    @Test
+    func `revalidation keeps historical selection evidence while refreshing exact execution state`() async throws {
+        let application = AutomationTestFixtures.application()
+        let original = AutomationTestFixtures.window(title: "Selected Document", isMinimized: false)
+        let refreshed = AutomationTestFixtures.window(title: "Renamed Document", isMinimized: true)
+        let sibling = AutomationTestFixtures.window(windowID: 202, title: "Selected Document", index: 0)
+        let spy = WindowPlannerInventorySpy(
+            applicationInventories: [[application], [application], [application]],
+            windows: [.application("PID:101"): [original]])
+        let planner = spy.planner()
+        let plan = try await planner.plan(selector: InteractionTargetSelector(
+            applicationIdentifier: "Test App",
+            windowTitle: "Selected Document"))
+        spy.windows[.application("PID:101")] = [sibling, original]
+        spy.windows[.windowId(201)] = [refreshed]
+        spy.partialWindowTargets = [.windowId(201)]
+
+        let revalidated = try await planner.revalidate(plan)
+
+        #expect(revalidated.selectionWindow == original)
+        #expect(revalidated.selectorProof == plan.selectorProof)
+        #expect(revalidated.identity.hasSameStableReceipt(as: plan.identity))
+        #expect(revalidated.identity.isMinimized == true)
+        #expect(spy.requestedWindowTargets == [.application("PID:101"), .windowId(201)])
+    }
+
+    @Test
+    func `ownerless relative mutation selector refuses before inventory`() async {
+        let spy = WindowPlannerInventorySpy(applicationInventories: [], windows: [:])
+
+        await #expect(throws: DesktopTargetPlanningError.invalidSelector(.windowSelectorRequiresApplication)) {
+            _ = try await spy.planner().plan(
+                selector: InteractionTargetSelector(windowTitle: "Document"))
+        }
+        #expect(spy.applicationReadCount == 0)
+        #expect(spy.requestedWindowTargets.isEmpty)
+    }
+}
+
+@MainActor
+private final class WindowPlannerInventorySpy {
+    private var applicationInventories: [[ServiceApplicationInfo]]
+    var windows: [WindowTarget: [ServiceWindowInfo]]
+    var partialWindowTargets = Set<WindowTarget>()
+    private(set) var applicationReadCount = 0
+    private(set) var requestedWindowTargets: [WindowTarget] = []
+    private(set) var mutationCallCount = 0
+
+    init(
+        applicationInventories: [[ServiceApplicationInfo]],
+        windows: [WindowTarget: [ServiceWindowInfo]])
+    {
+        self.applicationInventories = applicationInventories
+        self.windows = windows
+    }
+
+    func planner() -> DesktopTargetPlanning.WindowMutationPlanner {
+        let applications = DesktopTargetPlanning.ApplicationMutationPlanner(
+            inventoryProvider: { try .complete(self.nextApplications()) })
+        return DesktopTargetPlanning.WindowMutationPlanner(
+            applicationPlanner: applications,
+            windowInventoryProvider: { target in
+                self.requestedWindowTargets.append(target)
+                let windows = self.windows[target] ?? []
+                if self.partialWindowTargets.contains(target) {
+                    return .partial(windows, warnings: ["Broad catalog became partial"])
+                }
+                return .complete(windows)
+            })
+    }
+
+    func nextApplications() throws -> [ServiceApplicationInfo] {
+        guard self.applicationReadCount < self.applicationInventories.count else {
+            throw PeekabooError.commandFailed("Unexpected application inventory read")
+        }
+        defer { self.applicationReadCount += 1 }
+        return self.applicationInventories[self.applicationReadCount]
+    }
+}

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/WindowMutationPlannerTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/WindowMutationPlannerTests.swift
@@ -52,6 +52,9 @@ struct WindowMutationPlannerTests {
         let plan = try await planner.plan(selector: InteractionTargetSelector(windowID: window.windowID))
 
         #expect(plan.identity == window.mutationIdentity)
+        let bounds = try #require(plan.identity.capturedBounds)
+        #expect(try plan.expectedTargetIdentity == DesktopTargetIdentity(
+            exactWindow: UIAutomationTarget.ExactWindow(identity: plan.identity, bounds: bounds)))
     }
 
     @Test
@@ -85,6 +88,29 @@ struct WindowMutationPlannerTests {
     }
 
     @Test
+    func `application scoped window listing target loss stays stale instead of unavailable`() async throws {
+        let application = AutomationTestFixtures.application()
+        let expectedIdentity = try #require(application.processIdentity)
+        let applications = DesktopTargetPlanning.ApplicationMutationPlanner(
+            inventoryProvider: { .complete([application]) })
+
+        for error in [
+            PeekabooError.appNotFound("PID:101"),
+            PeekabooError.snapshotStale("fixture generation changed"),
+        ] {
+            let planner = DesktopTargetPlanning.WindowMutationPlanner(
+                applicationPlanner: applications,
+                windowInventoryProvider: { _ in throw error })
+
+            await #expect(throws: DesktopTargetPlanningError.staleApplication(expected: expectedIdentity)) {
+                _ = try await planner.plan(selector: InteractionTargetSelector(
+                    applicationIdentifier: "Test App",
+                    windowTitle: "Test Window"))
+            }
+        }
+    }
+
+    @Test
     func `exact window absence becomes not found initially and stale after selection`() async throws {
         let application = AutomationTestFixtures.application()
         let window = AutomationTestFixtures.window()
@@ -110,6 +136,35 @@ struct WindowMutationPlannerTests {
         isMissing.value = true
         await #expect(throws: DesktopTargetPlanningError.staleWindow(expected: plan.identity)) {
             _ = try await planner.revalidate(plan)
+        }
+    }
+
+    @Test
+    func `application and generation loss during exact revalidation stay stale`() async throws {
+        let application = AutomationTestFixtures.application()
+        let window = AutomationTestFixtures.window()
+
+        for error in [
+            PeekabooError.appNotFound("PID:101"),
+            PeekabooError.snapshotStale("fixture generation changed"),
+        ] {
+            let shouldFail = AutomationTestLockedValue(false)
+            let applications = DesktopTargetPlanning.ApplicationMutationPlanner(
+                inventoryProvider: { .complete([application]) })
+            let planner = DesktopTargetPlanning.WindowMutationPlanner(
+                applicationPlanner: applications,
+                windowInventoryProvider: { _ in
+                    if shouldFail.value {
+                        throw error
+                    }
+                    return .complete([window])
+                })
+            let plan = try await planner.plan(selector: InteractionTargetSelector(windowID: window.windowID))
+            shouldFail.value = true
+
+            await #expect(throws: DesktopTargetPlanningError.staleWindow(expected: plan.identity)) {
+                _ = try await planner.revalidate(plan)
+            }
         }
     }
 

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/WindowMutationPlannerTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/WindowMutationPlannerTests.swift
@@ -251,7 +251,7 @@ struct WindowMutationPlannerTests {
             bundleIdentifier: "com.example.Other",
             name: "Other")
         let wrongOwnerSpy = WindowPlannerInventorySpy(
-            applicationInventories: [[other]],
+            applicationInventories: [[other], [other]],
             windows: [.windowId(201): [window]])
         await #expect(throws: try DesktopTargetPlanningError.windowOwnerMismatch(
             windowID: 201,
@@ -280,6 +280,47 @@ struct WindowMutationPlannerTests {
                 windowIndex: 0))
         }
         #expect(spy.mutationCallCount == 0)
+    }
+
+    @Test
+    func `selection failures revalidate an already selected owner before returning`() async throws {
+        let original = AutomationTestFixtures.application()
+        let changed = AutomationTestFixtures.wrongGenerationApplication()
+        let replacementOwner = AutomationTestFixtures.processIdentity(
+            processIdentifier: 202,
+            processStartIdentity: 2002)
+        let replacement = AutomationTestFixtures.window(processIdentity: replacementOwner)
+
+        for windows in [[], [replacement]] {
+            let spy = WindowPlannerInventorySpy(
+                applicationInventories: [[original], [changed]],
+                windows: [.application("PID:101"): windows])
+
+            await #expect(throws: try DesktopTargetPlanningError.staleApplication(
+                expected: #require(original.processIdentity)))
+            {
+                _ = try await spy.planner().plan(selector: InteractionTargetSelector(
+                    applicationIdentifier: "Test App",
+                    windowTitle: "Test Window"))
+            }
+        }
+    }
+
+    @Test
+    func `selection failure stays not found when the selected owner is still current`() async throws {
+        let application = AutomationTestFixtures.application()
+        let spy = WindowPlannerInventorySpy(
+            applicationInventories: [[application], [application]],
+            windows: [.application("PID:101"): []])
+
+        await #expect(throws: DesktopTargetPlanningError.windowNotFound(
+            selector: "title containing 'Test Window'",
+            candidateWindowIDs: []))
+        {
+            _ = try await spy.planner().plan(selector: InteractionTargetSelector(
+                applicationIdentifier: "Test App",
+                windowTitle: "Test Window"))
+        }
     }
 
     @Test

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/WindowSelectorResolutionProofTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/WindowSelectorResolutionProofTests.swift
@@ -63,6 +63,7 @@ struct WindowSelectorResolutionProofTests {
         let candidates = [safari, preview, mail]
 
         for (selection, selected) in [
+            (WindowSelection.automatic, preview),
             (WindowSelection.id(70), preview),
             (.index(0), preview),
             (.title("Safari"), preview),

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/WindowSelectorResolutionProofTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/WindowSelectorResolutionProofTests.swift
@@ -63,7 +63,6 @@ struct WindowSelectorResolutionProofTests {
         let candidates = [safari, preview, mail]
 
         for (selection, selected) in [
-            (WindowSelection.automatic, preview),
             (WindowSelection.id(70), preview),
             (.index(0), preview),
             (.title("Safari"), preview),

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/WindowStateMutationPolicyTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/WindowStateMutationPolicyTests.swift
@@ -193,24 +193,38 @@ struct WindowStateMutationPolicyTests {
 
     @Test
     func `exact offscreen lookup carries AX minimized state into mutation receipt`() throws {
+        let originalBounds = CGRect(x: 10, y: 20, width: 800, height: 600)
+        let refreshedBounds = CGRect(x: 30, y: 40, width: 900, height: 700)
+        let originalIdentity = WindowMutationIdentity(
+            windowID: 924,
+            ownerProcessIdentifier: 42,
+            ownerProcessStartIdentity: 7,
+            capturedBounds: originalBounds,
+            isMinimized: false)
         let cgWindow = ServiceWindowInfo(
             windowID: 924,
             title: "",
-            bounds: CGRect(x: 10, y: 20, width: 800, height: 600),
+            bounds: originalBounds,
             isOffScreen: true,
             isOnScreen: false,
-            mutationIdentity: self.identity.withMinimizedState(false))
+            mutationIdentity: originalIdentity)
 
         let enriched = cgWindow.withExactAXState(
             title: "Fixture",
-            bounds: CGRect(x: 30, y: 40, width: 900, height: 700),
+            bounds: refreshedBounds,
             isMinimized: true)
 
         #expect(enriched.title == "Fixture")
-        #expect(enriched.bounds == CGRect(x: 30, y: 40, width: 900, height: 700))
+        #expect(enriched.bounds == refreshedBounds)
         #expect(enriched.isMinimized)
         #expect(!enriched.isOnScreen)
-        #expect(try #require(enriched.mutationIdentity).isMinimized == true)
+        let enrichedIdentity = try #require(enriched.mutationIdentity)
+        #expect(enrichedIdentity.capturedBounds == refreshedBounds)
+        #expect(enrichedIdentity.isMinimized == true)
+        #expect(enrichedIdentity.processIdentity == originalIdentity.processIdentity)
+        try DesktopTargetPlanning.WindowCandidateSelector.validate(
+            enriched,
+            expectedOwner: originalIdentity.processIdentity)
     }
 
     @Test


### PR DESCRIPTION
## Summary

- add one canonical application/window mutation planner with deterministic exact selectors, complete-inventory requirements, immutable process/window receipts, and exact-ID revalidation
- add lightweight generation-bracketed application inventory plus truthful window omission accounting, including AX-only and hybrid enumeration gaps
- keep historical selector evidence separate from refreshed execution identity, with mutation-specific automatic ranking and a restore intent that can select minimized windows
- preserve the existing Bridge protocol at 1.29; wire transport and compatibility are intentionally deferred to the next stacked slice

## Safety and compatibility

- broad name, bundle, title, index, and automatic selection fail closed on partial or contradictory inventories
- exact PID/window-ID lookups remain available through direct receipt-bearing providers
- provider transport failures remain distinct from proved target disappearance
- complete AX-only window listings remain usable without Screen Recording; missing identity rows remain partial
- no capture-ownership, dialog, hide-other/show-all, Bridge wire, AppleScript, or UI behavior is changed

## Proof

- `swift test --package-path Core/PeekabooAutomationKit --no-parallel` — 1025 tests passed on current `main` and its refreshed submodule pins
- `swift build --package-path Core/PeekabooCore` — passed
- `swift build --package-path Apps/CLI -Xswiftc -DPEEKABOO_SKIP_AUTOMATION` — passed
- changed-file strict SwiftLint — clean
- `swiftformat --lint .` — clean
- `git diff --check origin/main...HEAD` — clean
- autoreview, Codex, local diff through P2 — clean after two accepted completeness findings were fixed
