### PR TITLE
fix(cli): show native browser status guidance

### DIFF
--- a/Apps/CLI/Sources/PeekabooCLI/Commands/MCP/BrowserCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/MCP/BrowserCommand.swift
@@ -123,7 +123,7 @@ InjectedRuntimeBackedCommand {
                 services: self.services,
                 executionPolicy: self.toolExecutionPolicy
             )
-            let tool = BrowserTool(context: context)
+            let tool = BrowserTool(context: context, instructionAudience: .commandLine)
             let response = try await tool.execute(arguments: ToolArguments(raw: arguments))
             try MCPToolCommandOutput.output(
                 tool: tool.name,

--- a/Apps/CLI/Tests/CLIRuntimeTests/CLIRuntimeSmokeTests.swift
+++ b/Apps/CLI/Tests/CLIRuntimeTests/CLIRuntimeSmokeTests.swift
@@ -258,7 +258,27 @@ struct CLIRuntimeSmokeTests {
         #expect(json["success"] as? Bool == true)
         #expect(payload["tool"] as? String == "browser")
         #expect(payload["isError"] as? Bool == false)
-        #expect((payload["text"] as? String)?.contains("Chrome DevTools MCP Status") == true)
+        let text = try #require(payload["text"] as? String)
+        #expect(text.contains("Chrome DevTools MCP Status"))
+        #expect(text.contains("Run `peekaboo browser connect --channel stable --foreground`."))
+        #expect(text.contains("pass `--browser-url`"))
+        #expect(!text.contains("Run browser {"))
+        #expect(!text.contains("pass browser_url"))
+    }
+
+    @Test
+    func `peekaboo browser disconnected status prints CLI-native recovery instructions`() async throws {
+        guard Self.ensureLocalRuntimeAvailable() else { return }
+        let result = try await TestChildProcess.runPeekaboo(["browser", "status", "--no-remote"])
+
+        #expect(result.status == .exited(0))
+        #expect(result.standardError.isEmpty)
+        #expect(result.standardOutput.contains(
+            "Run `peekaboo browser connect --channel stable --foreground`."
+        ))
+        #expect(result.standardOutput.contains("pass `--browser-url`"))
+        #expect(!result.standardOutput.contains("Run browser {"))
+        #expect(!result.standardOutput.contains("pass browser_url"))
     }
 
     @Test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Replace arbitrary provider-authored Agent trace field names with deterministic ordinal placeholders at every argument nesting level.
 - Treat an exact missing-window readback after `window close` as confirmed closure instead of a retry-unsafe failure.
 - Refuse capture before permission or backend dispatch when the macOS GUI session is locked, while explaining that `screen list` can still report connected displays.
+- Show CLI-native recovery commands in disconnected browser status output while preserving MCP guidance.
 
 ## [4.2.2] - 2026-08-20
 

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/BrowserTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/BrowserTool.swift
@@ -3,10 +3,16 @@ import MCP
 import PeekabooFoundation
 import TachikomaMCP
 
