### PR TITLE
chore(deps): update TauTUI terminal buffering

### DIFF
--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Preserve local Option/Meta chords while buffering fragmented terminal escape sequences longer over SSH, and ignore stale cancelled escape timers that arrive after a newer sequence.
 - Update AXorcist so synchronous and legacy element observers share the bounded registration and cleanup state machine, preventing a wedged endpoint from blocking Peekaboo's main actor indefinitely or escaping late-result rollback.
 - Bound asynchronous Accessibility notification add and remove waits, removal joins, and subscription setup retries so one wedged endpoint cannot hang global observer startup or teardown. Thanks @SebTardif for AXorcist #47.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Fixed
+- Preserve local Option/Meta chords while buffering fragmented terminal escape sequences longer over SSH, and ignore stale cancelled escape timers that arrive after a newer sequence.
 - Update AXorcist so synchronous and legacy element observers share the bounded registration and cleanup state machine, preventing a wedged endpoint from blocking Peekaboo's main actor indefinitely or escaping late-result rollback.
 - Keep JSON-output flags after the `--` option terminator as child arguments instead of changing Peekaboo's own error envelope.
 - Route CLI and MCP multi-phase result composition through the canonical target-aware sequence accumulator while preserving their established output contracts.


### PR DESCRIPTION
## Summary

- pin TauTUI to its landed adaptive terminal-input buffering fix
- preserve the 30 ms local Option/Meta window, 50 ms incomplete-sequence window, and 100 ms SSH window
- ignore stale cancelled Escape timers after a newer sequence and document the user-visible fix in both Unreleased changelogs

Upstream: steipete/TauTUI#17, merge `9dd08f3312d173ef3a3f12870f23c12e59cf7512`.

## Proof

- `pnpm run build:cli`
- `pnpm run test:safe` (including 484 CLI tests / 62 suites)
- `pnpm run lint` (0 serious; 84 existing warnings)
- `pnpm run format` (0/1573 files changed)
- parent-only P0-P1 autoreview: clean, no accepted/actionable findings
- upstream TauTUI: 182 tests, release build, SwiftFormat, SwiftLint, mutation proof for the stale-callback generation guard, exact-head CI across macOS/Ubuntu Swift 6.2/6.3.3, and clean ClawSweeper review
