### PR TITLE
chore(release): close out 4.2.2 update metadata

### DIFF
--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to Peekaboo CLI will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.2.3] - Unreleased
+
 ## [4.2.2] - 2026-08-20
 
 ### Highlights

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Changelog
 
-## [Unreleased]
+## [4.2.3] - Unreleased
 
 ### Fixed
 - Fail closed instead of generating or accepting a release-qualification manifest until final-cycle liveness witnesses have a cryptographic trust anchor.
+
 ## [4.2.2] - 2026-08-20
 
 ### Highlights

--- a/appcast.xml
+++ b/appcast.xml
@@ -6,6 +6,20 @@
         <description>Peekaboo macOS app updates (Sparkle)</description>
         <language>en</language>
         <item>
+            <title>Peekaboo 4.2.2</title>
+            <link>https://github.com/openclaw/Peekaboo/releases/tag/v4.2.2</link>
+            <sparkle:releaseNotesLink>https://github.com/openclaw/Peekaboo/releases/tag/v4.2.2</sparkle:releaseNotesLink>
+            <pubDate>Thu, 20 Aug 2026 10:42:13 +0000</pubDate>
+            <enclosure
+              url="https://github.com/openclaw/Peekaboo/releases/download/v4.2.2/Peekaboo-4.2.2.app.zip"
+              sparkle:version="4020299"
+              sparkle:shortVersionString="4.2.2"
+              sparkle:minimumSystemVersion="15.0"
+              length="21178455"
+              type="application/octet-stream"
+              sparkle:edSignature="qdt6GrVhB+O9vEogQGSuLyWbI2EjIeYohCIRUeo679d2BIjBbiG8v3Wzl5eko3flqlOtNj7xSwCHpV2KFglNBg==" />
+        </item>
+        <item>
             <title>Peekaboo 4.2.0</title>
             <link>https://github.com/openclaw/Peekaboo/releases/tag/v4.2.0</link>
             <sparkle:releaseNotesLink>https://github.com/openclaw/Peekaboo/releases/tag/v4.2.0</sparkle:releaseNotesLink>

--- a/homebrew/peekaboo.rb
+++ b/homebrew/peekaboo.rb
@@ -1,10 +1,10 @@
 class Peekaboo < Formula
   desc "Lightning-fast macOS screenshots & AI vision analysis"
   homepage "https://github.com/openclaw/Peekaboo"
-  url "https://github.com/openclaw/Peekaboo/releases/download/v3.2.0/peekaboo-macos-universal.tar.gz"
-  sha256 "255ded65abdedfc61d0c2e9decfa0eb206c26ca916d1519f16d8f83dcc1af444"
+  url "https://github.com/openclaw/Peekaboo/releases/download/v4.2.2/peekaboo-macos-universal.tar.gz"
+  sha256 "80b1983a9a2468e715e176167b75aabb4f43feb4882d667ffccc9373d706602e"
   license "MIT"
-  version "3.2.0"
+  version "4.2.2"
 
   # macOS Sequoia (15.0) or later required
   depends_on macos: :sequoia


### PR DESCRIPTION
## Summary

- publish the already-generated 4.2.2 Sparkle appcast entry on `main`
- update the in-repo Homebrew formula to the exact released universal tarball URL and SHA-256
- open 4.2.3 development sections in both changelogs after the verified release

## Root cause

The 4.2.2 GitHub/npm release and Homebrew tap update completed, but the release closeout commits remained on their source branch. As a result, `main` still advertised 4.2.0 through `appcast.xml` and retained an obsolete in-repo formula.

## Proof

- exact published app ZIP SHA-256: `acf7f380c4783813b96abd7f03b28b04ea292461619d69f9d6fb054b5bc8e16e`
- exact universal tarball SHA-256: `80b1983a9a2468e715e176167b75aabb4f43feb4882d667ffccc9373d706602e`
- retained Sparkle Ed25519 signature validates against the exact published ZIP and the app's embedded public key
- unique appcast entry binds version 4.2.2, build 4020299, released URL, and byte length 21178455
- `node scripts/test-update-appcast-entry.mjs`
- `scripts/test-release-signing-policy.sh`
- `scripts/mac-release check-assets v4.2.2`
- neutral-cwd `npm exec` reports Peekaboo 4.2.2
- `xmllint --noout appcast.xml`
- `ruby -c homebrew/peekaboo.rb`
- structured pre-commit review: clean
