### PR TITLE
perf(cli): reuse runtime host handshake

### DIFF
--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/RuntimeHostResolver+Resolution.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/RuntimeHostResolver+Resolution.swift
@@ -1,9 +1,75 @@
 import Darwin
+import Foundation
 import PeekabooAutomationKit
 import PeekabooBridge
 import PeekabooCore
 
 extension RuntimeHostResolver {
+    /// Reuses fully authenticated handshakes only within one runtime-resolution attempt.
+    /// Candidate requirements are reapplied before selection, and the retained client keeps the
+    /// listener identity and operation session that every later request revalidates before writing.
+    @MainActor
+    final class RemoteHandshakeCache {
+        struct Entry {
+            let client: PeekabooBridgeClient
+            let response: PeekabooBridgeHandshakeResponse
+        }
+
+        let identity: PeekabooBridgeClientIdentity
+        private var entriesBySocketPath: [String: Entry] = [:]
+
+        convenience init() {
+            self.init(identity: PeekabooBridgeClientIdentity(
+                bundleIdentifier: Bundle.main.bundleIdentifier,
+                teamIdentifier: nil,
+                processIdentifier: getpid(),
+                hostname: Host.current().name
+            ))
+        }
+
+        init(identity: PeekabooBridgeClientIdentity) {
+            self.identity = identity
+        }
+
+        func handshake(
+            _ candidate: ImplicitRemoteCandidate,
+            identity: PeekabooBridgeClientIdentity
+        ) async throws -> Entry {
+            guard self.isBound(to: identity) else {
+                throw POSIXError(.EINVAL)
+            }
+            let socketPath = Self.standardizedSocketPath(candidate.socketPath)
+            if let entry = self.entriesBySocketPath[socketPath] {
+                return entry
+            }
+
+            let client = PeekabooBridgeClient(socketPath: candidate.socketPath)
+            let response = try await client.handshake(client: self.identity, requestedHost: nil)
+            let entry = Entry(client: client, response: response)
+            self.entriesBySocketPath[socketPath] = entry
+            return entry
+        }
+
+        func entry(
+            for candidate: ImplicitRemoteCandidate,
+            identity: PeekabooBridgeClientIdentity
+        ) -> Entry? {
+            guard self.isBound(to: identity) else { return nil }
+            return self.entriesBySocketPath[Self.standardizedSocketPath(candidate.socketPath)]
+        }
+
+        private func isBound(to identity: PeekabooBridgeClientIdentity) -> Bool {
+            self.identity.bundleIdentifier == identity.bundleIdentifier &&
+                self.identity.teamIdentifier == identity.teamIdentifier &&
+                self.identity.processIdentifier == identity.processIdentifier &&
+                self.identity.hostname == identity.hostname
+        }
+
+        private static func standardizedSocketPath(_ socketPath: String) -> String {
+            NSString(string: socketPath).standardizingPath
+        }
+    }
+
     struct ImplicitRemoteCandidate: Equatable {
         let socketPath: String
         let requireReusableDaemon: Bool

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/RuntimeHostResolver+ScreenCaptureKitOwner.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/RuntimeHostResolver+ScreenCaptureKitOwner.swift
@@ -17,7 +17,8 @@ extension RuntimeHostResolver {
     typealias ScreenCaptureKitSafetyInspector = @MainActor @Sendable (
         _ options: CommandRuntimeOptions,
         _ environment: [String: String],
-        _ candidates: [ImplicitRemoteCandidate]?
+        _ candidates: [ImplicitRemoteCandidate]?,
+        _ handshakeCache: RemoteHandshakeCache
     ) async throws -> ScreenCaptureKitOwnerUnawareHost?
     typealias ScreenCaptureKitSafetyRecorder = @MainActor (ScreenCaptureKitOwnerUnawareHost) -> Void
     typealias ScreenCaptureKitHandshake = @MainActor @Sendable (
@@ -39,7 +40,7 @@ extension RuntimeHostResolver {
             makeLocalServices: @escaping LocalServiceFactory,
             claimScreenCaptureKitOwner: @escaping ScreenCaptureKitOwnerClaim,
             inspectScreenCaptureKitOwner: @escaping ScreenCaptureKitOwnerInspector,
-            inspectScreenCaptureKitSafety: @escaping ScreenCaptureKitSafetyInspector = { _, _, _ in nil },
+            inspectScreenCaptureKitSafety: @escaping ScreenCaptureKitSafetyInspector = { _, _, _, _ in nil },
             recordScreenCaptureKitSafetyBlocker: @escaping ScreenCaptureKitSafetyRecorder = { _ in },
             remoteCandidatePlan: @escaping RemoteCandidatePlanner = RuntimeHostResolver.remoteCandidatePlan
         ) {
@@ -55,7 +56,7 @@ extension RuntimeHostResolver {
             makeLocalServices: RuntimeServiceFactory.makeLocalServices,
             claimScreenCaptureKitOwner: { try ScreenCaptureKitOwnerLease().claim().receipt },
             inspectScreenCaptureKitOwner: { try ScreenCaptureKitOwnerLease.currentOwnerReceiptIfHeld() },
-            inspectScreenCaptureKitSafety: { options, environment, candidates in
+            inspectScreenCaptureKitSafety: { options, environment, candidates, handshakeCache in
                 let resolvedCandidates: [ImplicitRemoteCandidate]
                 if let suppliedCandidates = candidates {
                     resolvedCandidates = suppliedCandidates
@@ -68,12 +69,8 @@ extension RuntimeHostResolver {
                 }
                 return try await RuntimeHostResolver.firstScreenCaptureKitOwnerUnawareHost(
                     candidates: resolvedCandidates,
-                    identity: PeekabooBridgeClientIdentity(
-                        bundleIdentifier: Bundle.main.bundleIdentifier,
-                        teamIdentifier: nil,
-                        processIdentifier: getpid(),
-                        hostname: Host.current().name
-                    )
+                    identity: handshakeCache.identity,
+                    handshakeCache: handshakeCache
                 )
             },
             recordScreenCaptureKitSafetyBlocker: { host in
@@ -92,11 +89,30 @@ extension RuntimeHostResolver {
         let environment: [String: String]
         let candidatePlan: RemoteCandidatePlan
         let identity: PeekabooBridgeClientIdentity
+        let handshakeCache: RemoteHandshakeCache
         let snapshotInvalidationRemoteSocketPaths: [String]
         let preferredScreenCaptureKitOwner: ScreenCaptureKitOwnerLease.OwnerReceipt?
         let makeLocalServices: LocalServiceFactory
         let inspectScreenCaptureKitSafety: ScreenCaptureKitSafetyInspector
         let recordScreenCaptureKitSafetyBlocker: ScreenCaptureKitSafetyRecorder
+
+        func resolveRemoteServices(
+            candidates: [ImplicitRemoteCandidate],
+            requiredProtocolVersion: PeekabooBridgeProtocolVersion? = nil,
+            requiredOwner: ScreenCaptureKitOwnerLease.OwnerReceipt? = nil,
+            permissionRejections: inout [String]
+        ) async throws -> Resolution? {
+            try await RuntimeHostResolver.resolveRemoteServices(
+                candidates: candidates,
+                identity: self.identity,
+                options: self.options,
+                requiredProtocolVersion: requiredProtocolVersion,
+                requiredOwner: requiredOwner,
+                snapshotInvalidationRemoteSocketPaths: self.snapshotInvalidationRemoteSocketPaths,
+                permissionRejections: &permissionRejections,
+                handshakeCache: self.handshakeCache
+            )
+        }
     }
 
     struct ScreenCaptureKitOwnerUnawareHost: Equatable {
@@ -405,10 +421,8 @@ extension RuntimeHostResolver {
     static func firstScreenCaptureKitOwnerUnawareHost(
         candidates: [ImplicitRemoteCandidate],
         identity: PeekabooBridgeClientIdentity,
-        handshake: @escaping ScreenCaptureKitHandshake = { candidate, identity in
-            try await PeekabooBridgeClient(socketPath: candidate.socketPath)
-                .handshake(client: identity, requestedHost: nil)
-        },
+        handshakeCache: RemoteHandshakeCache? = nil,
+        handshake: ScreenCaptureKitHandshake? = nil,
         externalHostPresence: @escaping ScreenCaptureKitExternalHostInspector = {
             RuntimeHostResolver.knownExternalHostPresence(socketPath: $0)
         }
@@ -417,7 +431,14 @@ extension RuntimeHostResolver {
             try Task.checkCancellation()
             let response: PeekabooBridgeHandshakeResponse
             do {
-                response = try await handshake(candidate, identity)
+                if let handshake {
+                    response = try await handshake(candidate, identity)
+                } else if let handshakeCache {
+                    response = try await handshakeCache.handshake(candidate, identity: identity).response
+                } else {
+                    response = try await PeekabooBridgeClient(socketPath: candidate.socketPath)
+                        .handshake(client: identity, requestedHost: nil)
+                }
                 try Task.checkCancellation()
             } catch let error as CancellationError {
                 throw error

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/RuntimeHostResolver.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/RuntimeHostResolver.swift
@@ -27,6 +27,7 @@ enum RuntimeHostResolver {
         var deferredScreenCaptureKitSafetyBlocker = false
         var captureEngineSafetyOverride: CaptureEnginePreference?
         var toolCapturePreflightRefusal: MCPToolCapturePreflightRefusal?
+        var handshakeCache: RemoteHandshakeCache?
         if self.requiresCallerLocalModernOwnerClaim(options: options, environment: environment) {
             do {
                 if let owner = try dependencies.inspectScreenCaptureKitOwner(),
@@ -43,10 +44,13 @@ enum RuntimeHostResolver {
         if self.requiresCallerLocalScreenCaptureKitSafetyCheck(options: options, environment: environment) {
             let plan = await dependencies.remoteCandidatePlan(options, environment)
             safetyPlan = plan
+            let resolvedHandshakeCache = RemoteHandshakeCache()
+            handshakeCache = resolvedHandshakeCache
             if let oldHost = try await dependencies.inspectScreenCaptureKitSafety(
                 options,
                 environment,
-                self.screenCaptureKitSafetyCandidates(from: plan)
+                self.screenCaptureKitSafetyCandidates(from: plan),
+                resolvedHandshakeCache
             ) {
                 // The live recorder installs an irreversible process-lifetime tombstone. One
                 // discovered old host therefore blocks every later SCK leaf even if another old
@@ -165,18 +169,13 @@ enum RuntimeHostResolver {
             )
         }
 
-        let identity = PeekabooBridgeClientIdentity(
-            bundleIdentifier: Bundle.main.bundleIdentifier,
-            teamIdentifier: nil,
-            processIdentifier: getpid(),
-            hostname: Host.current().name
-        )
-
+        let resolvedHandshakeCache = handshakeCache ?? RemoteHandshakeCache()
         var resolution = try await self.resolveRemoteRouting(context: RemoteResolutionContext(
             options: options,
             environment: environment,
             candidatePlan: candidatePlan,
-            identity: identity,
+            identity: resolvedHandshakeCache.identity,
+            handshakeCache: resolvedHandshakeCache,
             snapshotInvalidationRemoteSocketPaths: snapshotInvalidationRemoteSocketPaths,
             preferredScreenCaptureKitOwner: preferredScreenCaptureKitOwner,
             makeLocalServices: dependencies.makeLocalServices,
@@ -218,7 +217,8 @@ enum RuntimeHostResolver {
            let oldHost = try await context.inspectScreenCaptureKitSafety(
                options,
                context.environment,
-               candidatePlan.candidates
+               candidatePlan.candidates,
+               context.handshakeCache
            ) {
             context.recordScreenCaptureKitSafetyBlocker(oldHost)
             throw self.ownerCapabilityRefusal(host: oldHost, selectedSocket: explicitSocket)
@@ -227,12 +227,9 @@ enum RuntimeHostResolver {
         if let preferredScreenCaptureKitOwner = context.preferredScreenCaptureKitOwner {
             // An explicit socket remains authoritative: validate only that host against the
             // process-lifetime owner instead of silently rerouting to a different Bridge.
-            if let resolved = try await resolveRemoteServices(
+            if let resolved = try await context.resolveRemoteServices(
                 candidates: ownerAwareCandidates,
-                identity: context.identity,
-                options: options,
                 requiredOwner: preferredScreenCaptureKitOwner,
-                snapshotInvalidationRemoteSocketPaths: snapshotInvalidationRemoteSocketPaths,
                 permissionRejections: &permissionRejections
             ) {
                 return await self.finalizeExactBuildScopedResolution(resolved, candidatePlan: candidatePlan)
@@ -262,12 +259,9 @@ enum RuntimeHostResolver {
                 requiredHostKind: .onDemand,
                 requiresValidatedHistoricalDaemon: false
             )
-            if let resolved = try await resolveRemoteServices(
+            if let resolved = try await context.resolveRemoteServices(
                 candidates: [exactCandidate],
-                identity: context.identity,
-                options: options,
                 requiredProtocolVersion: PeekabooBridgeConstants.protocolVersion,
-                snapshotInvalidationRemoteSocketPaths: snapshotInvalidationRemoteSocketPaths,
                 permissionRejections: &permissionRejections
             ) {
                 return await self.finalizeExactBuildScopedResolution(resolved, candidatePlan: candidatePlan)
@@ -281,28 +275,22 @@ enum RuntimeHostResolver {
                    socketPath: buildScopedDaemonSocketPath,
                    environment: context.environment
                ),
-               let resolved = try await resolveRemoteServices(
+               let resolved = try await context.resolveRemoteServices(
                    candidates: [ImplicitRemoteCandidate(
                        socketPath: resolvedDaemonSocket,
                        requireReusableDaemon: true,
                        requiredHostKind: .onDemand,
                        requiresValidatedHistoricalDaemon: false
                    )],
-                   identity: context.identity,
-                   options: options,
                    requiredProtocolVersion: PeekabooBridgeConstants.protocolVersion,
-                   snapshotInvalidationRemoteSocketPaths: snapshotInvalidationRemoteSocketPaths,
                    permissionRejections: &permissionRejections
                ) {
                 return await self.finalizeExactBuildScopedResolution(resolved, candidatePlan: candidatePlan)
             }
         }
 
-        if let resolved = try await resolveRemoteServices(
+        if let resolved = try await context.resolveRemoteServices(
             candidates: candidatePlan.candidates,
-            identity: context.identity,
-            options: options,
-            snapshotInvalidationRemoteSocketPaths: snapshotInvalidationRemoteSocketPaths,
             permissionRejections: &permissionRejections
         ) {
             return await self.finalizeExactBuildScopedResolution(resolved, candidatePlan: candidatePlan)
@@ -330,16 +318,13 @@ enum RuntimeHostResolver {
                 socketPath: autoStartSocketPath,
                 environment: context.environment
             ),
-                let resolved = try await resolveRemoteServices(
+                let resolved = try await context.resolveRemoteServices(
                     candidates: [ImplicitRemoteCandidate(
                         socketPath: resolvedDaemonSocket,
                         requireReusableDaemon: true,
                         requiredHostKind: nil,
                         requiresValidatedHistoricalDaemon: false
                     )],
-                    identity: context.identity,
-                    options: options,
-                    snapshotInvalidationRemoteSocketPaths: snapshotInvalidationRemoteSocketPaths,
                     permissionRejections: &permissionRejections
                 ) {
                 return await self.finalizeExactBuildScopedResolution(resolved, candidatePlan: candidatePlan)
@@ -677,18 +662,25 @@ enum RuntimeHostResolver {
         requiredOwner: ScreenCaptureKitOwnerLease.OwnerReceipt? = nil,
         snapshotInvalidationRemoteSocketPaths: [String],
         permissionRejections: inout [String],
-        handshake: ScreenCaptureKitHandshake? = nil
+        handshake: ScreenCaptureKitHandshake? = nil,
+        handshakeCache: RemoteHandshakeCache? = nil
     )
     async throws -> Resolution? {
         for candidate in candidates {
             try Task.checkCancellation()
             let socketPath = candidate.socketPath
-            let client = PeekabooBridgeClient(socketPath: socketPath)
             do {
-                let handshakeResponse = if let handshake {
-                    try await handshake(candidate, identity)
+                let client: PeekabooBridgeClient
+                let handshakeResponse: PeekabooBridgeHandshakeResponse
+                if let handshake {
+                    client = PeekabooBridgeClient(socketPath: socketPath)
+                    handshakeResponse = try await handshake(candidate, identity)
+                } else if let cached = handshakeCache?.entry(for: candidate, identity: identity) {
+                    client = cached.client
+                    handshakeResponse = cached.response
                 } else {
-                    try await client.handshake(client: identity, requestedHost: nil)
+                    client = PeekabooBridgeClient(socketPath: socketPath)
+                    handshakeResponse = try await client.handshake(client: identity, requestedHost: nil)
                 }
                 try Task.checkCancellation()
                 let validation = await self.validateRemoteCandidate(

--- a/Apps/CLI/Tests/CLIRuntimeTests/AgentExecutionProcessLimitRuntimeTests.swift
+++ b/Apps/CLI/Tests/CLIRuntimeTests/AgentExecutionProcessLimitRuntimeTests.swift
@@ -182,12 +182,13 @@ struct AgentExecutionProcessLimitRuntimeTests {
             return request.operation
         }
         let invalidationCount = operations.count(where: { $0 == .invalidateImplicitLatestSnapshot })
-        #expect(handshakeCount == 2, "Bridge requests: \(requestBodies)")
+        // SCK safety inspection and runtime selection retain one authenticated client/session.
+        #expect(handshakeCount == 1, "Bridge requests: \(requestBodies)")
         #expect((0...1).contains(invalidationCount), "Bridge requests: \(requestBodies)")
         #expect(operations.count(where: { $0 == .getFrontmostApplication }) == 2)
         #expect(operations.count(where: { $0 == .getFocusedWindow }) == 2)
         #expect(operations.count(where: { $0 == .listApplications }) == 3)
-        #expect(requests.count == 9 + invalidationCount, "Bridge requests: \(requestBodies)")
+        #expect(requests.count == 8 + invalidationCount, "Bridge requests: \(requestBodies)")
     }
 
     private static func response(for request: PeekabooBridgeRequest) -> PeekabooBridgeResponse {

--- a/Apps/CLI/Tests/CoreCLITests/CaptureVideoLocalIngestTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/CaptureVideoLocalIngestTests.swift
@@ -106,7 +106,7 @@ struct CaptureVideoLocalIngestTests {
                     inspectOwnerCalls += 1
                     return Self.ownerReceipt()
                 },
-                inspectScreenCaptureKitSafety: { _, _, _ in
+                inspectScreenCaptureKitSafety: { _, _, _, _ in
                     inspectSafetyCalls += 1
                     return RuntimeHostResolver.ScreenCaptureKitOwnerUnawareHost(
                         socketPath: "/tmp/old-owner.sock",

--- a/Apps/CLI/Tests/CoreCLITests/RuntimeHostHandshakeReuseTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/RuntimeHostHandshakeReuseTests.swift
@@ -1,0 +1,104 @@
+import Darwin
+import Foundation
+import PeekabooAutomationKit
+import PeekabooBridge
+import Testing
+@testable import PeekabooCLI
+
+extension ScreenCaptureKitOwnerRuntimeTests {
+    @Test
+    func `SCK safety handshake is reused for selection and authenticated dispatch`() async throws {
+        let socketPath = "/tmp/peekaboo-safety-handshake-reuse-\(UUID().uuidString).sock"
+        var permissionEvaluationCount = 0
+        let host = try await Self.startHost(
+            socketPath: socketPath,
+            processIdentifier: 4242,
+            processStartIdentity: 9001,
+            codeSignatureHash: "owner-build",
+            permissionEvaluationObserver: {
+                permissionEvaluationCount += 1
+            }
+        )
+        defer { Task { await host.stop() } }
+
+        let identity = PeekabooBridgeClientIdentity(
+            bundleIdentifier: "boo.peekaboo.test.client",
+            teamIdentifier: nil,
+            processIdentifier: getpid()
+        )
+        let candidate = RuntimeHostResolver.ImplicitRemoteCandidate(
+            socketPath: socketPath,
+            requireReusableDaemon: false,
+            requiredHostKind: nil,
+            requiresValidatedHistoricalDaemon: false
+        )
+        let handshakeCache = RuntimeHostResolver.RemoteHandshakeCache(identity: identity)
+
+        let unawareHost = try await RuntimeHostResolver.firstScreenCaptureKitOwnerUnawareHost(
+            candidates: [candidate],
+            identity: identity,
+            handshakeCache: handshakeCache,
+            externalHostPresence: { _ in .absent }
+        )
+        #expect(unawareHost == nil)
+        #expect(permissionEvaluationCount == 1)
+        #expect(handshakeCache.entry(
+            for: candidate,
+            identity: PeekabooBridgeClientIdentity(
+                bundleIdentifier: identity.bundleIdentifier,
+                teamIdentifier: identity.teamIdentifier,
+                processIdentifier: identity.processIdentifier + 1,
+                hostname: identity.hostname
+            )
+        ) == nil)
+
+        var options = CommandRuntimeOptions()
+        options.captureEnginePreference = "auto"
+        options.transportsCaptureEnginePreference = true
+        options.requiresCaptureEnginePreferenceHost = true
+        options.requiresScreenCaptureKitOwnerCapability = true
+        options.requiresDesktopObservation = true
+        options.requiresScreenCapturePermission = true
+
+        var permissionRejections: [String] = []
+        let mismatched = try await RuntimeHostResolver.resolveRemoteServices(
+            candidates: [candidate],
+            identity: identity,
+            options: options,
+            requiredOwner: ScreenCaptureKitOwnerLease.OwnerReceipt(
+                processIdentifier: 4242,
+                processStartIdentity: 9001,
+                codeSignatureHash: "different-build"
+            ),
+            snapshotInvalidationRemoteSocketPaths: [],
+            permissionRejections: &permissionRejections,
+            handshakeCache: handshakeCache
+        )
+        #expect(mismatched == nil)
+        #expect(permissionEvaluationCount == 1)
+
+        let resolved = try await RuntimeHostResolver.resolveRemoteServices(
+            candidates: [candidate],
+            identity: identity,
+            options: options,
+            requiredOwner: ScreenCaptureKitOwnerLease.OwnerReceipt(
+                processIdentifier: 4242,
+                processStartIdentity: 9001,
+                codeSignatureHash: "owner-build"
+            ),
+            snapshotInvalidationRemoteSocketPaths: [],
+            permissionRejections: &permissionRejections,
+            handshakeCache: handshakeCache
+        )
+        let resolution = try #require(resolved)
+
+        #expect(resolution.selectedRemoteSocketPath == socketPath)
+        #expect(permissionRejections.isEmpty)
+        #expect(permissionEvaluationCount == 1)
+
+        let permissions = try await resolution.services.permissionsStatus()
+        #expect(permissions.screenRecording)
+        #expect(permissionEvaluationCount == 2)
+        await host.stop()
+    }
+}

--- a/Apps/CLI/Tests/CoreCLITests/ScreenCaptureKitDynamicToolRuntimeTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/ScreenCaptureKitDynamicToolRuntimeTests.swift
@@ -53,7 +53,7 @@ extension ScreenCaptureKitOwnerRuntimeTests {
                     inspectOwnerCalls += 1
                     return nil
                 },
-                inspectScreenCaptureKitSafety: { _, _, _ in legacyOwner },
+                inspectScreenCaptureKitSafety: { _, _, _, _ in legacyOwner },
                 remoteCandidatePlan: { _, _ in
                     RuntimeHostResolver.RemoteCandidatePlan(
                         explicitSocket: selectedSocket,
@@ -111,7 +111,7 @@ extension ScreenCaptureKitOwnerRuntimeTests {
                     },
                     claimScreenCaptureKitOwner: { Self.ownerReceipt() },
                     inspectScreenCaptureKitOwner: { nil },
-                    inspectScreenCaptureKitSafety: { _, _, _ in
+                    inspectScreenCaptureKitSafety: { _, _, _, _ in
                         RuntimeHostResolver.ScreenCaptureKitOwnerUnawareHost(
                             socketPath: "/tmp/unrelated-legacy-owner.sock",
                             processIdentifier: nil,
@@ -182,7 +182,7 @@ extension ScreenCaptureKitOwnerRuntimeTests {
                 makeLocalServices: { _ in PeekabooServices() },
                 claimScreenCaptureKitOwner: { Self.ownerReceipt() },
                 inspectScreenCaptureKitOwner: { nil },
-                inspectScreenCaptureKitSafety: { _, _, _ in legacyOwner },
+                inspectScreenCaptureKitSafety: { _, _, _, _ in legacyOwner },
                 remoteCandidatePlan: { _, _ in
                     RuntimeHostResolver.RemoteCandidatePlan(
                         explicitSocket: selectedSocket,

--- a/Apps/CLI/Tests/CoreCLITests/ScreenCaptureKitOwnerRuntimeTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/ScreenCaptureKitOwnerRuntimeTests.swift
@@ -130,7 +130,7 @@ struct ScreenCaptureKitOwnerRuntimeTests {
                     inspectOwnerCalls += 1
                     return Self.ownerReceipt()
                 },
-                inspectScreenCaptureKitSafety: { _, _, _ in
+                inspectScreenCaptureKitSafety: { _, _, _, _ in
                     inspectSafetyCalls += 1
                     return RuntimeHostResolver.ScreenCaptureKitOwnerUnawareHost(
                         socketPath: "/tmp/old-host.sock",
@@ -185,7 +185,7 @@ struct ScreenCaptureKitOwnerRuntimeTests {
                     inspectOwnerCalls += 1
                     return Self.ownerReceipt()
                 },
-                inspectScreenCaptureKitSafety: { _, _, _ in
+                inspectScreenCaptureKitSafety: { _, _, _, _ in
                     inspectSafetyCalls += 1
                     return RuntimeHostResolver.ScreenCaptureKitOwnerUnawareHost(
                         socketPath: "/tmp/old-host.sock",
@@ -281,7 +281,7 @@ struct ScreenCaptureKitOwnerRuntimeTests {
                         inspectCalls += 1
                         return nil
                     },
-                    inspectScreenCaptureKitSafety: { _, _, _ in
+                    inspectScreenCaptureKitSafety: { _, _, _, _ in
                         RuntimeHostResolver.ScreenCaptureKitOwnerUnawareHost(
                             socketPath: explicitSocket,
                             processIdentifier: 3131,
@@ -351,7 +351,7 @@ struct ScreenCaptureKitOwnerRuntimeTests {
                 },
                 claimScreenCaptureKitOwner: { Self.ownerReceipt() },
                 inspectScreenCaptureKitOwner: { nil },
-                inspectScreenCaptureKitSafety: { _, _, _ in auxiliaryBlocker },
+                inspectScreenCaptureKitSafety: { _, _, _, _ in auxiliaryBlocker },
                 recordScreenCaptureKitSafetyBlocker: { recordedBlockers.append($0) }
             )
         )
@@ -398,7 +398,7 @@ struct ScreenCaptureKitOwnerRuntimeTests {
                     },
                     claimScreenCaptureKitOwner: { Self.ownerReceipt() },
                     inspectScreenCaptureKitOwner: { nil },
-                    inspectScreenCaptureKitSafety: { _, _, _ in auxiliaryBlocker },
+                    inspectScreenCaptureKitSafety: { _, _, _, _ in auxiliaryBlocker },
                     recordScreenCaptureKitSafetyBlocker: { recordedBlockers.append($0) }
                 )
             )
@@ -820,7 +820,7 @@ extension ScreenCaptureKitOwnerRuntimeTests {
                     inspectOwnerCalls += 1
                     return nil
                 },
-                inspectScreenCaptureKitSafety: { _, _, _ in
+                inspectScreenCaptureKitSafety: { _, _, _, _ in
                     inspectSafetyCalls += 1
                     return RuntimeHostResolver.ScreenCaptureKitOwnerUnawareHost(
                         socketPath: "/tmp/old-host.sock",
@@ -1436,7 +1436,8 @@ extension ScreenCaptureKitOwnerRuntimeTests {
         codeSignatureHash: String,
         ownerAware: Bool = true,
         screenRecording: Bool = true,
-        serviceOverride: (any PeekabooBridgeServiceProviding)? = nil
+        serviceOverride: (any PeekabooBridgeServiceProviding)? = nil,
+        permissionEvaluationObserver: @escaping @MainActor @Sendable () -> Void = {}
     ) async throws -> PeekabooBridgeHost {
         let services: any PeekabooBridgeServiceProviding = if let serviceOverride {
             serviceOverride
@@ -1455,6 +1456,7 @@ extension ScreenCaptureKitOwnerRuntimeTests {
                 upper: PeekabooBridgeConstants.exactForcedDialogDismissExecutionVersion
             )),
             allowedOperations: [
+                .permissionsStatus,
                 .captureScreen,
                 .desktopObservation,
                 .invalidateImplicitLatestSnapshot,
@@ -1477,7 +1479,8 @@ extension ScreenCaptureKitOwnerRuntimeTests {
                 codeSignatureHash: codeSignatureHash
             ),
             permissionStatusEvaluator: { _ in
-                PermissionsStatus(
+                permissionEvaluationObserver()
+                return PermissionsStatus(
                     screenRecording: screenRecording,
                     accessibility: true,
                     appleScript: false,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add a Git-blob-bound final qualification manifest that requires byte-identical local/Studio installations, candidate-bound CLI and monitor identities, both elevation receipts, guarded task-owned process trees, and freshly re-executed native-only policy scans.
 
 ### Fixed
+- Reuse the authenticated ScreenCaptureKit safety handshake during normal runtime-host selection, avoiding a duplicate signature and permission round trip while preserving fail-closed host validation.
 - Preserve exact application/window selector proofs through capture hardening and accept proofless exact-ID PID observations, while keeping fuzzy selectors and stable process/window receipt fields fail closed.
 - Keep CLI wall-clock timeouts bounded under sustained executor load by sharing one monotonic dispatch timer and canceling losing timer/work paths without releasing mutation barriers early.
 - Make macOS release signing retry each validated Sparkle leaf independently before sealing the outer app, and pin the exact workspace package graph so Xcode cannot silently drift release dependencies.


### PR DESCRIPTION
## Summary

- reuse the fully authenticated ScreenCaptureKit safety handshake during normal runtime-host selection
- scope cached clients and handshake responses to one resolution attempt, one complete client identity, and one standardized socket path
- keep all protocol, host-kind, capability, permission, reusable-daemon, build, and exact-owner validation in the normal selection path
- retain per-request listener authentication so a restarted or substituted host still fails closed before dispatch

## Root cause

Signed timeout stress showed periodic 3.8-5.0 second process latency even though the `see` command itself completed in 2-9 ms. Unified timing placed the delay before command execution: an SCK-capable request first handshook every candidate for owner-safety inspection, then normal routing immediately performed the same mutual code-signature validation, permission snapshot, and operation-session handshake again.

The resolution-scoped cache keeps the already-authenticated client/session from the safety inspection and feeds it into the existing candidate validator. It is not a cross-command cache, and it does not cache failed handshakes or bypass any selection requirement.

## Proof

- `swift test --package-path Apps/CLI --filter ScreenCaptureKitOwnerRuntimeTests` (34/34)
- `swift test --package-path Apps/CLI --filter CaptureVideoLocalIngestTests` (2/2)
- `swift test --package-path Apps/CLI --filter AgentExecutionProcessLimitRuntimeTests` (2/2)
- full `swift test --package-path Apps/CLI --no-parallel -Xswiftc -DPEEKABOO_SKIP_AUTOMATION` (1,176/1,176)
- touched SwiftFormat clean
- touched SwiftLint clean
- `git diff --check origin/main...HEAD`
- structured Autoreview clean on the rebased exact branch with no accepted/actionable findings

The new regression uses a real local Bridge and proves safety inspection plus selection performs one permission evaluation/handshake, mismatched owner validation stays rejected without another handshake, the matching owner is selected, and authenticated dispatch succeeds on the retained session.

No foreground behavior, AppleScript/JXA, virtualization, persistent cache, public unsafe flag, permission weakening, or protocol change was introduced.
