### PR TITLE
refactor: centralize snapshot target receipts

### DIFF
--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/ClickCommand+StatelessVariants.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/ClickCommand+StatelessVariants.swift
@@ -26,7 +26,7 @@ extension ClickCommand {
     ) async throws -> UIAutomationTarget.ExactWindow {
         guard !snapshotId.isEmpty,
               let detection = try await self.services.snapshots.getDetectionResult(snapshotId: snapshotId),
-              let context = detection.metadata.windowContext
+              detection.metadata.windowContext != nil
         else {
             throw ValidationError(
                 "Background middle- and triple-clicks require a fresh exact-window snapshot."
@@ -34,15 +34,10 @@ extension ClickCommand {
         }
         let receipt: SnapshotTargetReceipt
         do {
-            receipt = try SnapshotTargetReceipt(
+            receipt = try SnapshotTargetReceiptPlanner.assemble(
                 snapshotID: snapshotId,
-                evidence: [.init(
-                    processIdentifier: context.applicationProcessId,
-                    windowID: context.windowID,
-                    windowIdentity: context.windowMutationIdentity,
-                    windowBounds: context.windowBounds
-                )]
-            )
+                detectionResult: detection
+            ).receipt
         } catch {
             throw ValidationError(
                 "Background middle- and triple-clicks require a consistent exact-window snapshot."

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/ClickCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/ClickCommand.swift
@@ -1043,33 +1043,22 @@ extension ClickCommand {
     private func backgroundClickSnapshotProcessIdentity(snapshotId: String?) async throws
     -> ApplicationProcessIdentity? {
         guard let snapshotId else { return nil }
-        var evidence: [DesktopTargetIdentity.Evidence] = []
-        var hasProcessIdentifier = false
-        if let snapshot = try? await self.services.snapshots.getUIAutomationSnapshot(snapshotId: snapshotId),
-           let processIdentifier = snapshot.applicationProcessId {
-            hasProcessIdentifier = true
-            evidence.append(.init(
-                processIdentifier: processIdentifier,
-                processIdentity: snapshot.windowMutationIdentity?.processIdentity
-            ))
-        }
-        if let detection = try? await self.services.snapshots.getDetectionResult(snapshotId: snapshotId),
-           let context = detection.metadata.windowContext,
-           let processIdentifier = context.applicationProcessId {
-            hasProcessIdentifier = true
-            evidence.append(.init(
-                processIdentifier: processIdentifier,
-                processIdentity: context.windowMutationIdentity?.processIdentity
-            ))
-        }
-        guard hasProcessIdentifier else {
-            throw ValidationError(
-                "Snapshot '\(snapshotId)' does not identify a target process. Run see again before clicking."
-            )
-        }
         do {
-            return try SnapshotTargetReceipt(snapshotID: snapshotId, evidence: evidence)
-                .requireIdentity().processIdentity
+            let plan = try await SnapshotTargetReceiptPlanner(
+                snapshots: self.services.snapshots,
+                sourceFailurePolicy: .omitUnavailableSources
+            )
+            .planProcessIdentity(snapshotID: snapshotId)
+            guard plan.hasProcessIdentifierEvidence else {
+                throw ValidationError(
+                    "Snapshot '\(snapshotId)' does not identify a target process. Run see again before clicking."
+                )
+            }
+            return try plan.receipt.requireIdentity().processIdentity
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch let error as Commander.ValidationError {
+            throw error
         } catch DesktopTargetIdentityError.missingProcessGeneration,
             DesktopTargetIdentityError.incompleteExactWindow {
             throw ValidationError(
@@ -1097,25 +1086,16 @@ extension ClickCommand {
     ) async throws -> InteractionCoordinateResolution {
         guard let detection = try await self.services.snapshots.getDetectionResult(snapshotId: snapshotId),
               !detection.screenshotPath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
-              let captured = detection.metadata.windowContext
+              detection.metadata.windowContext != nil
         else {
             throw ValidationError(Self.backgroundCoordinateReferenceMessage)
         }
         let coordinateAuthority: SnapshotTargetReceipt.CoordinateAuthority
         do {
-            coordinateAuthority = try SnapshotTargetReceipt(
+            coordinateAuthority = try SnapshotTargetReceiptPlanner.assemble(
                 snapshotID: snapshotId,
-                evidence: [.init(
-                    processIdentifier: captured.applicationProcessId,
-                    windowID: captured.windowID,
-                    windowIdentity: captured.windowMutationIdentity,
-                    windowBounds: captured.windowBounds
-                )],
-                applicationBundleIdentifier: captured.applicationBundleId,
-                applicationName: captured.applicationName,
-                coordinateContext: detection.metadata.captureCoordinateContext
-            )
-            .requireCoordinateAuthority()
+                detectionResult: detection
+            ).receipt.requireCoordinateAuthority()
         } catch {
             throw ValidationError(Self.backgroundCoordinateReferenceMessage)
         }
@@ -1200,23 +1180,16 @@ extension ClickCommand {
             throw ValidationError(Self.backgroundCoordinateReferenceMessage)
         }
         guard let detection = try await self.services.snapshots.getDetectionResult(snapshotId: snapshotId),
-              let captured = detection.metadata.windowContext
+              detection.metadata.windowContext != nil
         else {
             throw ValidationError(Self.backgroundCoordinateReferenceMessage)
         }
         let authority: SnapshotTargetReceipt.CoordinateAuthority
         do {
-            authority = try SnapshotTargetReceipt(
+            authority = try SnapshotTargetReceiptPlanner.assemble(
                 snapshotID: snapshotId,
-                evidence: [.init(
-                    processIdentifier: captured.applicationProcessId,
-                    windowID: captured.windowID,
-                    windowIdentity: captured.windowMutationIdentity,
-                    windowBounds: captured.windowBounds
-                )],
-                coordinateContext: detection.metadata.captureCoordinateContext
-            )
-            .requireCoordinateAuthority()
+                detectionResult: detection
+            ).receipt.requireCoordinateAuthority()
         } catch {
             throw ValidationError(Self.backgroundCoordinateReferenceMessage)
         }

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/KeyboardDeliverySupport.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/KeyboardDeliverySupport.swift
@@ -86,33 +86,15 @@ enum KeyboardDeliverySupport {
         snapshotId: String,
         services: any PeekabooServiceProviding
     ) async throws -> UIAutomationTarget.ExactWindow {
-        var evidence: [DesktopTargetIdentity.Evidence] = []
-        if let snapshot = try await services.snapshots.getUIAutomationSnapshot(snapshotId: snapshotId) {
-            evidence.append(.init(
-                processIdentifier: snapshot.applicationProcessId,
-                windowID: snapshot.windowID.map(Int.init),
-                windowIdentity: snapshot.windowMutationIdentity,
-                windowBounds: snapshot.windowBounds,
-                focusedElement: snapshot.focusedElement
-            ))
-        }
-        if let detectionResult = try await services.snapshots.getDetectionResult(snapshotId: snapshotId),
-           let context = detectionResult.metadata.windowContext {
-            evidence.append(.init(
-                processIdentifier: context.applicationProcessId,
-                windowID: context.windowID,
-                windowIdentity: context.windowMutationIdentity,
-                windowBounds: context.windowBounds,
-                focusedElement: context.focusedElement
-            ))
-        }
-
         do {
-            let receipt = try SnapshotTargetReceipt(snapshotID: snapshotId, evidence: evidence)
+            let receipt = try await SnapshotTargetReceiptPlanner(snapshots: services.snapshots)
+                .plan(snapshotID: snapshotId).receipt
             guard let exactWindow = try receipt.requireIdentity().exactWindow else {
                 throw DesktopTargetIdentityError.incompleteExactWindow
             }
             return exactWindow
+        } catch is CancellationError {
+            throw CancellationError()
         } catch DesktopTargetIdentityError.missingProcessGeneration,
             DesktopTargetIdentityError.incompleteExactWindow {
             throw ValidationError(

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 - Bound asynchronous Accessibility notification add and remove waits, removal joins, and subscription setup retries so one wedged endpoint cannot hang global observer startup or teardown. Thanks @SebTardif for AXorcist #47.
+- Centralize snapshot target-evidence adapters and receipt planning across AutomationKit, CLI, Bridge, and MCP so exact-window identity, coordinate authority, source contradictions, and cancellation keep one fail-closed contract.
 - Route background mutation authorization through one completeness-aware application/window planner, so MCP window, Space, and exact-window paste targets reject fuzzy selectors and partial catalogs before dispatch.
 
 ## [4.2.1] - 2026-08-17

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Observation/DesktopObservationService.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Observation/DesktopObservationService.swift
@@ -282,10 +282,8 @@ public enum ObservationActionResultSemantics {
         .Evidence]
     {
         if let mutationTarget = result.target.mutationTargetIdentity {
-            return [.init(
-                processIdentifier: mutationTarget.processIdentity.processIdentifier,
+            return [DesktopTargetEvidenceAdapter.evidence(
                 processIdentity: mutationTarget.processIdentity,
-                windowID: mutationTarget.windowIdentity?.windowID,
                 windowIdentity: mutationTarget.windowIdentity,
                 windowBounds: mutationTarget.windowBounds)]
         }
@@ -308,34 +306,25 @@ public enum ObservationActionResultSemantics {
         .Evidence?
     {
         guard let application,
-              let processStartIdentity = application.processStartIdentity
+              application.processStartIdentity != nil
         else { return nil }
-        return .init(
-            processIdentifier: application.processIdentifier,
-            processIdentity: .init(
-                processIdentifier: application.processIdentifier,
-                processStartIdentity: processStartIdentity))
+        return DesktopTargetEvidenceAdapter.evidence(application: application)
     }
 
     private static func targetEvidence(_ application: ServiceApplicationInfo?)
         -> DesktopTargetIdentity.Evidence?
     {
         guard let application,
-              let processIdentity = application.processIdentity
+              application.processIdentity != nil
         else { return nil }
-        return .init(
-            processIdentifier: application.processIdentifier,
-            processIdentity: processIdentity)
+        return DesktopTargetEvidenceAdapter.evidence(application: application)
     }
 
     private static func targetEvidence(_ window: ServiceWindowInfo) -> DesktopTargetIdentity.Evidence? {
         guard let identity = window.mutationIdentity else { return nil }
-        return .init(
-            processIdentifier: identity.ownerProcessIdentifier,
-            processIdentity: identity.processIdentity,
-            windowID: identity.windowID,
+        return DesktopTargetEvidenceAdapter.evidence(
             windowIdentity: identity,
-            windowBounds: window.bounds)
+            bounds: window.bounds)
     }
 
     private static func targetEvidence(_ context: WindowContext?) -> [DesktopTargetIdentity.Evidence] {
@@ -344,12 +333,9 @@ public enum ObservationActionResultSemantics {
               let bounds = context.windowBounds
         else { return [] }
         return [
-            .init(
-                processIdentifier: identity.ownerProcessIdentifier,
-                processIdentity: identity.processIdentity,
-                windowID: identity.windowID,
+            DesktopTargetEvidenceAdapter.evidence(
                 windowIdentity: identity,
-                windowBounds: bounds,
+                bounds: bounds,
                 focusedElement: context.focusedElement),
         ]
     }

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/ClickService.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/ClickService.swift
@@ -1079,24 +1079,20 @@ extension ClickService {
         guard let targetWindowID, let targetProcessIdentifier else { return nil }
         guard let snapshotId,
               let detection = try? await self.snapshotManager.getDetectionResult(snapshotId: snapshotId),
-              let context = detection.metadata.windowContext
+              detection.metadata.windowContext != nil
         else {
             throw PeekabooError.snapshotStale(
                 "Exact-window click snapshot has no capture-time process-generation receipt and bounds")
         }
         do {
-            let receipt = try SnapshotTargetReceipt(
+            let receipt = try SnapshotTargetReceiptPlanner.assemble(
                 snapshotID: snapshotId,
-                evidence: [
+                detectionResult: detection,
+                additionalEvidence: [
                     .init(
                         processIdentifier: targetProcessIdentifier,
                         windowID: Int(targetWindowID)),
-                    .init(
-                        processIdentifier: context.applicationProcessId,
-                        windowID: context.windowID,
-                        windowIdentity: context.windowMutationIdentity,
-                        windowBounds: context.windowBounds),
-                ])
+                ]).receipt
             guard let exactWindow = try receipt.requireIdentity().exactWindow else {
                 throw DesktopTargetIdentityError.incompleteExactWindow
             }

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Strategy/DesktopOperationSnapshotReceiptValidator.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Strategy/DesktopOperationSnapshotReceiptValidator.swift
@@ -27,8 +27,7 @@ enum DesktopOperationSnapshotReceiptValidator {
         guard detectionResult.snapshotId == snapshotID else {
             throw PeekabooError.snapshotStale("snapshot identity changed before desktop mutation planning")
         }
-        guard let context = detectionResult.metadata.windowContext,
-              let identity = context.windowMutationIdentity
+        guard detectionResult.metadata.windowContext?.windowMutationIdentity != nil
         else {
             guard !requireExactWindow else {
                 throw PeekabooError.snapshotStale(
@@ -48,16 +47,10 @@ enum DesktopOperationSnapshotReceiptValidator {
         }
         let captureReceipt: DesktopOperationPlan.CaptureReceipt
         do {
-            captureReceipt = try DesktopOperationPlan.CaptureReceipt(snapshotReceipt: SnapshotTargetReceipt(
-                snapshotID: snapshotID,
-                evidence: [.init(
-                    processIdentifier: context.applicationProcessId,
-                    windowID: context.windowID,
-                    windowIdentity: identity,
-                    windowBounds: context.windowBounds)],
-                applicationBundleIdentifier: context.applicationBundleId,
-                applicationName: context.applicationName,
-                coordinateContext: detectionResult.metadata.captureCoordinateContext))
+            captureReceipt = try DesktopOperationPlan.CaptureReceipt(snapshotReceipt: SnapshotTargetReceiptPlanner
+                .assemble(
+                    snapshotID: snapshotID,
+                    detectionResult: detectionResult).receipt)
         } catch let error as DesktopTargetIdentityError {
             throw SnapshotTargetReceiptPreDispatchError(error)
         }

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Strategy/DesktopTargetEvidenceAdapter.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Strategy/DesktopTargetEvidenceAdapter.swift
@@ -1,0 +1,159 @@
+import CoreGraphics
+import Foundation
+import PeekabooFoundation
+
+/// Canonical conversion from automation models into transport-neutral desktop target evidence.
+public enum DesktopTargetEvidenceAdapter {
+    public static func evidence(application: ServiceApplicationInfo) -> DesktopTargetIdentity.Evidence {
+        self.processEvidence(
+            processIdentifier: application.processIdentifier,
+            processStartIdentity: application.processStartIdentity)
+    }
+
+    public static func evidence(application: ApplicationIdentity) -> DesktopTargetIdentity.Evidence {
+        self.processEvidence(
+            processIdentifier: application.processIdentifier,
+            processStartIdentity: application.processStartIdentity)
+    }
+
+    public static func evidence(window: ServiceWindowInfo) -> DesktopTargetIdentity.Evidence {
+        .init(
+            processIdentifier: window.mutationIdentity?.ownerProcessIdentifier,
+            processIdentity: window.mutationIdentity?.processIdentity,
+            windowID: window.windowID,
+            windowIdentity: window.mutationIdentity,
+            windowBounds: window.bounds)
+    }
+
+    public static func evidence(window: WindowIdentity) -> DesktopTargetIdentity.Evidence {
+        .init(windowID: window.windowID, windowBounds: window.bounds)
+    }
+
+    public static func evidence(
+        windowIdentity: WindowMutationIdentity,
+        bounds: CGRect? = nil,
+        focusedElement: FocusedElementIdentity? = nil) -> DesktopTargetIdentity.Evidence
+    {
+        .init(
+            processIdentifier: windowIdentity.ownerProcessIdentifier,
+            processIdentity: windowIdentity.processIdentity,
+            windowID: windowIdentity.windowID,
+            windowIdentity: windowIdentity,
+            windowBounds: bounds ?? windowIdentity.capturedBounds,
+            focusedElement: focusedElement)
+    }
+
+    public static func evidence(context: WindowContext) -> DesktopTargetIdentity.Evidence {
+        .init(
+            processIdentifier: context.applicationProcessId,
+            processIdentity: context.windowMutationIdentity?.processIdentity,
+            windowID: context.windowID,
+            windowIdentity: context.windowMutationIdentity,
+            windowBounds: context.windowBounds,
+            focusedElement: context.focusedElement)
+    }
+
+    public static func evidence(snapshot: UIAutomationSnapshot) -> DesktopTargetIdentity.Evidence {
+        .init(
+            processIdentifier: snapshot.applicationProcessId,
+            processIdentity: snapshot.windowMutationIdentity?.processIdentity,
+            windowID: snapshot.windowID.map(Int.init),
+            windowIdentity: snapshot.windowMutationIdentity,
+            windowBounds: snapshot.windowBounds,
+            focusedElement: snapshot.focusedElement)
+    }
+
+    public static func evidence(receipt: DesktopActionTargetReceipt) -> DesktopTargetIdentity.Evidence {
+        .init(
+            processIdentifier: receipt.processIdentifier,
+            processIdentity: .init(
+                processIdentifier: receipt.processIdentifier,
+                processStartIdentity: receipt.processStartIdentity),
+            windowID: receipt.windowID)
+    }
+
+    public static func evidence(
+        processIdentifier: Int32?,
+        processStartIdentity: UInt64?,
+        windowID: Int?,
+        windowIdentity: WindowMutationIdentity?,
+        windowBounds: CGRect?,
+        focusedElement: FocusedElementIdentity?) -> DesktopTargetIdentity.Evidence
+    {
+        .init(
+            processIdentifier: processIdentifier,
+            processIdentity: self.processIdentity(
+                processIdentifier: processIdentifier,
+                processStartIdentity: processStartIdentity),
+            windowID: windowID,
+            windowIdentity: windowIdentity,
+            windowBounds: windowBounds,
+            focusedElement: focusedElement)
+    }
+
+    public static func evidence(
+        processIdentity: ApplicationProcessIdentity,
+        windowIdentity: WindowMutationIdentity? = nil,
+        windowBounds: CGRect? = nil,
+        focusedElement: FocusedElementIdentity? = nil) -> DesktopTargetIdentity.Evidence
+    {
+        .init(
+            processIdentifier: processIdentity.processIdentifier,
+            processIdentity: processIdentity,
+            windowID: windowIdentity?.windowID,
+            windowIdentity: windowIdentity,
+            windowBounds: windowBounds,
+            focusedElement: focusedElement)
+    }
+
+    public static func fragments(captureMetadata: CaptureMetadata) -> [DesktopTargetIdentity.Evidence] {
+        [
+            captureMetadata.applicationInfo.map { self.evidence(application: $0) },
+            captureMetadata.windowInfo.map { self.evidence(window: $0) },
+        ].compactMap(\.self)
+    }
+
+    public static func fragments(dialogResult: DialogActionResult) -> [DesktopTargetIdentity.Evidence] {
+        var evidence: [DesktopTargetIdentity.Evidence] = []
+        if let resolvedTarget = dialogResult.resolvedTarget {
+            evidence.append(.init(target: DesktopTargetIdentity(exactWindow: resolvedTarget.target)))
+        }
+        if dialogResult.targetWindowIdentity != nil ||
+            dialogResult.targetWindowBounds != nil ||
+            dialogResult.focusedElement != nil
+        {
+            evidence.append(.init(
+                processIdentifier: dialogResult.targetWindowIdentity?.ownerProcessIdentifier,
+                processIdentity: dialogResult.targetWindowIdentity?.processIdentity,
+                windowID: dialogResult.targetWindowIdentity?.windowID,
+                windowIdentity: dialogResult.targetWindowIdentity,
+                windowBounds: dialogResult.targetWindowBounds,
+                focusedElement: dialogResult.focusedElement))
+        }
+        if let receipt = dialogResult.targetReceipt {
+            evidence.append(self.evidence(receipt: receipt))
+        }
+        return evidence
+    }
+
+    private static func processEvidence(
+        processIdentifier: Int32,
+        processStartIdentity: UInt64?) -> DesktopTargetIdentity.Evidence
+    {
+        .init(
+            processIdentifier: processIdentifier,
+            processIdentity: self.processIdentity(
+                processIdentifier: processIdentifier,
+                processStartIdentity: processStartIdentity))
+    }
+
+    private static func processIdentity(
+        processIdentifier: Int32?,
+        processStartIdentity: UInt64?) -> ApplicationProcessIdentity?
+    {
+        guard let processIdentifier, let processStartIdentity else { return nil }
+        return ApplicationProcessIdentity(
+            processIdentifier: processIdentifier,
+            processStartIdentity: processStartIdentity)
+    }
+}

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Strategy/DesktopTargetEvidenceAdapter.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Strategy/DesktopTargetEvidenceAdapter.swift
@@ -25,10 +25,6 @@ public enum DesktopTargetEvidenceAdapter {
             windowBounds: window.bounds)
     }
 
-    public static func evidence(window: WindowIdentity) -> DesktopTargetIdentity.Evidence {
-        .init(windowID: window.windowID, windowBounds: window.bounds)
-    }
-
     public static func evidence(
         windowIdentity: WindowMutationIdentity,
         bounds: CGRect? = nil,

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Strategy/DesktopTargetEvidenceAdapter.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Strategy/DesktopTargetEvidenceAdapter.swift
@@ -25,6 +25,10 @@ public enum DesktopTargetEvidenceAdapter {
             windowBounds: window.bounds)
     }
 
+    public static func evidence(window: WindowIdentity) -> DesktopTargetIdentity.Evidence {
+        .init(windowID: window.windowID, windowBounds: window.bounds)
+    }
+
     public static func evidence(
         windowIdentity: WindowMutationIdentity,
         bounds: CGRect? = nil,

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Strategy/DesktopTargetPlanning.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Strategy/DesktopTargetPlanning.swift
@@ -101,6 +101,7 @@ public enum DesktopTargetIdentityError: LocalizedError, Equatable, Sendable {
     case incompleteExactWindow
     case invalidatedSnapshotReceipt
     case invalidSnapshotIdentifier
+    case snapshotSourceMismatch
     case coordinateReferenceMismatch
     case coordinateWindowMismatch
     case coordinateBoundsMismatch
@@ -133,6 +134,8 @@ public enum DesktopTargetIdentityError: LocalizedError, Equatable, Sendable {
             "Snapshot target receipt was invalidated by contradictory or removed metadata."
         case .invalidSnapshotIdentifier:
             "Snapshot identifier must not be empty."
+        case .snapshotSourceMismatch:
+            "Snapshot receipt sources refer to a different snapshot identifier."
         case .coordinateReferenceMismatch:
             "Capture coordinate reference does not identify the selected snapshot."
         case .coordinateWindowMismatch:

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Strategy/SnapshotTargetReceiptPlanner.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Strategy/SnapshotTargetReceiptPlanner.swift
@@ -1,0 +1,182 @@
+import Foundation
+
+public struct SnapshotTargetReceiptPlan: Equatable, Sendable {
+    public let receipt: SnapshotTargetReceipt
+    public let sourceEvidence: [DesktopTargetIdentity.Evidence]
+
+    public var hasProcessIdentifierEvidence: Bool {
+        self.sourceEvidence.contains { evidence in
+            evidence.processIdentifier != nil || evidence.processIdentity != nil
+        }
+    }
+}
+
+/// Loads and assembles the canonical target receipt for one snapshot identifier.
+public struct SnapshotTargetReceiptPlanner: Sendable {
+    public enum SourceFailurePolicy: Equatable, Sendable {
+        case propagate
+        case omitUnavailableSources
+    }
+
+    typealias AutomationSnapshotProvider =
+        @Sendable (_ snapshotID: String) async throws -> UIAutomationSnapshot?
+    typealias DetectionResultProvider =
+        @Sendable (_ snapshotID: String) async throws -> ElementDetectionResult?
+
+    private enum EvidenceScope {
+        case completeTarget
+        case processIdentity
+    }
+
+    private let automationSnapshotProvider: AutomationSnapshotProvider
+    private let detectionResultProvider: DetectionResultProvider
+    private let sourceFailurePolicy: SourceFailurePolicy
+
+    public init(
+        snapshots: any SnapshotManagerProtocol,
+        sourceFailurePolicy: SourceFailurePolicy = .propagate)
+    {
+        self.init(
+            automationSnapshotProvider: { snapshotID in
+                try await snapshots.getUIAutomationSnapshot(snapshotId: snapshotID)
+            },
+            detectionResultProvider: { snapshotID in
+                try await snapshots.getDetectionResult(snapshotId: snapshotID)
+            },
+            sourceFailurePolicy: sourceFailurePolicy)
+    }
+
+    init(
+        automationSnapshotProvider: @escaping AutomationSnapshotProvider,
+        detectionResultProvider: @escaping DetectionResultProvider,
+        sourceFailurePolicy: SourceFailurePolicy = .propagate)
+    {
+        self.automationSnapshotProvider = automationSnapshotProvider
+        self.detectionResultProvider = detectionResultProvider
+        self.sourceFailurePolicy = sourceFailurePolicy
+    }
+
+    public func plan(snapshotID: String) async throws -> SnapshotTargetReceiptPlan {
+        try await self.plan(snapshotID: snapshotID, evidenceScope: .completeTarget)
+    }
+
+    /// Resolves only stable process identity while leaving exact-window completeness to the mutation planner.
+    public func planProcessIdentity(snapshotID: String) async throws -> SnapshotTargetReceiptPlan {
+        try await self.plan(snapshotID: snapshotID, evidenceScope: .processIdentity)
+    }
+
+    private func plan(
+        snapshotID: String,
+        evidenceScope: EvidenceScope) async throws -> SnapshotTargetReceiptPlan
+    {
+        try Task.checkCancellation()
+        let snapshot = try await self.loadAutomationSnapshot(snapshotID: snapshotID)
+        try Task.checkCancellation()
+        let detectionResult = try await self.loadDetectionResult(snapshotID: snapshotID)
+        try Task.checkCancellation()
+        return try Self.assemble(
+            snapshotID: snapshotID,
+            automationSnapshot: snapshot,
+            detectionResult: detectionResult,
+            evidenceScope: evidenceScope)
+    }
+
+    public static func assemble(
+        snapshotID: String,
+        automationSnapshot: UIAutomationSnapshot? = nil,
+        detectionResult: ElementDetectionResult? = nil,
+        additionalEvidence: [DesktopTargetIdentity.Evidence] = [],
+        targetReceiptInvalidated: Bool = false,
+        applicationBundleIdentifier: String? = nil,
+        applicationName: String? = nil,
+        coordinateContext: CaptureCoordinateContext? = nil) throws -> SnapshotTargetReceiptPlan
+    {
+        try self.assemble(
+            snapshotID: snapshotID,
+            automationSnapshot: automationSnapshot,
+            detectionResult: detectionResult,
+            additionalEvidence: additionalEvidence,
+            targetReceiptInvalidated: targetReceiptInvalidated,
+            applicationBundleIdentifier: applicationBundleIdentifier,
+            applicationName: applicationName,
+            coordinateContext: coordinateContext,
+            evidenceScope: .completeTarget)
+    }
+
+    private static func assemble(
+        snapshotID: String,
+        automationSnapshot: UIAutomationSnapshot?,
+        detectionResult: ElementDetectionResult?,
+        additionalEvidence: [DesktopTargetIdentity.Evidence] = [],
+        targetReceiptInvalidated: Bool = false,
+        applicationBundleIdentifier: String? = nil,
+        applicationName: String? = nil,
+        coordinateContext: CaptureCoordinateContext? = nil,
+        evidenceScope: EvidenceScope) throws -> SnapshotTargetReceiptPlan
+    {
+        if let detectionResult, detectionResult.snapshotId != snapshotID {
+            throw DesktopTargetIdentityError.snapshotSourceMismatch
+        }
+        var evidence = additionalEvidence.map { self.evidence($0, scopedTo: evidenceScope) }
+        if let automationSnapshot {
+            evidence.append(self.evidence(
+                DesktopTargetEvidenceAdapter.evidence(snapshot: automationSnapshot),
+                scopedTo: evidenceScope))
+        }
+        if let context = detectionResult?.metadata.windowContext {
+            evidence.append(self.evidence(
+                DesktopTargetEvidenceAdapter.evidence(context: context),
+                scopedTo: evidenceScope))
+        }
+        let detectionContext = detectionResult?.metadata.windowContext
+        let receipt = try SnapshotTargetReceipt(
+            snapshotID: snapshotID,
+            evidence: evidence,
+            targetReceiptInvalidated: targetReceiptInvalidated,
+            applicationBundleIdentifier: applicationBundleIdentifier ??
+                detectionContext?.applicationBundleId ?? automationSnapshot?.applicationBundleId,
+            applicationName: applicationName ?? detectionContext?.applicationName ?? automationSnapshot?
+                .applicationName,
+            coordinateContext: coordinateContext ??
+                detectionResult?.metadata.captureCoordinateContext ?? automationSnapshot?.captureCoordinateContext)
+        return SnapshotTargetReceiptPlan(receipt: receipt, sourceEvidence: evidence)
+    }
+
+    private static func evidence(
+        _ evidence: DesktopTargetIdentity.Evidence,
+        scopedTo scope: EvidenceScope) -> DesktopTargetIdentity.Evidence
+    {
+        switch scope {
+        case .completeTarget:
+            evidence
+        case .processIdentity:
+            .init(
+                processIdentifier: evidence.processIdentifier,
+                processIdentity: evidence.processIdentity)
+        }
+    }
+
+    private func loadAutomationSnapshot(snapshotID: String) async throws -> UIAutomationSnapshot? {
+        do {
+            return try await self.automationSnapshotProvider(snapshotID)
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch {
+            try Task.checkCancellation()
+            guard self.sourceFailurePolicy == .omitUnavailableSources else { throw error }
+            return nil
+        }
+    }
+
+    private func loadDetectionResult(snapshotID: String) async throws -> ElementDetectionResult? {
+        do {
+            return try await self.detectionResultProvider(snapshotID)
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch {
+            try Task.checkCancellation()
+            guard self.sourceFailurePolicy == .omitUnavailableSources else { throw error }
+            return nil
+        }
+    }
+}

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKitTestSupport/AutomationTestFixtures.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKitTestSupport/AutomationTestFixtures.swift
@@ -224,6 +224,7 @@ public enum AutomationTestFixtures {
     public static func windowContext(
         application: ServiceApplicationInfo = Self.application(),
         window: ServiceWindowInfo = Self.window(),
+        focusedElement: FocusedElementIdentity? = nil,
         requiresFreshAccessibilityTree: Bool = true) -> WindowContext
     {
         if let receipt = window.mutationIdentity {
@@ -240,6 +241,7 @@ public enum AutomationTestFixtures {
             windowID: window.windowID,
             windowBounds: window.bounds,
             windowMutationIdentity: window.mutationIdentity,
+            focusedElement: focusedElement,
             requiresFreshAccessibilityTree: requiresFreshAccessibilityTree)
     }
 

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKitTestSupport/LinkedDesktopTargetFixture.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKitTestSupport/LinkedDesktopTargetFixture.swift
@@ -87,7 +87,10 @@ extension AutomationTestFixtures {
                 window: window,
                 processTargetIdentity: processTargetIdentity,
                 windowTargetIdentity: windowTargetIdentity,
-                windowContext: self.windowContext(application: application, window: window))
+                windowContext: self.windowContext(
+                    application: application,
+                    window: window,
+                    focusedElement: focusedElement))
         } catch {
             preconditionFailure("Invalid linked desktop target fixture: \(error.localizedDescription)")
         }

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKitTestSupport/LinkedSnapshotTargetFixture.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKitTestSupport/LinkedSnapshotTargetFixture.swift
@@ -1,0 +1,68 @@
+import CoreGraphics
+import Foundation
+import PeekabooAutomationKit
+import PeekabooFoundation
+
+/// Coherent automation-snapshot and detection-result sources for one exact desktop target.
+public struct LinkedSnapshotTargetFixture: Sendable {
+    public let snapshotID: String
+    public let desktopTarget: LinkedDesktopTargetFixture
+    public let automationSnapshot: UIAutomationSnapshot
+    public let detectionResult: ElementDetectionResult
+    public let coordinateContext: CaptureCoordinateContext
+}
+
+extension AutomationTestFixtures {
+    public static func linkedSnapshotTarget(
+        snapshotID: String = "snapshot-1",
+        processIdentity: ApplicationProcessIdentity = Self.processIdentity(),
+        bundleIdentifier: String? = "com.example.TestApp",
+        applicationName: String = "Test App",
+        windowID: Int = 201,
+        windowTitle: String = "Test Window",
+        bounds: CGRect = CGRect(x: 10, y: 20, width: 640, height: 480),
+        focusedElement: FocusedElementIdentity? = nil) -> LinkedSnapshotTargetFixture
+    {
+        let target = self.linkedDesktopTarget(
+            processIdentity: processIdentity,
+            bundleIdentifier: bundleIdentifier,
+            applicationName: applicationName,
+            windowID: windowID,
+            windowTitle: windowTitle,
+            bounds: bounds,
+            focusedElement: focusedElement)
+        let coordinateContext = self.captureCoordinateContext(
+            snapshotID: snapshotID,
+            window: target.window)
+        let automationSnapshot = UIAutomationSnapshot(
+            creatorProcessId: 999,
+            uiMap: [:],
+            lastUpdateTime: Date(timeIntervalSinceReferenceDate: 1),
+            applicationName: target.application.name,
+            applicationBundleId: target.application.bundleIdentifier,
+            applicationProcessId: target.processIdentity.processIdentifier,
+            windowTitle: target.window.title,
+            windowBounds: target.window.bounds,
+            windowMutationIdentity: target.windowIdentity,
+            focusedElement: focusedElement,
+            captureCoordinateContext: coordinateContext,
+            windowID: CGWindowID(target.window.windowID))
+        let detectionResult = ElementDetectionResult(
+            snapshotId: snapshotID,
+            screenshotPath: "/tmp/peekaboo-linked-snapshot.png",
+            elements: DetectedElements(),
+            metadata: DetectionMetadata(
+                detectionTime: 0,
+                elementCount: 0,
+                method: "linked-test-fixture",
+                windowContext: target.windowContext,
+                truncationInfo: nil,
+                captureCoordinateContext: coordinateContext))
+        return LinkedSnapshotTargetFixture(
+            snapshotID: snapshotID,
+            desktopTarget: target,
+            automationSnapshot: automationSnapshot,
+            detectionResult: detectionResult,
+            coordinateContext: coordinateContext)
+    }
+}

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/AutomationKitTestSupportTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/AutomationKitTestSupportTests.swift
@@ -8,6 +8,33 @@ import Testing
 @MainActor
 struct AutomationKitTestSupportTests {
     @Test
+    func `linked snapshot target keeps automation and detection sources coherent`() throws {
+        let fixture = AutomationTestFixtures.linkedSnapshotTarget(
+            snapshotID: "snapshot-linked",
+            processIdentity: AutomationTestFixtures.processIdentity(
+                processIdentifier: 42,
+                processStartIdentity: 1001),
+            windowID: 71)
+
+        #expect(fixture.automationSnapshot.applicationProcessId == 42)
+        #expect(fixture.automationSnapshot.windowMutationIdentity == fixture.desktopTarget.windowIdentity)
+        #expect(fixture.automationSnapshot.windowBounds == fixture.desktopTarget.window.bounds)
+        #expect(fixture.automationSnapshot.captureCoordinateContext == fixture.coordinateContext)
+        #expect(fixture.detectionResult.snapshotId == fixture.snapshotID)
+        let detectionContext = try #require(fixture.detectionResult.metadata.windowContext)
+        #expect(
+            DesktopTargetEvidenceAdapter.evidence(context: detectionContext) ==
+                DesktopTargetEvidenceAdapter.evidence(context: fixture.desktopTarget.windowContext))
+        #expect(fixture.detectionResult.metadata.captureCoordinateContext == fixture.coordinateContext)
+
+        let authority = try SnapshotTargetReceiptPlanner.assemble(
+            snapshotID: fixture.snapshotID,
+            automationSnapshot: fixture.automationSnapshot,
+            detectionResult: fixture.detectionResult).receipt.requireCoordinateAuthority()
+        #expect(authority.target.identity == fixture.desktopTarget.windowIdentity)
+    }
+
+    @Test
     func `linked desktop target keeps every receipt on one process generation`() {
         let process = AutomationTestFixtures.processIdentity(
             processIdentifier: 42,

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/SnapshotTargetReceiptPlannerTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/SnapshotTargetReceiptPlannerTests.swift
@@ -1,0 +1,177 @@
+import PeekabooAutomationKitTestSupport
+import Testing
+@testable import PeekabooAutomationKit
+
+struct SnapshotTargetReceiptPlannerTests {
+    @Test
+    func `evidence adapters preserve linked process and exact-window identity`() {
+        let focusedElement = AutomationTestFixtures.focusedElement()
+        let fixture = AutomationTestFixtures.linkedSnapshotTarget(focusedElement: focusedElement)
+        let snapshotEvidence = DesktopTargetEvidenceAdapter.evidence(snapshot: fixture.automationSnapshot)
+        let contextEvidence = DesktopTargetEvidenceAdapter.evidence(context: fixture.desktopTarget.windowContext)
+        let rawEvidence = DesktopTargetEvidenceAdapter.evidence(
+            processIdentifier: fixture.desktopTarget.processIdentity.processIdentifier,
+            processStartIdentity: fixture.desktopTarget.processIdentity.processStartIdentity,
+            windowID: fixture.desktopTarget.windowIdentity.windowID,
+            windowIdentity: fixture.desktopTarget.windowIdentity,
+            windowBounds: fixture.desktopTarget.window.bounds,
+            focusedElement: focusedElement)
+        let applicationEvidence = DesktopTargetEvidenceAdapter.evidence(
+            application: fixture.desktopTarget.application)
+        let windowEvidence = DesktopTargetEvidenceAdapter.evidence(window: fixture.desktopTarget.window)
+
+        #expect(snapshotEvidence == contextEvidence)
+        #expect(snapshotEvidence == rawEvidence)
+        #expect(snapshotEvidence.focusedElement == focusedElement)
+        for evidence in [snapshotEvidence, contextEvidence, rawEvidence, windowEvidence] {
+            #expect(evidence.processIdentifier == fixture.desktopTarget.processIdentity.processIdentifier)
+            #expect(evidence.processIdentity == fixture.desktopTarget.processIdentity)
+            #expect(evidence.windowID == fixture.desktopTarget.windowIdentity.windowID)
+            #expect(evidence.windowIdentity == fixture.desktopTarget.windowIdentity)
+            #expect(evidence.windowBounds == fixture.desktopTarget.window.bounds)
+        }
+        #expect(applicationEvidence.processIdentifier == fixture.desktopTarget.processIdentity.processIdentifier)
+        #expect(applicationEvidence.processIdentity == fixture.desktopTarget.processIdentity)
+        #expect(applicationEvidence.windowID == nil)
+    }
+
+    @Test
+    func `planner merges linked sources and preserves coordinate authority`() throws {
+        let fixture = AutomationTestFixtures.linkedSnapshotTarget()
+
+        let plan = try SnapshotTargetReceiptPlanner.assemble(
+            snapshotID: fixture.snapshotID,
+            automationSnapshot: fixture.automationSnapshot,
+            detectionResult: fixture.detectionResult)
+        let identity = try plan.receipt.requireIdentity()
+        let authority = try plan.receipt.requireCoordinateAuthority()
+
+        #expect(plan.sourceEvidence.count == 2)
+        #expect(plan.hasProcessIdentifierEvidence)
+        #expect(identity.exactWindow?.identity == fixture.desktopTarget.windowIdentity)
+        #expect(plan.receipt.applicationBundleIdentifier == fixture.desktopTarget.application.bundleIdentifier)
+        #expect(plan.receipt.applicationName == fixture.desktopTarget.application.name)
+        #expect(authority.snapshotID == fixture.snapshotID)
+        #expect(authority.target.identity == fixture.desktopTarget.windowIdentity)
+        #expect(authority.sourceBounds == fixture.desktopTarget.window.bounds)
+        #expect(authority.context == fixture.coordinateContext)
+    }
+
+    @Test
+    func `planner fails closed when snapshot sources identify different process generations`() {
+        let snapshotFixture = AutomationTestFixtures.linkedSnapshotTarget()
+        let detectionFixture = AutomationTestFixtures.linkedSnapshotTarget(
+            processIdentity: AutomationTestFixtures.processIdentity(
+                processIdentifier: snapshotFixture.desktopTarget.processIdentity.processIdentifier,
+                processStartIdentity: snapshotFixture.desktopTarget.processIdentity.processStartIdentity + 1))
+
+        #expect(throws: DesktopTargetIdentityError.contradictoryProcessGeneration) {
+            _ = try SnapshotTargetReceiptPlanner.assemble(
+                snapshotID: snapshotFixture.snapshotID,
+                automationSnapshot: snapshotFixture.automationSnapshot,
+                detectionResult: detectionFixture.detectionResult)
+        }
+    }
+
+    @Test
+    func `planner rejects detection evidence from another snapshot`() {
+        let fixture = AutomationTestFixtures.linkedSnapshotTarget(snapshotID: "snapshot-1")
+
+        #expect(throws: DesktopTargetIdentityError.snapshotSourceMismatch) {
+            _ = try SnapshotTargetReceiptPlanner.assemble(
+                snapshotID: "snapshot-2",
+                detectionResult: fixture.detectionResult)
+        }
+    }
+
+    @Test
+    func `best-effort loading omits an unavailable source without weakening the receipt`() async throws {
+        let fixture = AutomationTestFixtures.linkedSnapshotTarget()
+        let planner = SnapshotTargetReceiptPlanner(
+            automationSnapshotProvider: { _ in throw SnapshotPlannerTestError.unavailable },
+            detectionResultProvider: { _ in fixture.detectionResult },
+            sourceFailurePolicy: .omitUnavailableSources)
+
+        let plan = try await planner.plan(snapshotID: fixture.snapshotID)
+
+        #expect(plan.sourceEvidence.count == 1)
+        #expect(try plan.receipt.requireIdentity().exactWindow?.identity == fixture.desktopTarget.windowIdentity)
+        #expect(try plan.receipt.requireCoordinateAuthority().context == fixture.coordinateContext)
+    }
+
+    @Test
+    func `process identity planning defers incomplete exact-window evidence to mutation planning`() async throws {
+        let fixture = AutomationTestFixtures.linkedSnapshotTarget()
+        let incompleteIdentity = WindowMutationIdentity(
+            windowID: fixture.desktopTarget.windowIdentity.windowID,
+            ownerProcessIdentifier: fixture.desktopTarget.processIdentity.processIdentifier,
+            ownerProcessStartIdentity: fixture.desktopTarget.processIdentity.processStartIdentity)
+        let detection = AutomationTestFixtures.detectionResult(
+            snapshotID: fixture.snapshotID,
+            windowContext: WindowContext(
+                applicationProcessId: fixture.desktopTarget.processIdentity.processIdentifier,
+                windowID: incompleteIdentity.windowID,
+                windowBounds: fixture.desktopTarget.window.bounds,
+                windowMutationIdentity: incompleteIdentity))
+        let planner = SnapshotTargetReceiptPlanner(
+            automationSnapshotProvider: { _ in nil },
+            detectionResultProvider: { _ in detection })
+
+        await #expect(throws: DesktopTargetIdentityError.incompleteExactWindow) {
+            _ = try await planner.plan(snapshotID: fixture.snapshotID)
+        }
+        let processPlan = try await planner.planProcessIdentity(snapshotID: fixture.snapshotID)
+        let identity = try processPlan.receipt.requireIdentity()
+        #expect(identity.processIdentity == fixture.desktopTarget.processIdentity)
+        #expect(identity.exactWindow == nil)
+    }
+
+    @Test
+    func `best-effort loading still propagates cancellation`() async {
+        let snapshotCancellation = SnapshotTargetReceiptPlanner(
+            automationSnapshotProvider: { _ in throw CancellationError() },
+            detectionResultProvider: { _ in nil },
+            sourceFailurePolicy: .omitUnavailableSources)
+        let detectionCancellation = SnapshotTargetReceiptPlanner(
+            automationSnapshotProvider: { _ in nil },
+            detectionResultProvider: { _ in throw CancellationError() },
+            sourceFailurePolicy: .omitUnavailableSources)
+
+        await #expect(throws: CancellationError.self) {
+            _ = try await snapshotCancellation.plan(snapshotID: "snapshot-1")
+        }
+        await #expect(throws: CancellationError.self) {
+            _ = try await detectionCancellation.plan(snapshotID: "snapshot-1")
+        }
+    }
+
+    @Test
+    func `planner observes cancellation even when a source returns normally`() async {
+        let fixture = AutomationTestFixtures.linkedSnapshotTarget()
+        let sourceStarted = AsyncTestLatch()
+        let sourceRelease = AsyncTestLatch()
+        let planner = SnapshotTargetReceiptPlanner(
+            automationSnapshotProvider: { _ in
+                await sourceStarted.open()
+                await sourceRelease.wait()
+                return fixture.automationSnapshot
+            },
+            detectionResultProvider: { _ in fixture.detectionResult },
+            sourceFailurePolicy: .omitUnavailableSources)
+        let task = Task {
+            try await planner.plan(snapshotID: fixture.snapshotID)
+        }
+
+        #expect(await sourceStarted.opensWithin(.seconds(1)))
+        task.cancel()
+        await sourceRelease.open()
+
+        await #expect(throws: CancellationError.self) {
+            _ = try await task.value
+        }
+    }
+}
+
+private enum SnapshotPlannerTestError: Error {
+    case unavailable
+}

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/UISnapshotStore.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/UISnapshotStore.swift
@@ -325,26 +325,18 @@ actor UISnapshot {
                 focusedElement: cache.focusedElement,
                 invalidated: cache.targetReceiptInvalidated)
         }
-        let processIdentity: ApplicationProcessIdentity? = if let processIdentifier = cached.processIdentifier,
-                                                              let processStartIdentity = cached.processStartIdentity
-        {
-            ApplicationProcessIdentity(
-                processIdentifier: processIdentifier,
-                processStartIdentity: processStartIdentity)
-        } else {
-            nil
-        }
-        return try SnapshotTargetReceipt(
+        let evidence = DesktopTargetEvidenceAdapter.evidence(
+            processIdentifier: cached.processIdentifier,
+            processStartIdentity: cached.processStartIdentity,
+            windowID: cached.windowIdentity == nil ? nil : cached.windowID,
+            windowIdentity: cached.windowIdentity,
+            windowBounds: cached.windowIdentity == nil ? nil : cached.windowBounds,
+            focusedElement: cached.windowIdentity == nil ? nil : cached.focusedElement)
+        return try SnapshotTargetReceiptPlanner.assemble(
             snapshotID: self.id,
-            evidence: [.init(
-                processIdentifier: cached.processIdentifier,
-                processIdentity: processIdentity,
-                windowID: cached.windowIdentity == nil ? nil : cached.windowID,
-                windowIdentity: cached.windowIdentity,
-                windowBounds: cached.windowIdentity == nil ? nil : cached.windowBounds,
-                focusedElement: cached.windowIdentity == nil ? nil : cached.focusedElement)],
+            additionalEvidence: [evidence],
             targetReceiptInvalidated: cached.invalidated,
-            applicationName: cached.applicationName)
+            applicationName: cached.applicationName).receipt
     }
 }
 

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeOperationReceipts.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeOperationReceipts.swift
@@ -346,6 +346,7 @@ public struct PeekabooBridgeTargetAttributionFailure: Codable, Equatable, Sendab
         case incompleteExactWindow = "incomplete_exact_window"
         case invalidatedSnapshotReceipt = "invalidated_snapshot_receipt"
         case invalidSnapshotIdentifier = "invalid_snapshot_identifier"
+        case snapshotSourceMismatch = "snapshot_source_mismatch"
         case coordinateReferenceMismatch = "coordinate_reference_mismatch"
         case coordinateWindowMismatch = "coordinate_window_mismatch"
         case coordinateBoundsMismatch = "coordinate_bounds_mismatch"
@@ -378,6 +379,7 @@ extension PeekabooBridgeTargetAttributionFailure.Code {
         case .incompleteExactWindow: .incompleteExactWindow
         case .invalidatedSnapshotReceipt: .invalidatedSnapshotReceipt
         case .invalidSnapshotIdentifier: .invalidSnapshotIdentifier
+        case .snapshotSourceMismatch: .snapshotSourceMismatch
         case .coordinateReferenceMismatch: .coordinateReferenceMismatch
         case .coordinateWindowMismatch: .coordinateWindowMismatch
         case .coordinateBoundsMismatch: .coordinateBoundsMismatch

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeOperationResponseTargetEvidence.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeOperationResponseTargetEvidence.swift
@@ -72,38 +72,36 @@ extension PeekabooBridgeResponse {
             return payload.response.operationTargetEvidence(for: operation)
         case let .desktopObservation(result):
             if let mutationTargetIdentity = result.target.mutationTargetIdentity {
-                return [.init(
-                    processIdentifier: mutationTargetIdentity.processIdentity.processIdentifier,
+                return [DesktopTargetEvidenceAdapter.evidence(
                     processIdentity: mutationTargetIdentity.processIdentity,
-                    windowID: mutationTargetIdentity.windowIdentity?.windowID,
                     windowIdentity: mutationTargetIdentity.windowIdentity,
                     windowBounds: mutationTargetIdentity.windowBounds)]
             }
             return [
-                Self.evidence(result.target.detectionContext),
-                Self.evidence(result.target.app),
-                Self.evidence(result.target.window),
-            ].compactMap(\.self) + Self.evidence(result.capture.metadata)
+                result.target.detectionContext.map { DesktopTargetEvidenceAdapter.evidence(context: $0) },
+                result.target.app.map { DesktopTargetEvidenceAdapter.evidence(application: $0) },
+                result.target.window.map { DesktopTargetEvidenceAdapter.evidence(window: $0) },
+            ].compactMap(\.self) + DesktopTargetEvidenceAdapter.fragments(captureMetadata: result.capture.metadata)
         case let .capture(result):
-            return Self.evidence(result.metadata)
+            return DesktopTargetEvidenceAdapter.fragments(captureMetadata: result.metadata)
         case let .elementDetection(result):
             return operation == .inspectAccessibilityTree
-                ? [Self.evidence(result.metadata.windowContext)].compactMap(\.self)
+                ? result.metadata.windowContext.map { [DesktopTargetEvidenceAdapter.evidence(context: $0)] } ?? []
                 : []
         case let .window(window):
             return PeekabooBridgeOperationResultSemantics.operationPolicy(for: operation)
                 .windowResponseProof == .postMutationState
                 ? []
-                : window.map(Self.evidence).map { [$0] } ?? []
+                : window.map { [DesktopTargetEvidenceAdapter.evidence(window: $0)] } ?? []
         case let .application(application):
-            return [Self.evidence(application)].compactMap(\.self)
+            return [DesktopTargetEvidenceAdapter.evidence(application: application)]
         case let .browserToolResponse(result):
             return operation == .browserExecute
-                ? [Self.evidence(result.connectionReceipt)].compactMap(\.self)
+                ? [Self.browserEvidence(result.connectionReceipt)].compactMap(\.self)
                 : []
         case let .browserStatus(status):
             return operation == .browserConnect
-                ? [Self.evidence(status.connectionReceipt)].compactMap(\.self)
+                ? [Self.browserEvidence(status.connectionReceipt)].compactMap(\.self)
                 : []
         case let .preparedDialogAction(receipt):
             return [.init(target: DesktopTargetIdentity(exactWindow: receipt.target))]
@@ -115,125 +113,26 @@ extension PeekabooBridgeResponse {
             }
             return [.init(target: DesktopTargetIdentity(exactWindow: target))]
         case let .dialogResult(result):
-            return Self.evidence(result)
+            return DesktopTargetEvidenceAdapter.fragments(dialogResult: result)
         case let .exactWindowHeldPointerTermination(termination?):
-            return [.init(
-                processIdentifier: termination.receipt.windowIdentity.ownerProcessIdentifier,
-                processIdentity: termination.receipt.windowIdentity.processIdentity,
-                windowID: termination.receipt.windowIdentity.windowID,
+            return [DesktopTargetEvidenceAdapter.evidence(
                 windowIdentity: termination.receipt.windowIdentity,
-                windowBounds: termination.receipt.windowBounds)]
+                bounds: termination.receipt.windowBounds)]
         case .focusedElement:
             return []
         case let .error(envelope):
-            return [Self.evidence(envelope.actionTargetReceipt)].compactMap(\.self)
+            return envelope.actionTargetReceipt.map { [DesktopTargetEvidenceAdapter.evidence(receipt: $0)] } ?? []
         default:
             return []
         }
     }
 
-    private static func evidence(_ metadata: CaptureMetadata) -> [DesktopTargetIdentity.Evidence] {
-        [
-            self.evidence(metadata.applicationInfo),
-            metadata.windowInfo.map(self.evidence),
-        ].compactMap(\.self)
-    }
-
-    private static func evidence(_ context: WindowContext?) -> DesktopTargetIdentity.Evidence? {
-        guard let context else { return nil }
-        return .init(
-            processIdentifier: context.applicationProcessId,
-            windowID: context.windowID,
-            windowIdentity: context.windowMutationIdentity,
-            windowBounds: context.windowBounds,
-            focusedElement: context.focusedElement)
-    }
-
-    private static func evidence(_ window: WindowIdentity?) -> DesktopTargetIdentity.Evidence? {
-        guard let window else { return nil }
-        return .init(windowID: window.windowID, windowBounds: window.bounds)
-    }
-
-    private static func evidence(_ window: ServiceWindowInfo) -> DesktopTargetIdentity.Evidence {
-        .init(
-            processIdentifier: window.mutationIdentity?.ownerProcessIdentifier,
-            processIdentity: window.mutationIdentity?.processIdentity,
-            windowID: window.windowID,
-            windowIdentity: window.mutationIdentity,
-            windowBounds: window.bounds)
-    }
-
-    private static func evidence(_ identity: WindowMutationIdentity) -> DesktopTargetIdentity.Evidence {
-        .init(
-            processIdentifier: identity.ownerProcessIdentifier,
-            processIdentity: identity.processIdentity,
-            windowID: identity.windowID,
-            windowIdentity: identity,
-            windowBounds: identity.capturedBounds)
-    }
-
-    private static func evidence(_ application: ApplicationIdentity?) -> DesktopTargetIdentity.Evidence? {
-        guard let application else { return nil }
-        return .init(
-            processIdentifier: application.processIdentifier,
-            processIdentity: application.processStartIdentity.map {
-                .init(
-                    processIdentifier: application.processIdentifier,
-                    processStartIdentity: $0)
-            })
-    }
-
-    private static func evidence(
+    private static func browserEvidence(
         _ receipt: PeekabooBridgeBrowserConnectionReceipt?) -> DesktopTargetIdentity.Evidence?
     {
         guard let processIdentity = receipt?.localProcessIdentity else { return nil }
         return .init(
             processIdentifier: processIdentity.processIdentifier,
             processIdentity: processIdentity)
-    }
-
-    private static func evidence(
-        _ application: ServiceApplicationInfo?) -> DesktopTargetIdentity.Evidence?
-    {
-        guard let application else { return nil }
-        return .init(
-            processIdentifier: application.processIdentifier,
-            processIdentity: application.processStartIdentity.map {
-                .init(
-                    processIdentifier: application.processIdentifier,
-                    processStartIdentity: $0)
-            })
-    }
-
-    private static func evidence(_ result: DialogActionResult) -> [DesktopTargetIdentity.Evidence] {
-        var evidence: [DesktopTargetIdentity.Evidence] = []
-        if let resolvedTarget = result.resolvedTarget {
-            evidence.append(.init(target: DesktopTargetIdentity(exactWindow: resolvedTarget.target)))
-        }
-        if result.targetWindowIdentity != nil || result.targetWindowBounds != nil || result.focusedElement != nil {
-            evidence.append(.init(
-                processIdentifier: result.targetWindowIdentity?.ownerProcessIdentifier,
-                processIdentity: result.targetWindowIdentity?.processIdentity,
-                windowID: result.targetWindowIdentity?.windowID,
-                windowIdentity: result.targetWindowIdentity,
-                windowBounds: result.targetWindowBounds,
-                focusedElement: result.focusedElement))
-        }
-        if let receiptEvidence = self.evidence(result.targetReceipt) {
-            evidence.append(receiptEvidence)
-        }
-        return evidence
-    }
-
-    private static func evidence(
-        _ receipt: DesktopActionTargetReceipt?) -> DesktopTargetIdentity.Evidence?
-    {
-        guard let receipt else { return nil }
-        return .init(
-            processIdentifier: receipt.processIdentifier,
-            processIdentity: .init(
-                processIdentifier: receipt.processIdentifier,
-                processStartIdentity: receipt.processStartIdentity),
-            windowID: receipt.windowID)
     }
 }

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/UISnapshotStoreConcurrencyTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/UISnapshotStoreConcurrencyTests.swift
@@ -215,6 +215,36 @@ struct UISnapshotStoreConcurrencyTests {
     }
 
     @Test
+    func `receiptless window metadata does not mint exact-window authority`() async throws {
+        let snapshot = UISnapshot()
+        let bounds = CGRect(x: 10, y: 20, width: 200, height: 100)
+        await snapshot.setScreenshot(
+            path: "/tmp/screenshot.png",
+            metadata: CaptureMetadata(
+                size: bounds.size,
+                mode: .window,
+                applicationInfo: ServiceApplicationInfo(
+                    processIdentifier: 901,
+                    processStartIdentity: 91,
+                    bundleIdentifier: "com.example.editor",
+                    name: "Editor")))
+
+        await snapshot.setTargetMetadata(from: WindowContext(
+            applicationName: "Editor",
+            applicationProcessId: 901,
+            windowTitle: "Document",
+            windowID: 42,
+            windowBounds: bounds))
+
+        let identity = try snapshot.targetReceipt().requireIdentity()
+        #expect(identity.processIdentity == ApplicationProcessIdentity(
+            processIdentifier: 901,
+            processStartIdentity: 91))
+        #expect(identity.exactWindow == nil)
+        #expect(!snapshot.targetReceiptInvalidated)
+    }
+
+    @Test
     func `screenshot rejects conflicting application and window receipts`() async {
         let conflictingIdentities = [
             WindowMutationIdentity(


### PR DESCRIPTION
## Summary

- centralize desktop model-to-target evidence conversion in PeekabooAutomationKit
- add one snapshot receipt planner for strict source loading, process-only lookup, cancellation, contradiction, and cross-snapshot validation
- migrate CLI, AutomationKit, Bridge, and MCP receipt assembly while preserving each surface's result and invalidation policy
- add coherent linked snapshot fixtures and focused fail-closed regression coverage

## Testing

- `pnpm run test:safe`
- `pnpm run format`
- `pnpm run lint` (0 serious violations)
- focused AutomationKit planner, target-planning, click, observation, and operation-plan suites
- focused CLI background-delivery, click, and snapshot pre-dispatch suites
- focused MCP snapshot-store and Bridge operation-receipt suites
- autoreview: clean, no accepted or actionable findings
