### PR TITLE
refactor: centralize background mutation authority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 - Bound asynchronous Accessibility notification add and remove waits, removal joins, and subscription setup retries so one wedged endpoint cannot hang global observer startup or teardown. Thanks @SebTardif for AXorcist #47.
+- Route background mutation authorization through one completeness-aware application/window planner, so MCP window, Space, and exact-window paste targets reject fuzzy selectors and partial catalogs before dispatch.
 
 ## [4.2.1] - 2026-08-17
 

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Strategy/DesktopTargetPlanning+BackgroundKeyboard.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Strategy/DesktopTargetPlanning+BackgroundKeyboard.swift
@@ -47,16 +47,14 @@ extension DesktopTargetPlanning {
     /// eligibility, and implicit-window ambiguity.
     @MainActor
     public struct BackgroundKeyboardTargetPlanner {
-        private let applications: ApplicationMutationPlanner
-        private let windows: WindowMutationPlanner
+        private let authorities: MutationAuthorityPlanner
         private let windowInventoryProvider: WindowMutationPlanner.WindowInventoryProvider
 
         public init(
             applications: any ApplicationServiceProtocol,
             windows: any WindowManagementServiceProtocol)
         {
-            self.applications = ApplicationMutationPlanner(applications: applications)
-            self.windows = WindowMutationPlanner(applications: applications, windows: windows)
+            self.authorities = MutationAuthorityPlanner(applications: applications, windows: windows)
             self.windowInventoryProvider = { target in
                 try await windows.mutationInventory(target: target)
             }
@@ -67,8 +65,9 @@ extension DesktopTargetPlanning {
             windowPlanner: WindowMutationPlanner,
             windowInventoryProvider: @escaping WindowMutationPlanner.WindowInventoryProvider)
         {
-            self.applications = applicationPlanner
-            self.windows = windowPlanner
+            self.authorities = MutationAuthorityPlanner(
+                applicationPlanner: applicationPlanner,
+                windowPlanner: windowPlanner)
             self.windowInventoryProvider = windowInventoryProvider
         }
 
@@ -87,25 +86,12 @@ extension DesktopTargetPlanning {
             let snapshotIdentity = try Self.snapshotIdentity(
                 processIdentity: snapshotProcessIdentity,
                 exactWindow: snapshotExactWindow)
-            let windowPlan: WindowMutationPlan?
-            let selectedApplication: ApplicationMutationPlan?
-            let selectedIdentity: DesktopTargetIdentity?
-
-            if selector.hasWindowInput {
-                let plan = try await self.windows.plan(selector: selector)
-                windowPlan = plan
-                selectedApplication = plan.owner
-                selectedIdentity = try plan.expectedTargetIdentity
-            } else if selector.hasOwnerInput {
-                let plan = try await self.applications.plan(selector: selector)
-                windowPlan = nil
-                selectedApplication = plan
-                selectedIdentity = try plan.expectedTargetIdentity
+            let selectedAuthority = if selector.hasAnyInput {
+                try await self.authorities.plan(selector: selector)
             } else {
-                windowPlan = nil
-                selectedApplication = nil
-                selectedIdentity = nil
+                nil as MutationAuthorityPlan?
             }
+            let selectedIdentity = try selectedAuthority?.targetIdentity
 
             guard let resolvedIdentity = try DesktopTargetPlanning.DesktopTargetIdentityCoalescer.coalesce([
                 snapshotIdentity,
@@ -114,14 +100,16 @@ extension DesktopTargetPlanning {
                 throw BackgroundKeyboardTargetPlanningError.targetRequired
             }
 
-            let applicationPlan: ApplicationMutationPlan = if let selectedApplication {
-                selectedApplication
+            var currentAuthority: MutationAuthorityPlan = if let selectedAuthority {
+                selectedAuthority
             } else {
-                try await self.applications.plan(
-                    processIdentifier: resolvedIdentity.processIdentity.processIdentifier,
-                    expectedIdentity: resolvedIdentity.processIdentity)
+                try await self.authorities.plan(
+                    selector: InteractionTargetSelector(
+                        processIdentifier: Int(resolvedIdentity.processIdentity.processIdentifier)),
+                    expectedProcessIdentity: resolvedIdentity.processIdentity)
             }
-            var currentApplication = try await self.applications.revalidate(applicationPlan)
+            currentAuthority = try await self.authorities.revalidate(currentAuthority)
+            var currentApplication = currentAuthority.application
             try Self.requireBackgroundInputEligibility(currentApplication)
 
             if let exactWindow = resolvedIdentity.exactWindow {
@@ -133,7 +121,7 @@ extension DesktopTargetPlanning {
                         process: process,
                         exactWindow: exactWindow),
                     application: currentApplication,
-                    window: windowPlan,
+                    window: currentAuthority.window,
                     snapshotIdentity: snapshotIdentity)
             }
 
@@ -161,7 +149,8 @@ extension DesktopTargetPlanning {
 
             // Window enumeration can race process exit/relaunch. Revalidate after the catalog read
             // before returning authority to a caller that will dispatch keyboard input.
-            currentApplication = try await self.applications.revalidate(currentApplication)
+            currentAuthority = try await self.authorities.revalidate(currentAuthority)
+            currentApplication = currentAuthority.application
             try Self.requireBackgroundInputEligibility(currentApplication)
             let process = try UIAutomationTarget.Process(
                 processIdentifier: currentApplication.processIdentity.processIdentifier,
@@ -171,7 +160,7 @@ extension DesktopTargetPlanning {
                     process: process,
                     eligibleWindows: eligibleWindows),
                 application: currentApplication,
-                window: windowPlan,
+                window: currentAuthority.window,
                 snapshotIdentity: snapshotIdentity)
         }
 

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Strategy/DesktopTargetPlanning+MutationAuthority.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Strategy/DesktopTargetPlanning+MutationAuthority.swift
@@ -1,0 +1,112 @@
+import Foundation
+import PeekabooFoundation
+
+extension DesktopTargetPlanning {
+    /// One generation-pinned desktop mutation authority produced from a complete catalog.
+    public enum MutationAuthorityPlan: Equatable, Sendable {
+        case application(ApplicationMutationPlan)
+        case window(WindowMutationPlan)
+
+        public var application: ApplicationMutationPlan {
+            switch self {
+            case let .application(plan): plan
+            case let .window(plan): plan.owner
+            }
+        }
+
+        public var window: WindowMutationPlan? {
+            guard case let .window(plan) = self else { return nil }
+            return plan
+        }
+
+        public var targetIdentity: DesktopTargetIdentity {
+            get throws {
+                switch self {
+                case let .application(plan):
+                    try plan.expectedTargetIdentity
+                case let .window(plan):
+                    try plan.expectedTargetIdentity
+                }
+            }
+        }
+    }
+
+    public enum MutationAuthorityRequirement: Equatable, Sendable {
+        /// Preserve the most specific target explicitly supplied by the selector.
+        case mostSpecific
+
+        /// Resolve one exact window, using the supplied policy when the selector names only its owner.
+        case exactWindow(automaticSelection: WindowSelectionPolicy)
+    }
+
+    /// Shared application/window authority planner for mutation surfaces.
+    ///
+    /// Surface adapters own argument parsing, policy, and presentation. This planner owns catalog
+    /// completeness, exact selection, process-generation pinning, and pre-dispatch revalidation.
+    @MainActor
+    public struct MutationAuthorityPlanner {
+        private let applications: ApplicationMutationPlanner
+        private let windows: WindowMutationPlanner
+
+        public init(
+            applications: any ApplicationServiceProtocol,
+            windows: any WindowManagementServiceProtocol)
+        {
+            let applicationPlanner = ApplicationMutationPlanner(applications: applications)
+            self.applications = applicationPlanner
+            self.windows = WindowMutationPlanner(
+                applicationPlanner: applicationPlanner,
+                windowInventoryProvider: { target in
+                    try await windows.mutationInventory(target: target)
+                })
+        }
+
+        public init(
+            applicationPlanner: ApplicationMutationPlanner,
+            windowPlanner: WindowMutationPlanner)
+        {
+            self.applications = applicationPlanner
+            self.windows = windowPlanner
+        }
+
+        public func plan(
+            selector: InteractionTargetSelector,
+            requirement: MutationAuthorityRequirement = .mostSpecific,
+            expectedProcessIdentity: ApplicationProcessIdentity? = nil) async throws -> MutationAuthorityPlan
+        {
+            switch requirement {
+            case .mostSpecific where selector.hasWindowInput:
+                let plan = try await self.windows.plan(selector: selector)
+                try Self.requireExpectedProcessIdentity(expectedProcessIdentity, actual: plan.owner.processIdentity)
+                return .window(plan)
+            case .mostSpecific:
+                return try await .application(self.applications.plan(
+                    selector: selector,
+                    expectedIdentity: expectedProcessIdentity))
+            case let .exactWindow(automaticSelection):
+                let plan = try await self.windows.plan(
+                    selector: selector,
+                    automaticSelection: automaticSelection)
+                try Self.requireExpectedProcessIdentity(expectedProcessIdentity, actual: plan.owner.processIdentity)
+                return .window(plan)
+            }
+        }
+
+        public func revalidate(_ plan: MutationAuthorityPlan) async throws -> MutationAuthorityPlan {
+            switch plan {
+            case let .application(application):
+                try await .application(self.applications.revalidate(application))
+            case let .window(window):
+                try await .window(self.windows.revalidate(window))
+            }
+        }
+
+        private static func requireExpectedProcessIdentity(
+            _ expected: ApplicationProcessIdentity?,
+            actual: ApplicationProcessIdentity) throws
+        {
+            guard let expected, expected != actual else { return }
+            throw DesktopTargetPlanningError.staleApplication(expected: expected)
+        }
+    }
+}

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKitTestSupport/MutationAuthorityCatalogScript.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKitTestSupport/MutationAuthorityCatalogScript.swift
@@ -1,0 +1,92 @@
+import Foundation
+import PeekabooAutomationKit
+import PeekabooFoundation
+
+/// Instance-owned complete/partial catalog sequence for mutation-authority tests.
+@MainActor
+public final class MutationAuthorityCatalogScript {
+    public private(set) var applicationInventoryRequestCount = 0
+    public private(set) var exactApplicationRequests: [String] = []
+    public private(set) var windowInventoryTargets: [WindowTarget] = []
+
+    private let applicationInventories: [DesktopTargetPlanning.Inventory<ServiceApplicationInfo>]
+    private let windowInventories: [DesktopTargetPlanning.Inventory<ServiceWindowInfo>]
+    private var applicationInventoryIndex = 0
+    private var windowInventoryIndex = 0
+    private var currentApplications: [ServiceApplicationInfo]
+
+    public init(
+        applicationInventories: [DesktopTargetPlanning.Inventory<ServiceApplicationInfo>],
+        windowInventories: [DesktopTargetPlanning.Inventory<ServiceWindowInfo>])
+    {
+        self.applicationInventories = applicationInventories
+        self.windowInventories = windowInventories
+        self.currentApplications = applicationInventories.first?.items ?? []
+    }
+
+    public convenience init(
+        applications: [ServiceApplicationInfo],
+        windowInventories: [DesktopTargetPlanning.Inventory<ServiceWindowInfo>])
+    {
+        self.init(
+            applicationInventories: [.complete(applications)],
+            windowInventories: windowInventories)
+    }
+
+    public func planner() -> DesktopTargetPlanning.MutationAuthorityPlanner {
+        let applicationPlanner = DesktopTargetPlanning.ApplicationMutationPlanner(
+            inventoryProvider: { [self] in self.nextApplicationInventory() },
+            exactIdentifierProvider: { [self] identifier in
+                try self.exactApplication(identifier: identifier)
+            })
+        let windowProvider: DesktopTargetPlanning.WindowMutationPlanner.WindowInventoryProvider = { [self] target in
+            self.nextWindowInventory(target: target)
+        }
+        return DesktopTargetPlanning.MutationAuthorityPlanner(
+            applicationPlanner: applicationPlanner,
+            windowPlanner: DesktopTargetPlanning.WindowMutationPlanner(
+                applicationPlanner: applicationPlanner,
+                windowInventoryProvider: windowProvider))
+    }
+
+    private func nextApplicationInventory() -> DesktopTargetPlanning.Inventory<ServiceApplicationInfo> {
+        self.applicationInventoryRequestCount += 1
+        let inventory = Self.step(self.applicationInventories, index: &self.applicationInventoryIndex)
+        self.currentApplications = inventory.items
+        return inventory
+    }
+
+    private func nextWindowInventory(
+        target: WindowTarget) -> DesktopTargetPlanning.Inventory<ServiceWindowInfo>
+    {
+        self.windowInventoryTargets.append(target)
+        return Self.step(self.windowInventories, index: &self.windowInventoryIndex)
+    }
+
+    private func exactApplication(identifier: String) throws -> ServiceApplicationInfo {
+        self.exactApplicationRequests.append(identifier)
+        let normalized = identifier.trimmingCharacters(in: .whitespacesAndNewlines)
+        let pid = normalized.uppercased().hasPrefix("PID:")
+            ? Int32(normalized.dropFirst(4))
+            : nil
+        let matches = self.currentApplications.filter { application in
+            pid.map { application.processIdentifier == $0 } == true ||
+                application.bundleIdentifier?.caseInsensitiveCompare(normalized) == .orderedSame ||
+                application.name.caseInsensitiveCompare(normalized) == .orderedSame
+        }
+        guard matches.count == 1, let application = matches.first else {
+            throw PeekabooError.appNotFound(identifier)
+        }
+        return application
+    }
+
+    private static func step<Element: Sendable>(
+        _ steps: [DesktopTargetPlanning.Inventory<Element>],
+        index: inout Int) -> DesktopTargetPlanning.Inventory<Element>
+    {
+        guard !steps.isEmpty else { return .complete([]) }
+        let selected = steps[min(index, steps.count - 1)]
+        index += 1
+        return selected
+    }
+}

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/MutationAuthorityPlannerTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/MutationAuthorityPlannerTests.swift
@@ -1,0 +1,105 @@
+import CoreGraphics
+import PeekabooAutomationKitTestSupport
+import PeekabooFoundation
+import Testing
+@testable import PeekabooAutomationKit
+
+@MainActor
+struct MutationAuthorityPlannerTests {
+    @Test
+    func `most-specific authority preserves application and exact-window scope`() async throws {
+        let fixture = AutomationTestFixtures.linkedDesktopTarget(
+            applicationName: "Editor",
+            windowID: 42)
+        let script = MutationAuthorityCatalogScript(
+            applications: [fixture.application],
+            windowInventories: [.complete([fixture.window])])
+        let planner = script.planner()
+
+        let application = try await planner.plan(
+            selector: InteractionTargetSelector(applicationIdentifier: "Editor"))
+        let window = try await planner.plan(
+            selector: InteractionTargetSelector(
+                applicationIdentifier: "Editor",
+                windowID: fixture.window.windowID))
+
+        #expect(application.window == nil)
+        #expect(try application.targetIdentity == fixture.processTargetIdentity)
+        #expect(window.window?.identity == fixture.windowIdentity)
+        #expect(try window.targetIdentity == fixture.windowTargetIdentity)
+    }
+
+    @Test
+    func `exact-window authority resolves the preferred window from a complete catalog`() async throws {
+        let fixture = AutomationTestFixtures.linkedDesktopTarget(
+            applicationName: "Editor",
+            windowID: 42)
+        let script = MutationAuthorityCatalogScript(
+            applications: [fixture.application],
+            windowInventories: [.complete([fixture.window])])
+
+        let authority = try await script.planner().plan(
+            selector: InteractionTargetSelector(applicationIdentifier: "Editor"),
+            requirement: .exactWindow(automaticSelection: .preferredMutationWindow(.general)))
+
+        #expect(authority.window?.identity == fixture.windowIdentity)
+        #expect(try authority.targetIdentity == fixture.windowTargetIdentity)
+    }
+
+    @Test
+    func `broad exact-window authority refuses a partial catalog while direct ID remains admissible`() async throws {
+        let fixture = AutomationTestFixtures.linkedDesktopTarget(
+            applicationName: "Editor",
+            windowID: 42)
+        let warning = "AX enumeration timed out"
+        let broadScript = MutationAuthorityCatalogScript(
+            applications: [fixture.application],
+            windowInventories: [.partial([fixture.window], warnings: [warning])])
+
+        await #expect(throws: DesktopTargetPlanningError.incompleteWindowInventory(
+            selector: "window title 'Test Window'",
+            warnings: [warning]))
+        {
+            _ = try await broadScript.planner().plan(
+                selector: InteractionTargetSelector(
+                    applicationIdentifier: "Editor",
+                    windowTitle: fixture.window.title),
+                requirement: .exactWindow(automaticSelection: .preferredMutationWindow(.general)))
+        }
+
+        let directScript = MutationAuthorityCatalogScript(
+            applications: [fixture.application],
+            windowInventories: [.partial([fixture.window], warnings: [warning])])
+        let direct = try await directScript.planner().plan(
+            selector: InteractionTargetSelector(windowID: fixture.window.windowID),
+            requirement: .exactWindow(automaticSelection: .preferredMutationWindow(.general)))
+
+        #expect(direct.window?.identity == fixture.windowIdentity)
+    }
+
+    @Test
+    func `authority revalidation rejects same-ID bounds drift`() async throws {
+        let fixture = AutomationTestFixtures.linkedDesktopTarget(
+            applicationName: "Editor",
+            windowID: 42)
+        let replacement = AutomationTestFixtures.window(
+            copying: fixture.window,
+            bounds: CGRect(x: 40, y: 20, width: 640, height: 480))
+        let script = MutationAuthorityCatalogScript(
+            applications: [fixture.application],
+            windowInventories: [
+                .complete([fixture.window]),
+                .complete([replacement]),
+            ])
+        let planner = script.planner()
+        let authority = try await planner.plan(
+            selector: InteractionTargetSelector(
+                applicationIdentifier: "Editor",
+                windowID: fixture.window.windowID),
+            requirement: .exactWindow(automaticSelection: .preferredMutationWindow(.general)))
+
+        await #expect(throws: DesktopTargetPlanningError.staleWindow(expected: fixture.windowIdentity)) {
+            _ = try await planner.revalidate(authority)
+        }
+    }
+}

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/AuthorizedDesktopTargetPlan.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/AuthorizedDesktopTargetPlan.swift
@@ -10,6 +10,7 @@ import PeekabooFoundation
 struct AuthorizedDesktopTargetPlan: Sendable, Equatable {
     let targetIdentity: DesktopTargetIdentity
     let selectedWindow: ServiceWindowInfo?
+    let mutationAuthority: DesktopTargetPlanning.MutationAuthorityPlan?
 
     init(
         targetIdentity: DesktopTargetIdentity,
@@ -17,6 +18,13 @@ struct AuthorizedDesktopTargetPlan: Sendable, Equatable {
     {
         self.targetIdentity = targetIdentity
         self.selectedWindow = selectedWindow
+        self.mutationAuthority = nil
+    }
+
+    init(mutationAuthority: DesktopTargetPlanning.MutationAuthorityPlan) throws {
+        self.targetIdentity = try mutationAuthority.targetIdentity
+        self.selectedWindow = mutationAuthority.window?.selectionWindow
+        self.mutationAuthority = mutationAuthority
     }
 
     @TaskLocal

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/MCPToolContext+BackgroundApplicationTarget.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/MCPToolContext+BackgroundApplicationTarget.swift
@@ -1,5 +1,6 @@
 import Foundation
 import PeekabooAutomationKit
+import PeekabooFoundation
 import TachikomaMCP
 
 extension MCPToolContext {
@@ -12,16 +13,39 @@ extension MCPToolContext {
 
     private struct BackgroundExactWindowSelector {
         let keys: BackgroundExactWindowSelectorKeys
-        let applicationIdentifier: String?
-        let selection: ExactWindowSelectorResolver.Selection
-        let windowID: Int?
+        let selector: InteractionTargetSelector
     }
 
+    @MainActor
     func backgroundTargetRevalidation(
         _ authorization: BackgroundTargetAuthorization,
         toolName: String) async -> ToolResponse?
     {
         guard let plan = authorization.targetPlan else { return nil }
+        if let authority = plan.mutationAuthority {
+            let planner = DesktopTargetPlanning.MutationAuthorityPlanner(
+                applications: self.applications,
+                windows: self.windows)
+            do {
+                let current = try await planner.revalidate(authority)
+                _ = try plan.targetIdentity.coalescing(current.targetIdentity)
+                let application = current.application.application
+                return self.executionPolicy.systemSurfaceRejection(
+                    toolName: toolName,
+                    applicationBundleIdentifier: application.bundleIdentifier,
+                    applicationName: application.name)
+            } catch {
+                let detail = plan.targetIdentity.exactWindow == nil
+                    ? "the selected application changed process generation before dispatch"
+                    : "the selected window changed identity or bounds before dispatch"
+                return self.executionPolicy.unresolvedTargetRejection(
+                    toolName: toolName,
+                    detail: detail)
+            }
+        }
+
+        // Snapshot-backed authorizations do not originate from a live inventory plan. Retain their
+        // exact identity revalidation until snapshot receipt planning moves into the shared planner.
         let identity = plan.processIdentity
         do {
             let application = try await self.applications.findApplication(
@@ -101,6 +125,7 @@ extension MCPToolContext {
         }
     }
 
+    @MainActor
     func backgroundExactWindowTargetAuthorization(
         toolName: String,
         arguments: ToolArguments) async throws -> BackgroundTargetAuthorization?
@@ -110,84 +135,45 @@ extension MCPToolContext {
             arguments: arguments)
         else { return nil }
 
-        let explicitlyResolvedApplications = try await self.resolveApplications(
-            selector.applicationIdentifier.map { [$0] } ?? [])
-        let inventoryTarget: WindowTarget
-        if let windowID = selector.windowID {
-            inventoryTarget = .windowId(windowID)
-        } else if let application = explicitlyResolvedApplications.first {
-            inventoryTarget = .application("PID:\(application.processIdentifier)")
-        } else {
-            throw BackgroundTargetResolutionError(
-                "the selected application owner could not be resolved before dispatch")
-        }
-
-        let windows: [ServiceWindowInfo]
+        let planner = DesktopTargetPlanning.MutationAuthorityPlanner(
+            applications: self.applications,
+            windows: self.windows)
+        let authority: DesktopTargetPlanning.MutationAuthorityPlan
         do {
-            windows = try await self.windows.listWindows(target: inventoryTarget)
-        } catch {
-            throw BackgroundTargetResolutionError("the selected window inventory could not be resolved before dispatch")
-        }
-        let selectedWindow: ServiceWindowInfo
-        do {
-            selectedWindow = try ExactWindowSelectorResolver.select(
-                from: windows,
-                selection: selector.selection,
-                operation: "Background \(toolName)")
+            let automaticSelection: DesktopTargetPlanning.WindowSelectionPolicy =
+                toolName == "window" && arguments.getString("action")?.lowercased() == "restore"
+                    ? .preferredMutationWindow(.restore)
+                    : .preferredMutationWindow(.general)
+            authority = try await planner.plan(
+                selector: selector.selector,
+                requirement: .exactWindow(automaticSelection: automaticSelection))
         } catch {
             throw BackgroundTargetResolutionError(error.localizedDescription)
         }
-
-        let exactWindowTarget: DesktopTargetIdentity
-        do {
-            exactWindowTarget = try DesktopTargetIdentity(
-                exactWindow: UIAutomationTarget.ExactWindow(window: selectedWindow))
-        } catch {
+        guard let windowPlan = authority.window else {
             throw BackgroundTargetResolutionError(
-                "the selected window has no generation-pinned identity with immutable bounds")
+                "background \(toolName) did not resolve one exact window authority")
         }
-        let ownerApplications: [ServiceApplicationInfo] = if explicitlyResolvedApplications.isEmpty {
-            try await self.resolveApplications([
-                "PID:\(exactWindowTarget.processIdentity.processIdentifier)",
-            ])
-        } else {
-            explicitlyResolvedApplications
-        }
-        let processIdentity = try Self.validatedProcessIdentity(
-            applications: ownerApplications,
-            windowProcessIdentities: [exactWindowTarget.processIdentity])
-        for application in ownerApplications {
-            if let rejection = self.executionPolicy.systemSurfaceRejection(
-                toolName: toolName,
-                applicationBundleIdentifier: application.bundleIdentifier,
-                applicationName: application.name)
-            {
-                return BackgroundTargetAuthorization(arguments: arguments, rejection: rejection, targetPlan: nil)
-            }
-        }
-
-        let processTarget = try DesktopTargetIdentity(processIdentity: processIdentity)
-        let authorizedTarget: DesktopTargetIdentity
-        do {
-            authorizedTarget = try processTarget.coalescing(exactWindowTarget)
-        } catch {
-            throw BackgroundTargetResolutionError(
-                "the selected application and window identify different process-generation owners")
+        let application = authority.application.application
+        if let rejection = self.executionPolicy.systemSurfaceRejection(
+            toolName: toolName,
+            applicationBundleIdentifier: application.bundleIdentifier,
+            applicationName: application.name)
+        {
+            return BackgroundTargetAuthorization(arguments: arguments, rejection: rejection, targetPlan: nil)
         }
 
         var pinned = Self.argumentsPinnedToProcess(
             arguments,
             toolName: toolName,
-            processIdentifier: processIdentity.processIdentifier).rawDictionary
-        pinned["window_id"] = selectedWindow.windowID
+            processIdentifier: authority.application.processIdentity.processIdentifier).rawDictionary
+        pinned["window_id"] = windowPlan.identity.windowID
         pinned.removeValue(forKey: selector.keys.title)
         pinned.removeValue(forKey: selector.keys.index)
-        return BackgroundTargetAuthorization(
+        return try BackgroundTargetAuthorization(
             arguments: ToolArguments(raw: pinned),
             rejection: nil,
-            targetPlan: AuthorizedDesktopTargetPlan(
-                targetIdentity: authorizedTarget,
-                selectedWindow: selectedWindow))
+            targetPlan: AuthorizedDesktopTargetPlan(mutationAuthority: authority))
     }
 
     private static func backgroundExactWindowSelector(
@@ -213,8 +199,6 @@ extension MCPToolContext {
         guard applicationSelector.value == nil || pid == nil else {
             throw BackgroundTargetResolutionError("app and pid are mutually exclusive")
         }
-        let applicationIdentifier = applicationSelector.value ?? pid.map { "PID:\($0)" }
-
         let windowID = try arguments.validatedInt("window_id")
         let windowIndex = try arguments.validatedInt(keys.index)
         guard windowID.map({ $0 > 0 && UInt32(exactly: $0) != nil }) ?? true else {
@@ -230,25 +214,18 @@ extension MCPToolContext {
         if toolName == "paste", selectorCount == 0 {
             return nil
         }
-        guard windowID != nil || applicationIdentifier != nil else {
+        guard windowID != nil || applicationSelector.value != nil || pid != nil else {
             throw BackgroundTargetResolutionError(
                 "background window mutation requires an application or exact window_id owner")
         }
-
-        let selection: ExactWindowSelectorResolver.Selection = if let windowID {
-            .id(windowID)
-        } else if let title = titleSelector.value {
-            .title(title)
-        } else if let windowIndex {
-            .index(windowIndex)
-        } else {
-            .automatic
-        }
         return BackgroundExactWindowSelector(
             keys: keys,
-            applicationIdentifier: applicationIdentifier,
-            selection: selection,
-            windowID: windowID)
+            selector: InteractionTargetSelector(
+                applicationIdentifier: applicationSelector.value,
+                processIdentifier: pid,
+                windowID: windowID,
+                windowTitle: titleSelector.value,
+                windowIndex: windowIndex))
     }
 
     private static func backgroundExactWindowSelectorKeys(

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/MCPToolContext+BackgroundApplicationTarget.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/MCPToolContext+BackgroundApplicationTarget.swift
@@ -19,7 +19,7 @@ extension MCPToolContext {
     @MainActor
     func backgroundTargetRevalidation(
         _ authorization: BackgroundTargetAuthorization,
-        toolName: String) async -> ToolResponse?
+        toolName: String) async throws -> ToolResponse?
     {
         guard let plan = authorization.targetPlan else { return nil }
         if let authority = plan.mutationAuthority {
@@ -34,7 +34,10 @@ extension MCPToolContext {
                     toolName: toolName,
                     applicationBundleIdentifier: application.bundleIdentifier,
                     applicationName: application.name)
+            } catch is CancellationError {
+                throw CancellationError()
             } catch {
+                try Task.checkCancellation()
                 let detail = plan.targetIdentity.exactWindow == nil
                     ? "the selected application changed process generation before dispatch"
                     : "the selected window changed identity or bounds before dispatch"
@@ -62,7 +65,10 @@ extension MCPToolContext {
             {
                 return rejection
             }
+        } catch is CancellationError {
+            throw CancellationError()
         } catch {
+            try Task.checkCancellation()
             return self.executionPolicy.unresolvedTargetRejection(
                 toolName: toolName,
                 detail: "the selected application disappeared before dispatch")
@@ -82,7 +88,10 @@ extension MCPToolContext {
                     toolName: toolName,
                     detail: "the selected window changed identity or bounds before dispatch")
             }
+        } catch is CancellationError {
+            throw CancellationError()
         } catch {
+            try Task.checkCancellation()
             return self.executionPolicy.unresolvedTargetRejection(
                 toolName: toolName,
                 detail: "the selected window disappeared before dispatch")

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/MCPToolContext.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/MCPToolContext.swift
@@ -278,10 +278,16 @@ public struct MCPToolContext: @unchecked Sendable {
             await self.snapshotExecutionGate.release()
             return rejection
         }
-        if let rejection = try await self.backgroundTargetRevalidation(
-            targetAuthorization,
-            toolName: tool.name)
-        {
+        let targetRevalidation: ToolResponse?
+        do {
+            targetRevalidation = try await self.backgroundTargetRevalidation(
+                targetAuthorization,
+                toolName: tool.name)
+        } catch {
+            await self.snapshotExecutionGate.release()
+            throw error
+        }
+        if let rejection = targetRevalidation {
             await self.snapshotExecutionGate.release()
             return rejection
         }

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/MCPToolContext.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/MCPToolContext.swift
@@ -278,7 +278,7 @@ public struct MCPToolContext: @unchecked Sendable {
             await self.snapshotExecutionGate.release()
             return rejection
         }
-        if let rejection = await self.backgroundTargetRevalidation(
+        if let rejection = try await self.backgroundTargetRevalidation(
             targetAuthorization,
             toolName: tool.name)
         {
@@ -404,7 +404,7 @@ public struct MCPToolContext: @unchecked Sendable {
             if let rejection = authorization.rejection {
                 return rejection
             }
-            if let rejection = await self.backgroundTargetRevalidation(
+            if let rejection = try await self.backgroundTargetRevalidation(
                 authorization,
                 toolName: tool.name)
             {

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/PasteToolExactWindowTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/PasteToolExactWindowTests.swift
@@ -538,7 +538,7 @@ private final class PredispatchProcessPasteAutomationService: MockAutomationServ
     }
 }
 
-private actor PasteSiblingWindowService: WindowManagementServiceProtocol {
+private actor PasteSiblingWindowService: WindowManagementServiceProtocol, WindowMutationInventoryProviding {
     private let windows: [ServiceWindowInfo]
 
     init(windows: [ServiceWindowInfo]) {
@@ -564,6 +564,12 @@ private actor PasteSiblingWindowService: WindowManagementServiceProtocol {
         case .application, .frontmost:
             self.windows
         }
+    }
+
+    func windowMutationInventory(
+        target: WindowTarget) async throws -> DesktopTargetPlanning.Inventory<ServiceWindowInfo>
+    {
+        try await .complete(self.listWindows(target: target))
     }
 
     func getFocusedWindow() async throws -> ServiceWindowInfo? {

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/WindowToolExactRoutingTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/WindowToolExactRoutingTests.swift
@@ -164,6 +164,29 @@ struct WindowToolExactRoutingTests {
         #expect(service.receivedIdentities.map(\.ownerProcessStartIdentity) == [7])
     }
 
+    @Test
+    @MainActor
+    func `background target revalidation preserves cancellation before dispatch`() async throws {
+        let service = ExactRoutingWindowService()
+        service.mutationInventoryErrorStartingAtCall = (2, CancellationError())
+        let context = await MCPToolTestHelpers.makeContext(
+            applications: Self.fixtureApplications(),
+            windows: service,
+            executionPolicy: .backgroundOnly)
+
+        await #expect(throws: CancellationError.self) {
+            _ = try await context.execute(
+                tool: WindowTool(context: context),
+                arguments: ToolArguments(raw: [
+                    "action": "close",
+                    "app": "Fixture",
+                ]))
+        }
+
+        #expect(service.mutationDispatchCount == 0)
+        #expect(service.closeTargets.isEmpty)
+    }
+
     @Test(arguments: ["close", "minimize", "restore", "maximize", "move", "resize", "set-bounds"])
     @MainActor
     func `background window selectors stay pinned across post-authorization inventory reorder`(
@@ -818,6 +841,8 @@ private final class ExactRoutingWindowService: WindowManagementActionResultProvi
     nonisolated(unsafe) var replacementWindowStartingAtListCall: (Int, ServiceWindowInfo)?
     nonisolated(unsafe) var listHandler: ((WindowTarget, Int) -> [ServiceWindowInfo])?
     nonisolated(unsafe) var mutationInventoryWarnings: [String] = []
+    nonisolated(unsafe) var mutationInventoryErrorStartingAtCall: (Int, any Error)?
+    private(set) nonisolated(unsafe) var mutationInventoryRequestCount = 0
     private(set) nonisolated(unsafe) var mutationDispatchCount = 0
 
     func listWindows(target: WindowTarget) async throws -> [ServiceWindowInfo] {
@@ -844,6 +869,12 @@ private final class ExactRoutingWindowService: WindowManagementActionResultProvi
     func windowMutationInventory(
         target: WindowTarget) async throws -> DesktopTargetPlanning.Inventory<ServiceWindowInfo>
     {
+        self.mutationInventoryRequestCount += 1
+        if let (startingCall, error) = self.mutationInventoryErrorStartingAtCall,
+           self.mutationInventoryRequestCount >= startingCall
+        {
+            throw error
+        }
         let windows = try await self.listWindows(target: target)
         guard !self.mutationInventoryWarnings.isEmpty else { return .complete(windows) }
         return .partial(windows, warnings: self.mutationInventoryWarnings)

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/WindowToolExactRoutingTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/WindowToolExactRoutingTests.swift
@@ -83,6 +83,87 @@ struct WindowToolExactRoutingTests {
         #expect(meta["retry_safe"] == .bool(true))
     }
 
+    @Test
+    @MainActor
+    func `background window mutation refuses one title match from a partial catalog`() async throws {
+        let service = ExactRoutingWindowService()
+        service.mutationInventoryWarnings = ["AX enumeration timed out"]
+        let context = await MCPToolTestHelpers.makeContext(
+            applications: Self.fixtureApplications(),
+            windows: service,
+            executionPolicy: .backgroundOnly)
+
+        let response = try await context.execute(
+            tool: WindowTool(context: context),
+            arguments: ToolArguments(raw: [
+                "action": "close",
+                "app": "Fixture",
+                "title": "Fixture",
+            ]))
+
+        #expect(response.isError)
+        #expect(service.mutationDispatchCount == 0)
+        #expect(service.listTargets.map(\.description) == ["application(PID:42)"])
+        guard case let .text(message, _, _)? = response.content.first else {
+            Issue.record("Expected partial-inventory refusal text")
+            return
+        }
+        #expect(message.contains("incomplete"))
+        #expect(message.contains("AX enumeration timed out"))
+        let meta = try #require(response.meta?.objectValue)
+        #expect(meta["mutation_dispatched"] == .bool(false))
+        #expect(meta["retry_safe"] == .bool(true))
+    }
+
+    @Test
+    @MainActor
+    func `background window mutation refuses a fuzzy application selector before window lookup`() async throws {
+        let service = ExactRoutingWindowService()
+        let context = await MCPToolTestHelpers.makeContext(
+            applications: Self.fixtureApplications(),
+            windows: service,
+            executionPolicy: .backgroundOnly)
+
+        let response = try await context.execute(
+            tool: WindowTool(context: context),
+            arguments: ToolArguments(raw: [
+                "action": "close",
+                "app": "Fixt",
+            ]))
+
+        #expect(response.isError)
+        #expect(service.mutationDispatchCount == 0)
+        #expect(service.listTargets.isEmpty)
+        guard case let .text(message, _, _)? = response.content.first else {
+            Issue.record("Expected fuzzy-selector refusal text")
+            return
+        }
+        #expect(message.contains("not allowed for mutation"))
+    }
+
+    @Test
+    @MainActor
+    func `background exact window ID remains admissible with legacy partial catalog evidence`() async throws {
+        let service = ExactRoutingWindowService()
+        service.mutationInventoryWarnings = ["Legacy host omitted completeness metadata"]
+        let context = await MCPToolTestHelpers.makeContext(
+            applications: Self.fixtureApplications(),
+            windows: service,
+            executionPolicy: .backgroundOnly)
+
+        let response = try await context.execute(
+            tool: WindowTool(context: context),
+            arguments: ToolArguments(raw: [
+                "action": "close",
+                "window_id": 924,
+            ]))
+
+        #expect(!response.isError)
+        #expect(service.mutationDispatchCount == 1)
+        #expect(service.closeTargets.map(\.description) == ["windowId(924)"])
+        #expect(service.receivedIdentities.map(\.ownerProcessStartIdentity) == [7])
+    }
+
     @Test(arguments: ["close", "minimize", "restore", "maximize", "move", "resize", "set-bounds"])
     @MainActor
     func `background window selectors stay pinned across post-authorization inventory reorder`(
@@ -697,6 +778,7 @@ struct WindowToolExactRoutingTests {
 
 private final class ExactRoutingWindowService: WindowManagementActionResultProviding,
     WindowManagementPinnedFocusActionResultProviding,
+    WindowMutationInventoryProviding,
     @unchecked Sendable
 {
     nonisolated(unsafe) var actionOutcome: DesktopActionOutcome? = .confirmedChange(
@@ -735,6 +817,7 @@ private final class ExactRoutingWindowService: WindowManagementActionResultProvi
     nonisolated(unsafe) var postMutationReadbackStartingAtListCall = 2
     nonisolated(unsafe) var replacementWindowStartingAtListCall: (Int, ServiceWindowInfo)?
     nonisolated(unsafe) var listHandler: ((WindowTarget, Int) -> [ServiceWindowInfo])?
+    nonisolated(unsafe) var mutationInventoryWarnings: [String] = []
     private(set) nonisolated(unsafe) var mutationDispatchCount = 0
 
     func listWindows(target: WindowTarget) async throws -> [ServiceWindowInfo] {
@@ -756,6 +839,14 @@ private final class ExactRoutingWindowService: WindowManagementActionResultProvi
             return [replacementWindowStartingAtListCall.1]
         }
         return [self.window]
+    }
+
+    func windowMutationInventory(
+        target: WindowTarget) async throws -> DesktopTargetPlanning.Inventory<ServiceWindowInfo>
+    {
+        let windows = try await self.listWindows(target: target)
+        guard !self.mutationInventoryWarnings.isEmpty else { return .complete(windows) }
+        return .partial(windows, warnings: self.mutationInventoryWarnings)
     }
 
     func closeWindow(target: WindowTarget) async throws {

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/WindowToolExactRoutingTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/WindowToolExactRoutingTests.swift
@@ -168,7 +168,7 @@ struct WindowToolExactRoutingTests {
     @MainActor
     func `background target revalidation preserves cancellation before dispatch`() async throws {
         let service = ExactRoutingWindowService()
-        service.mutationInventoryErrorStartingAtCall = (2, CancellationError())
+        service.mutationInventoryErrorAtCall = (2, CancellationError())
         let context = await MCPToolTestHelpers.makeContext(
             applications: Self.fixtureApplications(),
             windows: service,
@@ -185,6 +185,34 @@ struct WindowToolExactRoutingTests {
 
         #expect(service.mutationDispatchCount == 0)
         #expect(service.closeTargets.isEmpty)
+
+        let followUpCompleted = await withTaskGroup(of: Bool.self) { group in
+            group.addTask {
+                do {
+                    let response = try await context.execute(
+                        tool: WindowTool(context: context),
+                        arguments: ToolArguments(raw: [
+                            "action": "close",
+                            "app": "Fixture",
+                        ]))
+                    return !response.isError
+                } catch {
+                    return false
+                }
+            }
+            group.addTask {
+                try? await Task.sleep(for: .milliseconds(250))
+                return false
+            }
+
+            let completed = await group.next() ?? false
+            group.cancelAll()
+            return completed
+        }
+
+        #expect(followUpCompleted)
+        #expect(service.mutationDispatchCount == 1)
+        #expect(service.closeTargets.map(\.description) == ["windowId(924)"])
     }
 
     @Test(arguments: ["close", "minimize", "restore", "maximize", "move", "resize", "set-bounds"])
@@ -841,7 +869,7 @@ private final class ExactRoutingWindowService: WindowManagementActionResultProvi
     nonisolated(unsafe) var replacementWindowStartingAtListCall: (Int, ServiceWindowInfo)?
     nonisolated(unsafe) var listHandler: ((WindowTarget, Int) -> [ServiceWindowInfo])?
     nonisolated(unsafe) var mutationInventoryWarnings: [String] = []
-    nonisolated(unsafe) var mutationInventoryErrorStartingAtCall: (Int, any Error)?
+    nonisolated(unsafe) var mutationInventoryErrorAtCall: (Int, any Error)?
     private(set) nonisolated(unsafe) var mutationInventoryRequestCount = 0
     private(set) nonisolated(unsafe) var mutationDispatchCount = 0
 
@@ -870,8 +898,8 @@ private final class ExactRoutingWindowService: WindowManagementActionResultProvi
         target: WindowTarget) async throws -> DesktopTargetPlanning.Inventory<ServiceWindowInfo>
     {
         self.mutationInventoryRequestCount += 1
-        if let (startingCall, error) = self.mutationInventoryErrorStartingAtCall,
-           self.mutationInventoryRequestCount >= startingCall
+        if let (call, error) = self.mutationInventoryErrorAtCall,
+           self.mutationInventoryRequestCount == call
         {
             throw error
         }


### PR DESCRIPTION
## Summary

- add one canonical application/window mutation-authority plan in PeekabooAutomationKit
- make background keyboard delivery and MCP exact-window authorization share completeness, exact-selection, generation-pinning, and revalidation semantics
- retain MCP parsing, policy, and compatibility argument rewriting while rejecting fuzzy selectors and partial broad catalogs before dispatch
- add a reusable scripted mutation catalog and focused coverage for partial inventories, exact-ID compatibility, and drift

## Tests

- `swift test --filter MutationAuthorityPlannerTests` (Core/PeekabooAutomationKit)
- `swift test --filter DesktopTargetPlanningTests` (Core/PeekabooAutomationKit)
- `swift test --filter WindowToolExactRoutingTests` (Core/PeekabooCore)
- `swift test --filter PasteToolExactWindowTests` (Core/PeekabooCore)
- `PEEKABOO_INCLUDE_AUTOMATION_TESTS=true swift test --filter TargetedInteractionDefaultDeliveryTests` (Apps/CLI)
- `PEEKABOO_INCLUDE_AUTOMATION_TESTS=true swift test --filter SpaceToolTests` (Apps/CLI)
- `pnpm run format`
- `pnpm run lint` (baseline warnings only)
- `pnpm run test:safe`
- autoreview: clean
