### PR TITLE
refactor: consolidate inventory test fixtures

### DIFF
--- a/Apps/CLI/Tests/CLIAutomationTests/Support/TestServices.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/Support/TestServices.swift
@@ -1,6 +1,7 @@
 import AppKit
 import CoreGraphics
 import Foundation
+import PeekabooAutomationKitTestSupport
 import PeekabooFoundation
 import UniformTypeIdentifiers
 @testable import PeekabooCLI
@@ -577,11 +578,7 @@ ExactWindowTargetedClickServiceProtocol, ElementActionAutomationServiceProtocol 
 }
 
 @MainActor
-class StubApplicationService: ApplicationServiceProtocol, ApplicationMutationInventoryProviding {
-    let supportsApplicationLaunchOptions = true
-    let supportsApplicationRelaunch = true
-    var applications: [ServiceApplicationInfo]
-    var windowsByApp: [String: [ServiceWindowInfo]]
+class StubApplicationService: ScriptedApplicationInventoryService {
     var launchResults: [String: ServiceApplicationInfo]
     var launchCalls: [String] = []
     var activateCalls: [String] = []
@@ -596,88 +593,19 @@ class StubApplicationService: ApplicationServiceProtocol, ApplicationMutationInv
     var showAllCallCount = 0
 
     init(applications: [ServiceApplicationInfo], windowsByApp: [String: [ServiceWindowInfo]] = [:]) {
-        self.applications = applications
-        self.windowsByApp = windowsByApp
         self.launchResults = [:]
-    }
-
-    func listApplications() async throws -> UnifiedToolOutput<ServiceApplicationListData> {
-        let data = ServiceApplicationListData(applications: applications)
-        let summary = UnifiedToolOutput<ServiceApplicationListData>.Summary(
-            brief: "Stub application list",
-            status: .success,
-            counts: ["applications": self.applications.count]
-        )
-        return UnifiedToolOutput(
-            data: data,
-            summary: summary,
-            metadata: .init(duration: 0)
+        super.init(
+            applications: applications,
+            windowsByIdentifier: windowsByApp,
+            propagatesApplicationMetadataWarnings: false,
+            supportsApplicationLaunchOptions: true,
+            supportsApplicationRelaunch: true,
+            supportsProcessGenerationPinnedApplicationQuit: true,
+            supportsProcessGenerationPinnedApplicationActivation: true
         )
     }
 
-    func applicationMutationInventory() async throws
-    -> DesktopTargetPlanning.Inventory<ServiceApplicationInfo> {
-        .complete(self.applications)
-    }
-
-    func findApplication(identifier: String) async throws -> ServiceApplicationInfo {
-        if let pid = Self.parsePID(identifier),
-           let match = applications.first(where: { $0.processIdentifier == pid }) {
-            return match
-        }
-
-        if let match = applications.first(where: { $0.name == identifier || $0.bundleIdentifier == identifier }) {
-            return match
-        }
-        throw PeekabooError.appNotFound(identifier)
-    }
-
-    private static func parsePID(_ identifier: String) -> pid_t? {
-        let trimmed = identifier.trimmingCharacters(in: .whitespacesAndNewlines)
-        let pidString: String = if trimmed.uppercased().hasPrefix("PID:") {
-            String(trimmed.dropFirst(4))
-        } else {
-            trimmed
-        }
-
-        guard let rawPID = Int32(pidString), rawPID > 0 else { return nil }
-        return pid_t(rawPID)
-    }
-
-    func listWindows(
-        for appIdentifier: String,
-        timeout: Float?
-    ) async throws -> UnifiedToolOutput<ServiceWindowListData> {
-        let targetApp = self.applications.first {
-            $0.name == appIdentifier || $0.bundleIdentifier == appIdentifier
-        }
-        let windows = self.windowsByApp[appIdentifier]
-            ?? targetApp.flatMap { self.windowsByApp[$0.name] } ?? []
-        let data = ServiceWindowListData(windows: windows, targetApplication: targetApp)
-        let summary = UnifiedToolOutput<ServiceWindowListData>.Summary(
-            brief: "Stub window list",
-            status: .success,
-            counts: ["windows": windows.count]
-        )
-        return UnifiedToolOutput(
-            data: data,
-            summary: summary,
-            metadata: .init(duration: 0)
-        )
-    }
-
-    func getFrontmostApplication() async throws -> ServiceApplicationInfo {
-        guard let first = applications.first else {
-            throw PeekabooError.appNotFound("frontmost")
-        }
-        return first
-    }
-
-    func isApplicationRunning(identifier: String) async -> Bool {
-        self.applications.contains { $0.name == identifier || $0.bundleIdentifier == identifier }
-    }
-
-    func launchApplication(identifier: String) async throws -> ServiceApplicationInfo {
+    override func launchApplication(identifier: String) async throws -> ServiceApplicationInfo {
         self.launchCalls.append(identifier)
         if let result = launchResults[identifier] {
             return result
@@ -693,21 +621,28 @@ class StubApplicationService: ApplicationServiceProtocol, ApplicationMutationInv
         )
     }
 
-    func launchApplication(request: ApplicationLaunchRequest) async throws -> ServiceApplicationInfo {
+    override func launchApplication(request: ApplicationLaunchRequest) async throws -> ServiceApplicationInfo {
         let identifier = request.applicationBundleIdentifier ?? request.applicationIdentifier ?? "default handler"
         return try await self.launchApplication(identifier: identifier)
     }
 
-    func relaunchApplication(request: ApplicationRelaunchRequest) async throws -> ServiceApplicationInfo {
+    override func relaunchApplication(request: ApplicationRelaunchRequest) async throws -> ServiceApplicationInfo {
         try await self.launchApplication(request: request.launchRequest)
     }
 
-    func activateApplication(identifier: String) async throws {
+    override func getFrontmostApplication() async throws -> ServiceApplicationInfo {
+        guard let application = self.applications.first else {
+            throw PeekabooError.appNotFound("frontmost")
+        }
+        return application
+    }
+
+    override func activateApplication(identifier: String) async throws {
         self.activateCalls.append(identifier)
         try await self.activateApplicationHandler?(identifier)
     }
 
-    func activateApplication(request: ApplicationActivationRequest) async throws {
+    override func activateApplication(request: ApplicationActivationRequest) async throws {
         if let expectedIdentity = request.expectedIdentity {
             let application = try await self.findApplication(identifier: request.identifier)
             guard application.processIdentity == expectedIdentity else {
@@ -717,12 +652,12 @@ class StubApplicationService: ApplicationServiceProtocol, ApplicationMutationInv
         try await self.activateApplication(identifier: request.identifier)
     }
 
-    func quitApplication(identifier: String, force: Bool) async throws -> Bool {
+    override func quitApplication(identifier: String, force: Bool) async throws -> Bool {
         self.quitCalls.append((identifier: identifier, force: force))
         return self.quitShouldSucceed
     }
 
-    func quitApplication(request: ApplicationQuitRequest) async throws -> Bool {
+    override func quitApplication(request: ApplicationQuitRequest) async throws -> Bool {
         self.quitRequests.append(request)
         guard let expectedIdentity = request.expectedIdentity,
               self.applications.first(where: {
@@ -738,19 +673,19 @@ class StubApplicationService: ApplicationServiceProtocol, ApplicationMutationInv
         return self.quitShouldSucceed
     }
 
-    func hideApplication(identifier: String) async throws {
+    override func hideApplication(identifier: String) async throws {
         self.hideCalls.append(identifier)
     }
 
-    func unhideApplication(identifier: String) async throws {
+    override func unhideApplication(identifier: String) async throws {
         self.unhideCalls.append(identifier)
     }
 
-    func hideOtherApplications(identifier: String) async throws {
+    override func hideOtherApplications(identifier: String) async throws {
         self.hideOtherCalls.append(identifier)
     }
 
-    func showAllApplications() async throws {
+    override func showAllApplications() async throws {
         self.showAllCallCount += 1
     }
 }

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKitTestSupport/ScriptedInventoryServices.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKitTestSupport/ScriptedInventoryServices.swift
@@ -1,0 +1,844 @@
+import CoreGraphics
+import Foundation
+import PeekabooAutomationKit
+import PeekabooFoundation
+
+private enum ScriptedApplicationIdentifier {
+    static func canonicalKey(_ identifier: String) -> String? {
+        let trimmed = identifier.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+
+        let pidText = trimmed.uppercased().hasPrefix("PID:")
+            ? String(trimmed.dropFirst(4))
+            : trimmed
+        if let processIdentifier = Int32(pidText), processIdentifier > 0 {
+            return "pid:\(processIdentifier)"
+        }
+        return "literal:\(trimmed)"
+    }
+}
+
+public enum LinkedApplicationInventoryGraphError: Error, Equatable, LocalizedError, Sendable {
+    case invalidProcessIdentity(processIdentifier: Int32, processStartIdentity: UInt64?)
+    case duplicateProcessIdentifier(Int32)
+    case contradictoryApplicationMetadata(processIdentifier: Int32)
+    case ambiguousApplicationIdentifier(String)
+    case invalidWindowIdentifier(Int)
+    case duplicateWindowIdentifier(Int)
+    case invalidWindowBounds(windowID: Int)
+    case contradictoryWindowReceipt(windowID: Int)
+    case contradictoryApplicationWindowIDs(processIdentifier: Int32)
+
+    public var errorDescription: String? {
+        switch self {
+        case let .invalidProcessIdentity(processIdentifier, processStartIdentity):
+            "Application PID \(processIdentifier) has invalid process-generation identity " +
+                (processStartIdentity.map(String.init) ?? "nil") + "."
+        case let .duplicateProcessIdentifier(processIdentifier):
+            "Application inventory contains duplicate PID \(processIdentifier)."
+        case let .contradictoryApplicationMetadata(processIdentifier):
+            "Application inventory contains contradictory metadata for PID \(processIdentifier)."
+        case let .ambiguousApplicationIdentifier(identifier):
+            "Application inventory maps identifier '\(identifier)' to multiple process generations."
+        case let .invalidWindowIdentifier(windowID):
+            "Window inventory contains invalid WindowServer ID \(windowID)."
+        case let .duplicateWindowIdentifier(windowID):
+            "Window inventory contains duplicate WindowServer ID \(windowID)."
+        case let .invalidWindowBounds(windowID):
+            "Window \(windowID) has invalid bounds."
+        case let .contradictoryWindowReceipt(windowID):
+            "Window \(windowID) has a receipt that contradicts its application or geometry."
+        case let .contradictoryApplicationWindowIDs(processIdentifier):
+            "Application PID \(processIdentifier) has window IDs that contradict its linked windows."
+        }
+    }
+}
+
+/// A coherent application, window, and process-generation graph for inventory-driven tests.
+///
+/// The graph rejects contradictory identity evidence and supplies a missing mutation receipt for a
+/// window when its owning application has a valid process generation. Application window counts and
+/// an omitted `windowIDs` catalog are normalized from the linked windows.
+public struct LinkedApplicationInventoryGraph: Sendable {
+    public struct Node: Sendable {
+        public let application: ServiceApplicationInfo
+        public let windows: [ServiceWindowInfo]
+
+        public init(application: ServiceApplicationInfo, windows: [ServiceWindowInfo]) {
+            self.application = application
+            self.windows = windows
+        }
+
+        public init(linkedTarget: LinkedDesktopTargetFixture) {
+            self.init(
+                application: linkedTarget.application,
+                windows: [linkedTarget.window])
+        }
+    }
+
+    public let nodes: [Node]
+    public let applications: [ServiceApplicationInfo]
+    public let windowsByIdentifier: [String: [ServiceWindowInfo]]
+
+    public init(nodes: [Node]) throws {
+        var processIdentifiers = Set<Int32>()
+        var windowIdentifiers = Set<Int>()
+        var normalizedNodes: [Node] = []
+
+        for node in nodes {
+            guard let processIdentity = node.application.processIdentity,
+                  processIdentity.processIdentifier > 0,
+                  processIdentity.processStartIdentity > 0
+            else {
+                throw LinkedApplicationInventoryGraphError.invalidProcessIdentity(
+                    processIdentifier: node.application.processIdentifier,
+                    processStartIdentity: node.application.processStartIdentity)
+            }
+            guard processIdentifiers.insert(processIdentity.processIdentifier).inserted else {
+                throw LinkedApplicationInventoryGraphError.duplicateProcessIdentifier(
+                    processIdentity.processIdentifier)
+            }
+
+            var normalizedWindows: [ServiceWindowInfo] = []
+            for window in node.windows {
+                guard window.windowID > 0, UInt64(window.windowID) <= UInt64(UInt32.max) else {
+                    throw LinkedApplicationInventoryGraphError.invalidWindowIdentifier(window.windowID)
+                }
+                guard windowIdentifiers.insert(window.windowID).inserted else {
+                    throw LinkedApplicationInventoryGraphError.duplicateWindowIdentifier(window.windowID)
+                }
+                guard Self.hasValidBounds(window.bounds) else {
+                    throw LinkedApplicationInventoryGraphError.invalidWindowBounds(windowID: window.windowID)
+                }
+
+                if let receipt = window.mutationIdentity {
+                    guard receipt.windowID == window.windowID,
+                          receipt.processIdentity == processIdentity,
+                          receipt.capturedBounds == window.bounds,
+                          receipt.isMinimized == nil || receipt.isMinimized == window.isMinimized
+                    else {
+                        throw LinkedApplicationInventoryGraphError.contradictoryWindowReceipt(
+                            windowID: window.windowID)
+                    }
+                    normalizedWindows.append(window)
+                } else {
+                    normalizedWindows.append(AutomationTestFixtures.window(
+                        copying: window,
+                        processIdentity: processIdentity))
+                }
+            }
+
+            let linkedWindowIDs = normalizedWindows.map(\.windowID)
+            if let reportedWindowIDs = node.application.windowIDs,
+               Set(reportedWindowIDs) != Set(linkedWindowIDs) || reportedWindowIDs.count != linkedWindowIDs.count
+            {
+                throw LinkedApplicationInventoryGraphError.contradictoryApplicationWindowIDs(
+                    processIdentifier: processIdentity.processIdentifier)
+            }
+            let normalizedApplication = Self.application(
+                copying: node.application,
+                windowCount: normalizedWindows.count,
+                windowIDs: linkedWindowIDs)
+            normalizedNodes.append(Node(
+                application: normalizedApplication,
+                windows: normalizedWindows))
+        }
+
+        var windowsByIdentifier: [String: [ServiceWindowInfo]] = [:]
+        var processIdentifierByAlias: [String: Int32] = [:]
+        for node in normalizedNodes {
+            let application = node.application
+            var seenIdentifiers = Set<String>()
+            let identifiers = [
+                "PID:\(application.processIdentifier)",
+                String(application.processIdentifier),
+                application.name,
+                application.bundleIdentifier,
+            ].compactMap(\.self).filter { seenIdentifiers.insert($0).inserted }
+            for identifier in identifiers {
+                guard let canonicalIdentifier = ScriptedApplicationIdentifier.canonicalKey(identifier) else {
+                    continue
+                }
+                if let existingProcessIdentifier = processIdentifierByAlias[canonicalIdentifier],
+                   existingProcessIdentifier != application.processIdentifier
+                {
+                    throw LinkedApplicationInventoryGraphError.ambiguousApplicationIdentifier(identifier)
+                }
+                processIdentifierByAlias[canonicalIdentifier] = application.processIdentifier
+                windowsByIdentifier[identifier] = node.windows
+            }
+        }
+
+        self.nodes = normalizedNodes
+        self.applications = normalizedNodes.map(\.application)
+        self.windowsByIdentifier = windowsByIdentifier
+    }
+
+    public init(linkedTargets: [LinkedDesktopTargetFixture]) throws {
+        var nodes: [Node] = []
+        var nodeIndexByProcessIdentifier: [Int32: Int] = [:]
+
+        for target in linkedTargets {
+            let processIdentifier = target.processIdentity.processIdentifier
+            if let index = nodeIndexByProcessIdentifier[processIdentifier] {
+                let node = nodes[index]
+                guard node.application.processIdentity == target.processIdentity else {
+                    throw LinkedApplicationInventoryGraphError.duplicateProcessIdentifier(processIdentifier)
+                }
+                guard Self.hasMatchingNonWindowMetadata(node.application, target.application) else {
+                    throw LinkedApplicationInventoryGraphError.contradictoryApplicationMetadata(
+                        processIdentifier: processIdentifier)
+                }
+                let windows = node.windows + [target.window]
+                nodes[index] = Node(
+                    application: Self.application(
+                        copying: node.application,
+                        windowCount: windows.count,
+                        windowIDs: windows.map(\.windowID)),
+                    windows: windows)
+            } else {
+                nodeIndexByProcessIdentifier[processIdentifier] = nodes.count
+                nodes.append(Node(linkedTarget: target))
+            }
+        }
+
+        try self.init(nodes: nodes)
+    }
+
+    private static func hasValidBounds(_ bounds: CGRect) -> Bool {
+        !bounds.isEmpty &&
+            bounds.origin.x.isFinite &&
+            bounds.origin.y.isFinite &&
+            bounds.width.isFinite &&
+            bounds.height.isFinite
+    }
+
+    private static func hasMatchingNonWindowMetadata(
+        _ lhs: ServiceApplicationInfo,
+        _ rhs: ServiceApplicationInfo) -> Bool
+    {
+        self.application(copying: lhs, windowCount: 0, windowIDs: []) ==
+            self.application(copying: rhs, windowCount: 0, windowIDs: [])
+    }
+
+    private static func application(
+        copying application: ServiceApplicationInfo,
+        windowCount: Int,
+        windowIDs: [Int]) -> ServiceApplicationInfo
+    {
+        ServiceApplicationInfo(
+            processIdentifier: application.processIdentifier,
+            processStartIdentity: application.processStartIdentity,
+            bundleIdentifier: application.bundleIdentifier,
+            name: application.name,
+            bundlePath: application.bundlePath,
+            executablePath: application.executablePath,
+            isActive: application.isActive,
+            isHidden: application.isHidden,
+            isHiddenKnown: application.isHiddenKnown,
+            windowCount: windowCount,
+            windowIDs: windowIDs,
+            activationPolicy: application.activationPolicy,
+            isFinishedLaunching: application.isFinishedLaunching,
+            metadataWarnings: application.metadataWarnings,
+            selectorResolutionProofs: application.selectorResolutionProofs)
+    }
+}
+
+extension AutomationTestFixtures {
+    public static func linkedApplicationInventoryGraph(
+        processIdentity: ApplicationProcessIdentity = Self.processIdentity(),
+        bundleIdentifier: String? = "com.example.TestApp",
+        applicationName: String = "Test App",
+        windowID: Int = 201,
+        windowTitle: String = "Test Window",
+        bounds: CGRect = CGRect(x: 10, y: 20, width: 640, height: 480)) throws
+        -> LinkedApplicationInventoryGraph
+    {
+        let linkedTarget = self.linkedDesktopTarget(
+            processIdentity: processIdentity,
+            bundleIdentifier: bundleIdentifier,
+            applicationName: applicationName,
+            windowID: windowID,
+            windowTitle: windowTitle,
+            bounds: bounds)
+        return try LinkedApplicationInventoryGraph(linkedTargets: [linkedTarget])
+    }
+}
+
+/// Mutable application inventory double with finite, saturating inventory scripts.
+///
+/// Empty scripts derive their result from `applications` on every read. Nonempty scripts advance one
+/// response per mutation-inventory request and repeat the last response after exhaustion.
+@MainActor
+open class ScriptedApplicationInventoryService:
+    ApplicationServiceProtocol,
+    ApplicationMutationInventoryProviding
+{
+    public typealias Inventory = DesktopTargetPlanning.Inventory<ServiceApplicationInfo>
+
+    public var applications: [ServiceApplicationInfo]
+    public var windowsByIdentifier: [String: [ServiceWindowInfo]]
+    public var inventoryCompleteness: Inventory.Completeness
+    public var inventoryWarnings: [String]
+    public var applicationInventorySequence: [Inventory] {
+        didSet { self.applicationInventorySequenceIndex = 0 }
+    }
+
+    private let launchOptionsSupported: Bool
+    private let relaunchSupported: Bool
+    private let pinnedQuitSupported: Bool
+    private let pinnedActivationSupported: Bool
+    private let applicationMetadataWarningsPropagated: Bool
+
+    public private(set) var listApplicationsCallCount = 0
+    public private(set) var applicationMutationInventoryCallCount = 0
+    public private(set) var findApplicationRequests: [String] = []
+    public private(set) var listWindowsRequests: [(identifier: String, timeout: Float?)] = []
+    public private(set) var frontmostApplicationCallCount = 0
+    public private(set) var runningApplicationRequests: [String] = []
+    public private(set) var launchIdentifiers: [String] = []
+    public private(set) var launchRequests: [ApplicationLaunchRequest] = []
+    public private(set) var relaunchRequests: [ApplicationRelaunchRequest] = []
+    public private(set) var activationIdentifiers: [String] = []
+    public private(set) var recordedActivationRequests: [ApplicationActivationRequest] = []
+    public private(set) var recordedQuitRequests: [ApplicationQuitRequest] = []
+    public private(set) var hideRequests: [String] = []
+    public private(set) var unhideRequests: [String] = []
+    public private(set) var hideOtherRequests: [String] = []
+    public private(set) var showAllApplicationsCallCount = 0
+
+    private var applicationInventorySequenceIndex = 0
+
+    public init(
+        applications: [ServiceApplicationInfo] = [],
+        windowsByIdentifier: [String: [ServiceWindowInfo]] = [:],
+        inventoryCompleteness: Inventory.Completeness = .complete,
+        inventoryWarnings: [String] = [],
+        applicationInventorySequence: [Inventory] = [],
+        propagatesApplicationMetadataWarnings: Bool = true,
+        supportsApplicationLaunchOptions: Bool = false,
+        supportsApplicationRelaunch: Bool = false,
+        supportsProcessGenerationPinnedApplicationQuit: Bool = false,
+        supportsProcessGenerationPinnedApplicationActivation: Bool = true)
+    {
+        self.applications = applications
+        self.windowsByIdentifier = windowsByIdentifier
+        self.inventoryCompleteness = inventoryCompleteness
+        self.inventoryWarnings = inventoryWarnings
+        self.applicationInventorySequence = applicationInventorySequence
+        self.applicationMetadataWarningsPropagated = propagatesApplicationMetadataWarnings
+        self.launchOptionsSupported = supportsApplicationLaunchOptions
+        self.relaunchSupported = supportsApplicationRelaunch
+        self.pinnedQuitSupported = supportsProcessGenerationPinnedApplicationQuit
+        self.pinnedActivationSupported = supportsProcessGenerationPinnedApplicationActivation
+    }
+
+    public convenience init(
+        graph: LinkedApplicationInventoryGraph,
+        inventoryCompleteness: Inventory.Completeness = .complete,
+        inventoryWarnings: [String] = [],
+        applicationInventorySequence: [Inventory] = [],
+        propagatesApplicationMetadataWarnings: Bool = true,
+        supportsApplicationLaunchOptions: Bool = false,
+        supportsApplicationRelaunch: Bool = false,
+        supportsProcessGenerationPinnedApplicationQuit: Bool = false,
+        supportsProcessGenerationPinnedApplicationActivation: Bool = true)
+    {
+        self.init(
+            applications: graph.applications,
+            windowsByIdentifier: graph.windowsByIdentifier,
+            inventoryCompleteness: inventoryCompleteness,
+            inventoryWarnings: inventoryWarnings,
+            applicationInventorySequence: applicationInventorySequence,
+            propagatesApplicationMetadataWarnings: propagatesApplicationMetadataWarnings,
+            supportsApplicationLaunchOptions: supportsApplicationLaunchOptions,
+            supportsApplicationRelaunch: supportsApplicationRelaunch,
+            supportsProcessGenerationPinnedApplicationQuit: supportsProcessGenerationPinnedApplicationQuit,
+            supportsProcessGenerationPinnedApplicationActivation:
+            supportsProcessGenerationPinnedApplicationActivation)
+    }
+
+    open var supportsApplicationLaunchOptions: Bool {
+        self.launchOptionsSupported
+    }
+
+    open var supportsApplicationRelaunch: Bool {
+        self.relaunchSupported
+    }
+
+    open var supportsProcessGenerationPinnedApplicationQuit: Bool {
+        self.pinnedQuitSupported
+    }
+
+    open var supportsProcessGenerationPinnedApplicationActivation: Bool {
+        self.pinnedActivationSupported
+    }
+
+    open func replaceApplicationsForTesting(_ applications: [ServiceApplicationInfo]) {
+        self.applications = applications
+    }
+
+    open func listApplications() async throws -> UnifiedToolOutput<ServiceApplicationListData> {
+        self.listApplicationsCallCount += 1
+        let warnings = self.effectiveInventoryWarnings()
+        return UnifiedToolOutput(
+            data: ServiceApplicationListData(applications: self.applications),
+            summary: .init(
+                brief: "Found \(self.applications.count) apps",
+                status: warnings.isEmpty ? .success : .partial,
+                counts: ["applications": self.applications.count]),
+            metadata: .init(duration: 0, warnings: warnings))
+    }
+
+    open func applicationMutationInventory() async throws -> Inventory {
+        self.applicationMutationInventoryCallCount += 1
+        guard !self.applicationInventorySequence.isEmpty else {
+            let warnings = self.effectiveInventoryWarnings()
+            let completeness: Inventory.Completeness = warnings.isEmpty
+                ? self.inventoryCompleteness
+                : .partial
+            return Inventory(
+                items: self.applications,
+                completeness: completeness,
+                warnings: warnings)
+        }
+        let index = min(
+            self.applicationInventorySequenceIndex,
+            self.applicationInventorySequence.count - 1)
+        self.applicationInventorySequenceIndex = min(
+            self.applicationInventorySequenceIndex + 1,
+            self.applicationInventorySequence.count - 1)
+        return self.applicationInventorySequence[index]
+    }
+
+    open func findApplication(identifier: String) async throws -> ServiceApplicationInfo {
+        self.findApplicationRequests.append(identifier)
+        guard let application = self.resolvedApplication(identifier: identifier) else {
+            throw PeekabooError.appNotFound(identifier)
+        }
+        return application
+    }
+
+    open func listWindows(
+        for appIdentifier: String,
+        timeout: Float?) async throws -> UnifiedToolOutput<ServiceWindowListData>
+    {
+        self.listWindowsRequests.append((appIdentifier, timeout))
+        let application = self.resolvedApplication(identifier: appIdentifier)
+        let windows = self.resolvedWindows(
+            directIdentifier: appIdentifier,
+            application: application)
+        return UnifiedToolOutput(
+            data: ServiceWindowListData(windows: windows, targetApplication: application),
+            summary: .init(
+                brief: "Found \(windows.count) windows",
+                status: .success,
+                counts: ["windows": windows.count]),
+            metadata: .init(duration: 0))
+    }
+
+    open func getFrontmostApplication() async throws -> ServiceApplicationInfo {
+        self.frontmostApplicationCallCount += 1
+        guard let application = self.applications.first(where: \.isActive) ?? self.applications.first else {
+            throw PeekabooError.appNotFound("frontmost")
+        }
+        return application
+    }
+
+    /// Keeps the protocol's throwing signature so importing test targets can override with scripted failures.
+    open func isApplicationRunning(identifier: String) async throws -> Bool {
+        self.runningApplicationRequests.append(identifier)
+        return self.resolvedApplication(identifier: identifier) != nil
+    }
+
+    open func launchApplication(identifier: String) async throws -> ServiceApplicationInfo {
+        self.launchIdentifiers.append(identifier)
+        if let existing = self.resolvedApplication(identifier: identifier) {
+            return existing
+        }
+        let application = self.syntheticApplication(
+            identifier: identifier,
+            bundleIdentifier: identifier,
+            activates: true)
+        self.applications.append(application)
+        return application
+    }
+
+    open func launchApplication(request: ApplicationLaunchRequest) async throws -> ServiceApplicationInfo {
+        self.launchRequests.append(request)
+        let identifier = request.applicationBundleIdentifier ??
+            request.applicationIdentifier ??
+            "Default Handler"
+        let application = self.syntheticApplication(
+            identifier: identifier,
+            bundleIdentifier: request.applicationBundleIdentifier,
+            activates: request.activates)
+        self.applications.append(application)
+        return application
+    }
+
+    open func relaunchApplication(request: ApplicationRelaunchRequest) async throws -> ServiceApplicationInfo {
+        self.relaunchRequests.append(request)
+        guard let application = self.resolvedApplication(identifier: request.targetIdentifier) else {
+            throw PeekabooError.appNotFound(request.targetIdentifier)
+        }
+        if let expectedIdentity = request.expectedTargetIdentity,
+           application.processIdentity != expectedIdentity
+        {
+            throw PeekabooError.commandFailed("Application process generation changed before relaunch")
+        }
+        return try await self.launchApplication(request: request.launchRequest)
+    }
+
+    open func activateApplication(identifier: String) async throws {
+        self.activationIdentifiers.append(identifier)
+        guard self.resolvedApplication(identifier: identifier) != nil else {
+            throw PeekabooError.appNotFound(identifier)
+        }
+    }
+
+    open func activateApplication(request: ApplicationActivationRequest) async throws {
+        self.recordedActivationRequests.append(request)
+        if request.expectedIdentity != nil, !self.pinnedActivationSupported {
+            throw PeekabooError.serviceUnavailable(
+                "Scripted application service does not support process-generation-pinned activation")
+        }
+        let application = try await self.findApplication(identifier: request.identifier)
+        if let expectedIdentity = request.expectedIdentity,
+           application.processIdentity != expectedIdentity
+        {
+            throw PeekabooError.commandFailed("Application process generation changed before activation")
+        }
+    }
+
+    open func quitApplication(identifier: String, force: Bool) async throws -> Bool {
+        try await self.quitApplication(request: ApplicationQuitRequest(
+            identifier: identifier,
+            force: force))
+    }
+
+    open func quitApplication(request: ApplicationQuitRequest) async throws -> Bool {
+        self.recordedQuitRequests.append(request)
+        if request.expectedIdentity != nil, !self.pinnedQuitSupported {
+            throw PeekabooError.serviceUnavailable(
+                "Scripted application service does not support process-generation-pinned quit")
+        }
+        guard let application = self.resolvedApplication(identifier: request.identifier) else {
+            throw PeekabooError.appNotFound(request.identifier)
+        }
+        if let expectedIdentity = request.expectedIdentity,
+           application.processIdentity != expectedIdentity
+        {
+            throw PeekabooError.commandFailed("Application process generation changed before quit")
+        }
+        return true
+    }
+
+    open func hideApplication(identifier: String) async throws {
+        self.hideRequests.append(identifier)
+    }
+
+    open func unhideApplication(identifier: String) async throws {
+        self.unhideRequests.append(identifier)
+    }
+
+    open func hideOtherApplications(identifier: String) async throws {
+        self.hideOtherRequests.append(identifier)
+    }
+
+    open func showAllApplications() async throws {
+        self.showAllApplicationsCallCount += 1
+    }
+
+    open func resetRecordedCalls() {
+        self.listApplicationsCallCount = 0
+        self.applicationMutationInventoryCallCount = 0
+        self.findApplicationRequests = []
+        self.listWindowsRequests = []
+        self.frontmostApplicationCallCount = 0
+        self.runningApplicationRequests = []
+        self.launchIdentifiers = []
+        self.launchRequests = []
+        self.relaunchRequests = []
+        self.activationIdentifiers = []
+        self.recordedActivationRequests = []
+        self.recordedQuitRequests = []
+        self.hideRequests = []
+        self.unhideRequests = []
+        self.hideOtherRequests = []
+        self.showAllApplicationsCallCount = 0
+    }
+
+    private func resolvedApplication(identifier: String) -> ServiceApplicationInfo? {
+        guard let canonicalIdentifier = ScriptedApplicationIdentifier.canonicalKey(identifier) else {
+            return nil
+        }
+        return self.applications.first {
+            ScriptedApplicationIdentifier.canonicalKey($0.name) == canonicalIdentifier ||
+                $0.bundleIdentifier.flatMap(ScriptedApplicationIdentifier.canonicalKey) == canonicalIdentifier ||
+                ScriptedApplicationIdentifier.canonicalKey("PID:\($0.processIdentifier)") == canonicalIdentifier
+        }
+    }
+
+    private func resolvedWindows(
+        directIdentifier: String,
+        application: ServiceApplicationInfo?) -> [ServiceWindowInfo]
+    {
+        if let windows = self.windowsByIdentifier[directIdentifier] {
+            return windows
+        }
+        let aliases = [
+            application.map { "PID:\($0.processIdentifier)" },
+            application.map { String($0.processIdentifier) },
+            application?.bundleIdentifier,
+            application?.name,
+        ].compactMap(\.self)
+        for alias in aliases {
+            if let windows = self.windowsByIdentifier[alias] {
+                return windows
+            }
+        }
+        return []
+    }
+
+    private func syntheticApplication(
+        identifier: String,
+        bundleIdentifier: String?,
+        activates: Bool) -> ServiceApplicationInfo
+    {
+        let processIdentifier = max(self.applications.map(\.processIdentifier).max() ?? 0, 0) + 1
+        return ServiceApplicationInfo(
+            processIdentifier: processIdentifier,
+            processStartIdentity: UInt64(processIdentifier) * 1000,
+            bundleIdentifier: bundleIdentifier,
+            name: identifier,
+            isActive: activates,
+            isFinishedLaunching: true)
+    }
+
+    private func effectiveInventoryWarnings() -> [String] {
+        let applicationWarnings = self.applicationMetadataWarningsPropagated
+            ? self.applications.flatMap { $0.metadataWarnings ?? [] }
+            : []
+        return Self.uniqueWarnings(self.inventoryWarnings + applicationWarnings)
+    }
+
+    private static func uniqueWarnings(_ warnings: [String]) -> [String] {
+        var seen = Set<String>()
+        return warnings.filter { seen.insert($0).inserted }
+    }
+}
+
+/// Mutable window inventory double with target-specific, saturating inventory scripts.
+@MainActor
+open class ScriptedWindowInventoryService:
+    WindowManagementServiceProtocol,
+    WindowMutationInventoryProviding
+{
+    public typealias Inventory = DesktopTargetPlanning.Inventory<ServiceWindowInfo>
+
+    public var windowsByIdentifier: [String: [ServiceWindowInfo]]
+    public var focusedWindow: ServiceWindowInfo?
+    public var inventoryCompleteness: Inventory.Completeness
+    public var inventoryWarnings: [String]
+    public var defaultInventorySequence: [Inventory] {
+        didSet { self.defaultInventorySequenceIndex = 0 }
+    }
+
+    public var inventorySequencesByTarget: [WindowTarget: [Inventory]] {
+        didSet { self.inventorySequenceIndicesByTarget = [:] }
+    }
+
+    public private(set) var listWindowRequests: [WindowTarget] = []
+    public private(set) var windowMutationInventoryRequests: [WindowTarget] = []
+    public private(set) var focusedWindowCallCount = 0
+    public private(set) var closeRequests: [(target: WindowTarget, allowForegroundFallback: Bool)] = []
+    public private(set) var minimizeRequests: [WindowTarget] = []
+    public private(set) var restoreRequests: [WindowTarget] = []
+    public private(set) var maximizeRequests: [WindowTarget] = []
+    public private(set) var moveRequests: [(target: WindowTarget, position: CGPoint)] = []
+    public private(set) var resizeRequests: [(target: WindowTarget, size: CGSize)] = []
+    public private(set) var setBoundsRequests: [(target: WindowTarget, bounds: CGRect)] = []
+    public private(set) var focusRequests: [WindowTarget] = []
+
+    private var defaultInventorySequenceIndex = 0
+    private var inventorySequenceIndicesByTarget: [WindowTarget: Int] = [:]
+
+    public init(
+        windowsByIdentifier: [String: [ServiceWindowInfo]] = [:],
+        focusedWindow: ServiceWindowInfo? = nil,
+        inventoryCompleteness: Inventory.Completeness = .complete,
+        inventoryWarnings: [String] = [],
+        defaultInventorySequence: [Inventory] = [],
+        inventorySequencesByTarget: [WindowTarget: [Inventory]] = [:])
+    {
+        self.windowsByIdentifier = windowsByIdentifier
+        self.focusedWindow = focusedWindow
+        self.inventoryCompleteness = inventoryCompleteness
+        self.inventoryWarnings = inventoryWarnings
+        self.defaultInventorySequence = defaultInventorySequence
+        self.inventorySequencesByTarget = inventorySequencesByTarget
+    }
+
+    public convenience init(
+        graph: LinkedApplicationInventoryGraph,
+        focusedWindow: ServiceWindowInfo? = nil,
+        inventoryCompleteness: Inventory.Completeness = .complete,
+        inventoryWarnings: [String] = [],
+        defaultInventorySequence: [Inventory] = [],
+        inventorySequencesByTarget: [WindowTarget: [Inventory]] = [:])
+    {
+        self.init(
+            windowsByIdentifier: graph.windowsByIdentifier,
+            focusedWindow: focusedWindow,
+            inventoryCompleteness: inventoryCompleteness,
+            inventoryWarnings: inventoryWarnings,
+            defaultInventorySequence: defaultInventorySequence,
+            inventorySequencesByTarget: inventorySequencesByTarget)
+    }
+
+    @MainActor
+    open func replaceWindowsForTesting(_ windowsByIdentifier: [String: [ServiceWindowInfo]]) {
+        self.windowsByIdentifier = windowsByIdentifier
+    }
+
+    @MainActor
+    open func closeWindow(target: WindowTarget) async throws {
+        try await self.closeWindow(target: target, allowForegroundFallback: false)
+    }
+
+    @MainActor
+    open func closeWindow(target: WindowTarget, allowForegroundFallback: Bool) async throws {
+        self.closeRequests.append((target, allowForegroundFallback))
+    }
+
+    @MainActor
+    open func minimizeWindow(target: WindowTarget) async throws {
+        self.minimizeRequests.append(target)
+    }
+
+    @MainActor
+    open func restoreWindow(target: WindowTarget) async throws {
+        self.restoreRequests.append(target)
+    }
+
+    @MainActor
+    open func maximizeWindow(target: WindowTarget) async throws {
+        self.maximizeRequests.append(target)
+    }
+
+    @MainActor
+    open func moveWindow(target: WindowTarget, to position: CGPoint) async throws {
+        self.moveRequests.append((target, position))
+    }
+
+    @MainActor
+    open func resizeWindow(target: WindowTarget, to size: CGSize) async throws {
+        self.resizeRequests.append((target, size))
+    }
+
+    @MainActor
+    open func setWindowBounds(target: WindowTarget, bounds: CGRect) async throws {
+        self.setBoundsRequests.append((target, bounds))
+    }
+
+    @MainActor
+    open func focusWindow(target: WindowTarget) async throws {
+        self.focusRequests.append(target)
+    }
+
+    @MainActor
+    open func listWindows(target: WindowTarget) async throws -> [ServiceWindowInfo] {
+        self.listWindowRequests.append(target)
+        return self.resolvedWindows(target: target)
+    }
+
+    @MainActor
+    open func windowMutationInventory(target: WindowTarget) async throws -> Inventory {
+        self.windowMutationInventoryRequests.append(target)
+        if let sequence = self.inventorySequencesByTarget[target], !sequence.isEmpty {
+            let currentIndex = self.inventorySequenceIndicesByTarget[target] ?? 0
+            let index = min(currentIndex, sequence.count - 1)
+            self.inventorySequenceIndicesByTarget[target] = min(currentIndex + 1, sequence.count - 1)
+            return sequence[index]
+        }
+        if !self.defaultInventorySequence.isEmpty {
+            let index = min(
+                self.defaultInventorySequenceIndex,
+                self.defaultInventorySequence.count - 1)
+            self.defaultInventorySequenceIndex = min(
+                self.defaultInventorySequenceIndex + 1,
+                self.defaultInventorySequence.count - 1)
+            return self.defaultInventorySequence[index]
+        }
+        return Inventory(
+            items: self.resolvedWindows(target: target),
+            completeness: self.inventoryWarnings.isEmpty ? self.inventoryCompleteness : .partial,
+            warnings: self.inventoryWarnings)
+    }
+
+    @MainActor
+    open func getFocusedWindow() async throws -> ServiceWindowInfo? {
+        self.focusedWindowCallCount += 1
+        return self.focusedWindow
+    }
+
+    @MainActor
+    open func resetRecordedCalls() {
+        self.listWindowRequests = []
+        self.windowMutationInventoryRequests = []
+        self.focusedWindowCallCount = 0
+        self.closeRequests = []
+        self.minimizeRequests = []
+        self.restoreRequests = []
+        self.maximizeRequests = []
+        self.moveRequests = []
+        self.resizeRequests = []
+        self.setBoundsRequests = []
+        self.focusRequests = []
+    }
+
+    private func resolvedWindows(target: WindowTarget) -> [ServiceWindowInfo] {
+        switch target {
+        case let .application(identifier):
+            return self.windowsByIdentifier[identifier] ?? []
+        case let .applicationAndTitle(identifier, title):
+            return (self.windowsByIdentifier[identifier] ?? []).filter {
+                $0.title.localizedCaseInsensitiveContains(title)
+            }
+        case .frontmost:
+            if let focusedWindow = self.focusedWindow {
+                return [focusedWindow]
+            }
+            let windows = self.allWindows()
+            if let frontmost = windows.first(where: { $0.isFrontmost == true }) ??
+                windows.first(where: { $0.isKeyWindow == true }) ??
+                windows.first(where: \.isMainWindow)
+            {
+                return [frontmost]
+            }
+            return Array(windows.prefix(1))
+        case let .windowId(windowID):
+            return self.allWindows().filter { $0.windowID == windowID }
+        case let .title(title):
+            return self.allWindows().filter { $0.title.localizedCaseInsensitiveContains(title) }
+        case let .index(identifier, index):
+            guard index >= 0,
+                  let windows = self.windowsByIdentifier[identifier],
+                  index < windows.count
+            else { return [] }
+            return [windows[index]]
+        }
+    }
+
+    private func allWindows() -> [ServiceWindowInfo] {
+        var seen = Set<Int>()
+        return self.windowsByIdentifier.values
+            .flatMap(\.self)
+            .sorted { lhs, rhs in
+                lhs.index == rhs.index ? lhs.windowID < rhs.windowID : lhs.index < rhs.index
+            }
+            .filter { seen.insert($0.windowID).inserted }
+    }
+}

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ScriptedInventoryServicesTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ScriptedInventoryServicesTests.swift
@@ -1,0 +1,299 @@
+import CoreGraphics
+import PeekabooAutomationKitTestSupport
+import PeekabooFoundation
+import Testing
+@testable import PeekabooAutomationKit
+
+@Suite(.serialized)
+@MainActor
+struct ScriptedInventoryServicesTests {
+    @Test
+    func `graph links missing receipts and normalizes application window metadata`() throws {
+        let process = AutomationTestFixtures.processIdentity(
+            processIdentifier: 42,
+            processStartIdentity: 1001)
+        let application = AutomationTestFixtures.application(
+            processIdentifier: process.processIdentifier,
+            processStartIdentity: process.processStartIdentity,
+            bundleIdentifier: "com.example.Linked",
+            name: "Linked App")
+        let first = AutomationTestFixtures.window(
+            windowID: 71,
+            title: "First",
+            processIdentity: process,
+            includesMutationIdentity: false)
+        let second = AutomationTestFixtures.window(
+            windowID: 72,
+            title: "Second",
+            processIdentity: process,
+            includesMutationIdentity: false,
+            index: 1)
+
+        let graph = try LinkedApplicationInventoryGraph(nodes: [
+            .init(application: application, windows: [first, second]),
+        ])
+        let linkedApplication = try #require(graph.applications.first)
+        let linkedWindows = try #require(graph.windowsByIdentifier["PID:42"])
+
+        #expect(linkedApplication.windowCount == 2)
+        #expect(linkedApplication.windowIDs == [71, 72])
+        #expect(linkedWindows.map(\.mutationIdentity?.processIdentity) == [process, process])
+        #expect(linkedWindows.map(\.mutationIdentity?.windowID) == [71, 72])
+        #expect(graph.windowsByIdentifier["42"] == linkedWindows)
+        #expect(graph.windowsByIdentifier["Linked App"] == linkedWindows)
+        #expect(graph.windowsByIdentifier["com.example.Linked"] == linkedWindows)
+    }
+
+    @Test
+    func `graph rejects explicit contradictory process and window evidence`() throws {
+        let application = AutomationTestFixtures.application(windowIDs: [999])
+        let window = AutomationTestFixtures.window(includesMutationIdentity: false)
+        #expect(throws: LinkedApplicationInventoryGraphError.contradictoryApplicationWindowIDs(
+            processIdentifier: application.processIdentifier))
+        {
+            _ = try LinkedApplicationInventoryGraph(nodes: [
+                .init(application: application, windows: [window]),
+            ])
+        }
+
+        let wrongOwner = AutomationTestFixtures.processIdentity(
+            processIdentifier: 202,
+            processStartIdentity: 2002)
+        let wrongWindow = AutomationTestFixtures.window(processIdentity: wrongOwner)
+        #expect(throws: LinkedApplicationInventoryGraphError.contradictoryWindowReceipt(
+            windowID: wrongWindow.windowID))
+        {
+            _ = try LinkedApplicationInventoryGraph(nodes: [
+                .init(application: AutomationTestFixtures.application(), windows: [wrongWindow]),
+            ])
+        }
+    }
+
+    @Test
+    func `graph rejects aliases shared by distinct process generations`() throws {
+        let firstProcess = AutomationTestFixtures.processIdentity()
+        let secondProcess = AutomationTestFixtures.processIdentity(
+            processIdentifier: 202,
+            processStartIdentity: 2002)
+        let firstApplication = AutomationTestFixtures.application(name: "Shared App")
+        let secondApplication = AutomationTestFixtures.application(
+            processIdentifier: secondProcess.processIdentifier,
+            processStartIdentity: secondProcess.processStartIdentity,
+            bundleIdentifier: "com.example.Second",
+            name: "Shared App")
+        let firstWindow = AutomationTestFixtures.window(processIdentity: firstProcess)
+        let secondWindow = AutomationTestFixtures.window(
+            windowID: 202,
+            processIdentity: secondProcess)
+
+        #expect(throws: LinkedApplicationInventoryGraphError.ambiguousApplicationIdentifier("Shared App")) {
+            _ = try LinkedApplicationInventoryGraph(nodes: [
+                .init(application: firstApplication, windows: [firstWindow]),
+                .init(application: secondApplication, windows: [secondWindow]),
+            ])
+        }
+
+        let pidAliasApplication = AutomationTestFixtures.application(
+            processIdentifier: secondProcess.processIdentifier,
+            processStartIdentity: secondProcess.processStartIdentity,
+            bundleIdentifier: "com.example.PIDAlias",
+            name: "pid:\(firstProcess.processIdentifier)")
+        #expect(throws: LinkedApplicationInventoryGraphError.ambiguousApplicationIdentifier("pid:101")) {
+            _ = try LinkedApplicationInventoryGraph(nodes: [
+                .init(application: firstApplication, windows: [firstWindow]),
+                .init(application: pidAliasApplication, windows: [secondWindow]),
+            ])
+        }
+    }
+
+    @Test
+    func `graph groups linked windows for one process and rejects contradictory app metadata`() throws {
+        let process = AutomationTestFixtures.processIdentity()
+        let first = AutomationTestFixtures.linkedDesktopTarget(
+            processIdentity: process,
+            windowID: 201,
+            windowTitle: "First")
+        let second = AutomationTestFixtures.linkedDesktopTarget(
+            processIdentity: process,
+            windowID: 202,
+            windowTitle: "Second",
+            windowIndex: 1)
+
+        let graph = try LinkedApplicationInventoryGraph(linkedTargets: [first, second])
+        #expect(graph.nodes.count == 1)
+        #expect(graph.applications.first?.windowIDs == [201, 202])
+        #expect(graph.nodes.first?.windows.map(\.windowID) == [201, 202])
+
+        let contradictory = AutomationTestFixtures.linkedDesktopTarget(
+            processIdentity: process,
+            applicationName: "Different App",
+            windowID: 203)
+        #expect(throws: LinkedApplicationInventoryGraphError.contradictoryApplicationMetadata(
+            processIdentifier: process.processIdentifier))
+        {
+            _ = try LinkedApplicationInventoryGraph(linkedTargets: [first, contradictory])
+        }
+    }
+
+    @Test
+    func `application inventories sequence then saturate while dynamic inventory remains mutable`() async throws {
+        let first = AutomationTestFixtures.application(name: "First")
+        let second = AutomationTestFixtures.application(
+            processIdentifier: 202,
+            processStartIdentity: 2002,
+            bundleIdentifier: "com.example.Second",
+            name: "Second")
+        let service = ScriptedApplicationInventoryService(
+            applications: [first],
+            applicationInventorySequence: [
+                .complete([first]),
+                .partial([second], warnings: ["bounded lookup timed out"]),
+            ])
+
+        #expect(try await service.applicationMutationInventory() == .complete([first]))
+        let partial = try await service.applicationMutationInventory()
+        #expect(partial == .partial([second], warnings: ["bounded lookup timed out"]))
+        #expect(try await service.applicationMutationInventory() == partial)
+        #expect(service.applicationMutationInventoryCallCount == 3)
+
+        service.applicationInventorySequence = []
+        service.replaceApplicationsForTesting([second])
+        #expect(try await service.applicationMutationInventory() == .complete([second]))
+
+        let warned = ServiceApplicationInfo(
+            processIdentifier: 303,
+            bundleIdentifier: nil,
+            name: "Warned",
+            metadataWarnings: ["metadata timed out"])
+        let warningsSuppressed = ScriptedApplicationInventoryService(
+            applications: [warned],
+            propagatesApplicationMetadataWarnings: false)
+        #expect(try await warningsSuppressed.applicationMutationInventory() == .complete([warned]))
+        #expect(try await warningsSuppressed.listApplications().summary.status == .success)
+    }
+
+    @Test
+    func `application service covers common reads and records lifecycle requests`() async throws {
+        let graph = try AutomationTestFixtures.linkedApplicationInventoryGraph()
+        let service = ScriptedApplicationInventoryService(graph: graph)
+        let application = try #require(graph.applications.first)
+        let identity = try #require(application.processIdentity)
+
+        #expect(try await service.listApplications().data.applications == [application])
+        #expect(try await service.findApplication(identifier: "PID:101") == application)
+        #expect(try await service.findApplication(identifier: "  pid:101  ") == application)
+        #expect(try await service.findApplication(identifier: "com.example.TestApp") == application)
+        #expect(try await service.listWindows(for: "Test App", timeout: 0.5).data.windows.count == 1)
+        #expect(try await service.getFrontmostApplication() == application)
+        #expect(try await service.isApplicationRunning(identifier: "101"))
+
+        try await service.activateApplication(request: ApplicationActivationRequest(
+            identifier: "PID:101",
+            expectedIdentity: identity))
+        let launch = ApplicationLaunchRequest(
+            applicationBundleIdentifier: "com.example.Launched",
+            activates: false)
+        _ = try await service.launchApplication(request: launch)
+        let relaunch = ApplicationRelaunchRequest(
+            targetIdentifier: "PID:101",
+            expectedTargetIdentity: identity,
+            launchRequest: launch)
+        _ = try await service.relaunchApplication(request: relaunch)
+
+        #expect(service.listApplicationsCallCount == 1)
+        #expect(service.findApplicationRequests == [
+            "PID:101",
+            "  pid:101  ",
+            "com.example.TestApp",
+            "PID:101",
+        ])
+        #expect(service.listWindowsRequests.count == 1)
+        #expect(service.frontmostApplicationCallCount == 1)
+        #expect(service.runningApplicationRequests == ["101"])
+        #expect(service.recordedActivationRequests.count == 1)
+        #expect(service.launchRequests == [launch, launch])
+        #expect(service.relaunchRequests == [relaunch])
+
+        service.replaceApplicationsForTesting([AutomationTestFixtures.wrongGenerationApplication()])
+        await #expect(throws: PeekabooError.self) {
+            try await service.relaunchApplication(request: relaunch)
+        }
+        #expect(service.launchRequests == [launch, launch])
+
+        let unsupportedPinning = ScriptedApplicationInventoryService(applications: [application])
+        await #expect(throws: PeekabooError.self) {
+            try await unsupportedPinning.quitApplication(request: ApplicationQuitRequest(
+                identifier: "PID:101",
+                force: false,
+                expectedIdentity: identity))
+        }
+    }
+
+    @Test
+    func `window inventories saturate independently per target and list protocol filters`() async throws {
+        let graph = try AutomationTestFixtures.linkedApplicationInventoryGraph()
+        let window = try #require(graph.nodes.first?.windows.first)
+        let renamed = AutomationTestFixtures.window(copying: window, title: "Renamed")
+        let appTarget = WindowTarget.application("Test App")
+        let idTarget = WindowTarget.windowId(window.windowID)
+        let service = ScriptedWindowInventoryService(
+            graph: graph,
+            focusedWindow: window,
+            inventorySequencesByTarget: [
+                appTarget: [
+                    .complete([window]),
+                    .partial([renamed], warnings: ["AX timed out"]),
+                ],
+                idTarget: [.complete([window])],
+            ])
+
+        #expect(try await service.listWindows(target: .applicationAndTitle(
+            app: "Test App",
+            title: "test")) == [window])
+        #expect(try await service.listWindows(target: .title("WINDOW")) == [window])
+        #expect(try await service.listWindows(target: .index(app: "Test App", index: 0)) == [window])
+        #expect(try await service.getFocusedWindow() == window)
+
+        #expect(try await service.windowMutationInventory(target: appTarget) == .complete([window]))
+        let partial = try await service.windowMutationInventory(target: appTarget)
+        #expect(partial == .partial([renamed], warnings: ["AX timed out"]))
+        #expect(try await service.windowMutationInventory(target: appTarget) == partial)
+        #expect(try await service.windowMutationInventory(target: idTarget) == .complete([window]))
+        #expect(try await service.windowMutationInventory(target: idTarget) == .complete([window]))
+
+        #expect(service.listWindowRequests.count == 3)
+        #expect(service.windowMutationInventoryRequests == [
+            appTarget,
+            appTarget,
+            appTarget,
+            idTarget,
+            idTarget,
+        ])
+        #expect(service.focusedWindowCallCount == 1)
+    }
+
+    @Test
+    func `application inventory service is subclassable from the importing test module`() async throws {
+        let expected = AutomationTestFixtures.application(name: "Overridden")
+        let service = OverridingApplicationInventoryService(expected: expected)
+
+        #expect(try await service.findApplication(identifier: "anything") == expected)
+        #expect(service.overrideRequests == ["anything"])
+    }
+}
+
+@MainActor
+private final class OverridingApplicationInventoryService: ScriptedApplicationInventoryService {
+    let expected: ServiceApplicationInfo
+    private(set) var overrideRequests: [String] = []
+
+    init(expected: ServiceApplicationInfo) {
+        self.expected = expected
+        super.init()
+    }
+
+    override func findApplication(identifier: String) async throws -> ServiceApplicationInfo {
+        self.overrideRequests.append(identifier)
+        return self.expected
+    }
+}

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPToolExecutionTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPToolExecutionTests.swift
@@ -15,6 +15,22 @@ import UniformTypeIdentifiers
 
 @Suite(.serialized)
 struct MCPToolExecutionTests {
+    @Test
+    @MainActor
+    func `Mock application request quit preserves legacy delegation`() async throws {
+        let applications = MockApplicationService()
+
+        #expect(try await applications.quitApplication(request: ApplicationQuitRequest(
+            identifier: "Missing App",
+            force: false)))
+        await #expect(throws: PeekabooError.self) {
+            try await applications.quitApplication(request: ApplicationQuitRequest(
+                identifier: "PID:42",
+                force: false,
+                expectedIdentity: AutomationTestFixtures.processIdentity(processIdentifier: 42)))
+        }
+    }
+
     // MARK: - Sleep Tool Tests
 
     @Test
