### PR TITLE
fix(agent): allow proven non-modal SwiftUI mutations

### DIFF
--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add Bridge protocol 1.30 application and window inventories that distinguish complete from partial evidence while retaining conservative compatibility with older hosts.
 
 ### Fixed
+- Keep non-modal SwiftUI `AXDialog`-subrole windows eligible for exact background mutations while preserving modal, sheet, and file-dialog protections, and recognize `inspect_ui` as fresh Agent perception in recovery guidance.
 - Pin background type, paste, press, targeted clicks, and app, window, or menu mutations to one exact process and window generation; refuse fuzzy, ambiguous, stale, or incomplete targets before dispatch.
 - Keep TextEdit document fields and other editable controls discoverable when optional Accessibility attributes are unavailable.
 - Resolve exact minimized and off-Space windows without treating unreadable WindowServer catalogs as proof that a target is absent.

--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Bind signed `set-value` results to the opaque requested element and refuse older Bridge hosts before dispatch.
+- Keep non-modal SwiftUI `AXDialog`-subrole windows eligible for exact background mutations while preserving modal, sheet, and file-dialog protections, and recognize `inspect_ui` as fresh Agent perception in recovery guidance.
 
 ## [4.2.2] - 2026-08-20
 
@@ -26,7 +27,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add Bridge protocol 1.30 application and window inventories that distinguish complete from partial evidence while retaining conservative compatibility with older hosts.
 
 ### Fixed
-- Keep non-modal SwiftUI `AXDialog`-subrole windows eligible for exact background mutations while preserving modal, sheet, and file-dialog protections, and recognize `inspect_ui` as fresh Agent perception in recovery guidance.
 - Pin background type, paste, press, targeted clicks, and app, window, or menu mutations to one exact process and window generation; refuse fuzzy, ambiguous, stale, or incomplete targets before dispatch.
 - Keep TextEdit document fields and other editable controls discoverable when optional Accessibility attributes are unavailable.
 - Resolve exact minimized and off-Space windows without treating unreadable WindowServer catalogs as proof that a target is absent.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add receipt-required Bridge protocol 1.32 observation of exact process generations for signed liveness and absence evidence.
 - Bind signed `set-value` results to the opaque requested element and refuse older Bridge hosts before dispatch.
 - Preserve verified process-generation receipts for background AX-only reads when an app has no actionable WindowServer window, while keeping window mutations exact-window-only.
