### PR TITLE
fix: centralize background keyboard target planning

### DIFF
--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Include the authenticated Bridge host's stamped source commit and negotiated protocol version in live receipt-validation results for exact-build protocol certification.
 
 ### Fixed
+- Route CLI and MCP background keyboard delivery through one completeness-aware target planner, refusing fuzzy application selectors and partial window catalogs before type, paste, or press dispatch.
 - Make application and window inventories report omitted or identity-incomplete rows as partial, while keeping complete AX-only window listings usable without Screen Recording.
 - Update AXorcist and Tachikoma so Accessibility permission observation cancellation cannot deadlock the main queue or install timers after termination, while Realtime tool execution preserves the first completion/cancellation winner, keeps timeout returns bounded while owning delayed cleanup, preserves completed results during timer cancellation, and rejects invalid audio deadlines before dispatch. Thanks @SebTardif for AXorcist #46 and Tachikoma #68; follow-up fixes landed in AXorcist #48 and Tachikoma #69/#70.
 

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/KeyboardDeliverySupport.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/KeyboardDeliverySupport.swift
@@ -20,76 +20,52 @@ enum KeyboardDeliverySupport {
         } else {
             nil
         }
-        let selectedWindow = try await self.resolveSelectedWindow(target: target, services: services)
-        let selectedProcessIdentity = try await self.resolveSelectedProcessIdentity(
-            target: target,
-            services: services
+        let planner = DesktopTargetPlanning.BackgroundKeyboardTargetPlanner(
+            applications: services.applications,
+            windows: services.windows
         )
-
-        let exactWindow: UIAutomationTarget.ExactWindow?
-        switch (snapshotTarget, selectedWindow) {
-        case let (snapshot?, selected?):
-            let merged: DesktopTargetIdentity?
-            do {
-                merged = try DesktopTargetPlanning.DesktopTargetIdentityCoalescer.coalesce([
-                    DesktopTargetIdentity(exactWindow: snapshot),
-                    DesktopTargetIdentity(exactWindow: selected),
-                ])
-            } catch {
-                throw ValidationError(
-                    "The selected snapshot and window selector identify different exact windows. " +
-                        "Capture fresh UI state."
-                )
+        do {
+            return try await planner.plan(
+                selector: target.selector,
+                snapshotExactWindow: snapshotTarget,
+                requiresExplicitExactWindow: requiresExplicitExactWindow
+            ).target
+        } catch DesktopTargetPlanning.BackgroundKeyboardTargetPlanningError.targetRequired {
+            throw PreDispatchActionError(
+                message: "Keyboard input requires --app, --pid, --window-id, or --snapshot for background delivery.",
+                code: .VALIDATION_ERROR,
+                hint: "Use --foreground for intentional global input.",
+                reason: .invalidRequest
+            )
+        } catch let error as DesktopTargetPlanning.BackgroundKeyboardTargetPlanningError {
+            throw ValidationError(error.localizedDescription)
+        } catch let error as DesktopTargetPlanningError {
+            if case let .applicationNotFound(identifier, _) = error {
+                throw PeekabooError.appNotFound(identifier)
             }
-            guard let mergedWindow = merged?.exactWindow else {
-                throw ValidationError("The selected exact-window receipts are incomplete.")
-            }
-            exactWindow = mergedWindow
-        case let (snapshot?, nil):
-            exactWindow = snapshot
-        case let (nil, selected?):
-            exactWindow = selected
-        case (nil, nil):
-            exactWindow = nil
-        }
-
-        let processIdentity = try self.requireConsistentProcessIdentity(
-            selected: selectedProcessIdentity,
-            snapshot: snapshotTarget?.identity.processIdentity,
-            window: selectedWindow?.identity.processIdentity
-        )
-        try await self.requireBackgroundInputEligibility(
-            processIdentity: processIdentity,
-            services: services
-        )
-        let process = try UIAutomationTarget.Process(
-            processIdentifier: processIdentity.processIdentifier,
-            identity: processIdentity
-        )
-
-        if let exactWindow {
-            return try UIAutomationTarget.backgroundKeyboard(
-                process: process,
-                exactWindow: exactWindow
+            throw self.validationError(for: error)
+        } catch let error as DesktopTargetIdentityError {
+            throw ValidationError(
+                "The selected app, window, and snapshot do not identify the same process generation or exact " +
+                    "window receipt. " +
+                    "Capture fresh UI state. (\(error.localizedDescription))"
             )
         }
+    }
 
-        let eligibleWindows: [UIAutomationTarget.ExactWindow]
-        if requiresExplicitExactWindow {
-            eligibleWindows = []
-        } else {
-            let windows = try await services.windows.listWindows(
-                target: .application("PID:\(processIdentity.processIdentifier)")
+    private static func validationError(for error: DesktopTargetPlanningError) -> Commander.ValidationError {
+        switch error {
+        case .windowNotFound:
+            ValidationError("Could not resolve one exact background keyboard target: no matching window.")
+        case .ambiguousWindow:
+            ValidationError("Could not resolve one exact background keyboard target: multiple matching windows.")
+        case let .missingProcessIdentity(processIdentifier):
+            ValidationError(
+                "The runtime host could not pin PID:\(processIdentifier) to a process generation; update the host."
             )
-            eligibleWindows = try ObservationTargetResolver.captureCandidates(from: windows).map {
-                try UIAutomationTarget.ExactWindow(window: $0)
-            }
+        default:
+            ValidationError(error.localizedDescription)
         }
-        return try UIAutomationTarget.backgroundKeyboard(
-            process: process,
-            eligibleWindows: eligibleWindows,
-            requiresExplicitExactWindow: requiresExplicitExactWindow
-        )
     }
 
     static func validateForegroundFlags(
@@ -146,124 +122,5 @@ enum KeyboardDeliverySupport {
         } catch {
             throw ValidationError("Snapshot '\(snapshotId)' has inconsistent process/window metadata.")
         }
-    }
-
-    private static func resolveSelectedWindow(
-        target: InteractionTargetOptions,
-        services: any PeekabooServiceProviding
-    ) async throws -> UIAutomationTarget.ExactWindow? {
-        guard target.windowId != nil || target.windowTitle != nil || target.windowIndex != nil else {
-            return nil
-        }
-        guard let windowTarget = try target.toWindowTarget() else {
-            throw ValidationError("Could not resolve the requested exact window.")
-        }
-        let matches = try await services.windows.listWindows(target: windowTarget)
-        guard matches.count == 1, let window = matches.first else {
-            let detail = matches.isEmpty ? "no matching window" : "multiple matching windows"
-            throw ValidationError("Could not resolve one exact background keyboard target: \(detail).")
-        }
-        do {
-            return try DesktopTargetPlanning.DesktopTargetIdentityCoalescer.exactWindow(from: window)
-        } catch {
-            throw ValidationError(
-                "The selected window has no valid process-generation, window ID, and capture-bounds receipt. " +
-                    "Capture fresh UI state."
-            )
-        }
-    }
-
-    private static func resolveSelectedProcessIdentity(
-        target: InteractionTargetOptions,
-        services: any PeekabooServiceProviding
-    ) async throws -> ApplicationProcessIdentity? {
-        if let pid = target.pid {
-            guard pid > 0 else { throw ValidationError("--pid must be greater than 0") }
-            return try await self.requireCurrentProcessIdentity(
-                processIdentifier: pid,
-                services: services
-            )
-        }
-        guard let appIdentifier = target.app?.trimmingCharacters(in: .whitespacesAndNewlines),
-              !appIdentifier.isEmpty
-        else { return nil }
-        let app = try await services.applications.findApplication(identifier: appIdentifier)
-        return try self.requireProcessIdentity(app, targetDescription: "--app '\(appIdentifier)'")
-    }
-
-    private static func requireConsistentProcessIdentity(
-        selected: ApplicationProcessIdentity?,
-        snapshot: ApplicationProcessIdentity?,
-        window: ApplicationProcessIdentity?
-    ) throws -> ApplicationProcessIdentity {
-        let identities = try [selected, snapshot, window].map { identity throws -> DesktopTargetIdentity? in
-            guard let identity else { return nil }
-            return try DesktopTargetIdentity(processIdentity: identity)
-        }
-        let targetIdentity: DesktopTargetIdentity?
-        do {
-            targetIdentity = try DesktopTargetPlanning.DesktopTargetIdentityCoalescer.coalesce(identities)
-        } catch {
-            throw ValidationError(
-                "The selected app, window, and snapshot do not identify the same process generation. " +
-                    "Capture fresh UI state."
-            )
-        }
-        guard let identity = targetIdentity?.processIdentity else {
-            throw PreDispatchActionError(
-                message: "Keyboard input requires --app, --pid, --window-id, or --snapshot for background delivery.",
-                code: .VALIDATION_ERROR,
-                hint: "Use --foreground for intentional global input.",
-                reason: .invalidRequest
-            )
-        }
-        return identity
-    }
-
-    private static func requireBackgroundInputEligibility(
-        processIdentity: ApplicationProcessIdentity,
-        services: any PeekabooServiceProviding
-    ) async throws {
-        let app = try await services.applications.findApplication(
-            identifier: "PID:\(processIdentity.processIdentifier)"
-        )
-        guard app.processIdentity == processIdentity else {
-            throw ValidationError(
-                "Target process PID \(processIdentity.processIdentifier) changed identity while " +
-                    "resolving keyboard input."
-            )
-        }
-        guard app.isEligibleForBackgroundInput else {
-            throw ValidationError(
-                "Target process PID \(processIdentity.processIdentifier) cannot receive background input because it " +
-                    "is a prohibited helper or its application metadata is incomplete."
-            )
-        }
-    }
-
-    private static func requireCurrentProcessIdentity(
-        processIdentifier: Int32,
-        services: any PeekabooServiceProviding
-    ) async throws -> ApplicationProcessIdentity {
-        let app = try await services.applications.findApplication(identifier: "PID:\(processIdentifier)")
-        guard app.processIdentifier == processIdentifier else {
-            throw ValidationError("Could not resolve running process PID:\(processIdentifier).")
-        }
-        return try self.requireProcessIdentity(app, targetDescription: "PID:\(processIdentifier)")
-    }
-
-    private static func requireProcessIdentity(
-        _ app: ServiceApplicationInfo,
-        targetDescription: String
-    ) throws -> ApplicationProcessIdentity {
-        guard app.processIdentifier > 0 else {
-            throw ValidationError("Could not resolve a running process for \(targetDescription).")
-        }
-        guard let processIdentity = app.processIdentity else {
-            throw ValidationError(
-                "The runtime host could not pin \(targetDescription) to a process generation; update the host."
-            )
-        }
-        return processIdentity
     }
 }

--- a/Apps/CLI/Tests/CLIAutomationTests/Support/TestServices.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/Support/TestServices.swift
@@ -577,7 +577,7 @@ ExactWindowTargetedClickServiceProtocol, ElementActionAutomationServiceProtocol 
 }
 
 @MainActor
-class StubApplicationService: ApplicationServiceProtocol {
+class StubApplicationService: ApplicationServiceProtocol, ApplicationMutationInventoryProviding {
     let supportsApplicationLaunchOptions = true
     let supportsApplicationRelaunch = true
     var applications: [ServiceApplicationInfo]
@@ -613,6 +613,11 @@ class StubApplicationService: ApplicationServiceProtocol {
             summary: summary,
             metadata: .init(duration: 0)
         )
+    }
+
+    func applicationMutationInventory() async throws
+    -> DesktopTargetPlanning.Inventory<ServiceApplicationInfo> {
+        .complete(self.applications)
     }
 
     func findApplication(identifier: String) async throws -> ServiceApplicationInfo {
@@ -1500,7 +1505,7 @@ final class StubDialogService: DialogServiceProtocol {
 }
 
 @MainActor
-class StubWindowService: WindowManagementServiceProtocol {
+class StubWindowService: WindowManagementServiceProtocol, WindowMutationInventoryProviding {
     var windowsByApp: [String: [ServiceWindowInfo]]
     var focusCalls: [WindowTarget] = []
     var closeFallbackRequests: [Bool] = []
@@ -1620,6 +1625,12 @@ class StubWindowService: WindowManagementServiceProtocol {
             guard let windows = windowsByApp[app], index < windows.count else { return [] }
             return [windows[index]]
         }
+    }
+
+    func windowMutationInventory(
+        target: WindowTarget
+    ) async throws -> DesktopTargetPlanning.Inventory<ServiceWindowInfo> {
+        try await .complete(self.listWindows(target: target))
     }
 
     func getFocusedWindow() async throws -> ServiceWindowInfo? {

--- a/Apps/CLI/Tests/CLIAutomationTests/TargetedInteractionDefaultDeliveryTests.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/TargetedInteractionDefaultDeliveryTests.swift
@@ -1,6 +1,7 @@
 import Commander
 import CoreGraphics
 import Foundation
+import PeekabooAutomationKitTestSupport
 import PeekabooCore
 import Testing
 @testable import PeekabooCLI
@@ -101,6 +102,78 @@ struct TargetedInteractionDefaultDeliveryTests {
     }
 
     @Test
+    func `CLI background keyboard refuses fuzzy application selectors before dispatch`() async throws {
+        let application = AutomationTestFixtures.application(
+            processIdentifier: 2468,
+            processStartIdentity: 7,
+            bundleIdentifier: "com.apple.TextEdit",
+            name: "TextEdit",
+            isHiddenKnown: true,
+            activationPolicy: .regular
+        )
+        let automation = StubAutomationService()
+        let services = TestServicesFactory.makePeekabooServices(
+            applications: StubApplicationService(applications: [application]),
+            windows: StubWindowService(windowsByApp: [:]),
+            clipboard: StubClipboardService(),
+            automation: automation
+        )
+
+        let result = try await InProcessCommandRunner.run(
+            ["type", "must not dispatch", "--app", "Text", "--no-remote"],
+            services: services
+        )
+
+        #expect(result.exitStatus != 0)
+        #expect(result.combinedOutput.contains("not allowed for mutation"))
+        #expect(automation.targetedTypeActionsCalls.isEmpty)
+        #expect(automation.typeActionsCalls.isEmpty)
+    }
+
+    @Test
+    func `CLI background keyboard refuses one title match from a partial catalog`() async throws {
+        let processIdentity = AutomationTestFixtures.processIdentity(
+            processIdentifier: 2468,
+            processStartIdentity: 7
+        )
+        let application = AutomationTestFixtures.application(
+            processIdentifier: processIdentity.processIdentifier,
+            processStartIdentity: processIdentity.processStartIdentity,
+            bundleIdentifier: "com.apple.TextEdit",
+            name: "TextEdit",
+            isHiddenKnown: true,
+            activationPolicy: .regular
+        )
+        let window = AutomationTestFixtures.window(
+            windowID: 42,
+            title: "Document",
+            processIdentity: processIdentity
+        )
+        let automation = StubAutomationService()
+        let windows = PartialKeyboardWindowInventoryService(windowsByApp: ["TextEdit": [window]])
+        let services = TestServicesFactory.makePeekabooServices(
+            applications: StubApplicationService(applications: [application]),
+            windows: windows,
+            clipboard: StubClipboardService(),
+            automation: automation
+        )
+
+        let result = try await InProcessCommandRunner.run(
+            [
+                "type", "must not dispatch", "--app", "TextEdit", "--window-title", "Document",
+                "--no-remote",
+            ],
+            services: services
+        )
+
+        #expect(result.exitStatus != 0)
+        #expect(result.combinedOutput.contains("incomplete"))
+        #expect(result.combinedOutput.contains("AX enumeration timed out"))
+        #expect(automation.targetedTypeActionsCalls.isEmpty)
+        #expect(automation.typeActionsCalls.isEmpty)
+    }
+
+    @Test
     func `foreground explicitly preserves intentional global keyboard delivery`() async throws {
         let automation = StubAutomationService()
         let services = TestServicesFactory.makePeekabooServices(
@@ -126,6 +199,7 @@ struct TargetedInteractionDefaultDeliveryTests {
     func `unresolved background window selectors refuse instead of collapsing to pid`() async throws {
         let app = ServiceApplicationInfo(
             processIdentifier: 2468,
+            processStartIdentity: 7,
             bundleIdentifier: "com.apple.TextEdit",
             name: "TextEdit"
         )
@@ -612,6 +686,18 @@ struct TargetedInteractionDefaultDeliveryTests {
             )
         )
         return snapshotID
+    }
+}
+
+@MainActor
+private final class PartialKeyboardWindowInventoryService: StubWindowService {
+    override func windowMutationInventory(
+        target: WindowTarget
+    ) async throws -> DesktopTargetPlanning.Inventory<ServiceWindowInfo> {
+        try await .partial(
+            self.listWindows(target: target),
+            warnings: ["AX enumeration timed out"]
+        )
     }
 }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Add a live-physical multi-target finalizer that binds exact protocol-1.30 background controllers, a source-owned epoch monitor, attributed foreground activity, restoration, crash evidence, and protocol-1.29 signed receipt validation into one fail-closed run.
 
 ### Fixed
+- Route CLI and MCP background keyboard delivery through one completeness-aware target planner, refusing fuzzy application selectors and partial window catalogs before type, paste, or press dispatch.
 - Keep exact background pointer routing and dialog postcondition checks correct for minimized and off-Space windows, while treating failed WindowServer catalog reads as unreadable instead of confirmed absence.
 - Bound held-pointer owner and terminal-replay retention in long-lived hosts, make idle-owner disconnect a signed no-change close, and prevent cancelled begins from returning an already-terminated hold receipt.
 - Release cancelled exact-window held hotkeys only to their original process generation, include cleanup events in typed unit counts, and never retarget cleanup to a recycled PID.

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Strategy/DesktopTargetPlanning+BackgroundKeyboard.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Strategy/DesktopTargetPlanning+BackgroundKeyboard.swift
@@ -1,0 +1,195 @@
+import Foundation
+import PeekabooFoundation
+
+extension DesktopTargetPlanning {
+    public enum BackgroundKeyboardTargetPlanningError: LocalizedError, Equatable, Sendable {
+        case targetRequired
+        case explicitExactWindowRequired
+        case applicationIneligible(processIdentifier: Int32)
+
+        public var errorDescription: String? {
+            switch self {
+            case .targetRequired:
+                "Background keyboard input requires an application, process, window, or snapshot target."
+            case .explicitExactWindowRequired:
+                "Background raw key presses require an explicit exact-window or snapshot receipt."
+            case let .applicationIneligible(processIdentifier):
+                "Target process PID \(processIdentifier) cannot receive background input because it is a " +
+                    "prohibited helper or its application metadata is incomplete."
+            }
+        }
+    }
+
+    /// One background keyboard destination selected from a complete, generation-pinned catalog.
+    public struct BackgroundKeyboardTargetPlan: Equatable, Sendable {
+        public let target: UIAutomationTarget
+        public let application: ApplicationMutationPlan
+        public let window: WindowMutationPlan?
+        public let snapshotIdentity: DesktopTargetIdentity?
+
+        init(
+            target: UIAutomationTarget,
+            application: ApplicationMutationPlan,
+            window: WindowMutationPlan?,
+            snapshotIdentity: DesktopTargetIdentity?)
+        {
+            self.target = target
+            self.application = application
+            self.window = window
+            self.snapshotIdentity = snapshotIdentity
+        }
+    }
+
+    /// Shared completeness-aware planner for CLI and MCP background keyboard delivery.
+    ///
+    /// Surface adapters own only parsing and error wording. This planner owns selector admission,
+    /// application/window catalog completeness, process-generation coalescing, background-input
+    /// eligibility, and implicit-window ambiguity.
+    @MainActor
+    public struct BackgroundKeyboardTargetPlanner {
+        private let applications: ApplicationMutationPlanner
+        private let windows: WindowMutationPlanner
+        private let windowInventoryProvider: WindowMutationPlanner.WindowInventoryProvider
+
+        public init(
+            applications: any ApplicationServiceProtocol,
+            windows: any WindowManagementServiceProtocol)
+        {
+            self.applications = ApplicationMutationPlanner(applications: applications)
+            self.windows = WindowMutationPlanner(applications: applications, windows: windows)
+            self.windowInventoryProvider = { target in
+                try await windows.mutationInventory(target: target)
+            }
+        }
+
+        public init(
+            applicationPlanner: ApplicationMutationPlanner,
+            windowPlanner: WindowMutationPlanner,
+            windowInventoryProvider: @escaping WindowMutationPlanner.WindowInventoryProvider)
+        {
+            self.applications = applicationPlanner
+            self.windows = windowPlanner
+            self.windowInventoryProvider = windowInventoryProvider
+        }
+
+        public func plan(
+            selector: InteractionTargetSelector,
+            snapshotProcessIdentity: ApplicationProcessIdentity? = nil,
+            snapshotExactWindow: UIAutomationTarget.ExactWindow? = nil,
+            requiresExplicitExactWindow: Bool = false) async throws -> BackgroundKeyboardTargetPlan
+        {
+            do {
+                try selector.validate(policy: .mutationSafe)
+            } catch let error as InteractionTargetSelector.ValidationError {
+                throw DesktopTargetPlanningError.invalidSelector(error)
+            }
+
+            let snapshotIdentity = try Self.snapshotIdentity(
+                processIdentity: snapshotProcessIdentity,
+                exactWindow: snapshotExactWindow)
+            let windowPlan: WindowMutationPlan?
+            let selectedApplication: ApplicationMutationPlan?
+            let selectedIdentity: DesktopTargetIdentity?
+
+            if selector.hasWindowInput {
+                let plan = try await self.windows.plan(selector: selector)
+                windowPlan = plan
+                selectedApplication = plan.owner
+                selectedIdentity = try plan.expectedTargetIdentity
+            } else if selector.hasOwnerInput {
+                let plan = try await self.applications.plan(selector: selector)
+                windowPlan = nil
+                selectedApplication = plan
+                selectedIdentity = try plan.expectedTargetIdentity
+            } else {
+                windowPlan = nil
+                selectedApplication = nil
+                selectedIdentity = nil
+            }
+
+            guard let resolvedIdentity = try DesktopTargetPlanning.DesktopTargetIdentityCoalescer.coalesce([
+                snapshotIdentity,
+                selectedIdentity,
+            ]) else {
+                throw BackgroundKeyboardTargetPlanningError.targetRequired
+            }
+
+            let applicationPlan: ApplicationMutationPlan = if let selectedApplication {
+                selectedApplication
+            } else {
+                try await self.applications.plan(
+                    processIdentifier: resolvedIdentity.processIdentity.processIdentifier,
+                    expectedIdentity: resolvedIdentity.processIdentity)
+            }
+            var currentApplication = try await self.applications.revalidate(applicationPlan)
+            try Self.requireBackgroundInputEligibility(currentApplication)
+
+            if let exactWindow = resolvedIdentity.exactWindow {
+                let process = try UIAutomationTarget.Process(
+                    processIdentifier: currentApplication.processIdentity.processIdentifier,
+                    identity: currentApplication.processIdentity)
+                return try BackgroundKeyboardTargetPlan(
+                    target: UIAutomationTarget.backgroundKeyboard(
+                        process: process,
+                        exactWindow: exactWindow),
+                    application: currentApplication,
+                    window: windowPlan,
+                    snapshotIdentity: snapshotIdentity)
+            }
+
+            guard !requiresExplicitExactWindow else {
+                throw BackgroundKeyboardTargetPlanningError.explicitExactWindowRequired
+            }
+
+            let inventory = try await self.windowInventoryProvider(.application(currentApplication.target))
+            guard inventory.isComplete else {
+                throw DesktopTargetPlanningError.incompleteWindowInventory(
+                    selector: "the application's eligible keyboard windows",
+                    warnings: inventory.warnings)
+            }
+            let eligibleWindows = try ObservationTargetResolver.captureCandidates(from: inventory.items).map { window in
+                guard let identity = window.mutationIdentity else {
+                    throw DesktopTargetPlanningError.missingWindowIdentity(windowID: window.windowID)
+                }
+                guard identity.processIdentity == currentApplication.processIdentity else {
+                    throw DesktopTargetPlanningError.windowOwnerMismatch(
+                        windowID: window.windowID,
+                        expected: currentApplication.processIdentity)
+                }
+                return try DesktopTargetPlanning.DesktopTargetIdentityCoalescer.exactWindow(from: window)
+            }
+
+            // Window enumeration can race process exit/relaunch. Revalidate after the catalog read
+            // before returning authority to a caller that will dispatch keyboard input.
+            currentApplication = try await self.applications.revalidate(currentApplication)
+            try Self.requireBackgroundInputEligibility(currentApplication)
+            let process = try UIAutomationTarget.Process(
+                processIdentifier: currentApplication.processIdentity.processIdentifier,
+                identity: currentApplication.processIdentity)
+            return try BackgroundKeyboardTargetPlan(
+                target: UIAutomationTarget.backgroundKeyboard(
+                    process: process,
+                    eligibleWindows: eligibleWindows),
+                application: currentApplication,
+                window: windowPlan,
+                snapshotIdentity: snapshotIdentity)
+        }
+
+        private static func snapshotIdentity(
+            processIdentity: ApplicationProcessIdentity?,
+            exactWindow: UIAutomationTarget.ExactWindow?) throws -> DesktopTargetIdentity?
+        {
+            try DesktopTargetPlanning.DesktopTargetIdentityCoalescer.coalesce([
+                processIdentity.map { try DesktopTargetIdentity(processIdentity: $0) },
+                exactWindow.map(DesktopTargetIdentity.init(exactWindow:)),
+            ])
+        }
+
+        private static func requireBackgroundInputEligibility(_ plan: ApplicationMutationPlan) throws {
+            guard plan.application.isEligibleForBackgroundInput else {
+                throw BackgroundKeyboardTargetPlanningError.applicationIneligible(
+                    processIdentifier: plan.processIdentity.processIdentifier)
+            }
+        }
+    }
+}

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/DesktopTargetPlanningTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/DesktopTargetPlanningTests.swift
@@ -1,5 +1,6 @@
 import CoreGraphics
 import PeekabooAutomationKitTestSupport
+import PeekabooFoundation
 import Testing
 @testable import PeekabooAutomationKit
 
@@ -275,5 +276,80 @@ struct DesktopTargetPlanningTests {
                 viewport: viewport))
 
         #expect(try receipt.requireCoordinateAuthority().sourceBounds == window.bounds)
+    }
+
+    @MainActor
+    @Test
+    func `background keyboard planner preserves a snapshot-only exact target`() async throws {
+        let fixture = AutomationTestFixtures.linkedDesktopTarget(
+            applicationName: "Editor",
+            windowID: 42)
+        let planner = self.backgroundKeyboardPlanner(
+            application: fixture.application,
+            windowInventory: .complete([]))
+
+        let plan = try await planner.plan(
+            selector: InteractionTargetSelector(),
+            snapshotExactWindow: fixture.windowTargetIdentity.exactWindow)
+
+        #expect(plan.target == fixture.windowTargetIdentity.target)
+        #expect(plan.application.processIdentity == fixture.processIdentity)
+        #expect(plan.window == nil)
+    }
+
+    @MainActor
+    @Test
+    func `background keyboard planner selects one exact window only from a complete catalog`() async throws {
+        let fixture = AutomationTestFixtures.linkedDesktopTarget(
+            applicationName: "Editor",
+            windowID: 42)
+        let planner = self.backgroundKeyboardPlanner(
+            application: fixture.application,
+            windowInventory: .complete([fixture.window]))
+
+        let plan = try await planner.plan(
+            selector: InteractionTargetSelector(applicationIdentifier: "Editor"))
+
+        #expect(plan.target == fixture.windowTargetIdentity.target)
+        #expect(plan.window == nil)
+    }
+
+    @MainActor
+    @Test
+    func `background keyboard planner refuses one implicit match from a partial catalog`() async throws {
+        let fixture = AutomationTestFixtures.linkedDesktopTarget(
+            applicationName: "Editor",
+            windowID: 42)
+        let planner = self.backgroundKeyboardPlanner(
+            application: fixture.application,
+            windowInventory: .partial([fixture.window], warnings: ["AX enumeration timed out"]))
+
+        await #expect(throws: DesktopTargetPlanningError.incompleteWindowInventory(
+            selector: "the application's eligible keyboard windows",
+            warnings: ["AX enumeration timed out"]))
+        {
+            _ = try await planner.plan(
+                selector: InteractionTargetSelector(applicationIdentifier: "Editor"))
+        }
+    }
+
+    @MainActor
+    private func backgroundKeyboardPlanner(
+        application: ServiceApplicationInfo,
+        windowInventory: DesktopTargetPlanning.Inventory<ServiceWindowInfo>)
+        -> DesktopTargetPlanning.BackgroundKeyboardTargetPlanner
+    {
+        let applicationPlanner = DesktopTargetPlanning.ApplicationMutationPlanner(
+            inventoryProvider: { .complete([application]) },
+            exactIdentifierProvider: { _ in application })
+        let windowProvider: DesktopTargetPlanning.WindowMutationPlanner.WindowInventoryProvider = { _ in
+            windowInventory
+        }
+        return DesktopTargetPlanning.BackgroundKeyboardTargetPlanner(
+            applicationPlanner: applicationPlanner,
+            windowPlanner: DesktopTargetPlanning.WindowMutationPlanner(
+                applicationPlanner: applicationPlanner,
+                windowInventoryProvider: windowProvider),
+            windowInventoryProvider: windowProvider)
     }
 }

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/MCPInteractionTarget.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/MCPInteractionTarget.swift
@@ -17,13 +17,15 @@ enum MCPInteractionTargetError: LocalizedError, Equatable {
     case backgroundWindowTargetAmbiguous
     case backgroundWindowTargetMismatch
     case backgroundTargetIneligible
+    case backgroundTargetPlanningFailed(String)
 
     var refusalReason: DesktopActionOutcome.RefusalReason {
         switch self {
         case .targetProcessNotFound,
              .backgroundWindowTargetAmbiguous,
              .backgroundWindowTargetMismatch,
-             .backgroundTargetIneligible:
+             .backgroundTargetIneligible,
+             .backgroundTargetPlanningFailed:
             .targetUnavailable
         case .targetProcessIdentityUnavailable:
             .runtimeIncompatible
@@ -73,6 +75,8 @@ enum MCPInteractionTargetError: LocalizedError, Equatable {
         case .backgroundTargetIneligible:
             "The target cannot receive background input because it is a prohibited helper or its metadata is " +
                 "incomplete."
+        case let .backgroundTargetPlanningFailed(message):
+            message
         }
     }
 }
@@ -512,6 +516,7 @@ struct MCPInteractionTarget {
         return identity
     }
 
+    @MainActor
     func requireBackgroundKeyboardTarget(
         applications: any ApplicationServiceProtocol,
         windows: any WindowManagementServiceProtocol,
@@ -520,125 +525,34 @@ struct MCPInteractionTarget {
         requiresExplicitExactWindow: Bool = false) async throws -> UIAutomationTarget
     {
         try self.validate()
-        let selectedWindow: UIAutomationTarget.ExactWindow? = if self.hasWindowSelector {
-            try await self.requireSelectedExactWindow(windows: windows)
-        } else {
-            nil
-        }
-        let exactWindow: UIAutomationTarget.ExactWindow?
-        if let snapshotExactWindow, let selectedWindow {
-            let merged: DesktopTargetIdentity?
-            do {
-                merged = try DesktopTargetPlanning.DesktopTargetIdentityCoalescer.coalesce([
-                    DesktopTargetIdentity(exactWindow: snapshotExactWindow),
-                    DesktopTargetIdentity(exactWindow: selectedWindow),
-                ])
-            } catch {
-                throw MCPInteractionTargetError.backgroundWindowTargetMismatch
-            }
-            guard let mergedWindow = merged?.exactWindow else {
-                throw MCPInteractionTargetError.backgroundWindowTargetMismatch
-            }
-            exactWindow = mergedWindow
-        } else {
-            exactWindow = snapshotExactWindow ?? selectedWindow
-        }
-
-        let selectedProcessIdentity = try await self.selectedProcessIdentity(applications: applications)
-        let stableIdentities: [DesktopTargetIdentity?]
+        let planner = DesktopTargetPlanning.BackgroundKeyboardTargetPlanner(
+            applications: applications,
+            windows: windows)
         do {
-            stableIdentities = try [selectedProcessIdentity, snapshotProcessIdentity].map { identity in
-                guard let identity else { return nil }
-                return try DesktopTargetIdentity(processIdentity: identity)
-            } + [
-                snapshotExactWindow.map(DesktopTargetIdentity.init(exactWindow:)),
-                selectedWindow.map(DesktopTargetIdentity.init(exactWindow:)),
-            ]
-        } catch {
-            throw MCPInteractionTargetError.backgroundWindowTargetMismatch
-        }
-        let stableIdentity: DesktopTargetIdentity?
-        do {
-            stableIdentity = try DesktopTargetPlanning.DesktopTargetIdentityCoalescer.coalesce(stableIdentities)
-        } catch {
-            throw MCPInteractionTargetError.backgroundWindowTargetMismatch
-        }
-        guard let processIdentity = stableIdentity?.processIdentity else {
+            return try await planner.plan(
+                selector: self.selector,
+                snapshotProcessIdentity: snapshotProcessIdentity,
+                snapshotExactWindow: snapshotExactWindow,
+                requiresExplicitExactWindow: requiresExplicitExactWindow).target
+        } catch DesktopTargetPlanning.BackgroundKeyboardTargetPlanningError.targetRequired {
             throw MCPInteractionTargetError.backgroundTargetRequired
-        }
-
-        let listedApplications = try await applications.listApplications().data.applications
-        guard let application = listedApplications.first(where: {
-            $0.processIdentifier == processIdentity.processIdentifier
-        }) else {
-            throw MCPInteractionTargetError.targetProcessNotFound
-        }
-        guard application.processIdentity == processIdentity else {
-            throw MCPInteractionTargetError.targetProcessIdentityUnavailable
-        }
-        guard application.isEligibleForBackgroundInput else {
+        } catch DesktopTargetPlanning.BackgroundKeyboardTargetPlanningError.applicationIneligible {
             throw MCPInteractionTargetError.backgroundTargetIneligible
-        }
-
-        let process = try UIAutomationTarget.Process(
-            processIdentifier: processIdentity.processIdentifier,
-            identity: processIdentity)
-        if let exactWindow {
-            return try UIAutomationTarget.backgroundKeyboard(
-                process: process,
-                exactWindow: exactWindow)
-        }
-
-        let eligibleWindows: [UIAutomationTarget.ExactWindow]
-        if requiresExplicitExactWindow {
-            eligibleWindows = []
-        } else {
-            let listed = try await windows.listWindows(
-                target: .application("PID:\(processIdentity.processIdentifier)"))
-            eligibleWindows = try ObservationTargetResolver.captureCandidates(from: listed).map {
-                try UIAutomationTarget.ExactWindow(window: $0)
-            }
-        }
-        return try UIAutomationTarget.backgroundKeyboard(
-            process: process,
-            eligibleWindows: eligibleWindows,
-            requiresExplicitExactWindow: requiresExplicitExactWindow)
-    }
-
-    private func selectedProcessIdentity(
-        applications: any ApplicationServiceProtocol) async throws -> ApplicationProcessIdentity?
-    {
-        let application: ServiceApplicationInfo
-        if let pid {
-            application = try await applications.findApplication(identifier: "PID:\(pid)")
-            guard application.processIdentifier == pid else {
-                throw MCPInteractionTargetError.targetProcessNotFound
-            }
-        } else if let app = self.app?.trimmingCharacters(in: .whitespacesAndNewlines), !app.isEmpty {
-            application = try await applications.findApplication(identifier: app)
-        } else {
-            return nil
-        }
-        guard let identity = application.processIdentity else {
-            throw MCPInteractionTargetError.targetProcessIdentityUnavailable
-        }
-        return identity
-    }
-
-    private func requireSelectedExactWindow(
-        windows: any WindowManagementServiceProtocol) async throws -> UIAutomationTarget.ExactWindow
-    {
-        guard let windowTarget = try self.toWindowTarget() else {
-            throw MCPInteractionTargetError.backgroundWindowTargetUnsupported
-        }
-        let matches = try await windows.listWindows(target: windowTarget)
-        guard matches.count == 1, let window = matches.first else {
-            throw MCPInteractionTargetError.backgroundWindowTargetAmbiguous
-        }
-        do {
-            return try DesktopTargetPlanning.DesktopTargetIdentityCoalescer.exactWindow(from: window)
-        } catch {
+        } catch is DesktopTargetIdentityError {
             throw MCPInteractionTargetError.backgroundWindowTargetMismatch
+        } catch let error as DesktopTargetPlanningError {
+            switch error {
+            case .applicationNotFound:
+                throw MCPInteractionTargetError.targetProcessNotFound
+            case .missingProcessIdentity, .invalidProcessIdentity, .staleApplication:
+                throw MCPInteractionTargetError.targetProcessIdentityUnavailable
+            case .windowNotFound, .missingWindowIdentity, .incompleteWindowIdentity, .windowOwnerMismatch, .staleWindow:
+                throw MCPInteractionTargetError.backgroundWindowTargetMismatch
+            default:
+                throw MCPInteractionTargetError.backgroundTargetPlanningFailed(error.localizedDescription)
+            }
+        } catch let error as DesktopTargetPlanning.BackgroundKeyboardTargetPlanningError {
+            throw MCPInteractionTargetError.backgroundTargetPlanningFailed(error.localizedDescription)
         }
     }
 

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/MCPInteractionTarget.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/MCPInteractionTarget.swift
@@ -546,7 +546,9 @@ struct MCPInteractionTarget {
                 throw MCPInteractionTargetError.targetProcessNotFound
             case .missingProcessIdentity, .invalidProcessIdentity, .staleApplication:
                 throw MCPInteractionTargetError.targetProcessIdentityUnavailable
-            case .windowNotFound, .missingWindowIdentity, .incompleteWindowIdentity, .windowOwnerMismatch, .staleWindow:
+            case .windowNotFound, .ambiguousWindow:
+                throw MCPInteractionTargetError.backgroundWindowTargetAmbiguous
+            case .missingWindowIdentity, .incompleteWindowIdentity, .windowOwnerMismatch, .staleWindow:
                 throw MCPInteractionTargetError.backgroundWindowTargetMismatch
             default:
                 throw MCPInteractionTargetError.backgroundTargetPlanningFailed(error.localizedDescription)

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPInteractionTargetTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPInteractionTargetTests.swift
@@ -120,6 +120,73 @@ struct MCPInteractionTargetTests {
 
     @MainActor
     @Test
+    func `MCP background keyboard refuses fuzzy application selectors`() async throws {
+        let applications = MockApplicationService(applications: [AutomationTestFixtures.application(
+            processIdentifier: 4242,
+            processStartIdentity: 71,
+            bundleIdentifier: "com.example.editor",
+            name: "Editor",
+            isHiddenKnown: true,
+            activationPolicy: .regular)])
+        let target = try Self.makeTarget(Selectors(
+            app: "Edit",
+            pid: nil,
+            windowTitle: nil,
+            windowIndex: nil,
+            windowID: nil))
+
+        do {
+            _ = try await target.requireBackgroundKeyboardTarget(
+                applications: applications,
+                windows: EmptyRecordingWindowService())
+            Issue.record("Expected fuzzy background target planning to fail")
+        } catch let error as MCPInteractionTargetError {
+            #expect(error.refusalReason == .targetUnavailable)
+            #expect(error.localizedDescription.contains("not allowed for mutation"))
+        }
+    }
+
+    @MainActor
+    @Test
+    func `MCP background keyboard refuses one title match from a partial catalog`() async throws {
+        let processIdentity = AutomationTestFixtures.processIdentity(
+            processIdentifier: 4242,
+            processStartIdentity: 71)
+        let applications = MockApplicationService(applications: [AutomationTestFixtures.application(
+            processIdentifier: processIdentity.processIdentifier,
+            processStartIdentity: processIdentity.processStartIdentity,
+            bundleIdentifier: "com.example.editor",
+            name: "Editor",
+            isHiddenKnown: true,
+            activationPolicy: .regular)])
+        let window = Self.window(
+            windowID: 42,
+            processIdentity: processIdentity,
+            bounds: CGRect(x: 10, y: 20, width: 640, height: 480),
+            capturedBounds: CGRect(x: 10, y: 20, width: 640, height: 480))
+        let target = try Self.makeTarget(Selectors(
+            app: "Editor",
+            pid: nil,
+            windowTitle: "Document",
+            windowIndex: nil,
+            windowID: nil))
+
+        do {
+            _ = try await target.requireBackgroundKeyboardTarget(
+                applications: applications,
+                windows: ReceiptWindowService(
+                    window: window,
+                    inventoryWarnings: ["AX enumeration timed out"]))
+            Issue.record("Expected partial window inventory to fail")
+        } catch let error as MCPInteractionTargetError {
+            #expect(error.refusalReason == .targetUnavailable)
+            #expect(error.localizedDescription.contains("incomplete"))
+            #expect(error.localizedDescription.contains("AX enumeration timed out"))
+        }
+    }
+
+    @MainActor
+    @Test
     func `legacy nil focus outcome refuses before foreground typing`() async throws {
         try await self.expectForegroundTypingRefusal(
             outcome: nil,
@@ -624,11 +691,13 @@ final class MCPFocusResultWindowService: WindowManagementPinnedFocusActionResult
     }
 }
 
-private actor ReceiptWindowService: WindowManagementServiceProtocol {
+private actor ReceiptWindowService: WindowManagementServiceProtocol, WindowMutationInventoryProviding {
     let window: ServiceWindowInfo
+    let inventoryWarnings: [String]
 
-    init(window: ServiceWindowInfo) {
+    init(window: ServiceWindowInfo, inventoryWarnings: [String] = []) {
         self.window = window
+        self.inventoryWarnings = inventoryWarnings
     }
 
     func closeWindow(target _: WindowTarget) async throws {}
@@ -640,6 +709,15 @@ private actor ReceiptWindowService: WindowManagementServiceProtocol {
     func focusWindow(target _: WindowTarget) async throws {}
     func listWindows(target _: WindowTarget) async throws -> [ServiceWindowInfo] {
         [self.window]
+    }
+
+    func windowMutationInventory(
+        target _: WindowTarget) async throws -> DesktopTargetPlanning.Inventory<ServiceWindowInfo>
+    {
+        if self.inventoryWarnings.isEmpty {
+            return .complete([self.window])
+        }
+        return .partial([self.window], warnings: self.inventoryWarnings)
     }
 
     func getFocusedWindow() async throws -> ServiceWindowInfo? {

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPInteractionTargetTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPInteractionTargetTests.swift
@@ -99,10 +99,18 @@ struct MCPInteractionTargetTests {
         ]
 
         for window in malformedWindows {
-            await #expect(throws: MCPInteractionTargetError.backgroundWindowTargetMismatch) {
-                _ = try await target.requireBackgroundKeyboardTarget(
-                    applications: applications,
-                    windows: ReceiptWindowService(window: window))
+            if window.windowID == 42 {
+                await #expect(throws: MCPInteractionTargetError.backgroundWindowTargetMismatch) {
+                    _ = try await target.requireBackgroundKeyboardTarget(
+                        applications: applications,
+                        windows: ReceiptWindowService(window: window))
+                }
+            } else {
+                await #expect(throws: MCPInteractionTargetError.backgroundWindowTargetAmbiguous) {
+                    _ = try await target.requireBackgroundKeyboardTarget(
+                        applications: applications,
+                        windows: ReceiptWindowService(window: window))
+                }
             }
         }
 
@@ -116,6 +124,48 @@ struct MCPInteractionTargetTests {
             windows: ReceiptWindowService(window: valid))
         #expect(resolved.exactWindow?.identity == valid.mutationIdentity)
         #expect(resolved.exactWindow?.bounds == bounds)
+    }
+
+    @MainActor
+    @Test
+    func `background keyboard window adapter preserves missing and ambiguous selector errors`() async throws {
+        let processIdentity = AutomationTestFixtures.processIdentity(
+            processIdentifier: 4242,
+            processStartIdentity: 71)
+        let applications = MockApplicationService(applications: [AutomationTestFixtures.application(
+            processIdentifier: processIdentity.processIdentifier,
+            processStartIdentity: processIdentity.processStartIdentity,
+            bundleIdentifier: "com.example.editor",
+            name: "Editor")])
+        let target = try Self.makeTarget(Selectors(
+            app: "Editor",
+            pid: nil,
+            windowTitle: "Document",
+            windowIndex: nil,
+            windowID: nil))
+
+        await #expect(throws: MCPInteractionTargetError.backgroundWindowTargetAmbiguous) {
+            _ = try await target.requireBackgroundKeyboardTarget(
+                applications: applications,
+                windows: EmptyRecordingWindowService())
+        }
+
+        let bounds = CGRect(x: 10, y: 20, width: 640, height: 480)
+        let first = Self.window(
+            windowID: 42,
+            processIdentity: processIdentity,
+            bounds: bounds,
+            capturedBounds: bounds)
+        let second = Self.window(
+            windowID: 43,
+            processIdentity: processIdentity,
+            bounds: bounds.offsetBy(dx: 700, dy: 0),
+            capturedBounds: bounds.offsetBy(dx: 700, dy: 0))
+        await #expect(throws: MCPInteractionTargetError.backgroundWindowTargetAmbiguous) {
+            _ = try await target.requireBackgroundKeyboardTarget(
+                applications: applications,
+                windows: ReceiptWindowService(window: first, additionalWindow: second))
+        }
     }
 
     @MainActor
@@ -693,10 +743,16 @@ final class MCPFocusResultWindowService: WindowManagementPinnedFocusActionResult
 
 private actor ReceiptWindowService: WindowManagementServiceProtocol, WindowMutationInventoryProviding {
     let window: ServiceWindowInfo
+    let additionalWindow: ServiceWindowInfo?
     let inventoryWarnings: [String]
 
-    init(window: ServiceWindowInfo, inventoryWarnings: [String] = []) {
+    init(
+        window: ServiceWindowInfo,
+        additionalWindow: ServiceWindowInfo? = nil,
+        inventoryWarnings: [String] = [])
+    {
         self.window = window
+        self.additionalWindow = additionalWindow
         self.inventoryWarnings = inventoryWarnings
     }
 
@@ -708,16 +764,17 @@ private actor ReceiptWindowService: WindowManagementServiceProtocol, WindowMutat
     func setWindowBounds(target _: WindowTarget, bounds _: CGRect) async throws {}
     func focusWindow(target _: WindowTarget) async throws {}
     func listWindows(target _: WindowTarget) async throws -> [ServiceWindowInfo] {
-        [self.window]
+        [self.window, self.additionalWindow].compactMap(\.self)
     }
 
     func windowMutationInventory(
         target _: WindowTarget) async throws -> DesktopTargetPlanning.Inventory<ServiceWindowInfo>
     {
+        let windows = [self.window, self.additionalWindow].compactMap(\.self)
         if self.inventoryWarnings.isEmpty {
-            return .complete([self.window])
+            return .complete(windows)
         }
-        return .partial([self.window], warnings: self.inventoryWarnings)
+        return .partial(windows, warnings: self.inventoryWarnings)
     }
 
     func getFocusedWindow() async throws -> ServiceWindowInfo? {

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPToolExecutionTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPToolExecutionTests.swift
@@ -853,7 +853,7 @@ final class PointerPolicyWindowService: WindowManagementServiceProtocol, @unchec
     }
 }
 
-actor EmptyRecordingWindowService: WindowManagementServiceProtocol {
+actor EmptyRecordingWindowService: WindowManagementServiceProtocol, WindowMutationInventoryProviding {
     private(set) var requestedWindowIDs: [Int] = []
     private(set) var focusRequests: [WindowTarget] = []
 
@@ -872,6 +872,12 @@ actor EmptyRecordingWindowService: WindowManagementServiceProtocol {
             self.requestedWindowIDs.append(windowID)
         }
         return []
+    }
+
+    func windowMutationInventory(
+        target _: WindowTarget) async throws -> DesktopTargetPlanning.Inventory<ServiceWindowInfo>
+    {
+        .complete([])
     }
 
     func getFocusedWindow() async throws -> ServiceWindowInfo? {
@@ -1296,7 +1302,7 @@ final class MockScreenService: ScreenServiceProtocol {
 }
 
 @MainActor
-class MockApplicationService: ApplicationServiceProtocol {
+class MockApplicationService: ApplicationServiceProtocol, ApplicationMutationInventoryProviding {
     let supportsProcessGenerationPinnedApplicationActivation = true
     private(set) var applications: [ServiceApplicationInfo]
     private(set) var launchRequests: [ApplicationLaunchRequest] = []
@@ -1324,6 +1330,16 @@ class MockApplicationService: ApplicationServiceProtocol {
                 status: warnings.isEmpty ? .success : .partial,
                 counts: ["applications": self.applications.count]),
             metadata: .init(duration: 0, warnings: warnings))
+    }
+
+    func applicationMutationInventory() async throws
+        -> DesktopTargetPlanning.Inventory<ServiceApplicationInfo>
+    {
+        let warnings = self.applications.flatMap { $0.metadataWarnings ?? [] }
+        return DesktopTargetPlanning.Inventory(
+            items: self.applications,
+            completeness: warnings.isEmpty ? .complete : .partial,
+            warnings: warnings)
     }
 
     func findApplication(identifier: String) async throws -> ServiceApplicationInfo {


### PR DESCRIPTION
## Summary

- centralize background keyboard target selection in one AutomationKit planner shared by CLI and MCP
- require complete application/window inventory evidence for non-exact selectors while preserving exact PID, exact window, and snapshot receipt paths
- refuse fuzzy application selectors and partial title/index catalogs before type, paste, or press dispatch
- retain surface-specific CLI and MCP error wording while deleting their duplicate planning implementations

## Root cause

CLI `KeyboardDeliverySupport` and MCP `MCPInteractionTarget` independently resolved applications and windows through compatibility list APIs. Those APIs return rows but do not preserve the complete/partial inventory proof required to establish selector uniqueness. This bypassed the canonical `ApplicationMutationPlanner` and `WindowMutationPlanner` rules already used by other mutation surfaces.

The new `BackgroundKeyboardTargetPlanner` owns selector admission, inventory completeness, application/window generation binding, snapshot/selector coalescing, background-input eligibility, implicit-window ambiguity, and final application revalidation. CLI and MCP now adapt into that owner.

## Pre-fix proof limitation

No executable red-test artifact was recorded against clean source `a48c462c757acbf320b22a6c9b34852e26bcb763` before the regression tests were added. The pre-fix proof is direct source inspection: both adapters called compatibility application/window lookup paths, while the existing mutation planners explicitly reject fuzzy application selectors and partial catalogs. The added CLI, MCP, and AutomationKit regressions pass on this branch and bind those cases going forward.

## Verification

- `pnpm run test:safe` — exit 0 on the exact final diff; Foundation 1004/1004 and CLI 484/484 passed after all preceding release-policy gates
- `swift test --package-path Core/PeekabooAutomationKit --filter DesktopTargetPlanningTests` — 18/18 passed
- `PEEKABOO_INCLUDE_AUTOMATION_TESTS=true swift test --package-path Apps/CLI --filter TargetedInteractionDefaultDeliveryTests` — 13/13 passed
- `swift test --package-path Core/PeekabooCore --filter MCPInteractionTargetTests` — 21/21 passed
- `pnpm run format` — passed
- `pnpm run lint` — completed with zero serious violations
- structured Codex autoreview through P2 — clean, no actionable findings

## Documentation

- updated the root and CLI 4.2.1 changelogs
