### PR TITLE
feat(bridge): attest process-generation observations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 - Fail closed instead of generating or accepting a release-qualification manifest until final-cycle liveness witnesses have a cryptographic trust anchor.
+- Add receipt-required Bridge protocol 1.32 observation of exact process generations for signed liveness and absence evidence.
 
 ## [4.2.2] - 2026-08-20
 

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeClient+ProcessGenerationObservation.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeClient+ProcessGenerationObservation.swift
@@ -1,0 +1,88 @@
+import Foundation
+
+public struct PeekabooBridgeProcessGenerationObservationDelivery: Sendable {
+    public let response: PeekabooBridgeProcessGenerationObservationResponse
+    public let receiptBundle: PeekabooBridgeOperationReceiptBundle
+}
+
+extension PeekabooBridgeClient {
+    public func observeProcessGeneration(
+        _ request: PeekabooBridgeProcessGenerationObservationRequest) async throws
+        -> PeekabooBridgeProcessGenerationObservationResponse
+    {
+        try await self.observeProcessGenerationWithReceipt(request).response
+    }
+
+    public func observeProcessGenerationWithReceipt(
+        _ request: PeekabooBridgeProcessGenerationObservationRequest) async throws
+        -> PeekabooBridgeProcessGenerationObservationDelivery
+    {
+        try self.requireProcessGenerationObservation()
+        try request.validate()
+        let reply = try await self.sendCarryingActionOutcome(
+            .observeProcessGeneration(request),
+            operationReceiptRequirement: .required)
+        let response = try Self.validatedProcessGenerationObservationResponse(
+            reply.response,
+            request: request)
+        guard let receiptBundle = reply.operationReceiptBundle else {
+            throw PeekabooBridgeOperationReceiptError.receiptMismatch("the required terminal bundle")
+        }
+        return .init(response: response, receiptBundle: receiptBundle)
+    }
+
+    /// Returns the exact signed bundle even when observation failed without producing a disposition.
+    public func observeProcessGenerationReceiptBundle(
+        _ request: PeekabooBridgeProcessGenerationObservationRequest) async throws
+        -> PeekabooBridgeOperationReceiptBundle
+    {
+        try self.requireProcessGenerationObservation()
+        try request.validate()
+        let reply = try await self.sendCarryingActionOutcome(
+            .observeProcessGeneration(request),
+            operationReceiptRequirement: .required,
+            throwsActionFailures: false)
+        switch reply.response {
+        case let .processGenerationObservation(response):
+            try response.validate(request: request)
+        case .error:
+            break
+        default:
+            throw PeekabooBridgeErrorEnvelope(
+                code: .invalidRequest,
+                message: "Unexpected process-generation observation response")
+        }
+        guard let receiptBundle = reply.operationReceiptBundle else {
+            throw PeekabooBridgeOperationReceiptError.receiptMismatch("the required terminal bundle")
+        }
+        try receiptBundle.validateIntegrity()
+        return receiptBundle
+    }
+
+    private func requireProcessGenerationObservation() throws {
+        guard self.processGenerationObservationEnabled else {
+            throw PeekabooBridgeErrorEnvelope(
+                code: .operationNotSupported,
+                message: "Bridge protocol 1.32 signed process-generation observation is unavailable",
+                details: "The host must advertise and enable observeProcessGeneration before use.")
+        }
+    }
+
+    private nonisolated static func validatedProcessGenerationObservationResponse(
+        _ response: PeekabooBridgeResponse,
+        request: PeekabooBridgeProcessGenerationObservationRequest) throws
+        -> PeekabooBridgeProcessGenerationObservationResponse
+    {
+        switch response {
+        case let .processGenerationObservation(result):
+            try result.validate(request: request)
+            return result
+        case let .error(envelope):
+            throw envelope
+        default:
+            throw PeekabooBridgeErrorEnvelope(
+                code: .invalidRequest,
+                message: "Unexpected process-generation observation response")
+        }
+    }
+}

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeClient+Transport.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeClient+Transport.swift
@@ -190,6 +190,14 @@ extension PeekabooBridgeClient {
     }
 
     private func requireNegotiatedInputCapabilities(for request: PeekabooBridgeRequest) throws {
+        if request.unwrappedOperationRequest.operation == .observeProcessGeneration,
+           !self.processGenerationObservationEnabled
+        {
+            throw PeekabooBridgeErrorEnvelope(
+                code: .operationNotSupported,
+                message: "Bridge protocol 1.32 signed process-generation observation is unavailable",
+                details: "The host must advertise and enable observeProcessGeneration before use.")
+        }
         if request.unwrappedOperationRequest.operation == .agentExecutionTrace,
            !self.agentExecutionTraceEnabled
         {

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeClient.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeClient.swift
@@ -55,6 +55,7 @@ public actor PeekabooBridgeClient {
     var statelessClickVariantPayloadsEnabled = false
     var statelessClickVariantsEnabled = false
     var agentExecutionTraceEnabled = false
+    var processGenerationObservationEnabled = false
     var operationAttestation: PeekabooBridgeListenerAttestation?
     var latestVerifiedOperationReceipt: PeekabooBridgeOperationReceipt?
     var latestVerifiedOperationReceiptBundle: PeekabooBridgeOperationReceiptBundle?
@@ -442,6 +443,7 @@ public actor PeekabooBridgeClient {
         self.statelessClickVariantPayloadsEnabled = false
         self.statelessClickVariantsEnabled = false
         self.agentExecutionTraceEnabled = false
+        self.processGenerationObservationEnabled = false
     }
 
     /// Creates or joins one successor-session handshake using the most recent successful public inputs.
@@ -872,6 +874,7 @@ public actor PeekabooBridgeClient {
             handshake.negotiatedVersion >= PeekabooBridgeConstants.statelessClickVariantVersion,
             statelessClickVariantsEnabled: Self.supportsStatelessClickVariants(handshake),
             agentExecutionTraceEnabled: Self.supportsAgentExecutionTrace(handshake),
+            processGenerationObservationEnabled: Self.supportsProcessGenerationObservation(handshake),
             listenerAttestation: listenerAttestation,
             listenerLiveIdentity: listenerLiveIdentity,
             sessionAttestation: sessionAttestation,
@@ -891,6 +894,14 @@ public actor PeekabooBridgeClient {
             handshake.hostCapabilities?.contains(PeekabooBridgeHostCapability.agentExecutionTrace) == true &&
             handshake.supportedOperations.contains(.agentExecutionTrace) &&
             (handshake.enabledOperations?.contains(.agentExecutionTrace) ?? true)
+    }
+
+    private static func supportsProcessGenerationObservation(_ handshake: PeekabooBridgeHandshakeResponse) -> Bool {
+        handshake.negotiatedVersion >= PeekabooBridgeConstants.processGenerationObservationVersion &&
+            handshake.hostCapabilities?.contains(
+                PeekabooBridgeHostCapability.processGenerationObservation) == true &&
+            handshake.supportedOperations.contains(.observeProcessGeneration) &&
+            (handshake.enabledOperations?.contains(.observeProcessGeneration) ?? true)
     }
 
     private func installHandshakeCandidate(
@@ -936,6 +947,7 @@ public actor PeekabooBridgeClient {
         self.statelessClickVariantPayloadsEnabled = candidate.statelessClickVariantPayloadsEnabled
         self.statelessClickVariantsEnabled = candidate.statelessClickVariantsEnabled
         self.agentExecutionTraceEnabled = candidate.agentExecutionTraceEnabled
+        self.processGenerationObservationEnabled = candidate.processGenerationObservationEnabled
         self.operationAttestation = candidate.listenerAttestation
         self.installReceiptlessAuthenticatedHost(candidate.receiptlessAuthenticatedHost)
         if let listenerAttestation = candidate.listenerAttestation,
@@ -1221,6 +1233,7 @@ private struct PeekabooBridgeClientHandshakeCandidate: Sendable {
     let statelessClickVariantPayloadsEnabled: Bool
     let statelessClickVariantsEnabled: Bool
     let agentExecutionTraceEnabled: Bool
+    let processGenerationObservationEnabled: Bool
     let listenerAttestation: PeekabooBridgeListenerAttestation?
     let listenerLiveIdentity: PeekabooBridgeLivePeerIdentity?
     let sessionAttestation: PeekabooBridgeOperationSessionAttestation?

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeConstants.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeConstants.swift
@@ -65,7 +65,11 @@ public enum PeekabooBridgeConstants {
     }
 
     /// Current protocol version supported by this build.
-    public static let protocolVersion = PeekabooBridgeProtocolVersion(major: 1, minor: 31)
+    public static let protocolVersion = PeekabooBridgeProtocolVersion(major: 1, minor: 32)
+
+    /// First protocol with a receipt-required, host-derived exact process-generation observation.
+    public static let processGenerationObservationVersion =
+        PeekabooBridgeProtocolVersion(major: 1, minor: 32)
 
     /// First protocol whose Bridge can launch the exact authenticated CLI peer as a suspended
     /// background Agent and return one listener-signed terminal execution trace.

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeModels.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeModels.swift
@@ -41,6 +41,7 @@ public enum PeekabooBridgeOperation: String, Codable, Sendable, CaseIterable, Ha
     case daemonStatus
     case daemonStop
     case agentExecutionTrace
+    case observeProcessGeneration
     // Browser MCP
     case browserStatus
     case browserConnect
@@ -258,6 +259,9 @@ public enum PeekabooBridgeOperation: String, Codable, Sendable, CaseIterable, Ha
         if version < PeekabooBridgeConstants.agentExecutionTraceVersion {
             compatible.remove(.agentExecutionTrace)
         }
+        if version < PeekabooBridgeConstants.processGenerationObservationVersion {
+            compatible.remove(.observeProcessGeneration)
+        }
         return compatible
     }
     // swiftlint:enable cyclomatic_complexity
@@ -366,6 +370,7 @@ public enum PeekabooBridgeHostCapability {
     public static let exactWindowHeldPointerLifecycle = "exactWindowHeldPointerLifecycle"
     public static let statelessClickVariants = "statelessClickVariants"
     public static let agentExecutionTrace = "agentExecutionTrace"
+    public static let processGenerationObservation = "processGenerationObservation"
 }
 
 public struct PeekabooBridgeHandshakeResponse: Codable, Sendable {

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeOperation+Policy.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeOperation+Policy.swift
@@ -1,6 +1,10 @@
 import Foundation
 
 extension PeekabooBridgeOperation {
+    var mutatesDesktop: Bool {
+        PeekabooBridgeOperationResultSemantics.contract(for: self).completion.mutatesDesktop
+    }
+
     /// Whether Peekaboo's concrete native service retains desktop-lane ownership through its dispatch leaf.
     ///
     /// Bridge routing consults this policy together with the service provider's ownership claim. Keeping the
@@ -47,6 +51,7 @@ extension PeekabooBridgeOperation {
             [.accessibility]
         case ._appleScriptProbe,
              .agentExecutionTrace,
+             .observeProcessGeneration,
              .createExactWindowHeldPointerOwner,
              .releaseExactWindowHeldPointer,
              .revokeExactWindowHeldPointer,
@@ -97,6 +102,7 @@ extension PeekabooBridgeOperation {
         .daemonStatus,
         .daemonStop,
         .agentExecutionTrace,
+        .observeProcessGeneration,
         .browserStatus,
         .browserConnect,
         .browserDisconnect,

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeOperationReceiptModels.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeOperationReceiptModels.swift
@@ -1127,6 +1127,7 @@ enum PeekabooBridgeOperationReceiptSemantics {
         case (.familyOnly, _, _),
              (.noSuccessResponse, _, _),
              (.agentExecutionTrace, _, _),
+             (.processGenerationObservation, .observeProcessGeneration, .processGenerationObservation),
              (.typeActions, _, _),
              (.setValue, _, _),
              (.performAction, _, _),

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeOperationResultSemantics.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeOperationResultSemantics.swift
@@ -83,6 +83,7 @@ enum PeekabooBridgeOperationResultSemantics {
         case menuStructure
         case ok
         case permissionsStatus
+        case processGenerationObservation
         case preparedDialogAction
         case rect
         case snapshotID
@@ -125,6 +126,7 @@ enum PeekabooBridgeOperationResultSemantics {
                  (.menuStructure, .menuStructure),
                  (.ok, .ok),
                  (.permissionsStatus, .permissionsStatus),
+                 (.processGenerationObservation, .processGenerationObservation),
                  (.preparedDialogAction, .preparedDialogAction),
                  (.rect, .rect),
                  (.snapshotID, .snapshotId),
@@ -253,6 +255,7 @@ enum PeekabooBridgeOperationResultSemantics {
     enum TypedResponseRule: Equatable, Sendable {
         case none
         case agentExecutionTrace(PeekabooBridgeAgentExecutionTraceRequest)
+        case processGenerationObservation(PeekabooBridgeProcessGenerationObservationRequest)
         case typeActions(TypeActionResultRule)
         case setValue(target: String, value: String)
         case performAction(target: String, actionName: String)
@@ -266,6 +269,12 @@ enum PeekabooBridgeOperationResultSemantics {
             switch binding {
             case .agentExecutionTrace:
                 if case .agentExecutionTrace = self {
+                    true
+                } else {
+                    false
+                }
+            case .processGenerationObservation:
+                if case .processGenerationObservation = self {
                     true
                 } else {
                     false
@@ -344,6 +353,7 @@ enum PeekabooBridgeOperationResultSemantics {
         /// The response family is the complete typed contract; no request field is echoed by the result.
         case familyOnly
         case agentExecutionTrace
+        case processGenerationObservation
         /// This operation intentionally has no successful response family.
         case noSuccessResponse
         case typeActions
@@ -426,6 +436,10 @@ enum PeekabooBridgeOperationResultSemantics {
                 return
             case let (.agentExecutionTrace(request), .agentExecutionTrace(result)):
                 try result.validate(request: request)
+            case (.processGenerationObservation, .error):
+                return
+            case let (.processGenerationObservation(request), .processGenerationObservation(result)):
+                try result.validate(request: request)
             case (.setValue, .error):
                 // A canonical failure has no success payload to bind. Its outcome, target receipt,
                 // and dispatch count are validated by the failure and receipt contracts instead.
@@ -467,7 +481,8 @@ enum PeekabooBridgeOperationResultSemantics {
                     throw PeekabooBridgeOperationReceiptError.receiptMismatch(
                         "perform-action response request semantics")
                 }
-            case (.agentExecutionTrace, _), (.typeActions, _), (.setValue, _), (.performAction, _):
+            case (.agentExecutionTrace, _), (.processGenerationObservation, _),
+                 (.typeActions, _), (.setValue, _), (.performAction, _):
                 throw PeekabooBridgeOperationReceiptError.receiptMismatch("bound typed response family")
             }
         }
@@ -597,6 +612,7 @@ extension PeekabooBridgeOperationResultSemantics {
             .service
         case .permissionsStatus,
              .agentExecutionTrace,
+             .observeProcessGeneration,
              .createExactWindowHeldPointerOwner,
              .requestPostEventPermission,
              .daemonStatus,
@@ -677,6 +693,7 @@ extension PeekabooBridgeOperationResultSemantics {
             .globalExclusive
         case .permissionsStatus,
              .agentExecutionTrace,
+             .observeProcessGeneration,
              .requestPostEventPermission,
              .daemonStatus,
              .daemonStop,
@@ -776,6 +793,7 @@ extension PeekabooBridgeOperationResultSemantics {
             .required
         case .permissionsStatus,
              .agentExecutionTrace,
+             .observeProcessGeneration,
              .requestPostEventPermission,
              .daemonStatus,
              .daemonStop,
@@ -883,6 +901,8 @@ extension PeekabooBridgeOperationResultSemantics {
         switch operation {
         case .agentExecutionTrace:
             .agentExecutionTrace
+        case .observeProcessGeneration:
+            .processGenerationObservation
         case .typeActions, .targetedTypeActions, .exactWindowTargetedTypeActions:
             .typeActions
         case .setValue:
@@ -1137,6 +1157,7 @@ extension PeekabooBridgeOperationResultSemantics {
             .init(completion: .requestDependent(mutatesDesktop: false), targetPolicy: .requestDependent)
         case .permissionsStatus,
              .createExactWindowHeldPointerOwner,
+             .observeProcessGeneration,
              .daemonStatus,
              .daemonStop,
              .browserStatus,
@@ -1541,6 +1562,8 @@ extension PeekabooBridgeOperationResultSemantics {
         switch request {
         case let .agentExecutionTrace(payload):
             .agentExecutionTrace(payload)
+        case let .observeProcessGeneration(payload):
+            .processGenerationObservation(payload)
         case let .typeActions(payload):
             .typeActions(.init(actions: payload.actions))
         case let .targetedTypeActions(payload):
@@ -1742,7 +1765,7 @@ extension PeekabooBridgeOperationResultSemantics {
             return [.dispatchedUnverified]
         case .browserConnect:
             return [.confirmedNoChange, .dispatchedUnverified]
-        case .permissionsStatus, .createExactWindowHeldPointerOwner,
+        case .permissionsStatus, .observeProcessGeneration, .createExactWindowHeldPointerOwner,
              .daemonStatus, .daemonStop, .browserStatus,
              .browserDisconnect,
              .getFocusedElement, .waitForElement, .listWindows, .getFocusedWindow,
@@ -1791,6 +1814,7 @@ extension PeekabooBridgeOperationResultSemantics {
         switch operation {
         case .permissionsStatus: [.permissionsStatus]
         case .agentExecutionTrace: [.agentExecutionTrace]
+        case .observeProcessGeneration: [.processGenerationObservation]
         case .requestPostEventPermission: [.bool]
         case .daemonStatus: [.daemonStatus]
         case .daemonStop: [.bool]
@@ -2612,11 +2636,5 @@ extension PeekabooBridgeOperationResultSemantics {
         case .operationUnsupported:
             "Use a host that supports this operation."
         }
-    }
-}
-
-extension PeekabooBridgeOperation {
-    var mutatesDesktop: Bool {
-        PeekabooBridgeOperationResultSemantics.contract(for: self).completion.mutatesDesktop
     }
 }

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeProcessGenerationObservationModels.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeProcessGenerationObservationModels.swift
@@ -1,0 +1,228 @@
+import Foundation
+
+public struct PeekabooBridgeProcessGenerationIdentity: Codable, Equatable, Sendable {
+    public let processIdentifier: Int32
+    public let processStartIdentity: UInt64
+
+    public init(processIdentifier: Int32, processStartIdentity: UInt64) {
+        self.processIdentifier = processIdentifier
+        self.processStartIdentity = processStartIdentity
+    }
+
+    private enum CodingKeys: String, CodingKey, CaseIterable {
+        case processIdentifier
+        case processStartIdentity
+    }
+
+    public init(from decoder: any Decoder) throws {
+        try PeekabooBridgeClosedPayload.requireExactKeys(CodingKeys.self, from: decoder)
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.processIdentifier = try container.decode(Int32.self, forKey: .processIdentifier)
+        let decimal = try container.decode(String.self, forKey: .processStartIdentity)
+        guard let processStartIdentity = PeekabooBridgeOperationReceiptCoding.uint64(decimal: decimal) else {
+            throw DecodingError.dataCorruptedError(
+                forKey: .processStartIdentity,
+                in: container,
+                debugDescription: "Process start identity must be a canonical positive decimal string")
+        }
+        self.processStartIdentity = processStartIdentity
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(self.processIdentifier, forKey: .processIdentifier)
+        try container.encode(String(self.processStartIdentity), forKey: .processStartIdentity)
+    }
+
+    func validate() throws {
+        guard self.processIdentifier > 0, self.processStartIdentity > 0 else {
+            throw PeekabooBridgeErrorEnvelope(
+                code: .invalidRequest,
+                message: "Process-generation observation requires a positive PID and start identity")
+        }
+    }
+}
+
+public struct PeekabooBridgeProcessGenerationObservationRequest: Codable, Equatable, Sendable {
+    public let schemaVersion: Int
+    public let expected: PeekabooBridgeProcessGenerationIdentity
+
+    public init(
+        schemaVersion: Int = 1,
+        expected: PeekabooBridgeProcessGenerationIdentity)
+    {
+        self.schemaVersion = schemaVersion
+        self.expected = expected
+    }
+
+    private enum CodingKeys: String, CodingKey, CaseIterable {
+        case schemaVersion
+        case expected
+    }
+
+    public init(from decoder: any Decoder) throws {
+        try PeekabooBridgeClosedPayload.requireExactKeys(CodingKeys.self, from: decoder)
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.schemaVersion = try container.decode(Int.self, forKey: .schemaVersion)
+        self.expected = try container.decode(PeekabooBridgeProcessGenerationIdentity.self, forKey: .expected)
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(self.schemaVersion, forKey: .schemaVersion)
+        try container.encode(self.expected, forKey: .expected)
+    }
+
+    func validate() throws {
+        guard self.schemaVersion == 1 else {
+            throw PeekabooBridgeErrorEnvelope(
+                code: .invalidRequest,
+                message: "Unsupported process-generation observation schema")
+        }
+        try self.expected.validate()
+    }
+}
+
+public enum PeekabooBridgeProcessGenerationDisposition: String, Codable, Equatable, Sendable {
+    case sameGenerationAlive
+    case exactGenerationAbsent
+    case pidReused
+}
+
+public struct PeekabooBridgeProcessGenerationObservationResponse: Codable, Equatable, Sendable {
+    public let schemaVersion: Int
+    public let expected: PeekabooBridgeProcessGenerationIdentity
+    public let disposition: PeekabooBridgeProcessGenerationDisposition
+    public let observed: PeekabooBridgeProcessGenerationIdentity?
+    public let observationStartedAtUnixMilliseconds: Int64
+    public let observationCompletedAtUnixMilliseconds: Int64
+
+    public init(
+        schemaVersion: Int = 1,
+        expected: PeekabooBridgeProcessGenerationIdentity,
+        disposition: PeekabooBridgeProcessGenerationDisposition,
+        observed: PeekabooBridgeProcessGenerationIdentity?,
+        observationStartedAtUnixMilliseconds: Int64,
+        observationCompletedAtUnixMilliseconds: Int64)
+    {
+        self.schemaVersion = schemaVersion
+        self.expected = expected
+        self.disposition = disposition
+        self.observed = observed
+        self.observationStartedAtUnixMilliseconds = observationStartedAtUnixMilliseconds
+        self.observationCompletedAtUnixMilliseconds = observationCompletedAtUnixMilliseconds
+    }
+
+    private enum CodingKeys: String, CodingKey, CaseIterable {
+        case schemaVersion
+        case expected
+        case disposition
+        case observed
+        case observationStartedAtUnixMilliseconds
+        case observationCompletedAtUnixMilliseconds
+    }
+
+    public init(from decoder: any Decoder) throws {
+        try PeekabooBridgeClosedPayload.requireExactKeys(CodingKeys.self, from: decoder)
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.schemaVersion = try container.decode(Int.self, forKey: .schemaVersion)
+        self.expected = try container.decode(PeekabooBridgeProcessGenerationIdentity.self, forKey: .expected)
+        self.disposition = try container.decode(
+            PeekabooBridgeProcessGenerationDisposition.self,
+            forKey: .disposition)
+        self.observed = try container.decodeIfPresent(
+            PeekabooBridgeProcessGenerationIdentity.self,
+            forKey: .observed)
+        self.observationStartedAtUnixMilliseconds = try container.decode(
+            Int64.self,
+            forKey: .observationStartedAtUnixMilliseconds)
+        self.observationCompletedAtUnixMilliseconds = try container.decode(
+            Int64.self,
+            forKey: .observationCompletedAtUnixMilliseconds)
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(self.schemaVersion, forKey: .schemaVersion)
+        try container.encode(self.expected, forKey: .expected)
+        try container.encode(self.disposition, forKey: .disposition)
+        try container.encode(self.observed, forKey: .observed)
+        try container.encode(
+            self.observationStartedAtUnixMilliseconds,
+            forKey: .observationStartedAtUnixMilliseconds)
+        try container.encode(
+            self.observationCompletedAtUnixMilliseconds,
+            forKey: .observationCompletedAtUnixMilliseconds)
+    }
+
+    func validate(request: PeekabooBridgeProcessGenerationObservationRequest) throws {
+        do {
+            try request.validate()
+            try self.observed?.validate()
+        } catch {
+            throw PeekabooBridgeOperationReceiptError.receiptMismatch(
+                "process-generation observation identity")
+        }
+        guard self.schemaVersion == 1,
+              self.expected == request.expected,
+              self.observationStartedAtUnixMilliseconds > 0,
+              self.observationCompletedAtUnixMilliseconds >= self.observationStartedAtUnixMilliseconds
+        else {
+            throw PeekabooBridgeOperationReceiptError.receiptMismatch(
+                "process-generation observation request and timing")
+        }
+
+        switch self.disposition {
+        case .sameGenerationAlive:
+            guard self.observed == self.expected else {
+                throw PeekabooBridgeOperationReceiptError.receiptMismatch(
+                    "same-generation observation identity")
+            }
+        case .exactGenerationAbsent:
+            guard self.observed == nil else {
+                throw PeekabooBridgeOperationReceiptError.receiptMismatch(
+                    "absent process-generation observation identity")
+            }
+        case .pidReused:
+            guard let observed = self.observed,
+                  observed.processIdentifier == self.expected.processIdentifier,
+                  observed.processStartIdentity > 0,
+                  observed.processStartIdentity != self.expected.processStartIdentity
+            else {
+                throw PeekabooBridgeOperationReceiptError.receiptMismatch(
+                    "reused process-generation observation identity")
+            }
+        }
+    }
+}
+
+private enum PeekabooBridgeClosedPayload {
+    private struct AnyKey: CodingKey {
+        let stringValue: String
+        let intValue: Int?
+
+        init?(stringValue: String) {
+            self.stringValue = stringValue
+            self.intValue = nil
+        }
+
+        init?(intValue: Int) {
+            self.stringValue = String(intValue)
+            self.intValue = intValue
+        }
+    }
+
+    static func requireExactKeys<Keys: CodingKey & CaseIterable>(
+        _ keys: Keys.Type,
+        from decoder: any Decoder) throws
+    where Keys.AllCases: Collection {
+        let container = try decoder.container(keyedBy: AnyKey.self)
+        let actual = Set(container.allKeys.map(\.stringValue))
+        let expected = Set(keys.allCases.map(\.stringValue))
+        guard actual == expected else {
+            throw DecodingError.dataCorrupted(.init(
+                codingPath: decoder.codingPath,
+                debugDescription: "Process-generation observation payload keys are not closed"))
+        }
+    }
+}

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeRequest+DesktopMutation.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeRequest+DesktopMutation.swift
@@ -34,6 +34,8 @@ extension PeekabooBridgeRequest {
         switch self.unwrappedOperationRequest.operation {
         case .agentExecutionTrace:
             return PeekabooBridgeConstants.agentExecutionTraceVersion
+        case .observeProcessGeneration:
+            return PeekabooBridgeConstants.processGenerationObservationVersion
         case .createExactWindowHeldPointerOwner,
              .beginExactWindowHeldPointer,
              .releaseExactWindowHeldPointer,

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeRequestResponse.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeRequestResponse.swift
@@ -12,6 +12,7 @@ public enum PeekabooBridgeRequest: Codable, Sendable {
     case daemonStop
     case daemonStopIf(PeekabooBridgeDaemonStopRequest)
     case agentExecutionTrace(PeekabooBridgeAgentExecutionTraceRequest)
+    case observeProcessGeneration(PeekabooBridgeProcessGenerationObservationRequest)
     case browserStatus(PeekabooBridgeBrowserChannelRequest)
     case browserConnect(PeekabooBridgeBrowserChannelRequest)
     case browserDisconnect
@@ -131,6 +132,7 @@ extension PeekabooBridgeRequest {
         case .daemonStop: .daemonStop
         case .daemonStopIf: .daemonStop
         case .agentExecutionTrace: .agentExecutionTrace
+        case .observeProcessGeneration: .observeProcessGeneration
         case .browserStatus: .browserStatus
         case .browserConnect: .browserConnect
         case .browserDisconnect: .browserDisconnect
@@ -247,6 +249,7 @@ public enum PeekabooBridgeResponse: Codable, Sendable {
     case permissionsStatus(PermissionsStatus)
     case daemonStatus(PeekabooDaemonStatus)
     case agentExecutionTrace(PeekabooBridgeAgentExecutionTraceResponse)
+    case processGenerationObservation(PeekabooBridgeProcessGenerationObservationResponse)
     case browserStatus(PeekabooBridgeBrowserStatus)
     case browserToolResponse(PeekabooBridgeBrowserToolResponse)
     case capture(CaptureResult)

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer+Handlers.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer+Handlers.swift
@@ -16,6 +16,12 @@ extension PeekabooBridgeServer {
                 response: self.handleCoreRequest(request, peer: peer, permissions: permissions))
         case .agentExecutionTrace:
             return try await self.handleAgentExecutionTraceRequest(request, peer: peer)
+        case .observeProcessGeneration:
+            guard case let .observeProcessGeneration(payload) = request else {
+                throw Self.invalidRequest(for: request)
+            }
+            return try .init(response: .processGenerationObservation(
+                self.handleProcessGenerationObservation(payload)))
         case .requestPostEventPermission:
             return self.handlePostEventPermissionRequest()
         case .browserStatus, .browserDisconnect:

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer+Handshake.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer+Handshake.swift
@@ -72,6 +72,10 @@ extension PeekabooBridgeServer {
             usesAttestedOperationReceipts: supportsAttestedOperationReceipts)
         var advertisedOps = compatibleOperations.advertised.sorted { $0.rawValue < $1.rawValue }
         var enabledOps = compatibleOperations.enabled
+        if (try? self.requireCertificationCaller(peer)) == nil {
+            advertisedOps.removeAll { $0 == .observeProcessGeneration }
+            enabledOps.remove(.observeProcessGeneration)
+        }
         if negotiated >= PeekabooBridgeConstants.exactWindowHeldPointerLifecycleVersion,
            !supportsAttestedOperationReceipts
         {
@@ -154,6 +158,13 @@ extension PeekabooBridgeServer {
             !enabledOps.contains(.agentExecutionTrace)
         {
             advertisedCapabilities.remove(PeekabooBridgeHostCapability.agentExecutionTrace)
+        }
+        if !supportsAttestedOperationReceipts ||
+            negotiated < PeekabooBridgeConstants.processGenerationObservationVersion ||
+            !advertisedOps.contains(.observeProcessGeneration) ||
+            !enabledOps.contains(.observeProcessGeneration)
+        {
+            advertisedCapabilities.remove(PeekabooBridgeHostCapability.processGenerationObservation)
         }
         if supportsAttestedOperationReceipts {
             advertisedCapabilities.insert(PeekabooBridgeHostCapability.attestedOperationReceipts)
@@ -262,6 +273,9 @@ extension PeekabooBridgeServer {
         usesAttestedOperationReceipts: Bool) -> Set<PeekabooBridgeOperation>
     {
         var compatible = PeekabooBridgeOperation.compatible(operations, with: negotiated)
+        if !usesAttestedOperationReceipts {
+            compatible.remove(.observeProcessGeneration)
+        }
         if usesAttestedOperationReceipts,
            !self.services.dialogs.supportsBackgroundExactDialogInput
         {

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer+ProcessGenerationObservation.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer+ProcessGenerationObservation.swift
@@ -1,0 +1,97 @@
+import Darwin
+import Foundation
+
+@MainActor
+extension PeekabooBridgeServer {
+    typealias ProcessBSDInfoProvider = (pid_t) -> proc_bsdinfo?
+    typealias ProcessAbsenceProvider = (pid_t) -> Bool
+
+    nonisolated static let certificationCallerTeamIdentifier = "FWJYW4S8P8"
+
+    nonisolated static func observeProcessPresence(
+        _ processIdentifier: pid_t,
+        processInfoProvider: ProcessBSDInfoProvider = { processIdentifier in
+            var info = proc_bsdinfo()
+            let expectedSize = Int32(MemoryLayout<proc_bsdinfo>.stride)
+            guard proc_pidinfo(
+                processIdentifier,
+                PROC_PIDTBSDINFO,
+                0,
+                &info,
+                expectedSize) == expectedSize
+            else { return nil }
+            return info
+        },
+        absenceProvider: ProcessAbsenceProvider = { processIdentifier in
+            Darwin.kill(processIdentifier, 0) == -1 && errno == ESRCH
+        }) -> Bool?
+    {
+        guard processIdentifier > 0 else { return nil }
+        if let info = processInfoProvider(processIdentifier) {
+            // A zombie retains both its PID and start identity until waitpid reaps it. It is
+            // terminal evidence, never a live generation.
+            return info.pbi_status == SZOMB ? nil : true
+        }
+        // ESRCH is useful negative evidence after process metadata disappeared. Every positive
+        // or permission-limited result remains ambiguous rather than proving life.
+        return absenceProvider(processIdentifier) ? false : nil
+    }
+
+    func requireCertificationCaller(_ peer: PeekabooBridgePeer?) throws {
+        guard let peer,
+              let liveIdentity = peer.liveIdentity,
+              peer.bundleIdentifier == PeekabooBridgeConstants.cliBundleIdentifier,
+              peer.teamIdentifier == Self.certificationCallerTeamIdentifier,
+              peer.userIdentifier == geteuid(),
+              peer.processIdentifier > 0,
+              peer.processIdentifier == liveIdentity.processIdentifier,
+              peer.auditTokenProcessIdentifierVersion == liveIdentity.processIdentifierVersion,
+              peer.processStartIdentity == liveIdentity.processStartIdentity,
+              let codeSignatureHash = peer.codeSignatureHash,
+              !codeSignatureHash.isEmpty,
+              codeSignatureHash == liveIdentity.codeSignatureHash
+        else {
+            throw PeekabooBridgeErrorEnvelope(
+                code: .unauthorizedClient,
+                message: "Process-generation observation requires the authenticated Foundation-signed Peekaboo CLI")
+        }
+    }
+
+    func handleProcessGenerationObservation(
+        _ request: PeekabooBridgeProcessGenerationObservationRequest) throws
+        -> PeekabooBridgeProcessGenerationObservationResponse
+    {
+        try request.validate()
+        let startedAt = PeekabooBridgeOperationReceiptCoding.unixMilliseconds()
+        let before = self.processStartIdentityProvider(request.expected.processIdentifier)
+        let presence = self.processPresenceProvider(request.expected.processIdentifier)
+        let after = self.processStartIdentityProvider(request.expected.processIdentifier)
+        let completedAt = max(startedAt, PeekabooBridgeOperationReceiptCoding.unixMilliseconds())
+
+        let disposition: PeekabooBridgeProcessGenerationDisposition
+        let observed: PeekabooBridgeProcessGenerationIdentity?
+        switch (before, presence, after) {
+        case let (before?, true, after?) where before == after:
+            observed = .init(
+                processIdentifier: request.expected.processIdentifier,
+                processStartIdentity: after)
+            disposition = after == request.expected.processStartIdentity ? .sameGenerationAlive : .pidReused
+        case (nil, false, nil):
+            observed = nil
+            disposition = .exactGenerationAbsent
+        default:
+            throw PeekabooBridgeErrorEnvelope(
+                code: .internalError,
+                message: "The exact process generation changed or could not be observed unambiguously")
+        }
+
+        let response = PeekabooBridgeProcessGenerationObservationResponse(
+            expected: request.expected,
+            disposition: disposition,
+            observed: observed,
+            observationStartedAtUnixMilliseconds: startedAt,
+            observationCompletedAtUnixMilliseconds: completedAt)
+        try response.validate(request: request)
+        return response
+    }
+}

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer.swift
@@ -82,6 +82,7 @@ public final class PeekabooBridgeServer {
     let windowBoundsProvider: @Sendable (CGWindowID) -> CGRect?
     let maximizedVisibleWorkAreaProvider: @MainActor @Sendable (CGRect) -> CGRect?
     let processStartIdentityProvider: @Sendable (pid_t) -> UInt64?
+    let processPresenceProvider: @Sendable (pid_t) -> Bool?
     let desktopMutationWatermarkStore: DesktopMutationWatermarkStore?
     let desktopOperationLaneCoordinator: DesktopOperationLaneCoordinator
     let automationActivityObserver: (@Sendable (pid_t) -> Void)?
@@ -122,6 +123,7 @@ public final class PeekabooBridgeServer {
         maximizedVisibleWorkAreaProvider: (@MainActor @Sendable (CGRect) -> CGRect?)? = nil,
         processStartIdentityProvider: @escaping @Sendable (pid_t) -> UInt64? =
             SystemIdentityResolver.processStartIdentity,
+        processPresenceProvider: (@Sendable (pid_t) -> Bool?)? = nil,
         encoder: JSONEncoder = .peekabooBridgeEncoder(),
         decoder: JSONDecoder = .peekabooBridgeDecoder())
     {
@@ -175,6 +177,13 @@ public final class PeekabooBridgeServer {
         } else {
             resolvedHostCapabilities.remove(PeekabooBridgeHostCapability.agentExecutionTrace)
         }
+        if supportedVersions.upperBound >= PeekabooBridgeConstants.processGenerationObservationVersion,
+           self.allowedOperations.contains(.observeProcessGeneration)
+        {
+            resolvedHostCapabilities.insert(PeekabooBridgeHostCapability.processGenerationObservation)
+        } else {
+            resolvedHostCapabilities.remove(PeekabooBridgeHostCapability.processGenerationObservation)
+        }
         if self.allowedOperations.contains(.launchApplicationWithOptions),
            services.applications.supportsSafeBackgroundApplicationLaunchNoOp
         {
@@ -203,6 +212,7 @@ public final class PeekabooBridgeServer {
             WindowMutationGeometryPostcondition.currentMaximizedVisibleWorkArea(for: bounds)
         }
         self.processStartIdentityProvider = processStartIdentityProvider
+        self.processPresenceProvider = processPresenceProvider ?? { Self.observeProcessPresence($0) }
         let resolvedPostEventAccessEvaluator = postEventAccessEvaluator ?? { [services] in
             services.permissions.checkPostEventPermission()
         }
@@ -827,6 +837,14 @@ public final class PeekabooBridgeServer {
             throw PeekabooBridgeErrorEnvelope(
                 code: .operationNotSupported,
                 message: "Operation \(op.rawValue) is not supported by this host")
+        }
+        if op == .observeProcessGeneration {
+            try self.requireCertificationCaller(peer)
+            guard PeekabooBridgeRequestContext.usesAttestedOperationResultSemantics else {
+                throw PeekabooBridgeErrorEnvelope(
+                    code: .operationNotSupported,
+                    message: "Process-generation observation requires a signed Bridge operation receipt")
+            }
         }
         if let minimumVersion = request.minimumNegotiatedProtocolVersion {
             let session = PeekabooBridgeRequestContext.negotiatedSessionCapabilities

--- a/Core/PeekabooCore/Tests/PeekabooBridgeTests/AgentExecutionTraceContractTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooBridgeTests/AgentExecutionTraceContractTests.swift
@@ -9,7 +9,7 @@ struct AgentExecutionTraceContractTests {
     @Test
     func `Protocol and allowlists fail closed before 1.31`() {
         let previous = PeekabooBridgeProtocolVersion(major: 1, minor: 30)
-        #expect(PeekabooBridgeConstants.protocolVersion == .init(major: 1, minor: 31))
+        #expect(PeekabooBridgeConstants.protocolVersion == .init(major: 1, minor: 32))
         #expect(!PeekabooBridgeOperation.compatible([.agentExecutionTrace], with: previous)
             .contains(.agentExecutionTrace))
         #expect(PeekabooBridgeOperation.compatible(

--- a/Core/PeekabooCore/Tests/PeekabooBridgeTests/ExactDialogInputWireTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooBridgeTests/ExactDialogInputWireTests.swift
@@ -15,7 +15,7 @@ struct ExactDialogInputWireTests {
         ]
         let legacyVersion = PeekabooBridgeProtocolVersion(major: 1, minor: 26)
 
-        #expect(PeekabooBridgeConstants.protocolVersion == .init(major: 1, minor: 31))
+        #expect(PeekabooBridgeConstants.protocolVersion == .init(major: 1, minor: 32))
         #expect(PeekabooBridgeConstants.attestedOperationReceiptVersion == .init(major: 1, minor: 29))
         #expect(PeekabooBridgeConstants.plannerInventoryTransportVersion == .init(major: 1, minor: 30))
         #expect(PeekabooBridgeConstants.exactDialogInputExecutionVersion == .init(major: 1, minor: 27))

--- a/Core/PeekabooCore/Tests/PeekabooBridgeTests/ProcessGenerationObservationContractTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooBridgeTests/ProcessGenerationObservationContractTests.swift
@@ -1,0 +1,149 @@
+import Foundation
+import Testing
+@testable import PeekabooBridge
+
+@Suite("Bridge process-generation observation contract")
+struct ProcessGenerationObservationContractTests {
+    @Test
+    func `Protocol and allowlist fail closed before 1.32`() {
+        let previous = PeekabooBridgeProtocolVersion(major: 1, minor: 31)
+        #expect(PeekabooBridgeConstants.protocolVersion == .init(major: 1, minor: 32))
+        #expect(!PeekabooBridgeOperation.compatible([.observeProcessGeneration], with: previous)
+            .contains(.observeProcessGeneration))
+        #expect(PeekabooBridgeOperation.compatible(
+            [.observeProcessGeneration],
+            with: PeekabooBridgeConstants.processGenerationObservationVersion)
+            .contains(.observeProcessGeneration))
+        #expect(PeekabooBridgeOperation.remoteDefaultAllowlist.contains(.observeProcessGeneration))
+        #expect(PeekabooBridgeOperation.observeProcessGeneration.requiredPermissions.isEmpty)
+    }
+
+    @Test
+    func `Observation is read only receipt bound and targetless`() {
+        let request = PeekabooBridgeRequest.observeProcessGeneration(Self.request())
+        let plan = PeekabooBridgeOperationResultSemantics.semanticPlan(for: request)
+        #expect(request.minimumNegotiatedProtocolVersion ==
+            PeekabooBridgeConstants.processGenerationObservationVersion)
+        #expect(!request.mayMutateDesktop)
+        #expect(plan.contract.completion == .readOnly)
+        #expect(plan.contract.targetPolicy == .notApplicable)
+        #expect(plan.responseFamilies == [.processGenerationObservation])
+        #expect(plan.operationPolicy.typedResponse == .processGenerationObservation)
+    }
+
+    @Test
+    func `Request wire is closed and cannot carry identity claims or an expected disposition`() throws {
+        let data = try JSONEncoder.peekabooBridgeEncoder().encode(Self.request())
+        let object = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        #expect(Set(object.keys) == ["schemaVersion", "expected"])
+        let expected = try #require(object["expected"] as? [String: Any])
+        #expect(Set(expected.keys) == ["processIdentifier", "processStartIdentity"])
+        #expect(expected["processStartIdentity"] as? String == "18446744073709551615")
+        #expect(object["teamIdentifier"] == nil)
+        #expect(object["signingIdentifier"] == nil)
+        #expect(object["codeSignatureHash"] == nil)
+        #expect(object["expectedDisposition"] == nil)
+        #expect(object["digest"] == nil)
+        #expect(object["file"] == nil)
+    }
+
+    @Test
+    func `Closed request decoder rejects outer and nested unknown keys`() throws {
+        let decoder = JSONDecoder.peekabooBridgeDecoder()
+        let outer = Data(
+            #"{"schemaVersion":1,"expected":{"processIdentifier":42,"processStartIdentity":"99"},"digest":"forbidden"}"#
+                .utf8)
+        #expect(throws: DecodingError.self) {
+            _ = try decoder.decode(PeekabooBridgeProcessGenerationObservationRequest.self, from: outer)
+        }
+
+        let nested = Data(
+            #"{"schemaVersion":1,"expected":{"processIdentifier":42,"processStartIdentity":"99","teamIdentifier":"FWJYW4S8P8"}}"#
+                .utf8)
+        #expect(throws: DecodingError.self) {
+            _ = try decoder.decode(PeekabooBridgeProcessGenerationObservationRequest.self, from: nested)
+        }
+    }
+
+    @Test
+    func `Missing malformed and nonpositive identities fail closed`() throws {
+        let decoder = JSONDecoder.peekabooBridgeDecoder()
+        let missing = Data(#"{"schemaVersion":1,"expected":{"processIdentifier":42}}"#.utf8)
+        #expect(throws: DecodingError.self) {
+            _ = try decoder.decode(PeekabooBridgeProcessGenerationObservationRequest.self, from: missing)
+        }
+        let numericStart = Data(#"{"schemaVersion":1,"expected":{"processIdentifier":42,"processStartIdentity":99}}"#
+            .utf8)
+        #expect(throws: DecodingError.self) {
+            _ = try decoder.decode(PeekabooBridgeProcessGenerationObservationRequest.self, from: numericStart)
+        }
+        #expect(throws: PeekabooBridgeErrorEnvelope.self) {
+            try PeekabooBridgeProcessGenerationObservationRequest(
+                expected: .init(processIdentifier: 0, processStartIdentity: 99)).validate()
+        }
+        #expect(throws: PeekabooBridgeErrorEnvelope.self) {
+            try PeekabooBridgeProcessGenerationObservationRequest(
+                schemaVersion: 2,
+                expected: .init(processIdentifier: 42, processStartIdentity: 99)).validate()
+        }
+    }
+
+    @Test
+    func `All three dispositions have one exact identity shape and explicit null carriage`() throws {
+        let request = PeekabooBridgeProcessGenerationObservationRequest(
+            expected: .init(processIdentifier: 42, processStartIdentity: 99))
+        let alive = Self.response(request: request, disposition: .sameGenerationAlive, observedStart: 99)
+        let absent = Self.response(request: request, disposition: .exactGenerationAbsent, observedStart: nil)
+        let reused = Self.response(request: request, disposition: .pidReused, observedStart: 100)
+        try alive.validate(request: request)
+        try absent.validate(request: request)
+        try reused.validate(request: request)
+
+        let encoder = JSONEncoder.peekabooBridgeEncoder()
+        let decoder = JSONDecoder.peekabooBridgeDecoder()
+        let absentData = try encoder.encode(absent)
+        let absentObject = try #require(JSONSerialization.jsonObject(with: absentData) as? [String: Any])
+        #expect(Set(absentObject.keys) == [
+            "schemaVersion", "expected", "disposition", "observed",
+            "observationStartedAtUnixMilliseconds", "observationCompletedAtUnixMilliseconds",
+        ])
+        #expect(absentObject["observed"] is NSNull)
+        #expect(try decoder.decode(
+            PeekabooBridgeProcessGenerationObservationResponse.self,
+            from: absentData) == absent)
+
+        #expect(throws: PeekabooBridgeOperationReceiptError.self) {
+            try Self.response(request: request, disposition: .sameGenerationAlive, observedStart: 100)
+                .validate(request: request)
+        }
+        #expect(throws: PeekabooBridgeOperationReceiptError.self) {
+            try Self.response(request: request, disposition: .exactGenerationAbsent, observedStart: 99)
+                .validate(request: request)
+        }
+        #expect(throws: PeekabooBridgeOperationReceiptError.self) {
+            try Self.response(request: request, disposition: .pidReused, observedStart: 99)
+                .validate(request: request)
+        }
+    }
+
+    private static func request() -> PeekabooBridgeProcessGenerationObservationRequest {
+        .init(expected: .init(
+            processIdentifier: 42,
+            processStartIdentity: UInt64.max))
+    }
+
+    private static func response(
+        request: PeekabooBridgeProcessGenerationObservationRequest,
+        disposition: PeekabooBridgeProcessGenerationDisposition,
+        observedStart: UInt64?) -> PeekabooBridgeProcessGenerationObservationResponse
+    {
+        .init(
+            expected: request.expected,
+            disposition: disposition,
+            observed: observedStart.map {
+                .init(processIdentifier: request.expected.processIdentifier, processStartIdentity: $0)
+            },
+            observationStartedAtUnixMilliseconds: 1000,
+            observationCompletedAtUnixMilliseconds: 1001)
+    }
+}

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/PermissionsToolSelectedHostTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/PermissionsToolSelectedHostTests.swift
@@ -11,7 +11,7 @@ import Testing
 struct PermissionsToolSelectedHostTests {
     @Test
     func `permission provider remains additive at protocol 1_22`() {
-        #expect(PeekabooBridgeConstants.protocolVersion == .init(major: 1, minor: 31))
+        #expect(PeekabooBridgeConstants.protocolVersion == .init(major: 1, minor: 32))
     }
 
     private struct PermissionCase: Sendable, CustomTestStringConvertible {

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeActionOutcomeProjectionTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeActionOutcomeProjectionTests.swift
@@ -934,7 +934,7 @@ extension PeekabooBridgeActionOutcomeProjectionTests {
 
     @Test
     func `current protocol 1 30 preserves projection capability introduced at 1 23`() {
-        let currentVersion = PeekabooBridgeProtocolVersion(major: 1, minor: 31)
+        let currentVersion = PeekabooBridgeProtocolVersion(major: 1, minor: 32)
         let projectionVersion = PeekabooBridgeProtocolVersion(major: 1, minor: 23)
 
         #expect(PeekabooBridgeConstants.protocolVersion == currentVersion)

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeAgentExecutionTraceTransportTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeAgentExecutionTraceTransportTests.swift
@@ -36,7 +36,7 @@ struct PeekabooBridgeAgentExecutionTraceTransportTests {
 
         let client = TrustedBridgeClientFixture.make(socketPath: socketPath, requestTimeoutSec: 2)
         let handshake = try await client.handshake(client: Self.clientIdentity)
-        #expect(handshake.negotiatedVersion == PeekabooBridgeConstants.agentExecutionTraceVersion)
+        #expect(handshake.negotiatedVersion == PeekabooBridgeConstants.protocolVersion)
         #expect(handshake.supportedOperations.contains(.agentExecutionTrace))
         #expect(handshake.enabledOperations?.contains(.agentExecutionTrace) == true)
         #expect(handshake.hostCapabilities?.contains(PeekabooBridgeHostCapability.agentExecutionTrace) == true)

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeOperationSemanticPlanTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeOperationSemanticPlanTests.swift
@@ -27,7 +27,7 @@ struct PeekabooBridgeOperationSemanticPlanTests {
 
         // This count is intentionally reviewed whenever the wire enum grows. The exhaustive
         // policy switches also make a missing classification a compile error.
-        #expect(operations.count == 109)
+        #expect(operations.count == 110)
 
         func partition<Value: Equatable>(_ values: [Value], by keyPath: KeyPath<Semantics.OperationPolicy, Value>) {
             let groups = values.map { expected in
@@ -50,6 +50,7 @@ struct PeekabooBridgeOperationSemanticPlanTests {
             [
                 .familyOnly,
                 .agentExecutionTrace,
+                .processGenerationObservation,
                 .noSuccessResponse,
                 .typeActions,
                 .setValue,

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeOperationSessionAuthenticationTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeOperationSessionAuthenticationTests.swift
@@ -297,21 +297,21 @@ struct PeekabooBridgeOperationSessionAuthenticationTests {
                 to: currentRequest)
             let previousRequest = try await peer.nextRequest()
             guard case let .handshake(previousPayload) = try previousRequest.decode() else {
-                Issue.record("Expected trusted protocol 1.29 fallback request")
+                Issue.record("Expected trusted protocol 1.31 fallback request")
                 await peer.stop()
                 return
             }
-            #expect(previousPayload.protocolVersion == .init(major: 1, minor: 29))
+            #expect(previousPayload.protocolVersion == .init(major: 1, minor: 31))
             try await peer.respond(
-                .error(.init(code: .versionMismatch, message: "Protocol 1.29 unavailable")),
+                .error(.init(code: .versionMismatch, message: "Protocol 1.31 unavailable")),
                 to: previousRequest)
             let legacyRequest = try await peer.nextRequest()
             guard case let .handshake(legacyPayload) = try legacyRequest.decode() else {
-                Issue.record("Expected trusted protocol 1.28 fallback request")
+                Issue.record("Expected trusted protocol 1.30 fallback request")
                 await peer.stop()
                 return
             }
-            #expect(legacyPayload.protocolVersion == .init(major: 1, minor: 28))
+            #expect(legacyPayload.protocolVersion == .init(major: 1, minor: 30))
             try await peer.respond(.handshake(Self.legacyHandshake()), to: legacyRequest)
             let response = try await handshake.value
             #expect(response.negotiatedVersion == .init(major: 1, minor: 28))

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgePlannerInventoryTransportTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgePlannerInventoryTransportTests.swift
@@ -69,7 +69,7 @@ struct PeekabooBridgePlannerInventoryTransportTests {
             allowlistedTeams: [],
             allowlistedBundles: [])
 
-        #expect(PeekabooBridgeConstants.protocolVersion == .init(major: 1, minor: 31))
+        #expect(PeekabooBridgeConstants.protocolVersion == .init(major: 1, minor: 32))
         #expect(PeekabooBridgeConstants.attestedOperationReceiptVersion == .init(major: 1, minor: 29))
         #expect(PeekabooBridgeConstants.plannerInventoryTransportVersion == .init(major: 1, minor: 30))
         #expect(!legacyServer.hostCapabilities.contains(PeekabooBridgeHostCapability.plannerInventoryTransport))
@@ -173,7 +173,7 @@ struct PeekabooBridgePlannerInventoryTransportTests {
 
         let client = TrustedBridgeClientFixture.make(socketPath: socketPath, requestTimeoutSec: 2)
         let current = try await client.handshake(client: Self.clientIdentity)
-        #expect(current.negotiatedVersion == .init(major: 1, minor: 31))
+        #expect(current.negotiatedVersion == .init(major: 1, minor: 32))
         #expect(current.hostCapabilities?.contains(PeekabooBridgeHostCapability.plannerInventoryTransport) == true)
 
         let remoteApplications = RemoteApplicationService(client: client)

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeProcessGenerationObservationTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeProcessGenerationObservationTests.swift
@@ -1,0 +1,436 @@
+import Darwin
+import Foundation
+import PeekabooAutomationKitTestSupport
+import PeekabooFoundation
+import Testing
+@testable import PeekabooBridge
+@testable import PeekabooCore
+
+@Suite("Bridge signed process-generation observation", .serialized)
+@MainActor
+struct PeekabooBridgeProcessGenerationObservationTests {
+    @Test
+    func `Classifier returns stable alive absent and reused dispositions`() throws {
+        let expected = PeekabooBridgeProcessGenerationIdentity(
+            processIdentifier: 4242,
+            processStartIdentity: 100)
+        let request = PeekabooBridgeProcessGenerationObservationRequest(expected: expected)
+
+        let alive = Self.server(start: 100, presence: true)
+        let aliveResponse = try alive.handleProcessGenerationObservation(request)
+        #expect(aliveResponse.disposition == .sameGenerationAlive)
+        #expect(aliveResponse.observed == expected)
+
+        let absent = Self.server(start: nil, presence: false)
+        let absentResponse = try absent.handleProcessGenerationObservation(request)
+        #expect(absentResponse.disposition == .exactGenerationAbsent)
+        #expect(absentResponse.observed == nil)
+
+        let reused = Self.server(start: 101, presence: true)
+        let reusedResponse = try reused.handleProcessGenerationObservation(request)
+        #expect(reusedResponse.disposition == .pidReused)
+        #expect(reusedResponse.observed == .init(processIdentifier: 4242, processStartIdentity: 101))
+
+        for response in [aliveResponse, absentResponse, reusedResponse] {
+            #expect(response.observationStartedAtUnixMilliseconds > 0)
+            #expect(response.observationCompletedAtUnixMilliseconds >=
+                response.observationStartedAtUnixMilliseconds)
+            try response.validate(request: request)
+        }
+    }
+
+    @Test
+    func `Ambiguous and failed presence observations are errors not a fourth disposition`() {
+        let request = PeekabooBridgeProcessGenerationObservationRequest(
+            expected: .init(processIdentifier: 4242, processStartIdentity: 100))
+        #expect(throws: PeekabooBridgeErrorEnvelope.self) {
+            _ = try Self.server(start: nil, presence: true).handleProcessGenerationObservation(request)
+        }
+        #expect(throws: PeekabooBridgeErrorEnvelope.self) {
+            _ = try Self.server(start: nil, presence: nil).handleProcessGenerationObservation(request)
+        }
+        #expect(throws: PeekabooBridgeErrorEnvelope.self) {
+            _ = try Self.server(start: 100, presence: nil).handleProcessGenerationObservation(request)
+        }
+
+        let samples = ProcessStartSamples([100, 101])
+        let drifting = Self.server(
+            startProvider: { _ in samples.next() },
+            presence: true)
+        #expect(throws: PeekabooBridgeErrorEnvelope.self) {
+            _ = try drifting.handleProcessGenerationObservation(request)
+        }
+    }
+
+    @Test
+    func `Unreaped zombie is terminal signed-error evidence not an alive generation`() {
+        var zombie = proc_bsdinfo()
+        zombie.pbi_status = UInt32(SZOMB)
+        #expect(PeekabooBridgeServer.observeProcessPresence(
+            4242,
+            processInfoProvider: { _ in zombie },
+            absenceProvider: { _ in false }) == nil)
+
+        var running = proc_bsdinfo()
+        running.pbi_status = UInt32(SRUN)
+        #expect(PeekabooBridgeServer.observeProcessPresence(
+            4242,
+            processInfoProvider: { _ in running },
+            absenceProvider: { _ in false }) == true)
+        #expect(PeekabooBridgeServer.observeProcessPresence(
+            4242,
+            processInfoProvider: { _ in nil },
+            absenceProvider: { _ in true }) == false)
+    }
+
+    @Test
+    func `Only live current Foundation CLI identity is authorized`() throws {
+        let live = try #require(OperationReceiptSessionFixture.currentPeer().liveIdentity)
+        let accepted = PeekabooBridgePeer(
+            liveIdentity: live,
+            bundleIdentifier: PeekabooBridgeConstants.cliBundleIdentifier,
+            teamIdentifier: PeekabooBridgeServer.certificationCallerTeamIdentifier)
+        try Self.server(start: 100, presence: true).requireCertificationCaller(accepted)
+
+        let rejected: [PeekabooBridgePeer?] = [
+            nil,
+            PeekabooBridgePeer(
+                liveIdentity: live,
+                bundleIdentifier: "boo.peekaboo.other",
+                teamIdentifier: PeekabooBridgeServer.certificationCallerTeamIdentifier),
+            PeekabooBridgePeer(
+                liveIdentity: live,
+                bundleIdentifier: PeekabooBridgeConstants.cliBundleIdentifier,
+                teamIdentifier: "Y5PE65HELJ"),
+            PeekabooBridgePeer(
+                processIdentifier: live.processIdentifier,
+                auditTokenProcessIdentifierVersion: live.processIdentifierVersion,
+                processStartIdentity: live.processStartIdentity,
+                codeSignatureHash: live.codeSignatureHash,
+                userIdentifier: live.effectiveUserIdentifier,
+                bundleIdentifier: PeekabooBridgeConstants.cliBundleIdentifier,
+                teamIdentifier: PeekabooBridgeServer.certificationCallerTeamIdentifier),
+        ]
+        for peer in rejected {
+            #expect(throws: PeekabooBridgeErrorEnvelope.self) {
+                try Self.server(start: 100, presence: true).requireCertificationCaller(peer)
+            }
+        }
+    }
+
+    @Test
+    func `Attested observation signs exact response and encloses host timing`() async throws {
+        let root = URL(fileURLWithPath: "/tmp/pb-process-observation-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let authority = try PeekabooBridgeOperationReceiptAuthority(
+            socketPath: root.appendingPathComponent("authority.sock").path)
+        let peer = try Self.certificationPeer()
+        let session = try await OperationReceiptSessionFixture.make(authority: authority, peer: peer)
+        let server = Self.server(start: 100, presence: true)
+        let request = PeekabooBridgeRequest.observeProcessGeneration(.init(
+            expected: .init(processIdentifier: 4242, processStartIdentity: 100)))
+        let payload = session.request(authority: authority, sequence: 0, request: request)
+        let data = try await PeekabooBridgeRequestContext.$operationReceiptAuthority.withValue(authority) {
+            try await server.handleAttestedOperation(payload, peer: session.peer)
+        }
+        guard case let .attestedOperation(attested) = try JSONDecoder.peekabooBridgeDecoder().decode(
+            PeekabooBridgeResponse.self,
+            from: data),
+            case let .processGenerationObservation(response) = attested.response
+        else {
+            Issue.record("Expected signed process-generation observation")
+            return
+        }
+        let bundle = try OperationReceiptSessionFixture.bundle(
+            authority: authority,
+            sessionAttestation: session.attestation,
+            receipt: attested.receipt,
+            request: request,
+            response: attested.response)
+        try bundle.validateIntegrity()
+        #expect(bundle.receipt.payload.operation == .observeProcessGeneration)
+        #expect(bundle.receipt.payload.target == .global)
+        #expect(bundle.receipt.payload.outcome == nil)
+        #expect(bundle.receipt.payload.startedAtUnixMilliseconds <=
+            response.observationStartedAtUnixMilliseconds)
+        #expect(response.observationCompletedAtUnixMilliseconds <=
+            bundle.receipt.payload.completedAtUnixMilliseconds)
+    }
+
+    @Test
+    func `Unauthorized caller gets signed refusal before observing process state`() async throws {
+        let root = URL(fileURLWithPath: "/tmp/pb-process-refusal-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let authority = try PeekabooBridgeOperationReceiptAuthority(
+            socketPath: root.appendingPathComponent("authority.sock").path)
+        let live = try #require(OperationReceiptSessionFixture.currentPeer().liveIdentity)
+        let transitionalPeer = PeekabooBridgePeer(
+            liveIdentity: live,
+            bundleIdentifier: PeekabooBridgeConstants.cliBundleIdentifier,
+            teamIdentifier: "Y5PE65HELJ")
+        let session = try await OperationReceiptSessionFixture.make(
+            authority: authority,
+            peer: transitionalPeer)
+        let observations = ObservationCounter()
+        let server = Self.server(
+            startProvider: { _ in
+                observations.increment()
+                return 100
+            },
+            presence: true)
+        let request = PeekabooBridgeRequest.observeProcessGeneration(.init(
+            expected: .init(processIdentifier: 4242, processStartIdentity: 100)))
+        let payload = session.request(authority: authority, sequence: 0, request: request)
+        let data = try await PeekabooBridgeRequestContext.$operationReceiptAuthority.withValue(authority) {
+            try await server.handleAttestedOperation(payload, peer: session.peer)
+        }
+        guard case let .attestedOperation(attested) = try JSONDecoder.peekabooBridgeDecoder().decode(
+            PeekabooBridgeResponse.self,
+            from: data),
+            case let .error(envelope) = attested.response
+        else {
+            Issue.record("Expected signed unauthorized refusal")
+            return
+        }
+        #expect(envelope.code == .unauthorizedClient)
+        #expect(observations.isEmpty)
+        let bundle = try OperationReceiptSessionFixture.bundle(
+            authority: authority,
+            sessionAttestation: session.attestation,
+            receipt: attested.receipt,
+            request: request,
+            response: attested.response)
+        try bundle.validateIntegrity()
+        #expect(bundle.receipt.payload.operation == .observeProcessGeneration)
+        #expect(bundle.receipt.payload.target == .global)
+    }
+
+    @Test
+    func `Receiptless access and receiptless advertisement fail before observation`() async throws {
+        let observations = ObservationCounter()
+        let server = Self.server(
+            startProvider: { _ in
+                observations.increment()
+                return 100
+            },
+            presence: true,
+            allowedOperations: [.observeProcessGeneration])
+        let peer = try Self.certificationPeer()
+        let request = PeekabooBridgeRequest.observeProcessGeneration(.init(
+            expected: .init(processIdentifier: 4242, processStartIdentity: 100)))
+        await #expect(throws: PeekabooBridgeErrorEnvelope.self) {
+            _ = try await server.route(request, peer: peer)
+        }
+        #expect(observations.isEmpty)
+
+        let handshakeResponse = try await server.handleHandshake(
+            .init(
+                protocolVersion: PeekabooBridgeConstants.protocolVersion,
+                client: .init(
+                    bundleIdentifier: "untrusted-handshake-claims",
+                    teamIdentifier: "Y5PE65HELJ",
+                    processIdentifier: getpid())),
+            peer: peer,
+            permissions: PermissionsStatus(screenRecording: true, accessibility: true, postEvent: true))
+        guard case let .handshake(handshake) = handshakeResponse else {
+            Issue.record("Expected receiptless handshake response")
+            return
+        }
+        #expect(!handshake.supportedOperations.contains(.observeProcessGeneration))
+        #expect(handshake.enabledOperations?.contains(.observeProcessGeneration) == false)
+        #expect(handshake.hostCapabilities?.contains(
+            PeekabooBridgeHostCapability.processGenerationObservation) == false)
+    }
+
+    @Test
+    func `Live client requires capability and retains the required receipt`() async throws {
+        let socketPath = "/tmp/peekaboo-process-observation-\(UUID().uuidString).sock"
+        let server = Self.server(start: 100, presence: true, allowedOperations: [.observeProcessGeneration])
+        let host = PeekabooBridgeHost(socketPath: socketPath, server: server, allowedTeamIDs: [])
+        await host.setAuthenticationForTesting(Self.certificationAuthentication())
+        try await host.startChecked()
+        defer { Task { await host.stop() } }
+
+        let client = TrustedBridgeClientFixture.make(socketPath: socketPath, requestTimeoutSec: 2)
+        let handshake = try await client.handshake(client: .init(
+            bundleIdentifier: "caller-claims-are-not-authority",
+            teamIdentifier: "Y5PE65HELJ",
+            processIdentifier: getpid()))
+        #expect(handshake.negotiatedVersion == .init(major: 1, minor: 32))
+        #expect(handshake.supportedOperations.contains(.observeProcessGeneration))
+        #expect(handshake.enabledOperations?.contains(.observeProcessGeneration) == true)
+        #expect(handshake.hostCapabilities?.contains(
+            PeekabooBridgeHostCapability.processGenerationObservation) == true)
+
+        let request = PeekabooBridgeProcessGenerationObservationRequest(
+            expected: .init(processIdentifier: 4242, processStartIdentity: 100))
+        let delivery = try await client.observeProcessGenerationWithReceipt(request)
+        #expect(delivery.response.disposition == .sameGenerationAlive)
+        try delivery.receiptBundle.validate(
+            trustAnchor: .listenerAttestation(#require(handshake.operationAttestation)))
+        #expect(delivery.receiptBundle.receipt.payload.operation == .observeProcessGeneration)
+        #expect(await client.lastOperationReceiptBundle() == delivery.receiptBundle)
+
+        let substitutedResponse = PeekabooBridgeResponse.processGenerationObservation(.init(
+            expected: request.expected,
+            disposition: .pidReused,
+            observed: .init(processIdentifier: 4242, processStartIdentity: 101),
+            observationStartedAtUnixMilliseconds:
+            delivery.response.observationStartedAtUnixMilliseconds,
+            observationCompletedAtUnixMilliseconds:
+            delivery.response.observationCompletedAtUnixMilliseconds))
+        let forged = try PeekabooBridgeOperationReceiptBundle(
+            operationAttestation: delivery.receiptBundle.operationAttestation,
+            operationSessionAttestation: delivery.receiptBundle.operationSessionAttestation,
+            receipt: delivery.receiptBundle.receipt,
+            canonicalListenerAttestationPayload:
+            delivery.receiptBundle.canonicalListenerAttestationPayload,
+            canonicalSessionAttestationPayload:
+            delivery.receiptBundle.canonicalSessionAttestationPayload,
+            canonicalReceiptPayload: delivery.receiptBundle.canonicalReceiptPayload,
+            canonicalRequest: delivery.receiptBundle.canonicalRequest,
+            canonicalResponse: PeekabooBridgeOperationReceiptCoding.canonicalData(substitutedResponse))
+        #expect(throws: PeekabooBridgeOperationReceiptError.self) {
+            try forged.validateIntegrity()
+        }
+        await host.stop()
+    }
+
+    @Test
+    func `Client refuses missing capability before observation`() async throws {
+        let socketPath = "/tmp/peekaboo-process-observation-disabled-\(UUID().uuidString).sock"
+        let observations = ObservationCounter()
+        let server = Self.server(
+            startProvider: { _ in
+                observations.increment()
+                return 100
+            },
+            presence: true,
+            allowedOperations: [.permissionsStatus])
+        let host = PeekabooBridgeHost(socketPath: socketPath, server: server, allowedTeamIDs: [])
+        await host.setAuthenticationForTesting(Self.certificationAuthentication())
+        try await host.startChecked()
+        defer { Task { await host.stop() } }
+
+        let client = TrustedBridgeClientFixture.make(socketPath: socketPath, requestTimeoutSec: 2)
+        let handshake = try await client.handshake(client: .init(
+            bundleIdentifier: nil,
+            teamIdentifier: nil,
+            processIdentifier: getpid()))
+        #expect(!handshake.supportedOperations.contains(.observeProcessGeneration))
+        await #expect(throws: PeekabooBridgeErrorEnvelope.self) {
+            _ = try await client.observeProcessGeneration(.init(
+                expected: .init(processIdentifier: 4242, processStartIdentity: 100)))
+        }
+        #expect(observations.isEmpty)
+        await host.stop()
+    }
+
+    @Test
+    func `Ambiguous observation remains available as a signed error bundle`() async throws {
+        let socketPath = "/tmp/peekaboo-process-observation-error-\(UUID().uuidString).sock"
+        let server = Self.server(start: nil, presence: nil, allowedOperations: [.observeProcessGeneration])
+        let host = PeekabooBridgeHost(socketPath: socketPath, server: server, allowedTeamIDs: [])
+        await host.setAuthenticationForTesting(Self.certificationAuthentication())
+        try await host.startChecked()
+        defer { Task { await host.stop() } }
+
+        let client = TrustedBridgeClientFixture.make(socketPath: socketPath, requestTimeoutSec: 2)
+        let handshake = try await client.handshake(client: .init(
+            bundleIdentifier: nil,
+            teamIdentifier: nil,
+            processIdentifier: getpid()))
+        let request = PeekabooBridgeProcessGenerationObservationRequest(
+            expected: .init(processIdentifier: 4242, processStartIdentity: 100))
+        let bundle = try await client.observeProcessGenerationReceiptBundle(request)
+        try bundle.validate(trustAnchor: .listenerAttestation(#require(handshake.operationAttestation)))
+        guard case let .error(envelope) = try JSONDecoder.peekabooBridgeDecoder().decode(
+            PeekabooBridgeResponse.self,
+            from: bundle.canonicalResponse)
+        else {
+            Issue.record("Expected signed observation failure")
+            return
+        }
+        #expect(envelope.code == .internalError)
+        #expect(bundle.receipt.payload.operation == .observeProcessGeneration)
+        await host.stop()
+    }
+
+    private static func server(
+        start: UInt64?,
+        presence: Bool?,
+        allowedOperations: Set<PeekabooBridgeOperation> = PeekabooBridgeOperation.remoteDefaultAllowlist)
+        -> PeekabooBridgeServer
+    {
+        self.server(
+            startProvider: { _ in start },
+            presence: presence,
+            allowedOperations: allowedOperations)
+    }
+
+    private static func server(
+        startProvider: @escaping @Sendable (pid_t) -> UInt64?,
+        presence: Bool?,
+        allowedOperations: Set<PeekabooBridgeOperation> = PeekabooBridgeOperation.remoteDefaultAllowlist)
+        -> PeekabooBridgeServer
+    {
+        PeekabooBridgeServer(
+            services: StubServices(),
+            allowlistedTeams: [],
+            allowlistedBundles: [],
+            allowedOperations: allowedOperations,
+            permissionStatusEvaluator: { _ in
+                PermissionsStatus(screenRecording: true, accessibility: true, postEvent: true)
+            },
+            processStartIdentityProvider: startProvider,
+            processPresenceProvider: { _ in presence })
+    }
+
+    private static func certificationPeer() throws -> PeekabooBridgePeer {
+        let live = try #require(OperationReceiptSessionFixture.currentPeer().liveIdentity)
+        return PeekabooBridgePeer(
+            liveIdentity: live,
+            bundleIdentifier: PeekabooBridgeConstants.cliBundleIdentifier,
+            teamIdentifier: PeekabooBridgeServer.certificationCallerTeamIdentifier)
+    }
+
+    private static func certificationAuthentication() -> PeekabooBridgeHostAuthentication {
+        .init(
+            liveIdentity: { try PeekabooBridgeSocketIO.livePeerIdentity(fd: $0) },
+            coldPeer: { identity, _ in
+                PeekabooBridgePeer(
+                    liveIdentity: identity,
+                    bundleIdentifier: PeekabooBridgeConstants.cliBundleIdentifier,
+                    teamIdentifier: PeekabooBridgeServer.certificationCallerTeamIdentifier)
+            })
+    }
+}
+
+private final class ProcessStartSamples: @unchecked Sendable {
+    private let lock = NSLock()
+    private var samples: [UInt64?]
+
+    init(_ samples: [UInt64?]) {
+        self.samples = samples
+    }
+
+    func next() -> UInt64? {
+        self.lock.withLock {
+            guard !self.samples.isEmpty else { return nil }
+            return self.samples.removeFirst()
+        }
+    }
+}
+
+private final class ObservationCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value = 0
+
+    var isEmpty: Bool {
+        self.lock.withLock { self.value == 0 }
+    }
+
+    func increment() {
+        self.lock.withLock { self.value += 1 }
+    }
+}

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeTargetedClickTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeTargetedClickTests.swift
@@ -212,7 +212,7 @@ struct PeekabooBridgeTargetedClickTests {
         defer { Task { await currentHost.stop() } }
         let currentClient = TrustedBridgeClientFixture.make(socketPath: currentSocket, requestTimeoutSec: 2)
         let handshake = try await currentClient.handshake(client: Self.clientIdentity)
-        #expect(handshake.negotiatedVersion == PeekabooBridgeConstants.statelessClickVariantVersion)
+        #expect(handshake.negotiatedVersion == PeekabooBridgeConstants.protocolVersion)
         #expect(handshake.hostCapabilities?.contains(PeekabooBridgeHostCapability.statelessClickVariants) == false)
 
         _ = try await currentClient.clickWithOutcome(


### PR DESCRIPTION
## Summary

- add Bridge protocol 1.32 `observeProcessGeneration` as a receipt-required, read-only operation
- authenticate the caller from its live audit-token-bound Foundation signing identity and reject the transitional Team
- return signed, timed `sameGenerationAlive`, `exactGenerationAbsent`, or `pidReused` evidence while failing closed on ambiguity, drift, and terminal/zombie state
- add closed decimal-safe wire models, handshake capability gating, client receipt adapters, receipt semantic validation, and adversarial coverage

## Safety boundary

The request carries only schema version and exact PID/start-generation identity. It cannot carry a digest, file, expected disposition, executable, arguments, environment, or signing claims. No producer, finalizer, catalog, installation, or release behavior is included.

## Proof

- `pnpm run test:safe`
  - background certification: 29 + 136 + 31 + 49
  - PeekabooFoundation: 70
  - CLI runtime: 115
  - certification controller: 48
  - CLI: 503
- focused process-generation observation: 16 tests
- operation semantic plan: 37 tests
- Agent transport compatibility: 3 tests
- trusted protocol fallback: 1 test
- `pnpm run format`
- `pnpm run lint` (0 serious)
- independent P2 review: clean, no findings