+- Keep verified non-modal SwiftUI windows eligible for exact background mutation, retain fail-closed file-dialog classification, and recognize `inspect_ui` as fresh Agent perception.
 
 ## [4.2.2] - 2026-08-20
 

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/DetachedAXObservationWorker.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/DetachedAXObservationWorker.swift
@@ -257,7 +257,10 @@ enum DetachedAXObservationWorker {
         self.prepare(window, deadline: deadline)
         let title = self.stringAttribute(kAXTitleAttribute, of: window) ?? request.windowTitle ?? "Untitled"
         let bounds = self.frame(of: window)
+        let role = self.stringAttribute(kAXRoleAttribute, of: window) ?? ""
         let subrole = self.stringAttribute(kAXSubroleAttribute, of: window) ?? ""
+        let identifier = self.stringAttribute(kAXIdentifierAttribute, of: window) ?? ""
+        let isModal = self.boolAttribute(kAXModalAttribute, of: window)
         var state = TraversalState()
         self.process(
             window,
@@ -286,7 +289,13 @@ enum DetachedAXObservationWorker {
             windowID: AXWindowIDResolver.windowID(of: window).map(Int.init) ?? request.windowID,
             windowTitle: title,
             windowBounds: bounds,
-            isDialog: ["AXDialog", "AXSystemDialog", "AXSheet"].contains(subrole) || self.isFileDialogTitle(title),
+            isDialog: DialogElementClassifier.isObservationDialog(DialogElementEvidence(
+                role: role,
+                subrole: subrole,
+                roleDescription: "",
+                identifier: identifier,
+                title: title,
+                isModal: isModal)),
             truncationInfo: state.truncationInfo)
         try validateIdentity(request)
         return result

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/DialogElementClassification.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/DialogElementClassification.swift
@@ -7,6 +7,23 @@ struct DialogElementEvidence: Equatable, Sendable {
     let roleDescription: String
     let identifier: String
     let title: String
+    let isModal: Bool?
+
+    init(
+        role: String,
+        subrole: String,
+        roleDescription: String,
+        identifier: String,
+        title: String,
+        isModal: Bool? = nil)
+    {
+        self.role = role
+        self.subrole = subrole
+        self.roleDescription = roleDescription
+        self.identifier = identifier
+        self.title = title
+        self.isModal = isModal
+    }
 }
 
 enum DialogElementClassifier {
@@ -19,7 +36,8 @@ enum DialogElementClassifier {
             subrole: element.subrole() ?? "",
             roleDescription: element.attribute(Attribute<String>("AXRoleDescription")) ?? "",
             identifier: element.attribute(Attribute<String>("AXIdentifier")) ?? "",
-            title: element.title() ?? "")
+            title: element.title() ?? "",
+            isModal: element.attribute(Attribute<Bool>("AXModal")))
     }
 
     static func isDialog(
@@ -39,7 +57,7 @@ enum DialogElementClassifier {
         if evidence.roleDescription.localizedCaseInsensitiveContains("dialog") {
             return true
         }
-        if evidence.identifier.contains("NSOpenPanel") || evidence.identifier.contains("NSSavePanel") {
+        if self.hasFilePanelIdentifier(evidence.identifier) {
             return true
         }
         return titleHints.contains { evidence.title.localizedCaseInsensitiveContains($0) }
@@ -49,14 +67,24 @@ enum DialogElementClassifier {
         _ evidence: DialogElementEvidence,
         titleHints: [String] = Self.titleHints) -> Bool
     {
-        evidence.identifier.contains("NSOpenPanel") ||
-            evidence.identifier.contains("NSSavePanel") ||
+        self.hasFilePanelIdentifier(evidence.identifier) ||
             titleHints.contains { evidence.title.localizedCaseInsensitiveContains($0) }
     }
 
     static func isObservationDialog(_ evidence: DialogElementEvidence) -> Bool {
-        ["AXDialog", "AXSystemDialog", "AXSheet"].contains(evidence.subrole) ||
-            self.isObservationFileDialogTitle(evidence.title)
+        if self.hasFilePanelIdentifier(evidence.identifier) || self.isObservationFileDialogTitle(evidence.title) {
+            return true
+        }
+        // SwiftUI WindowGroup windows can expose AXWindow/AXDialog while explicitly reporting AXModal=false.
+        // Require the WindowGroup identity too; modality alone does not distinguish modeless native panels.
+        if evidence.role == "AXWindow",
+           evidence.subrole == "AXDialog",
+           evidence.isModal == false,
+           self.isSwiftUIWindowGroupIdentifier(evidence.identifier)
+        {
+            return false
+        }
+        return ["AXDialog", "AXSystemDialog", "AXSheet"].contains(evidence.subrole)
     }
 
     static func isStructuralDialog(_ evidence: DialogElementEvidence) -> Bool {
@@ -90,5 +118,13 @@ enum DialogElementClassifier {
 
     private static func isObservationFileDialogTitle(_ title: String) -> Bool {
         ["Open", "Save", "Export", "Import"].contains(title) || title.hasPrefix("Save As")
+    }
+
+    private static func hasFilePanelIdentifier(_ identifier: String) -> Bool {
+        identifier.contains("NSOpenPanel") || identifier.contains("NSSavePanel")
+    }
+
+    private static func isSwiftUIWindowGroupIdentifier(_ identifier: String) -> Bool {
+        identifier.hasPrefix("SwiftUI.WindowGroup-AppWindow-")
     }
 }

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/ElementDetectionCache.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/ElementDetectionCache.swift
@@ -32,10 +32,16 @@ import PeekabooFoundation
     public struct CachedElements: Sendable {
         public let elements: [DetectedElement]
         public let truncationInfo: DetectionTruncationInfo?
+        public let isDialog: Bool?
 
-        public init(elements: [DetectedElement], truncationInfo: DetectionTruncationInfo? = nil) {
+        public init(
+            elements: [DetectedElement],
+            truncationInfo: DetectionTruncationInfo? = nil,
+            isDialog: Bool? = nil)
+        {
             self.elements = elements
             self.truncationInfo = truncationInfo
+            self.isDialog = isDialog
         }
     }
 
@@ -89,7 +95,12 @@ import PeekabooFoundation
         return nil
     }
 
-    public func store(_ elements: [DetectedElement], truncationInfo: DetectionTruncationInfo? = nil, for key: Key) {
+    public func store(
+        _ elements: [DetectedElement],
+        truncationInfo: DetectionTruncationInfo? = nil,
+        isDialog: Bool? = nil,
+        for key: Key)
+    {
         if truncationInfo?.deadlineReached == true || truncationInfo?.incompleteAccessibilityRead == true {
             // A retry may use a longer timeout or the target may recover from a transient AX refusal.
             // Remove any older entry too: replaying stale completeness is less honest than recollecting.
@@ -98,7 +109,10 @@ import PeekabooFoundation
         }
         self.entries[key] = Entry(
             cachedAt: self.now(),
-            result: CachedElements(elements: elements, truncationInfo: truncationInfo))
+            result: CachedElements(
+                elements: elements,
+                truncationInfo: truncationInfo,
+                isDialog: isDialog))
     }
 
     public func removeAll() {

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/ElementDetectionService.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/ElementDetectionService.swift
@@ -9,7 +9,6 @@ struct CachedDetachedAXObservationContext: Sendable {
     let windowID: Int?
     let windowTitle: String?
     let windowBounds: CGRect?
-    let isDialog: Bool
 }
 
 struct DetachedAXObservationOutcome: Sendable {
@@ -234,6 +233,7 @@ public final class ElementDetectionService {
                 self.axTreeCache.store(
                     detectedElements,
                     truncationInfo: collection.truncationInfo,
+                    isDialog: windowResolution.isDialog,
                     for: cacheKey)
             }
             usedCache = false
@@ -285,7 +285,7 @@ public final class ElementDetectionService {
                 windowID: cachedContext.windowID,
                 windowTitle: cachedContext.windowTitle,
                 windowBounds: cachedContext.windowBounds,
-                isDialog: cachedContext.isDialog,
+                isDialog: cached.isDialog ?? true,
                 truncationInfo: cached.truncationInfo,
                 usedCache: true)
         }
@@ -295,6 +295,7 @@ public final class ElementDetectionService {
             self.axTreeCache.store(
                 detachedResult.elements,
                 truncationInfo: detachedResult.truncationInfo,
+                isDialog: detachedResult.isDialog,
                 for: cacheKey)
         }
         return DetachedAXObservationOutcome(
@@ -379,8 +380,7 @@ public final class ElementDetectionService {
                 processStartIdentity: processStartIdentity,
                 windowID: context?.windowID,
                 windowTitle: context?.windowTitle,
-                windowBounds: context?.windowBounds,
-                isDialog: false))
+                windowBounds: context?.windowBounds))
         {
             if let expectedWindowGeneration = context?.windowMutationIdentity?.ownerProcessStartIdentity,
                expectedWindowGeneration != processStartIdentity

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/DialogElementClassificationTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/DialogElementClassificationTests.swift
@@ -65,6 +65,42 @@ struct DialogElementClassificationTests {
         #expect(!DialogElementClassifier.isDialog(evidence))
     }
 
+    @Test
+    func `ordinary non-modal SwiftUI dialog-subrole window remains mutation eligible`() {
+        let ordinaryWindow = DialogElementEvidence(
+            role: "AXWindow",
+            subrole: "AXDialog",
+            roleDescription: "dialog",
+            identifier: "SwiftUI.WindowGroup-AppWindow-1",
+            title: "Playground",
+            isModal: false)
+        let modalWindow = DialogElementEvidence(
+            role: "AXWindow",
+            subrole: "AXDialog",
+            roleDescription: "dialog",
+            identifier: "",
+            title: "Confirmation",
+            isModal: true)
+        let unknownModality = DialogElementEvidence(
+            role: "AXWindow",
+            subrole: "AXDialog",
+            roleDescription: "dialog",
+            identifier: "",
+            title: "Confirmation")
+        let nonModalSheet = DialogElementEvidence(
+            role: "AXWindow",
+            subrole: "AXSheet",
+            roleDescription: "sheet",
+            identifier: "",
+            title: "Save",
+            isModal: false)
+
+        #expect(!DialogElementClassifier.isObservationDialog(ordinaryWindow))
+        #expect(DialogElementClassifier.isObservationDialog(modalWindow))
+        #expect(DialogElementClassifier.isObservationDialog(unknownModality))
+        #expect(DialogElementClassifier.isObservationDialog(nonModalSheet))
+    }
+
     @Test(arguments: [
         ("AXSheet", ""),
         ("AXDialog", ""),
@@ -156,6 +192,45 @@ struct DialogElementClassificationTests {
             roleDescription: "standard window",
             identifier: "",
             title: title)
+
+        #expect(DialogElementClassifier.isObservationDialog(evidence))
+    }
+
+    @Test(arguments: ["Open", "Save", "Export", "Import", "Save As Document"])
+    func `non-modal AXDialog shape never overrides exact file dialog titles`(title: String) {
+        let evidence = DialogElementEvidence(
+            role: "AXWindow",
+            subrole: "AXDialog",
+            roleDescription: "dialog",
+            identifier: "",
+            title: title,
+            isModal: false)
+
+        #expect(DialogElementClassifier.isObservationDialog(evidence))
+    }
+
+    @Test(arguments: ["NSOpenPanel", "NSSavePanel"])
+    func `non-modal localized file panels remain observation dialogs by identifier`(identifier: String) {
+        let evidence = DialogElementEvidence(
+            role: "AXWindow",
+            subrole: "AXDialog",
+            roleDescription: "dialog",
+            identifier: identifier,
+            title: "Öffnen",
+            isModal: false)
+
+        #expect(DialogElementClassifier.isObservationDialog(evidence))
+    }
+
+    @Test(arguments: ["", "NSDocumentController", "SwiftUI.WindowGroup"])
+    func `unproven non-modal AXDialog shapes remain observation dialogs`(identifier: String) {
+        let evidence = DialogElementEvidence(
+            role: "AXWindow",
+            subrole: "AXDialog",
+            roleDescription: "dialog",
+            identifier: identifier,
+            title: "Benutzerdefiniert",
+            isModal: false)
 
         #expect(DialogElementClassifier.isObservationDialog(evidence))
     }

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ElementDetectionServiceDetachedObservationTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ElementDetectionServiceDetachedObservationTests.swift
@@ -153,12 +153,47 @@ struct ElementDetectionServiceDetachedObservationTests {
         #expect(state.requestBuildCount == 2)
     }
 
+    @Test
+    func `cached detached observation preserves the worker dialog verdict`() async throws {
+        let cache = ElementDetectionCache()
+        let cacheKey = try #require(cache.key(windowID: 42, processID: 123, allowWebFocus: false))
+        let state = RunnerState()
+        let service = ElementDetectionService(
+            snapshotManager: nil,
+            applicationService: nil,
+            axTreeCache: cache,
+            detachedAXObservationRunner: { request in
+                state.requests.append(request)
+                return Self.completeResult(request, isDialog: true)
+            })
+
+        let first = try await service.cachedOrRunDetachedAXObservation(
+            cacheKey: cacheKey,
+            invalidatedThrough: nil,
+            cachedContext: Self.cachedContext,
+            makeRequest: { state.makeRequest(timeoutSeconds: 20) })
+        #expect(!first.usedCache)
+        #expect(first.isDialog)
+
+        let second = try await service.cachedOrRunDetachedAXObservation(
+            cacheKey: cacheKey,
+            invalidatedThrough: nil,
+            cachedContext: Self.cachedContext,
+            makeRequest: {
+                Issue.record("A complete cached dialog result must not rerun the AX request")
+                return state.makeRequest(timeoutSeconds: 20)
+            })
+        #expect(second.usedCache)
+        #expect(second.isDialog)
+        #expect(state.requests.count == 1)
+        #expect(state.requestBuildCount == 1)
+    }
+
     private static let cachedContext = CachedDetachedAXObservationContext(
         processStartIdentity: 7,
         windowID: 42,
         windowTitle: "Cached fixture",
-        windowBounds: CGRect(x: 10, y: 20, width: 800, height: 600),
-        isDialog: false)
+        windowBounds: CGRect(x: 10, y: 20, width: 800, height: 600))
 
     private nonisolated static func resolutionFailure(
         _ request: DetachedAXObservationRequest,
@@ -207,7 +242,8 @@ struct ElementDetectionServiceDetachedObservationTests {
         attributes: [:])
 
     private nonisolated static func completeResult(
-        _ request: DetachedAXObservationRequest) -> DetachedAXObservationResult
+        _ request: DetachedAXObservationRequest,
+        isDialog: Bool = false) -> DetachedAXObservationResult
     {
         DetachedAXObservationResult(
             elements: [
@@ -224,7 +260,7 @@ struct ElementDetectionServiceDetachedObservationTests {
             windowID: request.windowID,
             windowTitle: "Injected fixture",
             windowBounds: request.expectedWindowBounds,
-            isDialog: false,
+            isDialog: isDialog,
             truncationInfo: nil)
     }
 }

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/Agent/PeekabooAgentService+TurnBoundary.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/Agent/PeekabooAgentService+TurnBoundary.swift
@@ -3,7 +3,8 @@ import Tachikoma
 @available(macOS 14.0, *)
 extension PeekabooAgentService {
     static let freshPerceptionTerminalRejection =
-        "Completion rejected: call `see` successfully before claiming the result of the last UI mutation."
+        "Completion rejected: call `inspect_ui` or `see` successfully before claiming the result of the last " +
+        "UI mutation."
 
     static let completionEvidenceTerminalRejectionPrefix = "Completion rejected: "
     static let invalidTurnBoundaryReason =

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/Agent/QueueMode.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/Agent/QueueMode.swift
@@ -110,14 +110,14 @@ final class AgentTurnBoundary {
         case .initial:
             self.perceptionState = .required
             return .continueNextStep(
-                reason: "Stopped after \(normalizedName); call `see` before the next UI action.")
+                reason: "Stopped after \(normalizedName); call `inspect_ui` or `see` before the next UI action.")
         case .perceived:
             self.perceptionState = .required
             return .continueNextStep(
-                reason: "Stopped after \(normalizedName); call `see` again before the next UI action.")
+                reason: "Stopped after \(normalizedName); call `inspect_ui` or `see` again before the next UI action.")
         case .required:
             return .skipUntilPerception(
-                reason: "Skipped \(normalizedName); call `see` successfully before another UI action.")
+                reason: "Skipped \(normalizedName); call `inspect_ui` or `see` successfully before another UI action.")
         }
     }
 
@@ -137,7 +137,7 @@ final class AgentTurnBoundary {
 
         self.perceptionState = .required
         return .continueNextStep(
-            reason: "Stopped after \(normalizedName); call `see` before the next UI action.")
+            reason: "Stopped after \(normalizedName); call `inspect_ui` or `see` before the next UI action.")
     }
 
     func recordSuccessfulCompletion(

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/Agent/Tools/AgentSystemPrompt.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/Agent/Tools/AgentSystemPrompt.swift
@@ -174,8 +174,9 @@ public struct AgentSystemPrompt {
           Repeat the exact same target and predicates; only a later identical satisfied receipt clears the debt. An
           unrelated predicate on the same window cannot prove the committed postcondition.
         - Emit at most one desktop-mutating tool call in each model response. After that mutation succeeds, Peekaboo
-          ends the provider step and skips later mutations until a fresh successful `see`. You may batch read-only
-          observations, but send the next click, type, scroll, press, or other desktop mutation in a later response.
+          ends the provider step and skips later mutations until a fresh successful observation. Use `inspect_ui`
+          when AX-only state is enough, or `see` when pixels are required. You may batch read-only observations, but
+          send the next click, type, scroll, press, or other desktop mutation in a later response.
         - Prefer `verify_state` over fixed sleeps when waiting for exact window bounds or native element
           existence/value/enabled/selected state. It is observation-only and requires stable fresh AX samples.
           Its predicates are structured JSON objects, never prose strings or AX expressions; follow the tool's

--- a/Core/PeekabooCore/Tests/PeekabooAgentRuntimeTests/AgentSystemPromptTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooAgentRuntimeTests/AgentSystemPromptTests.swift
@@ -132,7 +132,9 @@ struct AgentSystemPromptTests {
         let prompt = AgentSystemPrompt.generate()
 
         #expect(prompt.contains("at most one desktop-mutating tool call in each model response"))
-        #expect(prompt.contains("skips later mutations until a fresh successful `see`"))
+        #expect(prompt.contains("skips later mutations until a fresh successful observation"))
+        #expect(prompt.contains("Use `inspect_ui`"))
+        #expect(prompt.contains("or `see` when pixels are required"))
         #expect(prompt.contains("You may batch read-only"))
     }
 

--- a/Core/PeekabooCore/Tests/PeekabooAgentRuntimeTests/AgentTurnBoundaryTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooAgentRuntimeTests/AgentTurnBoundaryTests.swift
@@ -28,9 +28,9 @@ struct AgentTurnBoundaryTests {
         let boundary = AgentTurnBoundary()
 
         #expect(boundary.record(toolName: "click") == .continueNextStep(
-            reason: "Stopped after click; call `see` before the next UI action."))
+            reason: "Stopped after click; call `inspect_ui` or `see` before the next UI action."))
         #expect(boundary.record(toolName: "type") == .skipUntilPerception(
-            reason: "Skipped type; call `see` successfully before another UI action."))
+            reason: "Skipped type; call `inspect_ui` or `see` successfully before another UI action."))
     }
 
     @Test
