### PR TITLE
chore(deps): update bounded AX observer lifecycle

### DIFF
--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Update AXorcist so synchronous and legacy element observers share the bounded registration and cleanup state machine, preventing a wedged endpoint from blocking Peekaboo's main actor indefinitely or escaping late-result rollback.
 - Bound asynchronous Accessibility notification add and remove waits, removal joins, and subscription setup retries so one wedged endpoint cannot hang global observer startup or teardown. Thanks @SebTardif for AXorcist #47.
 
 ## [4.2.1] - 2026-08-17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Fixed
+- Update AXorcist so synchronous and legacy element observers share the bounded registration and cleanup state machine, preventing a wedged endpoint from blocking Peekaboo's main actor indefinitely or escaping late-result rollback.
 - Keep JSON-output flags after the `--` option terminator as child arguments instead of changing Peekaboo's own error envelope.
 - Route CLI and MCP multi-phase result composition through the canonical target-aware sequence accumulator while preserving their established output contracts.
 - Bound asynchronous Accessibility notification add and remove waits, removal joins, and subscription setup retries so one wedged endpoint cannot hang global observer startup or teardown. Thanks @SebTardif for AXorcist #47.


### PR DESCRIPTION
## Summary

- update AXorcist from `470cbd64a7814298a48d3350beeb957a3342c2b9` to `87242ce526e405aca90e419635ae09e3724ad613`
- route synchronous, asynchronous, and legacy element observers through AXorcist's shared bounded pending registration and cleanup lifecycle
- preserve exact late-result rollback, PID-generation isolation, and bounded compatibility removal behavior

## Test plan

- `pnpm run test:safe`
- focused `WindowTrackerServiceTests` — 4/4
- focused `PeekabooDaemonTests` — 9/9
- SwiftFormat — 0/1573
- SwiftLint — exit 0; 84 baseline warnings, 0 serious
- parent-only P0/P1 autoreview — clean
- upstream AXorcist full suite — 201 tests
- upstream AXorcist exact-head CI, Bugbot, ClawSweeper, and Socket checks — clean
- live native smoke — registered `AXFocusedUIElementChanged` against Safari and cancelled cleanly

Upstream implementation and review: openclaw/AXorcist#50.

No release or version publication is included.
