### PR TITLE
fix: preserve uncertain set-value outcomes

### DIFF
--- a/Apps/CLI/Tests/CLIAutomationTests/ActionOutcomeCommandTests.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/ActionOutcomeCommandTests.swift
@@ -1245,7 +1245,7 @@ struct ActionOutcomeCommandTests {
         return snapshotID
     }
 
-    private static func storeExactWindowElementSnapshot(in snapshots: StubSnapshotManager) async throws -> String {
+    static func storeExactWindowElementSnapshot(in snapshots: StubSnapshotManager) async throws -> String {
         let snapshotID = try await snapshots.createSnapshot()
         let bounds = CGRect(x: 100, y: 100, width: 500, height: 400)
         let processIdentity = AutomationTestFixtures.processIdentity(

--- a/Apps/CLI/Tests/CLIAutomationTests/SetValueOutcomeCommandTests.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/SetValueOutcomeCommandTests.swift
@@ -1,0 +1,74 @@
+import Foundation
+import PeekabooAutomationKit
+import PeekabooAutomationKitTestSupport
+import PeekabooCore
+import PeekabooFoundation
+import Testing
+@testable import PeekabooCLI
+
+@MainActor
+@Suite(.serialized)
+struct SetValueOutcomeCommandTests {
+    @Test
+    func `post-dispatch readback failure preserves receipt and blocks blind replay`() async throws {
+        let automation = OutcomeStubAutomationService()
+        let snapshots = StubSnapshotManager()
+        let services = TestServicesFactory.makePeekabooServices(
+            snapshots: snapshots,
+            automation: automation
+        )
+        let snapshotID = try await ActionOutcomeCommandTests.storeExactWindowElementSnapshot(in: snapshots)
+        let targetReceipt = DesktopActionTargetReceipt(
+            processIdentifier: 12345,
+            processStartIdentity: 7,
+            windowID: 42
+        )
+        automation.uiAutomationOutcomeScript.appendFailure(
+            DesktopActionFailure.indeterminate(
+                delivery: .init(mechanism: .accessibilityValue, mode: .background),
+                evidence: .completionUnknown,
+                unitCount: .one,
+                message: "The submitted value could not be read back.",
+                hint: "Observe the exact target before retrying."
+            )
+            .attributed(to: targetReceipt),
+            for: .setValue
+        )
+        let arguments = [
+            "set-value", "updated", "--on", "elem_3", "--snapshot", snapshotID,
+            "--json", "--no-remote",
+        ]
+
+        let first = try await InProcessCommandRunner.run(arguments, services: services)
+        let firstObject = try Self.jsonObject(first.stdout)
+        let outcome = try #require(firstObject["outcome"] as? [String: Any])
+        let error = try #require(firstObject["error"] as? [String: Any])
+        let receipt = try #require(firstObject["target_receipt"] as? [String: Any])
+        #expect(first.exitStatus == 1)
+        #expect(outcome["state"] as? String == "indeterminate")
+        #expect(outcome["delivery_mechanism"] as? String == "accessibility_value")
+        #expect(outcome["delivery_mode"] as? String == "background")
+        #expect(outcome["dispatch_state"] as? String == "may_have_dispatched")
+        #expect(outcome["dispatched_unit_count"] as? Int == 1)
+        #expect(outcome["retry_safe"] as? Bool == false)
+        #expect(outcome["requires_fresh_observation"] as? Bool == true)
+        #expect(error["retry_safe"] as? Bool == false)
+        #expect(error["mutation_dispatched"] as? Bool == true)
+        #expect(receipt["pid"] as? Int == Int(targetReceipt.processIdentifier))
+        #expect(receipt["process_start_identity_decimal"] as? String == "7")
+        #expect(receipt["window_id"] as? Int == targetReceipt.windowID)
+
+        let second = try await InProcessCommandRunner.run(arguments, services: services)
+        let secondObject = try Self.jsonObject(second.stdout)
+        let secondOutcome = try #require(secondObject["outcome"] as? [String: Any])
+        #expect(second.exitStatus == 1)
+        #expect(secondOutcome["state"] as? String == "refused")
+        #expect(secondOutcome["mutation_dispatched"] as? Bool == false)
+        #expect(automation.uiAutomationOutcomeScript.callCount(for: .setValue) == 1)
+        #expect(try await snapshots.getDetectionResult(snapshotId: snapshotID) != nil)
+    }
+
+    private static func jsonObject(_ output: String) throws -> [String: Any] {
+        try #require(JSONSerialization.jsonObject(with: Data(output.utf8)) as? [String: Any])
+    }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 - Refuse fuzzy application selectors before CLI or MCP mutations are pinned to a process, while preserving fuzzy read-only discovery.
+- Preserve exact target and dispatch receipts when a submitted Accessibility `set-value` write cannot be verified, so CLI, MCP, and Bridge callers receive retry-unsafe guidance instead of a raw error.
 - Preserve local Option/Meta chords while buffering fragmented terminal escape sequences longer over SSH, and ignore stale cancelled escape timers that arrive after a newer sequence.
 - Update AXorcist so synchronous and legacy element observers share the bounded registration and cleanup state machine, preventing a wedged endpoint from blocking Peekaboo's main actor indefinitely or escaping late-result rollback.
 - Keep JSON-output flags after the `--` option terminator as child arguments instead of changing Peekaboo's own error envelope.

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/ActionInputDriver.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/ActionInputDriver.swift
@@ -355,18 +355,18 @@ struct ActionInputDriver: ActionInputDriving {
                 let requested = try Self.booleanValue(value, role: element.role)
                 let selectedBefore = element.selectedValue
                 let alreadyMatched = selectedBefore == requested
-                if !alreadyMatched {
-                    try element.setAutomationSelected(requested)
+                if alreadyMatched {
+                    return UIInputExecutionResult.Action(
+                        outcome: .confirmedNoChange(),
+                        actionName: kAXSelectedAttribute as String,
+                        anchorPoint: element.anchorPoint,
+                        elementRole: element.role)
                 }
+                try element.setAutomationSelected(requested)
                 guard element.selectedValue == requested else {
-                    throw ActionInputError.failed(
-                        "Accessibility selection did not change to the requested value. " +
-                            "This control may require input events; click or focus it, then use targeted typing, " +
-                            "or retry with explicit foreground delivery.")
+                    throw Self.unverifiedValueMutationFailure(attribute: kAXSelectedAttribute as String)
                 }
-                let outcome = Self.valueMutationOutcome(
-                    alreadyMatched: alreadyMatched,
-                    preStateKnown: selectedBefore != nil)
+                let outcome = Self.dispatchedValueMutationOutcome(preStateKnown: selectedBefore != nil)
                 return UIInputExecutionResult.Action(
                     outcome: outcome,
                     actionName: kAXSelectedAttribute as String,
@@ -377,35 +377,41 @@ struct ActionInputDriver: ActionInputDriving {
             let valueBefore = element.value
             let requested = try Self.coerceValue(value, currentValue: valueBefore, role: element.role)
             let alreadyMatched = Self.value(valueBefore, matches: requested)
-            if !alreadyMatched {
-                try element.setAutomationValue(requested)
+            if alreadyMatched {
+                return UIInputExecutionResult.Action(
+                    outcome: .confirmedNoChange(),
+                    actionName: AXActionNames.kAXSetValueAction,
+                    anchorPoint: element.anchorPoint,
+                    elementRole: element.role)
             }
+            try element.setAutomationValue(requested)
             guard Self.value(element.value, matches: requested) else {
-                throw ActionInputError.failed(
-                    "Accessibility value did not change to the requested value. " +
-                        "This control may require input events; click or focus it, then use targeted typing, " +
-                        "or retry with explicit foreground delivery.")
+                throw Self.unverifiedValueMutationFailure(attribute: AXActionNames.kAXSetValueAction)
             }
-            let outcome = Self.valueMutationOutcome(
-                alreadyMatched: alreadyMatched,
-                preStateKnown: valueBefore != nil)
+            let outcome = Self.dispatchedValueMutationOutcome(preStateKnown: valueBefore != nil)
             return UIInputExecutionResult.Action(
                 outcome: outcome,
                 actionName: AXActionNames.kAXSetValueAction,
                 anchorPoint: element.anchorPoint,
                 elementRole: element.role)
+        } catch let failure as DesktopActionFailure {
+            throw failure
         } catch {
             throw Self.classify(error)
         }
     }
 
-    private static func valueMutationOutcome(
-        alreadyMatched: Bool,
-        preStateKnown: Bool) -> DesktopActionOutcome
-    {
-        if alreadyMatched {
-            return .confirmedNoChange()
-        }
+    private static func unverifiedValueMutationFailure(attribute: String) -> DesktopActionFailure {
+        .indeterminate(
+            delivery: self.accessibilityValueDelivery,
+            evidence: .completionUnknown,
+            unitCount: .one,
+            message: "The accessibility value write was accepted, but its requested result could not be verified.",
+            hint: "Observe the exact target before deciding whether to retry; do not reuse the prior snapshot.",
+            causeDescription: "Post-dispatch readback did not confirm \(attribute).")
+    }
+
+    private static func dispatchedValueMutationOutcome(preStateKnown: Bool) -> DesktopActionOutcome {
         if preStateKnown {
             return .confirmedChange(delivery: self.accessibilityValueDelivery)
         }

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Strategy/DesktopOperationExecutor.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Strategy/DesktopOperationExecutor.swift
@@ -22,11 +22,15 @@ final class DesktopOperationExecutor {
         _ plan: DesktopOperationPlan) async throws -> UIAutomationActionResult<UIInputExecutionResult>
     {
         let targetIdentity = try plan.targetIdentity()
-        let result = try await self.execute(plan)
-        return UIAutomationActionResult(
-            payload: result,
-            outcome: result.outcome,
-            targetIdentity: targetIdentity)
+        do {
+            let result = try await self.execute(plan)
+            return UIAutomationActionResult(
+                payload: result,
+                outcome: result.outcome,
+                targetIdentity: targetIdentity)
+        } catch let failure as DesktopActionFailure {
+            throw failure.attributed(to: targetIdentity?.actionTargetReceipt)
+        }
     }
 
     func executeOwned(_ plan: DesktopOperationPlan) async throws -> UIInputExecutionResult {

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ActionInputDriverTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ActionInputDriverTests.swift
@@ -102,6 +102,25 @@ struct ActionInputDriverTests {
         #expect(reason == .valueNotSettable)
     }
 
+    @MainActor
+    @Test
+    func `set value predispatch refusal never acquires dispatch semantics`() {
+        let element = MockAutomationElement(
+            role: "AXSecureTextField",
+            value: "secret",
+            isValueSettable: true)
+
+        do {
+            _ = try ActionInputDriver().trySetValueForTesting(element: element, value: .string("replacement"))
+            Issue.record("Expected secure value mutation to be refused")
+        } catch let error as ActionInputError {
+            #expect(error == .unsupported(.secureValueNotAllowed))
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+        #expect(element.setValues.isEmpty)
+    }
+
     @Test
     func `scroll action unavailable becomes fallback eligible`() {
         #expect(ActionInputDriver.shouldContinueTryingScrollActionForTesting(after: .targetUnavailable))
@@ -829,7 +848,7 @@ struct ActionInputDriverTests {
 
     @MainActor
     @Test
-    func `phantom-success setter fails when value does not change`() {
+    func `accepted value setter with unconfirmed readback is retry unsafe`() {
         let element = MockAutomationElement(
             role: AXRoleNames.kAXSliderRole,
             value: 50.0,
@@ -839,22 +858,23 @@ struct ActionInputDriverTests {
         do {
             _ = try ActionInputDriver().trySetValueForTesting(element: element, value: .string("0.75"))
             Issue.record("Expected unchanged value to fail verification")
-        } catch let error as ActionInputError {
-            guard case let .failed(message) = error else {
-                Issue.record("Unexpected action input error: \(error)")
-                return
-            }
-            #expect(message.contains("did not change"))
-            #expect(message.contains("targeted typing"))
-            #expect(element.setValues == [.double(0.75)])
+        } catch let failure as DesktopActionFailure {
+            #expect(failure.outcome.state == .indeterminate)
+            #expect(failure.outcome.evidence == .completionUnknown)
+            #expect(failure.outcome.delivery == .init(mechanism: .accessibilityValue, mode: .background))
+            #expect(failure.outcome.dispatchState == .mayHaveDispatched(unitCount: .one))
+            #expect(failure.outcome.retrySafety == .unsafe)
+            #expect(failure.outcome.projection.requiresFreshObservation)
+            #expect(failure.hint?.contains("Observe the exact target") == true)
         } catch {
             Issue.record("Unexpected error: \(error)")
         }
+        #expect(element.setValues == [.double(0.75)])
     }
 
     @MainActor
     @Test
-    func `unverifiable value setter fails instead of fabricating a result`() {
+    func `unreadable post-dispatch value is indeterminate instead of a raw driver error`() {
         let element = MockAutomationElement(
             role: AXRoleNames.kAXSliderRole,
             isValueSettable: true,
@@ -863,14 +883,15 @@ struct ActionInputDriverTests {
         do {
             _ = try ActionInputDriver().trySetValueForTesting(element: element, value: .double(0.75))
             Issue.record("Expected unverifiable value to fail")
-        } catch let error as ActionInputError {
-            guard case .failed = error else {
-                Issue.record("Unexpected action input error: \(error)")
-                return
-            }
+        } catch let failure as DesktopActionFailure {
+            #expect(failure.outcome.state == .indeterminate)
+            #expect(failure.outcome.dispatchState == .mayHaveDispatched(unitCount: .one))
+            #expect(failure.outcome.retrySafety == .unsafe)
+            #expect(failure.targetReceipt == nil)
         } catch {
             Issue.record("Unexpected error: \(error)")
         }
+        #expect(element.setValues == [.double(0.75)])
     }
 
     @MainActor

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/DesktopOperationExecutorTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/DesktopOperationExecutorTests.swift
@@ -200,6 +200,42 @@ struct DesktopOperationExecutorTests {
     }
 
     @Test
+    func `target-aware execution attributes post-dispatch failure to exact window`() async throws {
+        let process = ApplicationProcessIdentity(processIdentifier: 503, processStartIdentity: 17)
+        let bounds = CGRect(x: 10, y: 20, width: 640, height: 480)
+        let windowIdentity = WindowMutationIdentity(
+            windowID: 91,
+            ownerProcessIdentifier: process.processIdentifier,
+            ownerProcessStartIdentity: process.processStartIdentity,
+            capturedBounds: bounds)
+        let receipt = try DesktopOperationPlan.CaptureReceipt(
+            target: .exactWindow(.init(identity: windowIdentity, bounds: bounds)))
+        let plan = try self.makePlan(
+            strategy: .actionOnly,
+            receipt: receipt,
+            action: .init {
+                throw DesktopActionFailure.indeterminate(
+                    delivery: .init(mechanism: .accessibilityValue, mode: .background),
+                    evidence: .completionUnknown,
+                    unitCount: .one,
+                    message: "Readback failed")
+            },
+            synthesis: .init { Self.backgroundSynthOutcome })
+
+        do {
+            _ = try await DesktopOperationExecutor().executeWithTargetIdentity(plan)
+            Issue.record("Expected attributed post-dispatch failure")
+        } catch let failure as DesktopActionFailure {
+            #expect(failure.targetReceipt == DesktopActionTargetReceipt(
+                processIdentifier: process.processIdentifier,
+                processStartIdentity: process.processStartIdentity,
+                windowID: windowIdentity.windowID))
+            #expect(failure.outcome.dispatchState == .mayHaveDispatched(unitCount: .one))
+            #expect(failure.outcome.retrySafety == .unsafe)
+        }
+    }
+
+    @Test
     func `background plan preserves unsafe foreground failure semantics`() async throws {
         let identity = ApplicationProcessIdentity(processIdentifier: 501, processStartIdentity: 1)
         let plan = try self.makePlan(

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeOperationResultSemantics.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeOperationResultSemantics.swift
@@ -401,6 +401,10 @@ enum PeekabooBridgeOperationResultSemantics {
             switch (self.typedResponseRule, response) {
             case (.none, _):
                 return
+            case (.setValue, .error):
+                // A canonical failure has no success payload to bind. Its outcome, target receipt,
+                // and dispatch count are validated by the failure and receipt contracts instead.
+                return
             case let (.typeActions(expected), .typeResult(result)):
                 guard expected.keyPresses > 0 else {
                     throw PeekabooBridgeOperationReceiptError.receiptMismatch(

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPToolExecutionTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPToolExecutionTests.swift
@@ -817,6 +817,52 @@ struct MCPToolExecutionTests {
     }
 
     @Test
+    func `set_value tool preserves post-dispatch readback failure and exact retry guidance`() async throws {
+        let automation = await MainActor.run { MockElementActionAutomationService(accessibilityGranted: true) }
+        let receipt = DesktopActionTargetReceipt(
+            processIdentifier: 42,
+            processStartIdentity: 9,
+            windowID: 73)
+        await MainActor.run {
+            automation.uiAutomationOutcomeScript.appendFailure(
+                DesktopActionFailure.indeterminate(
+                    delivery: .init(mechanism: .accessibilityValue, mode: .background),
+                    evidence: .completionUnknown,
+                    unitCount: .one,
+                    message: "The submitted value could not be read back.",
+                    hint: "Observe the exact target before retrying.")
+                    .attributed(to: receipt),
+                for: .setValue)
+        }
+        let context = await MCPToolTestHelpers.makeLegacyContext(automation: automation)
+        let snapshot = await UISnapshotManager.shared.createSnapshot()
+        let snapshotID = await snapshot.id
+
+        let response = try await SetValueTool(context: context).execute(arguments: ToolArguments(raw: [
+            "on": "T1",
+            "value": "hello",
+            "snapshot": snapshotID,
+        ]))
+
+        let meta = try #require(response.meta?.objectValue)
+        let target = try #require(meta["target_receipt"]?.objectValue)
+        #expect(response.isError)
+        #expect(meta["state"] == .string("indeterminate"))
+        #expect(meta["delivery_mechanism"] == .string("accessibility_value"))
+        #expect(meta["delivery_mode"] == .string("background"))
+        #expect(meta["dispatch_state"] == .string("may_have_dispatched"))
+        #expect(meta["dispatched_unit_count"] == .int(1))
+        #expect(meta["retry_safe"] == .bool(false))
+        #expect(meta["requires_fresh_observation"] == .bool(true))
+        #expect(meta["invalidated_snapshot"] == .string(snapshotID))
+        #expect(target["pid"] == .int(Int(receipt.processIdentifier)))
+        #expect(target["process_start_identity_decimal"] == .string("9"))
+        #expect(target["window_id"] == .int(73))
+        #expect(await UISnapshotManager.shared.getSnapshot(id: nil) == nil)
+        #expect(await MainActor.run { automation.setValueCalls.isEmpty })
+    }
+
+    @Test
     func `action tool validates request shape`() async throws {
         let automation = await MainActor.run { MockElementActionAutomationService(accessibilityGranted: true) }
         let context = await MCPToolTestHelpers.makeLegacyContext(automation: automation)
@@ -1151,7 +1197,8 @@ TargetedTypeServiceProtocol {
 }
 
 @MainActor
-private final class MockElementActionAutomationService: MockAutomationService, ElementActionAutomationServiceProtocol {
+private final class MockElementActionAutomationService: MockAutomationService, ElementActionAutomationServiceProtocol,
+ScriptedUIAutomationActionOutcomeProviding {
     struct SetValueCall {
         let target: String
         let value: UIElementValue
@@ -1166,6 +1213,7 @@ private final class MockElementActionAutomationService: MockAutomationService, E
 
     private(set) var setValueCalls: [SetValueCall] = []
     private(set) var performActionCalls: [PerformActionCall] = []
+    let uiAutomationOutcomeScript = UIAutomationOutcomeScript()
 
     func setValue(target: String, value: UIElementValue, snapshotId: String?) async throws -> ElementActionResult {
         self.setValueCalls.append(SetValueCall(target: target, value: value, snapshotId: snapshotId))

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeSetValueFailureTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeSetValueFailureTests.swift
@@ -1,0 +1,75 @@
+import Foundation
+import PeekabooAutomationKit
+import PeekabooBridgeTestSupport
+import PeekabooCore
+import PeekabooFoundation
+import Testing
+@testable import PeekabooBridge
+
+struct PeekabooBridgeSetValueFailureTests {
+    @Test
+    func `signed client preserves post-dispatch readback failure and target receipt`() async throws {
+        let socketPath = "/tmp/peekaboo-bridge-set-value-failure-\(UUID().uuidString).sock"
+        let services = await MainActor.run { StubServices() }
+        let processGeneration = try #require(SystemIdentityResolver.processStartIdentity(getpid()))
+        let targetReceipt = DesktopActionTargetReceipt(
+            processIdentifier: getpid(),
+            processStartIdentity: processGeneration)
+        await MainActor.run {
+            services.automationStub.actionOutcome = .dispatchedUnverified(
+                delivery: .init(mechanism: .accessibilityValue, mode: .background),
+                evidence: .deliveryAccepted,
+                unitCount: .one)
+            services.automationStub.uiAutomationOutcomeTargetIdentity = try? DesktopTargetIdentity(
+                processIdentity: .init(
+                    processIdentifier: getpid(),
+                    processStartIdentity: processGeneration))
+            services.automationStub.elementActionError = DesktopActionFailure.indeterminate(
+                delivery: .init(mechanism: .accessibilityValue, mode: .background),
+                evidence: .completionUnknown,
+                unitCount: .one,
+                message: "The submitted value could not be read back.",
+                hint: "Observe the exact target before retrying.")
+                .attributed(to: targetReceipt)
+        }
+        let server = await MainActor.run {
+            PeekabooBridgeServer(
+                services: services,
+                hostKind: .gui,
+                allowlistedTeams: [],
+                allowlistedBundles: [])
+        }
+        let host = PeekabooBridgeHost(
+            socketPath: socketPath,
+            server: server,
+            allowedTeamIDs: [],
+            requestTimeoutSec: 2)
+        try await host.startChecked()
+        defer { Task { await host.stop() } }
+
+        let client = TrustedBridgeClientFixture.make(socketPath: socketPath, requestTimeoutSec: 2)
+        _ = try await client.handshake(client: .init(
+            bundleIdentifier: "dev.peekaboo.set-value-failure-tests",
+            teamIdentifier: nil,
+            processIdentifier: getpid(),
+            hostname: nil))
+        let remote = await MainActor.run { RemoteElementActionUIAutomationService(client: client) }
+        do {
+            _ = try await remote.setValueWithOutcome(
+                target: "T1",
+                value: .string("hello"),
+                snapshotId: "S1")
+            Issue.record("Expected typed set-value failure")
+        } catch let failure as DesktopActionFailure {
+            #expect(failure.message == "The submitted value could not be read back.")
+            #expect(failure.outcome.route == .bridge)
+            #expect(failure.outcome.state == .indeterminate)
+            #expect(failure.outcome.delivery == .init(mechanism: .accessibilityValue, mode: .background))
+            #expect(failure.outcome.dispatchState == .mayHaveDispatched(unitCount: .one))
+            #expect(failure.outcome.retrySafety == .unsafe)
+            #expect(failure.outcome.projection.requiresFreshObservation)
+            #expect(failure.targetReceipt == targetReceipt)
+            #expect(failure.hint?.contains("Observe the exact target") == true)
+        }
+    }
+}

--- a/docs/commands/set-value.md
+++ b/docs/commands/set-value.md
@@ -28,6 +28,9 @@ read_when:
 - A result with `requires_fresh_observation: true`, or no canonical outcome, makes that snapshot mutation-ineligible.
   The old evidence stays readable, but another mutation must use a new `peekaboo see` snapshot and otherwise fails
   before dispatch.
+- If the Accessibility write is accepted but its readback cannot be verified, Peekaboo reports an indeterminate,
+  retry-unsafe result with the exact target receipt. Observe the target again before deciding whether to retry; never
+  replay the write against the old snapshot.
 - Secure/password fields are rejected; use explicit typing flows for those contexts.
 - This is not a replacement for `peekaboo type` when the app needs observable keystrokes, IME handling, autocomplete, or undo grouping.
 - JSON output includes `target`, `actionName`, `oldValue`, `newValue`, and `executionTime`.


### PR DESCRIPTION
## Summary

- return a canonical retry-unsafe indeterminate outcome when an accepted Accessibility value write cannot be confirmed by readback
- attach the capture-time process/window receipt to typed execution failures
- preserve the typed failure through CLI, MCP, and signed Bridge transport, and refuse replay against the consumed snapshot

## Tests

- `swift test --package-path Core/PeekabooAutomationKit --filter 'ActionInputDriverTests|DesktopOperationExecutorTests'`
- `PEEKABOO_INCLUDE_AUTOMATION_TESTS=true PEEKABOO_INCLUDE_AMBIENT_STATE_TESTS=false swift test --package-path Apps/CLI -Xswiftc -DPEEKABOO_SKIP_AUTOMATION --filter 'post-dispatch readback failure preserves receipt and blocks blind replay'`
- `swift test --package-path Core/PeekabooCore --filter 'set_value tool preserves post-dispatch readback failure|signed client preserves post-dispatch readback failure'`
- `pnpm run test:safe` (before the changelog-only rebase resolution; rebased focused tests repeated above)
- `swiftlint lint --config .swiftlint.yml --quiet`
- autoreview clean against `origin/main`

## Documentation

- document the observe-before-retry contract for unverified `set-value` writes
- add an Unreleased changelog entry
