### PR TITLE
feat(agent): expose dry-run UI authority

### DIFF
--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Treat empty `type`, `press`, `action`, `set-value`, and `click` invocations as invalid usage in both human and JSON output while preserving explicit help as a successful no-runtime path.
+- Expose requested foreground access and effective background/foreground UI authority in deterministic Agent dry-run human and JSON output without invoking models, tools, or sessions.
 - Keep CLI wall-clock timeouts bounded under sustained executor load by sharing one monotonic dispatch timer and canceling losing timer/work paths without releasing mutation barriers early.
 - Pin foreground menu focus, clicks, and listing to one exact process/window generation across CLI and MCP, preserving focus outcomes when a later menu read fails.
 - Refuse fuzzy application selectors before app, menu, window, or background click mutations are pinned to a process, while preserving fuzzy read-only discovery.

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/AI/AgentCommand+Commander.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/AI/AgentCommand+Commander.swift
@@ -120,11 +120,24 @@ struct AgentRunSubcommand: RuntimeBackedCommand {
     var runtimeOptions = AgentRunSubcommand.localRuntimeOptions()
 
     mutating func run(using runtime: CommandRuntime) async throws {
+        var command = self.makeAgentCommand()
+        try await command.run(using: runtime)
+    }
+
+    private func makeAgentCommand() -> AgentCommand {
         var command = AgentCommand()
         command.task = self.task
         self.options.apply(to: &command)
         command.runtimeOptions = self.runtimeOptions
-        try await command.run(using: runtime)
+        return command
+    }
+
+    func validateBeforeRuntime() throws {
+        do {
+            try self.makeAgentCommand().validateDryRunRequest()
+        } catch {
+            throw ValidationError(error.localizedDescription)
+        }
     }
 }
 
@@ -216,6 +229,7 @@ extension AgentRunSubcommand {
 }
 
 extension AgentRunSubcommand: AsyncRuntimeCommand {}
