### PR TITLE
refactor(automation): bind mutation authority to receipts

### DIFF
--- a/Apps/CLI/Tests/CLIAutomationTests/SpaceToolTests.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/SpaceToolTests.swift
@@ -1,6 +1,8 @@
 import CoreGraphics
 import Foundation
 import MCP
+import PeekabooAutomationKit
+import PeekabooAutomationKitTestSupport
 import PeekabooFoundation
 import TachikomaMCP
 import Testing
@@ -304,6 +306,7 @@ struct SpaceToolExecutionHostTests {
     }
 
     @Test
+    @MainActor
     func `background Space move refuses a leaf window from a different authorized generation`() async throws {
         let testContext = self.makeTestContext(processGeneration: 222)
         let context = self.makeToolContext(
@@ -317,9 +320,20 @@ struct SpaceToolExecutionHostTests {
             processIdentifier: 999,
             processStartIdentity: 111
         ))
+        let planner = MutationAuthorityCatalogScript(
+            applications: [AutomationTestFixtures.application(
+                processIdentifier: 999,
+                processStartIdentity: 111,
+                name: "Authorized"
+            )],
+            windowInventories: []
+        ).planner()
+        let authorizedPlan = try await AuthorizedDesktopTargetPlan(
+            mutationAuthority: planner.bind(identity: authorizedTarget)
+        )
 
         let response = try await AuthorizedDesktopTargetPlan.$current.withValue(
-            AuthorizedDesktopTargetPlan(targetIdentity: authorizedTarget)
+            authorizedPlan
         ) {
             try await tool.execute(arguments: self.makeArguments([
                 "action": .string("move-window"),

--- a/Apps/CLI/Tests/CLIAutomationTests/TargetedInteractionDefaultDeliveryTests.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/TargetedInteractionDefaultDeliveryTests.swift
@@ -299,8 +299,17 @@ struct TargetedInteractionDefaultDeliveryTests {
             bundleIdentifier: "com.apple.TextEdit",
             name: "TextEdit"
         )
+        let window = AutomationTestFixtures.window(
+            windowID: 42,
+            bounds: bounds,
+            processIdentity: ApplicationProcessIdentity(
+                processIdentifier: processIdentifier,
+                processStartIdentity: processStartIdentity
+            )
+        )
         let context = TestServicesFactory.makeAutomationTestContext(
-            applications: StubApplicationService(applications: [application])
+            applications: StubApplicationService(applications: [application]),
+            windows: StubWindowService(windowsByApp: ["TextEdit": [window]])
         )
         let malformedReceipts: [(windowID: Int, capturedBounds: CGRect?)] = [
             (42, nil),

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Strategy/DesktopTargetPlanning+BackgroundKeyboard.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Strategy/DesktopTargetPlanning+BackgroundKeyboard.swift
@@ -100,19 +100,22 @@ extension DesktopTargetPlanning {
                 throw BackgroundKeyboardTargetPlanningError.targetRequired
             }
 
-            var currentAuthority: MutationAuthorityPlan = if let selectedAuthority {
-                selectedAuthority
+            // The resolved identity already includes the selector authority. Replanning below only upgrades
+            // matching application authority to the exact snapshot window; it cannot change the selected owner.
+            let boundAuthority: ReceiptBoundMutationAuthorityPlan = if let selectedAuthority,
+                                                                       selectedAuthority.window != nil ||
+                                                                       resolvedIdentity.exactWindow == nil
+            {
+                try self.authorities.bind(identity: resolvedIdentity, authority: selectedAuthority)
             } else {
-                try await self.authorities.plan(
-                    selector: InteractionTargetSelector(
-                        processIdentifier: Int(resolvedIdentity.processIdentity.processIdentifier)),
-                    expectedProcessIdentity: resolvedIdentity.processIdentity)
+                try await self.authorities.bind(identity: resolvedIdentity)
             }
-            currentAuthority = try await self.authorities.revalidate(currentAuthority)
+            var currentBoundAuthority = try await self.authorities.revalidate(boundAuthority)
+            var currentAuthority = currentBoundAuthority.authority
             var currentApplication = currentAuthority.application
             try Self.requireBackgroundInputEligibility(currentApplication)
 
-            if let exactWindow = resolvedIdentity.exactWindow {
+            if let exactWindow = currentBoundAuthority.targetIdentity.exactWindow {
                 let process = try UIAutomationTarget.Process(
                     processIdentifier: currentApplication.processIdentity.processIdentifier,
                     identity: currentApplication.processIdentity)
@@ -149,7 +152,8 @@ extension DesktopTargetPlanning {
 
             // Window enumeration can race process exit/relaunch. Revalidate after the catalog read
             // before returning authority to a caller that will dispatch keyboard input.
-            currentAuthority = try await self.authorities.revalidate(currentAuthority)
+            currentBoundAuthority = try await self.authorities.revalidate(currentBoundAuthority)
+            currentAuthority = currentBoundAuthority.authority
             currentApplication = currentAuthority.application
             try Self.requireBackgroundInputEligibility(currentApplication)
             let process = try UIAutomationTarget.Process(

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Strategy/DesktopTargetPlanning+Candidates.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Strategy/DesktopTargetPlanning+Candidates.swift
@@ -18,6 +18,7 @@ public enum DesktopTargetPlanningError: LocalizedError, Equatable, Sendable {
     case conflictingWindowEntries(windowID: Int)
     case missingWindowIdentity(windowID: Int)
     case incompleteWindowIdentity(windowID: Int)
+    case underScopedMutationAuthority(windowID: Int)
     case windowOwnerMismatch(windowID: Int, expected: ApplicationProcessIdentity)
     case staleWindow(expected: WindowMutationIdentity)
     case incompleteWindowInventory(selector: String, warnings: [String])
@@ -69,6 +70,8 @@ public enum DesktopTargetPlanningError: LocalizedError, Equatable, Sendable {
             "Window \(windowID) did not include a process-generation mutation receipt."
         case let .incompleteWindowIdentity(windowID):
             "Window \(windowID) did not include complete ID, owner-generation, and bounds evidence."
+        case let .underScopedMutationAuthority(windowID):
+            "Exact-window receipt \(windowID) was paired with application-only mutation authority."
         case let .windowOwnerMismatch(windowID, expected):
             "Window \(windowID) is not owned by selected application PID \(expected.processIdentifier) " +
                 "and its exact process generation."

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Strategy/DesktopTargetPlanning+MutationAuthority.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Strategy/DesktopTargetPlanning+MutationAuthority.swift
@@ -31,6 +31,31 @@ extension DesktopTargetPlanning {
         }
     }
 
+    /// One snapshot/observation identity bound to live mutation authority.
+    ///
+    /// `targetIdentity` is the canonical coalescing of the immutable source receipt and the
+    /// catalog-selected authority. Revalidation repeats that coalescing so callers cannot retain
+    /// live authority while accidentally dropping the receipt that originally constrained it.
+    public struct ReceiptBoundMutationAuthorityPlan: Equatable, Sendable {
+        public let sourceIdentity: DesktopTargetIdentity
+        public let authority: MutationAuthorityPlan
+        public let targetIdentity: DesktopTargetIdentity
+
+        public var selectedWindow: ServiceWindowInfo? {
+            self.authority.window?.selectionWindow
+        }
+
+        fileprivate init(
+            sourceIdentity: DesktopTargetIdentity,
+            authority: MutationAuthorityPlan,
+            targetIdentity: DesktopTargetIdentity)
+        {
+            self.sourceIdentity = sourceIdentity
+            self.authority = authority
+            self.targetIdentity = targetIdentity
+        }
+    }
+
     public enum MutationAuthorityRequirement: Equatable, Sendable {
         /// Preserve the most specific target explicitly supplied by the selector.
         case mostSpecific
@@ -92,6 +117,44 @@ extension DesktopTargetPlanning {
             }
         }
 
+        /// Resolves live mutation authority from one immutable source receipt and binds both identities.
+        public func bind(
+            identity sourceIdentity: DesktopTargetIdentity,
+            requirement: MutationAuthorityRequirement = .mostSpecific) async throws
+            -> ReceiptBoundMutationAuthorityPlan
+        {
+            let sourceIdentity = try Self.validated(sourceIdentity)
+            let authority = try await self.plan(
+                selector: InteractionTargetSelector(
+                    processIdentifier: Int(sourceIdentity.processIdentity.processIdentifier),
+                    windowID: sourceIdentity.exactWindow?.identity.windowID),
+                requirement: requirement,
+                expectedProcessIdentity: sourceIdentity.processIdentity)
+            return try self.bind(identity: sourceIdentity, authority: authority)
+        }
+
+        /// Binds an already-selected authority without repeating its inventory lookup.
+        public func bind(
+            identity sourceIdentity: DesktopTargetIdentity,
+            authority: MutationAuthorityPlan) throws -> ReceiptBoundMutationAuthorityPlan
+        {
+            let sourceIdentity = try Self.validated(sourceIdentity)
+            if let exactWindow = sourceIdentity.exactWindow, authority.window == nil {
+                throw DesktopTargetPlanningError.underScopedMutationAuthority(
+                    windowID: exactWindow.identity.windowID)
+            }
+            let targetIdentity = try sourceIdentity.coalescing(authority.targetIdentity)
+            return ReceiptBoundMutationAuthorityPlan(
+                sourceIdentity: sourceIdentity,
+                authority: authority,
+                targetIdentity: targetIdentity)
+        }
+
+        /// Normalizes selector-only authority into the same receipt-bound representation.
+        public func bind(authority: MutationAuthorityPlan) throws -> ReceiptBoundMutationAuthorityPlan {
+            try self.bind(identity: authority.targetIdentity, authority: authority)
+        }
+
         public func revalidate(_ plan: MutationAuthorityPlan) async throws -> MutationAuthorityPlan {
             switch plan {
             case let .application(application):
@@ -101,12 +164,31 @@ extension DesktopTargetPlanning {
             }
         }
 
+        /// Revalidates live authority and rebinds it to the original immutable source receipt.
+        public func revalidate(
+            _ plan: ReceiptBoundMutationAuthorityPlan) async throws -> ReceiptBoundMutationAuthorityPlan
+        {
+            let authority = try await self.revalidate(plan.authority)
+            let current = try self.bind(identity: plan.targetIdentity, authority: authority)
+            return try ReceiptBoundMutationAuthorityPlan(
+                sourceIdentity: plan.sourceIdentity,
+                authority: authority,
+                targetIdentity: plan.sourceIdentity.coalescing(current.targetIdentity))
+        }
+
         private static func requireExpectedProcessIdentity(
             _ expected: ApplicationProcessIdentity?,
             actual: ApplicationProcessIdentity) throws
         {
             guard let expected, expected != actual else { return }
             throw DesktopTargetPlanningError.staleApplication(expected: expected)
+        }
+
+        private static func validated(_ identity: DesktopTargetIdentity) throws -> DesktopTargetIdentity {
+            guard let validated = try DesktopTargetIdentityCoalescer.coalesce([identity]) else {
+                preconditionFailure("A desktop target identity cannot normalize to missing evidence")
+            }
+            return validated
         }
     }
 }

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKitTestSupport/LinkedSnapshotTargetFixture.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKitTestSupport/LinkedSnapshotTargetFixture.swift
@@ -10,6 +10,21 @@ public struct LinkedSnapshotTargetFixture: Sendable {
     public let automationSnapshot: UIAutomationSnapshot
     public let detectionResult: ElementDetectionResult
     public let coordinateContext: CaptureCoordinateContext
+
+    public var receiptPlan: SnapshotTargetReceiptPlan {
+        get throws {
+            try SnapshotTargetReceiptPlanner.assemble(
+                snapshotID: self.snapshotID,
+                automationSnapshot: self.automationSnapshot,
+                detectionResult: self.detectionResult)
+        }
+    }
+
+    public var targetIdentity: DesktopTargetIdentity {
+        get throws {
+            try self.receiptPlan.receipt.requireIdentity()
+        }
+    }
 }
 
 extension AutomationTestFixtures {

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/AutomationKitTestSupportTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/AutomationKitTestSupportTests.swift
@@ -27,10 +27,7 @@ struct AutomationKitTestSupportTests {
                 DesktopTargetEvidenceAdapter.evidence(context: fixture.desktopTarget.windowContext))
         #expect(fixture.detectionResult.metadata.captureCoordinateContext == fixture.coordinateContext)
 
-        let authority = try SnapshotTargetReceiptPlanner.assemble(
-            snapshotID: fixture.snapshotID,
-            automationSnapshot: fixture.automationSnapshot,
-            detectionResult: fixture.detectionResult).receipt.requireCoordinateAuthority()
+        let authority = try fixture.receiptPlan.receipt.requireCoordinateAuthority()
         #expect(authority.target.identity == fixture.desktopTarget.windowIdentity)
     }
 

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/DesktopTargetPlanningTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/DesktopTargetPlanningTests.swift
@@ -294,8 +294,8 @@ struct DesktopTargetPlanningTests {
             applicationName: "Editor",
             windowID: 42)
         let planner = self.backgroundKeyboardPlanner(
-            application: fixture.application,
-            windowInventory: .complete([]))
+            applications: [fixture.application],
+            windowInventory: .complete([fixture.window]))
 
         let plan = try await planner.plan(
             selector: InteractionTargetSelector(),
@@ -303,7 +303,29 @@ struct DesktopTargetPlanningTests {
 
         #expect(plan.target == fixture.windowTargetIdentity.target)
         #expect(plan.application.processIdentity == fixture.processIdentity)
-        #expect(plan.window == nil)
+        #expect(plan.window?.identity == fixture.windowIdentity)
+    }
+
+    @MainActor
+    @Test
+    func `background keyboard planner rejects a selector from another snapshot owner`() async throws {
+        let snapshot = AutomationTestFixtures.linkedDesktopTarget(
+            processIdentity: .init(processIdentifier: 42, processStartIdentity: 7),
+            applicationName: "Editor",
+            windowID: 42)
+        let selected = AutomationTestFixtures.linkedDesktopTarget(
+            processIdentity: .init(processIdentifier: 43, processStartIdentity: 8),
+            applicationName: "Other Editor",
+            windowID: 43)
+        let planner = self.backgroundKeyboardPlanner(
+            applications: [snapshot.application, selected.application],
+            windowInventory: .complete([selected.window]))
+
+        await #expect(throws: DesktopTargetIdentityError.contradictoryProcessIdentifier) {
+            _ = try await planner.plan(
+                selector: InteractionTargetSelector(applicationIdentifier: "Other Editor"),
+                snapshotExactWindow: snapshot.windowTargetIdentity.exactWindow)
+        }
     }
 
     @MainActor
@@ -313,7 +335,7 @@ struct DesktopTargetPlanningTests {
             applicationName: "Editor",
             windowID: 42)
         let planner = self.backgroundKeyboardPlanner(
-            application: fixture.application,
+            applications: [fixture.application],
             windowInventory: .complete([fixture.window]))
 
         let plan = try await planner.plan(
@@ -330,7 +352,7 @@ struct DesktopTargetPlanningTests {
             applicationName: "Editor",
             windowID: 42)
         let planner = self.backgroundKeyboardPlanner(
-            application: fixture.application,
+            applications: [fixture.application],
             windowInventory: .partial([fixture.window], warnings: ["AX enumeration timed out"]))
 
         await #expect(throws: DesktopTargetPlanningError.incompleteWindowInventory(
@@ -344,13 +366,27 @@ struct DesktopTargetPlanningTests {
 
     @MainActor
     private func backgroundKeyboardPlanner(
-        application: ServiceApplicationInfo,
+        applications: [ServiceApplicationInfo],
         windowInventory: DesktopTargetPlanning.Inventory<ServiceWindowInfo>)
         -> DesktopTargetPlanning.BackgroundKeyboardTargetPlanner
     {
         let applicationPlanner = DesktopTargetPlanning.ApplicationMutationPlanner(
-            inventoryProvider: { .complete([application]) },
-            exactIdentifierProvider: { _ in application })
+            inventoryProvider: { .complete(applications) },
+            exactIdentifierProvider: { identifier in
+                let normalized = identifier.trimmingCharacters(in: .whitespacesAndNewlines)
+                let pid = normalized.uppercased().hasPrefix("PID:")
+                    ? Int32(normalized.dropFirst(4))
+                    : nil
+                let matches = applications.filter { application in
+                    pid.map { application.processIdentifier == $0 } == true ||
+                        application.bundleIdentifier?.caseInsensitiveCompare(normalized) == .orderedSame ||
+                        application.name.caseInsensitiveCompare(normalized) == .orderedSame
+                }
+                guard matches.count == 1, let application = matches.first else {
+                    throw PeekabooError.appNotFound(identifier)
+                }
+                return application
+            })
         let windowProvider: DesktopTargetPlanning.WindowMutationPlanner.WindowInventoryProvider = { _ in
             windowInventory
         }

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/MutationAuthorityPlannerTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/MutationAuthorityPlannerTests.swift
@@ -7,6 +7,209 @@ import Testing
 @MainActor
 struct MutationAuthorityPlannerTests {
     @Test
+    func `selector-only authority normalizes to its own receipt-bound identity`() async throws {
+        let fixture = AutomationTestFixtures.linkedDesktopTarget(
+            applicationName: "Editor",
+            windowID: 42)
+        let script = MutationAuthorityCatalogScript(
+            applications: [fixture.application],
+            windowInventories: [.complete([fixture.window])])
+        let planner = script.planner()
+        let authority = try await planner.plan(
+            selector: InteractionTargetSelector(applicationIdentifier: "Editor"))
+
+        let plan = try planner.bind(authority: authority)
+
+        #expect(plan.sourceIdentity == fixture.processTargetIdentity)
+        #expect(plan.targetIdentity == fixture.processTargetIdentity)
+        #expect(plan.authority == authority)
+        #expect(plan.selectedWindow == nil)
+    }
+
+    @Test
+    func `receipt-bound authority retains its source target and selected window`() async throws {
+        let fixture = AutomationTestFixtures.linkedSnapshotTarget(
+            applicationName: "Editor",
+            windowID: 42)
+        let script = MutationAuthorityCatalogScript(
+            applications: [fixture.desktopTarget.application],
+            windowInventories: [.complete([fixture.desktopTarget.window])])
+        let planner = script.planner()
+
+        let plan = try await planner.bind(identity: fixture.targetIdentity)
+
+        #expect(plan.sourceIdentity == fixture.desktopTarget.windowTargetIdentity)
+        #expect(plan.targetIdentity == fixture.desktopTarget.windowTargetIdentity)
+        #expect(plan.authority.window?.identity == fixture.desktopTarget.windowIdentity)
+        #expect(plan.selectedWindow == fixture.desktopTarget.window)
+    }
+
+    @Test
+    func `exact receipt rejects application-only live authority`() async throws {
+        let fixture = AutomationTestFixtures.linkedSnapshotTarget(
+            applicationName: "Editor",
+            windowID: 42)
+        let script = MutationAuthorityCatalogScript(
+            applications: [fixture.desktopTarget.application],
+            windowInventories: [])
+        let planner = script.planner()
+        let applicationAuthority = try await planner.plan(
+            selector: InteractionTargetSelector(applicationIdentifier: "Editor"))
+
+        #expect(throws: DesktopTargetPlanningError.underScopedMutationAuthority(windowID: 42)) {
+            _ = try planner.bind(identity: fixture.targetIdentity, authority: applicationAuthority)
+        }
+    }
+
+    @Test
+    func `malformed exact receipt rejects before live authority lookup`() async throws {
+        let bounds = CGRect(x: 10, y: 20, width: 640, height: 480)
+        let malformed = try DesktopTargetIdentity(exactWindow: UIAutomationTarget.ExactWindow(
+            identity: WindowMutationIdentity(
+                windowID: 42,
+                ownerProcessIdentifier: 101,
+                ownerProcessStartIdentity: 7,
+                capturedBounds: nil),
+            bounds: bounds))
+        let script = MutationAuthorityCatalogScript(
+            applications: [],
+            windowInventories: [])
+
+        await #expect(throws: DesktopTargetIdentityError.incompleteExactWindow) {
+            _ = try await script.planner().bind(identity: malformed)
+        }
+        #expect(script.applicationInventoryRequestCount == 0)
+        #expect(script.exactApplicationRequests.isEmpty)
+        #expect(script.windowInventoryTargets.isEmpty)
+    }
+
+    @Test
+    func `direct binding cannot repair a malformed exact receipt from live authority`() async throws {
+        let fixture = AutomationTestFixtures.linkedDesktopTarget(
+            applicationName: "Editor",
+            windowID: 42)
+        let script = MutationAuthorityCatalogScript(
+            applications: [fixture.application],
+            windowInventories: [.complete([fixture.window])])
+        let planner = script.planner()
+        let authority = try await planner.plan(
+            selector: InteractionTargetSelector(windowID: fixture.window.windowID))
+        let malformed = try DesktopTargetIdentity(exactWindow: UIAutomationTarget.ExactWindow(
+            identity: WindowMutationIdentity(
+                windowID: fixture.window.windowID,
+                ownerProcessIdentifier: fixture.processIdentity.processIdentifier,
+                ownerProcessStartIdentity: fixture.processIdentity.processStartIdentity,
+                capturedBounds: nil),
+            bounds: fixture.window.bounds))
+
+        #expect(throws: DesktopTargetIdentityError.incompleteExactWindow) {
+            _ = try planner.bind(identity: malformed, authority: authority)
+        }
+    }
+
+    @Test
+    func `receipt binding rejects same window ID with substituted bounds`() async throws {
+        let fixture = AutomationTestFixtures.linkedSnapshotTarget(
+            applicationName: "Editor",
+            windowID: 42)
+        let replacement = AutomationTestFixtures.window(
+            copying: fixture.desktopTarget.window,
+            bounds: CGRect(x: 40, y: 20, width: 640, height: 480))
+        let script = MutationAuthorityCatalogScript(
+            applications: [fixture.desktopTarget.application],
+            windowInventories: [.complete([replacement])])
+
+        await #expect(throws: DesktopTargetIdentityError.contradictoryWindowBounds) {
+            _ = try await script.planner().bind(identity: fixture.targetIdentity)
+        }
+    }
+
+    @Test
+    func `receipt-bound revalidation retains the original source receipt`() async throws {
+        let fixture = AutomationTestFixtures.linkedSnapshotTarget(
+            applicationName: "Editor",
+            windowID: 42)
+        let script = MutationAuthorityCatalogScript(
+            applications: [fixture.desktopTarget.application],
+            windowInventories: [
+                .complete([fixture.desktopTarget.window]),
+                .complete([fixture.desktopTarget.window]),
+            ])
+        let planner = script.planner()
+        let plan = try await planner.bind(identity: fixture.targetIdentity)
+
+        let current = try await planner.revalidate(plan)
+
+        #expect(current.sourceIdentity == plan.sourceIdentity)
+        #expect(current.targetIdentity == plan.targetIdentity)
+        #expect(current.selectedWindow == fixture.desktopTarget.window)
+    }
+
+    @Test
+    func `receipt-bound revalidation retains exact authority selected for a process receipt`() async throws {
+        let fixture = AutomationTestFixtures.linkedDesktopTarget(
+            applicationName: "Editor",
+            windowID: 42)
+        let script = MutationAuthorityCatalogScript(
+            applications: [fixture.application],
+            windowInventories: [
+                .complete([fixture.window]),
+                .complete([fixture.window]),
+            ])
+        let planner = script.planner()
+        let plan = try await planner.bind(
+            identity: fixture.processTargetIdentity,
+            requirement: .exactWindow(automaticSelection: .preferredMutationWindow(.general)))
+
+        let current = try await planner.revalidate(plan)
+
+        #expect(current.sourceIdentity == fixture.processTargetIdentity)
+        #expect(current.targetIdentity == fixture.windowTargetIdentity)
+        #expect(current.selectedWindow == fixture.window)
+    }
+
+    @Test(arguments: ["bounds", "generation", "window"])
+    func `receipt-bound revalidation rejects exact drift after upgrading a process receipt`(
+        drift: String) async throws
+    {
+        let fixture = AutomationTestFixtures.linkedDesktopTarget(
+            applicationName: "Editor",
+            windowID: 42)
+        let replacement = switch drift {
+        case "bounds":
+            AutomationTestFixtures.window(
+                copying: fixture.window,
+                bounds: CGRect(x: 40, y: 20, width: 640, height: 480))
+        case "generation":
+            AutomationTestFixtures.window(
+                copying: fixture.window,
+                processIdentity: ApplicationProcessIdentity(
+                    processIdentifier: fixture.processIdentity.processIdentifier,
+                    processStartIdentity: fixture.processIdentity.processStartIdentity + 1))
+        case "window":
+            AutomationTestFixtures.window(
+                copying: fixture.window,
+                windowID: fixture.window.windowID + 1)
+        default:
+            preconditionFailure("Unexpected drift fixture")
+        }
+        let script = MutationAuthorityCatalogScript(
+            applications: [fixture.application],
+            windowInventories: [
+                .complete([fixture.window]),
+                .complete([replacement]),
+            ])
+        let planner = script.planner()
+        let plan = try await planner.bind(
+            identity: fixture.processTargetIdentity,
+            requirement: .exactWindow(automaticSelection: .preferredMutationWindow(.general)))
+
+        await #expect(throws: DesktopTargetPlanningError.staleWindow(expected: fixture.windowIdentity)) {
+            _ = try await planner.revalidate(plan)
+        }
+    }
+
+    @Test
     func `most-specific authority preserves application and exact-window scope`() async throws {
         let fixture = AutomationTestFixtures.linkedDesktopTarget(
             applicationName: "Editor",

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/SnapshotTargetReceiptPlannerTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/SnapshotTargetReceiptPlannerTests.swift
@@ -39,10 +39,7 @@ struct SnapshotTargetReceiptPlannerTests {
     func `planner merges linked sources and preserves coordinate authority`() throws {
         let fixture = AutomationTestFixtures.linkedSnapshotTarget()
 
-        let plan = try SnapshotTargetReceiptPlanner.assemble(
-            snapshotID: fixture.snapshotID,
-            automationSnapshot: fixture.automationSnapshot,
-            detectionResult: fixture.detectionResult)
+        let plan = try fixture.receiptPlan
         let identity = try plan.receipt.requireIdentity()
         let authority = try plan.receipt.requireCoordinateAuthority()
 

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/AuthorizedDesktopTargetPlan.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/AuthorizedDesktopTargetPlan.swift
@@ -10,20 +10,11 @@ import PeekabooFoundation
 struct AuthorizedDesktopTargetPlan: Sendable, Equatable {
     let targetIdentity: DesktopTargetIdentity
     let selectedWindow: ServiceWindowInfo?
-    let mutationAuthority: DesktopTargetPlanning.MutationAuthorityPlan?
+    let mutationAuthority: DesktopTargetPlanning.ReceiptBoundMutationAuthorityPlan
 
-    init(
-        targetIdentity: DesktopTargetIdentity,
-        selectedWindow: ServiceWindowInfo? = nil)
-    {
-        self.targetIdentity = targetIdentity
-        self.selectedWindow = selectedWindow
-        self.mutationAuthority = nil
-    }
-
-    init(mutationAuthority: DesktopTargetPlanning.MutationAuthorityPlan) throws {
-        self.targetIdentity = try mutationAuthority.targetIdentity
-        self.selectedWindow = mutationAuthority.window?.selectionWindow
+    init(mutationAuthority: DesktopTargetPlanning.ReceiptBoundMutationAuthorityPlan) {
+        self.targetIdentity = mutationAuthority.targetIdentity
+        self.selectedWindow = mutationAuthority.selectedWindow
         self.mutationAuthority = mutationAuthority
     }
 

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/MCPToolContext+BackgroundApplicationTarget.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/MCPToolContext+BackgroundApplicationTarget.swift
@@ -22,18 +22,12 @@ extension MCPToolContext {
         toolName: String) async throws -> ToolResponse?
     {
         guard let plan = authorization.targetPlan else { return nil }
-        guard let authority = plan.mutationAuthority else {
-            return self.executionPolicy.unresolvedTargetRejection(
-                toolName: toolName,
-                detail: "the selected target has no shared mutation authority")
-        }
         let planner = DesktopTargetPlanning.MutationAuthorityPlanner(
             applications: self.applications,
             windows: self.windows)
         do {
-            let current = try await planner.revalidate(authority)
-            _ = try plan.targetIdentity.coalescing(current.targetIdentity)
-            let application = current.application.application
+            let current = try await planner.revalidate(plan.mutationAuthority)
+            let application = current.authority.application.application
             return self.executionPolicy.systemSurfaceRejection(
                 toolName: toolName,
                 applicationBundleIdentifier: application.bundleIdentifier,
@@ -71,24 +65,19 @@ extension MCPToolContext {
             detectionResult: detectionResult,
             additionalEvidence: [.init(target: mirroredIdentity)],
             applicationName: mirroredReceipt.applicationName).receipt.requireIdentity()
-        let authority = try await self.sharedMutationAuthority(for: identity)
-        return try AuthorizedDesktopTargetPlan(mutationAuthority: authority)
+        let authority = try await self.receiptBoundMutationAuthority(for: identity)
+        return AuthorizedDesktopTargetPlan(mutationAuthority: authority)
     }
 
     @MainActor
-    func sharedMutationAuthority(
-        for identity: DesktopTargetIdentity) async throws -> DesktopTargetPlanning.MutationAuthorityPlan
+    func receiptBoundMutationAuthority(
+        for identity: DesktopTargetIdentity) async throws
+        -> DesktopTargetPlanning.ReceiptBoundMutationAuthorityPlan
     {
         let planner = DesktopTargetPlanning.MutationAuthorityPlanner(
             applications: self.applications,
             windows: self.windows)
-        let authority = try await planner.plan(
-            selector: InteractionTargetSelector(
-                processIdentifier: Int(identity.processIdentity.processIdentifier),
-                windowID: identity.exactWindow?.identity.windowID),
-            expectedProcessIdentity: identity.processIdentity)
-        _ = try identity.coalescing(authority.targetIdentity)
-        return authority
+        return try await planner.bind(identity: identity)
     }
 
     struct BackgroundApplicationTargetSchema {
@@ -171,10 +160,11 @@ extension MCPToolContext {
         pinned["window_id"] = windowPlan.identity.windowID
         pinned.removeValue(forKey: selector.keys.title)
         pinned.removeValue(forKey: selector.keys.index)
-        return try BackgroundTargetAuthorization(
+        let boundAuthority = try planner.bind(authority: authority)
+        return BackgroundTargetAuthorization(
             arguments: ToolArguments(raw: pinned),
             rejection: nil,
-            targetPlan: AuthorizedDesktopTargetPlan(mutationAuthority: authority))
+            targetPlan: AuthorizedDesktopTargetPlan(mutationAuthority: boundAuthority))
     }
 
     private static func backgroundExactWindowSelector(
@@ -305,20 +295,20 @@ extension MCPToolContext {
 
     @MainActor
     func resolveApplicationAuthorities(
-        _ identifiers: [String]) async throws -> [DesktopTargetPlanning.MutationAuthorityPlan]
+        _ identifiers: [String]) async throws -> [DesktopTargetPlanning.ReceiptBoundMutationAuthorityPlan]
     {
         let planner = DesktopTargetPlanning.MutationAuthorityPlanner(
             applications: self.applications,
             windows: self.windows)
         do {
-            var resolved: [DesktopTargetPlanning.MutationAuthorityPlan] = []
+            var resolved: [DesktopTargetPlanning.ReceiptBoundMutationAuthorityPlan] = []
             var expectedIdentity: ApplicationProcessIdentity?
             for identifier in identifiers {
                 let authority = try await planner.plan(
                     selector: InteractionTargetSelector(applicationIdentifier: identifier),
                     expectedProcessIdentity: expectedIdentity)
                 expectedIdentity = authority.application.processIdentity
-                resolved.append(authority)
+                try resolved.append(planner.bind(authority: authority))
             }
             return resolved
         } catch is CancellationError {

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/MCPToolContext.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/MCPToolContext.swift
@@ -668,7 +668,7 @@ public struct MCPToolContext: @unchecked Sendable {
                     "the mutation has no explicit application or exact-window owner")
             }
             let authorities = try await self.resolveApplicationAuthorities(identifiers)
-            let applications = authorities.map(\.application.application)
+            let applications = authorities.map(\.authority.application.application)
             let processIdentity = try Self.validatedProcessIdentity(
                 applications: applications,
                 windowProcessIdentities: windowProcessIdentities)
@@ -690,10 +690,10 @@ public struct MCPToolContext: @unchecked Sendable {
             }
             let targetPlan: AuthorizedDesktopTargetPlan
             if windowTargetIdentities.isEmpty, let authority = authorities.first {
-                targetPlan = try AuthorizedDesktopTargetPlan(mutationAuthority: authority)
+                targetPlan = AuthorizedDesktopTargetPlan(mutationAuthority: authority)
             } else {
-                let authority = try await self.sharedMutationAuthority(for: authorizedTarget)
-                targetPlan = try AuthorizedDesktopTargetPlan(mutationAuthority: authority)
+                let authority = try await self.receiptBoundMutationAuthority(for: authorizedTarget)
+                targetPlan = AuthorizedDesktopTargetPlan(mutationAuthority: authority)
             }
             return BackgroundTargetAuthorization(
                 arguments: Self.argumentsPinnedToProcess(

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/AuthorizedDesktopTargetPlanTestSupport.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/AuthorizedDesktopTargetPlanTestSupport.swift
@@ -1,0 +1,34 @@
+import PeekabooAutomationKit
+import PeekabooAutomationKitTestSupport
+import PeekabooFoundation
+@testable import PeekabooAgentRuntime
+
+@MainActor
+func makeAuthorizedDesktopTargetPlan(
+    targetIdentity: DesktopTargetIdentity,
+    applicationName: String = "Fixture") async throws -> AuthorizedDesktopTargetPlan
+{
+    let processIdentity = targetIdentity.processIdentity
+    let selectedWindow = targetIdentity.exactWindow.map { exactWindow in
+        ServiceWindowInfo(
+            windowID: exactWindow.identity.windowID,
+            title: "Authorized Window",
+            bounds: exactWindow.bounds,
+            mutationIdentity: exactWindow.identity)
+    }
+    let application = AutomationTestFixtures.application(
+        processIdentifier: processIdentity.processIdentifier,
+        processStartIdentity: processIdentity.processStartIdentity,
+        bundleIdentifier: "com.example.Authorized",
+        name: applicationName,
+        windowCount: selectedWindow == nil ? 0 : 1,
+        windowIDs: selectedWindow.map { [$0.windowID] })
+    let windowInventories: [DesktopTargetPlanning.Inventory<ServiceWindowInfo>] = selectedWindow.map {
+        [.complete([$0])]
+    } ?? []
+    let planner = MutationAuthorityCatalogScript(
+        applications: [application],
+        windowInventories: windowInventories).planner()
+    return try await AuthorizedDesktopTargetPlan(
+        mutationAuthority: planner.bind(identity: targetIdentity))
+}

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPMenuDockOutcomeTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPMenuDockOutcomeTests.swift
@@ -83,7 +83,7 @@ struct MCPMenuDockOutcomeTests {
             menu: menu,
             applications: applications,
             executionPolicy: .backgroundOnly)
-        let authority = try AuthorizedDesktopTargetPlan(
+        let authority = try await makeAuthorizedDesktopTargetPlan(
             targetIdentity: DesktopTargetIdentity(processIdentity: authorizedIdentity))
 
         let response = try await AuthorizedDesktopTargetPlan.$current.withValue(authority) {
@@ -113,7 +113,7 @@ struct MCPMenuDockOutcomeTests {
             windows: windows,
             applications: applications,
             executionPolicy: .backgroundOnly)
-        let authority = try AuthorizedDesktopTargetPlan(
+        let authority = try await makeAuthorizedDesktopTargetPlan(
             targetIdentity: DesktopTargetIdentity(processIdentity: ApplicationProcessIdentity(
                 processIdentifier: 43,
                 processStartIdentity: 8)))
@@ -148,15 +148,10 @@ struct MCPMenuDockOutcomeTests {
             windows: windows,
             executionPolicy: .backgroundOnly)
         let bounds = try #require(windows.identity.capturedBounds)
-        let authority = try AuthorizedDesktopTargetPlan(
+        let authority = try await makeAuthorizedDesktopTargetPlan(
             targetIdentity: DesktopTargetIdentity(exactWindow: UIAutomationTarget.ExactWindow(
                 identity: windows.identity,
-                bounds: bounds)),
-            selectedWindow: ServiceWindowInfo(
-                windowID: windows.identity.windowID,
-                title: "Fixture",
-                bounds: bounds,
-                mutationIdentity: windows.identity))
+                bounds: bounds)))
 
         let response = try await AuthorizedDesktopTargetPlan.$current.withValue(authority) {
             try await MenuTool(context: context).execute(arguments: ToolArguments(raw: [

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/WindowToolExactRoutingTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/WindowToolExactRoutingTests.swift
@@ -327,6 +327,49 @@ struct WindowToolExactRoutingTests {
         #expect(meta["retry_safe"] == .bool(true))
     }
 
+    @Test(arguments: [924, 925])
+    @MainActor
+    func `background focus rejects post-authorization same-process window or bounds replacement`(
+        replacementWindowID: Int) async throws
+    {
+        let replacementBounds = if replacementWindowID == 924 {
+            CGRect(x: 140, y: 120, width: 800, height: 600)
+        } else {
+            CGRect(x: 100, y: 100, width: 800, height: 600)
+        }
+        let service = ExactRoutingWindowService()
+        service.replacementWindowStartingAtListCall = (
+            2,
+            ServiceWindowInfo(
+                windowID: replacementWindowID,
+                title: "Replacement",
+                bounds: replacementBounds,
+                mutationIdentity: .init(
+                    windowID: replacementWindowID,
+                    ownerProcessIdentifier: 42,
+                    ownerProcessStartIdentity: 7,
+                    capturedBounds: replacementBounds)))
+        let context = await MCPToolTestHelpers.makeContext(
+            applications: Self.fixtureApplications(),
+            windows: service,
+            executionPolicy: .backgroundOnly)
+
+        let response = try await context.execute(
+            tool: WindowTool(context: context),
+            arguments: ToolArguments(raw: [
+                "action": "focus",
+                "app": "PID:42",
+                "window_id": 924,
+            ]))
+
+        #expect(response.isError)
+        #expect(service.focusTargets.isEmpty)
+        #expect(service.receivedIdentities.isEmpty)
+        let meta = try #require(response.meta?.objectValue)
+        #expect(meta["mutation_dispatched"] == .bool(false))
+        #expect(meta["retry_safe"] == .bool(true))
+    }
+
     @Test
     @MainActor
     func `close pins a broad selector to the listed exact window`() async throws {
@@ -447,9 +490,8 @@ struct WindowToolExactRoutingTests {
         let context = await MCPToolTestHelpers.makeContext(
             windows: service,
             executionPolicy: .backgroundOnly)
-        let plan = try AuthorizedDesktopTargetPlan(
-            targetIdentity: Self.authorizedFocusTarget(),
-            selectedWindow: Self.authorizedFocusWindow())
+        let plan = try await makeAuthorizedDesktopTargetPlan(
+            targetIdentity: Self.authorizedFocusTarget())
 
         let response = try await AuthorizedDesktopTargetPlan.$current.withValue(plan) {
             try await WindowTool(context: context).execute(arguments: ToolArguments(raw: [
@@ -465,58 +507,6 @@ struct WindowToolExactRoutingTests {
             CGRect(x: 100, y: 100, width: 800, height: 600),
         ])
         #expect(service.listTargets.isEmpty)
-    }
-
-    @Test(arguments: [924, 925])
-    @MainActor
-    func `focus rejects post-authorization same-process window or bounds replacement before dispatch`(
-        replacementWindowID: Int) async throws
-    {
-        let replacementBounds = if replacementWindowID == 924 {
-            CGRect(x: 140, y: 120, width: 800, height: 600)
-        } else {
-            CGRect(x: 100, y: 100, width: 800, height: 600)
-        }
-        let service = ExactRoutingWindowService()
-        service.replacementWindowStartingAtListCall = (
-            1,
-            ServiceWindowInfo(
-                windowID: replacementWindowID,
-                title: "Replacement",
-                bounds: replacementBounds,
-                mutationIdentity: .init(
-                    windowID: replacementWindowID,
-                    ownerProcessIdentifier: 42,
-                    ownerProcessStartIdentity: 7,
-                    capturedBounds: replacementBounds)))
-        let context = await MCPToolTestHelpers.makeContext(
-            windows: service,
-            executionPolicy: .backgroundOnly)
-        let plan = try AuthorizedDesktopTargetPlan(
-            targetIdentity: Self.authorizedFocusTarget(),
-            selectedWindow: ServiceWindowInfo(
-                windowID: replacementWindowID,
-                title: "Replacement",
-                bounds: replacementBounds,
-                mutationIdentity: .init(
-                    windowID: replacementWindowID,
-                    ownerProcessIdentifier: 42,
-                    ownerProcessStartIdentity: 7,
-                    capturedBounds: replacementBounds)))
-
-        let response = try await AuthorizedDesktopTargetPlan.$current.withValue(plan) {
-            try await WindowTool(context: context).execute(arguments: ToolArguments(raw: [
-                "action": "focus",
-                "app": "Safari",
-            ]))
-        }
-
-        #expect(response.isError)
-        #expect(service.focusTargets.isEmpty)
-        #expect(service.receivedIdentities.isEmpty)
-        let meta = try #require(response.meta?.objectValue)
-        #expect(meta["mutation_dispatched"] == .bool(false))
-        #expect(meta["retry_safe"] == .bool(true))
     }
 
     @Test(arguments: [


### PR DESCRIPTION
## Summary

- add a shared AutomationKit plan that binds immutable snapshot/observation identity to live mutation authority
- preserve the original source receipt and canonical exact target across final revalidation
- migrate background keyboard and MCP target authorization to the shared fail-closed plan
- consolidate coherent snapshot fixtures while keeping malformed evidence explicit

Exact-window receipts can no longer be paired with application-only authority, and malformed receipts are rejected before live catalog data can repair missing evidence. Revalidation retains process generation, window ID, immutable bounds, and prior target specificity.

## Tests

- AutomationKit receipt/planner/fixture suites: 47 passed
- MCP snapshot/menu/policy/window suites: 107 passed
- CLI Space and keyboard suites: 31 passed
- `pnpm run test:safe`
- `pnpm run format`
- `pnpm run lint` (0 serious violations)
- `git diff --check`
- structured Autoreview through P2: clean

## Scope

The separate coordinate-click capture lifecycle and cryptographic final-cycle redesign are intentionally unchanged.
