### PR TITLE
fix(see): fail MCP see when observation omits element detection

### DIFF
--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/SeeTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/SeeTool.swift
@@ -321,7 +321,8 @@ public struct SeeTool: MCPTool {
         snapshot: UISnapshot) async throws -> ([UIElement], [AutomationDetectedElement])
     {
         guard let detectionResult = observation.elements else {
-            return ([], [])
+            throw OperationError.captureFailed(
+                reason: "Observation completed without element detection")
         }
 
         let detectedElements = await MainActor.run { detectionResult.elements.all }

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPToolTestHelpers.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPToolTestHelpers.swift
@@ -1,3 +1,4 @@
+import Foundation
 import PeekabooAutomationKit
 import PeekabooFoundation
 import TachikomaMCP
@@ -16,6 +17,7 @@ enum MCPToolTestHelpers {
         screens: (any ScreenServiceProtocol)? = nil,
         clipboard: (any ClipboardServiceProtocol)? = nil,
         snapshots: (any SnapshotManagerProtocol)? = nil,
+        desktopObservation: (any DesktopObservationServiceProtocol)? = nil,
         permissionsStatusProvider: (any PermissionsStatusProviding)? = nil,
         snapshotMutationCoordinator: (any MCPToolSnapshotMutationCoordinating)? = nil,
         snapshotExecutionGate: MCPToolSnapshotExecutionGate = MCPToolSnapshotExecutionGate(),
@@ -43,7 +45,7 @@ enum MCPToolTestHelpers {
                 dialogs: dialogs ?? services.dialogs,
                 dock: services.dock,
                 screenCapture: screenCapture ?? services.screenCapture,
-                desktopObservation: DesktopObservationService(
+                desktopObservation: desktopObservation ?? DesktopObservationService(
                     screenCapture: screenCapture ?? services.screenCapture,
                     automation: automation ?? services.automation,
                     applications: applications ?? services.applications,
@@ -142,5 +144,25 @@ enum MCPToolTestHelpers {
         return try await MCPToolContext.withContext(context) {
             try await operation()
         }
+    }
+}
+
+@MainActor
+final class MissingDetectionObservationService: DesktopObservationServiceProtocol {
+    func observe(_ request: DesktopObservationRequest) async throws -> DesktopObservationResult {
+        let path = try #require(request.output.path)
+        let imageData = Data("see-missing-detection".utf8)
+        try imageData.write(to: URL(fileURLWithPath: path), options: .atomic)
+        return DesktopObservationResult(
+            target: ResolvedObservationTarget(kind: .screen(index: 0)),
+            capture: CaptureResult(
+                imageData: imageData,
+                savedPath: path,
+                metadata: CaptureMetadata(
+                    size: CGSize(width: 1, height: 1),
+                    mode: .screen,
+                    timestamp: Date())),
+            elements: nil,
+            files: DesktopObservationFiles(rawScreenshotPath: path))
     }
 }

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/PeekabooMCPServerTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/PeekabooMCPServerTests.swift
@@ -47,6 +47,42 @@ struct PeekabooMCPServerTests {
     }
 
     @Test
+    @MainActor
+    func `see wire fails closed when its observation has no detection result`() async throws {
+        let observation = MissingDetectionObservationService()
+        let context = await MCPToolTestHelpers.makeContext(desktopObservation: observation)
+        let session = try await MCPWireSession.connect(context: context)
+        let outputURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("peekaboo-mcp-see-missing-detection-\(UUID().uuidString).png")
+        defer { try? FileManager.default.removeItem(at: outputURL) }
+
+        do {
+            let request: RequestContext<CallTool.Result> = try await session.client.callTool(
+                name: "see",
+                arguments: ["path": .string(outputURL.path)])
+            let result = try await request.value
+
+            #expect(result.isError == true)
+            #expect(result.content.contains { content in
+                guard case let .text(text, _, _) = content else { return false }
+                return text.contains("without element detection")
+            })
+            #expect(!result.content.contains { content in
+                if case .image = content {
+                    return true
+                }
+                return false
+            })
+            #expect(!FileManager.default.fileExists(atPath: outputURL.path))
+        } catch {
+            await session.stop()
+            throw error
+        }
+
+        await session.stop()
+    }
+
+    @Test
     func `server preserves tool response metadata on the MCP wire result`() throws {
         let response = ToolResponse.text(
             "Captured image",

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/SeeToolImageOwnershipTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/SeeToolImageOwnershipTests.swift
@@ -14,7 +14,7 @@ struct SeeToolImageOwnershipTests {
         let observation = await MainActor.run {
             CoordinatedFileOnlyObservationService(imageData: [firstPixels, secondPixels])
         }
-        let context = await self.makeContext(desktopObservation: observation)
+        let context = await MCPToolTestHelpers.makeContext(desktopObservation: observation)
         let tool = SeeTool(context: context)
         let outputURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("peekaboo-see-shared-\(UUID().uuidString).png")
@@ -59,7 +59,7 @@ struct SeeToolImageOwnershipTests {
         let observation = await MainActor.run {
             AnnotatedFileOnlyObservationService(rawData: rawPixels, annotatedData: annotatedPixels)
         }
-        let context = await self.makeContext(desktopObservation: observation)
+        let context = await MCPToolTestHelpers.makeContext(desktopObservation: observation)
         let tool = SeeTool(context: context)
         let outputURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("peekaboo-see-annotated-\(UUID().uuidString).png")
@@ -91,7 +91,7 @@ struct SeeToolImageOwnershipTests {
         let observation = await MainActor.run {
             AnnotatedFileOnlyObservationService(rawData: rawPixels, annotatedData: Data("unused".utf8))
         }
-        let context = await self.makeContext(desktopObservation: observation)
+        let context = await MCPToolTestHelpers.makeContext(desktopObservation: observation)
         let tool = SeeTool(context: context)
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("peekaboo-see-symlink-\(UUID().uuidString)", isDirectory: true)
@@ -119,7 +119,7 @@ struct SeeToolImageOwnershipTests {
                 annotatedData: Data("unused".utf8),
                 captureData: untrustedPixels)
         }
-        let context = await self.makeContext(desktopObservation: observation)
+        let context = await MCPToolTestHelpers.makeContext(desktopObservation: observation)
         let outputURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("peekaboo-see-owned-raster-\(UUID().uuidString).png")
         defer { try? FileManager.default.removeItem(at: outputURL) }
@@ -135,9 +135,38 @@ struct SeeToolImageOwnershipTests {
     }
 
     @Test
+    func `See fails closed when observation omits element detection`() async throws {
+        let observation = await MainActor.run { MissingDetectionObservationService() }
+        let context = await MCPToolTestHelpers.makeContext(desktopObservation: observation)
+        let outputURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("peekaboo-see-missing-detection-\(UUID().uuidString).png")
+        defer { try? FileManager.default.removeItem(at: outputURL) }
+
+        let response = try await SeeTool(context: context).execute(arguments: ToolArguments(raw: [
+            "path": outputURL.path,
+        ]))
+
+        #expect(response.isError)
+        let text = response.content.compactMap { content -> String? in
+            if case let .text(value, annotations: _, _meta: _) = content {
+                return value
+            }
+            return nil
+        }.joined()
+        #expect(text.contains("without element detection"))
+        #expect(!response.content.contains { content in
+            if case .image = content {
+                return true
+            }
+            return false
+        })
+        #expect(!FileManager.default.fileExists(atPath: outputURL.path))
+    }
+
+    @Test
     func `post-processing failure preserves dispatched web focus outcome and process target`() async throws {
         let observation = await MainActor.run { OutcomeMissingArtifactObservationService() }
-        let context = await self.makeContext(desktopObservation: observation)
+        let context = await MCPToolTestHelpers.makeContext(desktopObservation: observation)
 
         let response = try await SeeTool(context: context).execute(arguments: ToolArguments(raw: [
             "web_focus": true,
@@ -172,7 +201,7 @@ struct SeeToolImageOwnershipTests {
                     unitCount: .one),
                 targetIdentity: target)
         }
-        let context = await self.makeContext(desktopObservation: observation)
+        let context = await MCPToolTestHelpers.makeContext(desktopObservation: observation)
 
         let response = try await SeeTool(context: context).execute(arguments: ToolArguments(raw: [
             "web_focus": true,
@@ -192,7 +221,7 @@ struct SeeToolImageOwnershipTests {
     @Test
     func `ROI response exposes local elements and snapshot bound coordinate metadata`() async throws {
         let observation = await MainActor.run { ROIFileObservationService() }
-        let context = await self.makeContext(desktopObservation: observation)
+        let context = await MCPToolTestHelpers.makeContext(desktopObservation: observation)
         let response = try await SeeTool(context: context).execute(arguments: ToolArguments(raw: [
             "window_id": 42,
             "roi": "10,20,30,20",
@@ -218,31 +247,6 @@ struct SeeToolImageOwnershipTests {
         #expect(logicalX == 210)
         #expect(logicalWidth == 30)
         #expect(!snapshotID.isEmpty)
-    }
-
-    private func makeContext(
-        desktopObservation: any DesktopObservationServiceProtocol) async -> MCPToolContext
-    {
-        let base = await MCPToolTestHelpers.makeContext()
-        return await MainActor.run {
-            MCPToolContext(
-                automation: base.automation,
-                menu: base.menu,
-                windows: base.windows,
-                applications: base.applications,
-                dialogs: base.dialogs,
-                dock: base.dock,
-                screenCapture: base.screenCapture,
-                desktopObservation: desktopObservation,
-                snapshots: base.snapshots,
-                screens: base.screens,
-                agent: base.agent,
-                permissions: base.permissions,
-                clipboard: base.clipboard,
-                browser: base.browser,
-                snapshotMutationCoordinator: base.snapshotMutationCoordinator,
-                snapshotExecutionGate: base.snapshotExecutionGate)
-        }
     }
 
     private static func imageData(_ response: ToolResponse) throws -> Data {
@@ -312,7 +316,11 @@ private final class CoordinatedFileOnlyObservationService: DesktopObservationSer
                     size: CGSize(width: 1, height: 1),
                     mode: .screen,
                     timestamp: Date())),
-            elements: nil,
+            elements: ElementDetectionResult(
+                snapshotId: "snapshot",
+                screenshotPath: path,
+                elements: DetectedElements(),
+                metadata: DetectionMetadata(detectionTime: 0, elementCount: 0, method: "mock")),
             files: DesktopObservationFiles(
                 rawScreenshotPath: path,
                 annotatedScreenshotPath: annotatedPath))


### PR DESCRIPTION
## What Problem This Solves

CLI `see` throws `Observation completed without element detection` when `observation.elements` is nil. MCP `see` treated that as a successful capture with zero elements, so agents could click nothing after a failed detection.

## Evidence

A scripted observation that writes a screenshot and sets `elements` to nil:

```console
$ unfixed MCP see
isError → false
summary contains "Elements found: 0"

$ fixed MCP see
isError → true
error text contains "without element detection"
```

## Real behavior proof

- **Behavior or issue addressed:** MCP `see` reported a successful empty element map when detection never ran.
- **Real environment tested:** macOS arm64, Peekaboo `origin/main` 028cd9eb plus this patch, production `SeeTool.execute`.
- **Exact steps or command run after this patch:** ran `SeeTool.execute` against a desktop-observation stub that writes a screenshot and leaves `elements` nil.
- **Evidence after fix:** terminal output from the patched tool:

  ```console
  isError=true
  Failed to capture UI state: Observation completed without element detection
  ```

- **Observed result after fix:** MCP `see` fails closed, matching CLI `see`. An empty `ElementDetectionResult` (zero elements after a real scan) still succeeds.
- **What was not tested:** a live ScreenCaptureKit session with Accessibility denied.

## Change

- `SeeTool.detectUIElements` throws `OperationError.captureFailed` when `elements` is nil.
- Image-ownership fixtures that only care about pixels now supply an empty detection result.

## Validation

Red: unfixed `SeeTool.execute` returned `isError == false` and "Elements found: 0".
Green: fixed execute returns an error containing "without element detection". Concurrent pixel-ownership case still passes.
