### PR TITLE
fix(input): name the working route when a window lacks keyboard focus

### DIFF
--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Core/Protocols/UIAutomationOperationModels.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Core/Protocols/UIAutomationOperationModels.swift
@@ -263,6 +263,22 @@ public enum FocusedElementReceiptError: LocalizedError, Equatable, Sendable {
     }
 }
 
+/// Next step for every refusal that means "the exact target window does not hold this
+/// application's keyboard focus".
+///
+/// Background keystrokes are posted to the application, which routes them to whichever window holds
+/// its own keyboard focus — not to the window the caller named. Failing closed is therefore correct,
+/// but the caller still has a route that reaches an unfocused window: an accessibility value write.
+/// Keep this text attached to those refusals so background writing never ends in a dead end.
+public enum BackgroundKeyboardFocusRemediation {
+    public static let message = "Background keystrokes follow the application's own keyboard focus " +
+        "and cannot be aimed at a window that does not hold it; such a window also refuses " +
+        "accessibility focus requests, so no amount of retrying moves focus there in the " +
+        "background. To write into this window without focusing it, observe it and set its editable " +
+        "element's accessibility value (`set-value` command, `set_value` tool). Use foreground " +
+        "delivery only when the window may take focus."
+}
+
 public struct ExactWindowKeyboardTarget: Sendable, Codable, Equatable {
     public let windowIdentity: WindowMutationIdentity
     public let windowBounds: CGRect

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/UIAutomationService+ElementLookup.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/UIAutomationService+ElementLookup.swift
@@ -145,8 +145,8 @@ extension UIAutomationService {
     private func exactWindowKeyboardFocusChangedError() -> PeekabooError {
         PeekabooError.invalidInput(
             field: "target",
-            reason: "Exact-window keyboard focus changed before dispatch; capture a fresh snapshot or use " +
-                "foreground delivery")
+            reason: "Exact-window keyboard focus is not on the target window at dispatch. " +
+                BackgroundKeyboardFocusRemediation.message)
     }
 
     private func focusInfo(for element: Element, processIdentifier: pid_t?) -> UIFocusInfo {

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Strategy/UIAutomationTarget.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Strategy/UIAutomationTarget.swift
@@ -250,13 +250,14 @@ public enum UIAutomationTarget: Sendable, Equatable {
         else {
             throw PeekabooError.invalidInput(
                 field: "target",
-                reason: FocusedElementReceiptError.noFocusedElement.localizedDescription +
-                    " Focus an explicit field and capture fresh exact-window UI state.")
+                reason: FocusedElementReceiptError.noFocusedElement.localizedDescription + " " +
+                    BackgroundKeyboardFocusRemediation.message)
         }
         guard focus.processId == Int(exactWindow.identity.ownerProcessIdentifier) else {
             throw PeekabooError.invalidInput(
                 field: "target",
-                reason: FocusedElementReceiptError.processMismatch.localizedDescription)
+                reason: FocusedElementReceiptError.processMismatch.localizedDescription + " " +
+                    BackgroundKeyboardFocusRemediation.message)
         }
         guard focus.windowID != nil else {
             throw PeekabooError.invalidInput(
@@ -273,7 +274,8 @@ public enum UIAutomationTarget: Sendable, Equatable {
         else {
             throw PeekabooError.invalidInput(
                 field: "target",
-                reason: FocusedElementReceiptError.windowMismatch.localizedDescription)
+                reason: FocusedElementReceiptError.windowMismatch.localizedDescription + " " +
+                    BackgroundKeyboardFocusRemediation.message)
         }
         guard exactWindow.bounds.contains(CGPoint(x: focusedElement.frame.midX, y: focusedElement.frame.midY)) else {
             throw PeekabooError.invalidInput(

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/UIAutomationExactWindowFocusTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/UIAutomationExactWindowFocusTests.swift
@@ -252,6 +252,39 @@ final class UIAutomationExactWindowFocusTests: XCTestCase {
         }
     }
 
+    /// A window that does not hold its application's keyboard focus can never receive background
+    /// keystrokes, and it also refuses accessibility focus requests, so "retry" and "focus it first"
+    /// are both dead ends. The refusal must hand back the route that does reach such a window.
+    func testUnfocusedExactWindowRefusalNamesTheAccessibilityWriteRoute() async throws {
+        let bounds = CGRect(x: 0, y: 0, width: 800, height: 600)
+        let identity = WindowMutationIdentity(
+            windowID: 42,
+            ownerProcessIdentifier: 930_006,
+            ownerProcessStartIdentity: 91,
+            capturedBounds: bounds)
+        let service = UIAutomationService(
+            actionInputDriver: ActionInputDriver(),
+            automationElementResolver: AutomationElementResolver(),
+            exactWindowFocusReader: { processIdentifier in
+                ExactWindowFocusSnapshot(
+                    processIdentifier: processIdentifier,
+                    windowID: identity.windowID + 1,
+                    frame: CGRect(x: 50, y: 100, width: 200, height: 30))
+            },
+            exactWindowIdentityValidator: { _, _ in true })
+
+        do {
+            try await service.requireExactWindowKeyboardFocus(
+                expectedWindowIdentity: identity,
+                expectedWindowBounds: bounds)
+            XCTFail("Expected an unfocused exact window to refuse background keystrokes")
+        } catch let PeekabooError.invalidInput(message) {
+            XCTAssertTrue(message.contains("set-value"), message)
+            XCTAssertTrue(message.contains("set_value"), message)
+            XCTAssertTrue(message.contains("accessibility value"), message)
+        }
+    }
+
     private static func seconds(_ duration: Duration) -> TimeInterval {
         let components = duration.components
         return Double(components.seconds) + Double(components.attoseconds) / 1_000_000_000_000_000_000


### PR DESCRIPTION
## Problem

Background typing into a window that does not hold its application's keyboard focus is refused, and
the refusal ends the caller's turn:

```
Invalid target: Exact-window keyboard focus changed before dispatch; capture a fresh snapshot or
use foreground delivery
Invalid target: The focused element belongs to a different window.
```

Both suggestions are dead ends for the case that actually produces them. "Capture a fresh snapshot"
implies a stale-snapshot race — but the window is not stale, it simply never holds focus, so
retrying with a snapshot captured milliseconds earlier fails identically. "Use foreground delivery"
means giving up the one thing background delivery exists for. Nothing in the message names an action
that reaches an unfocused window, so an agent that wants to write into a background document window
has no next step.

## Cause — and why the guard stays

The guard is correct and stays. Background keystrokes are posted per-PID
(`SLEventPostToPid`, falling back to `CGEvent.postToPid`); the application receives them and routes
them to *its own* key window's first responder. The requested window is not part of that routing, so
without the guard the text lands in a different window of the same app.

Measured directly, bypassing Peekaboo, with two TextEdit documents open — `bgwrite2.txt` holding the
app's focus, `bgwrite.txt` not:

```
posted 3 units ("ZZZ") to pid 3764 with kCGEventTargetUnixProcessID set
  bgwrite.txt  (the window a caller would name) : "BGTEST1seed line"   <- unchanged
  bgwrite2.txt (the app's key window)           : "ZZZsecond seed"     <- received the keystrokes
  frontmost: Finder (TextEdit never activated)
```

So synthetic keystrokes are simply the wrong mechanism for writing into a specific unfocused window,
and failing closed is the right call.

"Focus it first, then type" is not a workaround either: an unfocused window also refuses
accessibility focus requests. A background `click` on the same text area returns
`The selected element did not report AXFocused=true after the native focus request`, and the
following `type` is refused again. The refusal text must not suggest it.

What *does* reach an unfocused window is an accessibility value write — `set-value` / `set_value` —
which needs neither key-window status nor frontmost status. That is the action the refusal has to
name.

## Fix

One shared `BackgroundKeyboardFocusRemediation.message`, attached to every refusal that means "the
exact target window does not hold this application's keyboard focus":

- `UIAutomationService.exactWindowKeyboardFocusChangedError()` (the dispatch-time guard), whose
  leading clause also stops claiming the focus "changed" when it was never there.
- `UIAutomationTarget.pinningCurrentFocusedElement()` — the `noFocusedElement`, `processMismatch`
  and `windowMismatch` refusals reached from `type`, `press` and `paste`.

The message states the mechanism, names the route that works, and marks foreground delivery as the
deliberate focus-stealing option rather than the default advice. Geometry- and receipt-shape
refusals are left alone; they mean something else.

No guard is weakened: same conditions, same refusal, same `refused` outcome and
`target_unavailable` reason. Only the text changes. Production delta **+16 / −6**.

## User impact

An agent or operator that hits this refusal now learns, in the refusal itself, how to complete the
write without touching the user's focus. Together with the observation fix (which is what makes the
editable element appear in the first place), background writing to a text document works end to end.

## Evidence

Live CLI, TextEdit not frontmost, `bgwrite.txt` not the app's key window:

**Before**

```
$ peekaboo type "BLOCKED" --app TextEdit --window-title bgwrite.txt
effect: refused
Invalid input: Invalid target: The focused element belongs to a different window.
```

**After**

```
$ peekaboo type "MUST NOT LAND" --app TextEdit --window-title bgwrite.txt
effect: refused
Invalid input: Invalid target: The focused element belongs to a different window. Background
keystrokes follow the application's own keyboard focus and cannot be aimed at a window that does not
hold it; such a window also refuses accessibility focus requests, so no amount of retrying moves
focus there in the background. To write into this window without focusing it, observe it and set its
editable element's accessibility value (`set-value` command, `set_value` tool). Use foreground
delivery only when the window may take focus.
```

Following that guidance on the same window, with the observation fix applied:

```
set-value "Background write OK" --on elem_2 --snapshot <id>
  state: confirmed_change   old: 'seed line\n' -> new: 'Background write OK'
frontmost: Finder (unchanged)   cursor: 2525.957,1245.520 (unchanged)   key window: bgwrite2.txt (unchanged)
```

**Regression test** — `UIAutomationExactWindowFocusTests.testUnfocusedExactWindowRefusalNamesTheAccessibilityWriteRoute`
drives `requireExactWindowKeyboardFocus` with a focus reader reporting a different window and asserts
the refusal names the accessibility-value route. It fails pre-fix with the exact shipped text:

```
XCTAssertTrue failed - Invalid target: Exact-window keyboard focus changed before dispatch;
capture a fresh snapshot or use foreground delivery
```

**Suites** — `swift test --package-path Core/PeekabooAutomationKit --no-parallel`: 1085 Swift Testing
tests in 105 suites + 191 XCTest, 0 failures. `swiftformat --lint` / `swiftlint` clean on touched
files. Two `Core/PeekabooCore` failures seen locally reproduce identically on pristine `origin/main`
and are unrelated.

## Note on ordering

This PR makes the refusal actionable; the route it names only has an element to target once the
sibling observation fix lands (`AXTextArea` is currently dropped from TextEdit observations). The two
diffs are disjoint and can land in either order, but the product outcome needs both.
