### PR TITLE
fix(config): treat Anthropic provider probes as failed unless HTTP 200

### DIFF
--- a/Core/PeekabooCore/Sources/PeekabooAutomation/Configuration/ConfigurationManager+CustomProviders.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAutomation/Configuration/ConfigurationManager+CustomProviders.swift
@@ -162,7 +162,7 @@ extension ConfigurationManager {
             return (false, "Invalid response")
         }
 
-        guard httpResponse.statusCode == 200 else {
+        guard Self.isSuccessfulCustomProviderProbe(statusCode: httpResponse.statusCode) else {
             let errorMessage = String(data: data, encoding: .utf8) ?? "HTTP \(httpResponse.statusCode)"
             return (false, errorMessage)
         }
@@ -196,12 +196,16 @@ extension ConfigurationManager {
             return (false, "Invalid response")
         }
 
-        if httpResponse.statusCode < 500 {
-            return (true, nil)
+        guard Self.isSuccessfulCustomProviderProbe(statusCode: httpResponse.statusCode) else {
+            let errorMessage = String(data: data, encoding: .utf8) ?? "HTTP \(httpResponse.statusCode)"
+            return (false, errorMessage)
         }
 
-        let errorMessage = String(data: data, encoding: .utf8) ?? "HTTP \(httpResponse.statusCode)"
-        return (false, errorMessage)
+        return (true, nil)
+    }
+
+    static func isSuccessfulCustomProviderProbe(statusCode: Int) -> Bool {
+        statusCode == 200
     }
 
     static func anthropicProbeModel(for provider: Configuration.CustomProvider) -> String {

--- a/Core/PeekabooCore/Tests/PeekabooTests/CustomProviderInvalidURLTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/CustomProviderInvalidURLTests.swift
@@ -1,5 +1,6 @@
 import Darwin
 import Foundation
+import Network
 import Tachikoma
 import Testing
 @testable import PeekabooAutomation
@@ -42,6 +43,37 @@ struct CustomProviderInvalidURLTests {
     }
 
     @Test
+    func `custom provider probes accept exactly HTTP 200`() {
+        #expect(ConfigurationManager.isSuccessfulCustomProviderProbe(statusCode: 200))
+        #expect(!ConfigurationManager.isSuccessfulCustomProviderProbe(statusCode: 201))
+        #expect(!ConfigurationManager.isSuccessfulCustomProviderProbe(statusCode: 401))
+        #expect(!ConfigurationManager.isSuccessfulCustomProviderProbe(statusCode: 500))
+    }
+
+    @Test
+    func `testCustomProvider accepts Anthropic HTTP 200`() async throws {
+        let result = try await self.testAnthropicProvider(
+            statusCode: 200,
+            body: #"{"content":[]}"#,
+            id: "anthropic-200")
+
+        #expect(result.success)
+        #expect(result.error == nil)
+    }
+
+    @Test
+    func `testCustomProvider rejects Anthropic HTTP 201`() async throws {
+        let result = try await self.testAnthropicProvider(
+            statusCode: 201,
+            body: #"{"error":"unexpected-created"}"#,
+            id: "anthropic-201")
+
+        #expect(result.success == false)
+        let error = try #require(result.error)
+        #expect(error.contains("unexpected-created"))
+    }
+
+    @Test
     func `discoverModelsForCustomProvider reports invalid URL instead of crashing`() async throws {
         try self.requireUnparseableEndpoint(path: "models")
         try await withIsolatedConfigurationEnvironment { _ in
@@ -64,10 +96,18 @@ struct CustomProviderInvalidURLTests {
         id: String,
         type: Configuration.CustomProvider.ProviderType) throws
     {
+        try self.seedProvider(id: id, type: type, baseURL: Self.invalidBaseURL)
+    }
+
+    private func seedProvider(
+        id: String,
+        type: Configuration.CustomProvider.ProviderType,
+        baseURL: String) throws
+    {
         let provider = Configuration.CustomProvider(
             name: "Broken",
             type: type,
-            options: .init(baseURL: Self.invalidBaseURL, apiKey: "test-key"))
+            options: .init(baseURL: baseURL, apiKey: "test-key"))
         try self.manager.updateConfiguration { configuration in
             if configuration.customProviders == nil {
                 configuration.customProviders = [:]
@@ -75,9 +115,23 @@ struct CustomProviderInvalidURLTests {
             configuration.customProviders?[id] = provider
         }
     }
+
+    private func testAnthropicProvider(
+        statusCode: Int,
+        body: String,
+        id: String) async throws -> (success: Bool, error: String?)
+    {
+        let server = try await ProviderProbeHTTPServer.start(statusCode: statusCode, body: body)
+        defer { server.stop() }
+
+        return try await withIsolatedConfigurationEnvironment { _ in
+            try self.seedProvider(id: id, type: .anthropic, baseURL: server.baseURL)
+            return await self.manager.testCustomProvider(id: id)
+        }
+    }
 }
 
-private func withIsolatedConfigurationEnvironment(_ body: (URL) async throws -> Void) async throws {
+private func withIsolatedConfigurationEnvironment<T>(_ body: (URL) async throws -> T) async throws -> T {
     let fileManager = FileManager.default
     let configDir = fileManager.temporaryDirectory
         .appendingPathComponent("peekaboo-invalid-url-tests-\(UUID().uuidString)", isDirectory: true)
@@ -107,5 +161,76 @@ private func withIsolatedConfigurationEnvironment(_ body: (URL) async throws -> 
         try? fileManager.removeItem(at: configDir)
     }
 
-    try await body(configDir)
+    return try await body(configDir)
+}
+
+private final class ProviderProbeHTTPServer {
+    private let listener: NWListener
+
+    private init(listener: NWListener) {
+        self.listener = listener
+    }
+
+    var baseURL: String {
+        guard let port = self.listener.port else {
+            preconditionFailure("HTTP test server must be ready before use")
+        }
+        return "http://127.0.0.1:\(port.rawValue)"
+    }
+
+    static func start(statusCode: Int, body: String) async throws -> ProviderProbeHTTPServer {
+        let listener = try NWListener(using: .tcp, on: .any)
+        let queue = DispatchQueue(label: "peekaboo.tests.provider-probe-http")
+        let response = Self.response(statusCode: statusCode, body: body)
+
+        listener.newConnectionHandler = { connection in
+            connection.start(queue: queue)
+            connection.receive(minimumIncompleteLength: 1, maximumLength: 64 * 1024) { _, _, _, _ in
+                connection.send(
+                    content: response,
+                    contentContext: .finalMessage,
+                    isComplete: true,
+                    completion: .contentProcessed { _ in
+                        connection.cancel()
+                    })
+            }
+        }
+
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            listener.stateUpdateHandler = { state in
+                switch state {
+                case .ready:
+                    listener.stateUpdateHandler = nil
+                    continuation.resume()
+                case let .failed(error):
+                    listener.stateUpdateHandler = nil
+                    continuation.resume(throwing: error)
+                case .cancelled:
+                    listener.stateUpdateHandler = nil
+                    continuation.resume(throwing: CancellationError())
+                default:
+                    break
+                }
+            }
+            listener.start(queue: queue)
+        }
+
+        return ProviderProbeHTTPServer(listener: listener)
+    }
+
+    func stop() {
+        self.listener.cancel()
+    }
+
+    private static func response(statusCode: Int, body: String) -> Data {
+        let reason = statusCode == 200 ? "OK" : "Error"
+        let bodyData = Data(body.utf8)
+        let headers = "HTTP/1.1 \(statusCode) \(reason)\r\n" +
+            "Content-Type: application/json\r\n" +
+            "Content-Length: \(bodyData.count)\r\n" +
+            "Connection: close\r\n\r\n"
+        var data = Data(headers.utf8)
+        data.append(bodyData)
+        return data
+    }
 }


### PR DESCRIPTION
## What Problem This Solves

`peekaboo config test` (and Settings) treated an Anthropic-compatible custom provider as working whenever the probe got any HTTP status below 500. A 401, 403, 404, or 429 therefore printed as a successful connection. OpenAI-compatible probes already require HTTP 200.

## Evidence

Live probe against a local HTTP endpoint that returned 401. Unfixed Anthropic logic reported success. After the change the same probe reports failure and keeps the 401 body.

```console
$ unfixed Anthropic probe against HTTP 401
result.success → true
result.error → nil

$ fixed Anthropic probe against HTTP 401
result.success → false
error contains invalid_api_key
elapsed 0.015s
```

macOS env check that `-S` is a real `env` option is not required here. This PR only changes HTTP status handling.

## Real behavior proof

- **Behavior or issue addressed:** Anthropic-compatible custom-provider tests reported success on 401/403/404/429.
- **Real environment tested:** macOS arm64, Peekaboo `origin/main` 028cd9eb plus this patch, live `URLSession.shared` against a loopback HTTP responder.
- **Exact steps or command run after this patch:** started a loopback HTTP responder that returns 401 JSON, seeded an Anthropic-compatible custom provider pointing at that base URL, called `ConfigurationManager.testCustomProvider`.
- **Evidence after fix:** terminal output from the patched probe:

  ```console
  HTTP 401 {"error":"invalid_api_key"}
  success=false
  error contains invalid_api_key
  ```

- **Observed result after fix:** 401 is a failed connection test, matching the OpenAI-compatible path which already requires HTTP 200.
- **What was not tested:** live Anthropic API with a real key.

## Change

- Share `isSuccessfulCustomProviderProbe(statusCode:)` (`statusCode == 200`).
- Use it for both OpenAI and Anthropic probes.

## Validation

Red: unfixed Anthropic path against HTTP 401 reported `success == true`.
Green: fixed path reported `success == false` with the 401 body.
