### PR TITLE
test(qualification): bind concurrent Agent contract

### DIFF
--- a/scripts/final-qualification/README.md
+++ b/scripts/final-qualification/README.md
@@ -185,12 +185,63 @@ The tool accepts only the coordinator's exact phase-dependent window schema, can
 node "$TOOLS/managed-launcher.mjs" --spec "$EVIDENCE_ROOT/coordinator-launch-spec.json"
 ```
 
-The Agent has no separate launcher, invocation receipt, process receipt, or exit receipt. Protocol 1.31 makes the entire Agent lifetime one authenticated Bridge request. Retain the exact task as UTF-8 plus one terminal newline, create a canonical owner-owned mode-0700 run root, and start the hidden qualification adapter in a second attached PTY. Its stdout is the canonical signed terminal bundle:
+The Agent has no separate launcher, invocation receipt, process receipt, or exit receipt. Protocol 1.31 makes the entire Agent lifetime one authenticated Bridge request. The task is not prose: retain one closed version-1 JSON contract as canonical compact UTF-8 plus exactly one terminal newline. Its two ordered targets must be copied from the plan's `controller-a`/`controller-b` controlled-fixture bindings, while each expected value comes from the fresh baseline and intended postcondition for that exact target. The five evidence-checkpoint slots and all fixed constraints/postconditions below are mandatory; do not paraphrase or add keys. The expanded object is shown only for readability: serialize it with `canonicalBytes` from `lib.mjs`, then append one LF. The expanded representation itself is not a valid retained task.
+
+```json
+{
+  "version": 1,
+  "kind": "peekaboo-concurrent-agent-qualification",
+  "goal": "two-target-background-mutate-verify-restore-with-concurrent-cu",
+  "constraints": {
+    "delivery_mode": "background",
+    "foreground": "forbidden",
+    "progress_interleaving": "before-and-after-integrated-cu",
+    "shell": "forbidden",
+    "skips_and_failures": "forbidden"
+  },
+  "targets": [
+    {
+      "label": "target-a",
+      "target": {"pid": 301, "start_identity": "301001", "window_id": 401},
+      "steps": [
+        {"phase": "baseline", "expected_value": "alpha"},
+        {"phase": "mutate", "family": "set_value", "expected_value": "alpha!"},
+        {"phase": "verify-mutated", "expected_value": "alpha!"},
+        {"phase": "restore", "family": "set_value", "expected_value": "alpha"},
+        {"phase": "verify-restored", "expected_value": "alpha"}
+      ]
+    },
+    {
+      "label": "target-b",
+      "target": {"pid": 302, "start_identity": "302001", "window_id": 402},
+      "steps": [
+        {"phase": "baseline", "expected_value": "beta"},
+        {"phase": "mutate", "family": "paste", "expected_value": "beta!"},
+        {"phase": "verify-mutated", "expected_value": "beta!"},
+        {"phase": "restore", "family": "type", "expected_value": "beta"},
+        {"phase": "verify-restored", "expected_value": "beta"}
+      ]
+    }
+  ],
+  "postconditions": {
+    "all_targets_restored": true,
+    "cleanup": "restore-exact-baselines",
+    "exact_dispatched_mutation_count": 4,
+    "exact_target_count": 2,
+    "minimum_primary_mutation_family_count": 2,
+    "novel_restoration_family_required": true,
+    "target_b_distinct_restoration_family": true
+  }
+}
+```
+
+The example identities and values are illustrative; the retained contract must use the current run's plan and readbacks. `mutate` and `restore` are the four Agent dispatches. `baseline`, `verify-mutated`, and `verify-restored` precommit the owner semantic-readback checkpoints that bracket those dispatches; they are not represented as separate Agent trace calls. Create a canonical owner-owned mode-0700 run root, load the task file without its terminal newline into `AGENT_TASK_TEXT`, and start the hidden qualification adapter in a second attached PTY. Its stdout is the canonical signed terminal bundle:
 
 ```bash
 umask 077
 AGENT_RUN_ROOT="$EVIDENCE_ROOT/agent-execution"
 mkdir -m 700 "$AGENT_RUN_ROOT"
+AGENT_TASK_TEXT="$(/bin/cat "$EVIDENCE_ROOT/agent-task.txt")"
 
 "$PEEKABOO_BIN" bridge _agent-execution-trace \
   --task "$AGENT_TASK_TEXT" \
@@ -260,9 +311,9 @@ A fork, exec, or exit observed before authorization, stale readiness, a pre-exis
 
 The coordinator launcher still writes the only standalone invocation and exit receipts. Successful qualification requires its exit code 0 with no signal. The Agent's outer protocol-1.31 terminal bundle replaces every legacy Agent launcher artifact. Live authentication must prove the connected listener, requester, child PID/generation/CDHash, fixed nine-argument background-only invocation, task/run-root/socket commitments, closed environment policy, `processCreationLimit:0`, exact coordination and acknowledgement bytes, and complete bounded stdout/stderr. A successful terminal response must be `processDisposition:"exited"`, exit code 0, no signal, `outputDisposition:"validated_execution_trace"`, and carry an untruncated execution trace identical to the trace decoded from stdout. Any cleanup, wait-anchor, output, or protocol failure is terminal and cannot be resealed by caller-authored JSON. Manifest validation later proves that the lifecycle guard published those exact signed acknowledgement bytes.
 
-`agent-readbacks.json` contains exactly two ordered targets (`target-a`, `target-b`). Each identity must equal the same-ID controlled target already projected into the live-v4 plan for `controller-a` or `controller-b`; an unrelated, swapped, recycled-generation, or different-window claim fails even when every Agent trace, bundle, validator, and readback is consistently resealed. The source-owned final certification summary must independently carry the matching same-ID `target_sha256` over the full exact-window target, and the local/during process tree must contain both PID generations as candidate Playground fixture roots. Each readback entry has exact `{pid,start_identity,window_id}`, `baseline_readback_path`, and `mutation`/`restoration` objects with `{trace_call_id,family,readback_path,bundle_path,validator_report_path}`. Each referenced semantic readback is closed `{version,target,phase,value,observed_at_milliseconds,passed}` with phases `baseline`, `mutated`, or `restored`; hashes are derived from those actual bytes and values, never accepted as caller claims. The baseline observation must strictly precede mutation dispatch, mutation observation must strictly follow mutation completion and precede restoration dispatch, and the restoration observation must strictly follow restoration completion; zero-duration dispatch receipts fail. Every bundle is revalidated by the exact source-bound Peekaboo executable against the exact authenticated live Bridge socket and host policy; the retained validator JSON must equal that fresh result but is never itself a trust anchor. Each signed bundle must carry the Agent PID/start generation as its client, match the trace/readback PID/window and operation family, prove a definite background dispatch, and fall wholly inside `operations-start..operations-complete`. Bundle SHA-256 values, authenticated listener/request identities, and authenticated listener/session/sequence claims are corpus-unique, so copied or hard-linked files cannot provide a second receipt or remap one receipt to another trace call. The receipt-directory inventory and `agent_bundles` list must be identical, including observation bundles; any unlisted or unmapped dispatched bundle fails.
+`agent-readbacks.json` contains exactly two ordered targets (`target-a`, `target-b`). Each identity must equal both the same-ID task-contract target and the controlled target already projected into the live-v4 plan for `controller-a` or `controller-b`; an unrelated, swapped, recycled-generation, or different-window claim fails even when every Agent trace, bundle, validator, task, and readback is consistently resealed. The source-owned final certification summary must independently carry the matching same-ID `target_sha256` over the full exact-window target, and the local/during process tree must contain both PID generations as candidate Playground fixture roots. Each readback entry has exact `{pid,start_identity,window_id}`, `baseline_readback_path`, and `mutation`/`restoration` objects with `{trace_call_id,family,readback_path,bundle_path,validator_report_path}`. Each referenced semantic readback is closed `{version,target,phase,value,observed_at_milliseconds,passed}` with phases `baseline`, `mutated`, or `restored`; hashes are derived from those actual bytes and values, never accepted as caller claims. Those values and operation families must equal the signed task's explicit baseline/mutate/verify/restore/verify expectations. Qualification actions are restricted to `set_value`, `type`, and `paste`: `set_value` and `type` must carry explicit nonempty snapshot selectors, while `paste` must carry the exact PID/window. The validator decodes each authenticated bundle's signed canonical Bridge request and binds those sanitized trace selectors to the signed request; every resulting trace/request binding must be unique. A caller-authored call-ID-to-bundle map therefore cannot substitute a valid target receipt for a trace call aimed elsewhere. The baseline observation must strictly precede mutation dispatch, mutation observation must strictly follow mutation completion and precede restoration dispatch, and the restoration observation must strictly follow restoration completion; zero-duration dispatch receipts fail. Every bundle is revalidated by the exact source-bound Peekaboo executable against the exact authenticated live Bridge socket and host policy; the retained validator JSON must equal that fresh result but is never itself a trust anchor. Each signed bundle must carry the Agent PID/start generation as its client, match the trace/readback PID/window and operation family, prove a definite background dispatch, and fall wholly inside `operations-start..operations-complete`. Bundle SHA-256 values, authenticated listener/request identities, and authenticated listener/session/sequence claims are corpus-unique, so copied or hard-linked files cannot provide a second receipt or remap one receipt to another trace call. The receipt-directory inventory and `agent_bundles` list must be identical, including observation bundles; any unlisted or unmapped dispatched bundle fails.
 
