### PR TITLE
fix(bridge): resolve signed tree observation targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Treat empty `type`, `press`, `action`, `set-value`, and `click` invocations as invalid usage in both human and JSON output while preserving explicit help as a successful no-runtime path.
 - Expose requested foreground access and effective background/foreground UI authority in deterministic Agent dry-run human and JSON output without invoking models, tools, or sessions.
 - Warn when implicit Bridge hosts reject the CLI before local fallback while preserving the established `bridge status --json` schema.
+- Resolve signed AX-only window, PID, app, and title selectors from canonical host results while preserving request constraints and rejecting malformed or contradictory target evidence.
 - Reuse the authenticated ScreenCaptureKit safety handshake during normal runtime-host selection, avoiding a duplicate signature and permission round trip while preserving fail-closed host validation.
 - Preserve exact application/window selector proofs through capture hardening and accept proofless exact-ID PID observations, while keeping fuzzy selectors and stable process/window receipt fields fail closed.
 - Keep CLI wall-clock timeouts bounded under sustained executor load by sharing one monotonic dispatch timer and canceling losing timer/work paths without releasing mutation barriers early.

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/ElementDetectionService.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/ElementDetectionService.swift
@@ -106,7 +106,8 @@ public final class ElementDetectionService {
         self.logger.info("Starting element detection")
         return try await self.inspectElements(
             snapshotId: snapshotId,
-            windowContext: windowContext)
+            windowContext: windowContext,
+            preservesRequestedApplicationIdentity: true)
     }
 
     /// Inspect UI elements via the accessibility tree without a screenshot.
@@ -114,16 +115,32 @@ public final class ElementDetectionService {
         snapshotId: String?,
         windowContext: WindowContext?) async throws -> ElementDetectionResult
     {
+        try await self.inspectElements(
+            snapshotId: snapshotId,
+            windowContext: windowContext,
+            preservesRequestedApplicationIdentity: false)
+    }
+
+    private func inspectElements(
+        snapshotId: String?,
+        windowContext: WindowContext?,
+        preservesRequestedApplicationIdentity: Bool) async throws -> ElementDetectionResult
+    {
         self.logger.info("Starting accessibility tree inspection")
 
         let effectiveSnapshotId = snapshotId ?? UUID().uuidString
 
         let targetApp = try await self.windowResolver.resolveApplication(windowContext: windowContext)
+        let applicationIdentity = Self.applicationIdentity(
+            targetApp,
+            requested: windowContext,
+            preservesRequestedIdentity: preservesRequestedApplicationIdentity)
         if windowContext?.shouldFocusWebContent != true {
             return try await self.inspectReadOnlyElements(
                 targetApp: targetApp,
                 snapshotId: effectiveSnapshotId,
-                windowContext: windowContext)
+                windowContext: windowContext,
+                applicationIdentity: applicationIdentity)
         }
 
         let windowResolution = try await self.windowResolver.resolveWindow(for: targetApp, context: windowContext)
