### PR TITLE
fix(capture): explain locked GUI sessions

### DIFF
--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Report `retry_safe: false` whenever an Agent trace cannot prove whether a mutation dispatched.
 - Replace arbitrary provider-authored Agent trace field names with deterministic ordinal placeholders at every argument nesting level.
 - Treat an exact missing-window readback after `window close` as confirmed closure instead of a retry-unsafe failure.
+- Explain that locked macOS GUI sessions cannot be captured even when `screen list` still reports connected displays.
 
 ## [4.2.2] - 2026-08-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Report `retry_safe: false` whenever an Agent trace cannot prove whether a mutation dispatched.
 - Replace arbitrary provider-authored Agent trace field names with deterministic ordinal placeholders at every argument nesting level.
 - Treat an exact missing-window readback after `window close` as confirmed closure instead of a retry-unsafe failure.
+- Refuse capture before permission or backend dispatch when the macOS GUI session is locked, while explaining that `screen list` can still report connected displays.
 
 ## [4.2.2] - 2026-08-20
 

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/ScreenCaptureService+Operations.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/ScreenCaptureService+Operations.swift
@@ -65,6 +65,12 @@ extension ScreenCaptureService {
         return try await ScreenCaptureKitCaptureGate.withExclusiveCaptureOperation(
             operationName: operation.metricName)
         {
+            if self.screenLockProbe() == true {
+                throw OperationError.captureFailed(
+                    reason: "Screen capture is unavailable while the macOS GUI session is locked. " +
+                        "`screen list` can still report connected displays; unlock the active user session and retry.")
+            }
+
             // Permission probing may call ScreenCaptureKit on CLI builds where
             // CGPreflightScreenCaptureAccess is unreliable; keep that probe in
             // the same cross-process transaction as the capture itself.

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/ScreenCaptureService.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/ScreenCaptureService.swift
@@ -49,6 +49,7 @@ public final class ScreenCaptureService: ScreenCaptureServiceProtocol, EngineAwa
             -> any ModernScreenCaptureOperating
         let makeLegacyOperator: @MainActor @Sendable (CategoryLogger)
             -> any LegacyScreenCaptureOperating
+        let screenLockProbe: @MainActor @Sendable () -> Bool?
         public init(
             feedbackClient: any AutomationFeedbackClient,
             permissionEvaluator: any ScreenRecordingPermissionEvaluating,
@@ -58,7 +59,8 @@ public final class ScreenCaptureService: ScreenCaptureServiceProtocol, EngineAwa
             makeModernOperator: @escaping @MainActor @Sendable (CategoryLogger, any AutomationFeedbackClient)
                 -> any ModernScreenCaptureOperating,
             makeLegacyOperator: @escaping @MainActor @Sendable (CategoryLogger)
-                -> any LegacyScreenCaptureOperating)
+                -> any LegacyScreenCaptureOperating,
+            screenLockProbe: @escaping @MainActor @Sendable () -> Bool? = { nil })
         {
             self.feedbackClient = feedbackClient
             self.permissionEvaluator = permissionEvaluator
@@ -67,6 +69,7 @@ public final class ScreenCaptureService: ScreenCaptureServiceProtocol, EngineAwa
             self.makeFrameSource = makeFrameSource
             self.makeModernOperator = makeModernOperator
             self.makeLegacyOperator = makeLegacyOperator
+            self.screenLockProbe = screenLockProbe
         }
 
         @MainActor
@@ -94,7 +97,8 @@ public final class ScreenCaptureService: ScreenCaptureServiceProtocol, EngineAwa
                 },
                 makeLegacyOperator: { logger in
                     LegacyScreenCaptureOperator(logger: logger)
-                })
+                },
+                screenLockProbe: DesktopSessionLockState.currentScreenIsLocked)
         }
     }
 
@@ -105,6 +109,7 @@ public final class ScreenCaptureService: ScreenCaptureServiceProtocol, EngineAwa
     let applicationResolver: any ApplicationResolving
     let modernOperator: any ModernScreenCaptureOperating
     let legacyOperator: any LegacyScreenCaptureOperating
