### PR TITLE
fix(certification): fail closed without trust anchor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+- Fail closed instead of generating or accepting a release-qualification manifest until final-cycle liveness witnesses have a cryptographic trust anchor.
 ## [4.2.2] - 2026-08-20
 
 ### Highlights

--- a/scripts/final-qualification/README.md
+++ b/scripts/final-qualification/README.md
@@ -326,7 +326,13 @@ node "$TOOLS/validate-concurrent-run.mjs" \
 
 Success requires the exact four-event coordinator lifecycle ending in eligible `completed` with the summary's exact size and SHA-256, a closed version-2 certification summary whose structural, foreground-postcondition, slot, first-party, and offline sub-gates all passed with no failures, coordinator zero exit, one authenticated protocol-1.31 Agent terminal success, exactly four mapped and signed background mutations with no extra dispatch, six in-window semantic readbacks on the two authenticated, physically disjoint controlled fixtures, an untruncated trace with no Shell/foreground/skipped/failed/possibly-dispatched call, the calibrated emitter, both integrated-CU readbacks, and a signed Agent lifetime covering the entire authoritative `operations-start` through `operations-complete` monitor interval. The terminal bundle's inner coordination and acknowledgement child/requester identities must equal the outer receipt. At least one signed Agent mutation must complete strictly before the integrated-CU perform readback and at least one must start strictly afterward; shared process lifetime or equal boundary timestamps are not accepted as concurrent progress. The integrated-CU perform timestamp must be within two seconds of the retained readback file mtime, and both values form the authenticated interleaving pivot. Manifest generation and verification independently rederive that pivot, bind the terminal identities and acknowledgement to the local/during readiness roots and guard authorization, and recheck the Agent action intervals, closed summary success and event commitment, controlled-fixture ownership, readback/dispatch order, and fresh live bundle authentication instead of trusting the concurrent report or caller-authored validator JSON.
 
-## 6. Generate and verify the final qualification manifest
+## 6. Final qualification manifest is disabled pending a trust anchor
+
+Production `generate` and `verify` currently fail closed. The retained crash, monitor, Playground semantic,
+and process-exit witnesses do not yet have one cryptographic trust anchor that proves their live producer
+generations after capture. Hashing same-user evidence files is not sufficient release authority. The `tooling`
+action below remains available to freeze the reviewed source set; structural regression tests use the explicit
+non-release claim `structural-validation-only`.
 
 First create the immutable, self-verifying source manifest for the frozen qualification tools. The file order is part of the aggregate:
 
