### PR TITLE
fix(cli): stop env from parsing config-edit editor strings as options

### DIFF
--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Core/ConfigCommand+InitShowEdit.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Core/ConfigCommand+InitShowEdit.swift
@@ -265,6 +265,10 @@ extension ConfigCommand {
         var printPath: Bool = false
         @RuntimeStorage var runtime: CommandRuntime?
 
+        static func editorProcessArguments(editor: String, configPath: String) -> [String] {
+            ["--", editor, configPath]
+        }
+
         mutating func run(using runtime: CommandRuntime) async throws {
             self.prepare(using: runtime)
 
@@ -293,7 +297,7 @@ extension ConfigCommand {
 
             let process = Process()
             process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
-            process.arguments = [editorCommand, self.configPath]
+            process.arguments = Self.editorProcessArguments(editor: editorCommand, configPath: self.configPath)
 
             do {
                 try process.run()

--- a/Apps/CLI/Tests/CoreCLITests/ConfigEditorLaunchTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/ConfigEditorLaunchTests.swift
@@ -1,0 +1,24 @@
+import Testing
+@testable import PeekabooCLI
+
+struct ConfigEditorLaunchTests {
+    @Test
+    func `EditCommand terminates env options before an option-like editor`() {
+        let arguments = ConfigCommand.EditCommand.editorProcessArguments(
+            editor: "-S/usr/bin/touch /tmp/pwned",
+            configPath: "/tmp/config.json"
+        )
+
+        #expect(arguments == ["--", "-S/usr/bin/touch /tmp/pwned", "/tmp/config.json"])
+    }
+
+    @Test
+    func `EditCommand preserves a normal editor after the env option terminator`() {
+        let arguments = ConfigCommand.EditCommand.editorProcessArguments(
+            editor: "/usr/bin/nano",
+            configPath: "/tmp/config.json"
+        )
+
+        #expect(arguments == ["--", "/usr/bin/nano", "/tmp/config.json"])
+    }
+}


### PR DESCRIPTION
## What Problem This Solves

`peekaboo config edit` launches `/usr/bin/env` with the editor string as argv[1] and no `--`. On current macOS, `env -S` is a real option, so `--editor -S/...` or a crafted `$EDITOR` is parsed as env flags instead of an editor path.

This is local CLI / environment input. The process still runs as the calling user.

## Evidence

This Mac's `/usr/bin/env` accepts `-S` unless `--` stops option parsing:

```console
$ /usr/bin/env -S printf "env-S-ran\n"
env-S-ran

$ /usr/bin/env -- -S printf "should-not-run\n"
env: -S: No such file or directory
```

After the patch, `EditCommand.editorProcessArguments` always emits `--` first:

```console
["--", "-S/usr/bin/touch /tmp/pwned", "/tmp/config.json"]
```

## Real behavior proof

- **Behavior or issue addressed:** `peekaboo config edit` passed the editor string to `/usr/bin/env` without `--`.
- **Real environment tested:** macOS arm64, `/usr/bin/env` from this host, Peekaboo `origin/main` 028cd9eb plus this patch.
- **Exact steps or command run after this patch:** ran `/usr/bin/env -S` and `/usr/bin/env -- -S`, then evaluated `ConfigCommand.EditCommand.editorProcessArguments`.
- **Evidence after fix:** terminal output from this host:

  ```console
  /usr/bin/env -S printf ...
  env-S-ran
  /usr/bin/env -- -S printf ...
  env: -S: No such file or directory
  editorProcessArguments -> ["--", "-S/usr/bin/touch /tmp/pwned", "/tmp/config.json"]
  ```

- **Observed result after fix:** env no longer treats the editor string as flags. A leading `-S` is looked up as an executable name.
- **What was not tested:** launching a real GUI editor through `peekaboo config edit` on this host.

## Change

- `editorProcessArguments` returns `["--", editor, configPath]`.
- `waitUntilExit` is unchanged. Interactive editors are supposed to block.

## Validation

Red: helper without `--` produced `["-S/usr/bin/touch /tmp/pwned", "/tmp/config.json"]`.
Green: helper produces `["--", ...]`.