@@ -117,13 +117,13 @@ struct AgentTurnBoundaryTests {
         #expect(boundary.record(toolName: "see") == .continueTurn)
         boundary.recordSuccessfulCompletion(toolName: "see")
         #expect(boundary.record(toolName: "type") == .continueNextStep(
-            reason: "Stopped after type; call `see` again before the next UI action."))
+            reason: "Stopped after type; call `inspect_ui` or `see` again before the next UI action."))
         #expect(boundary.record(toolName: "click") == .skipUntilPerception(
-            reason: "Skipped click; call `see` successfully before another UI action."))
+            reason: "Skipped click; call `inspect_ui` or `see` successfully before another UI action."))
         #expect(boundary.record(toolName: "see") == .continueTurn)
         boundary.recordSuccessfulCompletion(toolName: "see")
         #expect(boundary.record(toolName: "click") == .continueNextStep(
-            reason: "Stopped after click; call `see` again before the next UI action."))
+            reason: "Stopped after click; call `inspect_ui` or `see` again before the next UI action."))
     }
 
     @Test
@@ -139,10 +139,10 @@ struct AgentTurnBoundaryTests {
         #expect(try boundary.recordResult(
             toolName: "browser",
             result: Self.canonicalResult(outcome)) == .continueNextStep(
-            reason: "Stopped after browser; call `see` before the next UI action."))
+            reason: "Stopped after browser; call `inspect_ui` or `see` before the next UI action."))
         #expect(boundary.requiresFreshPerception)
         #expect(boundary.record(toolName: "click") == .skipUntilPerception(