-Exactly four—and only four—trace call IDs may report `mutationDispatch:"dispatched"`: mutate and restore for target A, then mutate and restore for target B. The two controlled fixtures must be distinct process generations/windows and disjoint from the Bridge host, observer/foreground target, integrated-CU emitter, and sentinel infrastructure. Both primary mutations must use different families; target B's restoration uses a different family from its primary mutation.
+Exactly four—and only four—trace call IDs may report `mutationDispatch:"dispatched"`: mutate and restore for target A, then mutate and restore for target B, in the signed task order. The two controlled fixtures must be distinct process generations/windows and disjoint from the Bridge host, observer/foreground target, integrated-CU emitter, and sentinel infrastructure. Both primary mutations must use different families; at least one restoration family must be outside the primary-family set, and target B's restoration must differ from its primary mutation. The validation report records the task file SHA-256, signed task SHA-256, canonical semantic-contract SHA-256, fixed constraints/postconditions, plan-derived targets, family choices, and hashes of all expected values. Manifest generation and read-only verification do not trust that projection: both reparse the retained canonical task against the bound plan, independently regenerate the complete projection, compare it to the report, bind it back to the terminal response, and then regenerate the remaining semantic validation from the retained trace, bundles, and readbacks.
 
 ```bash
 node "$TOOLS/validate-concurrent-run.mjs" \
@@ -355,6 +406,6 @@ The generated version-2 manifest hashes every file, including both authenticated
 ## Current product-output gaps that remain explicit hard boundaries
 
 - Coordinator stdout has the lifecycle and eligible completion but not process identity, invocation, exit status, or operation-fence timestamps. The managed launcher supplies identity/invocation/exit authority; the validator reads fence times from coordinator-owned `monitor/monitor-evidence.json`.
-- Agent stdout has the authoritative execution trace but not value content or linkage from a trace call to a nested signed receipt/readback file. The outer protocol-1.31 terminal bundle supplies exact requester/child identity, fixed argv/policy, coordination, acknowledgement bytes, complete stdout/stderr, lifetime, and terminal exit authority; the local/during version-4 process receipt separately proves lifecycle-guard publication. The closed Agent readback map remains mandatory for semantic values and trace-to-receipt linkage.
+- Agent stdout has the authoritative execution trace but not value content or linkage from a trace call to a nested signed receipt/readback file. The outer protocol-1.31 terminal bundle supplies exact requester/child identity, fixed argv/policy, coordination, acknowledgement bytes, complete stdout/stderr, lifetime, and terminal exit authority; the local/during version-4 process receipt separately proves lifecycle-guard publication. The closed Agent readback map remains mandatory for semantic values and trace-to-receipt linkage. Those owner-private readbacks are source-shaped, stable-file and mtime corroborated, but not listener-signed producer receipts; qualification treats their controlled owner as an explicit remaining trust boundary rather than claiming the Agent itself emitted the three observation checkpoints.
 - Integrated Computer Use has no machine-readable emitter PID/generation/Team/CDHash or closed semantic readback receipt. The passive native calibrator and the two owner readback files supply those facts. If event-tap permission is unavailable or source identity is ambiguous, qualification stops.
 - A `window list` plus process receipt does not itself emit the observer's exact focused semantic element and baseline in the coordinator schema. The fresh semantic readback must be projected once into the closed `observer_semantic` receipt; a missing/ambiguous identifier/title or frame outside the exact window is rejected.

--- a/scripts/final-qualification/qualification-manifest.mjs
+++ b/scripts/final-qualification/qualification-manifest.mjs
@@ -9,6 +9,13 @@ import {
   validateSuccessfulCertificationSummary,
 } from '../finalize-multi-target-certification.mjs';
 import {
+  AGENT_TASK_CONSTRAINTS,
+  AGENT_TASK_GOAL,
+  AGENT_TASK_KIND,
+  AGENT_TASK_POSTCONDITIONS,
+  parseAgentTaskContract,
+  projectAgentTaskContractReport,
+  validateAgentTraceOperationBinding,
   validateConcurrentRunSpec,
   validateCoordinatorExecutionEvidence,
 } from './validate-concurrent-run.mjs';
@@ -1314,7 +1321,7 @@ function semanticConcurrentValidation(filePath) {
     'stderr_sha256', 'coordination_receipt_sha256', 'acknowledgement_sha256',
     'spawned_at_milliseconds', 'coordination_published_at_milliseconds',
     'acknowledged_at_milliseconds', 'released_at_milliseconds',
-    'terminal_observation_ended_at_milliseconds', 'readbacks_sha256',
+    'terminal_observation_ended_at_milliseconds', 'task_contract', 'readbacks_sha256',
     'controlled_fixture_targets', 'mutation_families', 'mapped_call_ids',
     'signed_bundle_count', 'signed_bundles', 'semantic_readbacks', 'trace_entry_count',
     'progress_interleaving',
@@ -1360,6 +1367,56 @@ function semanticConcurrentValidation(filePath) {
     `${binding.target.pid}:${binding.target.start_identity}:${binding.target.window_id}`
   ))).size === controlledFixtureTargets.length,
   'Agent/CU concurrent validation report controlled fixture targets are not distinct');
+  const taskContract = value.agent.task_contract;
+  exactKeys(taskContract, [
+    'version', 'kind', 'goal', 'task_file_sha256', 'signed_task_sha256',
+    'semantic_contract_sha256', 'constraints', 'postconditions', 'target_expectations',
+  ], 'Agent/CU concurrent validation report task contract');
+  exactKeys(taskContract.constraints, Object.keys(AGENT_TASK_CONSTRAINTS),
+    'Agent/CU concurrent validation report task constraints');
+  exactKeys(taskContract.postconditions, Object.keys(AGENT_TASK_POSTCONDITIONS),
+    'Agent/CU concurrent validation report task postconditions');
+  requireCondition(taskContract.version === 1
+    && taskContract.kind === AGENT_TASK_KIND
+    && taskContract.goal === AGENT_TASK_GOAL
+    && SHA256.test(taskContract.task_file_sha256 ?? '')
+    && SHA256.test(taskContract.signed_task_sha256 ?? '')
+    && SHA256.test(taskContract.semantic_contract_sha256 ?? '')
+    && taskContract.signed_task_sha256 === taskContract.semantic_contract_sha256
+    && sameJSON(taskContract.constraints, AGENT_TASK_CONSTRAINTS)
+    && sameJSON(taskContract.postconditions, AGENT_TASK_POSTCONDITIONS),
+  'Agent/CU concurrent validation report task contract is not closed');
+  requireCondition(Array.isArray(taskContract.target_expectations)
+    && taskContract.target_expectations.length === 2,
+  'Agent/CU concurrent validation report task contract lacks two expectations');
+  const contractMutationFamilies = new Set();
+  const contractRestorationFamilies = new Set();
+  taskContract.target_expectations.forEach((expectation, index) => {
+    exactKeys(expectation, [
+      'label', 'target', 'baseline_value_sha256', 'mutation_family',
+      'mutated_value_sha256', 'restoration_family', 'restored_value_sha256',
+    ], `Agent/CU concurrent validation report task expectation ${index}`);
+    requireCondition(expectation.label === controlledFixtureTargets[index].label
+      && sameJSON(expectation.target, controlledFixtureTargets[index].target)
+      && SHA256.test(expectation.baseline_value_sha256 ?? '')
+      && SHA256.test(expectation.mutated_value_sha256 ?? '')
+      && SHA256.test(expectation.restored_value_sha256 ?? '')
+      && expectation.baseline_value_sha256 === expectation.restored_value_sha256
+      && expectation.mutated_value_sha256 !== expectation.baseline_value_sha256
+      && expectation.mutation_family === normalizedAgentToolName(expectation.mutation_family)
+      && expectation.restoration_family
+        === normalizedAgentToolName(expectation.restoration_family)
+      && isAgentMutatingToolName(expectation.mutation_family)
+      && isAgentMutatingToolName(expectation.restoration_family),
+    `Agent/CU concurrent validation report task expectation ${index} is invalid`);
+    contractMutationFamilies.add(expectation.mutation_family);
+    contractRestorationFamilies.add(expectation.restoration_family);
+  });
+  requireCondition(contractMutationFamilies.size >= 2
+    && taskContract.target_expectations[1].mutation_family
+      !== taskContract.target_expectations[1].restoration_family
+    && [...contractRestorationFamilies].some((family) => !contractMutationFamilies.has(family)),
+  'Agent/CU concurrent validation report task families are not diverse');
   const overlap = value.overlap;
   requireCondition(value.version === 1 && value.passed === true
     && value.coordinator?.exit_code === 0
@@ -1407,6 +1464,7 @@ function semanticConcurrentValidation(filePath) {
     && Array.isArray(value.agent?.mapped_call_ids) && value.agent.mapped_call_ids.length === 4
     && new Set(value.agent.mapped_call_ids).size === 4
     && Array.isArray(value.agent?.mutation_families) && value.agent.mutation_families.length >= 2
+    && sameJSON([...contractMutationFamilies].sort(), value.agent.mutation_families)
     && Number.isSafeInteger(value.agent?.progress_interleaving?.integrated_cu_perform_at_milliseconds)
     && Number.isSafeInteger(
       value.agent?.progress_interleaving?.integrated_cu_perform_readback_mtime_milliseconds,
@@ -1760,6 +1818,20 @@ function retainedAgentTaskAndRequest(taskPath, runRootPath, label) {
   };
 }
 
+function validateConcurrentTaskBinding(task, terminal, concurrent, plan, label) {
+  const parsed = parseAgentTaskContract(task.task, plan);
+  const signedTaskSHA256 = sha256(Buffer.from(task.request.task, 'utf8'));
+  const projected = projectAgentTaskContractReport(parsed, terminal);
+  requireCondition(task.request.task === parsed.text
+    && task.task.sha256 === concurrent.agent.task_contract.task_file_sha256
+    && signedTaskSHA256 === concurrent.agent.task_contract.signed_task_sha256
+    && signedTaskSHA256 === concurrent.agent.task_contract.semantic_contract_sha256
+    && terminal.response.taskSHA256 === signedTaskSHA256
+    && sameJSON(projected, concurrent.agent.task_contract),
+  `${label} independently derived task contract differs from the signed terminal request/report`);
+  return parsed;
+}
+
 function agentBundleAuthentication(plan, terminal, authenticateBundle, label) {
   requireCondition(typeof authenticateBundle === 'function'
     && plan?.bridge && typeof plan.bridge.socket_path === 'string'
@@ -1843,6 +1915,7 @@ function validateConcurrentInterleavingBinding(
   performReadbackPath,
   controlledFixtureTargets,
   terminal,
+  taskContract,
   label,
 ) {
   const readbacks = readStableJSON(agentReadbacksPath, `${label} Agent readback map`).value;
@@ -1868,6 +1941,7 @@ function validateConcurrentInterleavingBinding(
     `${label} Agent bundle paths are not unique`);
   const actionIntervals = [];
   const primaryMutationFamilies = new Set();
+  const traceRequestBindings = new Set();
   for (const [targetIndex, target] of readbacks.targets.entries()) {
     exactKeys(target, [
       'label', 'target', 'baseline_readback_path', 'mutation', 'restoration',
@@ -1879,6 +1953,10 @@ function validateConcurrentInterleavingBinding(
     requireCondition(target.label === controlledFixtureTargets[targetIndex].label
       && sameJSON(expectedTarget, controlledFixtureTargets[targetIndex].target),
     `${label} Agent target ${targetIndex} is not its exact live-v4 controlled fixture target`);
+    const taskExpectation = taskContract.target_expectations[targetIndex];
+    requireCondition(taskExpectation.label === target.label
+      && sameJSON(taskExpectation.target, expectedTarget),
+    `${label} Agent target ${targetIndex} differs from its authenticated task expectation`);
     const baseline = semanticAgentReadback(
       target.baseline_readback_path,
       `${label} Agent target ${targetIndex}.baseline`,
@@ -1887,6 +1965,9 @@ function validateConcurrentInterleavingBinding(
       `${label} Agent target ${targetIndex} baseline phase is invalid`);
     requireCondition(sameJSON(baseline.target, expectedTarget),
       `${label} Agent target ${targetIndex} baseline belongs to another target`);
+    requireCondition(baseline.value_sha256
+      === sha256(Buffer.from(taskExpectation.baseline_value, 'utf8')),
+    `${label} Agent target ${targetIndex} baseline differs from its authenticated task expectation`);
     const actionEvidence = {};
     for (const [kind, phase] of [['mutation', 'mutated'], ['restoration', 'restored']]) {
       const action = target[kind];
@@ -1898,10 +1979,10 @@ function validateConcurrentInterleavingBinding(
         `${label} Agent target ${targetIndex}.${kind} is absent from the bound corpus`);
       const traceEntry = traceByID.get(action.trace_call_id);
       const traceFamily = normalizedAgentToolName(traceEntry?.name);
+      const taskAction = taskExpectation[kind];
       requireCondition(isAgentMutatingToolName(traceFamily)
         && traceFamily === action.family
-        && traceEntry.arguments?.pid === expectedTarget.pid
-        && traceEntry.arguments?.window_id === expectedTarget.window_id
+        && action.family === taskAction.family
         && traceEntry.disposition === 'executed/succeeded'
         && traceEntry.isError === false
         && traceEntry.mutationDispatch === 'dispatched'
@@ -1918,6 +1999,16 @@ function validateConcurrentInterleavingBinding(
         targetFromPayload(pair.payload, `${label} Agent target ${targetIndex}.${kind}`),
         expectedTarget,
       ), `${label} Agent target ${targetIndex}.${kind} signed target differs`);
+      const traceRequestBinding = validateAgentTraceOperationBinding(
+        traceEntry,
+        pair,
+        action.family,
+        expectedTarget,
+        `${label} Agent target ${targetIndex}.${kind}`,
+      );
+      requireCondition(!traceRequestBindings.has(traceRequestBinding),
+        `${label} Agent target ${targetIndex}.${kind} reuses a trace/request binding`);
+      traceRequestBindings.add(traceRequestBinding);
       const startedAt = pair.payload.startedAtUnixMilliseconds;
       const completedAt = pair.payload.completedAtUnixMilliseconds;
       requireCondition(typeof action.trace_call_id === 'string' && action.trace_call_id.length > 0
@@ -1937,6 +2028,9 @@ function validateConcurrentInterleavingBinding(
         `${label} Agent target ${targetIndex}.${kind} readback phase is invalid`);
       requireCondition(sameJSON(readback.target, expectedTarget),
         `${label} Agent target ${targetIndex}.${kind} readback belongs to another target`);
+      requireCondition(readback.value_sha256
+        === sha256(Buffer.from(taskAction.expected_value, 'utf8')),
+      `${label} Agent target ${targetIndex}.${kind} readback differs from its authenticated task expectation`);
       requireCondition(completedAt < readback.observed_at_milliseconds,
         `${label} Agent target ${targetIndex}.${kind} readback does not strictly follow dispatch completion`);
       actionEvidence[kind] = { startedAt, completedAt, readback };
@@ -1961,6 +2055,10 @@ function validateConcurrentInterleavingBinding(
   requireCondition(primaryMutationFamilies.size >= 2
     && sameJSON([...primaryMutationFamilies].sort(), concurrent.agent.mutation_families),
   `${label} mutation families differ from the signed terminal trace/readback map`);
+  requireCondition(actionIntervals.every((entry, index) => index === 0
+    || actionIntervals[index - 1].completed_at_milliseconds
+      < entry.started_at_milliseconds),
+  `${label} signed mutation intervals do not follow the task action order`);
   const retainedPerform = readStableJSON(
     performReadbackPath,
     `${label} integrated-CU perform readback`,
@@ -2674,6 +2772,13 @@ function projectInput(input, authenticateBundle) {
     authenticateBundle,
     label: 'Agent manifest terminal bundle',
   });
+  const agentTaskContract = validateConcurrentTaskBinding(
+    agentTask,
+    terminal,
+    concurrentValue,
+    boundPlanValue,
+    'Agent manifest',
+  );
   const authentication = agentBundleAuthentication(
     boundPlanValue,
     terminal,
@@ -2751,6 +2856,7 @@ function projectInput(input, authenticateBundle) {
     input.agent_cu.perform_readback,
     adjunctBinding.controlledFixtureTargets,
     terminal,
+    agentTaskContract,
     'Agent manifest',
   );
   requireCondition(Array.isArray(input.agent_cu.semantic_readbacks)
@@ -3201,6 +3307,13 @@ function validateSemanticEvidence(evidence, authenticateBundle) {
     authenticateBundle,
     label: 'verified Agent terminal bundle',
   });
+  const verifiedAgentTaskContract = validateConcurrentTaskBinding(
+    verifiedAgentTask,
+    terminal,
+    concurrentValue,
+    verifiedPlanValue,
+    'verified Agent manifest',
+  );
   validateTerminalConcurrentBinding(
     terminal,
     concurrentValue,
@@ -3270,6 +3383,7 @@ function validateSemanticEvidence(evidence, authenticateBundle) {
     evidence.agent_cu.perform_readback.path,
     adjunctBinding.controlledFixtureTargets,
     terminal,
+    verifiedAgentTaskContract,
     'verified Agent manifest',
   );
   const semanticReadbacks = evidence.agent_cu.semantic_readbacks.map((receipt, index) => (

--- a/scripts/final-qualification/test/qualification-tools.test.mjs
+++ b/scripts/final-qualification/test/qualification-tools.test.mjs
@@ -21,7 +21,10 @@ import {
   verifyManifest as verifyManifestProduction,
   verifySourceManifest,
 } from '../qualification-manifest.mjs';
-import { validateConcurrentRun as validateConcurrentRunProduction } from '../validate-concurrent-run.mjs';
+import {
+  validateAgentTraceOperationBinding,
+  validateConcurrentRun as validateConcurrentRunProduction,
+} from '../validate-concurrent-run.mjs';
 import { aggregateSHA256 as multiTargetAggregateSHA256 } from '../../finalize-multi-target-certification.mjs';
 import {
   aggregateSHA256,
@@ -2027,6 +2030,29 @@ function signedOperationRequestFixture(operation, traceArguments) {
     projectedAction: { _0: { request: { [requestCase]: { _0: payload } } } },
   }).toString('base64');
 }
+
+test('same-target paste bindings remain distinct by authenticated request identity', () => {
+  const target = { pid: 302, start_identity: '302001', window_id: 402 };
+  const entry = traceEntry('paste', 'paste', target.pid, target.window_id);
+  const signed = (requestKey) => ({
+    bundle: {
+      value: {
+        canonicalRequest: signedOperationRequestFixture(
+          'exactWindowTargetedTypeActions',
+          entry.arguments,
+        ),
+      },
+    },
+    identity: { request_key: requestKey },
+  });
+  const first = validateAgentTraceOperationBinding(
+    entry, signed('listener:first'), 'paste', target, 'first paste',
+  );
+  const second = validateAgentTraceOperationBinding(
+    entry, signed('listener:second'), 'paste', target, 'second paste',
+  );
+  assert.notEqual(first, second);
+});
 
 let fixtureRequestCounter = 1;
 function signedBundleFixture(root, name, operation, targetValue, startedAt, completedAt, {

--- a/scripts/final-qualification/test/qualification-tools.test.mjs
+++ b/scripts/final-qualification/test/qualification-tools.test.mjs
@@ -2008,13 +2008,24 @@ function heldPointerClientID(executionNonce) {
   return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
 }
 
-function traceEntry(id, name, pid, windowID) {
+function traceEntry(id, name, pid, windowID, arguments_ = null) {
   return {
-    id, name, arguments: { pid, window_id: windowID, foreground: false },
+    id,
+    name,
+    arguments: arguments_ ?? { pid, window_id: windowID, foreground: false },
     result: { success: true, mutation_dispatched: true, mutation_dispatch: 'dispatched' },
     isError: false, disposition: 'executed/succeeded', mutationDispatch: 'dispatched',
     actionOutcome: actionOutcome(),
   };
+}
+
+function signedOperationRequestFixture(operation, traceArguments) {
+  const [requestCase, payload] = operation === 'setValue'
+    ? ['setValue', { target: traceArguments.on, snapshotId: traceArguments.snapshot }]
+    : ['exactWindowTargetedTypeActions', { snapshotId: traceArguments.snapshot ?? null }];
+  return canonicalBytes({
+    projectedAction: { _0: { request: { [requestCase]: { _0: payload } } } },
+  }).toString('base64');
 }
 
 let fixtureRequestCounter = 1;
@@ -2031,6 +2042,7 @@ function signedBundleFixture(root, name, operation, targetValue, startedAt, comp
   targetAbsent = false,
   outcome = null,
   outcomeAttested = mutating,
+  traceArguments = {},
 } = {}) {
   const requestOrdinal = fixtureRequestCounter++;
   const requestID = `00000000-0000-4000-8000-${String(requestOrdinal).padStart(12, '0')}`;
@@ -2065,7 +2077,10 @@ function signedBundleFixture(root, name, operation, targetValue, startedAt, comp
       requires_fresh_observation: false,
     }),
   };
-  const bundle = writeJSON(path.join(directory, `${name}-bundle.json`), { receipt: { payload } });
+  const bundle = writeJSON(path.join(directory, `${name}-bundle.json`), {
+    receipt: { payload },
+    canonicalRequest: signedOperationRequestFixture(operation, traceArguments),
+  });
   const validator = writeJSON(path.join(root, `${name}-validator.json`), {
     success: true,
     data: {
@@ -2273,9 +2288,55 @@ function semanticReadbackFixture(root, name, targetValue, phase, value, observed
   return filePath;
 }
 
+function agentTaskContractFixture(targetA, targetB) {
+  const steps = (baseline, mutationFamily, mutated, restorationFamily) => [
+    { phase: 'baseline', expected_value: baseline },
+    { phase: 'mutate', family: mutationFamily, expected_value: mutated },
+    { phase: 'verify-mutated', expected_value: mutated },
+    { phase: 'restore', family: restorationFamily, expected_value: baseline },
+    { phase: 'verify-restored', expected_value: baseline },
+  ];
+  return {
+    version: 1,
+    kind: 'peekaboo-concurrent-agent-qualification',
+    goal: 'two-target-background-mutate-verify-restore-with-concurrent-cu',
+    constraints: {
+      delivery_mode: 'background',
+      foreground: 'forbidden',
+      progress_interleaving: 'before-and-after-integrated-cu',
+      shell: 'forbidden',
+      skips_and_failures: 'forbidden',
+    },
+    targets: [
+      {
+        label: 'target-a',
+        target: structuredClone(targetA),
+        steps: steps('alpha', 'set_value', 'alpha!', 'set_value'),
+      },
+      {
+        label: 'target-b',
+        target: structuredClone(targetB),
+        steps: steps('beta', 'paste', 'beta!', 'type'),
+      },
+    ],
+    postconditions: {
+      all_targets_restored: true,
+      cleanup: 'restore-exact-baselines',
+      exact_dispatched_mutation_count: 4,
+      exact_target_count: 2,
+      minimum_primary_mutation_family_count: 2,
+      novel_restoration_family_required: true,
+      target_b_distinct_restoration_family: true,
+    },
+  };
+}
+
 function concurrentFixture(root, {
   agentFinishesBeforeIntegratedCU = false,
   agentTouchesIntegratedCUBoundary = false,
+  taskTextOverride = null,
+  taskContractMutator = null,
+  taskEncoding = 'canonical',
 } = {}) {
   const runRoot = privateDirectory(root, 'run');
   const monitorDirectory = privateDirectory(runRoot, 'monitor');
@@ -2287,6 +2348,8 @@ function concurrentFixture(root, {
   const operationsComplete = now - 2000;
   const foregroundTarget = target(203, '203001', 303);
   const sentinel = target(204, '204001', 304, 500);
+  const targetA = { pid: 301, start_identity: '301001', window_id: 401 };
+  const targetB = { pid: 302, start_identity: '302001', window_id: 402 };
   const planValue = {
     version: 1,
     peekaboo_executable: agentExecutable,
@@ -2412,19 +2475,28 @@ function concurrentFixture(root, {
     execution_plan_sha256: sha256(fs.readFileSync(plan)),
     execution_staged: true,
   });
-  const taskText = 'Operate only through Peekaboo background tools on two exact controlled windows.';
+  const taskContract = agentTaskContractFixture(targetA, targetB);
+  if (taskContractMutator !== null) taskContractMutator(taskContract);
+  const encodedTask = taskEncoding === 'pretty'
+    ? JSON.stringify(taskContract, null, 2)
+    : canonicalBytes(taskContract).toString('utf8');
+  const taskText = taskTextOverride ?? encodedTask;
   const taskPath = writeFile(path.join(root, 'agent-task.txt'), `${taskText}\n`, 0o400);
   const agentRunRoot = privateDirectory(root, 'agent-run-root');
   const agentReceipts = privateDirectory(agentRunRoot, 'agent-operation-receipts');
+  const traceArguments = {
+    aMutate: { on: 'fixture-a', snapshot: 'snapshot-a' },
+    aRestore: { on: 'fixture-a', snapshot: 'snapshot-a-restore' },
+    bMutate: { pid: 302, window_id: 402, foreground: false },
+    bRestore: { on: 'fixture-b', snapshot: 'snapshot-b-restore' },
+  };
   const entries = [
-    traceEntry('a-mutate', 'set_value', 301, 401),
-    traceEntry('a-restore', 'set_value', 301, 401),
-    traceEntry('b-mutate', 'paste', 302, 402),
-    traceEntry('b-restore', 'type', 302, 402),
+    traceEntry('a-mutate', 'set_value', 301, 401, traceArguments.aMutate),
+    traceEntry('a-restore', 'set_value', 301, 401, traceArguments.aRestore),
+    traceEntry('b-mutate', 'paste', 302, 402, traceArguments.bMutate),
+    traceEntry('b-restore', 'type', 302, 402, traceArguments.bRestore),
   ];
   const agentTrace = { entries, totalCallCount: entries.length, truncated: false };
-  const targetA = { pid: 301, start_identity: '301001', window_id: 401 };
-  const targetB = { pid: 302, start_identity: '302001', window_id: 402 };
   const agentClient = {
     pid: 901,
     start_identity: '901001',
@@ -2464,11 +2536,11 @@ function concurrentFixture(root, {
   );
   const bundleA = signedBundleFixture(
     root, 'a-mutate', 'setValue', targetA, operationsStart + 100, operationsStart + 200,
-    { directory: agentReceipts, client: agentClient },
+    { directory: agentReceipts, client: agentClient, traceArguments: traceArguments.aMutate },
   );
   const bundleARestore = signedBundleFixture(
     root, 'a-restore', 'setValue', targetA, operationsStart + 300, operationsStart + 400,
-    { directory: agentReceipts, client: agentClient },
+    { directory: agentReceipts, client: agentClient, traceArguments: traceArguments.aRestore },
   );
   const bundleB = signedBundleFixture(
     root, 'b-mutate', 'exactWindowTargetedTypeActions', targetB,
@@ -2478,7 +2550,7 @@ function concurrentFixture(root, {
     operationsStart + (agentFinishesBeforeIntegratedCU
       ? 440
       : agentTouchesIntegratedCUBoundary ? 490 : 650),
-    { directory: agentReceipts, client: agentClient },
+    { directory: agentReceipts, client: agentClient, traceArguments: traceArguments.bMutate },
   );
   const bundleBRestore = signedBundleFixture(
     root, 'b-restore', 'exactWindowTargetedTypeActions', targetB,
@@ -2488,7 +2560,7 @@ function concurrentFixture(root, {
     operationsStart + (agentFinishesBeforeIntegratedCU
       ? 480
       : agentTouchesIntegratedCUBoundary ? 550 : 850),
-    { directory: agentReceipts, client: agentClient },
+    { directory: agentReceipts, client: agentClient, traceArguments: traceArguments.bRestore },
   );
   const action = (id, family, readbackPath, bundle) => ({
     trace_call_id: id,
@@ -2604,6 +2676,48 @@ function mutateAgentTerminalBundle(spec, mutate) {
   writeJSON(spec.agent_execution_validator_report, validator);
 }
 
+function substituteAgentTerminalTask(spec, taskText) {
+  const bundle = JSON.parse(fs.readFileSync(spec.agent_execution_bundle));
+  const requestWire = JSON.parse(Buffer.from(bundle.canonicalRequest, 'base64'));
+  const responseWire = JSON.parse(Buffer.from(bundle.canonicalResponse, 'base64'));
+  const request = requestWire.projectedAction._0.request.agentExecutionTrace._0;
+  const response = responseWire.projectedAction._0.response.agentExecutionTrace._0;
+  request.task = taskText;
+  const taskSHA256 = sha256(Buffer.from(taskText, 'utf8'));
+  response.taskSHA256 = taskSHA256;
+  response.arguments[2] = taskText;
+  response.argumentsSHA256 = sha256(canonicalBytes(response.arguments));
+  const acknowledgement = JSON.parse(Buffer.from(response.acknowledgement.bytes, 'base64'));
+  acknowledgement.taskSHA256 = taskSHA256;
+  acknowledgement.argumentsSHA256 = response.argumentsSHA256;
+  const acknowledgementBytes = canonicalBytes(acknowledgement);
+  writeFile(response.acknowledgementPath, acknowledgementBytes);
+  response.acknowledgement = {
+    bytes: acknowledgementBytes.toString('base64'),
+    sha256: sha256(acknowledgementBytes),
+    byteCount: acknowledgementBytes.length,
+    truncated: false,
+    readErrorCode: null,
+  };
+  const requestBytes = canonicalBytes(requestWire);
+  const responseBytes = canonicalBytes(responseWire);
+  bundle.canonicalRequest = requestBytes.toString('base64');
+  bundle.canonicalResponse = responseBytes.toString('base64');
+  bundle.receipt.payload.requestSHA256 = sha256(requestBytes);
+  bundle.receipt.payload.responseSHA256 = sha256(responseBytes);
+  fs.chmodSync(spec.agent_task, 0o600);
+  writeFile(spec.agent_task, `${taskText}\n`, 0o400);
+  writeJSON(spec.agent_execution_bundle, bundle);
+  const plan = JSON.parse(fs.readFileSync(spec.plan));
+  const validator = JSON.parse(fs.readFileSync(spec.agent_execution_validator_report));
+  validator.data = fixtureAuthenticatedBundle({
+    bundlePath: spec.agent_execution_bundle,
+    expectedHost: plan.bridge.expected_host,
+  });
+  writeJSON(spec.agent_execution_validator_report, validator);
+  return { response, taskSHA256 };
+}
+
 function resealAgentTarget(fixture, targetIndex, replacement) {
   const readbackMap = JSON.parse(fs.readFileSync(fixture.spec.agent_readbacks));
   const targetEntry = readbackMap.targets[targetIndex];
@@ -2651,6 +2765,106 @@ function resealAgentTarget(fixture, targetIndex, replacement) {
   writeJSON(fixture.spec.agent_readbacks, readbackMap);
 }
 
+test('post-run validator rejects signed-consistent complex Agent-task substitutions', async (t) => {
+  const cases = [
+    {
+      name: 'empty task',
+      options: { taskTextOverride: '' },
+      error: /closed UTF-8 JSON contract/,
+    },
+    {
+      name: 'plausible but unstructured task',
+      options: {
+        taskTextOverride: 'Operate safely in the background on two controlled windows and restore them.',
+      },
+      error: /closed machine-readable JSON contract/,
+    },
+    {
+      name: 'empty semantic goal',
+      options: {
+        taskContractMutator: (contract) => {
+          contract.goal = '';
+        },
+      },
+      error: /goal is not the closed concurrent qualification goal/,
+    },
+    {
+      name: 'open task contract',
+      options: {
+        taskContractMutator: (contract) => {
+          contract.caller_claim = true;
+        },
+      },
+      error: /Agent task contract keys are not closed/,
+    },
+    {
+      name: 'noncanonical task encoding',
+      options: { taskEncoding: 'pretty' },
+      error: /canonical JSON encoding/,
+    },
+    {
+      name: 'plausible but wrong expected value',
+      options: {
+        taskContractMutator: (contract) => {
+          contract.targets[0].steps[1].expected_value = 'alpha?';
+          contract.targets[0].steps[2].expected_value = 'alpha?';
+        },
+      },
+      error: /mutation readback differs from its signed task expected value/,
+    },
+    {
+      name: 'cross-target expectation substitution',
+      options: {
+        taskContractMutator: (contract) => {
+          const firstValues = contract.targets[0].steps.map((step) => step.expected_value);
+          const secondValues = contract.targets[1].steps.map((step) => step.expected_value);
+          contract.targets[0].steps.forEach((step, index) => {
+            step.expected_value = secondValues[index];
+          });
+          contract.targets[1].steps.forEach((step, index) => {
+            step.expected_value = firstValues[index];
+          });
+        },
+      },
+      error: /baseline differs from its signed task expectation/,
+    },
+    {
+      name: 'task-goal substitution',
+      options: {
+        taskContractMutator: (contract) => {
+          contract.goal = 'observe-two-controlled-targets-and-report';
+        },
+      },
+      error: /goal is not the closed concurrent qualification goal/,
+    },
+    {
+      name: 'non-novel restoration family',
+      options: {
+        taskContractMutator: (contract) => {
+          contract.targets[1].steps[3].family = 'set_value';
+        },
+      },
+      error: /restoration family outside the primary mutations/,
+    },
+  ];
+  for (const item of cases) {
+    await t.test(item.name, () => {
+      const root = fs.mkdtempSync('/private/tmp/pbq-tools-task-contract-');
+      fs.chmodSync(root, 0o700);
+      try {
+        const fix = concurrentFixture(root, item.options);
+        const specPath = writeJSON(path.join(root, 'validation-input.json'), fix.spec);
+        assert.throws(
+          () => validateConcurrentRun(specPath, path.join(root, 'invalid-task-report.json')),
+          item.error,
+        );
+      } finally {
+        fs.rmSync(root, { recursive: true, force: true });
+      }
+    });
+  }
+});
+
 test('post-run validator requires zero exits, exact Agent generation, background trace, restoration, and overlap', () => {
   const root = fs.mkdtempSync('/private/tmp/pbq-tools-validate-');
   fs.chmodSync(root, 0o700);
@@ -2660,6 +2874,14 @@ test('post-run validator requires zero exits, exact Agent generation, background
     const output = path.join(root, 'validation-report.json');
     const result = validateConcurrentRun(specPath, output);
     assert.equal(result.report.passed, true);
+    const taskFileBytes = fs.readFileSync(fix.spec.agent_task);
+    const signedTaskBytes = taskFileBytes.subarray(0, taskFileBytes.length - 1);
+    assert.equal(result.report.agent.task_contract.task_file_sha256, sha256(taskFileBytes));
+    assert.equal(result.report.agent.task_contract.signed_task_sha256, sha256(signedTaskBytes));
+    assert.equal(
+      result.report.agent.task_contract.semantic_contract_sha256,
+      sha256(canonicalBytes(JSON.parse(signedTaskBytes.toString('utf8')))),
+    );
     assert.deepEqual(result.report.agent.mutation_families, ['paste', 'set_value']);
     assert.equal(result.report.overlap.agent_covers_operation_interval, true);
     assert.equal(
@@ -2914,6 +3136,51 @@ test('post-run validator rejects trace remapping through a copied signed receipt
   }
 });
 
+test('post-run validator binds every allowed trace target to its signed Bridge request', async (t) => {
+  const cases = [
+    {
+      name: 'set-value snapshot substitution',
+      index: 0,
+      mutate: (arguments_) => { arguments_.snapshot = 'substituted-set-value-snapshot'; },
+      error: /trace selectors differ from the signed Bridge request/,
+    },
+    {
+      name: 'paste exact-target substitution',
+      index: 2,
+      mutate: (arguments_) => {
+        arguments_.pid = 999;
+        arguments_.window_id = 1999;
+      },
+      error: /exact trace target differs from the signed Bridge request target/,
+    },
+    {
+      name: 'type snapshot substitution',
+      index: 3,
+      mutate: (arguments_) => { arguments_.snapshot = 'substituted-type-snapshot'; },
+      error: /trace snapshot differs from the signed Bridge request/,
+    },
+  ];
+  for (const testCase of cases) {
+    await t.test(testCase.name, () => {
+      const root = fs.mkdtempSync('/private/tmp/pbq-tools-trace-request-binding-');
+      fs.chmodSync(root, 0o700);
+      try {
+        const fix = concurrentFixture(root);
+        mutateAgentTerminalBundle(fix.spec, ({ stdoutRoot }) => {
+          testCase.mutate(stdoutRoot.result.executionTrace.entries[testCase.index].arguments);
+        });
+        const specPath = writeJSON(path.join(root, 'validation-input.json'), fix.spec);
+        assert.throws(
+          () => validateConcurrentRun(specPath, path.join(root, 'binding-substitution-report.json')),
+          testCase.error,
+        );
+      } finally {
+        fs.rmSync(root, { recursive: true, force: true });
+      }
+    });
+  }
+});
+
 test('post-run validator requires one closed successful certification summary', () => {
   const root = fs.mkdtempSync('/private/tmp/pbq-tools-summary-');
   fs.chmodSync(root, 0o700);
@@ -3146,6 +3413,29 @@ test('post-run validator requires positive signed durations and strict readback 
       assert.throws(
         () => validateConcurrentRun(specPath, path.join(root, 'equal-readback-report.json')),
         /does not strictly follow its signed dispatch/,
+      );
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  await t.test('cross-target signed interval overlap', () => {
+    const root = fs.mkdtempSync('/private/tmp/pbq-tools-overlapping-actions-');
+    fs.chmodSync(root, 0o700);
+    try {
+      const fix = concurrentFixture(root);
+      const firstPayload = JSON.parse(
+        fs.readFileSync(fix.agentBundles[0].bundle_path),
+      ).receipt.payload;
+      const operationsStart = firstPayload.startedAtUnixMilliseconds - 100;
+      mutateFixtureBundle(fix.spec, fix.agentBundles[2], (payload) => {
+        payload.startedAtUnixMilliseconds = operationsStart + 360;
+        payload.completedAtUnixMilliseconds = operationsStart + 390;
+      });
+      const specPath = writeJSON(path.join(root, 'validation-input.json'), fix.spec);
+      assert.throws(
+        () => validateConcurrentRun(specPath, path.join(root, 'overlapping-actions-report.json')),
+        /signed mutation intervals do not follow the task action order/,
       );
     } finally {
       fs.rmSync(root, { recursive: true, force: true });
@@ -4289,6 +4579,150 @@ test('qualification manifest closes every required evidence class and detects by
     );
     writeFile(concurrent.spec.agent_execution_bundle, retainedTerminalBundle);
     writeFile(concurrent.spec.agent_execution_validator_report, retainedTerminalValidator);
+    const traceSelectorInput = structuredClone(inputValue);
+    mutateAgentTerminalBundle(concurrent.spec, ({ stdoutRoot }) => {
+      stdoutRoot.result.executionTrace.entries[0].arguments.snapshot
+        = 'manifest-substituted-snapshot';
+    });
+    const traceSelectorBundle = JSON.parse(fs.readFileSync(
+      concurrent.spec.agent_execution_bundle,
+    ));
+    const traceSelectorResponseWire = JSON.parse(Buffer.from(
+      traceSelectorBundle.canonicalResponse,
+      'base64',
+    ));
+    const traceSelectorResponse = traceSelectorResponseWire.projectedAction._0.response
+      .agentExecutionTrace._0;
+    const traceSelectorConcurrent = structuredClone(concurrentValue);
+    traceSelectorConcurrent.agent.terminal_bundle_sha256 = sha256(fs.readFileSync(
+      concurrent.spec.agent_execution_bundle,
+    ));
+    traceSelectorConcurrent.agent.terminal_validator_report_sha256 = sha256(fs.readFileSync(
+      concurrent.spec.agent_execution_validator_report,
+    ));
+    traceSelectorConcurrent.agent.stdout_sha256 = traceSelectorResponse.stdout.sha256;
+    traceSelectorInput.agent_cu.validation_report = writeJSON(
+      path.join(root, 'trace-selector-substitution-concurrent.json'),
+      traceSelectorConcurrent,
+    );
+    assert.throws(
+      () => generateManifest(
+        writeJSON(path.join(root, 'trace-selector-substitution-input.json'), traceSelectorInput),
+        path.join(root, 'trace-selector-substitution-manifest.json'),
+      ),
+      /trace selectors differ from the signed Bridge request/,
+    );
+    writeFile(concurrent.spec.agent_execution_bundle, retainedTerminalBundle);
+    writeFile(concurrent.spec.agent_execution_validator_report, retainedTerminalValidator);
+    const retainedAgentTask = fs.readFileSync(concurrent.spec.agent_task);
+    const retainedAgentAcknowledgement = fs.readFileSync(
+      path.join(concurrent.spec.agent_run_root, 'agent-execution-ack.json'),
+    );
+    const arbitraryTaskContract = JSON.parse(retainedAgentTask);
+    arbitraryTaskContract.goal = 'arbitrary-signed-goal';
+    const arbitraryTaskText = canonicalBytes(arbitraryTaskContract).toString('utf8');
+    const substitutedTask = substituteAgentTerminalTask(concurrent.spec, arbitraryTaskText);
+    const arbitraryTaskInput = structuredClone(inputValue);
+    const arbitraryTaskConcurrent = structuredClone(concurrentValue);
+    arbitraryTaskConcurrent.agent.terminal_bundle_sha256 = sha256(fs.readFileSync(
+      concurrent.spec.agent_execution_bundle,
+    ));
+    arbitraryTaskConcurrent.agent.terminal_validator_report_sha256 = sha256(fs.readFileSync(
+      concurrent.spec.agent_execution_validator_report,
+    ));
+    arbitraryTaskConcurrent.agent.acknowledgement_sha256
+      = substitutedTask.response.acknowledgement.sha256;
+    arbitraryTaskConcurrent.agent.task_contract.task_file_sha256 = sha256(fs.readFileSync(
+      concurrent.spec.agent_task,
+    ));
+    arbitraryTaskConcurrent.agent.task_contract.signed_task_sha256 = substitutedTask.taskSHA256;
+    arbitraryTaskConcurrent.agent.task_contract.semantic_contract_sha256
+      = substitutedTask.taskSHA256;
+    arbitraryTaskInput.agent_cu.validation_report = writeJSON(
+      path.join(root, 'arbitrary-signed-task-concurrent.json'),
+      arbitraryTaskConcurrent,
+    );
+    assert.throws(
+      () => generateManifest(
+        writeJSON(path.join(root, 'arbitrary-signed-task-input.json'), arbitraryTaskInput),
+        path.join(root, 'arbitrary-signed-task-manifest.json'),
+      ),
+      /goal is not the closed concurrent qualification goal/,
+    );
+    fs.chmodSync(concurrent.spec.agent_task, 0o600);
+    writeFile(concurrent.spec.agent_task, retainedAgentTask, 0o400);
+    writeFile(
+      path.join(concurrent.spec.agent_run_root, 'agent-execution-ack.json'),
+      retainedAgentAcknowledgement,
+    );
+    writeFile(concurrent.spec.agent_execution_bundle, retainedTerminalBundle);
+    writeFile(concurrent.spec.agent_execution_validator_report, retainedTerminalValidator);
+    for (const taskMismatch of [
+      {
+        name: 'signed-task-value-mismatch',
+        mutateTask: (task) => {
+          task.targets[0].steps[1].expected_value = 'signed-alpha-different';
+          task.targets[0].steps[2].expected_value = 'signed-alpha-different';
+        },
+        mutateReport: (report) => {
+          report.agent.task_contract.target_expectations[0].mutated_value_sha256
+            = sha256(Buffer.from('signed-alpha-different'));
+        },
+        error: /readback differs from (?:its signed task expected value|its authenticated task expectation)/,
+      },
+      {
+        name: 'signed-task-per-target-family-swap',
+        mutateTask: (task) => {
+          task.targets[0].steps[1].family = 'paste';
+          task.targets[1].steps[1].family = 'set_value';
+        },
+        mutateReport: (report) => {
+          report.agent.task_contract.target_expectations[0].mutation_family = 'paste';
+          report.agent.task_contract.target_expectations[1].mutation_family = 'set_value';
+        },
+        error: /family differs from its signed task contract|differs from its signed terminal trace/,
+      },
+    ]) {
+      const task = JSON.parse(retainedAgentTask);
+      taskMismatch.mutateTask(task);
+      const taskText = canonicalBytes(task).toString('utf8');
+      const substituted = substituteAgentTerminalTask(concurrent.spec, taskText);
+      const mismatchInput = structuredClone(inputValue);
+      const mismatchConcurrent = structuredClone(concurrentValue);
+      mismatchConcurrent.agent.terminal_bundle_sha256 = sha256(fs.readFileSync(
+        concurrent.spec.agent_execution_bundle,
+      ));
+      mismatchConcurrent.agent.terminal_validator_report_sha256 = sha256(fs.readFileSync(
+        concurrent.spec.agent_execution_validator_report,
+      ));
+      mismatchConcurrent.agent.acknowledgement_sha256
+        = substituted.response.acknowledgement.sha256;
+      mismatchConcurrent.agent.task_contract.task_file_sha256 = sha256(fs.readFileSync(
+        concurrent.spec.agent_task,
+      ));
+      mismatchConcurrent.agent.task_contract.signed_task_sha256 = substituted.taskSHA256;
+      mismatchConcurrent.agent.task_contract.semantic_contract_sha256 = substituted.taskSHA256;
+      taskMismatch.mutateReport(mismatchConcurrent);
+      mismatchInput.agent_cu.validation_report = writeJSON(
+        path.join(root, `${taskMismatch.name}-concurrent.json`),
+        mismatchConcurrent,
+      );
+      assert.throws(
+        () => generateManifest(
+          writeJSON(path.join(root, `${taskMismatch.name}-input.json`), mismatchInput),
+          path.join(root, `${taskMismatch.name}-manifest.json`),
+        ),
+        taskMismatch.error,
+      );
+      fs.chmodSync(concurrent.spec.agent_task, 0o600);
+      writeFile(concurrent.spec.agent_task, retainedAgentTask, 0o400);
+      writeFile(
+        path.join(concurrent.spec.agent_run_root, 'agent-execution-ack.json'),
+        retainedAgentAcknowledgement,
+      );
+      writeFile(concurrent.spec.agent_execution_bundle, retainedTerminalBundle);
+      writeFile(concurrent.spec.agent_execution_validator_report, retainedTerminalValidator);
+    }
     const requesterSubstitutionInput = structuredClone(inputValue);
     const requesterSubstitutionConcurrent = structuredClone(concurrentValue);
     requesterSubstitutionConcurrent.agent.requester.pid += 20_000;
@@ -4430,38 +4864,6 @@ test('qualification manifest closes every required evidence class and detects by
       ),
       /does not match its trace family|signed terminal trace does not contain exactly the mapped dispatched calls/,
     );
-    const traceTargetDriftInput = structuredClone(inputValue);
-    mutateAgentTerminalBundle(concurrent.spec, ({ stdoutRoot }) => {
-      stdoutRoot.result.executionTrace.entries[0].arguments.pid += 1;
-    });
-    const traceTargetDriftBundle = JSON.parse(fs.readFileSync(
-      concurrent.spec.agent_execution_bundle,
-    ));
-    const traceTargetDriftResponse = JSON.parse(Buffer.from(
-      traceTargetDriftBundle.canonicalResponse,
-      'base64',
-    )).projectedAction._0.response.agentExecutionTrace._0;
-    const traceTargetDriftConcurrent = structuredClone(concurrentValue);
-    traceTargetDriftConcurrent.agent.terminal_bundle_sha256 = sha256(fs.readFileSync(
-      concurrent.spec.agent_execution_bundle,
-    ));
-    traceTargetDriftConcurrent.agent.terminal_validator_report_sha256 = sha256(fs.readFileSync(
-      concurrent.spec.agent_execution_validator_report,
-    ));
-    traceTargetDriftConcurrent.agent.stdout_sha256 = traceTargetDriftResponse.stdout.sha256;
-    traceTargetDriftInput.agent_cu.validation_report = writeJSON(
-      path.join(root, 'trace-target-drift-concurrent.json'),
-      traceTargetDriftConcurrent,
-    );
-    assert.throws(
-      () => generateManifest(
-        writeJSON(path.join(root, 'trace-target-drift-input.json'), traceTargetDriftInput),
-        path.join(root, 'trace-target-drift-manifest.json'),
-      ),
-      /trace lacks the exact PID\/window|differs from its signed terminal trace/,
-    );
-    writeFile(concurrent.spec.agent_execution_bundle, retainedTerminalBundle);
-    writeFile(concurrent.spec.agent_execution_validator_report, retainedTerminalValidator);
     const extraShellInput = structuredClone(inputValue);
     mutateAgentTerminalBundle(concurrent.spec, ({ stdoutRoot }) => {
       stdoutRoot.result.executionTrace.entries.push({

--- a/scripts/final-qualification/validate-concurrent-run.mjs
+++ b/scripts/final-qualification/validate-concurrent-run.mjs
@@ -14,8 +14,10 @@ import {
   authenticateAgentExecutionTerminalBundle,
   authenticateLiveBridgeBundle,
   authenticatedBridgeReceiptIdentity,
+  canonicalBytes,
   controlledFixtureBindings,
   corroboratedObservationTime,
+  decodeCanonicalBase64JSON,
   exactKeys,
   isAgentMutatingToolName,
   normalizedAgentToolName,
@@ -231,12 +233,221 @@ function signedBundle(filePath, validatorPath, operation, label, authentication)
 function expectedBridgeOperation(family) {
   return {
     set_value: 'setValue',
-    action: 'performAction',
-    click: 'exactWindowTargetedClick',
     type: 'exactWindowTargetedTypeActions',
     paste: 'exactWindowTargetedTypeActions',
-    press: 'exactWindowTargetedHotkey',
   }[family] ?? null;
+}
+
+function requiredTraceString(arguments_, key, label) {
+  const value = arguments_?.[key];
+  requireCondition(typeof value === 'string' && value.length > 0 && !value.includes('\0'),
+    `${label} trace ${key} selector is missing`);
+  return value;
+}
+
+function projectedSignedRequest(signed, requestCase, label) {
+  const decoded = decodeCanonicalBase64JSON(
+    signed.bundle.value?.canonicalRequest,
+    `${label} signed canonical request`,
+  ).value;
+  exactKeys(decoded, ['projectedAction'], `${label} signed request`);
+  exactKeys(decoded.projectedAction, ['_0'], `${label} signed projected action`);
+  const projection = decoded.projectedAction._0;
+  exactKeys(projection, ['request'], `${label} signed projected action payload`);
+  exactKeys(projection.request, [requestCase], `${label} signed Bridge request case`);
+  exactKeys(projection.request[requestCase], ['_0'], `${label} signed Bridge request payload`);
+  const request = projection.request[requestCase]._0;
+  requireCondition(request && typeof request === 'object' && !Array.isArray(request),
+    `${label} signed Bridge request payload is malformed`);
+  return request;
+}
+
+// Bind the provider-authored trace call to the listener-authenticated Bridge request. The
+// readback map alone is not authority for call-ID-to-bundle correlation.
+export function validateAgentTraceOperationBinding(entry, signed, family, expectedTarget, label) {
+  requireCondition(entry && typeof entry.arguments === 'object' && !Array.isArray(entry.arguments),
+    `${label} trace arguments are malformed`);
+  if (family === 'set_value') {
+    const on = requiredTraceString(entry.arguments, 'on', label);
+    const snapshot = requiredTraceString(entry.arguments, 'snapshot', label);
+    const request = projectedSignedRequest(signed, 'setValue', label);
+    requireCondition(request.target === on && request.snapshotId === snapshot,
+      `${label} trace selectors differ from the signed Bridge request`);
+    return `set_value:${snapshot}:${on}`;
+  }
+  if (family === 'type') {
+    const snapshot = requiredTraceString(entry.arguments, 'snapshot', label);
+    const request = projectedSignedRequest(signed, 'exactWindowTargetedTypeActions', label);
+    requireCondition(request.snapshotId === snapshot,
+      `${label} trace snapshot differs from the signed Bridge request`);
+    return `type:${snapshot}`;
+  }
+  if (family === 'paste') {
+    const request = projectedSignedRequest(signed, 'exactWindowTargetedTypeActions', label);
+    requireCondition(entry.arguments.pid === expectedTarget.pid
+      && entry.arguments.window_id === expectedTarget.window_id
+      && (request.snapshotId === undefined || request.snapshotId === null),
+    `${label} exact trace target differs from the signed Bridge request target`);
+    return `paste:${expectedTarget.pid}:${expectedTarget.start_identity}:${expectedTarget.window_id}`;
+  }
+  requireCondition(false, `${label} has no closed trace/request binding`);
+}
+
+export const AGENT_TASK_KIND = 'peekaboo-concurrent-agent-qualification';
+export const AGENT_TASK_GOAL = 'two-target-background-mutate-verify-restore-with-concurrent-cu';
+export const AGENT_TASK_CONSTRAINTS = Object.freeze({
+  delivery_mode: 'background',
+  foreground: 'forbidden',
+  progress_interleaving: 'before-and-after-integrated-cu',
+  shell: 'forbidden',
+  skips_and_failures: 'forbidden',
+});
+export const AGENT_TASK_POSTCONDITIONS = Object.freeze({
+  all_targets_restored: true,
+  cleanup: 'restore-exact-baselines',
+  exact_dispatched_mutation_count: 4,
+  exact_target_count: 2,
+  minimum_primary_mutation_family_count: 2,
+  novel_restoration_family_required: true,
+  target_b_distinct_restoration_family: true,
+});
+const AGENT_TASK_STEP_PHASES = [
+  'baseline', 'mutate', 'verify-mutated', 'restore', 'verify-restored',
+];
+
+function taskExpectedValue(value, label) {
+  requireCondition(typeof value === 'string' && Buffer.byteLength(value, 'utf8') <= 4096,
+    `${label} expected value is invalid`);
+  return value;
+}
+
+export function parseAgentTaskContract(taskReceipt, plan) {
+  let fileText;
+  try {
+    fileText = new TextDecoder('utf-8', { fatal: true }).decode(taskReceipt.bytes);
+  } catch {
+    requireCondition(false, 'Agent task must be one closed UTF-8 JSON contract plus one terminal newline');
+  }
+  requireCondition(fileText.endsWith('\n'),
+    'Agent task must be one closed UTF-8 JSON contract plus one terminal newline');
+  const taskText = fileText.slice(0, -1);
+  requireCondition(taskText.length > 0 && !taskText.endsWith('\n') && !taskText.includes('\0')
+    && Buffer.from(`${taskText}\n`, 'utf8').equals(taskReceipt.bytes),
+  'Agent task must be one closed UTF-8 JSON contract plus one terminal newline');
+  let contract;
+  try {
+    contract = JSON.parse(taskText);
+  } catch {
+    requireCondition(false, 'Agent task must be one closed machine-readable JSON contract');
+  }
+  requireCondition(Buffer.from(taskText, 'utf8').equals(canonicalBytes(contract)),
+    'Agent task must be the canonical JSON encoding of its closed contract');
+  exactKeys(contract, [
+    'version', 'kind', 'goal', 'constraints', 'targets', 'postconditions',
+  ], 'Agent task contract');
+  requireCondition(contract.version === 1 && contract.kind === AGENT_TASK_KIND,
+    'Agent task contract kind/version is invalid');
+  requireCondition(contract.goal === AGENT_TASK_GOAL,
+    'Agent task contract goal is not the closed concurrent qualification goal');
+  exactKeys(contract.constraints, Object.keys(AGENT_TASK_CONSTRAINTS),
+    'Agent task contract constraints');
+  requireCondition(sameJSON(contract.constraints, AGENT_TASK_CONSTRAINTS),
+    'Agent task contract constraints do not require background-only, no-Shell, failure-free interleaving');
+  exactKeys(contract.postconditions, Object.keys(AGENT_TASK_POSTCONDITIONS),
+    'Agent task contract postconditions');
+  requireCondition(sameJSON(contract.postconditions, AGENT_TASK_POSTCONDITIONS),
+    'Agent task contract postconditions are not the closed restoration/cleanup contract');
+  requireCondition(Array.isArray(contract.targets) && contract.targets.length === 2,
+    'Agent task contract must contain exactly two controlled targets');
+  const fixtureBindings = controlledFixtureBindings(plan, 'live-v4 plan').targets;
+  const primaryMutationFamilies = new Set();
+  const restorationFamilies = new Set();
+  const targetExpectations = contract.targets.map((entry, index) => {
+    const label = `target-${index === 0 ? 'a' : 'b'}`;
+    exactKeys(entry, ['label', 'target', 'steps'], `Agent task contract ${label}`);
+    requireCondition(entry.label === label, 'Agent task contract target order is not canonical');
+    exactKeys(entry.target, ['pid', 'start_identity', 'window_id'],
+      `Agent task contract ${label}.target`);
+    requireCondition(positiveInteger(entry.target.pid)
+      && positiveDecimal(entry.target.start_identity)
+      && positiveInteger(entry.target.window_id),
+    `Agent task contract ${label} target is malformed`);
+    requireCondition(sameJSON(entry.target, fixtureBindings[index].target),
+      `Agent task contract ${label} is not its exact live-v4 controlled fixture target`);
+    requireCondition(Array.isArray(entry.steps) && entry.steps.length === 5,
+      `Agent task contract ${label} must contain baseline/mutate/verify/restore/verify`);
+    const [baseline, mutation, mutationVerification, restoration, restorationVerification]
+      = entry.steps;
+    for (const [stepIndex, step] of entry.steps.entries()) {
+      const mutating = stepIndex === 1 || stepIndex === 3;
+      exactKeys(step, mutating ? ['phase', 'family', 'expected_value'] : ['phase', 'expected_value'],
+        `Agent task contract ${label}.steps[${stepIndex}]`);
+      requireCondition(step.phase === AGENT_TASK_STEP_PHASES[stepIndex],
+        `Agent task contract ${label} step order is not baseline/mutate/verify/restore/verify`);
+      taskExpectedValue(step.expected_value,
+        `Agent task contract ${label}.steps[${stepIndex}]`);
+    }
+    for (const [step, kind] of [[mutation, 'mutation'], [restoration, 'restoration']]) {
+      requireCondition(step.family === normalizedAgentToolName(step.family)
+        && expectedBridgeOperation(step.family) !== null,
+      `Agent task contract ${label} ${kind} family is unsupported`);
+    }
+    requireCondition(mutation.expected_value !== baseline.expected_value
+      && mutationVerification.expected_value === mutation.expected_value,
+    `Agent task contract ${label} mutated value/postcondition is inconsistent`);
+    requireCondition(restoration.expected_value === baseline.expected_value
+      && restorationVerification.expected_value === baseline.expected_value,
+    `Agent task contract ${label} restoration does not require the exact baseline`);
+    primaryMutationFamilies.add(mutation.family);
+    restorationFamilies.add(restoration.family);
+    if (label === 'target-b') {
+      requireCondition(restoration.family !== mutation.family,
+        'Agent task contract target-b restoration family must differ from its primary mutation');
+    }
+    return {
+      label,
+      target: structuredClone(entry.target),
+      baseline_value: baseline.expected_value,
+      mutation: { family: mutation.family, expected_value: mutation.expected_value },
+      restoration: { family: restoration.family, expected_value: restoration.expected_value },
+    };
+  });
+  requireCondition(primaryMutationFamilies.size >= 2,
+    'Agent task contract must require two primary mutation families');
+  requireCondition([...restorationFamilies].some((family) => !primaryMutationFamilies.has(family)),
+    'Agent task contract must require a restoration family outside the primary mutations');
+  return {
+    receipt: taskReceipt,
+    text: taskText,
+    contract,
+    semantic_sha256: sha256(canonicalBytes(contract)),
+    target_expectations: targetExpectations,
+  };
+}
+
+export function projectAgentTaskContractReport(taskContract, terminal) {
+  const signedTaskSHA256 = sha256(Buffer.from(taskContract.text, 'utf8'));
+  requireCondition(terminal.response.taskSHA256 === signedTaskSHA256,
+    'signed terminal task digest differs from the Agent task contract');
+  return {
+    version: 1,
+    kind: taskContract.contract.kind,
+    goal: taskContract.contract.goal,
+    task_file_sha256: taskContract.receipt.sha256,
+    signed_task_sha256: signedTaskSHA256,
+    semantic_contract_sha256: taskContract.semantic_sha256,
+    constraints: structuredClone(taskContract.contract.constraints),
+    postconditions: structuredClone(taskContract.contract.postconditions),
+    target_expectations: taskContract.target_expectations.map((entry) => ({
+      label: entry.label,
+      target: structuredClone(entry.target),
+      baseline_value_sha256: sha256(Buffer.from(entry.baseline_value, 'utf8')),
+      mutation_family: entry.mutation.family,
+      mutated_value_sha256: sha256(Buffer.from(entry.mutation.expected_value, 'utf8')),
+      restoration_family: entry.restoration.family,
+      restored_value_sha256: sha256(Buffer.from(entry.restoration.expected_value, 'utf8')),
+    })),
+  };
 }
 
 function agentBundleCorpus(
@@ -305,7 +516,7 @@ function agentBundleCorpus(
   return corpus;
 }
 
-function agentReadbacks(filePath, agent, trace, operation, plan, corpus) {
+function agentReadbacks(filePath, agent, trace, operation, plan, corpus, taskContract) {
   const retained = readStableJSON(filePath, 'Agent readback evidence');
   const value = retained.value;
   exactKeys(value, ['version', 'agent', 'targets'], 'Agent readback evidence');
@@ -330,6 +541,8 @@ function agentReadbacks(filePath, agent, trace, operation, plan, corpus) {
   const targetWindows = new Set();
   const readbackReceipts = [];
   const actionIntervals = [];
+  const orderedActionCallIDs = [];
+  const traceRequestBindings = new Set();
   for (const [index, target] of value.targets.entries()) {
     exactKeys(target, [
       'label', 'target', 'baseline_readback_path', 'mutation', 'restoration',
@@ -341,6 +554,10 @@ function agentReadbacks(filePath, agent, trace, operation, plan, corpus) {
       && positiveInteger(target.target.window_id), `Agent readback ${target.label} identity is invalid`);
     requireCondition(sameJSON(target.target, fixtureBindings[index].target),
       `Agent ${target.label} is not its exact live-v4 controlled fixture target`);
+    const taskExpectation = taskContract.target_expectations[index];
+    requireCondition(taskExpectation.label === target.label
+      && sameJSON(taskExpectation.target, target.target),
+    `Agent ${target.label} readback map differs from its signed task contract`);
     const processKey = `${target.target.pid}:${target.target.start_identity}`;
     targetProcesses.add(processKey);
     targetWindows.add(`${processKey}:${target.target.window_id}`);
@@ -353,6 +570,8 @@ function agentReadbacks(filePath, agent, trace, operation, plan, corpus) {
       operation,
       `Agent ${target.label} baseline readback`,
     );
+    requireCondition(baseline.value.value === taskExpectation.baseline_value,
+      `Agent ${target.label} baseline differs from its signed task expectation`);
     readbackReceipts.push(baseline);
     const actionReceipts = {};
     for (const [kind, phase] of [['mutation', 'mutated'], ['restoration', 'restored']]) {
@@ -369,11 +588,11 @@ function agentReadbacks(filePath, agent, trace, operation, plan, corpus) {
       const entry = trace.entriesByID.get(action.trace_call_id);
       requireCondition(action.family === normalizedAgentToolName(action.family)
         && isAgentMutatingToolName(action.family), `Agent readback ${target.label}.${kind} family is invalid`);
+      const taskAction = taskExpectation[kind];
+      requireCondition(action.family === taskAction.family,
+        `Agent readback ${target.label}.${kind} family differs from its signed task contract`);
       requireCondition(entry && normalizedAgentToolName(entry.name) === action.family,
         `Agent readback ${target.label}.${kind} does not match its trace family`);
-      requireCondition(entry.arguments?.pid === target.target.pid
-        && entry.arguments?.window_id === target.target.window_id,
-      `Agent readback ${target.label}.${kind} trace lacks the exact PID/window`);
       const expectedOperation = expectedBridgeOperation(action.family);
       requireCondition(expectedOperation !== null, `Agent ${target.label}.${kind} has no closed Bridge operation map`);
       const corpusEntry = corpus.get(action.bundle_path);
@@ -392,6 +611,16 @@ function agentReadbacks(filePath, agent, trace, operation, plan, corpus) {
       `Agent ${target.label}.${kind} signed outcome is not one definite background dispatch`);
       requireCondition(sameJSON(signedBundleTarget(signed.payload, `Agent ${target.label}.${kind}`), target.target),
         `Agent ${target.label}.${kind} signed target differs from its trace/readback target`);
+      const traceRequestBinding = validateAgentTraceOperationBinding(
+        entry,
+        signed,
+        action.family,
+        target.target,
+        `Agent ${target.label}.${kind}`,
+      );
+      requireCondition(!traceRequestBindings.has(traceRequestBinding),
+        `Agent ${target.label}.${kind} reuses a trace/request binding`);
+      traceRequestBindings.add(traceRequestBinding);
       requireCondition(signed.payload.startedAtUnixMilliseconds >= operation.start
         && signed.payload.completedAtUnixMilliseconds <= operation.complete,
       `Agent ${target.label}.${kind} signed interval falls outside live-v4 operations`);
@@ -402,6 +631,8 @@ function agentReadbacks(filePath, agent, trace, operation, plan, corpus) {
         operation,
         `Agent ${target.label} ${kind} readback`,
       );
+      requireCondition(readback.value.value === taskAction.expected_value,
+        `Agent ${target.label}.${kind} readback differs from its signed task expected value`);
       requireCondition(signed.payload.completedAtUnixMilliseconds < readback.value.observed_at_milliseconds,
         `Agent ${target.label}.${kind} readback does not strictly follow its signed dispatch`);
       readbackReceipts.push(readback);
@@ -411,6 +642,7 @@ function agentReadbacks(filePath, agent, trace, operation, plan, corpus) {
         started_at_milliseconds: signed.payload.startedAtUnixMilliseconds,
         completed_at_milliseconds: signed.payload.completedAtUnixMilliseconds,
       });
+      orderedActionCallIDs.push(action.trace_call_id);
     }
     requireCondition(actionReceipts.mutation.readback.value.value !== baseline.value.value,
       `Agent ${target.label} mutation did not change the baseline`);
@@ -448,6 +680,14 @@ function agentReadbacks(filePath, agent, trace, operation, plan, corpus) {
   requireCondition(usedCallIDs.size === 4
     && sameJSON([...usedCallIDs].sort(), [...trace.dispatchedCallIDs].sort()),
   'Agent trace must contain exactly the four mapped dispatched mutation call IDs');
+  requireCondition(orderedActionCallIDs.every((callID, index) => index === 0
+    || trace.entryIndexByID.get(orderedActionCallIDs[index - 1])
+      < trace.entryIndexByID.get(callID)),
+  'Agent trace does not follow the signed target-a then target-b mutate/restore task order');
+  requireCondition(actionIntervals.every((entry, index) => index === 0
+    || actionIntervals[index - 1].completed_at_milliseconds
+      < entry.started_at_milliseconds),
+  'Agent signed mutation intervals do not follow the task action order');
   for (const [bundlePath, item] of corpus.entries()) {
     if (usedBundlePaths.has(bundlePath)) continue;
     requireCondition(item.payload.outcome?.mutation_dispatched !== true
@@ -679,11 +919,11 @@ export function validateConcurrentRunSpec(spec, outputPath, {
     && new Set(plan.bridge.trusted_host_team_ids).size === plan.bridge.trusted_host_team_ids.length,
   'live-v4 plan Bridge trust policy is invalid');
   requirePrivateDirectory(spec.agent_run_root, 'Agent execution run root');
-  const agentTask = readStableFile(spec.agent_task, 'Agent task');
-  const taskText = agentTask.bytes.toString('utf8').replace(/\n$/, '');
-  requireCondition(taskText.length > 0 && !taskText.includes('\0')
-    && Buffer.from(`${taskText}\n`, 'utf8').equals(agentTask.bytes),
-  'Agent task must contain exact UTF-8 task text plus one terminal newline');
+  const agentTask = parseAgentTaskContract(
+    readStableFile(spec.agent_task, 'Agent task'),
+    plan,
+  );
+  const taskText = agentTask.text;
   const agentExecutable = requireStableExecutable(plan.peekaboo_executable, 'Agent executable', {
     allowRootOwner: true,
   });
@@ -786,6 +1026,7 @@ export function validateConcurrentRunSpec(spec, outputPath, {
     operation,
     plan,
     corpus,
+    agentTask,
   );
   const cuPerformAt = performReadback.value.observed_at_milliseconds;
   requireCondition(readbacks.action_intervals.some((entry) => (
@@ -835,6 +1076,7 @@ export function validateConcurrentRunSpec(spec, outputPath, {
       acknowledged_at_milliseconds: terminal.response.acknowledgedAt,
       released_at_milliseconds: terminal.response.releasedAt,
       terminal_observation_ended_at_milliseconds: terminal.response.terminalObservationEndedAt,
+      task_contract: projectAgentTaskContractReport(agentTask, terminal),
       readbacks_sha256: readbacks.retained.sha256,
       controlled_fixture_targets: readbacks.controlled_fixture_targets,
       mutation_families: readbacks.mutation_families,

--- a/scripts/final-qualification/validate-concurrent-run.mjs
+++ b/scripts/final-qualification/validate-concurrent-run.mjs
@@ -288,7 +288,13 @@ export function validateAgentTraceOperationBinding(entry, signed, family, expect
       && entry.arguments.window_id === expectedTarget.window_id
       && (request.snapshotId === undefined || request.snapshotId === null),
     `${label} exact trace target differs from the signed Bridge request target`);
-    return `paste:${expectedTarget.pid}:${expectedTarget.start_identity}:${expectedTarget.window_id}`;
+    return [
+      'paste',
+      expectedTarget.pid,
+      expectedTarget.start_identity,
+      expectedTarget.window_id,
+      signed.identity.request_key,
+    ].join(':');
   }
   requireCondition(false, `${label} has no closed trace/request binding`);
 }


### PR DESCRIPTION
## What Problem This Solves

The terminal qualification accepted a prose Agent task and caller-authored mappings between trace calls, signed Bridge receipts, and semantic readbacks. That could not objectively prove the user's final requirement: one real Agent completing a multi-step two-target background automation task while independent integrated computer use overlaps it.

## Why This Change Was Made

- requires one canonical signed JSON task with exactly two plan-owned targets, background-only/no-Shell/no-skip constraints, baseline → mutate → verify → restore → verify steps, two primary mutation families, and a novel restoration family
- limits qualification actions to `set_value`, `type`, and `paste`, then binds every sanitized Agent trace selector to the listener-authenticated canonical Bridge request and exact signed target
- independently reparses the retained task and regenerates per-target families and expected-value hashes during run validation, manifest generation, and manifest verification
- retains owner-authored semantic readbacks as an explicit trust boundary instead of describing them as Agent-emitted observations

## User Impact

The final physical certificate can no longer pass with an empty/prose/substituted goal, cross-target expectations, remapped receipts, different per-target families or values, non-novel restoration, overlapping dispatches, or missing Agent progress around integrated computer use. This changes qualification evidence only; it does not launch apps, alter runtime behavior, or publish artifacts.

## Compatibility Decision

This intentionally makes prose-task qualification evidence incompatible. The earlier evidence is diagnostic, not a published API or release artifact, and it cannot prove the terminal two-target Agent requirement. We accept the strict cutover and will regenerate the private physical qualification from the final merged source; no compatibility parser or trust-weakening fallback will be retained.

## Evidence

- three Node syntax checks
- qualification tools: 45/45 passed, including set-value/paste/type trace-request substitutions, same-target distinct paste receipts, and resealed signed-task semantic substitutions
- `pnpm run test:safe`: passed, including 45 qualification tests, Foundation, and 503 CLI tests in 64 suites
- `pnpm run lint`: exit 0, 88 existing warnings and 0 serious violations
- `pnpm run format`: 0 files changed
- structured Autoreview: clean after fixing three accepted P0 false-proof paths
- Cursor follow-up fixed and locally re-reviewed: same-target paste dispatches remain distinct by authenticated request identity
- `git diff --check`

AI-assisted: yes. I reviewed the complete four-file change and its trust boundaries.
