### PR TITLE
fix(automation): resolve exact windows the on-screen list omits

### DIFF
--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Utilities/WindowIdentityUtilities.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Utilities/WindowIdentityUtilities.swift
@@ -261,7 +261,15 @@ public final class WindowIdentityService {
     }
 
     public func isWindowOnScreen(windowID: CGWindowID) -> Bool {
-        self.windowExists(windowID: windowID)
+        // Existence and visibility are different questions: `windowExists` also resolves minimized and
+        // off-Space windows through the full catalog, so on-screen state needs the on-screen list.
+        guard let windowList = CGWindowListCopyWindowInfo(
+            [.optionIncludingWindow],
+            windowID) as? [[String: Any]]
+        else {
+            return false
+        }
+        return Self.exactWindowDictionary(windowID: windowID, in: windowList) != nil
     }
 
     public func isTopmostRenderableWindow(windowID: CGWindowID) -> Bool {
@@ -303,10 +311,26 @@ public final class WindowIdentityService {
     }
 
     private func exactWindowServerInfo(windowID: CGWindowID) -> WindowIdentityInfo? {
-        guard let windowList = CGWindowListCopyWindowInfo(
-            [.optionIncludingWindow, .excludeDesktopElements],
-            windowID) as? [[String: Any]],
-            let window = Self.exactWindowDictionary(windowID: windowID, in: windowList),
+        Self.exactWindowServerInfo(
+            windowID: windowID,
+            windowListProvider: { options, relativeToWindow in
+                CGWindowListCopyWindowInfo(options, relativeToWindow) as? [[String: Any]]
+            })
+    }
+
+    /// Resolve one exact window through the shared catalog lookup.
+    ///
+    /// `optionIncludingWindow` alone omits minimized and off-Space windows, so resolving only through
+    /// it reported live windows as gone while window listing — which scans `optionAll` — still returned
+    /// them. `exactWindowCatalog` owns that fallback; a window absent from both lists stays unresolved.
+    static func exactWindowServerInfo(
+        windowID: CGWindowID,
+        windowListProvider: (CGWindowListOption, CGWindowID) -> [[String: Any]]?) -> WindowIdentityInfo?
+    {
+        guard let windowList = SystemIdentityResolver.exactWindowCatalog(
+            windowID,
+            windowListProvider: windowListProvider),
+            let window = exactWindowDictionary(windowID: windowID, in: windowList),
             let ownerPID = Self.ownerPID(from: window)
         else {
             return nil

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/WindowIdentityExactWindowLookupTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/WindowIdentityExactWindowLookupTests.swift
@@ -1,0 +1,79 @@
+import CoreGraphics
+import Foundation
+import Testing
+@testable import PeekabooAutomationKit
+
+/// The window listing path scans `[.optionAll, .excludeDesktopElements]`, so it reports minimized and
+/// off-Space windows. Exact-window lookup must agree with it: resolving only through
+/// `optionIncludingWindow` reported those live windows as gone, which surfaced to callers as a stale
+/// snapshot at dispatch time for a window the listing had just handed out.
+@MainActor
+struct WindowIdentityExactWindowLookupTests {
+    @Test
+    func `Exact window lookup resolves a window optionIncludingWindow omits`() throws {
+        let bounds = CGRect(x: 463, y: 187, width: 586, height: 488)
+        let catalog = WindowServerCatalogFixture(
+            onScreenWindowIDs: [10847],
+            allWindows: [
+                Self.windowDictionary(windowID: 10847, ownerPID: 3764, bounds: bounds),
+                Self.windowDictionary(windowID: 10852, ownerPID: 3764, bounds: bounds),
+            ])
+
+        let info = try #require(WindowIdentityService.exactWindowServerInfo(
+            windowID: 10852,
+            windowListProvider: catalog.windowList))
+
+        #expect(info.windowID == 10852)
+        #expect(info.ownerPID == 3764)
+        #expect(info.bounds == bounds)
+    }
+
+    @Test
+    func `Exact window lookup stays unresolved for a window absent from the whole catalog`() {
+        let catalog = WindowServerCatalogFixture(
+            onScreenWindowIDs: [10847],
+            allWindows: [
+                Self.windowDictionary(
+                    windowID: 10847,
+                    ownerPID: 3764,
+                    bounds: CGRect(x: 405, y: 129, width: 586, height: 488)),
+            ])
+
+        #expect(WindowIdentityService.exactWindowServerInfo(
+            windowID: 10852,
+            windowListProvider: catalog.windowList) == nil)
+    }
+
+    /// Mirrors the measured WindowServer contract: `optionIncludingWindow` answers only for on-screen
+    /// windows, while the full catalog still carries every live window's exact identity.
+    private struct WindowServerCatalogFixture {
+        let onScreenWindowIDs: Set<CGWindowID>
+        let allWindows: [[String: Any]]
+
+        func windowList(_ options: CGWindowListOption, _ relativeToWindow: CGWindowID) -> [[String: Any]]? {
+            guard options.contains(.optionIncludingWindow) else {
+                return self.allWindows
+            }
+            guard self.onScreenWindowIDs.contains(relativeToWindow) else {
+                return []
+            }
+            return self.allWindows.filter {
+                ($0[kCGWindowNumber as String] as? Int).map(CGWindowID.init) == relativeToWindow
+            }
+        }
+    }
+
+    private static func windowDictionary(
+        windowID: Int,
+        ownerPID: Int,
+        bounds: CGRect) -> [String: Any]
+    {
+        [
+            kCGWindowNumber as String: windowID,
+            kCGWindowOwnerPID as String: ownerPID,
+            kCGWindowBounds as String: bounds.dictionaryRepresentation,
+            kCGWindowLayer as String: 0,
+            kCGWindowAlpha as String: 1,
+        ]
+    }
+}


