### PR TITLE
chore(release): close out 4.2.2

### DIFF
--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to Peekaboo CLI will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.2.3] - Unreleased
+
 ## [4.2.2] - 2026-08-20
 
 ### Highlights

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Changelog
 
-## [Unreleased]
+## [4.2.3] - Unreleased
 
 ### Fixed
 - Fail closed instead of generating or accepting a release-qualification manifest until final-cycle liveness witnesses have a cryptographic trust anchor.
+
 ## [4.2.2] - 2026-08-20
 
 ### Highlights

--- a/appcast.xml
+++ b/appcast.xml
@@ -6,6 +6,20 @@
         <description>Peekaboo macOS app updates (Sparkle)</description>
         <language>en</language>
         <item>
+            <title>Peekaboo 4.2.2</title>
+            <link>https://github.com/openclaw/Peekaboo/releases/tag/v4.2.2</link>
+            <sparkle:releaseNotesLink>https://github.com/openclaw/Peekaboo/releases/tag/v4.2.2</sparkle:releaseNotesLink>
+            <pubDate>Thu, 20 Aug 2026 10:42:13 +0000</pubDate>
+            <enclosure
+              url="https://github.com/openclaw/Peekaboo/releases/download/v4.2.2/Peekaboo-4.2.2.app.zip"
+              sparkle:version="4020299"
+              sparkle:shortVersionString="4.2.2"
+              sparkle:minimumSystemVersion="15.0"
+              length="21178455"
+              type="application/octet-stream"
+              sparkle:edSignature="qdt6GrVhB+O9vEogQGSuLyWbI2EjIeYohCIRUeo679d2BIjBbiG8v3Wzl5eko3flqlOtNj7xSwCHpV2KFglNBg==" />
+        </item>
+        <item>
             <title>Peekaboo 4.2.0</title>
             <link>https://github.com/openclaw/Peekaboo/releases/tag/v4.2.0</link>
             <sparkle:releaseNotesLink>https://github.com/openclaw/Peekaboo/releases/tag/v4.2.0</sparkle:releaseNotesLink>

--- a/homebrew/peekaboo.rb
+++ b/homebrew/peekaboo.rb
@@ -1,10 +1,10 @@
 class Peekaboo < Formula
   desc "Lightning-fast macOS screenshots & AI vision analysis"
   homepage "https://github.com/openclaw/Peekaboo"
-  url "https://github.com/openclaw/Peekaboo/releases/download/v3.2.0/peekaboo-macos-universal.tar.gz"
-  sha256 "255ded65abdedfc61d0c2e9decfa0eb206c26ca916d1519f16d8f83dcc1af444"
+  url "https://github.com/openclaw/Peekaboo/releases/download/v4.2.2/peekaboo-macos-universal.tar.gz"
+  sha256 "80b1983a9a2468e715e176167b75aabb4f43feb4882d667ffccc9373d706602e"
   license "MIT"
-  version "3.2.0"
+  version "4.2.2"
 
   # macOS Sequoia (15.0) or later required
   depends_on macos: :sequoia


### PR DESCRIPTION
## Summary

- Publish the verified Sparkle 4.2.2 item and refresh the checked-in Homebrew formula to the live v4.2.2 archive and SHA.
- Open 4.2.3 Unreleased in both changelogs without losing post-release main changes, including the existing Fixed entry from #547.
- Confirm the v4.2.2 tag and release target are corrected to exact artifact source `05675b0b5e2c382146963e19493787d9dac0d45b`.

## Tests and proof

- Sparkle appcast signature, length, codesign, Gatekeeper, and stapler verification passed against the published asset.
- Homebrew update workflow [32362145264](https://github.com/openclaw/Peekaboo/actions/runs/32362145264) and macOS 26 artifact smoke [32362206152](https://github.com/openclaw/Peekaboo/actions/runs/32362206152) passed.
- Docs lint, release-preflight contract tests, formula syntax, XML validation, deterministic release dry-run, `git diff --check`, and autoreview passed.
