### PR TITLE
refactor(automation): centralize target-aware result composition

### DIFF
--- a/Apps/CLI/Sources/PeekabooCLI/Commands/AI/SeeCommand+Types.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/AI/SeeCommand+Types.swift
@@ -91,6 +91,11 @@ struct SeeExecutionReceipt: Equatable, Sendable {
         guard let first = receipts.first else { return .none }
         guard receipts.count > 1 else { return first }
 
+        let outcome = DesktopActionSequenceAccumulator.completedBatch(
+            outcomes: receipts.map(\.outcome),
+            succeededCount: receipts.count,
+            attemptedCount: receipts.count
+        )
         var sequence = UIAutomationActionResultSequenceAccumulator()
         for receipt in receipts {
             sequence.record(
@@ -101,7 +106,7 @@ struct SeeExecutionReceipt: Equatable, Sendable {
             )
         }
         let resolution = sequence.resolution
-        return Self(outcome: resolution.outcome, targetReceipt: resolution.targetReceipt)
+        return Self(outcome: outcome, targetReceipt: resolution.targetReceipt)
     }
 
     func requirePublishableOutcome(operation: String, requiresOutcome: Bool) throws {

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/AI/SeeCommand+Types.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/AI/SeeCommand+Types.swift
@@ -91,22 +91,17 @@ struct SeeExecutionReceipt: Equatable, Sendable {
         guard let first = receipts.first else { return .none }
         guard receipts.count > 1 else { return first }
 
-        let outcomes = receipts.map(\.outcome)
-        let outcome = DesktopActionSequenceAccumulator.completedBatch(
-            outcomes: outcomes,
-            succeededCount: receipts.count,
-            attemptedCount: receipts.count
-        )
-        let targetReceipt: DesktopActionTargetReceipt? =
-            if let firstTarget = first.targetReceipt,
-            receipts.allSatisfy({
-                $0.targetReceipt == firstTarget
-            }) {
-                firstTarget
-            } else {
-                nil
-            }
-        return Self(outcome: outcome, targetReceipt: targetReceipt)
+        var sequence = UIAutomationActionResultSequenceAccumulator()
+        for receipt in receipts {
+            sequence.record(
+                outcome: receipt.outcome,
+                targetReceipt: receipt.targetReceipt,
+                attribution: .operationTarget,
+                defaultDispatchedUnitCount: .one
+            )
+        }
+        let resolution = sequence.resolution
+        return Self(outcome: resolution.outcome, targetReceipt: resolution.targetReceipt)
     }
 
     func requirePublishableOutcome(operation: String, requiresOutcome: Bool) throws {
@@ -124,15 +119,19 @@ struct SeeExecutionReceipt: Equatable, Sendable {
     ) -> any Error {
         guard let outcome = self.outcome else { return error }
         if let failure = error as? DesktopActionFailure {
-            var sequence = DesktopActionSequenceAccumulator()
-            sequence.record(.outcome(outcome))
-            let composed = sequence.failure(
+            var sequence = UIAutomationActionResultSequenceAccumulator()
+            sequence.record(
+                outcome: outcome,
+                targetReceipt: self.targetReceipt,
+                attribution: .operationTarget
+            )
+            return sequence.failure(
                 combining: failure,
+                operation: operation,
                 message: failure.message,
                 hint: failure.hint ?? "Observe the target before deciding whether to retry \(operation).",
                 causeDescription: failure.causeDescription
             )
-            return composed.attributed(to: self.aggregateTarget(with: failure))
         }
 
         return postResultProcessingError(
@@ -175,49 +174,6 @@ struct SeeExecutionReceipt: Equatable, Sendable {
             processStartIdentity: identity.ownerProcessStartIdentity,
             windowID: identity.windowID
         )
-    }
-
-    private func aggregateTarget(with laterFailure: DesktopActionFailure)
-    -> DesktopActionTargetReceipt? {
-        guard let outcome = self.outcome else { return laterFailure.targetReceipt }
-        switch (
-            outcome.dispatchState.mutationDispatched,
-            laterFailure.outcome.dispatchState.mutationDispatched
-        ) {
-        case (true, true):
-            guard self.targetReceipt != nil, laterFailure.targetReceipt != nil else { return nil }
-            return Self.compatibleTarget(self.targetReceipt, laterFailure.targetReceipt)
-        case (true, false):
-            return self.targetReceipt
-        case (false, true):
-            return laterFailure.targetReceipt
-        case (false, false):
-            return Self.compatibleTarget(self.targetReceipt, laterFailure.targetReceipt)
-        }
-    }
-
-    private static func compatibleTarget(
-        _ prior: DesktopActionTargetReceipt?,
-        _ later: DesktopActionTargetReceipt?
-    ) -> DesktopActionTargetReceipt? {
-        switch (prior, later) {
-        case let (prior?, later?):
-            guard prior.processIdentifier == later.processIdentifier,
-                  prior.processStartIdentity == later.processStartIdentity
-            else { return nil }
-            if prior.windowID == later.windowID {
-                return prior
-            }
-            guard prior.windowID == nil || later.windowID == nil else { return nil }
-            return DesktopActionTargetReceipt(
-                processIdentifier: prior.processIdentifier,
-                processStartIdentity: prior.processStartIdentity
-            )
-        case (let target?, nil), (nil, let target?):
-            return target
-        case (nil, nil):
-            return nil
-        }
     }
 }
 

--- a/Apps/CLI/Tests/CLIAutomationTests/SeeCommandReceiptTests.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/SeeCommandReceiptTests.swift
@@ -474,6 +474,34 @@ extension SeeCommandRuntimeTests {
         #expect(incompatible.outcome == nil)
         #expect(incompatible.targetReceipt == targetA)
 
+        let missingOutcome = SeeExecutionReceipt.combining([
+            SeeExecutionReceipt(
+                outcome: .confirmedChange(route: .bridge, delivery: delivery, unitCount: .one),
+                targetReceipt: targetA
+            ),
+            SeeExecutionReceipt(outcome: nil, targetReceipt: targetA),
+        ])
+        #expect(missingOutcome.outcome?.state == .indeterminate)
+        #expect(missingOutcome.outcome?.route == .bridge)
+        #expect(missingOutcome.outcome?.dispatchState == .mayHaveDispatched(
+            unitCount: DesktopActionOutcome.DispatchUnitCount(2)
+        ))
+        #expect(missingOutcome.targetReceipt == targetA)
+
+        let partial = SeeExecutionReceipt.combining([
+            SeeExecutionReceipt(
+                outcome: .partial(route: .bridge, delivery: delivery, unitCount: .one),
+                targetReceipt: targetA
+            ),
+            SeeExecutionReceipt(
+                outcome: .confirmedNoChange(route: .bridge),
+                targetReceipt: targetA
+            ),
+        ])
+        #expect(partial.outcome?.state == .partial)
+        #expect(partial.outcome?.dispatchState.unitCount == .one)
+        #expect(partial.targetReceipt == targetA)
+
         let processTarget = try DesktopTargetIdentity(processIdentity: ApplicationProcessIdentity(
             processIdentifier: 10,
             processStartIdentity: 20

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Observation/DesktopObservationService.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Observation/DesktopObservationService.swift
@@ -185,6 +185,17 @@ public enum ObservationActionResultSemantics {
                 causeDescription: failure.causeDescription)
         }
 
+        var validation = UIAutomationActionResultSequenceAccumulator()
+        validation.record(
+            outcome: outcome,
+            targetReceipt: targetReceipt,
+            selectedLeafEvidence: selectedLeafEvidence,
+            attribution: .operationTarget)
+        let validationResolution = validation.resolution
+        let validatedSelectedLeafEvidence = validationResolution.hasInvalidSelectedLeafEvidence
+            ? nil
+            : validationResolution.selectedLeafEvidence
+
         let message = error.localizedDescription
         let hint = "Observe the target before retrying \(operation)."
         let causeDescription = String(describing: error)
@@ -195,7 +206,7 @@ public enum ObservationActionResultSemantics {
             causeDescription: causeDescription,
             targetReceipt: targetReceipt)
         {
-            return failure.selectingLeaves(selectedLeafEvidence)
+            return failure.selectingLeaves(validatedSelectedLeafEvidence)
         }
         switch outcome.state {
         case .confirmedChange:
@@ -208,7 +219,7 @@ public enum ObservationActionResultSemantics {
                 hint: hint,
                 causeDescription: causeDescription)
                 .attributed(to: targetReceipt)
-                .selectingLeaves(selectedLeafEvidence)
+                .selectingLeaves(validatedSelectedLeafEvidence)
         case .confirmedNoChange:
             return DesktopActionFailure.preDispatchRefusal(
                 route: outcome.route,

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Observation/DesktopObservationService.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Observation/DesktopObservationService.swift
@@ -123,6 +123,19 @@ public enum ObservationActionResultSemantics {
 
     public static func preservingFailure(
         _ error: any Error,
+        after result: UIAutomationActionResult<some Sendable>,
+        operation: String) -> any Error
+    {
+        self.preservingFailure(
+            error,
+            after: result.outcome,
+            targetReceipt: self.targetReceipt(result.targetIdentity),
+            selectedLeafEvidence: result.selectedLeafEvidence,
+            operation: operation)
+    }
+
+    public static func preservingFailure(
+        _ error: any Error,
         after outcome: DesktopActionOutcome?,
         targetIdentity: DesktopTargetIdentity?,
         operation: String) -> any Error
@@ -131,6 +144,7 @@ public enum ObservationActionResultSemantics {
             error,
             after: outcome,
             targetReceipt: self.targetReceipt(targetIdentity),
+            selectedLeafEvidence: nil,
             operation: operation)
     }
 
@@ -140,20 +154,35 @@ public enum ObservationActionResultSemantics {
         targetReceipt: DesktopActionTargetReceipt?,
         operation: String) -> any Error
     {
+        self.preservingFailure(
+            error,
+            after: outcome,
+            targetReceipt: targetReceipt,
+            selectedLeafEvidence: nil,
+            operation: operation)
+    }
+
+    private static func preservingFailure(
+        _ error: any Error,
+        after outcome: DesktopActionOutcome?,
+        targetReceipt: DesktopActionTargetReceipt?,
+        selectedLeafEvidence: [DesktopSelectedLeafEvidence]?,
+        operation: String) -> any Error
+    {
         guard let outcome else { return error }
         if let failure = error as? DesktopActionFailure {
-            var sequence = DesktopActionSequenceAccumulator()
-            sequence.record(.outcome(outcome))
-            let composed = sequence.failure(
+            var sequence = UIAutomationActionResultSequenceAccumulator()
+            sequence.record(
+                outcome: outcome,
+                targetReceipt: targetReceipt,
+                selectedLeafEvidence: selectedLeafEvidence,
+                attribution: .operationTarget)
+            return sequence.failure(
                 combining: failure,
+                operation: operation,
                 message: failure.message,
                 hint: failure.hint ?? "Observe the target before retrying \(operation).",
                 causeDescription: failure.causeDescription)
-            return composed.attributed(
-                to: self.aggregateTarget(
-                    priorOutcome: outcome,
-                    priorTarget: targetReceipt,
-                    laterFailure: failure))
         }
 
         let message = error.localizedDescription
@@ -166,7 +195,7 @@ public enum ObservationActionResultSemantics {
             causeDescription: causeDescription,
             targetReceipt: targetReceipt)
         {
-            return failure
+            return failure.selectingLeaves(selectedLeafEvidence)
         }
         switch outcome.state {
         case .confirmedChange:
@@ -179,6 +208,7 @@ public enum ObservationActionResultSemantics {
                 hint: hint,
                 causeDescription: causeDescription)
                 .attributed(to: targetReceipt)
+                .selectingLeaves(selectedLeafEvidence)
         case .confirmedNoChange:
             return DesktopActionFailure.preDispatchRefusal(
                 route: outcome.route,
@@ -211,50 +241,6 @@ public enum ObservationActionResultSemantics {
         -> DesktopActionTargetReceipt?
     {
         identity?.actionTargetReceipt
-    }
-
-    private static func aggregateTarget(
-        priorOutcome: DesktopActionOutcome,
-        priorTarget: DesktopActionTargetReceipt?,
-        laterFailure: DesktopActionFailure) -> DesktopActionTargetReceipt?
-    {
-        switch (
-            priorOutcome.dispatchState.mutationDispatched,
-            laterFailure.outcome.dispatchState.mutationDispatched)
-        {
-        case (true, true):
-            guard priorTarget != nil, laterFailure.targetReceipt != nil else { return nil }
-            return self.compatibleTarget(priorTarget, laterFailure.targetReceipt)
-        case (true, false):
-            return priorTarget
-        case (false, true):
-            return laterFailure.targetReceipt
-        case (false, false):
-            return self.compatibleTarget(priorTarget, laterFailure.targetReceipt)
-        }
-    }
-
-    private static func compatibleTarget(
-        _ prior: DesktopActionTargetReceipt?,
-        _ later: DesktopActionTargetReceipt?) -> DesktopActionTargetReceipt?
-    {
-        switch (prior, later) {
-        case let (prior?, later?):
-            guard prior.processIdentifier == later.processIdentifier,
-                  prior.processStartIdentity == later.processStartIdentity
-            else { return nil }
-            if prior.windowID == later.windowID {
-                return prior
-            }
-            guard prior.windowID == nil || later.windowID == nil else { return nil }
-            return DesktopActionTargetReceipt(
-                processIdentifier: prior.processIdentifier,
-                processStartIdentity: prior.processStartIdentity)
-        case (let target?, nil), (nil, let target?):
-            return target
-        case (nil, nil):
-            return nil
-        }
     }
 
     private static func coalescedTarget(
@@ -847,76 +833,23 @@ public final class DesktopObservationService: DesktopObservationActionResultProv
         requireCompatibleTarget: Bool) throws -> UIAutomationActionResult<ResolvedObservationTarget>
     {
         guard let actionOutcome = action.outcome else { return resolution }
-        var sequence = DesktopActionSequenceAccumulator()
-        if let resolutionOutcome = resolution.outcome {
-            sequence.record(.outcome(resolutionOutcome))
-        }
-        sequence.record(.outcome(actionOutcome))
-        let sequenceResolution = sequence.successResolution()
-        let outcome = sequenceResolution.outcome ?? .indeterminate(
+        var sequence = UIAutomationActionResultSequenceAccumulator()
+        sequence.record(resolution, attribution: .mutationTarget)
+        sequence.record(action, attribution: .mutationTarget)
+        let sequenceResolution = sequence.resolution
+        let fallbackOutcome = DesktopActionOutcome.indeterminate(
             route: actionOutcome.route,
             delivery: nil,
             evidence: .completionUnknown,
             unitCount: sequenceResolution.mutationDisposition.unitCount)
-        let targetComposition = self.composedMutationTarget(
-            priorOutcome: resolution.outcome,
-            priorTarget: resolution.targetIdentity,
-            laterOutcome: actionOutcome,
-            laterTarget: action.targetIdentity)
-        let selectedLeafEvidence = self.combinedSelectedLeafEvidence(
-            resolution.selectedLeafEvidence,
-            action.selectedLeafEvidence)
-        if requireCompatibleTarget, targetComposition.conflicts {
-            throw self.incompatiblePipelineFailure(
-                outcome: outcome,
-                selectedLeafEvidence: selectedLeafEvidence,
-                operation: operation,
-                cause: DesktopTargetIdentityError.contradictoryWindowIdentity)
-        }
-        return UIAutomationActionResult(
+        return try sequence.result(
             payload: resolution.payload,
-            outcome: outcome,
-            targetIdentity: targetComposition.target,
-            selectedLeafEvidence: selectedLeafEvidence)
-    }
-
-    private static func composedMutationTarget(
-        priorOutcome: DesktopActionOutcome?,
-        priorTarget: DesktopTargetIdentity?,
-        laterOutcome: DesktopActionOutcome,
-        laterTarget: DesktopTargetIdentity?) -> (target: DesktopTargetIdentity?, conflicts: Bool)
-    {
-        let priorDispatched = priorOutcome?.dispatchState.mutationDispatched == true
-        let laterDispatched = laterOutcome.dispatchState.mutationDispatched
-        switch (priorDispatched, laterDispatched) {
-        case (false, false):
-            return (nil, false)
-        case (true, false):
-            return (priorTarget, false)
-        case (false, true):
-            return (laterTarget, false)
-        case (true, true):
-            switch (priorTarget, laterTarget) {
-            case let (prior?, later?):
-                do {
-                    return try (prior.coalescing(later), false)
-                } catch {
-                    return (nil, true)
-                }
-            case (nil, nil):
-                return (nil, false)
-            case (.some, nil), (nil, .some):
-                return (nil, true)
-            }
-        }
-    }
-
-    private static func combinedSelectedLeafEvidence(
-        _ prior: [DesktopSelectedLeafEvidence]?,
-        _ later: [DesktopSelectedLeafEvidence]?) -> [DesktopSelectedLeafEvidence]?
-    {
-        let combined = (prior ?? []) + (later ?? [])
-        return combined.isEmpty ? nil : combined
+            fallbackOutcome: fallbackOutcome,
+            operation: operation,
+            requiresOutcome: true,
+            requiresCompatibleTarget: requireCompatibleTarget,
+            failureMessage: "Desktop observation could not safely compose its setup and \(operation) targets.",
+            failureHint: "Observe both targets before retrying this observation.")
     }
 
     private static func incompatiblePipelineFailure(
@@ -1058,15 +991,10 @@ public final class DesktopObservationService: DesktopObservationActionResultProv
         _ error: any Error,
         resolution: UIAutomationActionResult<ResolvedObservationTarget>) -> any Error
     {
-        let preserved = ObservationActionResultSemantics.preservingFailure(
+        ObservationActionResultSemantics.preservingFailure(
             error,
-            after: resolution.outcome,
-            targetIdentity: resolution.targetIdentity,
+            after: resolution,
             operation: "desktop observation")
-        guard let failure = preserved as? DesktopActionFailure else { return preserved }
-        return failure.selectingLeaves(self.combinedSelectedLeafEvidence(
-            resolution.selectedLeafEvidence,
-            failure.selectedLeafEvidence))
     }
 
     private func withCaptureTransaction<T: Sendable>(

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Strategy/UIAutomationActionResultSequenceAccumulator.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Strategy/UIAutomationActionResultSequenceAccumulator.swift
@@ -1,0 +1,416 @@
+import Foundation
+import PeekabooFoundation
+
+/// Target-aware composition for multi-phase automation results.
+///
+/// ``DesktopActionSequenceAccumulator`` remains the sole owner of outcome-state composition. This
+/// layer keeps target attribution and selected-leaf evidence aligned with the phases that actually
+/// dispatched, so setup results cannot silently lend their target to an unattributed leaf.
+public struct UIAutomationActionResultSequenceAccumulator: Sendable {
+    public enum PhaseAttributionRule: Equatable, Sendable {
+        /// Only a phase that dispatched mutation contributes its target to the aggregate.
+        case mutationTarget
+
+        /// A reported target describes the operation even when no dispatch was necessary.
+        case operationTarget
+
+        /// This phase must report its own stable target; an earlier phase cannot substitute for it.
+        case requiredTarget
+
+        /// The phase is intentionally global and the aggregate must not claim an exact target.
+        case targetless
+    }
+
+    public struct Resolution: Sendable {
+        public let outcome: DesktopActionOutcome?
+        public let mutationDisposition: DesktopActionMutationDisposition
+        public let targetIdentity: DesktopTargetIdentity?
+        public let targetReceipt: DesktopActionTargetReceipt?
+        public let mutationTargetReceipt: DesktopActionTargetReceipt?
+        public let selectedLeafEvidence: [DesktopSelectedLeafEvidence]?
+        public let hasTargetConflict: Bool
+        public let hasProhibitedTarget: Bool
+        public let hasMissingRequiredTarget: Bool
+        public let hasInvalidSelectedLeafEvidence: Bool
+    }
+
+    private struct TargetAccumulator: Sendable {
+        private(set) var contributionCount = 0
+        private(set) var missingCount = 0
+        private(set) var hasContradiction = false
+        private var mergedReceipt: DesktopActionTargetReceipt?
+        private var mergedIdentity: DesktopTargetIdentity?
+        private var hasMissingIdentity = false
+
+        var hasIncompatibleContributions: Bool {
+            self.hasContradiction || (self.contributionCount > 1 && self.missingCount > 0)
+        }
+
+        var receipt: DesktopActionTargetReceipt? {
+            guard !self.hasContradiction, self.missingCount == 0 else { return nil }
+            return self.mergedReceipt
+        }
+
+        var identity: DesktopTargetIdentity? {
+            guard !self.hasContradiction,
+                  self.missingCount == 0,
+                  !self.hasMissingIdentity,
+                  let receipt = self.mergedReceipt
+            else { return nil }
+
+            if receipt.windowID == nil {
+                return try? DesktopTargetIdentity(processIdentity: ApplicationProcessIdentity(
+                    processIdentifier: receipt.processIdentifier,
+                    processStartIdentity: receipt.processStartIdentity))
+            }
+            guard let identity = self.mergedIdentity,
+                  identity.actionTargetReceipt == receipt
+            else { return nil }
+            return identity
+        }
+
+        mutating func record(
+            identity: DesktopTargetIdentity?,
+            receipt explicitReceipt: DesktopActionTargetReceipt?)
+        {
+            self.contributionCount += 1
+            let identityReceipt = identity?.actionTargetReceipt
+            if let identityReceipt, let explicitReceipt, identityReceipt != explicitReceipt {
+                self.hasContradiction = true
+                self.mergedReceipt = nil
+                self.mergedIdentity = nil
+                return
+            }
+            guard let receipt = explicitReceipt ?? identityReceipt else {
+                self.missingCount += 1
+                self.hasMissingIdentity = true
+                return
+            }
+
+            if let current = self.mergedReceipt {
+                guard let merged = Self.commonScope(current, receipt) else {
+                    self.hasContradiction = true
+                    self.mergedReceipt = nil
+                    self.mergedIdentity = nil
+                    return
+                }
+                self.mergedReceipt = merged
+            } else {
+                self.mergedReceipt = receipt
+            }
+
+            guard let identity else {
+                self.hasMissingIdentity = true
+                return
+            }
+            if let current = self.mergedIdentity {
+                do {
+                    self.mergedIdentity = try current.coalescing(identity)
+                } catch {
+                    self.hasContradiction = true
+                    self.mergedReceipt = nil
+                    self.mergedIdentity = nil
+                }
+            } else {
+                self.mergedIdentity = identity
+            }
+        }
+
+        fileprivate static func commonScope(
+            _ lhs: DesktopActionTargetReceipt,
+            _ rhs: DesktopActionTargetReceipt) -> DesktopActionTargetReceipt?
+        {
+            guard lhs.processIdentifier == rhs.processIdentifier,
+                  lhs.processStartIdentity == rhs.processStartIdentity
+            else { return nil }
+            if lhs.windowID == rhs.windowID {
+                return lhs
+            }
+            guard lhs.windowID == nil || rhs.windowID == nil else { return nil }
+            return DesktopActionTargetReceipt(
+                processIdentifier: lhs.processIdentifier,
+                processStartIdentity: lhs.processStartIdentity)
+        }
+    }
+
+    private var sequence = DesktopActionSequenceAccumulator()
+    private var operationTargets = TargetAccumulator()
+    private var mutationTargets = TargetAccumulator()
+    private var selectedLeaves: [DesktopSelectedLeafEvidence] = []
+    private var recordedPhaseCount = 0
+    private var forcesTargetlessResult = false
+    private var targetlessPhaseReturnedTarget = false
+    private var missingRequiredTarget = false
+    private var invalidSelectedLeafEvidence = false
+
+    public init() {}
+
+    public mutating func record(
+        _ result: UIAutomationActionResult<some Sendable>,
+        attribution: PhaseAttributionRule,
+        defaultDispatchedUnitCount: DesktopActionOutcome.DispatchUnitCount? = nil)
+    {
+        self.record(
+            outcome: result.outcome,
+            targetIdentity: result.targetIdentity,
+            targetReceipt: nil,
+            selectedLeafEvidence: result.selectedLeafEvidence,
+            attribution: attribution,
+            defaultDispatchedUnitCount: defaultDispatchedUnitCount)
+    }
+
+    public mutating func record(
+        outcome: DesktopActionOutcome?,
+        targetIdentity: DesktopTargetIdentity? = nil,
+        targetReceipt: DesktopActionTargetReceipt? = nil,
+        selectedLeafEvidence: [DesktopSelectedLeafEvidence]? = nil,
+        attribution: PhaseAttributionRule,
+        defaultDispatchedUnitCount: DesktopActionOutcome.DispatchUnitCount? = nil)
+    {
+        self.recordedPhaseCount += 1
+        if let outcome {
+            if let defaultDispatchedUnitCount {
+                self.sequence.record(.reportedOutcome(
+                    outcome,
+                    defaultDispatchedUnitCount: defaultDispatchedUnitCount))
+            } else {
+                self.sequence.record(.outcome(outcome))
+            }
+        }
+
+        let didDispatch = outcome?.dispatchState.mutationDispatched == true
+        let hasTarget = targetIdentity != nil || targetReceipt != nil
+        switch attribution {
+        case .mutationTarget:
+            if didDispatch {
+                self.recordTargetContribution(
+                    identity: targetIdentity,
+                    receipt: targetReceipt,
+                    contributesToOperation: true)
+            }
+        case .operationTarget:
+            self.recordTargetContribution(
+                identity: targetIdentity,
+                receipt: targetReceipt,
+                contributesToOperation: true,
+                contributesToMutation: didDispatch)
+        case .requiredTarget:
+            if !hasTarget {
+                self.missingRequiredTarget = true
+            }
+            self.recordTargetContribution(
+                identity: targetIdentity,
+                receipt: targetReceipt,
+                contributesToOperation: true,
+                contributesToMutation: didDispatch)
+        case .targetless:
+            self.forcesTargetlessResult = true
+            self.targetlessPhaseReturnedTarget = self.targetlessPhaseReturnedTarget || hasTarget
+        }
+
+        guard let selectedLeafEvidence else { return }
+        guard didDispatch,
+              !selectedLeafEvidence.isEmpty,
+              selectedLeafEvidence.allSatisfy(\.isCanonical)
+        else {
+            self.invalidSelectedLeafEvidence = true
+            return
+        }
+        self.selectedLeaves.append(contentsOf: selectedLeafEvidence)
+    }
+
+    public var resolution: Resolution {
+        let sequenceResolution = self.sequence.successResolution()
+        let targetConflict = self.targetlessPhaseReturnedTarget ||
+            self.operationTargets.hasIncompatibleContributions
+        return Resolution(
+            outcome: sequenceResolution.outcome,
+            mutationDisposition: sequenceResolution.mutationDisposition,
+            targetIdentity: self.forcesTargetlessResult ? nil : self.operationTargets.identity,
+            targetReceipt: self.forcesTargetlessResult ? nil : self.operationTargets.receipt,
+            mutationTargetReceipt: self.forcesTargetlessResult ? nil : self.mutationTargets.receipt,
+            selectedLeafEvidence: self.selectedLeaves.isEmpty ? nil : self.selectedLeaves,
+            hasTargetConflict: targetConflict,
+            hasProhibitedTarget: self.targetlessPhaseReturnedTarget,
+            hasMissingRequiredTarget: self.missingRequiredTarget,
+            hasInvalidSelectedLeafEvidence: self.invalidSelectedLeafEvidence)
+    }
+
+    public func result<Payload: Sendable>(
+        payload: Payload,
+        fallbackOutcome: DesktopActionOutcome? = nil,
+        operation: String,
+        requiresOutcome: Bool = false,
+        requiresTarget: Bool = false,
+        requiresCompatibleTarget: Bool = false,
+        failureMessage: String? = nil,
+        failureHint: String = "Observe the target before retrying.") throws -> UIAutomationActionResult<Payload>
+    {
+        let resolution = self.resolution
+        let outcome = resolution.outcome ?? fallbackOutcome
+        if resolution.hasInvalidSelectedLeafEvidence {
+            throw self.compositionFailure(
+                outcome: outcome,
+                operation: operation,
+                message: failureMessage ?? "\(operation) returned invalid selected-leaf evidence.",
+                hint: failureHint,
+                causeDescription: "Selected-leaf evidence requires a dispatched mutation and canonical fields.")
+        }
+        if resolution.hasMissingRequiredTarget {
+            throw self.compositionFailure(
+                outcome: outcome,
+                operation: operation,
+                message: failureMessage ?? "\(operation) returned without its required phase target.",
+                hint: failureHint,
+                causeDescription: DesktopTargetIdentityError.missingProcessGeneration.localizedDescription)
+        }
+        if resolution.hasProhibitedTarget {
+            throw self.compositionFailure(
+                outcome: outcome,
+                operation: operation,
+                message: failureMessage ?? "\(operation) returned a target for a targetless phase.",
+                hint: failureHint,
+                causeDescription: "A globally delivered phase cannot claim exact target attribution.")
+        }
+        if requiresCompatibleTarget, resolution.hasTargetConflict {
+            throw self.compositionFailure(
+                outcome: outcome,
+                operation: operation,
+                message: failureMessage ?? "\(operation) returned contradictory phase targets.",
+                hint: failureHint,
+                causeDescription: DesktopTargetIdentityError.contradictoryWindowIdentity.localizedDescription)
+        }
+        if requiresTarget, resolution.targetIdentity == nil {
+            throw self.compositionFailure(
+                outcome: outcome,
+                operation: operation,
+                message: failureMessage ?? "\(operation) returned without its required aggregate target.",
+                hint: failureHint,
+                causeDescription: DesktopTargetIdentityError.missingProcessGeneration.localizedDescription)
+        }
+        if requiresOutcome, outcome == nil {
+            throw self.compositionFailure(
+                outcome: nil,
+                operation: operation,
+                message: failureMessage ?? "\(operation) returned without a canonical aggregate outcome.",
+                hint: failureHint,
+                causeDescription: nil)
+        }
+        return UIAutomationActionResult(
+            payload: payload,
+            outcome: outcome,
+            targetIdentity: resolution.targetIdentity,
+            selectedLeafEvidence: resolution.selectedLeafEvidence)
+    }
+
+    public func failure(
+        combining leafFailure: DesktopActionFailure,
+        operation: String,
+        message: String? = nil,
+        hint: String? = nil,
+        causeDescription: String? = nil) -> DesktopActionFailure
+    {
+        guard self.recordedPhaseCount > 0 else { return leafFailure }
+        let composed = self.sequence.failure(
+            combining: leafFailure,
+            message: message ?? leafFailure.message,
+            hint: hint ?? leafFailure.hint,
+            causeDescription: causeDescription ?? leafFailure.causeDescription)
+        let targetReceipt = self.failureTargetReceipt(leafFailure)
+        let evidence = self.combinedSelectedLeafEvidence(leafFailure.selectedLeafEvidence)
+        return self.assigning(targetReceipt, to: composed)
+            .selectingLeaves(evidence)
+    }
+
+    private mutating func recordTargetContribution(
+        identity: DesktopTargetIdentity?,
+        receipt: DesktopActionTargetReceipt?,
+        contributesToOperation: Bool,
+        contributesToMutation: Bool = true)
+    {
+        if contributesToOperation {
+            self.operationTargets.record(identity: identity, receipt: receipt)
+        }
+        if contributesToMutation {
+            self.mutationTargets.record(identity: identity, receipt: receipt)
+        }
+    }
+
+    private func failureTargetReceipt(_ leafFailure: DesktopActionFailure) -> DesktopActionTargetReceipt? {
+        guard !self.forcesTargetlessResult else { return nil }
+        let priorTarget = self.resolution.mutationTargetReceipt
+        switch (
+            self.sequence.mutationDisposition.mutationDispatched,
+            leafFailure.outcome.dispatchState.mutationDispatched)
+        {
+        case (true, true):
+            guard let priorTarget, let laterTarget = leafFailure.targetReceipt else { return nil }
+            return TargetAccumulator.commonScope(priorTarget, laterTarget)
+        case (true, false):
+            return priorTarget
+        case (false, true):
+            return leafFailure.targetReceipt
+        case (false, false):
+            switch (self.resolution.targetReceipt, leafFailure.targetReceipt) {
+            case let (prior?, later?):
+                return TargetAccumulator.commonScope(prior, later)
+            case let (target?, nil), let (nil, target?):
+                return target
+            case (nil, nil):
+                return nil
+            }
+        }
+    }
+
+    private func combinedSelectedLeafEvidence(
+        _ leafEvidence: [DesktopSelectedLeafEvidence]?) -> [DesktopSelectedLeafEvidence]?
+    {
+        let evidence = self.selectedLeaves + (leafEvidence ?? [])
+        guard !evidence.isEmpty, evidence.allSatisfy(\.isCanonical) else { return nil }
+        return evidence
+    }
+
+    private func assigning(
+        _ targetReceipt: DesktopActionTargetReceipt?,
+        to failure: DesktopActionFailure) -> DesktopActionFailure
+    {
+        if let targetReceipt {
+            return failure.attributed(to: targetReceipt)
+        }
+        guard failure.targetReceipt != nil,
+              let unattributed = DesktopActionFailure(
+                  outcome: failure.outcome,
+                  message: failure.message,
+                  hint: failure.hint,
+                  causeDescription: failure.causeDescription,
+                  selectedLeafEvidence: failure.selectedLeafEvidence)
+        else { return failure }
+        return unattributed
+    }
+
+    private func compositionFailure(
+        outcome: DesktopActionOutcome?,
+        operation _: String,
+        message: String,
+        hint: String,
+        causeDescription: String?) -> DesktopActionFailure
+    {
+        let failure = outcome.flatMap {
+            DesktopActionFailure(
+                outcome: $0,
+                message: message,
+                hint: hint,
+                causeDescription: causeDescription)
+        } ?? .indeterminate(
+            route: outcome?.route ?? .local,
+            delivery: outcome?.delivery,
+            evidence: .completionUnknown,
+            unitCount: outcome?.dispatchState.unitCount ?? self.sequence.mutationDisposition.unitCount,
+            message: message,
+            hint: hint,
+            causeDescription: causeDescription)
+        return failure
+            .attributed(to: self.resolution.targetReceipt)
+            .selectingLeaves(self.resolution.selectedLeafEvidence)
+    }
+}

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Strategy/UIAutomationActionResultSequenceAccumulator.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Strategy/UIAutomationActionResultSequenceAccumulator.swift
@@ -31,6 +31,7 @@ public struct UIAutomationActionResultSequenceAccumulator: Sendable {
         public let hasTargetConflict: Bool
         public let hasProhibitedTarget: Bool
         public let hasMissingRequiredTarget: Bool
+        public let hasContradictoryRequiredTarget: Bool
         public let hasInvalidSelectedLeafEvidence: Bool
     }
 
@@ -131,6 +132,17 @@ public struct UIAutomationActionResultSequenceAccumulator: Sendable {
                 processIdentifier: lhs.processIdentifier,
                 processStartIdentity: lhs.processStartIdentity)
         }
+
+        fileprivate static func contains(
+            _ candidate: DesktopActionTargetReceipt,
+            within scope: DesktopActionTargetReceipt) -> Bool
+        {
+            guard candidate.processIdentifier == scope.processIdentifier,
+                  candidate.processStartIdentity == scope.processStartIdentity
+            else { return false }
+            guard let scopeWindowID = scope.windowID else { return true }
+            return candidate.windowID == scopeWindowID
+        }
     }
 
     private var sequence = DesktopActionSequenceAccumulator()
@@ -141,6 +153,7 @@ public struct UIAutomationActionResultSequenceAccumulator: Sendable {
     private var forcesTargetlessResult = false
     private var targetlessPhaseReturnedTarget = false
     private var missingRequiredTarget = false
+    private var contradictoryRequiredTarget = false
     private var invalidSelectedLeafEvidence = false
 
     public init() {}
@@ -197,6 +210,11 @@ public struct UIAutomationActionResultSequenceAccumulator: Sendable {
         case .requiredTarget:
             if !hasTarget {
                 self.missingRequiredTarget = true
+            } else if let identityReceipt = targetIdentity?.actionTargetReceipt,
+                      let targetReceipt,
+                      identityReceipt != targetReceipt
+            {
+                self.contradictoryRequiredTarget = true
             }
             self.recordTargetContribution(
                 identity: targetIdentity,
@@ -209,9 +227,23 @@ public struct UIAutomationActionResultSequenceAccumulator: Sendable {
         }
 
         guard let selectedLeafEvidence else { return }
+        let identityTargetReceipt = targetIdentity?.actionTargetReceipt
+        let phaseTargetReceipt: DesktopActionTargetReceipt? = if let identityTargetReceipt,
+                                                                 let targetReceipt
+        {
+            identityTargetReceipt == targetReceipt ? targetReceipt : nil
+        } else {
+            targetReceipt ?? identityTargetReceipt
+        }
         guard didDispatch,
               !selectedLeafEvidence.isEmpty,
-              selectedLeafEvidence.allSatisfy(\.isCanonical)
+              selectedLeafEvidence.allSatisfy(\.isCanonical),
+              let phaseTargetReceipt,
+              selectedLeafEvidence.allSatisfy({ evidence in
+                  TargetAccumulator.contains(
+                      evidence.selectedTargetReceipt,
+                      within: phaseTargetReceipt)
+              })
         else {
             self.invalidSelectedLeafEvidence = true
             return
@@ -233,6 +265,7 @@ public struct UIAutomationActionResultSequenceAccumulator: Sendable {
             hasTargetConflict: targetConflict,
             hasProhibitedTarget: self.targetlessPhaseReturnedTarget,
             hasMissingRequiredTarget: self.missingRequiredTarget,
+            hasContradictoryRequiredTarget: self.contradictoryRequiredTarget,
             hasInvalidSelectedLeafEvidence: self.invalidSelectedLeafEvidence)
     }
 
@@ -263,6 +296,15 @@ public struct UIAutomationActionResultSequenceAccumulator: Sendable {
                 message: failureMessage ?? "\(operation) returned without its required phase target.",
                 hint: failureHint,
                 causeDescription: DesktopTargetIdentityError.missingProcessGeneration.localizedDescription)
+        }
+        if resolution.hasContradictoryRequiredTarget {
+            throw self.compositionFailure(
+                outcome: outcome,
+                operation: operation,
+                message: failureMessage ??
+                    "\(operation) returned contradictory identity and receipt for a required phase target.",
+                hint: failureHint,
+                causeDescription: DesktopTargetIdentityError.contradictoryWindowIdentity.localizedDescription)
         }
         if resolution.hasProhibitedTarget {
             throw self.compositionFailure(
@@ -351,6 +393,7 @@ public struct UIAutomationActionResultSequenceAccumulator: Sendable {
         case (false, true):
             return leafFailure.targetReceipt
         case (false, false):
+            guard !self.resolution.hasTargetConflict else { return nil }
             switch (self.resolution.targetReceipt, leafFailure.targetReceipt) {
             case let (prior?, later?):
                 return TargetAccumulator.commonScope(prior, later)

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Strategy/UIAutomationActionResultSequenceAccumulator.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Strategy/UIAutomationActionResultSequenceAccumulator.swift
@@ -149,7 +149,6 @@ public struct UIAutomationActionResultSequenceAccumulator: Sendable {
     private var operationTargets = TargetAccumulator()
     private var mutationTargets = TargetAccumulator()
     private var selectedLeaves: [DesktopSelectedLeafEvidence] = []
-    private var recordedPhaseCount = 0
     private var forcesTargetlessResult = false
     private var targetlessPhaseReturnedTarget = false
     private var missingRequiredTarget = false
@@ -180,7 +179,6 @@ public struct UIAutomationActionResultSequenceAccumulator: Sendable {
         attribution: PhaseAttributionRule,
         defaultDispatchedUnitCount: DesktopActionOutcome.DispatchUnitCount? = nil)
     {
-        self.recordedPhaseCount += 1
         if let outcome {
             if let defaultDispatchedUnitCount {
                 self.sequence.record(.reportedOutcome(
@@ -255,13 +253,26 @@ public struct UIAutomationActionResultSequenceAccumulator: Sendable {
         let sequenceResolution = self.sequence.successResolution()
         let targetConflict = self.targetlessPhaseReturnedTarget ||
             self.operationTargets.hasIncompatibleContributions
+        let targetReceipt = self.forcesTargetlessResult ? nil : self.operationTargets.receipt
+        let selectedLeafEvidence: [DesktopSelectedLeafEvidence]? = if let targetReceipt,
+                                                                      !self.selectedLeaves.isEmpty,
+                                                                      self.selectedLeaves.allSatisfy({ leaf in
+                                                                          TargetAccumulator.contains(
+                                                                              leaf.selectedTargetReceipt,
+                                                                              within: targetReceipt)
+                                                                      })
+        {
+            self.selectedLeaves
+        } else {
+            nil
+        }
         return Resolution(
             outcome: sequenceResolution.outcome,
             mutationDisposition: sequenceResolution.mutationDisposition,
             targetIdentity: self.forcesTargetlessResult ? nil : self.operationTargets.identity,
-            targetReceipt: self.forcesTargetlessResult ? nil : self.operationTargets.receipt,
+            targetReceipt: targetReceipt,
             mutationTargetReceipt: self.forcesTargetlessResult ? nil : self.mutationTargets.receipt,
-            selectedLeafEvidence: self.selectedLeaves.isEmpty ? nil : self.selectedLeaves,
+            selectedLeafEvidence: selectedLeafEvidence,
             hasTargetConflict: targetConflict,
             hasProhibitedTarget: self.targetlessPhaseReturnedTarget,
             hasMissingRequiredTarget: self.missingRequiredTarget,
@@ -352,7 +363,6 @@ public struct UIAutomationActionResultSequenceAccumulator: Sendable {
         hint: String? = nil,
         causeDescription: String? = nil) -> DesktopActionFailure
     {
-        guard self.recordedPhaseCount > 0 else { return leafFailure }
         let composed = self.sequence.failure(
             combining: leafFailure,
             message: message ?? leafFailure.message,
@@ -442,24 +452,6 @@ public struct UIAutomationActionResultSequenceAccumulator: Sendable {
             else { return nil }
         }
         return evidence
-    }
-
-    private func assigning(
-        _ targetReceipt: DesktopActionTargetReceipt?,
-        to failure: DesktopActionFailure) -> DesktopActionFailure
-    {
-        if let targetReceipt {
-            return failure.attributed(to: targetReceipt)
-        }
-        guard failure.targetReceipt != nil,
-              let unattributed = DesktopActionFailure(
-                  outcome: failure.outcome,
-                  message: failure.message,
-                  hint: failure.hint,
-                  causeDescription: failure.causeDescription,
-                  selectedLeafEvidence: failure.selectedLeafEvidence)
-        else { return failure }
-        return unattributed
     }
 
     private func compositionFailure(

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Strategy/UIAutomationActionResultSequenceAccumulator.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Strategy/UIAutomationActionResultSequenceAccumulator.swift
@@ -224,7 +224,7 @@ public struct UIAutomationActionResultSequenceAccumulator: Sendable {
             self.targetlessPhaseReturnedTarget = self.targetlessPhaseReturnedTarget || hasTarget
         }
 
-        guard let selectedLeafEvidence else { return }
+        guard let selectedLeafEvidence, !selectedLeafEvidence.isEmpty else { return }
         let identityTargetReceipt = targetIdentity?.actionTargetReceipt
         let phaseTargetReceipt: DesktopActionTargetReceipt? = if let identityTargetReceipt,
                                                                  let targetReceipt
@@ -234,7 +234,6 @@ public struct UIAutomationActionResultSequenceAccumulator: Sendable {
             targetReceipt ?? identityTargetReceipt
         }
         guard didDispatch,
-              !selectedLeafEvidence.isEmpty,
               selectedLeafEvidence.allSatisfy(\.isCanonical),
               let phaseTargetReceipt,
               selectedLeafEvidence.allSatisfy({ evidence in

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Strategy/UIAutomationActionResultSequenceAccumulator.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Strategy/UIAutomationActionResultSequenceAccumulator.swift
@@ -359,9 +359,20 @@ public struct UIAutomationActionResultSequenceAccumulator: Sendable {
             hint: hint ?? leafFailure.hint,
             causeDescription: causeDescription ?? leafFailure.causeDescription)
         let targetReceipt = self.failureTargetReceipt(leafFailure)
-        let evidence = self.combinedSelectedLeafEvidence(leafFailure.selectedLeafEvidence)
-        return self.assigning(targetReceipt, to: composed)
-            .selectingLeaves(evidence)
+        let evidence = self.combinedSelectedLeafEvidence(
+            leafFailure,
+            targetReceipt: targetReceipt)
+        guard let normalized = DesktopActionFailure(
+            outcome: composed.outcome,
+            message: composed.message,
+            hint: composed.hint,
+            causeDescription: composed.causeDescription,
+            targetReceipt: targetReceipt,
+            selectedLeafEvidence: evidence)
+        else {
+            preconditionFailure("Composed action failures must retain a non-confirmed canonical outcome")
+        }
+        return normalized
     }
 
     private mutating func recordTargetContribution(
@@ -406,10 +417,30 @@ public struct UIAutomationActionResultSequenceAccumulator: Sendable {
     }
 
     private func combinedSelectedLeafEvidence(
-        _ leafEvidence: [DesktopSelectedLeafEvidence]?) -> [DesktopSelectedLeafEvidence]?
+        _ leafFailure: DesktopActionFailure,
+        targetReceipt: DesktopActionTargetReceipt?) -> [DesktopSelectedLeafEvidence]?
     {
-        let evidence = self.selectedLeaves + (leafEvidence ?? [])
-        guard !evidence.isEmpty, evidence.allSatisfy(\.isCanonical) else { return nil }
+        let leafEvidence = leafFailure.selectedLeafEvidence ?? []
+        let evidence = self.selectedLeaves + leafEvidence
+        guard !evidence.isEmpty,
+              let targetReceipt,
+              evidence.allSatisfy(\.isCanonical),
+              evidence.allSatisfy({ leaf in
+                  TargetAccumulator.contains(
+                      leaf.selectedTargetReceipt,
+                      within: targetReceipt)
+              })
+        else { return nil }
+        if !leafEvidence.isEmpty {
+            guard leafFailure.outcome.dispatchState.mutationDispatched,
+                  let leafTargetReceipt = leafFailure.targetReceipt,
+                  leafEvidence.allSatisfy({ leaf in
+                      TargetAccumulator.contains(
+                          leaf.selectedTargetReceipt,
+                          within: leafTargetReceipt)
+                  })
+            else { return nil }
+        }
         return evidence
     }
 

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKitTestSupport/LinkedDesktopTargetFixture.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKitTestSupport/LinkedDesktopTargetFixture.swift
@@ -1,0 +1,173 @@
+import CoreGraphics
+import Foundation
+import PeekabooAutomationKit
+import PeekabooFoundation
+
+/// One internally coherent application, window, target, and receipt graph for happy-path tests.
+///
+/// Malformed and compatibility tests should continue constructing their values explicitly so this
+/// fixture cannot accidentally repair the contradiction under test.
+public struct LinkedDesktopTargetFixture: Sendable {
+    public let processIdentity: ApplicationProcessIdentity
+    public let application: ServiceApplicationInfo
+    public let windowIdentity: WindowMutationIdentity
+    public let window: ServiceWindowInfo
+    public let processTargetIdentity: DesktopTargetIdentity
+    public let windowTargetIdentity: DesktopTargetIdentity
+    public let windowContext: WindowContext
+
+    public var processTargetReceipt: DesktopActionTargetReceipt {
+        self.processTargetIdentity.actionTargetReceipt
+    }
+
+    public var windowTargetReceipt: DesktopActionTargetReceipt {
+        self.windowTargetIdentity.actionTargetReceipt
+    }
+}
+
+extension AutomationTestFixtures {
+    public static func linkedDesktopTarget(
+        processIdentity: ApplicationProcessIdentity = Self.processIdentity(),
+        bundleIdentifier: String? = "com.example.TestApp",
+        applicationName: String = "Test App",
+        windowID: Int = 201,
+        windowTitle: String = "Test Window",
+        bounds: CGRect = CGRect(x: 10, y: 20, width: 640, height: 480),
+        isMinimized: Bool = false,
+        isMainWindow: Bool = true,
+        isKeyWindow: Bool? = true,
+        isFrontmost: Bool? = false,
+        windowIndex: Int = 0,
+        focusedElement: FocusedElementIdentity? = nil) -> LinkedDesktopTargetFixture
+    {
+        precondition(
+            processIdentity.processIdentifier > 0 && processIdentity.processStartIdentity > 0,
+            "A linked desktop target fixture requires a positive process generation")
+        precondition(
+            windowID > 0 && UInt64(windowID) <= UInt64(UInt32.max),
+            "A linked desktop target fixture requires a WindowServer-compatible window ID")
+        precondition(
+            !bounds.isEmpty &&
+                bounds.origin.x.isFinite &&
+                bounds.origin.y.isFinite &&
+                bounds.width.isFinite &&
+                bounds.height.isFinite,
+            "A linked desktop target fixture requires finite nonempty bounds")
+
+        let application = self.application(
+            processIdentifier: processIdentity.processIdentifier,
+            processStartIdentity: processIdentity.processStartIdentity,
+            bundleIdentifier: bundleIdentifier,
+            name: applicationName,
+            windowCount: 1,
+            windowIDs: [windowID])
+        let window = self.window(
+            windowID: windowID,
+            title: windowTitle,
+            bounds: bounds,
+            processIdentity: processIdentity,
+            isMinimized: isMinimized,
+            isMainWindow: isMainWindow,
+            isKeyWindow: isKeyWindow,
+            isFrontmost: isFrontmost,
+            index: windowIndex)
+        guard let windowIdentity = window.mutationIdentity else {
+            preconditionFailure("A linked desktop target fixture requires a window mutation identity")
+        }
+
+        do {
+            let processTargetIdentity = try DesktopTargetIdentity(processIdentity: processIdentity)
+            let windowTargetIdentity = try DesktopTargetIdentity(exactWindow: UIAutomationTarget.ExactWindow(
+                window: window,
+                focusedElement: focusedElement))
+            return LinkedDesktopTargetFixture(
+                processIdentity: processIdentity,
+                application: application,
+                windowIdentity: windowIdentity,
+                window: window,
+                processTargetIdentity: processTargetIdentity,
+                windowTargetIdentity: windowTargetIdentity,
+                windowContext: self.windowContext(application: application, window: window))
+        } catch {
+            preconditionFailure("Invalid linked desktop target fixture: \(error.localizedDescription)")
+        }
+    }
+
+    /// Copies a valid window fixture while overriding the fields relevant to target and state tests.
+    ///
+    /// The mutation identity is rebuilt from the resolved window ID, process generation, bounds, and
+    /// minimized state. Any mutation postcondition evidence is dropped when one of those fields changes.
+    public static func window(
+        copying source: ServiceWindowInfo,
+        windowID: Int? = nil,
+        title: String? = nil,
+        bounds: CGRect? = nil,
+        processIdentity: ApplicationProcessIdentity? = nil,
+        isMinimized: Bool? = nil,
+        isMainWindow: Bool? = nil,
+        isKeyWindow: Bool? = nil,
+        isFrontmost: Bool? = nil,
+        windowLevel: Int? = nil,
+        alpha: CGFloat? = nil,
+        index: Int? = nil,
+        isOffScreen: Bool? = nil,
+        layer: Int? = nil,
+        isOnScreen: Bool? = nil) -> ServiceWindowInfo
+    {
+        let resolvedWindowID = windowID ?? source.windowID
+        let resolvedBounds = bounds ?? source.bounds
+        let resolvedMinimized = isMinimized ?? source.isMinimized
+        let sourceIdentity = source.mutationIdentity
+        let resolvedProcessIdentity = processIdentity ?? sourceIdentity?.processIdentity
+        let resolvedCapturedBounds = bounds != nil || sourceIdentity == nil
+            ? resolvedBounds
+            : sourceIdentity?.capturedBounds
+        let resolvedIdentityMinimized = isMinimized != nil || sourceIdentity == nil
+            ? resolvedMinimized
+            : sourceIdentity?.isMinimized
+        let resolvedMutationIdentity = resolvedProcessIdentity.map {
+            WindowMutationIdentity(
+                windowID: resolvedWindowID,
+                ownerProcessIdentifier: $0.processIdentifier,
+                ownerProcessStartIdentity: $0.processStartIdentity,
+                capturedBounds: resolvedCapturedBounds,
+                isMinimized: resolvedIdentityMinimized)
+        }
+        let preservesPostcondition = windowID == nil &&
+            bounds == nil &&
+            processIdentity == nil &&
+            isMinimized == nil &&
+            isMainWindow == nil &&
+            isKeyWindow == nil &&
+            isFrontmost == nil &&
+            windowLevel == nil &&
+            alpha == nil &&
+            isOffScreen == nil &&
+            layer == nil &&
+            isOnScreen == nil
+
+        return ServiceWindowInfo(
+            windowID: resolvedWindowID,
+            title: title ?? source.title,
+            bounds: resolvedBounds,
+            isMinimized: resolvedMinimized,
+            isMainWindow: isMainWindow ?? source.isMainWindow,
+            isKeyWindow: isKeyWindow ?? source.isKeyWindow,
+            isFrontmost: isFrontmost ?? source.isFrontmost,
+            subrole: source.subrole,
+            windowLevel: windowLevel ?? source.windowLevel,
+            alpha: alpha ?? source.alpha,
+            index: index ?? source.index,
+            spaceID: source.spaceID,
+            spaceName: source.spaceName,
+            screenIndex: source.screenIndex,
+            screenName: source.screenName,
+            isOffScreen: isOffScreen ?? source.isOffScreen,
+            layer: layer ?? source.layer,
+            isOnScreen: isOnScreen ?? source.isOnScreen,
+            sharingState: source.sharingState,
+            isExcludedFromWindowsMenu: source.isExcludedFromWindowsMenu,
+            mutationIdentity: resolvedMutationIdentity,
+            mutationPostconditionEvidence: preservesPostcondition ? source.mutationPostconditionEvidence : nil)
+    }
+}

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ApplicationMutationPlannerTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ApplicationMutationPlannerTests.swift
@@ -85,6 +85,8 @@ struct ApplicationMutationPlannerTests {
         let plan = try await planner.plan(identifier: "PID:101")
 
         #expect(plan.processIdentity == application.processIdentity)
+        #expect(try plan.expectedTargetIdentity.processIdentity == application.processIdentity)
+        #expect(try plan.expectedTargetIdentity.exactWindow == nil)
         #expect(broadReadCount == 0)
         #expect(directReadCount == 2)
     }

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/AutomationKitTestSupportTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/AutomationKitTestSupportTests.swift
@@ -1,3 +1,4 @@
+import CoreGraphics
 import PeekabooAutomationKitTestSupport
 import PeekabooFoundation
 import Testing
@@ -6,6 +7,106 @@ import Testing
 @Suite(.serialized)
 @MainActor
 struct AutomationKitTestSupportTests {
+    @Test
+    func `linked desktop target keeps every receipt on one process generation`() {
+        let process = AutomationTestFixtures.processIdentity(
+            processIdentifier: 42,
+            processStartIdentity: 1001)
+        let bounds = CGRect(x: 10, y: 20, width: 300, height: 200)
+        let fixture = AutomationTestFixtures.linkedDesktopTarget(
+            processIdentity: process,
+            bundleIdentifier: "com.example.Linked",
+            applicationName: "Linked App",
+            windowID: 71,
+            windowTitle: "Linked Window",
+            bounds: bounds)
+
+        #expect(fixture.application.processIdentity == process)
+        #expect(fixture.application.windowCount == 1)
+        #expect(fixture.application.windowIDs == [71])
+        #expect(fixture.window.mutationIdentity == fixture.windowIdentity)
+        #expect(fixture.windowIdentity.processIdentity == process)
+        #expect(fixture.processTargetIdentity.processIdentity == process)
+        #expect(fixture.windowTargetIdentity.exactWindow?.identity == fixture.windowIdentity)
+        #expect(fixture.processTargetReceipt == DesktopActionTargetReceipt(
+            processIdentifier: 42,
+            processStartIdentity: 1001))
+        #expect(fixture.windowTargetReceipt == DesktopActionTargetReceipt(
+            processIdentifier: 42,
+            processStartIdentity: 1001,
+            windowID: 71))
+        #expect(fixture.windowContext.windowMutationIdentity == fixture.windowIdentity)
+        #expect(fixture.windowContext.windowBounds == bounds)
+    }
+
+    @Test
+    func `window copy overrides coherent identity fields and preserves unrelated metadata`() {
+        let originalBounds = CGRect(x: 1, y: 2, width: 300, height: 200)
+        let originalIdentity = AutomationTestFixtures.windowIdentity(
+            windowID: 71,
+            processIdentity: .init(processIdentifier: 42, processStartIdentity: 1001),
+            bounds: originalBounds)
+        let evidence = WindowMutationPostconditionEvidence(
+            isMaximized: true,
+            verifiedVisibleWorkArea: CGRect(x: 0, y: 0, width: 1200, height: 800))
+        let original = ServiceWindowInfo(
+            windowID: 71,
+            title: "Original",
+            bounds: originalBounds,
+            isMainWindow: true,
+            isKeyWindow: true,
+            isFrontmost: false,
+            subrole: "AXStandardWindow",
+            windowLevel: 3,
+            alpha: 0.75,
+            index: 4,
+            spaceID: 5,
+            spaceName: "Work",
+            screenIndex: 1,
+            screenName: "Studio Display",
+            sharingState: .readWrite,
+            isExcludedFromWindowsMenu: true,
+            mutationIdentity: originalIdentity,
+            mutationPostconditionEvidence: evidence)
+
+        let renamed = AutomationTestFixtures.window(copying: original, title: "Renamed")
+        #expect(renamed.mutationIdentity == originalIdentity)
+        #expect(renamed.mutationPostconditionEvidence == evidence)
+
+        let replacementProcess = AutomationTestFixtures.processIdentity(
+            processIdentifier: 43,
+            processStartIdentity: 1002)
+        let movedBounds = originalBounds.offsetBy(dx: 10, dy: 20)
+        let moved = AutomationTestFixtures.window(
+            copying: original,
+            bounds: movedBounds,
+            processIdentity: replacementProcess,
+            isMinimized: true,
+            isOffScreen: true,
+            isOnScreen: false)
+
+        #expect(moved.bounds == movedBounds)
+        #expect(moved.isMinimized)
+        #expect(moved.isOffScreen)
+        #expect(!moved.isOnScreen)
+        #expect(moved.mutationIdentity == AutomationTestFixtures.windowIdentity(
+            windowID: 71,
+            processIdentity: replacementProcess,
+            bounds: movedBounds,
+            isMinimized: true))
+        #expect(moved.subrole == original.subrole)
+        #expect(moved.windowLevel == original.windowLevel)
+        #expect(moved.alpha == original.alpha)
+        #expect(moved.index == original.index)
+        #expect(moved.spaceID == original.spaceID)
+        #expect(moved.spaceName == original.spaceName)
+        #expect(moved.screenIndex == original.screenIndex)
+        #expect(moved.screenName == original.screenName)
+        #expect(moved.sharingState == original.sharingState)
+        #expect(moved.isExcludedFromWindowsMenu == original.isExcludedFromWindowsMenu)
+        #expect(moved.mutationPostconditionEvidence == nil)
+    }
+
     @Test
     func `script sequences outcomes and failures without sharing instance state`() async throws {
         let first = Self.outcome(evidence: .deliveryAccepted)

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ObservationActionResultSemanticsTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ObservationActionResultSemanticsTests.swift
@@ -1,5 +1,6 @@
 import CoreGraphics
 import Foundation
+import PeekabooAutomationKitTestSupport
 import PeekabooFoundation
 import Testing
 @testable import PeekabooAutomationKit
@@ -79,11 +80,14 @@ struct ObservationActionResultSemanticsTests {
         let provider = try DesktopTargetIdentity(processIdentity: .init(
             processIdentifier: 543,
             processStartIdentity: 6543))
-        let payload = Self.detectionResult(
-            processIdentifier: 544,
-            processStartIdentity: 6544,
+        let payloadFixture = AutomationTestFixtures.linkedDesktopTarget(
+            processIdentity: .init(processIdentifier: 544, processStartIdentity: 6544),
             windowID: 73,
             bounds: bounds)
+        let payload = AutomationTestFixtures.detectionResult(
+            snapshotID: "targeted",
+            screenshotPath: "",
+            windowContext: payloadFixture.windowContext)
         let outcome = DesktopActionOutcome.dispatchedUnverified(
             delivery: Self.delivery,
             evidence: .deliveryAccepted,
@@ -111,11 +115,14 @@ struct ObservationActionResultSemanticsTests {
         let provider = try DesktopTargetIdentity(processIdentity: .init(
             processIdentifier: 545,
             processStartIdentity: 6545))
-        let payload = Self.detectionResult(
-            processIdentifier: 545,
-            processStartIdentity: 6545,
+        let payloadFixture = AutomationTestFixtures.linkedDesktopTarget(
+            processIdentity: provider.processIdentity,
             windowID: 74,
             bounds: bounds)
+        let payload = AutomationTestFixtures.detectionResult(
+            snapshotID: "targeted",
+            screenshotPath: "",
+            windowContext: payloadFixture.windowContext)
 
         let target = try ObservationActionResultSemantics.coalescedTarget(
             actionTarget: provider,
@@ -151,50 +158,35 @@ struct ObservationActionResultSemanticsTests {
     @Test
     func `menu-bar mutation target excludes the captured popover identity`() throws {
         let statusBounds = CGRect(x: 900, y: 0, width: 20, height: 20)
-        let statusIdentity = WindowMutationIdentity(
+        let statusFixture = AutomationTestFixtures.linkedDesktopTarget(
+            processIdentity: .init(processIdentifier: 545, processStartIdentity: 6545),
             windowID: 70,
-            ownerProcessIdentifier: 545,
-            ownerProcessStartIdentity: 6545,
-            capturedBounds: statusBounds)
-        let statusTarget = try DesktopTargetIdentity(exactWindow: UIAutomationTarget.ExactWindow(
-            identity: statusIdentity,
-            bounds: statusBounds))
+            bounds: statusBounds)
+        let statusTarget = statusFixture.windowTargetIdentity
         let popoverBounds = CGRect(x: 700, y: 20, width: 240, height: 300)
-        let popoverIdentity = WindowMutationIdentity(
-            windowID: 71,
-            ownerProcessIdentifier: 546,
-            ownerProcessStartIdentity: 6546,
-            capturedBounds: popoverBounds)
-        let popoverApplication = ServiceApplicationInfo(
-            processIdentifier: 546,
-            processStartIdentity: 6546,
+        let popoverFixture = AutomationTestFixtures.linkedDesktopTarget(
+            processIdentity: .init(processIdentifier: 546, processStartIdentity: 6546),
             bundleIdentifier: "dev.peekaboo.popover",
-            name: "Popover")
-        let popoverWindow = ServiceWindowInfo(
+            applicationName: "Popover",
             windowID: 71,
-            title: "Popover",
+            windowTitle: "Popover",
             bounds: popoverBounds,
-            index: 0,
-            mutationIdentity: popoverIdentity)
+            isMainWindow: false)
         let payload = DesktopObservationResult(
             target: ResolvedObservationTarget(
                 kind: .menubarPopover,
-                app: ApplicationIdentity(popoverApplication),
-                window: WindowIdentity(popoverWindow),
+                app: ApplicationIdentity(popoverFixture.application),
+                window: WindowIdentity(popoverFixture.window),
                 bounds: popoverBounds,
-                detectionContext: WindowContext(
-                    applicationProcessId: 546,
-                    windowID: 71,
-                    windowBounds: popoverBounds,
-                    windowMutationIdentity: popoverIdentity),
+                detectionContext: popoverFixture.windowContext,
                 mutationTargetIdentity: DesktopObservationMutationTargetIdentity(statusTarget)),
             capture: CaptureResult(
                 imageData: Data([1]),
                 metadata: CaptureMetadata(
                     size: popoverBounds.size,
                     mode: .window,
-                    applicationInfo: popoverApplication,
-                    windowInfo: popoverWindow)),
+                    applicationInfo: popoverFixture.application,
+                    windowInfo: popoverFixture.window)),
             elements: nil)
 
         let target = try ObservationActionResultSemantics.coalescedTarget(
@@ -230,30 +222,4 @@ struct ObservationActionResultSemanticsTests {
         .confirmedNoChange(),
         .dispatchedUnverified(delivery: Self.delivery, evidence: .deliveryAccepted, unitCount: .one),
     ]
-
-    private static func detectionResult(
-        processIdentifier: Int32,
-        processStartIdentity: UInt64,
-        windowID: Int,
-        bounds: CGRect) -> ElementDetectionResult
-    {
-        let identity = WindowMutationIdentity(
-            windowID: windowID,
-            ownerProcessIdentifier: processIdentifier,
-            ownerProcessStartIdentity: processStartIdentity,
-            capturedBounds: bounds)
-        return ElementDetectionResult(
-            snapshotId: "targeted",
-            screenshotPath: "",
-            elements: DetectedElements(),
-            metadata: DetectionMetadata(
-                detectionTime: 0,
-                elementCount: 0,
-                method: "fixture",
-                windowContext: WindowContext(
-                    applicationProcessId: processIdentifier,
-                    windowID: windowID,
-                    windowBounds: bounds,
-                    windowMutationIdentity: identity)))
-    }
 }

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ObservationActionResultSemanticsTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ObservationActionResultSemanticsTests.swift
@@ -203,6 +203,48 @@ struct ObservationActionResultSemanticsTests {
         #expect(target?.exactWindow?.identity.windowID == 70)
     }
 
+    @Test
+    func `generic failures reject selected leaves from an unrelated target`() throws {
+        let phase = AutomationTestFixtures.linkedDesktopTarget(
+            processIdentity: .init(processIdentifier: 545, processStartIdentity: 6545),
+            windowID: 70)
+        let unrelated = AutomationTestFixtures.linkedDesktopTarget(
+            processIdentity: .init(processIdentifier: 546, processStartIdentity: 6546),
+            windowID: 71)
+        let evidence = try DesktopSelectedLeafEvidence(
+            kind: .menuBarItem,
+            normalizedSelector: "fixture",
+            matchKind: .exact,
+            selectedTargetReceipt: unrelated.windowTargetReceipt,
+            selectedIndex: 0,
+            selectedTitle: "Fixture",
+            selectedIdentifier: "fixture.item",
+            selectedRole: "AXMenuBarItem",
+            selectedFrame: CGRect(x: 0, y: 0, width: 18, height: 18),
+            candidateSetSHA256: DesktopSelectedLeafEvidence.digestCandidateSet(["fixture"]),
+            candidateCount: 1)
+        let result = UIAutomationActionResult(
+            payload: (),
+            outcome: DesktopActionOutcome.dispatchedUnverified(
+                delivery: Self.delivery,
+                evidence: .deliveryAccepted,
+                unitCount: .one),
+            targetIdentity: phase.windowTargetIdentity,
+            selectedLeafEvidence: [evidence])
+
+        let preserved = ObservationActionResultSemantics.preservingFailure(
+            FixtureError.failed,
+            after: result,
+            operation: "Fixture observation")
+        let failure = try #require(preserved as? DesktopActionFailure)
+
+        #expect(failure.outcome.state == .dispatchedUnverified)
+        #expect(failure.message == FixtureError.failed.localizedDescription)
+        #expect(failure.causeDescription == String(describing: FixtureError.failed))
+        #expect(failure.targetReceipt == phase.windowTargetReceipt)
+        #expect(failure.selectedLeafEvidence == nil)
+    }
+
     private static let delivery = DesktopActionOutcome.Delivery(
         mechanism: .accessibilityAction,
         mode: .background)
@@ -222,4 +264,8 @@ struct ObservationActionResultSemanticsTests {
         .confirmedNoChange(),
         .dispatchedUnverified(delivery: Self.delivery, evidence: .deliveryAccepted, unitCount: .one),
     ]
+
+    private enum FixtureError: Error {
+        case failed
+    }
 }

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/UIAutomationActionResultSemanticsTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/UIAutomationActionResultSemanticsTests.swift
@@ -1,22 +1,29 @@
 import CoreGraphics
+import PeekabooAutomationKitTestSupport
 import PeekabooFoundation
 import Testing
 @testable import PeekabooAutomationKit
 
 struct UIAutomationActionResultSemanticsTests {
+    private static let windowBounds = CGRect(x: 10, y: 20, width: 300, height: 200)
+
     private let backgroundDelivery = DesktopActionOutcome.Delivery(
         mechanism: .accessibilityAction,
         mode: .background)
 
     @Test
-    func `receipt projection preserves process and exact window generations`() throws {
+    func `receipt projection preserves process and exact window generations`() {
         let process = ApplicationProcessIdentity(processIdentifier: 42, processStartIdentity: 1001)
-        let processTarget = try DesktopTargetIdentity(processIdentity: process)
+        let fixture = AutomationTestFixtures.linkedDesktopTarget(
+            processIdentity: process,
+            windowID: 71,
+            bounds: Self.windowBounds)
+        let processTarget = fixture.processTargetIdentity
         #expect(processTarget.actionTargetReceipt == DesktopActionTargetReceipt(
             processIdentifier: process.processIdentifier,
             processStartIdentity: process.processStartIdentity))
 
-        let window = try self.windowTarget(windowID: 71, process: process)
+        let window = fixture.windowTargetIdentity
         #expect(window.actionTargetReceipt == DesktopActionTargetReceipt(
             processIdentifier: process.processIdentifier,
             processStartIdentity: process.processStartIdentity,
@@ -25,9 +32,9 @@ struct UIAutomationActionResultSemanticsTests {
 
     @Test
     func `shared validator accepts configured success and target policy`() throws {
-        let target = try DesktopTargetIdentity(processIdentity: .init(
-            processIdentifier: 42,
-            processStartIdentity: 1001))
+        let target = AutomationTestFixtures.linkedDesktopTarget(
+            processIdentity: .init(processIdentifier: 42, processStartIdentity: 1001))
+            .processTargetIdentity
         let result = UIAutomationActionResult(
             payload: (),
             outcome: DesktopActionOutcome.dispatchedUnverified(
@@ -47,9 +54,9 @@ struct UIAutomationActionResultSemanticsTests {
 
     @Test
     func `shared validator rejects delivery drift and attributes the target`() throws {
-        let target = try DesktopTargetIdentity(processIdentity: .init(
-            processIdentifier: 42,
-            processStartIdentity: 1001))
+        let target = AutomationTestFixtures.linkedDesktopTarget(
+            processIdentity: .init(processIdentifier: 42, processStartIdentity: 1001))
+            .processTargetIdentity
         let result = UIAutomationActionResult(
             payload: (),
             outcome: DesktopActionOutcome.confirmedChange(delivery: .init(
@@ -73,12 +80,15 @@ struct UIAutomationActionResultSemanticsTests {
 
     @Test
     func `shared validator rejects missing or contradictory targets after dispatch`() throws {
-        let expected = try self.windowTarget(
+        let process = ApplicationProcessIdentity(processIdentifier: 42, processStartIdentity: 1001)
+        let expected = AutomationTestFixtures.linkedDesktopTarget(
+            processIdentity: process,
             windowID: 71,
-            process: .init(processIdentifier: 42, processStartIdentity: 1001))
-        let other = try self.windowTarget(
+            bounds: Self.windowBounds).windowTargetIdentity
+        let other = AutomationTestFixtures.linkedDesktopTarget(
+            processIdentity: process,
             windowID: 72,
-            process: .init(processIdentifier: 42, processStartIdentity: 1001))
+            bounds: Self.windowBounds).windowTargetIdentity
         let outcome = DesktopActionOutcome.confirmedChange(delivery: self.backgroundDelivery)
 
         for actual in [DesktopTargetIdentity?.none, other] {
@@ -115,19 +125,5 @@ struct UIAutomationActionResultSemanticsTests {
             #expect(failure.outcome == result.outcome)
             #expect(failure.targetReceipt == nil)
         }
-    }
-
-    private func windowTarget(
-        windowID: Int,
-        process: ApplicationProcessIdentity) throws -> DesktopTargetIdentity
-    {
-        let bounds = CGRect(x: 10, y: 20, width: 300, height: 200)
-        return try DesktopTargetIdentity(exactWindow: UIAutomationTarget.ExactWindow(
-            identity: .init(
-                windowID: windowID,
-                ownerProcessIdentifier: process.processIdentifier,
-                ownerProcessStartIdentity: process.processStartIdentity,
-                capturedBounds: bounds),
-            bounds: bounds))
     }
 }

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/UIAutomationActionResultSequenceAccumulatorTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/UIAutomationActionResultSequenceAccumulatorTests.swift
@@ -177,6 +177,7 @@ struct UIAutomationActionResultSequenceAccumulatorTests {
         let target = AutomationTestFixtures.linkedDesktopTarget(
             windowID: 71,
             bounds: Self.windowBounds).windowTargetIdentity
+        let evidence = try self.leaf(index: 0, target: target.actionTargetReceipt)
         let pointerDelivery = DesktopActionOutcome.Delivery(
             mechanism: .globalEvents,
             mode: .foreground)
@@ -185,7 +186,8 @@ struct UIAutomationActionResultSequenceAccumulatorTests {
             UIAutomationActionResult(
                 payload: (),
                 outcome: .confirmedChange(delivery: self.backgroundDelivery, unitCount: .one),
-                targetIdentity: target),
+                targetIdentity: target,
+                selectedLeafEvidence: [evidence]),
             attribution: .mutationTarget)
         sequence.record(
             UIAutomationActionResult(
@@ -199,6 +201,7 @@ struct UIAutomationActionResultSequenceAccumulatorTests {
             requiresOutcome: true,
             requiresCompatibleTarget: true)
         #expect(result.targetIdentity == nil)
+        #expect(result.selectedLeafEvidence == nil)
         #expect(result.outcome?.delivery?.mechanism == .composite)
 
         var invalid = UIAutomationActionResultSequenceAccumulator()
@@ -279,6 +282,65 @@ struct UIAutomationActionResultSequenceAccumulatorTests {
 
         #expect(failure.targetReceipt == target.windowTargetReceipt)
         #expect(failure.selectedLeafEvidence == nil)
+    }
+
+    @Test
+    func `zero-prefix failure normalizes selected leaves against its terminal target`() throws {
+        let target = AutomationTestFixtures.linkedDesktopTarget(
+            processIdentity: .init(processIdentifier: 42, processStartIdentity: 1001),
+            windowID: 71,
+            bounds: Self.windowBounds)
+        let sibling = AutomationTestFixtures.linkedDesktopTarget(
+            processIdentity: target.processIdentity,
+            windowID: 72,
+            bounds: Self.windowBounds)
+        let invalidEvidence = try self.leaf(index: 0, target: sibling.windowTargetReceipt)
+        let terminalFailure = DesktopActionFailure.indeterminate(
+            delivery: self.backgroundDelivery,
+            evidence: .completionUnknown,
+            unitCount: .one,
+            message: "Standalone terminal failure")
+            .attributed(to: target.windowTargetReceipt)
+            .selectingLeaves([invalidEvidence])
+        let sequence = UIAutomationActionResultSequenceAccumulator()
+
+        let failure = sequence.failure(
+            combining: terminalFailure,
+            operation: "Invalid standalone terminal evidence")
+
+        #expect(failure.outcome == terminalFailure.outcome)
+        #expect(failure.message == terminalFailure.message)
+        #expect(failure.targetReceipt == target.windowTargetReceipt)
+        #expect(failure.selectedLeafEvidence == nil)
+    }
+
+    @Test
+    func `target-conflicted aggregate drops selected leaves when compatibility is optional`() throws {
+        let first = AutomationTestFixtures.linkedDesktopTarget(
+            windowID: 71,
+            bounds: Self.windowBounds)
+        let second = AutomationTestFixtures.linkedDesktopTarget(
+            windowID: 72,
+            bounds: Self.windowBounds)
+        let evidence = try self.leaf(index: 0, target: first.windowTargetReceipt)
+        var sequence = UIAutomationActionResultSequenceAccumulator()
+        sequence.record(
+            outcome: .confirmedChange(delivery: self.backgroundDelivery, unitCount: .one),
+            targetReceipt: first.windowTargetReceipt,
+            selectedLeafEvidence: [evidence],
+            attribution: .operationTarget)
+        sequence.record(
+            outcome: .confirmedNoChange(),
+            targetReceipt: second.windowTargetReceipt,
+            attribution: .operationTarget)
+
+        let result = try sequence.result(
+            payload: (),
+            operation: "Optional target compatibility",
+            requiresOutcome: true)
+
+        #expect(result.targetIdentity == nil)
+        #expect(result.selectedLeafEvidence == nil)
     }
 
     @Test

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/UIAutomationActionResultSequenceAccumulatorTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/UIAutomationActionResultSequenceAccumulatorTests.swift
@@ -367,6 +367,28 @@ struct UIAutomationActionResultSequenceAccumulatorTests {
     }
 
     @Test
+    func `empty selected-leaf collection is normalized to absent evidence`() throws {
+        let target = AutomationTestFixtures.linkedDesktopTarget(
+            windowID: 71,
+            bounds: Self.windowBounds)
+        var sequence = UIAutomationActionResultSequenceAccumulator()
+        sequence.record(
+            outcome: .confirmedChange(delivery: self.backgroundDelivery, unitCount: .one),
+            targetReceipt: target.windowTargetReceipt,
+            selectedLeafEvidence: [],
+            attribution: .mutationTarget)
+
+        let result = try sequence.result(
+            payload: (),
+            operation: "Empty selected leaves",
+            requiresOutcome: true,
+            requiresCompatibleTarget: true)
+
+        #expect(result.outcome?.state == .confirmedChange)
+        #expect(result.selectedLeafEvidence == nil)
+    }
+
+    @Test
     func `selected leaves must be contained by the attributed phase target`() throws {
         let phase = AutomationTestFixtures.linkedDesktopTarget(
             processIdentity: .init(processIdentifier: 42, processStartIdentity: 1001),

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/UIAutomationActionResultSequenceAccumulatorTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/UIAutomationActionResultSequenceAccumulatorTests.swift
@@ -250,6 +250,38 @@ struct UIAutomationActionResultSequenceAccumulatorTests {
     }
 
     @Test
+    func `terminal failure drops selected leaves outside its own target`() throws {
+        let target = AutomationTestFixtures.linkedDesktopTarget(
+            processIdentity: .init(processIdentifier: 42, processStartIdentity: 1001),
+            windowID: 71,
+            bounds: Self.windowBounds)
+        let sibling = AutomationTestFixtures.linkedDesktopTarget(
+            processIdentity: target.processIdentity,
+            windowID: 72,
+            bounds: Self.windowBounds)
+        let invalidEvidence = try self.leaf(index: 0, target: sibling.windowTargetReceipt)
+        var sequence = UIAutomationActionResultSequenceAccumulator()
+        sequence.record(
+            outcome: .confirmedChange(delivery: self.backgroundDelivery, unitCount: .one),
+            targetReceipt: target.windowTargetReceipt,
+            attribution: .mutationTarget)
+        let terminalFailure = DesktopActionFailure.indeterminate(
+            delivery: self.backgroundDelivery,
+            evidence: .completionUnknown,
+            unitCount: .one,
+            message: "Terminal failure")
+            .attributed(to: target.windowTargetReceipt)
+            .selectingLeaves([invalidEvidence])
+
+        let failure = sequence.failure(
+            combining: terminalFailure,
+            operation: "Invalid terminal evidence")
+
+        #expect(failure.targetReceipt == target.windowTargetReceipt)
+        #expect(failure.selectedLeafEvidence == nil)
+    }
+
+    @Test
     func `selected leaves require canonical dispatched evidence`() throws {
         let target = AutomationTestFixtures.linkedDesktopTarget(
             windowID: 71,

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/UIAutomationActionResultSequenceAccumulatorTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/UIAutomationActionResultSequenceAccumulatorTests.swift
@@ -1,16 +1,21 @@
 import CoreGraphics
+import PeekabooAutomationKitTestSupport
 import PeekabooFoundation
 import Testing
 @testable import PeekabooAutomationKit
 
 struct UIAutomationActionResultSequenceAccumulatorTests {
+    private static let windowBounds = CGRect(x: 10, y: 20, width: 300, height: 200)
+
     private let backgroundDelivery = DesktopActionOutcome.Delivery(
         mechanism: .accessibilityAction,
         mode: .background)
 
     @Test
     func `homogeneous mutation phases preserve target leaves and exact units`() throws {
-        let target = try self.windowTarget(windowID: 71)
+        let target = AutomationTestFixtures.linkedDesktopTarget(
+            windowID: 71,
+            bounds: Self.windowBounds).windowTargetIdentity
         let receipt = target.actionTargetReceipt
         let firstLeaf = try self.leaf(index: 0, target: receipt)
         let secondLeaf = try self.leaf(index: 1, target: receipt)
@@ -46,9 +51,13 @@ struct UIAutomationActionResultSequenceAccumulatorTests {
 
     @Test
     func `process and exact mutation phases retain only their common process scope`() throws {
-        let process = ApplicationProcessIdentity(processIdentifier: 42, processStartIdentity: 1001)
-        let processTarget = try DesktopTargetIdentity(processIdentity: process)
-        let windowTarget = try self.windowTarget(windowID: 71, process: process)
+        let fixture = AutomationTestFixtures.linkedDesktopTarget(
+            processIdentity: .init(processIdentifier: 42, processStartIdentity: 1001),
+            windowID: 71,
+            bounds: Self.windowBounds)
+        let process = fixture.processIdentity
+        let processTarget = fixture.processTargetIdentity
+        let windowTarget = fixture.windowTargetIdentity
         var sequence = UIAutomationActionResultSequenceAccumulator()
         for target in [processTarget, windowTarget] {
             sequence.record(
@@ -73,8 +82,12 @@ struct UIAutomationActionResultSequenceAccumulatorTests {
 
     @Test
     func `different exact mutation targets fail closed`() throws {
-        let first = try self.windowTarget(windowID: 71)
-        let second = try self.windowTarget(windowID: 72)
+        let first = AutomationTestFixtures.linkedDesktopTarget(
+            windowID: 71,
+            bounds: Self.windowBounds).windowTargetIdentity
+        let second = AutomationTestFixtures.linkedDesktopTarget(
+            windowID: 72,
+            bounds: Self.windowBounds).windowTargetIdentity
         var sequence = UIAutomationActionResultSequenceAccumulator()
         for target in [first, second] {
             sequence.record(
@@ -101,7 +114,9 @@ struct UIAutomationActionResultSequenceAccumulatorTests {
 
     @Test
     func `required leaf cannot borrow a setup target`() throws {
-        let target = try self.windowTarget(windowID: 71)
+        let target = AutomationTestFixtures.linkedDesktopTarget(
+            windowID: 71,
+            bounds: Self.windowBounds).windowTargetIdentity
         var sequence = UIAutomationActionResultSequenceAccumulator()
         sequence.record(
             UIAutomationActionResult(
@@ -129,7 +144,9 @@ struct UIAutomationActionResultSequenceAccumulatorTests {
 
     @Test
     func `targetless leaf suppresses setup attribution and rejects its own target`() throws {
-        let target = try self.windowTarget(windowID: 71)
+        let target = AutomationTestFixtures.linkedDesktopTarget(
+            windowID: 71,
+            bounds: Self.windowBounds).windowTargetIdentity
         let pointerDelivery = DesktopActionOutcome.Delivery(
             mechanism: .globalEvents,
             mode: .foreground)
@@ -170,7 +187,9 @@ struct UIAutomationActionResultSequenceAccumulatorTests {
 
     @Test
     func `failure composition follows dispatched targets and preserves prior leaves`() throws {
-        let target = try self.windowTarget(windowID: 71)
+        let target = AutomationTestFixtures.linkedDesktopTarget(
+            windowID: 71,
+            bounds: Self.windowBounds).windowTargetIdentity
         let evidence = try self.leaf(index: 0, target: target.actionTargetReceipt)
         var sequence = UIAutomationActionResultSequenceAccumulator()
         sequence.record(
@@ -183,10 +202,12 @@ struct UIAutomationActionResultSequenceAccumulatorTests {
                 targetIdentity: target,
                 selectedLeafEvidence: [evidence]),
             attribution: .operationTarget)
-        let leafFailure = try DesktopActionFailure.preDispatchRefusal(
+        let leafFailure = DesktopActionFailure.preDispatchRefusal(
             reason: .targetUnavailable,
             message: "Later phase refused")
-            .attributed(to: self.windowTarget(windowID: 72).actionTargetReceipt)
+            .attributed(to: AutomationTestFixtures.linkedDesktopTarget(
+                windowID: 72,
+                bounds: Self.windowBounds).windowTargetReceipt)
 
         let failure = sequence.failure(
             combining: leafFailure,
@@ -200,7 +221,9 @@ struct UIAutomationActionResultSequenceAccumulatorTests {
 
     @Test
     func `selected leaves require canonical dispatched evidence`() throws {
-        let target = try self.windowTarget(windowID: 71)
+        let target = AutomationTestFixtures.linkedDesktopTarget(
+            windowID: 71,
+            bounds: Self.windowBounds).windowTargetIdentity
         let evidence = try self.leaf(index: 0, target: target.actionTargetReceipt)
         var sequence = UIAutomationActionResultSequenceAccumulator()
         sequence.record(
@@ -217,22 +240,6 @@ struct UIAutomationActionResultSequenceAccumulatorTests {
                 operation: "No-dispatch leaf sequence",
                 requiresOutcome: true)
         }
-    }
-
-    private func windowTarget(
-        windowID: Int,
-        process: ApplicationProcessIdentity = .init(
-            processIdentifier: 42,
-            processStartIdentity: 1001)) throws -> DesktopTargetIdentity
-    {
-        let bounds = CGRect(x: 10, y: 20, width: 300, height: 200)
-        return try DesktopTargetIdentity(exactWindow: UIAutomationTarget.ExactWindow(
-            identity: WindowMutationIdentity(
-                windowID: windowID,
-                ownerProcessIdentifier: process.processIdentifier,
-                ownerProcessStartIdentity: process.processStartIdentity,
-                capturedBounds: bounds),
-            bounds: bounds))
     }
 
     private func leaf(

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/UIAutomationActionResultSequenceAccumulatorTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/UIAutomationActionResultSequenceAccumulatorTests.swift
@@ -1,0 +1,255 @@
+import CoreGraphics
+import PeekabooFoundation
+import Testing
+@testable import PeekabooAutomationKit
+
+struct UIAutomationActionResultSequenceAccumulatorTests {
+    private let backgroundDelivery = DesktopActionOutcome.Delivery(
+        mechanism: .accessibilityAction,
+        mode: .background)
+
+    @Test
+    func `homogeneous mutation phases preserve target leaves and exact units`() throws {
+        let target = try self.windowTarget(windowID: 71)
+        let receipt = target.actionTargetReceipt
+        let firstLeaf = try self.leaf(index: 0, target: receipt)
+        let secondLeaf = try self.leaf(index: 1, target: receipt)
+        var sequence = UIAutomationActionResultSequenceAccumulator()
+        sequence.record(
+            UIAutomationActionResult(
+                payload: (),
+                outcome: .confirmedChange(delivery: self.backgroundDelivery, unitCount: .one),
+                targetIdentity: target,
+                selectedLeafEvidence: [firstLeaf]),
+            attribution: .mutationTarget)
+        sequence.record(
+            UIAutomationActionResult(
+                payload: (),
+                outcome: .confirmedChange(delivery: self.backgroundDelivery, unitCount: .one),
+                targetIdentity: target,
+                selectedLeafEvidence: [secondLeaf]),
+            attribution: .mutationTarget)
+
+        let result = try sequence.result(
+            payload: true,
+            operation: "Fixture sequence",
+            requiresOutcome: true,
+            requiresTarget: true,
+            requiresCompatibleTarget: true)
+
+        #expect(result.payload)
+        #expect(result.outcome?.state == .confirmedChange)
+        #expect(result.outcome?.dispatchState.unitCount == DesktopActionOutcome.DispatchUnitCount(2))
+        #expect(result.targetIdentity == target)
+        #expect(result.selectedLeafEvidence == [firstLeaf, secondLeaf])
+    }
+
+    @Test
+    func `process and exact mutation phases retain only their common process scope`() throws {
+        let process = ApplicationProcessIdentity(processIdentifier: 42, processStartIdentity: 1001)
+        let processTarget = try DesktopTargetIdentity(processIdentity: process)
+        let windowTarget = try self.windowTarget(windowID: 71, process: process)
+        var sequence = UIAutomationActionResultSequenceAccumulator()
+        for target in [processTarget, windowTarget] {
+            sequence.record(
+                UIAutomationActionResult(
+                    payload: (),
+                    outcome: .confirmedChange(delivery: self.backgroundDelivery, unitCount: .one),
+                    targetIdentity: target),
+                attribution: .mutationTarget)
+        }
+
+        let result = try sequence.result(
+            payload: (),
+            operation: "Mixed-scope sequence",
+            requiresOutcome: true,
+            requiresTarget: true,
+            requiresCompatibleTarget: true)
+
+        #expect(result.targetIdentity?.processIdentity == process)
+        #expect(result.targetIdentity?.exactWindow == nil)
+        #expect(result.actionTargetReceipt == processTarget.actionTargetReceipt)
+    }
+
+    @Test
+    func `different exact mutation targets fail closed`() throws {
+        let first = try self.windowTarget(windowID: 71)
+        let second = try self.windowTarget(windowID: 72)
+        var sequence = UIAutomationActionResultSequenceAccumulator()
+        for target in [first, second] {
+            sequence.record(
+                UIAutomationActionResult(
+                    payload: (),
+                    outcome: .confirmedChange(delivery: self.backgroundDelivery, unitCount: .one),
+                    targetIdentity: target),
+                attribution: .mutationTarget)
+        }
+
+        do {
+            _ = try sequence.result(
+                payload: (),
+                operation: "Conflicting sequence",
+                requiresOutcome: true,
+                requiresCompatibleTarget: true)
+            Issue.record("Expected contradictory exact targets to fail")
+        } catch let failure as DesktopActionFailure {
+            #expect(failure.outcome.state == .indeterminate)
+            #expect(failure.outcome.dispatchState.unitCount == DesktopActionOutcome.DispatchUnitCount(2))
+            #expect(failure.targetReceipt == nil)
+        }
+    }
+
+    @Test
+    func `required leaf cannot borrow a setup target`() throws {
+        let target = try self.windowTarget(windowID: 71)
+        var sequence = UIAutomationActionResultSequenceAccumulator()
+        sequence.record(
+            UIAutomationActionResult(
+                payload: (),
+                outcome: .confirmedChange(delivery: self.backgroundDelivery, unitCount: .one),
+                targetIdentity: target),
+            attribution: .mutationTarget)
+        sequence.record(
+            UIAutomationActionResult(
+                payload: (),
+                outcome: .confirmedChange(delivery: self.backgroundDelivery, unitCount: .one)),
+            attribution: .requiredTarget)
+
+        do {
+            _ = try sequence.result(
+                payload: (),
+                operation: "Required leaf sequence",
+                requiresOutcome: true)
+            Issue.record("Expected a missing required leaf target to fail")
+        } catch let failure as DesktopActionFailure {
+            #expect(failure.outcome.state == .indeterminate)
+            #expect(failure.targetReceipt == nil)
+        }
+    }
+
+    @Test
+    func `targetless leaf suppresses setup attribution and rejects its own target`() throws {
+        let target = try self.windowTarget(windowID: 71)
+        let pointerDelivery = DesktopActionOutcome.Delivery(
+            mechanism: .globalEvents,
+            mode: .foreground)
+        var sequence = UIAutomationActionResultSequenceAccumulator()
+        sequence.record(
+            UIAutomationActionResult(
+                payload: (),
+                outcome: .confirmedChange(delivery: self.backgroundDelivery, unitCount: .one),
+                targetIdentity: target),
+            attribution: .mutationTarget)
+        sequence.record(
+            UIAutomationActionResult(
+                payload: (),
+                outcome: .confirmedChange(delivery: pointerDelivery, unitCount: .one)),
+            attribution: .targetless)
+
+        let result = try sequence.result(
+            payload: (),
+            operation: "Global pointer sequence",
+            requiresOutcome: true,
+            requiresCompatibleTarget: true)
+        #expect(result.targetIdentity == nil)
+        #expect(result.outcome?.delivery?.mechanism == .composite)
+
+        var invalid = UIAutomationActionResultSequenceAccumulator()
+        invalid.record(
+            UIAutomationActionResult(
+                payload: (),
+                outcome: .confirmedChange(delivery: pointerDelivery, unitCount: .one),
+                targetIdentity: target),
+            attribution: .targetless)
+        #expect(throws: DesktopActionFailure.self) {
+            _ = try invalid.result(
+                payload: (),
+                operation: "Invalid global pointer")
+        }
+    }
+
+    @Test
+    func `failure composition follows dispatched targets and preserves prior leaves`() throws {
+        let target = try self.windowTarget(windowID: 71)
+        let evidence = try self.leaf(index: 0, target: target.actionTargetReceipt)
+        var sequence = UIAutomationActionResultSequenceAccumulator()
+        sequence.record(
+            UIAutomationActionResult(
+                payload: (),
+                outcome: .dispatchedUnverified(
+                    delivery: self.backgroundDelivery,
+                    evidence: .deliveryAccepted,
+                    unitCount: .one),
+                targetIdentity: target,
+                selectedLeafEvidence: [evidence]),
+            attribution: .operationTarget)
+        let leafFailure = try DesktopActionFailure.preDispatchRefusal(
+            reason: .targetUnavailable,
+            message: "Later phase refused")
+            .attributed(to: self.windowTarget(windowID: 72).actionTargetReceipt)
+
+        let failure = sequence.failure(
+            combining: leafFailure,
+            operation: "Fixture sequence")
+
+        #expect(failure.outcome.state == .indeterminate)
+        #expect(failure.outcome.dispatchState.unitCount == .one)
+        #expect(failure.targetReceipt == target.actionTargetReceipt)
+        #expect(failure.selectedLeafEvidence == [evidence])
+    }
+
+    @Test
+    func `selected leaves require canonical dispatched evidence`() throws {
+        let target = try self.windowTarget(windowID: 71)
+        let evidence = try self.leaf(index: 0, target: target.actionTargetReceipt)
+        var sequence = UIAutomationActionResultSequenceAccumulator()
+        sequence.record(
+            UIAutomationActionResult(
+                payload: (),
+                outcome: .confirmedNoChange(),
+                targetIdentity: target,
+                selectedLeafEvidence: [evidence]),
+            attribution: .operationTarget)
+
+        #expect(throws: DesktopActionFailure.self) {
+            _ = try sequence.result(
+                payload: (),
+                operation: "No-dispatch leaf sequence",
+                requiresOutcome: true)
+        }
+    }
+
+    private func windowTarget(
+        windowID: Int,
+        process: ApplicationProcessIdentity = .init(
+            processIdentifier: 42,
+            processStartIdentity: 1001)) throws -> DesktopTargetIdentity
+    {
+        let bounds = CGRect(x: 10, y: 20, width: 300, height: 200)
+        return try DesktopTargetIdentity(exactWindow: UIAutomationTarget.ExactWindow(
+            identity: WindowMutationIdentity(
+                windowID: windowID,
+                ownerProcessIdentifier: process.processIdentifier,
+                ownerProcessStartIdentity: process.processStartIdentity,
+                capturedBounds: bounds),
+            bounds: bounds))
+    }
+
+    private func leaf(
+        index: Int,
+        target: DesktopActionTargetReceipt) throws -> DesktopSelectedLeafEvidence
+    {
+        try DesktopSelectedLeafEvidence(
+            kind: .menuBarItem,
+            normalizedSelector: "fixture-\(index)",
+            matchKind: .exact,
+            selectedTargetReceipt: target,
+            selectedIndex: index,
+            selectedTitle: "Fixture \(index)",
+            selectedIdentifier: "fixture.\(index)",
+            selectedRole: "AXMenuBarItem",
+            selectedFrame: CGRect(x: index * 20, y: 0, width: 18, height: 18),
+            candidateSetSHA256: DesktopSelectedLeafEvidence.digestCandidateSet(["fixture", "\(index)"]),
+            candidateCount: 1)
+    }
+}

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/UIAutomationActionResultSequenceAccumulatorTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/UIAutomationActionResultSequenceAccumulatorTests.swift
@@ -143,6 +143,36 @@ struct UIAutomationActionResultSequenceAccumulatorTests {
     }
 
     @Test
+    func `required phase rejects contradictory identity and receipt without compatibility opt in`() throws {
+        let identityTarget = AutomationTestFixtures.linkedDesktopTarget(
+            windowID: 71,
+            bounds: Self.windowBounds)
+        let explicitTarget = AutomationTestFixtures.linkedDesktopTarget(
+            windowID: 72,
+            bounds: Self.windowBounds)
+        var sequence = UIAutomationActionResultSequenceAccumulator()
+        sequence.record(
+            outcome: .confirmedNoChange(),
+            targetIdentity: identityTarget.windowTargetIdentity,
+            targetReceipt: explicitTarget.windowTargetReceipt,
+            attribution: .requiredTarget)
+
+        do {
+            _ = try sequence.result(
+                payload: (),
+                operation: "Contradictory required target",
+                requiresOutcome: true)
+            Issue.record("Expected the contradictory required target to fail without compatibility opt in")
+        } catch let failure as DesktopActionFailure {
+            #expect(failure.outcome.state == .indeterminate)
+            #expect(failure.outcome.dispatchState.unitCount == nil)
+            #expect(failure.targetReceipt == nil)
+            #expect(failure.causeDescription ==
+                DesktopTargetIdentityError.contradictoryWindowIdentity.localizedDescription)
+        }
+    }
+
+    @Test
     func `targetless leaf suppresses setup attribution and rejects its own target`() throws {
         let target = AutomationTestFixtures.linkedDesktopTarget(
             windowID: 71,
@@ -240,6 +270,95 @@ struct UIAutomationActionResultSequenceAccumulatorTests {
                 operation: "No-dispatch leaf sequence",
                 requiresOutcome: true)
         }
+    }
+
+    @Test
+    func `selected leaves must be contained by the attributed phase target`() throws {
+        let phase = AutomationTestFixtures.linkedDesktopTarget(
+            processIdentity: .init(processIdentifier: 42, processStartIdentity: 1001),
+            windowID: 71,
+            bounds: Self.windowBounds)
+        let sibling = AutomationTestFixtures.linkedDesktopTarget(
+            processIdentity: phase.processIdentity,
+            windowID: 72,
+            bounds: Self.windowBounds)
+        for unrelatedTarget in [sibling.windowTargetReceipt, phase.processTargetReceipt] {
+            let evidence = try self.leaf(index: 0, target: unrelatedTarget)
+            var sequence = UIAutomationActionResultSequenceAccumulator()
+            sequence.record(
+                UIAutomationActionResult(
+                    payload: (),
+                    outcome: .confirmedChange(delivery: self.backgroundDelivery, unitCount: .one),
+                    targetIdentity: phase.windowTargetIdentity,
+                    selectedLeafEvidence: [evidence]),
+                attribution: .mutationTarget)
+
+            #expect(throws: DesktopActionFailure.self) {
+                _ = try sequence.result(
+                    payload: (),
+                    operation: "Mismatched selected leaf",
+                    requiresOutcome: true,
+                    requiresCompatibleTarget: true)
+            }
+            let failure = sequence.failure(
+                combining: .preDispatchRefusal(
+                    reason: .targetUnavailable,
+                    message: "Later phase refused"),
+                operation: "Mismatched selected leaf")
+            #expect(failure.selectedLeafEvidence == nil)
+        }
+    }
+
+    @Test
+    func `process phase accepts selected leaves from an exact child window`() throws {
+        let phase = AutomationTestFixtures.linkedDesktopTarget(
+            processIdentity: .init(processIdentifier: 42, processStartIdentity: 1001),
+            windowID: 71,
+            bounds: Self.windowBounds)
+        let evidence = try self.leaf(index: 0, target: phase.windowTargetReceipt)
+        var sequence = UIAutomationActionResultSequenceAccumulator()
+        sequence.record(
+            outcome: .confirmedChange(delivery: self.backgroundDelivery, unitCount: .one),
+            targetIdentity: phase.processTargetIdentity,
+            selectedLeafEvidence: [evidence],
+            attribution: .mutationTarget)
+
+        let result = try sequence.result(
+            payload: (),
+            operation: "Process selected leaf",
+            requiresOutcome: true,
+            requiresCompatibleTarget: true)
+
+        #expect(result.selectedLeafEvidence == [evidence])
+    }
+
+    @Test
+    func `no-dispatch failure cannot hide a prior operation target conflict`() {
+        let first = AutomationTestFixtures.linkedDesktopTarget(
+            windowID: 71,
+            bounds: Self.windowBounds)
+        let second = AutomationTestFixtures.linkedDesktopTarget(
+            windowID: 72,
+            bounds: Self.windowBounds)
+        let later = AutomationTestFixtures.linkedDesktopTarget(
+            windowID: 73,
+            bounds: Self.windowBounds)
+        var sequence = UIAutomationActionResultSequenceAccumulator()
+        for target in [first, second] {
+            sequence.record(
+                outcome: .confirmedNoChange(),
+                targetReceipt: target.windowTargetReceipt,
+                attribution: .operationTarget)
+        }
+
+        let failure = sequence.failure(
+            combining: DesktopActionFailure.preDispatchRefusal(
+                reason: .targetUnavailable,
+                message: "Later phase refused")
+                .attributed(to: later.windowTargetReceipt),
+            operation: "Conflicting no-dispatch targets")
+
+        #expect(failure.targetReceipt == nil)
     }
 
     private func leaf(

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/WindowMutationPlannerTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/WindowMutationPlannerTests.swift
@@ -8,8 +8,9 @@ import Testing
 struct WindowMutationPlannerTests {
     @Test
     func `partial window inventory refuses title and index uniqueness`() async {
-        let application = AutomationTestFixtures.application()
-        let window = AutomationTestFixtures.window()
+        let fixture = AutomationTestFixtures.linkedDesktopTarget()
+        let application = fixture.application
+        let window = fixture.window
         let applications = DesktopTargetPlanning.ApplicationMutationPlanner(
             inventoryProvider: { .complete([application]) })
         let planner = DesktopTargetPlanning.WindowMutationPlanner(
@@ -38,8 +39,9 @@ struct WindowMutationPlannerTests {
 
     @Test
     func `exact window ID can use a partial direct lookup`() async throws {
-        let application = AutomationTestFixtures.application()
-        let window = AutomationTestFixtures.window()
+        let fixture = AutomationTestFixtures.linkedDesktopTarget()
+        let application = fixture.application
+        let window = fixture.window
         let applications = DesktopTargetPlanning.ApplicationMutationPlanner(
             inventoryProvider: { .complete([application]) })
         let planner = DesktopTargetPlanning.WindowMutationPlanner(
@@ -87,8 +89,9 @@ struct WindowMutationPlannerTests {
 
     @Test
     func `window provider transport failures stay unavailable instead of impersonating target loss`() async throws {
-        let application = AutomationTestFixtures.application()
-        let window = AutomationTestFixtures.window()
+        let fixture = AutomationTestFixtures.linkedDesktopTarget()
+        let application = fixture.application
+        let window = fixture.window
         let shouldFail = AutomationTestLockedValue(true)
         let applications = DesktopTargetPlanning.ApplicationMutationPlanner(
             inventoryProvider: { .complete([application]) })
@@ -140,8 +143,9 @@ struct WindowMutationPlannerTests {
 
     @Test
     func `exact window absence becomes not found initially and stale after selection`() async throws {
-        let application = AutomationTestFixtures.application()
-        let window = AutomationTestFixtures.window()
+        let fixture = AutomationTestFixtures.linkedDesktopTarget()
+        let application = fixture.application
+        let window = fixture.window
         let isMissing = AutomationTestLockedValue(true)
         let applications = DesktopTargetPlanning.ApplicationMutationPlanner(
             inventoryProvider: { .complete([application]) })
@@ -238,8 +242,9 @@ struct WindowMutationPlannerTests {
 
     @Test
     func `relative selector lists only by canonical exact PID and returns exact target`() async throws {
-        let application = AutomationTestFixtures.application()
-        let window = AutomationTestFixtures.window()
+        let fixture = AutomationTestFixtures.linkedDesktopTarget()
+        let application = fixture.application
+        let window = fixture.window
         let spy = WindowPlannerInventorySpy(
             applicationInventories: [[application], [application]],
             windows: [.application("PID:101"): [window]])
@@ -264,8 +269,9 @@ struct WindowMutationPlannerTests {
 
     @Test
     func `exact ID alone derives owner while a wrong explicit owner refuses`() async throws {
-        let application = AutomationTestFixtures.application()
-        let window = AutomationTestFixtures.window()
+        let fixture = AutomationTestFixtures.linkedDesktopTarget()
+        let application = fixture.application
+        let window = fixture.window
         let exactSpy = WindowPlannerInventorySpy(
             applicationInventories: [[application], [application]],
             windows: [.windowId(201): [window]])
@@ -293,9 +299,10 @@ struct WindowMutationPlannerTests {
 
     @Test
     func `owner drift after window inventory refuses pre-dispatch`() async throws {
-        let original = AutomationTestFixtures.application()
+        let fixture = AutomationTestFixtures.linkedDesktopTarget()
+        let original = fixture.application
         let changed = AutomationTestFixtures.wrongGenerationApplication()
-        let window = AutomationTestFixtures.window()
+        let window = fixture.window
         let spy = WindowPlannerInventorySpy(
             applicationInventories: [[original], [changed]],
             windows: [.application("PID:101"): [window]])
@@ -356,6 +363,7 @@ struct WindowMutationPlannerTests {
         let application = AutomationTestFixtures.application()
         let original = AutomationTestFixtures.window()
         let moved = AutomationTestFixtures.window(
+            copying: original,
             bounds: original.bounds.offsetBy(dx: 1, dy: 0))
         let spy = WindowPlannerInventorySpy(
             applicationInventories: [[application], [application], [application]],
@@ -376,7 +384,9 @@ struct WindowMutationPlannerTests {
         let replacementOwner = AutomationTestFixtures.processIdentity(
             processIdentifier: 202,
             processStartIdentity: 2002)
-        let replacement = AutomationTestFixtures.window(processIdentity: replacementOwner)
+        let replacement = AutomationTestFixtures.window(
+            copying: original,
+            processIdentity: replacementOwner)
         let spy = WindowPlannerInventorySpy(
             applicationInventories: [[application], [application]],
             windows: [.windowId(201): [original]])
@@ -393,7 +403,10 @@ struct WindowMutationPlannerTests {
     func `revalidation keeps historical selection evidence while refreshing exact execution state`() async throws {
         let application = AutomationTestFixtures.application()
         let original = AutomationTestFixtures.window(title: "Selected Document", isMinimized: false)
-        let refreshed = AutomationTestFixtures.window(title: "Renamed Document", isMinimized: true)
+        let refreshed = AutomationTestFixtures.window(
+            copying: original,
+            title: "Renamed Document",
+            isMinimized: true)
         let sibling = AutomationTestFixtures.window(windowID: 202, title: "Selected Document", index: 0)
         let spy = WindowPlannerInventorySpy(
             applicationInventories: [[application], [application], [application]],

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/ObservationActionResultSupport.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/ObservationActionResultSupport.swift
@@ -9,10 +9,10 @@ enum ObservationActionResultSupport {
         after result: UIAutomationActionResult<some Sendable>?,
         operation: String) -> any Error
     {
-        ObservationActionResultSemantics.preservingFailure(
+        guard let result else { return error }
+        return ObservationActionResultSemantics.preservingFailure(
             error,
-            after: result?.outcome,
-            targetIdentity: result?.targetIdentity,
+            after: result,
             operation: operation)
     }
 


### PR DESCRIPTION
## Summary

- centralize multi-phase automation result composition in one target-aware accumulator
- keep operation, mutation, required, and targetless attribution rules explicit
- consolidate process/window target fixtures used across planner and result-semantic tests
- preserve canonical outcomes and original observation errors while rejecting contradictory target or selected-leaf evidence

## Safety invariants

- required phases cannot borrow a prior target or contradict their own identity receipt
- selected-leaf evidence must be dispatched and contained by both its phase target and final aggregate target
- targetless, target-conflicted, zero-prefix, and terminal-failure paths cannot publish unattributed leaf evidence
- empty optional leaf collections normalize to absent evidence
- incompatible failure targets cannot be hidden by a later no-dispatch failure

## Proof

- focused post-rebase result/observation suites: 24/24
- full AutomationKit suite on the reviewed stack: 1,049/1,049
- full PeekabooCore suite (serial)
- explicit PeekabooCore and CLI builds
- `pnpm run test:safe`, including 478 CLI automation tests
- `pnpm run format` (zero changes)
- `pnpm run lint` (66 inherited warnings, 0 serious)
- docs lint and `git diff --check`
- final whole-branch P0-P2 Autoreview: no accepted/actionable findings
