### PR TITLE
fix(cli): validate malformed requests before runtime

### DIFF
--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Pin foreground menu focus, clicks, and listing to one exact process/window generation across CLI and MCP, preserving focus outcomes when a later menu read fails.
 - Refuse fuzzy application selectors before app, menu, window, or background click mutations are pinned to a process, while preserving fuzzy read-only discovery.
 - Align CLI help and Agent guidance with receipt-pinned background keyboard input, targeted dialog AXValue, and explicit foreground consent for foreground-exposing actions.
+- Refuse targetless background typing, malformed browser requests, and invalid video inputs before runtime discovery, with path-specific media errors and CLI-native browser recovery.
 - Preserve local Option/Meta chords while buffering fragmented terminal escape sequences longer over SSH, and ignore stale cancelled escape timers that arrive after a newer sequence.
 - Update AXorcist so synchronous and legacy element observers share the bounded registration and cleanup state machine, preventing a wedged endpoint from blocking Peekaboo's main actor indefinitely or escaping late-result rollback.
 - Bound asynchronous Accessibility notification add and remove waits, removal joins, and subscription setup retries so one wedged endpoint cannot hang global observer startup or teardown. Thanks @SebTardif for AXorcist #47.

--- a/Apps/CLI/Sources/PeekabooCLI/CLI/CommanderRuntimeExecutor.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/CLI/CommanderRuntimeExecutor.swift
@@ -26,12 +26,26 @@ enum CommanderRuntimeExecutorError: LocalizedError {
 
 @MainActor
 enum CommanderRuntimeExecutor {
-    static func resolveAndRun(arguments: [String]) async throws {
-        let resolved = try CommanderRuntimeRouter.resolve(argv: arguments)
-        try await self.run(resolved: resolved)
+    struct RuntimeFactory {
+        let make: @MainActor (CommandRuntimeOptions) async throws -> CommandRuntime
+
+        static let live = Self { options in
+            try await CommandRuntime.makeDefaultAsync(options: options)
+        }
     }
 
-    static func run(resolved: CommanderResolvedCommand) async throws {
+    static func resolveAndRun(
+        arguments: [String],
+        runtimeFactory: RuntimeFactory = .live
+    ) async throws {
+        let resolved = try CommanderRuntimeRouter.resolve(argv: arguments)
+        try await self.run(resolved: resolved, runtimeFactory: runtimeFactory)
+    }
+
+    static func run(
+        resolved: CommanderResolvedCommand,
+        runtimeFactory: RuntimeFactory = .live
+    ) async throws {
         let command = try CommanderCLIBinder.instantiateCommand(
             type: resolved.type,
             parsedValues: resolved.parsedValues
@@ -41,13 +55,14 @@ enum CommanderRuntimeExecutor {
             if let validatingCommand = command as? any PreRuntimeValidatingCommand {
                 try validatingCommand.validateBeforeRuntime()
             }
-            try await self.runCommand(command, resolved: resolved)
+            try await self.runCommand(command, resolved: resolved, runtimeFactory: runtimeFactory)
         }
     }
 
     private static func runCommand(
         _ command: any ParsableCommand,
-        resolved: CommanderResolvedCommand
+        resolved: CommanderResolvedCommand,
+        runtimeFactory: RuntimeFactory
     ) async throws {
         if var runtimeCommand = command as? any AsyncRuntimeCommand {
             let runtimeOptions = try CommanderCLIBinder.makeRuntimeOptions(
@@ -59,7 +74,7 @@ enum CommanderRuntimeExecutor {
                 // Respect explicit engine choice; also allow disabling CG globally.
                 setenv("PEEKABOO_CAPTURE_ENGINE", capturePreference, 1)
             }
-            let runtime = try await CommandRuntime.makeDefaultAsync(options: runtimeOptions)
+            let runtime = try await runtimeFactory.make(runtimeOptions)
             try await self.catchUpSelectedHostIfNeeded(
                 using: runtime,
                 required: runtimeOptions.requiresImplicitSnapshotInvalidation ||

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Core/CaptureCommand+Video.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Core/CaptureCommand+Video.swift
@@ -7,6 +7,55 @@ import PeekabooFoundation
 
 // MARK: Video capture
 
+private enum CaptureVideoInputError: LocalizedError, ResultEnvelopeError {
+    case invalidOption(String)
+    case missingFile(String)
+    case unreadableFile(String)
+    case nonFileInput(String)
+
+    nonisolated var errorDescription: String? {
+        switch self {
+        case let .invalidOption(message):
+            "Invalid input: \(message)"
+        case let .missingFile(path):
+            "Input video file does not exist: \(path)"
+        case let .unreadableFile(path):
+            "Input video file is not readable: \(path)"
+        case let .nonFileInput(path):
+            "Input video path is not a regular file: \(path)"
+        }
+    }
+
+    nonisolated var envelopeCode: ErrorCode? {
+        .INVALID_INPUT
+    }
+
+    nonisolated var envelopeEffect: ActionEffect? {
+        nil
+    }
+
+    nonisolated var envelopeRetrySafe: Bool? {
+        true
+    }
+
+    nonisolated var envelopeMutationDispatched: Bool? {
+        false
+    }
+
+    nonisolated var envelopeHint: String? {
+        switch self {
+        case let .invalidOption(message):
+            if message.hasPrefix("sample-fps") {
+                "Use --sample-fps with a finite value greater than 0."
+            } else {
+                "Correct the video sampling options and retry."
+            }
+        case .missingFile, .unreadableFile, .nonFileInput:
+            "Check the path and pass an existing readable video file."
+        }
+    }
+}
+
 @MainActor
 struct CaptureVideoCommand: ErrorHandlingCommand, OutputFormattable, RuntimeOptionsConfigurable,
 InjectedRuntimeBackedCommand {
@@ -32,14 +81,12 @@ InjectedRuntimeBackedCommand {
     var runtimeOptions = CommandRuntimeOptions()
 
     mutating func run(using runtime: CommandRuntime) async throws {
+        try self.validateBeforeRuntime()
         self.runtime = runtime
         self.logger.setJsonOutputMode(self.jsonOutput)
         self.logger.operationStart("capture_video", metadata: ["input": self.input])
 
         do {
-            if self.sampleFps != nil, self.every != nil {
-                throw ValidationError("--sample-fps and --every are mutually exclusive")
-            }
             let outputDir = try self.resolveOutputDirectory()
             let options = try self.buildOptions()
             let videoURL = self.inputVideoURL()
@@ -106,6 +153,41 @@ InjectedRuntimeBackedCommand {
         }
     }
 
+    func validateBeforeRuntime() throws {
+        if self.sampleFps != nil, self.every != nil {
+            throw ValidationError("--sample-fps and --every are mutually exclusive")
+        }
+        do {
+            try VideoFrameRequestValidator.validate(
+                sampleFps: self.sampleFps,
+                everyMs: self.every?.roundedMilliseconds,
+                startMs: self.start?.roundedMilliseconds,
+                endMs: self.end?.roundedMilliseconds,
+                resolutionCap: self.resolutionCap
+            )
+        } catch let PeekabooError.invalidInput(message) {
+            throw CaptureVideoInputError.invalidOption(message)
+        }
+        _ = try self.buildOptions()
+
+        let videoURL = self.inputVideoURL()
+        let resolvedVideoURL = videoURL.resolvingSymlinksInPath()
+        var isDirectory = ObjCBool(false)
+        guard FileManager.default.fileExists(atPath: resolvedVideoURL.path, isDirectory: &isDirectory) else {
+            throw CaptureVideoInputError.missingFile(videoURL.path)
+        }
+        guard !isDirectory.boolValue else {
+            throw CaptureVideoInputError.nonFileInput(videoURL.path)
+        }
+        let attributes = try? FileManager.default.attributesOfItem(atPath: resolvedVideoURL.path)
+        guard attributes?[.type] as? FileAttributeType == .typeRegular else {
+            throw CaptureVideoInputError.nonFileInput(videoURL.path)
+        }
+        guard FileManager.default.isReadableFile(atPath: resolvedVideoURL.path) else {
+            throw CaptureVideoInputError.unreadableFile(videoURL.path)
+        }
+    }
+
     func buildOptions() throws -> CaptureOptions {
         let maxFrames = max(self.maxFrames ?? 10000, 1)
         let resolutionCap = self.resolutionCap ?? 1440
@@ -169,6 +251,7 @@ extension CaptureVideoCommand: ParsableCommand {
 }
 
 extension CaptureVideoCommand: AsyncRuntimeCommand {}
+extension CaptureVideoCommand: PreRuntimeValidatingCommand {}
 
 @MainActor
 extension CaptureVideoCommand: CommanderBindableCommand {

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/KeyboardDeliverySupport.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/KeyboardDeliverySupport.swift
@@ -9,6 +9,18 @@ enum KeyboardDeliveryMode: String {
 }
 
 enum KeyboardDeliverySupport {
+    static func validateBackgroundTargetRequirement(
+        target: InteractionTargetOptions,
+        snapshotId: String?,
+        foreground: Bool
+    ) throws {
+        guard !foreground else { return }
+        let hasSnapshot = snapshotId?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
+        guard target.hasAnyTarget || hasSnapshot else {
+            throw self.backgroundTargetRequiredError()
+        }
+    }
+
     static func requireBackgroundKeyboardTarget(
         target: InteractionTargetOptions,
         snapshotId: String?,
@@ -31,12 +43,7 @@ enum KeyboardDeliverySupport {
                 requiresExplicitExactWindow: requiresExplicitExactWindow
             ).target
         } catch DesktopTargetPlanning.BackgroundKeyboardTargetPlanningError.targetRequired {
-            throw PreDispatchActionError(
-                message: "Keyboard input requires --app, --pid, --window-id, or --snapshot for background delivery.",
-                code: .VALIDATION_ERROR,
-                hint: "Use --foreground for intentional global input.",
-                reason: .invalidRequest
-            )
+            throw self.backgroundTargetRequiredError()
         } catch let error as DesktopTargetPlanning.BackgroundKeyboardTargetPlanningError {
             throw ValidationError(error.localizedDescription)
         } catch let error as DesktopTargetPlanningError {
@@ -51,6 +58,15 @@ enum KeyboardDeliverySupport {
                     "Capture fresh UI state. (\(error.localizedDescription))"
             )
         }
+    }
+
+    private static func backgroundTargetRequiredError() -> PreDispatchActionError {
+        PreDispatchActionError(
+            message: "Keyboard input requires --app, --pid, --window-id, or --snapshot for background delivery.",
+            code: .VALIDATION_ERROR,
+            hint: "Use --foreground for intentional global input.",
+            reason: .invalidRequest
+        )
     }
 
     private static func validationError(for error: DesktopTargetPlanningError) -> Commander.ValidationError {

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/TypeCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/TypeCommand.swift
@@ -408,6 +408,11 @@ extension TypeCommand: PreRuntimeValidatingCommand {
         var command = self
         try command.validate()
         _ = try command.buildActions()
+        try KeyboardDeliverySupport.validateBackgroundTargetRequirement(
+            target: self.target,
+            snapshotId: self.snapshot,
+            foreground: self.focusOptions.foreground
+        )
     }
 }
 

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/MCP/BrowserCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/MCP/BrowserCommand.swift
@@ -1,7 +1,37 @@
 import Commander
 import Foundation
 import PeekabooCore
+import PeekabooFoundation
 import TachikomaMCP
+
+private struct BrowserCommandInputError: LocalizedError, ResultEnvelopeError {
+    let errorDescription: String?
+    let envelopeHint: String?
+
+    nonisolated var envelopeCode: ErrorCode? {
+        .VALIDATION_ERROR
+    }
+
+    nonisolated var envelopeEffect: ActionEffect? {
+        nil
+    }
+
+    nonisolated var envelopeRetrySafe: Bool? {
+        true
+    }
+
+    nonisolated var envelopeMutationDispatched: Bool? {
+        false
+    }
+
+    static func invalidBrowserURL() -> Self {
+        Self(
+            errorDescription: "Invalid --browser-url. Expected http://127.0.0.1:<port>, " +
+                "http://[::1]:<port>, or http://localhost:<port>.",
+            envelopeHint: "Run `peekaboo browser connect --browser-url http://127.0.0.1:9222 --foreground`."
+        )
+    }
+}
 
 @MainActor
 struct BrowserCommand: ErrorHandlingCommand, OutputFormattable, RuntimeOptionsConfigurable,
@@ -127,6 +157,10 @@ InjectedRuntimeBackedCommand {
         self.foreground ? .foregroundAllowed : .backgroundOnly
     }
 
+    func validateBeforeRuntime() throws {
+        _ = try self.arguments()
+    }
+
     private func arguments() throws -> [String: Any] {
         let normalizedAction = self.action
             .trimmingCharacters(in: .whitespacesAndNewlines)
@@ -137,6 +171,11 @@ InjectedRuntimeBackedCommand {
         if let channel, BrowserMCPChannel(rawValue: channel) == nil {
             let choices = BrowserMCPChannel.allCases.map(\.rawValue).joined(separator: "|")
             throw ValidationError("Unsupported browser channel '\(channel)' (expected \(choices))")
+        }
+        if normalizedAction == BrowserAction.connect.rawValue,
+           let browserUrl,
+           BrowserLoopbackEndpoint(browserURL: browserUrl) == nil {
+            throw BrowserCommandInputError.invalidBrowserURL()
         }
 
         var arguments: [String: Any] = ["action": normalizedAction]
@@ -222,6 +261,7 @@ InjectedRuntimeBackedCommand {
 
 extension BrowserCommand: ParsableCommand {}
 extension BrowserCommand: AsyncRuntimeCommand {}
+extension BrowserCommand: PreRuntimeValidatingCommand {}
 
 extension BrowserCommand: CommanderSignatureProviding {
     static func commanderSignature() -> CommandSignature {

--- a/Apps/CLI/Tests/CLIRuntimeTests/InvalidInputOrderingCLITests.swift
+++ b/Apps/CLI/Tests/CLIRuntimeTests/InvalidInputOrderingCLITests.swift
@@ -1,0 +1,203 @@
+import Darwin
+import Foundation
+import Subprocess
+import Testing
+
+@Suite(.serialized)
+struct InvalidInputOrderingCLITests {
+    struct JSONCase: Sendable {
+        let arguments: [String]
+        let code: String
+        let message: String
+        let hint: String?
+    }
+
+    @Test(arguments: [
+        JSONCase(
+            arguments: ["type", "alpha", "--json"],
+            code: "VALIDATION_ERROR",
+            message: "Keyboard input requires --app, --pid, --window-id, or --snapshot for background delivery.",
+            hint: "Use --foreground for intentional global input."
+        ),
+        JSONCase(
+            arguments: ["browser", "frobnicate", "--json"],
+            code: "VALIDATION_ERROR",
+            message: "Unsupported browser action 'frobnicate'",
+            hint: nil
+        ),
+        JSONCase(
+            arguments: [
+                "browser", "connect", "--browser-url", "ftp://127.0.0.1:1", "--json",
+            ],
+            code: "VALIDATION_ERROR",
+            message: "Invalid --browser-url. Expected http://127.0.0.1:<port>, " +
+                "http://[::1]:<port>, or http://localhost:<port>.",
+            hint: "Run `peekaboo browser connect --browser-url http://127.0.0.1:9222 --foreground`."
+        ),
+    ])
+    func `semantic-invalid JSON requests refuse before runtime discovery`(_ testCase: JSONCase) async throws {
+        let startedAt = ContinuousClock.now
+        let result = try await TestChildProcess.runPeekaboo(testCase.arguments)
+        let elapsed = startedAt.duration(to: .now)
+
+        #expect(result.status == .exited(1))
+        #expect(result.standardError.isEmpty)
+        let envelope = try Self.errorEnvelope(from: result.standardOutput)
+        #expect(envelope.code == testCase.code)
+        #expect(envelope.message == testCase.message)
+        #expect(envelope.hint == testCase.hint)
+        #expect(envelope.debugLogs.isEmpty)
+        #expect(elapsed < .seconds(2))
+    }
+
+    @Test
+    func `video input failures retain exact paths and skip runtime discovery`() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("peekaboo-video-input-cli-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let missing = root.appendingPathComponent("missing.mp4")
+        let missingResult = try await TestChildProcess.runPeekaboo([
+            "capture", "video", missing.path, "--json",
+        ])
+        let missingEnvelope = try Self.errorEnvelope(from: missingResult.standardOutput)
+        #expect(missingResult.status == .exited(1))
+        #expect(missingResult.standardError.isEmpty)
+        #expect(missingEnvelope.code == "INVALID_INPUT")
+        #expect(missingEnvelope.message == "Input video file does not exist: \(missing.path)")
+        #expect(missingEnvelope.hint == "Check the path and pass an existing readable video file.")
+        #expect(missingEnvelope.debugLogs.isEmpty)
+
+        let empty = root.appendingPathComponent("empty.mp4")
+        try Data().write(to: empty)
+        let cadenceResult = try await TestChildProcess.runPeekaboo([
+            "capture", "video", empty.path, "--sample-fps", "-1", "--json",
+        ])
+        let cadenceEnvelope = try Self.errorEnvelope(from: cadenceResult.standardOutput)
+        #expect(cadenceResult.status == .exited(1))
+        #expect(cadenceResult.standardError.isEmpty)
+        #expect(cadenceEnvelope.code == "INVALID_INPUT")
+        #expect(cadenceEnvelope.message == "Invalid input: sample-fps must be a positive finite value")
+        #expect(cadenceEnvelope.hint == "Use --sample-fps with a finite value greater than 0.")
+        #expect(cadenceEnvelope.debugLogs.isEmpty)
+
+        let fifo = root.appendingPathComponent("stream.mp4")
+        #expect(mkfifo(fifo.path, mode_t(S_IRUSR | S_IWUSR)) == 0)
+        let fifoResult = try await TestChildProcess.runPeekaboo([
+            "capture", "video", fifo.path, "--json",
+        ])
+        let fifoEnvelope = try Self.errorEnvelope(from: fifoResult.standardOutput)
+        #expect(fifoResult.status == .exited(1))
+        #expect(fifoResult.standardError.isEmpty)
+        #expect(fifoEnvelope.code == "INVALID_INPUT")
+        #expect(fifoEnvelope.message == "Input video path is not a regular file: \(fifo.path)")
+        #expect(fifoEnvelope.debugLogs.isEmpty)
+
+        let optionCases: [([String], String, String, String?)] = [
+            (
+                ["--every", "0ms"],
+                "INVALID_INPUT",
+                "Invalid input: every-ms must be greater than zero",
+                "Correct the video sampling options and retry."
+            ),
+            (
+                ["--start=-1ms"],
+                "INVALID_ARGUMENT",
+                "Invalid value '-1ms' for start: Unable to parse CLIDuration",
+                nil
+            ),
+            (
+                ["--end=-1ms"],
+                "INVALID_ARGUMENT",
+                "Invalid value '-1ms' for end: Unable to parse CLIDuration",
+                nil
+            ),
+            (
+                ["--start", "2s", "--end", "1s"],
+                "INVALID_INPUT",
+                "Invalid input: end-ms must exceed start-ms",
+                "Correct the video sampling options and retry."
+            ),
+            (
+                ["--resolution-cap", "0"],
+                "INVALID_INPUT",
+                "Invalid input: resolution-cap must be a positive finite value",
+                "Correct the video sampling options and retry."
+            ),
+            (
+                ["--diff-strategy", "slow"],
+                "VALIDATION_ERROR",
+                "Unsupported diff strategy 'slow'.",
+                "Use fast or quality."
+            ),
+        ]
+        for (options, expectedCode, expectedMessage, expectedHint) in optionCases {
+            let result = try await TestChildProcess.runPeekaboo(
+                ["capture", "video", empty.path] + options + ["--json"]
+            )
+            let envelope = try Self.errorEnvelope(from: result.standardOutput)
+            #expect(result.status == .exited(1))
+            #expect(result.standardError.isEmpty)
+            #expect(envelope.code == expectedCode)
+            #expect(envelope.message == expectedMessage)
+            #expect(envelope.hint == expectedHint)
+            #expect(envelope.debugLogs.isEmpty)
+        }
+    }
+
+    @Test
+    func `human failures remain concise and CLI native`() async throws {
+        let missing = FileManager.default.temporaryDirectory
+            .appendingPathComponent("peekaboo-human-missing-\(UUID().uuidString).mp4")
+        let cases: [([String], String)] = [
+            (
+                ["type", "alpha"],
+                "Error: Keyboard input requires --app, --pid, --window-id, or --snapshot for background " +
+                    "delivery. Hint: Use --foreground for intentional global input.\n"
+            ),
+            (
+                ["browser", "frobnicate"],
+                "Error: Unsupported browser action 'frobnicate'\n"
+            ),
+            (
+                ["browser", "connect", "--browser-url", "ftp://127.0.0.1:1"],
+                "Error: Invalid --browser-url. Expected http://127.0.0.1:<port>, http://[::1]:<port>, or " +
+                    "http://localhost:<port>. Hint: Run `peekaboo browser connect --browser-url " +
+                    "http://127.0.0.1:9222 --foreground`.\n"
+            ),
+            (
+                ["capture", "video", missing.path],
+                "Error: Input video file does not exist: \(missing.path) Hint: Check the path and pass an " +
+                    "existing readable video file.\n"
+            ),
+        ]
+
+        for (arguments, expectedError) in cases {
+            let result = try await TestChildProcess.runPeekaboo(arguments)
+            #expect(result.status == .exited(1))
+            #expect(result.standardOutput.isEmpty)
+            #expect(result.standardError == expectedError)
+            #expect(!result.standardError.contains("Run browser {"))
+        }
+    }
+
+    private static func errorEnvelope(from output: String) throws -> (
+        code: String,
+        message: String,
+        hint: String?,
+        debugLogs: [String]
+    ) {
+        let object = try #require(
+            JSONSerialization.jsonObject(with: Data(output.utf8)) as? [String: Any]
+        )
+        #expect(object["success"] as? Bool == false)
+        let error = try #require(object["error"] as? [String: Any])
+        return try (
+            code: #require(error["code"] as? String),
+            message: #require(error["message"] as? String),
+            hint: error["hint"] as? String,
+            debugLogs: #require(object["debug_logs"] as? [String])
+        )
+    }
+}

--- a/Apps/CLI/Tests/CLIRuntimeTests/InvalidInputOrderingCLITests.swift
+++ b/Apps/CLI/Tests/CLIRuntimeTests/InvalidInputOrderingCLITests.swift
@@ -114,6 +114,12 @@ struct InvalidInputOrderingCLITests {
                 nil
             ),
             (
+                ["--end", "0ms"],
+                "INVALID_INPUT",
+                "Invalid input: end-ms must exceed start-ms",
+                "Correct the video sampling options and retry."
+            ),
+            (
                 ["--start", "2s", "--end", "1s"],
                 "INVALID_INPUT",
                 "Invalid input: end-ms must exceed start-ms",

--- a/Apps/CLI/Tests/CoreCLITests/PreRuntimeInvalidInputOrderingTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/PreRuntimeInvalidInputOrderingTests.swift
@@ -73,6 +73,10 @@ struct PreRuntimeInvalidInputOrderingTests {
                 "Invalid value '-1ms' for end: Unable to parse CLIDuration"
             ),
             (
+                ["--end", "0ms"],
+                "Invalid input: end-ms must exceed start-ms"
+            ),
+            (
                 ["--start", "2s", "--end", "1s"],
                 "Invalid input: end-ms must exceed start-ms"
             ),

--- a/Apps/CLI/Tests/CoreCLITests/PreRuntimeInvalidInputOrderingTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/PreRuntimeInvalidInputOrderingTests.swift
@@ -1,0 +1,180 @@
+import Darwin
+import Foundation
+import Testing
+@testable import PeekabooCLI
+
+@Suite(.serialized, .tags(.safe))
+@MainActor
+struct PreRuntimeInvalidInputOrderingTests {
+    @Test(arguments: [
+        (
+            ["peekaboo", "type", "alpha", "--json"],
+            "Keyboard input requires --app, --pid, --window-id, or --snapshot for background delivery."
+        ),
+        (
+            ["peekaboo", "browser", "frobnicate", "--json"],
+            "Unsupported browser action 'frobnicate'"
+        ),
+        (
+            [
+                "peekaboo", "browser", "connect", "--browser-url", "ftp://127.0.0.1:1", "--json",
+            ],
+            "Invalid --browser-url. Expected http://127.0.0.1:<port>, " +
+                "http://[::1]:<port>, or http://localhost:<port>."
+        ),
+    ])
+    func `semantic-invalid commands refuse before runtime construction`(
+        arguments: [String],
+        expectedMessage: String
+    ) async throws {
+        try await Self.requirePreRuntimeRefusal(arguments: arguments, expectedMessage: expectedMessage)
+    }
+
+    @Test
+    func `invalid video file and cadence refuse before runtime construction`() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("peekaboo-pre-runtime-video-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let missing = root.appendingPathComponent("missing.mp4")
+        try await Self.requirePreRuntimeRefusal(
+            arguments: ["peekaboo", "capture", "video", missing.path, "--json"],
+            expectedMessage: "Input video file does not exist: \(missing.path)"
+        )
+
+        let empty = root.appendingPathComponent("empty.mp4")
+        try Data().write(to: empty)
+        try await Self.requirePreRuntimeRefusal(
+            arguments: [
+                "peekaboo", "capture", "video", empty.path, "--sample-fps", "-1", "--json",
+            ],
+            expectedMessage: "Invalid input: sample-fps must be a positive finite value"
+        )
+
+        let fifo = root.appendingPathComponent("stream.mp4")
+        #expect(mkfifo(fifo.path, mode_t(S_IRUSR | S_IWUSR)) == 0)
+        try await Self.requirePreRuntimeRefusal(
+            arguments: ["peekaboo", "capture", "video", fifo.path, "--json"],
+            expectedMessage: "Input video path is not a regular file: \(fifo.path)"
+        )
+
+        let invalidOptions: [([String], String)] = [
+            (
+                ["--every", "0ms"],
+                "Invalid input: every-ms must be greater than zero"
+            ),
+            (
+                ["--start=-1ms"],
+                "Invalid value '-1ms' for start: Unable to parse CLIDuration"
+            ),
+            (
+                ["--end=-1ms"],
+                "Invalid value '-1ms' for end: Unable to parse CLIDuration"
+            ),
+            (
+                ["--start", "2s", "--end", "1s"],
+                "Invalid input: end-ms must exceed start-ms"
+            ),
+            (
+                ["--resolution-cap", "0"],
+                "Invalid input: resolution-cap must be a positive finite value"
+            ),
+            (
+                ["--diff-strategy", "slow"],
+                "Unsupported diff strategy 'slow'. Use fast or quality."
+            ),
+        ]
+        for (options, expectedMessage) in invalidOptions {
+            try await Self.requirePreRuntimeRefusal(
+                arguments: ["peekaboo", "capture", "video", empty.path] + options + ["--json"],
+                expectedMessage: expectedMessage
+            )
+        }
+    }
+
+    @Test(arguments: [
+        ["peekaboo", "type", "alpha", "--foreground", "--json"],
+        ["peekaboo", "browser", "status", "--json"],
+    ])
+    func `valid request shapes continue to runtime construction`(arguments: [String]) async throws {
+        let resolved = try CommanderRuntimeRouter.resolve(argv: arguments)
+        var runtimeConstructionCount = 0
+
+        do {
+            try await CommanderRuntimeExecutor.run(
+                resolved: resolved,
+                runtimeFactory: .init { _ in
+                    runtimeConstructionCount += 1
+                    throw RuntimeConstructionProbe.reached
+                }
+            )
+            Issue.record("Expected the runtime construction probe to stop execution")
+        } catch RuntimeConstructionProbe.reached {
+            // Expected: request-only validation completed and runtime construction began exactly once.
+        }
+
+        #expect(runtimeConstructionCount == 1)
+    }
+
+    @Test
+    func `valid video request shape continues to runtime construction`() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("peekaboo-valid-video-shape-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let target = root.appendingPathComponent("target.mp4")
+        let input = root.appendingPathComponent("input.mp4")
+        try Data().write(to: target)
+        try FileManager.default.createSymbolicLink(at: input, withDestinationURL: target)
+
+        let resolved = try CommanderRuntimeRouter.resolve(argv: [
+            "peekaboo", "capture", "video", input.path, "--sample-fps", "2", "--json",
+        ])
+        var runtimeConstructionCount = 0
+
+        do {
+            try await CommanderRuntimeExecutor.run(
+                resolved: resolved,
+                runtimeFactory: .init { _ in
+                    runtimeConstructionCount += 1
+                    throw RuntimeConstructionProbe.reached
+                }
+            )
+            Issue.record("Expected the runtime construction probe to stop execution")
+        } catch RuntimeConstructionProbe.reached {
+            // Expected.
+        }
+
+        #expect(runtimeConstructionCount == 1)
+    }
+
+    private static func requirePreRuntimeRefusal(
+        arguments: [String],
+        expectedMessage: String
+    ) async throws {
+        let resolved = try CommanderRuntimeRouter.resolve(argv: arguments)
+        var runtimeConstructionCount = 0
+
+        do {
+            try await CommanderRuntimeExecutor.run(
+                resolved: resolved,
+                runtimeFactory: .init { _ in
+                    runtimeConstructionCount += 1
+                    throw RuntimeConstructionProbe.reached
+                }
+            )
+            Issue.record("Expected request-only validation to refuse the command")
+        } catch RuntimeConstructionProbe.reached {
+            Issue.record("Runtime construction was reached for malformed request: \(arguments)")
+        } catch {
+            #expect(error.localizedDescription == expectedMessage)
+        }
+
+        #expect(runtimeConstructionCount == 0)
+    }
+}
+
+private enum RuntimeConstructionProbe: Error {
+    case reached
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Preserve exact target and dispatch receipts when a submitted Accessibility `set-value` write cannot be verified, so CLI, MCP, and Bridge callers receive retry-unsafe guidance instead of a raw error.
 - Preserve exact scroll dispatch counts and stop retrying through another route after any accepted or possibly accepted scroll prefix; SwiftUI tab presses likewise require fresh observation instead of replaying a synthetic click after an accepted `AXPress`.
 - Align Agent, MCP, CLI help, and documentation with snapshot-pinned background press/type, targeted background dialog AXValue, and explicit foreground consent for cold launch, Space switching, and foreground-exposing AX actions.
+- Refuse targetless background typing, malformed browser requests, and invalid video inputs before runtime discovery, with path-specific media errors and CLI-native browser recovery.
 - Preserve local Option/Meta chords while buffering fragmented terminal escape sequences longer over SSH, and ignore stale cancelled escape timers that arrive after a newer sequence.
 - Update AXorcist so synchronous and legacy element observers share the bounded registration and cleanup state machine, preventing a wedged endpoint from blocking Peekaboo's main actor indefinitely or escaping late-result rollback.
 - Keep JSON-output flags after the `--` option terminator as child arguments instead of changing Peekaboo's own error envelope.

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/VideoFrameRequestValidator.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/VideoFrameRequestValidator.swift
@@ -1,0 +1,32 @@
+import Foundation
+import PeekabooFoundation
+
+/// Synchronous request validation shared by CLI/MCP admission and the video frame source.
+public enum VideoFrameRequestValidator {
+    public static func validate(
+        sampleFps: Double?,
+        everyMs: Int?,
+        startMs: Int?,
+        endMs: Int?,
+        resolutionCap: Double?) throws
+    {
+        if let sampleFps, !sampleFps.isFinite || sampleFps <= 0 {
+            throw PeekabooError.invalidInput("sample-fps must be a positive finite value")
+        }
+        if let everyMs, everyMs <= 0 {
+            throw PeekabooError.invalidInput("every-ms must be greater than zero")
+        }
+        if let startMs, startMs < 0 {
+            throw PeekabooError.invalidInput("start-ms must be zero or greater")
+        }
+        if let endMs, endMs < 0 {
+            throw PeekabooError.invalidInput("end-ms must be zero or greater")
+        }
+        if let startMs, let endMs, endMs <= startMs {
+            throw PeekabooError.invalidInput("end-ms must exceed start-ms")
+        }
+        if let resolutionCap, !resolutionCap.isFinite || resolutionCap <= 0 {
+            throw PeekabooError.invalidInput("resolution-cap must be a positive finite value")
+        }
+    }
+}

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/VideoFrameRequestValidator.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/VideoFrameRequestValidator.swift
@@ -22,7 +22,7 @@ public enum VideoFrameRequestValidator {
         if let endMs, endMs < 0 {
             throw PeekabooError.invalidInput("end-ms must be zero or greater")
         }
-        if let startMs, let endMs, endMs <= startMs {
+        if let endMs, endMs <= (startMs ?? 0) {
             throw PeekabooError.invalidInput("end-ms must exceed start-ms")
         }
         if let resolutionCap, !resolutionCap.isFinite || resolutionCap <= 0 {

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/VideoFrameSource.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/VideoFrameSource.swift
@@ -38,21 +38,12 @@ public final class VideoFrameSource: CaptureFrameSource {
     {
         self.sourceURL = url
         self.decodeTimeout = .seconds(5)
-        if let sampleFps, !sampleFps.isFinite || sampleFps <= 0 {
-            throw PeekabooError.invalidInput("sample-fps must be a positive finite value")
-        }
-        if let everyMs, everyMs <= 0 {
-            throw PeekabooError.invalidInput("every-ms must be greater than zero")
-        }
-        if let startMs, startMs < 0 {
-            throw PeekabooError.invalidInput("start-ms must be zero or greater")
-        }
-        if let endMs, endMs < 0 {
-            throw PeekabooError.invalidInput("end-ms must be zero or greater")
-        }
-        if let resolutionCap, !resolutionCap.isFinite || resolutionCap <= 0 {
-            throw PeekabooError.invalidInput("resolution-cap must be a positive finite value")
-        }
+        try VideoFrameRequestValidator.validate(
+            sampleFps: sampleFps,
+            everyMs: everyMs,
+            startMs: startMs,
+            endMs: endMs,
+            resolutionCap: resolutionCap.map(Double.init))
 
         let asset = AVAsset(url: url)
         let duration: CMTime = if #available(macOS 13.0, *) {

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/VideoFrameRequestValidatorTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/VideoFrameRequestValidatorTests.swift
@@ -1,0 +1,82 @@
+import PeekabooFoundation
+import Testing
+@testable import PeekabooAutomationKit
+
+struct VideoFrameRequestValidatorTests {
+    struct Case: Sendable {
+        let sampleFps: Double?
+        let everyMs: Int?
+        let startMs: Int?
+        let endMs: Int?
+        let resolutionCap: Double?
+        let expectedMessage: String
+    }
+
+    @Test(arguments: [
+        Case(
+            sampleFps: 0,
+            everyMs: nil,
+            startMs: nil,
+            endMs: nil,
+            resolutionCap: nil,
+            expectedMessage: "Invalid input: sample-fps must be a positive finite value"),
+        Case(
+            sampleFps: nil,
+            everyMs: 0,
+            startMs: nil,
+            endMs: nil,
+            resolutionCap: nil,
+            expectedMessage: "Invalid input: every-ms must be greater than zero"),
+        Case(
+            sampleFps: nil,
+            everyMs: nil,
+            startMs: -1,
+            endMs: nil,
+            resolutionCap: nil,
+            expectedMessage: "Invalid input: start-ms must be zero or greater"),
+        Case(
+            sampleFps: nil,
+            everyMs: nil,
+            startMs: nil,
+            endMs: -1,
+            resolutionCap: nil,
+            expectedMessage: "Invalid input: end-ms must be zero or greater"),
+        Case(
+            sampleFps: nil,
+            everyMs: nil,
+            startMs: 2000,
+            endMs: 1000,
+            resolutionCap: nil,
+            expectedMessage: "Invalid input: end-ms must exceed start-ms"),
+        Case(
+            sampleFps: nil,
+            everyMs: nil,
+            startMs: nil,
+            endMs: nil,
+            resolutionCap: 0,
+            expectedMessage: "Invalid input: resolution-cap must be a positive finite value"),
+    ])
+    func `invalid video request values fail synchronously`(_ testCase: Case) {
+        let error = #expect(throws: PeekabooError.self) {
+            try VideoFrameRequestValidator.validate(
+                sampleFps: testCase.sampleFps,
+                everyMs: testCase.everyMs,
+                startMs: testCase.startMs,
+                endMs: testCase.endMs,
+                resolutionCap: testCase.resolutionCap)
+        }
+        #expect(error?.localizedDescription == testCase.expectedMessage)
+    }
+
+    @Test
+    func `valid video request values pass synchronously`() {
+        #expect(throws: Never.self) {
+            try VideoFrameRequestValidator.validate(
+                sampleFps: 2,
+                everyMs: nil,
+                startMs: 0,
+                endMs: 2000,
+                resolutionCap: 1440)
+        }
+    }
+}

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/VideoFrameRequestValidatorTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/VideoFrameRequestValidatorTests.swift
@@ -44,6 +44,13 @@ struct VideoFrameRequestValidatorTests {
         Case(
             sampleFps: nil,
             everyMs: nil,
+            startMs: nil,
+            endMs: 0,
+            resolutionCap: nil,
+            expectedMessage: "Invalid input: end-ms must exceed start-ms"),
+        Case(
+            sampleFps: nil,
+            everyMs: nil,
             startMs: 2000,
             endMs: 1000,
             resolutionCap: nil,


### PR DESCRIPTION
## Summary

- reject targetless background typing, unknown browser actions, and invalid loopback endpoints before runtime-host discovery
- map missing, unreadable, and nonregular video inputs to path-specific fail-closed errors and centralize video option validation
- add a narrow runtime-construction test seam and end-to-end CLI regressions proving malformed requests never bootstrap the runtime

## Verification

- source-blind 23-case invalid-input/MCP matrix against the exact signed arm64 Release binary: no stream-shape or runtime-discovery failures; repaired cases complete in 50-55 ms; malformed MCP calls preserve a healthy `tools/list`
- rebased focused CLI/core proof: 40 command/result tests plus 3 live CLI ordering tests
- `TypeCommandTests`: 40/40
- `WatchCaptureSessionTests`: 25/25
- `VideoFrameRequestValidatorTests`: 2/2
- pre-rebase `pnpm run test:safe`: exit 0, including 484 CLI tests in 62 suites; the intervening base PR has exact-head green CI
- SwiftLint exit 0 with the existing non-serious warning baseline; SwiftFormat lint clean on all substantive changed Swift files; `git diff --check` clean
- final P1 structured review: no actionable findings, patch correct at 0.93 confidence

## Documentation

- update both Unreleased changelogs with the faster fail-closed behavior and improved recovery guidance