@@ -1340,6 +1356,14 @@ class MockApplicationService: ScriptedApplicationInventoryService {
 
     override func quitApplication(identifier _: String, force _: Bool) async throws -> Bool {
         true
+    }
+
+    override func quitApplication(request: ApplicationQuitRequest) async throws -> Bool {
+        guard request.expectedIdentity == nil else {
+            throw PeekabooError.serviceUnavailable(
+                "This application service does not support process-generation-pinned quit; update the runtime host")
+        }
+        return try await self.quitApplication(identifier: request.identifier, force: request.force)
     }
 }
 

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPToolExecutionTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPToolExecutionTests.swift
@@ -3,6 +3,7 @@ import Foundation
 import ImageIO
 import MCP
 import PeekabooAutomationKit
+import PeekabooAutomationKitTestSupport
 import PeekabooFoundation
 import TachikomaMCP
 import Testing
@@ -474,9 +475,11 @@ struct MCPToolExecutionTests {
 
     @Test
     func `See tool app target detects against resolved observation window`() async throws {
-        let (app, windows) = await MainActor.run {
-            Self.makeWindowedTestApp()
+        let graph = try await MainActor.run {
+            try Self.makeWindowedTestGraph()
         }
+        let app = try #require(graph.applications.first)
+        let windows = try #require(graph.nodes.first?.windows)
         let detectionResult = ElementDetectionResult(
             snapshotId: "snapshot-2",
             screenshotPath: "/tmp/peekaboo-see-observation-test.png",
@@ -492,11 +495,13 @@ struct MCPToolExecutionTests {
             MockAutomationService(accessibilityGranted: true, detectionResult: detectionResult)
         }
         let applications = await MainActor.run {
-            MockApplicationService(applications: [app], windowsByIdentifier: [
-                app.bundleIdentifier ?? app.name: windows,
-            ])
+            MockApplicationService(graph: graph)
         }
-        let screenCapture = await MainActor.run { MockScreenCaptureService(screenRecordingGranted: true) }
+        let screenCapture = await MainActor.run {
+            MockScreenCaptureService(
+                screenRecordingGranted: true,
+                windowMetadata: Self.captureMetadata(application: app, windows: windows))
+        }
         let context = await MCPToolTestHelpers.makeLegacyContext(
             automation: automation,
             screenCapture: screenCapture,
@@ -521,9 +526,11 @@ struct MCPToolExecutionTests {
 
     @Test
     func `See tool PID target with window index uses shared observation parser`() async throws {
-        let (app, windows) = await MainActor.run {
-            Self.makeWindowedTestApp()
+        let graph = try await MainActor.run {
+            try Self.makeWindowedTestGraph()
         }
+        let app = try #require(graph.applications.first)
+        let windows = try #require(graph.nodes.first?.windows)
         let detectionResult = ElementDetectionResult(
             snapshotId: "snapshot-pid-window",
             screenshotPath: "/tmp/peekaboo-see-pid-window-test.png",
@@ -539,11 +546,13 @@ struct MCPToolExecutionTests {
             MockAutomationService(accessibilityGranted: true, detectionResult: detectionResult)
         }
         let applications = await MainActor.run {
-            MockApplicationService(applications: [app], windowsByIdentifier: [
-                app.bundleIdentifier ?? app.name: windows,
-            ])
+            MockApplicationService(graph: graph)
         }
-        let screenCapture = await MainActor.run { MockScreenCaptureService(screenRecordingGranted: true) }
+        let screenCapture = await MainActor.run {
+            MockScreenCaptureService(
+                screenRecordingGranted: true,
+                windowMetadata: Self.captureMetadata(application: app, windows: windows))
+        }
         let context = await MCPToolTestHelpers.makeLegacyContext(
             automation: automation,
             screenCapture: screenCapture,
@@ -559,9 +568,10 @@ struct MCPToolExecutionTests {
     }
 
     @MainActor
-    private static func makeWindowedTestApp() -> (ServiceApplicationInfo, [ServiceWindowInfo]) {
-        let app = ServiceApplicationInfo(
+    private static func makeWindowedTestGraph() throws -> LinkedApplicationInventoryGraph {
+        let app = AutomationTestFixtures.application(
             processIdentifier: 1234,
+            processStartIdentity: 700,
             bundleIdentifier: "com.test.zephyr",
             name: "Zephyr Agency",
             isActive: true,
@@ -570,24 +580,39 @@ struct MCPToolExecutionTests {
         let visibleOrigin = CGPoint(x: screenFrame.minX + 20, y: screenFrame.minY + 20)
         let offscreenOrigin = CGPoint(x: screenFrame.maxX + 10000, y: screenFrame.maxY + 10000)
 
-        return (app, [
-            ServiceWindowInfo(
-                windowID: 100,
-                title: "",
-                bounds: CGRect(origin: offscreenOrigin, size: CGSize(width: 2560, height: 30)),
-                index: 0,
-                isOnScreen: false),
-            ServiceWindowInfo(
-                windowID: 41,
-                title: "Small Utility",
-                bounds: CGRect(origin: visibleOrigin, size: CGSize(width: 120, height: 90)),
-                index: 1),
-            ServiceWindowInfo(
-                windowID: 42,
-                title: "Zephyr Agency",
-                bounds: CGRect(origin: visibleOrigin, size: CGSize(width: 1460, height: 945)),
-                index: 2),
+        return try LinkedApplicationInventoryGraph(nodes: [
+            .init(application: app, windows: [
+                ServiceWindowInfo(
+                    windowID: 100,
+                    title: "",
+                    bounds: CGRect(origin: offscreenOrigin, size: CGSize(width: 2560, height: 30)),
+                    index: 0,
+                    isOnScreen: false),
+                ServiceWindowInfo(
+                    windowID: 41,
+                    title: "Small Utility",
+                    bounds: CGRect(origin: visibleOrigin, size: CGSize(width: 120, height: 90)),
+                    index: 1),
+                ServiceWindowInfo(
+                    windowID: 42,
+                    title: "Zephyr Agency",
+                    bounds: CGRect(origin: visibleOrigin, size: CGSize(width: 1460, height: 945)),
+                    index: 2),
+            ]),
         ])
+    }
+
+    private static func captureMetadata(
+        application: ServiceApplicationInfo,
+        windows: [ServiceWindowInfo]) -> [CGWindowID: CaptureMetadata]
+    {
+        Dictionary(uniqueKeysWithValues: windows.map { window in
+            (CGWindowID(window.windowID), CaptureMetadata(
+                size: window.bounds.size,
+                mode: .window,
+                applicationInfo: application,
+                windowInfo: window))
+        })
     }
 
     private static func observationSpanNames(from response: ToolResponse) -> [String] {
@@ -1302,132 +1327,20 @@ final class MockScreenService: ScreenServiceProtocol {
 }
 
 @MainActor
-class MockApplicationService: ApplicationServiceProtocol, ApplicationMutationInventoryProviding {
-    let supportsProcessGenerationPinnedApplicationActivation = true
-    private(set) var applications: [ServiceApplicationInfo]
-    private(set) var launchRequests: [ApplicationLaunchRequest] = []
-    private(set) var relaunchRequests: [ApplicationRelaunchRequest] = []
-    private let windowsByIdentifier: [String: [ServiceWindowInfo]]
-
-    init(
-        applications: [ServiceApplicationInfo] = [],
-        windowsByIdentifier: [String: [ServiceWindowInfo]] = [:])
-    {
-        self.applications = applications
-        self.windowsByIdentifier = windowsByIdentifier
+class MockApplicationService: ScriptedApplicationInventoryService {
+    override func getFrontmostApplication() async throws -> ServiceApplicationInfo {
+        self.applications.first ?? ServiceApplicationInfo(
+            processIdentifier: 0,
+            bundleIdentifier: nil,
+            name: "Mock")
     }
 
-    func replaceApplicationsForTesting(_ applications: [ServiceApplicationInfo]) {
-        self.applications = applications
-    }
+    override func activateApplication(identifier _: String) async throws {}
+    override func activateApplication(request _: ApplicationActivationRequest) async throws {}
 
-    func listApplications() async throws -> UnifiedToolOutput<ServiceApplicationListData> {
-        let warnings = self.applications.flatMap { $0.metadataWarnings ?? [] }
-        return UnifiedToolOutput(
-            data: ServiceApplicationListData(applications: self.applications),
-            summary: .init(
-                brief: "Found \(self.applications.count) apps",
-                status: warnings.isEmpty ? .success : .partial,
-                counts: ["applications": self.applications.count]),
-            metadata: .init(duration: 0, warnings: warnings))
-    }
-
-    func applicationMutationInventory() async throws
-        -> DesktopTargetPlanning.Inventory<ServiceApplicationInfo>
-    {
-        let warnings = self.applications.flatMap { $0.metadataWarnings ?? [] }
-        return DesktopTargetPlanning.Inventory(
-            items: self.applications,
-            completeness: warnings.isEmpty ? .complete : .partial,
-            warnings: warnings)
-    }
-
-    func findApplication(identifier: String) async throws -> ServiceApplicationInfo {
-        let pid = identifier.uppercased().hasPrefix("PID:") ? Int32(identifier.dropFirst(4)) : nil
-        if let match = self.applications.first(where: {
-            $0.name == identifier || $0.bundleIdentifier == identifier || $0.processIdentifier == pid
-        }) {
-            return match
-        }
-        throw PeekabooError.appNotFound(identifier)
-    }
-
-    func listWindows(for appIdentifier: String, timeout _: Float?) async throws
-        -> UnifiedToolOutput<ServiceWindowListData>
-    {
-        let targetApp = try? await self.findApplication(identifier: appIdentifier)
-        let windows: [ServiceWindowInfo] = if let direct = self.windowsByIdentifier[appIdentifier] {
-            direct
-        } else if let bundleIdentifier = targetApp?.bundleIdentifier,
-                  let bundleWindows = self.windowsByIdentifier[bundleIdentifier]
-        {
-            bundleWindows
-        } else if let appName = targetApp?.name,
-                  let namedWindows = self.windowsByIdentifier[appName]
-        {
-            namedWindows
-        } else {
-            []
-        }
-        return UnifiedToolOutput(
-            data: ServiceWindowListData(windows: windows, targetApplication: targetApp),
-            summary: .init(brief: "Found \(windows.count) windows", status: .success),
-            metadata: .init(duration: 0))
-    }
-
-    func getFrontmostApplication() async throws -> ServiceApplicationInfo {
-        self.applications.first ?? ServiceApplicationInfo(processIdentifier: 0, bundleIdentifier: nil, name: "Mock")
-    }
-
-    func isApplicationRunning(identifier: String) async -> Bool {
-        self.applications.contains { app in
-            app.name == identifier || app.bundleIdentifier == identifier
-        }
-    }
-
-    func launchApplication(identifier: String) async throws -> ServiceApplicationInfo {
-        let app = ServiceApplicationInfo(
-            processIdentifier: Int32(self.applications.count + 1),
-            bundleIdentifier: identifier,
-            name: identifier,
-            isActive: true)
-        self.applications.append(app)
-        return app
-    }
-
-    func launchApplication(request: ApplicationLaunchRequest) async throws -> ServiceApplicationInfo {
-        self.launchRequests.append(request)
-        let identifier = request.applicationBundleIdentifier ?? request.applicationIdentifier ?? "Default Handler"
-        let app = ServiceApplicationInfo(
-            processIdentifier: Int32(self.applications.count + 1),
-            processStartIdentity: UInt64(self.applications.count + 1) * 1000,
-            bundleIdentifier: request.applicationBundleIdentifier,
-            name: identifier,
-            isActive: request.activates,
-            isFinishedLaunching: true)
-        self.applications.append(app)
-        return app
-    }
-
-    func relaunchApplication(request: ApplicationRelaunchRequest) async throws -> ServiceApplicationInfo {
-        self.relaunchRequests.append(request)
-        return try await self.launchApplication(request: request.launchRequest)
-    }
-
-    func activateApplication(identifier _: String) async throws {}
-    func activateApplication(request _: ApplicationActivationRequest) async throws {}
-
-    func quitApplication(identifier _: String, force _: Bool) async throws -> Bool {
+    override func quitApplication(identifier _: String, force _: Bool) async throws -> Bool {
         true
     }
-
-    func hideApplication(identifier _: String) async throws {}
-
-    func unhideApplication(identifier _: String) async throws {}
-
-    func hideOtherApplications(identifier _: String) async throws {}
-
-    func showAllApplications() async throws {}
 }
 
 struct MCPToolErrorHandlingTests {

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeTests.swift
@@ -2008,7 +2008,7 @@ final class StubServices: PeekabooBridgeServiceProviding {
     init(
         applications: any ApplicationServiceProtocol = StubApplicationService(),
         automation: (any UIAutomationServiceProtocol)? = nil,
-        windows: any WindowManagementServiceProtocol = StubWindowService(),
+        windows: any WindowManagementServiceProtocol = makeStubWindowService(),
         snapshots: any SnapshotManagerProtocol = SnapshotManager(),
         desktopObservation: (any DesktopObservationServiceProtocol)? = nil,
         ownedDesktopOperationLanes: Set<PeekabooBridgeOperation> = [])
@@ -2105,7 +2105,7 @@ private final class StubNonTargetedServices: PeekabooBridgeServiceProviding {
     let screenCapture: any ScreenCaptureServiceProtocol = StubScreenCaptureService()
     let automation: any UIAutomationServiceProtocol = StubNonTargetedAutomationService()
     let applications: any ApplicationServiceProtocol = StubApplicationService()
-    let windows: any WindowManagementServiceProtocol = StubWindowService()
+    let windows: any WindowManagementServiceProtocol = makeStubWindowService()
     let menu: any MenuServiceProtocol = UnimplementedMenuService()
     let dock: any DockServiceProtocol = UnimplementedDockService()
     let dialogs: any DialogServiceProtocol = UnimplementedDialogService()
@@ -2119,7 +2119,7 @@ private final class StubRemoteAutomationServices: PeekabooBridgeServiceProviding
     let screenCapture: any ScreenCaptureServiceProtocol = StubScreenCaptureService()
     let automation: any UIAutomationServiceProtocol
     let applications: any ApplicationServiceProtocol = StubApplicationService()
-    let windows: any WindowManagementServiceProtocol = StubWindowService()
+    let windows: any WindowManagementServiceProtocol = makeStubWindowService()
     let menu: any MenuServiceProtocol = UnimplementedMenuService()
     let dock: any DockServiceProtocol = UnimplementedDockService()
     let dialogs: any DialogServiceProtocol = UnimplementedDialogService()
@@ -2641,25 +2641,25 @@ final class StubNonTargetedAutomationService: UIAutomationServiceProtocol {
 }
 
 @MainActor
-private final class StubWindowService: WindowManagementServiceProtocol {
-    private let windowsList: [ServiceWindowInfo] = [
-        ServiceWindowInfo(windowID: 1, title: "Stub", bounds: .init(x: 0, y: 0, width: 100, height: 100)),
-    ]
-
-    func closeWindow(target _: WindowTarget) async throws {}
-    func minimizeWindow(target _: WindowTarget) async throws {}
-    func maximizeWindow(target _: WindowTarget) async throws {}
-    func moveWindow(target _: WindowTarget, to _: CGPoint) async throws {}
-    func resizeWindow(target _: WindowTarget, to _: CGSize) async throws {}
-    func setWindowBounds(target _: WindowTarget, bounds _: CGRect) async throws {}
-    func focusWindow(target _: WindowTarget) async throws {}
-    func listWindows(target _: WindowTarget) async throws -> [ServiceWindowInfo] {
-        self.windowsList
+private func makeStubWindowService() -> ScriptedWindowInventoryService {
+    let linkedTarget = AutomationTestFixtures.linkedDesktopTarget(
+        processIdentity: AutomationTestFixtures.processIdentity(
+            processIdentifier: 123,
+            processStartIdentity: 456),
+        bundleIdentifier: "dev.stub",
+        applicationName: "StubApp",
+        windowID: 1,
+        windowTitle: "Stub",
+        bounds: .init(x: 0, y: 0, width: 100, height: 100))
+    let graph: LinkedApplicationInventoryGraph
+    do {
+        graph = try LinkedApplicationInventoryGraph(linkedTargets: [linkedTarget])
+    } catch {
+        preconditionFailure("Invalid bridge inventory fixture: \(error)")
     }
-
-    func getFocusedWindow() async throws -> ServiceWindowInfo? {
-        self.windowsList.first
-    }
+    return ScriptedWindowInventoryService(
+        graph: graph,
+        focusedWindow: linkedTarget.window)
 }
 
 @MainActor


### PR DESCRIPTION
## Summary

- add coherent linked application/window inventory graphs with fail-closed identity validation
- add reusable scripted application and window inventory services with saturating sequences and call recording
- migrate representative CLI, MCP, and Bridge doubles while preserving their transport-specific behavior

## Safety and architecture

- rejects contradictory process generations, window receipts, bounds, window catalogs, and application metadata
- rejects aliases that collide after the same whitespace and PID normalization used during lookup
- revalidates pinned activation, quit, and relaunch targets before scripted mutation
- keeps malformed compatibility fixtures explicit instead of silently repairing them

## Proof

- `pnpm run test:safe` (twice on the final parent; 484 CLI tests in 62 suites plus all release, native-only, certification, and Foundation gates)
- `swift test --package-path Core/PeekabooAutomationKit --filter ScriptedInventoryServicesTests --no-parallel` (8 tests)
- focused Core Bridge/MCP suites (160 tests)
- focused CLI Type/Paste/AppHide/inventory suites (86 tests)
- `pnpm run format`
- `pnpm run lint` (zero serious findings; existing warnings only)
- final P0-P2 structured review clean

No production behavior, protocol, release metadata, or submodule pin changes are included.
