### PR TITLE
test(automation): expect exact scroll dispatch count

### DIFF
--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/UIAutomationActionOutcomeProvidingTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/UIAutomationActionOutcomeProvidingTests.swift
@@ -152,7 +152,11 @@ struct UIAutomationActionOutcomeProvidingTests {
         let result = try await service.scrollWithOutcome(request)
         try await service.scroll(request)
 
-        #expect(result.outcome == Self.foregroundOutcome)
+        let expected = DesktopActionOutcome.dispatchedUnverified(
+            delivery: .init(mechanism: .globalEvents, mode: .foreground),
+            evidence: .deliveryAccepted,
+            unitCount: .one)
+        #expect(result.outcome == expected)
         #expect(synthetic.scrollCount == 2)
     }
 


### PR DESCRIPTION
## Summary

- update the stale scroll adapter expectation to include the exact single emitted dispatch unit
- retain result-returning and legacy adapter parity coverage

Production scroll accounting already reports exact tick counts; this test still expected the pre-#523 count-unknown outcome.

## Tests

- focused outcome adapter and foreground scroll accounting tests: 2 passed
- ApplicationInventoryTimeoutTests follow-up after unrelated full-suite host-load failure: 14 passed
- changed-file SwiftLint: 0 violations
- Autoreview through P2: clean

The full AutomationKit run reached 1,134 tests with the former scroll failure fixed; its only remaining failure was the unrelated inventory deadline assertion, which passed immediately in isolation.
