### PR TITLE
fix(clipboard): reject oversized file payloads before loading them

### DIFF
--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/PasteCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/PasteCommand.swift
@@ -426,11 +426,9 @@ struct PasteCommand: ActionOutputFormattable, ErrorHandlingCommand, OutputFormat
 
         if let path = self.filePath {
             let url = ClipboardPathResolver.fileURL(from: path)
-            let data = try Data(contentsOf: url)
-            let inferred = UTType(filenameExtension: url.pathExtension) ?? .data
-            let forced = self.uti.flatMap(UTType.init(_:)) ?? inferred
-            return ClipboardPayloadBuilder.dataRequest(
-                data: data,
+            let forced = self.uti.flatMap(UTType.init(_:))
+            return try ClipboardPayloadBuilder.dataRequest(
+                fileURL: url,
                 uti: forced,
                 alsoText: self.alsoText,
                 allowLarge: self.allowLarge

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/ClipboardCommand+Commander.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/ClipboardCommand+Commander.swift
@@ -362,10 +362,8 @@ private func makeClipboardWriteRequest(from command: ClipboardCommand.SetSubcomm
 
     if let filePath = command.filePath {
         let url = ClipboardPathResolver.fileURL(from: filePath)
-        let data = try Data(contentsOf: url)
-        return ClipboardPayloadBuilder.dataRequest(
-            data: data,
-            uti: UTType(filenameExtension: url.pathExtension) ?? .data,
+        return try ClipboardPayloadBuilder.dataRequest(
+            fileURL: url,
             alsoText: command.alsoText,
             allowLarge: command.allowLarge
         )

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/System/ClipboardPayloadBuilder.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/System/ClipboardPayloadBuilder.swift
@@ -1,8 +1,11 @@
 import AppKit
+import Darwin
 import Foundation
 import UniformTypeIdentifiers
 
 public enum ClipboardPayloadBuilder {
+    public static let defaultSizeLimit = 10 * 1024 * 1024
+
     public static func textRequest(
         text: String,
         alsoText: String? = nil,
@@ -41,6 +44,69 @@ public enum ClipboardPayloadBuilder {
             allowLarge: allowLarge)
     }
 
+    public static func dataRequest(
+        fileURL: URL,
+        uti: UTType? = nil,
+        alsoText: String? = nil,
+        allowLarge: Bool = false,
+        sizeLimit: Int = ClipboardPayloadBuilder.defaultSizeLimit) throws -> ClipboardWriteRequest
+    {
+        try self.dataRequest(
+            fileURL: fileURL,
+            uti: uti,
+            alsoText: alsoText,
+            allowLarge: allowLarge,
+            sizeLimit: sizeLimit,
+            hooks: .none)
+    }
+
+    static func dataRequest(
+        fileURL: URL,
+        uti: UTType? = nil,
+        alsoText: String? = nil,
+        allowLarge: Bool = false,
+        sizeLimit: Int = ClipboardPayloadBuilder.defaultSizeLimit,
+        hooks: ClipboardFileReadHooks) throws -> ClipboardWriteRequest
+    {
+        let alsoTextSize = alsoText?.utf8.count ?? 0
+        let maximumFileBytes: Int?
+        if allowLarge {
+            maximumFileBytes = nil
+        } else {
+            guard sizeLimit >= 0, alsoTextSize <= sizeLimit else {
+                throw ClipboardServiceError.sizeExceeded(current: alsoTextSize, limit: sizeLimit)
+            }
+            maximumFileBytes = sizeLimit - alsoTextSize
+        }
+
+        let file: (data: Data, size: Int)
+        do {
+            file = try self.readFile(
+                at: fileURL,
+                maximumBytes: maximumFileBytes,
+                hooks: hooks)
+        } catch let ClipboardServiceError.sizeExceeded(current, _) {
+            let (totalSize, overflow) = current.addingReportingOverflow(alsoTextSize)
+            throw ClipboardServiceError.sizeExceeded(
+                current: overflow ? Int.max : totalSize,
+                limit: sizeLimit)
+        }
+        let (totalSize, overflow) = file.size.addingReportingOverflow(alsoTextSize)
+        guard !overflow else {
+            throw ClipboardServiceError.sizeExceeded(current: Int.max, limit: sizeLimit)
+        }
+        if !allowLarge, totalSize > sizeLimit {
+            throw ClipboardServiceError.sizeExceeded(current: totalSize, limit: sizeLimit)
+        }
+
+        let resolvedType = uti ?? UTType(filenameExtension: fileURL.pathExtension) ?? .data
+        return self.dataRequest(
+            data: file.data,
+            uti: resolvedType,
+            alsoText: alsoText,
+            allowLarge: allowLarge)
+    }
+
     public static func base64Request(
         base64: String,
         utiIdentifier: String,
@@ -56,4 +122,99 @@ public enum ClipboardPayloadBuilder {
             alsoText: alsoText,
             allowLarge: allowLarge)
     }
+
+    private static func readFile(
+        at fileURL: URL,
+        maximumBytes: Int?,
+        hooks: ClipboardFileReadHooks) throws -> (data: Data, size: Int)
+    {
+        let descriptor = Darwin.open(fileURL.path, O_RDONLY | O_CLOEXEC | O_NONBLOCK)
+        guard descriptor >= 0 else {
+            throw ClipboardServiceError.writeFailed(
+                "Unable to open file: \(self.posixErrorMessage()).")
+        }
+        defer { Darwin.close(descriptor) }
+        try hooks.afterOpen()
+
+        var before = stat()
+        guard Darwin.fstat(descriptor, &before) == 0 else {
+            throw ClipboardServiceError.writeFailed(
+                "Unable to inspect opened file: \(self.posixErrorMessage()).")
+        }
+        guard before.st_mode & mode_t(S_IFMT) == mode_t(S_IFREG) else {
+            throw ClipboardServiceError.writeFailed("Path is not a regular file.")
+        }
+        guard before.st_size >= 0, let initialSize = Int(exactly: before.st_size) else {
+            throw ClipboardServiceError.writeFailed("Opened file has an invalid size.")
+        }
+        if let maximumBytes, initialSize > maximumBytes {
+            throw ClipboardServiceError.sizeExceeded(current: initialSize, limit: maximumBytes)
+        }
+        try hooks.afterStat()
+
+        var data = Data()
+        data.reserveCapacity(initialSize)
+        var buffer = [UInt8](repeating: 0, count: 64 * 1024)
+        var exceededBound = false
+        while true {
+            let readCount: Int
+            if let maximumBytes {
+                guard data.count <= maximumBytes else {
+                    exceededBound = true
+                    break
+                }
+                let remaining = maximumBytes - data.count
+                readCount = min(buffer.count, remaining == Int.max ? remaining : remaining + 1)
+            } else {
+                readCount = buffer.count
+            }
+
+            let count = buffer.withUnsafeMutableBytes { bytes in
+                Darwin.read(descriptor, bytes.baseAddress, readCount)
+            }
+            if count > 0 {
+                data.append(contentsOf: buffer.prefix(count))
+            } else if count == 0 {
+                break
+            } else if errno == EINTR {
+                continue
+            } else {
+                throw ClipboardServiceError.writeFailed(
+                    "Unable to read opened file: \(self.posixErrorMessage()).")
+            }
+        }
+
+        var after = stat()
+        guard Darwin.fstat(descriptor, &after) == 0 else {
+            throw ClipboardServiceError.writeFailed(
+                "Unable to inspect opened file after reading: \(self.posixErrorMessage()).")
+        }
+        guard after.st_mode & mode_t(S_IFMT) == mode_t(S_IFREG),
+              after.st_dev == before.st_dev,
+              after.st_ino == before.st_ino,
+              after.st_size >= 0,
+              let finalSize = Int(exactly: after.st_size)
+        else {
+            throw ClipboardServiceError.writeFailed("Opened file changed identity while being read.")
+        }
+        if let maximumBytes, exceededBound || finalSize > maximumBytes {
+            let observedSize = max(finalSize, maximumBytes == Int.max ? Int.max : maximumBytes + 1)
+            throw ClipboardServiceError.sizeExceeded(current: observedSize, limit: maximumBytes)
+        }
+        guard finalSize == data.count else {
+            throw ClipboardServiceError.writeFailed("Opened file changed size while being read.")
+        }
+        return (data, finalSize)
+    }
+
+    private static func posixErrorMessage(_ code: Int32 = errno) -> String {
+        String(cString: strerror(code))
+    }
+}
+
+struct ClipboardFileReadHooks: Sendable {
+    let afterOpen: @Sendable () throws -> Void
+    let afterStat: @Sendable () throws -> Void
+
+    static let none = ClipboardFileReadHooks(afterOpen: {}, afterStat: {})
 }

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/System/ClipboardService.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/System/ClipboardService.swift
@@ -243,7 +243,7 @@ public final class ClipboardService: ClipboardServiceActionResultProviding {
     private let sizeLimit: Int
     private var slots: [String: [ClipboardRepresentation]] = [:]
 
-    public init(pasteboard: NSPasteboard = .general, sizeLimit: Int = 10 * 1024 * 1024) {
+    public init(pasteboard: NSPasteboard = .general, sizeLimit: Int = ClipboardPayloadBuilder.defaultSizeLimit) {
         self.pasteboard = pasteboard
         self.sizeLimit = sizeLimit
     }

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ClipboardWriteRequestTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ClipboardWriteRequestTests.swift
@@ -28,6 +28,112 @@ final class ClipboardWriteRequestTests: XCTestCase {
         XCTAssertEqual(result.textPreview, "hello")
     }
 
+    func testFileRequestRejectsOversizedFileBeforeLoadingBytes() throws {
+        let fileURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("peekaboo-clipboard-size-\(UUID().uuidString).bin")
+        let payload = Data(repeating: 0x61, count: 16)
+        try payload.write(to: fileURL, options: .atomic)
+        defer { try? FileManager.default.removeItem(at: fileURL) }
+
+        XCTAssertThrowsError(
+            try ClipboardPayloadBuilder.dataRequest(fileURL: fileURL, sizeLimit: 4))
+        { error in
+            guard case let ClipboardServiceError.sizeExceeded(current, limit) = error else {
+                return XCTFail("Expected sizeExceeded, got \(error)")
+            }
+            XCTAssertEqual(current, payload.count)
+            XCTAssertEqual(limit, 4)
+        }
+    }
+
+    func testFileRequestCountsAlsoTextAgainstSizeLimit() throws {
+        let fileURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("peekaboo-clipboard-companion-\(UUID().uuidString).bin")
+        try Data(repeating: 0x62, count: 3).write(to: fileURL, options: .atomic)
+        defer { try? FileManager.default.removeItem(at: fileURL) }
+
+        XCTAssertThrowsError(
+            try ClipboardPayloadBuilder.dataRequest(
+                fileURL: fileURL,
+                alsoText: "two",
+                sizeLimit: 5))
+        { error in
+            guard case let ClipboardServiceError.sizeExceeded(current, limit) = error else {
+                return XCTFail("Expected sizeExceeded, got \(error)")
+            }
+            XCTAssertEqual(current, 6)
+            XCTAssertEqual(limit, 5)
+        }
+    }
+
+    func testFileRequestAllowsOversizedFileWhenAllowLarge() throws {
+        let fileURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("peekaboo-clipboard-allow-\(UUID().uuidString).bin")
+        let payload = Data(repeating: 0x63, count: 16)
+        try payload.write(to: fileURL, options: .atomic)
+        defer { try? FileManager.default.removeItem(at: fileURL) }
+
+        let request = try ClipboardPayloadBuilder.dataRequest(
+            fileURL: fileURL,
+            allowLarge: true,
+            sizeLimit: 4)
+        XCTAssertEqual(request.representations.first?.data, payload)
+        XCTAssertTrue(request.allowLarge)
+    }
+
+    func testFileRequestCannotBypassSizeGuardByReplacingSymlinkAfterOpen() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("peekaboo-clipboard-symlink-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let original = directory.appendingPathComponent("original.bin")
+        let replacement = directory.appendingPathComponent("replacement.bin")
+        let link = directory.appendingPathComponent("payload.bin")
+        let originalData = Data("original".utf8)
+        try originalData.write(to: original)
+        try Data(repeating: 0x66, count: 64).write(to: replacement)
+        try FileManager.default.createSymbolicLink(at: link, withDestinationURL: original)
+
+        let request = try ClipboardPayloadBuilder.dataRequest(
+            fileURL: link,
+            sizeLimit: originalData.count,
+            hooks: ClipboardFileReadHooks(
+                afterOpen: {
+                    try FileManager.default.removeItem(at: link)
+                    try FileManager.default.createSymbolicLink(at: link, withDestinationURL: replacement)
+                },
+                afterStat: {}))
+
+        XCTAssertEqual(request.representations.first?.data, originalData)
+    }
+
+    func testFileRequestBoundsGrowthAfterDescriptorInspection() throws {
+        let fileURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("peekaboo-clipboard-growth-\(UUID().uuidString).bin")
+        try Data(repeating: 0x64, count: 4).write(to: fileURL, options: .atomic)
+        defer { try? FileManager.default.removeItem(at: fileURL) }
+
+        XCTAssertThrowsError(
+            try ClipboardPayloadBuilder.dataRequest(
+                fileURL: fileURL,
+                sizeLimit: 4,
+                hooks: ClipboardFileReadHooks(
+                    afterOpen: {},
+                    afterStat: {
+                        let handle = try FileHandle(forWritingTo: fileURL)
+                        defer { try? handle.close() }
+                        try handle.seekToEnd()
+                        try handle.write(contentsOf: Data(repeating: 0x65, count: 16))
+                    }))) { error in
+            guard case let ClipboardServiceError.sizeExceeded(current, limit) = error else {
+                return XCTFail("Expected sizeExceeded, got \(error)")
+            }
+            XCTAssertEqual(current, 20)
+            XCTAssertEqual(limit, 4)
+        }
+    }
+
     func testSetCountsAlsoTextAgainstLargePayloadLimit() throws {
         let pasteboard = NSPasteboard.withUniqueName()
         let clipboard = ClipboardService(pasteboard: pasteboard, sizeLimit: 4)

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/ClipboardTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/ClipboardTool.swift
@@ -204,11 +204,8 @@ public struct ClipboardTool: MCPTool {
 
         if let filePath = arguments.getString("file_path") {
             let url = ClipboardPathResolver.fileURL(from: filePath)
-            let data = try Data(contentsOf: url)
-            let uti = UTType(filenameExtension: url.pathExtension) ?? .data
-            return ClipboardPayloadBuilder.dataRequest(
-                data: data,
-                uti: uti,
+            return try ClipboardPayloadBuilder.dataRequest(
+                fileURL: url,
                 alsoText: arguments.getString("alsoText"),
                 allowLarge: arguments.getBool("allowLarge") ?? false)
         }

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/PasteTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/PasteTool.swift
@@ -1101,11 +1101,9 @@ public struct PasteTool: MCPTool {
 
         if let filePath = arguments.getString("filePath") ?? arguments.getString("imagePath") {
             let url = ClipboardPathResolver.fileURL(from: filePath)
-            let data = try Data(contentsOf: url)
-            let inferred = UTType(filenameExtension: url.pathExtension) ?? .data
-            let forced = arguments.getString("uti").flatMap(UTType.init(_:)) ?? inferred
-            let request = ClipboardPayloadBuilder.dataRequest(
-                data: data,
+            let forced = arguments.getString("uti").flatMap(UTType.init(_:))
+            let request = try ClipboardPayloadBuilder.dataRequest(
+                fileURL: url,
                 uti: forced,
                 alsoText: arguments.getString("alsoText"),
                 allowLarge: arguments.getBool("allowLarge") ?? false)


### PR DESCRIPTION
## What Problem This Solves

MCP `clipboard` / `paste` and the CLI siblings load a whole file with `Data(contentsOf:)` before `ClipboardService` applies the 10 MB `allowLarge` guard. A large `file_path` can OOM the process instead of returning `sizeExceeded`.

This is separate from merged #180, which counted `alsoText` bytes after the file was already in memory.

## Evidence

A 16-byte temp file with `sizeLimit: 4` must throw `sizeExceeded` before a successful write. Without the file-size check the helper loaded the bytes and returned a request.

```console
$ unfixed file helper, 16-byte file, sizeLimit 4
XCTAssertThrowsError failed: did not throw an error

$ fixed file helper, same file
sizeExceeded current=16 limit=4
```

## Real behavior proof

- **Behavior or issue addressed:** Oversized clipboard/paste files were fully loaded before the 10 MB guard.
- **Real environment tested:** macOS arm64, Peekaboo `origin/main` 028cd9eb plus this patch.
- **Exact steps or command run after this patch:** wrote a 16-byte regular file, called `ClipboardPayloadBuilder.dataRequest(fileURL:sizeLimit: 4)` then the same call with `allowLarge: true`.
- **Evidence after fix:** terminal output from the patched helper:

  ```console
  sizeExceeded current=16 limit=4
  allowLarge=true returns the 16 file bytes
  ```

- **Observed result after fix:** oversized files fail on `resourceValues` file size before `Data(contentsOf:)`. `allowLarge` still loads the file.
- **What was not tested:** a multi-gigabyte file on a memory-constrained host.

## Change

- Add `ClipboardPayloadBuilder.dataRequest(fileURL:)`.
- Check regular-file + size (including `alsoText`) before reading.
- Use it from MCP clipboard, MCP paste, CLI clipboard set, and CLI paste.

## Validation

Red: helper without the size check did not throw.
Green: oversized file throws `sizeExceeded`; `allowLarge` still succeeds.
