### PR TITLE
feat(playground): expose semantic AX witnesses

### DIFF
--- a/Apps/CLI/Tests/CLIAutomationTests/SeeCommandPlaygroundTests.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/SeeCommandPlaygroundTests.swift
@@ -1,4 +1,6 @@
+import AppKit
 import Foundation
+import PeekabooCore
 import Testing
 @testable import PeekabooCLI
 
@@ -9,18 +11,37 @@ private enum SeeCommandPlaygroundTestConfig {
         ProcessInfo.processInfo.environment["RUN_LOCAL_TESTS"]?.lowercased() == "true"
     }
 
-    @preconcurrency
-    nonisolated static func playgroundIdentifier() -> String {
-        ProcessInfo.processInfo.environment["PEEKABOO_PLAYGROUND_APP"] ?? "Playground"
+    @MainActor
+    static func playgroundURL() -> URL? {
+        if let path = ProcessInfo.processInfo.environment["PEEKABOO_PLAYGROUND_APP"],
+           path.hasPrefix("/") {
+            return URL(fileURLWithPath: path)
+        }
+        return NSWorkspace.shared.urlForApplication(withBundleIdentifier: "boo.peekaboo.playground.debug") ??
+            NSWorkspace.shared.urlForApplication(withBundleIdentifier: "boo.peekaboo.playground")
     }
 }
 
 private enum SeeCommandPlaygroundHarness {
-    static func launchArguments(playgroundIdentifier: String) -> [String] {
-        [
-            "app", "launch", playgroundIdentifier,
-            "--new-instance", "--wait-for-window", "--no-remote", "--json",
-        ]
+    struct Launch {
+        let pid: Int32
+        let processStartIdentity: UInt64
+    }
+
+    @MainActor
+    static func launchBackgroundApplication() async throws -> Launch {
+        let applicationURL = try #require(SeeCommandPlaygroundTestConfig.playgroundURL())
+        let configuration = NSWorkspace.OpenConfiguration()
+        configuration.activates = false
+        configuration.addsToRecentItems = false
+        configuration.createsNewApplicationInstance = true
+        let application = try await NSWorkspace.shared.openApplication(
+            at: applicationURL,
+            configuration: configuration
+        )
+        let pid = application.processIdentifier
+        let processStartIdentity = try #require(SystemIdentityResolver.processStartIdentity(pid))
+        return Launch(pid: pid, processStartIdentity: processStartIdentity)
     }
 
     static func run(
@@ -39,16 +60,6 @@ private enum SeeCommandPlaygroundHarness {
 
 struct SeeCommandPlaygroundHarnessContractTests {
     @Test
-    func `Playground launch uses current v4 syntax`() {
-        let arguments = SeeCommandPlaygroundHarness.launchArguments(playgroundIdentifier: "Playground")
-        #expect(arguments == [
-            "app", "launch", "Playground",
-            "--new-instance", "--wait-for-window", "--no-remote", "--json",
-        ])
-        #expect(!arguments.contains("--name"))
-    }
-
-    @Test
     func `Harness command failures throw instead of being swallowed`() {
         #expect(throws: CommandExecutionError.self) {
             _ = try SeeCommandPlaygroundHarness.run(
@@ -66,28 +77,18 @@ struct SeeCommandPlaygroundHarnessContractTests {
 )
 struct SeeCommandPlaygroundTests {
     @Test
-    func `Hidden web-style fields are detected in Playground`() throws {
-        struct LaunchData: Codable {
-            let pid: Int32
-            let process_start_identity: UInt64
-        }
-
-        let launchOutput = try SeeCommandPlaygroundHarness.run(
-            SeeCommandPlaygroundHarness.launchArguments(
-                playgroundIdentifier: SeeCommandPlaygroundTestConfig.playgroundIdentifier()
-            )
-        )
-        let launchData = try #require(launchOutput.data(using: .utf8))
-        let launch = try JSONDecoder().decode(CodableJSONResponse<LaunchData>.self, from: launchData)
+    @MainActor
+    func `Hidden web-style fields are detected in Playground`() async throws {
+        let launch = try await SeeCommandPlaygroundHarness.launchBackgroundApplication()
         let cleanupArguments = [
-            "app", "quit", "--pid", String(launch.data.pid),
-            "--expected-process-start-identity", String(launch.data.process_start_identity),
+            "app", "quit", "--pid", String(launch.pid),
+            "--expected-process-start-identity", String(launch.processStartIdentity),
             "--force", "--no-remote", "--json",
         ]
 
         do {
             let output = try SeeCommandPlaygroundHarness.run([
-                "see", "--pid", String(launch.data.pid), "--no-remote", "--json",
+                "see", "--pid", String(launch.pid), "--no-remote", "--json",
             ])
             let data = try #require(output.data(using: .utf8))
             let envelope = try JSONDecoder().decode(CodableJSONResponse<SeeResult>.self, from: data)
@@ -105,6 +106,103 @@ struct SeeCommandPlaygroundTests {
             #expect(identifiers.contains("permission-deny-button"))
             #expect(roles["permission-allow-button"]?.first?.label == "Allow")
             #expect(roles["permission-deny-button"]?.first?.label == "Don't Allow")
+        } catch {
+            _ = try? SeeCommandPlaygroundHarness.run(cleanupArguments)
+            throw error
+        }
+
+        _ = try SeeCommandPlaygroundHarness.run(cleanupArguments)
+    }
+
+    @Test
+    @MainActor
+    func `Semantic witnesses survive the live detached AX reader`() async throws {
+        struct Window: Codable {
+            let window_title: String
+            let window_id: UInt32
+        }
+
+        struct WindowList: Codable {
+            let windows: [Window]
+        }
+
+        struct FailureResponse: Codable {
+            struct Failure: Codable {
+                let code: String
+                let message: String
+            }
+
+            let success: Bool
+            let error: Failure
+        }
+
+        let launch = try await SeeCommandPlaygroundHarness.launchBackgroundApplication()
+        let cleanupArguments = [
+            "app", "quit", "--pid", String(launch.pid),
+            "--expected-process-start-identity", String(launch.processStartIdentity),
+            "--force", "--no-remote", "--json",
+        ]
+
+        do {
+            let fixtures: [(title: String, values: [(identifier: String, expected: String?)])] = [
+                ("Text Fixture", [("basic-text-last-submitted", "")]),
+                ("Click Fixture", [("single-click-count", "0"), ("secondary-click-count", "0")]),
+                ("Scroll Fixture", [("vertical-scroll-offset", nil)]),
+            ]
+            for fixture in fixtures {
+                _ = try SeeCommandPlaygroundHarness.run([
+                    "menu", "click", "--pid", String(launch.pid),
+                    "--path", "Fixtures > Open \(fixture.title)", "--no-remote", "--json",
+                ])
+            }
+
+            let windowOutput = try SeeCommandPlaygroundHarness.run([
+                "window", "list", "--pid", String(launch.pid), "--no-remote", "--json",
+            ])
+            let windowData = try #require(windowOutput.data(using: .utf8))
+            let windows = try JSONDecoder().decode(CodableJSONResponse<WindowList>.self, from: windowData).data.windows
+
+            for fixture in fixtures {
+                let window = try #require(windows.first(where: { $0.window_title == fixture.title }))
+                let output = try SeeCommandPlaygroundHarness.run([
+                    "see", "--pid", String(launch.pid),
+                    "--window-id", String(window.window_id),
+                    "--max-elements", "20", "--timeout", "5s", "--no-remote", "--json",
+                ])
+                let data = try #require(output.data(using: .utf8))
+                let result = try JSONDecoder().decode(CodableJSONResponse<SeeResult>.self, from: data).data
+                let byIdentifier = Dictionary(
+                    grouping: result.ui_elements,
+                    by: { $0.identifier ?? "" }
+                )
+
+                for (identifier, expectedValue) in fixture.values {
+                    let elements = try #require(byIdentifier[identifier])
+                    #expect(elements.count == 1)
+                    let element = try #require(elements.first)
+                    #expect(element.ax_role == "AXStaticText")
+                    #expect(element.bounds.width > 5)
+                    #expect(element.bounds.height > 5)
+                    if let expectedValue {
+                        #expect(element.value == expectedValue)
+                    } else {
+                        #expect(element.value.flatMap(Double.init)?.isFinite == true)
+                    }
+
+                    if identifier == "basic-text-last-submitted" {
+                        let actionOutput = try SeeCommandPlaygroundHarness.run([
+                            "action", "AXIncrement", "--on", element.id,
+                            "--snapshot", result.snapshot_id, "--no-remote", "--json",
+                        ], allowedExitStatuses: [1])
+                        let actionData = try #require(actionOutput.data(using: .utf8))
+                        let failure = try JSONDecoder().decode(FailureResponse.self, from: actionData)
+                        #expect(!failure.success)
+                        #expect(failure.error.code == "INVALID_INPUT")
+                        #expect(failure.error.message.contains("not supported by \(element.id) staticText"))
+                        #expect(!failure.error.message.localizedCaseInsensitiveContains("not found"))
+                    }
+                }
+            }
         } catch {
             _ = try? SeeCommandPlaygroundHarness.run(cleanupArguments)
             throw error

--- a/Apps/CLI/Tests/CLIAutomationTests/SeeCommandPlaygroundTests.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/SeeCommandPlaygroundTests.swift
@@ -51,9 +51,11 @@ private enum SeeCommandPlaygroundHarness {
             configuration: configuration
         )
         let pid = application.processIdentifier
-        let processStartIdentity = try #require(SystemIdentityResolver.processStartIdentity(pid))
-        let launch = Launch(pid: pid, processStartIdentity: processStartIdentity)
+        var processStartIdentity: UInt64?
         do {
+            let identity = try #require(SystemIdentityResolver.processStartIdentity(pid))
+            processStartIdentity = identity
+            let launch = Launch(pid: pid, processStartIdentity: identity)
             let deadline = ContinuousClock.now + .seconds(5)
             while ContinuousClock.now < deadline {
                 if application.isFinishedLaunching,
@@ -67,7 +69,12 @@ private enum SeeCommandPlaygroundHarness {
             }
             throw HarnessError.windowReadinessTimedOut(pid: pid)
         } catch {
-            _ = try? self.run(self.cleanupArguments(for: launch))
+            if let cleanupArguments = self.cleanupArguments(
+                pid: pid,
+                processStartIdentity: processStartIdentity
+            ) {
+                _ = try? self.run(cleanupArguments)
+            }
             if !application.isTerminated {
                 _ = application.forceTerminate()
             }
@@ -91,6 +98,17 @@ private enum SeeCommandPlaygroundHarness {
             "--expected-process-start-identity", String(launch.processStartIdentity),
             "--force", "--no-remote", "--json",
         ]
+    }
+
+    static func cleanupArguments(
+        pid: Int32,
+        processStartIdentity: UInt64?
+    ) -> [String]? {
+        guard let processStartIdentity else { return nil }
+        return self.cleanupArguments(for: Launch(
+            pid: pid,
+            processStartIdentity: processStartIdentity
+        ))
     }
 
     static func run(
@@ -140,6 +158,10 @@ struct SeeCommandPlaygroundHarnessContractTests {
             "--expected-process-start-identity", "9001",
             "--force", "--no-remote", "--json",
         ])
+        #expect(SeeCommandPlaygroundHarness.cleanupArguments(
+            pid: 42,
+            processStartIdentity: nil
+        ) == nil)
     }
 }
 

--- a/Apps/CLI/Tests/CLIAutomationTests/SeeCommandPlaygroundTests.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/SeeCommandPlaygroundTests.swift
@@ -52,18 +52,27 @@ private enum SeeCommandPlaygroundHarness {
         )
         let pid = application.processIdentifier
         let processStartIdentity = try #require(SystemIdentityResolver.processStartIdentity(pid))
-        let deadline = ContinuousClock.now + .seconds(5)
-        while ContinuousClock.now < deadline {
-            if application.isFinishedLaunching,
-               let output = try? self.run([
-                   "window", "list", "--pid", String(pid), "--no-remote", "--json",
-               ]),
-               self.hasWindow(output) {
-                return Launch(pid: pid, processStartIdentity: processStartIdentity)
+        let launch = Launch(pid: pid, processStartIdentity: processStartIdentity)
+        do {
+            let deadline = ContinuousClock.now + .seconds(5)
+            while ContinuousClock.now < deadline {
+                if application.isFinishedLaunching,
+                   let output = try? self.run([
+                       "window", "list", "--pid", String(pid), "--no-remote", "--json",
+                   ]),
+                   self.hasWindow(output) {
+                    return launch
+                }
+                try await Task.sleep(for: .milliseconds(50))
             }
-            try await Task.sleep(for: .milliseconds(50))
+            throw HarnessError.windowReadinessTimedOut(pid: pid)
+        } catch {
+            _ = try? self.run(self.cleanupArguments(for: launch))
+            if !application.isTerminated {
+                _ = application.forceTerminate()
+            }
+            throw error
         }
-        throw HarnessError.windowReadinessTimedOut(pid: pid)
     }
 
     static func hasWindow(_ output: String) -> Bool {
@@ -74,6 +83,14 @@ private enum SeeCommandPlaygroundHarness {
               let windows = payload["windows"] as? [Any]
         else { return false }
         return !windows.isEmpty
+    }
+
+    static func cleanupArguments(for launch: Launch) -> [String] {
+        [
+            "app", "quit", "--pid", String(launch.pid),
+            "--expected-process-start-identity", String(launch.processStartIdentity),
+            "--force", "--no-remote", "--json",
+        ]
     }
 
     static func run(
@@ -113,6 +130,17 @@ struct SeeCommandPlaygroundHarnessContractTests {
             #"{"success":false,"data":{"windows":[{"window_id":42}]}}"#
         ))
     }
+
+    @Test
+    func `Launch cleanup is exact-generation pinned`() {
+        #expect(SeeCommandPlaygroundHarness.cleanupArguments(
+            for: .init(pid: 42, processStartIdentity: 9001)
+        ) == [
+            "app", "quit", "--pid", "42",
+            "--expected-process-start-identity", "9001",
+            "--force", "--no-remote", "--json",
+        ])
+    }
 }
 
 @Suite(
@@ -125,11 +153,7 @@ struct SeeCommandPlaygroundTests {
     @MainActor
     func `Hidden web-style fields are detected in Playground`() async throws {
         let launch = try await SeeCommandPlaygroundHarness.launchBackgroundApplication()
-        let cleanupArguments = [
-            "app", "quit", "--pid", String(launch.pid),
-            "--expected-process-start-identity", String(launch.processStartIdentity),
-            "--force", "--no-remote", "--json",
-        ]
+        let cleanupArguments = SeeCommandPlaygroundHarness.cleanupArguments(for: launch)
 
         do {
             let output = try SeeCommandPlaygroundHarness.run([
@@ -182,11 +206,7 @@ struct SeeCommandPlaygroundTests {
         }
 
         let launch = try await SeeCommandPlaygroundHarness.launchBackgroundApplication()
-        let cleanupArguments = [
-            "app", "quit", "--pid", String(launch.pid),
-            "--expected-process-start-identity", String(launch.processStartIdentity),
-            "--force", "--no-remote", "--json",
-        ]
+        let cleanupArguments = SeeCommandPlaygroundHarness.cleanupArguments(for: launch)
 
         do {
             let fixtures: [(title: String, values: [(identifier: String, expected: String?)])] = [

--- a/Apps/CLI/Tests/CLIAutomationTests/SeeCommandPlaygroundTests.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/SeeCommandPlaygroundTests.swift
@@ -23,6 +23,17 @@ private enum SeeCommandPlaygroundTestConfig {
 }
 
 private enum SeeCommandPlaygroundHarness {
+    enum HarnessError: LocalizedError {
+        case windowReadinessTimedOut(pid: Int32)
+
+        var errorDescription: String? {
+            switch self {
+            case let .windowReadinessTimedOut(pid):
+                "Playground process \(pid) did not publish a window before the readiness deadline."
+            }
+        }
+    }
+
     struct Launch {
         let pid: Int32
         let processStartIdentity: UInt64
@@ -41,7 +52,28 @@ private enum SeeCommandPlaygroundHarness {
         )
         let pid = application.processIdentifier
         let processStartIdentity = try #require(SystemIdentityResolver.processStartIdentity(pid))
-        return Launch(pid: pid, processStartIdentity: processStartIdentity)
+        let deadline = ContinuousClock.now + .seconds(5)
+        while ContinuousClock.now < deadline {
+            if application.isFinishedLaunching,
+               let output = try? self.run([
+                   "window", "list", "--pid", String(pid), "--no-remote", "--json",
+               ]),
+               self.hasWindow(output) {
+                return Launch(pid: pid, processStartIdentity: processStartIdentity)
+            }
+            try await Task.sleep(for: .milliseconds(50))
+        }
+        throw HarnessError.windowReadinessTimedOut(pid: pid)
+    }
+
+    static func hasWindow(_ output: String) -> Bool {
+        guard let data = output.data(using: .utf8),
+              let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              root["success"] as? Bool == true,
+              let payload = root["data"] as? [String: Any],
+              let windows = payload["windows"] as? [Any]
+        else { return false }
+        return !windows.isEmpty
     }
 
     static func run(
@@ -67,6 +99,19 @@ struct SeeCommandPlaygroundHarnessContractTests {
                 environment: ["PEEKABOO_CLI_PATH": "/usr/bin/false"]
             )
         }
+    }
+
+    @Test
+    func `Launch readiness requires a successful nonempty window inventory`() {
+        #expect(SeeCommandPlaygroundHarness.hasWindow(
+            #"{"success":true,"data":{"windows":[{"window_id":42}]}}"#
+        ))
+        #expect(!SeeCommandPlaygroundHarness.hasWindow(
+            #"{"success":true,"data":{"windows":[]}}"#
+        ))
+        #expect(!SeeCommandPlaygroundHarness.hasWindow(
+            #"{"success":false,"data":{"windows":[{"window_id":42}]}}"#
+        ))
     }
 }
 
@@ -167,6 +212,7 @@ struct SeeCommandPlaygroundTests {
                 let output = try SeeCommandPlaygroundHarness.run([
                     "see", "--pid", String(launch.pid),
                     "--window-id", String(window.window_id),
+                    // Witness overlays are root-adjacent; keep the subprocess JSON below pipe capacity.
                     "--max-elements", "20", "--timeout", "5s", "--no-remote", "--json",
                 ])
                 let data = try #require(output.data(using: .utf8))

--- a/Apps/Playground/Playground/PlaygroundSemanticWitness.swift
+++ b/Apps/Playground/Playground/PlaygroundSemanticWitness.swift
@@ -1,0 +1,125 @@
+import AppKit
+import SwiftUI
+
+enum PlaygroundSemanticWitnessIdentifier: String, CaseIterable, Sendable {
+    case basicTextLastSubmitted = "basic-text-last-submitted"
+    case secondaryClickCount = "secondary-click-count"
+    case singleClickCount = "single-click-count"
+    case verticalScrollOffset = "vertical-scroll-offset"
+
+    var label: String {
+        switch self {
+        case .basicTextLastSubmitted: "Basic Text Last Submitted"
+        case .secondaryClickCount: "Secondary Click Count"
+        case .singleClickCount: "Single Click Count"
+        case .verticalScrollOffset: "Vertical Scroll Offset"
+        }
+    }
+}
+
+enum PlaygroundSemanticWitnessLayout {
+    /// Both the current and detached AX readers omit elements whose dimensions are 5 points or less.
+    static let frameDimension: CGFloat = 8
+}
+
+struct TextInputSemanticState: Equatable, Sendable {
+    private(set) var basicTextLastSubmitted = ""
+
+    mutating func recordBasicTextSubmission(_ text: String) {
+        self.basicTextLastSubmitted = text
+    }
+}
+
+struct ClickTestingSemanticState: Equatable, Sendable {
+    private(set) var singleClickCount = 0
+    private(set) var secondaryClickCount = 0
+
+    mutating func recordSingleClick() {
+        self.singleClickCount += 1
+    }
+
+    mutating func recordSecondaryClick() {
+        self.secondaryClickCount += 1
+    }
+}
+
+struct ScrollTestingSemanticState: Equatable, Sendable {
+    private(set) var verticalScrollOffset = "0"
+
+    mutating func recordVerticalScrollOffset(_ offset: CGFloat) {
+        let rounded = (offset * 100).rounded() / 100
+        guard rounded != 0 else {
+            self.verticalScrollOffset = "0"
+            return
+        }
+        self.verticalScrollOffset = String(
+            format: "%.2f",
+            locale: Locale(identifier: "en_US_POSIX"),
+            rounded)
+    }
+}
+
+struct PlaygroundSemanticWitness: NSViewRepresentable {
+    let identifier: PlaygroundSemanticWitnessIdentifier
+    let value: String
+
+    func makeNSView(context: Context) -> PlaygroundSemanticWitnessNSView {
+        let view = PlaygroundSemanticWitnessNSView(frame: .zero)
+        view.configure(identifier: self.identifier, value: self.value)
+        return view
+    }
+
+    func updateNSView(_ nsView: PlaygroundSemanticWitnessNSView, context: Context) {
+        nsView.configure(identifier: self.identifier, value: self.value)
+    }
+}
+
+final class PlaygroundSemanticWitnessNSView: NSTextField {
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        self.isBezeled = false
+        self.isBordered = false
+        self.isEditable = false
+        self.isSelectable = false
+        self.drawsBackground = false
+        self.textColor = .clear
+        self.focusRingType = .none
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        nil
+    }
+
+    func configure(identifier: PlaygroundSemanticWitnessIdentifier, value: String) {
+        let valueChanged = self.accessibilityValue() != value
+        self.stringValue = value
+        self.setAccessibilityElement(true)
+        self.setAccessibilityRole(.staticText)
+        self.setAccessibilityIdentifier(identifier.rawValue)
+        self.setAccessibilityLabel(identifier.label)
+        self.setAccessibilityValue(value)
+
+        if valueChanged, self.window != nil {
+            NSAccessibility.post(element: self, notification: .valueChanged)
+        }
+    }
+}
+
+extension View {
+    func playgroundSemanticWitness(
+        _ identifier: PlaygroundSemanticWitnessIdentifier,
+        value: String) -> some View
+    {
+        self.overlay(alignment: .topLeading) {
+            PlaygroundSemanticWitness(identifier: identifier, value: value)
+                .frame(
+                    width: PlaygroundSemanticWitnessLayout.frameDimension,
+                    height: PlaygroundSemanticWitnessLayout.frameDimension)
+        }
+    }
+}

--- a/Apps/Playground/Playground/Views/ClickTestingView.swift
+++ b/Apps/Playground/Playground/Views/ClickTestingView.swift
@@ -3,7 +3,7 @@ import SwiftUI
 struct ClickTestingView: View {
     @EnvironmentObject var actionLogger: ActionLogger
     @State private var toggleState = false
-    @State private var clickCount = 0
+    @State private var semanticState = ClickTestingSemanticState()
     @State private var lastClickType = ""
 
     var body: some View {
@@ -15,17 +15,18 @@ struct ClickTestingView: View {
                 GroupBox("Basic Buttons") {
                     HStack(spacing: 20) {
                         Button("Single Click") {
-                            self.clickCount += 1
+                            self.semanticState.recordSingleClick()
                             self.lastClickType = "Single"
                             self.actionLogger.log(
                                 .click,
                                 "Single click on 'Single Click' button",
-                                details: "Click count: \(self.clickCount)")
+                                details: "Click count: \(self.semanticState.singleClickCount)")
                         }
                         .buttonStyle(.borderedProminent)
                         .accessibilityIdentifier("single-click-button")
 
                         Button("Secondary Button") {
+                            self.semanticState.recordSecondaryClick()
                             self.actionLogger.log(.click, "Clicked 'Secondary Button'")
                         }
                         .buttonStyle(.bordered)
@@ -166,10 +167,10 @@ struct ClickTestingView: View {
                 }
 
                 // Status display
-                if self.clickCount > 0 {
+                if self.semanticState.singleClickCount > 0 {
                     GroupBox("Click Statistics") {
                         HStack {
-                            Label("\(self.clickCount) total clicks", systemImage: "hand.tap")
+                            Label("\(self.semanticState.singleClickCount) total clicks", systemImage: "hand.tap")
                             Spacer()
                             if !self.lastClickType.isEmpty {
                                 Text("Last: \(self.lastClickType)")
@@ -181,6 +182,12 @@ struct ClickTestingView: View {
             }
             .padding()
         }
+        .playgroundSemanticWitness(
+            .singleClickCount,
+            value: String(self.semanticState.singleClickCount))
+        .playgroundSemanticWitness(
+            .secondaryClickCount,
+            value: String(self.semanticState.secondaryClickCount))
     }
 }
 

--- a/Apps/Playground/Playground/Views/ScrollTestingView.swift
+++ b/Apps/Playground/Playground/Views/ScrollTestingView.swift
@@ -11,6 +11,7 @@ struct ScrollTestingView: View {
     @State private var lastHorizontalOffset: CGFloat?
     @State private var lastNestedInnerOffset: CGFloat?
     @State private var lastNestedOuterOffset: CGFloat?
+    @State private var semanticState = ScrollTestingSemanticState()
 
     var body: some View {
         VStack(spacing: 20) {
@@ -299,10 +300,14 @@ struct ScrollTestingView: View {
             Spacer()
         }
         .padding()
+        .playgroundSemanticWitness(
+            .verticalScrollOffset,
+            value: self.semanticState.verticalScrollOffset)
     }
 
     private func logVerticalScrollChange(offset: CGFloat) {
         let rounded = (offset * 100).rounded() / 100
+        self.semanticState.recordVerticalScrollOffset(rounded)
         if let lastOffset = self.lastVerticalOffset, abs(lastOffset - rounded) < 5 {
             return
         }

--- a/Apps/Playground/Playground/Views/TextInputView.swift
+++ b/Apps/Playground/Playground/Views/TextInputView.swift
@@ -9,6 +9,7 @@ struct TextInputView: View {
     @State private var prefilledText = "This text is pre-filled"
     @State private var searchText = ""
     @State private var formattedText = ""
+    @State private var semanticState = TextInputSemanticState()
     @FocusState private var focusedField: Field?
 
     enum Field: String {
@@ -30,6 +31,7 @@ struct TextInputView: View {
                             identifier: "basic-text-field")
                             .focused(self.$focusedField, equals: .basic)
                             .onSubmit {
+                                self.semanticState.recordBasicTextSubmission(self.basicText)
                                 self.actionLogger.log(
                                     .text,
                                     "Submitted basic text field",
@@ -242,6 +244,9 @@ struct TextInputView: View {
             }
             .padding()
         }
+        .playgroundSemanticWitness(
+            .basicTextLastSubmitted,
+            value: self.semanticState.basicTextLastSubmitted)
         .onAppear {
             self.actionLogger.log(.focus, "Text input view appeared")
         }

--- a/Apps/Playground/Tests/PlaygroundTests/PlaygroundSemanticWitnessTests.swift
+++ b/Apps/Playground/Tests/PlaygroundTests/PlaygroundSemanticWitnessTests.swift
@@ -1,0 +1,62 @@
+import AppKit
+import Testing
+@testable import Playground
+
+@MainActor
+struct PlaygroundSemanticWitnessTests {
+    @Test
+    func `semantic witness identifiers are stable and unique`() {
+        #expect(PlaygroundSemanticWitnessIdentifier.basicTextLastSubmitted.rawValue == "basic-text-last-submitted")
+        #expect(PlaygroundSemanticWitnessIdentifier.secondaryClickCount.rawValue == "secondary-click-count")
+        #expect(PlaygroundSemanticWitnessIdentifier.singleClickCount.rawValue == "single-click-count")
+        #expect(PlaygroundSemanticWitnessIdentifier.verticalScrollOffset.rawValue == "vertical-scroll-offset")
+
+        let identifiers = PlaygroundSemanticWitnessIdentifier.allCases.map(\.rawValue)
+        #expect(Set(identifiers).count == identifiers.count)
+    }
+
+    @Test
+    func `semantic state exposes deterministic initial and transition values`() {
+        var textState = TextInputSemanticState()
+        #expect(textState.basicTextLastSubmitted.isEmpty)
+        textState.recordBasicTextSubmission("background text")
+        #expect(textState.basicTextLastSubmitted == "background text")
+
+        var clickState = ClickTestingSemanticState()
+        #expect(clickState.singleClickCount == 0)
+        #expect(clickState.secondaryClickCount == 0)
+        clickState.recordSingleClick()
+        clickState.recordSecondaryClick()
+        clickState.recordSecondaryClick()
+        #expect(clickState.singleClickCount == 1)
+        #expect(clickState.secondaryClickCount == 2)
+
+        var scrollState = ScrollTestingSemanticState()
+        #expect(scrollState.verticalScrollOffset == "0")
+        scrollState.recordVerticalScrollOffset(-123.456)
+        #expect(scrollState.verticalScrollOffset == "-123.46")
+        scrollState.recordVerticalScrollOffset(0.004)
+        #expect(scrollState.verticalScrollOffset == "0")
+    }
+
+    @Test
+    func `AX witness retains its identifier while exposing value transitions`() {
+        let dimension = PlaygroundSemanticWitnessLayout.frameDimension
+        #expect(dimension > 5)
+        let view = PlaygroundSemanticWitnessNSView(
+            frame: CGRect(x: 0, y: 0, width: dimension, height: dimension))
+        view.configure(identifier: .singleClickCount, value: "0")
+
+        #expect(view.frame.width > 5)
+        #expect(view.frame.height > 5)
+        #expect(view.isAccessibilityElement())
+        #expect(view.accessibilityRole() == .staticText)
+        #expect(view.accessibilityIdentifier() == "single-click-count")
+        #expect(view.accessibilityLabel() == "Single Click Count")
+        #expect(view.accessibilityValue() == "0")
+
+        view.configure(identifier: .singleClickCount, value: "1")
+        #expect(view.accessibilityIdentifier() == "single-click-count")
+        #expect(view.accessibilityValue() == "1")
+    }
+}

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/AXDescriptorReaderPolicyTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/AXDescriptorReaderPolicyTests.swift
@@ -121,6 +121,28 @@ struct AXDescriptorReaderPolicyTests {
     }
 
     @Test
+    func `Current AX reader retains a production semantic witness frame`() {
+        let required = Self.requiredDescriptorReads(
+            size: CGSize(width: 8, height: 8),
+            role: "AXStaticText",
+            identifier: "single-click-count",
+            value: "2")
+
+        let result = AXDescriptorReader.describeWithSingleAttributeReads { name in
+            required[name] ?? AXDescriptorReader.SingleAttributeRead(error: .noValue, value: nil)
+        }
+
+        guard case let .descriptor(descriptor) = result else {
+            Issue.record("Expected the current AX reader to retain the semantic witness")
+            return
+        }
+        #expect(descriptor.frame.size == CGSize(width: 8, height: 8))
+        #expect(descriptor.role == "AXStaticText")
+        #expect(descriptor.identifier == "single-click-count")
+        #expect(descriptor.value == "2")
+    }
+
+    @Test
     func `Single-read fallback treats successful nil value as malformed`() {
         let required = Self.requiredDescriptorReads()
 
@@ -183,17 +205,31 @@ struct AXDescriptorReaderPolicyTests {
             values: values) == .values)
     }
 
-    private static func requiredDescriptorReads() -> [String: AXDescriptorReader.SingleAttributeRead] {
+    private static func requiredDescriptorReads(
+        size: CGSize = CGSize(width: 100, height: 40),
+        role: String = "AXButton",
+        identifier: String? = nil,
+        value: String? = nil) -> [String: AXDescriptorReader.SingleAttributeRead]
+    {
         var point = CGPoint(x: 10, y: 20)
-        var size = CGSize(width: 100, height: 40)
-        return [
+        var size = size
+        var reads = [
             "AXPosition": AXDescriptorReader.SingleAttributeRead(
                 error: .success,
                 value: AXValueCreate(.cgPoint, &point)),
             "AXSize": AXDescriptorReader.SingleAttributeRead(
                 error: .success,
                 value: AXValueCreate(.cgSize, &size)),
-            "AXRole": AXDescriptorReader.SingleAttributeRead(error: .success, value: "AXButton"),
+            "AXRole": AXDescriptorReader.SingleAttributeRead(error: .success, value: role),
         ]
+        if let identifier {
+            reads["AXIdentifier"] = AXDescriptorReader.SingleAttributeRead(
+                error: .success,
+                value: identifier)
+        }
+        if let value {
+            reads["AXValue"] = AXDescriptorReader.SingleAttributeRead(error: .success, value: value)
+        }
+        return reads
     }
 }

--- a/scripts/background-computer-use-catalog.json
+++ b/scripts/background-computer-use-catalog.json
@@ -61,7 +61,7 @@
     {"id":"stale-snapshot","surface":"cli","command":"click","phase":"background","expected_exit":"failure","expected_effect":"refused","expected_error_code":"SNAPSHOT_STALE","contamination_retry_safe":true,"required_oracles":["snapshot_window_drift","target_window_restored"]},
     {"id":"type-ambiguous-pid-refused","surface":"cli","command":"type","phase":"background","expected_exit":"failure","expected_effect":"refused","expected_error_code":"INVALID_INPUT","contamination_retry_safe":true,"required_oracles":["refusal_guidance"]},
     {"id":"type-exact-window","surface":"cli","command":"type","phase":"background","expected_exit":"success","expected_effect":"unverifiable","expected_delivery":"background","required_oracles":["background_delivery","playground_log_line"]},
-    {"id":"press-exact-window","surface":"cli","command":"press","phase":"background","expected_exit":"success","expected_effect":"unverifiable","expected_delivery":"background","required_oracles":["background_delivery","playground_log_line"]},
+    {"id":"press-exact-window","surface":"cli","command":"press","phase":"background","expected_exit":"success","expected_effect":"unverifiable","expected_delivery":"background","required_oracles":["background_delivery","playground_log_line","submitted_text_witness"]},
     {"id":"press-pid-refused","surface":"cli","command":"press","phase":"background","expected_exit":"failure","expected_effect":"refused","expected_error_code":"INTERACTION_FAILED","contamination_retry_safe":true,"required_oracles":["refusal_guidance"]},
     {"id":"press-app-refused","surface":"cli","command":"press","phase":"background","expected_exit":"failure","expected_effect":"refused","expected_error_code":"INTERACTION_FAILED","contamination_retry_safe":true,"required_oracles":["refusal_guidance"]},
     {"id":"paste-text","surface":"cli","command":"paste","phase":"background","expected_exit":"success","expected_effect":"unverifiable","expected_delivery":"background","required_oracles":["background_delivery","playground_log"]},
@@ -73,14 +73,14 @@
     {"id":"menu-open-scroll","surface":"cli","command":"menu click","phase":"background","expected_exit":"success","expected_effect":"confirmed","expected_delivery":"background","required_oracles":[]},
     {"id":"list-window-scroll","surface":"cli","command":"window list","phase":"background","expected_exit":"success","contamination_retry_safe":true,"required_oracles":["window_discovery"]},
     {"id":"see-click","surface":"cli","command":"see","phase":"background","expected_exit":"success","contamination_retry_safe":true,"required_oracles":["snapshot_identifiers","artifact"]},
-    {"id":"click-id","surface":"cli","command":"click","phase":"background","expected_exit":"success","expected_effect":"confirmed","expected_delivery":"background","required_oracles":["background_delivery","click_id_readback","playground_log_delta"]},
+    {"id":"click-id","surface":"cli","command":"click","phase":"background","expected_exit":"success","expected_effect":"confirmed","expected_delivery":"background","required_oracles":["background_delivery","click_id_readback","playground_log_delta","single_click_witness"]},
     {"id":"see-click-after-id","surface":"cli","command":"see","phase":"background","expected_exit":"success","contamination_retry_safe":true,"required_oracles":["artifact"]},
-    {"id":"click-query","surface":"cli","command":"click","phase":"background","expected_exit":"success","expected_effect":"confirmed","expected_delivery":"background","required_oracles":["background_delivery","playground_log_delta"]},
+    {"id":"click-query","surface":"cli","command":"click","phase":"background","expected_exit":"success","expected_effect":"confirmed","expected_delivery":"background","required_oracles":["background_delivery","playground_log_delta","secondary_click_witness"]},
     {"id":"see-click-for-action","surface":"cli","command":"see","phase":"background","expected_exit":"success","contamination_retry_safe":true,"required_oracles":["snapshot_identifiers","artifact"]},
-    {"id":"action","surface":"cli","command":"action","phase":"background","expected_exit":"success","expected_effect":"confirmed","required_oracles":["action_readback","playground_log_delta"]},
+    {"id":"action","surface":"cli","command":"action","phase":"background","expected_exit":"success","expected_effect":"confirmed","required_oracles":["action_readback","playground_log_delta","single_click_witness"]},
     {"id":"see-click-after-action","surface":"cli","command":"see","phase":"background","expected_exit":"success","contamination_retry_safe":true,"required_oracles":["artifact"]},
     {"id":"unsupported-action","surface":"cli","command":"action","phase":"background","expected_exit":"failure","expected_effect":"refused","expected_error_code":"INVALID_INPUT","contamination_retry_safe":true,"required_oracles":["refusal_guidance"]},
     {"id":"see-scroll","surface":"cli","command":"see","phase":"background","expected_exit":"success","contamination_retry_safe":true,"required_oracles":["snapshot_identifiers","artifact"]},
-    {"id":"scroll-action-background","surface":"cli","command":"scroll","phase":"background","expected_exit":"success","expected_effect":"confirmed","required_oracles":["confirmed_scroll","scroll_offset_changed"]}
+    {"id":"scroll-action-background","surface":"cli","command":"scroll","phase":"background","expected_exit":"success","expected_effect":"confirmed","required_oracles":["confirmed_scroll","scroll_offset_changed","scroll_witness_changed"]}
   ]
 }

--- a/scripts/test-background-computer-use.sh
+++ b/scripts/test-background-computer-use.sh
@@ -2508,6 +2508,37 @@ element_id_from_result() {
     ' "$result_file"
 }
 
+semantic_witness_value_from_result() {
+    local result_file="$1"
+    local identifier="$2"
+    jq -er --arg identifier "$identifier" '
+        [(.data.ui_elements? // .ui_elements? // [])[] |
+            select(.identifier == $identifier) |
+            select(.ax_role == "AXStaticText") |
+            select(.bounds.width > 5 and .bounds.height > 5) |
+            .value |
+            select(type == "string")] |
+        select(length == 1) |
+        .[0]
+    ' "$result_file"
+}
+
+assert_semantic_witness() {
+    local case_name="$1"
+    local oracle="$2"
+    local result_file="$3"
+    local identifier="$4"
+    local expected="$5"
+    local observed
+    observed="$(semantic_witness_value_from_result "$result_file" "$identifier" 2>/dev/null || true)"
+    if [[ "$observed" != "$expected" ]]; then
+        record_case_oracle "$case_name" "$oracle" false || true
+        record_failure "$case_name did not expose exact $identifier semantic witness value"
+        return 1
+    fi
+    record_case_oracle "$case_name" "$oracle" true
+}
+
 assert_result_contains() {
     local oracle="$1"
     local result_file="$2"
@@ -2991,6 +3022,8 @@ run_checked_case see-text-after-paste unchanged success \
     --path "$ARTIFACT_ROOT/text-after-paste.png" || true
 assert_case_artifacts see-text-after-paste "$ARTIFACT_ROOT/text-after-paste.png" || true
 assert_result_contains paste_readback "$LAST_RESULT" "$PASTE_TOKEN" || true
+assert_semantic_witness \
+    press-exact-window submitted_text_witness "$LAST_RESULT" basic-text-last-submitted "$TYPE_TOKEN" || true
 TEXT_SNAPSHOT="$(snapshot_id_from_result "$LAST_RESULT")"
 BASIC_FIELD_ID="$(element_id_from_result "$LAST_RESULT" basic-text-field)"
 
@@ -3035,6 +3068,7 @@ run_checked_case see-click-after-id unchanged success \
     --path "$ARTIFACT_ROOT/click-after-id.png" || true
 assert_case_artifacts see-click-after-id "$ARTIFACT_ROOT/click-after-id.png" || true
 assert_case_result_contains click-id click_id_readback "$LAST_RESULT" "1 total clicks" || true
+assert_semantic_witness click-id single_click_witness "$LAST_RESULT" single-click-count "1" || true
 CLICK_LOG_AFTER_ID="$ARTIFACT_ROOT/playground-click-after-id.json"
 capture_playground_log "$CLICK_LOG_AFTER_ID"
 assert_playground_log_delta click-id "$CLICK_LOG_BASELINE" "$CLICK_LOG_AFTER_ID" \
@@ -3052,6 +3086,8 @@ CLICK_SNAPSHOT="$(snapshot_id_from_result "$LAST_RESULT")"
 SINGLE_CLICK_ID="$(element_id_from_result "$LAST_RESULT" single-click-button)"
 assert_case_artifacts see-click-for-action "$ARTIFACT_ROOT/click-for-action.png" || true
 assert_snapshot_identifiers see-click-for-action "$CLICK_SNAPSHOT" "$SINGLE_CLICK_ID" || true
+assert_semantic_witness \
+    click-query secondary_click_witness "$LAST_RESULT" secondary-click-count "1" || true
 CLICK_LOG_AFTER_QUERY="$ARTIFACT_ROOT/playground-click-after-query.json"
 capture_playground_log "$CLICK_LOG_AFTER_QUERY"
 assert_playground_log_delta click-query "$CLICK_LOG_AFTER_ID" "$CLICK_LOG_AFTER_QUERY" \
@@ -3064,6 +3100,7 @@ run_checked_case see-click-after-action unchanged success \
     --path "$ARTIFACT_ROOT/click-after-action.png" || true
 assert_case_artifacts see-click-after-action "$ARTIFACT_ROOT/click-after-action.png" || true
 assert_case_result_contains action action_readback "$LAST_RESULT" "2 total clicks" || true
+assert_semantic_witness action single_click_witness "$LAST_RESULT" single-click-count "2" || true
 CLICK_LOG_AFTER_ACTION="$ARTIFACT_ROOT/playground-click-after-action.json"
 capture_playground_log "$CLICK_LOG_AFTER_ACTION"
 assert_playground_log_delta action "$CLICK_LOG_AFTER_QUERY" "$CLICK_LOG_AFTER_ACTION" \
@@ -3080,6 +3117,9 @@ run_checked_case see-scroll unchanged success \
     --path "$ARTIFACT_ROOT/scroll-see.png" || true
 SCROLL_SNAPSHOT="$(snapshot_id_from_result "$LAST_RESULT")"
 VERTICAL_SCROLL_ID="$(element_id_from_result "$LAST_RESULT" vertical-scroll)"
+SCROLL_WITNESS_BEFORE="$(
+    semantic_witness_value_from_result "$LAST_RESULT" vertical-scroll-offset 2>/dev/null || true
+)"
 assert_case_artifacts see-scroll "$ARTIFACT_ROOT/scroll-see.png" || true
 assert_snapshot_identifiers see-scroll "$SCROLL_SNAPSHOT" "$VERTICAL_SCROLL_ID" || true
 if [[ -z "$SCROLL_SNAPSHOT" || -z "$VERTICAL_SCROLL_ID" ]]; then
@@ -3097,6 +3137,25 @@ else
         record_last_case_oracle confirmed_scroll true
     fi
     sleep 0.3
+    SCROLL_WITNESS_READBACK="$ARTIFACT_ROOT/scroll-semantic-readback.json"
+    if ! pb see --tree --no-screenshot --pid "$PLAYGROUND_PID" --window-id "$SCROLL_WINDOW_ID" \
+        --json > "$SCROLL_WITNESS_READBACK"; then
+        record_last_case_oracle scroll_witness_changed false || true
+        record_failure "scroll-action-background could not read the vertical-scroll-offset witness"
+    else
+        SCROLL_WITNESS_AFTER="$(
+            semantic_witness_value_from_result \
+                "$SCROLL_WITNESS_READBACK" vertical-scroll-offset 2>/dev/null || true
+        )"
+        if [[ ! "$SCROLL_WITNESS_BEFORE" =~ ^-?[0-9]+([.][0-9]{2})?$ ]] ||
+           [[ ! "$SCROLL_WITNESS_AFTER" =~ ^-?[0-9]+([.][0-9]{2})?$ ]] ||
+           [[ "$SCROLL_WITNESS_AFTER" == "$SCROLL_WITNESS_BEFORE" ]]; then
+            record_last_case_oracle scroll_witness_changed false || true
+            record_failure "scroll-action-background did not change its exact AX semantic witness"
+        else
+            record_last_case_oracle scroll_witness_changed true
+        fi
+    fi
     SCROLL_LOG_AFTER="$ARTIFACT_ROOT/playground-scroll-after.json"
     capture_playground_log "$SCROLL_LOG_AFTER"
     assert_playground_scroll_changed scroll-action-background "$SCROLL_LOG_BEFORE" "$SCROLL_LOG_AFTER" || true


### PR DESCRIPTION
## Summary

- expose always-present, transparent native AppKit Accessibility witnesses for submitted basic text, single and secondary click counts, and vertical scroll offset
- make every witness non-interactive while retaining a real AX frame above Peekaboo's strict greater-than-5-point reader boundary
- require the 42-case background matrix to consume exact witness values for submit/click outcomes and a finite changed value for scroll, so missing, duplicate, filtered, or stale witnesses fail closed
- add source-blind live coverage that proves the witnesses survive both the detached observation reader and the current live element resolver
- launch that signed fixture without activation, wait for a successful nonempty PID-scoped window inventory, and generation-pin cleanup on every post-launch error

## Typed producer boundary

The typed `observerSemantic` producer is orthogonal to this fixture surface. It cryptographically attests three consecutive `getFocusedElement` readbacks for one foreground semantic target during concurrent certification. These Playground witnesses expose app-owned background fixture outcomes for the physical matrix; they neither replace nor weaken the typed producer, listener-signature, exact-generation, or receipt requirements.

The original bare 1x1 `NSView` witnesses were not viable: both AX readers filter dimensions of 5 points or less, and a source-blind signed run confirmed that the bare custom view was still absent after merely enlarging it. The repaired fixture uses a transparent, non-editable `NSTextField`, whose standard `AXStaticText` node is retained by native Accessibility while `hitTest` remains disabled.

## Verification

- `swift test --package-path Apps/Playground --filter PlaygroundSemanticWitnessTests` (3 tests)
- `swift test --package-path Core/PeekabooAutomationKit --filter AXDescriptorReaderPolicyTests` (11 tests)
- `PEEKABOO_INCLUDE_AUTOMATION_TESTS=true RUN_LOCAL_TESTS=true swift test --package-path Apps/CLI --filter 'Semantic witnesses survive the live detached AX reader'` against a Foundation-signed Playground and Foundation-signed Peekaboo CLI (1 source-blind live test, 5.7s on fixture commit `e65f7d6e4`)
- `PEEKABOO_INCLUDE_AUTOMATION_TESTS=true swift test --package-path Apps/CLI --filter SeeCommandPlaygroundHarnessContractTests` (3 tests on readiness/cleanup follow-ups `486d6c7b2`, `ab7ca4341`, and `96170b2ac`)
- `node --test Tests/background-computer-use-report.test.mjs` (31 tests)
- `scripts/test-background-computer-use.sh --self-test`
- `pnpm run format`
- `pnpm run lint` (0 serious violations; 94 existing repository warnings)
- Autoreview clean

The live source-blind test found exactly one greater-than-5-point `AXStaticText` node for each identifier, required the expected initial values or finite scroll baseline, then used a background-safe unsupported action to prove the current resolver found the witness rather than returning element-not-found. The witnesses draw no visible content, so a before/after screenshot would be identical. The full physical 42-case run remains the final integration exercise; this PR adds the enforced oracles and their structural/self-test coverage.