+public enum BrowserToolInstructionAudience: Sendable {
+    case mcp
+    case commandLine
+}
+
 public struct BrowserTool: MCPTool {
     private let client: any BrowserMCPClientProviding
     private let connectionPolicy: BrowserMCPExecutionConnectionPolicy
     private let executionPolicy: MCPToolExecutionPolicy
+    private let instructionAudience: BrowserToolInstructionAudience
 
     public let name = "browser"
     public let description = """
@@ -108,9 +114,14 @@ public struct BrowserTool: MCPTool {
             required: ["action"])
     }
 
-    public init(context: MCPToolContext = .shared, client: (any BrowserMCPClientProviding)? = nil) {
+    public init(
+        context: MCPToolContext = .shared,
+        client: (any BrowserMCPClientProviding)? = nil,
+        instructionAudience: BrowserToolInstructionAudience = .mcp)
+    {
         self.client = client ?? context.browser
         self.executionPolicy = context.executionPolicy
+        self.instructionAudience = instructionAudience
         self.connectionPolicy = context.executionPolicy == .backgroundOnly
             ? .requireExistingLiveReceipt
             : .allowAutoConnect
@@ -118,10 +129,12 @@ public struct BrowserTool: MCPTool {
 
     public init(
         client: any BrowserMCPClientProviding,
-        executionPolicy: MCPToolExecutionPolicy = .backgroundOnly)
+        executionPolicy: MCPToolExecutionPolicy = .backgroundOnly,
+        instructionAudience: BrowserToolInstructionAudience = .mcp)
     {
         self.client = client
         self.executionPolicy = executionPolicy
+        self.instructionAudience = instructionAudience
         self.connectionPolicy = executionPolicy == .backgroundOnly
             ? .requireExistingLiveReceipt
             : .allowAutoConnect
@@ -191,7 +204,7 @@ public struct BrowserTool: MCPTool {
                 for: failure,
                 invalidatedSnapshotID: nil)
         } catch {
-            return ToolResponse.error(Self.permissionHelp(error: error))
+            return ToolResponse.error(self.permissionHelp(error: error))
         }
     }
 
@@ -372,7 +385,7 @@ public struct BrowserTool: MCPTool {
 
         if !status.isConnected {
             lines.append("")
-            lines.append(contentsOf: Self.permissionInstructions())
+            lines.append(contentsOf: self.permissionInstructions())
         }
 
         return try ToolResponse.text(
@@ -420,21 +433,33 @@ public struct BrowserTool: MCPTool {
         return meta
     }
 
-    private static func permissionHelp(error: any Error) -> String {
+    private func permissionHelp(error: any Error) -> String {
         var lines = ["Chrome DevTools MCP failed: \(error.localizedDescription)", ""]
         lines.append(contentsOf: self.permissionInstructions())
         return lines.joined(separator: "\n")
     }
 
-    private static func permissionInstructions() -> [String] {
-        [
+    private func permissionInstructions() -> [String] {
+        let connectInstruction: String
+        let endpointInstruction: String
+        switch self.instructionAudience {
+        case .mcp:
+            connectInstruction = "4. Run browser { \"action\": \"connect\" }."
+            endpointInstruction = "If multiple Chrome processes share a channel, pass browser_url for one exact " +
+                "loopback DevTools port."
+        case .commandLine:
+            connectInstruction = "4. Run `peekaboo browser connect --channel stable --foreground`."
+            endpointInstruction = "If multiple Chrome processes share a channel, pass `--browser-url` for one " +
+                "exact loopback DevTools port."
+        }
+        return [
             "To enable browser control:",
             "1. Open Chrome 144+.",
             "2. Visit chrome://inspect/#remote-debugging.",
             "3. Enable remote debugging for this profile.",
-            "4. Run browser { \"action\": \"connect\" }.",
+            connectInstruction,
             "5. Accept Chrome's remote debugging permission prompt.",
-            "If multiple Chrome processes share a channel, pass browser_url for one exact loopback DevTools port.",
+            endpointInstruction,
         ]
     }
 }

--- a/Core/PeekabooCore/Tests/PeekabooAgentRuntimeTests/BrowserToolTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooAgentRuntimeTests/BrowserToolTests.swift
@@ -227,6 +227,30 @@ struct BrowserToolTests {
         #expect(text.contains("Connected: no"))
         #expect(text.contains("chrome://inspect/#remote-debugging"))
         #expect(text.contains("remote debugging permission prompt"))
+        #expect(text.contains(#"Run browser { "action": "connect" }."#))
+        #expect(text.contains("pass browser_url"))
+        #expect(!text.contains("peekaboo browser connect"))
+    }
+
+    @Test
+    func `Browser tool command-line status uses CLI-native permission instructions`() async throws {
+        let client = MockBrowserMCPClient(status: BrowserMCPStatus(
+            isConnected: false,
+            toolCount: 0,
+            detectedBrowsers: []))
+        let tool = BrowserTool(
+            client: client,
+            executionPolicy: .unrestricted,
+            instructionAudience: .commandLine)
+
+        let response = try await tool.execute(arguments: ToolArguments(raw: ["action": "status"]))
+
+        #expect(response.isError == false)
+        let text = Self.text(from: response)
+        #expect(text.contains("Run `peekaboo browser connect --channel stable --foreground`."))
+        #expect(text.contains("pass `--browser-url`"))
+        #expect(!text.contains("Run browser {"))
+        #expect(!text.contains("pass browser_url"))
     }
 
     @Test


### PR DESCRIPTION
## Summary

- render disconnected browser remediation in native standalone CLI syntax
- keep the existing MCP-native instruction unchanged for MCP and Agent callers
- cover both audiences plus real human and JSON child-process output

## Proof

- `swift test --package-path Core/PeekabooCore --filter BrowserToolTests` (41 tests)
- focused `CLIRuntimeSmokeTests` browser-status subprocess cases (2 tests)
- `pnpm run test:safe`
- `pnpm run format`
- `pnpm run lint` (0 serious findings)
- `pnpm run lint:docs`
- structured Autoreview clean at 0.99

No browser connection, foreground action, UI mutation, AppleScript/JXA, account flow, or virtualization was used.
