### PR TITLE
refactor(mcp): share snapshot mutation authority

### DIFF
--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/MCPToolContext+BackgroundApplicationTarget.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/MCPToolContext+BackgroundApplicationTarget.swift
@@ -22,81 +22,73 @@ extension MCPToolContext {
         toolName: String) async throws -> ToolResponse?
     {
         guard let plan = authorization.targetPlan else { return nil }
-        if let authority = plan.mutationAuthority {
-            let planner = DesktopTargetPlanning.MutationAuthorityPlanner(
-                applications: self.applications,
-                windows: self.windows)
-            do {
-                let current = try await planner.revalidate(authority)
-                _ = try plan.targetIdentity.coalescing(current.targetIdentity)
-                let application = current.application.application
-                return self.executionPolicy.systemSurfaceRejection(
-                    toolName: toolName,
-                    applicationBundleIdentifier: application.bundleIdentifier,
-                    applicationName: application.name)
-            } catch is CancellationError {
-                throw CancellationError()
-            } catch {
-                try Task.checkCancellation()
-                let detail = plan.targetIdentity.exactWindow == nil
-                    ? "the selected application changed process generation before dispatch"
-                    : "the selected window changed identity or bounds before dispatch"
-                return self.executionPolicy.unresolvedTargetRejection(
-                    toolName: toolName,
-                    detail: detail)
-            }
+        guard let authority = plan.mutationAuthority else {
+            return self.executionPolicy.unresolvedTargetRejection(
+                toolName: toolName,
+                detail: "the selected target has no shared mutation authority")
         }
-
-        // Snapshot-backed authorizations do not originate from a live inventory plan. Retain their
-        // exact identity revalidation until snapshot receipt planning moves into the shared planner.
-        let identity = plan.processIdentity
+        let planner = DesktopTargetPlanning.MutationAuthorityPlanner(
+            applications: self.applications,
+            windows: self.windows)
         do {
-            let application = try await self.applications.findApplication(
-                identifier: "PID:\(identity.processIdentifier)")
-            guard application.processStartIdentity == identity.processStartIdentity else {
-                return self.executionPolicy.unresolvedTargetRejection(
-                    toolName: toolName,
-                    detail: "the selected application changed process generation before dispatch")
-            }
-            if let rejection = self.executionPolicy.systemSurfaceRejection(
+            let current = try await planner.revalidate(authority)
+            _ = try plan.targetIdentity.coalescing(current.targetIdentity)
+            let application = current.application.application
+            return self.executionPolicy.systemSurfaceRejection(
                 toolName: toolName,
                 applicationBundleIdentifier: application.bundleIdentifier,
                 applicationName: application.name)
-            {
-                return rejection
-            }
         } catch is CancellationError {
             throw CancellationError()
         } catch {
             try Task.checkCancellation()
+            let detail = plan.targetIdentity.exactWindow == nil
+                ? "the selected application changed process generation before dispatch"
+                : "the selected window changed identity or bounds before dispatch"
             return self.executionPolicy.unresolvedTargetRejection(
                 toolName: toolName,
-                detail: "the selected application disappeared before dispatch")
+                detail: detail)
         }
+    }
 
-        guard let expectedWindow = plan.targetIdentity.exactWindow else { return nil }
-        do {
-            let windows = try await self.windows.listWindows(target: .windowId(expectedWindow.identity.windowID))
-            guard windows.count == 1,
-                  let currentWindow = windows.first,
-                  let currentIdentity = currentWindow.mutationIdentity,
-                  currentIdentity.hasSameStableReceipt(as: expectedWindow.identity),
-                  currentIdentity.capturedBounds == currentWindow.bounds,
-                  currentWindow.bounds == expectedWindow.bounds
-            else {
-                return self.executionPolicy.unresolvedTargetRejection(
-                    toolName: toolName,
-                    detail: "the selected window changed identity or bounds before dispatch")
-            }
-        } catch is CancellationError {
-            throw CancellationError()
-        } catch {
-            try Task.checkCancellation()
-            return self.executionPolicy.unresolvedTargetRejection(
-                toolName: toolName,
-                detail: "the selected window disappeared before dispatch")
+    @MainActor
+    func backgroundSnapshotTargetPlan(
+        snapshotID: String,
+        mirroredSnapshot: UISnapshot,
+        detectionResult: ElementDetectionResult) async throws -> AuthorizedDesktopTargetPlan
+    {
+        let mirroredReceipt = try mirroredSnapshot.targetReceipt()
+        let mirroredIdentity = try mirroredReceipt.requireIdentity()
+        if let mirroredName = Self.nonEmpty(mirroredReceipt.applicationName),
+           let detectionName = Self.nonEmpty(detectionResult.metadata.windowContext?.applicationName),
+           mirroredName.caseInsensitiveCompare(detectionName) != .orderedSame
+        {
+            throw DesktopTargetIdentityError.snapshotSourceMismatch
         }
-        return nil
+        guard mirroredIdentity.exactWindow != nil else { throw DesktopTargetIdentityError.incompleteExactWindow }
+        let identity = try SnapshotTargetReceiptPlanner.assemble(
+            snapshotID: snapshotID,
+            detectionResult: detectionResult,
+            additionalEvidence: [.init(target: mirroredIdentity)],
+            applicationName: mirroredReceipt.applicationName).receipt.requireIdentity()
+        let authority = try await self.sharedMutationAuthority(for: identity)
+        return try AuthorizedDesktopTargetPlan(mutationAuthority: authority)
+    }
+
+    @MainActor
+    func sharedMutationAuthority(
+        for identity: DesktopTargetIdentity) async throws -> DesktopTargetPlanning.MutationAuthorityPlan
+    {
+        let planner = DesktopTargetPlanning.MutationAuthorityPlanner(
+            applications: self.applications,
+            windows: self.windows)
+        let authority = try await planner.plan(
+            selector: InteractionTargetSelector(
+                processIdentifier: Int(identity.processIdentity.processIdentifier),
+                windowID: identity.exactWindow?.identity.windowID),
+            expectedProcessIdentity: identity.processIdentity)
+        _ = try identity.coalescing(authority.targetIdentity)
+        return authority
     }
 
     struct BackgroundApplicationTargetSchema {

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/MCPToolContext.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/MCPToolContext.swift
@@ -271,21 +271,22 @@ public struct MCPToolContext: @unchecked Sendable {
 
         // Target authorization and leaf dispatch stay inside the same shared gate. Observation tools therefore cannot
         // replace either snapshot store between the identity check and the exact pinned tool invocation.
-        let targetAuthorization = await self.backgroundTargetAuthorization(
-            toolName: tool.name,
-            arguments: arguments)
-        if let rejection = targetAuthorization.rejection {
-            await self.snapshotExecutionGate.release()
-            return rejection
-        }
+        let targetAuthorization: BackgroundTargetAuthorization
         let targetRevalidation: ToolResponse?
         do {
+            targetAuthorization = try await self.backgroundTargetAuthorization(
+                toolName: tool.name,
+                arguments: arguments)
             targetRevalidation = try await self.backgroundTargetRevalidation(
                 targetAuthorization,
                 toolName: tool.name)
         } catch {
             await self.snapshotExecutionGate.release()
             throw error
+        }
+        if let rejection = targetAuthorization.rejection {
+            await self.snapshotExecutionGate.release()
+            return rejection
         }
         if let rejection = targetRevalidation {
             await self.snapshotExecutionGate.release()
@@ -404,7 +405,7 @@ public struct MCPToolContext: @unchecked Sendable {
         if self.executionPolicy == .backgroundOnly,
            MCPToolRequestSemantics.isSafeBackgroundApplicationLaunchNoOp(arguments)
         {
-            authorization = await self.backgroundTargetAuthorization(
+            authorization = try await self.backgroundTargetAuthorization(
                 toolName: tool.name,
                 arguments: arguments)
             if let rejection = authorization.rejection {
@@ -493,7 +494,7 @@ public struct MCPToolContext: @unchecked Sendable {
 
     private func backgroundTargetAuthorization(
         toolName: String,
-        arguments: ToolArguments) async -> BackgroundTargetAuthorization
+        arguments: ToolArguments) async throws -> BackgroundTargetAuthorization
     {
         func permitted(_ arguments: ToolArguments) -> BackgroundTargetAuthorization {
             BackgroundTargetAuthorization(arguments: arguments, rejection: nil, targetPlan: nil)
@@ -568,11 +569,23 @@ public struct MCPToolContext: @unchecked Sendable {
                 toolName: toolName,
                 detail: "no current snapshot identifies the target"))
         }
-        let detectionResult = try? await self.snapshots.getDetectionResult(snapshotId: effectiveSnapshotID)
-        guard let detectionResult,
-              detectionResult.snapshotId == effectiveSnapshotID,
-              let windowContext = detectionResult.metadata.windowContext
-        else {
+        let detectionResult: ElementDetectionResult
+        do {
+            guard let result = try await self.snapshots.getDetectionResult(snapshotId: effectiveSnapshotID),
+                  result.snapshotId == effectiveSnapshotID
+            else {
+                throw DesktopTargetIdentityError.snapshotSourceMismatch
+            }
+            detectionResult = result
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch {
+            try Task.checkCancellation()
+            return refused(self.executionPolicy.unresolvedTargetRejection(
+                toolName: toolName,
+                detail: "snapshot '\(effectiveSnapshotID)' has no authoritative application identity"))
+        }
+        guard let windowContext = detectionResult.metadata.windowContext else {
             return refused(self.executionPolicy.unresolvedTargetRejection(
                 toolName: toolName,
                 detail: "snapshot '\(effectiveSnapshotID)' has no authoritative application identity"))
@@ -601,7 +614,16 @@ public struct MCPToolContext: @unchecked Sendable {
                 toolName: toolName,
                 detail: "snapshot '\(effectiveSnapshotID)' is absent from the tool snapshot store"))
         }
-        guard Self.sameTarget(mirroredSnapshot, windowContext) else {
+        let targetPlan: AuthorizedDesktopTargetPlan
+        do {
+            targetPlan = try await self.backgroundSnapshotTargetPlan(
+                snapshotID: effectiveSnapshotID,
+                mirroredSnapshot: mirroredSnapshot,
+                detectionResult: detectionResult)
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch {
+            try Task.checkCancellation()
             return refused(self.executionPolicy.unresolvedTargetRejection(
                 toolName: toolName,
                 detail: "the tool and automation snapshots disagree about target ownership"))
@@ -614,7 +636,10 @@ public struct MCPToolContext: @unchecked Sendable {
         if coordinateReference != nil {
             pinnedArguments["coordinate_reference"] = effectiveSnapshotID
         }
-        return permitted(ToolArguments(raw: pinnedArguments))
+        return BackgroundTargetAuthorization(
+            arguments: ToolArguments(raw: pinnedArguments),
+            rejection: nil,
+            targetPlan: targetPlan)
     }
 
     private func backgroundApplicationTargetAuthorization(
@@ -663,10 +688,12 @@ public struct MCPToolContext: @unchecked Sendable {
             let authorizedTarget = try windowTargetIdentities.reduce(processTarget) { partial, windowTarget in
                 try partial.coalescing(windowTarget)
             }
-            let targetPlan = if windowTargetIdentities.isEmpty, let authority = authorities.first {
-                try AuthorizedDesktopTargetPlan(mutationAuthority: authority)
+            let targetPlan: AuthorizedDesktopTargetPlan
+            if windowTargetIdentities.isEmpty, let authority = authorities.first {
+                targetPlan = try AuthorizedDesktopTargetPlan(mutationAuthority: authority)
             } else {
-                AuthorizedDesktopTargetPlan(targetIdentity: authorizedTarget)
+                let authority = try await self.sharedMutationAuthority(for: authorizedTarget)
+                targetPlan = try AuthorizedDesktopTargetPlan(mutationAuthority: authority)
             }
             return BackgroundTargetAuthorization(
                 arguments: Self.argumentsPinnedToProcess(
@@ -718,32 +745,6 @@ public struct MCPToolContext: @unchecked Sendable {
             return StrictStringSelector(isInvalid: true, value: nil)
         }
         return StrictStringSelector(isInvalid: false, value: value)
-    }
-
-    private static func sameTarget(_ snapshot: UISnapshot, _ context: WindowContext) -> Bool {
-        guard let snapshotIdentity = try? snapshot.targetReceipt().requireIdentity(),
-              let snapshotExactWindow = snapshotIdentity.exactWindow,
-              let contextIdentity = try? DesktopTargetPlanning.DesktopTargetIdentityCoalescer.resolve([
-                  .init(
-                      processIdentifier: context.applicationProcessId,
-                      windowID: context.windowID,
-                      windowIdentity: context.windowMutationIdentity,
-                      windowBounds: context.windowBounds,
-                      focusedElement: context.focusedElement),
-              ]),
-              let contextExactWindow = contextIdentity.exactWindow,
-              snapshotExactWindow.identity.hasSameStableReceipt(as: contextExactWindow.identity),
-              snapshotExactWindow.bounds == contextExactWindow.bounds
-        else {
-            return false
-        }
-        if let applicationName = Self.nonEmpty(context.applicationName),
-           let mirroredName = Self.nonEmpty(snapshot.applicationName),
-           applicationName.caseInsensitiveCompare(mirroredName) != .orderedSame
-        {
-            return false
-        }
-        return true
     }
 
     @MainActor

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPBackgroundSnapshotAuthorityTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPBackgroundSnapshotAuthorityTests.swift
@@ -1,0 +1,331 @@
+import CoreGraphics
+import PeekabooAutomationKit
+import PeekabooAutomationKitTestSupport
+import PeekabooFoundation
+import TachikomaMCP
+import Testing
+@testable import PeekabooAgentRuntime
+@testable import PeekabooAutomation
+@testable import PeekabooCore
+
+@Suite(.serialized)
+struct MCPBackgroundSnapshotAuthorityTests {
+    @Test
+    @MainActor
+    func `snapshot mutation uses one shared receipt and live authority`() async throws {
+        let fixture = AutomationTestFixtures.linkedSnapshotTarget(snapshotID: "shared-authority")
+        let graph = try LinkedApplicationInventoryGraph(linkedTargets: [fixture.desktopTarget])
+        let applications = ScriptedApplicationInventoryService(graph: graph)
+        let windows = ScriptedWindowInventoryService(graph: graph)
+        let automation = SnapshotAuthorityAutomationService()
+        let context = await Self.makeContext(
+            fixture: fixture,
+            automation: automation,
+            applications: applications,
+            windows: windows)
+
+        let response = try await context.execute(
+            tool: ClickTool(context: context),
+            arguments: ToolArguments(raw: [
+                "coords": "30,40",
+                "snapshot": fixture.snapshotID,
+            ]))
+
+        #expect(!response.isError)
+        #expect(automation.targetedClickCalls.count == 1)
+        #expect(applications.findApplicationRequests.count >= 2)
+        #expect(windows.windowMutationInventoryRequests.count >= 2)
+    }
+
+    @Test
+    @MainActor
+    func `contradictory snapshot sources refuse before inventory or dispatch`() async throws {
+        let fixture = AutomationTestFixtures.linkedSnapshotTarget(snapshotID: "contradictory-sources")
+        let graph = try LinkedApplicationInventoryGraph(linkedTargets: [fixture.desktopTarget])
+        let applications = ScriptedApplicationInventoryService(graph: graph)
+        let windows = ScriptedWindowInventoryService(graph: graph)
+        let automation = SnapshotAuthorityAutomationService()
+        let owner = MCPToolSnapshotOwner()
+        let uiSnapshots = MCPToolUISnapshotStore(owner: owner)
+        let snapshot = await uiSnapshots.createSnapshot(id: fixture.snapshotID)
+        let otherProcess = AutomationTestFixtures.processIdentity(
+            processIdentifier: fixture.desktopTarget.processIdentity.processIdentifier,
+            processStartIdentity: fixture.desktopTarget.processIdentity.processStartIdentity + 1)
+        let contradictoryWindow = AutomationTestFixtures.window(
+            windowID: fixture.desktopTarget.window.windowID,
+            bounds: fixture.desktopTarget.window.bounds,
+            processIdentity: otherProcess)
+        await snapshot.setScreenshot(
+            path: fixture.detectionResult.screenshotPath,
+            metadata: CaptureMetadata(
+                size: contradictoryWindow.bounds.size,
+                mode: .window,
+                applicationInfo: AutomationTestFixtures.application(
+                    processIdentifier: otherProcess.processIdentifier,
+                    processStartIdentity: otherProcess.processStartIdentity,
+                    bundleIdentifier: fixture.desktopTarget.application.bundleIdentifier,
+                    name: fixture.desktopTarget.application.name),
+                windowInfo: contradictoryWindow))
+        let snapshots = InMemorySnapshotManager(detectionResult: fixture.detectionResult)
+        let context = await MCPToolTestHelpers.makeContext(
+            automation: automation,
+            applications: applications,
+            windows: windows,
+            snapshots: snapshots,
+            snapshotOwner: owner)
+
+        let response = try await context.execute(
+            tool: ClickTool(context: context),
+            arguments: ToolArguments(raw: [
+                "coords": "30,40",
+                "snapshot": fixture.snapshotID,
+            ]))
+
+        #expect(response.isError)
+        #expect(automation.targetedClickCalls.isEmpty)
+        #expect(applications.applicationMutationInventoryCallCount == 0)
+        #expect(windows.windowMutationInventoryRequests.isEmpty)
+        Self.expectSafeTargetRefusal(response)
+    }
+
+    @Test
+    @MainActor
+    func `partial exact-window inventory without the receipt target refuses before dispatch`() async throws {
+        let fixture = AutomationTestFixtures.linkedSnapshotTarget(snapshotID: "partial-inventory")
+        let graph = try LinkedApplicationInventoryGraph(linkedTargets: [fixture.desktopTarget])
+        let applications = ScriptedApplicationInventoryService(graph: graph)
+        let windows = ScriptedWindowInventoryService(
+            graph: graph,
+            inventorySequencesByTarget: [
+                .windowId(fixture.desktopTarget.window.windowID): [
+                    .partial([], warnings: ["exact window inventory timed out"]),
+                ],
+            ])
+        let automation = SnapshotAuthorityAutomationService()
+        let context = await Self.makeContext(
+            fixture: fixture,
+            automation: automation,
+            applications: applications,
+            windows: windows)
+
+        let response = try await context.execute(
+            tool: ClickTool(context: context),
+            arguments: ToolArguments(raw: [
+                "coords": "30,40",
+                "snapshot": fixture.snapshotID,
+            ]))
+
+        #expect(response.isError)
+        #expect(automation.targetedClickCalls.isEmpty)
+        Self.expectSafeTargetRefusal(response)
+    }
+
+    @Test
+    @MainActor
+    func `process generation replacement during final revalidation refuses before dispatch`() async throws {
+        let fixture = AutomationTestFixtures.linkedSnapshotTarget(snapshotID: "replaced-generation")
+        let graph = try LinkedApplicationInventoryGraph(linkedTargets: [fixture.desktopTarget])
+        let replacement = AutomationTestFixtures.application(
+            processIdentifier: fixture.desktopTarget.processIdentity.processIdentifier,
+            processStartIdentity: fixture.desktopTarget.processIdentity.processStartIdentity + 1,
+            bundleIdentifier: fixture.desktopTarget.application.bundleIdentifier,
+            name: fixture.desktopTarget.application.name,
+            windowCount: 1,
+            windowIDs: [fixture.desktopTarget.window.windowID])
+        let applications = ReplacingSnapshotAuthorityApplicationService(
+            graph: graph,
+            responses: [fixture.desktopTarget.application, fixture.desktopTarget.application, replacement])
+        let windows = ScriptedWindowInventoryService(graph: graph)
+        let automation = SnapshotAuthorityAutomationService()
+        let context = await Self.makeContext(
+            fixture: fixture,
+            automation: automation,
+            applications: applications,
+            windows: windows)
+
+        let response = try await context.execute(
+            tool: ClickTool(context: context),
+            arguments: ToolArguments(raw: [
+                "coords": "30,40",
+                "snapshot": fixture.snapshotID,
+            ]))
+
+        #expect(response.isError)
+        #expect(automation.targetedClickCalls.isEmpty)
+        Self.expectSafeTargetRefusal(response)
+    }
+
+    @Test
+    @MainActor
+    func `missing capture generation refuses before inventory or dispatch`() async throws {
+        let fixture = AutomationTestFixtures.linkedSnapshotTarget(snapshotID: "missing-generation")
+        let graph = try LinkedApplicationInventoryGraph(linkedTargets: [fixture.desktopTarget])
+        let applications = ScriptedApplicationInventoryService(graph: graph)
+        let windows = ScriptedWindowInventoryService(graph: graph)
+        let automation = SnapshotAuthorityAutomationService()
+        let owner = MCPToolSnapshotOwner()
+        let uiSnapshot = await MCPToolUISnapshotStore(owner: owner).createSnapshot(id: fixture.snapshotID)
+        let incompleteContext = WindowContext(
+            applicationName: fixture.desktopTarget.application.name,
+            applicationBundleId: fixture.desktopTarget.application.bundleIdentifier,
+            applicationProcessId: fixture.desktopTarget.processIdentity.processIdentifier,
+            windowTitle: fixture.desktopTarget.window.title,
+            windowID: fixture.desktopTarget.window.windowID,
+            windowBounds: fixture.desktopTarget.window.bounds)
+        await uiSnapshot.setTargetMetadata(from: incompleteContext)
+        let detection = AutomationTestFixtures.detectionResult(
+            snapshotID: fixture.snapshotID,
+            windowContext: incompleteContext)
+        let context = await MCPToolTestHelpers.makeContext(
+            automation: automation,
+            applications: applications,
+            windows: windows,
+            snapshots: InMemorySnapshotManager(detectionResult: detection),
+            snapshotOwner: owner)
+
+        let response = try await context.execute(
+            tool: ClickTool(context: context),
+            arguments: ToolArguments(raw: [
+                "coords": "30,40",
+                "snapshot": fixture.snapshotID,
+            ]))
+
+        #expect(response.isError)
+        #expect(automation.targetedClickCalls.isEmpty)
+        #expect(applications.findApplicationRequests.isEmpty)
+        #expect(windows.windowMutationInventoryRequests.isEmpty)
+        Self.expectSafeTargetRefusal(response)
+    }
+
+    @Test
+    @MainActor
+    func `snapshot authority preserves cancellation`() async throws {
+        let fixture = AutomationTestFixtures.linkedSnapshotTarget(snapshotID: "cancelled-authority")
+        let graph = try LinkedApplicationInventoryGraph(linkedTargets: [fixture.desktopTarget])
+        let applications = CancellingSnapshotAuthorityApplicationService(graph: graph)
+        let windows = ScriptedWindowInventoryService(graph: graph)
+        let automation = SnapshotAuthorityAutomationService()
+        let context = await Self.makeContext(
+            fixture: fixture,
+            automation: automation,
+            applications: applications,
+            windows: windows)
+
+        do {
+            _ = try await context.execute(
+                tool: ClickTool(context: context),
+                arguments: ToolArguments(raw: [
+                    "coords": "30,40",
+                    "snapshot": fixture.snapshotID,
+                ]))
+            Issue.record("Expected cancellation to escape snapshot authority planning")
+        } catch is CancellationError {
+            // Expected.
+        }
+        #expect(automation.targetedClickCalls.isEmpty)
+
+        let followUpCompleted = await withTaskGroup(of: Bool.self) { group in
+            group.addTask {
+                do {
+                    let response = try await context.execute(
+                        tool: ClickTool(context: context),
+                        arguments: ToolArguments(raw: [
+                            "coords": "30,40",
+                            "snapshot": fixture.snapshotID,
+                        ]))
+                    return !response.isError
+                } catch {
+                    return false
+                }
+            }
+            group.addTask {
+                try? await Task.sleep(for: .milliseconds(250))
+                return false
+            }
+            let completed = await group.next() ?? false
+            group.cancelAll()
+            return completed
+        }
+        #expect(followUpCompleted)
+        #expect(automation.targetedClickCalls.count == 1)
+    }
+
+    @MainActor
+    private static func makeContext(
+        fixture: LinkedSnapshotTargetFixture,
+        automation: SnapshotAuthorityAutomationService,
+        applications: ScriptedApplicationInventoryService,
+        windows: ScriptedWindowInventoryService) async -> MCPToolContext
+    {
+        let owner = MCPToolSnapshotOwner()
+        let snapshot = await MCPToolUISnapshotStore(owner: owner).createSnapshot(id: fixture.snapshotID)
+        await snapshot.setScreenshot(
+            path: fixture.detectionResult.screenshotPath,
+            metadata: CaptureMetadata(
+                size: fixture.desktopTarget.window.bounds.size,
+                mode: .window,
+                applicationInfo: fixture.desktopTarget.application,
+                windowInfo: fixture.desktopTarget.window))
+        return await MCPToolTestHelpers.makeContext(
+            automation: automation,
+            applications: applications,
+            windows: windows,
+            snapshots: InMemorySnapshotManager(detectionResult: fixture.detectionResult),
+            snapshotOwner: owner)
+    }
+
+    private static func expectSafeTargetRefusal(_ response: ToolResponse) {
+        guard case let .object(metadata) = response.meta else {
+            Issue.record("Expected structured target refusal")
+            return
+        }
+        #expect(metadata["dispatch_state"] == .string("none"))
+        #expect(metadata["mutation_dispatched"] == .bool(false))
+        #expect(metadata["retry_safe"] == .bool(true))
+        #expect(metadata["refusal_reason"] == .string("target_unavailable"))
+    }
+}
+
+@MainActor
+private final class SnapshotAuthorityAutomationService: MockAutomationService,
+ScriptedUIAutomationActionOutcomeProviding {
+    let uiAutomationOutcomeScript = UIAutomationOutcomeScript(defaultResponse: .outcome(.confirmedChange(
+        delivery: .init(mechanism: .windowTargetedEvents, mode: .background),
+        unitCount: .one)))
+
+    init() {
+        super.init(accessibilityGranted: true)
+    }
+}
+
+@MainActor
+private final class CancellingSnapshotAuthorityApplicationService: ScriptedApplicationInventoryService {
+    private var shouldCancel = true
+
+    override func findApplication(identifier: String) async throws -> ServiceApplicationInfo {
+        if self.shouldCancel {
+            self.shouldCancel = false
+            throw CancellationError()
+        }
+        return try await super.findApplication(identifier: identifier)
+    }
+}
+
+@MainActor
+private final class ReplacingSnapshotAuthorityApplicationService: ScriptedApplicationInventoryService {
+    private var responses: [ServiceApplicationInfo]
+
+    init(graph: LinkedApplicationInventoryGraph, responses: [ServiceApplicationInfo]) {
+        self.responses = responses
+        super.init(
+            applications: graph.applications,
+            windowsByIdentifier: graph.windowsByIdentifier)
+    }
+
+    override func findApplication(identifier _: String) async throws -> ServiceApplicationInfo {
+        guard !self.responses.isEmpty else {
+            throw PeekabooError.appNotFound("replacement fixture exhausted")
+        }
+        return self.responses.removeFirst()
+    }
+}


### PR DESCRIPTION
## Summary

- route MCP snapshot-backed background mutations through the shared snapshot receipt and mutation-authority planners
- coalesce mirrored UI and detection evidence into one exact process/window receipt, then require complete live inventory authority
- revalidate the same `MutationAuthorityPlan` immediately before leaf dispatch under the existing snapshot execution gate
- delete the bespoke snapshot process/window revalidation and `sameTarget` path; production diff is net -7 lines

## Root cause

MCP had two target-authorization architectures. Explicit app/window mutations used `MutationAuthorityPlanner`, while snapshot-backed click/action/set-value/scroll/type/press retained a local process lookup, window listing, and identity comparison path. That duplicated generation, exact-window, bounds, inventory-completeness, cancellation, and error semantics across layers, making future safety changes touch both implementations.

The new path assembles the snapshot receipt with `SnapshotTargetReceiptPlanner`, derives one shared `MutationAuthorityPlan`, coalesces it with the signed snapshot identity, and revalidates it just before dispatch. Public tool arguments and schemas are unchanged.

## Proof

- `swift test --package-path Core/PeekabooCore --filter 'MCP(BackgroundSnapshotAuthority|BackgroundPolicyExecution|ToolSnapshotMutation)Tests'` (59/59)
- `swift test --package-path Core/PeekabooAutomationKit --filter SnapshotTargetReceiptPlannerTests` (8/8)
- `pnpm run test:safe` (background certification 241/241, Foundation 70/70, CLI runtime 110/110, CLI automation 48/48, CLI 503/503)
- scoped SwiftFormat clean
- scoped SwiftLint: zero serious findings; two established size warnings
- `git diff --check origin/main...HEAD`
- final structured Autoreview clean with no accepted/actionable findings

New adversarial fixtures cover success, contradictory mirrored/detection sources, partial or missing exact inventory, replaced process generation, missing generation, cancellation, and post-cancellation gate reuse.

No public schema, protocol, foreground behavior, fallback, timeout, AppleScript/JXA, virtualization, or result contract changed.