-            reason: "Skipped click; call `see` successfully before another UI action."))
+            reason: "Skipped click; call `inspect_ui` or `see` successfully before another UI action."))
     }
 
     @Test
@@ -159,7 +159,7 @@ struct AgentTurnBoundaryTests {
         #expect(try boundary.recordResult(
             toolName: "browser",
             result: Self.canonicalResult(outcome)) == .continueNextStep(
-            reason: "Stopped after browser; call `see` before the next UI action."))
+            reason: "Stopped after browser; call `inspect_ui` or `see` before the next UI action."))
         #expect(boundary.requiresFreshPerception)
     }
 
@@ -179,7 +179,7 @@ struct AgentTurnBoundaryTests {
             ])) == .continueTurn)
         #expect(!boundary.requiresFreshPerception)
         #expect(boundary.record(toolName: "click") == .continueNextStep(
-            reason: "Stopped after click; call `see` again before the next UI action."))
+            reason: "Stopped after click; call `inspect_ui` or `see` again before the next UI action."))
     }
 
     @Test
@@ -209,7 +209,7 @@ struct AgentTurnBoundaryTests {
             result: Self.canonicalResult(.confirmedNoChange(route: .bridge))) == .continueTurn)
         #expect(!noOpBoundary.requiresFreshPerception)
         #expect(noOpBoundary.record(toolName: "click") == .continueNextStep(