### PR DESCRIPTION
## Problem

Two window-enumeration paths disagreed, so callers received window references and full observations for windows the action path already considered gone — and only found out at dispatch.

Measured live against TextEdit on macOS 26:

1. Window listing returns windowID `10852` ("Untitled 10").
2. A window-state observation on it succeeds and hands back a full accessibility tree with element references and a snapshot id.
3. Any action targeting those elements fails with:
   `Snapshot is stale: Snapshot window is no longer available (windowID: 10852, app: TextEdit, bundle: com.apple.TextEdit, title: Untitled 10). Run 'peekaboo see' again before targeting elements from this snapshot.`

Reproducible on every attempt. The window is not gone — it is minimized (an off-Space window behaves the same way).

## Cause

The three paths asked WindowServer three different questions:

| Path | Lookup |
|---|---|
| Listing — `ApplicationWindowEnumerationContext.collectCGSnapshot()` (`ApplicationWindowEnumerationContext.swift:146`) | `[.optionAll, .excludeDesktopElements]`, `kCGNullWindowID` |
| Observation — `ObservationTargetResolver` via `SystemIdentityResolver.windowIdentity` (`SystemIdentityResolver.swift:100`) | `exactWindowCatalog`: `[.optionIncludingWindow]`, then falls back to `[.optionAll, .excludeDesktopElements]` |
| Action — `WindowIdentityService.exactWindowServerInfo` (`WindowIdentityUtilities.swift:305`, pre-fix) | `[.optionIncludingWindow, .excludeDesktopElements]`, `windowID` — **no fallback** |

`kCGWindowListOptionIncludingWindow` answers only for **on-screen** windows. A minimized or off-Space window is absent from it while `optionAll` still carries its exact ID, owner, and frame. Listing and observation both see such a window; the action path alone declared it gone.

`WindowMovementTracking.adjustPoint` (`WindowMovementTracking.swift:49`) calls `currentWindow(for:)` → `identityService.getWindowInfo(windowID:)` → `exactWindowServerInfo`, which is where the stale-snapshot error is produced.

`SystemIdentityResolver.exactWindowCatalog` (`SystemIdentityResolver.swift:119-137`) already owns exactly this fallback, and its doc comment already names the invariant. `WindowIdentityService` was simply never migrated onto it — an incomplete prior repair leaving a second, divergent option set.

Live measurement of the divergence (same TextEdit process, real WindowServer):

