### PR TITLE
style(cli): format capability runtime fixture

### DIFF
--- a/Apps/CLI/Tests/CLIRuntimeTests/ScreenCaptureKitProcessCapabilityRuntimeTests.swift
+++ b/Apps/CLI/Tests/CLIRuntimeTests/ScreenCaptureKitProcessCapabilityRuntimeTests.swift
@@ -70,8 +70,7 @@ struct ScreenCaptureKitProcessCapabilityRuntimeTests {
                 )
                 if FileManager.default.fileExists(atPath: marker.path),
                    FileManager.default.fileExists(atPath: socketPath),
-                   FileManager.default.fileExists(atPath: "\(socketPath).lock")
-                {
+                   FileManager.default.fileExists(atPath: "\(socketPath).lock") {
                     return identity
                 }
             }


### PR DESCRIPTION
## Summary

- apply the canonical SwiftFormat output to the SCK capability runtime fixture
- eliminate the one-file dirty clone that correctly stopped the source-bound artifact driver

## Proof

- `pnpm run format` — 0/1,595 files changed after this correction
- focused `ScreenCaptureKitProcessCapabilityRuntimeTests` — pass
- structured Autoreview — clean, confidence 1.0

This is formatting-only and does not change runtime behavior.
