### PR TITLE
fix(cli): keep command timeouts bounded under load

### DIFF
--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add Bridge protocol 1.31 one-request signed background Agent execution with authenticated CLI derivation, an irreversible earliest-entrypoint process limit, lifecycle-covered release acknowledgement, exact-leader reaping, canonical terminal receipt bundles, and nested exact-lane receipts.
 
 ### Fixed
+- Keep CLI wall-clock timeouts bounded under sustained executor load by sharing one monotonic dispatch timer and canceling losing timer/work paths without releasing mutation barriers early.
 - Pin foreground menu focus, clicks, and listing to one exact process/window generation across CLI and MCP, preserving focus outcomes when a later menu read fails.
 - Refuse fuzzy application selectors before app, menu, window, or background click mutations are pinned to a process, while preserving fuzzy read-only discovery.
 - Align CLI help and Agent guidance with receipt-pinned background keyboard input, targeted dialog AXValue, and explicit foreground consent for foreground-exposing actions.

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommandUtilities.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommandUtilities.swift
@@ -7,6 +7,37 @@ import PeekabooFoundation
 
 // MARK: - Timeout Utilities
 
+private final nonisolated class CommandTimeoutTimer: @unchecked Sendable {
+    private let workItem: DispatchWorkItem
+
+    init(seconds: TimeInterval, action: @escaping @Sendable () -> Void) {
+        let workItem = DispatchWorkItem(block: action)
+        self.workItem = workItem
+        // Keep the deadline off the cooperative executor, and cancel the work item when another
+        // result wins so successful commands do not accumulate later timer-task wakeups.
+        DispatchQueue.global(qos: .userInitiated).asyncAfter(
+            deadline: .now() + seconds,
+            execute: workItem
+        )
+    }
+
+    func cancel() {
+        self.workItem.cancel()
+    }
+}
+
+private func makeCommandTimeoutTimer(
+    seconds: TimeInterval,
+    race: TimeoutRace,
+    workTask: Task<Void, Never>,
+    error: @escaping @Sendable () -> any Error
+) -> CommandTimeoutTimer {
+    CommandTimeoutTimer(seconds: seconds) {
+        race.resume(with: Result<Bool, any Error>.failure(error()))
+        workTask.cancel()
+    }
+}
+
 /// Execute an async operation with a timeout
 func withTimeout<T: Sendable>(
     seconds: TimeInterval,
@@ -22,21 +53,16 @@ func withTimeout<T: Sendable>(
         }
     }
 
-    let timeoutTask = Task.detached {
-        do {
-            try await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
-        } catch {
-            return
-        }
-        race.resume(with: Result<T, any Error>.failure(
-            CaptureError.captureFailure("Operation timed out after \(seconds) seconds")
-        ))
-        workTask.cancel()
-    }
+    let timeoutTimer = makeCommandTimeoutTimer(
+        seconds: seconds,
+        race: race,
+        workTask: workTask,
+        error: { CaptureError.captureFailure("Operation timed out after \(seconds) seconds") }
+    )
 
     defer {
         workTask.cancel()
-        timeoutTask.cancel()
+        timeoutTimer.cancel()
     }
     return try await withTaskCancellationHandler {
         try await withCheckedThrowingContinuation { continuation in
@@ -45,7 +71,7 @@ func withTimeout<T: Sendable>(
     } onCancel: {
         race.resume(with: Result<T, any Error>.failure(CancellationError()))
         workTask.cancel()
-        timeoutTask.cancel()
+        timeoutTimer.cancel()
     }
 }
 
@@ -142,19 +168,17 @@ func withCommandTimeout<T: Sendable>(
         }
     }
 
-    let timeoutTask = Task.detached {
-        do {
-            try await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
-        } catch {
-            return
-        }
-        race.resume(with: Result<T, any Error>.failure(PeekabooError.timeout(
-            operation: operationName,
-            duration: seconds
-        )))
-        workTask.cancel()
-    }
+    let timeoutTimer = makeCommandTimeoutTimer(
+        seconds: seconds,
+        race: race,
+        workTask: workTask,
+        error: { PeekabooError.timeout(operation: operationName, duration: seconds) }
+    )
 