@@ -406,7 +412,12 @@ node "$TOOLS/qualification-manifest.mjs" verify \
   > /private/tmp/peekaboo-qualification-sealed-verification.json
 ```
 
-The generated version-2 manifest hashes every file, including both authenticated artifact manifests and their cross-binding, the qualification-tools file manifest, both installed inventories and elevation receipts, six process snapshots, collector, executable-policy reports/scanner, plan constructor, and crash scanner. It also carries the two derived same-ID Agent-to-controller controlled-fixture bindings. It binds a version-2 domain-separated aggregate and states both `qualification_claim:"release-qualification"` and `adjuncts_are_live_v4_slots:false`. Verification rehashes the tool source tree and re-runs installed-parity, artifact/source/tool/elevation binding, task-root/process-policy/coverage binding, cycle uniqueness, crash, concurrent/interleaving, signed-bundle, authenticated controlled-target summary, controller, process-generation, cross-run, readback, and restoration checks in addition to closed shape, unique paths, bytes, sizes, hashes, and aggregate.
+The two commands above intentionally exit nonzero until the signed final-cycle witness contract is implemented.
+They do not create or accept a `release-qualification` manifest.
+
+Structural version-2 test manifests still hash every file and rerun the complete evidence graph, but they carry
+`qualification_claim:"structural-validation-only"`. Production does not generate or accept that test claim as
+release authority.
 
 ## Current product-output gaps that remain explicit hard boundaries
 

--- a/scripts/final-qualification/qualification-manifest.mjs
+++ b/scripts/final-qualification/qualification-manifest.mjs
@@ -3713,7 +3713,11 @@ function validateSemanticEvidence(evidence, authenticateBundle) {
   );
 }
 
-export function generateManifest(inputPath, outputPath, {
+const RELEASE_QUALIFICATION_DISABLED =
+  'Release qualification is disabled until final-cycle crash, monitor, semantic, and process-exit witnesses have a cryptographic trust anchor.';
+const STRUCTURAL_TEST_CLAIM = 'structural-validation-only';
+
+function generateManifestWithClaim(inputPath, outputPath, qualificationClaim, {
   authenticateBundle = authenticateLiveBridgeBundle,
 } = {}) {
   const input = readStableJSON(inputPath, 'qualification manifest input').value;
@@ -3726,7 +3730,7 @@ export function generateManifest(inputPath, outputPath, {
   });
   const manifest = {
     version: 2,
-    qualification_claim: 'release-qualification',
+    qualification_claim: qualificationClaim,
     adjuncts_are_live_v4_slots: false,
     evidence,
     evidence_aggregate_sha256: aggregateSHA256('evidence-manifest', evidence),
@@ -3735,7 +3739,7 @@ export function generateManifest(inputPath, outputPath, {
   return { manifest, manifest_sha256: written.sha256 };
 }
 
-export function verifyManifest(manifestPath, {
+function verifyManifestWithClaim(manifestPath, qualificationClaim, {
   authenticateBundle = authenticateLiveBridgeBundle,
 } = {}) {
   const retained = readStableJSON(manifestPath, 'qualification manifest');
@@ -3745,7 +3749,7 @@ export function verifyManifest(manifestPath, {
     'evidence_aggregate_sha256',
   ], 'qualification manifest');
   requireCondition(manifest.version === 2
-    && manifest.qualification_claim === 'release-qualification'
+    && manifest.qualification_claim === qualificationClaim
     && manifest.adjuncts_are_live_v4_slots === false,
   'qualification manifest claim metadata is invalid');
   const checkedPaths = new Set();
@@ -3784,6 +3788,24 @@ export function verifyManifest(manifestPath, {
     evidence_aggregate_sha256: manifest.evidence_aggregate_sha256,
     adjuncts_are_live_v4_slots: false,
   };
+}
+
+export function generateManifest() {
+  throw new TypeError(RELEASE_QUALIFICATION_DISABLED);
+}
+
+export function verifyManifest() {
+  throw new TypeError(RELEASE_QUALIFICATION_DISABLED);
+}
+
+// Structural regression tests keep exercising the complete evidence graph without
+// minting or accepting a release claim while the cryptographic trust anchor is absent.
+export function generateStructuralManifestForTesting(inputPath, outputPath, options = {}) {
+  return generateManifestWithClaim(inputPath, outputPath, STRUCTURAL_TEST_CLAIM, options);
+}
+
+export function verifyStructuralManifestForTesting(manifestPath, options = {}) {
+  return verifyManifestWithClaim(manifestPath, STRUCTURAL_TEST_CLAIM, options);
 }
 
 function invokedAsScript() {

--- a/scripts/final-qualification/test/qualification-tools.test.mjs
+++ b/scripts/final-qualification/test/qualification-tools.test.mjs
@@ -24,9 +24,11 @@ import {
   validatePlaygroundAlertLifecycle,
 } from '../playground-alert-lifecycle.mjs';
 import {
-  generateManifest as generateManifestProduction,
+  generateManifest as generateReleaseManifest,
+  generateStructuralManifestForTesting as generateManifestProduction,
   generateSourceManifest,
-  verifyManifest as verifyManifestProduction,
+  verifyManifest as verifyReleaseManifest,
+  verifyStructuralManifestForTesting as verifyManifestProduction,
   verifySourceManifest,
 } from '../qualification-manifest.mjs';
 import {
@@ -1238,6 +1240,37 @@ function projectionFixture(root) {
   };
   return { fixtureHome, spec, emitterExecutable };
 }
+
+test('release qualification generation and verification fail closed without a trust anchor', () => {
+  const root = fs.mkdtempSync('/private/tmp/pbq-release-disabled-');
+  fs.chmodSync(root, 0o700);
+  try {
+    const missingInput = path.join(root, 'missing-input.json');
+    const missingManifest = path.join(root, 'missing-manifest.json');
+    const output = path.join(root, 'release-manifest.json');
+    const refusal = /Release qualification is disabled until .* cryptographic trust anchor/;
+
+    assert.throws(() => generateReleaseManifest(missingInput, output), refusal);
+    assert.throws(() => verifyReleaseManifest(missingManifest), refusal);
+    assert.equal(fs.existsSync(output), false);
+
+    const helper = path.join(toolRoot, 'qualification-manifest.mjs');
+    const generate = spawnSync(process.execPath, [
+      helper, 'generate', '--input', missingInput, '--output', output,
+    ], { encoding: 'utf8' });
+    assert.notEqual(generate.status, 0);
+    assert.match(generate.stderr, refusal);
+    assert.equal(fs.existsSync(output), false);
+
+    const verify = spawnSync(process.execPath, [
+      helper, 'verify', '--manifest', missingManifest,
+    ], { encoding: 'utf8' });
+    assert.notEqual(verify.status, 0);
+    assert.match(verify.stderr, refusal);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
 
 test('closed raw receipts project deterministic live-v4 bindings and reject ambiguity', () => {
   const root = fs.mkdtempSync('/private/tmp/pbq-tools-project-');


### PR DESCRIPTION
## Summary

- make production final-qualification manifest generation and verification fail closed before reading inputs or writing outputs
- preserve the complete structural evidence regression suite under the explicit non-release `structural-validation-only` claim
- document the missing cryptographic trust anchor and add an Unreleased changelog entry

## Why

The current release-qualification path promotes retained crash, monitor, Playground semantic, and process-exit files into release authority. Those same-user files do not yet share a cryptographic trust anchor that proves their live producer generations after capture. Hashing them prevents later byte drift but cannot establish liveness or provenance. Until protocol-backed witnesses exist, minting or accepting `release-qualification` would be a false claim.

The `tooling` source-freeze action remains available. Production `generate` and `verify` now refuse immediately, while structural tests keep exercising the full graph without producing a release claim.

## Proof

- `pnpm run test:background-certification` — 29 + 136 + 31 + 49 passed
- `pnpm run lint:docs`
- `git diff --check`
- P2 structured Autoreview, exact rebased head — clean, no findings

Release qualification remains intentionally blocked until the signed final-cycle witness contract lands.