```
listed windows for pid 3764: 5
  wid=10852 title="Untitled 10" onScreen=false
    pre-fix  exactWindowServerInfo -> nil  (action fails: 'no longer available')
    post-fix exactWindowServerInfo -> resolved
  wid=10847 title="Untitled 7" onScreen=true
    pre-fix  exactWindowServerInfo -> resolved
    post-fix exactWindowServerInfo -> resolved
  ...
dead windowID 999999999: pre-fix=nil post-fix=nil
```

## Fix

`WindowIdentityService.exactWindowServerInfo` now resolves through `SystemIdentityResolver.exactWindowCatalog` instead of carrying its own option set. One canonical exact-window lookup; the divergent second one is deleted.

This is the "`currentWindow(for:)` was over-filtering live windows" side of the invariant, so it is widened — not loosened. `exactWindowCatalog` returns nil when the ID is absent from **both** lists, so a genuinely closed window still fails closed and targeting it still throws. Verified against a real window closed mid-session (below).

`isWindowOnScreen` was a straight alias of `windowExists`. Now that existence also resolves minimized and off-Space windows, that alias would have become an actively wrong answer, so it asks the on-screen list directly. It has no production callers today; this keeps the public API honest rather than leaving a landmine.

Production delta: +29 / −5 in one file.

## User Impact

Actions targeting a minimized or off-Space window no longer fail with a false "window is no longer available". Window listing, observation, and dispatch now agree on which windows exist. Genuinely dead windows are unaffected and still fail closed.

## Evidence

**Regression test** — `Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/WindowIdentityExactWindowLookupTests.swift`, two tests driven by an injected catalog that reproduces the measured WindowServer contract (`optionIncludingWindow` answers only for on-screen windows; the full catalog carries every live window).

Proven to fail pre-fix for the intended reason: with the test in place, only the lookup body was reverted to the old `[.optionIncludingWindow, .excludeDesktopElements]` option set —

```
✘ Test "Exact window lookup resolves a window optionIncludingWindow omits" recorded an issue at
  WindowIdentityExactWindowLookupTests.swift:22:24: Expectation failed:
  WindowIdentityService.exactWindowServerInfo(windowID: 10852, windowListProvider: catalog.windowList)
✔ Test "Exact window lookup stays unresolved for a window absent from the whole catalog" passed
```

The fail-closed test passes both before and after, so the suite is not simply green-by-construction. With the fix restored, both pass.

**Full package suite** — `swift test` in `Core/PeekabooAutomationKit`: 1083 tests in 106 suites.

Four failures, all in `ApplicationServiceOperationLaneTests` and `ScreenCaptureKitTimeoutRaceTests` (100 ms lane-open windows, 1 s flock deadlines). Confirmed pre-existing and load-sensitive, not caused by this change:
- On pristine `origin/main` with this branch's changes removed, the same tests fail the same way (1081 tests, same assertions at `ApplicationServiceOperationLaneTests.swift:59` and `:117`).
- Run in isolation on this branch, all 12 tests in those suites pass.

Window-identity surfaces: `WindowIdentityExactWindowLookupTests`, `SystemIdentityResolverTests`, `WindowCGInfoLookupTests`, `WindowMovementTracking*`, `WindowTrackerServiceTests`, `WindowStateMutationPolicyTests` — 79 tests in 6 suites, all pass.

**Live behavior** — before/after replication of both implementations against the real WindowServer, output above. Fail-closed re-verified on a genuinely closed window:

```
-- before close --  windowID 10849: post-fix resolves = true
-- after close  --  windowID 10849: post-fix resolves = false
```

SwiftFormat and SwiftLint clean on both touched files.

Full CLI end-to-end proof was not run: a locally built unsigned `peekaboo` binary does not inherit the Screen Recording / Accessibility grants needed to drive the flow, so the proof above is taken at the WindowServer layer the bug lives in.

## Follow-ups (not in this PR)

Two other sites do an exact-ID lookup with the same on-screen-only option set and no `optionAll` fallback. Neither is on the reported path, so they are left alone here rather than widening scope:
- `Services/UI/DialogService+PreparedActions.swift:802`
- `Services/UI/BackgroundInputDriver.swift:793` (deliberate exact route, but same omission class for off-Space windows)
