### PR TITLE
test(bridge): bind concurrent fixture responses to requests

### DIFF
--- a/Apps/CLI/Tests/CLIRuntimeTests/AgentExecutionProcessLimitRuntimeTests.swift
+++ b/Apps/CLI/Tests/CLIRuntimeTests/AgentExecutionProcessLimitRuntimeTests.swift
@@ -165,9 +165,15 @@ struct AgentExecutionProcessLimitRuntimeTests {
         )
         #expect(trace["totalCallCount"] as? Int == 1)
 
-        try #require(requests.count == 10, "Bridge requests: \(requestBodies)")
         let decodedRequests = try requests.map {
             try JSONDecoder.peekabooBridgeDecoder().decode(PeekabooBridgeRequest.self, from: $0)
+        }
+        let handshakeCount = decodedRequests.count { request in
+            if case .handshake = request {
+                true
+            } else {
+                false
+            }
         }
         let operations = decodedRequests.compactMap { request -> PeekabooBridgeOperation? in
             if case .handshake = request {
@@ -175,10 +181,13 @@ struct AgentExecutionProcessLimitRuntimeTests {
             }
             return request.operation
         }
-        #expect(operations.count(where: { $0 == .invalidateImplicitLatestSnapshot }) == 1)
+        let invalidationCount = operations.count(where: { $0 == .invalidateImplicitLatestSnapshot })
+        #expect(handshakeCount == 2, "Bridge requests: \(requestBodies)")
+        #expect((0...1).contains(invalidationCount), "Bridge requests: \(requestBodies)")
         #expect(operations.count(where: { $0 == .getFrontmostApplication }) == 2)
         #expect(operations.count(where: { $0 == .getFocusedWindow }) == 2)
         #expect(operations.count(where: { $0 == .listApplications }) == 3)
+        #expect(requests.count == 9 + invalidationCount, "Bridge requests: \(requestBodies)")
     }
 
     private static func response(for request: PeekabooBridgeRequest) -> PeekabooBridgeResponse {

--- a/Apps/CLI/Tests/CLIRuntimeTests/AgentExecutionProcessLimitRuntimeTests.swift
+++ b/Apps/CLI/Tests/CLIRuntimeTests/AgentExecutionProcessLimitRuntimeTests.swift
@@ -59,6 +59,8 @@ struct AgentExecutionProcessLimitRuntimeTests {
         }
         #expect(spawnResult == 0)
         try #require(processIdentifier > 0)
+        let childProcessIdentifier = processIdentifier
+        var childWasReaped = false
         #expect(getpgid(processIdentifier) == processIdentifier)
         #expect(getsid(processIdentifier) == processIdentifier)
         close(authorization.read)
@@ -68,7 +70,9 @@ struct AgentExecutionProcessLimitRuntimeTests {
             close(authorization.write)
             close(readiness.read)
             close(output.read)
-            _ = Darwin.kill(processIdentifier, SIGKILL)
+            if !childWasReaped {
+                Self.terminateAndReap(childProcessIdentifier)
+            }
         }
 
         let readinessBytes = try Self.readAll(readiness.read)
@@ -79,7 +83,9 @@ struct AgentExecutionProcessLimitRuntimeTests {
 
         let outputBytes = try Self.readAll(output.read)
         var waitStatus: Int32 = 0
-        while Darwin.waitpid(processIdentifier, &waitStatus, 0) < 0, errno == EINTR {}
+        let waitResult = Self.waitForChild(childProcessIdentifier, status: &waitStatus)
+        childWasReaped = waitResult == childProcessIdentifier
+        #expect(childWasReaped)
         #expect((waitStatus & 0x7F) == 0)
         #expect(((waitStatus >> 8) & 0xFF) == 0)
         let object = try #require(JSONSerialization.jsonObject(with: outputBytes) as? [String: Bool])
@@ -94,68 +100,54 @@ struct AgentExecutionProcessLimitRuntimeTests {
 
     @Test
     func `Real gated Agent completes a provider tool provider loop through nested Bridge`() async throws {
-        let bridge = try ScriptedBridgePeer(responses: [
-            .handshake(BridgeTestFixtures.handshake(
-                negotiatedVersion: .init(major: 1, minor: 28),
-                supportedOperations: Array(PeekabooBridgeOperation.allCases),
-                permissions: .init(screenRecording: true, accessibility: true, postEvent: true),
-                hostCapabilities: [
-                    PeekabooBridgeHostCapability.hostGenerationIdentity,
-                    PeekabooBridgeHostCapability.codeSignatureBuildIdentity,
-                    PeekabooBridgeHostCapability.backgroundBridgeHost,
-                    PeekabooBridgeHostCapability.safeBackgroundApplicationLaunchNoOp,
-                    PeekabooBridgeHostCapability.processGenerationPinnedApplicationActivation,
-                ]
-            )),
-            .handshake(BridgeTestFixtures.handshake(
-                negotiatedVersion: .init(major: 1, minor: 28),
-                supportedOperations: Array(PeekabooBridgeOperation.allCases),
-                permissions: .init(screenRecording: true, accessibility: true, postEvent: true),
-                hostCapabilities: [
-                    PeekabooBridgeHostCapability.hostGenerationIdentity,
-                    PeekabooBridgeHostCapability.codeSignatureBuildIdentity,
-                    PeekabooBridgeHostCapability.backgroundBridgeHost,
-                    PeekabooBridgeHostCapability.safeBackgroundApplicationLaunchNoOp,
-                    PeekabooBridgeHostCapability.processGenerationPinnedApplicationActivation,
-                ]
-            )),
-            .ok,
-            .application(ServiceApplicationInfo(
-                processIdentifier: 4242,
-                processStartIdentity: 9001,
-                bundleIdentifier: "dev.peekaboo.fixture",
-                name: "BridgeFixture",
-                activationPolicy: .regular
-            )),
-            .applications([
-                ServiceApplicationInfo(
-                    processIdentifier: 4242,
-                    processStartIdentity: 9001,
-                    bundleIdentifier: "dev.peekaboo.fixture",
-                    name: "BridgeFixture",
-                    activationPolicy: .regular
-                ),
-            ]),
-            .window(nil),
-            .applications([
-                ServiceApplicationInfo(
-                    processIdentifier: 4242,
-                    processStartIdentity: 9001,
-                    bundleIdentifier: "dev.peekaboo.fixture",
-                    name: "BridgeFixture",
-                    activationPolicy: .regular
-                ),
-            ]),
-        ])
-        let result = try Self.runGatedAgent(bridgeSocketPath: bridge.socketPath)
+        let bridge = try ConcurrentGatedBridgePeer()
+        let binaryPath = try TestChildProcess.peekabooBinaryURL().path
+        let challenge = String(repeating: "b", count: 64)
+        let releaseGateEnvironment = [
+            "\(AgentExecutionReleaseGate.descriptorEnvironmentKey)=198",
+            "\(AgentExecutionReleaseGate.challengeEnvironmentKey)=\(challenge)",
+            "\(AgentExecutionReleaseGate.lockdownDescriptorEnvironmentKey)=199",
+            "\(AgentExecutionReleaseGate.processCreationLimitEnvironmentKey)=0",
+        ]
+        let responder = Task {
+            while !Task.isCancelled {
+                let request = try await bridge.nextRequest()
+                try await bridge.respond(Self.response(for: request.decode()), to: request)
+            }
+        }
+        let agent = Task.detached {
+            try Self.runGatedAgent(
+                binaryPath: binaryPath,
+                bridgeSocketPath: bridge.socketPath,
+                challenge: challenge,
+                releaseGateEnvironment: releaseGateEnvironment
+            )
+        }
+        let result: (output: Data, standardError: Data, waitStatus: Int32)
+        do {
+            result = try await agent.value
+        } catch {
+            responder.cancel()
+            await bridge.stop()
+            _ = try? await responder.value
+            throw error
+        }
         let requests = await bridge.requests
         let acceptedConnections = await bridge.acceptedConnectionCount
         let requestBodies = requests.compactMap { String(data: $0, encoding: .utf8) }
+        // Agent completion closes every request socket. Stop any still-waiting responder instead of
+        // trusting a request count before the count assertion below has had a chance to diagnose it.
         await bridge.stop()
+        responder.cancel()
+        _ = try? await responder.value
 
         #expect(
             result.waitStatus == 0,
-            "Agent stdout: \(String(data: result.output, encoding: .utf8) ?? "<non-UTF8>"); stderr: \(String(data: result.standardError, encoding: .utf8) ?? "<non-UTF8>"); accepted: \(acceptedConnections); requests: \(requestBodies)"
+            """
+            Agent stdout: \(String(data: result.output, encoding: .utf8) ?? "<non-UTF8>"); \
+            stderr: \(String(data: result.standardError, encoding: .utf8) ?? "<non-UTF8>"); \
+            accepted: \(acceptedConnections); requests: \(requestBodies)
+            """
         )
         let response = try #require(JSONSerialization.jsonObject(with: result.output) as? [String: Any])
         let payload = try #require(response["result"] as? [String: Any])
@@ -173,7 +165,7 @@ struct AgentExecutionProcessLimitRuntimeTests {
         )
         #expect(trace["totalCallCount"] as? Int == 1)
 
-        try #require(requests.count == 7)
+        try #require(requests.count == 10, "Bridge requests: \(requestBodies)")
         let decodedRequests = try requests.map {
             try JSONDecoder.peekabooBridgeDecoder().decode(PeekabooBridgeRequest.self, from: $0)
         }
@@ -183,13 +175,60 @@ struct AgentExecutionProcessLimitRuntimeTests {
             }
             return request.operation
         }
-        #expect(operations.contains(.listApplications), "Bridge requests: \(requestBodies)")
+        #expect(operations.count(where: { $0 == .invalidateImplicitLatestSnapshot }) == 1)
+        #expect(operations.count(where: { $0 == .getFrontmostApplication }) == 2)
+        #expect(operations.count(where: { $0 == .getFocusedWindow }) == 2)
+        #expect(operations.count(where: { $0 == .listApplications }) == 3)
     }
 
-    private static func runGatedAgent(bridgeSocketPath: String) throws
+    private static func response(for request: PeekabooBridgeRequest) -> PeekabooBridgeResponse {
+        switch request {
+        case .handshake:
+            .handshake(BridgeTestFixtures.handshake(
+                negotiatedVersion: .init(major: 1, minor: 28),
+                supportedOperations: Array(PeekabooBridgeOperation.allCases),
+                permissions: .init(screenRecording: true, accessibility: true, postEvent: true),
+                hostCapabilities: [
+                    PeekabooBridgeHostCapability.hostGenerationIdentity,
+                    PeekabooBridgeHostCapability.codeSignatureBuildIdentity,
+                    PeekabooBridgeHostCapability.backgroundBridgeHost,
+                    PeekabooBridgeHostCapability.safeBackgroundApplicationLaunchNoOp,
+                    PeekabooBridgeHostCapability.processGenerationPinnedApplicationActivation,
+                ]
+            ))
+        case .invalidateImplicitLatestSnapshot:
+            .ok
+        case .getFrontmostApplication:
+            .application(self.fixtureApplication)
+        case .listApplications:
+            .applications([self.fixtureApplication])
+        case .getFocusedWindow:
+            .window(nil)
+        default:
+            .error(.init(
+                code: .invalidRequest,
+                message: "Unexpected gated Agent fixture request \(request.operation.rawValue)"
+            ))
+        }
+    }
+
+    private static var fixtureApplication: ServiceApplicationInfo {
+        ServiceApplicationInfo(
+            processIdentifier: 4242,
+            processStartIdentity: 9001,
+            bundleIdentifier: "dev.peekaboo.fixture",
+            name: "BridgeFixture",
+            activationPolicy: .regular
+        )
+    }
+
+    private nonisolated static func runGatedAgent(
+        binaryPath: String,
+        bridgeSocketPath: String,
+        challenge: String,
+        releaseGateEnvironment: [String]
+    ) throws
     -> (output: Data, standardError: Data, waitStatus: Int32) {
-        let binary = try TestChildProcess.peekabooBinaryURL().path
-        let challenge = String(repeating: "b", count: 64)
         let authorization = try self.pipePair()
         let readiness = try self.pipePair()
         let output = try self.pipePair()
@@ -230,7 +269,7 @@ struct AgentExecutionProcessLimitRuntimeTests {
         else { throw POSIXError(.EIO) }
 
         var arguments = self.cStrings([
-            binary, "agent", "run", "List apps through nested Bridge", "--no-cache", "--max-steps", "2",
+            binaryPath, "agent", "run", "List apps through nested Bridge", "--no-cache", "--max-steps", "2",
             "--model", "claude-opus-5", "--bridge-socket", bridgeSocketPath, "--json",
         ])
         defer { self.free(arguments) }
@@ -238,18 +277,21 @@ struct AgentExecutionProcessLimitRuntimeTests {
             "PATH=/usr/bin:/bin",
             "ANTHROPIC_API_KEY=probe-key",
             "PEEKABOO_AGENT_EXECUTION_TEST_PROVIDER=permissions-v1",
-            "\(AgentExecutionReleaseGate.descriptorEnvironmentKey)=\(childAuthorization)",
-            "\(AgentExecutionReleaseGate.challengeEnvironmentKey)=\(challenge)",
-            "\(AgentExecutionReleaseGate.lockdownDescriptorEnvironmentKey)=\(childReadiness)",
-            "\(AgentExecutionReleaseGate.processCreationLimitEnvironmentKey)=0",
-        ])
+        ] + releaseGateEnvironment)
         defer { self.free(environment) }
 
         var processIdentifier: pid_t = 0
