### PR TITLE
feat(bridge): add planner inventory transport

### DIFF
--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [4.2.1] - Unreleased
 
 ### Added
+- Add Bridge protocol 1.30 planner inventory transport with explicit complete/partial evidence, while protocol 1.29 hosts keep legacy list bytes and conservative exact-target compatibility.
 - Add authenticated `bridge receipt validate` for fail-closed, agent-readable verification of private protocol 1.29 bundles against the exact live listener that produced them.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [4.2.1] - Unreleased
 
 ### Added
+- Add Bridge protocol 1.30 planner inventory transport with explicit complete/partial evidence, while protocol 1.29 hosts keep legacy list bytes and conservative exact-target compatibility.
 - Add authenticated `peekaboo bridge receipt validate` for fail-closed, agent-readable verification of private protocol 1.29 bundles against the exact live listener that produced them.
 
 ### Fixed

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeClient+WindowsApplications.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeClient+WindowsApplications.swift
@@ -16,6 +16,28 @@ extension PeekabooBridgeClient {
         }
     }
 
+    public func listWindowMutationInventory(
+        target: WindowTarget) async throws -> DesktopTargetPlanning.Inventory<ServiceWindowInfo>
+    {
+        guard self.windowMutationInventoryTransportEnabled else {
+            return try await .partial(
+                self.listWindows(target: target),
+                warnings: ["Bridge host did not report window mutation inventory completeness."])
+        }
+        let response = try await self.send(.listWindowMutationInventory(
+            PeekabooBridgeWindowTargetRequest(target: target)))
+        switch response {
+        case let .windowMutationInventory(inventory):
+            return inventory
+        case let .error(envelope):
+            throw envelope
+        default:
+            throw PeekabooBridgeErrorEnvelope(
+                code: .invalidRequest,
+                message: "Unexpected listWindowMutationInventory response")
+        }
+    }
+
     public func focusWindow(target: WindowTarget) async throws {
         _ = try await self.focusWindowResult(target: target)
     }
