### PR TITLE
fix(bridge): refuse unverifiable set-value hosts

### DIFF
--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [4.2.3] - Unreleased
 
+### Fixed
+- Bind signed `set-value` results to the opaque requested element and refuse older Bridge hosts before dispatch.
+
 ## [4.2.2] - 2026-08-20
 
 ### Highlights

--- a/Apps/CLI/Tests/CLIAutomationTests/SetValueOutcomeCommandTests.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/SetValueOutcomeCommandTests.swift
@@ -68,6 +68,46 @@ struct SetValueOutcomeCommandTests {
         #expect(try await snapshots.getDetectionResult(snapshotId: snapshotID) != nil)
     }
 
+    @Test
+    func `Bridge result binding refusal stays retry safe and preserves the snapshot`() async throws {
+        let automation = OutcomeStubAutomationService()
+        let snapshots = StubSnapshotManager()
+        let services = TestServicesFactory.makePeekabooServices(
+            snapshots: snapshots,
+            automation: automation
+        )
+        let snapshotID = try await ActionOutcomeCommandTests.storeExactWindowElementSnapshot(in: snapshots)
+        automation.uiAutomationOutcomeScript.appendFailure(
+            DesktopActionFailure.preDispatchRefusal(
+                route: .bridge,
+                reason: .runtimeIncompatible,
+                message: "This Bridge host cannot return a verifiable set-value result.",
+                hint: "Update and relaunch Peekaboo before retrying set-value."
+            ),
+            for: .setValue
+        )
+
+        let result = try await InProcessCommandRunner.run([
+            "set-value", "updated", "--on", "elem_3", "--snapshot", snapshotID,
+            "--json", "--no-remote",
+        ], services: services)
+        let object = try Self.jsonObject(result.stdout)
+        let outcome = try #require(object["outcome"] as? [String: Any])
+        let error = try #require(object["error"] as? [String: Any])
+
+        #expect(result.exitStatus == 1)
+        #expect(outcome["state"] as? String == "refused")
+        #expect(outcome["route"] as? String == "bridge")
+        #expect(outcome["dispatch_state"] as? String == "none")
+        #expect(outcome["refusal_reason"] as? String == "runtime_incompatible")
+        #expect(outcome["retry_safe"] as? Bool == true)
+        #expect(outcome["requires_fresh_observation"] as? Bool == false)
+        #expect(error["retry_safe"] as? Bool == true)
+        #expect(error["mutation_dispatched"] as? Bool == false)
+        #expect(automation.uiAutomationOutcomeScript.callCount(for: .setValue) == 1)
+        #expect(try await snapshots.getDetectionResult(snapshotId: snapshotID) != nil)
+    }
+
     private static func jsonObject(_ output: String) throws -> [String: Any] {
         try #require(JSONSerialization.jsonObject(with: Data(output.utf8)) as? [String: Any])
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 - Fail closed instead of generating or accepting a release-qualification manifest until final-cycle liveness witnesses have a cryptographic trust anchor.
 - Add receipt-required Bridge protocol 1.32 observation of exact process generations for signed liveness and absence evidence.
+- Bind signed `set-value` results to the opaque requested element and refuse older Bridge hosts before dispatch.
 
 ## [4.2.2] - 2026-08-20
 

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Core/Protocols/UIAutomationServiceProtocol.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Core/Protocols/UIAutomationServiceProtocol.swift
@@ -678,6 +678,14 @@ extension TargetedClickServiceProtocol {
 /// Optional capability for automation services that can invoke accessibility actions directly.
 @MainActor
 public protocol ElementActionAutomationServiceProtocol: UIAutomationServiceProtocol {
+    var supportsSetValueResultTargetBinding: Bool { get }
+
     func setValue(target: String, value: UIElementValue, snapshotId: String?) async throws -> ElementActionResult
     func performAction(target: String, actionName: String, snapshotId: String?) async throws -> ElementActionResult
+}
+
+extension ElementActionAutomationServiceProtocol {
+    public var supportsSetValueResultTargetBinding: Bool {
+        false
+    }
 }

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/UIAutomationService+ElementActions.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/UIAutomationService+ElementActions.swift
@@ -97,7 +97,7 @@ extension UIAutomationService: ElementActionAutomationServiceProtocol {
             payload: ElementActionResult(
                 target: target,
                 actionName: result.actionName,
-                anchorPoint: result.anchorPoint,
+                anchorPoint: nil,
                 oldValue: oldValue,
                 newValue: newValue),
             outcome: result.outcome,

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/UIAutomationService+ElementActions.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/UIAutomationService+ElementActions.swift
@@ -8,6 +8,10 @@ private typealias ResolvedElementMutationTarget = (
     windowContext: WindowContext?)
 
 extension UIAutomationService: ElementActionAutomationServiceProtocol {
+    public var supportsSetValueResultTargetBinding: Bool {
+        true
+    }
+
     public func setValue(
         target: String,
         value: UIElementValue,
@@ -85,13 +89,13 @@ extension UIAutomationService: ElementActionAutomationServiceProtocol {
             try await self.desktopOperationExecutor.executeWithTargetIdentity(plan)
         }
         let result = execution.payload
-        guard let resolved, let newValue else {
+        guard resolved != nil, let newValue else {
             throw PeekabooError.operationError(message: "Element value result was not captured")
         }
 
         return UIAutomationActionResult(
             payload: ElementActionResult(
-                target: resolved.description,
+                target: target,
                 actionName: result.actionName,
                 anchorPoint: result.anchorPoint,
                 oldValue: oldValue,

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/UIAutomationActionOutcomeProvidingTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/UIAutomationActionOutcomeProvidingTests.swift
@@ -174,10 +174,17 @@ struct UIAutomationActionOutcomeProvidingTests {
     }
 
     @Test
-    func `set value result preserves payload and exact outcome with legacy payload parity`() async throws {
+    func `set value result strips driver anchors and preserves receipt semantics with legacy parity`() async throws {
         let expected = Self.outcome(mechanism: .accessibilityValue, mode: .background)
-        let resultDriver = OutcomeActionInputDriver(outcome: expected, storedValue: "old")
-        let legacyDriver = OutcomeActionInputDriver(outcome: expected, storedValue: "old")
+        let driverAnchor = CGPoint(x: 17, y: 29)
+        let resultDriver = OutcomeActionInputDriver(
+            outcome: expected,
+            storedValue: "old",
+            setValueAnchorPoint: driverAnchor)
+        let legacyDriver = OutcomeActionInputDriver(
+            outcome: expected,
+            storedValue: "old",
+            setValueAnchorPoint: driverAnchor)
         let resultService = self.makeElementActionService(actionDriver: resultDriver)
         let legacyService = self.makeElementActionService(actionDriver: legacyDriver)
 
@@ -192,9 +199,12 @@ struct UIAutomationActionOutcomeProvidingTests {
 
         #expect(result.outcome == expected)
         #expect(result.payload == legacy)
-        #expect(result.payload.target == "E1")
-        #expect(result.payload.oldValue == "old")
-        #expect(result.payload.newValue == "new")
+        #expect(result.payload == ElementActionResult(
+            target: "E1",
+            actionName: "AXSetValue",
+            anchorPoint: nil,
+            oldValue: "old",
+            newValue: "new"))
         #expect(result.targetIdentity?.exactWindow != nil)
         #expect(resultDriver.setValueCount == 1)
         #expect(legacyDriver.setValueCount == 1)
@@ -573,10 +583,16 @@ private final class OutcomeActionInputDriver: ActionInputDriving {
     private(set) var setValueCount = 0
     private(set) var performActionCount = 0
     private(set) var storedValue: String?
+    private let setValueAnchorPoint: CGPoint?
 
-    init(outcome: DesktopActionOutcome, storedValue: String? = nil) {
+    init(
+        outcome: DesktopActionOutcome,
+        storedValue: String? = nil,
+        setValueAnchorPoint: CGPoint? = nil)
+    {
         self.outcome = outcome
         self.storedValue = storedValue
+        self.setValueAnchorPoint = setValueAnchorPoint
     }
 
     func tryClick(element _: AutomationElement) throws -> UIInputExecutionResult.Action {
@@ -617,7 +633,8 @@ private final class OutcomeActionInputDriver: ActionInputDriving {
         self.storedValue = value.displayString
         return UIInputExecutionResult.Action(
             outcome: self.outcome,
-            actionName: "AXSetValue")
+            actionName: "AXSetValue",
+            anchorPoint: self.setValueAnchorPoint)
     }
 
     func tryPerformAction(element _: AutomationElement, actionName: String) throws

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/UIAutomationActionOutcomeProvidingTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/UIAutomationActionOutcomeProvidingTests.swift
@@ -192,6 +192,7 @@ struct UIAutomationActionOutcomeProvidingTests {
 
         #expect(result.outcome == expected)
         #expect(result.payload == legacy)
+        #expect(result.payload.target == "E1")
         #expect(result.payload.oldValue == "old")
         #expect(result.payload.newValue == "new")
         #expect(result.targetIdentity?.exactWindow != nil)

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeClient+Transport.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeClient+Transport.swift
@@ -190,6 +190,15 @@ extension PeekabooBridgeClient {
     }
 
     private func requireNegotiatedInputCapabilities(for request: PeekabooBridgeRequest) throws {
+        if request.unwrappedOperationRequest.operation == .setValue,
+           !self.setValueResultTargetBindingEnabled
+        {
+            throw DesktopActionFailure.preDispatchRefusal(
+                route: .bridge,
+                reason: .runtimeIncompatible,
+                message: "This Bridge host cannot return a verifiable set-value result.",
+                hint: "Update and relaunch Peekaboo before retrying set-value.")
+        }
         if request.unwrappedOperationRequest.operation == .observeProcessGeneration,
            !self.processGenerationObservationEnabled
         {

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeClient.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeClient.swift
@@ -56,6 +56,7 @@ public actor PeekabooBridgeClient {
     var statelessClickVariantsEnabled = false
     var agentExecutionTraceEnabled = false
     var processGenerationObservationEnabled = false
+    var setValueResultTargetBindingEnabled = false
     var operationAttestation: PeekabooBridgeListenerAttestation?
     var latestVerifiedOperationReceipt: PeekabooBridgeOperationReceipt?
     var latestVerifiedOperationReceiptBundle: PeekabooBridgeOperationReceiptBundle?
@@ -444,6 +445,7 @@ public actor PeekabooBridgeClient {
         self.statelessClickVariantsEnabled = false
         self.agentExecutionTraceEnabled = false
         self.processGenerationObservationEnabled = false
+        self.setValueResultTargetBindingEnabled = false
     }
 
     /// Creates or joins one successor-session handshake using the most recent successful public inputs.
@@ -875,6 +877,7 @@ public actor PeekabooBridgeClient {
             statelessClickVariantsEnabled: Self.supportsStatelessClickVariants(handshake),
             agentExecutionTraceEnabled: Self.supportsAgentExecutionTrace(handshake),
             processGenerationObservationEnabled: Self.supportsProcessGenerationObservation(handshake),
+            setValueResultTargetBindingEnabled: Self.supportsSetValueResultTargetBinding(handshake),
             listenerAttestation: listenerAttestation,
             listenerLiveIdentity: listenerLiveIdentity,
             sessionAttestation: sessionAttestation,
@@ -902,6 +905,13 @@ public actor PeekabooBridgeClient {
                 PeekabooBridgeHostCapability.processGenerationObservation) == true &&
             handshake.supportedOperations.contains(.observeProcessGeneration) &&
             (handshake.enabledOperations?.contains(.observeProcessGeneration) ?? true)
+    }
+
+    private static func supportsSetValueResultTargetBinding(_ handshake: PeekabooBridgeHandshakeResponse) -> Bool {
+        handshake.negotiatedVersion >= PeekabooBridgeConstants.setValueResultTargetBindingVersion &&
+            handshake.hostCapabilities?.contains(
+                PeekabooBridgeHostCapability.setValueResultTargetBinding) == true &&
+            handshake.supportedOperations.contains(.setValue)
     }
 
     private func installHandshakeCandidate(
@@ -948,6 +958,7 @@ public actor PeekabooBridgeClient {
         self.statelessClickVariantsEnabled = candidate.statelessClickVariantsEnabled
         self.agentExecutionTraceEnabled = candidate.agentExecutionTraceEnabled
         self.processGenerationObservationEnabled = candidate.processGenerationObservationEnabled
+        self.setValueResultTargetBindingEnabled = candidate.setValueResultTargetBindingEnabled
         self.operationAttestation = candidate.listenerAttestation
         self.installReceiptlessAuthenticatedHost(candidate.receiptlessAuthenticatedHost)
         if let listenerAttestation = candidate.listenerAttestation,
@@ -1234,6 +1245,7 @@ private struct PeekabooBridgeClientHandshakeCandidate: Sendable {
     let statelessClickVariantsEnabled: Bool
     let agentExecutionTraceEnabled: Bool
     let processGenerationObservationEnabled: Bool
+    let setValueResultTargetBindingEnabled: Bool
     let listenerAttestation: PeekabooBridgeListenerAttestation?
     let listenerLiveIdentity: PeekabooBridgeLivePeerIdentity?
     let sessionAttestation: PeekabooBridgeOperationSessionAttestation?

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeConstants.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeConstants.swift
@@ -71,6 +71,11 @@ public enum PeekabooBridgeConstants {
     public static let processGenerationObservationVersion =
         PeekabooBridgeProtocolVersion(major: 1, minor: 32)
 
+    /// First protocol whose set-value result preserves the exact opaque request target so its
+    /// signed response can be bound to the request without post-dispatch ambiguity.
+    public static let setValueResultTargetBindingVersion =
+        PeekabooBridgeProtocolVersion(major: 1, minor: 32)
+
     /// First protocol whose Bridge can launch the exact authenticated CLI peer as a suspended
     /// background Agent and return one listener-signed terminal execution trace.
     public static let agentExecutionTraceVersion =

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeModels.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeModels.swift
@@ -371,6 +371,7 @@ public enum PeekabooBridgeHostCapability {
     public static let statelessClickVariants = "statelessClickVariants"
     public static let agentExecutionTrace = "agentExecutionTrace"
     public static let processGenerationObservation = "processGenerationObservation"
+    public static let setValueResultTargetBinding = "setValueResultTargetBinding"
 }
 
 public struct PeekabooBridgeHandshakeResponse: Codable, Sendable {

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer+Handshake.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer+Handshake.swift
@@ -166,6 +166,14 @@ extension PeekabooBridgeServer {
         {
             advertisedCapabilities.remove(PeekabooBridgeHostCapability.processGenerationObservation)
         }
+        if !supportsAttestedOperationReceipts ||
+            negotiated < PeekabooBridgeConstants.setValueResultTargetBindingVersion ||
+            (self.services.automation as? any ElementActionAutomationServiceProtocol)?
+            .supportsSetValueResultTargetBinding != true ||
+            !advertisedOps.contains(.setValue)
+        {
+            advertisedCapabilities.remove(PeekabooBridgeHostCapability.setValueResultTargetBinding)
+        }
         if supportsAttestedOperationReceipts {
             advertisedCapabilities.insert(PeekabooBridgeHostCapability.attestedOperationReceipts)
         }

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer.swift
@@ -992,5 +992,8 @@ private func protocolHostCapabilities(
     if supportedVersions.upperBound >= PeekabooBridgeConstants.statelessClickVariantVersion {
         capabilities.insert(PeekabooBridgeHostCapability.statelessClickVariants)
     }
+    if supportedVersions.upperBound >= PeekabooBridgeConstants.setValueResultTargetBindingVersion {
+        capabilities.insert(PeekabooBridgeHostCapability.setValueResultTargetBinding)
+    }
     return capabilities
 }

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPDesktopActionOutcomeProjectionTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPDesktopActionOutcomeProjectionTests.swift
@@ -1049,6 +1049,41 @@ extension MCPDesktopActionOutcomeProjectionTests {
 
     @Test
     @MainActor
+    func `set value maps a Bridge result binding refusal without invalidating its snapshot`() async throws {
+        let automation = StubAutomationService()
+        automation.uiAutomationOutcomeScript.appendFailure(
+            DesktopActionFailure.preDispatchRefusal(
+                route: .bridge,
+                reason: .runtimeIncompatible,
+                message: "This Bridge host cannot return a verifiable set-value result.",
+                hint: "Update and relaunch Peekaboo before retrying set-value."),
+            for: .setValue)
+        let context = await MCPToolTestHelpers.makeContext(automation: automation)
+        await context.uiSnapshots.removeOwner()
+        let snapshot = await context.uiSnapshots.createSnapshot()
+        let snapshotID = await snapshot.id
+
+        let response = try await SetValueTool(context: context).execute(arguments: ToolArguments(raw: [
+            "on": "T1",
+            "value": "hello",
+            "snapshot": snapshotID,
+        ]))
+
+        #expect(response.isError)
+        try MCPToolTestHelpers.expectCanonicalOutcomeMetadata(
+            .refused(route: .bridge, reason: .runtimeIncompatible),
+            in: response)
+        let meta = try #require(response.meta?.objectValue)
+        #expect(meta["route"] == .string("bridge"))
+        #expect(meta["mutation_dispatched"] == .bool(false))
+        #expect(meta["retry_safe"] == .bool(true))
+        #expect(meta["requires_fresh_observation"] == .bool(false))
+        #expect(meta["invalidated_snapshot"] == nil)
+        #expect(await context.uiSnapshots.getSnapshot(id: snapshotID) != nil)
+    }
+
+    @Test
+    @MainActor
     func `mutation tool validation emits canonical predispatch refusals`() async throws {
         let automation = MockAutomationService(accessibilityGranted: true)
         let context = await MCPToolTestHelpers.makeContext(automation: automation)

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeSetValueReceiptCapabilityTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeSetValueReceiptCapabilityTests.swift
@@ -1,0 +1,142 @@
+import Foundation
+import PeekabooAutomationKit
+import PeekabooFoundation
+import Testing
+@testable import PeekabooBridge
+
+@Suite(.serialized)
+@MainActor
+struct PeekabooBridgeSetValueReceiptCapabilityTests {
+    private static let clientIdentity = PeekabooBridgeClientIdentity(
+        bundleIdentifier: "dev.peekaboo.set-value-receipt-tests",
+        teamIdentifier: nil,
+        processIdentifier: getpid())
+
+    @Test
+    func `protocol 1 31 host refuses set value before dispatch without result target binding`() async throws {
+        let oldVersion = PeekabooBridgeProtocolVersion(major: 1, minor: 31)
+        let services = try Self.services()
+        let socketPath = "/tmp/peekaboo-set-value-old-host-\(UUID().uuidString).sock"
+        let server = PeekabooBridgeServer(
+            services: services,
+            allowlistedTeams: [],
+            allowlistedBundles: [],
+            supportedVersions: PeekabooBridgeConstants.minimumProtocolVersion...oldVersion,
+            allowedOperations: [.setValue])
+        let host = PeekabooBridgeHost(
+            socketPath: socketPath,
+            server: server,
+            allowedTeamIDs: [],
+            requestTimeoutSec: 2)
+        try await host.startChecked()
+        defer { Task { await host.stop() } }
+
+        let client = TrustedBridgeClientFixture.make(socketPath: socketPath, requestTimeoutSec: 2)
+        let handshake = try await client.handshake(
+            client: Self.clientIdentity,
+            protocolVersion: oldVersion)
+        #expect(handshake.negotiatedVersion == oldVersion)
+        #expect(handshake.supportedOperations.contains(.setValue))
+        #expect(handshake.hostCapabilities?.contains(
+            PeekabooBridgeHostCapability.setValueResultTargetBinding) == false)
+
+        do {
+            _ = try await client.setValue(
+                target: "T1",
+                value: .string("updated"),
+                snapshotId: "snapshot")
+            Issue.record("Expected an old host capability refusal")
+        } catch let failure as DesktopActionFailure {
+            #expect(failure.outcome.state == .refused)
+            #expect(failure.outcome.route == .bridge)
+            #expect(failure.outcome.dispatchState == .none)
+            #expect(failure.outcome.retrySafety == .safe)
+            #expect(failure.outcome.refusalReason == .runtimeIncompatible)
+            #expect(failure.message.contains("verifiable set-value result"))
+        }
+        #expect(services.automationStub.lastSetValue == nil)
+        await host.stop()
+    }
+
+    @Test
+    func `fixed host advertises binding and returns a valid signed set value result`() async throws {
+        let services = try Self.services()
+        let socketPath = "/tmp/peekaboo-set-value-fixed-host-\(UUID().uuidString).sock"
+        let server = PeekabooBridgeServer(
+            services: services,
+            allowlistedTeams: [],
+            allowlistedBundles: [],
+            allowedOperations: [.setValue])
+        let host = PeekabooBridgeHost(
+            socketPath: socketPath,
+            server: server,
+            allowedTeamIDs: [],
+            requestTimeoutSec: 2)
+        try await host.startChecked()
+        defer { Task { await host.stop() } }
+
+        let client = TrustedBridgeClientFixture.make(socketPath: socketPath, requestTimeoutSec: 2)
+        let handshake = try await client.handshake(client: Self.clientIdentity)
+        #expect(handshake.negotiatedVersion == PeekabooBridgeConstants.protocolVersion)
+        #expect(handshake.hostCapabilities?.contains(
+            PeekabooBridgeHostCapability.setValueResultTargetBinding) == true)
+
+        let result = try await client.setValue(
+            target: "T1",
+            value: .string("updated"),
+            snapshotId: "snapshot")
+
+        #expect(result.target == "T1")
+        #expect(services.automationStub.lastSetValue?.target == "T1")
+        let bundle = try #require(await client.lastOperationReceiptBundle())
+        try bundle.validate()
+        #expect(bundle.receipt.payload.operation == .setValue)
+        await host.stop()
+    }
+
+    @Test
+    func `host omits binding capability when its element provider does not claim it`() async throws {
+        let services = try Self.services()
+        services.automationStub.supportsSetValueResultTargetBinding = false
+        let socketPath = "/tmp/peekaboo-set-value-unbound-provider-\(UUID().uuidString).sock"
+        let server = PeekabooBridgeServer(
+            services: services,
+            allowlistedTeams: [],
+            allowlistedBundles: [],
+            allowedOperations: [.setValue])
+        let host = PeekabooBridgeHost(
+            socketPath: socketPath,
+            server: server,
+            allowedTeamIDs: [],
+            requestTimeoutSec: 2)
+        try await host.startChecked()
+        defer { Task { await host.stop() } }
+
+        let client = TrustedBridgeClientFixture.make(socketPath: socketPath, requestTimeoutSec: 2)
+        let handshake = try await client.handshake(client: Self.clientIdentity)
+        #expect(handshake.hostCapabilities?.contains(
+            PeekabooBridgeHostCapability.setValueResultTargetBinding) == false)
+
+        await #expect(throws: DesktopActionFailure.self) {
+            _ = try await client.setValue(
+                target: "T1",
+                value: .string("updated"),
+                snapshotId: "snapshot")
+        }
+        #expect(services.automationStub.lastSetValue == nil)
+        await host.stop()
+    }
+
+    private static func services() throws -> StubServices {
+        let services = StubServices()
+        services.automationStub.actionOutcome = .dispatchedUnverified(
+            delivery: .init(mechanism: .accessibilityValue, mode: .background),
+            evidence: .deliveryAccepted,
+            unitCount: .one)
+        services.automationStub.uiAutomationOutcomeTargetIdentity = try DesktopTargetIdentity(
+            processIdentity: .init(
+                processIdentifier: getpid(),
+                processStartIdentity: #require(SystemIdentityResolver.processStartIdentity(getpid()))))
+        return services
+    }
+}

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeTests.swift
@@ -2227,6 +2227,7 @@ final class StubAutomationService: TargetedHotkeyServiceProtocol, TargetedTypeSe
     ElementActionAutomationServiceProtocol, TargetedFocusedElementServiceProtocol,
     ExactWindowTargetedKeyboardServiceProtocol
 {
+    var supportsSetValueResultTargetBinding = true
     var dragError: (any Error)?
     let supportsProcessGenerationPinnedHotkeys = true
     let supportsProcessGenerationPinnedTypeActions = true


### PR DESCRIPTION
## Summary

- bind `setValue` results to the exact opaque target from the request instead of a human-readable element description
- advertise the corrected result contract only when the host's element provider explicitly supports it
- make new clients refuse older hosts before dispatch when a verifiable set-value result is unavailable
- preserve retry-safe refusal metadata and the caller's snapshot through CLI and MCP projections

## Root cause

Released 4.2.2 hosts dispatch the Accessibility value mutation, then construct `ElementActionResult.target` from the resolved element description. Signed receipt semantics require exact equality with the opaque request target. The host therefore rejects its own response carriage after mutation and falls back to a plain legacy error; the client correctly classifies that as an indeterminate lost response.

A client cannot safely accept a signed envelope that the old host never emits. The compatibility boundary is therefore capability-gated: fixed hosts return a verifiable signed response, while new clients refuse old hosts before any mutation dispatch.

## Proof

- 69 focused AutomationKit, Bridge host/client, CLI, and MCP tests passed
- protocol-1.31 host regression proves refusal with `dispatch_state:none` and no service call
- fixed protocol-1.32 host regression proves opaque target equality and a valid signed receipt bundle
- provider opt-in regression prevents false capability advertisement
- repeated source-blind Core and CLI validation passed
- `pnpm run format`
- `pnpm run lint` with zero serious violations
- `git diff --check`
- structured pre-commit review: clean

The physical reproduction used a Foundation-signed current-main CLI against the installed 4.2.2 GUI Bridge: mutation and restoration both occurred, while both responses were correctly treated as indeterminate. This PR removes that unsafe compatibility path rather than teaching the client to trust an unsigned fallback.