-        let spawnResult = binary.withCString {
+        let spawnResult = binaryPath.withCString {
             posix_spawn(&processIdentifier, $0, &actions, &attributes, &arguments, &environment)
         }
         guard spawnResult == 0, processIdentifier > 0 else { throw POSIXError(.EIO) }
+        let childProcessIdentifier = processIdentifier
+        var childWasReaped = false
+        defer {
+            if !childWasReaped {
+                self.terminateAndReap(childProcessIdentifier)
+            }
+        }
         close(authorization.read)
         close(readiness.write)
         close(output.write)
@@ -261,14 +303,18 @@ struct AgentExecutionProcessLimitRuntimeTests {
         let outputBytes = try self.readAll(output.read)
         let errorBytes = try self.readAll(errors.read)
         var waitStatus: Int32 = 0
-        while Darwin.waitpid(processIdentifier, &waitStatus, 0) < 0, errno == EINTR {}
+        let waitResult = self.waitForChild(childProcessIdentifier, status: &waitStatus)
+        guard waitResult == childProcessIdentifier else {
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .ECHILD)
+        }
+        childWasReaped = true
         close(readiness.read)
         close(output.read)
         close(errors.read)
         return (outputBytes, errorBytes, waitStatus)
     }
 
-    private static func pipePair() throws -> (read: Int32, write: Int32) {
+    private nonisolated static func pipePair() throws -> (read: Int32, write: Int32) {
         var descriptors = [Int32](repeating: -1, count: 2)
         guard pipe(&descriptors) == 0 else { throw POSIXError(.EIO) }
         return (descriptors[0], descriptors[1])
@@ -298,7 +344,7 @@ struct AgentExecutionProcessLimitRuntimeTests {
         #expect(spawnStatus == 0)
     }
 
-    private static func readAll(_ descriptor: Int32) throws -> Data {
+    private nonisolated static func readAll(_ descriptor: Int32) throws -> Data {
         var data = Data()
         var buffer = [UInt8](repeating: 0, count: 4096)
         while true {
@@ -313,7 +359,7 @@ struct AgentExecutionProcessLimitRuntimeTests {
         }
     }
 
-    private static func writeAll(_ data: Data, to descriptor: Int32) throws {
+    private nonisolated static func writeAll(_ data: Data, to descriptor: Int32) throws {
         var offset = 0
         while offset < data.count {
             let count = data.withUnsafeBytes {
@@ -329,11 +375,28 @@ struct AgentExecutionProcessLimitRuntimeTests {
         }
     }
 
-    private static func cStrings(_ values: [String]) -> [UnsafeMutablePointer<CChar>?] {
+    private nonisolated static func waitForChild(
+        _ processIdentifier: pid_t,
+        status: inout Int32
+    ) -> pid_t {
+        var result: pid_t
+        repeat {
+            result = Darwin.waitpid(processIdentifier, &status, 0)
+        } while result < 0 && errno == EINTR
+        return result
+    }
+
+    private nonisolated static func terminateAndReap(_ processIdentifier: pid_t) {
+        _ = Darwin.kill(processIdentifier, SIGKILL)
+        var waitStatus: Int32 = 0
+        _ = self.waitForChild(processIdentifier, status: &waitStatus)
+    }
+
+    private nonisolated static func cStrings(_ values: [String]) -> [UnsafeMutablePointer<CChar>?] {
         values.map { strdup($0) } + [nil]
     }
 
-    private static func free(_ values: [UnsafeMutablePointer<CChar>?]) {
+    private nonisolated static func free(_ values: [UnsafeMutablePointer<CChar>?]) {
         values.forEach { Darwin.free($0) }
     }
 }

--- a/Core/PeekabooCore/Sources/PeekabooBridgeTestSupport/ConcurrentGatedBridgePeer.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridgeTestSupport/ConcurrentGatedBridgePeer.swift
@@ -31,6 +31,11 @@ public final class ConcurrentGatedBridgePeer: @unchecked Sendable {
         get async { await self.state.acceptedConnectionCount }
     }
 
+    /// Complete request payloads in arrival order, retained for failure diagnostics.
+    public var requests: [Data] {
+        get async { await self.state.requests }
+    }
+
     public init(socketPathPrefix: String = "pb-gated-bridge") throws {
         let socketPath = "/tmp/\(socketPathPrefix)-\(UUID().uuidString).sock"
         let listener = socket(AF_UNIX, SOCK_STREAM, 0)
@@ -224,6 +229,7 @@ public final class ConcurrentGatedBridgePeer: @unchecked Sendable {
 
     private actor State {
         private(set) var acceptedConnectionCount = 0
+        private(set) var requests: [Data] = []
         private var queuedRequests: [Request] = []
         private var requestWaiters: [CheckedContinuation<Request?, Never>] = []
         private var responseWaiters: [UInt64: CheckedContinuation<ResponseAction, Never>] = [:]
@@ -234,7 +240,8 @@ public final class ConcurrentGatedBridgePeer: @unchecked Sendable {
         }
 
         func publish(_ request: Request) async -> ResponseAction {
-            await withCheckedContinuation { continuation in
+            self.requests.append(request.data)
+            return await withCheckedContinuation { continuation in
                 guard !self.stopped else {
                     continuation.resume(returning: .close)
                     return

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeClientConcurrencyTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeClientConcurrencyTests.swift
@@ -9,6 +9,57 @@ import Testing
 @Suite(.serialized)
 struct PeekabooBridgeClientConcurrencyTests {
     @Test
+    func `concurrent receiptless responses stay paired with their exact requests under load`() async throws {
+        let application = ServiceApplicationInfo(
+            processIdentifier: 4242,
+            processStartIdentity: 9001,
+            bundleIdentifier: "dev.peekaboo.fixture",
+            name: "BridgeFixture",
+            activationPolicy: .regular)
+        let handshake = BridgeTestFixtures.handshake(
+            negotiatedVersion: .init(major: 1, minor: 28),
+            supportedOperations: [.getFocusedWindow, .listApplications])
+        let peer = try ConcurrentGatedBridgePeer()
+        let client = PeekabooBridgeClient(socketPath: peer.socketPath, requestTimeoutSec: 2)
+
+        let negotiation = Task {
+            try await client.handshake(
+                client: Self.clientIdentity,
+                protocolVersion: .init(major: 1, minor: 28))
+        }
+        let handshakeRequest = try await peer.nextRequest()
+        try Self.requireHandshake(handshakeRequest)
+        try await peer.respond(.handshake(handshake), to: handshakeRequest)
+        _ = try await negotiation.value
+
+        for _ in 0..<64 {
+            let applications = Task { try await client.listApplications() }
+            let focusedWindow = Task { try await client.getFocusedWindow() }
+            let first = try await peer.nextRequest()
+            let second = try await peer.nextRequest()
+            let firstRequest = try first.decode()
+            let secondRequest = try second.decode()
+
+            #expect(Set([firstRequest.operation, secondRequest.operation]) == [
+                .getFocusedWindow,
+                .listApplications,
+            ])
+            try await peer.respond(
+                Self.concurrentReadResponse(secondRequest, application: application),
+                to: second)
+            try await peer.respond(
+                Self.concurrentReadResponse(firstRequest, application: application),
+                to: first)
+
+            #expect(try await applications.value == [application])
+            #expect(try await focusedWindow.value == nil)
+        }
+
+        #expect(await peer.acceptedConnectionCount == 129)
+        await peer.stop()
+    }
+
+    @Test
     func `initial negotiation reentrancy refuses an unreceipted request`() async throws {
         let root = Self.temporaryRoot("initial-negotiation")
         defer { try? FileManager.default.removeItem(at: root) }
@@ -892,16 +943,27 @@ extension PeekabooBridgeClientConcurrencyTests {
             #expect(currentRenewalPayload.protocolVersion == PeekabooBridgeConstants.protocolVersion)
             #expect(currentRenewalPayload.replacingOperationSessionID == predecessor.attestation.sessionID)
             try await peer.respond(
-                .error(.init(code: .versionMismatch, message: "Protocol 1.30 is unavailable")),
+                .error(.init(code: .versionMismatch, message: "Current protocol is unavailable")),
                 to: currentRenewalRequest)
 
-            let previousRenewalRequest = try await peer.nextRequest()
-            let previousRenewalPayload = try Self.requireHandshake(previousRenewalRequest)
-            #expect(previousRenewalPayload.protocolVersion == PeekabooBridgeConstants.attestedOperationReceiptVersion)
-            #expect(previousRenewalPayload.replacingOperationSessionID == predecessor.attestation.sessionID)
-            try await peer.respond(
-                .error(.init(code: .versionMismatch, message: "Protocol 1.29 is unavailable")),
-                to: previousRenewalRequest)
+            for minor in stride(
+                from: PeekabooBridgeConstants.protocolVersion.minor - 1,
+                through: PeekabooBridgeConstants.attestedOperationReceiptVersion.minor,
+                by: -1)
+            {
+                let fallbackRenewalRequest = try await peer.nextRequest()
+                let fallbackRenewalPayload = try Self.requireHandshake(fallbackRenewalRequest)
+                let expectedVersion = PeekabooBridgeProtocolVersion(
+                    major: PeekabooBridgeConstants.protocolVersion.major,
+                    minor: minor)
+                #expect(fallbackRenewalPayload.protocolVersion == expectedVersion)
+                #expect(fallbackRenewalPayload.replacingOperationSessionID == predecessor.attestation.sessionID)
+                try await peer.respond(
+                    .error(.init(
+                        code: .versionMismatch,
+                        message: "Protocol \(expectedVersion.major).\(expectedVersion.minor) is unavailable")),
+                    to: fallbackRenewalRequest)
+            }
 
             let legacyRenewalRequest = try await peer.nextRequest()
             let legacyRenewalPayload = try Self.requireHandshake(legacyRenewalRequest)
@@ -951,7 +1013,10 @@ extension PeekabooBridgeClientConcurrencyTests {
                 return
             }
             #expect(await client.lastOperationReceipt() == nil)
-            #expect(await peer.acceptedConnectionCount == 6)
+            let automaticAttestedAttemptCount = PeekabooBridgeConstants.protocolVersion.minor -
+                PeekabooBridgeConstants.attestedOperationReceiptVersion.minor + 1
+            let expectedConnectionCount = 1 + automaticAttestedAttemptCount + 1 + 1 + 1
+            #expect(await peer.acceptedConnectionCount == expectedConnectionCount)
         } catch {
             await peer.stop()
             throw error
@@ -1410,6 +1475,20 @@ extension PeekabooBridgeClientConcurrencyTests {
             teamIdentifier: nil,
             processIdentifier: getpid(),
             hostname: nil)
+    }
+
+    private static func concurrentReadResponse(
+        _ request: PeekabooBridgeRequest,
+        application: ServiceApplicationInfo) -> PeekabooBridgeResponse
+    {
+        switch request {
+        case .listApplications: .applications([application])
+        case .getFocusedWindow: .window(nil)
+        default:
+            .error(.init(
+                code: .invalidRequest,
+                message: "Unexpected concurrent read request \(request.operation.rawValue)"))
+        }
     }
 
     private static func temporaryRoot(_ suffix: String) -> URL {


### PR DESCRIPTION
## Summary

- route the real gated Agent test's Bridge replies from each decoded request instead of socket accept order
- retain concurrent-peer request history so runtime failures include the complete wire sequence
- stress exact request/response ownership for 64 reversed-completion cycles
- make the existing renewal-downgrade test follow every current-to-attested protocol fallback version

## Root cause

`DesktopContextService` deliberately overlaps frontmost-window and recent-application reads. `ScriptedBridgePeer` assigns canned responses by connection accept order, which is not request order under full-suite load. The failing 1.31 run accepted `handshake, handshake, invalidateImplicitLatestSnapshot, listApplications, getFrontmostApplication, ...`; the fourth canned `.application` response therefore reached `listApplications` and raised `Unexpected listApplications response`.

Production Bridge transport already owns request and response bytes per socket. The test now uses `ConcurrentGatedBridgePeer` and responds to the exact decoded request. This also exercises the full Agent desktop-context refresh path while allowing the one watermark-dependent snapshot catch-up request to be absent on a clean host.

## Proof

- 30 consecutive focused `AgentExecutionProcessLimitRuntimeTests` runs
- `CLIRuntimeTests --no-parallel`: 110/110
- `PeekabooBridgeClientConcurrencyTests --no-parallel`: 19/19
- `pnpm run test:safe` (including final CLI suite: 503/503)
- `pnpm run format`: clean
- `pnpm run lint`: exit 0; baseline warnings only
- autoreview: no accepted/actionable findings

Test-only change; no changelog entry.