+    let screenLockProbe: @MainActor @Sendable () -> Bool?
     @TaskLocal static var captureEnginePreference: CaptureEnginePreference = .auto
 
     public convenience init(
@@ -125,6 +130,7 @@ public final class ScreenCaptureService: ScreenCaptureServiceProtocol, EngineAwa
         self.applicationResolver = dependencies.applicationResolver
         self.modernOperator = dependencies.makeModernOperator(self.logger, self.feedbackClient)
         self.legacyOperator = dependencies.makeLegacyOperator(self.logger)
+        self.screenLockProbe = dependencies.screenLockProbe
 
         // Only connect to visualizer if we're not running inside the Mac app
         // The Mac app provides the visualizer service, not consumes it

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/System/DesktopSessionLockState.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/System/DesktopSessionLockState.swift
@@ -1,0 +1,14 @@
+import CoreGraphics
+import Foundation
+
+enum DesktopSessionLockState {
+    private static let screenIsLockedKey = "CGSSessionScreenIsLocked"
+
+    static func currentScreenIsLocked() -> Bool? {
+        self.screenIsLocked(in: CGSessionCopyCurrentDictionary() as NSDictionary?)
+    }
+
+    static func screenIsLocked(in session: NSDictionary?) -> Bool? {
+        session?[self.screenIsLockedKey] as? Bool
+    }
+}

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/UIAutomationService.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/UIAutomationService.swift
@@ -254,7 +254,8 @@ public final class UIAutomationService: TargetedHotkeyServiceProtocol, TargetedT
             applicationResolver: baseCaptureDeps.applicationResolver,
             makeFrameSource: baseCaptureDeps.makeFrameSource,
             makeModernOperator: baseCaptureDeps.makeModernOperator,
-            makeLegacyOperator: baseCaptureDeps.makeLegacyOperator)
+            makeLegacyOperator: baseCaptureDeps.makeLegacyOperator,
+            screenLockProbe: baseCaptureDeps.screenLockProbe)
         self.screenCaptureService = ScreenCaptureService(loggingService: logger, dependencies: captureDeps)
 
         // Connect to visual feedback if available.

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/DesktopSessionLockStateTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/DesktopSessionLockStateTests.swift
@@ -1,0 +1,25 @@
+import Foundation
+import Testing
+@testable import PeekabooAutomationKit
+
+struct DesktopSessionLockStateTests {
+    @Test
+    func `reports locked when the native session dictionary says locked`() {
+        let session: NSDictionary = ["CGSSessionScreenIsLocked": true]
+
+        #expect(DesktopSessionLockState.screenIsLocked(in: session) == true)
+    }
+
+    @Test
+    func `reports unlocked when the native session dictionary says unlocked`() {
+        let session: NSDictionary = ["CGSSessionScreenIsLocked": false]
+
+        #expect(DesktopSessionLockState.screenIsLocked(in: session) == false)
+    }
+
+    @Test
+    func `reports unknown when the native lock state is absent`() {
+        #expect(DesktopSessionLockState.screenIsLocked(in: [:]) == nil)
+        #expect(DesktopSessionLockState.screenIsLocked(in: nil) == nil)
+    }
+}

--- a/Core/PeekabooCore/Tests/PeekabooTests/ScreenCaptureServiceFlowTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/ScreenCaptureServiceFlowTests.swift
@@ -202,6 +202,68 @@ struct ScreenCaptureServiceFlowTests {
         }
     }
 
