### PR TITLE
test(mcp): report exact keyboard inventory completeness

### DIFF
--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPExactWindowKeyboardToolTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPExactWindowKeyboardToolTests.swift
@@ -291,7 +291,7 @@ private final class ExactKeyboardAutomationService: MockAutomationService,
     }
 }
 
-private actor ExactKeyboardWindowService: WindowManagementServiceProtocol {
+private actor ExactKeyboardWindowService: WindowManagementServiceProtocol, WindowMutationInventoryProviding {
     let windows: [ServiceWindowInfo]
     let cancelWindowListing: Bool
 
@@ -319,6 +319,12 @@ private actor ExactKeyboardWindowService: WindowManagementServiceProtocol {
         case let .index(_, index): self.windows.filter { $0.index == index }
         case .application, .frontmost: self.windows
         }
+    }
+
+    func windowMutationInventory(
+        target: WindowTarget) async throws -> DesktopTargetPlanning.Inventory<ServiceWindowInfo>
+    {
+        try await .complete(self.listWindows(target: target))
     }
 
     func getFocusedWindow() async throws -> ServiceWindowInfo? {


### PR DESCRIPTION
## Summary

- make the exact-keyboard test window service report the completeness of its fully owned stable catalog
- preserve the production planner's fail-closed completeness requirement
- restore the existing app-target success and ambiguity regression without changing assertions or timeouts

## Root cause

`ExactKeyboardWindowService` was written before mutation inventories carried explicit completeness. The production `BackgroundKeyboardTargetPlanner` now correctly rejects broad per-app selection when a service cannot prove its catalog is complete. Real `WindowManagementService` implements that contract, while this fixture still exposed only `listWindows`, so one of six exact-keyboard tests failed before exercising its intended behavior.

The fixture now adopts `WindowMutationInventoryProviding` and marks its own complete, deterministic listing as complete, matching the equivalent paste fixture.

## Proof

- `swift test --package-path Core/PeekabooCore --filter MCPExactWindowKeyboardToolTests` (6/6)
- `pnpm run format` (no changes)
- `pnpm run lint` (0 serious findings; established warnings only)
- `git diff --check`
- structured Autoreview clean with no accepted/actionable findings

Test-only change; no product behavior, assertion, timeout, protocol, or public API changed.
