### PR TITLE
fix(bridge): bind read-only application selectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 - Treat empty `type`, `press`, `action`, `set-value`, and `click` invocations as invalid usage in both human and JSON output while preserving explicit help as a successful no-runtime path.
 - Expose requested foreground access and effective background/foreground UI authority in deterministic Agent dry-run human and JSON output without invoking models, tools, or sessions.
 - Warn when implicit Bridge hosts reject the CLI before local fallback while preserving the established `bridge status --json` schema.
-- Resolve signed AX-only window, PID, app, and title selectors from canonical host results while preserving request constraints and rejecting malformed or contradictory target evidence.
+- Resolve signed read-only window, PID, name, bundle/executable-path, and title selectors from canonical host results while preserving request constraints and rejecting malformed or contradictory target evidence.
 - Reuse the authenticated ScreenCaptureKit safety handshake during normal runtime-host selection, avoiding a duplicate signature and permission round trip while preserving fail-closed host validation.
 - Preserve exact application/window selector proofs through capture hardening and accept proofless exact-ID PID observations, while keeping fuzzy selectors and stable process/window receipt fields fail closed.
 - Keep CLI wall-clock timeouts bounded under sustained executor load by sharing one monotonic dispatch timer and canceling losing timer/work paths without releasing mutation barriers early.

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Core/Protocols/ElementDetectionModels.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Core/Protocols/ElementDetectionModels.swift
@@ -198,6 +198,12 @@ public nonisolated struct WindowContext: Sendable, Codable {
     /// Bundle identifier (preferred for disambiguating same-named apps)
     public let applicationBundleId: String?
 
+    /// Canonical bundle path of the resolved application.
+    public let applicationBundlePath: String?
+
+    /// Canonical executable path of the resolved application.
+    public let applicationExecutablePath: String?
+
     /// Process identifier (most precise when available)
     public let applicationProcessId: Int32?
 
@@ -235,6 +241,8 @@ public nonisolated struct WindowContext: Sendable, Codable {
     public init(
         applicationName: String? = nil,
         applicationBundleId: String? = nil,
+        applicationBundlePath: String? = nil,
+        applicationExecutablePath: String? = nil,
         applicationProcessId: Int32? = nil,
         windowTitle: String? = nil,
         windowID: Int? = nil,
@@ -249,6 +257,8 @@ public nonisolated struct WindowContext: Sendable, Codable {
     {
         self.applicationName = applicationName
         self.applicationBundleId = applicationBundleId
+        self.applicationBundlePath = applicationBundlePath
+        self.applicationExecutablePath = applicationExecutablePath
         self.applicationProcessId = applicationProcessId
         self.windowTitle = windowTitle
         self.windowID = windowID
@@ -265,6 +275,8 @@ public nonisolated struct WindowContext: Sendable, Codable {
     public init(
         applicationName: String? = nil,
         applicationBundleId: String? = nil,
+        applicationBundlePath: String? = nil,
+        applicationExecutablePath: String? = nil,
         applicationProcessId: Int32? = nil,
         windowTitle: String? = nil,
         windowID: Int? = nil,
@@ -279,6 +291,8 @@ public nonisolated struct WindowContext: Sendable, Codable {
         self.init(
             applicationName: applicationName,
             applicationBundleId: applicationBundleId,
+            applicationBundlePath: applicationBundlePath,
+            applicationExecutablePath: applicationExecutablePath,
             applicationProcessId: applicationProcessId,
             windowTitle: windowTitle,
             windowID: windowID,

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/ElementDetectionService.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/ElementDetectionService.swift
@@ -487,7 +487,7 @@ public final class ElementDetectionService {
             accessibilityTimeoutSeconds: requested?.accessibilityTimeoutSeconds)
     }
 
-    private struct ResolvedApplicationIdentity {
+    struct ResolvedApplicationIdentity: Sendable {
         let name: String
         let bundleIdentifier: String?
         let bundlePath: String?
@@ -501,18 +501,29 @@ public final class ElementDetectionService {
     {
         let canonicalName = application.localizedName ?? application.bundleIdentifier ??
             "PID:\(application.processIdentifier)"
-        guard preservesRequestedIdentity else {
-            return ResolvedApplicationIdentity(
+        return self.projectedApplicationIdentity(
+            canonical: ResolvedApplicationIdentity(
                 name: canonicalName,
                 bundleIdentifier: application.bundleIdentifier,
                 bundlePath: application.bundleURL?.standardizedFileURL.path,
-                executablePath: application.executableURL?.standardizedFileURL.path)
+                executablePath: application.executableURL?.standardizedFileURL.path),
+            requested: requested,
+            preservesRequestedIdentity: preservesRequestedIdentity)
+    }
+
+    nonisolated static func projectedApplicationIdentity(
+        canonical: ResolvedApplicationIdentity,
+        requested: WindowContext?,
+        preservesRequestedIdentity: Bool) -> ResolvedApplicationIdentity
+    {
+        guard preservesRequestedIdentity else {
+            return canonical
         }
         return ResolvedApplicationIdentity(
-            name: requested?.applicationName ?? canonicalName,
-            bundleIdentifier: requested?.applicationBundleId ?? application.bundleIdentifier,
-            bundlePath: requested?.applicationBundlePath,
-            executablePath: requested?.applicationExecutablePath)
+            name: requested?.applicationName ?? canonical.name,
+            bundleIdentifier: requested?.applicationBundleId ?? canonical.bundleIdentifier,
+            bundlePath: requested?.applicationBundlePath == nil ? nil : canonical.bundlePath,
+            executablePath: requested?.applicationExecutablePath == nil ? nil : canonical.executablePath)
     }
 
     nonisolated struct ActionableWindowReceipt: Equatable {

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/ElementDetectionService.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/ElementDetectionService.swift
@@ -167,6 +167,8 @@ public final class ElementDetectionService {
         let resolvedWindowContext = WindowContext(
             applicationName: applicationIdentity.name,
             applicationBundleId: applicationIdentity.bundleIdentifier,
+            applicationBundlePath: applicationIdentity.bundlePath,
+            applicationExecutablePath: applicationIdentity.executablePath,
             applicationProcessId: windowContext?.applicationProcessId ?? targetApp.processIdentifier,
             windowTitle: windowName,
             windowID: resolvedWindowID,
@@ -330,6 +332,8 @@ public final class ElementDetectionService {
         let preliminaryContext = WindowContext(
             applicationName: applicationIdentity.name,
             applicationBundleId: applicationIdentity.bundleIdentifier,
+            applicationBundlePath: applicationIdentity.bundlePath,
+            applicationExecutablePath: applicationIdentity.executablePath,
             applicationProcessId: processIdentifier,
             windowTitle: context?.windowTitle,
             windowID: context?.windowID,
@@ -387,6 +391,8 @@ public final class ElementDetectionService {
         let resolvedContext = WindowContext(
             applicationName: applicationIdentity.name,
             applicationBundleId: applicationIdentity.bundleIdentifier,
+            applicationBundlePath: applicationIdentity.bundlePath,
+            applicationExecutablePath: applicationIdentity.executablePath,
             applicationProcessId: processIdentifier,
             windowTitle: outcome.windowTitle,
             windowID: outcome.windowID,
@@ -433,6 +439,8 @@ public final class ElementDetectionService {
             return WindowContext(
                 applicationName: applicationIdentity.name,
                 applicationBundleId: applicationIdentity.bundleIdentifier,
+                applicationBundlePath: applicationIdentity.bundlePath,
+                applicationExecutablePath: applicationIdentity.executablePath,
                 applicationProcessId: targetApp.processIdentifier,
                 windowTitle: requested?.windowTitle ?? liveWindow.title,
                 windowID: requestedWindowID,
@@ -465,6 +473,8 @@ public final class ElementDetectionService {
         return WindowContext(
             applicationName: applicationIdentity.name,
             applicationBundleId: applicationIdentity.bundleIdentifier,
+            applicationBundlePath: applicationIdentity.bundlePath,
+            applicationExecutablePath: applicationIdentity.executablePath,
             applicationProcessId: targetApp.processIdentifier,
             windowTitle: window.title,
             windowID: window.windowID,
@@ -480,6 +490,8 @@ public final class ElementDetectionService {
     private struct ResolvedApplicationIdentity {
         let name: String
         let bundleIdentifier: String?
+        let bundlePath: String?
+        let executablePath: String?
     }
 
     private static func applicationIdentity(
@@ -492,11 +504,15 @@ public final class ElementDetectionService {
         guard preservesRequestedIdentity else {
             return ResolvedApplicationIdentity(
                 name: canonicalName,
-                bundleIdentifier: application.bundleIdentifier)
+                bundleIdentifier: application.bundleIdentifier,
+                bundlePath: application.bundleURL?.standardizedFileURL.path,
+                executablePath: application.executableURL?.standardizedFileURL.path)
         }
         return ResolvedApplicationIdentity(
             name: requested?.applicationName ?? canonicalName,
-            bundleIdentifier: requested?.applicationBundleId ?? application.bundleIdentifier)
+            bundleIdentifier: requested?.applicationBundleId ?? application.bundleIdentifier,
+            bundlePath: requested?.applicationBundlePath,
+            executablePath: requested?.applicationExecutablePath)
     }
 
     nonisolated struct ActionableWindowReceipt: Equatable {

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/ElementDetectionWindowResolver.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/ElementDetectionWindowResolver.swift
@@ -38,29 +38,21 @@ struct ElementDetectionWindowResolver {
                 throw PeekabooError.appNotFound("PID:\(pid)")
             }
         } else if let bundleId = windowContext?.applicationBundleId {
-            self.logger.debug("Looking for application via bundle ID: \(bundleId)")
-
-            let appInfo = try await self.applicationService.findApplication(identifier: bundleId)
-
-            guard let runningApp = NSRunningApplication(processIdentifier: appInfo.processIdentifier) else {
-                self.logger.error("Could not get NSRunningApplication for PID: \(appInfo.processIdentifier)")
-                throw PeekabooError.appNotFound(bundleId)
-            }
-
-            self.logger.debug("Resolved application: \(runningApp.localizedName ?? "unknown")")
-            runningApplication = runningApp
+            runningApplication = try await self.resolveRunningApplication(
+                identifier: bundleId,
+                source: "bundle ID")
         } else if let appName = windowContext?.applicationName {
-            self.logger.debug("Looking for application via ApplicationService: \(appName)")
-
-            let appInfo = try await self.applicationService.findApplication(identifier: appName)
-
-            guard let runningApp = NSRunningApplication(processIdentifier: appInfo.processIdentifier) else {
-                self.logger.error("Could not get NSRunningApplication for PID: \(appInfo.processIdentifier)")
-                throw PeekabooError.appNotFound(appName)
-            }
-
-            self.logger.debug("Resolved application: \(runningApp.localizedName ?? "unknown")")
-            runningApplication = runningApp
+            runningApplication = try await self.resolveRunningApplication(
+                identifier: appName,
+                source: "application selector")
+        } else if let bundlePath = windowContext?.applicationBundlePath {
+            runningApplication = try await self.resolveRunningApplication(
+                identifier: bundlePath,
+                source: "bundle path")
+        } else if let executablePath = windowContext?.applicationExecutablePath {
+            runningApplication = try await self.resolveRunningApplication(
+                identifier: executablePath,
+                source: "executable path")
         } else if let windowID = windowContext?.windowID {
             guard let processIdentifier = Self.stableExactWindowOwner(
                 windowID: windowID,
@@ -92,6 +84,17 @@ struct ElementDetectionWindowResolver {
         if let mismatch = Self.applicationConstraintMismatch(candidate: candidate, context: windowContext) {
             throw PeekabooError.invalidInput(field: "windowContext", reason: mismatch)
         }
+        return runningApplication
+    }
+
+    private func resolveRunningApplication(identifier: String, source: String) async throws -> NSRunningApplication {
+        self.logger.debug("Looking for application via \(source): \(identifier)")
+        let appInfo = try await self.applicationService.findApplication(identifier: identifier)
+        guard let runningApplication = NSRunningApplication(processIdentifier: appInfo.processIdentifier) else {
+            self.logger.error("Could not get NSRunningApplication for PID: \(appInfo.processIdentifier)")
+            throw PeekabooError.appNotFound(identifier)
+        }
+        self.logger.debug("Resolved application: \(runningApplication.localizedName ?? "unknown")")
         return runningApplication
     }
 

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/ElementDetectionWindowResolver.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/ElementDetectionWindowResolver.swift
@@ -28,16 +28,16 @@ struct ElementDetectionWindowResolver {
     }
 
     func resolveApplication(windowContext: WindowContext?) async throws -> NSRunningApplication {
+        let runningApplication: NSRunningApplication
         if let pid = windowContext?.applicationProcessId {
             if let runningApp = NSRunningApplication(processIdentifier: pid) {
                 self.logger.debug("Resolved application via PID: \(pid)")
-                return runningApp
+                runningApplication = runningApp
+            } else {
+                self.logger.error("Could not resolve NSRunningApplication for PID: \(pid)")
+                throw PeekabooError.appNotFound("PID:\(pid)")
             }
-            self.logger.error("Could not resolve NSRunningApplication for PID: \(pid)")
-            throw PeekabooError.appNotFound("PID:\(pid)")
-        }
-
-        if let bundleId = windowContext?.applicationBundleId {
+        } else if let bundleId = windowContext?.applicationBundleId {
             self.logger.debug("Looking for application via bundle ID: \(bundleId)")
 
             let appInfo = try await self.applicationService.findApplication(identifier: bundleId)
@@ -48,10 +48,8 @@ struct ElementDetectionWindowResolver {
             }
 
             self.logger.debug("Resolved application: \(runningApp.localizedName ?? "unknown")")
-            return runningApp
-        }
-
-        if let appName = windowContext?.applicationName {
+            runningApplication = runningApp
+        } else if let appName = windowContext?.applicationName {
             self.logger.debug("Looking for application via ApplicationService: \(appName)")
 
             let appInfo = try await self.applicationService.findApplication(identifier: appName)
@@ -62,10 +60,8 @@ struct ElementDetectionWindowResolver {
             }
 
             self.logger.debug("Resolved application: \(runningApp.localizedName ?? "unknown")")
-            return runningApp
-        }
-
-        if let windowID = windowContext?.windowID {
+            runningApplication = runningApp
+        } else if let windowID = windowContext?.windowID {
             guard let processIdentifier = Self.stableExactWindowOwner(
                 windowID: windowID,
                 receipt: windowContext?.windowMutationIdentity,
@@ -76,14 +72,60 @@ struct ElementDetectionWindowResolver {
                 throw PeekabooError.windowNotFound(criteria: "live owner for exact window id \(windowID)")
             }
             self.logger.debug("Resolved application via exact window \(windowID), PID: \(processIdentifier)")
-            return runningApp
+            runningApplication = runningApp
+        } else {
+            guard let frontmost = NSWorkspace.shared.frontmostApplication else {
+                self.logger.error("No frontmost application")
+                throw PeekabooError.operationError(message: "No frontmost application")
+            }
+            runningApplication = frontmost
         }
 
-        guard let frontmost = NSWorkspace.shared.frontmostApplication else {
-            self.logger.error("No frontmost application")
-            throw PeekabooError.operationError(message: "No frontmost application")
+        let candidate = ApplicationIdentifierMatcher.Candidate(
+            processIdentifier: runningApplication.processIdentifier,
+            bundleIdentifier: runningApplication.bundleIdentifier,
+            name: runningApplication.localizedName ?? runningApplication.bundleIdentifier ?? "Unknown",
+            bundlePath: runningApplication.bundleURL?.standardizedFileURL.path,
+            executablePath: runningApplication.executableURL?.standardizedFileURL.path,
+            allowsFuzzyMatching: runningApplication.activationPolicy != .prohibited,
+            isRegularApplication: runningApplication.activationPolicy == .regular)
+        if let mismatch = Self.applicationConstraintMismatch(candidate: candidate, context: windowContext) {
+            throw PeekabooError.invalidInput(field: "windowContext", reason: mismatch)
         }
-        return frontmost
+        return runningApplication
+    }
+
+    nonisolated static func applicationConstraintMismatch(
+        candidate: ApplicationIdentifierMatcher.Candidate,
+        context: WindowContext?) -> String?
+    {
+        guard let context else { return nil }
+        if let processIdentifier = context.applicationProcessId,
+           processIdentifier != candidate.processIdentifier
+        {
+            return "applicationProcessId contradicts the resolved application"
+        }
+        if let bundleIdentifier = context.applicationBundleId,
+           bundleIdentifier != candidate.bundleIdentifier
+        {
+            return "applicationBundleId contradicts the resolved application"
+        }
+        if let applicationName = context.applicationName,
+           !ApplicationIdentifierMatcher.matches(candidate, identifier: applicationName)
+        {
+            return "applicationName contradicts the resolved application"
+        }
+        if let bundlePath = context.applicationBundlePath,
+           bundlePath != candidate.bundlePath
+        {
+            return "applicationBundlePath contradicts the resolved application"
+        }
+        if let executablePath = context.applicationExecutablePath,
+           executablePath != candidate.executablePath
+        {
+            return "applicationExecutablePath contradicts the resolved application"
+        }
+        return nil
     }
 
     nonisolated static func stableExactWindowOwner(

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/ElementDetectionWindowResolver.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/ElementDetectionWindowResolver.swift
@@ -8,6 +8,20 @@ import PeekabooFoundation
 /// Resolves the application and AX window that should provide detection elements.
 @MainActor
 struct ElementDetectionWindowResolver {
+    enum ApplicationIdentifierSource: String, Equatable, Sendable {
+        case bundlePath = "bundle path"
+        case executablePath = "executable path"
+        case bundleIdentifier = "bundle ID"
+        case applicationName = "application selector"
+    }
+
+    enum ApplicationResolutionAuthority: Equatable, Sendable {
+        case processIdentifier(pid_t)
+        case exactWindow(Int)
+        case identifier(String, source: ApplicationIdentifierSource)
+        case frontmost
+    }
+
     private let logger = Logger(subsystem: "boo.peekaboo.core", category: "ElementDetectionWindowResolver")
     private let applicationService: ApplicationService
     private let windowIdentityService = WindowIdentityService()
@@ -29,7 +43,8 @@ struct ElementDetectionWindowResolver {
 
     func resolveApplication(windowContext: WindowContext?) async throws -> NSRunningApplication {
         let runningApplication: NSRunningApplication
-        if let pid = windowContext?.applicationProcessId {
+        switch Self.applicationResolutionAuthority(for: windowContext) {
+        case let .processIdentifier(pid):
             if let runningApp = NSRunningApplication(processIdentifier: pid) {
                 self.logger.debug("Resolved application via PID: \(pid)")
                 runningApplication = runningApp
@@ -37,23 +52,7 @@ struct ElementDetectionWindowResolver {
                 self.logger.error("Could not resolve NSRunningApplication for PID: \(pid)")
                 throw PeekabooError.appNotFound("PID:\(pid)")
             }
-        } else if let bundleId = windowContext?.applicationBundleId {
-            runningApplication = try await self.resolveRunningApplication(
-                identifier: bundleId,
-                source: "bundle ID")
-        } else if let appName = windowContext?.applicationName {
-            runningApplication = try await self.resolveRunningApplication(
-                identifier: appName,
-                source: "application selector")
-        } else if let bundlePath = windowContext?.applicationBundlePath {
-            runningApplication = try await self.resolveRunningApplication(
-                identifier: bundlePath,
-                source: "bundle path")
-        } else if let executablePath = windowContext?.applicationExecutablePath {
-            runningApplication = try await self.resolveRunningApplication(
-                identifier: executablePath,
-                source: "executable path")
-        } else if let windowID = windowContext?.windowID {
+        case let .exactWindow(windowID):
             guard let processIdentifier = Self.stableExactWindowOwner(
                 windowID: windowID,
                 receipt: windowContext?.windowMutationIdentity,
@@ -65,7 +64,11 @@ struct ElementDetectionWindowResolver {
             }
             self.logger.debug("Resolved application via exact window \(windowID), PID: \(processIdentifier)")
             runningApplication = runningApp
-        } else {
+        case let .identifier(identifier, source):
+            runningApplication = try await self.resolveRunningApplication(
+                identifier: identifier,
+                source: source.rawValue)
+        case .frontmost:
             guard let frontmost = NSWorkspace.shared.frontmostApplication else {
                 self.logger.error("No frontmost application")
                 throw PeekabooError.operationError(message: "No frontmost application")
@@ -85,6 +88,31 @@ struct ElementDetectionWindowResolver {
             throw PeekabooError.invalidInput(field: "windowContext", reason: mismatch)
         }
         return runningApplication
+    }
+
+    nonisolated static func applicationResolutionAuthority(
+        for context: WindowContext?) -> ApplicationResolutionAuthority
+    {
+        guard let context else { return .frontmost }
+        if let processIdentifier = context.applicationProcessId {
+            return .processIdentifier(processIdentifier)
+        }
+        if let windowID = context.windowID {
+            return .exactWindow(windowID)
+        }
+        if let bundlePath = context.applicationBundlePath {
+            return .identifier(bundlePath, source: .bundlePath)
+        }
+        if let executablePath = context.applicationExecutablePath {
+            return .identifier(executablePath, source: .executablePath)
+        }
+        if let bundleIdentifier = context.applicationBundleId {
+            return .identifier(bundleIdentifier, source: .bundleIdentifier)
+        }
+        if let applicationName = context.applicationName {
+            return .identifier(applicationName, source: .applicationName)
+        }
+        return .frontmost
     }
 
     private func resolveRunningApplication(identifier: String, source: String) async throws -> NSRunningApplication {

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ElementDetectionReadOnlyWindowSelectionTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ElementDetectionReadOnlyWindowSelectionTests.swift
@@ -78,6 +78,44 @@ final class ElementDetectionReadOnlyWindowSelectionTests: XCTestCase {
         }
     }
 
+    func testApplicationResolutionAuthorityPrefersUniquePathsOverBroadSelectors() {
+        let bundlePathContext = WindowContext(
+            applicationName: "Fixt",
+            applicationBundleId: "dev.peekaboo.fixture",
+            applicationBundlePath: Self.bundlePath)
+        XCTAssertEqual(
+            ElementDetectionWindowResolver.applicationResolutionAuthority(for: bundlePathContext),
+            .identifier(Self.bundlePath, source: .bundlePath))
+        XCTAssertNil(ElementDetectionWindowResolver.applicationConstraintMismatch(
+            candidate: Self.applicationCandidate,
+            context: bundlePathContext))
+
+        let executablePathContext = WindowContext(
+            applicationName: "Fixt",
+            applicationBundleId: "dev.peekaboo.fixture",
+            applicationExecutablePath: Self.executablePath)
+        XCTAssertEqual(
+            ElementDetectionWindowResolver.applicationResolutionAuthority(for: executablePathContext),
+            .identifier(Self.executablePath, source: .executablePath))
+        XCTAssertNil(ElementDetectionWindowResolver.applicationConstraintMismatch(
+            candidate: Self.applicationCandidate,
+            context: executablePathContext))
+    }
+
+    func testApplicationResolutionAuthorityPrefersExactWindowOverAmbiguousBroadSelector() {
+        let context = WindowContext(
+            applicationName: "Fixt",
+            applicationBundleId: "dev.peekaboo.fixture",
+            windowID: 73)
+
+        XCTAssertEqual(
+            ElementDetectionWindowResolver.applicationResolutionAuthority(for: context),
+            .exactWindow(73))
+        XCTAssertNil(ElementDetectionWindowResolver.applicationConstraintMismatch(
+            candidate: Self.applicationCandidate,
+            context: context))
+    }
+
     @MainActor
     func testPathOnlySelectorsResolveTheirNonFrontmostApplication() async throws {
         let target = try Self.uniqueNonFrontmostApplication()

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ElementDetectionReadOnlyWindowSelectionTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ElementDetectionReadOnlyWindowSelectionTests.swift
@@ -3,6 +3,33 @@ import XCTest
 @testable import PeekabooAutomationKit
 
 final class ElementDetectionReadOnlyWindowSelectionTests: XCTestCase {
+    func testDetectProjectionOmitsUnrequestedResolvedPaths() {
+        let projected = Self.detectProjection(requested: WindowContext(applicationName: "Fixture"))
+
+        XCTAssertNil(projected.bundlePath)
+        XCTAssertNil(projected.executablePath)
+    }
+
+    func testDetectProjectionPublishesCanonicalPathsForMatchingExplicitConstraints() {
+        let projected = Self.detectProjection(requested: WindowContext(
+            applicationName: "Fixture",
+            applicationBundlePath: Self.bundlePath,
+            applicationExecutablePath: Self.executablePath))
+
+        XCTAssertEqual(projected.bundlePath, Self.bundlePath)
+        XCTAssertEqual(projected.executablePath, Self.executablePath)
+    }
+
+    func testDetectProjectionNeverCopiesContradictoryCallerPathsAsResolvedFacts() {
+        let projected = Self.detectProjection(requested: WindowContext(
+            applicationName: "Fixture",
+            applicationBundlePath: "/Applications/Other.app",
+            applicationExecutablePath: "/Applications/Other.app/Contents/MacOS/other"))
+
+        XCTAssertEqual(projected.bundlePath, Self.bundlePath)
+        XCTAssertEqual(projected.executablePath, Self.executablePath)
+    }
+
     func testRequestedTitleSelectsExactSiblingInsteadOfBestWindow() throws {
         let bestWindow = Self.window(
             id: 100,
@@ -141,6 +168,21 @@ final class ElementDetectionReadOnlyWindowSelectionTests: XCTestCase {
         { error in
             XCTAssertTrue(error.localizedDescription.contains("capture-time process-generation receipt"))
         }
+    }
+
+    private static let bundlePath = "/Applications/Fixture.app"
+    private static let executablePath = bundlePath + "/Contents/MacOS/fixture"
+
+    private static func detectProjection(requested: WindowContext) -> ElementDetectionService
+    .ResolvedApplicationIdentity {
+        ElementDetectionService.projectedApplicationIdentity(
+            canonical: .init(
+                name: "Fixture",
+                bundleIdentifier: "dev.peekaboo.fixture",
+                bundlePath: self.bundlePath,
+                executablePath: self.executablePath),
+            requested: requested,
+            preservesRequestedIdentity: true)
     }
 
     func testExactReadOnlyObservationCapturesActionableReceiptWhenCallerHasNone() throws {

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ElementDetectionReadOnlyWindowSelectionTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ElementDetectionReadOnlyWindowSelectionTests.swift
@@ -1,3 +1,4 @@
+import AppKit
 import CoreGraphics
 import XCTest
 @testable import PeekabooAutomationKit
@@ -74,6 +75,49 @@ final class ElementDetectionReadOnlyWindowSelectionTests: XCTestCase {
             XCTAssertNotNil(ElementDetectionWindowResolver.applicationConstraintMismatch(
                 candidate: Self.applicationCandidate,
                 context: context))
+        }
+    }
+
+    @MainActor
+    func testPathOnlySelectorsResolveTheirNonFrontmostApplication() async throws {
+        let target = try Self.uniqueNonFrontmostApplication()
+        let bundlePath = try XCTUnwrap(target.bundleURL?.standardizedFileURL.path)
+        let executablePath = try XCTUnwrap(target.executableURL?.standardizedFileURL.path)
+        let applicationService = ApplicationService()
+        let bundleMatch = try await applicationService.findApplication(identifier: bundlePath)
+        let executableMatch = try await applicationService.findApplication(identifier: executablePath)
+        XCTAssertEqual(bundleMatch.processIdentifier, target.processIdentifier)
+        XCTAssertEqual(executableMatch.processIdentifier, target.processIdentifier)
+        let refreshed = try XCTUnwrap(NSRunningApplication(processIdentifier: target.processIdentifier))
+        XCTAssertEqual(
+            refreshed.bundleURL?.standardizedFileURL.path,
+            bundlePath,
+            "original=\(bundlePath) refreshed=\(refreshed.bundleURL?.standardizedFileURL.path ?? "nil")")
+        let resolver = ElementDetectionWindowResolver(applicationService: applicationService)
+
+        for context in [
+            WindowContext(applicationBundlePath: bundlePath),
+            WindowContext(applicationExecutablePath: executablePath),
+        ] {
+            let resolved = try await resolver.resolveApplication(windowContext: context)
+            XCTAssertEqual(resolved.processIdentifier, target.processIdentifier)
+        }
+    }
+
+    @MainActor
+    func testPathResolutionRejectsContradictoryDualPathBeforeObservation() async throws {
+        let target = try Self.uniqueNonFrontmostApplication()
+        let bundlePath = try XCTUnwrap(target.bundleURL?.standardizedFileURL.path)
+        let resolver = ElementDetectionWindowResolver(applicationService: ApplicationService())
+        let context = WindowContext(
+            applicationBundlePath: bundlePath,
+            applicationExecutablePath: bundlePath + "/Contents/MacOS/not-the-target")
+
+        do {
+            _ = try await resolver.resolveApplication(windowContext: context)
+            XCTFail("Contradictory explicit paths must fail before observation")
+        } catch {
+            XCTAssertTrue(error.localizedDescription.contains("applicationExecutablePath contradicts"))
         }
     }
 
@@ -227,6 +271,26 @@ final class ElementDetectionReadOnlyWindowSelectionTests: XCTestCase {
         executablePath: executablePath,
         allowsFuzzyMatching: true,
         isRegularApplication: true)
+
+    @MainActor
+    private static func uniqueNonFrontmostApplication() throws -> NSRunningApplication {
+        let frontmostProcessIdentifier = NSWorkspace.shared.frontmostApplication?.processIdentifier
+        let running = NSWorkspace.shared.runningApplications.filter { !$0.isTerminated }
+        guard let target = running.first(where: { application in
+            guard application.processIdentifier != frontmostProcessIdentifier,
+                  let bundlePath = application.bundleURL?.standardizedFileURL.path,
+                  let executablePath = application.executableURL?.standardizedFileURL.path
+            else { return false }
+            return running.count(where: {
+                $0.bundleURL?.standardizedFileURL.path == bundlePath
+            }) == 1 && running.count(where: {
+                $0.executableURL?.standardizedFileURL.path == executablePath
+            }) == 1
+        }) else {
+            throw XCTSkip("No unique non-frontmost application is available for path-only resolution")
+        }
+        return target
+    }
 
     private static func detectProjection(requested: WindowContext) -> ElementDetectionService
     .ResolvedApplicationIdentity {

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ElementDetectionReadOnlyWindowSelectionTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ElementDetectionReadOnlyWindowSelectionTests.swift
@@ -30,6 +30,53 @@ final class ElementDetectionReadOnlyWindowSelectionTests: XCTestCase {
         XCTAssertEqual(projected.executablePath, Self.executablePath)
     }
 
+    func testResolvedApplicationAcceptsEveryMatchingSingleSelectorAndCombinedConstraints() {
+        let matchingContexts = [
+            WindowContext(applicationProcessId: 42),
+            WindowContext(applicationBundleId: "dev.peekaboo.fixture"),
+            WindowContext(applicationName: "Fixt"),
+            WindowContext(applicationName: Self.bundlePath),
+            WindowContext(applicationName: Self.executablePath),
+            WindowContext(applicationName: "fixture"),
+            WindowContext(applicationBundlePath: Self.bundlePath),
+            WindowContext(applicationExecutablePath: Self.executablePath),
+            WindowContext(
+                applicationName: "Fixture",
+                applicationBundleId: "dev.peekaboo.fixture",
+                applicationBundlePath: Self.bundlePath,
+                applicationExecutablePath: Self.executablePath,
+                applicationProcessId: 42),
+        ]
+
+        for context in matchingContexts {
+            XCTAssertNil(ElementDetectionWindowResolver.applicationConstraintMismatch(
+                candidate: Self.applicationCandidate,
+                context: context))
+        }
+    }
+
+    func testResolvedApplicationRejectsContradictoryCombinedSelectorsBeforeObservation() {
+        let contradictoryContexts = [
+            WindowContext(applicationName: "Other", applicationProcessId: 42),
+            WindowContext(applicationName: "/Applications/Other.app", applicationProcessId: 42),
+            WindowContext(
+                applicationName: "Other",
+                applicationBundleId: "dev.peekaboo.fixture"),
+            WindowContext(
+                applicationName: "Fixture",
+                applicationBundlePath: "/Applications/Other.app"),
+            WindowContext(
+                applicationName: "Fixture",
+                applicationExecutablePath: "/Applications/Fixture.app/Contents/MacOS/other"),
+        ]
+
+        for context in contradictoryContexts {
+            XCTAssertNotNil(ElementDetectionWindowResolver.applicationConstraintMismatch(
+                candidate: Self.applicationCandidate,
+                context: context))
+        }
+    }
+
     func testRequestedTitleSelectsExactSiblingInsteadOfBestWindow() throws {
         let bestWindow = Self.window(
             id: 100,
@@ -172,6 +219,14 @@ final class ElementDetectionReadOnlyWindowSelectionTests: XCTestCase {
 
     private static let bundlePath = "/Applications/Fixture.app"
     private static let executablePath = bundlePath + "/Contents/MacOS/fixture"
+    private static let applicationCandidate = ApplicationIdentifierMatcher.Candidate(
+        processIdentifier: 42,
+        bundleIdentifier: "dev.peekaboo.fixture",
+        name: "Fixture",
+        bundlePath: bundlePath,
+        executablePath: executablePath,
+        allowsFuzzyMatching: true,
+        isRegularApplication: true)
 
     private static func detectProjection(requested: WindowContext) -> ElementDetectionService
     .ResolvedApplicationIdentity {

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeWindowContextBinding.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeWindowContextBinding.swift
@@ -9,6 +9,8 @@ enum PeekabooBridgeWindowContextBinding {
         guard let actual else { return false }
         return actual.applicationName == requested.applicationName &&
             actual.applicationBundleId == requested.applicationBundleId &&
+            actual.applicationBundlePath == requested.applicationBundlePath &&
+            actual.applicationExecutablePath == requested.applicationExecutablePath &&
             actual.applicationProcessId == requested.applicationProcessId &&
             actual.windowTitle == requested.windowTitle &&
             actual.windowID == requested.windowID &&
@@ -26,6 +28,8 @@ enum PeekabooBridgeWindowContextBinding {
         guard let requested else { return actual == nil }
         guard let actual else { return false }
         return self.applicationSelector(in: requested, matches: actual) &&
+            self.satisfies(requested.applicationBundlePath, with: actual.applicationBundlePath) &&
+            self.satisfies(requested.applicationExecutablePath, with: actual.applicationExecutablePath) &&
             self.satisfies(requested.applicationProcessId, with: actual.applicationProcessId) &&
             self.windowTitle(actual.windowTitle, matches: requested.windowTitle) &&
             self.satisfies(requested.windowID, with: actual.windowID) &&
@@ -80,6 +84,8 @@ enum PeekabooBridgeWindowContextBinding {
                 processIdentifier: processIdentifier,
                 bundleIdentifier: actual.applicationBundleId,
                 name: name,
+                bundlePath: actual.applicationBundlePath,
+                executablePath: actual.applicationExecutablePath,
                 allowsFuzzyMatching: true,
                 isRegularApplication: true),
             identifier: identifier)

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeTypedResultReceiptBindingTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeTypedResultReceiptBindingTests.swift
@@ -68,6 +68,8 @@ struct PeekabooBridgeTypedResultReceiptBindingTests {
         let resolvedContext = Self.resolvedTreeContext(fixture: fixture)
         let response = PeekabooBridgeResponse.elementDetection(
             Self.detection(snapshotID: "resolved-tree", context: resolvedContext))
+        let bundlePath = "/Applications/Fixture.app"
+        let executablePath = bundlePath + "/Contents/MacOS/fixture"
         let validSelectors = [
             WindowContext(windowID: fixture.windowIdentity.windowID),
             WindowContext(
@@ -76,7 +78,10 @@ struct PeekabooBridgeTypedResultReceiptBindingTests {
             WindowContext(
                 applicationName: "Fixt",
                 windowID: fixture.windowIdentity.windowID),
-            WindowContext(windowTitle: "doc", windowID: fixture.windowIdentity.windowID),
+            WindowContext(applicationName: bundlePath, windowID: fixture.windowIdentity.windowID),
+            WindowContext(applicationName: executablePath, windowID: fixture.windowIdentity.windowID),
+            WindowContext(windowTitle: "dOcUmEnT", windowID: fixture.windowIdentity.windowID),
+            WindowContext(windowTitle: "cume", windowID: fixture.windowIdentity.windowID),
             WindowContext(
                 applicationBundleId: "dev.peekaboo.fixture",
                 windowID: fixture.windowIdentity.windowID),
@@ -116,6 +121,12 @@ struct PeekabooBridgeTypedResultReceiptBindingTests {
             capturedBounds: fixture.windowIdentity.capturedBounds)
         let contradictorySelectors = [
             WindowContext(applicationName: "Other", windowID: fixture.windowIdentity.windowID),
+            WindowContext(
+                applicationName: "/Applications/Other.app",
+                windowID: fixture.windowIdentity.windowID),
+            WindowContext(
+                applicationName: "/Applications/Fixture.app/Contents/MacOS/other",
+                windowID: fixture.windowIdentity.windowID),
             WindowContext(applicationBundleId: "dev.peekaboo.other", windowID: fixture.windowIdentity.windowID),
             WindowContext(
                 applicationProcessId: fixture.windowIdentity.ownerProcessIdentifier + 1,
@@ -506,6 +517,8 @@ struct PeekabooBridgeTypedResultReceiptBindingTests {
         WindowContext(
             applicationName: "Fixture",
             applicationBundleId: "dev.peekaboo.fixture",
+            applicationBundlePath: "/Applications/Fixture.app",
+            applicationExecutablePath: "/Applications/Fixture.app/Contents/MacOS/fixture",
             applicationProcessId: fixture.windowIdentity.ownerProcessIdentifier,
             windowTitle: "Document",
             windowID: fixture.windowIdentity.windowID,

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeTypedResultReceiptBindingTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeTypedResultReceiptBindingTests.swift
@@ -219,6 +219,68 @@ struct PeekabooBridgeTypedResultReceiptBindingTests {
     }
 
     @Test
+    func `signed detect projection binds only explicitly requested application paths`() async throws {
+        let fixture = try await Self.makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        let pathless = Self.exactDetectionContext(
+            fixture: fixture,
+            applicationBundlePath: nil,
+            applicationExecutablePath: nil)
+        let pathlessRequest = PeekabooBridgeRequest.detectElements(.init(
+            imageData: Data([1]),
+            snapshotId: "snapshot",
+            windowContext: pathless))
+        let pathlessResponse = PeekabooBridgeResponse.elementDetection(
+            Self.detection(snapshotID: "snapshot", context: pathless))
+        let pathlessBundle = try await Self.signedBundle(
+            fixture: fixture,
+            sequence: 0,
+            request: pathlessRequest,
+            response: pathlessResponse,
+            target: .global)
+        try pathlessBundle.validateIntegrity()
+
+        let canonical = Self.exactDetectionContext(
+            fixture: fixture,
+            applicationBundlePath: "/Applications/Fixture.app",
+            applicationExecutablePath: "/Applications/Fixture.app/Contents/MacOS/fixture")
+        let canonicalRequest = PeekabooBridgeRequest.detectElements(.init(
+            imageData: Data([1]),
+            snapshotId: "snapshot",
+            windowContext: canonical))
+        let canonicalResponse = PeekabooBridgeResponse.elementDetection(
+            Self.detection(snapshotID: "snapshot", context: canonical))
+        let canonicalBundle = try await Self.signedBundle(
+            fixture: fixture,
+            sequence: 1,
+            request: canonicalRequest,
+            response: canonicalResponse,
+            target: .global)
+        try canonicalBundle.validateIntegrity()
+
+        let contradictory = Self.exactDetectionContext(
+            fixture: fixture,
+            applicationBundlePath: "/Applications/Other.app",
+            applicationExecutablePath: "/Applications/Other.app/Contents/MacOS/other")
+        let contradictoryRequest = PeekabooBridgeRequest.detectElements(.init(
+            imageData: Data([1]),
+            snapshotId: "snapshot",
+            windowContext: contradictory))
+        let contradictoryBundle = try await Self.signedBundle(
+            fixture: fixture,
+            sequence: 2,
+            request: contradictoryRequest,
+            response: canonicalResponse,
+            target: .global)
+        #expect(throws: PeekabooBridgeOperationReceiptError.receiptMismatch(
+            "element-detection response window context"))
+        {
+            try contradictoryBundle.validateIntegrity()
+        }
+    }
+
+    @Test
     func `forged keyed read responses fail live and offline`() async throws {
         let fixture = try await Self.makeFixture()
         defer { try? FileManager.default.removeItem(at: fixture.root) }
@@ -504,6 +566,28 @@ struct PeekabooBridgeTypedResultReceiptBindingTests {
                 elementCount: 0,
                 method: "fixture",
                 windowContext: context))
+    }
+
+    private static func exactDetectionContext(
+        fixture: Fixture,
+        applicationBundlePath: String?,
+        applicationExecutablePath: String?) -> WindowContext
+    {
+        WindowContext(
+            applicationName: "Fixture",
+            applicationBundleId: "dev.peekaboo.fixture",
+            applicationBundlePath: applicationBundlePath,
+            applicationExecutablePath: applicationExecutablePath,
+            applicationProcessId: fixture.windowIdentity.ownerProcessIdentifier,
+            windowTitle: "Document",
+            windowID: fixture.windowIdentity.windowID,
+            windowBounds: fixture.windowIdentity.capturedBounds,
+            windowMutationIdentity: fixture.windowIdentity,
+            shouldFocusWebContent: false,
+            includeMenuBarElements: true,
+            traversalBudget: AXTraversalBudget(),
+            requiresFreshAccessibilityTree: false,
+            accessibilityTimeoutSeconds: 20)
     }
 
     private static func resolvedTreeContext(


### PR DESCRIPTION
## Summary

- carry canonical bundle and executable paths in signed read-only window contexts
- resolve PID, exact-window, path, bundle, and name constraints through one most-specific application authority
- reject contradictory combined selectors before Accessibility observation while preserving exact detect projections

## Tests

- `swift test --filter ElementDetectionReadOnlyWindowSelectionTests` (24/24)
- `swift test --filter PeekabooBridgeTypedResultReceiptBindingTests` (8/8)
- full PeekabooAutomationKit suite: 1,132/1,134; the two failures reproduce on clean `main` and are unrelated existing scroll-unit/inventory-deadline expectations
- SwiftFormat clean; changed-file SwiftLint clean; docs lint clean
- structured P2 Autoreview clean
