### PR TITLE
fix(certification): make monitor acknowledgements race-free

### DIFF
--- a/docs/testing/background-computer-use.md
+++ b/docs/testing/background-computer-use.md
@@ -64,6 +64,28 @@ deltas; result contracts cover the remaining cases. Unrelated app windows and co
 directories must be new or empty so a rerun cannot reuse old summaries, images, or logs. Results go under
 `.artifacts/background-computer-use/<UTC>/`.
 
+The native monitor has one authorization-epoch state machine for producer publication and all input, activation, and
+focused-window callbacks. Each callback is admitted on one atomic cutoff and retains that epoch plus the PID,
+process-start identity, and focused window sampled during the callback. Publishing a higher producer revision closes the
+old epoch before the new epoch can admit evidence; heartbeat closure uses the same cutoff, so there is no separate
+drain-to-heartbeat interval. Every higher revision is a transition barrier, including a producer-only update or an
+unchanged foreground target. Its acknowledgement advertises the new revision and target but cannot advance
+`lastCleanSequence`; the next fully closed stable epoch may do so. Repeating the current revision is idempotent only when
+the exact producer set (ignoring array order) and optional foreground payload are unchanged.
+
+The producer document may label one exact process generation with role `foreground-controller` and pair it with
+`foreground: {active: true, target: {pid, startIdentity, windowID}}`. A foreground grant requires exactly one such
+controller and at least one ordinary Bridge producer; inactive policy permits neither a controller nor a target. The
+baseline focus observer remains installed, a new granted-target observer is installed before publication, and observers
+for prior targets remain alive through transition closure. They retire only after the acknowledgement has consumed the
+old epoch. Observer installation/removal failure, controller recycling, or current/deferred target generation or window
+drift disables attribution. Hardware-origin mouse movement may be recorded as observational when the harness opts in;
+other user input still makes the attempt indeterminate.
+
+This state machine is deterministic infrastructure only in the current slice. The dual-controller command continues to
+refuse before UI setup: no physical foreground grant/revoke coordinator is enabled, and these epoch contracts alone are
+not concurrent certification.
+
 The 34 required CLI cases are source-controlled in `scripts/background-computer-use-catalog.json`. Each row declares
 its exit contract and, where applicable, its effect, delivery, refusal code, allowed outcome tuples, and named checks.
 The catalog is the canonical list of monitored invariant families and projects their names into the native probe,

--- a/docs/testing/background-computer-use.md
+++ b/docs/testing/background-computer-use.md
@@ -66,9 +66,12 @@ directories must be new or empty so a rerun cannot reuse old summaries, images, 
 
 The native monitor has one authorization-epoch state machine for producer publication and all input, activation, and
 focused-window callbacks. Each callback is admitted on one atomic cutoff and retains that epoch plus the PID,
-process-start identity, and focused window sampled during the callback. Publishing a higher producer revision closes the
-old epoch before the new epoch can admit evidence; heartbeat closure uses the same cutoff, so there is no separate
-drain-to-heartbeat interval. Every higher revision is a transition barrier, including a producer-only update or an
+process-start identity, and focused window sampled during the callback. Admission reserves a cheap immutable token,
+releases the publication lock while sampling native process/focus evidence, and completes that exact token afterward;
+sealed epochs cannot reach a heartbeat while any reservation remains incomplete. Input and activation callbacks use
+exact Accessibility focus lookup rather than a broad WindowServer inventory. Publishing a higher producer revision
+closes the old epoch before the new epoch can admit evidence; heartbeat closure uses the same cutoff, so there is no
+separate drain-to-heartbeat interval. Every higher revision is a transition barrier, including a producer-only update or an
 unchanged foreground target. Its acknowledgement advertises the new revision and target but cannot advance
 `lastCleanSequence`; the next fully closed stable epoch may do so. Repeating the current revision is idempotent only when
 the exact producer set (ignoring array order) and optional foreground payload are unchanged.

