### PR TITLE
fix(cli): reject empty mutation invocations

### DIFF
--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add Bridge protocol 1.31 one-request signed background Agent execution with authenticated CLI derivation, an irreversible earliest-entrypoint process limit, lifecycle-covered release acknowledgement, exact-leader reaping, canonical terminal receipt bundles, and nested exact-lane receipts.
 
 ### Fixed
+- Treat empty `type`, `press`, `action`, `set-value`, and `click` invocations as invalid usage in both human and JSON output while preserving explicit help as a successful no-runtime path.
 - Keep CLI wall-clock timeouts bounded under sustained executor load by sharing one monotonic dispatch timer and canceling losing timer/work paths without releasing mutation barriers early.
 - Pin foreground menu focus, clicks, and listing to one exact process/window generation across CLI and MCP, preserving focus outcomes when a later menu read fails.
 - Refuse fuzzy application selectors before app, menu, window, or background click mutations are pinned to a process, while preserving fuzzy read-only discovery.

--- a/Apps/CLI/Sources/PeekabooCLI/CLI/CommanderEmptyInvocationPolicy.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/CLI/CommanderEmptyInvocationPolicy.swift
@@ -1,0 +1,26 @@
+import Commander
+
+/// Marks leaf commands whose empty invocation is missing required semantic input.
+///
+/// These commands still render discovery-oriented help, but the invocation is invalid usage rather than a
+/// successful help request. Explicit `--help` remains the successful help path.
+@MainActor
+protocol CommanderRejectsEmptyInvocation {}
+
+extension TypeCommand: CommanderRejectsEmptyInvocation {}
+extension PressCommand: CommanderRejectsEmptyInvocation {}
+extension ActionCommand: CommanderRejectsEmptyInvocation {}
+extension SetValueCommand: CommanderRejectsEmptyInvocation {}
+extension ClickCommand: CommanderRejectsEmptyInvocation {}
+
+enum CommanderEmptyInvocationPolicy {
+    @MainActor
+    static func error(for descriptor: CommanderCommandDescriptor) -> CommanderUsageError? {
+        guard descriptor.type is any CommanderRejectsEmptyInvocation.Type else { return nil }
+        let command = descriptor.metadata.name
+        return CommanderUsageError(
+            message: "Command 'peekaboo \(command)' requires command input; " +
+                "run 'peekaboo \(command) --help' for usage."
+        )
+    }
+}

--- a/Apps/CLI/Sources/PeekabooCLI/CLI/CommanderRuntimeRouter.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/CLI/CommanderRuntimeRouter.swift
@@ -172,6 +172,13 @@ enum CommanderRuntimeRouter {
         })
     }()
 
+    private static let runtimeFlagNames: Set<String> = {
+        let signature = CommandSignature().withPeekabooRuntimeFlags().flattened()
+        return Set(signature.flags.flatMap { flag in
+            flag.names.map(\.commandLineToken)
+        })
+    }()
+
     private static func runtimeOptionConsumesFollowingValue(_ token: String) -> Bool {
         !token.contains("=") && self.runtimeValueOptionNames.contains(token)
     }
@@ -186,6 +193,31 @@ enum CommanderRuntimeRouter {
                 guard index < tokens.count else { return false }
                 index += 1
             }
+        }
+        return true
+    }
+
+    /// Empty-input detection must not inherit root help/version's intentional tolerance for unknown options.
+    private static func containsOnlyRecognizedRuntimeOptions(_ tokens: [String]) -> Bool {
+        var index = 0
+        while index < tokens.count {
+            let token = tokens[index]
+            let components = token.split(separator: "=", maxSplits: 1, omittingEmptySubsequences: false)
+            let name = String(components[0])
+            if self.runtimeFlagNames.contains(name) {
+                guard components.count == 1 else { return false }
+                index += 1
+                continue
+            }
+            guard self.runtimeValueOptionNames.contains(name) else { return false }
+            if components.count == 2 {
+                guard !components[1].isEmpty else { return false }
+                index += 1
+                continue
+            }
+            index += 1
+            guard index < tokens.count, !tokens[index].hasPrefix("-") else { return false }
+            index += 1
         }
         return true
     }
