### PR TITLE
fix(bridge): validate exact observation receipts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add a Git-blob-bound final qualification manifest that requires byte-identical local/Studio installations, candidate-bound CLI and monitor identities, both elevation receipts, guarded task-owned process trees, and freshly re-executed native-only policy scans.
 
 ### Fixed
+- Preserve exact application/window selector proofs through capture hardening and accept proofless exact-ID PID observations, while keeping fuzzy selectors and stable process/window receipt fields fail closed.
 - Keep CLI wall-clock timeouts bounded under sustained executor load by sharing one monotonic dispatch timer and canceling losing timer/work paths without releasing mutation barriers early.
 - Make macOS release signing retry each validated Sparkle leaf independently before sealing the outer app, and pin the exact workspace package graph so Xcode cannot silently drift release dependencies.
 - Pin foreground menu focus, clicks, and listing to one exact process/window generation across CLI and MCP, preserving focus outcomes when a later menu read fails.

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Observation/ObservationTargetResolver.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Observation/ObservationTargetResolver.swift
@@ -188,7 +188,10 @@ public final class ObservationTargetResolver: ObservationTargetResolving {
                 else {
                     return resolved
                 }
-                return try self.resolveExactWindow(exactWindowID, for: app)
+                return try self.resolveExactWindow(
+                    exactWindowID,
+                    for: app,
+                    selectorResolutionProofs: resolved.selectorResolutionProofs)
             }
         }
 
@@ -302,7 +305,8 @@ public final class ObservationTargetResolver: ObservationTargetResolving {
 
     private func resolveExactWindow(
         _ windowID: CGWindowID,
-        for app: ServiceApplicationInfo) throws -> ResolvedObservationTarget
+        for app: ServiceApplicationInfo,
+        selectorResolutionProofs: [SelectorResolutionProof]? = nil) throws -> ResolvedObservationTarget
     {
         guard let metadata = self.exactWindowMetadataProvider.metadata(for: windowID),
               let processStartIdentity = app.processStartIdentity,
@@ -315,7 +319,11 @@ public final class ObservationTargetResolver: ObservationTargetResolving {
                 "window id \(windowID) owned by PID \(app.processIdentifier)")
         }
 