-            reason: "Stopped after click; call `see` before the next UI action."))
+            reason: "Stopped after click; call `inspect_ui` or `see` before the next UI action."))
 
         let dispatchedBoundary = AgentTurnBoundary()
         let indeterminate = DesktopActionOutcome.indeterminate(
@@ -222,7 +222,7 @@ struct AgentTurnBoundaryTests {
         #expect(try dispatchedBoundary.recordResult(
             toolName: "app",
             result: Self.canonicalResult(indeterminate)) == .continueNextStep(
-            reason: "Stopped after app; call `see` before the next UI action."))
+            reason: "Stopped after app; call `inspect_ui` or `see` before the next UI action."))
         #expect(dispatchedBoundary.requiresFreshPerception)
     }
 
@@ -246,11 +246,11 @@ struct AgentTurnBoundaryTests {
         #expect(boundary.record(toolName: "see") == .continueTurn)
         boundary.recordSuccessfulCompletion(toolName: "see")
         #expect(boundary.record(toolName: "type") == .continueNextStep(
-            reason: "Stopped after type; call `see` again before the next UI action."))
+            reason: "Stopped after type; call `inspect_ui` or `see` again before the next UI action."))
         #expect(boundary.record(toolName: "inspect_ui") == .continueTurn)
         boundary.recordSuccessfulCompletion(toolName: "inspect_ui")
         #expect(boundary.record(toolName: "click") == .continueNextStep(
-            reason: "Stopped after click; call `see` again before the next UI action."))
+            reason: "Stopped after click; call `inspect_ui` or `see` again before the next UI action."))
     }
 
     @Test
@@ -260,10 +260,10 @@ struct AgentTurnBoundaryTests {
         #expect(boundary.record(toolName: "see") == .continueTurn)
         boundary.recordSuccessfulCompletion(toolName: "see")
         #expect(boundary.record(toolName: "type") == .continueNextStep(
-            reason: "Stopped after type; call `see` again before the next UI action."))
+            reason: "Stopped after type; call `inspect_ui` or `see` again before the next UI action."))
         #expect(boundary.record(toolName: "see") == .continueTurn)
         #expect(boundary.record(toolName: "click") == .skipUntilPerception(
