### PR TITLE
fix(observation): keep a declined AX attribute from erasing an element

### DIFF
--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/AXDescriptorReader.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/AXDescriptorReader.swift
@@ -27,6 +27,40 @@ import CoreGraphics
             true
         }
     }
+
+    /// Attributes that identify and place a node. Without them the element cannot be emitted or
+    /// targeted at all, so a hard error on one of them really does make the node unreadable.
+    @_spi(Testing) public static let nodeIdentityAttributeNames: Set<String> = [
+        kAXRoleAttribute,
+        kAXPositionAttribute,
+        kAXSizeAttribute,
+    ]
+
+    /// Decides whether one attribute's embedded AX error invalidates the whole node.
+    ///
+    /// Applications answer inapplicable optional attributes with a generic `.failure` instead of
+    /// `.attributeUnsupported`: NSTextView does it for `AXDescription`, Finder's window root does it
+    /// for `AXValue`. Reading that as an unreadable node drops the element *and* abandons its subtree,
+    /// which is how a document's editable text area disappears from an otherwise healthy observation.
+    /// Only a node-identity attribute, or an error proving the read itself did not complete
+    /// (dead element, unanswered request), may invalidate the node.
+    @_spi(Testing) public static func attributeErrorInvalidatesNode(
+        _ error: AXError,
+        attribute: String) -> Bool
+    {
+        guard self.isIncomplete(error: error) else { return false }
+        return error != .failure || self.nodeIdentityAttributeNames.contains(attribute)
+    }
+
+    @_spi(Testing) public static func hasNodeInvalidatingErrorValue(
+        names: [String],
+        values: [Any]) -> Bool
+    {
+        zip(names, values).contains { name, value in
+            guard let error = self.embeddedError(in: value) else { return false }
+            return self.attributeErrorInvalidatesNode(error, attribute: name)
+        }
+    }
 }
 
 /// Reads the small descriptor surface element detection needs from AX elements.