+    @Test(arguments: [CaptureEnginePreference.auto, .modern, .legacy])
+    func `locked GUI session refuses capture before permission or backend dispatch`(
+        engine: CaptureEnginePreference) async throws
+    {
+        let fixtures = self.makeFixtures()
+        let permission = CountingPermissionEvaluator()
+        let modernOperator = FixtureCaptureOperator(fixtures: fixtures)
+        let legacyOperator = FixtureCaptureOperator(fixtures: fixtures)
+        let dependencies = ScreenCaptureService.Dependencies(
+            feedbackClient: StubAutomationFeedbackClient(),
+            permissionEvaluator: permission,
+            fallbackRunner: ScreenCaptureFallbackRunner(apis: [.legacy, .modern]),
+            applicationResolver: FixtureResolver(fixtures: fixtures),
+            makeFrameSource: { _ in NoOpCaptureFrameSource() },
+            makeModernOperator: { _, _ in modernOperator },
+            makeLegacyOperator: { _ in legacyOperator },
+            screenLockProbe: { true })
+        let service = ScreenCaptureService(
+            loggingService: MockLoggingService(),
+            dependencies: dependencies)
+
+        let error = await #expect(throws: PeekabooError.self) {
+            _ = try await service.withCaptureEngine(engine) {
+                try await service.captureScreen(displayIndex: 0)
+            }
+        }
+
+        guard case let .captureFailed(reason) = error else {
+            Issue.record("Expected captureFailed, got \(String(describing: error))")
+            return
+        }
+        #expect(reason.contains("macOS GUI session is locked"))
+        #expect(reason.contains("screen list"))
+        #expect(permission.callCount == 0)
+        #expect(modernOperator.captureScreenAttempts == 0)
+        #expect(legacyOperator.captureScreenAttempts == 0)
+    }
+
+    @Test
+    func `unknown GUI lock state falls through to normal capture checks`() async throws {
+        let fixtures = self.makeFixtures()
+        let permission = CountingPermissionEvaluator()
+        let modernOperator = FixtureCaptureOperator(fixtures: fixtures)
+        let dependencies = ScreenCaptureService.Dependencies(
+            feedbackClient: StubAutomationFeedbackClient(),
+            permissionEvaluator: permission,
+            fallbackRunner: ScreenCaptureFallbackRunner(apis: [.modern]),
+            applicationResolver: FixtureResolver(fixtures: fixtures),
+            makeFrameSource: { _ in NoOpCaptureFrameSource() },
+            makeModernOperator: { _, _ in modernOperator },
+            makeLegacyOperator: { _ in modernOperator },
+            screenLockProbe: { nil })
+        let service = ScreenCaptureService(
+            loggingService: MockLoggingService(),
+            dependencies: dependencies)
+
+        _ = try await service.captureScreen(displayIndex: 0)
+
+        #expect(permission.callCount == 1)
+        #expect(modernOperator.captureScreenAttempts == 1)
+    }
+
     @Test
     func `captureArea returns area metadata`() async throws {
         let fixtures = self.makeFixtures()
@@ -453,6 +515,7 @@ private struct FixtureResolver: ApplicationResolving {
 private final class FixtureCaptureOperator: ModernScreenCaptureOperating, LegacyScreenCaptureOperating,
 @unchecked Sendable {
     private let fixtures: ScreenCaptureService.TestFixtures
+    private(set) var captureScreenAttempts = 0
     private(set) var captureWindowIDAttempts = 0
     private(set) var visualizerModes: [CaptureVisualizerMode] = []
 
@@ -466,6 +529,7 @@ private final class FixtureCaptureOperator: ModernScreenCaptureOperating, Legacy
         visualizerMode: CaptureVisualizerMode,
         scale: CaptureScalePreference) async throws -> CaptureResult
     {
+        self.captureScreenAttempts += 1
         self.visualizerModes.append(visualizerMode)
         let display = try fixtures.display(at: displayIndex)
         let scaleFactor = scale == .native ? display.scaleFactor : 1.0


### PR DESCRIPTION
## Summary

- detect a confirmed locked macOS GUI session through native CoreGraphics state before capture permission/backend dispatch
- preserve the current capture path when session state is unlocked or unavailable
- return an actionable `CAPTURE_FAILED` explanation while retaining the existing fail-closed active-display guard
- document the user-visible diagnostic in both changelogs

## Root cause

AppKit can continue to enumerate connected displays while a locked Aqua session exposes no matching active capture topology. Peekaboo correctly refused the capture, but surfaced the low-level `Selected display ... is not in the active display list` error, making `screen list` and `see` appear contradictory.

## Proof

- native lock-state parser tests: 3 passed
- capture service flow tests: 21 passed
- source-blind locked/unlocked/unknown behavior validation: passed twice
- SwiftFormat: clean
- SwiftLint: zero serious violations
- structured pre-commit review: clean

The implementation uses no AppleScript, JXA, subprocess, permission change, fallback capture, or unlock attempt.
