### PR TITLE
fix: preserve exact window catalog evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Add a live-physical multi-target finalizer that binds exact protocol-1.30 background controllers, a source-owned epoch monitor, attributed foreground activity, restoration, crash evidence, and protocol-1.29 signed receipt validation into one fail-closed run.
 
 ### Fixed
+- Keep exact background pointer routing and dialog postcondition checks correct for minimized and off-Space windows, while treating failed WindowServer catalog reads as unreadable instead of confirmed absence.
 - Bound held-pointer owner and terminal-replay retention in long-lived hosts, make idle-owner disconnect a signed no-change close, and prevent cancelled begins from returning an already-terminated hold receipt.
 - Release cancelled exact-window held hotkeys only to their original process generation, include cleanup events in typed unit counts, and never retarget cleanup to a recycled PID.
 - Make application and window inventories report omitted or identity-incomplete rows as partial, while keeping complete AX-only window listings usable without Screen Recording.

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/System/SystemIdentityResolver.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/System/SystemIdentityResolver.swift
@@ -43,6 +43,12 @@ public struct SystemWindowIdentity: Sendable, Equatable {
 /// PIDs are generation-bound because they are recycled; CGWindowID is Apple's session-scoped
 /// WindowServer identifier, with owner generation and bounds retained as fail-closed change evidence.
 public enum SystemIdentityResolver {
+    enum ExactWindowCatalogObservation {
+        case found([String: Any])
+        case absent
+        case unreadable
+    }
+
     private struct WindowSafetyFingerprint: Equatable {
         let windowID: CGWindowID
         let ownerProcessIdentifier: pid_t
@@ -99,41 +105,40 @@ public enum SystemIdentityResolver {
     /// Resolves one exact window from the current WindowServer catalog without AX traversal.
     public static func windowIdentity(_ windowID: CGWindowID) -> SystemWindowIdentity? {
         guard windowID != kCGNullWindowID else { return nil }
-        guard let windows = self.exactWindowCatalog(
+        guard case let .found(window) = self.exactWindowCatalogObservation(
             windowID,
             windowListProvider: { options, relativeToWindow in
                 CGWindowListCopyWindowInfo(options, relativeToWindow) as? [[String: Any]]
-            }),
-            let identity = self.windowIdentity(windowID, in: windows)
-        else {
-            return nil
-        }
-        return identity
+            })
+        else { return nil }
+        return self.windowIdentity(from: window)
     }
 
-    /// Returns the catalog slice that contains one exact WindowServer ID.
+    /// Observes one exact WindowServer row without conflating absence with a failed catalog read.
     ///
     /// `optionIncludingWindow` can omit a minimized or off-Space window even while `optionAll`
     /// still carries its exact ID, owner, and frame. The fallback remains ID-only: descriptive
     /// metadata such as title and bounds is never used to select a different entry.
-    static func exactWindowCatalog(
+    static func exactWindowCatalogObservation(
         _ windowID: CGWindowID,
-        windowListProvider: (CGWindowListOption, CGWindowID) -> [[String: Any]]?) -> [[String: Any]]?
+        windowListProvider: (CGWindowListOption, CGWindowID) -> [[String: Any]]?)
+        -> ExactWindowCatalogObservation
     {
-        guard windowID != kCGNullWindowID else { return nil }
-        if let exact = windowListProvider([.optionIncludingWindow], windowID),
-           self.containsWindow(windowID, in: exact)
-        {
-            return exact
+        guard windowID != kCGNullWindowID else { return .absent }
+
+        let exact = windowListProvider([.optionIncludingWindow], windowID)
+        if let window = exact.flatMap({ self.exactWindowDictionary(windowID, in: $0) }) {
+            return .found(window)
         }
-        guard let all = windowListProvider(
+
+        let all = windowListProvider(
             [.optionAll, .excludeDesktopElements],
-            kCGNullWindowID),
-            self.containsWindow(windowID, in: all)
-        else {
-            return nil
+            kCGNullWindowID)
+        if let window = all.flatMap({ self.exactWindowDictionary(windowID, in: $0) }) {
+            return .found(window)
         }
-        return all
+
+        return exact != nil && all != nil ? .absent : .unreadable
     }
 
     /// Captures one generation-bound exact-window identity while allowing descriptive metadata
@@ -225,16 +230,14 @@ public enum SystemIdentityResolver {
         _ windowID: CGWindowID,
         in windows: [[String: Any]]) -> SystemWindowIdentity?
     {
-        windows.first(where: {
-            self.intValue($0[kCGWindowNumber as String]) == Int(windowID)
-        }).flatMap(self.windowIdentity(from:))
+        self.exactWindowDictionary(windowID, in: windows).flatMap(self.windowIdentity(from:))
     }
 
-    private static func containsWindow(
+    private static func exactWindowDictionary(
         _ windowID: CGWindowID,
-        in windows: [[String: Any]]) -> Bool
+        in windows: [[String: Any]]) -> [String: Any]?
     {
-        windows.contains {
+        windows.first {
             self.intValue($0[kCGWindowNumber as String]) == Int(windowID)
         }
     }

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/BackgroundInputDriver.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/BackgroundInputDriver.swift
@@ -793,20 +793,19 @@ enum BackgroundInputDriver {
             CGWindowListCopyWindowInfo(options, relativeToWindow) as? [[String: Any]]
         }) -> [MouseWindowRouteCandidate]
     {
-        let options: CGWindowListOption
-        let relativeToWindow: CGWindowID
+        let windows: [[String: Any]]
         if let exactWindowID {
-            // On-screen enumeration omits live windows on other Spaces; exact routes must query by ID.
-            options = [.optionIncludingWindow, .excludeDesktopElements]
-            relativeToWindow = exactWindowID
+            guard case let .found(window) = SystemIdentityResolver.exactWindowCatalogObservation(
+                exactWindowID,
+                windowListProvider: copyWindowInfo)
+            else { return [] }
+            windows = [window]
         } else {
-            options = [.optionOnScreenOnly, .excludeDesktopElements]
-            relativeToWindow = kCGNullWindowID
-        }
-
-        guard let windows = copyWindowInfo(options, relativeToWindow)
-        else {
-            return []
+            guard let onScreenWindows = copyWindowInfo(
+                [.optionOnScreenOnly, .excludeDesktopElements],
+                kCGNullWindowID)
+            else { return [] }
+            windows = onScreenWindows
         }
 
         return windows.compactMap { window in

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/DialogService+PreparedActions.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/DialogService+PreparedActions.swift
@@ -799,21 +799,29 @@ extension DialogService {
     }
 
     static func windowServerPresence(_ identity: WindowMutationIdentity) -> DialogPresence {
-        let windows = CGWindowListCopyWindowInfo(
-            [.optionIncludingWindow, .excludeDesktopElements],
-            CGWindowID(identity.windowID)) as? [[String: Any]]
-        return self.windowServerPresence(identity, windows: windows)
+        self.windowServerPresence(
+            identity,
+            windowListProvider: { options, relativeToWindow in
+                CGWindowListCopyWindowInfo(options, relativeToWindow) as? [[String: Any]]
+            })
     }
 
     static func windowServerPresence(
         _ identity: WindowMutationIdentity,
-        windows: [[String: Any]]?) -> DialogPresence
+        windowListProvider: (CGWindowListOption, CGWindowID) -> [[String: Any]]?) -> DialogPresence
     {
-        guard let windows else { return .unreadable }
-        guard let window = windows.first(where: {
-            ($0[kCGWindowNumber as String] as? NSNumber)?.intValue == identity.windowID
-        }) else { return .absent }
-        guard let ownerPID = window[kCGWindowOwnerPID as String] as? NSNumber else { return .unreadable }
-        return ownerPID.int32Value == identity.ownerProcessIdentifier ? .present : .absent
+        guard let windowID = CGWindowID(exactly: identity.windowID) else { return .unreadable }
+        switch SystemIdentityResolver.exactWindowCatalogObservation(
+            windowID,
+            windowListProvider: windowListProvider)
+        {
+        case let .found(window):
+            guard let ownerPID = window[kCGWindowOwnerPID as String] as? NSNumber else { return .unreadable }
+            return ownerPID.int32Value == identity.ownerProcessIdentifier ? .present : .absent
+        case .absent:
+            return .absent
+        case .unreadable:
+            return .unreadable
+        }
     }
 }

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/WindowCGInfoLookup.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/WindowCGInfoLookup.swift
@@ -31,7 +31,7 @@ struct WindowCGInfoLookup {
         // Exact ID refreshes happen after mutations and snapshot focus; keep them on the CG fast path
         // instead of walking every app's AX window list.
         guard let cgWindowID = CGWindowID(exactly: windowID),
-              let windowList = SystemIdentityResolver.exactWindowCatalog(
+              case let .found(window) = SystemIdentityResolver.exactWindowCatalogObservation(
                   cgWindowID,
                   windowListProvider: self.windowListProvider)
         else {
@@ -40,7 +40,7 @@ struct WindowCGInfoLookup {
 
         return Self.serviceWindowInfo(
             windowID: windowID,
-            windowList: windowList,
+            windowList: [window],
             isMainWindowProvider: self.isMainWindowProvider,
             processStartIdentityProvider: self.processStartIdentityProvider,
             currentWindowIdentityProvider: self.currentWindowIdentityProvider)

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Utilities/WindowIdentityUtilities.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Utilities/WindowIdentityUtilities.swift
@@ -322,15 +322,15 @@ public final class WindowIdentityService {
     ///
     /// `optionIncludingWindow` alone omits minimized and off-Space windows, so resolving only through
     /// it reported live windows as gone while window listing — which scans `optionAll` — still returned
-    /// them. `exactWindowCatalog` owns that fallback; a window absent from both lists stays unresolved.
+    /// them. The shared exact-window observation owns that fallback; a window absent from both lists
+    /// stays unresolved.
     static func exactWindowServerInfo(
         windowID: CGWindowID,
         windowListProvider: (CGWindowListOption, CGWindowID) -> [[String: Any]]?) -> WindowIdentityInfo?
     {
-        guard let windowList = SystemIdentityResolver.exactWindowCatalog(
+        guard case let .found(window) = SystemIdentityResolver.exactWindowCatalogObservation(
             windowID,
             windowListProvider: windowListProvider),
-            let window = exactWindowDictionary(windowID: windowID, in: windowList),
             let ownerPID = Self.ownerPID(from: window)
         else {
             return nil

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/BackgroundInputDriverWindowRoutingTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/BackgroundInputDriverWindowRoutingTests.swift
@@ -4,25 +4,18 @@ import Testing
 
 struct BackgroundInputDriverWindowRoutingTests {
     @Test
-    func `Exact window lookup includes a window on another Space`() throws {
-        var observedOptions: CGWindowListOption?
-        var observedRelativeWindow: CGWindowID?
+    func `Exact window lookup falls back to the full catalog for another Space`() throws {
+        var queries: [(CGWindowListOption, CGWindowID)] = []
         let candidates = BackgroundInputDriver
             .mouseWindowRouteCandidates(exactWindowID: 42) { options, relativeToWindow in
-                observedOptions = options
-                observedRelativeWindow = relativeToWindow
-                return [[
-                    kCGWindowNumber as String: 42,
-                    kCGWindowOwnerPID as String: 123,
-                    kCGWindowLayer as String: 0,
-                    kCGWindowBounds as String: [
-                        "X": 0,
-                        "Y": 0,
-                        "Width": 200,
-                        "Height": 200,
-                    ],
-                    kCGWindowIsOnscreen as String: false,
-                ]]
+                queries.append((options, relativeToWindow))
+                if options.contains(.optionIncludingWindow) {
+                    return []
+                }
+                return [Self.windowDictionary(
+                    windowID: 42,
+                    processIdentifier: 123,
+                    bounds: CGRect(x: 0, y: 0, width: 200, height: 200))]
             }
 
         let resolved = try BackgroundInputDriver.resolveTargetWindowID(
@@ -31,9 +24,58 @@ struct BackgroundInputDriverWindowRoutingTests {
             exactWindowID: 42,
             candidates: candidates)
 
-        #expect(observedOptions?.contains(.optionIncludingWindow) == true)
-        #expect(observedOptions?.contains(.optionOnScreenOnly) == false)
-        #expect(observedRelativeWindow == 42)
+        #expect(queries.count == 2)
+        #expect(queries[0].0 == [.optionIncludingWindow])
+        #expect(queries[0].1 == 42)
+        #expect(queries[1].0 == [.optionAll, .excludeDesktopElements])
+        #expect(queries[1].1 == kCGNullWindowID)
+        #expect(resolved == 42)
+    }
+
+    @Test
+    func `Exact window lookup stays stale when both catalogs omit it`() {
+        var queries: [(CGWindowListOption, CGWindowID)] = []
+        let candidates = BackgroundInputDriver.mouseWindowRouteCandidates(exactWindowID: 42) {
+            options,
+            relativeToWindow in
+            queries.append((options, relativeToWindow))
+            return []
+        }
+
+        #expect(throws: (any Error).self) {
+            try BackgroundInputDriver.resolveTargetWindowID(
+                at: CGPoint(x: 50, y: 50),
+                targetProcessIdentifier: 123,
+                exactWindowID: 42,
+                candidates: candidates)
+        }
+        #expect(queries.count == 2)
+        #expect(queries[0].0 == [.optionIncludingWindow])
+        #expect(queries[1].0 == [.optionAll, .excludeDesktopElements])
+    }
+
+    @Test
+    func `Targetless lookup remains on screen only`() throws {
+        var queries: [(CGWindowListOption, CGWindowID)] = []
+        let candidates = BackgroundInputDriver.mouseWindowRouteCandidates(exactWindowID: nil) {
+            options,
+            relativeToWindow in
+            queries.append((options, relativeToWindow))
+            return [Self.windowDictionary(
+                windowID: 42,
+                processIdentifier: 123,
+                bounds: CGRect(x: 0, y: 0, width: 200, height: 200))]
+        }
+
+        let resolved = try BackgroundInputDriver.resolveTargetWindowID(
+            at: CGPoint(x: 50, y: 50),
+            targetProcessIdentifier: 123,
+            exactWindowID: nil,
+            candidates: candidates)
+
+        #expect(queries.count == 1)
+        #expect(queries[0].0 == [.optionOnScreenOnly, .excludeDesktopElements])
+        #expect(queries[0].1 == kCGNullWindowID)
         #expect(resolved == 42)
     }
 
@@ -93,5 +135,18 @@ struct BackgroundInputDriverWindowRoutingTests {
             processIdentifier: processIdentifier,
             layer: 0,
             bounds: bounds)
+    }
+
+    private static func windowDictionary(
+        windowID: CGWindowID,
+        processIdentifier: pid_t,
+        bounds: CGRect) -> [String: Any]
+    {
+        [
+            kCGWindowNumber as String: Int(windowID),
+            kCGWindowOwnerPID as String: Int(processIdentifier),
+            kCGWindowLayer as String: 0,
+            kCGWindowBounds as String: bounds.dictionaryRepresentation,
+        ]
     }
 }

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/DialogPreparedActionStoreTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/DialogPreparedActionStoreTests.swift
@@ -199,17 +199,76 @@ struct DialogPreparedActionStoreTests {
     }
 
     @Test
-    func `window server absence is distinct from unreadable evidence`() throws {
+    func `window server presence falls back to the full catalog`() throws {
         let identity = try self.receipt().target.identity
-        #expect(DialogService.windowServerPresence(identity, windows: nil) == .unreadable)
-        #expect(DialogService.windowServerPresence(identity, windows: []) == .absent)
-        #expect(DialogService.windowServerPresence(identity, windows: [[
-            kCGWindowNumber as String: NSNumber(value: identity.windowID),
-        ]]) == .unreadable)
-        #expect(DialogService.windowServerPresence(identity, windows: [[
-            kCGWindowNumber as String: NSNumber(value: identity.windowID),
-            kCGWindowOwnerPID as String: NSNumber(value: identity.ownerProcessIdentifier),
-        ]]) == .present)
+        var queries: [(CGWindowListOption, CGWindowID)] = []
+        let presence = DialogService.windowServerPresence(identity, windowListProvider: {
+            options,
+            relativeToWindow in
+            queries.append((options, relativeToWindow))
+            if options.contains(.optionIncludingWindow) {
+                return []
+            }
+            return [Self.windowDictionary(identity: identity)]
+        })
+
+        #expect(presence == .present)
+        #expect(queries.count == 2)
+        #expect(queries[0].0 == [.optionIncludingWindow])
+        #expect(queries[0].1 == CGWindowID(identity.windowID))
+        #expect(queries[1].0 == [.optionAll, .excludeDesktopElements])
+        #expect(queries[1].1 == kCGNullWindowID)
+    }
+
+    @Test
+    func `window server absence requires successful misses from both catalogs`() throws {
+        let identity = try self.receipt().target.identity
+        var queryCount = 0
+        let presence = DialogService.windowServerPresence(identity, windowListProvider: { _, _ in
+            queryCount += 1
+            return []
+        })
+
+        #expect(presence == .absent)
+        #expect(queryCount == 2)
+    }
+
+    @Test
+    func `window server failed full catalog fallback remains unreadable`() throws {
+        let identity = try self.receipt().target.identity
+        var queryCount = 0
+        let presence = DialogService.windowServerPresence(identity, windowListProvider: { options, _ in
+            queryCount += 1
+            return options.contains(.optionIncludingWindow) ? [] : nil
+        })
+
+        #expect(presence == .unreadable)
+        #expect(queryCount == 2)
+    }
+
+    @Test
+    func `window server exact ID with the wrong owner is absent`() throws {
+        let identity = try self.receipt().target.identity
+        let presence = DialogService.windowServerPresence(identity, windowListProvider: { options, _ in
+            if options.contains(.optionIncludingWindow) {
+                return []
+            }
+            return [Self.windowDictionary(
+                identity: identity,
+                ownerProcessIdentifier: identity.ownerProcessIdentifier + 1)]
+        })
+
+        #expect(presence == .absent)
+    }
+
+    @Test
+    func `window server exact row without owner evidence is unreadable`() throws {
+        let identity = try self.receipt().target.identity
+        let presence = DialogService.windowServerPresence(identity, windowListProvider: { _, _ in
+            [[kCGWindowNumber as String: NSNumber(value: identity.windowID)]]
+        })
+
+        #expect(presence == .unreadable)
     }
 
     @Test
@@ -271,6 +330,17 @@ struct DialogPreparedActionStoreTests {
             token: UUID(),
             kind: .clickButton,
             target: UIAutomationTarget.ExactWindow(identity: identity, bounds: bounds))
+    }
+
+    private static func windowDictionary(
+        identity: WindowMutationIdentity,
+        ownerProcessIdentifier: pid_t? = nil) -> [String: Any]
+    {
+        [
+            kCGWindowNumber as String: NSNumber(value: identity.windowID),
+            kCGWindowOwnerPID as String: NSNumber(
+                value: ownerProcessIdentifier ?? identity.ownerProcessIdentifier),
+        ]
     }
 
     private func entry(


### PR DESCRIPTION
## Summary

- centralize exact WindowServer observation as found, authoritatively absent, or unreadable
- fall back from the direct exact-window query to the full catalog for minimized and off-Space windows
- keep background pointer routing exact and targetless routing on-screen-only
- prevent dialog postconditions from treating an unreadable or omitted live window as confirmed disappearance

## Test plan

- `swift test --package-path Core/PeekabooAutomationKit --filter 'BackgroundInputDriverWindowRoutingTests|DialogPreparedActionStoreTests|WindowIdentityExactWindowLookupTests|WindowCGInfoLookupTests'` — 41 passed
- `pnpm run format` — clean
- `pnpm run lint` — 0 serious findings; 82 existing warnings
- `pnpm run test:safe` — passed
- P0-P2 autoreview — clean, no actionable findings

The additional full AutomationKit run passed 1,088 of 1,089 tests; the unrelated 100 ms `Visibility mutation leaves unrelated process lanes available` timing assertion then passed in three consecutive focused suite reruns.