+extension AgentRunSubcommand: PreRuntimeValidatingCommand {}
 extension AgentResumeSubcommand: AsyncRuntimeCommand {}
 extension AgentSessionsSubcommand: AsyncRuntimeCommand {}
 extension AgentChatSubcommand: AsyncRuntimeCommand {}

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/AI/AgentCommand+Execution.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/AI/AgentCommand+Execution.swift
@@ -47,9 +47,12 @@ extension AgentCommand {
     }
 
     func dryRunHumanLines(instruction: String) -> [String] {
-        [
+        let policy = self.newSessionToolExecutionPolicy
+        return [
             "Dry run preview",
             "Instruction: \(instruction)",
+            "Requested foreground UI: \(self.allowForeground ? "yes" : "no")",
+            "Effective UI authority: \(policy.rawValue)",
             "Model execution: skipped",
             "Tool calls: 0",
             "Session saved: no",
@@ -76,6 +79,12 @@ extension AgentCommand {
         payload["dryRun"] = true
         payload["instruction"] = instruction
         payload["modelExecution"] = "skipped"
+        let policy = self.newSessionToolExecutionPolicy
+        payload["uiAuthority"] = [
+            "requestedForeground": self.allowForeground,
+            "effectivePolicy": policy.rawValue,
+            "backgroundOnly": policy == .backgroundOnly,
+        ]
         response["result"] = payload
         return response
     }

--- a/Apps/CLI/Tests/CLIRuntimeTests/CLIRuntimeSmokeTests.swift
+++ b/Apps/CLI/Tests/CLIRuntimeTests/CLIRuntimeSmokeTests.swift
@@ -602,9 +602,12 @@ struct CLIRuntimeSmokeTests {
                 JSONSerialization.jsonObject(with: Data(jsonResult.standardOutput.utf8)) as? [String: Any]
             )
             let error = try #require(response["error"] as? [String: Any])
+            let debugLogs = response["debug_logs"] as? [String] ?? []
             #expect(response["success"] as? Bool == false)
             #expect(error["code"] as? String == "VALIDATION_ERROR")
             #expect((error["message"] as? String)?.contains("Task argument is required for --dry-run.") == true)
+            #expect(!debugLogs.contains { $0.contains("Runtime host:") })
+            #expect(!jsonResult.standardOutput.contains("Runtime host:"))
 
             let humanResult = try await TestChildProcess.runPeekaboo(
                 prefix + ["--dry-run", "--simple", "--no-remote"]
@@ -612,6 +615,7 @@ struct CLIRuntimeSmokeTests {
             #expect(humanResult.status == .exited(1))
             #expect(humanResult.standardOutput.isEmpty)
             #expect(humanResult.standardError.contains("Task argument is required for --dry-run."))
+            #expect(!humanResult.standardError.contains("Runtime host:"))
         }
     }
 

--- a/Apps/CLI/Tests/CLIRuntimeTests/CLIRuntimeSmokeTests.swift
+++ b/Apps/CLI/Tests/CLIRuntimeTests/CLIRuntimeSmokeTests.swift
@@ -517,29 +517,44 @@ struct CLIRuntimeSmokeTests {
     func `peekaboo agent dry run is explicit for shorthand and run JSON`() async throws {
         guard Self.ensureLocalRuntimeAvailable() else { return }
 
+        let authorityCases: [(arguments: [String], requestedForeground: Bool, policy: String)] = [
+            (arguments: [], requestedForeground: false, policy: "background_only"),
+            (
+                arguments: ["--allow-foreground"],
+                requestedForeground: true,
+                policy: "foreground_allowed"
+            ),
+        ]
         for prefix in [["agent"], ["agent", "run"]] {
-            let arguments = prefix + ["  Inspect TextEdit  ", "--dry-run", "--json", "--no-remote"]
-            let result = try await TestChildProcess.runPeekaboo(arguments)
-            let repeated = try await TestChildProcess.runPeekaboo(arguments)
-            #expect(result.status == .exited(0))
-            #expect(result.standardError.isEmpty)
-            #expect(repeated.status == .exited(0))
-            #expect(repeated.standardError.isEmpty)
-            #expect(result.standardOutput == repeated.standardOutput)
+            for authorityCase in authorityCases {
+                let arguments = prefix + ["  Inspect TextEdit  ", "--dry-run", "--json", "--no-remote"] +
+                    authorityCase.arguments
+                let result = try await TestChildProcess.runPeekaboo(arguments)
+                let repeated = try await TestChildProcess.runPeekaboo(arguments)
+                #expect(result.status == .exited(0))
+                #expect(result.standardError.isEmpty)
+                #expect(repeated.status == .exited(0))
+                #expect(repeated.standardError.isEmpty)
+                #expect(result.standardOutput == repeated.standardOutput)
 
-            let response = try #require(
-                JSONSerialization.jsonObject(with: Data(result.standardOutput.utf8)) as? [String: Any]
-            )
-            let payload = try #require(response["result"] as? [String: Any])
-            let trace = try #require(payload["executionTrace"] as? [String: Any])
-            #expect(response["success"] as? Bool == true)
-            #expect(payload["dryRun"] as? Bool == true)
-            #expect(payload["instruction"] as? String == "Inspect TextEdit")
-            #expect(payload["modelExecution"] as? String == "skipped")
-            #expect((payload["toolCalls"] as? [Any])?.isEmpty == true)
-            #expect((trace["entries"] as? [Any])?.isEmpty == true)
-            #expect(trace["totalCallCount"] as? Int == 0)
-            #expect(payload["sessionId"] is NSNull)
+                let response = try #require(
+                    JSONSerialization.jsonObject(with: Data(result.standardOutput.utf8)) as? [String: Any]
+                )
+                let payload = try #require(response["result"] as? [String: Any])
+                let trace = try #require(payload["executionTrace"] as? [String: Any])
+                let authority = try #require(payload["uiAuthority"] as? [String: Any])
+                #expect(response["success"] as? Bool == true)
+                #expect(payload["dryRun"] as? Bool == true)
+                #expect(payload["instruction"] as? String == "Inspect TextEdit")
+                #expect(payload["modelExecution"] as? String == "skipped")
+                #expect((payload["toolCalls"] as? [Any])?.isEmpty == true)
+                #expect((trace["entries"] as? [Any])?.isEmpty == true)
+                #expect(trace["totalCallCount"] as? Int == 0)
+                #expect(payload["sessionId"] is NSNull)
+                #expect(authority["requestedForeground"] as? Bool == authorityCase.requestedForeground)
+                #expect(authority["effectivePolicy"] as? String == authorityCase.policy)
+                #expect(authority["backgroundOnly"] as? Bool == !authorityCase.requestedForeground)
+            }
         }
     }
 
@@ -547,20 +562,29 @@ struct CLIRuntimeSmokeTests {
     func `peekaboo agent dry run is explicit for shorthand and run human output`() async throws {
         guard Self.ensureLocalRuntimeAvailable() else { return }
 
+        let authorityCases: [(arguments: [String], requested: String, policy: String)] = [
+            (arguments: [], requested: "no", policy: "background_only"),
+            (arguments: ["--allow-foreground"], requested: "yes", policy: "foreground_allowed"),
+        ]
         for prefix in [["agent"], ["agent", "run"]] {
-            let result = try await TestChildProcess.runPeekaboo(
-                prefix + ["  Inspect TextEdit  ", "--dry-run", "--simple", "--no-remote"]
-            )
-            #expect(result.status == .exited(0))
-            #expect(result.standardError.isEmpty)
-            #expect(result.standardOutput == """
-            Dry run preview
-            Instruction: Inspect TextEdit
-            Model execution: skipped
-            Tool calls: 0
-            Session saved: no
+            for authorityCase in authorityCases {
+                let result = try await TestChildProcess.runPeekaboo(
+                    prefix + ["  Inspect TextEdit  ", "--dry-run", "--simple", "--no-remote"] +
+                        authorityCase.arguments
+                )
+                #expect(result.status == .exited(0))
+                #expect(result.standardError.isEmpty)
+                #expect(result.standardOutput == """
+                Dry run preview
+                Instruction: Inspect TextEdit
+                Requested foreground UI: \(authorityCase.requested)
+                Effective UI authority: \(authorityCase.policy)
+                Model execution: skipped
+                Tool calls: 0
+                Session saved: no
 
-            """)
+                """)
+            }
         }
     }
 

--- a/Apps/CLI/Tests/CoreCLITests/AgentDryRunTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/AgentDryRunTests.swift
@@ -9,35 +9,50 @@ import Testing
 @MainActor
 struct AgentDryRunTests {
     @Test
-    func `preview normalizes instruction and exposes explicit zero execution`() throws {
-        let command = try AgentCommand.parse(["  Inspect TextEdit  ", "--dry-run"])
-        let instruction = try #require(command.newTaskDryRunInstruction)
+    func `preview normalizes instruction and exposes background authority with zero execution`() throws {
+        for testCase in [
+            (arguments: ["  Inspect TextEdit  ", "--dry-run"], requestedForeground: false, policy: "background_only"),
+            (
+                arguments: ["  Inspect TextEdit  ", "--dry-run", "--allow-foreground"],
+                requestedForeground: true,
+                policy: "foreground_allowed"
+            ),
+        ] {
+            let command = try AgentCommand.parse(testCase.arguments)
+            let instruction = try #require(command.newTaskDryRunInstruction)
 
-        #expect(instruction == "Inspect TextEdit")
-        #expect(command.dryRunHumanLines(instruction: instruction) == [
-            "Dry run preview",
-            "Instruction: Inspect TextEdit",
-            "Model execution: skipped",
-            "Tool calls: 0",
-            "Session saved: no",
-        ])
+            #expect(instruction == "Inspect TextEdit")
+            #expect(command.dryRunHumanLines(instruction: instruction) == [
+                "Dry run preview",
+                "Instruction: Inspect TextEdit",
+                "Requested foreground UI: \(testCase.requestedForeground ? "yes" : "no")",
+                "Effective UI authority: \(testCase.policy)",
+                "Model execution: skipped",
+                "Tool calls: 0",
+                "Session saved: no",
+            ])
 
-        let response = command.makeDryRunJSONResponse(instruction: instruction)
-        #expect(response["success"] as? Bool == true)
-        let result = try #require(response["result"] as? [String: Any])
-        let metadata = try #require(result["metadata"] as? [String: Any])
-        let trace = try #require(result["executionTrace"] as? [String: Any])
-        #expect(result["dryRun"] as? Bool == true)
-        #expect(result["instruction"] as? String == instruction)
-        #expect(result["modelExecution"] as? String == "skipped")
-        #expect(result["sessionId"] is NSNull)
-        #expect((result["toolCalls"] as? [Any])?.isEmpty == true)
-        #expect(result["usage"] is NSNull)
-        #expect(metadata["toolCallCount"] as? Int == 0)
-        #expect(metadata["modelName"] as? String == "not_invoked")
-        #expect((trace["entries"] as? [Any])?.isEmpty == true)
-        #expect(trace["totalCallCount"] as? Int == 0)
-        #expect(trace["truncated"] as? Bool == false)
+            let response = command.makeDryRunJSONResponse(instruction: instruction)
+            #expect(response["success"] as? Bool == true)
+            let result = try #require(response["result"] as? [String: Any])
+            let metadata = try #require(result["metadata"] as? [String: Any])
+            let trace = try #require(result["executionTrace"] as? [String: Any])
+            let authority = try #require(result["uiAuthority"] as? [String: Any])
+            #expect(result["dryRun"] as? Bool == true)
+            #expect(result["instruction"] as? String == instruction)
+            #expect(result["modelExecution"] as? String == "skipped")
+            #expect(result["sessionId"] is NSNull)
+            #expect((result["toolCalls"] as? [Any])?.isEmpty == true)
+            #expect(result["usage"] is NSNull)
+            #expect(authority["requestedForeground"] as? Bool == testCase.requestedForeground)
+            #expect(authority["effectivePolicy"] as? String == testCase.policy)
+            #expect(authority["backgroundOnly"] as? Bool == !testCase.requestedForeground)
+            #expect(metadata["toolCallCount"] as? Int == 0)
+            #expect(metadata["modelName"] as? String == "not_invoked")
+            #expect((trace["entries"] as? [Any])?.isEmpty == true)
+            #expect(trace["totalCallCount"] as? Int == 0)
+            #expect(trace["truncated"] as? Bool == false)
+        }
     }
 
     @Test