-            reason: "Skipped click; call `see` successfully before another UI action."))
+            reason: "Skipped click; call `inspect_ui` or `see` successfully before another UI action."))
     }
 
     @Test
@@ -282,7 +282,7 @@ struct AgentTurnBoundaryTests {
         #expect(boundary.record(toolName: "see", arguments: observationTarget) == .continueTurn)
         boundary.recordSuccessfulCompletion(toolName: "see", arguments: observationTarget)
         #expect(boundary.record(toolName: "type") == .continueNextStep(
-            reason: "Stopped after type; call `see` again before the next UI action."))
+            reason: "Stopped after type; call `inspect_ui` or `see` again before the next UI action."))
         #expect(boundary.record(toolName: "see", arguments: observationTarget) == .continueTurn)
         boundary.recordSuccessfulCompletion(
             toolName: "see",
@@ -516,7 +516,7 @@ struct AgentTurnBoundaryTests {
             ModelMessage(role: .tool, content: [.toolResult(successfulSee)]),
         ])
         #expect(missingMutationResult.record(toolName: "click") == .skipUntilPerception(
-            reason: "Skipped click; call `see` successfully before another UI action."))
+            reason: "Skipped click; call `inspect_ui` or `see` successfully before another UI action."))
 
         let orphanedBoundary = AgentToolResult.success(
             toolCallId: "orphaned-call",
@@ -531,7 +531,7 @@ struct AgentTurnBoundaryTests {
             ModelMessage(role: .tool, content: [.toolResult(orphanedBoundary)]),
         ])
         #expect(unmatchedResult.record(toolName: "type") == .skipUntilPerception(
-            reason: "Skipped type; call `see` successfully before another UI action."))
+            reason: "Skipped type; call `inspect_ui` or `see` successfully before another UI action."))
 
         let successfulType = AgentToolResult.success(
             toolCallId: typeCall.id,
@@ -548,7 +548,7 @@ struct AgentTurnBoundaryTests {
             ModelMessage(role: .tool, content: [.toolResult(successfulSee)]),
         ])
         #expect(duplicatePerception.record(toolName: "click") == .skipUntilPerception(
-            reason: "Skipped click; call `see` successfully before another UI action."))
+            reason: "Skipped click; call `inspect_ui` or `see` successfully before another UI action."))
     }
 
     @Test
@@ -586,7 +586,7 @@ struct AgentTurnBoundaryTests {
         ])
 
         #expect(boundary.record(toolName: "click") == .skipUntilPerception(
-            reason: "Skipped click; call `see` successfully before another UI action."))
+            reason: "Skipped click; call `inspect_ui` or `see` successfully before another UI action."))
     }
 
     @Test
@@ -607,7 +607,7 @@ struct AgentTurnBoundaryTests {
         ])
 
         #expect(boundary.record(toolName: "click") == .skipUntilPerception(
-            reason: "Skipped click; call `see` successfully before another UI action."))
+            reason: "Skipped click; call `inspect_ui` or `see` successfully before another UI action."))
     }
 
     private static func verificationResult(

--- a/Core/PeekabooCore/Tests/PeekabooTests/AgentRun50PolicyTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/AgentRun50PolicyTests.swift
@@ -136,7 +136,8 @@ struct AgentRun50PolicyTests {
                 "action": AnyAgentToolValue(string: "launch"),
                 "name": AnyAgentToolValue(string: "TextEdit"),
                 "foreground": AnyAgentToolValue(bool: true),
-            ]) == .continueNextStep(reason: "Stopped after app; call `see` before the next UI action."))
+            ]) == .continueNextStep(
+            reason: "Stopped after app; call `inspect_ui` or `see` before the next UI action."))
 
         let backgroundMenuList = AgentTurnBoundary()
         #expect(backgroundMenuList.record(
@@ -153,6 +154,7 @@ struct AgentRun50PolicyTests {
                 "action": AnyAgentToolValue(string: "list"),
                 "app": AnyAgentToolValue(string: "TextEdit"),
                 "foreground": AnyAgentToolValue(bool: true),
-            ]) == .continueNextStep(reason: "Stopped after menu; call `see` before the next UI action."))
+            ]) == .continueNextStep(
+            reason: "Stopped after menu; call `inspect_ui` or `see` before the next UI action."))
     }
 }

--- a/Core/PeekabooCore/Tests/PeekabooTests/AgentRuntimeBoundaryRegressionTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/AgentRuntimeBoundaryRegressionTests.swift
@@ -270,8 +270,8 @@ struct AgentRuntimeBoundaryRegressionTests {
         #expect(provider.requestsContainingContinueBoundary == [false, true, true])
         #expect(provider.continueBoundaryReasons == [
             nil,
-            "Stopped after type; call `see` again before the next UI action.",
-            "Stopped after click; call `see` again before the next UI action.",
+            "Stopped after type; call `inspect_ui` or `see` again before the next UI action.",
+            "Stopped after click; call `inspect_ui` or `see` again before the next UI action.",
         ])
         #expect(await executions.snapshot() == ["see", "type", "see", "click", "done"])
         #expect(outcome.steps.count == 3)
