### PR TITLE
fix(certification): pin Activity Monitor title receipt

### DIFF
--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/WindowCommand+List.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/WindowCommand+List.swift
@@ -39,6 +39,9 @@ extension WindowCommand {
                 let windows = ObservationTargetResolver.filteredWindows(from: rawWindows, mode: .list)
                 var outputCompleteness = inventory.completeness
                 var outputWarnings = inventory.warnings
+                if inventory.completeness == .partial, outputWarnings.isEmpty {
+                    outputWarnings.append("Window inventory provider reported partial results without a reason.")
+                }
                 let omittedRowCount = rawWindows.count - windows.count
                 if omittedRowCount > 0 {
                     outputCompleteness = .partial

--- a/Apps/CLI/Tests/CLIAutomationTests/WindowCommandTests.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/WindowCommandTests.swift
@@ -325,6 +325,48 @@ struct WindowCommandTests {
     }
 
     @Test
+    func `window list explains partial inventory without provider warnings`() async throws {
+        let appName = "UnexplainedPartialApp"
+        let context = await MainActor.run {
+            self.makeWindowContext(
+                appInfo: ServiceApplicationInfo(
+                    processIdentifier: 5557,
+                    bundleIdentifier: "dev.partial-unexplained",
+                    name: appName
+                ),
+                windows: [
+                    appName: [
+                        ServiceWindowInfo(
+                            windowID: 13,
+                            title: "Document",
+                            bounds: CGRect(x: 50, y: 50, width: 1200, height: 800),
+                            index: 0
+                        ),
+                    ],
+                ]
+            )
+        }
+        await MainActor.run {
+            context.windowService.inventoryCompleteness = .partial
+            context.windowService.inventoryWarnings = []
+        }
+
+        let result = try await self.runWindowCommand([
+            "window", "list", "--app", appName, "--json",
+        ], context: context)
+        let output = result.stdout.isEmpty ? result.stderr : result.stdout
+        let response = try JSONDecoder().decode(
+            CodableJSONResponse<WindowListData>.self,
+            from: Data(output.utf8)
+        )
+
+        #expect(response.data.inventory_completeness == "partial")
+        #expect(response.data.inventory_warnings == [
+            "Window inventory provider reported partial results without a reason.",
+        ])
+    }
+
+    @Test
     func `window close help`() async throws {
         let output = try await runPeekabooCommand(["window", "close", "--help"])
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [4.2.3] - Unreleased
 
 ### Fixed
+- Let background certification pin Activity Monitor's exact source-declared window title while refusing unsafe partial, duplicate, or drifting title evidence.
 - Fail closed instead of generating or accepting a release-qualification manifest until final-cycle liveness witnesses have a cryptographic trust anchor.
 - Add receipt-required Bridge protocol 1.32 observation of exact process generations for signed liveness and absence evidence.
 - Bind certification crash, monitor, and foreground semantic evidence to exact authenticated producers and listener-signed Bridge receipts.

--- a/docs/testing/background-computer-use.md
+++ b/docs/testing/background-computer-use.md
@@ -21,11 +21,15 @@ setup launch must leave the sentinel unchanged; the harness never foregrounds a 
 foreground app after setup.
 
 The live matrix also requires one already-running process with one exact key or sole visible window for Safari,
-Calendar, System Settings, Calculator, Activity Monitor, and Finder. Those six processes are read-only prerequisites:
-the harness never launches, quits, closes, or otherwise mutates them. Together with the owned Playground and TextEdit
-targets, eight monitored screenshot-only exact-window cells prove cross-app routing without focus or cursor control.
+Calendar, System Settings, Calculator, and Finder. Activity Monitor instead uses the catalog's source-controlled exact
+application/window title to distinguish its main window from `Dock Icon Host Window`. Those six processes are read-only
+prerequisites: the harness never launches, quits, closes, or otherwise mutates them. Together with the owned Playground
+and TextEdit targets, eight monitored screenshot-only exact-window cells prove cross-app routing without focus or
+cursor control.
 Missing processes, duplicate instances, ambiguous windows, process-generation drift, or changed window receipts fail
-closed rather than selecting a first match.
+closed rather than selecting a first match. The exact-title route accepts a complete warning-free inventory or one
+partial inventory whose only warning proves that the omitted rows were non-renderable or duplicate; every other partial
+or malformed inventory is refused. The same exact selector and PID generation must still match after observation.
 
 The remaining cases exercise fresh, exact PID/window snapshots through `see` (including AX-only and screenshot-only
 modes), `capture live`, click by ID and query, exact-window `type`, `press`, and `paste`, app/PID-only raw-press refusal,
@@ -348,7 +352,8 @@ Use `--bin`, `--artifacts`, `--sentinel-bundle-id`, or `--playground-app ... --s
 binary, require an already-frontmost app, or use a prebuilt signed fixture. The harness refuses rather than activating a
 requested sentinel that is not already frontmost; the sentinel must not be any of the eight physical targets. Before a
 live run, leave exactly one visible key or sole window open for Safari, Calendar, System Settings, Calculator, Activity
-Monitor, and Finder. Add `--no-remote` when the exact CLI is team-signed and
+Monitor, and Finder; Activity Monitor may also retain auxiliary windows when exactly one visible window matches the
+catalog title. Add `--no-remote` when the exact CLI is team-signed and
 has local TCC grants; this prevents an installed bridge host from masking working-tree behavior. A prebuilt app must
 have a team signature and the exact current-source `PeekabooPlaygroundSource.json` manifest; ad-hoc or unstamped
 fixtures are rejected.

--- a/scripts/background-computer-use-catalog.json
+++ b/scripts/background-computer-use-catalog.json
@@ -36,6 +36,9 @@
     "activity-monitor": "com.apple.ActivityMonitor",
     "finder": "com.apple.finder"
   },
+  "physical_app_window_titles": {
+    "activity-monitor": "Activity Monitor"
+  },
   "cases": [
     {"id":"lifecycle-maximize","surface":"cli","command":"window maximize","phase":"background","expected_exit":"success","expected_effect":"confirmed","contamination_retry_safe":true,"required_oracles":["nonmaximized_precondition","verified_bounds"]},
     {"id":"lifecycle-close","surface":"cli","command":"window close","phase":"background","expected_exit":"success","expected_effect":"confirmed","required_oracles":[]},

--- a/scripts/test-background-computer-use.sh
+++ b/scripts/test-background-computer-use.sh
@@ -196,6 +196,19 @@ CERTIFICATION_PHYSICAL_APPS_JSON="$(jq -cer '
     echo "Certification catalog must declare eight unique physical app names." >&2
     exit 2
 }
+CERTIFICATION_PHYSICAL_APP_WINDOW_TITLES_JSON="$(jq -cer '
+    def normalized_title: gsub("^[[:space:]]+|[[:space:]]+$"; "");
+    .physical_app_window_titles |
+    select(type == "object" and keys == ["activity-monitor"]) |
+    select(all(to_entries[];
+        (.key | type) == "string" and
+        (.value | type) == "string" and
+        .value != "" and
+        (.value | normalized_title) == .value))
+' "$CERTIFICATION_CATALOG")" || {
+    echo "Certification catalog must declare one normalized Activity Monitor title selector." >&2
+    exit 2
+}
 
 if [[ -z "$ARTIFACT_ROOT" ]]; then
     ARTIFACT_ROOT="$ROOT_DIR/.artifacts/background-computer-use/$(date -u +%Y%m%dT%H%M%SZ)"
@@ -248,6 +261,16 @@ CERTIFICATION_PHYSICAL_APPS_JSON="$(jq -cer '
     select(type == "array" and length == 8) |
     select(all(.[]; type == "string" and length > 0)) |
     select((unique | length) == length)
+' "$CERTIFICATION_CATALOG")"
+CERTIFICATION_PHYSICAL_APP_WINDOW_TITLES_JSON="$(jq -cer '
+    def normalized_title: gsub("^[[:space:]]+|[[:space:]]+$"; "");
+    .physical_app_window_titles |
+    select(type == "object" and keys == ["activity-monitor"]) |
+    select(all(to_entries[];
+        (.key | type) == "string" and
+        (.value | type) == "string" and
+        .value != "" and
+        (.value | normalized_title) == .value))
 ' "$CERTIFICATION_CATALOG")"
 
 PROBE_BIN="$ARTIFACT_ROOT/bin/background-computer-use-probe"
@@ -738,6 +761,84 @@ exact_window_receipt_from_inventory() {
     ' "$inventory_file"
 }
 
+physical_expected_window_title() {
+    local slug="${1:?Physical app slug required}"
+    jq -er --arg slug "$slug" '.[$slug] // empty' \
+        <<< "$CERTIFICATION_PHYSICAL_APP_WINDOW_TITLES_JSON"
+}
+
+exact_named_window_receipt_from_inventory() {
+    local inventory_file="${1:?Window inventory required}"
+    local expected_title="${2:?Expected window title required}"
+    local expected_pid="${3:?Expected PID required}"
+    local expected_bundle_id="${4:?Expected bundle identifier required}"
+    local expected_application_name="${5:?Expected application name required}"
+    jq -cer \
+        --arg expectedTitle "$expected_title" \
+        --argjson expectedPID "$expected_pid" \
+        --arg expectedBundleID "$expected_bundle_id" \
+        --arg expectedApplicationName "$expected_application_name" '
+        def normalized_title: gsub("^[[:space:]]+|[[:space:]]+$"; "");
+        def exact_filter_warning:
+            type == "string" and
+            (test("^Window list omitted 1 non-renderable or duplicate inventory row\\.$") or
+                test("^Window list omitted (?:[2-9]|[1-9][0-9]+) non-renderable or duplicate inventory rows\\.$"));
+        def valid_window:
+            type == "object" and
+            (.window_id | type) == "number" and
+            .window_id > 0 and .window_id <= 4294967295 and
+            (.window_id | floor) == .window_id and
+            (.window_title | type) == "string" and
+            (.bounds | type) == "object" and
+            ([.bounds.x, .bounds.y, .bounds.width, .bounds.height] | all(type == "number")) and
+            .bounds.width > 0 and .bounds.height > 0 and
+            (.layer | type) == "number" and (.layer | floor) == .layer and
+            (.is_on_screen | type) == "boolean";
+        select(.success == true) |
+        .data as $data |
+        select(($expectedTitle | normalized_title) == $expectedTitle) |
+        select(($expectedApplicationName | normalized_title) == $expectedTitle) |
+        select(
+            $data.target_application_info.pid == $expectedPID and
+            $data.target_application_info.bundle_id == $expectedBundleID and
+            $data.target_application_info.app_name == $expectedApplicationName
+        ) |
+        $data.inventory_completeness as $completeness |
+        $data.inventory_warnings as $warnings |
+        select(
+            ($completeness == "complete" and ($warnings | type) == "array" and
+                ($warnings | length) == 0) or
+            ($completeness == "partial" and ($warnings | type) == "array" and
+                ($warnings | length) == 1 and ($warnings[0] | exact_filter_warning))
+        ) |
+        $data.windows as $windows |
+        select(($windows | type) == "array" and all($windows[]; valid_window)) |
+        [$windows[] |
+            select(.layer == 0 and .is_on_screen == true) |
+            select((.window_title | normalized_title) == $expectedTitle) |
+            {
+                window_id: .window_id,
+                window_title: .window_title,
+                bounds: .bounds
+            }] as $matches |
+        select(($matches | length) == 1) |
+        $matches[0]
+    ' "$inventory_file"
+}
+
+exact_window_receipts_match() {
+    local expected_file="${1:?Expected window receipt required}"
+    local observed_file="${2:?Observed window receipt required}"
+    jq -ne \
+        --slurpfile expected "$expected_file" \
+        --slurpfile observed "$observed_file" '
+        ($expected | length) == 1 and ($observed | length) == 1 and
+        $observed[0].window_id == $expected[0].window_id and
+        $observed[0].window_title == $expected[0].window_title and
+        $observed[0].bounds == $expected[0].bounds
+    ' >/dev/null
+}
+
 physical_target_receipt() {
     local slug="${1:?Physical app slug required}"
     local application_receipt_file="${2:?Application receipt required}"
@@ -880,6 +981,120 @@ if $SELF_TEST_ONLY; then
         "$APPLICATIONS_AMBIGUOUS_SELF_TEST" "$TEXTEDIT_BUNDLE_ID" >/dev/null 2>&1 || \
        exact_window_receipt_from_inventory "$WINDOWS_AMBIGUOUS_SELF_TEST" >/dev/null 2>&1; then
         echo "Owned application/window receipt self-test failed." >&2
+        exit 1
+    fi
+    NAMED_WINDOWS_SELF_TEST="$ARTIFACT_ROOT/named-windows-self-test.json"
+    NAMED_WINDOWS_COMPLETE_SELF_TEST="$ARTIFACT_ROOT/named-windows-complete-self-test.json"
+    NAMED_WINDOWS_DUPLICATE_SELF_TEST="$ARTIFACT_ROOT/named-windows-duplicate-self-test.json"
+    NAMED_WINDOWS_TITLE_DRIFT_SELF_TEST="$ARTIFACT_ROOT/named-windows-title-drift-self-test.json"
+    NAMED_WINDOWS_BOUNDS_DRIFT_SELF_TEST="$ARTIFACT_ROOT/named-windows-bounds-drift-self-test.json"
+    NAMED_WINDOWS_UNSAFE_PARTIAL_SELF_TEST="$ARTIFACT_ROOT/named-windows-unsafe-partial-self-test.json"
+    NAMED_WINDOWS_MIXED_PARTIAL_SELF_TEST="$ARTIFACT_ROOT/named-windows-mixed-partial-self-test.json"
+    NAMED_WINDOWS_BAD_SINGULAR_SELF_TEST="$ARTIFACT_ROOT/named-windows-bad-singular-self-test.json"
+    NAMED_WINDOWS_BAD_PLURAL_SELF_TEST="$ARTIFACT_ROOT/named-windows-bad-plural-self-test.json"
+    NAMED_WINDOWS_OWNER_MISMATCH_SELF_TEST="$ARTIFACT_ROOT/named-windows-owner-mismatch-self-test.json"
+    NAMED_WINDOWS_NAME_MISMATCH_SELF_TEST="$ARTIFACT_ROOT/named-windows-name-mismatch-self-test.json"
+    NAMED_WINDOWS_OFFSCREEN_SELF_TEST="$ARTIFACT_ROOT/named-windows-offscreen-self-test.json"
+    NAMED_WINDOWS_LAYER_SELF_TEST="$ARTIFACT_ROOT/named-windows-layer-self-test.json"
+    NAMED_WINDOWS_BOUNDS_SELF_TEST="$ARTIFACT_ROOT/named-windows-bounds-self-test.json"
+    NAMED_WINDOW_RECEIPT_SELF_TEST="$ARTIFACT_ROOT/named-window-receipt-self-test.json"
+    NAMED_WINDOW_COMPLETE_RECEIPT_SELF_TEST="$ARTIFACT_ROOT/named-window-complete-receipt-self-test.json"
+    NAMED_WINDOW_DRIFT_RECEIPT_SELF_TEST="$ARTIFACT_ROOT/named-window-drift-receipt-self-test.json"
+    printf '%s\n' \
+        '{"success":true,"data":{"inventory_completeness":"partial","inventory_warnings":["Window list omitted 5 non-renderable or duplicate inventory rows."],"target_application_info":{"pid":11393,"bundle_id":"com.apple.ActivityMonitor","app_name":"Activity Monitor"},"windows":[{"window_id":770,"window_title":"Activity Monitor","bounds":{"x":1250,"y":138,"width":960,"height":858},"layer":0,"is_on_screen":true},{"window_id":769,"window_title":"Dock Icon Host Window","bounds":{"x":416,"y":376,"width":361,"height":361},"layer":0,"is_on_screen":true}]}}' \
+        > "$NAMED_WINDOWS_SELF_TEST"
+    jq '.data.inventory_completeness = "complete" | .data.inventory_warnings = []' \
+        "$NAMED_WINDOWS_SELF_TEST" > "$NAMED_WINDOWS_COMPLETE_SELF_TEST"
+    jq '.data.windows += [(.data.windows[0] | .window_id = 771 | .window_title = " Activity Monitor ")]' \
+        "$NAMED_WINDOWS_SELF_TEST" > "$NAMED_WINDOWS_DUPLICATE_SELF_TEST"
+    jq '.data.windows[0].window_title = "CPU"' \
+        "$NAMED_WINDOWS_SELF_TEST" > "$NAMED_WINDOWS_TITLE_DRIFT_SELF_TEST"
+    jq '.data.inventory_warnings = ["Accessibility window enrichment was incomplete"]' \
+        "$NAMED_WINDOWS_SELF_TEST" > "$NAMED_WINDOWS_UNSAFE_PARTIAL_SELF_TEST"
+    jq '.data.inventory_warnings += ["Accessibility window enrichment was incomplete"]' \
+        "$NAMED_WINDOWS_SELF_TEST" > "$NAMED_WINDOWS_MIXED_PARTIAL_SELF_TEST"
+    jq '.data.inventory_warnings = ["Window list omitted 2 non-renderable or duplicate inventory row."]' \
+        "$NAMED_WINDOWS_SELF_TEST" > "$NAMED_WINDOWS_BAD_SINGULAR_SELF_TEST"
+    jq '.data.inventory_warnings = ["Window list omitted 1 non-renderable or duplicate inventory rows."]' \
+        "$NAMED_WINDOWS_SELF_TEST" > "$NAMED_WINDOWS_BAD_PLURAL_SELF_TEST"
+    jq '.data.target_application_info.pid = 11394' \
+        "$NAMED_WINDOWS_SELF_TEST" > "$NAMED_WINDOWS_OWNER_MISMATCH_SELF_TEST"
+    jq '.data.target_application_info.app_name = "Dock Icon Host Window"' \
+        "$NAMED_WINDOWS_SELF_TEST" > "$NAMED_WINDOWS_NAME_MISMATCH_SELF_TEST"
+    jq '.data.windows[0].is_on_screen = false' \
+        "$NAMED_WINDOWS_SELF_TEST" > "$NAMED_WINDOWS_OFFSCREEN_SELF_TEST"
+    jq '.data.windows[0].layer = 1' \
+        "$NAMED_WINDOWS_SELF_TEST" > "$NAMED_WINDOWS_LAYER_SELF_TEST"
+    jq '.data.windows[0].bounds.width = 0' \
+        "$NAMED_WINDOWS_SELF_TEST" > "$NAMED_WINDOWS_BOUNDS_SELF_TEST"
+    exact_named_window_receipt_from_inventory \
+        "$NAMED_WINDOWS_SELF_TEST" "Activity Monitor" 11393 com.apple.ActivityMonitor "Activity Monitor" \
+        > "$NAMED_WINDOW_RECEIPT_SELF_TEST"
+    exact_named_window_receipt_from_inventory \
+        "$NAMED_WINDOWS_COMPLETE_SELF_TEST" "Activity Monitor" 11393 \
+        com.apple.ActivityMonitor "Activity Monitor" \
+        > "$NAMED_WINDOW_COMPLETE_RECEIPT_SELF_TEST"
+    jq '.data.windows[0].bounds.x += 1' \
+        "$NAMED_WINDOWS_SELF_TEST" > "$NAMED_WINDOWS_BOUNDS_DRIFT_SELF_TEST"
+    exact_named_window_receipt_from_inventory \
+        "$NAMED_WINDOWS_BOUNDS_DRIFT_SELF_TEST" "Activity Monitor" 11393 \
+        com.apple.ActivityMonitor "Activity Monitor" \
+        > "$NAMED_WINDOW_DRIFT_RECEIPT_SELF_TEST"
+    if [[ "$(physical_expected_window_title activity-monitor)" != "Activity Monitor" ]] || \
+       physical_expected_window_title finder >/dev/null 2>&1 || \
+       ! jq -e '.window_id == 770 and .window_title == "Activity Monitor"' \
+        "$NAMED_WINDOW_RECEIPT_SELF_TEST" >/dev/null || \
+       ! exact_window_receipts_match \
+        "$NAMED_WINDOW_RECEIPT_SELF_TEST" "$NAMED_WINDOW_COMPLETE_RECEIPT_SELF_TEST" || \
+       ! exact_window_receipts_match \
+        "$NAMED_WINDOW_RECEIPT_SELF_TEST" "$NAMED_WINDOW_RECEIPT_SELF_TEST" || \
+       exact_window_receipts_match \
+        "$NAMED_WINDOW_RECEIPT_SELF_TEST" "$NAMED_WINDOW_DRIFT_RECEIPT_SELF_TEST" || \
+       exact_named_window_receipt_from_inventory \
+        "$NAMED_WINDOWS_DUPLICATE_SELF_TEST" "Activity Monitor" 11393 \
+        com.apple.ActivityMonitor "Activity Monitor" \
+        >/dev/null 2>&1 || \
+       exact_named_window_receipt_from_inventory \
+        "$NAMED_WINDOWS_TITLE_DRIFT_SELF_TEST" "Activity Monitor" 11393 \
+        com.apple.ActivityMonitor "Activity Monitor" \
+        >/dev/null 2>&1 || \
+       exact_named_window_receipt_from_inventory \
+        "$NAMED_WINDOWS_UNSAFE_PARTIAL_SELF_TEST" "Activity Monitor" 11393 \
+        com.apple.ActivityMonitor "Activity Monitor" \
+        >/dev/null 2>&1 || \
+       exact_named_window_receipt_from_inventory \
+        "$NAMED_WINDOWS_MIXED_PARTIAL_SELF_TEST" "Activity Monitor" 11393 \
+        com.apple.ActivityMonitor "Activity Monitor" \
+        >/dev/null 2>&1 || \
+       exact_named_window_receipt_from_inventory \
+        "$NAMED_WINDOWS_BAD_SINGULAR_SELF_TEST" "Activity Monitor" 11393 \
+        com.apple.ActivityMonitor "Activity Monitor" \
+        >/dev/null 2>&1 || \
+       exact_named_window_receipt_from_inventory \
+        "$NAMED_WINDOWS_BAD_PLURAL_SELF_TEST" "Activity Monitor" 11393 \
+        com.apple.ActivityMonitor "Activity Monitor" \
+        >/dev/null 2>&1 || \
+       exact_named_window_receipt_from_inventory \
+        "$NAMED_WINDOWS_OWNER_MISMATCH_SELF_TEST" "Activity Monitor" 11393 \
+        com.apple.ActivityMonitor "Activity Monitor" \
+        >/dev/null 2>&1 || \
+       exact_named_window_receipt_from_inventory \
+        "$NAMED_WINDOWS_NAME_MISMATCH_SELF_TEST" "Activity Monitor" 11393 \
+        com.apple.ActivityMonitor "Activity Monitor" \
+        >/dev/null 2>&1 || \
+       exact_named_window_receipt_from_inventory \
+        "$NAMED_WINDOWS_OFFSCREEN_SELF_TEST" "Activity Monitor" 11393 \
+        com.apple.ActivityMonitor "Activity Monitor" \
+        >/dev/null 2>&1 || \
+       exact_named_window_receipt_from_inventory \
+        "$NAMED_WINDOWS_LAYER_SELF_TEST" "Activity Monitor" 11393 \
+        com.apple.ActivityMonitor "Activity Monitor" \
+        >/dev/null 2>&1 || \
+       exact_named_window_receipt_from_inventory \
+        "$NAMED_WINDOWS_BOUNDS_SELF_TEST" "Activity Monitor" 11393 \
+        com.apple.ActivityMonitor "Activity Monitor" \
+        >/dev/null 2>&1; then
+        echo "Exact physical title receipt self-test failed." >&2
         exit 1
     fi
     HEARTBEAT_SELF_TEST="$ARTIFACT_ROOT/heartbeat-self-test.json"
@@ -1350,17 +1565,34 @@ resolve_existing_physical_target() {
         echo "Physical app $slug requires exactly one already-running $bundle_id process." >&2
         return 1
     fi
-    local pid process_start_identity
+    local pid process_start_identity application_name expected_window_title
     pid="$(jq -er '.pid' "$application_receipt")"
     process_start_identity="$(jq -er '.process_start_identity' "$application_receipt")"
+    application_name="$(jq -er '.application_name' "$application_receipt")"
+    expected_window_title="$(physical_expected_window_title "$slug" 2>/dev/null || true)"
     if ! process_generation_matches \
         "$pid" "$process_start_identity" "$target_dir/process-identity.json"; then
         echo "Physical app $slug changed process generation during setup." >&2
         return 1
     fi
-    if ! pb window list --pid "$pid" --json > "$window_inventory" ||
-       ! exact_window_receipt_from_inventory "$window_inventory" > "$window_receipt"; then
+    if ! pb window list --pid "$pid" --json > "$window_inventory"; then
+        echo "Physical app $slug window inventory failed." >&2
+        return 1
+    fi
+    if [[ -n "$expected_window_title" ]]; then
+        if ! exact_named_window_receipt_from_inventory \
+            "$window_inventory" "$expected_window_title" "$pid" "$bundle_id" "$application_name" \
+            > "$window_receipt"; then
+            echo "Physical app $slug requires one exact visible '$expected_window_title' window." >&2
+            return 1
+        fi
+    elif ! exact_window_receipt_from_inventory "$window_inventory" > "$window_receipt"; then
         echo "Physical app $slug requires one exact visible key or sole window." >&2
+        return 1
+    fi
+    if ! process_generation_matches \
+        "$pid" "$process_start_identity" "$target_dir/process-identity-after-window.json"; then
+        echo "Physical app $slug changed process generation during window selection." >&2
         return 1
     fi
     physical_target_receipt \
@@ -2341,10 +2573,11 @@ run_physical_observation() {
     local target
     target="$(jq -cer --arg slug "$slug" '.targets[$slug]' \
         "$ARTIFACT_ROOT/physical-targets.json")"
-    local pid process_start_identity window_id artifact case_dir
+    local pid process_start_identity window_id artifact case_dir expected_window_title
     pid="$(jq -er '.pid' <<< "$target")"
     process_start_identity="$(jq -er '.process_start_identity' <<< "$target")"
     window_id="$(jq -er '.window_id' <<< "$target")"
+    expected_window_title="$(physical_expected_window_title "$slug" 2>/dev/null || true)"
     case_dir="$(case_dir_path "$case_name")"
     artifact="$case_dir/window.png"
 
@@ -2356,6 +2589,7 @@ run_physical_observation() {
     local generation_file="$case_dir/target-process-identity.json"
     local executable_file="$case_dir/target-process-executable.json"
     local window_readback="$case_dir/target-window-readback.json"
+    local selector_readback="$case_dir/target-window-selector-readback.json"
     local target_verified=true
     if ! process_generation_matches \
         "$pid" "$process_start_identity" "$generation_file"; then
@@ -2373,13 +2607,31 @@ run_physical_observation() {
         "$(jq -er '.executable.code_signature_hash' <<< "$target")" ]]; then
         target_verified=false
     fi
-    if ! pb window list --pid "$pid" --json > "$window_readback" ||
-       ! jq -e --argjson target "$target" '
-            any(.data.windows[]?;
-                .window_id == $target.window_id and
-                .window_title == $target.window_title and
-                .bounds == $target.bounds)
-       ' "$window_readback" >/dev/null; then
+    if ! pb window list --pid "$pid" --json > "$window_readback"; then
+        target_verified=false
+    elif [[ -n "$expected_window_title" ]]; then
+        if ! exact_named_window_receipt_from_inventory \
+            "$window_readback" \
+            "$expected_window_title" \
+            "$pid" \
+            "$(jq -er '.bundle_id' <<< "$target")" \
+            "$(jq -er '.application_name' <<< "$target")" \
+            > "$selector_readback" ||
+           ! exact_window_receipts_match \
+            "$ARTIFACT_ROOT/physical-targets/$slug/target-receipt.json" \
+            "$selector_readback"; then
+            target_verified=false
+        fi
+    elif ! jq -e --argjson target "$target" '
+        any(.data.windows[]?;
+            .window_id == $target.window_id and
+            .window_title == $target.window_title and
+            .bounds == $target.bounds)
+    ' "$window_readback" >/dev/null; then
+        target_verified=false
+    fi
+    if ! process_generation_matches \
+        "$pid" "$process_start_identity" "$case_dir/target-process-identity-after-window-readback.json"; then
         target_verified=false
     fi
     if ! jq -e --argjson target "$target" --arg artifact "$artifact" '

--- a/scripts/validate-background-computer-use-report.mjs
+++ b/scripts/validate-background-computer-use-report.mjs
@@ -65,6 +65,22 @@ function validateCatalog(catalog) {
       "Catalog must map every physical app to one distinct exact bundle identifier",
     ));
   }
+  const physicalTitleKeys = catalog.physical_app_window_titles
+    && typeof catalog.physical_app_window_titles === "object"
+    && !Array.isArray(catalog.physical_app_window_titles)
+    ? Object.keys(catalog.physical_app_window_titles).sort()
+    : [];
+  if (JSON.stringify(physicalTitleKeys) !== JSON.stringify(["activity-monitor"])
+      || physicalTitleKeys.some((name) => !catalog.physical_apps?.includes(name))
+      || Object.values(catalog.physical_app_window_titles ?? {}).some((title) => (
+        typeof title !== "string" || title.length === 0 || title.trim() !== title
+      ))) {
+    failures.push(failure(
+      "catalog",
+      "physical_app_window_titles",
+      "Catalog must declare one normalized exact Activity Monitor window title",
+    ));
+  }
   const ids = catalog.cases.map((entry) => entry?.id).filter(Boolean);
   for (const id of duplicateValues(ids)) {
     failures.push(failure(id, "duplicate_catalog_case", `Catalog case '${id}' is duplicated`));
@@ -276,7 +292,7 @@ function isExactMonitorReceipt(receipt) {
     && receipt.final.wall_clock_milliseconds >= receipt.start.wall_clock_milliseconds;
 }
 
-function isExactPhysicalTarget(target, physicalApp, expectedBundleID) {
+function isExactPhysicalTarget(target, physicalApp, expectedBundleID, expectedWindowTitle) {
   const keys = target && typeof target === "object" && !Array.isArray(target)
     ? Object.keys(target).sort()
     : [];
@@ -291,6 +307,11 @@ function isExactPhysicalTarget(target, physicalApp, expectedBundleID) {
     && keys.every((key, index) => key === expectedKeys[index])
     && target.physical_app === physicalApp
     && typeof target.application_name === "string" && target.application_name.length > 0
+    && (expectedWindowTitle === undefined || (
+      target.application_name.trim() === expectedWindowTitle
+      && typeof target.window_title === "string"
+      && target.window_title.trim() === expectedWindowTitle
+    ))
     && target.bundle_id === expectedBundleID
     && Number.isSafeInteger(target.pid) && target.pid > 0
     && typeof target.process_start_identity === "string"
@@ -540,6 +561,7 @@ export function validateCertification(catalog, report, trustedSourceArtifacts = 
       observed.physical_target,
       expected.physical_app,
       catalog.physical_app_bundle_ids[expected.physical_app],
+      catalog.physical_app_window_titles?.[expected.physical_app],
     )) {
       failures.push(failure(
         expected.id,
@@ -664,6 +686,7 @@ export function makePassingReport(catalog) {
     const evidence = Object.fromEntries(catalog.required_evidence.map((name) => [name, true]));
     const oracles = Object.fromEntries(entry.required_oracles.map((name) => [name, true]));
     const invariants = catalog.invariants.map((name) => ({ name, passed: true }));
+    const expectedWindowTitle = catalog.physical_app_window_titles?.[entry.physical_app];
     return {
       id: entry.id,
       surface: entry.surface,
@@ -671,12 +694,12 @@ export function makePassingReport(catalog) {
       phase: entry.phase,
       physical_app: entry.physical_app ?? null,
       physical_target: entry.physical_app === undefined ? null : {
-        application_name: entry.physical_app,
+        application_name: expectedWindowTitle ?? entry.physical_app,
         bundle_id: catalog.physical_app_bundle_ids[entry.physical_app],
         pid: index + 100,
         process_start_identity: String(index + 1000),
         window_id: index + 200,
-        window_title: "Fixture",
+        window_title: expectedWindowTitle ?? "Fixture",
         bounds: { x: 0, y: 0, width: 800, height: 600 },
         physical_app: entry.physical_app,
         executable: {

--- a/tests/background-computer-use-report.test.mjs
+++ b/tests/background-computer-use-report.test.mjs
@@ -119,6 +119,33 @@ test("catalog has no monitored process launch and covers eight physical apps exa
     .filter(Boolean)
     .sort();
   assert.deepEqual(coveredApps, [...catalog.physical_apps].sort());
+  assert.deepEqual(catalog.physical_app_window_titles, {
+    "activity-monitor": "Activity Monitor",
+  });
+});
+
+test("physical title selector catalog is closed and exact", () => {
+  const missing = structuredClone(catalog);
+  delete missing.physical_app_window_titles;
+  assert.ok(rules(validateCertification(missing, makePassingReport(catalog)))
+    .has("physical_app_window_titles"));
+
+  const expanded = structuredClone(catalog);
+  expanded.physical_app_window_titles.finder = "Finder";
+  assert.ok(rules(validateCertification(expanded, makePassingReport(catalog)))
+    .has("physical_app_window_titles"));
+
+  const padded = structuredClone(catalog);
+  padded.physical_app_window_titles["activity-monitor"] = " Activity Monitor ";
+  assert.ok(rules(validateCertification(padded, makePassingReport(catalog)))
+    .has("physical_app_window_titles"));
+});
+
+test("Activity Monitor physical target must retain its catalog title", () => {
+  const report = makePassingReport(catalog);
+  const physical = caseById(report, "physical-activity-monitor").physical_target;
+  physical.window_title = "Dock Icon Host Window";
+  assert.ok(rules(validateCertification(catalog, report)).has("physical_target_mismatch"));
 });
 
 test("keyboard contract requires exact-window positives and app/PID raw-key refusals", () => {


### PR DESCRIPTION
## Summary

- define Activity Monitor's exact physical-test window title in the source-controlled certification catalog
- accept only one exact visible layer-zero title match from a complete inventory or a provably filter-only partial inventory
- pin PID generation, window ID, raw title, and bounds across setup, observation, and readback
- make unexplained partial window inventories explicit so they cannot masquerade as harmless filtered rows

## Root cause

Inactive Activity Monitor exposes neither an Accessibility key nor main window. Its user-owned process currently has the real `Activity Monitor` window plus `Dock Icon Host Window`, so the key-or-sole physical-target resolver correctly refused it. Closing or reconfiguring those windows would violate the read-only harness contract.

This keeps the exception harness-owned: the catalog declares the expected Activity Monitor title, while production window selection remains unchanged. Unknown localization/title drift, duplicate normalized matches, unsafe partial inventories, owner changes, and post-observation drift all refuse.

## Proof

- `bash -n scripts/test-background-computer-use.sh`
- `scripts/test-background-computer-use.sh --self-test --artifacts <fresh-private-root>`
- `node --test tests/background-computer-use-report.test.mjs` (31 passed)
- focused `WindowCommandTests` (22 runnable tests passed; 3 opt-in local integration tests skipped)
- `pnpm run test:safe` (certification 31 + 136 + 31 + 51, Foundation 70, CLI 505)
- `pnpm run format`
- `pnpm run lint` (0 serious violations)
- `pnpm run lint:docs`
- source-blind read-only validation against the existing Activity Monitor process through GUI Bridge and local signed CLI paths
- structured Autoreview: clean

No app was launched, activated, mutated, captured, or driven during live validation.

The prerequisite #553 has landed. This branch is rebased onto `main` and contains only the Activity Monitor/title-receipt change.
