### PR TITLE
test: remove release compiler warnings

### DIFF
--- a/Apps/CLI/Tests/CLIAutomationTests/DialogInputTargetJSONOutputTests.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/DialogInputTargetJSONOutputTests.swift
@@ -109,7 +109,7 @@ struct DialogInputTargetJSONOutputTests {
             ),
             textFields: [DialogTextField(index: 0)]
         ))
-        dialogService.enterTextResult = try DialogActionResult(
+        dialogService.enterTextResult = DialogActionResult(
             success: true,
             action: .enterText,
             details: ["field": "Name", "text_length": "5"],

--- a/Apps/CLI/Tests/CLIAutomationTests/SeeCommandReceiptTests.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/SeeCommandReceiptTests.swift
@@ -101,7 +101,9 @@ extension SeeCommandRuntimeTests {
             )
             defer { try? FileManager.default.removeItem(at: outputURL) }
 
-            let runCommand = {
+            let result = try await SeeCommandPreparationContext.$didCapture.withValue({
+                withUnsafeCurrentTask { $0?.cancel() }
+            }) {
                 try await InProcessCommandRunner.run(
                     [
                         "see",
@@ -113,10 +115,6 @@ extension SeeCommandRuntimeTests {
                     services: context.services
                 )
             }
-            let result = try await SeeCommandPreparationContext.$didCapture.withValue(
-                { withUnsafeCurrentTask { $0?.cancel() } },
-                operation: runCommand
-            )
             let envelope = try #require(
                 JSONSerialization.jsonObject(with: Data(result.stdout.utf8)) as? [String: Any]
             )

--- a/Apps/CLI/Tests/CLIAutomationTests/SeeCommandReceiptTests.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/SeeCommandReceiptTests.swift
@@ -101,9 +101,7 @@ extension SeeCommandRuntimeTests {
             )
             defer { try? FileManager.default.removeItem(at: outputURL) }
 
-            let result = try await SeeCommandPreparationContext.$didCapture.withValue({
-                withUnsafeCurrentTask { $0?.cancel() }
-            }) {
+            nonisolated(nonsending) func runCommand() async throws -> CommandRunResult {
                 try await InProcessCommandRunner.run(
                     [
                         "see",
@@ -115,6 +113,10 @@ extension SeeCommandRuntimeTests {
                     services: context.services
                 )
             }
+            let result = try await SeeCommandPreparationContext.$didCapture.withValue(
+                { withUnsafeCurrentTask { $0?.cancel() } },
+                operation: runCommand
+            )
             let envelope = try #require(
                 JSONSerialization.jsonObject(with: Data(result.stdout.utf8)) as? [String: Any]
             )


### PR DESCRIPTION
## Summary

- remove an unnecessary `try` from the dialog target fixture
- use Swift's nondeprecated caller-context `TaskLocal.withValue` overload in the See receipt cancellation test
- preserve the existing test behavior and cancellation timing

## Proof

- `PEEKABOO_INCLUDE_AUTOMATION_TESTS=true PEEKABOO_INCLUDE_AMBIENT_STATE_TESTS=false swift test --package-path Apps/CLI --filter 'DialogInputTargetJSONOutputTests|capture to prepare cancellation preserves conditional mutation receipt'` (4 tests passed)
- `pnpm run format`
- `pnpm run lint` (82 repository-baseline warnings, 0 serious; changed TaskLocal file has 0 violations)
- `pnpm run prepare-release -- --force` (all checks passed, including a clean reset release build with no Swift compiler warnings, full safe tests, package build, and CLI contracts)
- Codex autoreview through P2: clean on the original patch and the final isolation spelling, no accepted/actionable findings
