### PR TITLE
test(certification): publish fake readiness atomically

### DIFF
--- a/tests/live-multi-target-certification-coordinator.test.mjs
+++ b/tests/live-multi-target-certification-coordinator.test.mjs
@@ -274,7 +274,19 @@ const canonical = (value) => {
   return Object.fromEntries(Object.keys(value).sort().map((key) => [key, canonical(value[key])]));
 };
 const write = (file, value) => {
-  fs.writeFileSync(file, JSON.stringify(canonical(value), null, 2) + '\n', { flag: 'wx', mode: 0o600 });
+  const temporary = file + '.' + process.pid + '.' + randomUUID() + '.tmp';
+  const descriptor = fs.openSync(temporary, 'wx', 0o600);
+  try {
+    fs.writeFileSync(descriptor, JSON.stringify(canonical(value), null, 2) + '\n');
+    fs.fsyncSync(descriptor);
+  } finally {
+    fs.closeSync(descriptor);
+  }
+  if (fs.existsSync(file)) {
+    fs.unlinkSync(temporary);
+    throw new Error('fake controller output already exists');
+  }
+  fs.renameSync(temporary, file);
   fs.chmodSync(file, 0o600);
 };
 const sha = (bytes) => createHash('sha256').update(bytes).digest('hex');


### PR DESCRIPTION
## Summary

- publish fake certification-controller outputs through a same-directory temporary file
- flush complete JSON bytes before making the final path visible
- preserve the fixture's single-writer, absent-output contract while matching production atomic visibility

## Why

The full certification suite exposed a load-only fixture race. The coordinator waits for a readiness pathname and immediately parses it; the fake controller previously created that final pathname before its JSON write had completed. Under load, the coordinator could observe a truncated object and fail with `Unexpected end of JSON input`. Production already publishes readiness atomically, so this was test infrastructure rather than a product defect.

## Proof

- exact formerly failing test: 20/20 consecutive passes under concurrent suite load
- complete coordinator suite: 31/31
- `pnpm run test:background-certification`: 29 + 136 + 31 + 48 tests passed
- `pnpm run format`: 0 files changed
- `git diff --check`
- structured Autoreview: clean, no actionable findings