+    defer {
+        workTask.cancel()
+        timeoutTimer.cancel()
+    }
     return try await withTaskCancellationHandler {
         try await withCheckedThrowingContinuation { continuation in
             race.setContinuation(continuation)
@@ -162,7 +186,7 @@ func withCommandTimeout<T: Sendable>(
     } onCancel: {
         race.resume(with: Result<T, any Error>.failure(CancellationError()))
         workTask.cancel()
-        timeoutTask.cancel()
+        timeoutTimer.cancel()
     }
 }
 
@@ -203,17 +227,17 @@ func withMainActorCommandTimeout<T: Sendable>(
         race.resume(with: result)
     }
 
-    let timeoutTask = Task.detached {
-        do {
-            try await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
-        } catch {
-            return
-        }
-        let error = timeoutError?() ?? PeekabooError.timeout(operation: operationName, duration: seconds)
-        race.resume(with: Result<T, any Error>.failure(error))
-        workTask.cancel()
-    }
+    let timeoutTimer = makeCommandTimeoutTimer(
+        seconds: seconds,
+        race: race,
+        workTask: workTask,
+        error: { timeoutError?() ?? PeekabooError.timeout(operation: operationName, duration: seconds) }
+    )
 
+    defer {
+        workTask.cancel()
+        timeoutTimer.cancel()
+    }
     return try await withTaskCancellationHandler {
         try await withCheckedThrowingContinuation { continuation in
             race.setContinuation(continuation)
@@ -221,7 +245,7 @@ func withMainActorCommandTimeout<T: Sendable>(
     } onCancel: {
         race.resume(with: Result<T, any Error>.failure(CancellationError()))
         workTask.cancel()
-        timeoutTask.cancel()
+        timeoutTimer.cancel()
     }
 }
 

--- a/Apps/CLI/Tests/CLIRuntimeTests/ScreenCaptureKitProcessCapabilityRuntimeTests.swift
+++ b/Apps/CLI/Tests/CLIRuntimeTests/ScreenCaptureKitProcessCapabilityRuntimeTests.swift
@@ -26,7 +26,11 @@ struct ScreenCaptureKitProcessCapabilityRuntimeTests {
         try process.run()
         defer { Self.stop(process) }
 
-        let processStartIdentity = try await self.waitForProcessCapability(process, standardError: standardError)
+        let processStartIdentity = try await self.waitForProcessCapability(
+            process,
+            socketPath: socketPath,
+            standardError: standardError
+        )
         let conflicts = try ScreenCaptureKitOwnerLease.liveUncoordinatedProcesses(
             excluding: .current()
         )
@@ -43,8 +47,14 @@ struct ScreenCaptureKitProcessCapabilityRuntimeTests {
         try ScreenCaptureKitOwnerLease.removeStaleProcessCapabilityMarkers()
     }
 
-    private func waitForProcessCapability(_ process: Process, standardError: Pipe) async throws -> UInt64 {
-        for _ in 0..<100 {
+    private func waitForProcessCapability(
+        _ process: Process,
+        socketPath: String,
+        standardError: Pipe
+    ) async throws -> UInt64 {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: .seconds(5))
+        while clock.now < deadline {
             guard process.isRunning else {
                 let details = String(
                     decoding: standardError.fileHandleForReading.readDataToEndOfFile(),
@@ -58,20 +68,24 @@ struct ScreenCaptureKitProcessCapabilityRuntimeTests {
                     processIdentifier: process.processIdentifier,
                     processStartIdentity: identity
                 )
-                if FileManager.default.fileExists(atPath: marker.path) {
+                if FileManager.default.fileExists(atPath: marker.path),
+                   FileManager.default.fileExists(atPath: socketPath),
+                   FileManager.default.fileExists(atPath: "\(socketPath).lock")
+                {
                     return identity
                 }
             }
-            try await Task.sleep(for: .milliseconds(10))
+            try await clock.sleep(for: .milliseconds(10))
         }
-        throw RuntimeError("Peekaboo marker fixture did not publish its process capability")
+        throw RuntimeError("Peekaboo marker fixture did not publish its process capability and Bridge readiness")
     }
 
     @discardableResult
     private static func stop(_ process: Process) -> Bool {
         guard process.isRunning else { return true }
         process.terminate()
-        for _ in 0..<100 where process.isRunning {
+        let gracefulDeadline = DispatchTime.now() + .seconds(5)
+        while process.isRunning, DispatchTime.now() < gracefulDeadline {
             usleep(10000)
         }
         let exitedAfterSIGTERM = !process.isRunning

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add a Git-blob-bound final qualification manifest that requires byte-identical local/Studio installations, candidate-bound CLI and monitor identities, both elevation receipts, guarded task-owned process trees, and freshly re-executed native-only policy scans.
 
 ### Fixed
+- Keep CLI wall-clock timeouts bounded under sustained executor load by sharing one monotonic dispatch timer and canceling losing timer/work paths without releasing mutation barriers early.
 - Make macOS release signing retry each validated Sparkle leaf independently before sealing the outer app, and pin the exact workspace package graph so Xcode cannot silently drift release dependencies.
 - Pin foreground menu focus, clicks, and listing to one exact process/window generation across CLI and MCP, preserving focus outcomes when a later menu read fails.
 - Refuse fuzzy application selectors before CLI or MCP mutations are pinned to a process, while preserving fuzzy read-only discovery.


### PR DESCRIPTION
## Summary

- move the three shared CLI timeout races from detached Swift sleepers to one monotonic dispatch-timer owner
- cancel losing timer and work paths after every race while preserving durable mutation leases until cancellation-ignoring work actually exits
- make the live daemon capability fixture wait for both process capability and Bridge readiness before SIGTERM, with bounded graceful cleanup
- document the user-visible timeout fix in both changelogs

## Root cause

The release preflight exposed `see --timeout 1s` returning after 3.05 seconds. Instrumentation showed the timeout race won near 0.95 seconds, but successful commands left detached timeout sleepers alive until their original deadlines. Full-suite wakeup buildup and cooperative/MainActor scheduling delayed caller progress. A separate runtime test also signaled its daemon after only the process capability marker, before Bridge and signal-lifecycle readiness.

## Proof

- `pnpm run test:safe`
- `swiftlint lint --config .swiftlint.yml Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommandUtilities.swift Apps/CLI/Tests/CLIRuntimeTests/ScreenCaptureKitProcessCapabilityRuntimeTests.swift`
- exact `See publication remains inside the overall timeout` stress: 50/50
- complete `CLIAutomationTests` stress: 3/3, 503 tests each; publication case 1.053–1.065 seconds
- exact live daemon capability/Bridge readiness lifecycle stress: 20/20
- structured Autoreview: clean, no accepted/actionable findings

The first full safe run exposed the daemon fixture startup race; after the fixture correction, the complete rerun passed.
