### PR TITLE
chore(deps): update AXorcist observer bounds

### DIFF
--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to Peekaboo CLI will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Bound asynchronous Accessibility notification add and remove waits, removal joins, and subscription setup retries so one wedged endpoint cannot hang global observer startup or teardown. Thanks @SebTardif for AXorcist #47.
+
 ## [4.2.1] - 2026-08-17
 
 ### Highlights

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+- Bound asynchronous Accessibility notification add and remove waits, removal joins, and subscription setup retries so one wedged endpoint cannot hang global observer startup or teardown. Thanks @SebTardif for AXorcist #47.
+
 ## [4.2.1] - 2026-08-17
 
 ### Highlights


### PR DESCRIPTION
## Summary

- update AXorcist to `470cbd64a7814298a48d3350beeb957a3342c2b9`
- bound asynchronous Accessibility notification add/remove waits, removal joins, and subscription setup retries
- preserve late-result ownership so a wedged endpoint cannot hang global observer startup or teardown

## Test plan

- `pnpm run test:safe`
- focused `WindowTrackerServiceTests` (4/4)
- focused `PeekabooDaemonTests` (9/9)
- SwiftFormat (0/1564)
- SwiftLint (exit 0; 0 serious findings)
- docs lint
- parent-only autoreview (no findings)

Upstream AXorcist proof: full 186-test suite and green CI on the pinned SHA.

Thanks @SebTardif for AXorcist #47.