--- a/Apps/CLI/Tests/CoreCLITests/PreRuntimeInvalidInputOrderingTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/PreRuntimeInvalidInputOrderingTests.swift
@@ -30,6 +30,19 @@ struct PreRuntimeInvalidInputOrderingTests {
         try await Self.requirePreRuntimeRefusal(arguments: arguments, expectedMessage: expectedMessage)
     }
 
+    @Test(arguments: [
+        ["peekaboo", "agent", "--dry-run", "--no-remote"],
+        ["peekaboo", "agent", "--dry-run", "--json", "--no-remote"],
+        ["peekaboo", "agent", "run", "--dry-run", "--no-remote"],
+        ["peekaboo", "agent", "run", "--dry-run", "--json", "--no-remote"],
+    ])
+    func `taskless agent dry run refuses before runtime construction`(arguments: [String]) async throws {
+        try await Self.requirePreRuntimeRefusal(
+            arguments: arguments,
+            expectedMessage: "Invalid input: Task argument is required for --dry-run."
+        )
+    }
+
     @Test
     func `invalid video file and cadence refuse before runtime construction`() async throws {
         let root = FileManager.default.temporaryDirectory

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 - Treat empty `type`, `press`, `action`, `set-value`, and `click` invocations as invalid usage in both human and JSON output while preserving explicit help as a successful no-runtime path.
+- Expose requested foreground access and effective background/foreground UI authority in deterministic Agent dry-run human and JSON output without invoking models, tools, or sessions.
 - Reuse the authenticated ScreenCaptureKit safety handshake during normal runtime-host selection, avoiding a duplicate signature and permission round trip while preserving fail-closed host validation.
 - Preserve exact application/window selector proofs through capture hardening and accept proofless exact-ID PID observations, while keeping fuzzy selectors and stable process/window receipt fields fail closed.
 - Keep CLI wall-clock timeouts bounded under sustained executor load by sharing one monotonic dispatch timer and canceling losing timer/work paths without releasing mutation barriers early.

--- a/docs/commands/agent.md
+++ b/docs/commands/agent.md
@@ -16,7 +16,7 @@ read_when:
 | `resume [session-id]` | Resume the most recent session, or the exact full session ID, in chat mode. |
 | `sessions` | Print cached sessions with full IDs, tasks, lifecycle status, and stored policy maximum; accepts only the global `--json` output switch. |
 | `chat [initial-prompt]` | Start the interactive chat loop. |
-| `--dry-run` | Emit a deterministic preview of a required text task without calling a model, invoking tools, transcribing audio, or creating a session. JSON includes `dryRun`, the normalized `instruction`, and zero tool/trace counts. |
+| `--dry-run` | Emit a deterministic preview of a required text task without calling a model, invoking tools, transcribing audio, or creating a session. Human output names the requested foreground choice and effective UI authority. JSON also includes `uiAuthority.requestedForeground`, `uiAuthority.effectivePolicy`, and `uiAuthority.backgroundOnly`. |
 | `--max-steps <n>` | Cap model turns to `1...100` (default: 100). One turn may contain multiple tool calls. |
 | `--model gpt-5.6|gpt-5-mini|claude-opus-5|claude-fable-5|claude-sonnet-5|gemini-3-flash|minimax|minimax-cn/<model>|openrouter/<provider>/<model>|ollama/<model>|lmstudio/<model>` | Override the configured model. Concrete OpenAI and Anthropic selections are preserved; generic `gpt`/`openai` select GPT-5.6 Sol. Input is validated against supported hosted providers and local model providers. |
 | `--no-cache` | Run ephemerally without saving a resumable session. Cannot be combined with resume/list flags. |


### PR DESCRIPTION
## Summary

- expose requested foreground access and effective UI authority in deterministic Agent dry-run output
- preserve the default `background_only` policy and report explicit `--allow-foreground` as `foreground_allowed`
- reject taskless dry runs before runtime construction or host-selection logging

## Tests

- `pnpm run test:safe` (503/503 CLI tests)
- `swift test --package-path Apps/CLI --filter 'PreRuntimeInvalidInputOrderingTests' --no-parallel`
- `swift test --package-path Apps/CLI --filter 'AgentDryRunTests' --no-parallel`
- focused successful and taskless child-process dry-run runtime tests
- `pnpm run format`
- `pnpm run lint`
- `pnpm run lint:docs`
- `git diff --check`

## Behavior validation

Source-blind validation covered shorthand and `agent run`, human and JSON output, default and explicit foreground authority, deterministic replay, varied tasks, and missing-task errors. The first run exposed a real pre-runtime ordering defect: missing-task JSON output reported a local runtime before validation. The follow-up commit moves dry-run request validation ahead of runtime construction. The affected black-box rerun passed 6/6 with empty debug logs and no runtime-selection evidence.

Final structured Autoreview reported no accepted or actionable findings after the terminal rebase.