@@ -343,7 +343,7 @@ struct AgentRuntimeBoundaryRegressionTests {
         #expect(outcome.steps.first?.toolResults.map(\.toolCallId) == ["type-1", "click-1"])
         #expect(outcome.steps.first?.toolResults.map(\.isError) == [false, true])
         #expect(provider.continueBoundaryReasons[1] ==
-            "Stopped after type; call `see` before the next UI action.")
+            "Stopped after type; call `inspect_ui` or `see` before the next UI action.")
         #expect(!outcome.reachedStepLimit)
     }
 

--- a/Core/PeekabooCore/Tests/PeekabooTests/AgentToolMCPFailureSemanticsTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/AgentToolMCPFailureSemanticsTests.swift
@@ -627,7 +627,7 @@ struct AgentToolMCPFailureSemanticsTests {
         #expect(trace.disposition == .executedFailed)
         #expect(trace.actionOutcome == outcome.projection)
         #expect(context.turnBoundary.record(toolName: "click") == .continueNextStep(
-            reason: "Stopped after click; call `see` before the next UI action."))
+            reason: "Stopped after click; call `inspect_ui` or `see` before the next UI action."))
     }
 
     @Test
@@ -759,7 +759,7 @@ struct AgentToolMCPFailureSemanticsTests {
         #expect(summary["mutation_dispatched"]?.boolValue == false)
         #expect(summary["retry_safe"]?.boolValue == true)
         #expect(service.turnBoundarySignal(from: result) == .continueNextStep(
-            reason: "Stopped after click; call `see` before the next UI action."))
+            reason: "Stopped after click; call `inspect_ui` or `see` before the next UI action."))
     }
 
     @Test
@@ -789,7 +789,7 @@ struct AgentToolMCPFailureSemanticsTests {
         #expect(trace.disposition == .executedFailed)
         #expect(trace.isError == true)
         #expect(restored.record(toolName: "click") == .continueNextStep(
-            reason: "Stopped after click; call `see` before the next UI action."))
+            reason: "Stopped after click; call `inspect_ui` or `see` before the next UI action."))
     }
 
     @Test

--- a/Core/PeekabooCore/Tests/PeekabooTests/AgentTurnBoundaryTranscriptTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/AgentTurnBoundaryTranscriptTests.swift
@@ -51,7 +51,7 @@ struct AgentTurnBoundaryTranscriptTests {
         #expect(skippedJSON["skipped"] as? Bool == true)
         #expect((skippedJSON["reason"] as? String)?.contains("click") == true)
         #expect(service.turnBoundarySignal(from: step.toolResults) == .continueNextStep(
-            reason: "Stopped after click; call `see` again before the next UI action."))
+            reason: "Stopped after click; call `inspect_ui` or `see` again before the next UI action."))
         #expect(service.turnBoundaryStopReason(from: step.toolResults) == nil)
 
         let skippedBoundary = try #require(skippedJSON["turn_boundary"] as? [String: Any])
@@ -101,7 +101,7 @@ struct AgentTurnBoundaryTranscriptTests {
 
         #expect(step.toolResults.count == 2)
         #expect(service.turnBoundarySignal(from: step.toolResults) == .continueNextStep(
-            reason: "Stopped after browser; call `see` before the next UI action."))
+            reason: "Stopped after browser; call `inspect_ui` or `see` before the next UI action."))
         let skipped = try #require(try step.toolResults[1].result.toJSON() as? [String: Any])
         #expect(skipped["skipped"] as? Bool == true)
     }
@@ -147,7 +147,7 @@ struct AgentTurnBoundaryTranscriptTests {
 
         #expect(step.toolResults.count == 2)
         #expect(service.turnBoundarySignal(from: step.toolResults) == .continueNextStep(
-            reason: "Stopped after browser; call `see` before the next UI action."))
+            reason: "Stopped after browser; call `inspect_ui` or `see` before the next UI action."))
         #expect(step.toolResults[1].isError)
     }
 
@@ -172,7 +172,7 @@ struct AgentTurnBoundaryTranscriptTests {
         ])
 
         #expect(restored.record(toolName: "click") == .skipUntilPerception(
-            reason: "Skipped click; call `see` successfully before another UI action."))
+            reason: "Skipped click; call `inspect_ui` or `see` successfully before another UI action."))
     }
 
     @Test
@@ -221,7 +221,7 @@ struct AgentTurnBoundaryTranscriptTests {
 
         #expect(step.toolResults.count == 2)
         #expect(service.turnBoundarySignal(from: step.toolResults) == .continueNextStep(
-            reason: "Stopped after app; call `see` before the next UI action."))
+            reason: "Stopped after app; call `inspect_ui` or `see` before the next UI action."))
         #expect(step.toolResults[1].isError)
     }
 
@@ -248,7 +248,7 @@ struct AgentTurnBoundaryTranscriptTests {
         ])
 
         #expect(restored.record(toolName: "click") == .skipUntilPerception(
-            reason: "Skipped click; call `see` successfully before another UI action."))
+            reason: "Skipped click; call `inspect_ui` or `see` successfully before another UI action."))
     }
 
     @Test
@@ -355,7 +355,7 @@ struct AgentTurnBoundaryTranscriptTests {
             #expect(service.turnBoundarySignal(from: result) == .stopAgent(
                 reason: PeekabooAgentService.invalidTurnBoundaryReason))
             #expect(restored.record(toolName: "click") == .skipUntilPerception(
