### PR TITLE
fix(cli): explain Bridge local fallback

### DIFF
--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Treat empty `type`, `press`, `action`, `set-value`, and `click` invocations as invalid usage in both human and JSON output while preserving explicit help as a successful no-runtime path.
 - Expose requested foreground access and effective background/foreground UI authority in deterministic Agent dry-run human and JSON output without invoking models, tools, or sessions.
+- Warn when implicit Bridge hosts reject the CLI before local fallback while preserving the established `bridge status --json` schema.
 - Keep CLI wall-clock timeouts bounded under sustained executor load by sharing one monotonic dispatch timer and canceling losing timer/work paths without releasing mutation barriers early.
 - Pin foreground menu focus, clicks, and listing to one exact process/window generation across CLI and MCP, preserving focus outcomes when a later menu read fails.
 - Refuse fuzzy application selectors before app, menu, window, or background click mutations are pinned to a process, while preserving fuzzy read-only discovery.

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/RuntimeHostResolver+Resolution.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/RuntimeHostResolver+Resolution.swift
@@ -91,6 +91,29 @@ extension RuntimeHostResolver {
         let reusableDaemonStatus: PeekabooDaemonStatus?
     }
 
+    enum RemoteCandidateRejection: Equatable {
+        case protocolVersionMismatch
+        case hostKindMismatch
+        case missingPermissions(Set<PeekabooBridgePermissionKind>)
+        case requirementsNotMet
+        case reusableDaemonUnavailable
+        case historicalDaemonInvalid
+        case reusableDaemonIdentityUnavailable
+    }
+
+    struct RemoteCandidateEvaluation {
+        let validation: RemoteCandidateValidation?
+        let rejection: RemoteCandidateRejection?
+
+        static func accepted(_ validation: RemoteCandidateValidation) -> Self {
+            Self(validation: validation, rejection: nil)
+        }
+
+        static func rejected(_ rejection: RemoteCandidateRejection) -> Self {
+            Self(validation: nil, rejection: rejection)
+        }
+    }
+
     enum InitialRoutingDecision: Equatable {
         case local(snapshotInvalidationRemoteSocketPaths: [String])
         case remote
@@ -106,5 +129,63 @@ extension RuntimeHostResolver {
         let requiredHostFailure: String?
         var captureEngineSafetyOverride: CaptureEnginePreference?
         var toolCapturePreflightRefusal: MCPToolCapturePreflightRefusal?
+    }
+}
+
+extension RuntimeHostResolver {
+    static func evaluateRemoteCandidate(
+        _ candidate: ImplicitRemoteCandidate,
+        handshake: PeekabooBridgeHandshakeResponse,
+        options: CommandRuntimeOptions,
+        requiredProtocolVersion: PeekabooBridgeProtocolVersion? = nil,
+        fetchReusableDaemonStatus: (String) async -> PeekabooDaemonStatus? = { socketPath in
+            await DaemonControlClient(socketPath: socketPath).fetchReusableDaemonStatus()
+        }
+    ) async -> RemoteCandidateEvaluation {
+        guard requiredProtocolVersion == nil || handshake.negotiatedVersion == requiredProtocolVersion else {
+            return .rejected(.protocolVersionMismatch)
+        }
+        guard candidate.requiredHostKind == nil || handshake.hostKind == candidate.requiredHostKind else {
+            return .rejected(.hostKindMismatch)
+        }
+        let missingPermissions = BridgeCapabilityPolicy.explicitlyMissingRemotePermissions(
+            for: handshake,
+            options: options
+        )
+        guard missingPermissions.isEmpty else {
+            return .rejected(.missingPermissions(missingPermissions))
+        }
+        guard BridgeCapabilityPolicy.supportsRemoteRequirements(for: handshake, options: options) else {
+            return .rejected(.requirementsNotMet)
+        }
+
+        let requiresReusableHost = candidate.requireReusableDaemon ||
+            options.requiresApplicationRelaunch ||
+            options.requiresSurvivingApplicationHost
+        let reusableDaemonStatus: PeekabooDaemonStatus? = if requiresReusableHost {
+            await fetchReusableDaemonStatus(candidate.socketPath)
+        } else {
+            nil
+        }
+        guard !requiresReusableHost || reusableDaemonStatus != nil else {
+            return .rejected(.reusableDaemonUnavailable)
+        }
+
+        if candidate.requiresValidatedHistoricalDaemon {
+            guard let reusableDaemonStatus,
+                  DaemonControlResolver.isValidatedHistoricalTarget(
+                      status: reusableDaemonStatus,
+                      socketPath: candidate.socketPath
+                  ),
+                  DaemonControlPlanner.supportsCurrentDaemon(reusableDaemonStatus)
+            else {
+                return .rejected(.historicalDaemonInvalid)
+            }
+        }
+        if options.requiresApplicationRelaunch || options.requiresSurvivingApplicationHost,
+           reusableDaemonStatus?.pid == nil {
+            return .rejected(.reusableDaemonIdentityUnavailable)
+        }
+        return .accepted(RemoteCandidateValidation(reusableDaemonStatus: reusableDaemonStatus))
     }
 }

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/RuntimeHostResolver+Resolution.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/RuntimeHostResolver+Resolution.swift
@@ -93,7 +93,7 @@ extension RuntimeHostResolver {
 
     enum RemoteCandidateRejection: Equatable {
         case protocolVersionMismatch
-        case hostKindMismatch
+        case hostKindMismatch(expected: PeekabooBridgeHostKind)
         case missingPermissions(Set<PeekabooBridgePermissionKind>)
         case requirementsNotMet
         case reusableDaemonUnavailable
@@ -145,8 +145,9 @@ extension RuntimeHostResolver {
         guard requiredProtocolVersion == nil || handshake.negotiatedVersion == requiredProtocolVersion else {
             return .rejected(.protocolVersionMismatch)
         }
-        guard candidate.requiredHostKind == nil || handshake.hostKind == candidate.requiredHostKind else {
-            return .rejected(.hostKindMismatch)
+        if let requiredHostKind = candidate.requiredHostKind,
+           handshake.hostKind != requiredHostKind {
+            return .rejected(.hostKindMismatch(expected: requiredHostKind))
         }
         let missingPermissions = BridgeCapabilityPolicy.explicitlyMissingRemotePermissions(
             for: handshake,

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/RuntimeHostResolver.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/RuntimeHostResolver.swift
@@ -745,42 +745,13 @@ enum RuntimeHostResolver {
             await DaemonControlClient(socketPath: socketPath).fetchReusableDaemonStatus()
         }
     ) async -> RemoteCandidateValidation? {
-        guard requiredProtocolVersion == nil || handshake.negotiatedVersion == requiredProtocolVersion else {
-            return nil
-        }
-        guard candidate.requiredHostKind == nil || handshake.hostKind == candidate.requiredHostKind else {
-            return nil
-        }
-        guard BridgeCapabilityPolicy.supportsRemoteRequirements(for: handshake, options: options) else {
-            return nil
-        }
-
-        let requiresReusableHost = candidate.requireReusableDaemon ||
-            options.requiresApplicationRelaunch ||
-            options.requiresSurvivingApplicationHost
-        let reusableDaemonStatus: PeekabooDaemonStatus? = if requiresReusableHost {
-            await fetchReusableDaemonStatus(candidate.socketPath)
-        } else {
-            nil
-        }
-        guard !requiresReusableHost || reusableDaemonStatus != nil else { return nil }
-
-        if candidate.requiresValidatedHistoricalDaemon {
-            guard let reusableDaemonStatus,
-                  DaemonControlResolver.isValidatedHistoricalTarget(
-                      status: reusableDaemonStatus,
-                      socketPath: candidate.socketPath
-                  ),
-                  DaemonControlPlanner.supportsCurrentDaemon(reusableDaemonStatus)
-            else {
-                return nil
-            }
-        }
-        if options.requiresApplicationRelaunch || options.requiresSurvivingApplicationHost,
-           reusableDaemonStatus?.pid == nil {
-            return nil
-        }
-        return RemoteCandidateValidation(reusableDaemonStatus: reusableDaemonStatus)
+        await self.evaluateRemoteCandidate(
+            candidate,
+            handshake: handshake,
+            options: options,
+            requiredProtocolVersion: requiredProtocolVersion,
+            fetchReusableDaemonStatus: fetchReusableDaemonStatus
+        ).validation
     }
 
     static func remoteServices(

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Core/BridgeCommand+Diagnostics.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Core/BridgeCommand+Diagnostics.swift
@@ -73,6 +73,8 @@ struct BridgeDiagnostics {
 
         for probeResult in probeResults {
             let socketPath = probeResult.socketPath
+            let candidatePath = NSString(string: socketPath).standardizingPath
+            let runtimeCandidate = runtimeCandidateByPath[candidatePath]
             switch probeResult.outcome {
             case let .success(handshake):
                 let report = BridgeHandshakeReport(from: handshake)
@@ -80,20 +82,26 @@ struct BridgeDiagnostics {
                     "Bridge status: handshake OK \(handshake.hostKind.rawValue) via \(socketPath)",
                     category: "Bridge"
                 )
-                results.append(.init(socketPath: socketPath, result: .success(report)))
-
-                let candidatePath = NSString(string: socketPath).standardizingPath
+                var rejection: BridgeCandidateRejectionReport?
                 if selected == nil,
-                   let runtimeCandidate = runtimeCandidateByPath[candidatePath] {
-                    let validation = await RuntimeHostResolver.validateRemoteCandidate(
+                   let runtimeCandidate {
+                    let evaluation = await RuntimeHostResolver.evaluateRemoteCandidate(
                         runtimeCandidate,
                         handshake: handshake,
                         options: effectiveOptions
                     )
-                    if validation != nil {
+                    if evaluation.validation != nil {
                         selected = .remote(socketPath: socketPath, handshake: report)
+                    } else if let reason = evaluation.rejection {
+                        rejection = .runtime(reason, handshake: handshake)
                     }
                 }
+                results.append(.init(
+                    socketPath: socketPath,
+                    result: .success(report),
+                    selectionEligible: runtimeCandidate != nil,
+                    rejection: rejection
+                ))
             case let .failure(error):
                 if let errorCode = error.code {
                     self.logger.debug(
@@ -106,7 +114,12 @@ struct BridgeDiagnostics {
                         category: "Bridge"
                     )
                 }
-                results.append(.init(socketPath: socketPath, result: .failure(error)))
+                results.append(.init(
+                    socketPath: socketPath,
+                    result: .failure(error),
+                    selectionEligible: runtimeCandidate != nil,
+                    rejection: runtimeCandidate == nil ? nil : .bridgeFailure(error)
+                ))
             }
         }
 

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Core/BridgeCommand+Models.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Core/BridgeCommand+Models.swift
@@ -9,6 +9,18 @@ struct BridgeStatusReport: Codable {
     let candidates: [BridgeCandidateReport]
     let client: BridgeClientReport
 
+    var localFallbackWarningLines: [String] {
+        guard !self.remoteSkipped, self.selected.source == .local else { return [] }
+        let rejectionLines = self.candidates.compactMap { candidate -> String? in
+            guard candidate.selectionEligible, let rejection = candidate.rejection else { return nil }
+            return "- \(candidate.socketPath) — \(rejection.code): \(rejection.message)"
+        }
+        guard !rejectionLines.isEmpty else { return [] }
+        return [
+            "Warning: eligible remote Bridge hosts were rejected; using local (in-process) fallback.",
+        ] + rejectionLines
+    }
+
     /// Every candidate summary prints `perm: SR=… AX=… ES=…`, so a denial is visible but its remedy
     /// is not: the grant belongs to the host app behind that socket, never the CLI or terminal. One hint
     /// per denied candidate — a single first-match hint leaves the other probed hosts unexplained.
@@ -52,6 +64,39 @@ struct BridgeClientReport: Codable {
 struct BridgeCandidateReport: Codable {
     let socketPath: String
     let result: BridgeCandidateResult
+    let selectionEligible: Bool
+    let rejection: BridgeCandidateRejectionReport?
+
+    private enum CodingKeys: String, CodingKey {
+        case socketPath
+        case result
+    }
+
+    init(
+        socketPath: String,
+        result: BridgeCandidateResult,
+        selectionEligible: Bool = false,
+        rejection: BridgeCandidateRejectionReport? = nil
+    ) {
+        self.socketPath = socketPath
+        self.result = result
+        self.selectionEligible = selectionEligible
+        self.rejection = rejection
+    }
+
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.socketPath = try container.decode(String.self, forKey: .socketPath)
+        self.result = try container.decode(BridgeCandidateResult.self, forKey: .result)
+        self.selectionEligible = false
+        self.rejection = nil
+    }
+
+    func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(self.socketPath, forKey: .socketPath)
+        try container.encode(self.result, forKey: .result)
+    }
 
     var hostKind: String? {
         if case let .success(handshake) = self.result {
@@ -193,6 +238,60 @@ struct BridgeCandidateErrorReport: Codable, Sendable {
             return "\(code): \(self.message)"
         }
         return self.message
+    }
+}
+
+struct BridgeCandidateRejectionReport {
+    let code: String
+    let message: String
+
+    static func bridgeFailure(_ failure: BridgeCandidateErrorReport) -> Self? {
+        guard failure.kind == "bridge", let code = failure.code else { return nil }
+        return Self(code: code, message: failure.message)
+    }
+
+    static func runtime(
+        _ rejection: RuntimeHostResolver.RemoteCandidateRejection,
+        handshake: PeekabooBridgeHandshakeResponse
+    ) -> Self {
+        switch rejection {
+        case .protocolVersionMismatch:
+            return Self(
+                code: "protocolVersionMismatch",
+                message: "Host protocol does not match the required Bridge version."
+            )
+        case .hostKindMismatch:
+            return Self(
+                code: "hostKindMismatch",
+                message: "Host kind \(handshake.hostKind.rawValue) does not match this candidate role."
+            )
+        case let .missingPermissions(permissions):
+            let names = BridgeCapabilityPolicy.missingPermissionNames(permissions)
+            return Self(
+                code: "missingPermissions",
+                message: "Host is missing required \(names.joined(separator: ", "))."
+            )
+        case .requirementsNotMet:
+            return Self(
+                code: "requirementsNotMet",
+                message: "Host does not support the Bridge capabilities required by this command."
+            )
+        case .reusableDaemonUnavailable:
+            return Self(
+                code: "reusableDaemonUnavailable",
+                message: "Host did not prove it is a reusable Peekaboo daemon."
+            )
+        case .historicalDaemonInvalid:
+            return Self(
+                code: "historicalDaemonInvalid",
+                message: "Historical daemon identity or compatibility validation failed."
+            )
+        case .reusableDaemonIdentityUnavailable:
+            return Self(
+                code: "reusableDaemonIdentityUnavailable",
+                message: "Reusable daemon did not provide the required process identity."
+            )
+        }
     }
 }
 

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Core/BridgeCommand+Models.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Core/BridgeCommand+Models.swift
@@ -260,10 +260,11 @@ struct BridgeCandidateRejectionReport {
                 code: "protocolVersionMismatch",
                 message: "Host protocol does not match the required Bridge version."
             )
-        case .hostKindMismatch:
+        case let .hostKindMismatch(expected):
             return Self(
                 code: "hostKindMismatch",
-                message: "Host kind \(handshake.hostKind.rawValue) does not match this candidate role."
+                message: "Host kind \(handshake.hostKind.rawValue) does not match required " +
+                    "\(expected.rawValue) role."
             )
         case let .missingPermissions(permissions):
             let names = BridgeCapabilityPolicy.missingPermissionNames(permissions)

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Core/BridgeCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Core/BridgeCommand.swift
@@ -100,6 +100,14 @@ extension BridgeCommand {
                 return
             }
 
+            let fallbackWarningLines = report.localFallbackWarningLines
+            if !fallbackWarningLines.isEmpty {
+                print("")
+                for line in fallbackWarningLines {
+                    print(line)
+                }
+            }
+
             guard self.verbose else {
                 if report.selected.source == .local {
                     print("")

--- a/Apps/CLI/Tests/CLIRuntimeTests/BridgeStatusCLITests.swift
+++ b/Apps/CLI/Tests/CLIRuntimeTests/BridgeStatusCLITests.swift
@@ -9,6 +9,77 @@ import Testing
 
 struct BridgeStatusCLITests {
     @Test
+    func `implicit unauthorized daemon rejection warns before verbose diagnostics`() async throws {
+        guard TestChildProcess.canLocatePeekabooBinary() else {
+            Issue.record("Build peekaboo before running CLI runtime tests.")
+            return
+        }
+
+        let refusal = PeekabooBridgeResponse.error(.init(
+            code: .unauthorizedClient,
+            message: "Team TEST is not authorized"
+        ))
+        let peer = try ScriptedBridgePeer(responses: [refusal, refusal])
+        let result = try await TestChildProcess.runPeekaboo(
+            ["bridge", "status"],
+            environment: [
+                "PEEKABOO_BRIDGE_SOCKET": "",
+                "PEEKABOO_DAEMON_SOCKET": peer.socketPath,
+            ],
+            isolateFromRemoteHosts: false
+        )
+        await peer.waitUntilFinished()
+
+        #expect(result.status == .exited(0))
+        #expect(result.standardError.isEmpty)
+        #expect(result.standardOutput.contains("Selected: local (in-process)"))
+        #expect(result.standardOutput.contains("eligible remote Bridge hosts were rejected"))
+        #expect(result.standardOutput.contains(peer.socketPath))
+        #expect(result.standardOutput.contains("unauthorizedClient"))
+        #expect(!result.standardOutput.contains("Candidates:"))
+    }
+
+    @Test
+    func `implicit unauthorized rejection JSON preserves the established report`() async throws {
+        guard TestChildProcess.canLocatePeekabooBinary() else {
+            Issue.record("Build peekaboo before running CLI runtime tests.")
+            return
+        }
+
+        let refusal = PeekabooBridgeResponse.error(.init(
+            code: .unauthorizedClient,
+            message: "Team TEST is not authorized"
+        ))
+        let peer = try ScriptedBridgePeer(responses: [refusal, refusal])
+        let result = try await TestChildProcess.runPeekaboo(
+            ["bridge", "status", "--json"],
+            environment: [
+                "PEEKABOO_BRIDGE_SOCKET": "",
+                "PEEKABOO_DAEMON_SOCKET": peer.socketPath,
+            ],
+            isolateFromRemoteHosts: false
+        )
+        await peer.waitUntilFinished()
+
+        #expect(result.status == .exited(0))
+        #expect(result.standardError.isEmpty)
+        let object = try JSONSerialization.jsonObject(with: Data(result.standardOutput.utf8))
+        let envelope = try #require(object as? [String: Any])
+        let data = try #require(envelope["data"] as? [String: Any])
+        let selected = try #require(data["selected"] as? [String: Any])
+        let candidates = try #require(data["candidates"] as? [[String: Any]])
+        let candidate = try #require(candidates.first)
+        #expect(selected["source"] as? String == "local")
+        #expect(Set(data.keys) == ["remoteSkipped", "selected", "candidates", "client"])
+        #expect(Set(candidate.keys) == ["socketPath", "result"])
+        #expect(candidate["socketPath"] as? String == peer.socketPath)
+        #expect(candidate["selectionEligible"] == nil)
+        #expect(candidate["rejection"] == nil)
+        #expect(data["fallback"] == nil)
+        #expect(data["diagnostics"] == nil)
+    }
+
+    @Test
     func `Middle and triple clicks require complete negotiated stateless support`() throws {
         for flag in ["middle", "triple"] {
             let options = try CommanderCLIBinder.makeRuntimeOptions(
@@ -200,6 +271,8 @@ struct BridgeStatusCLITests {
         #expect((error["message"] as? String)?.contains(socketPath) == true)
         #expect((error["hint"] as? String)?.contains("--no-remote") == true)
         #expect(!result.standardOutput.contains(#""source" : "local""#))
+        #expect(!result.standardOutput.contains("remoteCandidatesRejected"))
+        #expect(!result.standardOutput.contains(#""fallback""#))
     }
 
     @Test

--- a/Apps/CLI/Tests/CoreCLITests/BridgeStatusReportHintTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/BridgeStatusReportHintTests.swift
@@ -234,6 +234,26 @@ struct BridgeStatusReportHintTests {
             handshake: missingCapabilityHandshake
         )
         #expect(capabilityReport.code == "requirementsNotMet")
+
+        let wrongHostKindHandshake = BridgeTestFixtures.handshake(
+            negotiatedVersion: PeekabooBridgeConstants.protocolVersion,
+            hostKind: .helper,
+            supportedOperations: [.setValue, .performAction]
+        )
+        let hostKindEvaluation = await RuntimeHostResolver.evaluateRemoteCandidate(
+            candidate,
+            handshake: wrongHostKindHandshake,
+            options: CommandRuntimeOptions()
+        )
+        #expect(hostKindEvaluation.validation == nil)
+        #expect(hostKindEvaluation.rejection == .hostKindMismatch(expected: .gui))
+        let hostKindRejection = try #require(hostKindEvaluation.rejection)
+        let hostKindReport = BridgeCandidateRejectionReport.runtime(
+            hostKindRejection,
+            handshake: wrongHostKindHandshake
+        )
+        #expect(hostKindReport.code == "hostKindMismatch")
+        #expect(hostKindReport.message == "Host kind helper does not match required gui role.")
     }
 
     @Test

--- a/Apps/CLI/Tests/CoreCLITests/BridgeStatusReportHintTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/BridgeStatusReportHintTests.swift
@@ -9,7 +9,9 @@ struct BridgeStatusReportHintTests {
     private func candidate(
         socketPath: String,
         hostKind: PeekabooBridgeHostKind,
-        permissions: PermissionsStatus
+        permissions: PermissionsStatus,
+        selectionEligible: Bool = false,
+        rejection: BridgeCandidateRejectionReport? = nil
     ) -> BridgeCandidateReport {
         let handshake = BridgeTestFixtures.handshake(
             negotiatedVersion: PeekabooBridgeProtocolVersion(major: 1, minor: 1),
@@ -20,15 +22,20 @@ struct BridgeStatusReportHintTests {
         )
         return BridgeCandidateReport(
             socketPath: socketPath,
-            result: .success(BridgeHandshakeReport(from: handshake))
+            result: .success(BridgeHandshakeReport(from: handshake)),
+            selectionEligible: selectionEligible,
+            rejection: rejection
         )
     }
 
-    private func report(candidates: [BridgeCandidateReport]) -> BridgeStatusReport {
+    private func report(
+        selected: BridgeSelectionReport = .local(),
+        candidates: [BridgeCandidateReport]
+    ) -> BridgeStatusReport {
         BridgeStatusReport(
             remoteSkipped: false,
             remoteSkipReason: nil,
-            selected: .local(),
+            selected: selected,
             candidates: candidates,
             client: BridgeClientReport(identity: PeekabooBridgeClientIdentity(
                 bundleIdentifier: nil,
@@ -132,6 +139,185 @@ struct BridgeStatusReportHintTests {
         #expect(hint.contains("allowed TeamID"))
         #expect(hint.contains("intended signed client"))
         #expect(hint.contains("DEBUG host only"))
+    }
+
+    @Test
+    func `unauthorized implicit GUI rejection is visible without verbose diagnostics`() throws {
+        let socketPath = "/tmp/gui.sock"
+        let failure = BridgeCandidateErrorReport.bridgeEnvelope(PeekabooBridgeErrorEnvelope(
+            code: .unauthorizedClient,
+            message: "Team TEST is not authorized"
+        ))
+        let rejection = try #require(BridgeCandidateRejectionReport.bridgeFailure(failure))
+        let status = self.report(candidates: [BridgeCandidateReport(
+            socketPath: socketPath,
+            result: .failure(failure),
+            selectionEligible: true,
+            rejection: rejection
+        )])
+
+        #expect(status.localFallbackWarningLines.count == 2)
+        #expect(status.localFallbackWarningLines[0].contains("using local (in-process) fallback"))
+        #expect(status.localFallbackWarningLines[1].contains(socketPath))
+        #expect(status.localFallbackWarningLines[1].contains("unauthorizedClient"))
+
+        let object = try #require(
+            JSONSerialization.jsonObject(with: JSONEncoder().encode(status)) as? [String: Any]
+        )
+        let candidates = try #require(object["candidates"] as? [[String: Any]])
+        let candidate = try #require(candidates.first)
+        #expect(Set(object.keys) == ["remoteSkipped", "selected", "candidates", "client"])
+        #expect(Set(candidate.keys) == ["socketPath", "result"])
+        #expect(candidate["selectionEligible"] == nil)
+        #expect(candidate["rejection"] == nil)
+        #expect(object["fallback"] == nil)
+    }
+
+    @Test
+    func `permission and capability rejections retain the resolver decision`() async throws {
+        let candidate = RuntimeHostResolver.ImplicitRemoteCandidate(
+            socketPath: "/tmp/gui.sock",
+            requireReusableDaemon: false,
+            requiredHostKind: .gui,
+            requiresValidatedHistoricalDaemon: false
+        )
+        var options = CommandRuntimeOptions()
+        options.requiresElementActions = true
+
+        let missingPermissionHandshake = BridgeTestFixtures.handshake(
+            negotiatedVersion: PeekabooBridgeConstants.protocolVersion,
+            hostKind: .gui,
+            supportedOperations: [.setValue, .performAction],
+            permissions: PermissionsStatus(
+                screenRecording: true,
+                accessibility: false,
+                appleScript: false,
+                postEvent: true
+            )
+        )
+        let permissionEvaluation = await RuntimeHostResolver.evaluateRemoteCandidate(
+            candidate,
+            handshake: missingPermissionHandshake,
+            options: options
+        )
+        #expect(permissionEvaluation.validation == nil)
+        #expect(permissionEvaluation.rejection == .missingPermissions([.accessibility]))
+        let permissionRejection = try #require(permissionEvaluation.rejection)
+        let permissionReport = BridgeCandidateRejectionReport.runtime(
+            permissionRejection,
+            handshake: missingPermissionHandshake
+        )
+        #expect(permissionReport.code == "missingPermissions")
+        #expect(permissionReport.message.contains("Accessibility"))
+
+        let missingCapabilityHandshake = BridgeTestFixtures.handshake(
+            negotiatedVersion: PeekabooBridgeConstants.protocolVersion,
+            hostKind: .gui,
+            supportedOperations: [],
+            permissions: PermissionsStatus(
+                screenRecording: true,
+                accessibility: true,
+                appleScript: false,
+                postEvent: true
+            )
+        )
+        let capabilityEvaluation = await RuntimeHostResolver.evaluateRemoteCandidate(
+            candidate,
+            handshake: missingCapabilityHandshake,
+            options: options
+        )
+        #expect(capabilityEvaluation.validation == nil)
+        #expect(capabilityEvaluation.rejection == .requirementsNotMet)
+        let capabilityRejection = try #require(capabilityEvaluation.rejection)
+        let capabilityReport = BridgeCandidateRejectionReport.runtime(
+            capabilityRejection,
+            handshake: missingCapabilityHandshake
+        )
+        #expect(capabilityReport.code == "requirementsNotMet")
+    }
+
+    @Test
+    func `successful implicit GUI selection has no fallback warning`() async {
+        let socketPath = "/tmp/gui.sock"
+        let candidate = RuntimeHostResolver.ImplicitRemoteCandidate(
+            socketPath: socketPath,
+            requireReusableDaemon: false,
+            requiredHostKind: .gui,
+            requiresValidatedHistoricalDaemon: false
+        )
+        let handshake = BridgeTestFixtures.handshake(
+            negotiatedVersion: PeekabooBridgeConstants.protocolVersion,
+            hostKind: .gui,
+            build: "4.2.0",
+            supportedOperations: [.permissionsStatus]
+        )
+        let evaluation = await RuntimeHostResolver.evaluateRemoteCandidate(
+            candidate,
+            handshake: handshake,
+            options: CommandRuntimeOptions()
+        )
+        #expect(evaluation.validation != nil)
+        #expect(evaluation.rejection == nil)
+
+        let handshakeReport = BridgeHandshakeReport(from: handshake)
+        let status = self.report(
+            selected: .remote(socketPath: socketPath, handshake: handshakeReport),
+            candidates: [BridgeCandidateReport(
+                socketPath: socketPath,
+                result: .success(handshakeReport),
+                selectionEligible: true
+            )]
+        )
+        #expect(status.localFallbackWarningLines.isEmpty)
+        #expect(status.selected.source == .remote)
+        #expect(status.selected.socketPath == socketPath)
+    }
+
+    @Test
+    func `JSON encoding preserves the established full status report`() throws {
+        let socketPath = "/tmp/gui.sock"
+        let handshake = BridgeTestFixtures.handshake(
+            negotiatedVersion: PeekabooBridgeConstants.protocolVersion,
+            hostKind: .gui,
+            build: "4.2.0",
+            supportedOperations: PeekabooBridgeOperation.allCases,
+            hostCapabilities: [
+                PeekabooBridgeHostCapability.backgroundBridgeHost,
+                PeekabooBridgeHostCapability.attestedOperationReceipts,
+            ]
+        )
+        let handshakeReport = BridgeHandshakeReport(from: handshake)
+        let status = self.report(
+            selected: .remote(socketPath: socketPath, handshake: handshakeReport),
+            candidates: [BridgeCandidateReport(
+                socketPath: socketPath,
+                result: .success(handshakeReport),
+                selectionEligible: true
+            )]
+        )
+
+        let data = try JSONEncoder().encode(status)
+        let object = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let selected = try #require(object["selected"] as? [String: Any])
+        let selectedHandshake = try #require(selected["handshake"] as? [String: Any])
+        let candidates = try #require(object["candidates"] as? [[String: Any]])
+        let encodedCandidate = try #require(candidates.first)
+        let candidateResult = try #require(encodedCandidate["result"] as? [String: Any])
+        let success = try #require(candidateResult["success"] as? [String: Any])
+        let candidateHandshake = try #require(success["_0"] as? [String: Any])
+
+        #expect(Set(object.keys) == ["remoteSkipped", "selected", "candidates", "client"])
+        #expect(Set(encodedCandidate.keys) == ["socketPath", "result"])
+        #expect(selectedHandshake["supportedOperations"] is [String])
+        #expect(candidateHandshake["supportedOperations"] is [String])
+        #expect(selectedHandshake["permissionTags"] is [String: Any])
+        #expect(candidateHandshake["permissionTags"] is [String: Any])
+        #expect(object["fallback"] == nil)
+        #expect(object["diagnostics"] == nil)
+
+        let decoded = try JSONDecoder().decode(BridgeStatusReport.self, from: data)
+        #expect(decoded.candidates.first?.selectionEligible == false)
+        #expect(decoded.candidates.first?.rejection == nil)
     }
 
     @Test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 - Treat empty `type`, `press`, `action`, `set-value`, and `click` invocations as invalid usage in both human and JSON output while preserving explicit help as a successful no-runtime path.
 - Expose requested foreground access and effective background/foreground UI authority in deterministic Agent dry-run human and JSON output without invoking models, tools, or sessions.
+- Warn when implicit Bridge hosts reject the CLI before local fallback while preserving the established `bridge status --json` schema.
 - Reuse the authenticated ScreenCaptureKit safety handshake during normal runtime-host selection, avoiding a duplicate signature and permission round trip while preserving fail-closed host validation.
 - Preserve exact application/window selector proofs through capture hardening and accept proofless exact-ID PID observations, while keeping fuzzy selectors and stable process/window receipt fields fail closed.
 - Keep CLI wall-clock timeouts bounded under sustained executor load by sharing one monotonic dispatch timer and canceling losing timer/work paths without releasing mutation barriers early.

--- a/docs/commands/bridge.md
+++ b/docs/commands/bridge.md
@@ -27,6 +27,7 @@ read_when:
   runtime. Pass `--no-remote` explicitly when caller-local execution is intended.
 - Status probes run concurrently and give each candidate one second to complete its read-only diagnostic handshake. A `timeout` entry means that host missed the diagnostic deadline; other candidates are still reported and normal runtime selection order is unchanged.
 - Hosts validate callers by code signature TeamID. If the host rejects the client (`unauthorizedClient`), install a signed Peekaboo CLI build or enable the debug-only escape hatch on the host.
+- If every selection-eligible implicit host is rejected, normal human output warns before the CLI reports local fallback. Structured output keeps the established full status-report schema for compatibility.
 - If `bridge status` reports `internalError` / “Bridge host returned no response”, the probed host likely closed the socket without replying (older host builds). Hosts built from `main` after 2025-12-18 return a structured `unauthorizedClient` error instead, which is much easier to debug.
 - If a candidate reports `perm: SR=N`, grant Screen Recording to that host app. For capture-only subprocesses whose caller already has Screen Recording, bypass Bridge with `--no-remote --capture-engine cg`.
 - Structured status includes optional `hostIdentity` and `hostCapabilities` from current hosts.
@@ -124,7 +125,7 @@ read_when:
 
 ## Examples
 ```bash
-# Human-readable status (selected host only)
+# Human-readable status (selected host plus any local-fallback rejection warning)
 peekaboo bridge status
 
 # Full probe results + structured output for agents


### PR DESCRIPTION
## Summary

- preserve the runtime resolver's exact rejection reason when an implicit Bridge handshake succeeds but cannot be selected
- warn in human `bridge status` output before local fallback, including actual and required host kinds
- keep the established structured status schema unchanged; selection/rejection metadata remains encoding-internal

Explicit `--bridge-socket` remains authoritative and fail-closed. `--no-remote` remains an intentional local selection without a rejection warning.

## Tests

- `pnpm run test:safe`
- `BridgeStatusReportHintTests` (9/9)
- `RuntimeHostResolverTests` (21/21)
- `BridgeStatusCLITests` (9/9)
- `pnpm run format`
- `pnpm run lint`
- `pnpm run lint:docs`
- `git diff --check`

## Behavior validation

A private Foundation-signed protocol-1.31 fixture completed a real authenticated handshake as host kind `helper` on an isolated socket. The Foundation-signed candidate CLI selected local fallback and emitted:

`hostKindMismatch: Host kind helper does not match required gui role.`

Source-blind validation confirmed exit 0, clean stderr, deterministic human diagnostics, unchanged JSON payload keys, candidate objects limited to `socketPath`/`result`, and no serialized internal rejection fields. All fixture sockets were contained under an isolated CoreFoundation home; no live/default host, TCC-backed UI service, or UI was contacted.

Final structured Autoreview reported no accepted or actionable findings for the full patch and the follow-up wording change.