@@ -206,13 +238,22 @@ enum CommanderRuntimeRouter {
         arguments: [String],
         descriptors: [CommanderCommandDescriptor]
     ) throws -> Bool {
-        guard arguments.count == 1 else { return false }
-        let token = arguments[0]
+        guard let token = arguments.first else { return false }
         guard let descriptor = descriptors.first(where: { $0.metadata.name == token }) else {
             return false
         }
         let description = descriptor.type.commandDescription
         guard description.showHelpOnEmptyInvocation else { return false }
+        let trailingArguments = Array(arguments.dropFirst())
+        if let emptyInvocationError = CommanderEmptyInvocationPolicy.error(for: descriptor) {
+            guard !trailingArguments.contains(where: Self.isHelpToken) else { return false }
+            guard self.containsOnlyRecognizedRuntimeOptions(trailingArguments) else { return false }
+            if !trailingArguments.contains(where: Self.isJSONOutputToken) {
+                self.printCommandHelp(descriptor, path: [token])
+            }
+            throw emptyInvocationError
+        }
+        guard trailingArguments.isEmpty else { return false }
         self.printCommandHelp(descriptor, path: [token])
         if !descriptor.metadata.subcommands.isEmpty {
             throw CommanderProgramError.missingSubcommand(command: token)
@@ -226,6 +267,10 @@ enum CommanderRuntimeRouter {
 
     private static func isVersionToken(_ token: String) -> Bool {
         token == "--version" || token == "-V"
+    }
+
+    private static func isJSONOutputToken(_ token: String) -> Bool {
+        token == "--json" || token == "-j" || token == "--json-output" || token == "--jsonOutput"
     }
 
     private static func printHelp(

--- a/Apps/CLI/Tests/CLIRuntimeTests/InvalidInputOrderingCLITests.swift
+++ b/Apps/CLI/Tests/CLIRuntimeTests/InvalidInputOrderingCLITests.swift
@@ -5,11 +5,77 @@ import Testing
 
 @Suite(.serialized)
 struct InvalidInputOrderingCLITests {
+    struct MissingSemanticInputCase: Sendable {
+        let command: String
+
+        var errorMessage: String {
+            "Command 'peekaboo \(self.command)' requires command input; " +
+                "run 'peekaboo \(self.command) --help' for usage."
+        }
+    }
+
     struct JSONCase: Sendable {
         let arguments: [String]
         let code: String
         let message: String
         let hint: String?
+    }
+
+    @Test(arguments: [
+        MissingSemanticInputCase(command: "type"),
+        MissingSemanticInputCase(command: "press"),
+        MissingSemanticInputCase(command: "action"),
+        MissingSemanticInputCase(command: "set-value"),
+        MissingSemanticInputCase(command: "click"),
+    ])
+    func `missing semantic input is invalid usage before runtime discovery`(
+        _ testCase: MissingSemanticInputCase
+    ) async throws {
+        let human = try await TestChildProcess.runPeekaboo([testCase.command])
+
+        #expect(human.status == .exited(1))
+        #expect(human.standardOutput.contains("Usage\n  peekaboo \(testCase.command)"))
+        #expect(human.standardError == "Error: \(testCase.errorMessage)\n")
+
+        let json = try await TestChildProcess.runPeekaboo([testCase.command, "--json"])
+
+        #expect(json.status == .exited(1))
+        #expect(json.standardError.isEmpty)
+        let envelope = try Self.errorEnvelope(from: json.standardOutput)
+        #expect(envelope.code == "INVALID_ARGUMENT")
+        #expect(envelope.message == "Command 'peekaboo \(testCase.command)' requires command input.")
+        #expect(envelope.hint == "Run 'peekaboo \(testCase.command) --help' for usage.")
+        #expect(envelope.debugLogs.isEmpty)
+
+        let unavailableRuntime = try await TestChildProcess.runPeekaboo(
+            [testCase.command, "--bridge-socket", "/tmp/peekaboo-missing-semantic-input.sock"],
+            isolateFromRemoteHosts: false
+        )
+        #expect(unavailableRuntime.status == .exited(1))
+        #expect(unavailableRuntime.standardOutput.contains("Usage\n  peekaboo \(testCase.command)"))
+        #expect(unavailableRuntime.standardError == "Error: \(testCase.errorMessage)\n")
+    }
+
+    @Test(arguments: ["type", "press", "action", "set-value", "click"])
+    func `explicit help remains successful for semantic input commands`(command: String) async throws {
+        let result = try await TestChildProcess.runPeekaboo(
+            [command, "--bridge-socket", "/tmp/peekaboo-help-missing.sock", "--help"],
+            isolateFromRemoteHosts: false
+        )
+
+        #expect(result.status == .exited(0))
+        #expect(result.standardError.isEmpty)
+        #expect(result.standardOutput.contains("Usage\n  peekaboo \(command)"))
+    }
+
+    @Test(arguments: ["type", "press", "action", "set-value", "click"])
+    func `unknown options are not hidden by empty invocation help`(command: String) async throws {
+        let result = try await TestChildProcess.runPeekaboo([command, "--bogus"])
+
+        #expect(result.status == .exited(1))
+        #expect(result.standardOutput.isEmpty)
+        #expect(result.standardError.contains("Unknown option --bogus"))
+        #expect(!result.standardError.contains("requires command input"))
     }
 
     @Test(arguments: [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add a Git-blob-bound final qualification manifest that requires byte-identical local/Studio installations, candidate-bound CLI and monitor identities, both elevation receipts, guarded task-owned process trees, and freshly re-executed native-only policy scans.
 
 ### Fixed
+- Treat empty `type`, `press`, `action`, `set-value`, and `click` invocations as invalid usage in both human and JSON output while preserving explicit help as a successful no-runtime path.
 - Reuse the authenticated ScreenCaptureKit safety handshake during normal runtime-host selection, avoiding a duplicate signature and permission round trip while preserving fail-closed host validation.
 - Preserve exact application/window selector proofs through capture hardening and accept proofless exact-ID PID observations, while keeping fuzzy selectors and stable process/window receipt fields fail closed.
 - Keep CLI wall-clock timeouts bounded under sustained executor load by sharing one monotonic dispatch timer and canceling losing timer/work paths without releasing mutation barriers early.


### PR DESCRIPTION
## Summary

- treat empty `type`, `press`, `action`, `set-value`, and `click` invocations as invalid usage
- preserve explicit help as a successful no-runtime path
- keep unknown options on the normal parser-error path

## Tests

- `swift test --package-path Apps/CLI --filter 'CoreCLITests.CommanderRuntimeRouterHelpPathTests' --no-parallel`
- `swift test --package-path Apps/CLI --filter 'CLIRuntimeTests.RootEarlyExitRuntimeTests' --no-parallel`
- `swift test --package-path Apps/CLI --filter 'CLIRuntimeTests.InvalidInputOrderingCLITests' --no-parallel`
- `pnpm run format`
- `pnpm run lint`
- `git diff --check`

## Behavior validation

Source-blind CLI validation passed all five contract clauses and 17 probes. Empty human and JSON invocations exit 1, help exits 0, unknown options remain distinct parser errors, and the no-runtime refusals complete in 48–52 ms without dispatching a mutation.

Final structured Autoreview reported no accepted or actionable findings.