-        return Self.resolvedExactWindow(windowID, app: app, metadata: metadata)
+        return Self.resolvedExactWindow(
+            windowID,
+            app: app,
+            metadata: metadata,
+            selectorResolutionProofs: selectorResolutionProofs)
     }
 
     private func resolveExactWindowIfAvailable(
@@ -349,13 +357,19 @@ public final class ObservationTargetResolver: ObservationTargetResolving {
     private static func resolvedExactWindow(
         _ windowID: CGWindowID,
         app: ServiceApplicationInfo,
-        metadata: ExactWindowObservationMetadata) -> ResolvedObservationTarget
+        metadata: ExactWindowObservationMetadata,
+        selectorResolutionProofs: [SelectorResolutionProof]? = nil) -> ResolvedObservationTarget
     {
         let window = WindowIdentity(
             windowID: Int(windowID),
             title: metadata.title,
             bounds: metadata.bounds,
             index: 0)
+        let windowIdentity = WindowMutationIdentity(
+            windowID: window.windowID,
+            ownerProcessIdentifier: metadata.ownerProcessIdentifier,
+            ownerProcessStartIdentity: metadata.ownerProcessStartIdentity,
+            capturedBounds: window.bounds)
         let context = WindowContext(
             applicationName: app.name,
             applicationBundleId: app.bundleIdentifier,
@@ -363,17 +377,17 @@ public final class ObservationTargetResolver: ObservationTargetResolving {
             windowTitle: window.title,
             windowID: window.windowID,
             windowBounds: window.bounds,
-            windowMutationIdentity: WindowMutationIdentity(
-                windowID: window.windowID,
-                ownerProcessIdentifier: metadata.ownerProcessIdentifier,
-                ownerProcessStartIdentity: metadata.ownerProcessStartIdentity,
-                capturedBounds: window.bounds))
+            windowMutationIdentity: windowIdentity)
+        let proofs = selectorResolutionProofs ?? app.selectorResolutionProofs?.map {
+            $0.selecting(windowIdentity: windowIdentity)
+        }
         return ResolvedObservationTarget(
             kind: .windowID(windowID),
             app: ApplicationIdentity(app),
             window: window,
             bounds: window.bounds,
-            detectionContext: context)
+            detectionContext: context,
+            selectorResolutionProofs: proofs)
     }
 
     private func fallbackApplication(pid: Int32) async throws -> ServiceApplicationInfo? {

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Observation/WindowSelectorResolutionProof.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Observation/WindowSelectorResolutionProof.swift
@@ -174,7 +174,7 @@ extension SelectorResolutionProof {
         guard let processIdentity,
               self.selectedProcessIdentity == processIdentity,
               let selectedWindowIdentity = selectedWindow.mutationIdentity,
-              self.selectedWindowIdentity == selectedWindowIdentity,
+              self.selectedWindowIdentity?.hasSameStableReceipt(as: selectedWindowIdentity) == true,
               selectedWindowIdentity.processIdentity == processIdentity
         else {
             return "selected window identity"

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/System/ApplicationSelectorResolutionProof.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/System/ApplicationSelectorResolutionProof.swift
@@ -122,7 +122,12 @@ public struct SelectorResolutionProof: Sendable, Codable, Equatable {
         else {
             return "selected process identity"
         }
-        guard self.selectedWindowIdentity == windowIdentity else {
+        let windowIdentityMatches = switch (self.selectedWindowIdentity, windowIdentity) {
+        case (nil, nil): true
+        case let (selected?, current?): selected.hasSameStableReceipt(as: current)
+        default: false
+        }
+        guard windowIdentityMatches else {
             return "selected window identity"
         }
         if let windowIdentity,

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ObservationExactWindowResolverTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ObservationExactWindowResolverTests.swift
@@ -73,6 +73,29 @@ final class ObservationExactWindowResolverTests: XCTestCase {
         XCTAssertEqual(resolved.kind, .windowID(42))
         XCTAssertEqual(resolved.window?.windowID, 42)
         XCTAssertEqual(resolved.detectionContext?.applicationBundleId, "com.example.fixture")
+        XCTAssertTrue(resolved.selectorResolutionProofs?.isEmpty ?? true)
+        XCTAssertEqual(service.listWindowsCalls, 0)
+    }
+
+    func testAppExactIDPreservesApplicationProofOnExactTarget() async throws {
+        let app = Self.app(pid: 123)
+        let service = ExactWindowApplicationService(app: app, windows: [])
+        let resolver = ObservationTargetResolver(
+            applications: service,
+            exactWindowMetadataProvider: TestExactWindowMetadataProvider { windowID in
+                Self.metadata(windowID: windowID, ownerPID: 123)
+            })
+
+        let resolved = try await resolver.resolve(
+            .app(identifier: "com.example.fixture", window: .id(42)),
+            snapshot: DesktopStateSnapshot(runningApplications: [ApplicationIdentity(app)]))
+
+        let proof = try XCTUnwrap(resolved.selectorResolutionProofs?.first)
+        let exactIdentity = try XCTUnwrap(resolved.detectionContext?.windowMutationIdentity)
+        XCTAssertEqual(resolved.selectorResolutionProofs?.count, 1)
+        XCTAssertEqual(proof.scope, .application)
+        XCTAssertEqual(proof.normalizedSelector, "com.example.fixture")
+        XCTAssertTrue(proof.selectedWindowIdentity?.hasSameStableReceipt(as: exactIdentity) == true)
         XCTAssertEqual(service.listWindowsCalls, 0)
     }
 
@@ -149,6 +172,31 @@ final class ObservationExactWindowResolverTests: XCTestCase {
             snapshot: DesktopStateSnapshot(runningApplications: [ApplicationIdentity(app)]))
 
         XCTAssertEqual(resolved.window?.windowID, 42)
+        let proof = try XCTUnwrap(resolved.selectorResolutionProofs?.first)
+        let exactIdentity = try XCTUnwrap(resolved.detectionContext?.windowMutationIdentity)
+        XCTAssertEqual(resolved.selectorResolutionProofs?.count, 1)
+        XCTAssertEqual(proof.scope, .window)
+        XCTAssertEqual(proof.normalizedSelector, WindowSelectorResolutionProof.normalizedSelector(.automatic))
+        XCTAssertTrue(proof.selectedWindowIdentity?.hasSameStableReceipt(as: exactIdentity) == true)
+
+        let appResolved = try await resolver.resolve(
+            .app(identifier: "com.example.fixture", window: .automatic),
+            snapshot: DesktopStateSnapshot(runningApplications: [ApplicationIdentity(app)]))
+        let appProofs = try XCTUnwrap(appResolved.selectorResolutionProofs)
+        XCTAssertEqual(appProofs.map(\.scope), [.application, .window])
+        XCTAssertTrue(appProofs.allSatisfy {
+            $0.selectedWindowIdentity?.hasSameStableReceipt(as: exactIdentity) == true
+        })
+
+        let titleResolved = try await resolver.resolve(
+            .pid(123, window: .title("Editor")),
+            snapshot: DesktopStateSnapshot(runningApplications: [ApplicationIdentity(app)]))
+        let titleProof = try XCTUnwrap(titleResolved.selectorResolutionProofs?.last)
+        XCTAssertEqual(titleProof.scope, .window)
+        XCTAssertEqual(
+            titleProof.normalizedSelector,
+            WindowSelectorResolutionProof.normalizedSelector(.title("Editor")))
+        XCTAssertTrue(titleProof.selectedWindowIdentity?.hasSameStableReceipt(as: exactIdentity) == true)
         XCTAssertEqual(service.listWindowsCalls, 0)
     }
 

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeSelectorResolutionBinding.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeSelectorResolutionBinding.swift
@@ -115,6 +115,7 @@ enum PeekabooBridgeSelectorResolutionBinding {
             selectorResolutionProofs: app.selectorResolutionProofs)
         let windowIdentity = result.target.detectionContext?.windowMutationIdentity ??
             result.capture.metadata.windowInfo?.mutationIdentity
+        let requiresWindowProof = requireProof && request.target.exactWindowID == nil
         let windowSelection: WindowSelection?
         switch request.target {
         case let .app(identifier, selection):
@@ -133,11 +134,19 @@ enum PeekabooBridgeSelectorResolutionBinding {
                 return "PID selector process"
             }
             if requireProof {
-                guard let proofs = result.target.selectorResolutionProofs,
-                      proofs.count == 1,
-                      proofs.first?.scope == .window
-                else {
-                    return "PID window selector proof order"
+                let proofs = result.target.selectorResolutionProofs ?? []
+                if requiresWindowProof {
+                    guard proofs.count == 1,
+                          proofs.first?.scope == .window
+                    else {
+                        return "PID window selector proof order"
+                    }
+                } else {
+                    guard proofs.count <= 1,
+                          proofs.allSatisfy({ $0.scope == .window })
+                    else {
+                        return "PID window selector proof order"
+                    }
                 }
             }
             windowSelection = selection
@@ -161,7 +170,7 @@ enum PeekabooBridgeSelectorResolutionBinding {
             application: application,
             window: serviceWindow,
             proofs: result.target.selectorResolutionProofs,
-            requireProof: requireProof)
+            requireProof: requiresWindowProof)
     }
 
     static func dialogMismatch(

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeDesktopObservationBindingTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeDesktopObservationBindingTests.swift
@@ -189,6 +189,236 @@ struct PeekabooBridgeDesktopObservationBindingTests: DesktopObservationBindingFi
     }
 
     @Test
+    @MainActor
+    func `exact window ID proof cardinality is strict without requiring redundant window proof`() async throws {
+        let fixture = Self.windowResult(.init(
+            processIdentifier: 42,
+            generation: 1001,
+            bundleIdentifier: "dev.peekaboo.fixture",
+            applicationName: "Fixture",
+            windowID: 73,
+            title: "Document",
+            index: 2,
+            windowSelector: .id(73)))
+        let proofs = try #require(fixture.result.target.selectorResolutionProofs)
+        let applicationProof = try #require(proofs.first)
+        let windowProof = try #require(proofs.last)
+        let contradictoryWindowProof = SelectorResolutionProof(
+            scope: .window,
+            normalizedSelector: WindowSelectorResolutionProof.normalizedSelector(.id(74)),
+            matchKind: windowProof.matchKind,
+            matchPrecedence: windowProof.matchPrecedence,
+            selectedProcessIdentity: windowProof.selectedProcessIdentity,
+            selectedWindowIdentity: windowProof.selectedWindowIdentity,
+            candidateSetSHA256: windowProof.candidateSetSHA256,
+            candidateCount: windowProof.candidateCount,
+            winningCandidateCount: windowProof.winningCandidateCount,
+            hasWinningTie: windowProof.hasWinningTie)
+        let wrongIdentity = WindowMutationIdentity(
+            windowID: 74,
+            ownerProcessIdentifier: fixture.identity.ownerProcessIdentifier,
+            ownerProcessStartIdentity: fixture.identity.ownerProcessStartIdentity,
+            capturedBounds: fixture.identity.capturedBounds)
+        let wrongIdentityWindowProof = windowProof.selecting(windowIdentity: wrongIdentity)
+        let pidRequest = DesktopObservationRequest(
+            target: .pid(42, window: .id(73)),
+            detection: .init(mode: .none))
+        let appRequest = DesktopObservationRequest(
+            target: .app(identifier: "dev.peekaboo.fixture", window: .id(73)),
+            detection: .init(mode: .none))
+
+        for (proofs, expected) in [
+            ([], nil),
+            ([windowProof], nil),
+            ([applicationProof], "PID window selector proof order"),
+            ([windowProof, windowProof], "PID window selector proof order"),
+            ([windowProof, applicationProof], "PID window selector proof order"),
+            ([contradictoryWindowProof], "window normalized selector"),
+            ([wrongIdentityWindowProof], "window selected window identity"),
+        ] as [([SelectorResolutionProof], String?)] {
+            let result = Self.replacingSelectorResolutionProofs(fixture.result, with: proofs)
+            #expect(PeekabooBridgeSelectorResolutionBinding.observationMismatch(
+                request: pidRequest,
+                result: result,
+                requireProof: true) == expected)
+        }
+
+        for (proofs, expected) in [
+            ([], "missing application selector proof"),
+            ([applicationProof], nil),
+            ([applicationProof, windowProof], nil),
+            ([windowProof, applicationProof], "application selector proof order"),
+            ([applicationProof, contradictoryWindowProof], "window normalized selector"),
+            ([applicationProof, wrongIdentityWindowProof], "window selected window identity"),
+        ] as [([SelectorResolutionProof], String?)] {
+            let result = Self.replacingSelectorResolutionProofs(fixture.result, with: proofs)
+            #expect(PeekabooBridgeSelectorResolutionBinding.observationMismatch(
+                request: appRequest,
+                result: result,
+                requireProof: true) == expected)
+        }
+
+        let applicationOnly = Self.replacingSelectorResolutionProofs(
+            fixture.result,
+            with: [applicationProof])
+        #expect(PeekabooBridgeSelectorResolutionBinding.observationMismatch(
+            request: .init(
+                target: .app(identifier: "dev.peekaboo.fixture", window: .title("Document")),
+                detection: .init(mode: .none)),
+            result: applicationOnly,
+            requireProof: true) == "missing window selector proof")
+        #expect(PeekabooBridgeSelectorResolutionBinding.observationMismatch(
+            request: .init(target: .pid(42, window: .title("Document")), detection: .init(mode: .none)),
+            result: Self.replacingSelectorResolutionProofs(fixture.result, with: []),
+            requireProof: true) == "PID window selector proof order")
+
+        let prooflessPIDResult = Self.replacingSelectorResolutionProofs(fixture.result, with: [])
+        let prooflessPIDBundle = try await Self.makeBundle(
+            request: .desktopObservation(pidRequest),
+            response: .desktopObservation(prooflessPIDResult),
+            target: .window(fixture.identity))
+        try prooflessPIDBundle.validateIntegrity()
+    }
+
+    @Test
+    @MainActor
+    func `exact ID proofs tolerate mutable minimized state in live and offline validation`() async throws {
+        let fixture = Self.windowResult(.init(
+            processIdentifier: 42,
+            generation: 1001,
+            bundleIdentifier: "dev.peekaboo.fixture",
+            applicationName: "Fixture",
+            windowID: 73,
+            title: "Document",
+            index: 2,
+            windowSelector: .id(73)))
+        let proofIdentity = WindowMutationIdentity(
+            windowID: fixture.identity.windowID,
+            ownerProcessIdentifier: fixture.identity.ownerProcessIdentifier,
+            ownerProcessStartIdentity: fixture.identity.ownerProcessStartIdentity,
+            capturedBounds: fixture.identity.capturedBounds,
+            isMinimized: false)
+        let proofs = try #require(fixture.result.target.selectorResolutionProofs).map {
+            $0.selecting(windowIdentity: proofIdentity)
+        }
+        let result = Self.replacingSelectorResolutionProofs(fixture.result, with: proofs)
+        let applicationOnlyResult = try Self.replacingSelectorResolutionProofs(
+            fixture.result,
+            with: [#require(proofs.first)])
+        let request = DesktopObservationRequest(
+            target: .app(identifier: "dev.peekaboo.fixture", window: .id(73)),
+            detection: .init(mode: .none))
+
+        #expect(PeekabooBridgeDesktopObservationBinding.mismatch(
+            request: request,
+            result: result,
+            requireSelectorResolutionProof: true) == nil)
+        let handled = try await PeekabooBridgeRequestContext.$usesAttestedOperationResultSemantics.withValue(true) {
+            try await Self.server(provider: ObservationProvider(result: result)).handleAuthorized(
+                .desktopObservation(request),
+                peer: nil,
+                permissions: Self.permissions)
+        }
+        guard case .desktopObservation = handled.response else {
+            Issue.record("Expected an exact app/window observation response")
+            return
+        }
+        let bundle = try await Self.makeBundle(
+            request: .desktopObservation(request),
+            response: .desktopObservation(result),
+            target: .window(fixture.identity))
+        try bundle.validateIntegrity()
+
+        let authorityRoot = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "peekaboo-exact-observation-\(UUID().uuidString)",
+            isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: authorityRoot) }
+        let authority = try PeekabooBridgeOperationReceiptAuthority(
+            socketPath: authorityRoot.appendingPathComponent("bridge.sock").path)
+        let session = try await OperationReceiptSessionFixture.make(authority: authority)
+        let wireRequest = PeekabooBridgeRequest.desktopObservation(request)
+        let attributionEvidence = PeekabooBridgeOperationTargetAttribution.evidence(
+            request: wireRequest,
+            response: .desktopObservation(applicationOnlyResult),
+            handledTarget: nil)
+        let attributed = try PeekabooBridgeOperationTargetAttribution.resolveEvidence(
+            request: wireRequest,
+            evidence: attributionEvidence)
+        #expect(attributed?.exactWindow?.identity.hasSameStableReceipt(as: fixture.identity) == true)
+        let payload = session.request(authority: authority, sequence: 0, request: wireRequest)
+        let strictServer = PeekabooBridgeServer(
+            services: StubServices(desktopObservation: ObservationProvider(result: applicationOnlyResult)),
+            allowlistedTeams: [],
+            allowlistedBundles: [],
+            allowedOperations: [.desktopObservation],
+            permissionStatusEvaluator: { _ in Self.permissions },
+            windowOwnerProcessIdentifierProvider: { $0 == 73 ? 42 : nil },
+            windowBoundsProvider: { $0 == 73 ? fixture.identity.capturedBounds : nil },
+            processStartIdentityProvider: { $0 == 42 ? 1001 : nil })
+        let data = try await PeekabooBridgeRequestContext.$operationReceiptAuthority.withValue(authority) {
+            try await strictServer.handleAttestedOperation(
+                payload,
+                peer: session.peer)
+        }
+        guard case let .attestedOperation(attested) = try JSONDecoder.peekabooBridgeDecoder().decode(
+            PeekabooBridgeResponse.self,
+            from: data)
+        else {
+            Issue.record("Expected an attested exact app/window observation response")
+            return
+        }
+        guard case .desktopObservation = attested.response else {
+            Issue.record("Expected a signed exact app/window observation response: \(attested.response)")
+            return
+        }
+        #expect(attested.receipt.payload.target == .window(fixture.identity))
+        let strictBundle = try OperationReceiptSessionFixture.bundle(
+            authority: authority,
+            sessionAttestation: session.attestation,
+            receipt: attested.receipt,
+            request: wireRequest,
+            response: attested.response)
+        try strictBundle.validateIntegrity()
+
+        let pidRequest = DesktopObservationRequest(
+            target: .pid(42, window: .id(73)),
+            detection: .init(mode: .none))
+        let pidWireRequest = PeekabooBridgeRequest.desktopObservation(pidRequest)
+        let prooflessPIDResult = Self.replacingSelectorResolutionProofs(fixture.result, with: [])
+        let pidPayload = session.request(authority: authority, sequence: 1, request: pidWireRequest)
+        let pidServer = PeekabooBridgeServer(
+            services: StubServices(desktopObservation: ObservationProvider(result: prooflessPIDResult)),
+            allowlistedTeams: [],
+            allowlistedBundles: [],
+            allowedOperations: [.desktopObservation],
+            permissionStatusEvaluator: { _ in Self.permissions },
+            windowOwnerProcessIdentifierProvider: { $0 == 73 ? 42 : nil },
+            windowBoundsProvider: { $0 == 73 ? fixture.identity.capturedBounds : nil },
+            processStartIdentityProvider: { $0 == 42 ? 1001 : nil })
+        let pidData = try await PeekabooBridgeRequestContext.$operationReceiptAuthority.withValue(authority) {
+            try await pidServer.handleAttestedOperation(
+                pidPayload,
+                peer: session.peer)
+        }
+        guard case let .attestedOperation(pidAttested) = try JSONDecoder.peekabooBridgeDecoder().decode(
+            PeekabooBridgeResponse.self,
+            from: pidData),
+            case .desktopObservation = pidAttested.response
+        else {
+            Issue.record("Expected a signed proofless PID/exact-window observation response")
+            return
+        }
+        #expect(pidAttested.receipt.payload.target == .window(fixture.identity))
+        let pidBundle = try OperationReceiptSessionFixture.bundle(
+            authority: authority,
+            sessionAttestation: session.attestation,
+            receipt: pidAttested.receipt,
+            request: pidWireRequest,
+            response: pidAttested.response)
+        try pidBundle.validateIntegrity()
+    }
+
+    @Test
     func `observation proof preserves prohibited helper fuzzy eligibility`() {
         let fixture = Self.windowResult(.init(
             processIdentifier: 42,
@@ -969,6 +1199,24 @@ struct PeekabooBridgeDesktopObservationBindingTests: DesktopObservationBindingFi
             timings: result.timings,
             diagnostics: result.diagnostics,
             captureContentDigest: result.captureContentDigest)
+    }
+
+    private static func replacingSelectorResolutionProofs(
+        _ result: DesktopObservationResult,
+        with proofs: [SelectorResolutionProof]) -> DesktopObservationResult
+    {
+        let target = result.target
+        return self.replacingTarget(
+            result,
+            with: ResolvedObservationTarget(
+                kind: target.kind,
+                app: target.app,
+                window: target.window,
+                bounds: target.bounds,
+                detectionContext: target.detectionContext,
+                captureScaleHint: target.captureScaleHint,
+                selectorResolutionProofs: proofs,
+                mutationTargetIdentity: target.mutationTargetIdentity))
     }
 
     private static func replacingCaptureMetadata(


### PR DESCRIPTION
## Summary

- accept exact PID/window observations with zero or one valid window selector proof while keeping fuzzy selection proof-required
- preserve application and window selector proofs when WindowServer catalog selection is hardened to an exact target
- compare selector-bound windows by stable receipt fields so mutable minimized-state hints cannot invalidate an otherwise exact signed observation
- add live attested and offline receipt regressions for exact app/PID routes, proof order/cardinality, stable identity, and automatic/title proof preservation

## Root cause

Signed candidate testing exposed two connected receipt failures. Exact PID/window requests intentionally emitted no fuzzy window proof, but strict validation required one. App-shaped observations also compared the resolver's pre-capture window identity with capture evidence using full equality, so a harmless `isMinimized` hint change was treated as a different window and then masked as incomplete target attribution. Catalog-selected window proofs were additionally dropped when the resolver replaced the selected row with exact WindowServer metadata.

The fix relaxes only redundant proof requirements for an already exact window ID. PID, process generation, window ID, bounds, proof scope/order/cardinality, and fuzzy candidate-set binding remain fail closed.

## Proof

- `swift test --package-path Core/PeekabooAutomationKit --filter ObservationExactWindowResolverTests` (9/9)
- `swift test --package-path Core/PeekabooCore --filter PeekabooBridgeDesktopObservationBindingTests` (15/15)
- `pnpm run format`
- `pnpm run lint` (0 serious findings; established warnings only)
- `pnpm run lint:docs`
- `pnpm run test:safe` (background certification 241/241, Foundation 70/70, CLI runtime 110/110, CLI automation 48/48, CLI 503/503)
- structured autoreview clean with no accepted/actionable findings

No foreground fallback, AppleScript/JXA, virtualization, TCC mutation, or protocol-shape change was introduced.