@@ -153,7 +187,11 @@ import CoreGraphics
         var valueByName: [String: Any] = [:]
         for name in self.descriptorAttributeNames {
             let read = copyAttribute(name)
-            switch self.singleAttributeReadDisposition(error: read.error, value: read.value) {
+            switch self.singleAttributeReadDisposition(
+                error: read.error,
+                value: read.value,
+                attribute: name)
+            {
             case .value:
                 guard let value = read.value else { return .incomplete }
                 valueByName[name] = value
@@ -274,21 +312,28 @@ import CoreGraphics
             return .fallbackRequired
         }
         guard error == .success, let values else { return .incomplete }
-        return AXAttributeReadCompletenessPolicy.hasIncompleteErrorValue(in: values) ? .incomplete : .values
+        return AXAttributeReadCompletenessPolicy.hasNodeInvalidatingErrorValue(
+            names: self.descriptorAttributeNames,
+            values: values) ? .incomplete : .values
     }
 
     static func singleAttributeReadDisposition(
         error: AXError,
-        value: Any?) -> SingleAttributeReadDisposition
+        value: Any?,
+        attribute: String) -> SingleAttributeReadDisposition
     {
         if error == .success {
             guard let value else { return .incomplete }
             guard let embeddedError = AXAttributeReadCompletenessPolicy.embeddedError(in: value) else {
                 return .value
             }
-            return AXAttributeReadCompletenessPolicy.isIncomplete(error: embeddedError) ? .incomplete : .sparse
+            return AXAttributeReadCompletenessPolicy.attributeErrorInvalidatesNode(
+                embeddedError,
+                attribute: attribute) ? .incomplete : .sparse
         }
-        return AXAttributeReadCompletenessPolicy.isIncomplete(error: error) ? .incomplete : .sparse
+        return AXAttributeReadCompletenessPolicy.attributeErrorInvalidatesNode(
+            error,
+            attribute: attribute) ? .incomplete : .sparse
     }
 
     @_spi(Testing) public static func stringValue(_ value: Any?) -> String? {

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/DetachedAXObservationWorker.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/DetachedAXObservationWorker.swift
@@ -147,32 +147,13 @@ enum DetachedAXObservationWorker {
     static func descriptorReadDisposition(error: AXError, values: [Any]?)
         -> DetachedAXMultiAttributeReadDisposition
     {
-        let disposition = self.multiAttributeReadDisposition(
-            error: error,
-            values: values,
-            expectedValueCount: self.descriptorAttributeNames.count)
-        guard disposition == .incomplete,
-              error == .success,
-              let values,
-              values.count == self.descriptorAttributeNames.count
-        else {
-            return disposition
+        if error == .success {
+            guard let values, values.count == self.descriptorAttributeNames.count else { return .incomplete }
+            return AXAttributeReadCompletenessPolicy.hasNodeInvalidatingErrorValue(
+                names: self.descriptorAttributeNames,
+                values: values) ? .incomplete : .values
         }
-
-        let byName = Dictionary(uniqueKeysWithValues: zip(self.descriptorAttributeNames, values))
-        let role = self.stringValue(byName[kAXRoleAttribute])
-        let hasHardFailure = byName.contains { name, value in
-            guard let embeddedError = AXAttributeReadCompletenessPolicy.embeddedError(in: value),
-                  AXAttributeReadCompletenessPolicy.isIncomplete(error: embeddedError)
-            else {
-                return false
-            }
-            // Finder exposes no semantic AXValue on its AXWindow root and reports the absence as
-            // a generic failure rather than attributeUnsupported. The exact window and its tree
-            // remain readable, so this one role-inapplicable value is sparse evidence.
-            return !(name == kAXValueAttribute && role == kAXWindowRole && embeddedError == .failure)
-        }
-        return hasHardFailure ? .incomplete : .values
+        return self.isUnsupported(error) ? .fallback : .incomplete
     }
 
     static func childrenReadDisposition(error: AXError, values: [Any]?)
@@ -631,7 +612,7 @@ enum DetachedAXObservationWorker {
         var valuesByName: [String: Any] = [:]
         for name in self.descriptorAttributeNames {
             let read = self.rawAttributeRead(name, of: element)
-            if read.isIncomplete {
+            if read.invalidatesNode(attribute: name) {
                 return .incomplete
             }
             if let value = read.value {
@@ -926,6 +907,10 @@ private struct AXAttributeReadResult {
 
     var isIncomplete: Bool {
         AXAttributeReadCompletenessPolicy.isIncomplete(error: self.error)
+    }
+
+    func invalidatesNode(attribute: String) -> Bool {
+        AXAttributeReadCompletenessPolicy.attributeErrorInvalidatesNode(self.error, attribute: attribute)
     }
 }
 

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/AXDescriptorReaderPolicyTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/AXDescriptorReaderPolicyTests.swift
@@ -53,10 +53,12 @@ struct AXDescriptorReaderPolicyTests {
         #expect(!AXAttributeReadCompletenessPolicy.hasIncompleteErrorValue(in: [sparseValue]))
         #expect(AXDescriptorReader.singleAttributeReadDisposition(
             error: .success,
-            value: failedValue) == .incomplete)
+            value: failedValue,
+            attribute: kAXDescriptionAttribute) == .incomplete)
         #expect(AXDescriptorReader.singleAttributeReadDisposition(
             error: .success,
-            value: sparseValue) == .sparse)
+            value: sparseValue,
+            attribute: kAXDescriptionAttribute) == .sparse)
 
         var failedValues = [Any](
             repeating: NSNull(),
@@ -136,16 +138,49 @@ struct AXDescriptorReaderPolicyTests {
 
     @Test
     func `Single-read fallback classifies hard and sparse AX errors separately`() {
-        for error in [AXError.cannotComplete, .invalidUIElement, .apiDisabled, .failure] {
+        for error in [AXError.cannotComplete, .invalidUIElement, .apiDisabled] {
             #expect(AXDescriptorReader.singleAttributeReadDisposition(
                 error: error,
-                value: nil) == .incomplete)
+                value: nil,
+                attribute: kAXDescriptionAttribute) == .incomplete)
         }
         for error in [AXError.noValue, .attributeUnsupported, .parameterizedAttributeUnsupported, .notImplemented] {
             #expect(AXDescriptorReader.singleAttributeReadDisposition(
                 error: error,
-                value: nil) == .sparse)
+                value: nil,
+                attribute: kAXDescriptionAttribute) == .sparse)
         }
