### PR TITLE
refactor: centralize CLI and MCP result semantics

### DIFF
--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Shared/CommandActionSequenceAccumulator.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Shared/CommandActionSequenceAccumulator.swift
@@ -8,21 +8,21 @@ func commandActionRoute(for services: any PeekabooServiceProviding) -> DesktopAc
 
 /// Command-layer composition for setup actions followed by one or more mutation leaves.
 ///
-/// `DesktopActionSequenceAccumulator` owns outcome semantics. This wrapper keeps the matching
-/// stable target identity beside it so a successful focus cannot be erased by a later refusal,
-/// and two successful phases cannot silently claim different targets.
+/// `UIAutomationActionResultSequenceAccumulator` owns outcome and target composition. This wrapper
+/// retains the command-facing validation and result surface used by the CLI.
 @MainActor
 final class CommandActionSequenceAccumulator {
-    private var sequence = DesktopActionSequenceAccumulator()
-    private var targetIdentityIsConsistent = true
+    private var sequence = UIAutomationActionResultSequenceAccumulator(
+        targetProjectionPolicy: .coalescedIdentity
+    )
     private(set) var targetIdentity: DesktopTargetIdentity?
 
     var mutationDisposition: DesktopActionMutationDisposition {
-        self.sequence.mutationDisposition
+        self.sequence.resolution.mutationDisposition
     }
 
     var resolution: DesktopActionSequenceAccumulator.Resolution {
-        self.sequence.successResolution()
+        self.sequence.sequenceResolution
     }
 
     func record(
@@ -44,28 +44,60 @@ final class CommandActionSequenceAccumulator {
         operation: String = "Desktop action",
         receiptlessStep: DesktopActionSequenceAccumulator.Step? = nil
     ) throws {
+        try self.record(
+            outcome: outcome,
+            targetIdentity: targetIdentity,
+            attribution: .sequenceTarget,
+            operation: operation,
+            receiptlessStep: receiptlessStep
+        )
+    }
+
+    private func record(
+        outcome: DesktopActionOutcome?,
+        targetIdentity: DesktopTargetIdentity?,
+        attribution: UIAutomationActionResultSequenceAccumulator.PhaseAttributionRule,
+        operation: String,
+        receiptlessStep: DesktopActionSequenceAccumulator.Step?
+    ) throws {
         if let outcome {
             try Self.requireSuccessfulOutcome(
                 outcome,
                 targetReceipt: targetIdentity?.actionTargetReceipt,
                 operation: operation
             )
-            self.sequence.record(.reportedOutcome(outcome, defaultDispatchedUnitCount: .one))
-        } else if let receiptlessStep {
-            self.sequence.record(receiptlessStep)
         }
 
-        guard let targetIdentity else { return }
-        do {
-            self.targetIdentity = try DesktopTargetPlanning.DesktopTargetIdentityCoalescer.coalesce([
-                self.targetIdentity,
-                targetIdentity,
-            ])
-        } catch {
-            // Once two completed phases disagree, no target may be projected for the aggregate.
-            self.targetIdentity = nil
-            self.targetIdentityIsConsistent = false
-            throw error
+        let step = outcome.map {
+            DesktopActionSequenceAccumulator.Step.reportedOutcome(
+                $0,
+                defaultDispatchedUnitCount: .one
+            )
+        } ?? receiptlessStep
+        let effectiveAttribution: UIAutomationActionResultSequenceAccumulator.PhaseAttributionRule =
+            attribution == .requiredTarget && targetIdentity != nil ? .sequenceTarget : attribution
+        let priorConflict = self.sequence.resolution.targetConflictError
+        if let step {
+            if targetIdentity != nil || attribution == .requiredTarget {
+                self.sequence.record(
+                    step,
+                    targetIdentity: targetIdentity,
+                    attribution: effectiveAttribution
+                )
+            } else {
+                self.sequence.record(step)
+            }
+        } else if targetIdentity != nil || attribution == .requiredTarget {
+            self.sequence.record(
+                outcome: nil,
+                targetIdentity: targetIdentity,
+                attribution: effectiveAttribution
+            )
+        }
+        let targetResolution = self.sequence.resolution
+        self.targetIdentity = targetResolution.targetIdentity
+        if priorConflict == nil, let conflict = targetResolution.targetConflictError {
+            throw conflict
         }
     }
 
@@ -80,13 +112,10 @@ final class CommandActionSequenceAccumulator {
         operation: String,
         receiptlessStep: DesktopActionSequenceAccumulator.Step? = nil
     ) throws {
-        if targetIdentity == nil {
-            self.targetIdentity = nil
-            self.targetIdentityIsConsistent = false
-        }
         try self.record(
             outcome: outcome,
             targetIdentity: targetIdentity,
+            attribution: .requiredTarget,
             operation: operation,
             receiptlessStep: receiptlessStep
         )
@@ -96,7 +125,7 @@ final class CommandActionSequenceAccumulator {
         UIAutomationActionResult(
             payload: payload,
             outcome: self.resolution.outcome,
-            targetIdentity: self.targetIdentityIsConsistent ? self.targetIdentity : nil
+            targetIdentity: self.targetIdentity
         )
     }
 
@@ -106,7 +135,7 @@ final class CommandActionSequenceAccumulator {
         message: String,
         hint: String
     ) -> any Error {
-        guard self.sequence.mutationDisposition.mutationDispatched else { return error }
+        guard self.sequence.resolution.mutationDisposition.mutationDispatched else { return error }
 
         let leafFailure: DesktopActionFailure = if let failure = error as? DesktopActionFailure {
             failure
@@ -118,56 +147,13 @@ final class CommandActionSequenceAccumulator {
                 causeDescription: String(describing: error)
             )
         }
-        let composite = self.sequence.failure(
+        return self.sequence.failure(
             combining: leafFailure,
+            operation: message,
             message: message,
             hint: hint,
             causeDescription: leafFailure.causeDescription ?? error.localizedDescription
         )
-        return composite.attributed(to: self.aggregateTarget(with: leafFailure))
-    }
-
-    private func aggregateTarget(with leafFailure: DesktopActionFailure) -> DesktopActionTargetReceipt? {
-        guard self.targetIdentityIsConsistent else { return nil }
-        let priorTarget = self.targetIdentity?.actionTargetReceipt
-        switch (
-            self.sequence.mutationDisposition.mutationDispatched,
-            leafFailure.outcome.dispatchState.mutationDispatched
-        ) {
-        case (true, true):
-            guard priorTarget != nil, leafFailure.targetReceipt != nil else { return nil }
-            return Self.compatibleTarget(priorTarget, leafFailure.targetReceipt)
-        case (true, false):
-            return priorTarget
-        case (false, true):
-            return leafFailure.targetReceipt
-        case (false, false):
-            return Self.compatibleTarget(priorTarget, leafFailure.targetReceipt)
-        }
-    }
-
-    private static func compatibleTarget(
-        _ prior: DesktopActionTargetReceipt?,
-        _ later: DesktopActionTargetReceipt?
-    ) -> DesktopActionTargetReceipt? {
-        switch (prior, later) {
-        case let (prior?, later?):
-            guard prior.processIdentifier == later.processIdentifier,
-                  prior.processStartIdentity == later.processStartIdentity
-            else { return nil }
-            if prior.windowID == later.windowID {
-                return prior
-            }
-            guard prior.windowID == nil || later.windowID == nil else { return nil }
-            return DesktopActionTargetReceipt(
-                processIdentifier: prior.processIdentifier,
-                processStartIdentity: prior.processStartIdentity
-            )
-        case let (target?, nil), let (nil, target?):
-            return target
-        case (nil, nil):
-            return nil
-        }
     }
 
     private static func requireSuccessfulOutcome(

--- a/Apps/CLI/Tests/CoreCLITests/CommandActionSequenceAccumulatorTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/CommandActionSequenceAccumulatorTests.swift
@@ -71,6 +71,34 @@ struct CommandActionSequenceAccumulatorTests {
     }
 
     @Test
+    func `cancellation after dispatch delegates retry and target semantics`() throws {
+        let target = try Self.target(pid: 48, generation: 14, windowID: 108)
+        let sequence = CommandActionSequenceAccumulator()
+        try sequence.record(UIAutomationActionResult(
+            payload: (),
+            outcome: .dispatchedUnverified(
+                route: .bridge,
+                delivery: .init(mechanism: .accessibilityAction, mode: .foreground),
+                evidence: .deliveryAccepted,
+                unitCount: .one
+            ),
+            targetIdentity: target
+        ))
+
+        let preserved = try #require(sequence.preservingFailure(
+            CancellationError(),
+            fallbackRoute: .bridge,
+            message: "The action was cancelled after dispatch.",
+            hint: "Observe before retrying."
+        ) as? DesktopActionFailure)
+
+        #expect(preserved.outcome.state == .indeterminate)
+        #expect(preserved.outcome.retrySafety == .unsafe)
+        #expect(preserved.outcome.dispatchState == .mayHaveDispatched(unitCount: .one))
+        #expect(preserved.targetReceipt == target.actionTargetReceipt)
+    }
+
+    @Test
     func `successful focus and leaf coalesce target and dispatch units`() throws {
         let target = try Self.target(pid: 42, generation: 8, windowID: 102)
         let processTarget = try DesktopTargetIdentity(processIdentity: target.processIdentity)
@@ -93,6 +121,37 @@ struct CommandActionSequenceAccumulatorTests {
         ))
 
         let result = sequence.result(payload: "done")
+        var canonical = UIAutomationActionResultSequenceAccumulator(
+            targetProjectionPolicy: .coalescedIdentity
+        )
+        canonical.record(
+            .reportedOutcome(
+                .confirmedChange(
+                    route: .local,
+                    delivery: .init(mechanism: .accessibilityAction, mode: .foreground)
+                ),
+                defaultDispatchedUnitCount: .one
+            ),
+            targetIdentity: target,
+            attribution: .sequenceTarget
+        )
+        canonical.record(
+            .reportedOutcome(
+                .confirmedChange(
+                    route: .local,
+                    delivery: .init(mechanism: .accessibilityValue, mode: .foreground)
+                ),
+                defaultDispatchedUnitCount: .one
+            ),
+            targetIdentity: processTarget,
+            attribution: .sequenceTarget
+        )
+        let canonicalResult = try canonical.result(
+            payload: "done",
+            operation: "Canonical command sequence",
+            requiresOutcome: true,
+            requiresCompatibleTarget: true
+        )
         #expect(result.payload == "done")
         #expect(result.outcome == .confirmedChange(
             route: .local,
@@ -100,6 +159,8 @@ struct CommandActionSequenceAccumulatorTests {
             unitCount: DesktopActionOutcome.DispatchUnitCount(2)
         ))
         #expect(result.targetIdentity == target)
+        #expect(result.outcome == canonicalResult.outcome)
+        #expect(result.targetIdentity == canonicalResult.targetIdentity)
     }
 
     @Test
@@ -206,6 +267,7 @@ struct CommandActionSequenceAccumulatorTests {
         } catch {
             contradiction = error
         }
+        #expect(contradiction as? DesktopTargetIdentityError == .contradictoryProcessIdentifier)
 
         let preserved = try #require(sequence.preservingFailure(
             contradiction,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Fixed
+- Route CLI and MCP multi-phase result composition through the canonical target-aware sequence accumulator while preserving their established output contracts.
 - Bound asynchronous Accessibility notification add and remove waits, removal joins, and subscription setup retries so one wedged endpoint cannot hang global observer startup or teardown. Thanks @SebTardif for AXorcist #47.
 - Centralize snapshot target-evidence adapters and receipt planning across AutomationKit, CLI, Bridge, and MCP so exact-window identity, coordinate authority, source contradictions, and cancellation keep one fail-closed contract.
 - Route background mutation authorization through one completeness-aware application/window planner, so MCP window, Space, and exact-window paste targets reject fuzzy selectors and partial catalogs before dispatch.

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Strategy/UIAutomationActionResultSequenceAccumulator.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Strategy/UIAutomationActionResultSequenceAccumulator.swift
@@ -7,12 +7,27 @@ import PeekabooFoundation
 /// layer keeps target attribution and selected-leaf evidence aligned with the phases that actually
 /// dispatched, so setup results cannot silently lend their target to an unattributed leaf.
 public struct UIAutomationActionResultSequenceAccumulator: Sendable {
+    public enum TargetProjectionPolicy: Equatable, Sendable {
+        /// Project only the target scope that every contributing phase independently attested.
+        case commonScope
+
+        /// Treat compatible phase identities as fragments of one target and retain the richest identity.
+        ///
+        /// This preserves the established CLI result contract while keeping the coalescing policy in
+        /// the canonical accumulator rather than in command-specific wrappers.
+        case coalescedIdentity
+    }
+
     public enum PhaseAttributionRule: Equatable, Sendable {
         /// Only a phase that dispatched mutation contributes its target to the aggregate.
         case mutationTarget
 
         /// A reported target describes the operation even when no dispatch was necessary.
         case operationTarget
+
+        /// A compatible target describes the surrounding sequence and remains available to a later
+        /// optional phase that dispatches without returning its own target.
+        case sequenceTarget
 
         /// This phase must report its own stable target; an earlier phase cannot substitute for it.
         case requiredTarget
@@ -29,6 +44,7 @@ public struct UIAutomationActionResultSequenceAccumulator: Sendable {
         public let mutationTargetReceipt: DesktopActionTargetReceipt?
         public let selectedLeafEvidence: [DesktopSelectedLeafEvidence]?
         public let hasTargetConflict: Bool
+        public let targetConflictError: DesktopTargetIdentityError?
         public let hasProhibitedTarget: Bool
         public let hasMissingRequiredTarget: Bool
         public let hasContradictoryRequiredTarget: Bool
@@ -39,6 +55,7 @@ public struct UIAutomationActionResultSequenceAccumulator: Sendable {
         private(set) var contributionCount = 0
         private(set) var missingCount = 0
         private(set) var hasContradiction = false
+        private(set) var conflictError: DesktopTargetIdentityError?
         private var mergedReceipt: DesktopActionTargetReceipt?
         private var mergedIdentity: DesktopTargetIdentity?
         private var hasMissingIdentity = false
@@ -70,6 +87,32 @@ public struct UIAutomationActionResultSequenceAccumulator: Sendable {
             return identity
         }
 
+        func projectedReceipt(policy: TargetProjectionPolicy) -> DesktopActionTargetReceipt? {
+            switch policy {
+            case .commonScope:
+                self.receipt
+            case .coalescedIdentity:
+                self.coalescedIdentity?.actionTargetReceipt
+            }
+        }
+
+        func projectedIdentity(policy: TargetProjectionPolicy) -> DesktopTargetIdentity? {
+            switch policy {
+            case .commonScope:
+                self.identity
+            case .coalescedIdentity:
+                self.coalescedIdentity
+            }
+        }
+
+        private var coalescedIdentity: DesktopTargetIdentity? {
+            guard !self.hasContradiction,
+                  self.missingCount == 0,
+                  !self.hasMissingIdentity
+            else { return nil }
+            return self.mergedIdentity
+        }
+
         mutating func record(
             identity: DesktopTargetIdentity?,
             receipt explicitReceipt: DesktopActionTargetReceipt?)
@@ -77,9 +120,7 @@ public struct UIAutomationActionResultSequenceAccumulator: Sendable {
             self.contributionCount += 1
             let identityReceipt = identity?.actionTargetReceipt
             if let identityReceipt, let explicitReceipt, identityReceipt != explicitReceipt {
-                self.hasContradiction = true
-                self.mergedReceipt = nil
-                self.mergedIdentity = nil
+                self.recordConflict(.contradictoryWindowIdentity)
                 return
             }
             guard let receipt = explicitReceipt ?? identityReceipt else {
@@ -90,9 +131,7 @@ public struct UIAutomationActionResultSequenceAccumulator: Sendable {
 
             if let current = self.mergedReceipt {
                 guard let merged = Self.commonScope(current, receipt) else {
-                    self.hasContradiction = true
-                    self.mergedReceipt = nil
-                    self.mergedIdentity = nil
+                    self.recordConflict(Self.conflict(between: current, and: receipt))
                     return
                 }
                 self.mergedReceipt = merged
@@ -107,10 +146,10 @@ public struct UIAutomationActionResultSequenceAccumulator: Sendable {
             if let current = self.mergedIdentity {
                 do {
                     self.mergedIdentity = try current.coalescing(identity)
+                } catch let error as DesktopTargetIdentityError {
+                    self.recordConflict(error)
                 } catch {
-                    self.hasContradiction = true
-                    self.mergedReceipt = nil
-                    self.mergedIdentity = nil
+                    self.recordConflict(.contradictoryWindowIdentity)
                 }
             } else {
                 self.mergedIdentity = identity
@@ -131,6 +170,26 @@ public struct UIAutomationActionResultSequenceAccumulator: Sendable {
             return DesktopActionTargetReceipt(
                 processIdentifier: lhs.processIdentifier,
                 processStartIdentity: lhs.processStartIdentity)
+        }
+
+        private static func conflict(
+            between lhs: DesktopActionTargetReceipt,
+            and rhs: DesktopActionTargetReceipt) -> DesktopTargetIdentityError
+        {
+            if lhs.processIdentifier != rhs.processIdentifier {
+                return .contradictoryProcessIdentifier
+            }
+            if lhs.processStartIdentity != rhs.processStartIdentity {
+                return .contradictoryProcessGeneration
+            }
+            return .contradictoryWindowIdentifier
+        }
+
+        private mutating func recordConflict(_ error: DesktopTargetIdentityError) {
+            self.hasContradiction = true
+            self.conflictError = self.conflictError ?? error
+            self.mergedReceipt = nil
+            self.mergedIdentity = nil
         }
 
         fileprivate static func contains(
@@ -154,8 +213,32 @@ public struct UIAutomationActionResultSequenceAccumulator: Sendable {
     private var missingRequiredTarget = false
     private var contradictoryRequiredTarget = false
     private var invalidSelectedLeafEvidence = false
+    private let targetProjectionPolicy: TargetProjectionPolicy
 
-    public init() {}
+    public init(targetProjectionPolicy: TargetProjectionPolicy = .commonScope) {
+        self.targetProjectionPolicy = targetProjectionPolicy
+    }
+
+    /// Records presentation-neutral sequence state without attaching target evidence.
+    public mutating func record(_ step: DesktopActionSequenceAccumulator.Step) {
+        self.sequence.record(step)
+    }
+
+    /// Records a raw sequence step together with its phase target policy.
+    public mutating func record(
+        _ step: DesktopActionSequenceAccumulator.Step,
+        targetIdentity: DesktopTargetIdentity?,
+        targetReceipt: DesktopActionTargetReceipt? = nil,
+        attribution: PhaseAttributionRule)
+    {
+        self.sequence.record(step)
+        self.recordTargetMetadata(
+            didDispatch: Self.didDispatch(step),
+            targetIdentity: targetIdentity,
+            targetReceipt: targetReceipt,
+            selectedLeafEvidence: nil,
+            attribution: attribution)
+    }
 
     public mutating func record(
         _ result: UIAutomationActionResult<some Sendable>,
@@ -189,7 +272,21 @@ public struct UIAutomationActionResultSequenceAccumulator: Sendable {
             }
         }
 
-        let didDispatch = outcome?.dispatchState.mutationDispatched == true
+        self.recordTargetMetadata(
+            didDispatch: outcome?.dispatchState.mutationDispatched == true,
+            targetIdentity: targetIdentity,
+            targetReceipt: targetReceipt,
+            selectedLeafEvidence: selectedLeafEvidence,
+            attribution: attribution)
+    }
+
+    private mutating func recordTargetMetadata(
+        didDispatch: Bool,
+        targetIdentity: DesktopTargetIdentity?,
+        targetReceipt: DesktopActionTargetReceipt?,
+        selectedLeafEvidence: [DesktopSelectedLeafEvidence]?,
+        attribution: PhaseAttributionRule)
+    {
         let hasTarget = targetIdentity != nil || targetReceipt != nil
         switch attribution {
         case .mutationTarget:
@@ -205,6 +302,11 @@ public struct UIAutomationActionResultSequenceAccumulator: Sendable {
                 receipt: targetReceipt,
                 contributesToOperation: true,
                 contributesToMutation: didDispatch)
+        case .sequenceTarget:
+            self.recordTargetContribution(
+                identity: targetIdentity,
+                receipt: targetReceipt,
+                contributesToOperation: true)
         case .requiredTarget:
             if !hasTarget {
                 self.missingRequiredTarget = true
@@ -252,7 +354,9 @@ public struct UIAutomationActionResultSequenceAccumulator: Sendable {
         let sequenceResolution = self.sequence.successResolution()
         let targetConflict = self.targetlessPhaseReturnedTarget ||
             self.operationTargets.hasIncompatibleContributions
-        let targetReceipt = self.forcesTargetlessResult ? nil : self.operationTargets.receipt
+        let targetReceipt = self.forcesTargetlessResult
+            ? nil
+            : self.operationTargets.projectedReceipt(policy: self.targetProjectionPolicy)
         let selectedLeafEvidence: [DesktopSelectedLeafEvidence]? = if let targetReceipt,
                                                                       !self.selectedLeaves.isEmpty,
                                                                       self.selectedLeaves.allSatisfy({ leaf in
@@ -268,15 +372,24 @@ public struct UIAutomationActionResultSequenceAccumulator: Sendable {
         return Resolution(
             outcome: sequenceResolution.outcome,
             mutationDisposition: sequenceResolution.mutationDisposition,
-            targetIdentity: self.forcesTargetlessResult ? nil : self.operationTargets.identity,
+            targetIdentity: self.forcesTargetlessResult
+                ? nil
+                : self.operationTargets.projectedIdentity(policy: self.targetProjectionPolicy),
             targetReceipt: targetReceipt,
-            mutationTargetReceipt: self.forcesTargetlessResult ? nil : self.mutationTargets.receipt,
+            mutationTargetReceipt: self.forcesTargetlessResult
+                ? nil
+                : self.mutationTargets.projectedReceipt(policy: self.targetProjectionPolicy),
             selectedLeafEvidence: selectedLeafEvidence,
             hasTargetConflict: targetConflict,
+            targetConflictError: self.operationTargets.conflictError,
             hasProhibitedTarget: self.targetlessPhaseReturnedTarget,
             hasMissingRequiredTarget: self.missingRequiredTarget,
             hasContradictoryRequiredTarget: self.contradictoryRequiredTarget,
             hasInvalidSelectedLeafEvidence: self.invalidSelectedLeafEvidence)
+    }
+
+    public var sequenceResolution: DesktopActionSequenceAccumulator.Resolution {
+        self.sequence.successResolution()
     }
 
     public func result<Payload: Sendable>(
@@ -330,7 +443,8 @@ public struct UIAutomationActionResultSequenceAccumulator: Sendable {
                 operation: operation,
                 message: failureMessage ?? "\(operation) returned contradictory phase targets.",
                 hint: failureHint,
-                causeDescription: DesktopTargetIdentityError.contradictoryWindowIdentity.localizedDescription)
+                causeDescription: resolution.targetConflictError?.localizedDescription ??
+                    DesktopTargetIdentityError.contradictoryWindowIdentity.localizedDescription)
         }
         if requiresTarget, resolution.targetIdentity == nil {
             throw self.compositionFailure(
@@ -358,6 +472,7 @@ public struct UIAutomationActionResultSequenceAccumulator: Sendable {
     public func failure(
         combining leafFailure: DesktopActionFailure,
         operation: String,
+        requiresCompatibleOperationTarget: Bool = false,
         message: String? = nil,
         hint: String? = nil,
         causeDescription: String? = nil) -> DesktopActionFailure
@@ -367,7 +482,9 @@ public struct UIAutomationActionResultSequenceAccumulator: Sendable {
             message: message ?? leafFailure.message,
             hint: hint ?? leafFailure.hint,
             causeDescription: causeDescription ?? leafFailure.causeDescription)
-        let targetReceipt = self.failureTargetReceipt(leafFailure)
+        let targetReceipt = requiresCompatibleOperationTarget
+            ? self.operationTargetReceipt(combining: leafFailure.targetReceipt)
+            : self.failureTargetReceipt(leafFailure)
         let evidence = self.combinedSelectedLeafEvidence(
             leafFailure,
             targetReceipt: targetReceipt)
@@ -382,6 +499,24 @@ public struct UIAutomationActionResultSequenceAccumulator: Sendable {
             preconditionFailure("Composed action failures must retain a non-confirmed canonical outcome")
         }
         return normalized
+    }
+
+    /// Reconciles a completed failure's target with this sequence's operation target without
+    /// recomposing the already-aggregated outcome.
+    public func reconcilingTarget(of failure: DesktopActionFailure) -> DesktopActionFailure {
+        let targetReceipt = self.operationTargetReceipt(combining: failure.targetReceipt)
+        if targetReceipt == nil, failure.targetReceipt != nil {
+            guard let unattributed = DesktopActionFailure(
+                outcome: failure.outcome,
+                message: failure.message,
+                hint: failure.hint,
+                causeDescription: failure.causeDescription)
+            else {
+                preconditionFailure("A reconciled desktop action failure must remain non-confirmed")
+            }
+            return unattributed
+        }
+        return failure.attributed(to: targetReceipt)
     }
 
     private mutating func recordTargetContribution(
@@ -423,6 +558,17 @@ public struct UIAutomationActionResultSequenceAccumulator: Sendable {
                 return nil
             }
         }
+    }
+
+    private func operationTargetReceipt(
+        combining leafTargetReceipt: DesktopActionTargetReceipt?) -> DesktopActionTargetReceipt?
+    {
+        guard !self.forcesTargetlessResult else { return nil }
+        var targets = self.operationTargets
+        if let leafTargetReceipt {
+            targets.record(identity: nil, receipt: leafTargetReceipt)
+        }
+        return targets.projectedReceipt(policy: self.targetProjectionPolicy)
     }
 
     private func combinedSelectedLeafEvidence(
@@ -477,5 +623,14 @@ public struct UIAutomationActionResultSequenceAccumulator: Sendable {
         return failure
             .attributed(to: self.resolution.targetReceipt)
             .selectingLeaves(self.resolution.selectedLeafEvidence)
+    }
+
+    private static func didDispatch(_ step: DesktopActionSequenceAccumulator.Step) -> Bool {
+        switch step {
+        case let .outcome(outcome), let .reportedOutcome(outcome, _):
+            outcome.dispatchState.mutationDispatched
+        case .dispatched, .mayHaveDispatched:
+            true
+        }
     }
 }

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/UIAutomationActionResultSequenceAccumulatorTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/UIAutomationActionResultSequenceAccumulatorTests.swift
@@ -449,6 +449,72 @@ struct UIAutomationActionResultSequenceAccumulatorTests {
     }
 
     @Test
+    func `coalesced projection preserves legacy richest-target semantics`() throws {
+        let fixture = AutomationTestFixtures.linkedDesktopTarget(
+            processIdentity: .init(processIdentifier: 42, processStartIdentity: 1001),
+            windowID: 71,
+            bounds: Self.windowBounds)
+        var sequence = UIAutomationActionResultSequenceAccumulator(
+            targetProjectionPolicy: .coalescedIdentity)
+        for target in [fixture.windowTargetIdentity, fixture.processTargetIdentity] {
+            sequence.record(
+                .reportedOutcome(
+                    .confirmedChange(delivery: self.backgroundDelivery),
+                    defaultDispatchedUnitCount: .one),
+                targetIdentity: target,
+                attribution: .sequenceTarget)
+        }
+
+        let result = try sequence.result(
+            payload: (),
+            operation: "Legacy-compatible sequence",
+            requiresOutcome: true,
+            requiresCompatibleTarget: true)
+
+        #expect(result.outcome?.dispatchState.unitCount == DesktopActionOutcome.DispatchUnitCount(2))
+        #expect(result.targetIdentity == fixture.windowTargetIdentity)
+        #expect(sequence.sequenceResolution.outcome == result.outcome)
+    }
+
+    @Test
+    func `raw required phase cannot borrow a sequence target`() throws {
+        let target = AutomationTestFixtures.linkedDesktopTarget(
+            windowID: 71,
+            bounds: Self.windowBounds).windowTargetIdentity
+        var sequence = UIAutomationActionResultSequenceAccumulator(
+            targetProjectionPolicy: .coalescedIdentity)
+        sequence.record(
+            .reportedOutcome(
+                .confirmedChange(delivery: self.backgroundDelivery),
+                defaultDispatchedUnitCount: .one),
+            targetIdentity: target,
+            attribution: .sequenceTarget)
+        sequence.record(
+            .reportedOutcome(
+                .dispatchedUnverified(
+                    delivery: self.backgroundDelivery,
+                    evidence: .deliveryAccepted),
+                defaultDispatchedUnitCount: .one),
+            targetIdentity: nil,
+            attribution: .requiredTarget)
+
+        #expect(sequence.resolution.hasMissingRequiredTarget)
+        #expect(sequence.resolution.targetIdentity == nil)
+        do {
+            _ = try sequence.result(
+                payload: (),
+                operation: "Required raw phase",
+                requiresOutcome: true)
+            Issue.record("Expected the missing required target to fail")
+        } catch let failure as DesktopActionFailure {
+            #expect(failure.outcome.state == .dispatchedUnverified)
+            #expect(failure.outcome.retrySafety == .unsafe)
+            #expect(failure.outcome.dispatchState.unitCount == DesktopActionOutcome.DispatchUnitCount(2))
+            #expect(failure.targetReceipt == nil)
+        }
+    }
+
+    @Test
     func `no-dispatch failure cannot hide a prior operation target conflict`() {
         let first = AutomationTestFixtures.linkedDesktopTarget(
             windowID: 71,

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/MCPInteractionTarget.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/MCPInteractionTarget.swift
@@ -111,14 +111,14 @@ struct MCPInteractionFocusResult {
             reason: .operationUnsupported,
             message: error.localizedDescription,
             causeDescription: String(describing: error))
-        var sequence = DesktopActionSequenceAccumulator()
-        self.record(into: &sequence)
-        let failure = sequence.failure(
+        let sequence = self.resultSequence()
+        return sequence.failure(
             combining: leaf,
+            operation: operation,
+            requiresCompatibleOperationTarget: true,
             message: "\(operation) failed after its exact setup focus completed.",
             hint: "Observe the focused target before deciding whether to retry.",
             causeDescription: leaf.causeDescription ?? error.localizedDescription)
-        return self.assigningCompatibleTarget(to: failure, leafTarget: leaf.targetReceipt)
     }
 
     /// Composes an exact setup focus with a global pointer failure without attributing the
@@ -131,26 +131,25 @@ struct MCPInteractionFocusResult {
             reason: .operationUnsupported,
             message: error.localizedDescription,
             causeDescription: String(describing: error))
-        var sequence = DesktopActionSequenceAccumulator()
-        self.record(into: &sequence)
-        let failure = sequence.failure(
+        var sequence = self.resultSequence()
+        sequence.record(
+            outcome: nil,
+            attribution: .targetless)
+        return sequence.failure(
             combining: leaf,
+            operation: operation,
             message: "\(operation) failed after its exact setup focus completed.",
             hint: "Observe the desktop before deciding whether to retry.",
             causeDescription: leaf.causeDescription ?? error.localizedDescription)
-        guard let unattributed = DesktopActionFailure(
-            outcome: failure.outcome,
-            message: failure.message,
-            hint: failure.hint,
-            causeDescription: failure.causeDescription)
-        else {
-            preconditionFailure("A composed global pointer failure must remain non-confirmed")
-        }
-        return unattributed
     }
 
     func attributing(_ failure: DesktopActionFailure) -> DesktopActionFailure {
-        self.assigningCompatibleTarget(to: failure, leafTarget: failure.targetReceipt)
+        var sequence = UIAutomationActionResultSequenceAccumulator()
+        sequence.record(
+            outcome: nil,
+            targetIdentity: self.targetIdentity,
+            attribution: .operationTarget)
+        return sequence.reconcilingTarget(of: failure)
     }
 
     func combining<Payload: Sendable>(
@@ -165,37 +164,26 @@ struct MCPInteractionFocusResult {
                     hint: "Observe the target before retrying and update the runtime host."),
                 operation: operation)
         }
-        var sequence = DesktopActionSequenceAccumulator()
-        self.record(into: &sequence)
-        sequence.record(.reportedOutcome(leafOutcome, defaultDispatchedUnitCount: .one))
-        let targetIdentity: DesktopTargetIdentity
-        do {
-            targetIdentity = try self.targetIdentity.coalescing(leaf.targetIdentity ?? self.targetIdentity)
-        } catch {
-            throw self.preservingLeafResultFailure(
-                DesktopActionFailure.preDispatchRefusal(
-                    reason: .targetUnavailable,
-                    message: "\(operation) returned a target different from its setup focus.",
-                    hint: "Observe both targets before retrying.",
-                    causeDescription: error.localizedDescription),
-                leafOutcome: leafOutcome,
-                leafTarget: leaf.targetIdentity?.actionTargetReceipt,
-                operation: operation)
+        var sequence = self.resultSequence(targetProjectionPolicy: .coalescedIdentity)
+        let step = DesktopActionSequenceAccumulator.Step.reportedOutcome(
+            leafOutcome,
+            defaultDispatchedUnitCount: .one)
+        if let targetIdentity = leaf.targetIdentity {
+            sequence.record(
+                step,
+                targetIdentity: targetIdentity,
+                attribution: .operationTarget)
+        } else {
+            sequence.record(step)
         }
-        guard let outcome = sequence.successResolution().outcome else {
-            throw self.preservingLeafResultFailure(
-                DesktopActionFailure.indeterminate(
-                    evidence: .completionUnknown,
-                    message: "\(operation) returned incompatible focus and leaf outcomes.",
-                    hint: "Observe the target before retrying."),
-                leafOutcome: leafOutcome,
-                leafTarget: leaf.targetIdentity?.actionTargetReceipt,
-                operation: operation)
-        }
-        return UIAutomationActionResult(
+        return try sequence.result(
             payload: leaf.payload,
-            outcome: outcome,
-            targetIdentity: targetIdentity)
+            operation: operation,
+            requiresOutcome: true,
+            requiresCompatibleTarget: true,
+            failureMessage:
+            "\(operation) returned untrustworthy target evidence after its exact setup focus completed.",
+            failureHint: "Observe the focused target before deciding whether to retry.")
     }
 
     func preservingLeafResultFailure(
@@ -208,48 +196,39 @@ struct MCPInteractionFocusResult {
             reason: .operationUnsupported,
             message: error.localizedDescription,
             causeDescription: String(describing: error))
-        var sequence = DesktopActionSequenceAccumulator()
-        self.record(into: &sequence)
-        sequence.record(.reportedOutcome(leafOutcome, defaultDispatchedUnitCount: .one))
-        let failure = sequence.failure(
+        var sequence = self.resultSequence()
+        let step = DesktopActionSequenceAccumulator.Step.reportedOutcome(
+            leafOutcome,
+            defaultDispatchedUnitCount: .one)
+        if let leafTarget {
+            sequence.record(
+                step,
+                targetIdentity: nil,
+                targetReceipt: leafTarget,
+                attribution: .operationTarget)
+        } else {
+            sequence.record(step)
+        }
+        return sequence.failure(
             combining: leafFailure,
+            operation: operation,
             message: "\(operation) returned untrustworthy target evidence after its exact setup focus completed.",
             hint: "Observe the focused target before deciding whether to retry.",
             causeDescription: leafFailure.causeDescription ?? error.localizedDescription)
-        return self.assigningCompatibleTarget(to: failure, leafTarget: leafTarget)
     }
 
-    private func compatibleTarget(
-        with leaf: DesktopActionTargetReceipt?) -> DesktopActionTargetReceipt?
+    private func resultSequence(
+        targetProjectionPolicy: UIAutomationActionResultSequenceAccumulator.TargetProjectionPolicy = .commonScope)
+        -> UIAutomationActionResultSequenceAccumulator
     {
-        let focus = self.targetIdentity.actionTargetReceipt
-        guard let leaf else { return focus }
-        guard focus.processIdentifier == leaf.processIdentifier,
-              focus.processStartIdentity == leaf.processStartIdentity,
-              focus.windowID == leaf.windowID || focus.windowID == nil || leaf.windowID == nil
-        else { return nil }
-        return focus.windowID == leaf.windowID ? focus : DesktopActionTargetReceipt(
-            processIdentifier: focus.processIdentifier,
-            processStartIdentity: focus.processStartIdentity)
-    }
-
-    private func assigningCompatibleTarget(
-        to failure: DesktopActionFailure,
-        leafTarget: DesktopActionTargetReceipt?) -> DesktopActionFailure
-    {
-        let target = self.compatibleTarget(with: leafTarget)
-        guard target == nil, leafTarget != nil else {
-            return failure.attributed(to: target)
-        }
-        guard let unattributed = DesktopActionFailure(
-            outcome: failure.outcome,
-            message: failure.message,
-            hint: failure.hint,
-            causeDescription: failure.causeDescription)
-        else {
-            preconditionFailure("A desktop action failure must remain non-confirmed")
-        }
-        return unattributed
+        var sequence = UIAutomationActionResultSequenceAccumulator(
+            targetProjectionPolicy: targetProjectionPolicy)
+        sequence.record(
+            outcome: self.outcome,
+            targetIdentity: self.targetIdentity,
+            attribution: .sequenceTarget,
+            defaultDispatchedUnitCount: .one)
+        return sequence
     }
 }
 

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPInteractionTargetTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPInteractionTargetTests.swift
@@ -296,6 +296,80 @@ struct MCPInteractionTargetTests {
     }
 
     @Test
+    func `focus combination matches canonical coalesced sequence semantics`() throws {
+        let service = MCPFocusResultWindowService()
+        let bounds = try #require(service.identity.capturedBounds)
+        let focusTarget = try DesktopTargetIdentity(exactWindow: UIAutomationTarget.ExactWindow(
+            identity: service.identity,
+            bounds: bounds))
+        let processTarget = try DesktopTargetIdentity(processIdentity: focusTarget.processIdentity)
+        let focusOutcome = DesktopActionOutcome.confirmedChange(
+            delivery: .init(mechanism: .nativeFramework, mode: .foreground),
+            unitCount: .one)
+        let leafOutcome = DesktopActionOutcome.confirmedChange(
+            delivery: .init(mechanism: .accessibilityAction, mode: .foreground),
+            unitCount: .one)
+        let focus = MCPInteractionFocusResult(
+            target: .windowId(service.identity.windowID),
+            actionResult: UIAutomationActionResult(
+                payload: (),
+                outcome: focusOutcome,
+                targetIdentity: focusTarget))
+        let leaf = UIAutomationActionResult(
+            payload: "done",
+            outcome: leafOutcome,
+            targetIdentity: processTarget)
+
+        let result = try focus.combining(leaf, operation: "Focused leaf")
+        var canonical = UIAutomationActionResultSequenceAccumulator(
+            targetProjectionPolicy: .coalescedIdentity)
+        canonical.record(
+            outcome: focusOutcome,
+            targetIdentity: focusTarget,
+            attribution: .sequenceTarget,
+            defaultDispatchedUnitCount: .one)
+        canonical.record(
+            outcome: leafOutcome,
+            targetIdentity: processTarget,
+            attribution: .operationTarget,
+            defaultDispatchedUnitCount: .one)
+        let canonicalResult = try canonical.result(
+            payload: "done",
+            operation: "Focused leaf",
+            requiresOutcome: true,
+            requiresCompatibleTarget: true)
+
+        #expect(result.outcome == canonicalResult.outcome)
+        #expect(result.targetIdentity == canonicalResult.targetIdentity)
+        #expect(result.targetIdentity == focusTarget)
+    }
+
+    @Test
+    func `focus cancellation after dispatch remains retry unsafe and exact`() throws {
+        let service = MCPFocusResultWindowService()
+        let bounds = try #require(service.identity.capturedBounds)
+        let focusTarget = try DesktopTargetIdentity(exactWindow: UIAutomationTarget.ExactWindow(
+            identity: service.identity,
+            bounds: bounds))
+        let focus = MCPInteractionFocusResult(
+            target: .windowId(service.identity.windowID),
+            actionResult: UIAutomationActionResult(
+                payload: (),
+                outcome: .dispatchedUnverified(
+                    delivery: .init(mechanism: .nativeFramework, mode: .foreground),
+                    evidence: .deliveryAccepted,
+                    unitCount: .one),
+                targetIdentity: focusTarget))
+
+        let failure = focus.preservingFailure(CancellationError(), operation: "Focused leaf")
+
+        #expect(failure.outcome.state == .indeterminate)
+        #expect(failure.outcome.retrySafety == .unsafe)
+        #expect(failure.outcome.dispatchState == .mayHaveDispatched(unitCount: .one))
+        #expect(failure.targetReceipt == focusTarget.actionTargetReceipt)
+    }
+
+    @Test
     func `focus and completed leaf target mismatch retains both dispatched units`() throws {
         let service = MCPFocusResultWindowService()
         let bounds = try #require(service.identity.capturedBounds)


### PR DESCRIPTION
## Summary

- route CLI and MCP multi-phase result composition through `UIAutomationActionResultSequenceAccumulator`
- keep compatibility projection, target conflict, and failure attribution policies in the canonical owner
- preserve existing CLI/MCP APIs and output behavior for cancellation, target conflicts, and required leaf targets

## Testing

- `swift test --package-path Core/PeekabooAutomationKit --filter UIAutomationActionResultSequenceAccumulatorTests`
- `swift test --package-path Apps/CLI --filter CommandActionSequenceAccumulatorTests`
- `swift test --package-path Core/PeekabooCore --filter MCPInteractionTargetTests`
- `pnpm run format`
- `pnpm run lint`
- `pnpm run test:safe` before the conflict-free receipt-planner rebase; focused suites rerun after rebase
- structured autoreview clean after rebase