--- a/docs/testing/background-computer-use.md
+++ b/docs/testing/background-computer-use.md
@@ -96,7 +96,8 @@ The producer document may label one exact process generation with role `foregrou
 controller and at least one ordinary Bridge producer; inactive policy permits neither a controller nor a target. The
 baseline focus observer remains installed, a new granted-target observer is installed before publication, and observers
 for prior targets remain alive while transition evidence is evaluated. They retire inside the acknowledgement cutoff;
-removal failure prevents the acknowledgement from being published. Every heartbeat revalidates all effective and pending
+removal or final liveness failure prevents the acknowledgement, publishes a non-acknowledging heartbeat, and records a
+sticky attribution failure without terminating the watcher. Every heartbeat revalidates all effective and pending
 foreground-controller generations even when no input arrived; ordinary Bridge generations remain publication-validated
 and event-time validated because short-lived CLI producers may exit before the post-command heartbeat. Foreground-activity
 counters are scoped to the advertised revision so an earlier grant cannot satisfy a later grant. Controller recycling or

--- a/docs/testing/background-computer-use.md
+++ b/docs/testing/background-computer-use.md
@@ -69,21 +69,39 @@ focused-window callbacks. Each callback is admitted on one atomic cutoff and ret
 process-start identity, and focused window sampled during the callback. Admission reserves a cheap immutable token,
 releases the publication lock while sampling native process/focus evidence, and completes that exact token afterward;
 sealed epochs cannot reach a heartbeat while any reservation remains incomplete. Input and activation callbacks use
-exact Accessibility focus lookup rather than a broad WindowServer inventory. Publishing a higher producer revision
-closes the old epoch before the new epoch can admit evidence; heartbeat closure uses the same cutoff, so there is no
-separate drain-to-heartbeat interval. Every higher revision is a transition barrier, including a producer-only update or an
-unchanged foreground target. Its acknowledgement advertises the new revision and target but cannot advance
-`lastCleanSequence`; the next fully closed stable epoch may do so. Repeating the current revision is idempotent only when
-the exact producer set (ignoring array order) and optional foreground payload are unchanged.
+exact Accessibility focus lookup rather than a broad WindowServer inventory. Each window lookup is bracketed by matching
+process-generation reads; generation drift discards the combined evidence instead of synthesizing a PID/window pair.
+Publishing a higher producer revision closes the old epoch before the new epoch can admit evidence; heartbeat closure
+uses the same cutoff, so there is no
+separate drain-to-heartbeat interval. Every higher revision is a transition barrier, including a producer-only update or
+an unchanged foreground target. A separate full callback run-loop turn and `beforeWaiting` idle barrier must finish before
+that revision becomes eligible for acknowledgement. A missed bounded idle barrier defers the transition while stable
+monitoring continues; persistent backlog eventually times out the harness acknowledgement wait rather than relabeling
+queued callbacks. Admission remains on the previously acknowledged policy through that barrier. A grant therefore cannot
+credit its new controller early, while a queued event from the prior grant is neither relabeled nor treated as outside
+input during
+revoke. The monitor will not publish an acknowledgement while its pre-ack bucket has a pending reservation or unevaluated
+event. Once that bucket is empty, observer reconciliation, the atomic heartbeat write, and the admission switch to the
+new authorization share one cutoff. Heartbeat bytes and the same-directory temporary file are prepared outside the
+cutoff, then a final adjacent idle barrier drains newly queued callbacks; any resulting evidence defers acknowledgement
+again. Current and prior controller generations and targets are revalidated inside the cutoff before observer retirement
+and atomic rename, so liveness cannot drift during the final barrier. Every evaluated transition summary is still published
+with `transitionAcknowledged: false` while waiting, so activation/focus counts are never discarded. The eventual
+acknowledgement advertises the new revision and target but cannot advance `lastCleanSequence`; the next fully closed stable
+epoch may do so. Repeating the current revision is idempotent only when the exact producer set (ignoring array order) and
+optional foreground payload are unchanged.
 
 The producer document may label one exact process generation with role `foreground-controller` and pair it with
 `foreground: {active: true, target: {pid, startIdentity, windowID}}`. A foreground grant requires exactly one such
 controller and at least one ordinary Bridge producer; inactive policy permits neither a controller nor a target. The
 baseline focus observer remains installed, a new granted-target observer is installed before publication, and observers
-for prior targets remain alive through transition closure. They retire only after the acknowledgement has consumed the
-old epoch. Observer installation/removal failure, controller recycling, or current/deferred target generation or window
-drift disables attribution. Hardware-origin mouse movement may be recorded as observational when the harness opts in;
-other user input still makes the attempt indeterminate.
+for prior targets remain alive while transition evidence is evaluated. They retire inside the acknowledgement cutoff;
+removal failure prevents the acknowledgement from being published. Every heartbeat revalidates all effective and pending
+foreground-controller generations even when no input arrived; ordinary Bridge generations remain publication-validated
+and event-time validated because short-lived CLI producers may exit before the post-command heartbeat. Foreground-activity
+counters are scoped to the advertised revision so an earlier grant cannot satisfy a later grant. Controller recycling or
+current/deferred target generation or window drift disables attribution. Hardware-origin mouse movement may be recorded as
+observational when the harness opts in; other user input still makes the attempt indeterminate.
 
 This state machine is deterministic infrastructure only in the current slice. The dual-controller command continues to
 refuse before UI setup: no physical foreground grant/revoke coordinator is enabled, and these epoch contracts alone are

--- a/docs/testing/background-computer-use.md
+++ b/docs/testing/background-computer-use.md
@@ -72,8 +72,9 @@ sealed epochs cannot reach a heartbeat while any reservation remains incomplete.
 exact Accessibility focus lookup rather than a broad WindowServer inventory. Each window lookup is bracketed by matching
 process-generation reads; generation drift discards the combined evidence instead of synthesizing a PID/window pair.
 Publishing a higher producer revision closes the old epoch before the new epoch can admit evidence; heartbeat closure
-uses the same cutoff, so there is no
-separate drain-to-heartbeat interval. Every higher revision is a transition barrier, including a producer-only update or
+uses the same cutoff, so there is no separate drain-to-heartbeat interval. Each heartbeat samples system state, drains
+callbacks that became ready during sampling, and only then closes/evaluates that epoch. Every higher revision is a
+transition barrier, including a producer-only update or
 an unchanged foreground target. A separate full callback run-loop turn and `beforeWaiting` idle barrier must finish before
 that revision becomes eligible for acknowledgement. A missed bounded idle barrier defers the transition while stable
 monitoring continues; persistent backlog eventually times out the harness acknowledgement wait rather than relabeling
@@ -83,8 +84,9 @@ input during
 revoke. The monitor will not publish an acknowledgement while its pre-ack bucket has a pending reservation or unevaluated
 event. Once that bucket is empty, observer reconciliation, the atomic heartbeat write, and the admission switch to the
 new authorization share one cutoff. Heartbeat bytes and the same-directory temporary file are prepared outside the
-cutoff, then a final adjacent idle barrier drains newly queued callbacks; any resulting evidence defers acknowledgement
-again. Current and prior controller generations and targets are revalidated inside the cutoff before observer retirement
+cutoff, then a final adjacent terminal-order idle barrier requires two `beforeWaiting` passes so work queued by another
+observer receives one more drain turn; any resulting evidence defers acknowledgement again. Current and prior controller
+generations and targets are revalidated inside the cutoff before observer retirement
 and atomic rename, so liveness cannot drift during the final barrier. Every evaluated transition summary is still published
 with `transitionAcknowledged: false` while waiting, so activation/focus counts are never discarded. The eventual
 acknowledgement advertises the new revision and target but cannot advance `lastCleanSequence`; the next fully closed stable

--- a/scripts/support/background-computer-use-probe.swift
+++ b/scripts/support/background-computer-use-probe.swift
@@ -7,6 +7,9 @@ import Dispatch
 import Foundation
 import Synchronization
 
+// The shell harness compiles this standalone probe directly; its deterministic contracts stay in the same source.
+// swiftlint:disable file_length
+
 @_silgen_name("_AXUIElementGetWindow")
 private func copyProbeAXWindowID(_ element: AXUIElement, _ windowID: inout CGWindowID) -> AXError
 
@@ -296,10 +299,21 @@ private enum MonitorPublicationResult: Equatable, Sendable {
     case rejected(reason: String)
 }
 
+private struct MonitorAdmissionToken: Equatable, Sendable {
+    let admission: UInt64
+    let epoch: MonitorEpoch
+}
+
+private struct MonitorEpochBucket: Sendable {
+    let epoch: MonitorEpoch
+    var events = [MonitorEvent]()
+    var pendingAdmissions = Set<UInt64>()
+    var upperAdmissionCutoff: UInt64?
+}
+
 private struct MonitorEpochMachineState: Sendable {
-    var openEpoch: MonitorEpoch
-    var openEvents: [MonitorEvent] = []
-    var queuedClosures: [ClosedMonitorEpoch] = []
+    var openBucket: MonitorEpochBucket
+    var sealedBuckets = [MonitorEpochBucket]()
     var lastAdmission: UInt64 = 0
     var nextEpochSerial: UInt64 = 2
 }
@@ -312,20 +326,20 @@ private final class MonitorEpochMachine: Sendable {
 
     init(initialAuthorization: MonitorAuthorization) {
         self.state = Mutex(MonitorEpochMachineState(
-            openEpoch: MonitorEpoch(
+            openBucket: MonitorEpochBucket(epoch: MonitorEpoch(
                 serial: 1,
                 authorization: initialAuthorization,
                 lowerAdmissionCutoff: 0,
-                transitionBarrier: false)))
+                transitionBarrier: false))))
     }
 
     var currentAuthorization: MonitorAuthorization {
-        self.state.withLock { $0.openEpoch.authorization }
+        self.state.withLock { $0.openBucket.epoch.authorization }
     }
 
     func publish(_ authorization: MonitorAuthorization) -> MonitorPublicationResult {
         self.state.withLock { state in
-            let current = state.openEpoch.authorization
+            let current = state.openBucket.epoch.authorization
             if authorization.revision == current.revision {
                 return current.hasExactlyEquivalentPayload(to: authorization.source)
                     ? .idempotent
@@ -334,12 +348,12 @@ private final class MonitorEpochMachine: Sendable {
             guard authorization.revision > current.revision else {
                 return .rejected(reason: "blocked_producer_revision_replay")
             }
-            state.queuedClosures.append(Self.closeOpenEpoch(state: &state))
-            state.openEpoch = MonitorEpoch(
+            Self.sealOpenBucket(state: &state)
+            state.openBucket = MonitorEpochBucket(epoch: MonitorEpoch(
                 serial: state.nextEpochSerial,
                 authorization: authorization,
                 lowerAdmissionCutoff: state.lastAdmission,
-                transitionBarrier: true)
+                transitionBarrier: true))
             state.nextEpochSerial += 1
             return .published
         }
@@ -347,14 +361,16 @@ private final class MonitorEpochMachine: Sendable {
 
     func admitInput(
         type: CGEventType,
-        evidence: () -> (source: ProcessWindowEvidence, sessionFocus: ProcessWindowEvidence?))
+        evidence: (MonitorAuthorization) -> (source: ProcessWindowEvidence, sessionFocus: ProcessWindowEvidence?))
     {
-        self.admit {
-            let sample = evidence()
-            return .input(InputEventEvidence(
-                type: type.rawValue,
-                source: sample.source,
-                sessionFocus: sample.sessionFocus))
+        let token = self.reserve()
+        let sample = evidence(token.epoch.authorization)
+        let kind = MonitorEventKind.input(InputEventEvidence(
+            type: type.rawValue,
+            source: sample.source,
+            sessionFocus: sample.sessionFocus))
+        if !self.complete(token, with: kind) {
+            self.admitFailure(reason: "blocked_admission_completion")
         }
     }
 
@@ -377,38 +393,103 @@ private final class MonitorEpochMachine: Sendable {
         self.admit { kind }
     }
 
-    func closeForHeartbeat() -> MonitorEpochClosure {
+    func admitForTesting(sample: () -> MonitorEventKind) {
+        self.admit(sample)
+    }
+
+    func reserveForTesting() -> MonitorAdmissionToken {
+        self.reserve()
+    }
+
+    @discardableResult
+    func completeForTesting(_ token: MonitorAdmissionToken, with kind: MonitorEventKind) -> Bool {
+        self.complete(token, with: kind)
+    }
+
+    @discardableResult
+    func cancelForTesting(_ token: MonitorAdmissionToken, reason: String) -> Bool {
+        self.complete(token, with: .attributionFailure(reason: reason, process: nil))
+    }
+
+    func closeForHeartbeat() -> MonitorEpochClosure? {
         self.state.withLock { state in
-            state.queuedClosures.append(Self.closeOpenEpoch(state: &state))
-            let closures = state.queuedClosures
-            state.queuedClosures.removeAll(keepingCapacity: true)
-            state.openEpoch = MonitorEpoch(
-                serial: state.nextEpochSerial,
-                authorization: state.openEpoch.authorization,
-                lowerAdmissionCutoff: state.lastAdmission,
-                transitionBarrier: false)
-            state.nextEpochSerial += 1
-            return MonitorEpochClosure(epochs: closures)
+            let shouldSealOpenBucket = state.sealedBuckets.isEmpty ||
+                state.openBucket.epoch.transitionBarrier ||
+                !state.openBucket.pendingAdmissions.isEmpty ||
+                !state.openBucket.events.isEmpty
+            if shouldSealOpenBucket {
+                Self.sealOpenBucket(state: &state)
+                state.openBucket = MonitorEpochBucket(epoch: MonitorEpoch(
+                    serial: state.nextEpochSerial,
+                    authorization: state.openBucket.epoch.authorization,
+                    lowerAdmissionCutoff: state.lastAdmission,
+                    transitionBarrier: false))
+                state.nextEpochSerial += 1
+            }
+            return Self.drainCompletedPrefix(state: &state)
         }
     }
 
     private func admit(_ evidence: () -> MonitorEventKind) {
-        self.state.withLock { state in
-            state.lastAdmission += 1
-            state.openEvents.append(MonitorEvent(
-                admission: state.lastAdmission,
-                epoch: state.openEpoch,
-                kind: evidence()))
+        let token = self.reserve()
+        let kind = evidence()
+        if !self.complete(token, with: kind) {
+            self.admitFailure(reason: "blocked_admission_completion")
         }
     }
 
-    private static func closeOpenEpoch(state: inout MonitorEpochMachineState) -> ClosedMonitorEpoch {
-        let closed = ClosedMonitorEpoch(
-            epoch: state.openEpoch,
-            upperAdmissionCutoff: state.lastAdmission,
-            events: state.openEvents)
-        state.openEvents.removeAll(keepingCapacity: true)
-        return closed
+    private func reserve() -> MonitorAdmissionToken {
+        self.state.withLock { state in
+            state.lastAdmission += 1
+            let token = MonitorAdmissionToken(
+                admission: state.lastAdmission,
+                epoch: state.openBucket.epoch)
+            state.openBucket.pendingAdmissions.insert(token.admission)
+            return token
+        }
+    }
+
+    private func complete(_ token: MonitorAdmissionToken, with kind: MonitorEventKind) -> Bool {
+        self.state.withLock { state in
+            if state.openBucket.epoch == token.epoch {
+                return Self.complete(token, with: kind, in: &state.openBucket)
+            }
+            guard let index = state.sealedBuckets.firstIndex(where: { $0.epoch == token.epoch }) else {
+                return false
+            }
+            return Self.complete(token, with: kind, in: &state.sealedBuckets[index])
+        }
+    }
+
+    private static func complete(
+        _ token: MonitorAdmissionToken,
+        with kind: MonitorEventKind,
+        in bucket: inout MonitorEpochBucket) -> Bool
+    {
+        guard bucket.pendingAdmissions.remove(token.admission) != nil else { return false }
+        bucket.events.append(MonitorEvent(
+            admission: token.admission,
+            epoch: token.epoch,
+            kind: kind))
+        return true
+    }
+
+    private static func sealOpenBucket(state: inout MonitorEpochMachineState) {
+        state.openBucket.upperAdmissionCutoff = state.lastAdmission
+        state.sealedBuckets.append(state.openBucket)
+    }
+
+    private static func drainCompletedPrefix(state: inout MonitorEpochMachineState) -> MonitorEpochClosure? {
+        let completedCount = state.sealedBuckets.prefix { $0.pendingAdmissions.isEmpty }.count
+        guard completedCount > 0 else { return nil }
+        let completed = state.sealedBuckets.prefix(completedCount).map { bucket in
+            ClosedMonitorEpoch(
+                epoch: bucket.epoch,
+                upperAdmissionCutoff: bucket.upperAdmissionCutoff ?? bucket.epoch.lowerAdmissionCutoff,
+                events: bucket.events.sorted { $0.admission < $1.admission })
+        }
+        state.sealedBuckets.removeFirst(completedCount)
+        return MonitorEpochClosure(epochs: completed)
     }
 }
 
@@ -532,8 +613,8 @@ private final class InputEventTracker {
         let sourcePID = sourcePIDValue > 0 && sourcePIDValue <= Int64(Int32.max)
             ? Int32(sourcePIDValue)
             : 0
-        self.machine.admitInput(type: type) {
-            inputEventEvidence(sourcePID: sourcePID)
+        self.machine.admitInput(type: type) { authorization in
+            inputEventEvidence(sourcePID: sourcePID, authorization: authorization)
         }
     }
 }
@@ -559,10 +640,9 @@ private final class ActivationTracker {
             }
             let pid = app.processIdentifier
             machine.admitActivation {
-                let windows = windowInfo()
-                return processWindowEvidence(
+                processWindowEvidence(
                     pid: pid,
-                    windowID: frontmostWindowID(pid: pid, windows: windows))
+                    windowID: focusedWindowID(pid: pid))
             }
         }
     }
@@ -653,20 +733,9 @@ private final class FocusedWindowTracker: FocusObserverTracking {
         guard let applicationElement = self.applicationElement else {
             return processWindowEvidence(pid: self.identity.pid, windowID: nil)
         }
-        var value: CFTypeRef?
-        guard AXUIElementCopyAttributeValue(
-            applicationElement,
-            kAXFocusedWindowAttribute as CFString,
-            &value) == .success,
-            let value,
-            CFGetTypeID(value) == AXUIElementGetTypeID()
-        else {
-            return processWindowEvidence(pid: self.identity.pid, windowID: nil)
-        }
-        let window = unsafeDowncast(value, to: AXUIElement.self)
-        var windowID: CGWindowID = 0
-        let resolvedWindowID = copyProbeAXWindowID(window, &windowID) == .success ? windowID : nil
-        return processWindowEvidence(pid: self.identity.pid, windowID: resolvedWindowID)
+        return processWindowEvidence(
+            pid: self.identity.pid,
+            windowID: focusedWindowID(applicationElement: applicationElement))
     }
 }
 
@@ -792,15 +861,40 @@ private func processWindowEvidence(pid: Int32, windowID: UInt32?) -> ProcessWind
         windowID: windowID)
 }
 
+private func focusedWindowID(pid: Int32) -> UInt32? {
+    guard pid > 0 else { return nil }
+    return focusedWindowID(applicationElement: AXUIElementCreateApplication(pid))
+}
+
+private func focusedWindowID(applicationElement: AXUIElement) -> UInt32? {
+    var value: CFTypeRef?
+    guard AXUIElementCopyAttributeValue(
+        applicationElement,
+        kAXFocusedWindowAttribute as CFString,
+        &value) == .success,
+        let value,
+        CFGetTypeID(value) == AXUIElementGetTypeID()
+    else {
+        return nil
+    }
+    let window = unsafeDowncast(value, to: AXUIElement.self)
+    var windowID: CGWindowID = 0
+    return copyProbeAXWindowID(window, &windowID) == .success ? windowID : nil
+}
+
 private func inputEventEvidence(
-    sourcePID: Int32) -> (source: ProcessWindowEvidence, sessionFocus: ProcessWindowEvidence?)
+    sourcePID: Int32,
+    authorization: MonitorAuthorization) -> (source: ProcessWindowEvidence, sessionFocus: ProcessWindowEvidence?)
 {
-    let windows = windowInfo()
-    let source = processWindowEvidence(
-        pid: sourcePID,
-        windowID: sourcePID > 0 ? frontmostWindowID(pid: sourcePID, windows: windows) : nil)
-    let sessionFocus = topWindowPID(windows: windows).map { pid in
-        processWindowEvidence(pid: pid, windowID: frontmostWindowID(pid: pid, windows: windows))
+    let source = processWindowEvidence(pid: sourcePID, windowID: nil)
+    guard authorization.producersByPID[sourcePID]?.effectiveRole == .foregroundController,
+          authorization.target != nil
+    else {
+        return (source: source, sessionFocus: nil)
+    }
+    let sessionFocus = NSWorkspace.shared.frontmostApplication.map { app in
+        let pid = app.processIdentifier
+        return processWindowEvidence(pid: pid, windowID: focusedWindowID(pid: pid))
     }
     return (source: source, sessionFocus: sessionFocus)
 }
@@ -957,7 +1051,10 @@ private func foregroundTargetIsLive(_ target: AllowedForegroundTarget) -> Bool {
     else {
         return false
     }
-    return windowInfo().contains { window in
+    let windows = CGWindowListCopyWindowInfo(
+        [.optionIncludingWindow, .excludeDesktopElements],
+        target.windowID) as? [[String: Any]] ?? []
+    return windows.contains { window in
         (window[kCGWindowOwnerPID as String] as? NSNumber)?.int32Value == target.pid &&
             (window[kCGWindowNumber as String] as? NSNumber)?.uint32Value == target.windowID
     }
@@ -1035,15 +1132,19 @@ private func applyMonitorAuthorization(
 
 private func closeMonitorEpoch(
     _ machine: MonitorEpochMachine,
-    observers: FocusObserverCoordinator) -> MonitorEpochClosure
+    observers: FocusObserverCoordinator) -> MonitorEpochClosure?
 {
-    var closure = machine.closeForHeartbeat()
-    if closure.transitionAcknowledged {
+    guard var closure = machine.closeForHeartbeat() else { return nil }
+    if closure.transitionAcknowledged,
+       closure.finalEpoch.epoch.authorization.revision == machine.currentAuthorization.revision
+    {
         do {
             try observers.reconcile(activeTarget: closure.finalEpoch.epoch.authorization.target)
         } catch {
             machine.admitFailure(reason: "blocked_focus_observer_removal")
-            closure = closure.appending(machine.closeForHeartbeat())
+            if let failureClosure = machine.closeForHeartbeat() {
+                closure = closure.appending(failureClosure)
+            }
         }
     }
     return closure
@@ -1565,7 +1666,9 @@ private func runWatch(arguments: [String]) throws -> Never {
         let producerData = try Data(contentsOf: URL(fileURLWithPath: allowedProducersPath))
         let allowedProducerSet = try JSONDecoder().decode(AllowedEventProducerSet.self, from: producerData)
         applyMonitorAuthorization(allowedProducerSet, to: machine, observers: focusObservers)
-        let closure = closeMonitorEpoch(machine, observers: focusObservers)
+        guard let closure = closeMonitorEpoch(machine, observers: focusObservers) else {
+            continue
+        }
         let current = try sample(includeClipboardDigest: false)
         let phase = try String(contentsOfFile: phasePath, encoding: .utf8)
             .trimmingCharacters(in: .whitespacesAndNewlines)
@@ -1700,6 +1803,113 @@ private final class MonitorClosureCapture: Sendable {
     }
 }
 
+private struct MonitorAdmissionLatencyResult: Sendable {
+    let publication: MonitorPublicationResult
+    let heartbeatDeferred: Bool
+    let elapsed: Duration
+}
+
+private final class MonitorAdmissionLatencyCapture: Sendable {
+    private let result = Mutex<MonitorAdmissionLatencyResult?>(nil)
+
+    func store(_ value: MonitorAdmissionLatencyResult) {
+        self.result.withLock { $0 = value }
+    }
+
+    func load() -> MonitorAdmissionLatencyResult? {
+        self.result.withLock { $0 }
+    }
+}
+
+private func suspendedSamplingDoesNotHoldPublicationLock() -> Bool {
+    let first = testAuthorization(testProducerSet(revision: 1, producers: []))
+    let second = testAuthorization(testProducerSet(revision: 2, producers: []))
+    let machine = MonitorEpochMachine(initialAuthorization: first)
+    let samplingStarted = DispatchSemaphore(value: 0)
+    let releaseSampling = DispatchSemaphore(value: 0)
+    let samplingFinished = DispatchSemaphore(value: 0)
+    let publicationFinished = DispatchSemaphore(value: 0)
+    let capture = MonitorAdmissionLatencyCapture()
+
+    DispatchQueue.global(qos: .userInitiated).async {
+        machine.admitForTesting {
+            samplingStarted.signal()
+            releaseSampling.wait()
+            return .activation(testEvidence(10, "1000", 100))
+        }
+        samplingFinished.signal()
+    }
+    guard samplingStarted.wait(timeout: .now() + .seconds(1)) == .success else { return false }
+
+    DispatchQueue.global(qos: .userInitiated).async {
+        let clock = ContinuousClock()
+        let start = clock.now
+        let publication = machine.publish(second)
+        let heartbeatDeferred = machine.closeForHeartbeat() == nil
+        capture.store(MonitorAdmissionLatencyResult(
+            publication: publication,
+            heartbeatDeferred: heartbeatDeferred,
+            elapsed: start.duration(to: clock.now)))
+        publicationFinished.signal()
+    }
+    let completedBeforeRelease = publicationFinished.wait(timeout: .now() + .milliseconds(100)) == .success
+    releaseSampling.signal()
+    guard samplingFinished.wait(timeout: .now() + .seconds(1)) == .success else { return false }
+    if !completedBeforeRelease {
+        _ = publicationFinished.wait(timeout: .now() + .seconds(1))
+        return false
+    }
+    guard let result = capture.load(),
+          result.publication == .published,
+          result.heartbeatDeferred,
+          result.elapsed < .milliseconds(50),
+          let closure = machine.closeForHeartbeat()
+    else {
+        return false
+    }
+    let events = closure.epochs.flatMap(\.events)
+    return events.count == 1 && events[0].epoch.authorization.revision == 1 &&
+        closure.epochs.contains(where: { $0.epoch.authorization.revision == 2 })
+}
+
+private func reservedAdmissionsCloseOnlyAfterCompletion() -> Bool {
+    let first = testAuthorization(testProducerSet(revision: 1, producers: []))
+    let second = testAuthorization(testProducerSet(revision: 2, producers: []))
+    let machine = MonitorEpochMachine(initialAuthorization: first)
+    let canceledOld = machine.reserveForTesting()
+    let completedOld = machine.reserveForTesting()
+    guard machine.publish(second) == .published else { return false }
+    let completedNew = machine.reserveForTesting()
+    guard machine.closeForHeartbeat() == nil else { return false }
+
+    guard machine.completeForTesting(
+        completedOld,
+        with: .activation(testEvidence(10, "1000", 100))),
+        machine.completeForTesting(
+            completedNew,
+            with: .activation(testEvidence(40, "4000", 401))),
+        machine.closeForHeartbeat() == nil,
+        machine.cancelForTesting(canceledOld, reason: "blocked_evidence_sampling"),
+        !machine.completeForTesting(
+            completedOld,
+            with: .activation(testEvidence(99, "9900", 991))),
+        let closure = machine.closeForHeartbeat()
+    else {
+        return false
+    }
+    let events = closure.epochs.flatMap(\.events)
+    guard events.map(\.admission) == [1, 2, 3],
+          events.map(\.epoch.authorization.revision) == [1, 1, 2],
+          closure.transitionAcknowledged
+    else {
+        return false
+    }
+    if case .attributionFailure(reason: "blocked_evidence_sampling", process: nil) = events[0].kind {
+        return true
+    }
+    return false
+}
+
 private func recordPublishDrainIsLinearizable() -> Bool {
     let bridge = testProducer(20, "2000")
     let first = testAuthorization(testProducerSet(revision: 1, producers: [bridge]))
@@ -1714,10 +1924,14 @@ private func recordPublishDrainIsLinearizable() -> Bool {
             case 1:
                 _ = machine.publish(second)
             default:
-                capture.append(machine.closeForHeartbeat())
+                if let closure = machine.closeForHeartbeat() {
+                    capture.append(closure)
+                }
             }
         }
-        capture.append(machine.closeForHeartbeat())
+        if let closure = machine.closeForHeartbeat() {
+            capture.append(closure)
+        }
         let epochs = capture.load().flatMap(\.epochs)
         let events = epochs.flatMap(\.events)
         guard events.count == 1,
@@ -1745,8 +1959,7 @@ private func exactPublicationCutoffIsClosed() -> Bool {
     machine.admitForTesting(.activation(testEvidence(10, "1000", 100)))
     guard machine.publish(second) == .published else { return false }
     machine.admitForTesting(.activation(testEvidence(10, "1000", 100)))
-    let closure = machine.closeForHeartbeat()
-    guard closure.epochs.count == 2 else { return false }
+    guard let closure = machine.closeForHeartbeat(), closure.epochs.count == 2 else { return false }
     let old = closure.epochs[0]
     let new = closure.epochs[1]
     return old.epoch.authorization.revision == 1 && old.upperAdmissionCutoff == 1 &&
@@ -1785,7 +1998,7 @@ private func queuedRevisionsRemainDistinct() -> Bool {
     for producerSet in revisions {
         guard machine.publish(testAuthorization(producerSet)) == .published else { return false }
     }
-    let closure = machine.closeForHeartbeat()
+    guard let closure = machine.closeForHeartbeat() else { return false }
     return closure.epochs.map(\.epoch.authorization.revision) == [1, 2, 3, 4, 5] &&
         closure.epochs.dropFirst().allSatisfy(\.epoch.transitionBarrier) &&
         closure.finalEpoch.epoch.authorization.target == nil
@@ -1841,7 +2054,8 @@ private func grantRetargetRevokeRetainsEventEpochs() -> Bool {
         type: CGEventType.keyDown.rawValue,
         source: testEvidence(30, "3000", nil),
         sessionFocus: testEvidence(40, "4000", 402))))
-    let events = machine.closeForHeartbeat().epochs.flatMap(\.events)
+    guard let closure = machine.closeForHeartbeat() else { return false }
+    let events = closure.epochs.flatMap(\.events)
     return events.count == 3 && events.map(\.epoch.authorization.revision) == [2, 3, 4]
 }
 
@@ -1917,7 +2131,7 @@ private func observerLifecycleIsBarrierBound() -> Bool {
     let firstIdentity = ProcessGenerationIdentity(pid: 40, startIdentity: "4000")
     let secondIdentity = ProcessGenerationIdentity(pid: 41, startIdentity: "4100")
     guard coordinator.observedIdentities == Set([baseline, firstIdentity]),
-          closeMonitorEpoch(machine, observers: coordinator).transitionAcknowledged
+          closeMonitorEpoch(machine, observers: coordinator)?.transitionAcknowledged == true
     else {
         return false
     }
@@ -1932,7 +2146,7 @@ private func observerLifecycleIsBarrierBound() -> Bool {
         processIdentity: identities,
         targetValidator: targetValidator)
     guard coordinator.observedIdentities == Set([baseline, firstIdentity]),
-          closeMonitorEpoch(machine, observers: coordinator).transitionAcknowledged
+          closeMonitorEpoch(machine, observers: coordinator)?.transitionAcknowledged == true
     else {
         return false
     }
@@ -1949,7 +2163,7 @@ private func observerLifecycleIsBarrierBound() -> Bool {
     guard coordinator.observedIdentities == Set([baseline, firstIdentity, secondIdentity]) else {
         return false
     }
-    let retargetAcknowledgement = closeMonitorEpoch(machine, observers: coordinator)
+    guard let retargetAcknowledgement = closeMonitorEpoch(machine, observers: coordinator) else { return false }
     guard retargetAcknowledgement.transitionAcknowledged,
           coordinator.observedIdentities == Set([baseline, secondIdentity]),
           store.stops == [firstIdentity]
@@ -1968,7 +2182,7 @@ private func observerLifecycleIsBarrierBound() -> Bool {
         observers: coordinator,
         processIdentity: identities,
         targetValidator: targetValidator)
-    let failedInstallClosure = closeMonitorEpoch(machine, observers: coordinator)
+    guard let failedInstallClosure = closeMonitorEpoch(machine, observers: coordinator) else { return false }
     guard machine.currentAuthorization.revision == 4,
           !coordinator.observedIdentities.contains(failedInstallIdentity),
           failedInstallClosure.epochs.flatMap(\.events).contains(where: {
@@ -1988,7 +2202,7 @@ private func observerLifecycleIsBarrierBound() -> Bool {
         observers: coordinator,
         processIdentity: identities,
         targetValidator: targetValidator)
-    let failedRemovalClosure = closeMonitorEpoch(machine, observers: coordinator)
+    guard let failedRemovalClosure = closeMonitorEpoch(machine, observers: coordinator) else { return false }
     return machine.currentAuthorization.revision == 6 && failedRemovalClosure.transitionAcknowledged &&
         coordinator.observedIdentities.contains(secondIdentity) &&
         failedRemovalClosure.epochs.flatMap(\.events).contains(where: {
@@ -2041,23 +2255,26 @@ private func transitionAcknowledgementNeverAdvancesClean(
         outputPath: "\(directory)/ack-violations.jsonl",
         contaminationPath: "\(directory)/ack-contamination.jsonl")
     let identities: (Int32) -> UInt64? = { [10: 1000, 20: 2000, 21: 2100][$0] }
+    guard let firstClosure = machine.closeForHeartbeat() else { return false }
     let firstHeartbeat = try watch.observe(
         current: desktop.sample,
         phase: "running",
-        closure: machine.closeForHeartbeat(),
+        closure: firstClosure,
         processIdentity: identities,
         targetValidator: { _ in true })
     guard machine.publish(second) == .published else { return false }
+    guard let acknowledgementClosure = machine.closeForHeartbeat() else { return false }
     let acknowledgement = try watch.observe(
         current: desktop.sample,
         phase: "running",
-        closure: machine.closeForHeartbeat(),
+        closure: acknowledgementClosure,
         processIdentity: identities,
         targetValidator: { _ in true })
+    guard let settledClosure = machine.closeForHeartbeat() else { return false }
     let settled = try watch.observe(
         current: desktop.sample,
         phase: "running",
-        closure: machine.closeForHeartbeat(),
+        closure: settledClosure,
         processIdentity: identities,
         targetValidator: { _ in true })
     return firstHeartbeat.lastCleanSequence == 1 &&
@@ -2103,10 +2320,11 @@ private func wrongWindowThenTargetStillViolates(
         clipboardDigest: "",
         peekabooWindowIDs: desktop.sample.peekabooWindowIDs,
         visibleScreenFramesTopLeft: desktop.sample.visibleScreenFramesTopLeft)
+    guard let closure = machine.closeForHeartbeat() else { return false }
     let heartbeat = try watch.observe(
         current: current,
         phase: "running",
-        closure: machine.closeForHeartbeat(),
+        closure: closure,
         processIdentity: { [10: 1000, 20: 2000, 30: 3000, 40: 4000][$0] },
         targetValidator: { $0 == target })
     let kinds = Set(decodeJSONLines(Violation.self, at: output).map(\.kind))
@@ -2150,10 +2368,11 @@ private func authorizedForegroundEvidenceIsClean(
         clipboardDigest: "",
         peekabooWindowIDs: desktop.sample.peekabooWindowIDs,
         visibleScreenFramesTopLeft: desktop.sample.visibleScreenFramesTopLeft)
+    guard let closure = machine.closeForHeartbeat() else { return false }
     let heartbeat = try watch.observe(
         current: current,
         phase: "running",
-        closure: machine.closeForHeartbeat(),
+        closure: closure,
         processIdentity: { [10: 1000, 20: 2000, 30: 3000, 40: 4000][$0] },
         targetValidator: { $0 == target })
     return heartbeat.lastCleanSequence == heartbeat.sequence &&
@@ -2182,10 +2401,11 @@ private func currentTargetDriftFailsClosed(
         projection: projection,
         outputPath: "\(directory)/current-target-drift-violations.jsonl",
         contaminationPath: contamination)
+    guard let closure = machine.closeForHeartbeat() else { return false }
     let heartbeat = try watch.observe(
         current: desktop.sample,
         phase: "running",
-        closure: machine.closeForHeartbeat(),
+        closure: closure,
         processIdentity: { [10: 1000, 20: 2000, 30: 3000][$0] },
         targetValidator: { _ in false })
     let states = Set(decodeJSONLines(ContaminationRecord.self, at: contamination).map(\.state))
@@ -2216,10 +2436,11 @@ private func controllerGenerationDriftFailsClosed(
         projection: projection,
         outputPath: "\(directory)/controller-drift-violations.jsonl",
         contaminationPath: contamination)
+    guard let closure = machine.closeForHeartbeat() else { return false }
     let heartbeat = try watch.observe(
         current: desktop.sample,
         phase: "running",
-        closure: machine.closeForHeartbeat(),
+        closure: closure,
         processIdentity: { [10: 1000, 20: 2000, 30: 3001, 40: 4000][$0] },
         targetValidator: { $0 == target })
     let states = Set(decodeJSONLines(ContaminationRecord.self, at: contamination).map(\.state))
@@ -2251,10 +2472,11 @@ private func deferredTargetDriftFailsClosed(
         projection: projection,
         outputPath: "\(directory)/deferred-target-drift-violations.jsonl",
         contaminationPath: contamination)
+    guard let closure = machine.closeForHeartbeat() else { return false }
     let heartbeat = try watch.observe(
         current: desktop.sample,
         phase: "running",
-        closure: machine.closeForHeartbeat(),
+        closure: closure,
         processIdentity: { [10: 1000, 20: 2000, 30: 3000, 40: 4001][$0] },
         targetValidator: { _ in false })
     let states = Set(decodeJSONLines(ContaminationRecord.self, at: contamination).map(\.state))
@@ -2288,10 +2510,11 @@ private func physicalCursorIsObservationalButOtherInputContaminates(
         clipboardDigest: "",
         peekabooWindowIDs: desktop.sample.peekabooWindowIDs,
         visibleScreenFramesTopLeft: desktop.sample.visibleScreenFramesTopLeft)
+    guard let physicalClosure = physicalMachine.closeForHeartbeat() else { return false }
     let physicalHeartbeat = try physicalWatch.observe(
         current: moved,
         phase: "running",
-        closure: physicalMachine.closeForHeartbeat(),
+        closure: physicalClosure,
         processIdentity: { $0 == 10 ? 1000 : nil },
         targetValidator: { _ in true })
 
@@ -2305,10 +2528,11 @@ private func physicalCursorIsObservationalButOtherInputContaminates(
         projection: projection,
         outputPath: "\(directory)/key-violations.jsonl",
         contaminationPath: "\(directory)/key-contamination.jsonl")
+    guard let keyClosure = keyMachine.closeForHeartbeat() else { return false }
     let keyHeartbeat = try keyWatch.observe(
         current: desktop.sample,
         phase: "running",
-        closure: keyMachine.closeForHeartbeat(),
+        closure: keyClosure,
         processIdentity: { $0 == 10 ? 1000 : nil },
         targetValidator: { _ in true })
     return physicalHeartbeat.cursorMovementObserved && !physicalHeartbeat.contaminationBlocked &&
@@ -2330,10 +2554,11 @@ private func unexpectedActivationViolatesFocus(
         projection: projection,
         outputPath: output,
         contaminationPath: "\(directory)/activation-contamination.jsonl")
+    guard let closure = machine.closeForHeartbeat() else { return false }
     _ = try watch.observe(
         current: desktop.sample,
         phase: "running",
-        closure: machine.closeForHeartbeat(),
+        closure: closure,
         processIdentity: { $0 == 10 ? 1000 : nil },
         targetValidator: { _ in true })
     let kinds = Set(decodeJSONLines(Violation.self, at: output).map(\.kind))
@@ -2371,6 +2596,12 @@ private func runSelfTest() throws {
     }
     guard recordPublishDrainIsLinearizable() else {
         throw ProbeError.invalidArguments("concurrent record, publish, and drain lost or relabeled evidence")
+    }
+    guard suspendedSamplingDoesNotHoldPublicationLock() else {
+        throw ProbeError.invalidArguments("slow evidence sampling held the publication or heartbeat lock")
+    }
+    guard reservedAdmissionsCloseOnlyAfterCompletion() else {
+        throw ProbeError.invalidArguments("reserved evidence was lost, emitted early, or relabeled after publication")
     }
     guard exactPublicationCutoffIsClosed() else {
         throw ProbeError.invalidArguments("events at the publication cutoff did not retain exact epochs")
@@ -2418,7 +2649,7 @@ private func runSelfTest() throws {
         throw ProbeError.invalidArguments("unexpected activation did not retain callback-time focus evidence")
     }
 
-    try writeJSON(SelfTestResult(success: true, tests: 18), to: nil)
+    try writeJSON(SelfTestResult(success: true, tests: 20), to: nil)
 }
 
 private func findApp(arguments: [String]) throws {

--- a/scripts/support/background-computer-use-probe.swift
+++ b/scripts/support/background-computer-use-probe.swift
@@ -3,7 +3,12 @@ import ApplicationServices
 import CoreGraphics
 import CryptoKit
 import Darwin
+import Dispatch
 import Foundation
+import Synchronization
+
+@_silgen_name("_AXUIElementGetWindow")
+private func copyProbeAXWindowID(_ element: AXUIElement, _ windowID: inout CGWindowID) -> AXError
 
 private struct Point: Codable, Equatable {
     let x: Double
@@ -47,6 +52,14 @@ private struct WatchHeartbeat: Codable {
     let cursorMovementObserved: Bool
     let pendingActivationCount: Int
     let pendingFocusedWindowChange: Bool
+    let authorizationEpoch: UInt64
+    let transitionAcknowledged: Bool
+    let foregroundActive: Bool
+    let foregroundTargetPID: Int32?
+    let foregroundTargetWindowID: UInt32?
+    let attributedForegroundEventCount: Int
+    let attributedForegroundSourcePIDs: [Int32]
+    let foregroundActivityObserved: Bool
 }
 
 private struct ContaminationRecord: Codable {
@@ -137,9 +150,10 @@ private struct InvariantProjection {
 }
 
 private struct InteractiveBaseline {
-    var frontmostPID: Int32?
-    var frontmostWindowID: UInt32?
-    var cursor: Point
+    let frontmostPID: Int32
+    let processStartIdentity: String
+    let frontmostWindowID: UInt32
+    let cursor: Point
 }
 
 private struct InvariantEvaluationContext {
@@ -151,29 +165,251 @@ private struct InvariantEvaluationContext {
     let projection: InvariantProjection
 }
 
-private struct InputEventBatch {
-    let producerEventCount: Int
-    let producerSourcePIDs: [Int32]
-    let producerEventTypes: [UInt32]
-    let externalEventCount: Int
-    let externalSourcePIDs: [Int32]
-    let externalEventTypes: [UInt32]
-    let attributionFailed: Bool
+private enum AllowedEventProducerRole: String, Codable, Hashable, Sendable {
+    case bridge
+    case foregroundController = "foreground-controller"
 }
 
-private func physicalInputIsObservational(_ batch: InputEventBatch, enabled: Bool) -> Bool {
-    enabled && batch.externalEventCount > 0 && batch.externalSourcePIDs == [0] &&
-        batch.externalEventTypes == [CGEventType.mouseMoved.rawValue]
+private struct AllowedEventProducer: Codable, Hashable, Sendable {
+    let pid: Int32
+    let startIdentity: String
+    let role: AllowedEventProducerRole?
+
+    var effectiveRole: AllowedEventProducerRole {
+        self.role ?? .bridge
+    }
 }
 
-private struct AllowedEventProducer: Codable, Hashable {
+private struct AllowedForegroundTarget: Codable, Equatable, Hashable, Sendable {
+    let pid: Int32
+    let startIdentity: String
+    let windowID: UInt32
+}
+
+private struct AllowedForegroundActivity: Codable, Equatable, Hashable, Sendable {
+    let active: Bool
+    let target: AllowedForegroundTarget?
+}
+
+private struct AllowedEventProducerSet: Codable, Equatable, Sendable {
+    let revision: UInt64
+    let producers: [AllowedEventProducer]
+    let foreground: AllowedForegroundActivity?
+
+    var effectiveForeground: AllowedForegroundActivity {
+        self.foreground ?? AllowedForegroundActivity(active: false, target: nil)
+    }
+
+    func hasExactlyEquivalentPayload(to other: AllowedEventProducerSet) -> Bool {
+        self.producers.count == other.producers.count &&
+            Set(self.producers) == Set(other.producers) &&
+            self.foreground == other.foreground
+    }
+}
+
+private struct ProcessGenerationIdentity: Hashable, Sendable {
     let pid: Int32
     let startIdentity: String
 }
 
-private struct AllowedEventProducerSet: Codable {
-    let revision: UInt64
-    let producers: [AllowedEventProducer]
+private struct ProcessWindowEvidence: Equatable, Sendable {
+    let pid: Int32
+    let startIdentity: String?
+    let windowID: UInt32?
+}
+
+private struct MonitorAuthorization: Equatable, Sendable {
+    let source: AllowedEventProducerSet
+    let producersByPID: [Int32: AllowedEventProducer]
+    let foreground: AllowedForegroundActivity
+
+    var revision: UInt64 {
+        self.source.revision
+    }
+
+    var target: AllowedForegroundTarget? {
+        self.foreground.active ? self.foreground.target : nil
+    }
+
+    func hasExactlyEquivalentPayload(to producerSet: AllowedEventProducerSet) -> Bool {
+        self.source.hasExactlyEquivalentPayload(to: producerSet)
+    }
+}
+
+private struct MonitorEpoch: Equatable, Sendable {
+    let serial: UInt64
+    let authorization: MonitorAuthorization
+    let lowerAdmissionCutoff: UInt64
+    let transitionBarrier: Bool
+}
+
+private struct InputEventEvidence: Equatable, Sendable {
+    let type: UInt32
+    let source: ProcessWindowEvidence
+    let sessionFocus: ProcessWindowEvidence?
+}
+
+private struct FocusEventEvidence: Equatable, Sendable {
+    let observer: ProcessGenerationIdentity
+    let observed: ProcessWindowEvidence
+}
+
+private enum MonitorEventKind: Equatable, Sendable {
+    case input(InputEventEvidence)
+    case activation(ProcessWindowEvidence)
+    case focus(FocusEventEvidence)
+    case attributionFailure(reason: String, process: ProcessWindowEvidence?)
+}
+
+private struct MonitorEvent: Equatable, Sendable {
+    let admission: UInt64
+    let epoch: MonitorEpoch
+    let kind: MonitorEventKind
+}
+
+private struct ClosedMonitorEpoch: Equatable, Sendable {
+    let epoch: MonitorEpoch
+    let upperAdmissionCutoff: UInt64
+    let events: [MonitorEvent]
+}
+
+private struct MonitorEpochClosure: Sendable {
+    let epochs: [ClosedMonitorEpoch]
+
+    var finalEpoch: ClosedMonitorEpoch {
+        precondition(!self.epochs.isEmpty)
+        return self.epochs[self.epochs.index(before: self.epochs.endIndex)]
+    }
+
+    var transitionAcknowledged: Bool {
+        self.epochs.contains { $0.epoch.transitionBarrier }
+    }
+
+    func appending(_ other: MonitorEpochClosure) -> MonitorEpochClosure {
+        MonitorEpochClosure(epochs: self.epochs + other.epochs)
+    }
+}
+
+private enum MonitorPublicationResult: Equatable, Sendable {
+    case idempotent
+    case published
+    case rejected(reason: String)
+}
+
+private struct MonitorEpochMachineState: Sendable {
+    var openEpoch: MonitorEpoch
+    var openEvents: [MonitorEvent] = []
+    var queuedClosures: [ClosedMonitorEpoch] = []
+    var lastAdmission: UInt64 = 0
+    var nextEpochSerial: UInt64 = 2
+}
+
+/// The one publication/admission authority for input, activation, and focus callbacks.
+/// A callback samples evidence while holding this cutoff, so it can only land wholly
+/// before or wholly after a policy publication.
+private final class MonitorEpochMachine: Sendable {
+    private let state: Mutex<MonitorEpochMachineState>
+
+    init(initialAuthorization: MonitorAuthorization) {
+        self.state = Mutex(MonitorEpochMachineState(
+            openEpoch: MonitorEpoch(
+                serial: 1,
+                authorization: initialAuthorization,
+                lowerAdmissionCutoff: 0,
+                transitionBarrier: false)))
+    }
+
+    var currentAuthorization: MonitorAuthorization {
+        self.state.withLock { $0.openEpoch.authorization }
+    }
+
+    func publish(_ authorization: MonitorAuthorization) -> MonitorPublicationResult {
+        self.state.withLock { state in
+            let current = state.openEpoch.authorization
+            if authorization.revision == current.revision {
+                return current.hasExactlyEquivalentPayload(to: authorization.source)
+                    ? .idempotent
+                    : .rejected(reason: "blocked_producer_revision_replay")
+            }
+            guard authorization.revision > current.revision else {
+                return .rejected(reason: "blocked_producer_revision_replay")
+            }
+            state.queuedClosures.append(Self.closeOpenEpoch(state: &state))
+            state.openEpoch = MonitorEpoch(
+                serial: state.nextEpochSerial,
+                authorization: authorization,
+                lowerAdmissionCutoff: state.lastAdmission,
+                transitionBarrier: true)
+            state.nextEpochSerial += 1
+            return .published
+        }
+    }
+
+    func admitInput(
+        type: CGEventType,
+        evidence: () -> (source: ProcessWindowEvidence, sessionFocus: ProcessWindowEvidence?))
+    {
+        self.admit {
+            let sample = evidence()
+            return .input(InputEventEvidence(
+                type: type.rawValue,
+                source: sample.source,
+                sessionFocus: sample.sessionFocus))
+        }
+    }
+
+    func admitActivation(evidence: () -> ProcessWindowEvidence) {
+        self.admit { .activation(evidence()) }
+    }
+
+    func admitFocus(
+        observer: ProcessGenerationIdentity,
+        evidence: () -> ProcessWindowEvidence)
+    {
+        self.admit { .focus(FocusEventEvidence(observer: observer, observed: evidence())) }
+    }
+
+    func admitFailure(reason: String, evidence: () -> ProcessWindowEvidence? = { nil }) {
+        self.admit { .attributionFailure(reason: reason, process: evidence()) }
+    }
+
+    func admitForTesting(_ kind: MonitorEventKind) {
+        self.admit { kind }
+    }
+
+    func closeForHeartbeat() -> MonitorEpochClosure {
+        self.state.withLock { state in
+            state.queuedClosures.append(Self.closeOpenEpoch(state: &state))
+            let closures = state.queuedClosures
+            state.queuedClosures.removeAll(keepingCapacity: true)
+            state.openEpoch = MonitorEpoch(
+                serial: state.nextEpochSerial,
+                authorization: state.openEpoch.authorization,
+                lowerAdmissionCutoff: state.lastAdmission,
+                transitionBarrier: false)
+            state.nextEpochSerial += 1
+            return MonitorEpochClosure(epochs: closures)
+        }
+    }
+
+    private func admit(_ evidence: () -> MonitorEventKind) {
+        self.state.withLock { state in
+            state.lastAdmission += 1
+            state.openEvents.append(MonitorEvent(
+                admission: state.lastAdmission,
+                epoch: state.openEpoch,
+                kind: evidence()))
+        }
+    }
+
+    private static func closeOpenEpoch(state: inout MonitorEpochMachineState) -> ClosedMonitorEpoch {
+        let closed = ClosedMonitorEpoch(
+            epoch: state.openEpoch,
+            upperAdmissionCutoff: state.lastAdmission,
+            events: state.openEvents)
+        state.openEvents.removeAll(keepingCapacity: true)
+        return closed
+    }
 }
 
 private struct AttemptContaminationState {
@@ -202,17 +438,13 @@ private final class InputEventTracker {
     private static let monitoredEventMask = CGEventMask.max &
         ~(CGEventMask(1) << CGEventType.null.rawValue)
 
-    private let lock = NSLock()
-    private var allowedProducerPIDs = Set<Int32>()
-    private var producerEventCount = 0
-    private var producerSourcePIDs = Set<Int32>()
-    private var producerEventTypes = Set<UInt32>()
-    private var externalEventCount = 0
-    private var externalSourcePIDs = Set<Int32>()
-    private var externalEventTypes = Set<UInt32>()
-    private var attributionFailed = false
+    private let machine: MonitorEpochMachine
     private var eventTap: CFMachPort?
     private var runLoopSource: CFRunLoopSource?
+
+    init(machine: MonitorEpochMachine) {
+        self.machine = machine
+    }
 
     func start() throws {
         guard CGPreflightListenEventAccess() else {
@@ -289,9 +521,7 @@ private final class InputEventTracker {
 
     func handle(type: CGEventType, event: CGEvent) {
         if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
-            self.lock.lock()
-            self.attributionFailed = true
-            self.lock.unlock()
+            self.machine.admitFailure(reason: "blocked_attribution")
             if let eventTap = self.eventTap {
                 CGEvent.tapEnable(tap: eventTap, enable: true)
             }
@@ -302,93 +532,39 @@ private final class InputEventTracker {
         let sourcePID = sourcePIDValue > 0 && sourcePIDValue <= Int64(Int32.max)
             ? Int32(sourcePIDValue)
             : 0
-        self.lock.lock()
-        if self.allowedProducerPIDs.contains(sourcePID) {
-            self.producerEventCount += 1
-            self.producerSourcePIDs.insert(sourcePID)
-            self.producerEventTypes.insert(type.rawValue)
-            self.lock.unlock()
-            return
+        self.machine.admitInput(type: type) {
+            inputEventEvidence(sourcePID: sourcePID)
         }
-        if self.externalSourcePIDs.count >= 128, !self.externalSourcePIDs.contains(sourcePID) {
-            self.attributionFailed = true
-            self.lock.unlock()
-            return
-        }
-        self.externalEventCount += 1
-        self.externalSourcePIDs.insert(sourcePID)
-        self.externalEventTypes.insert(type.rawValue)
-        self.lock.unlock()
-    }
-
-    func updateAllowedProducerPIDs(_ pids: Set<Int32>) {
-        self.lock.lock()
-        self.allowedProducerPIDs = pids
-        self.lock.unlock()
-    }
-
-    func drain() -> InputEventBatch {
-        self.lock.lock()
-        let producerEventCount = self.producerEventCount
-        let producerSourcePIDs = self.producerSourcePIDs.sorted()
-        let producerEventTypes = self.producerEventTypes.sorted()
-        let externalEventCount = self.externalEventCount
-        let externalSourcePIDs = self.externalSourcePIDs.sorted()
-        let externalEventTypes = self.externalEventTypes.sorted()
-        let attributionFailed = self.attributionFailed
-        self.producerEventCount = 0
-        self.producerSourcePIDs.removeAll(keepingCapacity: true)
-        self.producerEventTypes.removeAll(keepingCapacity: true)
-        self.externalEventCount = 0
-        self.externalSourcePIDs.removeAll(keepingCapacity: true)
-        self.externalEventTypes.removeAll(keepingCapacity: true)
-        self.attributionFailed = false
-        self.lock.unlock()
-        return InputEventBatch(
-            producerEventCount: producerEventCount,
-            producerSourcePIDs: producerSourcePIDs,
-            producerEventTypes: producerEventTypes,
-            externalEventCount: externalEventCount,
-            externalSourcePIDs: externalSourcePIDs,
-            externalEventTypes: externalEventTypes,
-            attributionFailed: attributionFailed)
     }
 }
 
 private final class ActivationTracker {
-    private let baselinePID: Int32?
-    private let lock = NSLock()
-    private var activatedPIDs = Set<Int32>()
+    private let machine: MonitorEpochMachine
     private var observer: (any NSObjectProtocol)?
 
-    init(baselinePID: Int32?) {
-        self.baselinePID = baselinePID
+    init(machine: MonitorEpochMachine) {
+        self.machine = machine
     }
 
     func start() {
+        let machine = self.machine
         self.observer = NSWorkspace.shared.notificationCenter.addObserver(
             forName: NSWorkspace.didActivateApplicationNotification,
             object: nil,
             queue: nil)
-        { [weak self] notification in
-            guard let self,
-                  let app = notification.userInfo?[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication,
-                  app.processIdentifier != self.baselinePID
+        { notification in
+            guard let app = notification.userInfo?[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication
             else {
                 return
             }
-            self.lock.lock()
-            self.activatedPIDs.insert(app.processIdentifier)
-            self.lock.unlock()
+            let pid = app.processIdentifier
+            machine.admitActivation {
+                let windows = windowInfo()
+                return processWindowEvidence(
+                    pid: pid,
+                    windowID: frontmostWindowID(pid: pid, windows: windows))
+            }
         }
-    }
-
-    func drain() -> [Int32] {
-        self.lock.lock()
-        defer { self.lock.unlock() }
-        let pids = self.activatedPIDs.sorted()
-        self.activatedPIDs.removeAll(keepingCapacity: true)
-        return pids
     }
 
     func stop() {
@@ -399,31 +575,47 @@ private final class ActivationTracker {
     }
 }
 
-private final class FocusedWindowTracker {
-    private let pid: Int32
-    private let lock = NSLock()
-    private var changed = false
+private protocol FocusObserverTracking: AnyObject {
+    var identity: ProcessGenerationIdentity { get }
+    func start() throws
+    func stop() throws
+}
+
+private final class FocusedWindowTracker: FocusObserverTracking {
+    let identity: ProcessGenerationIdentity
+    private let machine: MonitorEpochMachine
     private var observer: AXObserver?
     private var applicationElement: AXUIElement?
 
-    init(pid: Int32) {
-        self.pid = pid
+    init(identity: ProcessGenerationIdentity, machine: MonitorEpochMachine) {
+        self.identity = identity
+        self.machine = machine
     }
 
     func start() throws {
+        guard processStartIdentity(pid: self.identity.pid).map(String.init) == self.identity.startIdentity else {
+            throw ProbeError.focusedWindowObserverUnavailable
+        }
         var observer: AXObserver?
-        guard AXObserverCreate(self.pid, focusedWindowObserverCallback, &observer) == .success,
+        guard AXObserverCreate(self.identity.pid, focusedWindowObserverCallback, &observer) == .success,
               let observer
         else {
             throw ProbeError.focusedWindowObserverUnavailable
         }
-        let applicationElement = AXUIElementCreateApplication(self.pid)
+        let applicationElement = AXUIElementCreateApplication(self.identity.pid)
         guard AXObserverAddNotification(
             observer,
             applicationElement,
             kAXFocusedWindowChangedNotification as CFString,
             Unmanaged.passUnretained(self).toOpaque()) == .success
         else {
+            throw ProbeError.focusedWindowObserverUnavailable
+        }
+        guard processStartIdentity(pid: self.identity.pid).map(String.init) == self.identity.startIdentity else {
+            AXObserverRemoveNotification(
+                observer,
+                applicationElement,
+                kAXFocusedWindowChangedNotification as CFString)
             throw ProbeError.focusedWindowObserverUnavailable
         }
         self.observer = observer
@@ -435,25 +627,20 @@ private final class FocusedWindowTracker {
     }
 
     func recordChange() {
-        self.lock.lock()
-        self.changed = true
-        self.lock.unlock()
+        self.machine.admitFocus(observer: self.identity) {
+            self.focusedWindowEvidence()
+        }
     }
 
-    func drain() -> Bool {
-        self.lock.lock()
-        defer { self.lock.unlock() }
-        let changed = self.changed
-        self.changed = false
-        return changed
-    }
-
-    func stop() {
+    func stop() throws {
         guard let observer = self.observer, let applicationElement = self.applicationElement else { return }
-        AXObserverRemoveNotification(
+        guard AXObserverRemoveNotification(
             observer,
             applicationElement,
-            kAXFocusedWindowChangedNotification as CFString)
+            kAXFocusedWindowChangedNotification as CFString) == .success
+        else {
+            throw ProbeError.focusedWindowObserverUnavailable
+        }
         CFRunLoopRemoveSource(
             CFRunLoopGetCurrent(),
             AXObserverGetRunLoopSource(observer),
@@ -461,14 +648,103 @@ private final class FocusedWindowTracker {
         self.observer = nil
         self.applicationElement = nil
     }
+
+    private func focusedWindowEvidence() -> ProcessWindowEvidence {
+        guard let applicationElement = self.applicationElement else {
+            return processWindowEvidence(pid: self.identity.pid, windowID: nil)
+        }
+        var value: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(
+            applicationElement,
+            kAXFocusedWindowAttribute as CFString,
+            &value) == .success,
+            let value,
+            CFGetTypeID(value) == AXUIElementGetTypeID()
+        else {
+            return processWindowEvidence(pid: self.identity.pid, windowID: nil)
+        }
+        let window = unsafeDowncast(value, to: AXUIElement.self)
+        var windowID: CGWindowID = 0
+        let resolvedWindowID = copyProbeAXWindowID(window, &windowID) == .success ? windowID : nil
+        return processWindowEvidence(pid: self.identity.pid, windowID: resolvedWindowID)
+    }
 }
 
-private let focusedWindowObserverCallback: AXObserverCallback = { _, _, _, context in
+private final class FocusObserverCoordinator {
+    typealias Factory = (ProcessGenerationIdentity) -> any FocusObserverTracking
+
+    private let factory: Factory
+    private var baselineObserver: (any FocusObserverTracking)?
+    private var grantedObservers: [ProcessGenerationIdentity: any FocusObserverTracking] = [:]
+
+    init(factory: @escaping Factory) {
+        self.factory = factory
+    }
+
+    func startBaseline(_ identity: ProcessGenerationIdentity) throws {
+        let observer = self.factory(identity)
+        try observer.start()
+        self.baselineObserver = observer
+    }
+
+    func prepare(target: AllowedForegroundTarget?) throws {
+        guard let target else { return }
+        let identity = ProcessGenerationIdentity(pid: target.pid, startIdentity: target.startIdentity)
+        if self.baselineObserver?.identity == identity || self.grantedObservers[identity] != nil {
+            return
+        }
+        let observer = self.factory(identity)
+        try observer.start()
+        self.grantedObservers[identity] = observer
+    }
+
+    func reconcile(activeTarget: AllowedForegroundTarget?) throws {
+        let retainedIdentity = activeTarget.map {
+            ProcessGenerationIdentity(pid: $0.pid, startIdentity: $0.startIdentity)
+        }
+        for identity in self.grantedObservers.keys where identity != retainedIdentity {
+            guard let observer = self.grantedObservers[identity] else { continue }
+            try observer.stop()
+            self.grantedObservers.removeValue(forKey: identity)
+        }
+    }
+
+    func stop() {
+        for observer in self.grantedObservers.values {
+            try? observer.stop()
+        }
+        if let baselineObserver = self.baselineObserver {
+            try? baselineObserver.stop()
+        }
+        self.grantedObservers.removeAll()
+        self.baselineObserver = nil
+    }
+
+    var observedIdentities: Set<ProcessGenerationIdentity> {
+        var identities = Set(self.grantedObservers.keys)
+        if let baselineObserver = self.baselineObserver {
+            identities.insert(baselineObserver.identity)
+        }
+        return identities
+    }
+}
+
+private func focusedWindowObserverCallback(
+    _: AXObserver,
+    _: AXUIElement,
+    _: CFString,
+    context: UnsafeMutableRawPointer?)
+{
     guard let context else { return }
     Unmanaged<FocusedWindowTracker>.fromOpaque(context).takeUnretainedValue().recordChange()
 }
 
-private let inputEventTapCallback: CGEventTapCallBack = { _, type, event, userInfo in
+private func inputEventTapCallback(
+    _: CGEventTapProxy,
+    type: CGEventType,
+    event: CGEvent,
+    userInfo: UnsafeMutableRawPointer?) -> Unmanaged<CGEvent>?
+{
     guard let userInfo else { return Unmanaged.passUnretained(event) }
     let tracker = Unmanaged<InputEventTracker>.fromOpaque(userInfo).takeUnretainedValue()
     tracker.handle(type: type, event: event)
@@ -507,6 +783,26 @@ private func topWindowPID(windows: [[String: Any]]) -> Int32? {
     }.flatMap { window in
         (window[kCGWindowOwnerPID as String] as? NSNumber)?.int32Value
     }
+}
+
+private func processWindowEvidence(pid: Int32, windowID: UInt32?) -> ProcessWindowEvidence {
+    ProcessWindowEvidence(
+        pid: pid,
+        startIdentity: processStartIdentity(pid: pid).map(String.init),
+        windowID: windowID)
+}
+
+private func inputEventEvidence(
+    sourcePID: Int32) -> (source: ProcessWindowEvidence, sessionFocus: ProcessWindowEvidence?)
+{
+    let windows = windowInfo()
+    let source = processWindowEvidence(
+        pid: sourcePID,
+        windowID: sourcePID > 0 ? frontmostWindowID(pid: sourcePID, windows: windows) : nil)
+    let sessionFocus = topWindowPID(windows: windows).map { pid in
+        processWindowEvidence(pid: pid, windowID: frontmostWindowID(pid: pid, windows: windows))
+    }
+    return (source: source, sessionFocus: sessionFocus)
 }
 
 private func peekabooWindowIDs(windows: [[String: Any]]) -> [UInt32] {
@@ -605,13 +901,13 @@ private func violations(current: SystemSample, context: InvariantEvaluationConte
         if current.frontmostPID != context.interactiveBaseline.frontmostPID {
             result.insert(Violation(
                 kind: context.projection[.frontmostPID],
-                expected: context.interactiveBaseline.frontmostPID.map(String.init) ?? "null",
+                expected: String(context.interactiveBaseline.frontmostPID),
                 actual: current.frontmostPID.map(String.init) ?? "null"))
         }
         if current.frontmostWindowID != context.interactiveBaseline.frontmostWindowID {
             result.insert(Violation(
                 kind: context.projection[.frontmostWindow],
-                expected: context.interactiveBaseline.frontmostWindowID.map(String.init) ?? "null",
+                expected: String(context.interactiveBaseline.frontmostWindowID),
                 actual: current.frontmostWindowID.map(String.init) ?? "null"))
         }
 
@@ -645,52 +941,201 @@ private func violations(current: SystemSample, context: InvariantEvaluationConte
     return result
 }
 
-private func producerInputViolation(
-    batch: InputEventBatch,
-    projection: InvariantProjection) -> Violation?
+private func foregroundControllerCardinalityIsValid(
+    producers: [AllowedEventProducer],
+    foreground: AllowedForegroundActivity) -> Bool
 {
-    guard batch.producerEventCount > 0 else { return nil }
-    let sources = batch.producerSourcePIDs.map(String.init).joined(separator: ",")
-    let types = batch.producerEventTypes.map(String.init).joined(separator: ",")
-    return Violation(
-        kind: projection[.globalInputEvent],
-        expected: "no session-global input events",
-        actual: "pids=\(sources); types=\(types)")
+    let controllerCount = producers.count { $0.effectiveRole == .foregroundController }
+    return foreground.active ? controllerCount == 1 && foreground.target != nil
+        : controllerCount == 0 && foreground.target == nil
 }
 
-private func producerEventsMatchReceipts(
-    batch: InputEventBatch,
-    receipts: [Int32: String],
-    processIdentity: (Int32) -> UInt64?) -> Bool
-{
-    batch.producerSourcePIDs.allSatisfy { pid in
-        guard let expected = receipts[pid], let current = processIdentity(pid) else { return false }
-        return expected == String(current)
+private func foregroundTargetIsLive(_ target: AllowedForegroundTarget) -> Bool {
+    guard target.pid > 0,
+          target.windowID > 0,
+          processStartIdentity(pid: target.pid).map(String.init) == target.startIdentity
+    else {
+        return false
+    }
+    return windowInfo().contains { window in
+        (window[kCGWindowOwnerPID as String] as? NSNumber)?.int32Value == target.pid &&
+            (window[kCGWindowNumber as String] as? NSNumber)?.uint32Value == target.windowID
     }
 }
 
-private func transientFocusViolations(
-    externalEventCount: Int,
-    unexpectedActivations: [Int32],
-    focusedWindowChanged: Bool,
+private func makeMonitorAuthorization(
+    _ producerSet: AllowedEventProducerSet,
+    processIdentity: (Int32) -> UInt64? = processStartIdentity(pid:),
+    targetValidator: (AllowedForegroundTarget) -> Bool = foregroundTargetIsLive) throws -> MonitorAuthorization
+{
+    let producerPIDs = producerSet.producers.map(\.pid)
+    guard Set(producerPIDs).count == producerPIDs.count,
+          Set(producerSet.producers).count == producerSet.producers.count,
+          producerSet.producers.allSatisfy({ producer in
+              processIdentity(producer.pid).map(String.init) == producer.startIdentity
+          }),
+          producerSet.producers.isEmpty || producerSet.producers.contains(where: {
+              $0.effectiveRole == .bridge
+          })
+    else {
+        throw ProbeError.invalidArguments("blocked_producer_identity")
+    }
+    let foreground = producerSet.effectiveForeground
+    guard foregroundControllerCardinalityIsValid(
+        producers: producerSet.producers,
+        foreground: foreground),
+        !foreground.active || foreground.target.map(targetValidator) == true
+    else {
+        throw ProbeError.invalidArguments("blocked_foreground_contract")
+    }
+    return MonitorAuthorization(
+        source: producerSet,
+        producersByPID: Dictionary(uniqueKeysWithValues: producerSet.producers.map { ($0.pid, $0) }),
+        foreground: foreground)
+}
+
+private func applyMonitorAuthorization(
+    _ producerSet: AllowedEventProducerSet,
+    to machine: MonitorEpochMachine,
+    observers: FocusObserverCoordinator,
+    processIdentity: (Int32) -> UInt64? = processStartIdentity(pid:),
+    targetValidator: (AllowedForegroundTarget) -> Bool = foregroundTargetIsLive)
+{
+    let current = machine.currentAuthorization
+    if producerSet.revision == current.revision {
+        if !current.hasExactlyEquivalentPayload(to: producerSet) {
+            machine.admitFailure(reason: "blocked_producer_revision_replay")
+        }
+        return
+    }
+    guard producerSet.revision > current.revision else {
+        machine.admitFailure(reason: "blocked_producer_revision_replay")
+        return
+    }
+    let authorization: MonitorAuthorization
+    do {
+        authorization = try makeMonitorAuthorization(
+            producerSet,
+            processIdentity: processIdentity,
+            targetValidator: targetValidator)
+    } catch {
+        machine.admitFailure(reason: String(describing: error))
+        return
+    }
+    do {
+        try observers.prepare(target: authorization.target)
+    } catch {
+        machine.admitFailure(reason: "blocked_focus_observer_install")
+        return
+    }
+    if case let .rejected(reason) = machine.publish(authorization) {
+        machine.admitFailure(reason: reason)
+    }
+}
+
+private func closeMonitorEpoch(
+    _ machine: MonitorEpochMachine,
+    observers: FocusObserverCoordinator) -> MonitorEpochClosure
+{
+    var closure = machine.closeForHeartbeat()
+    if closure.transitionAcknowledged {
+        do {
+            try observers.reconcile(activeTarget: closure.finalEpoch.epoch.authorization.target)
+        } catch {
+            machine.admitFailure(reason: "blocked_focus_observer_removal")
+            closure = closure.appending(machine.closeForHeartbeat())
+        }
+    }
+    return closure
+}
+
+private func evidenceMatches(
+    _ evidence: ProcessWindowEvidence,
+    pid: Int32,
+    startIdentity: String,
+    windowID: UInt32) -> Bool
+{
+    evidence.pid == pid && evidence.startIdentity == startIdentity && evidence.windowID == windowID
+}
+
+private func focusEvidenceViolations(
+    _ evidence: ProcessWindowEvidence,
+    authorization: MonitorAuthorization,
     baseline: InteractiveBaseline,
     projection: InvariantProjection) -> Set<Violation>
 {
-    guard externalEventCount == 0 else { return [] }
+    var allowed = [ProcessWindowEvidence(
+        pid: baseline.frontmostPID,
+        startIdentity: baseline.processStartIdentity,
+        windowID: baseline.frontmostWindowID)]
+    if let target = authorization.target {
+        allowed.append(ProcessWindowEvidence(
+            pid: target.pid,
+            startIdentity: target.startIdentity,
+            windowID: target.windowID))
+    }
+    guard !allowed.contains(evidence) else { return [] }
     var result = Set<Violation>()
-    if !unexpectedActivations.isEmpty {
+    if !allowed.contains(where: { $0.pid == evidence.pid }) {
         result.insert(Violation(
             kind: projection[.frontmostPID],
-            expected: baseline.frontmostPID.map(String.init) ?? "null",
-            actual: "transient activations: \(unexpectedActivations.map(String.init).joined(separator: ","))"))
+            expected: allowed.map { String($0.pid) }.joined(separator: " or "),
+            actual: String(evidence.pid)))
     }
-    if focusedWindowChanged {
-        result.insert(Violation(
-            kind: projection[.frontmostWindow],
-            expected: baseline.frontmostWindowID.map(String.init) ?? "null",
-            actual: "transient focused-window change"))
-    }
+    result.insert(Violation(
+        kind: projection[.frontmostWindow],
+        expected: allowed.compactMap(\.windowID).map(String.init).joined(separator: " or "),
+        actual: evidence.windowID.map(String.init) ?? "unresolved"))
     return result
+}
+
+private func currentFocusViolations(
+    current: SystemSample,
+    closure: MonitorEpochClosure,
+    baseline: InteractiveBaseline,
+    projection: InvariantProjection) -> Set<Violation>
+{
+    var allowed = Set(["\(baseline.frontmostPID):\(baseline.frontmostWindowID)"])
+    let authorizations = closure.transitionAcknowledged
+        ? closure.epochs.map(\.epoch.authorization)
+        : [closure.finalEpoch.epoch.authorization]
+    for authorization in authorizations {
+        if let target = authorization.target {
+            allowed.insert("\(target.pid):\(target.windowID)")
+        }
+    }
+    let currentKey = current.frontmostPID.flatMap { pid in
+        current.frontmostWindowID.map { "\(pid):\($0)" }
+    }
+    guard let currentKey, allowed.contains(currentKey) else {
+        return [
+            Violation(
+                kind: projection[.frontmostPID],
+                expected: "authorized epoch focus",
+                actual: current.frontmostPID.map(String.init) ?? "null"),
+            Violation(
+                kind: projection[.frontmostWindow],
+                expected: "authorized epoch window",
+                actual: current.frontmostWindowID.map(String.init) ?? "null"),
+        ]
+    }
+    return []
+}
+
+private struct ClosedEpochEventClassification {
+    var externalInputs = [InputEventEvidence]()
+    var focusEvents = [ProcessWindowEvidence]()
+    var bridgeSources = Set<Int32>()
+    var bridgeTypes = Set<UInt32>()
+    var activationCount = 0
+    var focusCount = 0
+}
+
+private struct ClosedEpochEvaluation {
+    let violations: Set<Violation>
+    let permitsInteractiveEvaluation: Bool
+    let activationCount: Int
+    let focusCount: Int
 }
 
 private struct WatchState {
@@ -708,116 +1153,79 @@ private struct WatchState {
     private var contaminationRetries = 0
     private var contaminationState = AttemptContaminationState()
     private var inputAttributionAvailable = true
-    private var allowedProducerRevision: UInt64?
-    private var allowedProducerReceipts: [Int32: String] = [:]
-    private var pendingActivations: [Int32] = []
-    private var pendingFocusedWindowChange = false
     private var cursorMovementObserved = false
-
-    mutating func applyProducerSet(
-        _ producerSet: AllowedEventProducerSet,
-        to tracker: InputEventTracker) throws
-    {
-        guard self.allowedProducerRevision != producerSet.revision else { return }
-        let producerPIDs = producerSet.producers.map(\.pid)
-        let validatedPIDs = Set(producerSet.producers.compactMap { producer -> Int32? in
-            guard let currentStartIdentity = processStartIdentity(pid: producer.pid),
-                  producer.startIdentity == String(currentStartIdentity)
-            else {
-                return nil
-            }
-            return producer.pid
-        })
-        guard validatedPIDs.count == producerSet.producers.count,
-              Set(producerPIDs).count == producerPIDs.count
-        else {
-            try self.block(
-                reason: "blocked_producer_identity",
-                sourcePIDs: producerSet.producers.map(\.pid).sorted(),
-                eventTypes: [],
-                attributionFailed: true,
-                countsRetry: false)
-            return
-        }
-        tracker.updateAllowedProducerPIDs(validatedPIDs)
-        self.allowedProducerReceipts = Dictionary(uniqueKeysWithValues: producerSet.producers.map {
-            ($0.pid, $0.startIdentity)
-        })
-        self.allowedProducerRevision = producerSet.revision
-    }
+    private var attributedForegroundEventCount = 0
+    private var attributedForegroundSourcePIDs = Set<Int32>()
+    private var foregroundActivityObserved = false
 
     mutating func observe(
         current: SystemSample,
         phase: String,
-        inputBatch: InputEventBatch,
-        unexpectedActivations: [Int32],
-        focusedWindowChanged: Bool) throws -> WatchHeartbeat
+        closure: MonitorEpochClosure,
+        processIdentity: (Int32) -> UInt64? = processStartIdentity(pid:),
+        targetValidator: (AllowedForegroundTarget) -> Bool = foregroundTargetIsLive) throws -> WatchHeartbeat
     {
         if abs(current.cursor.x - self.interactiveBaseline.cursor.x) > 0.5 ||
             abs(current.cursor.y - self.interactiveBaseline.cursor.y) > 0.5
         {
             self.cursorMovementObserved = true
         }
-        let deferredActivations = self.pendingActivations
-        let deferredFocusedWindowChange = self.pendingFocusedWindowChange
-        self.pendingActivations = unexpectedActivations
-        self.pendingFocusedWindowChange = focusedWindowChanged
+        var currentViolations = Set<Violation>()
+        var totalActivationCount = 0
+        var totalFocusCount = 0
+        var allEpochsPermitInteractiveEvaluation = true
 
-        if inputBatch.attributionFailed {
+        if processIdentity(self.interactiveBaseline.frontmostPID).map(String.init) !=
+            self.interactiveBaseline.processStartIdentity
+        {
             try self.block(
-                reason: "blocked_attribution",
-                sourcePIDs: [],
+                reason: "blocked_baseline_generation_drift",
+                sourcePIDs: [self.interactiveBaseline.frontmostPID],
                 eventTypes: [],
                 attributionFailed: true,
                 countsRetry: false)
         }
-        let producerEventsValid = producerEventsMatchReceipts(
-            batch: inputBatch,
-            receipts: self.allowedProducerReceipts,
-            processIdentity: processStartIdentity(pid:))
-        if !producerEventsValid {
-            try self.block(
-                reason: "blocked_producer_generation_drift",
-                sourcePIDs: inputBatch.producerSourcePIDs,
-                eventTypes: inputBatch.producerEventTypes,
-                attributionFailed: true,
-                countsRetry: false)
+
+        for closedEpoch in closure.epochs {
+            let evaluation = try self.evaluate(
+                closedEpoch: closedEpoch,
+                phase: phase,
+                targetValidator: targetValidator)
+            currentViolations.formUnion(evaluation.violations)
+            totalActivationCount += evaluation.activationCount
+            totalFocusCount += evaluation.focusCount
+            allEpochsPermitInteractiveEvaluation = allEpochsPermitInteractiveEvaluation &&
+                evaluation.permitsInteractiveEvaluation
         }
-        let observesPhysicalInput = physicalInputIsObservational(
-            inputBatch,
-            enabled: self.physicalInputObservational)
-        if inputBatch.externalEventCount > 0, !observesPhysicalInput {
-            try self.block(
-                reason: phase == "setup" ? "blocked_setup_attempt" : "blocked_active_attempt",
-                sourcePIDs: inputBatch.externalSourcePIDs,
-                eventTypes: inputBatch.externalEventTypes,
-                attributionFailed: false,
-                countsRetry: true)
-        }
-        let externalInputPermitsEvaluation = observesPhysicalInput || inputBatch.externalEventCount == 0
-        let evaluateInteractive = externalInputPermitsEvaluation &&
-            unexpectedActivations.isEmpty && !focusedWindowChanged && self.inputAttributionAvailable &&
+
+        let evaluateInteractive = allEpochsPermitInteractiveEvaluation && self.inputAttributionAvailable &&
             self.contaminationState.permitsInteractiveEvaluation
         let context = InvariantEvaluationContext(
             baseline: self.baseline,
             interactiveBaseline: self.interactiveBaseline,
             allowClipboardMutation: self.allowClipboardMutation,
-            evaluateInteractiveInvariants: evaluateInteractive,
+            evaluateInteractiveInvariants: evaluateInteractive &&
+                !closure.finalEpoch.epoch.authorization.foreground.active &&
+                !closure.transitionAcknowledged,
             cursorObservational: self.cursorObservational,
             projection: self.projection)
-        var currentViolations = violations(current: current, context: context)
-        if self.contaminationState.permitsInteractiveEvaluation {
-            currentViolations.formUnion(transientFocusViolations(
-                externalEventCount: observesPhysicalInput ? 0 : inputBatch.externalEventCount,
-                unexpectedActivations: deferredActivations,
-                focusedWindowChanged: deferredFocusedWindowChange,
+        currentViolations.formUnion(violations(current: current, context: context))
+        if evaluateInteractive,
+           closure.finalEpoch.epoch.authorization.foreground.active || closure.transitionAcknowledged
+        {
+            currentViolations.formUnion(currentFocusViolations(
+                current: current,
+                closure: closure,
                 baseline: self.interactiveBaseline,
                 projection: self.projection))
-        }
-        if producerEventsValid,
-           let inputViolation = producerInputViolation(batch: inputBatch, projection: self.projection)
-        {
-            currentViolations.insert(inputViolation)
+            let cursorMoved = abs(current.cursor.x - self.interactiveBaseline.cursor.x) > 0.5 ||
+                abs(current.cursor.y - self.interactiveBaseline.cursor.y) > 0.5
+            if cursorMoved, !self.cursorObservational {
+                currentViolations.insert(Violation(
+                    kind: self.projection[.physicalCursor],
+                    expected: "\(self.interactiveBaseline.cursor.x),\(self.interactiveBaseline.cursor.y)",
+                    actual: "\(current.cursor.x),\(current.cursor.y)"))
+            }
         }
         for violation in currentViolations.subtracting(self.recorded) {
             try appendJSONLine(violation, to: self.outputPath)
@@ -825,9 +1233,10 @@ private struct WatchState {
         }
 
         self.sequence += 1
-        if evaluateInteractive {
+        if evaluateInteractive, !closure.transitionAcknowledged, currentViolations.isEmpty {
             self.lastCleanSequence = self.sequence
         }
+        let finalAuthorization = closure.finalEpoch.epoch.authorization
         return WatchHeartbeat(
             sequence: self.sequence,
             timestamp: current.timestamp,
@@ -835,11 +1244,190 @@ private struct WatchState {
             contaminationRetries: self.contaminationRetries,
             contaminationBlocked: self.contaminationState.blocked,
             inputAttributionAvailable: self.inputAttributionAvailable,
-            allowedProducerRevision: self.allowedProducerRevision ?? 0,
+            allowedProducerRevision: finalAuthorization.revision,
             phase: phase,
             cursorMovementObserved: self.cursorMovementObserved,
-            pendingActivationCount: self.pendingActivations.count,
-            pendingFocusedWindowChange: self.pendingFocusedWindowChange)
+            pendingActivationCount: totalActivationCount,
+            pendingFocusedWindowChange: totalFocusCount > 0,
+            authorizationEpoch: closure.finalEpoch.epoch.serial,
+            transitionAcknowledged: closure.transitionAcknowledged,
+            foregroundActive: finalAuthorization.foreground.active,
+            foregroundTargetPID: finalAuthorization.target?.pid,
+            foregroundTargetWindowID: finalAuthorization.target?.windowID,
+            attributedForegroundEventCount: self.attributedForegroundEventCount,
+            attributedForegroundSourcePIDs: self.attributedForegroundSourcePIDs.sorted(),
+            foregroundActivityObserved: self.foregroundActivityObserved)
+    }
+
+    private mutating func evaluate(
+        closedEpoch: ClosedMonitorEpoch,
+        phase: String,
+        targetValidator: (AllowedForegroundTarget) -> Bool) throws -> ClosedEpochEvaluation
+    {
+        let authorization = closedEpoch.epoch.authorization
+        if let target = authorization.target, !targetValidator(target) {
+            try self.block(
+                reason: "blocked_foreground_target_drift",
+                sourcePIDs: [target.pid],
+                eventTypes: [],
+                attributionFailed: true,
+                countsRetry: false)
+        }
+        let classification = try self.classify(
+            events: closedEpoch.events,
+            authorization: authorization)
+        var epochViolations = Set<Violation>()
+        if !classification.bridgeSources.isEmpty {
+            epochViolations.insert(Violation(
+                kind: self.projection[.globalInputEvent],
+                expected: "no session-global input events",
+                actual: "pids=\(classification.bridgeSources.sorted().map(String.init).joined(separator: ",")); " +
+                    "types=\(classification.bridgeTypes.sorted().map(String.init).joined(separator: ","))"))
+        }
+
+        let physicalInputIsObservational = self.physicalInputObservational &&
+            !classification.externalInputs.isEmpty && classification.externalInputs.allSatisfy { input in
+                input.source.pid == 0 && input.source.startIdentity == nil &&
+                    input.type == CGEventType.mouseMoved.rawValue
+            }
+        let permitsInteractiveEvaluation = classification.externalInputs.isEmpty || physicalInputIsObservational
+        if !permitsInteractiveEvaluation {
+            try self.block(
+                reason: phase == "setup" ? "blocked_setup_attempt" : "blocked_active_attempt",
+                sourcePIDs: Set(classification.externalInputs.map(\.source.pid)).sorted(),
+                eventTypes: Set(classification.externalInputs.map(\.type)).sorted(),
+                attributionFailed: false,
+                countsRetry: true)
+        } else {
+            try epochViolations.formUnion(self.focusViolations(
+                classification.focusEvents,
+                authorization: authorization))
+        }
+        return ClosedEpochEvaluation(
+            violations: epochViolations,
+            permitsInteractiveEvaluation: permitsInteractiveEvaluation,
+            activationCount: classification.activationCount,
+            focusCount: classification.focusCount)
+    }
+
+    private mutating func classify(
+        events: [MonitorEvent],
+        authorization: MonitorAuthorization) throws -> ClosedEpochEventClassification
+    {
+        var classification = ClosedEpochEventClassification()
+        for event in events {
+            switch event.kind {
+            case let .attributionFailure(reason, process):
+                try self.block(
+                    reason: reason,
+                    sourcePIDs: process.map { [$0.pid] } ?? [],
+                    eventTypes: [],
+                    attributionFailed: true,
+                    countsRetry: false)
+            case let .input(input):
+                try self.classify(
+                    input: input,
+                    authorization: authorization,
+                    into: &classification)
+            case let .activation(evidence):
+                classification.activationCount += 1
+                classification.focusEvents.append(evidence)
+            case let .focus(focus):
+                classification.focusCount += 1
+                if focus.observer.pid != focus.observed.pid ||
+                    focus.observer.startIdentity != focus.observed.startIdentity
+                {
+                    try self.block(
+                        reason: "blocked_focus_observer_generation_drift",
+                        sourcePIDs: [focus.observer.pid],
+                        eventTypes: [],
+                        attributionFailed: true,
+                        countsRetry: false)
+                }
+                classification.focusEvents.append(focus.observed)
+            }
+        }
+        return classification
+    }
+
+    private mutating func classify(
+        input: InputEventEvidence,
+        authorization: MonitorAuthorization,
+        into classification: inout ClosedEpochEventClassification) throws
+    {
+        guard let producer = authorization.producersByPID[input.source.pid] else {
+            classification.externalInputs.append(input)
+            return
+        }
+        guard input.source.startIdentity == producer.startIdentity else {
+            try self.block(
+                reason: "blocked_producer_generation_drift",
+                sourcePIDs: [input.source.pid],
+                eventTypes: [input.type],
+                attributionFailed: true,
+                countsRetry: false)
+            return
+        }
+        switch producer.effectiveRole {
+        case .bridge:
+            classification.bridgeSources.insert(input.source.pid)
+            classification.bridgeTypes.insert(input.type)
+        case .foregroundController:
+            guard let target = authorization.target,
+                  input.sessionFocus.map({ evidenceMatches(
+                      $0,
+                      pid: target.pid,
+                      startIdentity: target.startIdentity,
+                      windowID: target.windowID)
+                  }) == true
+            else {
+                try self.block(
+                    reason: "blocked_foreground_target_drift",
+                    sourcePIDs: [input.source.pid],
+                    eventTypes: [input.type],
+                    attributionFailed: true,
+                    countsRetry: false)
+                return
+            }
+            self.attributedForegroundEventCount += 1
+            self.attributedForegroundSourcePIDs.insert(input.source.pid)
+            self.foregroundActivityObserved = true
+        }
+    }
+
+    private mutating func focusViolations(
+        _ evidence: [ProcessWindowEvidence],
+        authorization: MonitorAuthorization) throws -> Set<Violation>
+    {
+        let allowedGenerations = [ProcessWindowEvidence(
+            pid: self.interactiveBaseline.frontmostPID,
+            startIdentity: self.interactiveBaseline.processStartIdentity,
+            windowID: self.interactiveBaseline.frontmostWindowID)] +
+            (authorization.target.map {
+                [ProcessWindowEvidence(
+                    pid: $0.pid,
+                    startIdentity: $0.startIdentity,
+                    windowID: $0.windowID)]
+            } ?? [])
+        var result = Set<Violation>()
+        for eventEvidence in evidence {
+            if allowedGenerations.contains(where: {
+                $0.pid == eventEvidence.pid && $0.startIdentity != eventEvidence.startIdentity
+            }) {
+                try self.block(
+                    reason: "blocked_focus_generation_drift",
+                    sourcePIDs: [eventEvidence.pid],
+                    eventTypes: [],
+                    attributionFailed: true,
+                    countsRetry: false)
+            }
+            result.formUnion(focusEvidenceViolations(
+                eventEvidence,
+                authorization: authorization,
+                baseline: self.interactiveBaseline,
+                projection: self.projection))
+        }
+        return result
     }
 
     private mutating func block(
@@ -925,20 +1513,32 @@ private func runWatch(arguments: [String]) throws -> Never {
     let invariantProjection = try InvariantProjection(json: invariantNamesJSON)
     let baselineData = try Data(contentsOf: URL(fileURLWithPath: baselinePath))
     let baseline = try JSONDecoder().decode(SystemSample.self, from: baselineData)
+    guard let baselinePID = baseline.frontmostPID,
+          let baselineWindowID = baseline.frontmostWindowID,
+          let baselineStartIdentity = processStartIdentity(pid: baselinePID).map(String.init)
+    else {
+        throw ProbeError.focusedWindowObserverUnavailable
+    }
+    let initialProducerData = try Data(contentsOf: URL(fileURLWithPath: allowedProducersPath))
+    let initialProducerSet = try JSONDecoder().decode(AllowedEventProducerSet.self, from: initialProducerData)
+    let initialAuthorization = try makeMonitorAuthorization(initialProducerSet)
     FileManager.default.createFile(atPath: outputPath, contents: nil)
     FileManager.default.createFile(atPath: contaminationOutputPath, contents: nil)
 
-    let inputTracker = InputEventTracker()
+    let machine = MonitorEpochMachine(initialAuthorization: initialAuthorization)
+    let inputTracker = InputEventTracker(machine: machine)
     try inputTracker.start()
-    let activationTracker = ActivationTracker(baselinePID: baseline.frontmostPID)
+    let activationTracker = ActivationTracker(machine: machine)
     activationTracker.start()
-    guard let baselinePID = baseline.frontmostPID else {
-        throw ProbeError.focusedWindowObserverUnavailable
+    let focusObservers = FocusObserverCoordinator { identity in
+        FocusedWindowTracker(identity: identity, machine: machine)
     }
-    let focusedWindowTracker = FocusedWindowTracker(pid: baselinePID)
-    try focusedWindowTracker.start()
+    try focusObservers.startBaseline(ProcessGenerationIdentity(
+        pid: baselinePID,
+        startIdentity: baselineStartIdentity))
+    try focusObservers.prepare(target: initialAuthorization.target)
     defer {
-        focusedWindowTracker.stop()
+        focusObservers.stop()
         activationTracker.stop()
         inputTracker.stop()
     }
@@ -946,8 +1546,9 @@ private func runWatch(arguments: [String]) throws -> Never {
     var watchState = WatchState(
         baseline: baseline,
         interactiveBaseline: InteractiveBaseline(
-            frontmostPID: baseline.frontmostPID,
-            frontmostWindowID: baseline.frontmostWindowID,
+            frontmostPID: baselinePID,
+            processStartIdentity: baselineStartIdentity,
+            frontmostWindowID: baselineWindowID,
             cursor: baseline.cursor),
         allowClipboardMutation: allowClipboardMutation,
         physicalInputObservational: physicalInputObservational,
@@ -961,23 +1562,20 @@ private func runWatch(arguments: [String]) throws -> Never {
             .defaultMode,
             Double(intervalMilliseconds) / 1000,
             true)
-        let current = try sample(includeClipboardDigest: false)
         let producerData = try Data(contentsOf: URL(fileURLWithPath: allowedProducersPath))
         let allowedProducerSet = try JSONDecoder().decode(AllowedEventProducerSet.self, from: producerData)
-        try watchState.applyProducerSet(allowedProducerSet, to: inputTracker)
+        applyMonitorAuthorization(allowedProducerSet, to: machine, observers: focusObservers)
+        let closure = closeMonitorEpoch(machine, observers: focusObservers)
+        let current = try sample(includeClipboardDigest: false)
         let phase = try String(contentsOfFile: phasePath, encoding: .utf8)
             .trimmingCharacters(in: .whitespacesAndNewlines)
         guard ["setup", "running", "complete"].contains(phase) else {
             throw ProbeError.invalidArguments("watch phase must be setup, running, or complete")
         }
-        let inputBatch = inputTracker.drain()
-        let unexpectedActivations = activationTracker.drain()
         let heartbeat = try watchState.observe(
             current: current,
             phase: phase,
-            inputBatch: inputBatch,
-            unexpectedActivations: unexpectedActivations,
-            focusedWindowChanged: focusedWindowTracker.drain())
+            closure: closure)
         try writeJSON(
             heartbeat,
             to: heartbeatPath)
@@ -993,234 +1591,834 @@ private func producerReceiptSchemaIsLossless() -> Bool {
     guard let decoded = try? JSONDecoder().decode(AllowedEventProducerSet.self, from: data) else { return false }
     return decoded.revision == 1 &&
         decoded.producers.first?.pid == 42 &&
-        decoded.producers.first?.startIdentity == "987654321"
+        decoded.producers.first?.startIdentity == "987654321" &&
+        decoded.producers.first?.effectiveRole == .bridge &&
+        decoded.effectiveForeground == AllowedForegroundActivity(active: false, target: nil)
 }
 
-private func physicalInputPolicyIsSafe() -> Bool {
-    let physicalBatch = InputEventBatch(
-        producerEventCount: 0,
-        producerSourcePIDs: [],
-        producerEventTypes: [],
-        externalEventCount: 1,
-        externalSourcePIDs: [0],
-        externalEventTypes: [CGEventType.mouseMoved.rawValue],
-        attributionFailed: false)
-    let processBatch = InputEventBatch(
-        producerEventCount: 0,
-        producerSourcePIDs: [],
-        producerEventTypes: [],
-        externalEventCount: 1,
-        externalSourcePIDs: [4242],
-        externalEventTypes: [CGEventType.keyDown.rawValue],
-        attributionFailed: false)
-    let physicalKeyBatch = InputEventBatch(
-        producerEventCount: 0,
-        producerSourcePIDs: [],
-        producerEventTypes: [],
-        externalEventCount: 1,
-        externalSourcePIDs: [0],
-        externalEventTypes: [CGEventType.keyDown.rawValue],
-        attributionFailed: false)
-    let physicalClickBatch = InputEventBatch(
-        producerEventCount: 0,
-        producerSourcePIDs: [],
-        producerEventTypes: [],
-        externalEventCount: 1,
-        externalSourcePIDs: [0],
-        externalEventTypes: [CGEventType.leftMouseDown.rawValue],
-        attributionFailed: false)
-    let physicalScrollBatch = InputEventBatch(
-        producerEventCount: 0,
-        producerSourcePIDs: [],
-        producerEventTypes: [],
-        externalEventCount: 1,
-        externalSourcePIDs: [0],
-        externalEventTypes: [CGEventType.scrollWheel.rawValue],
-        attributionFailed: false)
-    let mixedPhysicalBatch = InputEventBatch(
-        producerEventCount: 0,
-        producerSourcePIDs: [],
-        producerEventTypes: [],
-        externalEventCount: 2,
-        externalSourcePIDs: [0],
-        externalEventTypes: [CGEventType.mouseMoved.rawValue, CGEventType.keyDown.rawValue],
-        attributionFailed: false)
-    let unattributedBatch = InputEventBatch(
-        producerEventCount: 0,
-        producerSourcePIDs: [],
-        producerEventTypes: [],
-        externalEventCount: 1,
-        externalSourcePIDs: [],
-        externalEventTypes: [CGEventType.keyDown.rawValue],
-        attributionFailed: false)
-    return physicalInputIsObservational(physicalBatch, enabled: true) &&
-        !physicalInputIsObservational(physicalKeyBatch, enabled: true) &&
-        !physicalInputIsObservational(physicalClickBatch, enabled: true) &&
-        !physicalInputIsObservational(physicalScrollBatch, enabled: true) &&
-        !physicalInputIsObservational(mixedPhysicalBatch, enabled: true) &&
-        !physicalInputIsObservational(processBatch, enabled: true) &&
-        !physicalInputIsObservational(unattributedBatch, enabled: true) &&
-        !physicalInputIsObservational(physicalBatch, enabled: false)
+private func foregroundAuthorizationSchemaIsStrict() -> Bool {
+    let data = Data(
+        #"""
+        {
+          "revision": 2,
+          "producers": [
+            {"pid": 20, "startIdentity": "2000", "role": "bridge"},
+            {"pid": 30, "startIdentity": "3000", "role": "foreground-controller"}
+          ],
+          "foreground": {
+            "active": true,
+            "target": {"pid": 40, "startIdentity": "4000", "windowID": 401}
+          }
+        }
+        """#
+            .utf8)
+    guard let decoded = try? JSONDecoder().decode(AllowedEventProducerSet.self, from: data),
+          let authorization = try? makeMonitorAuthorization(
+              decoded,
+              processIdentity: { [20: 2000, 30: 3000][$0] },
+              targetValidator: { $0.pid == 40 && $0.startIdentity == "4000" && $0.windowID == 401 }),
+          authorization.target?.windowID == 401
+    else {
+        return false
+    }
+    let invalidInactive = testProducerSet(
+        revision: 3,
+        producers: [testProducer(20, "2000"), testProducer(30, "3000", role: .foregroundController)],
+        foreground: AllowedForegroundActivity(active: false, target: nil))
+    let invalidTarget = testProducerSet(
+        revision: 3,
+        producers: [testProducer(20, "2000"), testProducer(30, "3000", role: .foregroundController)],
+        foreground: AllowedForegroundActivity(
+            active: true,
+            target: AllowedForegroundTarget(pid: 40, startIdentity: "4000", windowID: 401)))
+    return (try? makeMonitorAuthorization(
+        invalidInactive,
+        processIdentity: { [20: 2000, 30: 3000][$0] },
+        targetValidator: { _ in true })) == nil &&
+        (try? makeMonitorAuthorization(
+            invalidTarget,
+            processIdentity: { [20: 2000, 30: 3000][$0] },
+            targetValidator: { _ in false })) == nil
 }
 
-private func runSelfTest() throws {
-    let projection = InvariantProjection(names: InvariantSlot.allCases.map { "slot-\($0.rawValue)" })
-    let baseline = SystemSample(
+private func testProducer(
+    _ pid: Int32,
+    _ startIdentity: String,
+    role: AllowedEventProducerRole? = nil) -> AllowedEventProducer
+{
+    AllowedEventProducer(pid: pid, startIdentity: startIdentity, role: role)
+}
+
+private func testProducerSet(
+    revision: UInt64,
+    producers: [AllowedEventProducer],
+    foreground: AllowedForegroundActivity? = nil) -> AllowedEventProducerSet
+{
+    AllowedEventProducerSet(revision: revision, producers: producers, foreground: foreground)
+}
+
+private func testAuthorization(_ producerSet: AllowedEventProducerSet) -> MonitorAuthorization {
+    MonitorAuthorization(
+        source: producerSet,
+        producersByPID: Dictionary(uniqueKeysWithValues: producerSet.producers.map { ($0.pid, $0) }),
+        foreground: producerSet.effectiveForeground)
+}
+
+private func testEvidence(_ pid: Int32, _ startIdentity: String?, _ windowID: UInt32?) -> ProcessWindowEvidence {
+    ProcessWindowEvidence(pid: pid, startIdentity: startIdentity, windowID: windowID)
+}
+
+private func selfTestDesktop() -> (sample: SystemSample, baseline: InteractiveBaseline) {
+    let sample = SystemSample(
         timestamp: 1,
-        frontmostPID: 101,
+        frontmostPID: 10,
         frontmostBundleIdentifier: "com.apple.calculator",
-        frontmostWindowID: 201,
+        frontmostWindowID: 100,
         cursor: Point(x: 50, y: 60),
         clipboardChangeCount: 3,
         clipboardDigest: "digest",
         peekabooWindowIDs: [301],
         visibleScreenFramesTopLeft: [Rectangle(x: 0, y: 0, width: 800, height: 600)])
+    return (
+        sample,
+        InteractiveBaseline(
+            frontmostPID: 10,
+            processStartIdentity: "1000",
+            frontmostWindowID: 100,
+            cursor: sample.cursor))
+}
 
-    let interactiveBaseline = InteractiveBaseline(
-        frontmostPID: baseline.frontmostPID,
-        frontmostWindowID: baseline.frontmostWindowID,
-        cursor: baseline.cursor)
+private final class MonitorClosureCapture: Sendable {
+    private let closures = Mutex<[MonitorEpochClosure]>([])
+
+    func append(_ closure: MonitorEpochClosure) {
+        self.closures.withLock { $0.append(closure) }
+    }
+
+    func load() -> [MonitorEpochClosure] {
+        self.closures.withLock { $0 }
+    }
+}
+
+private func recordPublishDrainIsLinearizable() -> Bool {
+    let bridge = testProducer(20, "2000")
+    let first = testAuthorization(testProducerSet(revision: 1, producers: [bridge]))
+    let second = testAuthorization(testProducerSet(revision: 2, producers: [bridge]))
+    for _ in 0..<100 {
+        let machine = MonitorEpochMachine(initialAuthorization: first)
+        let capture = MonitorClosureCapture()
+        DispatchQueue.concurrentPerform(iterations: 3) { index in
+            switch index {
+            case 0:
+                machine.admitForTesting(.activation(testEvidence(10, "1000", 100)))
+            case 1:
+                _ = machine.publish(second)
+            default:
+                capture.append(machine.closeForHeartbeat())
+            }
+        }
+        capture.append(machine.closeForHeartbeat())
+        let epochs = capture.load().flatMap(\.epochs)
+        let events = epochs.flatMap(\.events)
+        guard events.count == 1,
+              let event = events.first,
+              [UInt64(1), UInt64(2)].contains(event.epoch.authorization.revision),
+              epochs.contains(where: { closed in
+                  closed.events.contains(event) &&
+                      event.admission > closed.epoch.lowerAdmissionCutoff &&
+                      event.admission <= closed.upperAdmissionCutoff
+              }),
+              epochs.contains(where: {
+                  $0.epoch.authorization.revision == 2 && $0.epoch.transitionBarrier
+              })
+        else {
+            return false
+        }
+    }
+    return true
+}
+
+private func exactPublicationCutoffIsClosed() -> Bool {
+    let first = testAuthorization(testProducerSet(revision: 1, producers: []))
+    let second = testAuthorization(testProducerSet(revision: 2, producers: []))
+    let machine = MonitorEpochMachine(initialAuthorization: first)
+    machine.admitForTesting(.activation(testEvidence(10, "1000", 100)))
+    guard machine.publish(second) == .published else { return false }
+    machine.admitForTesting(.activation(testEvidence(10, "1000", 100)))
+    let closure = machine.closeForHeartbeat()
+    guard closure.epochs.count == 2 else { return false }
+    let old = closure.epochs[0]
+    let new = closure.epochs[1]
+    return old.epoch.authorization.revision == 1 && old.upperAdmissionCutoff == 1 &&
+        old.events.map(\.admission) == [1] &&
+        new.epoch.authorization.revision == 2 && new.epoch.lowerAdmissionCutoff == 1 &&
+        new.upperAdmissionCutoff == 2 && new.events.map(\.admission) == [2] &&
+        closure.transitionAcknowledged
+}
+
+private func queuedRevisionsRemainDistinct() -> Bool {
+    let bridge = testProducer(20, "2000")
+    let controller = testProducer(30, "3000", role: .foregroundController)
+    let targetA = AllowedForegroundTarget(pid: 40, startIdentity: "4000", windowID: 401)
+    let targetB = AllowedForegroundTarget(pid: 40, startIdentity: "4000", windowID: 402)
+    let targetC = AllowedForegroundTarget(pid: 40, startIdentity: "4001", windowID: 402)
+    let inactive = AllowedForegroundActivity(active: false, target: nil)
+    let machine = MonitorEpochMachine(initialAuthorization: testAuthorization(testProducerSet(
+        revision: 1,
+        producers: [bridge],
+        foreground: inactive)))
+    let revisions = [
+        testProducerSet(
+            revision: 2,
+            producers: [bridge, controller],
+            foreground: AllowedForegroundActivity(active: true, target: targetA)),
+        testProducerSet(
+            revision: 3,
+            producers: [bridge, controller],
+            foreground: AllowedForegroundActivity(active: true, target: targetB)),
+        testProducerSet(
+            revision: 4,
+            producers: [bridge, testProducer(30, "3001", role: .foregroundController)],
+            foreground: AllowedForegroundActivity(active: true, target: targetC)),
+        testProducerSet(revision: 5, producers: [bridge], foreground: inactive),
+    ]
+    for producerSet in revisions {
+        guard machine.publish(testAuthorization(producerSet)) == .published else { return false }
+    }
+    let closure = machine.closeForHeartbeat()
+    return closure.epochs.map(\.epoch.authorization.revision) == [1, 2, 3, 4, 5] &&
+        closure.epochs.dropFirst().allSatisfy(\.epoch.transitionBarrier) &&
+        closure.finalEpoch.epoch.authorization.target == nil
+}
+
+private func equalRevisionRequiresExactPayload() -> Bool {
+    let a = testProducer(20, "2000")
+    let b = testProducer(21, "2100")
+    let source = testProducerSet(revision: 7, producers: [a, b])
+    let machine = MonitorEpochMachine(initialAuthorization: testAuthorization(source))
+    let reordered = testAuthorization(testProducerSet(revision: 7, producers: [b, a]))
+    let mutated = testAuthorization(testProducerSet(
+        revision: 7,
+        producers: [a, b],
+        foreground: AllowedForegroundActivity(active: false, target: nil)))
+    guard machine.publish(reordered) == .idempotent else { return false }
+    guard case .rejected(reason: "blocked_producer_revision_replay") = machine.publish(mutated) else {
+        return false
+    }
+    return true
+}
+
+private func grantRetargetRevokeRetainsEventEpochs() -> Bool {
+    let bridge = testProducer(20, "2000")
+    let controller = testProducer(30, "3000", role: .foregroundController)
+    let targetA = AllowedForegroundTarget(pid: 40, startIdentity: "4000", windowID: 401)
+    let targetB = AllowedForegroundTarget(pid: 40, startIdentity: "4000", windowID: 402)
+    let inactive = AllowedForegroundActivity(active: false, target: nil)
+    let machine = MonitorEpochMachine(initialAuthorization: testAuthorization(testProducerSet(
+        revision: 1,
+        producers: [bridge],
+        foreground: inactive)))
+    let grant = testAuthorization(testProducerSet(
+        revision: 2,
+        producers: [bridge, controller],
+        foreground: AllowedForegroundActivity(active: true, target: targetA)))
+    let retarget = testAuthorization(testProducerSet(
+        revision: 3,
+        producers: [bridge, controller],
+        foreground: AllowedForegroundActivity(active: true, target: targetB)))
+    let revoke = testAuthorization(testProducerSet(revision: 4, producers: [bridge], foreground: inactive))
+    guard machine.publish(grant) == .published else { return false }
+    machine.admitForTesting(.input(InputEventEvidence(
+        type: CGEventType.keyDown.rawValue,
+        source: testEvidence(30, "3000", nil),
+        sessionFocus: testEvidence(40, "4000", 401))))
+    guard machine.publish(retarget) == .published else { return false }
+    machine.admitForTesting(.focus(FocusEventEvidence(
+        observer: ProcessGenerationIdentity(pid: 40, startIdentity: "4000"),
+        observed: testEvidence(40, "4000", 401))))
+    guard machine.publish(revoke) == .published else { return false }
+    machine.admitForTesting(.input(InputEventEvidence(
+        type: CGEventType.keyDown.rawValue,
+        source: testEvidence(30, "3000", nil),
+        sessionFocus: testEvidence(40, "4000", 402))))
+    let events = machine.closeForHeartbeat().epochs.flatMap(\.events)
+    return events.count == 3 && events.map(\.epoch.authorization.revision) == [2, 3, 4]
+}
+
+private enum FakeFocusObserverError: Error {
+    case requestedFailure
+}
+
+private final class FakeFocusObserverStore {
+    var failStart = Set<ProcessGenerationIdentity>()
+    var failStop = Set<ProcessGenerationIdentity>()
+    var starts = [ProcessGenerationIdentity]()
+    var stops = [ProcessGenerationIdentity]()
+}
+
+private final class FakeFocusObserver: FocusObserverTracking {
+    let identity: ProcessGenerationIdentity
+    private let store: FakeFocusObserverStore
+
+    init(identity: ProcessGenerationIdentity, store: FakeFocusObserverStore) {
+        self.identity = identity
+        self.store = store
+    }
+
+    func start() throws {
+        if self.store.failStart.contains(self.identity) {
+            throw FakeFocusObserverError.requestedFailure
+        }
+        self.store.starts.append(self.identity)
+    }
+
+    func stop() throws {
+        if self.store.failStop.contains(self.identity) {
+            throw FakeFocusObserverError.requestedFailure
+        }
+        self.store.stops.append(self.identity)
+    }
+}
+
+private func observerLifecycleIsBarrierBound() -> Bool {
+    let baseline = ProcessGenerationIdentity(pid: 10, startIdentity: "1000")
+    let first = AllowedForegroundTarget(pid: 40, startIdentity: "4000", windowID: 401)
+    let sameProcessWindow = AllowedForegroundTarget(pid: 40, startIdentity: "4000", windowID: 402)
+    let second = AllowedForegroundTarget(pid: 41, startIdentity: "4100", windowID: 411)
+    let failedInstall = AllowedForegroundTarget(pid: 42, startIdentity: "4200", windowID: 421)
+    let bridge = testProducer(20, "2000")
+    let controller = testProducer(30, "3000", role: .foregroundController)
+    let inactive = AllowedForegroundActivity(active: false, target: nil)
+    let store = FakeFocusObserverStore()
+    let coordinator = FocusObserverCoordinator { FakeFocusObserver(identity: $0, store: store) }
+    do {
+        try coordinator.startBaseline(baseline)
+    } catch {
+        return false
+    }
+    let machine = MonitorEpochMachine(initialAuthorization: testAuthorization(testProducerSet(
+        revision: 1,
+        producers: [bridge],
+        foreground: inactive)))
+    let identities: (Int32) -> UInt64? = {
+        [10: 1000, 20: 2000, 30: 3000, 40: 4000, 41: 4100, 42: 4200][$0]
+    }
+    let targetValidator: (AllowedForegroundTarget) -> Bool = { _ in true }
+
+    applyMonitorAuthorization(
+        testProducerSet(
+            revision: 2,
+            producers: [bridge, controller],
+            foreground: AllowedForegroundActivity(active: true, target: first)),
+        to: machine,
+        observers: coordinator,
+        processIdentity: identities,
+        targetValidator: targetValidator)
+    let firstIdentity = ProcessGenerationIdentity(pid: 40, startIdentity: "4000")
+    let secondIdentity = ProcessGenerationIdentity(pid: 41, startIdentity: "4100")
+    guard coordinator.observedIdentities == Set([baseline, firstIdentity]),
+          closeMonitorEpoch(machine, observers: coordinator).transitionAcknowledged
+    else {
+        return false
+    }
+
+    applyMonitorAuthorization(
+        testProducerSet(
+            revision: 3,
+            producers: [bridge, controller],
+            foreground: AllowedForegroundActivity(active: true, target: sameProcessWindow)),
+        to: machine,
+        observers: coordinator,
+        processIdentity: identities,
+        targetValidator: targetValidator)
+    guard coordinator.observedIdentities == Set([baseline, firstIdentity]),
+          closeMonitorEpoch(machine, observers: coordinator).transitionAcknowledged
+    else {
+        return false
+    }
+
+    applyMonitorAuthorization(
+        testProducerSet(
+            revision: 4,
+            producers: [bridge, controller],
+            foreground: AllowedForegroundActivity(active: true, target: second)),
+        to: machine,
+        observers: coordinator,
+        processIdentity: identities,
+        targetValidator: targetValidator)
+    guard coordinator.observedIdentities == Set([baseline, firstIdentity, secondIdentity]) else {
+        return false
+    }
+    let retargetAcknowledgement = closeMonitorEpoch(machine, observers: coordinator)
+    guard retargetAcknowledgement.transitionAcknowledged,
+          coordinator.observedIdentities == Set([baseline, secondIdentity]),
+          store.stops == [firstIdentity]
+    else {
+        return false
+    }
+
+    let failedInstallIdentity = ProcessGenerationIdentity(pid: 42, startIdentity: "4200")
+    store.failStart.insert(failedInstallIdentity)
+    applyMonitorAuthorization(
+        testProducerSet(
+            revision: 5,
+            producers: [bridge, controller],
+            foreground: AllowedForegroundActivity(active: true, target: failedInstall)),
+        to: machine,
+        observers: coordinator,
+        processIdentity: identities,
+        targetValidator: targetValidator)
+    let failedInstallClosure = closeMonitorEpoch(machine, observers: coordinator)
+    guard machine.currentAuthorization.revision == 4,
+          !coordinator.observedIdentities.contains(failedInstallIdentity),
+          failedInstallClosure.epochs.flatMap(\.events).contains(where: {
+              if case .attributionFailure(reason: "blocked_focus_observer_install", process: nil) = $0.kind {
+                  return true
+              }
+              return false
+          })
+    else {
+        return false
+    }
+
+    store.failStop.insert(secondIdentity)
+    applyMonitorAuthorization(
+        testProducerSet(revision: 6, producers: [bridge], foreground: inactive),
+        to: machine,
+        observers: coordinator,
+        processIdentity: identities,
+        targetValidator: targetValidator)
+    let failedRemovalClosure = closeMonitorEpoch(machine, observers: coordinator)
+    return machine.currentAuthorization.revision == 6 && failedRemovalClosure.transitionAcknowledged &&
+        coordinator.observedIdentities.contains(secondIdentity) &&
+        failedRemovalClosure.epochs.flatMap(\.events).contains(where: {
+            if case .attributionFailure(reason: "blocked_focus_observer_removal", process: nil) = $0.kind {
+                return true
+            }
+            return false
+        })
+}
+
+private func decodeJSONLines<T: Decodable>(_ type: T.Type, at path: String) -> [T] {
+    guard let contents = try? String(contentsOfFile: path, encoding: .utf8) else { return [] }
+    return contents.split(separator: "\n").compactMap {
+        try? JSONDecoder().decode(type, from: Data($0.utf8))
+    }
+}
+
+private func makeSelfTestWatchState(
+    desktop: (sample: SystemSample, baseline: InteractiveBaseline),
+    projection: InvariantProjection,
+    outputPath: String,
+    contaminationPath: String,
+    physicalInputObservational: Bool = true,
+    cursorObservational: Bool = true) -> WatchState
+{
+    WatchState(
+        baseline: desktop.sample,
+        interactiveBaseline: desktop.baseline,
+        allowClipboardMutation: false,
+        physicalInputObservational: physicalInputObservational,
+        cursorObservational: cursorObservational,
+        projection: projection,
+        outputPath: outputPath,
+        contaminationOutputPath: contaminationPath)
+}
+
+private func transitionAcknowledgementNeverAdvancesClean(
+    directory: String,
+    projection: InvariantProjection) throws -> Bool
+{
+    let desktop = selfTestDesktop()
+    let bridgeA = testProducer(20, "2000")
+    let bridgeB = testProducer(21, "2100")
+    let first = testAuthorization(testProducerSet(revision: 1, producers: [bridgeA]))
+    let second = testAuthorization(testProducerSet(revision: 2, producers: [bridgeA, bridgeB]))
+    let machine = MonitorEpochMachine(initialAuthorization: first)
+    var watch = makeSelfTestWatchState(
+        desktop: desktop,
+        projection: projection,
+        outputPath: "\(directory)/ack-violations.jsonl",
+        contaminationPath: "\(directory)/ack-contamination.jsonl")
+    let identities: (Int32) -> UInt64? = { [10: 1000, 20: 2000, 21: 2100][$0] }
+    let firstHeartbeat = try watch.observe(
+        current: desktop.sample,
+        phase: "running",
+        closure: machine.closeForHeartbeat(),
+        processIdentity: identities,
+        targetValidator: { _ in true })
+    guard machine.publish(second) == .published else { return false }
+    let acknowledgement = try watch.observe(
+        current: desktop.sample,
+        phase: "running",
+        closure: machine.closeForHeartbeat(),
+        processIdentity: identities,
+        targetValidator: { _ in true })
+    let settled = try watch.observe(
+        current: desktop.sample,
+        phase: "running",
+        closure: machine.closeForHeartbeat(),
+        processIdentity: identities,
+        targetValidator: { _ in true })
+    return firstHeartbeat.lastCleanSequence == 1 &&
+        acknowledgement.allowedProducerRevision == 2 && acknowledgement.transitionAcknowledged &&
+        acknowledgement.lastCleanSequence == 1 &&
+        settled.allowedProducerRevision == 2 && !settled.transitionAcknowledged &&
+        settled.lastCleanSequence == settled.sequence
+}
+
+private func wrongWindowThenTargetStillViolates(
+    directory: String,
+    projection: InvariantProjection) throws -> Bool
+{
+    let desktop = selfTestDesktop()
+    let bridge = testProducer(20, "2000")
+    let controller = testProducer(30, "3000", role: .foregroundController)
+    let target = AllowedForegroundTarget(pid: 40, startIdentity: "4000", windowID: 401)
+    let authorization = testAuthorization(testProducerSet(
+        revision: 2,
+        producers: [bridge, controller],
+        foreground: AllowedForegroundActivity(active: true, target: target)))
+    let machine = MonitorEpochMachine(initialAuthorization: authorization)
+    let observer = ProcessGenerationIdentity(pid: 40, startIdentity: "4000")
+    machine.admitForTesting(.focus(FocusEventEvidence(
+        observer: observer,
+        observed: testEvidence(40, "4000", 499))))
+    machine.admitForTesting(.focus(FocusEventEvidence(
+        observer: observer,
+        observed: testEvidence(40, "4000", 401))))
+    let output = "\(directory)/wrong-window-violations.jsonl"
+    var watch = makeSelfTestWatchState(
+        desktop: desktop,
+        projection: projection,
+        outputPath: output,
+        contaminationPath: "\(directory)/wrong-window-contamination.jsonl")
+    let current = SystemSample(
+        timestamp: 2,
+        frontmostPID: 40,
+        frontmostBundleIdentifier: nil,
+        frontmostWindowID: 401,
+        cursor: desktop.sample.cursor,
+        clipboardChangeCount: desktop.sample.clipboardChangeCount,
+        clipboardDigest: "",
+        peekabooWindowIDs: desktop.sample.peekabooWindowIDs,
+        visibleScreenFramesTopLeft: desktop.sample.visibleScreenFramesTopLeft)
+    let heartbeat = try watch.observe(
+        current: current,
+        phase: "running",
+        closure: machine.closeForHeartbeat(),
+        processIdentity: { [10: 1000, 20: 2000, 30: 3000, 40: 4000][$0] },
+        targetValidator: { $0 == target })
+    let kinds = Set(decodeJSONLines(Violation.self, at: output).map(\.kind))
+    return kinds.contains(projection[.frontmostWindow]) && !heartbeat.contaminationBlocked
+}
+
+private func authorizedForegroundEvidenceIsClean(
+    directory: String,
+    projection: InvariantProjection) throws -> Bool
+{
+    let desktop = selfTestDesktop()
+    let bridge = testProducer(20, "2000")
+    let controller = testProducer(30, "3000", role: .foregroundController)
+    let target = AllowedForegroundTarget(pid: 40, startIdentity: "4000", windowID: 401)
+    let authorization = testAuthorization(testProducerSet(
+        revision: 2,
+        producers: [bridge, controller],
+        foreground: AllowedForegroundActivity(active: true, target: target)))
+    let machine = MonitorEpochMachine(initialAuthorization: authorization)
+    machine.admitForTesting(.input(InputEventEvidence(
+        type: CGEventType.keyDown.rawValue,
+        source: testEvidence(30, "3000", nil),
+        sessionFocus: testEvidence(40, "4000", 401))))
+    machine.admitForTesting(.activation(testEvidence(40, "4000", 401)))
+    machine.admitForTesting(.focus(FocusEventEvidence(
+        observer: ProcessGenerationIdentity(pid: 40, startIdentity: "4000"),
+        observed: testEvidence(40, "4000", 401))))
+    let output = "\(directory)/authorized-foreground-violations.jsonl"
+    var watch = makeSelfTestWatchState(
+        desktop: desktop,
+        projection: projection,
+        outputPath: output,
+        contaminationPath: "\(directory)/authorized-foreground-contamination.jsonl")
+    let current = SystemSample(
+        timestamp: 2,
+        frontmostPID: 40,
+        frontmostBundleIdentifier: nil,
+        frontmostWindowID: 401,
+        cursor: desktop.sample.cursor,
+        clipboardChangeCount: desktop.sample.clipboardChangeCount,
+        clipboardDigest: "",
+        peekabooWindowIDs: desktop.sample.peekabooWindowIDs,
+        visibleScreenFramesTopLeft: desktop.sample.visibleScreenFramesTopLeft)
+    let heartbeat = try watch.observe(
+        current: current,
+        phase: "running",
+        closure: machine.closeForHeartbeat(),
+        processIdentity: { [10: 1000, 20: 2000, 30: 3000, 40: 4000][$0] },
+        targetValidator: { $0 == target })
+    return heartbeat.lastCleanSequence == heartbeat.sequence &&
+        heartbeat.attributedForegroundEventCount == 1 &&
+        heartbeat.attributedForegroundSourcePIDs == [30] &&
+        heartbeat.foregroundActivityObserved && !heartbeat.contaminationBlocked &&
+        decodeJSONLines(Violation.self, at: output).isEmpty
+}
+
+private func currentTargetDriftFailsClosed(
+    directory: String,
+    projection: InvariantProjection) throws -> Bool
+{
+    let desktop = selfTestDesktop()
+    let bridge = testProducer(20, "2000")
+    let controller = testProducer(30, "3000", role: .foregroundController)
+    let target = AllowedForegroundTarget(pid: 40, startIdentity: "4000", windowID: 401)
+    let authorization = testAuthorization(testProducerSet(
+        revision: 2,
+        producers: [bridge, controller],
+        foreground: AllowedForegroundActivity(active: true, target: target)))
+    let machine = MonitorEpochMachine(initialAuthorization: authorization)
+    let contamination = "\(directory)/current-target-drift-contamination.jsonl"
+    var watch = makeSelfTestWatchState(
+        desktop: desktop,
+        projection: projection,
+        outputPath: "\(directory)/current-target-drift-violations.jsonl",
+        contaminationPath: contamination)
+    let heartbeat = try watch.observe(
+        current: desktop.sample,
+        phase: "running",
+        closure: machine.closeForHeartbeat(),
+        processIdentity: { [10: 1000, 20: 2000, 30: 3000][$0] },
+        targetValidator: { _ in false })
+    let states = Set(decodeJSONLines(ContaminationRecord.self, at: contamination).map(\.state))
+    return heartbeat.contaminationBlocked && !heartbeat.inputAttributionAvailable &&
+        states == Set(["blocked_foreground_target_drift"])
+}
+
+private func controllerGenerationDriftFailsClosed(
+    directory: String,
+    projection: InvariantProjection) throws -> Bool
+{
+    let desktop = selfTestDesktop()
+    let bridge = testProducer(20, "2000")
+    let controller = testProducer(30, "3000", role: .foregroundController)
+    let target = AllowedForegroundTarget(pid: 40, startIdentity: "4000", windowID: 401)
+    let authorization = testAuthorization(testProducerSet(
+        revision: 2,
+        producers: [bridge, controller],
+        foreground: AllowedForegroundActivity(active: true, target: target)))
+    let machine = MonitorEpochMachine(initialAuthorization: authorization)
+    machine.admitForTesting(.input(InputEventEvidence(
+        type: CGEventType.keyDown.rawValue,
+        source: testEvidence(30, "3001", nil),
+        sessionFocus: testEvidence(40, "4000", 401))))
+    let contamination = "\(directory)/controller-drift-contamination.jsonl"
+    var watch = makeSelfTestWatchState(
+        desktop: desktop,
+        projection: projection,
+        outputPath: "\(directory)/controller-drift-violations.jsonl",
+        contaminationPath: contamination)
+    let heartbeat = try watch.observe(
+        current: desktop.sample,
+        phase: "running",
+        closure: machine.closeForHeartbeat(),
+        processIdentity: { [10: 1000, 20: 2000, 30: 3001, 40: 4000][$0] },
+        targetValidator: { $0 == target })
+    let states = Set(decodeJSONLines(ContaminationRecord.self, at: contamination).map(\.state))
+    return heartbeat.contaminationBlocked && !heartbeat.inputAttributionAvailable &&
+        states == Set(["blocked_producer_generation_drift"])
+}
+
+private func deferredTargetDriftFailsClosed(
+    directory: String,
+    projection: InvariantProjection) throws -> Bool
+{
+    let desktop = selfTestDesktop()
+    let bridge = testProducer(20, "2000")
+    let controller = testProducer(30, "3000", role: .foregroundController)
+    let target = AllowedForegroundTarget(pid: 40, startIdentity: "4000", windowID: 401)
+    let active = testAuthorization(testProducerSet(
+        revision: 1,
+        producers: [bridge, controller],
+        foreground: AllowedForegroundActivity(active: true, target: target)))
+    let revoked = testAuthorization(testProducerSet(
+        revision: 2,
+        producers: [bridge],
+        foreground: AllowedForegroundActivity(active: false, target: nil)))
+    let machine = MonitorEpochMachine(initialAuthorization: active)
+    guard machine.publish(revoked) == .published else { return false }
+    let contamination = "\(directory)/deferred-target-drift-contamination.jsonl"
+    var watch = makeSelfTestWatchState(
+        desktop: desktop,
+        projection: projection,
+        outputPath: "\(directory)/deferred-target-drift-violations.jsonl",
+        contaminationPath: contamination)
+    let heartbeat = try watch.observe(
+        current: desktop.sample,
+        phase: "running",
+        closure: machine.closeForHeartbeat(),
+        processIdentity: { [10: 1000, 20: 2000, 30: 3000, 40: 4001][$0] },
+        targetValidator: { _ in false })
+    let states = Set(decodeJSONLines(ContaminationRecord.self, at: contamination).map(\.state))
+    return heartbeat.transitionAcknowledged && heartbeat.contaminationBlocked &&
+        states == Set(["blocked_foreground_target_drift"])
+}
+
+private func physicalCursorIsObservationalButOtherInputContaminates(
+    directory: String,
+    projection: InvariantProjection) throws -> Bool
+{
+    let desktop = selfTestDesktop()
+    let authorization = testAuthorization(testProducerSet(revision: 1, producers: []))
+    let physicalMachine = MonitorEpochMachine(initialAuthorization: authorization)
+    physicalMachine.admitForTesting(.input(InputEventEvidence(
+        type: CGEventType.mouseMoved.rawValue,
+        source: testEvidence(0, nil, nil),
+        sessionFocus: testEvidence(10, "1000", 100))))
+    var physicalWatch = makeSelfTestWatchState(
+        desktop: desktop,
+        projection: projection,
+        outputPath: "\(directory)/physical-violations.jsonl",
+        contaminationPath: "\(directory)/physical-contamination.jsonl")
+    let moved = SystemSample(
+        timestamp: 2,
+        frontmostPID: 10,
+        frontmostBundleIdentifier: desktop.sample.frontmostBundleIdentifier,
+        frontmostWindowID: 100,
+        cursor: Point(x: 80, y: 90),
+        clipboardChangeCount: desktop.sample.clipboardChangeCount,
+        clipboardDigest: "",
+        peekabooWindowIDs: desktop.sample.peekabooWindowIDs,
+        visibleScreenFramesTopLeft: desktop.sample.visibleScreenFramesTopLeft)
+    let physicalHeartbeat = try physicalWatch.observe(
+        current: moved,
+        phase: "running",
+        closure: physicalMachine.closeForHeartbeat(),
+        processIdentity: { $0 == 10 ? 1000 : nil },
+        targetValidator: { _ in true })
+
+    let keyMachine = MonitorEpochMachine(initialAuthorization: authorization)
+    keyMachine.admitForTesting(.input(InputEventEvidence(
+        type: CGEventType.keyDown.rawValue,
+        source: testEvidence(0, nil, nil),
+        sessionFocus: testEvidence(10, "1000", 100))))
+    var keyWatch = makeSelfTestWatchState(
+        desktop: desktop,
+        projection: projection,
+        outputPath: "\(directory)/key-violations.jsonl",
+        contaminationPath: "\(directory)/key-contamination.jsonl")
+    let keyHeartbeat = try keyWatch.observe(
+        current: desktop.sample,
+        phase: "running",
+        closure: keyMachine.closeForHeartbeat(),
+        processIdentity: { $0 == 10 ? 1000 : nil },
+        targetValidator: { _ in true })
+    return physicalHeartbeat.cursorMovementObserved && !physicalHeartbeat.contaminationBlocked &&
+        keyHeartbeat.contaminationBlocked
+}
+
+private func unexpectedActivationViolatesFocus(
+    directory: String,
+    projection: InvariantProjection) throws -> Bool
+{
+    let desktop = selfTestDesktop()
+    let machine = MonitorEpochMachine(initialAuthorization: testAuthorization(testProducerSet(
+        revision: 1,
+        producers: [])))
+    machine.admitForTesting(.activation(testEvidence(99, "9900", 991)))
+    let output = "\(directory)/activation-violations.jsonl"
+    var watch = makeSelfTestWatchState(
+        desktop: desktop,
+        projection: projection,
+        outputPath: output,
+        contaminationPath: "\(directory)/activation-contamination.jsonl")
+    _ = try watch.observe(
+        current: desktop.sample,
+        phase: "running",
+        closure: machine.closeForHeartbeat(),
+        processIdentity: { $0 == 10 ? 1000 : nil },
+        targetValidator: { _ in true })
+    let kinds = Set(decodeJSONLines(Violation.self, at: output).map(\.kind))
+    return kinds == Set([projection[.frontmostPID], projection[.frontmostWindow]])
+}
+
+private func runSelfTest() throws {
+    let projection = InvariantProjection(names: InvariantSlot.allCases.map { "slot-\($0.rawValue)" })
+    let desktop = selfTestDesktop()
+    let testDirectory = "\(NSTemporaryDirectory())peekaboo-monitor-epoch-\(UUID().uuidString)"
+    try FileManager.default.createDirectory(
+        atPath: testDirectory,
+        withIntermediateDirectories: false,
+        attributes: [.posixPermissions: 0o700])
+    defer { try? FileManager.default.removeItem(atPath: testDirectory) }
+
     let baselineContext = InvariantEvaluationContext(
-        baseline: baseline,
-        interactiveBaseline: interactiveBaseline,
+        baseline: desktop.sample,
+        interactiveBaseline: desktop.baseline,
         allowClipboardMutation: false,
         evaluateInteractiveInvariants: true,
         cursorObservational: false,
         projection: projection)
-    guard violations(current: baseline, context: baselineContext).isEmpty
-    else {
+    guard violations(current: desktop.sample, context: baselineContext).isEmpty else {
         throw ProbeError.invalidArguments("equal samples must not produce violations")
-    }
-
-    let changed = SystemSample(
-        timestamp: 2,
-        frontmostPID: 102,
-        frontmostBundleIdentifier: nil,
-        frontmostWindowID: 202,
-        cursor: Point(x: 51, y: 60),
-        clipboardChangeCount: 4,
-        clipboardDigest: "different",
-        peekabooWindowIDs: [301, 302],
-        visibleScreenFramesTopLeft: baseline.visibleScreenFramesTopLeft)
-    let kinds = Set(violations(
-        current: changed,
-        context: InvariantEvaluationContext(
-            baseline: baseline,
-            interactiveBaseline: interactiveBaseline,
-            allowClipboardMutation: false,
-            evaluateInteractiveInvariants: true,
-            cursorObservational: false,
-            projection: projection)).map(\.kind))
-    let expected = Set(projection.names).subtracting([projection[.globalInputEvent]])
-    guard kinds == expected else {
-        throw ProbeError.invalidArguments("self-test violation mismatch: \(kinds)")
-    }
-    let allowedKinds = Set(violations(
-        current: changed,
-        context: InvariantEvaluationContext(
-            baseline: baseline,
-            interactiveBaseline: interactiveBaseline,
-            allowClipboardMutation: true,
-            evaluateInteractiveInvariants: true,
-            cursorObservational: false,
-            projection: projection)).map(\.kind))
-    guard !allowedKinds.contains(projection[.clipboardChangeCount]) else {
-        throw ProbeError.invalidArguments("clipboard mutation allowance was ignored")
-    }
-
-    let contaminatedKinds = Set(violations(
-        current: changed,
-        context: InvariantEvaluationContext(
-            baseline: baseline,
-            interactiveBaseline: interactiveBaseline,
-            allowClipboardMutation: false,
-            evaluateInteractiveInvariants: false,
-            cursorObservational: false,
-            projection: projection)).map(\.kind))
-    guard !contaminatedKinds.contains(projection[.frontmostPID]),
-          !contaminatedKinds.contains(projection[.frontmostWindow]),
-          !contaminatedKinds.contains(projection[.physicalCursor]),
-          contaminatedKinds.contains(projection[.clipboardChangeCount]),
-          contaminatedKinds.contains(projection[.peekabooOverlayWindow])
-    else {
-        throw ProbeError.invalidArguments("contaminated samples weakened fixed desktop invariants")
-    }
-
-    var contaminationState = AttemptContaminationState()
-    contaminationState.observe(externalInput: true, attributionFailed: false)
-    contaminationState.observe(externalInput: false, attributionFailed: false)
-    guard contaminationState.blocked, !contaminationState.permitsInteractiveEvaluation else {
-        throw ProbeError.invalidArguments("contamination did not remain sticky for the attempt")
-    }
-
-    let producerBatch = InputEventBatch(
-        producerEventCount: 1,
-        producerSourcePIDs: [getpid()],
-        producerEventTypes: [CGEventType.mouseMoved.rawValue],
-        externalEventCount: 0,
-        externalSourcePIDs: [],
-        externalEventTypes: [],
-        attributionFailed: false)
-    guard producerInputViolation(batch: producerBatch, projection: projection)?.kind ==
-        projection[.globalInputEvent]
-    else {
-        throw ProbeError.invalidArguments("global producer input was not retained as an invariant violation")
-    }
-    guard physicalInputPolicyIsSafe() else {
-        throw ProbeError.invalidArguments("only hardware-origin cursor motion may be observational")
-    }
-    guard let selfIdentity = processStartIdentity(pid: getpid()),
-          producerEventsMatchReceipts(
-              batch: producerBatch,
-              receipts: [getpid(): String(selfIdentity)],
-              processIdentity: processStartIdentity(pid:)),
-          !producerEventsMatchReceipts(
-              batch: producerBatch,
-              receipts: [getpid(): String(selfIdentity &+ 1)],
-              processIdentity: processStartIdentity(pid:))
-    else {
-        throw ProbeError.invalidArguments("producer event generation receipts did not fail closed")
     }
     guard InputEventTracker.validateMonitoredEventMask() else {
         throw ProbeError.invalidArguments("input event mask does not cover the complete public input family")
     }
     guard producerReceiptSchemaIsLossless() else {
-        throw ProbeError.invalidArguments("producer start identities must decode as lossless decimal strings")
+        throw ProbeError.invalidArguments("producer receipt schema lost default roles or decimal identities")
     }
-    let transientKinds = Set(transientFocusViolations(
-        externalEventCount: 0,
-        unexpectedActivations: [102],
-        focusedWindowChanged: true,
-        baseline: interactiveBaseline,
-        projection: projection).map(\.kind))
-    guard transientKinds == Set([projection[.frontmostPID], projection[.frontmostWindow]]),
-          transientFocusViolations(
-              externalEventCount: 1,
-              unexpectedActivations: [102],
-              focusedWindowChanged: true,
-              baseline: interactiveBaseline,
-              projection: projection).isEmpty
+    guard foregroundAuthorizationSchemaIsStrict() else {
+        throw ProbeError.invalidArguments("foreground authorization schema accepted an invalid role or target")
+    }
+    guard recordPublishDrainIsLinearizable() else {
+        throw ProbeError.invalidArguments("concurrent record, publish, and drain lost or relabeled evidence")
+    }
+    guard exactPublicationCutoffIsClosed() else {
+        throw ProbeError.invalidArguments("events at the publication cutoff did not retain exact epochs")
+    }
+    guard queuedRevisionsRemainDistinct() else {
+        throw ProbeError.invalidArguments("grant, retarget, generation change, or revoke epochs collapsed")
+    }
+    guard equalRevisionRequiresExactPayload() else {
+        throw ProbeError.invalidArguments("equal revision reorder/mutation semantics were not fail-closed")
+    }
+    guard grantRetargetRevokeRetainsEventEpochs() else {
+        throw ProbeError.invalidArguments("grant-era evidence was relabeled after retarget or revoke")
+    }
+    guard observerLifecycleIsBarrierBound() else {
+        throw ProbeError.invalidArguments("focus observer install/remove barrier contract failed")
+    }
+    guard try transitionAcknowledgementNeverAdvancesClean(
+        directory: testDirectory,
+        projection: projection)
     else {
-        throw ProbeError.invalidArguments("transient focus attribution did not distinguish external input")
+        throw ProbeError.invalidArguments("transition acknowledgement advanced the clean sequence")
+    }
+    guard try wrongWindowThenTargetStillViolates(directory: testDirectory, projection: projection) else {
+        throw ProbeError.invalidArguments("wrong-window callback collapsed into a later target callback")
+    }
+    guard try authorizedForegroundEvidenceIsClean(directory: testDirectory, projection: projection) else {
+        throw ProbeError.invalidArguments("exact foreground controller/focus evidence was not credited")
+    }
+    guard try currentTargetDriftFailsClosed(directory: testDirectory, projection: projection) else {
+        throw ProbeError.invalidArguments("current target generation/window drift did not fail closed")
+    }
+    guard try controllerGenerationDriftFailsClosed(directory: testDirectory, projection: projection) else {
+        throw ProbeError.invalidArguments("recycled foreground controller did not fail closed")
+    }
+    guard try deferredTargetDriftFailsClosed(directory: testDirectory, projection: projection) else {
+        throw ProbeError.invalidArguments("deferred target generation/window drift did not fail closed")
+    }
+    guard try physicalCursorIsObservationalButOtherInputContaminates(
+        directory: testDirectory,
+        projection: projection)
+    else {
+        throw ProbeError.invalidArguments("physical cursor and unrelated input policies were conflated")
+    }
+    guard try unexpectedActivationViolatesFocus(directory: testDirectory, projection: projection) else {
+        throw ProbeError.invalidArguments("unexpected activation did not retain callback-time focus evidence")
     }
 
-    let cursorObservationalKinds = Set(violations(
-        current: changed,
-        context: InvariantEvaluationContext(
-            baseline: baseline,
-            interactiveBaseline: interactiveBaseline,
-            allowClipboardMutation: false,
-            evaluateInteractiveInvariants: true,
-            cursorObservational: true,
-            projection: projection)).map(\.kind))
-    guard !cursorObservationalKinds.contains(projection[.physicalCursor]),
-          cursorObservationalKinds.contains(projection[.frontmostPID]),
-          cursorObservationalKinds.contains(projection[.frontmostWindow])
-    else {
-        throw ProbeError.invalidArguments("observational cursor mode weakened focus invariants")
-    }
-
-    try writeJSON(SelfTestResult(success: true, tests: 14), to: nil)
+    try writeJSON(SelfTestResult(success: true, tests: 18), to: nil)
 }
 
 private func findApp(arguments: [String]) throws {

--- a/scripts/support/background-computer-use-probe.swift
+++ b/scripts/support/background-computer-use-probe.swift
@@ -63,6 +63,29 @@ private struct WatchHeartbeat: Codable {
     let attributedForegroundEventCount: Int
     let attributedForegroundSourcePIDs: [Int32]
     let foregroundActivityObserved: Bool
+
+    func withTransitionAcknowledged(_ acknowledged: Bool) -> WatchHeartbeat {
+        WatchHeartbeat(
+            sequence: self.sequence,
+            timestamp: self.timestamp,
+            lastCleanSequence: self.lastCleanSequence,
+            contaminationRetries: self.contaminationRetries,
+            contaminationBlocked: self.contaminationBlocked,
+            inputAttributionAvailable: self.inputAttributionAvailable,
+            allowedProducerRevision: self.allowedProducerRevision,
+            phase: self.phase,
+            cursorMovementObserved: self.cursorMovementObserved,
+            pendingActivationCount: self.pendingActivationCount,
+            pendingFocusedWindowChange: self.pendingFocusedWindowChange,
+            authorizationEpoch: self.authorizationEpoch,
+            transitionAcknowledged: acknowledged,
+            foregroundActive: self.foregroundActive,
+            foregroundTargetPID: self.foregroundTargetPID,
+            foregroundTargetWindowID: self.foregroundTargetWindowID,
+            attributedForegroundEventCount: self.attributedForegroundEventCount,
+            attributedForegroundSourcePIDs: self.attributedForegroundSourcePIDs,
+            foregroundActivityObserved: self.foregroundActivityObserved)
+    }
 }
 
 private struct ContaminationRecord: Codable {
@@ -239,11 +262,44 @@ private struct MonitorAuthorization: Equatable, Sendable {
     }
 }
 
+private enum MonitorEpochPhase: Equatable, Sendable {
+    case stable
+    case transition(prior: MonitorAuthorization)
+    case awaitingAcknowledgement(prior: MonitorAuthorization)
+
+    var priorAuthorization: MonitorAuthorization? {
+        switch self {
+        case .stable:
+            nil
+        case let .transition(prior), let .awaitingAcknowledgement(prior):
+            prior
+        }
+    }
+
+    var isStable: Bool {
+        if case .stable = self {
+            return true
+        }
+        return false
+    }
+
+    var requiresAcknowledgementHeartbeat: Bool {
+        if case .transition = self {
+            return true
+        }
+        return false
+    }
+}
+
 private struct MonitorEpoch: Equatable, Sendable {
     let serial: UInt64
     let authorization: MonitorAuthorization
     let lowerAdmissionCutoff: UInt64
-    let transitionBarrier: Bool
+    let phase: MonitorEpochPhase
+
+    var focusAuthorization: MonitorAuthorization {
+        self.phase.priorAuthorization ?? self.authorization
+    }
 }
 
 private struct InputEventEvidence: Equatable, Sendable {
@@ -285,11 +341,12 @@ private struct MonitorEpochClosure: Sendable {
     }
 
     var transitionAcknowledged: Bool {
-        self.epochs.contains { $0.epoch.transitionBarrier }
-    }
-
-    func appending(_ other: MonitorEpochClosure) -> MonitorEpochClosure {
-        MonitorEpochClosure(epochs: self.epochs + other.epochs)
+        self.epochs.contains {
+            if case .transition = $0.epoch.phase {
+                return true
+            }
+            return false
+        }
     }
 }
 
@@ -316,11 +373,12 @@ private struct MonitorEpochMachineState: Sendable {
     var sealedBuckets = [MonitorEpochBucket]()
     var lastAdmission: UInt64 = 0
     var nextEpochSerial: UInt64 = 2
+    var acknowledgementReadyRevision: UInt64?
 }
 
 /// The one publication/admission authority for input, activation, and focus callbacks.
-/// A callback samples evidence while holding this cutoff, so it can only land wholly
-/// before or wholly after a policy publication.
+/// A callback reserves its epoch under this cutoff, samples outside the lock, and
+/// cannot be drained until that exact reservation completes.
 private final class MonitorEpochMachine: Sendable {
     private let state: Mutex<MonitorEpochMachineState>
 
@@ -330,11 +388,15 @@ private final class MonitorEpochMachine: Sendable {
                 serial: 1,
                 authorization: initialAuthorization,
                 lowerAdmissionCutoff: 0,
-                transitionBarrier: false))))
+                phase: .stable))))
     }
 
     var currentAuthorization: MonitorAuthorization {
         self.state.withLock { $0.openBucket.epoch.authorization }
+    }
+
+    var currentPhase: MonitorEpochPhase {
+        self.state.withLock { $0.openBucket.epoch.phase }
     }
 
     func publish(_ authorization: MonitorAuthorization) -> MonitorPublicationResult {
@@ -348,12 +410,15 @@ private final class MonitorEpochMachine: Sendable {
             guard authorization.revision > current.revision else {
                 return .rejected(reason: "blocked_producer_revision_replay")
             }
+            guard state.openBucket.epoch.phase.isStable else {
+                return .rejected(reason: "blocked_producer_revision_before_ack")
+            }
             Self.sealOpenBucket(state: &state)
             state.openBucket = MonitorEpochBucket(epoch: MonitorEpoch(
                 serial: state.nextEpochSerial,
                 authorization: authorization,
                 lowerAdmissionCutoff: state.lastAdmission,
-                transitionBarrier: true))
+                phase: .transition(prior: current)))
             state.nextEpochSerial += 1
             return .published
         }
@@ -364,7 +429,7 @@ private final class MonitorEpochMachine: Sendable {
         evidence: (MonitorAuthorization) -> (source: ProcessWindowEvidence, sessionFocus: ProcessWindowEvidence?))
     {
         let token = self.reserve()
-        let sample = evidence(token.epoch.authorization)
+        let sample = evidence(token.epoch.focusAuthorization)
         let kind = MonitorEventKind.input(InputEventEvidence(
             type: type.rawValue,
             source: sample.source,
@@ -414,19 +479,73 @@ private final class MonitorEpochMachine: Sendable {
     func closeForHeartbeat() -> MonitorEpochClosure? {
         self.state.withLock { state in
             let shouldSealOpenBucket = state.sealedBuckets.isEmpty ||
-                state.openBucket.epoch.transitionBarrier ||
+                state.openBucket.epoch.phase.requiresAcknowledgementHeartbeat ||
                 !state.openBucket.pendingAdmissions.isEmpty ||
                 !state.openBucket.events.isEmpty
             if shouldSealOpenBucket {
+                let closedEpoch = state.openBucket.epoch
                 Self.sealOpenBucket(state: &state)
                 state.openBucket = MonitorEpochBucket(epoch: MonitorEpoch(
                     serial: state.nextEpochSerial,
-                    authorization: state.openBucket.epoch.authorization,
+                    authorization: closedEpoch.authorization,
                     lowerAdmissionCutoff: state.lastAdmission,
-                    transitionBarrier: false))
+                    phase: Self.continuationPhase(after: closedEpoch.phase)))
                 state.nextEpochSerial += 1
             }
             return Self.drainCompletedPrefix(state: &state)
+        }
+    }
+
+    func acknowledge(revision: UInt64) -> MonitorPublicationResult {
+        self.acknowledge(revision: revision, preparing: {}, publishing: {})
+    }
+
+    func markAcknowledgementReady(revision: UInt64) -> MonitorPublicationResult {
+        self.state.withLock { state in
+            let openEpoch = state.openBucket.epoch
+            guard openEpoch.authorization.revision == revision else {
+                return .rejected(reason: "blocked_producer_ack_revision_mismatch")
+            }
+            guard case .awaitingAcknowledgement = openEpoch.phase else {
+                return .rejected(reason: "blocked_producer_ack_without_transition")
+            }
+            state.acknowledgementReadyRevision = revision
+            return .published
+        }
+    }
+
+    func acknowledge(
+        revision: UInt64,
+        preparing acknowledgementPreparation: () throws -> Void,
+        publishing acknowledgement: () throws -> Void) rethrows -> MonitorPublicationResult
+    {
+        try self.state.withLock { state in
+            let openEpoch = state.openBucket.epoch
+            guard openEpoch.authorization.revision == revision else {
+                return .rejected(reason: "blocked_producer_ack_revision_mismatch")
+            }
+            guard case .awaitingAcknowledgement = openEpoch.phase else {
+                return .rejected(reason: "blocked_producer_ack_without_transition")
+            }
+            guard state.acknowledgementReadyRevision == revision else {
+                return .rejected(reason: "blocked_producer_ack_before_callback_barrier")
+            }
+            guard state.sealedBuckets.isEmpty,
+                  state.openBucket.pendingAdmissions.isEmpty,
+                  state.openBucket.events.isEmpty
+            else {
+                return .rejected(reason: "blocked_producer_ack_evidence_pending")
+            }
+            try acknowledgementPreparation()
+            try acknowledgement()
+            state.openBucket = MonitorEpochBucket(epoch: MonitorEpoch(
+                serial: state.nextEpochSerial,
+                authorization: openEpoch.authorization,
+                lowerAdmissionCutoff: state.lastAdmission,
+                phase: .stable))
+            state.nextEpochSerial += 1
+            state.acknowledgementReadyRevision = nil
+            return .published
         }
     }
 
@@ -479,6 +598,15 @@ private final class MonitorEpochMachine: Sendable {
         state.sealedBuckets.append(state.openBucket)
     }
 
+    private static func continuationPhase(after phase: MonitorEpochPhase) -> MonitorEpochPhase {
+        switch phase {
+        case .stable:
+            .stable
+        case let .transition(prior), let .awaitingAcknowledgement(prior):
+            .awaitingAcknowledgement(prior: prior)
+        }
+    }
+
     private static func drainCompletedPrefix(state: inout MonitorEpochMachineState) -> MonitorEpochClosure? {
         let completedCount = state.sealedBuckets.prefix { $0.pendingAdmissions.isEmpty }.count
         guard completedCount > 0 else { return nil }
@@ -505,6 +633,42 @@ private struct AttemptContaminationState {
     var permitsInteractiveEvaluation: Bool {
         !self.blocked
     }
+}
+
+private final class RunLoopIdleBarrierState: Sendable {
+    private let reached = Mutex(false)
+
+    func markReached() {
+        self.reached.withLock { $0 = true }
+    }
+
+    func wasReached() -> Bool {
+        self.reached.withLock { $0 }
+    }
+}
+
+private func runLoopReachesIdle(timeout: TimeInterval) -> Bool {
+    let runLoop = CFRunLoopGetCurrent()
+    let state = RunLoopIdleBarrierState()
+    guard let observer = CFRunLoopObserverCreateWithHandler(
+        kCFAllocatorDefault,
+        CFRunLoopActivity.beforeWaiting.rawValue,
+        false,
+        0,
+        { _, _ in
+            state.markReached()
+            CFRunLoopStop(runLoop)
+        })
+    else {
+        return false
+    }
+    CFRunLoopAddObserver(runLoop, observer, .defaultMode)
+    defer {
+        CFRunLoopRemoveObserver(runLoop, observer, .defaultMode)
+        CFRunLoopObserverInvalidate(observer)
+    }
+    _ = CFRunLoopRunInMode(.defaultMode, timeout, false)
+    return state.wasReached()
 }
 
 private final class InputEventTracker {
@@ -640,9 +804,7 @@ private final class ActivationTracker {
             }
             let pid = app.processIdentifier
             machine.admitActivation {
-                processWindowEvidence(
-                    pid: pid,
-                    windowID: focusedWindowID(pid: pid))
+                processWindowEvidence(pid: pid) { focusedWindowID(pid: pid) }
             }
         }
     }
@@ -731,11 +893,11 @@ private final class FocusedWindowTracker: FocusObserverTracking {
 
     private func focusedWindowEvidence() -> ProcessWindowEvidence {
         guard let applicationElement = self.applicationElement else {
-            return processWindowEvidence(pid: self.identity.pid, windowID: nil)
+            return processWindowEvidence(pid: self.identity.pid) { nil }
         }
-        return processWindowEvidence(
-            pid: self.identity.pid,
-            windowID: focusedWindowID(applicationElement: applicationElement))
+        return processWindowEvidence(pid: self.identity.pid) {
+            focusedWindowID(applicationElement: applicationElement)
+        }
     }
 }
 
@@ -854,10 +1016,24 @@ private func topWindowPID(windows: [[String: Any]]) -> Int32? {
     }
 }
 
-private func processWindowEvidence(pid: Int32, windowID: UInt32?) -> ProcessWindowEvidence {
-    ProcessWindowEvidence(
+private func sampleProcessWindowEvidence(
+    pid: Int32,
+    processIdentity: () -> UInt64?,
+    windowID: () -> UInt32?) -> ProcessWindowEvidence
+{
+    let identityBefore = processIdentity()
+    let sampledWindowID = windowID()
+    let identityAfter = processIdentity()
+    guard identityBefore == identityAfter, let identityBefore else {
+        return ProcessWindowEvidence(pid: pid, startIdentity: nil, windowID: nil)
+    }
+    return ProcessWindowEvidence(pid: pid, startIdentity: String(identityBefore), windowID: sampledWindowID)
+}
+
+private func processWindowEvidence(pid: Int32, windowID: () -> UInt32?) -> ProcessWindowEvidence {
+    sampleProcessWindowEvidence(
         pid: pid,
-        startIdentity: processStartIdentity(pid: pid).map(String.init),
+        processIdentity: { processStartIdentity(pid: pid) },
         windowID: windowID)
 }
 
@@ -886,7 +1062,7 @@ private func inputEventEvidence(
     sourcePID: Int32,
     authorization: MonitorAuthorization) -> (source: ProcessWindowEvidence, sessionFocus: ProcessWindowEvidence?)
 {
-    let source = processWindowEvidence(pid: sourcePID, windowID: nil)
+    let source = processWindowEvidence(pid: sourcePID) { nil }
     guard authorization.producersByPID[sourcePID]?.effectiveRole == .foregroundController,
           authorization.target != nil
     else {
@@ -894,7 +1070,7 @@ private func inputEventEvidence(
     }
     let sessionFocus = NSWorkspace.shared.frontmostApplication.map { app in
         let pid = app.processIdentifier
-        return processWindowEvidence(pid: pid, windowID: focusedWindowID(pid: pid))
+        return processWindowEvidence(pid: pid) { focusedWindowID(pid: pid) }
     }
     return (source: source, sessionFocus: sessionFocus)
 }
@@ -1044,20 +1220,35 @@ private func foregroundControllerCardinalityIsValid(
         : controllerCount == 0 && foreground.target == nil
 }
 
-private func foregroundTargetIsLive(_ target: AllowedForegroundTarget) -> Bool {
+private func foregroundTargetIsLive(
+    _ target: AllowedForegroundTarget,
+    processIdentity: () -> UInt64?,
+    windowMatches: () -> Bool) -> Bool
+{
     guard target.pid > 0,
           target.windowID > 0,
-          processStartIdentity(pid: target.pid).map(String.init) == target.startIdentity
+          processIdentity().map(String.init) == target.startIdentity,
+          windowMatches(),
+          processIdentity().map(String.init) == target.startIdentity
     else {
         return false
     }
-    let windows = CGWindowListCopyWindowInfo(
-        [.optionIncludingWindow, .excludeDesktopElements],
-        target.windowID) as? [[String: Any]] ?? []
-    return windows.contains { window in
-        (window[kCGWindowOwnerPID as String] as? NSNumber)?.int32Value == target.pid &&
-            (window[kCGWindowNumber as String] as? NSNumber)?.uint32Value == target.windowID
-    }
+    return true
+}
+
+private func foregroundTargetIsLive(_ target: AllowedForegroundTarget) -> Bool {
+    foregroundTargetIsLive(
+        target,
+        processIdentity: { processStartIdentity(pid: target.pid) },
+        windowMatches: {
+            let windows = CGWindowListCopyWindowInfo(
+                [.optionIncludingWindow, .excludeDesktopElements],
+                target.windowID) as? [[String: Any]] ?? []
+            return windows.contains { window in
+                (window[kCGWindowOwnerPID as String] as? NSNumber)?.int32Value == target.pid &&
+                    (window[kCGWindowNumber as String] as? NSNumber)?.uint32Value == target.windowID
+            }
+        })
 }
 
 private func makeMonitorAuthorization(
@@ -1100,6 +1291,7 @@ private func applyMonitorAuthorization(
 {
     let current = machine.currentAuthorization
     if producerSet.revision == current.revision {
+        // Exact rereads are required while this revision waits for its acknowledgement barrier.
         if !current.hasExactlyEquivalentPayload(to: producerSet) {
             machine.admitFailure(reason: "blocked_producer_revision_replay")
         }
@@ -1107,6 +1299,10 @@ private func applyMonitorAuthorization(
     }
     guard producerSet.revision > current.revision else {
         machine.admitFailure(reason: "blocked_producer_revision_replay")
+        return
+    }
+    guard machine.currentPhase.isStable else {
+        machine.admitFailure(reason: "blocked_producer_revision_before_ack")
         return
     }
     let authorization: MonitorAuthorization
@@ -1130,24 +1326,68 @@ private func applyMonitorAuthorization(
     }
 }
 
-private func closeMonitorEpoch(
-    _ machine: MonitorEpochMachine,
-    observers: FocusObserverCoordinator) -> MonitorEpochClosure?
+private func publishMonitorTransitionAcknowledgement(
+    revision: UInt64,
+    machine: MonitorEpochMachine,
+    observers: FocusObserverCoordinator,
+    processIdentity: @escaping (Int32) -> UInt64? = processStartIdentity(pid:),
+    targetValidator: @escaping (AllowedForegroundTarget) -> Bool = foregroundTargetIsLive,
+    publish: () throws -> Void = {}) throws -> MonitorPublicationResult
 {
-    guard var closure = machine.closeForHeartbeat() else { return nil }
-    if closure.transitionAcknowledged,
-       closure.finalEpoch.epoch.authorization.revision == machine.currentAuthorization.revision
-    {
-        do {
-            try observers.reconcile(activeTarget: closure.finalEpoch.epoch.authorization.target)
-        } catch {
-            machine.admitFailure(reason: "blocked_focus_observer_removal")
-            if let failureClosure = machine.closeForHeartbeat() {
-                closure = closure.appending(failureClosure)
-            }
-        }
+    let authorization = machine.currentAuthorization
+    let priorAuthorization = machine.currentPhase.priorAuthorization
+    guard authorization.revision == revision else {
+        return .rejected(reason: "blocked_producer_ack_revision_mismatch")
     }
-    return closure
+    return try machine.acknowledge(
+        revision: revision,
+        preparing: {
+            let authorizations = [authorization] + (priorAuthorization.map { [$0] } ?? [])
+            guard authorizations.allSatisfy({ candidate in
+                candidate.source.producers.filter {
+                    $0.effectiveRole == .foregroundController
+                }.allSatisfy { producer in
+                    processIdentity(producer.pid).map(String.init) == producer.startIdentity
+                } && candidate.target.map(targetValidator) != false
+            }) else {
+                throw ProbeError.invalidArguments("blocked_foreground_ack_liveness")
+            }
+            try observers.reconcile(activeTarget: authorization.target)
+        },
+        publishing: publish)
+}
+
+private struct MonitorAcknowledgementGate {
+    private(set) var pendingRevision: UInt64?
+    private(set) var readyRevision: UInt64?
+
+    mutating func record(_ closure: MonitorEpochClosure) {
+        guard closure.transitionAcknowledged else { return }
+        self.pendingRevision = closure.finalEpoch.epoch.authorization.revision
+        self.readyRevision = nil
+    }
+
+    mutating func completeCallbackBarrier(machine: MonitorEpochMachine) throws {
+        guard let pendingRevision = self.pendingRevision else { return }
+        guard machine.markAcknowledgementReady(revision: pendingRevision) == .published else {
+            throw ProbeError.invalidArguments("blocked_producer_ack_callback_barrier")
+        }
+        self.readyRevision = pendingRevision
+    }
+
+    mutating func didPublish(revision: UInt64) {
+        precondition(self.pendingRevision == revision && self.readyRevision == revision)
+        self.pendingRevision = nil
+        self.readyRevision = nil
+    }
+}
+
+private func monitorRequiresIdleBarrier(
+    pendingAcknowledgementRevision: UInt64?,
+    currentRevision: UInt64,
+    proposedRevision: UInt64) -> Bool
+{
+    pendingAcknowledgementRevision != nil || proposedRevision > currentRevision
 }
 
 private func evidenceMatches(
@@ -1197,13 +1437,8 @@ private func currentFocusViolations(
     projection: InvariantProjection) -> Set<Violation>
 {
     var allowed = Set(["\(baseline.frontmostPID):\(baseline.frontmostWindowID)"])
-    let authorizations = closure.transitionAcknowledged
-        ? closure.epochs.map(\.epoch.authorization)
-        : [closure.finalEpoch.epoch.authorization]
-    for authorization in authorizations {
-        if let target = authorization.target {
-            allowed.insert("\(target.pid):\(target.windowID)")
-        }
+    if let target = closure.finalEpoch.epoch.focusAuthorization.target {
+        allowed.insert("\(target.pid):\(target.windowID)")
     }
     let currentKey = current.frontmostPID.flatMap { pid in
         current.frontmostWindowID.map { "\(pid):\($0)" }
@@ -1239,6 +1474,11 @@ private struct ClosedEpochEvaluation {
     let focusCount: Int
 }
 
+private struct ForegroundActivitySummary {
+    var eventCount = 0
+    var sourcePIDs = Set<Int32>()
+}
+
 private struct WatchState {
     let baseline: SystemSample
     let interactiveBaseline: InteractiveBaseline
@@ -1255,9 +1495,7 @@ private struct WatchState {
     private var contaminationState = AttemptContaminationState()
     private var inputAttributionAvailable = true
     private var cursorMovementObserved = false
-    private var attributedForegroundEventCount = 0
-    private var attributedForegroundSourcePIDs = Set<Int32>()
-    private var foregroundActivityObserved = false
+    private var foregroundActivityByRevision = [UInt64: ForegroundActivitySummary]()
 
     mutating func observe(
         current: SystemSample,
@@ -1291,6 +1529,7 @@ private struct WatchState {
             let evaluation = try self.evaluate(
                 closedEpoch: closedEpoch,
                 phase: phase,
+                processIdentity: processIdentity,
                 targetValidator: targetValidator)
             currentViolations.formUnion(evaluation.violations)
             totalActivationCount += evaluation.activationCount
@@ -1301,19 +1540,17 @@ private struct WatchState {
 
         let evaluateInteractive = allEpochsPermitInteractiveEvaluation && self.inputAttributionAvailable &&
             self.contaminationState.permitsInteractiveEvaluation
+        let finalEpoch = closure.finalEpoch.epoch
+        let focusAuthorization = finalEpoch.focusAuthorization
         let context = InvariantEvaluationContext(
             baseline: self.baseline,
             interactiveBaseline: self.interactiveBaseline,
             allowClipboardMutation: self.allowClipboardMutation,
-            evaluateInteractiveInvariants: evaluateInteractive &&
-                !closure.finalEpoch.epoch.authorization.foreground.active &&
-                !closure.transitionAcknowledged,
+            evaluateInteractiveInvariants: evaluateInteractive && !focusAuthorization.foreground.active,
             cursorObservational: self.cursorObservational,
             projection: self.projection)
         currentViolations.formUnion(violations(current: current, context: context))
-        if evaluateInteractive,
-           closure.finalEpoch.epoch.authorization.foreground.active || closure.transitionAcknowledged
-        {
+        if evaluateInteractive, focusAuthorization.foreground.active {
             currentViolations.formUnion(currentFocusViolations(
                 current: current,
                 closure: closure,
@@ -1334,10 +1571,12 @@ private struct WatchState {
         }
 
         self.sequence += 1
-        if evaluateInteractive, !closure.transitionAcknowledged, currentViolations.isEmpty {
+        if evaluateInteractive, finalEpoch.phase.isStable, currentViolations.isEmpty {
             self.lastCleanSequence = self.sequence
         }
         let finalAuthorization = closure.finalEpoch.epoch.authorization
+        let finalActivity = self.foregroundActivityByRevision[finalAuthorization.revision] ??
+            ForegroundActivitySummary()
         return WatchHeartbeat(
             sequence: self.sequence,
             timestamp: current.timestamp,
@@ -1355,18 +1594,34 @@ private struct WatchState {
             foregroundActive: finalAuthorization.foreground.active,
             foregroundTargetPID: finalAuthorization.target?.pid,
             foregroundTargetWindowID: finalAuthorization.target?.windowID,
-            attributedForegroundEventCount: self.attributedForegroundEventCount,
-            attributedForegroundSourcePIDs: self.attributedForegroundSourcePIDs.sorted(),
-            foregroundActivityObserved: self.foregroundActivityObserved)
+            attributedForegroundEventCount: finalActivity.eventCount,
+            attributedForegroundSourcePIDs: finalActivity.sourcePIDs.sorted(),
+            foregroundActivityObserved: finalActivity.eventCount > 0)
     }
 
     private mutating func evaluate(
         closedEpoch: ClosedMonitorEpoch,
         phase: String,
+        processIdentity: (Int32) -> UInt64?,
         targetValidator: (AllowedForegroundTarget) -> Bool) throws -> ClosedEpochEvaluation
     {
         let authorization = closedEpoch.epoch.authorization
-        if let target = authorization.target, !targetValidator(target) {
+        let producers = Set(
+            (authorization.source.producers + closedEpoch.epoch.focusAuthorization.source.producers).filter {
+                $0.effectiveRole == .foregroundController
+            })
+        for producer in producers
+            where processIdentity(producer.pid).map(String.init) != producer.startIdentity
+        {
+            try self.block(
+                reason: "blocked_producer_generation_drift",
+                sourcePIDs: [producer.pid],
+                eventTypes: [],
+                attributionFailed: true,
+                countsRetry: false)
+        }
+        let targets = Set([authorization.target, closedEpoch.epoch.focusAuthorization.target].compactMap(\.self))
+        for target in targets where !targetValidator(target) {
             try self.block(
                 reason: "blocked_foreground_target_drift",
                 sourcePIDs: [target.pid],
@@ -1376,7 +1631,7 @@ private struct WatchState {
         }
         let classification = try self.classify(
             events: closedEpoch.events,
-            authorization: authorization)
+            epoch: closedEpoch.epoch)
         var epochViolations = Set<Violation>()
         if !classification.bridgeSources.isEmpty {
             epochViolations.insert(Violation(
@@ -1402,7 +1657,7 @@ private struct WatchState {
         } else {
             try epochViolations.formUnion(self.focusViolations(
                 classification.focusEvents,
-                authorization: authorization))
+                authorization: closedEpoch.epoch.focusAuthorization))
         }
         return ClosedEpochEvaluation(
             violations: epochViolations,
@@ -1413,7 +1668,7 @@ private struct WatchState {
 
     private mutating func classify(
         events: [MonitorEvent],
-        authorization: MonitorAuthorization) throws -> ClosedEpochEventClassification
+        epoch: MonitorEpoch) throws -> ClosedEpochEventClassification
     {
         var classification = ClosedEpochEventClassification()
         for event in events {
@@ -1428,7 +1683,7 @@ private struct WatchState {
             case let .input(input):
                 try self.classify(
                     input: input,
-                    authorization: authorization,
+                    epoch: epoch,
                     into: &classification)
             case let .activation(evidence):
                 classification.activationCount += 1
@@ -1453,9 +1708,22 @@ private struct WatchState {
 
     private mutating func classify(
         input: InputEventEvidence,
-        authorization: MonitorAuthorization,
+        epoch: MonitorEpoch,
         into classification: inout ClosedEpochEventClassification) throws
     {
+        let authorization = epoch.focusAuthorization
+        if !epoch.phase.isStable,
+           authorization.producersByPID[input.source.pid] == nil,
+           epoch.authorization.producersByPID[input.source.pid]?.effectiveRole == .foregroundController
+        {
+            try self.block(
+                reason: "blocked_foreground_input_before_transition_ack",
+                sourcePIDs: [input.source.pid],
+                eventTypes: [input.type],
+                attributionFailed: true,
+                countsRetry: false)
+            return
+        }
         guard let producer = authorization.producersByPID[input.source.pid] else {
             classification.externalInputs.append(input)
             return
@@ -1490,10 +1758,16 @@ private struct WatchState {
                     countsRetry: false)
                 return
             }
-            self.attributedForegroundEventCount += 1
-            self.attributedForegroundSourcePIDs.insert(input.source.pid)
-            self.foregroundActivityObserved = true
+            var activity = self.foregroundActivityByRevision[authorization.revision] ??
+                ForegroundActivitySummary()
+            activity.eventCount += 1
+            activity.sourcePIDs.insert(input.source.pid)
+            self.foregroundActivityByRevision[authorization.revision] = activity
         }
+    }
+
+    func foregroundActivity(for revision: UInt64) -> ForegroundActivitySummary {
+        self.foregroundActivityByRevision[revision] ?? ForegroundActivitySummary()
     }
 
     private mutating func focusViolations(
@@ -1568,6 +1842,40 @@ private func writeJSON(_ value: some Encodable, to path: String?) throws {
     } else {
         FileHandle.standardOutput.write(data)
         FileHandle.standardOutput.write(Data("\n".utf8))
+    }
+}
+
+private final class PreparedJSONPublication {
+    private let temporaryURL: URL
+    private let destinationURL: URL
+    private var committed = false
+
+    init(_ value: some Encodable, destinationPath: String) throws {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        var data = try encoder.encode(value)
+        data.append(Data("\n".utf8))
+        self.destinationURL = URL(fileURLWithPath: destinationPath)
+        self.temporaryURL = self.destinationURL
+            .deletingLastPathComponent()
+            .appendingPathComponent(".\(self.destinationURL.lastPathComponent).\(UUID().uuidString).tmp")
+        try data.write(to: self.temporaryURL)
+    }
+
+    deinit {
+        if !self.committed {
+            try? FileManager.default.removeItem(at: self.temporaryURL)
+        }
+    }
+
+    func commit() throws {
+        guard !self.committed else {
+            throw ProbeError.invalidArguments("prepared JSON publication was already committed")
+        }
+        guard rename(self.temporaryURL.path, self.destinationURL.path) == 0 else {
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
+        self.committed = true
     }
 }
 
@@ -1658,15 +1966,28 @@ private func runWatch(arguments: [String]) throws -> Never {
         outputPath: outputPath,
         contaminationOutputPath: contaminationOutputPath)
     var firstSample = true
+    var acknowledgementGate = MonitorAcknowledgementGate()
     while true {
         CFRunLoopRunInMode(
             .defaultMode,
             Double(intervalMilliseconds) / 1000,
-            true)
+            false)
         let producerData = try Data(contentsOf: URL(fileURLWithPath: allowedProducersPath))
         let allowedProducerSet = try JSONDecoder().decode(AllowedEventProducerSet.self, from: producerData)
-        applyMonitorAuthorization(allowedProducerSet, to: machine, observers: focusObservers)
-        guard let closure = closeMonitorEpoch(machine, observers: focusObservers) else {
+        let publishingHigherRevision = allowedProducerSet.revision > machine.currentAuthorization.revision
+        let requiresIdleBarrier = monitorRequiresIdleBarrier(
+            pendingAcknowledgementRevision: acknowledgementGate.pendingRevision,
+            currentRevision: machine.currentAuthorization.revision,
+            proposedRevision: allowedProducerSet.revision)
+        let reachedIdleBarrier = !requiresIdleBarrier ||
+            runLoopReachesIdle(timeout: max(Double(intervalMilliseconds) / 1000, 0.1))
+        if reachedIdleBarrier {
+            try acknowledgementGate.completeCallbackBarrier(machine: machine)
+        }
+        if !publishingHigherRevision || reachedIdleBarrier {
+            applyMonitorAuthorization(allowedProducerSet, to: machine, observers: focusObservers)
+        }
+        guard let closure = machine.closeForHeartbeat() else {
             continue
         }
         let current = try sample(includeClipboardDigest: false)
@@ -1679,10 +2000,45 @@ private func runWatch(arguments: [String]) throws -> Never {
             current: current,
             phase: phase,
             closure: closure)
-        try writeJSON(
-            heartbeat,
-            to: heartbeatPath)
-        if firstSample {
+        acknowledgementGate.record(closure)
+        var publishedHeartbeat = false
+        if let revision = acknowledgementGate.pendingRevision {
+            if heartbeat.contaminationBlocked || !heartbeat.inputAttributionAvailable {
+                try writeJSON(heartbeat.withTransitionAcknowledged(false), to: heartbeatPath)
+                publishedHeartbeat = true
+            } else if acknowledgementGate.readyRevision == revision {
+                let preparedHeartbeat = try PreparedJSONPublication(
+                    heartbeat.withTransitionAcknowledged(true),
+                    destinationPath: heartbeatPath)
+                if runLoopReachesIdle(timeout: max(Double(intervalMilliseconds) / 1000, 0.1)) {
+                    let result = try publishMonitorTransitionAcknowledgement(
+                        revision: revision,
+                        machine: machine,
+                        observers: focusObservers,
+                        publish: { try preparedHeartbeat.commit() })
+                    switch result {
+                    case .published:
+                        acknowledgementGate.didPublish(revision: revision)
+                        publishedHeartbeat = true
+                    case .rejected(reason: "blocked_producer_ack_evidence_pending"):
+                        try writeJSON(heartbeat.withTransitionAcknowledged(false), to: heartbeatPath)
+                        publishedHeartbeat = true
+                    case .idempotent, .rejected:
+                        throw ProbeError.invalidArguments("blocked_producer_ack_publication")
+                    }
+                } else {
+                    try writeJSON(heartbeat.withTransitionAcknowledged(false), to: heartbeatPath)
+                    publishedHeartbeat = true
+                }
+            } else {
+                try writeJSON(heartbeat.withTransitionAcknowledged(false), to: heartbeatPath)
+                publishedHeartbeat = true
+            }
+        } else {
+            try writeJSON(heartbeat.withTransitionAcknowledged(false), to: heartbeatPath)
+            publishedHeartbeat = true
+        }
+        if firstSample, publishedHeartbeat {
             try Data("ready\n".utf8).write(to: URL(fileURLWithPath: readyPath), options: .atomic)
             firstSample = false
         }
@@ -1771,6 +2127,11 @@ private func testEvidence(_ pid: Int32, _ startIdentity: String?, _ windowID: UI
     ProcessWindowEvidence(pid: pid, startIdentity: startIdentity, windowID: windowID)
 }
 
+private func acknowledgeForTesting(_ machine: MonitorEpochMachine, revision: UInt64) -> Bool {
+    machine.markAcknowledgementReady(revision: revision) == .published &&
+        machine.acknowledge(revision: revision) == .published
+}
+
 private func selfTestDesktop() -> (sample: SystemSample, baseline: InteractiveBaseline) {
     let sample = SystemSample(
         timestamp: 1,
@@ -1806,7 +2167,6 @@ private final class MonitorClosureCapture: Sendable {
 private struct MonitorAdmissionLatencyResult: Sendable {
     let publication: MonitorPublicationResult
     let heartbeatDeferred: Bool
-    let elapsed: Duration
 }
 
 private final class MonitorAdmissionLatencyCapture: Sendable {
@@ -1842,17 +2202,14 @@ private func suspendedSamplingDoesNotHoldPublicationLock() -> Bool {
     guard samplingStarted.wait(timeout: .now() + .seconds(1)) == .success else { return false }
 
     DispatchQueue.global(qos: .userInitiated).async {
-        let clock = ContinuousClock()
-        let start = clock.now
         let publication = machine.publish(second)
         let heartbeatDeferred = machine.closeForHeartbeat() == nil
         capture.store(MonitorAdmissionLatencyResult(
             publication: publication,
-            heartbeatDeferred: heartbeatDeferred,
-            elapsed: start.duration(to: clock.now)))
+            heartbeatDeferred: heartbeatDeferred))
         publicationFinished.signal()
     }
-    let completedBeforeRelease = publicationFinished.wait(timeout: .now() + .milliseconds(100)) == .success
+    let completedBeforeRelease = publicationFinished.wait(timeout: .now() + .seconds(1)) == .success
     releaseSampling.signal()
     guard samplingFinished.wait(timeout: .now() + .seconds(1)) == .success else { return false }
     if !completedBeforeRelease {
@@ -1862,7 +2219,6 @@ private func suspendedSamplingDoesNotHoldPublicationLock() -> Bool {
     guard let result = capture.load(),
           result.publication == .published,
           result.heartbeatDeferred,
-          result.elapsed < .milliseconds(50),
           let closure = machine.closeForHeartbeat()
     else {
         return false
@@ -1943,7 +2299,8 @@ private func recordPublishDrainIsLinearizable() -> Bool {
                       event.admission <= closed.upperAdmissionCutoff
               }),
               epochs.contains(where: {
-                  $0.epoch.authorization.revision == 2 && $0.epoch.transitionBarrier
+                  $0.epoch.authorization.revision == 2 &&
+                      $0.epoch.phase.requiresAcknowledgementHeartbeat
               })
         else {
             return false
@@ -1962,14 +2319,303 @@ private func exactPublicationCutoffIsClosed() -> Bool {
     guard let closure = machine.closeForHeartbeat(), closure.epochs.count == 2 else { return false }
     let old = closure.epochs[0]
     let new = closure.epochs[1]
-    return old.epoch.authorization.revision == 1 && old.upperAdmissionCutoff == 1 &&
-        old.events.map(\.admission) == [1] &&
-        new.epoch.authorization.revision == 2 && new.epoch.lowerAdmissionCutoff == 1 &&
-        new.upperAdmissionCutoff == 2 && new.events.map(\.admission) == [2] &&
-        closure.transitionAcknowledged
+    guard old.epoch.authorization.revision == 1, old.upperAdmissionCutoff == 1,
+          old.events.map(\.admission) == [1], old.epoch.phase.isStable,
+          new.epoch.authorization.revision == 2, new.epoch.focusAuthorization.revision == 1,
+          new.epoch.lowerAdmissionCutoff == 1, new.upperAdmissionCutoff == 2,
+          new.events.map(\.admission) == [2], closure.transitionAcknowledged,
+          acknowledgeForTesting(machine, revision: second.revision)
+    else {
+        return false
+    }
+    machine.admitForTesting(.activation(testEvidence(10, "1000", 100)))
+    guard let stableClosure = machine.closeForHeartbeat(),
+          let stableEvent = stableClosure.epochs.flatMap(\.events).first
+    else {
+        return false
+    }
+    return stableEvent.epoch.authorization.revision == 2 && stableEvent.epoch.phase.isStable
 }
 
-private func queuedRevisionsRemainDistinct() -> Bool {
+private enum MonitorAcknowledgementTestError: Error {
+    case requestedFailure
+}
+
+private func acknowledgementWriteOwnsAdmissionCutoff() -> Bool {
+    let first = testAuthorization(testProducerSet(revision: 1, producers: []))
+    let second = testAuthorization(testProducerSet(revision: 2, producers: []))
+    let machine = MonitorEpochMachine(initialAuthorization: first)
+    guard machine.publish(second) == .published,
+          machine.acknowledge(revision: second.revision) ==
+          .rejected(reason: "blocked_producer_ack_without_transition"),
+          let closure = machine.closeForHeartbeat(),
+          closure.transitionAcknowledged,
+          machine.acknowledge(revision: second.revision + 1) ==
+          .rejected(reason: "blocked_producer_ack_revision_mismatch"),
+          machine.acknowledge(revision: second.revision) ==
+          .rejected(reason: "blocked_producer_ack_before_callback_barrier"),
+          machine.markAcknowledgementReady(revision: second.revision) == .published
+    else {
+        return false
+    }
+    do {
+        _ = try machine.acknowledge(revision: second.revision, preparing: {}, publishing: {
+            throw MonitorAcknowledgementTestError.requestedFailure
+        })
+        return false
+    } catch MonitorAcknowledgementTestError.requestedFailure {
+        guard !machine.currentPhase.isStable else { return false }
+    } catch {
+        return false
+    }
+
+    let reservationStarted = DispatchSemaphore(value: 0)
+    let reservationFinished = DispatchSemaphore(value: 0)
+    let capturedToken = Mutex<MonitorAdmissionToken?>(nil)
+    var reservationCompletedDuringWrite = false
+    let result: MonitorPublicationResult
+    do {
+        result = try machine.acknowledge(revision: second.revision, preparing: {}, publishing: {
+            DispatchQueue.global(qos: .userInitiated).async {
+                reservationStarted.signal()
+                let token = machine.reserveForTesting()
+                capturedToken.withLock { $0 = token }
+                reservationFinished.signal()
+            }
+            guard reservationStarted.wait(timeout: .now() + .seconds(1)) == .success else {
+                throw MonitorAcknowledgementTestError.requestedFailure
+            }
+            reservationCompletedDuringWrite =
+                reservationFinished.wait(timeout: .now() + .milliseconds(100)) == .success
+        })
+    } catch {
+        return false
+    }
+    guard result == .published, !reservationCompletedDuringWrite,
+          reservationFinished.wait(timeout: .now() + .seconds(1)) == .success,
+          let token = capturedToken.withLock({ $0 }), token.epoch.phase.isStable,
+          token.epoch.authorization.revision == second.revision,
+          machine.cancelForTesting(token, reason: "test_cleanup"),
+          machine.acknowledge(revision: second.revision) ==
+          .rejected(reason: "blocked_producer_ack_without_transition")
+    else {
+        return false
+    }
+    return true
+}
+
+private func sealedPreAcknowledgementBucketsBlockPublication() -> Bool {
+    let first = testAuthorization(testProducerSet(revision: 1, producers: []))
+    let second = testAuthorization(testProducerSet(revision: 2, producers: []))
+    let machine = MonitorEpochMachine(initialAuthorization: first)
+    guard machine.publish(second) == .published,
+          machine.closeForHeartbeat()?.transitionAcknowledged == true,
+          machine.markAcknowledgementReady(revision: second.revision) == .published
+    else {
+        return false
+    }
+    let firstPending = machine.reserveForTesting()
+    guard machine.closeForHeartbeat() == nil else { return false }
+    let secondPending = machine.reserveForTesting()
+    guard machine.closeForHeartbeat() == nil,
+          machine.completeForTesting(
+              firstPending,
+              with: .activation(testEvidence(10, "1000", 100))),
+          machine.closeForHeartbeat() != nil,
+          machine.acknowledge(revision: second.revision) ==
+          .rejected(reason: "blocked_producer_ack_evidence_pending"),
+          machine.completeForTesting(
+              secondPending,
+              with: .activation(testEvidence(10, "1000", 100))),
+          machine.closeForHeartbeat() != nil,
+          machine.acknowledge(revision: second.revision) == .published
+    else {
+        return false
+    }
+    return machine.currentPhase.isStable
+}
+
+private func acknowledgementGateRequiresNextCallbackTurn() -> Bool {
+    let first = testAuthorization(testProducerSet(revision: 1, producers: []))
+    let second = testAuthorization(testProducerSet(revision: 2, producers: []))
+    let machine = MonitorEpochMachine(initialAuthorization: first)
+    guard machine.publish(second) == .published,
+          let closure = machine.closeForHeartbeat(),
+          closure.transitionAcknowledged
+    else {
+        return false
+    }
+    var gate = MonitorAcknowledgementGate()
+    gate.record(closure)
+    guard gate.pendingRevision == second.revision, gate.readyRevision == nil,
+          machine.acknowledge(revision: second.revision) ==
+          .rejected(reason: "blocked_producer_ack_before_callback_barrier")
+    else {
+        return false
+    }
+    do {
+        try gate.completeCallbackBarrier(machine: machine)
+    } catch {
+        return false
+    }
+    guard gate.readyRevision == second.revision,
+          machine.acknowledge(revision: second.revision) == .published
+    else {
+        return false
+    }
+    gate.didPublish(revision: second.revision)
+    return gate.pendingRevision == nil && gate.readyRevision == nil && machine.currentPhase.isStable
+}
+
+private func stableMonitoringDoesNotRequireIdleBarrier() -> Bool {
+    !monitorRequiresIdleBarrier(
+        pendingAcknowledgementRevision: nil,
+        currentRevision: 7,
+        proposedRevision: 7) &&
+        !monitorRequiresIdleBarrier(
+            pendingAcknowledgementRevision: nil,
+            currentRevision: 7,
+            proposedRevision: 6) &&
+        monitorRequiresIdleBarrier(
+            pendingAcknowledgementRevision: nil,
+            currentRevision: 7,
+            proposedRevision: 8) &&
+        monitorRequiresIdleBarrier(
+            pendingAcknowledgementRevision: 7,
+            currentRevision: 7,
+            proposedRevision: 7)
+}
+
+private func finalIdleBarrierDefersQueuedEvidence() -> Bool {
+    let first = testAuthorization(testProducerSet(revision: 1, producers: []))
+    let second = testAuthorization(testProducerSet(revision: 2, producers: []))
+    let machine = MonitorEpochMachine(initialAuthorization: first)
+    guard machine.publish(second) == .published,
+          machine.closeForHeartbeat()?.transitionAcknowledged == true,
+          machine.markAcknowledgementReady(revision: second.revision) == .published
+    else {
+        return false
+    }
+    let runLoop = CFRunLoopGetCurrent()
+    CFRunLoopPerformBlock(runLoop, CFRunLoopMode.defaultMode.rawValue) {
+        machine.admitActivation { testEvidence(10, "1000", 100) }
+    }
+    CFRunLoopWakeUp(runLoop)
+    guard runLoopReachesIdle(timeout: 1),
+          machine.acknowledge(revision: second.revision) ==
+          .rejected(reason: "blocked_producer_ack_evidence_pending"),
+          let closure = machine.closeForHeartbeat()
+    else {
+        return false
+    }
+    return closure.epochs.flatMap(\.events).count == 1 && !machine.currentPhase.isStable
+}
+
+private func transitionHeartbeatRetainsPendingEvidence(
+    directory: String,
+    projection: InvariantProjection) throws -> Bool
+{
+    let desktop = selfTestDesktop()
+    let firstProducer = testProducer(20, "2000")
+    let secondProducer = testProducer(21, "2100")
+    let first = testAuthorization(testProducerSet(revision: 1, producers: [firstProducer]))
+    let second = testAuthorization(testProducerSet(revision: 2, producers: [firstProducer, secondProducer]))
+    let machine = MonitorEpochMachine(initialAuthorization: first)
+    guard machine.publish(second) == .published else { return false }
+    machine.admitActivation { testEvidence(10, "1000", 100) }
+    guard let closure = machine.closeForHeartbeat() else { return false }
+    var watch = makeSelfTestWatchState(
+        desktop: desktop,
+        projection: projection,
+        outputPath: "\(directory)/transition-summary-violations.jsonl",
+        contaminationPath: "\(directory)/transition-summary-contamination.jsonl")
+    let heartbeat = try watch.observe(
+        current: desktop.sample,
+        phase: "running",
+        closure: closure,
+        processIdentity: { [10: 1000, 20: 2000, 21: 2100][$0] },
+        targetValidator: { _ in true })
+    let unpublished = heartbeat.withTransitionAcknowledged(false)
+    return heartbeat.transitionAcknowledged && unpublished.pendingActivationCount == 1 &&
+        unpublished.pendingFocusedWindowChange == heartbeat.pendingFocusedWindowChange &&
+        !unpublished.transitionAcknowledged && unpublished.sequence == heartbeat.sequence &&
+        unpublished.allowedProducerRevision == heartbeat.allowedProducerRevision
+}
+
+private func notificationEvidenceIsCapturedAtAdmission() -> Bool {
+    let authorization = testAuthorization(testProducerSet(revision: 1, producers: []))
+    let machine = MonitorEpochMachine(initialAuthorization: authorization)
+    var activationEvidence = testEvidence(40, "4000", 401)
+    machine.admitActivation { activationEvidence }
+    activationEvidence = testEvidence(40, "4001", 402)
+    let observer = ProcessGenerationIdentity(pid: 40, startIdentity: "4000")
+    var focusEvidence = testEvidence(40, "4000", 401)
+    machine.admitFocus(observer: observer) { focusEvidence }
+    focusEvidence = testEvidence(40, "4001", 402)
+    guard let closure = machine.closeForHeartbeat() else { return false }
+    let events = closure.epochs.flatMap(\.events)
+    guard events.count == 2 else { return false }
+    guard case let .activation(capturedActivation) = events[0].kind,
+          case let .focus(capturedFocus) = events[1].kind
+    else {
+        return false
+    }
+    return capturedActivation == testEvidence(40, "4000", 401) &&
+        capturedFocus == FocusEventEvidence(observer: observer, observed: testEvidence(40, "4000", 401))
+}
+
+private func processWindowEvidenceRejectsGenerationABA() -> Bool {
+    var identities = [UInt64(4000), UInt64(4001)].makeIterator()
+    let driftedEvidence = sampleProcessWindowEvidence(
+        pid: 40,
+        processIdentity: { identities.next() },
+        windowID: { 401 })
+    guard driftedEvidence == testEvidence(40, nil, nil) else { return false }
+
+    let stableEvidence = sampleProcessWindowEvidence(
+        pid: 40,
+        processIdentity: { 4000 },
+        windowID: { 401 })
+    let target = AllowedForegroundTarget(pid: 40, startIdentity: "4000", windowID: 401)
+    var targetIdentities = [UInt64(4000), UInt64(4001)].makeIterator()
+    let driftedTargetAccepted = foregroundTargetIsLive(
+        target,
+        processIdentity: { targetIdentities.next() },
+        windowMatches: { true })
+    let stableTargetAccepted = foregroundTargetIsLive(
+        target,
+        processIdentity: { 4000 },
+        windowMatches: { true })
+    return stableEvidence == testEvidence(40, "4000", 401) &&
+        !driftedTargetAccepted && stableTargetAccepted
+}
+
+private func idleBarrierDrainsQueuedCallbacksBeforePublication() -> Bool {
+    let first = testAuthorization(testProducerSet(revision: 1, producers: []))
+    let second = testAuthorization(testProducerSet(revision: 2, producers: []))
+    let machine = MonitorEpochMachine(initialAuthorization: first)
+    let callbacks = Mutex<[Int]>([])
+    let runLoop = CFRunLoopGetCurrent()
+    CFRunLoopPerformBlock(runLoop, CFRunLoopMode.defaultMode.rawValue) {
+        callbacks.withLock { $0.append(1) }
+    }
+    CFRunLoopPerformBlock(runLoop, CFRunLoopMode.defaultMode.rawValue) {
+        callbacks.withLock { $0.append(2) }
+        machine.admitActivation { testEvidence(10, "1000", 100) }
+    }
+    CFRunLoopWakeUp(runLoop)
+    guard runLoopReachesIdle(timeout: 1), callbacks.withLock({ $0 }) == [1, 2],
+          machine.publish(second) == .published,
+          let closure = machine.closeForHeartbeat(),
+          let event = closure.epochs.flatMap(\.events).first
+    else {
+        return false
+    }
+    return event.epoch.authorization.revision == first.revision &&
+        closure.finalEpoch.epoch.authorization.revision == second.revision
+}
+
+private func revisionsRequireAcknowledgement() -> Bool {
     let bridge = testProducer(20, "2000")
     let controller = testProducer(30, "3000", role: .foregroundController)
     let targetA = AllowedForegroundTarget(pid: 40, startIdentity: "4000", windowID: 401)
@@ -1995,13 +2641,26 @@ private func queuedRevisionsRemainDistinct() -> Bool {
             foreground: AllowedForegroundActivity(active: true, target: targetC)),
         testProducerSet(revision: 5, producers: [bridge], foreground: inactive),
     ]
+    var acknowledgedRevisions = [UInt64]()
     for producerSet in revisions {
-        guard machine.publish(testAuthorization(producerSet)) == .published else { return false }
+        let authorization = testAuthorization(producerSet)
+        guard machine.publish(authorization) == .published else { return false }
+        if producerSet.revision == 2 {
+            let next = testAuthorization(revisions[1])
+            guard case .rejected(reason: "blocked_producer_revision_before_ack") = machine.publish(next) else {
+                return false
+            }
+        }
+        guard let closure = machine.closeForHeartbeat(),
+              closure.transitionAcknowledged,
+              closure.finalEpoch.epoch.authorization.revision == producerSet.revision,
+              acknowledgeForTesting(machine, revision: producerSet.revision)
+        else {
+            return false
+        }
+        acknowledgedRevisions.append(producerSet.revision)
     }
-    guard let closure = machine.closeForHeartbeat() else { return false }
-    return closure.epochs.map(\.epoch.authorization.revision) == [1, 2, 3, 4, 5] &&
-        closure.epochs.dropFirst().allSatisfy(\.epoch.transitionBarrier) &&
-        closure.finalEpoch.epoch.authorization.target == nil
+    return acknowledgedRevisions == [2, 3, 4, 5] && machine.currentAuthorization.target == nil
 }
 
 private func equalRevisionRequiresExactPayload() -> Bool {
@@ -2021,7 +2680,7 @@ private func equalRevisionRequiresExactPayload() -> Bool {
     return true
 }
 
-private func grantRetargetRevokeRetainsEventEpochs() -> Bool {
+private func queuedGrantEraEventsRetainAuthorization() -> Bool {
     let bridge = testProducer(20, "2000")
     let controller = testProducer(30, "3000", role: .foregroundController)
     let targetA = AllowedForegroundTarget(pid: 40, startIdentity: "4000", windowID: 401)
@@ -2040,23 +2699,42 @@ private func grantRetargetRevokeRetainsEventEpochs() -> Bool {
         producers: [bridge, controller],
         foreground: AllowedForegroundActivity(active: true, target: targetB)))
     let revoke = testAuthorization(testProducerSet(revision: 4, producers: [bridge], foreground: inactive))
-    guard machine.publish(grant) == .published else { return false }
-    machine.admitForTesting(.input(InputEventEvidence(
-        type: CGEventType.keyDown.rawValue,
-        source: testEvidence(30, "3000", nil),
-        sessionFocus: testEvidence(40, "4000", 401))))
-    guard machine.publish(retarget) == .published else { return false }
-    machine.admitForTesting(.focus(FocusEventEvidence(
-        observer: ProcessGenerationIdentity(pid: 40, startIdentity: "4000"),
-        observed: testEvidence(40, "4000", 401))))
-    guard machine.publish(revoke) == .published else { return false }
+    guard machine.publish(grant) == .published,
+          let grantClosure = machine.closeForHeartbeat(),
+          grantClosure.transitionAcknowledged,
+          acknowledgeForTesting(machine, revision: grant.revision)
+    else {
+        return false
+    }
+    let queuedGrantInput = machine.reserveForTesting()
+    guard machine.publish(retarget) == .published,
+          machine.completeForTesting(queuedGrantInput, with: .input(InputEventEvidence(
+              type: CGEventType.keyDown.rawValue,
+              source: testEvidence(30, "3000", nil),
+              sessionFocus: testEvidence(40, "4000", 401)))),
+          let retargetClosure = machine.closeForHeartbeat(),
+          retargetClosure.transitionAcknowledged,
+          acknowledgeForTesting(machine, revision: retarget.revision)
+    else {
+        return false
+    }
+    let queuedRetargetFocus = machine.reserveForTesting()
+    guard machine.publish(revoke) == .published,
+          machine.completeForTesting(queuedRetargetFocus, with: .focus(FocusEventEvidence(
+              observer: ProcessGenerationIdentity(pid: 40, startIdentity: "4000"),
+              observed: testEvidence(40, "4000", 402))))
+    else {
+        return false
+    }
     machine.admitForTesting(.input(InputEventEvidence(
         type: CGEventType.keyDown.rawValue,
         source: testEvidence(30, "3000", nil),
         sessionFocus: testEvidence(40, "4000", 402))))
-    guard let closure = machine.closeForHeartbeat() else { return false }
-    let events = closure.epochs.flatMap(\.events)
-    return events.count == 3 && events.map(\.epoch.authorization.revision) == [2, 3, 4]
+    guard let revokeClosure = machine.closeForHeartbeat(), revokeClosure.transitionAcknowledged else { return false }
+    let events = retargetClosure.epochs.flatMap(\.events) + revokeClosure.epochs.flatMap(\.events)
+    return events.count == 3 && events.map(\.epoch.authorization.revision) == [2, 3, 4] &&
+        events[0].epoch.phase.isStable && events[1].epoch.phase.isStable &&
+        events[2].epoch.phase.requiresAcknowledgementHeartbeat
 }
 
 private enum FakeFocusObserverError: Error {
@@ -2118,6 +2796,26 @@ private func observerLifecycleIsBarrierBound() -> Bool {
         [10: 1000, 20: 2000, 30: 3000, 40: 4000, 41: 4100, 42: 4200][$0]
     }
     let targetValidator: (AllowedForegroundTarget) -> Bool = { _ in true }
+    func closeAndAcknowledge() -> MonitorEpochClosure? {
+        guard let closure = machine.closeForHeartbeat(), closure.transitionAcknowledged else { return nil }
+        do {
+            guard machine.markAcknowledgementReady(
+                revision: closure.finalEpoch.epoch.authorization.revision) == .published
+            else {
+                return nil
+            }
+            let result = try publishMonitorTransitionAcknowledgement(
+                revision: closure.finalEpoch.epoch.authorization.revision,
+                machine: machine,
+                observers: coordinator,
+                processIdentity: identities,
+                targetValidator: targetValidator)
+            guard result == .published else { return nil }
+        } catch {
+            return nil
+        }
+        return closure
+    }
 
     applyMonitorAuthorization(
         testProducerSet(
@@ -2131,7 +2829,7 @@ private func observerLifecycleIsBarrierBound() -> Bool {
     let firstIdentity = ProcessGenerationIdentity(pid: 40, startIdentity: "4000")
     let secondIdentity = ProcessGenerationIdentity(pid: 41, startIdentity: "4100")
     guard coordinator.observedIdentities == Set([baseline, firstIdentity]),
-          closeMonitorEpoch(machine, observers: coordinator)?.transitionAcknowledged == true
+          closeAndAcknowledge() != nil
     else {
         return false
     }
@@ -2146,7 +2844,7 @@ private func observerLifecycleIsBarrierBound() -> Bool {
         processIdentity: identities,
         targetValidator: targetValidator)
     guard coordinator.observedIdentities == Set([baseline, firstIdentity]),
-          closeMonitorEpoch(machine, observers: coordinator)?.transitionAcknowledged == true
+          closeAndAcknowledge() != nil
     else {
         return false
     }
@@ -2163,7 +2861,7 @@ private func observerLifecycleIsBarrierBound() -> Bool {
     guard coordinator.observedIdentities == Set([baseline, firstIdentity, secondIdentity]) else {
         return false
     }
-    guard let retargetAcknowledgement = closeMonitorEpoch(machine, observers: coordinator) else { return false }
+    guard let retargetAcknowledgement = closeAndAcknowledge() else { return false }
     guard retargetAcknowledgement.transitionAcknowledged,
           coordinator.observedIdentities == Set([baseline, secondIdentity]),
           store.stops == [firstIdentity]
@@ -2182,7 +2880,7 @@ private func observerLifecycleIsBarrierBound() -> Bool {
         observers: coordinator,
         processIdentity: identities,
         targetValidator: targetValidator)
-    guard let failedInstallClosure = closeMonitorEpoch(machine, observers: coordinator) else { return false }
+    guard let failedInstallClosure = machine.closeForHeartbeat() else { return false }
     guard machine.currentAuthorization.revision == 4,
           !coordinator.observedIdentities.contains(failedInstallIdentity),
           failedInstallClosure.epochs.flatMap(\.events).contains(where: {
@@ -2202,15 +2900,283 @@ private func observerLifecycleIsBarrierBound() -> Bool {
         observers: coordinator,
         processIdentity: identities,
         targetValidator: targetValidator)
-    guard let failedRemovalClosure = closeMonitorEpoch(machine, observers: coordinator) else { return false }
-    return machine.currentAuthorization.revision == 6 && failedRemovalClosure.transitionAcknowledged &&
-        coordinator.observedIdentities.contains(secondIdentity) &&
-        failedRemovalClosure.epochs.flatMap(\.events).contains(where: {
-            if case .attributionFailure(reason: "blocked_focus_observer_removal", process: nil) = $0.kind {
+    guard let failedRemovalAcknowledgement = machine.closeForHeartbeat(),
+          failedRemovalAcknowledgement.transitionAcknowledged
+    else {
+        return false
+    }
+    var acknowledgementPublished = false
+    do {
+        guard machine.markAcknowledgementReady(
+            revision: failedRemovalAcknowledgement.finalEpoch.epoch.authorization.revision) == .published
+        else {
+            return false
+        }
+        _ = try publishMonitorTransitionAcknowledgement(
+            revision: failedRemovalAcknowledgement.finalEpoch.epoch.authorization.revision,
+            machine: machine,
+            observers: coordinator,
+            processIdentity: identities,
+            targetValidator: targetValidator)
+        {
+            acknowledgementPublished = true
+        }
+        return false
+    } catch {
+        return machine.currentAuthorization.revision == 6 && !machine.currentPhase.isStable &&
+            !acknowledgementPublished && coordinator.observedIdentities.contains(secondIdentity)
+    }
+}
+
+private func productionRevisionReplayFailsClosed(
+    directory: String,
+    projection: InvariantProjection) throws -> Bool
+{
+    let desktop = selfTestDesktop()
+    let first = testProducer(20, "2000")
+    let second = testProducer(21, "2100")
+    let source = testProducerSet(revision: 7, producers: [first, second])
+    let machine = MonitorEpochMachine(initialAuthorization: testAuthorization(source))
+    let store = FakeFocusObserverStore()
+    let observers = FocusObserverCoordinator { FakeFocusObserver(identity: $0, store: store) }
+    applyMonitorAuthorization(
+        testProducerSet(
+            revision: 7,
+            producers: [first, second],
+            foreground: AllowedForegroundActivity(active: false, target: nil)),
+        to: machine,
+        observers: observers,
+        processIdentity: { [20: 2000, 21: 2100][$0] },
+        targetValidator: { _ in true })
+    guard let closure = machine.closeForHeartbeat() else { return false }
+    let contamination = "\(directory)/revision-replay-contamination.jsonl"
+    var watch = makeSelfTestWatchState(
+        desktop: desktop,
+        projection: projection,
+        outputPath: "\(directory)/revision-replay-violations.jsonl",
+        contaminationPath: contamination)
+    let heartbeat = try watch.observe(
+        current: desktop.sample,
+        phase: "running",
+        closure: closure,
+        processIdentity: { [10: 1000, 20: 2000, 21: 2100][$0] },
+        targetValidator: { _ in true })
+    let states = Set(decodeJSONLines(ContaminationRecord.self, at: contamination).map(\.state))
+    return machine.currentAuthorization.source == source && store.starts.isEmpty && store.stops.isEmpty &&
+        heartbeat.contaminationBlocked && !heartbeat.inputAttributionAvailable &&
+        states == Set(["blocked_producer_revision_replay"])
+}
+
+private func productionRevisionBeforeAckDoesNotPrepareObserver() -> Bool {
+    let baseline = ProcessGenerationIdentity(pid: 10, startIdentity: "1000")
+    let firstTarget = AllowedForegroundTarget(pid: 40, startIdentity: "4000", windowID: 401)
+    let secondTarget = AllowedForegroundTarget(pid: 41, startIdentity: "4100", windowID: 411)
+    let bridge = testProducer(20, "2000")
+    let controller = testProducer(30, "3000", role: .foregroundController)
+    let store = FakeFocusObserverStore()
+    let observers = FocusObserverCoordinator { FakeFocusObserver(identity: $0, store: store) }
+    do {
+        try observers.startBaseline(baseline)
+    } catch {
+        return false
+    }
+    let machine = MonitorEpochMachine(initialAuthorization: testAuthorization(testProducerSet(
+        revision: 1,
+        producers: [bridge])))
+    let identities: (Int32) -> UInt64? = {
+        [10: 1000, 20: 2000, 30: 3000, 40: 4000, 41: 4100][$0]
+    }
+    applyMonitorAuthorization(
+        testProducerSet(
+            revision: 2,
+            producers: [bridge, controller],
+            foreground: AllowedForegroundActivity(active: true, target: firstTarget)),
+        to: machine,
+        observers: observers,
+        processIdentity: identities,
+        targetValidator: { _ in true })
+    let firstIdentity = ProcessGenerationIdentity(pid: 40, startIdentity: "4000")
+    let secondIdentity = ProcessGenerationIdentity(pid: 41, startIdentity: "4100")
+    guard observers.observedIdentities == Set([baseline, firstIdentity]) else { return false }
+    applyMonitorAuthorization(
+        testProducerSet(
+            revision: 3,
+            producers: [bridge, controller],
+            foreground: AllowedForegroundActivity(active: true, target: secondTarget)),
+        to: machine,
+        observers: observers,
+        processIdentity: identities,
+        targetValidator: { _ in true })
+    guard let closure = machine.closeForHeartbeat() else { return false }
+    return machine.currentAuthorization.revision == 2 && !machine.currentPhase.isStable &&
+        observers.observedIdentities == Set([baseline, firstIdentity]) &&
+        !observers.observedIdentities.contains(secondIdentity) &&
+        closure.epochs.flatMap(\.events).contains(where: {
+            if case .attributionFailure(reason: "blocked_producer_revision_before_ack", process: nil) = $0.kind {
                 return true
             }
             return false
         })
+}
+
+private func productionIdempotentRevisionIsAllowedBeforeAck() -> Bool {
+    let bridge = testProducer(20, "2000")
+    let controller = testProducer(30, "3000", role: .foregroundController)
+    let target = AllowedForegroundTarget(pid: 40, startIdentity: "4000", windowID: 401)
+    let initial = testProducerSet(revision: 1, producers: [bridge])
+    let grant = testProducerSet(
+        revision: 2,
+        producers: [bridge, controller],
+        foreground: AllowedForegroundActivity(active: true, target: target))
+    let machine = MonitorEpochMachine(initialAuthorization: testAuthorization(initial))
+    let observers = FocusObserverCoordinator { identity in
+        FakeFocusObserver(identity: identity, store: FakeFocusObserverStore())
+    }
+    let identities: (Int32) -> UInt64? = { [20: 2000, 30: 3000, 40: 4000][$0] }
+    applyMonitorAuthorization(
+        grant,
+        to: machine,
+        observers: observers,
+        processIdentity: identities,
+        targetValidator: { $0 == target })
+    guard machine.currentAuthorization.revision == 2, !machine.currentPhase.isStable else { return false }
+    applyMonitorAuthorization(
+        grant,
+        to: machine,
+        observers: observers,
+        processIdentity: identities,
+        targetValidator: { $0 == target })
+    guard let closure = machine.closeForHeartbeat() else { return false }
+    return closure.transitionAcknowledged && closure.epochs.flatMap(\.events).isEmpty &&
+        machine.currentAuthorization.revision == 2
+}
+
+private func acknowledgementRevalidatesControllerAndTargetLiveness() -> Bool {
+    let bridge = testProducer(20, "2000")
+    let controller = testProducer(30, "3000", role: .foregroundController)
+    let target = AllowedForegroundTarget(pid: 40, startIdentity: "4000", windowID: 401)
+    let active = testAuthorization(testProducerSet(
+        revision: 1,
+        producers: [bridge, controller],
+        foreground: AllowedForegroundActivity(active: true, target: target)))
+    let revoked = testAuthorization(testProducerSet(revision: 2, producers: [bridge]))
+
+    func blocks(
+        processIdentity: @escaping (Int32) -> UInt64?,
+        targetValidator: @escaping (AllowedForegroundTarget) -> Bool) -> Bool
+    {
+        let machine = MonitorEpochMachine(initialAuthorization: active)
+        let observers = FocusObserverCoordinator { identity in
+            FakeFocusObserver(identity: identity, store: FakeFocusObserverStore())
+        }
+        guard machine.publish(revoked) == .published,
+              machine.closeForHeartbeat()?.transitionAcknowledged == true,
+              machine.markAcknowledgementReady(revision: revoked.revision) == .published
+        else {
+            return false
+        }
+        var published = false
+        do {
+            _ = try publishMonitorTransitionAcknowledgement(
+                revision: revoked.revision,
+                machine: machine,
+                observers: observers,
+                processIdentity: processIdentity,
+                targetValidator: targetValidator)
+            {
+                published = true
+            }
+            return false
+        } catch {
+            return !published && !machine.currentPhase.isStable
+        }
+    }
+
+    let controllerDriftBlocked = blocks(
+        processIdentity: { [20: 2000, 30: 3001, 40: 4000][$0] },
+        targetValidator: { $0 == target })
+    let targetDriftBlocked = blocks(
+        processIdentity: { [20: 2000, 30: 3000, 40: 4000][$0] },
+        targetValidator: { _ in false })
+    return controllerDriftBlocked && targetDriftBlocked
+}
+
+private func pendingAcknowledgementEvidenceDrainsBeforePublication(
+    directory: String,
+    projection: InvariantProjection) throws -> Bool
+{
+    let desktop = selfTestDesktop()
+    let bridge = testProducer(20, "2000")
+    let controller = testProducer(30, "3000", role: .foregroundController)
+    let target = AllowedForegroundTarget(pid: 40, startIdentity: "4000", windowID: 401)
+    let active = testAuthorization(testProducerSet(
+        revision: 1,
+        producers: [bridge, controller],
+        foreground: AllowedForegroundActivity(active: true, target: target)))
+    let revoked = testAuthorization(testProducerSet(revision: 2, producers: [bridge]))
+    let machine = MonitorEpochMachine(initialAuthorization: active)
+    let observers = FocusObserverCoordinator { identity in
+        FakeFocusObserver(identity: identity, store: FakeFocusObserverStore())
+    }
+    guard machine.publish(revoked) == .published,
+          let transitionClosure = machine.closeForHeartbeat(),
+          transitionClosure.transitionAcknowledged
+    else {
+        return false
+    }
+    var watch = makeSelfTestWatchState(
+        desktop: desktop,
+        projection: projection,
+        outputPath: "\(directory)/pending-ack-violations.jsonl",
+        contaminationPath: "\(directory)/pending-ack-contamination.jsonl")
+    let identities: (Int32) -> UInt64? = { [10: 1000, 20: 2000, 30: 3000, 40: 4000][$0] }
+    _ = try watch.observe(
+        current: desktop.sample,
+        phase: "running",
+        closure: transitionClosure,
+        processIdentity: identities,
+        targetValidator: { $0 == target })
+    guard machine.markAcknowledgementReady(revision: revoked.revision) == .published else { return false }
+    let pending = machine.reserveForTesting()
+    var acknowledgementPublished = false
+    let deferred = try publishMonitorTransitionAcknowledgement(
+        revision: revoked.revision,
+        machine: machine,
+        observers: observers,
+        processIdentity: identities,
+        targetValidator: { $0 == target })
+    {
+        acknowledgementPublished = true
+    }
+    guard deferred == .rejected(reason: "blocked_producer_ack_evidence_pending"),
+          !acknowledgementPublished,
+          machine.completeForTesting(pending, with: .input(InputEventEvidence(
+              type: CGEventType.keyDown.rawValue,
+              source: testEvidence(30, "3000", nil),
+              sessionFocus: testEvidence(40, "4000", 401)))),
+          let evidenceClosure = machine.closeForHeartbeat()
+    else {
+        return false
+    }
+    let evidenceHeartbeat = try watch.observe(
+        current: desktop.sample,
+        phase: "running",
+        closure: evidenceClosure,
+        processIdentity: identities,
+        targetValidator: { $0 == target })
+    let published = try publishMonitorTransitionAcknowledgement(
+        revision: revoked.revision,
+        machine: machine,
+        observers: observers,
+        processIdentity: identities,
+        targetValidator: { $0 == target })
+    {
+        acknowledgementPublished = true
+    }
+    let priorActivity = watch.foregroundActivity(for: active.revision)
+    return published == .published && acknowledgementPublished && machine.currentPhase.isStable &&
+        !evidenceHeartbeat.contaminationBlocked && evidenceHeartbeat.inputAttributionAvailable &&
+        priorActivity.eventCount == 1 && priorActivity.sourcePIDs == Set([30])
 }
 
 private func decodeJSONLines<T: Decodable>(_ type: T.Type, at path: String) -> [T] {
@@ -2270,6 +3236,7 @@ private func transitionAcknowledgementNeverAdvancesClean(
         closure: acknowledgementClosure,
         processIdentity: identities,
         targetValidator: { _ in true })
+    guard acknowledgeForTesting(machine, revision: second.revision) else { return false }
     guard let settledClosure = machine.closeForHeartbeat() else { return false }
     let settled = try watch.observe(
         current: desktop.sample,
@@ -2282,6 +3249,295 @@ private func transitionAcknowledgementNeverAdvancesClean(
         acknowledgement.lastCleanSequence == 1 &&
         settled.allowedProducerRevision == 2 && !settled.transitionAcknowledged &&
         settled.lastCleanSequence == settled.sequence
+}
+
+private func preAcknowledgementForegroundActivityFailsClosed(
+    directory: String,
+    projection: InvariantProjection) throws -> Bool
+{
+    let desktop = selfTestDesktop()
+    let bridge = testProducer(20, "2000")
+    let controller = testProducer(30, "3000", role: .foregroundController)
+    let target = AllowedForegroundTarget(pid: 40, startIdentity: "4000", windowID: 401)
+    let initial = testAuthorization(testProducerSet(revision: 1, producers: [bridge]))
+    let granted = testAuthorization(testProducerSet(
+        revision: 2,
+        producers: [bridge, controller],
+        foreground: AllowedForegroundActivity(active: true, target: target)))
+    let machine = MonitorEpochMachine(initialAuthorization: initial)
+    guard machine.publish(granted) == .published else { return false }
+    machine.admitForTesting(.input(InputEventEvidence(
+        type: CGEventType.keyDown.rawValue,
+        source: testEvidence(30, "3000", nil),
+        sessionFocus: testEvidence(40, "4000", 401))))
+    machine.admitForTesting(.activation(testEvidence(40, "4000", 401)))
+    let output = "\(directory)/pre-ack-violations.jsonl"
+    let contamination = "\(directory)/pre-ack-contamination.jsonl"
+    var watch = makeSelfTestWatchState(
+        desktop: desktop,
+        projection: projection,
+        outputPath: output,
+        contaminationPath: contamination)
+    guard let closure = machine.closeForHeartbeat() else { return false }
+    let heartbeat = try watch.observe(
+        current: desktop.sample,
+        phase: "running",
+        closure: closure,
+        processIdentity: { [10: 1000, 20: 2000, 30: 3000, 40: 4000][$0] },
+        targetValidator: { $0 == target })
+    let states = Set(decodeJSONLines(ContaminationRecord.self, at: contamination).map(\.state))
+    let kinds = Set(decodeJSONLines(Violation.self, at: output).map(\.kind))
+    return heartbeat.transitionAcknowledged && heartbeat.lastCleanSequence == 0 &&
+        heartbeat.attributedForegroundEventCount == 0 && heartbeat.contaminationBlocked &&
+        states == Set(["blocked_foreground_input_before_transition_ack"]) &&
+        kinds == Set([projection[.frontmostPID], projection[.frontmostWindow]])
+}
+
+private func acknowledgementPublicationCutoffIsClosed(
+    directory: String,
+    projection: InvariantProjection) throws -> Bool
+{
+    let desktop = selfTestDesktop()
+    let bridge = testProducer(20, "2000")
+    let controller = testProducer(30, "3000", role: .foregroundController)
+    let target = AllowedForegroundTarget(pid: 40, startIdentity: "4000", windowID: 401)
+    let initial = testAuthorization(testProducerSet(revision: 1, producers: [bridge]))
+    let granted = testAuthorization(testProducerSet(
+        revision: 2,
+        producers: [bridge, controller],
+        foreground: AllowedForegroundActivity(active: true, target: target)))
+    let machine = MonitorEpochMachine(initialAuthorization: initial)
+    guard machine.publish(granted) == .published,
+          let acknowledgementClosure = machine.closeForHeartbeat(),
+          acknowledgementClosure.transitionAcknowledged
+    else {
+        return false
+    }
+    let admission = machine.reserveForTesting()
+    var acknowledgementPublished = false
+    guard machine.markAcknowledgementReady(revision: granted.revision) == .published,
+          machine.acknowledge(revision: granted.revision, preparing: {}, publishing: {
+              acknowledgementPublished = true
+          }) == .rejected(reason: "blocked_producer_ack_evidence_pending"),
+          !acknowledgementPublished,
+          machine.completeForTesting(admission, with: .input(InputEventEvidence(
+              type: CGEventType.keyDown.rawValue,
+              source: testEvidence(30, "3000", nil),
+              sessionFocus: testEvidence(40, "4000", 401)))),
+          let preAcknowledgementClosure = machine.closeForHeartbeat()
+    else {
+        return false
+    }
+    let contamination = "\(directory)/ack-cutoff-contamination.jsonl"
+    var watch = makeSelfTestWatchState(
+        desktop: desktop,
+        projection: projection,
+        outputPath: "\(directory)/ack-cutoff-violations.jsonl",
+        contaminationPath: contamination)
+    _ = try watch.observe(
+        current: desktop.sample,
+        phase: "running",
+        closure: acknowledgementClosure,
+        processIdentity: { [10: 1000, 20: 2000, 30: 3000, 40: 4000][$0] },
+        targetValidator: { $0 == target })
+    let heartbeat = try watch.observe(
+        current: desktop.sample,
+        phase: "running",
+        closure: preAcknowledgementClosure,
+        processIdentity: { [10: 1000, 20: 2000, 30: 3000, 40: 4000][$0] },
+        targetValidator: { $0 == target })
+    let states = Set(decodeJSONLines(ContaminationRecord.self, at: contamination).map(\.state))
+    return !machine.currentPhase.isStable && !preAcknowledgementClosure.transitionAcknowledged &&
+        heartbeat.contaminationBlocked &&
+        heartbeat.attributedForegroundEventCount == 0 &&
+        states == Set(["blocked_foreground_input_before_transition_ack"])
+}
+
+private func transitionSamplingUsesAcknowledgedAuthorization() -> Bool {
+    let bridge = testProducer(20, "2000")
+    let controller = testProducer(30, "3000", role: .foregroundController)
+    let target = AllowedForegroundTarget(pid: 40, startIdentity: "4000", windowID: 401)
+    let active = testAuthorization(testProducerSet(
+        revision: 1,
+        producers: [bridge, controller],
+        foreground: AllowedForegroundActivity(active: true, target: target)))
+    let revoked = testAuthorization(testProducerSet(revision: 2, producers: [bridge]))
+    let revokeMachine = MonitorEpochMachine(initialAuthorization: active)
+    var transitionSample: MonitorAuthorization?
+    guard revokeMachine.publish(revoked) == .published else { return false }
+    revokeMachine.admitInput(type: .keyDown) { authorization in
+        transitionSample = authorization
+        return (
+            source: testEvidence(30, "3000", nil),
+            sessionFocus: authorization.target.map {
+                testEvidence($0.pid, $0.startIdentity, $0.windowID)
+            })
+    }
+    guard let transitionClosure = revokeMachine.closeForHeartbeat(),
+          transitionSample == active,
+          let transitionInput = transitionClosure.epochs.flatMap(\.events).compactMap({ event -> InputEventEvidence? in
+              if case let .input(input) = event.kind {
+                  return input
+              }
+              return nil
+          }).first,
+          transitionInput.sessionFocus == testEvidence(40, "4000", 401)
+    else {
+        return false
+    }
+
+    var awaitingSample: MonitorAuthorization?
+    revokeMachine.admitInput(type: .keyDown) { authorization in
+        awaitingSample = authorization
+        return (
+            source: testEvidence(30, "3000", nil),
+            sessionFocus: authorization.target.map {
+                testEvidence($0.pid, $0.startIdentity, $0.windowID)
+            })
+    }
+    guard let awaitingClosure = revokeMachine.closeForHeartbeat(), awaitingSample == active,
+          awaitingClosure.epochs.flatMap(\.events).contains(where: {
+              if case let .input(input) = $0.kind {
+                  return input.sessionFocus == testEvidence(40, "4000", 401)
+              }
+              return false
+          })
+    else {
+        return false
+    }
+
+    let inactive = testAuthorization(testProducerSet(revision: 1, producers: [bridge]))
+    let granted = testAuthorization(testProducerSet(
+        revision: 2,
+        producers: [bridge, controller],
+        foreground: AllowedForegroundActivity(active: true, target: target)))
+    let grantMachine = MonitorEpochMachine(initialAuthorization: inactive)
+    var grantSample: MonitorAuthorization?
+    guard grantMachine.publish(granted) == .published else { return false }
+    grantMachine.admitInput(type: .keyDown) { authorization in
+        grantSample = authorization
+        return (source: testEvidence(30, "3000", nil), sessionFocus: nil)
+    }
+    return grantSample == inactive
+}
+
+private func queuedGrantEraEvidenceIsNeitherDroppedNorRelabeled(
+    directory: String,
+    projection: InvariantProjection) throws -> Bool
+{
+    let desktop = selfTestDesktop()
+    let bridge = testProducer(20, "2000")
+    let controller = testProducer(30, "3000", role: .foregroundController)
+    let target = AllowedForegroundTarget(pid: 40, startIdentity: "4000", windowID: 401)
+    let active = testAuthorization(testProducerSet(
+        revision: 1,
+        producers: [bridge, controller],
+        foreground: AllowedForegroundActivity(active: true, target: target)))
+    let revoked = testAuthorization(testProducerSet(revision: 2, producers: [bridge]))
+    let machine = MonitorEpochMachine(initialAuthorization: active)
+    let queuedInput = machine.reserveForTesting()
+    let queuedActivation = machine.reserveForTesting()
+    guard machine.publish(revoked) == .published,
+          machine.completeForTesting(queuedInput, with: .input(InputEventEvidence(
+              type: CGEventType.keyDown.rawValue,
+              source: testEvidence(30, "3000", nil),
+              sessionFocus: testEvidence(40, "4000", 401)))),
+          machine.completeForTesting(queuedActivation, with: .activation(testEvidence(99, "9900", 991))),
+          let closure = machine.closeForHeartbeat()
+    else {
+        return false
+    }
+    let output = "\(directory)/queued-grant-violations.jsonl"
+    let contamination = "\(directory)/queued-grant-contamination.jsonl"
+    var watch = makeSelfTestWatchState(
+        desktop: desktop,
+        projection: projection,
+        outputPath: output,
+        contaminationPath: contamination)
+    let heartbeat = try watch.observe(
+        current: desktop.sample,
+        phase: "running",
+        closure: closure,
+        processIdentity: { [10: 1000, 20: 2000, 30: 3000, 40: 4000, 99: 9900][$0] },
+        targetValidator: { $0 == target })
+    let kinds = Set(decodeJSONLines(Violation.self, at: output).map(\.kind))
+    let grantActivity = watch.foregroundActivity(for: active.revision)
+    return heartbeat.transitionAcknowledged && grantActivity.eventCount == 1 &&
+        grantActivity.sourcePIDs == Set([30]) && heartbeat.attributedForegroundEventCount == 0 &&
+        heartbeat.attributedForegroundSourcePIDs.isEmpty && !heartbeat.foregroundActivityObserved &&
+        !heartbeat.contaminationBlocked && decodeJSONLines(ContaminationRecord.self, at: contamination).isEmpty &&
+        kinds == Set([projection[.frontmostPID], projection[.frontmostWindow]])
+}
+
+private func foregroundActivityIsRevisionScoped(
+    directory: String,
+    projection: InvariantProjection) throws -> Bool
+{
+    let desktop = selfTestDesktop()
+    let bridge = testProducer(20, "2000")
+    let firstController = testProducer(30, "3000", role: .foregroundController)
+    let secondController = testProducer(31, "3100", role: .foregroundController)
+    let firstTarget = AllowedForegroundTarget(pid: 40, startIdentity: "4000", windowID: 401)
+    let secondTarget = AllowedForegroundTarget(pid: 41, startIdentity: "4100", windowID: 411)
+    let firstGrant = testAuthorization(testProducerSet(
+        revision: 1,
+        producers: [bridge, firstController],
+        foreground: AllowedForegroundActivity(active: true, target: firstTarget)))
+    let revoke = testAuthorization(testProducerSet(revision: 2, producers: [bridge]))
+    let secondGrant = testAuthorization(testProducerSet(
+        revision: 3,
+        producers: [bridge, secondController],
+        foreground: AllowedForegroundActivity(active: true, target: secondTarget)))
+    let machine = MonitorEpochMachine(initialAuthorization: firstGrant)
+    machine.admitForTesting(.input(InputEventEvidence(
+        type: CGEventType.keyDown.rawValue,
+        source: testEvidence(30, "3000", nil),
+        sessionFocus: testEvidence(40, "4000", 401))))
+    var watch = makeSelfTestWatchState(
+        desktop: desktop,
+        projection: projection,
+        outputPath: "\(directory)/activity-scope-violations.jsonl",
+        contaminationPath: "\(directory)/activity-scope-contamination.jsonl")
+    let identities: (Int32) -> UInt64? = {
+        [10: 1000, 20: 2000, 30: 3000, 31: 3100, 40: 4000, 41: 4100][$0]
+    }
+    guard let firstClosure = machine.closeForHeartbeat() else { return false }
+    let firstHeartbeat = try watch.observe(
+        current: desktop.sample,
+        phase: "running",
+        closure: firstClosure,
+        processIdentity: identities,
+        targetValidator: { $0 == firstTarget || $0 == secondTarget })
+    guard machine.publish(revoke) == .published,
+          let revokeClosure = machine.closeForHeartbeat()
+    else {
+        return false
+    }
+    let revokeHeartbeat = try watch.observe(
+        current: desktop.sample,
+        phase: "running",
+        closure: revokeClosure,
+        processIdentity: identities,
+        targetValidator: { $0 == firstTarget || $0 == secondTarget })
+    guard acknowledgeForTesting(machine, revision: revoke.revision),
+          machine.publish(secondGrant) == .published,
+          let secondGrantClosure = machine.closeForHeartbeat()
+    else {
+        return false
+    }
+    let secondGrantHeartbeat = try watch.observe(
+        current: desktop.sample,
+        phase: "running",
+        closure: secondGrantClosure,
+        processIdentity: identities,
+        targetValidator: { $0 == firstTarget || $0 == secondTarget })
+    return firstHeartbeat.attributedForegroundEventCount == 1 &&
+        firstHeartbeat.attributedForegroundSourcePIDs == [30] && firstHeartbeat.foregroundActivityObserved &&
+        revokeHeartbeat.attributedForegroundEventCount == 0 &&
+        revokeHeartbeat.attributedForegroundSourcePIDs.isEmpty && !revokeHeartbeat.foregroundActivityObserved &&
+        secondGrantHeartbeat.attributedForegroundEventCount == 0 &&
+        secondGrantHeartbeat.attributedForegroundSourcePIDs.isEmpty &&
+        !secondGrantHeartbeat.foregroundActivityObserved
 }
 
 private func wrongWindowThenTargetStillViolates(
@@ -2448,6 +3704,71 @@ private func controllerGenerationDriftFailsClosed(
         states == Set(["blocked_producer_generation_drift"])
 }
 
+private func idleProducerGenerationDriftFailsClosed(
+    directory: String,
+    projection: InvariantProjection) throws -> Bool
+{
+    let desktop = selfTestDesktop()
+    let bridge = testProducer(20, "2000")
+    let controller = testProducer(30, "3000", role: .foregroundController)
+    let target = AllowedForegroundTarget(pid: 40, startIdentity: "4000", windowID: 401)
+    let authorization = testAuthorization(testProducerSet(
+        revision: 2,
+        producers: [bridge, controller],
+        foreground: AllowedForegroundActivity(active: true, target: target)))
+    let machine = MonitorEpochMachine(initialAuthorization: authorization)
+    let contamination = "\(directory)/idle-controller-drift-contamination.jsonl"
+    var watch = makeSelfTestWatchState(
+        desktop: desktop,
+        projection: projection,
+        outputPath: "\(directory)/idle-controller-drift-violations.jsonl",
+        contaminationPath: contamination)
+    guard let closure = machine.closeForHeartbeat() else { return false }
+    let heartbeat = try watch.observe(
+        current: desktop.sample,
+        phase: "running",
+        closure: closure,
+        processIdentity: { [10: 1000, 20: 2000, 30: 3001, 40: 4000][$0] },
+        targetValidator: { $0 == target })
+    let states = Set(decodeJSONLines(ContaminationRecord.self, at: contamination).map(\.state))
+    return heartbeat.contaminationBlocked && !heartbeat.inputAttributionAvailable &&
+        heartbeat.lastCleanSequence == 0 && states == Set(["blocked_producer_generation_drift"])
+}
+
+private func focusNotificationGenerationDriftFailsClosed(
+    directory: String,
+    projection: InvariantProjection) throws -> Bool
+{
+    let desktop = selfTestDesktop()
+    let bridge = testProducer(20, "2000")
+    let controller = testProducer(30, "3000", role: .foregroundController)
+    let target = AllowedForegroundTarget(pid: 40, startIdentity: "4000", windowID: 401)
+    let authorization = testAuthorization(testProducerSet(
+        revision: 2,
+        producers: [bridge, controller],
+        foreground: AllowedForegroundActivity(active: true, target: target)))
+    let machine = MonitorEpochMachine(initialAuthorization: authorization)
+    machine.admitForTesting(.focus(FocusEventEvidence(
+        observer: ProcessGenerationIdentity(pid: 40, startIdentity: "4000"),
+        observed: testEvidence(40, "4001", 401))))
+    let contamination = "\(directory)/focus-generation-drift-contamination.jsonl"
+    var watch = makeSelfTestWatchState(
+        desktop: desktop,
+        projection: projection,
+        outputPath: "\(directory)/focus-generation-drift-violations.jsonl",
+        contaminationPath: contamination)
+    guard let closure = machine.closeForHeartbeat() else { return false }
+    let heartbeat = try watch.observe(
+        current: desktop.sample,
+        phase: "running",
+        closure: closure,
+        processIdentity: { [10: 1000, 20: 2000, 30: 3000, 40: 4000][$0] },
+        targetValidator: { $0 == target })
+    let states = Set(decodeJSONLines(ContaminationRecord.self, at: contamination).map(\.state))
+    return heartbeat.contaminationBlocked && !heartbeat.inputAttributionAvailable &&
+        states == Set(["blocked_focus_observer_generation_drift"])
+}
+
 private func deferredTargetDriftFailsClosed(
     directory: String,
     projection: InvariantProjection) throws -> Bool
@@ -2606,13 +3927,43 @@ private func runSelfTest() throws {
     guard exactPublicationCutoffIsClosed() else {
         throw ProbeError.invalidArguments("events at the publication cutoff did not retain exact epochs")
     }
-    guard queuedRevisionsRemainDistinct() else {
-        throw ProbeError.invalidArguments("grant, retarget, generation change, or revoke epochs collapsed")
+    guard acknowledgementWriteOwnsAdmissionCutoff() else {
+        throw ProbeError.invalidArguments("acknowledgement publication did not own the admission cutoff")
+    }
+    guard sealedPreAcknowledgementBucketsBlockPublication() else {
+        throw ProbeError.invalidArguments("sealed pre-acknowledgement evidence did not block publication")
+    }
+    guard acknowledgementGateRequiresNextCallbackTurn() else {
+        throw ProbeError.invalidArguments("acknowledgement did not wait for the next callback turn")
+    }
+    guard stableMonitoringDoesNotRequireIdleBarrier() else {
+        throw ProbeError.invalidArguments("stable monitoring incorrectly required a callback idle barrier")
+    }
+    guard finalIdleBarrierDefersQueuedEvidence() else {
+        throw ProbeError.invalidArguments("final idle barrier did not defer queued callback evidence")
+    }
+    guard try transitionHeartbeatRetainsPendingEvidence(
+        directory: testDirectory,
+        projection: projection)
+    else {
+        throw ProbeError.invalidArguments("pending transition heartbeat evidence was discarded")
+    }
+    guard notificationEvidenceIsCapturedAtAdmission() else {
+        throw ProbeError.invalidArguments("notification evidence was resampled after callback admission")
+    }
+    guard processWindowEvidenceRejectsGenerationABA() else {
+        throw ProbeError.invalidArguments("process/window evidence accepted generation ABA")
+    }
+    guard idleBarrierDrainsQueuedCallbacksBeforePublication() else {
+        throw ProbeError.invalidArguments("run-loop idle barrier relabeled a queued callback")
+    }
+    guard revisionsRequireAcknowledgement() else {
+        throw ProbeError.invalidArguments("authorization revisions bypassed acknowledgement gating")
     }
     guard equalRevisionRequiresExactPayload() else {
         throw ProbeError.invalidArguments("equal revision reorder/mutation semantics were not fail-closed")
     }
-    guard grantRetargetRevokeRetainsEventEpochs() else {
+    guard queuedGrantEraEventsRetainAuthorization() else {
         throw ProbeError.invalidArguments("grant-era evidence was relabeled after retarget or revoke")
     }
     guard observerLifecycleIsBarrierBound() else {
@@ -2623,6 +3974,48 @@ private func runSelfTest() throws {
         projection: projection)
     else {
         throw ProbeError.invalidArguments("transition acknowledgement advanced the clean sequence")
+    }
+    guard try preAcknowledgementForegroundActivityFailsClosed(
+        directory: testDirectory,
+        projection: projection)
+    else {
+        throw ProbeError.invalidArguments("foreground activity was credited before grant acknowledgement")
+    }
+    guard try acknowledgementPublicationCutoffIsClosed(
+        directory: testDirectory,
+        projection: projection)
+    else {
+        throw ProbeError.invalidArguments("pending evidence crossed the acknowledgement publication cutoff")
+    }
+    guard transitionSamplingUsesAcknowledgedAuthorization() else {
+        throw ProbeError.invalidArguments("transition sampling used an unacknowledged authorization")
+    }
+    guard try queuedGrantEraEvidenceIsNeitherDroppedNorRelabeled(
+        directory: testDirectory,
+        projection: projection)
+    else {
+        throw ProbeError.invalidArguments("queued grant-era focus or controller evidence was lost or relabeled")
+    }
+    guard try foregroundActivityIsRevisionScoped(directory: testDirectory, projection: projection) else {
+        throw ProbeError.invalidArguments("foreground activity leaked into a later authorization revision")
+    }
+    guard try productionRevisionReplayFailsClosed(directory: testDirectory, projection: projection) else {
+        throw ProbeError.invalidArguments("production revision replay handling did not fail closed")
+    }
+    guard productionRevisionBeforeAckDoesNotPrepareObserver() else {
+        throw ProbeError.invalidArguments("unacknowledged revision prepared an unaccepted focus observer")
+    }
+    guard productionIdempotentRevisionIsAllowedBeforeAck() else {
+        throw ProbeError.invalidArguments("idempotent current revision was rejected before acknowledgement")
+    }
+    guard acknowledgementRevalidatesControllerAndTargetLiveness() else {
+        throw ProbeError.invalidArguments("acknowledgement accepted stale controller or target liveness")
+    }
+    guard try pendingAcknowledgementEvidenceDrainsBeforePublication(
+        directory: testDirectory,
+        projection: projection)
+    else {
+        throw ProbeError.invalidArguments("pending acknowledgement evidence did not drain before publication")
     }
     guard try wrongWindowThenTargetStillViolates(directory: testDirectory, projection: projection) else {
         throw ProbeError.invalidArguments("wrong-window callback collapsed into a later target callback")
@@ -2635,6 +4028,15 @@ private func runSelfTest() throws {
     }
     guard try controllerGenerationDriftFailsClosed(directory: testDirectory, projection: projection) else {
         throw ProbeError.invalidArguments("recycled foreground controller did not fail closed")
+    }
+    guard try idleProducerGenerationDriftFailsClosed(directory: testDirectory, projection: projection) else {
+        throw ProbeError.invalidArguments("idle producer generation drift advanced a clean heartbeat")
+    }
+    guard try focusNotificationGenerationDriftFailsClosed(
+        directory: testDirectory,
+        projection: projection)
+    else {
+        throw ProbeError.invalidArguments("focus notification generation drift did not fail closed")
     }
     guard try deferredTargetDriftFailsClosed(directory: testDirectory, projection: projection) else {
         throw ProbeError.invalidArguments("deferred target generation/window drift did not fail closed")
@@ -2649,7 +4051,7 @@ private func runSelfTest() throws {
         throw ProbeError.invalidArguments("unexpected activation did not retain callback-time focus evidence")
     }
 
-    try writeJSON(SelfTestResult(success: true, tests: 20), to: nil)
+    try writeJSON(SelfTestResult(success: true, tests: 41), to: nil)
 }
 
 private func findApp(arguments: [String]) throws {

--- a/scripts/support/background-computer-use-probe.swift
+++ b/scripts/support/background-computer-use-probe.swift
@@ -1326,6 +1326,27 @@ private func applyMonitorAuthorization(
     }
 }
 
+private enum MonitorAcknowledgementPreparationError: Error {
+    case liveness
+    case observerRemoval
+
+    var reason: String {
+        switch self {
+        case .liveness:
+            "blocked_foreground_ack_liveness"
+        case .observerRemoval:
+            "blocked_focus_observer_removal"
+        }
+    }
+}
+
+private func recordMonitorAcknowledgementPreparationFailure(
+    _ error: MonitorAcknowledgementPreparationError,
+    machine: MonitorEpochMachine)
+{
+    machine.admitFailure(reason: error.reason)
+}
+
 private func publishMonitorTransitionAcknowledgement(
     revision: UInt64,
     machine: MonitorEpochMachine,
@@ -1339,20 +1360,30 @@ private func publishMonitorTransitionAcknowledgement(
     guard authorization.revision == revision else {
         return .rejected(reason: "blocked_producer_ack_revision_mismatch")
     }
+    let authorizations = [authorization] + (priorAuthorization.map { [$0] } ?? [])
+    func authorizationsAreLive() -> Bool {
+        authorizations.allSatisfy { candidate in
+            candidate.source.producers.filter {
+                $0.effectiveRole == .foregroundController
+            }.allSatisfy { producer in
+                processIdentity(producer.pid).map(String.init) == producer.startIdentity
+            } && candidate.target.map(targetValidator) != false
+        }
+    }
     return try machine.acknowledge(
         revision: revision,
         preparing: {
-            let authorizations = [authorization] + (priorAuthorization.map { [$0] } ?? [])
-            guard authorizations.allSatisfy({ candidate in
-                candidate.source.producers.filter {
-                    $0.effectiveRole == .foregroundController
-                }.allSatisfy { producer in
-                    processIdentity(producer.pid).map(String.init) == producer.startIdentity
-                } && candidate.target.map(targetValidator) != false
-            }) else {
-                throw ProbeError.invalidArguments("blocked_foreground_ack_liveness")
+            guard authorizationsAreLive() else {
+                throw MonitorAcknowledgementPreparationError.liveness
             }
-            try observers.reconcile(activeTarget: authorization.target)
+            do {
+                try observers.reconcile(activeTarget: authorization.target)
+            } catch {
+                throw MonitorAcknowledgementPreparationError.observerRemoval
+            }
+            guard authorizationsAreLive() else {
+                throw MonitorAcknowledgementPreparationError.liveness
+            }
         },
         publishing: publish)
 }
@@ -2011,20 +2042,26 @@ private func runWatch(arguments: [String]) throws -> Never {
                     heartbeat.withTransitionAcknowledged(true),
                     destinationPath: heartbeatPath)
                 if runLoopReachesIdle(timeout: max(Double(intervalMilliseconds) / 1000, 0.1)) {
-                    let result = try publishMonitorTransitionAcknowledgement(
-                        revision: revision,
-                        machine: machine,
-                        observers: focusObservers,
-                        publish: { try preparedHeartbeat.commit() })
-                    switch result {
-                    case .published:
-                        acknowledgementGate.didPublish(revision: revision)
-                        publishedHeartbeat = true
-                    case .rejected(reason: "blocked_producer_ack_evidence_pending"):
+                    do {
+                        let result = try publishMonitorTransitionAcknowledgement(
+                            revision: revision,
+                            machine: machine,
+                            observers: focusObservers,
+                            publish: { try preparedHeartbeat.commit() })
+                        switch result {
+                        case .published:
+                            acknowledgementGate.didPublish(revision: revision)
+                            publishedHeartbeat = true
+                        case .rejected(reason: "blocked_producer_ack_evidence_pending"):
+                            try writeJSON(heartbeat.withTransitionAcknowledged(false), to: heartbeatPath)
+                            publishedHeartbeat = true
+                        case .idempotent, .rejected:
+                            throw ProbeError.invalidArguments("blocked_producer_ack_publication")
+                        }
+                    } catch let error as MonitorAcknowledgementPreparationError {
+                        recordMonitorAcknowledgementPreparationFailure(error, machine: machine)
                         try writeJSON(heartbeat.withTransitionAcknowledged(false), to: heartbeatPath)
                         publishedHeartbeat = true
-                    case .idempotent, .rejected:
-                        throw ProbeError.invalidArguments("blocked_producer_ack_publication")
                     }
                 } else {
                     try writeJSON(heartbeat.withTransitionAcknowledged(false), to: heartbeatPath)
@@ -2542,6 +2579,32 @@ private func transitionHeartbeatRetainsPendingEvidence(
         unpublished.allowedProducerRevision == heartbeat.allowedProducerRevision
 }
 
+private func acknowledgementPreparationFailureRemainsObservable() -> Bool {
+    for error in [MonitorAcknowledgementPreparationError.liveness, .observerRemoval] {
+        let first = testAuthorization(testProducerSet(revision: 1, producers: []))
+        let second = testAuthorization(testProducerSet(revision: 2, producers: []))
+        let machine = MonitorEpochMachine(initialAuthorization: first)
+        guard machine.publish(second) == .published,
+              machine.closeForHeartbeat()?.transitionAcknowledged == true,
+              machine.markAcknowledgementReady(revision: second.revision) == .published
+        else {
+            return false
+        }
+        recordMonitorAcknowledgementPreparationFailure(error, machine: machine)
+        guard let closure = machine.closeForHeartbeat(), !machine.currentPhase.isStable,
+              closure.epochs.flatMap(\.events).contains(where: {
+                  if case let .attributionFailure(reason, process: nil) = $0.kind {
+                      return reason == error.reason
+                  }
+                  return false
+              })
+        else {
+            return false
+        }
+    }
+    return true
+}
+
 private func notificationEvidenceIsCapturedAtAdmission() -> Bool {
     let authorization = testAuthorization(testProducerSet(revision: 1, producers: []))
     let machine = MonitorEpochMachine(initialAuthorization: authorization)
@@ -2746,6 +2809,7 @@ private final class FakeFocusObserverStore {
     var failStop = Set<ProcessGenerationIdentity>()
     var starts = [ProcessGenerationIdentity]()
     var stops = [ProcessGenerationIdentity]()
+    var onStop: ((ProcessGenerationIdentity) -> Void)?
 }
 
 private final class FakeFocusObserver: FocusObserverTracking {
@@ -2765,6 +2829,7 @@ private final class FakeFocusObserver: FocusObserverTracking {
     }
 
     func stop() throws {
+        self.store.onStop?(self.identity)
         if self.store.failStop.contains(self.identity) {
             throw FakeFocusObserverError.requestedFailure
         }
@@ -3099,6 +3164,52 @@ private func acknowledgementRevalidatesControllerAndTargetLiveness() -> Bool {
         processIdentity: { [20: 2000, 30: 3000, 40: 4000][$0] },
         targetValidator: { _ in false })
     return controllerDriftBlocked && targetDriftBlocked
+}
+
+private func acknowledgementRevalidatesAfterObserverReconciliation() -> Bool {
+    let bridge = testProducer(20, "2000")
+    let controller = testProducer(30, "3000", role: .foregroundController)
+    let target = AllowedForegroundTarget(pid: 40, startIdentity: "4000", windowID: 401)
+    let active = testAuthorization(testProducerSet(
+        revision: 1,
+        producers: [bridge, controller],
+        foreground: AllowedForegroundActivity(active: true, target: target)))
+    let revoked = testAuthorization(testProducerSet(revision: 2, producers: [bridge]))
+    let machine = MonitorEpochMachine(initialAuthorization: active)
+    let store = FakeFocusObserverStore()
+    let observers = FocusObserverCoordinator { FakeFocusObserver(identity: $0, store: store) }
+    do {
+        try observers.prepare(target: target)
+    } catch {
+        return false
+    }
+    let controllerLive = Mutex(true)
+    store.onStop = { _ in controllerLive.withLock { $0 = false } }
+    guard machine.publish(revoked) == .published,
+          machine.closeForHeartbeat()?.transitionAcknowledged == true,
+          machine.markAcknowledgementReady(revision: revoked.revision) == .published
+    else {
+        return false
+    }
+    var published = false
+    do {
+        _ = try publishMonitorTransitionAcknowledgement(
+            revision: revoked.revision,
+            machine: machine,
+            observers: observers,
+            processIdentity: { pid in
+                [20: 2000, 30: controllerLive.withLock { $0 ? 3000 : 3001 }, 40: 4000][pid]
+            },
+            targetValidator: { $0 == target })
+        {
+            published = true
+        }
+        return false
+    } catch MonitorAcknowledgementPreparationError.liveness {
+        return !published && !machine.currentPhase.isStable && !controllerLive.withLock { $0 }
+    } catch {
+        return false
+    }
 }
 
 private func pendingAcknowledgementEvidenceDrainsBeforePublication(
@@ -3948,6 +4059,9 @@ private func runSelfTest() throws {
     else {
         throw ProbeError.invalidArguments("pending transition heartbeat evidence was discarded")
     }
+    guard acknowledgementPreparationFailureRemainsObservable() else {
+        throw ProbeError.invalidArguments("acknowledgement preparation failure terminated observability")
+    }
     guard notificationEvidenceIsCapturedAtAdmission() else {
         throw ProbeError.invalidArguments("notification evidence was resampled after callback admission")
     }
@@ -4011,6 +4125,9 @@ private func runSelfTest() throws {
     guard acknowledgementRevalidatesControllerAndTargetLiveness() else {
         throw ProbeError.invalidArguments("acknowledgement accepted stale controller or target liveness")
     }
+    guard acknowledgementRevalidatesAfterObserverReconciliation() else {
+        throw ProbeError.invalidArguments("post-reconciliation liveness drift was acknowledged")
+    }
     guard try pendingAcknowledgementEvidenceDrainsBeforePublication(
         directory: testDirectory,
         projection: projection)
@@ -4051,7 +4168,7 @@ private func runSelfTest() throws {
         throw ProbeError.invalidArguments("unexpected activation did not retain callback-time focus evidence")
     }
 
-    try writeJSON(SelfTestResult(success: true, tests: 41), to: nil)
+    try writeJSON(SelfTestResult(success: true, tests: 43), to: nil)
 }
 
 private func findApp(arguments: [String]) throws {

--- a/scripts/support/background-computer-use-probe.swift
+++ b/scripts/support/background-computer-use-probe.swift
@@ -636,14 +636,17 @@ private struct AttemptContaminationState {
 }
 
 private final class RunLoopIdleBarrierState: Sendable {
-    private let reached = Mutex(false)
+    private let idlePasses = Mutex(0)
 
-    func markReached() {
-        self.reached.withLock { $0 = true }
+    func recordIdlePass() -> Bool {
+        self.idlePasses.withLock { passes in
+            passes += 1
+            return passes >= 2
+        }
     }
 
-    func wasReached() -> Bool {
-        self.reached.withLock { $0 }
+    func reachedBarrier() -> Bool {
+        self.idlePasses.withLock { $0 >= 2 }
     }
 }
 
@@ -653,11 +656,15 @@ private func runLoopReachesIdle(timeout: TimeInterval) -> Bool {
     guard let observer = CFRunLoopObserverCreateWithHandler(
         kCFAllocatorDefault,
         CFRunLoopActivity.beforeWaiting.rawValue,
-        false,
-        0,
+        true,
+        CFIndex.max,
         { _, _ in
-            state.markReached()
-            CFRunLoopStop(runLoop)
+            if state.recordIdlePass() {
+                CFRunLoopStop(runLoop)
+            } else {
+                CFRunLoopPerformBlock(runLoop, CFRunLoopMode.defaultMode.rawValue) {}
+                CFRunLoopWakeUp(runLoop)
+            }
         })
     else {
         return false
@@ -668,7 +675,7 @@ private func runLoopReachesIdle(timeout: TimeInterval) -> Bool {
         CFRunLoopObserverInvalidate(observer)
     }
     _ = CFRunLoopRunInMode(.defaultMode, timeout, false)
-    return state.wasReached()
+    return state.reachedBarrier()
 }
 
 private final class InputEventTracker {
@@ -2020,10 +2027,12 @@ private func runWatch(arguments: [String]) throws -> Never {
         if !publishingHigherRevision || reachedIdleBarrier {
             applyMonitorAuthorization(allowedProducerSet, to: machine, observers: focusObservers)
         }
-        guard let closure = machine.closeForHeartbeat() else {
+        let current = try sample(includeClipboardDigest: false)
+        guard runLoopReachesIdle(timeout: max(Double(intervalMilliseconds) / 1000, 0.1)),
+              let closure = machine.closeForHeartbeat()
+        else {
             continue
         }
-        let current = try sample(includeClipboardDigest: false)
         let phase = try String(contentsOfFile: phasePath, encoding: .utf8)
             .trimmingCharacters(in: .whitespacesAndNewlines)
         guard ["setup", "running", "complete"].contains(phase) else {
@@ -2661,6 +2670,26 @@ private func idleBarrierDrainsQueuedCallbacksBeforePublication() -> Bool {
     let machine = MonitorEpochMachine(initialAuthorization: first)
     let callbacks = Mutex<[Int]>([])
     let runLoop = CFRunLoopGetCurrent()
+    guard let lateObserver = CFRunLoopObserverCreateWithHandler(
+        kCFAllocatorDefault,
+        CFRunLoopActivity.beforeWaiting.rawValue,
+        false,
+        0,
+        { _, _ in
+            CFRunLoopPerformBlock(runLoop, CFRunLoopMode.defaultMode.rawValue) {
+                callbacks.withLock { $0.append(3) }
+                machine.admitActivation { testEvidence(10, "1000", 100) }
+            }
+            CFRunLoopWakeUp(runLoop)
+        })
+    else {
+        return false
+    }
+    CFRunLoopAddObserver(runLoop, lateObserver, .defaultMode)
+    defer {
+        CFRunLoopRemoveObserver(runLoop, lateObserver, .defaultMode)
+        CFRunLoopObserverInvalidate(lateObserver)
+    }
     CFRunLoopPerformBlock(runLoop, CFRunLoopMode.defaultMode.rawValue) {
         callbacks.withLock { $0.append(1) }
     }
@@ -2669,15 +2698,47 @@ private func idleBarrierDrainsQueuedCallbacksBeforePublication() -> Bool {
         machine.admitActivation { testEvidence(10, "1000", 100) }
     }
     CFRunLoopWakeUp(runLoop)
-    guard runLoopReachesIdle(timeout: 1), callbacks.withLock({ $0 }) == [1, 2],
+    guard runLoopReachesIdle(timeout: 1), callbacks.withLock({ $0 }) == [1, 2, 3],
           machine.publish(second) == .published,
           let closure = machine.closeForHeartbeat(),
-          let event = closure.epochs.flatMap(\.events).first
+          closure.epochs.flatMap(\.events).count == 2
     else {
         return false
     }
-    return event.epoch.authorization.revision == first.revision &&
+    return closure.epochs.flatMap(\.events).allSatisfy { $0.epoch.authorization.revision == first.revision } &&
         closure.finalEpoch.epoch.authorization.revision == second.revision
+}
+
+private func sampleDrainCloseRetainsCallbackEvidence(
+    directory: String,
+    projection: InvariantProjection) throws -> Bool
+{
+    let desktop = selfTestDesktop()
+    let machine = MonitorEpochMachine(initialAuthorization: testAuthorization(testProducerSet(
+        revision: 1,
+        producers: [])))
+    let runLoop = CFRunLoopGetCurrent()
+    let current = desktop.sample
+    CFRunLoopPerformBlock(runLoop, CFRunLoopMode.defaultMode.rawValue) {
+        machine.admitActivation { testEvidence(99, "9900", 991) }
+    }
+    CFRunLoopWakeUp(runLoop)
+    guard runLoopReachesIdle(timeout: 1), let closure = machine.closeForHeartbeat() else { return false }
+    let output = "\(directory)/sample-cutoff-violations.jsonl"
+    var watch = makeSelfTestWatchState(
+        desktop: desktop,
+        projection: projection,
+        outputPath: output,
+        contaminationPath: "\(directory)/sample-cutoff-contamination.jsonl")
+    let heartbeat = try watch.observe(
+        current: current,
+        phase: "running",
+        closure: closure,
+        processIdentity: { $0 == 10 ? 1000 : nil },
+        targetValidator: { _ in true })
+    let kinds = Set(decodeJSONLines(Violation.self, at: output).map(\.kind))
+    return heartbeat.pendingActivationCount == 1 &&
+        kinds == Set([projection[.frontmostPID], projection[.frontmostWindow]])
 }
 
 private func revisionsRequireAcknowledgement() -> Bool {
@@ -4073,6 +4134,12 @@ private func runSelfTest() throws {
     guard idleBarrierDrainsQueuedCallbacksBeforePublication() else {
         throw ProbeError.invalidArguments("run-loop idle barrier relabeled a queued callback")
     }
+    guard try sampleDrainCloseRetainsCallbackEvidence(
+        directory: testDirectory,
+        projection: projection)
+    else {
+        throw ProbeError.invalidArguments("system sample callback evidence crossed the epoch cutoff")
+    }
     guard revisionsRequireAcknowledgement() else {
         throw ProbeError.invalidArguments("authorization revisions bypassed acknowledgement gating")
     }
@@ -4170,7 +4237,7 @@ private func runSelfTest() throws {
         throw ProbeError.invalidArguments("unexpected activation did not retain callback-time focus evidence")
     }
 
-    try writeJSON(SelfTestResult(success: true, tests: 43), to: nil)
+    try writeJSON(SelfTestResult(success: true, tests: 44), to: nil)
 }
 
 private func findApp(arguments: [String]) throws {

--- a/scripts/support/background-computer-use-probe.swift
+++ b/scripts/support/background-computer-use-probe.swift
@@ -1886,11 +1886,13 @@ private final class PreparedJSONPublication {
         encoder.outputFormatting = [.sortedKeys]
         var data = try encoder.encode(value)
         data.append(Data("\n".utf8))
-        self.destinationURL = URL(fileURLWithPath: destinationPath)
-        self.temporaryURL = self.destinationURL
+        let destinationURL = URL(fileURLWithPath: destinationPath)
+        let temporaryURL = destinationURL
             .deletingLastPathComponent()
-            .appendingPathComponent(".\(self.destinationURL.lastPathComponent).\(UUID().uuidString).tmp")
-        try data.write(to: self.temporaryURL)
+            .appendingPathComponent(".\(destinationURL.lastPathComponent).\(UUID().uuidString).tmp")
+        self.destinationURL = destinationURL
+        self.temporaryURL = temporaryURL
+        try data.write(to: temporaryURL)
     }
 
     deinit {


### PR DESCRIPTION
## Summary

- centralize input, activation, and focused-window evidence in one publication-cutoff-bound monitor epoch machine
- make foreground grant/retarget/revoke acknowledgement two-phase, prior-policy effective, callback-idle gated, and fail closed
- capture exact callback-time process generation/window evidence, bracket PID/window lookups against reuse, and scope activity to one authorization revision
- keep transition failures observable without publishing a false acknowledgement or terminating the watcher

This is certification infrastructure only. It does not enable the live dual-controller workflow or add a foreground-controller product feature.

## Proof

- `pnpm run test:background-certification`
- probe self-test: 43/43
- background report validator: 18/18
- dual-controller report validator: 18/18
- `pnpm run format`
- `pnpm run lint:docs`
- `pnpm run lint` (66 established warnings, 0 serious)
- `pnpm run test:safe`
- P0-P2 Autoreview and TruffleHog

Hosted CI remains authoritative before merge.