+    }
+
+    /// A declined optional attribute must not cost the caller the whole element; a declined
+    /// identity attribute must, because the element can no longer be placed or targeted.
+    @Test
+    func `A declined attribute is sparse unless the node depends on it`() {
+        #expect(AXDescriptorReader.singleAttributeReadDisposition(
+            error: .failure,
+            value: nil,
+            attribute: kAXDescriptionAttribute) == .sparse)
+        for attribute in AXAttributeReadCompletenessPolicy.nodeIdentityAttributeNames {
+            #expect(AXDescriptorReader.singleAttributeReadDisposition(
+                error: .failure,
+                value: nil,
+                attribute: attribute) == .incomplete)
+        }
+    }
+
+    @Test
+    func `A declined descriptive attribute keeps the batch usable`() throws {
+        var declined = AXError.failure
+        let declinedValue = try #require(AXValueCreate(.axError, &declined))
+        var values = [Any](
+            repeating: NSNull(),
+            count: AXDescriptorReader.descriptorAttributeCount)
+        // The identity attributes lead the descriptor batch, so the last slot is descriptive.
+        values[values.count - 1] = declinedValue
+
+        #expect(AXDescriptorReader.batchReadDisposition(
+            error: .success,
+            values: values) == .values)
     }
 
     private static func requiredDescriptorReads() -> [String: AXDescriptorReader.SingleAttributeRead] {

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/DetachedAXObservationWorkerTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/DetachedAXObservationWorkerTests.swift
@@ -121,44 +121,53 @@ struct DetachedAXObservationWorkerTests {
             values: values) == .incomplete)
     }
 
+    /// TextEdit's `AXTextArea` answers `AXDescription` with a generic `.failure`, and Finder's
+    /// `AXWindow` root answers `AXValue` the same way. Treating that as an unreadable node dropped
+    /// the element and abandoned its subtree, which is how a document's editable text area vanished
+    /// from an otherwise healthy observation.
     @Test
-    func `only a window value failure is sparse in an otherwise usable descriptor`() throws {
-        let valueIndex = try #require(DetachedAXObservationWorker.descriptorAttributeIndex(kAXValueAttribute))
-        var values = try Self.usableDescriptorValues(role: kAXWindowRole)
-        values[valueIndex] = try Self.errorValue(.failure)
-
-        #expect(DetachedAXObservationWorker.descriptorReadDisposition(
-            error: .success,
-            values: values) == .values)
-
-        for role in [kAXButtonRole, kAXTextFieldRole, kAXGroupRole] {
-            var controlValues = try Self.usableDescriptorValues(role: role)
-            controlValues[valueIndex] = try Self.errorValue(.failure)
-            #expect(DetachedAXObservationWorker.descriptorReadDisposition(
-                error: .success,
-                values: controlValues) == .incomplete)
-        }
-
-        for attribute in DetachedAXObservationWorker.descriptorAttributes where attribute != kAXValueAttribute {
-            var failedValues = try Self.usableDescriptorValues(role: kAXWindowRole)
+    func `a declined descriptive attribute stays sparse for every role`() throws {
+        for attribute in DetachedAXObservationWorker.descriptorAttributes
+            where !AXAttributeReadCompletenessPolicy.nodeIdentityAttributeNames.contains(attribute)
+        {
             let index = try #require(DetachedAXObservationWorker.descriptorAttributeIndex(attribute))
-            failedValues[index] = try Self.errorValue(.failure)
+            for role in [kAXTextAreaRole, kAXWindowRole, kAXButtonRole, kAXGroupRole] {
+                var values = try Self.usableDescriptorValues(role: role)
+                values[index] = try Self.errorValue(.failure)
+                #expect(DetachedAXObservationWorker.descriptorReadDisposition(
+                    error: .success,
+                    values: values) == .values)
+            }
+        }
+    }
+
+    @Test
+    func `a declined node identity attribute still invalidates the node`() throws {
+        for attribute in AXAttributeReadCompletenessPolicy.nodeIdentityAttributeNames {
+            let index = try #require(DetachedAXObservationWorker.descriptorAttributeIndex(attribute))
+            var values = try Self.usableDescriptorValues(role: kAXTextAreaRole)
+            values[index] = try Self.errorValue(.failure)
             #expect(DetachedAXObservationWorker.descriptorReadDisposition(
                 error: .success,
-                values: failedValues) == .incomplete)
+                values: values) == .incomplete)
         }
