### PR TITLE
fix(observation): preserve process-scoped AX read receipts

### DIFF
--- a/Apps/CLI/Sources/PeekabooCLI/Commands/AI/SeeCommand+DetectionPipeline.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/AI/SeeCommand+DetectionPipeline.swift
@@ -140,7 +140,7 @@ extension SeeCommand {
         )
         do {
             try self.requireUsableTreeOnlyEvidence(result)
-            try self.requireActionCapableTreeOnlyEvidence(result)
+            try self.requireBoundTreeOnlyEvidence(result, receipt: receipt.targetReceipt)
             let bound = ElementDetectionResult(
                 snapshotId: snapshotID,
                 screenshotPath: "",
@@ -184,20 +184,37 @@ extension SeeCommand {
         throw PeekabooError.operationError(message: message)
     }
 
-    private func requireActionCapableTreeOnlyEvidence(_ result: ElementDetectionResult) throws {
+    private func requireBoundTreeOnlyEvidence(
+        _ result: ElementDetectionResult,
+        receipt: DesktopActionTargetReceipt?
+    ) throws {
         guard let context = result.metadata.windowContext,
               let processIdentifier = context.applicationProcessId,
               processIdentifier > 0,
-              let windowID = context.windowID,
-              windowID > 0,
-              let bounds = context.windowBounds,
-              bounds.width > 0,
-              bounds.height > 0,
-              let identity = context.windowMutationIdentity,
-              identity.windowID == windowID,
-              identity.ownerProcessIdentifier == processIdentifier,
-              identity.ownerProcessStartIdentity > 0,
-              identity.capturedBounds == bounds
+              let processStartIdentity = context.applicationProcessStartIdentity ??
+              context.windowMutationIdentity?.ownerProcessStartIdentity,
+              processStartIdentity > 0,
+              receipt?.processIdentifier == processIdentifier,
+              receipt?.processStartIdentity == processStartIdentity
+        else {
+            throw PeekabooError.snapshotStale(
+                "AX-only see could not bind its elements to an exact process-generation receipt. "
+                    + "Run see again before background input."
+            )
+        }
+        guard receipt?.windowID != nil else { return }
+        guard
+            let windowID = context.windowID,
+            windowID > 0,
+            let bounds = context.windowBounds,
+            bounds.width > 0,
+            bounds.height > 0,
+            let identity = context.windowMutationIdentity,
+            identity.windowID == windowID,
+            identity.ownerProcessIdentifier == processIdentifier,
+            identity.ownerProcessStartIdentity == processStartIdentity,
+            receipt?.windowID == windowID,
+            identity.capturedBounds == bounds
         else {
             throw PeekabooError.snapshotStale(
                 "AX-only see could not bind its elements to an exact process-generation, window, and bounds "

--- a/Apps/CLI/Tests/CLIAutomationTests/SeeCommandReceiptTests.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/SeeCommandReceiptTests.swift
@@ -792,6 +792,68 @@ extension SeeCommandRuntimeTests {
 
     @Test
     @MainActor
+    func `tree only See publishes a process scoped read when no exact window receipt exists`() async throws {
+        try await self.withTempConfigEnv { _ in
+            let fixture = Self.makeSeeCommandRuntimeFixture()
+            let processStartIdentity = try #require(fixture.applicationInfo.processStartIdentity)
+            let processDetection = ElementDetectionResult(
+                snapshotId: "process-scoped-tree",
+                screenshotPath: "",
+                elements: fixture.detectionResult.elements,
+                metadata: DetectionMetadata(
+                    detectionTime: 0.1,
+                    elementCount: fixture.detectionResult.elements.all.count,
+                    method: "stub",
+                    windowContext: WindowContext(
+                        applicationName: fixture.applicationInfo.name,
+                        applicationProcessId: fixture.applicationInfo.processIdentifier,
+                        applicationProcessStartIdentity: processStartIdentity,
+                        windowTitle: "AX-only description",
+                        windowID: fixture.windowInfo.windowID,
+                        windowBounds: fixture.windowInfo.bounds
+                    )
+                )
+            )
+            let automation = StubAutomationService()
+            automation.inspectAccessibilityTreeHandler = { _ in processDetection }
+            let (context, _) = Self.makeSeeCommandRuntimeContext(
+                automation: automation,
+                screenCapture: fixture.screenCapture,
+                applicationInfo: fixture.applicationInfo,
+                windowInfo: fixture.windowInfo
+            )
+
+            let result = try await InProcessCommandRunner.run(
+                [
+                    "see",
+                    "--app", fixture.applicationInfo.name,
+                    "--tree",
+                    "--no-screenshot",
+                    "--json",
+                ],
+                services: context.services
+            )
+            #expect(result.exitStatus == 0, Comment(rawValue: result.combinedOutput))
+            let response = try JSONDecoder().decode(
+                CodableJSONResponse<SeeResult>.self,
+                from: Data(result.stdout.utf8)
+            )
+            let receipt = try #require(response.target_receipt)
+            let stored = try #require(
+                context.snapshots.detectionResults[response.data.snapshot_id]?.metadata.windowContext
+            )
+
+            #expect(response.data.ui_elements.map(\.id) == ["B1"])
+            #expect(receipt.processIdentifier == fixture.applicationInfo.processIdentifier)
+            #expect(receipt.processStartIdentity == processStartIdentity)
+            #expect(receipt.windowID == nil)
+            #expect(stored.applicationProcessStartIdentity == processStartIdentity)
+            #expect(stored.windowMutationIdentity == nil)
+        }
+    }
+
+    @Test
+    @MainActor
     func `tree only See refuses incomplete action receipts before snapshot publication`() async throws {
         try await self.withTempConfigEnv { _ in
             let fixture = Self.makeSeeCommandRuntimeFixture()
@@ -854,7 +916,7 @@ extension SeeCommandRuntimeTests {
                 )
 
                 #expect(result.exitStatus == 1)
-                #expect(result.combinedOutput.contains("exact process-generation, window, and bounds receipt"))
+                #expect(result.combinedOutput.contains("AX-only see could not bind"))
                 #expect(!result.combinedOutput.contains("\"snapshot_id\""))
                 #expect(!result.combinedOutput.contains("\"ui_elements\""))
                 #expect(context.snapshots.detectionResults.isEmpty)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fail closed instead of generating or accepting a release-qualification manifest until final-cycle liveness witnesses have a cryptographic trust anchor.
 - Add receipt-required Bridge protocol 1.32 observation of exact process generations for signed liveness and absence evidence.
 - Bind signed `set-value` results to the opaque requested element and refuse older Bridge hosts before dispatch.
+- Preserve verified process-generation receipts for background AX-only reads when an app has no actionable WindowServer window, while keeping window mutations exact-window-only.
 
 ## [4.2.2] - 2026-08-20
 

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Core/Protocols/ElementDetectionModels.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Core/Protocols/ElementDetectionModels.swift
@@ -207,6 +207,10 @@ public nonisolated struct WindowContext: Sendable, Codable {
     /// Process identifier (most precise when available)
     public let applicationProcessId: Int32?
 
+    /// Process generation verified across the accessibility observation.
+    /// This binds process-scoped read results when no exact window receipt is available.
+    public let applicationProcessStartIdentity: UInt64?
+
     /// Window title
     public let windowTitle: String?
 
@@ -244,6 +248,7 @@ public nonisolated struct WindowContext: Sendable, Codable {
         applicationBundlePath: String? = nil,
         applicationExecutablePath: String? = nil,
         applicationProcessId: Int32? = nil,
+        applicationProcessStartIdentity: UInt64? = nil,
         windowTitle: String? = nil,
         windowID: Int? = nil,
         windowBounds: CGRect? = nil,
@@ -260,6 +265,7 @@ public nonisolated struct WindowContext: Sendable, Codable {
         self.applicationBundlePath = applicationBundlePath
         self.applicationExecutablePath = applicationExecutablePath
         self.applicationProcessId = applicationProcessId
+        self.applicationProcessStartIdentity = applicationProcessStartIdentity
         self.windowTitle = windowTitle
         self.windowID = windowID
         self.windowBounds = windowBounds
@@ -278,6 +284,7 @@ public nonisolated struct WindowContext: Sendable, Codable {
         applicationBundlePath: String? = nil,
         applicationExecutablePath: String? = nil,
         applicationProcessId: Int32? = nil,
+        applicationProcessStartIdentity: UInt64? = nil,
         windowTitle: String? = nil,
         windowID: Int? = nil,
         windowBounds: CGRect? = nil,
@@ -294,6 +301,7 @@ public nonisolated struct WindowContext: Sendable, Codable {
             applicationBundlePath: applicationBundlePath,
             applicationExecutablePath: applicationExecutablePath,
             applicationProcessId: applicationProcessId,
+            applicationProcessStartIdentity: applicationProcessStartIdentity,
             windowTitle: windowTitle,
             windowID: windowID,
             windowBounds: windowBounds,

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Observation/DesktopObservationService.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Observation/DesktopObservationService.swift
@@ -328,16 +328,17 @@ public enum ObservationActionResultSemantics {
     }
 
     private static func targetEvidence(_ context: WindowContext?) -> [DesktopTargetIdentity.Evidence] {
-        guard let context,
-              let identity = context.windowMutationIdentity,
-              let bounds = context.windowBounds
-        else { return [] }
-        return [
-            DesktopTargetEvidenceAdapter.evidence(
+        guard let context else { return [] }
+        if let identity = context.windowMutationIdentity,
+           let bounds = context.windowBounds
+        {
+            return [DesktopTargetEvidenceAdapter.evidence(
                 windowIdentity: identity,
                 bounds: bounds,
-                focusedElement: context.focusedElement),
-        ]
+                focusedElement: context.focusedElement)]
+        }
+        guard context.applicationProcessStartIdentity != nil else { return [] }
+        return [DesktopTargetEvidenceAdapter.evidence(context: context)]
     }
 
     private static func targetFailure(

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/ElementDetectionCache.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/ElementDetectionCache.swift
@@ -10,17 +10,20 @@ import PeekabooFoundation
     public struct Key: Hashable, Sendable {
         public let windowID: Int
         public let processID: pid_t
+        public let processStartIdentity: UInt64
         public let allowWebFocus: Bool
         public let includeMenuBarElements: Bool
 
         public init(
             windowID: Int,
             processID: pid_t,
+            processStartIdentity: UInt64 = 0,
             allowWebFocus: Bool,
             includeMenuBarElements: Bool = false)
         {
             self.windowID = windowID
             self.processID = processID
+            self.processStartIdentity = processStartIdentity
             self.allowWebFocus = allowWebFocus
             self.includeMenuBarElements = includeMenuBarElements
         }
@@ -53,6 +56,7 @@ import PeekabooFoundation
     public func key(
         windowID: Int?,
         processID: pid_t,
+        processStartIdentity: UInt64 = 0,
         allowWebFocus: Bool,
         includeMenuBarElements: Bool = false) -> Key?
     {
@@ -60,6 +64,7 @@ import PeekabooFoundation
         return Key(
             windowID: windowID,
             processID: processID,
+            processStartIdentity: processStartIdentity,
             allowWebFocus: allowWebFocus,
             includeMenuBarElements: includeMenuBarElements)
     }

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/ElementDetectionService.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/ElementDetectionService.swift
@@ -5,6 +5,7 @@ import os.log
 import PeekabooFoundation
 
 struct CachedDetachedAXObservationContext: Sendable {
+    let processStartIdentity: UInt64
     let windowID: Int?
     let windowTitle: String?
     let windowBounds: CGRect?
@@ -12,6 +13,7 @@ struct CachedDetachedAXObservationContext: Sendable {
 }
 
 struct DetachedAXObservationOutcome: Sendable {
+    let processStartIdentity: UInt64
     let elements: [DetectedElement]
     let windowID: Int?
     let windowTitle: String?
@@ -170,6 +172,7 @@ public final class ElementDetectionService {
             applicationBundlePath: applicationIdentity.bundlePath,
             applicationExecutablePath: applicationIdentity.executablePath,
             applicationProcessId: windowContext?.applicationProcessId ?? targetApp.processIdentifier,
+            applicationProcessStartIdentity: resolvedWindowMutationIdentity?.ownerProcessStartIdentity,
             windowTitle: windowName,
             windowID: resolvedWindowID,
             windowBounds: resolvedWindowBounds,
@@ -197,6 +200,7 @@ public final class ElementDetectionService {
             ? self.axTreeCache.key(
                 windowID: resolvedWindowID,
                 processID: targetApp.processIdentifier,
+                processStartIdentity: resolvedWindowMutationIdentity?.ownerProcessStartIdentity ?? 0,
                 allowWebFocus: allowWebFocus,
                 includeMenuBarElements: includeMenuBarElements)
             : nil
@@ -276,6 +280,7 @@ public final class ElementDetectionService {
                invalidatedThrough: invalidatedThrough)
         {
             return DetachedAXObservationOutcome(
+                processStartIdentity: cachedContext.processStartIdentity,
                 elements: cached.elements,
                 windowID: cachedContext.windowID,
                 windowTitle: cachedContext.windowTitle,
@@ -293,6 +298,7 @@ public final class ElementDetectionService {
                 for: cacheKey)
         }
         return DetachedAXObservationOutcome(
+            processStartIdentity: cachedContext.processStartIdentity,
             elements: detachedResult.elements,
             windowID: detachedResult.windowID,
             windowTitle: detachedResult.windowTitle,
@@ -309,6 +315,10 @@ public final class ElementDetectionService {
         applicationIdentity: ResolvedApplicationIdentity) async throws -> ElementDetectionResult
     {
         let processIdentifier = targetApp.processIdentifier
+        guard let processStartIdentity = SystemIdentityResolver.processStartIdentity(processIdentifier) else {
+            throw PeekabooError.snapshotStale(
+                "Could not capture the target process generation before detached AX observation")
+        }
         let context = try Self.readOnlyWindowContext(
             targetApp: targetApp,
             requested: windowContext,
@@ -335,6 +345,7 @@ public final class ElementDetectionService {
             applicationBundlePath: applicationIdentity.bundlePath,
             applicationExecutablePath: applicationIdentity.executablePath,
             applicationProcessId: processIdentifier,
+            applicationProcessStartIdentity: processStartIdentity,
             windowTitle: context?.windowTitle,
             windowID: context?.windowID,
             windowBounds: context?.windowBounds,
@@ -355,6 +366,7 @@ public final class ElementDetectionService {
             ? self.axTreeCache.key(
                 windowID: context?.windowID,
                 processID: processIdentifier,
+                processStartIdentity: processStartIdentity,
                 allowWebFocus: false,
                 includeMenuBarElements: includeMenuBarElements)
             : nil
@@ -364,20 +376,21 @@ public final class ElementDetectionService {
             cacheKey: cacheKey,
             invalidatedThrough: invalidatedThrough,
             cachedContext: CachedDetachedAXObservationContext(
+                processStartIdentity: processStartIdentity,
                 windowID: context?.windowID,
                 windowTitle: context?.windowTitle,
                 windowBounds: context?.windowBounds,
                 isDialog: false))
         {
-            let expectedProcessStartIdentity = context?.windowMutationIdentity?.ownerProcessStartIdentity ??
-                SystemIdentityResolver.processStartIdentity(processIdentifier)
-            guard let expectedProcessStartIdentity else {
+            if let expectedWindowGeneration = context?.windowMutationIdentity?.ownerProcessStartIdentity,
+               expectedWindowGeneration != processStartIdentity
+            {
                 throw PeekabooError.snapshotStale(
-                    "Could not capture the target process generation before detached AX observation")
+                    "Exact AX observation window changed process generation before traversal")
             }
             return DetachedAXObservationRequest(
                 processIdentifier: processIdentifier,
-                expectedProcessStartIdentity: expectedProcessStartIdentity,
+                expectedProcessStartIdentity: processStartIdentity,
                 windowID: context?.windowID,
                 windowTitle: context?.windowTitle,
                 expectedWindowBounds: context?.windowBounds,
@@ -388,12 +401,18 @@ public final class ElementDetectionService {
                 timing: DetachedAXObservationTiming(hardTimeoutSeconds: timeoutSeconds))
         }
 
+        guard SystemIdentityResolver.processStartIdentity(processIdentifier) == outcome.processStartIdentity else {
+            throw PeekabooError.snapshotStale(
+                "Target PID \(processIdentifier) changed process generation during AX observation")
+        }
+
         let resolvedContext = WindowContext(
             applicationName: applicationIdentity.name,
             applicationBundleId: applicationIdentity.bundleIdentifier,
             applicationBundlePath: applicationIdentity.bundlePath,
             applicationExecutablePath: applicationIdentity.executablePath,
             applicationProcessId: processIdentifier,
+            applicationProcessStartIdentity: outcome.processStartIdentity,
             windowTitle: outcome.windowTitle,
             windowID: outcome.windowID,
             windowBounds: context?.windowBounds ?? outcome.windowBounds,
@@ -442,6 +461,7 @@ public final class ElementDetectionService {
                 applicationBundlePath: applicationIdentity.bundlePath,
                 applicationExecutablePath: applicationIdentity.executablePath,
                 applicationProcessId: targetApp.processIdentifier,
+                applicationProcessStartIdentity: actionableReceipt.identity.ownerProcessStartIdentity,
                 windowTitle: requested?.windowTitle ?? liveWindow.title,
                 windowID: requestedWindowID,
                 windowBounds: actionableReceipt.bounds,
@@ -476,6 +496,7 @@ public final class ElementDetectionService {
             applicationBundlePath: applicationIdentity.bundlePath,
             applicationExecutablePath: applicationIdentity.executablePath,
             applicationProcessId: targetApp.processIdentifier,
+            applicationProcessStartIdentity: actionableReceipt.identity.ownerProcessStartIdentity,
             windowTitle: window.title,
             windowID: window.windowID,
             windowBounds: actionableReceipt.bounds,

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Strategy/DesktopTargetEvidenceAdapter.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Strategy/DesktopTargetEvidenceAdapter.swift
@@ -44,13 +44,17 @@ public enum DesktopTargetEvidenceAdapter {
     }
 
     public static func evidence(context: WindowContext) -> DesktopTargetIdentity.Evidence {
-        .init(
+        let exactWindowIdentity = context.windowMutationIdentity
+        return .init(
             processIdentifier: context.applicationProcessId,
-            processIdentity: context.windowMutationIdentity?.processIdentity,
-            windowID: context.windowID,
-            windowIdentity: context.windowMutationIdentity,
-            windowBounds: context.windowBounds,
-            focusedElement: context.focusedElement)
+            processIdentity: self.processIdentity(
+                processIdentifier: context.applicationProcessId,
+                processStartIdentity: context.applicationProcessStartIdentity) ??
+                exactWindowIdentity?.processIdentity,
+            windowID: exactWindowIdentity.map { context.windowID ?? $0.windowID },
+            windowIdentity: exactWindowIdentity,
+            windowBounds: exactWindowIdentity.flatMap { context.windowBounds ?? $0.capturedBounds },
+            focusedElement: exactWindowIdentity == nil ? nil : context.focusedElement)
     }
 
     public static func evidence(snapshot: UIAutomationSnapshot) -> DesktopTargetIdentity.Evidence {

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ElementDetectionServiceDetachedObservationTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ElementDetectionServiceDetachedObservationTests.swift
@@ -154,6 +154,7 @@ struct ElementDetectionServiceDetachedObservationTests {
     }
 
     private static let cachedContext = CachedDetachedAXObservationContext(
+        processStartIdentity: 7,
         windowID: 42,
         windowTitle: "Cached fixture",
         windowBounds: CGRect(x: 10, y: 20, width: 800, height: 600),

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/SnapshotTargetReceiptPlannerTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/SnapshotTargetReceiptPlannerTests.swift
@@ -4,6 +4,25 @@ import Testing
 
 struct SnapshotTargetReceiptPlannerTests {
     @Test
+    func `process scoped context keeps generation and discards unreceipted window hints`() throws {
+        let context = WindowContext(
+            applicationProcessId: 42,
+            applicationProcessStartIdentity: 1001,
+            windowTitle: "AX-only description",
+            windowID: 73,
+            windowBounds: .init(x: 20, y: 30, width: 640, height: 480))
+
+        let evidence = DesktopTargetEvidenceAdapter.evidence(context: context)
+        let resolved = try DesktopTargetPlanning.DesktopTargetIdentityCoalescer.resolve([evidence])
+        let identity = try #require(resolved)
+
+        #expect(identity.processIdentity == .init(processIdentifier: 42, processStartIdentity: 1001))
+        #expect(identity.exactWindow == nil)
+        #expect(evidence.windowID == nil)
+        #expect(evidence.windowBounds == nil)
+    }
+
+    @Test
     func `evidence adapters preserve linked process and exact-window identity`() {
         let focusedElement = AutomationTestFixtures.focusedElement()
         let fixture = AutomationTestFixtures.linkedSnapshotTarget(focusedElement: focusedElement)

--- a/Core/PeekabooCore/Tests/PeekabooTests/ElementDetectionServiceTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/ElementDetectionServiceTests.swift
@@ -431,6 +431,26 @@ struct ElementDetectionCacheTests {
         #expect(cache.elements(for: unfocusedKey)?.map(\.id) == ["unfocused"])
     }
 
+    @Test
+    func `Cache key separates recycled process generations`() {
+        let cache = ElementDetectionCache()
+        let original = ElementDetectionCache.Key(
+            windowID: 7,
+            processID: pid_t(42),
+            processStartIdentity: 100,
+            allowWebFocus: false)
+        let replacement = ElementDetectionCache.Key(
+            windowID: 7,
+            processID: pid_t(42),
+            processStartIdentity: 101,
+            allowWebFocus: false)
+
+        cache.store([Self.element(id: "original")], for: original)
+
+        #expect(cache.elements(for: original)?.map(\.id) == ["original"])
+        #expect(cache.elements(for: replacement) == nil)
+    }
+
     private static func element(id: String) -> DetectedElement {
         DetectedElement(
             id: id,

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeOperationReceiptTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeOperationReceiptTests.swift
@@ -2294,6 +2294,28 @@ extension PeekabooBridgeOperationReceiptTests {
             request: inspectRequest,
             response: .elementDetection(detection)).target == .window(identity))
 
+        let processContext = WindowContext(
+            applicationName: "Fixture",
+            applicationProcessId: identity.ownerProcessIdentifier,
+            applicationProcessStartIdentity: identity.ownerProcessStartIdentity,
+            windowTitle: "AX-only description",
+            windowID: identity.windowID,
+            windowBounds: bounds)
+        let processDetection = ElementDetectionResult(
+            snapshotId: "process-snapshot",
+            screenshotPath: "",
+            elements: DetectedElements(),
+            metadata: .init(
+                detectionTime: 0,
+                elementCount: 0,
+                method: "fixture",
+                windowContext: processContext))
+        let processInspectRequest = PeekabooBridgeRequest.inspectAccessibilityTree(.init(
+            windowContext: WindowContext(applicationName: "Fixture")))
+        #expect(try PeekabooBridgeOperationTargetAttribution.resolveReceipt(
+            request: processInspectRequest,
+            response: .elementDetection(processDetection)).target == .process(identity.processIdentity))
+
         let selectorOnlyContexts = [
             WindowContext(windowID: identity.windowID),
             WindowContext(


### PR DESCRIPTION
## Summary

- preserve the process generation verified across detached AX-only observations when no actionable WindowServer window is available
- emit process-scoped read receipts while omitting unreceipted window hints from mutation authority
- key the short-lived AX tree cache by process generation so recycled PIDs cannot reuse stale elements
- keep exact-window receipts mandatory whenever the result claims window authority

## Root cause

`see --tree --no-screenshot` uses the dedicated Accessibility inspection path. The detached worker already bracketed traversal with a process-generation check, but the result only carried that generation through `windowMutationIdentity`. Finder and hidden TextEdit can expose useful AX trees without an actionable WindowServer window, so their verified process generation was dropped before Bridge receipt attribution and the read failed.

## Validation

- `pnpm run format`
- `pnpm run lint` (0 serious violations; existing warnings only)
- `swift test --package-path Core/PeekabooAutomationKit --filter 'ElementDetectionServiceDetachedObservationTests|SnapshotTargetReceiptPlannerTests'`
- `swift test --package-path Core/PeekabooCore --filter 'PeekabooBridgeOperationReceiptTests|ElementDetectionCacheTests'`
- `PEEKABOO_INCLUDE_AUTOMATION_TESTS=true PEEKABOO_INCLUDE_AMBIENT_STATE_TESTS=false swift test --package-path Apps/CLI --filter 'CLIAutomationTests.SeeCommandRuntimeTests' --no-parallel`
- autoreview: clean, no accepted/actionable findings

## Runtime reproduction

Installed 4.2.2 behavior was checked through the GUI Bridge without foreground actions:

- Finder and TextEdit app-only and PID-only AX reads failed because the signed target receipt had no process generation
- TextEdit exact-window reads succeeded
- Finder exact-window selection bypassed the attribution failure and returned the separate, truthful incomplete-AX error

The new tests cover the process-scoped success path, Bridge receipt projection, exact-window preservation, and cache separation across recycled process generations.