@@ -148,8 +165,8 @@ public final class ElementDetectionService {
             receipt: windowContext?.windowMutationIdentity,
             requiresActionCapability: windowContext?.shouldFocusWebContent == true)
         let resolvedWindowContext = WindowContext(
-            applicationName: windowContext?.applicationName ?? targetApp.localizedName,
-            applicationBundleId: windowContext?.applicationBundleId ?? targetApp.bundleIdentifier,
+            applicationName: applicationIdentity.name,
+            applicationBundleId: applicationIdentity.bundleIdentifier,
             applicationProcessId: windowContext?.applicationProcessId ?? targetApp.processIdentifier,
             windowTitle: windowName,
             windowID: resolvedWindowID,
@@ -286,10 +303,14 @@ public final class ElementDetectionService {
     private func inspectReadOnlyElements(
         targetApp: NSRunningApplication,
         snapshotId: String,
-        windowContext: WindowContext?) async throws -> ElementDetectionResult
+        windowContext: WindowContext?,
+        applicationIdentity: ResolvedApplicationIdentity) async throws -> ElementDetectionResult
     {
         let processIdentifier = targetApp.processIdentifier
-        let context = try Self.readOnlyWindowContext(targetApp: targetApp, requested: windowContext)
+        let context = try Self.readOnlyWindowContext(
+            targetApp: targetApp,
+            requested: windowContext,
+            applicationIdentity: applicationIdentity)
         if let requestedWindowID = context?.windowID {
             guard requestedWindowID > 0,
                   let cgWindowID = CGWindowID(exactly: requestedWindowID),
@@ -307,8 +328,8 @@ public final class ElementDetectionService {
             budget: budget,
             requiresFreshAccessibilityTree: context?.requiresFreshAccessibilityTree == true)
         let preliminaryContext = WindowContext(
-            applicationName: context?.applicationName ?? targetApp.localizedName,
-            applicationBundleId: context?.applicationBundleId ?? targetApp.bundleIdentifier,
+            applicationName: applicationIdentity.name,
+            applicationBundleId: applicationIdentity.bundleIdentifier,
             applicationProcessId: processIdentifier,
             windowTitle: context?.windowTitle,
             windowID: context?.windowID,
@@ -364,8 +385,8 @@ public final class ElementDetectionService {
         }
 
         let resolvedContext = WindowContext(
-            applicationName: context?.applicationName ?? targetApp.localizedName,
-            applicationBundleId: context?.applicationBundleId ?? targetApp.bundleIdentifier,
+            applicationName: applicationIdentity.name,
+            applicationBundleId: applicationIdentity.bundleIdentifier,
             applicationProcessId: processIdentifier,
             windowTitle: outcome.windowTitle,
             windowID: outcome.windowID,
@@ -392,7 +413,8 @@ public final class ElementDetectionService {
 
     private static func readOnlyWindowContext(
         targetApp: NSRunningApplication,
-        requested: WindowContext?) throws -> WindowContext?
+        requested: WindowContext?,
+        applicationIdentity: ResolvedApplicationIdentity) throws -> WindowContext?
     {
         if let requestedWindowID = requested?.windowID {
             let actionableReceipt = try Self.resolveActionableWindowReceipt(
@@ -409,8 +431,8 @@ public final class ElementDetectionService {
                     "Exact observation window changed before its process-generation receipt was captured")
             }
             return WindowContext(
-                applicationName: requested?.applicationName ?? targetApp.localizedName,
-                applicationBundleId: requested?.applicationBundleId ?? targetApp.bundleIdentifier,
+                applicationName: applicationIdentity.name,
+                applicationBundleId: applicationIdentity.bundleIdentifier,
                 applicationProcessId: targetApp.processIdentifier,
                 windowTitle: requested?.windowTitle ?? liveWindow.title,
                 windowID: requestedWindowID,
@@ -441,8 +463,8 @@ public final class ElementDetectionService {
             capturedBounds: window.bounds,
             receipt: window.mutationIdentity)
         return WindowContext(
-            applicationName: requested?.applicationName ?? targetApp.localizedName,
-            applicationBundleId: requested?.applicationBundleId ?? targetApp.bundleIdentifier,
+            applicationName: applicationIdentity.name,
+            applicationBundleId: applicationIdentity.bundleIdentifier,
             applicationProcessId: targetApp.processIdentifier,
             windowTitle: window.title,
             windowID: window.windowID,
@@ -453,6 +475,28 @@ public final class ElementDetectionService {
             traversalBudget: requested?.traversalBudget,
             requiresFreshAccessibilityTree: requested?.requiresFreshAccessibilityTree ?? false,
             accessibilityTimeoutSeconds: requested?.accessibilityTimeoutSeconds)
+    }
+
+    private struct ResolvedApplicationIdentity {
+        let name: String
+        let bundleIdentifier: String?
+    }
+
+    private static func applicationIdentity(
+        _ application: NSRunningApplication,
+        requested: WindowContext?,
+        preservesRequestedIdentity: Bool) -> ResolvedApplicationIdentity
+    {
+        let canonicalName = application.localizedName ?? application.bundleIdentifier ??
+            "PID:\(application.processIdentifier)"
+        guard preservesRequestedIdentity else {
+            return ResolvedApplicationIdentity(
+                name: canonicalName,
+                bundleIdentifier: application.bundleIdentifier)
+        }
+        return ResolvedApplicationIdentity(
+            name: requested?.applicationName ?? canonicalName,
+            bundleIdentifier: requested?.applicationBundleId ?? application.bundleIdentifier)
     }
 
     nonisolated struct ActionableWindowReceipt: Equatable {

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Strategy/DesktopTargetPlanning.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Strategy/DesktopTargetPlanning.swift
@@ -311,6 +311,9 @@ public enum DesktopTargetPlanning {
                     fragment.processIdentity != nil || fragment.windowID != nil || fragment.windowIdentity != nil ||
                     fragment.windowBounds != nil || fragment.focusedElement != nil
 
+                if let incomingProcessIdentifier = fragment.processIdentifier {
+                    try self.requireValidProcessIdentifier(incomingProcessIdentifier)
+                }
                 try self.merge(fragment.processIdentifier, into: &processIdentifier) {
                     .contradictoryProcessIdentifier
                 }
@@ -433,6 +436,12 @@ public enum DesktopTargetPlanning {
         private static func requireValidWindowIdentifier(_ windowID: Int) throws {
             guard windowID > 0, UInt32(exactly: windowID) != nil else {
                 throw DesktopTargetIdentityError.invalidWindowIdentifier
+            }
+        }
+
+        private static func requireValidProcessIdentifier(_ processIdentifier: Int32) throws {
+            guard processIdentifier > 0 else {
+                throw DesktopTargetIdentityError.invalidProcessIdentifier
             }
         }
 

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/DesktopTargetPlanningTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/DesktopTargetPlanningTests.swift
@@ -156,6 +156,15 @@ struct DesktopTargetPlanningTests {
         #expect(try DesktopTargetPlanning.DesktopTargetIdentityCoalescer.resolve([]) == nil)
     }
 
+    @Test(arguments: [Int32.zero, -1])
+    func `process fragments reject invalid identifiers before missing generation`(_ processIdentifier: Int32) {
+        #expect(throws: DesktopTargetIdentityError.invalidProcessIdentifier) {
+            _ = try DesktopTargetPlanning.DesktopTargetIdentityCoalescer.resolve([
+                .init(processIdentifier: processIdentifier),
+            ])
+        }
+    }
+
     @Test
     func `zero process generation is rejected`() {
         #expect(throws: DesktopTargetIdentityError.missingProcessGeneration) {

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeOperationReceiptModels.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeOperationReceiptModels.swift
@@ -1059,13 +1059,15 @@ enum PeekabooBridgeOperationReceiptSemantics {
                 actual,
                 expectedSnapshotID: expected.snapshotId,
                 expectedWindowContext: expected.windowContext,
-                requiresSnapshotBinding: true)
+                requiresSnapshotBinding: true,
+                allowsResolvedWindowContext: false)
         case let (.elementDetection, .inspectAccessibilityTree(expected), .elementDetection(actual)):
             try self.validateElementDetection(
                 actual,
                 expectedSnapshotID: nil,
                 expectedWindowContext: expected.windowContext,
-                requiresSnapshotBinding: false)
+                requiresSnapshotBinding: false,
+                allowsResolvedWindowContext: true)
         case let (.desktopObservation, .desktopObservation(expected), .desktopObservation(actual)):
             if let mismatch = PeekabooBridgeDesktopObservationBinding.mismatch(
                 request: expected,
@@ -1163,7 +1165,8 @@ enum PeekabooBridgeOperationReceiptSemantics {
         _ result: ElementDetectionResult,
         expectedSnapshotID: String?,
         expectedWindowContext: WindowContext?,
-        requiresSnapshotBinding: Bool) throws
+        requiresSnapshotBinding: Bool,
+        allowsResolvedWindowContext: Bool) throws
     {
         if requiresSnapshotBinding {
             if let expectedSnapshotID {
@@ -1176,28 +1179,19 @@ enum PeekabooBridgeOperationReceiptSemantics {
                     "element-detection generated snapshot")
             }
         }
-        guard self.windowContext(result.metadata.windowContext, matches: expectedWindowContext) else {
+        let windowContextMatches = if allowsResolvedWindowContext {
+            PeekabooBridgeWindowContextBinding.refines(
+                result.metadata.windowContext,
+                requested: expectedWindowContext)
+        } else {
+            PeekabooBridgeWindowContextBinding.matches(
+                result.metadata.windowContext,
+                requested: expectedWindowContext)
+        }
+        guard windowContextMatches else {
             throw PeekabooBridgeOperationReceiptError.receiptMismatch(
                 "element-detection response window context")
         }
-    }
-
-    private static func windowContext(_ actual: WindowContext?, matches expected: WindowContext?) -> Bool {
-        guard let expected else { return actual == nil }
-        guard let actual else { return false }
-        return actual.applicationName == expected.applicationName &&
-            actual.applicationBundleId == expected.applicationBundleId &&
-            actual.applicationProcessId == expected.applicationProcessId &&
-            actual.windowTitle == expected.windowTitle &&
-            actual.windowID == expected.windowID &&
-            actual.windowBounds == expected.windowBounds &&
-            actual.windowMutationIdentity == expected.windowMutationIdentity &&
-            actual.focusedElement == expected.focusedElement &&
-            actual.shouldFocusWebContent == expected.shouldFocusWebContent &&
-            actual.includeMenuBarElements == expected.includeMenuBarElements &&
-            actual.traversalBudget == expected.traversalBudget &&
-            actual.requiresFreshAccessibilityTree == expected.requiresFreshAccessibilityTree &&
-            actual.accessibilityTimeoutSeconds == expected.accessibilityTimeoutSeconds
     }
 
     private static func validateWaitResult(

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeOperationReceipts.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeOperationReceipts.swift
@@ -2131,8 +2131,17 @@ struct PeekabooBridgeResolvedOperationTarget: Sendable {
 
 enum PeekabooBridgeOperationTargetAttribution {
     static func resolveRequest(_ request: PeekabooBridgeRequest) throws -> DesktopTargetIdentity? {
-        let identity = try DesktopTargetPlanning.DesktopTargetIdentityCoalescer.resolve(
-            request.operationTargetEvidence)
+        let targetPolicy = PeekabooBridgeOperationResultSemantics.contract(for: request).targetPolicy
+        let identity: DesktopTargetIdentity?
+        do {
+            identity = try DesktopTargetPlanning.DesktopTargetIdentityCoalescer.resolve(
+                request.operationTargetEvidence)
+        } catch let error as DesktopTargetIdentityError {
+            guard targetPolicy == .responseResolved,
+                  error == .missingProcessGeneration || error == .incompleteExactWindow
+            else { throw error }
+            identity = nil
+        }
         if request.requiresStableOperationTarget, identity == nil {
             throw DesktopTargetIdentityError.incompleteExactWindow
         }

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeWindowContextBinding.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeWindowContextBinding.swift
@@ -1,0 +1,97 @@
+import Foundation
+import PeekabooAutomationKit
+
+enum PeekabooBridgeWindowContextBinding {
+    private static let defaultAccessibilityTimeoutSeconds: TimeInterval = 20
+
+    static func matches(_ actual: WindowContext?, requested: WindowContext?) -> Bool {
+        guard let requested else { return actual == nil }
+        guard let actual else { return false }
+        return actual.applicationName == requested.applicationName &&
+            actual.applicationBundleId == requested.applicationBundleId &&
+            actual.applicationProcessId == requested.applicationProcessId &&
+            actual.windowTitle == requested.windowTitle &&
+            actual.windowID == requested.windowID &&
+            actual.windowBounds == requested.windowBounds &&
+            actual.windowMutationIdentity == requested.windowMutationIdentity &&
+            actual.focusedElement == requested.focusedElement &&
+            actual.shouldFocusWebContent == requested.shouldFocusWebContent &&
+            actual.includeMenuBarElements == requested.includeMenuBarElements &&
+            actual.traversalBudget == requested.traversalBudget &&
+            actual.requiresFreshAccessibilityTree == requested.requiresFreshAccessibilityTree &&
+            actual.accessibilityTimeoutSeconds == requested.accessibilityTimeoutSeconds
+    }
+
+    static func refines(_ actual: WindowContext?, requested: WindowContext?) -> Bool {
+        guard let requested else { return actual == nil }
+        guard let actual else { return false }
+        return self.applicationSelector(in: requested, matches: actual) &&
+            self.satisfies(requested.applicationProcessId, with: actual.applicationProcessId) &&
+            self.windowTitle(actual.windowTitle, matches: requested.windowTitle) &&
+            self.satisfies(requested.windowID, with: actual.windowID) &&
+            self.satisfies(requested.windowBounds, with: actual.windowBounds) &&
+            self.satisfies(requested.windowMutationIdentity, with: actual.windowMutationIdentity) &&
+            self.satisfies(requested.focusedElement, with: actual.focusedElement) &&
+            self.satisfies(
+                requested.shouldFocusWebContent,
+                with: actual.shouldFocusWebContent,
+                defaultingTo: false) &&
+            self.satisfies(
+                requested.includeMenuBarElements,
+                with: actual.includeMenuBarElements,
+                defaultingTo: true) &&
+            self.satisfies(
+                requested.traversalBudget,
+                with: actual.traversalBudget,
+                defaultingTo: AXTraversalBudget()) &&
+            self.satisfies(
+                requested.requiresFreshAccessibilityTree,
+                with: actual.requiresFreshAccessibilityTree,
+                defaultingTo: false) &&
+            self.satisfies(
+                requested.accessibilityTimeoutSeconds,
+                with: actual.accessibilityTimeoutSeconds,
+                defaultingTo: self.defaultAccessibilityTimeoutSeconds)
+    }
+
+    private static func satisfies<Value: Equatable>(_ constraint: Value?, with actual: Value?) -> Bool {
+        constraint.map { $0 == actual } ?? true
+    }
+
+    private static func satisfies<Value: Equatable>(
+        _ constraint: Value?,
+        with actual: Value?,
+        defaultingTo defaultValue: Value) -> Bool
+    {
+        if let constraint {
+            return actual == constraint
+        }
+        return actual == nil || actual == defaultValue
+    }
+
+    private static func applicationSelector(in requested: WindowContext, matches actual: WindowContext) -> Bool {
+        if let bundleIdentifier = requested.applicationBundleId,
+           actual.applicationBundleId != bundleIdentifier
+        {
+            return false
+        }
+        guard let identifier = requested.applicationName else { return true }
+        guard let processIdentifier = actual.applicationProcessId, processIdentifier > 0 else { return false }
+        let name = actual.applicationName ?? actual.applicationBundleId ?? "PID:\(processIdentifier)"
+        return ApplicationIdentifierMatcher.matches(
+            .init(
+                processIdentifier: processIdentifier,
+                bundleIdentifier: actual.applicationBundleId,
+                name: name,
+                allowsFuzzyMatching: true,
+                isRegularApplication: true),
+            identifier: identifier)
+    }
+
+    private static func windowTitle(_ actual: String?, matches requested: String?) -> Bool {
+        guard let requested else { return true }
+        guard let actual else { return false }
+        return actual.localizedCaseInsensitiveCompare(requested) == .orderedSame ||
+            (!requested.isEmpty && actual.localizedCaseInsensitiveContains(requested))
+    }
+}

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeWindowContextBinding.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeWindowContextBinding.swift
@@ -40,10 +40,7 @@ enum PeekabooBridgeWindowContextBinding {
                 requested.includeMenuBarElements,
                 with: actual.includeMenuBarElements,
                 defaultingTo: true) &&
-            self.satisfies(
-                requested.traversalBudget,
-                with: actual.traversalBudget,
-                defaultingTo: AXTraversalBudget()) &&
+            self.traversalBudget(actual.traversalBudget, matches: requested.traversalBudget) &&
             self.satisfies(
                 requested.requiresFreshAccessibilityTree,
                 with: actual.requiresFreshAccessibilityTree,
@@ -93,5 +90,16 @@ enum PeekabooBridgeWindowContextBinding {
         guard let actual else { return false }
         return actual.localizedCaseInsensitiveCompare(requested) == .orderedSame ||
             (!requested.isEmpty && actual.localizedCaseInsensitiveContains(requested))
+    }
+
+    private static func traversalBudget(_ actual: AXTraversalBudget?, matches requested: AXTraversalBudget?) -> Bool {
+        if let requested {
+            return actual == AXTraversalBudget(
+                maxDepth: max(0, requested.maxDepth),
+                maxElementCount: max(0, requested.maxElementCount),
+                maxChildrenPerNode: max(0, requested.maxChildrenPerNode))
+        }
+        guard let actual else { return true }
+        return actual.maxDepth > 0 && actual.maxElementCount > 0 && actual.maxChildrenPerNode > 0
     }
 }

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeOperationReceiptTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeOperationReceiptTests.swift
@@ -2294,6 +2294,52 @@ extension PeekabooBridgeOperationReceiptTests {
             request: inspectRequest,
             response: .elementDetection(detection)).target == .window(identity))
 
+        let selectorOnlyContexts = [
+            WindowContext(windowID: identity.windowID),
+            WindowContext(
+                applicationProcessId: identity.ownerProcessIdentifier,
+                windowID: identity.windowID),
+            WindowContext(
+                applicationBundleId: "dev.peekaboo.fixture",
+                windowID: identity.windowID),
+        ]
+        for selectorContext in selectorOnlyContexts {
+            let selectorRequest = PeekabooBridgeRequest.inspectAccessibilityTree(.init(
+                windowContext: selectorContext))
+            #expect(try PeekabooBridgeOperationTargetAttribution.resolveRequest(selectorRequest) == nil)
+            #expect(try PeekabooBridgeOperationTargetAttribution.resolveReceipt(
+                request: selectorRequest,
+                response: .elementDetection(detection)).target == .window(identity))
+        }
+
+        let invalidProcessRequest = PeekabooBridgeRequest.inspectAccessibilityTree(.init(
+            windowContext: WindowContext(
+                applicationProcessId: 0,
+                windowID: identity.windowID)))
+        #expect(throws: DesktopTargetIdentityError.invalidProcessIdentifier) {
+            _ = try PeekabooBridgeOperationTargetAttribution.resolveRequest(invalidProcessRequest)
+        }
+
+        let wrongProcessRequest = PeekabooBridgeRequest.inspectAccessibilityTree(.init(
+            windowContext: WindowContext(
+                applicationProcessId: identity.ownerProcessIdentifier + 1,
+                windowID: identity.windowID)))
+        #expect(throws: DesktopTargetIdentityError.contradictoryProcessIdentifier) {
+            _ = try PeekabooBridgeOperationTargetAttribution.resolveReceipt(
+                request: wrongProcessRequest,
+                response: .elementDetection(detection))
+        }
+
+        let wrongWindowRequest = PeekabooBridgeRequest.inspectAccessibilityTree(.init(
+            windowContext: WindowContext(
+                applicationProcessId: identity.ownerProcessIdentifier,
+                windowID: identity.windowID + 1)))
+        #expect(throws: DesktopTargetIdentityError.contradictoryWindowIdentifier) {
+            _ = try PeekabooBridgeOperationTargetAttribution.resolveReceipt(
+                request: wrongWindowRequest,
+                response: .elementDetection(detection))
+        }
+
         try Self.expectWindowMutationAttributionFailures(
             identity: identity,
             incompleteIdentity: incompleteIdentity,

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeTypedResultReceiptBindingTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeTypedResultReceiptBindingTests.swift
@@ -162,12 +162,28 @@ struct PeekabooBridgeTypedResultReceiptBindingTests {
 
         let unconstrainedRequest = PeekabooBridgeRequest.inspectAccessibilityTree(.init(
             windowContext: WindowContext(windowID: fixture.windowIdentity.windowID)))
+        let hostConfiguredResponse = PeekabooBridgeResponse.elementDetection(Self.detection(
+            snapshotID: "host-configured-tree",
+            context: Self.resolvedTreeContext(
+                fixture: fixture,
+                traversalBudget: AXTraversalBudget(
+                    maxDepth: 7,
+                    maxElementCount: 321,
+                    maxChildrenPerNode: 45))))
+        let hostConfiguredBundle = try await Self.signedBundle(
+            fixture: fixture,
+            sequence: UInt64(validSelectors.count + contradictorySelectors.count),
+            request: unconstrainedRequest,
+            response: hostConfiguredResponse,
+            target: .window(fixture.windowIdentity))
+        try PeekabooBridgeOperationReceiptSemantics.validateReceiptCarriage(
+            hostConfiguredBundle.receipt.payload,
+            request: unconstrainedRequest,
+            response: hostConfiguredResponse)
+
         let hostileRefinements = [
             Self.resolvedTreeContext(fixture: fixture, shouldFocusWebContent: true),
             Self.resolvedTreeContext(fixture: fixture, includeMenuBarElements: false),
-            Self.resolvedTreeContext(
-                fixture: fixture,
-                traversalBudget: AXTraversalBudget(maxDepth: 1)),
             Self.resolvedTreeContext(fixture: fixture, requiresFreshAccessibilityTree: true),
             Self.resolvedTreeContext(fixture: fixture, accessibilityTimeoutSeconds: 3),
         ]
@@ -176,7 +192,7 @@ struct PeekabooBridgeTypedResultReceiptBindingTests {
                 Self.detection(snapshotID: "hostile-tree", context: context))
             let bundle = try await Self.signedBundle(
                 fixture: fixture,
-                sequence: UInt64(validSelectors.count + contradictorySelectors.count + offset),
+                sequence: UInt64(validSelectors.count + contradictorySelectors.count + 1 + offset),
                 request: unconstrainedRequest,
                 response: forgedResponse,
                 target: .window(fixture.windowIdentity))

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeTypedResultReceiptBindingTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeTypedResultReceiptBindingTests.swift
@@ -62,6 +62,136 @@ struct PeekabooBridgeTypedResultReceiptBindingTests {
     }
 
     @Test
+    func `signed tree inspection binds selector constraints while allowing response enrichment`() async throws {
+        let fixture = try await Self.makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        let resolvedContext = Self.resolvedTreeContext(fixture: fixture)
+        let response = PeekabooBridgeResponse.elementDetection(
+            Self.detection(snapshotID: "resolved-tree", context: resolvedContext))
+        let validSelectors = [
+            WindowContext(windowID: fixture.windowIdentity.windowID),
+            WindowContext(
+                applicationProcessId: fixture.windowIdentity.ownerProcessIdentifier,
+                windowID: fixture.windowIdentity.windowID),
+            WindowContext(
+                applicationName: "Fixt",
+                windowID: fixture.windowIdentity.windowID),
+            WindowContext(windowTitle: "doc", windowID: fixture.windowIdentity.windowID),
+            WindowContext(
+                applicationBundleId: "dev.peekaboo.fixture",
+                windowID: fixture.windowIdentity.windowID),
+            WindowContext(
+                applicationName: "Fixture",
+                applicationBundleId: "dev.peekaboo.fixture",
+                applicationProcessId: fixture.windowIdentity.ownerProcessIdentifier,
+                windowTitle: "Document",
+                windowID: fixture.windowIdentity.windowID,
+                windowBounds: fixture.windowIdentity.capturedBounds,
+                windowMutationIdentity: fixture.windowIdentity,
+                shouldFocusWebContent: false,
+                includeMenuBarElements: true,
+                traversalBudget: AXTraversalBudget(),
+                requiresFreshAccessibilityTree: false,
+                accessibilityTimeoutSeconds: 20),
+        ]
+        for (offset, selector) in validSelectors.enumerated() {
+            let request = PeekabooBridgeRequest.inspectAccessibilityTree(.init(windowContext: selector))
+            let bundle = try await Self.signedBundle(
+                fixture: fixture,
+                sequence: UInt64(offset),
+                request: request,
+                response: response,
+                target: .window(fixture.windowIdentity))
+            try PeekabooBridgeOperationReceiptSemantics.validateReceiptCarriage(
+                bundle.receipt.payload,
+                request: request,
+                response: response)
+            try bundle.validateIntegrity()
+        }
+
+        let wrongIdentity = WindowMutationIdentity(
+            windowID: fixture.windowIdentity.windowID,
+            ownerProcessIdentifier: fixture.windowIdentity.ownerProcessIdentifier,
+            ownerProcessStartIdentity: fixture.windowIdentity.ownerProcessStartIdentity + 1,
+            capturedBounds: fixture.windowIdentity.capturedBounds)
+        let contradictorySelectors = [
+            WindowContext(applicationName: "Other", windowID: fixture.windowIdentity.windowID),
+            WindowContext(applicationBundleId: "dev.peekaboo.other", windowID: fixture.windowIdentity.windowID),
+            WindowContext(
+                applicationProcessId: fixture.windowIdentity.ownerProcessIdentifier + 1,
+                windowID: fixture.windowIdentity.windowID),
+            WindowContext(windowTitle: "Other", windowID: fixture.windowIdentity.windowID),
+            WindowContext(windowID: fixture.windowIdentity.windowID + 1),
+            WindowContext(
+                windowID: fixture.windowIdentity.windowID,
+                windowBounds: CGRect(x: 1, y: 2, width: 3, height: 4)),
+            WindowContext(
+                windowID: fixture.windowIdentity.windowID,
+                windowMutationIdentity: wrongIdentity),
+            WindowContext(windowID: fixture.windowIdentity.windowID, includeMenuBarElements: false),
+            WindowContext(
+                windowID: fixture.windowIdentity.windowID,
+                traversalBudget: AXTraversalBudget(maxDepth: 1)),
+            WindowContext(
+                windowID: fixture.windowIdentity.windowID,
+                requiresFreshAccessibilityTree: true),
+            WindowContext(
+                windowID: fixture.windowIdentity.windowID,
+                accessibilityTimeoutSeconds: 3),
+        ]
+        for (offset, selector) in contradictorySelectors.enumerated() {
+            let request = PeekabooBridgeRequest.inspectAccessibilityTree(.init(windowContext: selector))
+            let bundle = try await Self.signedBundle(
+                fixture: fixture,
+                sequence: UInt64(validSelectors.count + offset),
+                request: request,
+                response: response,
+                target: .window(fixture.windowIdentity))
+            #expect(throws: PeekabooBridgeOperationReceiptError.receiptMismatch(
+                "element-detection response window context"))
+            {
+                try PeekabooBridgeOperationReceiptSemantics.validateReceiptCarriage(
+                    bundle.receipt.payload,
+                    request: request,
+                    response: response)
+            }
+            #expect(throws: PeekabooBridgeOperationReceiptError.self) {
+                try bundle.validateIntegrity()
+            }
+        }
+
+        let unconstrainedRequest = PeekabooBridgeRequest.inspectAccessibilityTree(.init(
+            windowContext: WindowContext(windowID: fixture.windowIdentity.windowID)))
+        let hostileRefinements = [
+            Self.resolvedTreeContext(fixture: fixture, shouldFocusWebContent: true),
+            Self.resolvedTreeContext(fixture: fixture, includeMenuBarElements: false),
+            Self.resolvedTreeContext(
+                fixture: fixture,
+                traversalBudget: AXTraversalBudget(maxDepth: 1)),
+            Self.resolvedTreeContext(fixture: fixture, requiresFreshAccessibilityTree: true),
+            Self.resolvedTreeContext(fixture: fixture, accessibilityTimeoutSeconds: 3),
+        ]
+        for (offset, context) in hostileRefinements.enumerated() {
+            let forgedResponse = PeekabooBridgeResponse.elementDetection(
+                Self.detection(snapshotID: "hostile-tree", context: context))
+            let bundle = try await Self.signedBundle(
+                fixture: fixture,
+                sequence: UInt64(validSelectors.count + contradictorySelectors.count + offset),
+                request: unconstrainedRequest,
+                response: forgedResponse,
+                target: .window(fixture.windowIdentity))
+            #expect(throws: PeekabooBridgeOperationReceiptError.receiptMismatch(
+                "element-detection response window context"))
+            {
+                try PeekabooBridgeOperationReceiptSemantics.validateReceiptCarriage(
+                    bundle.receipt.payload,
+                    request: unconstrainedRequest,
+                    response: forgedResponse)
+            }
+        }
+    }
+
+    @Test
     func `forged keyed read responses fail live and offline`() async throws {
         let fixture = try await Self.makeFixture()
         defer { try? FileManager.default.removeItem(at: fixture.root) }
@@ -347,6 +477,29 @@ struct PeekabooBridgeTypedResultReceiptBindingTests {
                 elementCount: 0,
                 method: "fixture",
                 windowContext: context))
+    }
+
+    private static func resolvedTreeContext(
+        fixture: Fixture,
+        shouldFocusWebContent: Bool? = false,
+        includeMenuBarElements: Bool? = true,
+        traversalBudget: AXTraversalBudget? = AXTraversalBudget(),
+        requiresFreshAccessibilityTree: Bool? = false,
+        accessibilityTimeoutSeconds: TimeInterval? = 20) -> WindowContext
+    {
+        WindowContext(
+            applicationName: "Fixture",
+            applicationBundleId: "dev.peekaboo.fixture",
+            applicationProcessId: fixture.windowIdentity.ownerProcessIdentifier,
+            windowTitle: "Document",
+            windowID: fixture.windowIdentity.windowID,
+            windowBounds: fixture.windowIdentity.capturedBounds,
+            windowMutationIdentity: fixture.windowIdentity,
+            shouldFocusWebContent: shouldFocusWebContent,
+            includeMenuBarElements: includeMenuBarElements,
+            traversalBudget: traversalBudget,
+            requiresFreshAccessibilityTree: requiresFreshAccessibilityTree ?? false,
+            accessibilityTimeoutSeconds: accessibilityTimeoutSeconds)
     }
 
     private static func application(selector: String) -> ServiceApplicationInfo {

--- a/Core/PeekabooCore/Tests/PeekabooTests/RemoteInspectUIBridgeTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/RemoteInspectUIBridgeTests.swift
@@ -97,6 +97,91 @@ struct RemoteInspectUIBridgeTests {
     }
 
     @Test
+    func `signed read only inspection resolves selector constraints from the response`() async throws {
+        let socketPath = "/tmp/peekaboo-bridge-read-only-inspect-\(UUID().uuidString).sock"
+        let bounds = CGRect(x: 50, y: 75, width: 900, height: 650)
+        let windowIdentity = WindowMutationIdentity(
+            windowID: 4242,
+            ownerProcessIdentifier: 5151,
+            ownerProcessStartIdentity: 6161,
+            capturedBounds: bounds)
+        let resolvedContext = WindowContext(
+            applicationName: "Fixture",
+            applicationBundleId: "dev.peekaboo.fixture",
+            applicationProcessId: windowIdentity.ownerProcessIdentifier,
+            windowTitle: "Main",
+            windowID: windowIdentity.windowID,
+            windowBounds: bounds,
+            windowMutationIdentity: windowIdentity)
+        let automation = await MainActor.run {
+            InspectUITestAutomationService(
+                accessibilityGranted: true,
+                detectionResult: ElementDetectionResult(
+                    snapshotId: "signed-read-only",
+                    screenshotPath: "",
+                    elements: DetectedElements(),
+                    metadata: DetectionMetadata(
+                        detectionTime: 0,
+                        elementCount: 0,
+                        method: "stub",
+                        windowContext: resolvedContext)))
+        }
+        let services = await MainActor.run { InspectUIBridgeServices(automation: automation) }
+        let server = await MainActor.run {
+            PeekabooBridgeServer(
+                services: services,
+                hostKind: .gui,
+                allowlistedTeams: [],
+                allowlistedBundles: [],
+                permissionStatusEvaluator: { _ in
+                    PermissionsStatus(
+                        screenRecording: false,
+                        accessibility: true,
+                        appleScript: false,
+                        postEvent: false)
+                })
+        }
+        let host = PeekabooBridgeHost(
+            socketPath: socketPath,
+            server: server,
+            allowedTeamIDs: [],
+            requestTimeoutSec: 2)
+        try await host.startChecked()
+        defer { Task { await host.stop() } }
+
+        let client = TrustedBridgeClientFixture.make(socketPath: socketPath, requestTimeoutSec: 2)
+        _ = try await client.handshake(client: PeekabooBridgeClientIdentity(
+            bundleIdentifier: "dev.peekaboo.remote-inspect-tests",
+            teamIdentifier: nil,
+            processIdentifier: getpid(),
+            hostname: nil))
+        let remote = await MainActor.run {
+            RemoteUIAutomationService(client: client, supportsInspectAccessibilityTree: true)
+        }
+        let selectorContexts = [
+            WindowContext(windowID: windowIdentity.windowID),
+            WindowContext(
+                applicationProcessId: windowIdentity.ownerProcessIdentifier,
+                windowID: windowIdentity.windowID),
+            WindowContext(
+                applicationBundleId: "dev.peekaboo.fixture",
+                windowID: windowIdentity.windowID),
+        ]
+
+        for selectorContext in selectorContexts {
+            let result = try await remote.inspectAccessibilityTreeActionResult(windowContext: selectorContext)
+            #expect(result.payload.snapshotId == "signed-read-only")
+            #expect(result.outcome == nil)
+            #expect(result.targetIdentity?.exactWindow?.identity == windowIdentity)
+            #expect(result.targetIdentity?.exactWindow?.bounds == bounds)
+            let receipt = try #require(await client.lastOperationReceipt())
+            #expect(receipt.payload.operation == .inspectAccessibilityTree)
+            #expect(receipt.payload.target == .window(windowIdentity))
+        }
+        await host.stop()
+    }
+
+    @Test
     func `remote web focus inspection preserves signed outcome and exact target`() async throws {
         let socketPath = "/tmp/peekaboo-bridge-web-focus-\(UUID().uuidString).sock"
         let bounds = CGRect(x: 50, y: 75, width: 900, height: 650)


### PR DESCRIPTION
## Summary

- defer structurally valid selector-only target fragments only for read-only `responseResolved` Bridge operations, then coalesce them with the handler's exact PID, process generation, window, and bounds
- bind canonical resolved application/window context while preserving every supplied app, PID, title, identity, bounds, and behavior constraint
- keep screenshot-backed detection exact, reject invalid PIDs before deferral, and retain fail-closed request-pinned and contradiction semantics

## Testing

- `pnpm run test:safe`
- `pnpm run lint` (0 serious)
- `pnpm run format`
- `swift test --package-path Core/PeekabooAutomationKit --filter 'DesktopTargetPlanningTests|ElementDetectionReadOnlyWindowSelectionTests'`
- `swift test --package-path Core/PeekabooCore --filter 'RemoteInspectUIBridgeTests|PeekabooBridgeTypedResultReceiptBindingTests|PeekabooBridgeOperationReceiptTests'`
- structured Autoreview: clean, 0.98

## Follow-up

Full offline proof for bundle-path and executable-path application selectors should add a resolved application identity to the public context model in a separate compatibility-reviewed change; this repair does not guess path identity from app names.