+    }
 
+    @Test
+    func `an unanswered attribute read invalidates the node whatever it describes`() throws {
+        let descriptionIndex = try #require(
+            DetachedAXObservationWorker.descriptorAttributeIndex(kAXDescriptionAttribute))
         for error in [AXError.cannotComplete, .invalidUIElement, .apiDisabled] {
-            var failedValues = try Self.usableDescriptorValues(role: kAXWindowRole)
-            failedValues[valueIndex] = try Self.errorValue(error)
+            var values = try Self.usableDescriptorValues(role: kAXTextAreaRole)
+            values[descriptionIndex] = try Self.errorValue(error)
             #expect(DetachedAXObservationWorker.descriptorReadDisposition(
                 error: .success,
-                values: failedValues) == .incomplete)
+                values: values) == .incomplete)
         }
 
-        #expect(DetachedAXObservationWorker.descriptorReadDisposition(
+        #expect(try DetachedAXObservationWorker.descriptorReadDisposition(
             error: .failure,
-            values: values) == .incomplete)
+            values: Self.usableDescriptorValues(role: kAXTextAreaRole)) == .incomplete)
     }
 
     @Test


### PR DESCRIPTION
## Problem

A window-state observation of a TextEdit document window never contains the editable text area.
`see`/`inspect_ui` return the ruler, the style controls, the scroll area and both scroll bars — but
not the `AXTextArea` the document actually lives in. Because the text area is missing, an
accessibility write cannot target the document at all; the closest element on offer is the scroll
area, and writing to that is correctly refused:

```
Cannot set value on elem_1 other: scroll area: Accessibility value is not settable
```

That makes background *writing* to a text document impossible — the headline capability, on the
most ordinary document window there is. Every such observation also carried the generic
`AX tree incomplete at incomplete accessibility read` warning, which reads as "the app is slow,
retry" and never gets better on retry.

## Cause

`DetachedAXObservationWorker` reads a node's descriptor as one batched
`AXUIElementCopyMultipleAttributeValues` call over 16 attributes, then classifies the result. Any
attribute whose embedded `AXError` is "hard" made the whole read `.incomplete`
(`AXAttributeReadCompletenessPolicy.isIncomplete`), and `.incomplete` means
`nodeTraversalDisposition == .stopIncomplete`: the element is not emitted *and* its subtree is
abandoned.

TextEdit's `NSTextView` answers `AXDescription` with a generic `kAXErrorFailure` (-25200) instead of
`kAXErrorAttributeUnsupported`. Direct AX probe of the live window, all 16 descriptor attributes:

```
- role=AXScrollArea copyMultipleError=0 count=16
    - role=AXTextArea copyMultipleError=0 count=16
        AXPosition = AXValue           AXRole = "AXTextArea"
        AXSize = AXValue               AXValue = "seed line\n"
        AXDescription = AXError(-25200) hardFailure=true   <-- kills the node
        AXRoleDescription = "text entry area"
        AXIdentifier = "First Text View"
        [valueSettable err=0 settable=true]                <-- it was writable all along
    - role=AXScrollBar  ... (emitted)
    - role=AXScrollBar  ... (emitted)
```

So the role mapping was never wrong (`axtextarea → .textField` exists in both classifiers) and no
depth/element/child budget was hit — `--depth 50 --max-elements 5000 --max-children 500` changes
nothing. The node was simply never emitted, and the only trace was the misleading "incomplete read"
warning. Its siblings survived because the failure is per-node.

The codebase already knew about this pathology: it carried a hardcoded carve-out for Finder, whose
`AXWindow` root answers `AXValue` the same way. That carve-out fixed one app's one attribute instead
of the class of bug.

## Fix

Classify a per-attribute embedded error against what that attribute is *for*, in one shared policy
(`AXAttributeReadCompletenessPolicy`):

- **Node-identity attributes** (`AXRole`, `AXPosition`, `AXSize`) — a hard error genuinely makes the
  node unreadable, because it can no longer be identified or placed. Still `.incomplete`.
