### PR TITLE
fix(cli): honor option terminator for JSON errors

### DIFF
--- a/Apps/CLI/Sources/PeekabooCLI/CLI/PeekabooEntryPoint.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/CLI/PeekabooEntryPoint.swift
@@ -50,8 +50,9 @@ func executePeekabooCLI(arguments: [String]) async -> Int32 {
 }
 
 private func containsJSONOutputFlag(_ arguments: [String]) -> Bool {
-    arguments.contains("--json") || arguments.contains("-j") || arguments.contains("--json-output") ||
-        arguments.contains("--jsonOutput")
+    let rootArguments = arguments.prefix { $0 != "--" }
+    return rootArguments.contains("--json") || rootArguments.contains("-j") ||
+        rootArguments.contains("--json-output") || rootArguments.contains("--jsonOutput")
 }
 
 func commanderErrorMessage(_ error: CommanderProgramError) -> String {

--- a/Apps/CLI/Tests/CLIRuntimeTests/RootEarlyExitRuntimeTests.swift
+++ b/Apps/CLI/Tests/CLIRuntimeTests/RootEarlyExitRuntimeTests.swift
@@ -122,4 +122,22 @@ struct RootEarlyExitRuntimeTests {
         #expect(result.standardOutput.isEmpty)
         #expect(result.standardError.contains("Unknown command '\(argument)'"))
     }
+
+    @Test(arguments: ["--json", "-j", "--json-output", "--jsonOutput"])
+    func `JSON flags after double dash stay ordinary child arguments`(jsonFlag: String) async throws {
+        guard TestChildProcess.canLocatePeekabooBinary() else {
+            Issue.record("Build peekaboo before running CLI runtime tests.")
+            return
+        }
+
+        let result = try await TestChildProcess.runPeekaboo(
+            ["--junk", "--", jsonFlag],
+            isolateFromRemoteHosts: false
+        )
+
+        #expect(result.status == .exited(1))
+        #expect(result.standardOutput.isEmpty)
+        #expect(result.standardError.contains("Error: Unknown command '--junk'"))
+        #expect(!result.standardError.contains("\"success\""))
+    }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Fixed
+- Keep JSON-output flags after the `--` option terminator as child arguments instead of changing Peekaboo's own error envelope.
 - Route CLI and MCP multi-phase result composition through the canonical target-aware sequence accumulator while preserving their established output contracts.
 - Bound asynchronous Accessibility notification add and remove waits, removal joins, and subscription setup retries so one wedged endpoint cannot hang global observer startup or teardown. Thanks @SebTardif for AXorcist #47.
 - Centralize snapshot target-evidence adapters and receipt planning across AutomationKit, CLI, Bridge, and MCP so exact-window identity, coordinate authority, source contradictions, and cancellation keep one fail-closed contract.


### PR DESCRIPTION
## Summary

- stop root JSON-error-mode detection at the standard `--` option terminator
- keep JSON-like child arguments from changing Peekaboo's stdout/stderr contract
- cover all four supported JSON flag spellings with a built-binary subprocess regression

## Testing

- `swift test --package-path Apps/CLI --filter RootEarlyExitRuntimeTests`
- `pnpm run format`
- strict SwiftLint on both touched Swift files
- whole-branch autoreview: clean, no accepted or actionable findings