-                reason: "Skipped click; call `see` successfully before another UI action."))
+                reason: "Skipped click; call `inspect_ui` or `see` successfully before another UI action."))
         }
 
         let malformedSingleBoundaries: [(String, AnyAgentToolValue)] = [

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPBackgroundPolicyExecutionTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPBackgroundPolicyExecutionTests.swift
@@ -197,6 +197,82 @@ struct MCPBackgroundPolicyExecutionTests {
     }
 
     @Test
+    func `exact non-dialog observation reaches set value while a modal snapshot stays fail closed`() async throws {
+        let bounds = CGRect(x: 100, y: 50, width: 1200, height: 800)
+        let identity = WindowMutationIdentity(
+            windowID: 42,
+            ownerProcessIdentifier: 333,
+            ownerProcessStartIdentity: 33,
+            capturedBounds: bounds)
+        let window = ServiceWindowInfo(
+            windowID: 42,
+            title: "Playground",
+            bounds: bounds,
+            index: 0,
+            mutationIdentity: identity)
+        let applications = await MainActor.run {
+            MockApplicationService(applications: [ServiceApplicationInfo(
+                processIdentifier: 333,
+                processStartIdentity: 33,
+                bundleIdentifier: "boo.peekaboo.playground.debug",
+                name: "Playground")])
+        }
+        let windowContext = WindowContext(
+            applicationName: "Playground",
+            applicationBundleId: "boo.peekaboo.playground.debug",
+            applicationProcessId: 333,
+            windowTitle: window.title,
+            windowID: window.windowID,
+            windowBounds: window.bounds,
+            windowMutationIdentity: identity)
+
+        for isDialog in [false, true] {
+            await Self.uiSnapshots.removeAllSnapshots()
+            let mirrored = await Self.uiSnapshots.createSnapshot()
+            let snapshotID = await mirrored.id
+            await mirrored.setTargetMetadata(from: windowContext)
+            let detection = ElementDetectionResult(
+                snapshotId: snapshotID,
+                screenshotPath: "",
+                elements: DetectedElements(textFields: [DetectedElement(
+                    id: "elem_18",
+                    type: .textField,
+                    label: "Type here...",
+                    bounds: CGRect(x: 120, y: 100, width: 500, height: 24),
+                    isEnabled: true,
+                    attributes: ["identifier": "basic-text-field"])]),
+                metadata: DetectionMetadata(
+                    detectionTime: 0.01,
+                    elementCount: 1,
+                    method: "AXorcist",
+                    windowContext: windowContext,
+                    isDialog: isDialog))
+            let context = await MCPToolTestHelpers.makeContext(
+                applications: applications,
+                windows: PointerPolicyWindowService(window: window),
+                snapshots: InMemorySnapshotManager(detectionResult: detection),
+                snapshotOwner: Self.uiSnapshots.owner,
+                executionPolicy: .backgroundOnly)
+            let counter = BackgroundPolicyInvocationCounter()
+
+            let response = try await context.execute(
+                tool: BackgroundPolicyMutationProbe(name: "set_value", counter: counter),
+                arguments: ToolArguments(raw: [
+                    "on": "elem_18",
+                    "value": "updated",
+                    "snapshot": snapshotID,
+                ]))
+
+            #expect(response.isError == isDialog)
+            #expect(await counter.invocationCount == (isDialog ? 0 : 1))
+            if isDialog {
+                #expect(response.meta?.objectValue?["refusal_reason"] == .string("target_unavailable"))
+                #expect(response.meta?.objectValue?["mutation_dispatched"] == .bool(false))
+            }
+        }
+    }
+
+    @Test
     func `App tool lifecycle examples include required foreground consent`() async {
         let context = await MCPToolTestHelpers.makeContext(snapshotOwner: Self.uiSnapshots.owner)
         let description = AppTool(context: context).description
@@ -606,8 +682,11 @@ private struct BackgroundPolicyMutationProbe: MCPTool {
                 "button": SchemaBuilder.string(),
                 "bundleId": SchemaBuilder.string(),
                 "name": SchemaBuilder.string(),
+                "on": SchemaBuilder.string(),
                 "pid": SchemaBuilder.integer(),
+                "snapshot": SchemaBuilder.string(),
                 "text": SchemaBuilder.string(),
+                "value": SchemaBuilder.string(),
             ],
             required: [])
     }


### PR DESCRIPTION
## Summary

- allow exact background mutations for the positively identified SwiftUI `WindowGroup` shape `AXWindow` / `AXDialog` / `AXModal=false`
- keep modal, unknown-modality, sheet, system-dialog, file-panel, identifier-less, and unrelated modeless dialog evidence fail-closed
- preserve the observed dialog verdict through detached AX tree cache reuse, with missing cache metadata defaulting unsafe
- recognize both `inspect_ui` and `see` as fresh Agent perception at turn boundaries

## Root cause

Ordinary SwiftUI `WindowGroup` windows can expose the `AXDialog` subrole even though they are explicitly non-modal. Detached observation classified the subrole alone as a dialog, so an Agent could obtain an exact `inspect_ui` snapshot but then have `set_value` refused.

The repair requires positive SwiftUI window identity in addition to the exact role, subrole, and non-modal evidence. Native file-panel identifiers and exact file-dialog titles are checked first. The detached AX cache now owns the dialog verdict instead of accepting a caller-authored default on cache hits.

## Proof

- focused AutomationKit classification and detached-cache tests: 16 passed
- `pnpm run test:safe`
- scoped SwiftFormat: clean
- scoped strict SwiftLint: 0 violations
- `pnpm run lint:docs`
- `git diff --check`
- widened P1 Autoreview: clean
- independent P1 safety audit: clean