- **Descriptive attributes** (everything else) — a bare `.failure` means the application declined to
  answer for that one attribute. Treat it as sparse metadata, exactly like `.attributeUnsupported`.
- **Errors that prove the read itself did not complete** (`.cannotComplete`, `.invalidUIElement`,
  `.apiDisabled`, …) — still `.incomplete` on any attribute, so genuine timeouts and dead elements
  keep failing closed and keep flagging the observation.

Both descriptor readers (`DetachedAXObservationWorker` for the default lane, `AXDescriptorReader`
for the AXorcist lane) and both of their single-attribute fallbacks now use it. The Finder carve-out
is deleted — it is subsumed by the general rule.

Production delta is net negative (**+11 / −26** in the worker, +50/−5 in the shared policy that
absorbed it), and one hardcoded app special case is gone.

## Evidence

Live, on the same non-frontmost TextEdit document window (`peekaboo see --tree --no-screenshot`).

**Before** (installed 4.2.0 from `main`) — 12 elements, no editable element, misleading warning:

```
📊 UI elements detected: 12
⚠️  Warning: AX tree incomplete at incomplete accessibility read. Retry once ...
  elem_1 [other] scroll area
  elem_2 [other] 0.1851851791143417 value_settable=true disabled
  elem_3 [other] 0.615384578704834  value_settable=true disabled
  (no text area)
```

**After** — 13 elements, the text area is present, typed, and settable; warning gone:

```
📊 UI elements detected: 13
  elem_2 [textField] BGTEST1seed line value="BGTEST1seed line\n" value_settable=true
```

**End-to-end background write** into that window — TextEdit not frontmost, and the target window is
not even the app's key window:

```
== BEFORE ==   frontmost: Finder   cursor: 2525.957,1245.520   key window: ['bgwrite2.txt']
               target doc: seed line
   set-value "Background write OK" --on elem_2 --snapshot <id>
     state: confirmed_change   old: 'seed line\n' -> new: 'Background write OK'
== AFTER  ==   frontmost: Finder   cursor: 2525.957,1245.520   key window: ['bgwrite2.txt']
               target doc: Background write OK
               other doc:  second seed   (untouched)
```

Frontmost application, cursor position, and key window all unchanged; the sibling document is
untouched; the value write is verified by read-back (`confirmed_change`).

**Regression tests** (`Core/PeekabooAutomationKit/Tests`):

- `a declined descriptive attribute stays sparse for every role` — every non-identity descriptor
  attribute × `AXTextArea`/`AXWindow`/`AXButton`/`AXGroup`.
- `a declined node identity attribute still invalidates the node`.
- `an unanswered attribute read invalidates the node whatever it describes`.
- `A declined attribute is sparse unless the node depends on it` and
  `A declined descriptive attribute keeps the batch usable` for the AXorcist lane.

All four fail on pre-fix behaviour for the intended reason. Proven by reverting only the policy
body (`attributeErrorInvalidatesNode` → old `isIncomplete`) and re-running:

```
✘ "a declined descriptive attribute stays sparse for every role"  — expected .values, got .incomplete
✘ "A declined descriptive attribute keeps the batch usable"       — expected .values, got .incomplete
✘ "A declined attribute is sparse unless the node depends on it"  — expected .sparse, got .incomplete
✔ "a declined node identity attribute still invalidates the node" — unchanged (control)
✔ "an unanswered attribute read invalidates the node ..."         — unchanged (control)
```

The old Finder-specific test `only a window value failure is sparse in an otherwise usable
descriptor` is replaced by the three general tests above; the behaviour it pinned is a strict subset
of the new rule.

**Suites**

- `swift test --package-path Core/PeekabooAutomationKit --no-parallel` — 1085 Swift Testing tests in
  105 suites + 191 XCTest, 0 failures.
- `swift test --package-path Core/PeekabooCore --no-parallel` — two failures
  (`See tool PID target with window index uses shared observation parser`,
  `minimized identity may dispatch when WindowServer omits its entry`) reproduce identically on
  pristine `origin/main`; pre-existing, not from this change.
- `swiftformat --lint` and `swiftlint` clean on the touched files.