@@ -351,6 +373,27 @@ extension PeekabooBridgeClient {
             throw envelope
         default:
             throw PeekabooBridgeErrorEnvelope(code: .invalidRequest, message: "Unexpected listApplications response")
+        }
+    }
+
+    public func listApplicationMutationInventory() async throws
+        -> DesktopTargetPlanning.Inventory<ServiceApplicationInfo>
+    {
+        guard self.applicationMutationInventoryTransportEnabled else {
+            return try await .partial(
+                self.listApplications(),
+                warnings: ["Bridge host did not report application mutation inventory completeness."])
+        }
+        let response = try await self.send(.listApplicationMutationInventory)
+        switch response {
+        case let .applicationMutationInventory(inventory):
+            return inventory
+        case let .error(envelope):
+            throw envelope
+        default:
+            throw PeekabooBridgeErrorEnvelope(
+                code: .invalidRequest,
+                message: "Unexpected listApplicationMutationInventory response")
         }
     }
 

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeClient.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeClient.swift
@@ -48,6 +48,8 @@ public actor PeekabooBridgeClient {
     var exactDialogInputExecutionEnabled = false
     var exactDialogForceDismissExecutionEnabled = false
     var dialogInputFocusPolicyEnabled = false
+    var applicationMutationInventoryTransportEnabled = false
+    var windowMutationInventoryTransportEnabled = false
     var operationAttestation: PeekabooBridgeListenerAttestation?
     var latestVerifiedOperationReceipt: PeekabooBridgeOperationReceipt?
     var latestVerifiedOperationReceiptBundle: PeekabooBridgeOperationReceiptBundle?
@@ -808,6 +810,18 @@ public actor PeekabooBridgeClient {
                 (handshake.enabledOperations?.contains(.dialogEnterText) ?? legacyInputAdvertised) &&
                 handshake.hostCapabilities?.contains(
                     PeekabooBridgeHostCapability.dialogInputFocusPolicy) == true,
+            applicationMutationInventoryTransportEnabled:
+            handshake.negotiatedVersion >= PeekabooBridgeConstants.plannerInventoryTransportVersion &&
+                handshake.hostCapabilities?.contains(
+                    PeekabooBridgeHostCapability.plannerInventoryTransport) == true &&
+                handshake.supportedOperations.contains(.listApplications) &&
+                (handshake.enabledOperations?.contains(.listApplications) ?? true),
+            windowMutationInventoryTransportEnabled:
+            handshake.negotiatedVersion >= PeekabooBridgeConstants.plannerInventoryTransportVersion &&
+                handshake.hostCapabilities?.contains(
+                    PeekabooBridgeHostCapability.plannerInventoryTransport) == true &&
+                handshake.supportedOperations.contains(.listWindows) &&
+                (handshake.enabledOperations?.contains(.listWindows) ?? true),
             listenerAttestation: listenerAttestation,
             listenerLiveIdentity: listenerLiveIdentity,
             sessionAttestation: sessionAttestation,
@@ -849,6 +863,9 @@ public actor PeekabooBridgeClient {
         self.exactDialogInputExecutionEnabled = candidate.exactDialogInputExecutionEnabled
         self.exactDialogForceDismissExecutionEnabled = candidate.exactDialogForceDismissExecutionEnabled
         self.dialogInputFocusPolicyEnabled = candidate.dialogInputFocusPolicyEnabled
+        self.applicationMutationInventoryTransportEnabled =
+            candidate.applicationMutationInventoryTransportEnabled
+        self.windowMutationInventoryTransportEnabled = candidate.windowMutationInventoryTransportEnabled
         self.operationAttestation = candidate.listenerAttestation
         self.installReceiptlessAuthenticatedHost(candidate.receiptlessAuthenticatedHost)
         if let listenerAttestation = candidate.listenerAttestation,
@@ -1127,6 +1144,8 @@ private struct PeekabooBridgeClientHandshakeCandidate: Sendable {
     let exactDialogInputExecutionEnabled: Bool
     let exactDialogForceDismissExecutionEnabled: Bool
     let dialogInputFocusPolicyEnabled: Bool
+    let applicationMutationInventoryTransportEnabled: Bool
+    let windowMutationInventoryTransportEnabled: Bool
     let listenerAttestation: PeekabooBridgeListenerAttestation?
     let listenerLiveIdentity: PeekabooBridgeLivePeerIdentity?
     let sessionAttestation: PeekabooBridgeOperationSessionAttestation?

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeConstants.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeConstants.swift
@@ -64,7 +64,11 @@ public enum PeekabooBridgeConstants {
     }
 
     /// Current protocol version supported by this build.
-    public static let protocolVersion = PeekabooBridgeProtocolVersion(major: 1, minor: 29)
+    public static let protocolVersion = PeekabooBridgeProtocolVersion(major: 1, minor: 30)
+
+    /// First protocol that transports mutation-planner inventories with explicit completeness evidence.
+    public static let plannerInventoryTransportVersion =
+        PeekabooBridgeProtocolVersion(major: 1, minor: 30)
 
     /// First protocol with listener-bound, signed per-operation receipts.
     public static let attestedOperationReceiptVersion =

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeModels.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeModels.swift
@@ -342,6 +342,7 @@ public enum PeekabooBridgeHostCapability {
     public static let exactForcedDialogDismissExecution = "exactForcedDialogDismissExecution"
     public static let dialogInputFocusPolicy = "dialogInputFocusPolicy"
     public static let attestedOperationReceipts = "attestedOperationReceipts"
+    public static let plannerInventoryTransport = "plannerInventoryTransport"
 }
 
 public struct PeekabooBridgeHandshakeResponse: Codable, Sendable {

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeOperationResultSemantics.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeOperationResultSemantics.swift
@@ -42,6 +42,7 @@ enum PeekabooBridgeOperationResultSemantics {
 
     enum ResponseFamily: Hashable, Sendable {
         case application
+        case applicationMutationInventory
         case applications
         case bool
         case browserStatus
@@ -73,11 +74,13 @@ enum PeekabooBridgeOperationResultSemantics {
         case typeResult
         case waitResult
         case window
+        case windowMutationInventory
         case windows
 
         func matches(_ response: PeekabooBridgeResponse) -> Bool {
             switch (self, response) {
             case (.application, .application),
+                 (.applicationMutationInventory, .applicationMutationInventory),
                  (.applications, .applications),
                  (.bool, .bool),
                  (.browserStatus, .browserStatus),
@@ -109,6 +112,7 @@ enum PeekabooBridgeOperationResultSemantics {
                  (.typeResult, .typeResult),
                  (.waitResult, .waitResult),
                  (.window, .window),
+                 (.windowMutationInventory, .windowMutationInventory),
                  (.windows, .windows):
                 true
             default:
@@ -1278,7 +1282,7 @@ extension PeekabooBridgeOperationResultSemantics {
             operation: operation,
             operationPolicy: operationPolicy,
             contract: contract,
-            responseFamilies: self.responseFamilies(for: operation),
+            responseFamilies: self.responseFamilies(for: request),
             deliveryRules: self.deliveryRules(for: request),
             allowedSuccessStates: self.allowedSuccessStates(for: request),
             successResponsePolicy: self.successResponsePolicy(for: request),
@@ -1495,6 +1499,7 @@ extension PeekabooBridgeOperationResultSemantics {
              .moveMouse,
              .waitForElement,
              .listWindows,
+             .listWindowMutationInventory,
              .focusWindow,
              .moveWindow,
              .resizeWindow,
@@ -1506,6 +1511,7 @@ extension PeekabooBridgeOperationResultSemantics {
              .maximizeWindow,
              .getFocusedWindow,
              .listApplications,
+             .listApplicationMutationInventory,
              .findApplication,
              .getFrontmostApplication,
              .isApplicationRunning,
@@ -1738,6 +1744,17 @@ extension PeekabooBridgeOperationResultSemantics {
         case .beginSnapshotMutation: [.snapshotMutationLease]
         case .cleanSnapshotsOlderThan, .cleanAllSnapshots: [.int]
         case ._appleScriptProbe: []
+        }
+    }
+
+    private static func responseFamilies(for request: PeekabooBridgeRequest) -> Set<ResponseFamily> {
+        switch request.unwrappedOperationRequest {
+        case .listApplicationMutationInventory:
+            [.applicationMutationInventory]
+        case .listWindowMutationInventory:
+            [.windowMutationInventory]
+        default:
+            self.responseFamilies(for: request.operation)
         }
     }
 

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeRequestResponse.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeRequestResponse.swift
@@ -41,6 +41,7 @@ public enum PeekabooBridgeRequest: Codable, Sendable {
     case moveMouse(PeekabooBridgeMoveMouseRequest)
     case waitForElement(PeekabooBridgeWaitRequest)
     case listWindows(PeekabooBridgeWindowTargetRequest)
+    case listWindowMutationInventory(PeekabooBridgeWindowTargetRequest)
     case focusWindow(PeekabooBridgeWindowTargetRequest)
     case moveWindow(PeekabooBridgeWindowMoveRequest)
     case resizeWindow(PeekabooBridgeWindowResizeRequest)
@@ -52,6 +53,7 @@ public enum PeekabooBridgeRequest: Codable, Sendable {
     case maximizeWindow(PeekabooBridgeWindowTargetRequest)
     case getFocusedWindow
     case listApplications
+    case listApplicationMutationInventory
     case findApplication(PeekabooBridgeAppIdentifierRequest)
     case getFrontmostApplication
     case isApplicationRunning(PeekabooBridgeAppIdentifierRequest)
@@ -152,7 +154,7 @@ extension PeekabooBridgeRequest {
         case .drag: .drag
         case .moveMouse: .moveMouse
         case .waitForElement: .waitForElement
-        case .listWindows: .listWindows
+        case .listWindows, .listWindowMutationInventory: .listWindows
         case .focusWindow: .focusWindow
         case .moveWindow: .moveWindow
         case .resizeWindow: .resizeWindow
@@ -163,7 +165,7 @@ extension PeekabooBridgeRequest {
         case .restoreWindow: .restoreWindow
         case .maximizeWindow: .maximizeWindow
         case .getFocusedWindow: .getFocusedWindow
-        case .listApplications: .listApplications
+        case .listApplications, .listApplicationMutationInventory: .listApplications
         case .findApplication: .findApplication
         case .getFrontmostApplication: .getFrontmostApplication
         case .isApplicationRunning: .isApplicationRunning
@@ -241,8 +243,10 @@ public enum PeekabooBridgeResponse: Codable, Sendable {
     case ok
     case waitResult(WaitForElementResult)
     case windows([ServiceWindowInfo])
+    case windowMutationInventory(DesktopTargetPlanning.Inventory<ServiceWindowInfo>)
     case window(ServiceWindowInfo?)
     case applications([ServiceApplicationInfo])
+    case applicationMutationInventory(DesktopTargetPlanning.Inventory<ServiceApplicationInfo>)
     case application(ServiceApplicationInfo)
     case bool(Bool)
     case typeResult(TypeResult)

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer+Handlers.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer+Handlers.swift
@@ -1149,6 +1149,9 @@ extension PeekabooBridgeServer {
         case let .listWindows(payload):
             let result = try await self.services.windows.listWindows(target: payload.target)
             return .init(response: .windows(result))
+        case let .listWindowMutationInventory(payload):
+            let inventory = try await self.services.windows.mutationInventory(target: payload.target)
+            return .init(response: .windowMutationInventory(inventory))
         case let .focusWindow(payload):
             return try await self.handleWindowFocus(payload)
         case let .moveWindow(payload):

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer+ServiceHandlers.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer+ServiceHandlers.swift
@@ -10,6 +10,9 @@ extension PeekabooBridgeServer {
         case .listApplications:
             let apps = try await self.services.applications.listApplications()
             return .init(response: .applications(apps.data.applications))
+        case .listApplicationMutationInventory:
+            let inventory = try await self.services.applications.mutationApplicationInventory()
+            return .init(response: .applicationMutationInventory(inventory))
         case let .findApplication(payload):
             let app = try await self.services.applications.findApplication(identifier: payload.identifier)
             return .init(response: .application(app))

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer.swift
@@ -906,5 +906,8 @@ private func protocolHostCapabilities(
         capabilities.insert(PeekabooBridgeHostCapability.exactForcedDialogDismissExecution)
         capabilities.insert(PeekabooBridgeHostCapability.dialogInputFocusPolicy)
     }
+    if supportedVersions.upperBound >= PeekabooBridgeConstants.plannerInventoryTransportVersion {
+        capabilities.insert(PeekabooBridgeHostCapability.plannerInventoryTransport)
+    }
     return capabilities
 }

--- a/Core/PeekabooCore/Sources/PeekabooCore/Support/RemoteApplicationService.swift
+++ b/Core/PeekabooCore/Sources/PeekabooCore/Support/RemoteApplicationService.swift
@@ -7,7 +7,9 @@ import PeekabooBridge
 import PeekabooFoundation
 
 @MainActor
-public final class RemoteApplicationService: ApplicationServiceProtocol, ApplicationServiceActionResultProviding,
+public final class RemoteApplicationService: ApplicationServiceProtocol,
+    ApplicationMutationInventoryProviding,
+    ApplicationServiceActionResultProviding,
     ApplicationServiceTargetedActionResultProviding
 {
     private let client: PeekabooBridgeClient
@@ -94,6 +96,12 @@ public final class RemoteApplicationService: ApplicationServiceProtocol, Applica
                     "incompleteApplications": apps.count(where: { !($0.metadataWarnings ?? []).isEmpty }),
                 ]),
             metadata: .init(duration: 0, warnings: warnings))
+    }
+
+    public func applicationMutationInventory() async throws
+        -> DesktopTargetPlanning.Inventory<ServiceApplicationInfo>
+    {
+        try await self.client.listApplicationMutationInventory()
     }
 
     public func findApplication(identifier: String) async throws -> ServiceApplicationInfo {

--- a/Core/PeekabooCore/Sources/PeekabooCore/Support/RemoteWindowManagementService.swift
+++ b/Core/PeekabooCore/Sources/PeekabooCore/Support/RemoteWindowManagementService.swift
@@ -2,11 +2,13 @@ import CoreGraphics
 import Foundation
 import PeekabooAgentRuntime
 import PeekabooAutomation
+import PeekabooAutomationKit
 import PeekabooBridge
 import PeekabooFoundation
 
 @MainActor
 public final class RemoteWindowManagementService: WindowManagementServiceProtocol,
+    WindowMutationInventoryProviding,
     WindowManagementActionOutcomeProviding,
     WindowManagementActionResultProviding,
     WindowManagementPinnedFocusActionResultProviding
@@ -310,6 +312,12 @@ public final class RemoteWindowManagementService: WindowManagementServiceProtoco
 
     public func listWindows(target: WindowTarget) async throws -> [ServiceWindowInfo] {
         try await self.client.listWindows(target: target)
+    }
+
+    public func windowMutationInventory(
+        target: WindowTarget) async throws -> DesktopTargetPlanning.Inventory<ServiceWindowInfo>
+    {
+        try await self.client.listWindowMutationInventory(target: target)
     }
 
     public func getFocusedWindow() async throws -> ServiceWindowInfo? {

--- a/Core/PeekabooCore/Tests/PeekabooBridgeTests/ExactDialogInputWireTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooBridgeTests/ExactDialogInputWireTests.swift
@@ -15,7 +15,9 @@ struct ExactDialogInputWireTests {
         ]
         let legacyVersion = PeekabooBridgeProtocolVersion(major: 1, minor: 26)
 
-        #expect(PeekabooBridgeConstants.protocolVersion == .init(major: 1, minor: 29))
+        #expect(PeekabooBridgeConstants.protocolVersion == .init(major: 1, minor: 30))
+        #expect(PeekabooBridgeConstants.attestedOperationReceiptVersion == .init(major: 1, minor: 29))
+        #expect(PeekabooBridgeConstants.plannerInventoryTransportVersion == .init(major: 1, minor: 30))
         #expect(PeekabooBridgeConstants.exactDialogInputExecutionVersion == .init(major: 1, minor: 27))
         #expect(PeekabooBridgeConstants.exactForcedDialogDismissExecutionVersion == .init(major: 1, minor: 28))
         #expect(PeekabooBridgeHostCapability.exactDialogInputExecution == "exactDialogInputExecution")

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/PermissionsToolSelectedHostTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/PermissionsToolSelectedHostTests.swift
@@ -11,7 +11,7 @@ import Testing
 struct PermissionsToolSelectedHostTests {
     @Test
     func `permission provider remains additive at protocol 1_22`() {
-        #expect(PeekabooBridgeConstants.protocolVersion == .init(major: 1, minor: 29))
+        #expect(PeekabooBridgeConstants.protocolVersion == .init(major: 1, minor: 30))
     }
 
     private struct PermissionCase: Sendable, CustomTestStringConvertible {

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeActionOutcomeProjectionTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeActionOutcomeProjectionTests.swift
@@ -933,8 +933,8 @@ extension PeekabooBridgeActionOutcomeProjectionTests {
     }
 
     @Test
-    func `current protocol 1 29 preserves projection capability introduced at 1 23`() {
-        let currentVersion = PeekabooBridgeProtocolVersion(major: 1, minor: 29)
+    func `current protocol 1 30 preserves projection capability introduced at 1 23`() {
+        let currentVersion = PeekabooBridgeProtocolVersion(major: 1, minor: 30)
         let projectionVersion = PeekabooBridgeProtocolVersion(major: 1, minor: 23)
 
         #expect(PeekabooBridgeConstants.protocolVersion == currentVersion)

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeCaptureWindowIDValidationTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeCaptureWindowIDValidationTests.swift
@@ -84,7 +84,9 @@ struct PeekabooBridgeCaptureWindowIDValidationTests {
         defer { Task { await host.stop() } }
 
         let client = TrustedBridgeClientFixture.make(socketPath: socketPath, requestTimeoutSec: 2)
-        let handshake = try await client.handshake(client: Self.clientIdentity)
+        let handshake = try await client.handshake(
+            client: Self.clientIdentity,
+            protocolVersion: PeekabooBridgeConstants.attestedOperationReceiptVersion)
         #expect(handshake.negotiatedVersion == PeekabooBridgeConstants.attestedOperationReceiptVersion)
 
         let request = Self.captureWindowRequest(windowId: windowId)

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeClientConcurrencyTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeClientConcurrencyTests.swift
@@ -892,8 +892,16 @@ extension PeekabooBridgeClientConcurrencyTests {
             #expect(currentRenewalPayload.protocolVersion == PeekabooBridgeConstants.protocolVersion)
             #expect(currentRenewalPayload.replacingOperationSessionID == predecessor.attestation.sessionID)
             try await peer.respond(
-                .error(.init(code: .versionMismatch, message: "Protocol 1.29 is unavailable")),
+                .error(.init(code: .versionMismatch, message: "Protocol 1.30 is unavailable")),
                 to: currentRenewalRequest)
+
+            let previousRenewalRequest = try await peer.nextRequest()
+            let previousRenewalPayload = try Self.requireHandshake(previousRenewalRequest)
+            #expect(previousRenewalPayload.protocolVersion == PeekabooBridgeConstants.attestedOperationReceiptVersion)
+            #expect(previousRenewalPayload.replacingOperationSessionID == predecessor.attestation.sessionID)
+            try await peer.respond(
+                .error(.init(code: .versionMismatch, message: "Protocol 1.29 is unavailable")),
+                to: previousRenewalRequest)
 
             let legacyRenewalRequest = try await peer.nextRequest()
             let legacyRenewalPayload = try Self.requireHandshake(legacyRenewalRequest)
@@ -943,7 +951,7 @@ extension PeekabooBridgeClientConcurrencyTests {
                 return
             }
             #expect(await client.lastOperationReceipt() == nil)
-            #expect(await peer.acceptedConnectionCount == 5)
+            #expect(await peer.acceptedConnectionCount == 6)
         } catch {
             await peer.stop()
             throw error

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeOperationReceiptTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeOperationReceiptTests.swift
@@ -142,7 +142,9 @@ struct PeekabooBridgeOperationReceiptTests {
                 socketPath: socketPath,
                 requestTimeoutSec: 2,
                 operationReceiptExportDirectory: exportDirectory)
-            let handshake = try await client.handshake(client: Self.clientIdentity)
+            let handshake = try await client.handshake(
+                client: Self.clientIdentity,
+                protocolVersion: PeekabooBridgeConstants.attestedOperationReceiptVersion)
             let attestation = try #require(handshake.operationAttestation)
             let sessionAttestation = try #require(handshake.operationSessionAttestation)
 

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeOperationSessionAuthenticationTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeOperationSessionAuthenticationTests.swift
@@ -210,7 +210,9 @@ struct PeekabooBridgeOperationSessionAuthenticationTests {
         defer { Task { await host.stop() } }
 
         let client = TrustedBridgeClientFixture.make(socketPath: socketPath)
-        let handshake = try await client.handshake(client: Self.clientIdentity)
+        let handshake = try await client.handshake(
+            client: Self.clientIdentity,
+            protocolVersion: PeekabooBridgeConstants.attestedOperationReceiptVersion)
         #expect(handshake.negotiatedVersion == PeekabooBridgeConstants.attestedOperationReceiptVersion)
         #expect(handshake.operationAttestation != nil)
         #expect(handshake.operationSessionAttestation != nil)
@@ -224,7 +226,11 @@ struct PeekabooBridgeOperationSessionAuthenticationTests {
             signingTeamIdentifier: "UNTRUSTED-TEST-HOST")
 
         do {
-            let handshake = Task { try await client.handshake(client: Self.clientIdentity) }
+            let handshake = Task {
+                try await client.handshake(
+                    client: Self.clientIdentity,
+                    protocolVersion: PeekabooBridgeConstants.attestedOperationReceiptVersion)
+            }
             let request = try await peer.nextRequest()
             guard case let .handshake(payload) = try request.decode() else {
                 Issue.record("Expected protocol 1.29 handshake request")
@@ -289,6 +295,16 @@ struct PeekabooBridgeOperationSessionAuthenticationTests {
             try await peer.respond(
                 .error(.init(code: .versionMismatch, message: "Legacy trusted host")),
                 to: currentRequest)
+            let previousRequest = try await peer.nextRequest()
+            guard case let .handshake(previousPayload) = try previousRequest.decode() else {
+                Issue.record("Expected trusted protocol 1.29 fallback request")
+                await peer.stop()
+                return
+            }
+            #expect(previousPayload.protocolVersion == .init(major: 1, minor: 29))
+            try await peer.respond(
+                .error(.init(code: .versionMismatch, message: "Protocol 1.29 unavailable")),
+                to: previousRequest)
             let legacyRequest = try await peer.nextRequest()
             guard case let .handshake(legacyPayload) = try legacyRequest.decode() else {
                 Issue.record("Expected trusted protocol 1.28 fallback request")
@@ -316,7 +332,7 @@ struct PeekabooBridgeOperationSessionAuthenticationTests {
                 return
             }
             #expect(await client.lastOperationReceipt() == nil)
-            #expect(await peer.acceptedConnectionCount == 3)
+            #expect(await peer.acceptedConnectionCount == 4)
         } catch {
             await peer.stop()
             throw error

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgePlannerInventoryTransportTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgePlannerInventoryTransportTests.swift
@@ -1,0 +1,267 @@
+import CoreGraphics
+import Foundation
+import PeekabooAutomationKit
+import PeekabooAutomationKitTestSupport
+import PeekabooBridgeTestSupport
+import PeekabooFoundation
+import Testing
+@testable import PeekabooBridge
+@testable import PeekabooCore
+
+@Suite(.serialized)
+@MainActor
+struct PeekabooBridgePlannerInventoryTransportTests {
+    private static let clientIdentity = PeekabooBridgeClientIdentity(
+        bundleIdentifier: "dev.peekaboo.planner-inventory-tests",
+        teamIdentifier: nil,
+        processIdentifier: getpid(),
+        hostname: nil)
+
+    @Test
+    func `planner inventory wire cases retain legacy operation and response families`() throws {
+        let applicationInventory = DesktopTargetPlanning.Inventory<ServiceApplicationInfo>.complete([])
+        let windowInventory = DesktopTargetPlanning.Inventory<ServiceWindowInfo>.complete([])
+        let applicationRequest = PeekabooBridgeRequest.listApplicationMutationInventory
+        let windowRequest = PeekabooBridgeRequest.listWindowMutationInventory(
+            PeekabooBridgeWindowTargetRequest(target: .application("TextEdit")))
+
+        #expect(applicationRequest.operation == .listApplications)
+        #expect(windowRequest.operation == .listWindows)
+        #expect(PeekabooBridgeOperationResultSemantics.responseMatchesContract(
+            .applicationMutationInventory(applicationInventory),
+            request: applicationRequest))
+        #expect(!PeekabooBridgeOperationResultSemantics.responseMatchesContract(
+            .applications([]),
+            request: applicationRequest))
+        #expect(PeekabooBridgeOperationResultSemantics.responseMatchesContract(
+            .windowMutationInventory(windowInventory),
+            request: windowRequest))
+        #expect(!PeekabooBridgeOperationResultSemantics.responseMatchesContract(
+            .windows([]),
+            request: windowRequest))
+        #expect(PeekabooBridgeOperationResultSemantics.responseMatchesContract(
+            .applications([]),
+            request: .listApplications))
+        #expect(!PeekabooBridgeOperationResultSemantics.responseMatchesContract(
+            .applicationMutationInventory(applicationInventory),
+            request: .listApplications))
+
+        let legacyWindowData = try PeekabooBridgeOperationReceiptCoding.canonicalData(
+            PeekabooBridgeRequest.listWindows(PeekabooBridgeWindowTargetRequest(
+                target: .application("TextEdit"))))
+        let legacyWindowJSON = try #require(String(data: legacyWindowData, encoding: .utf8))
+        #expect(legacyWindowJSON ==
+            #"{"listWindows":{"_0":{"target":{"app":"TextEdit","kind":"application"}}}}"#)
+        #expect(legacyWindowJSON.contains("\"listWindows\""))
+        #expect(!legacyWindowJSON.contains("MutationInventory"))
+        #expect(!legacyWindowJSON.contains("includeInventoryMetadata"))
+    }
+
+    @Test
+    func `planner inventory capability starts at protocol 1 30`() {
+        let previous = PeekabooBridgeProtocolVersion(major: 1, minor: 29)
+        let legacyServer = PeekabooBridgeServer(
+            services: StubServices(),
+            allowlistedTeams: [],
+            allowlistedBundles: [],
+            supportedVersions: previous...previous)
+        let currentServer = PeekabooBridgeServer(
+            services: StubServices(),
+            allowlistedTeams: [],
+            allowlistedBundles: [])
+
+        #expect(PeekabooBridgeConstants.protocolVersion == .init(major: 1, minor: 30))
+        #expect(PeekabooBridgeConstants.attestedOperationReceiptVersion == .init(major: 1, minor: 29))
+        #expect(PeekabooBridgeConstants.plannerInventoryTransportVersion == .init(major: 1, minor: 30))
+        #expect(!legacyServer.hostCapabilities.contains(PeekabooBridgeHostCapability.plannerInventoryTransport))
+        #expect(currentServer.hostCapabilities.contains(PeekabooBridgeHostCapability.plannerInventoryTransport))
+    }
+
+    @Test
+    func `legacy host inventories stay explicit partial and use legacy request cases`() async throws {
+        let protocolVersion = PeekabooBridgeProtocolVersion(major: 1, minor: 28)
+        let processIdentity = ApplicationProcessIdentity(
+            processIdentifier: 123,
+            processStartIdentity: 456)
+        let application = AutomationTestFixtures.application(
+            processIdentifier: processIdentity.processIdentifier,
+            processStartIdentity: processIdentity.processStartIdentity,
+            bundleIdentifier: "dev.stub",
+            name: "StubApp")
+        let window = AutomationTestFixtures.window(processIdentity: processIdentity)
+        let handshake = BridgeTestFixtures.handshake(
+            negotiatedVersion: protocolVersion,
+            supportedOperations: [.listApplications, .listWindows],
+            enabledOperations: [.listApplications, .listWindows])
+        let peer = try ScriptedBridgePeer(responses: [
+            .handshake(handshake),
+            .applications([application]),
+            .windows([window]),
+        ])
+        let client = PeekabooBridgeClient(socketPath: peer.socketPath, requestTimeoutSec: 1)
+        _ = try await client.handshake(client: Self.clientIdentity, protocolVersion: protocolVersion)
+
+        let applications = try await client.listApplicationMutationInventory()
+        let windows = try await client.listWindowMutationInventory(target: .windowId(window.windowID))
+
+        #expect(!applications.isComplete)
+        #expect(applications.items == [application])
+        #expect(applications.warnings == [
+            "Bridge host did not report application mutation inventory completeness.",
+        ])
+        #expect(!windows.isComplete)
+        #expect(windows.items == [window])
+        #expect(windows.warnings == [
+            "Bridge host did not report window mutation inventory completeness.",
+        ])
+
+        let requests = await peer.requests
+        #expect(requests.count == 3)
+        let applicationRequest = try JSONDecoder.peekabooBridgeDecoder().decode(
+            PeekabooBridgeRequest.self,
+            from: requests[1])
+        let windowRequest = try JSONDecoder.peekabooBridgeDecoder().decode(
+            PeekabooBridgeRequest.self,
+            from: requests[2])
+        guard case .listApplications = applicationRequest else {
+            Issue.record("Expected legacy listApplications request")
+            return
+        }
+        guard case .listWindows = windowRequest else {
+            Issue.record("Expected legacy listWindows request")
+            return
+        }
+        await peer.waitUntilFinished()
+    }
+
+    @Test
+    func `protocol 1 30 preserves signed partial inventories and downgrade clears transport`() async throws {
+        let socketPath = "/tmp/peekaboo-planner-inventory-\(UUID().uuidString).sock"
+        let processIdentity = ApplicationProcessIdentity(
+            processIdentifier: 123,
+            processStartIdentity: 456)
+        let window = AutomationTestFixtures.window(
+            windowID: 77,
+            title: "Fixture",
+            processIdentity: processIdentity)
+        let applications = PlannerInventoryApplicationService()
+        let windows = PlannerInventoryWindowService(inventory: .partial(
+            [window],
+            warnings: ["AX window enumeration timed out"]))
+        let server = PeekabooBridgeServer(
+            services: StubServices(applications: applications, windows: windows),
+            allowlistedTeams: [],
+            allowlistedBundles: [],
+            allowedOperations: [.listApplications, .findApplication, .getFrontmostApplication, .listWindows])
+        let host = PeekabooBridgeHost(
+            socketPath: socketPath,
+            server: server,
+            allowedTeamIDs: [],
+            requestTimeoutSec: 2)
+        try await host.startChecked()
+        defer { Task { await host.stop() } }
+
+        let client = TrustedBridgeClientFixture.make(socketPath: socketPath, requestTimeoutSec: 2)
+        let current = try await client.handshake(client: Self.clientIdentity)
+        #expect(current.negotiatedVersion == .init(major: 1, minor: 30))
+        #expect(current.hostCapabilities?.contains(PeekabooBridgeHostCapability.plannerInventoryTransport) == true)
+
+        let remoteApplications = RemoteApplicationService(client: client)
+        let remoteWindows = RemoteWindowManagementService(client: client)
+        let applicationInventory = try await remoteApplications.applicationMutationInventory()
+        let windowInventory = try await remoteWindows.windowMutationInventory(target: .windowId(window.windowID))
+        #expect(applicationInventory.isComplete)
+        #expect(applicationInventory.items.map(\.processIdentifier) == [123])
+        #expect(!windowInventory.isComplete)
+        #expect(windowInventory.items == [window])
+        #expect(windowInventory.warnings == ["AX window enumeration timed out"])
+
+        let receiptBundle = try #require(await client.lastOperationReceiptBundle())
+        try receiptBundle.validate()
+        let signedRequest = try JSONDecoder.peekabooBridgeDecoder().decode(
+            PeekabooBridgeRequest.self,
+            from: receiptBundle.canonicalRequest)
+        guard case .listWindowMutationInventory = signedRequest else {
+            Issue.record("Expected signed planner window inventory request")
+            return
+        }
+
+        let planner = DesktopTargetPlanning.WindowMutationPlanner(
+            applications: remoteApplications,
+            windows: remoteWindows)
+        await #expect(throws: DesktopTargetPlanningError.incompleteWindowInventory(
+            selector: "window title 'Fixture'",
+            warnings: ["AX window enumeration timed out"]))
+        {
+            _ = try await planner.plan(selector: InteractionTargetSelector(
+                applicationIdentifier: "StubApp",
+                windowTitle: "Fixture"))
+        }
+        let exact = try await planner.plan(selector: InteractionTargetSelector(windowID: window.windowID))
+        #expect(exact.identity == window.mutationIdentity)
+
+        let previous = PeekabooBridgeProtocolVersion(major: 1, minor: 29)
+        let downgraded = try await client.handshake(
+            client: Self.clientIdentity,
+            protocolVersion: previous)
+        #expect(downgraded.negotiatedVersion == previous)
+        let downgradedInventory = try await client.listApplicationMutationInventory()
+        #expect(!downgradedInventory.isComplete)
+        #expect(downgradedInventory.items.map(\.processIdentifier) == [123])
+        let downgradedBundle = try #require(await client.lastOperationReceiptBundle())
+        try downgradedBundle.validate()
+        let downgradedRequest = try JSONDecoder.peekabooBridgeDecoder().decode(
+            PeekabooBridgeRequest.self,
+            from: downgradedBundle.canonicalRequest)
+        guard case .listApplications = downgradedRequest else {
+            Issue.record("Expected protocol 1.29 downgrade to retain the legacy request")
+            return
+        }
+
+        await host.stop()
+    }
+}
+
+@MainActor
+private final class PlannerInventoryApplicationService: StubApplicationService,
+    ApplicationMutationInventoryProviding
+{
+    func applicationMutationInventory() async throws
+        -> DesktopTargetPlanning.Inventory<ServiceApplicationInfo>
+    {
+        try await .complete(self.listApplications().data.applications)
+    }
+}
+
+@MainActor
+private final class PlannerInventoryWindowService: WindowManagementServiceProtocol,
+    WindowMutationInventoryProviding
+{
+    private let inventory: DesktopTargetPlanning.Inventory<ServiceWindowInfo>
+
+    init(inventory: DesktopTargetPlanning.Inventory<ServiceWindowInfo>) {
+        self.inventory = inventory
+    }
+
+    func closeWindow(target _: WindowTarget) async throws {}
+    func minimizeWindow(target _: WindowTarget) async throws {}
+    func maximizeWindow(target _: WindowTarget) async throws {}
+    func moveWindow(target _: WindowTarget, to _: CGPoint) async throws {}
+    func resizeWindow(target _: WindowTarget, to _: CGSize) async throws {}
+    func setWindowBounds(target _: WindowTarget, bounds _: CGRect) async throws {}
+    func focusWindow(target _: WindowTarget) async throws {}
+
+    func listWindows(target _: WindowTarget) async throws -> [ServiceWindowInfo] {
+        self.inventory.items
+    }
+
+    func windowMutationInventory(
+        target _: WindowTarget) async throws -> DesktopTargetPlanning.Inventory<ServiceWindowInfo>
+    {
+        self.inventory
+    }
+
+    func getFocusedWindow() async throws -> ServiceWindowInfo? {
+        self.inventory.items.first
+    }
+}

--- a/docs/bridge-host.md
+++ b/docs/bridge-host.md
@@ -199,6 +199,15 @@ attestation. The session binds the listener, client-instance UUID, exact peer pr
 request capacity, and optional predecessor session. Protocol 1.28 and older handshakes omit both attestations and keep
 their existing raw, receiptless request/response behavior.
 
+Protocol `1.30` adds separate application and window mutation-inventory requests and responses. These responses carry
+the planner's catalog rows together with explicit `complete` or `partial` state and bounded warnings. The legacy
+`listApplications` and `listWindows` request bytes, response families, operations, and protocol 1.29 receipt contract
+remain unchanged. A client uses the new cases only after negotiating 1.30 plus the `plannerInventoryTransport`
+capability and the corresponding enabled list operation. Otherwise it converts the legacy row array into an explicit
+partial inventory: broad name, title, index, or automatic selection then fails closed, while the planner may still use
+a direct exact-PID or exact-window-ID provider. The selected mutation plan remains local; Bridge transports evidence,
+not a second host-owned selector policy.
+
 The client does not treat the response-carried, self-signed listener as provenance by itself. It captures the connected
 socket peer's audit token and requires exact PID/PID-version, process-start, live kernel CDHash, Apple-anchored signing
 identity, trusted team membership, and listener-host agreement before installing a 1.29 session. Bundled Peekaboo

--- a/docs/commands/bridge.md
+++ b/docs/commands/bridge.md
@@ -75,6 +75,10 @@ read_when:
   descriptor, and reports minimized hashes/identities rather than the canonical command/response bytes or private host
   archive path. The output fields `target_attested` and `outcome_attested` describe actual signed field presence; a
   valid read-only receipt can truthfully report `outcome_attested: false`.
+- Protocol 1.30 advertises `plannerInventoryTransport` and carries application/window mutation inventories through
+  separate request and response cases with explicit completeness and warnings. Protocol 1.29 list requests remain
+  byte-compatible; clients treat their row-only responses as partial evidence, refusing broad mutation selectors while
+  retaining direct exact-PID and exact-window-ID compatibility.
 - Target attribution delegates to the same canonical process/window receipt coalescer used by local automation.
   One exhaustive operation semantic plan also owns each success response family, allowed terminal states and result
   values, delivery/mode alternatives, dispatched-unit policy, and request/response/handler target provenance. The


### PR DESCRIPTION
## Summary

- advance the Bridge transport protocol to 1.30 and advertise `plannerInventoryTransport`
- transport complete application/window inventory evidence for remote mutation planning
- retain the legacy list transport as explicitly partial evidence when the capability is unavailable
- validate request-specific response families and clear negotiated planner state on downgrade

## Compatibility

Protocol 1.29 request bytes and signed operation-receipt semantics remain unchanged. The attested operation-receipt version stays at 1.29. New clients use the 1.30 inventory transport only when the negotiated version, capability, and operation are all present; older hosts keep using legacy list requests, which are converted to partial inventories so broad selectors fail closed while exact PID/window-ID compatibility remains available.

## Proof

- `swift test --package-path Core/PeekabooCore --filter PeekabooBridgePlannerInventoryTransportTests` (4/4)
- full `AutomationKit` test suite (1,035 tests)
- full `PeekabooCore` test suite
- `pnpm run test:safe` (478 automation tests plus Core/CLI suites)
- `pnpm run format`
- `pnpm run lint` (66 inherited warnings, 0 serious)
- docs lint, release preflight, SwiftPM consumer, signing/native-only, background-certification, and diff checks
- final P0-P2 Autoreview: no actionable findings
