### PR TITLE
fix(agent): redact provider-authored JSON traces

### DIFF
--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Bind signed `set-value` results to the opaque requested element and refuse older Bridge hosts before dispatch.
 - Keep non-modal SwiftUI `AXDialog`-subrole windows eligible for exact background mutations while preserving modal, sheet, and file-dialog protections, and recognize `inspect_ui` as fresh Agent perception in recovery guidance.
+- Keep legacy Agent JSON tool-call arguments privacy-safe and deterministic instead of exposing Swift implementation details and runtime addresses.
 
 ## [4.2.2] - 2026-08-20
 

--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bind signed `set-value` results to the opaque requested element and refuse older Bridge hosts before dispatch.
 - Keep non-modal SwiftUI `AXDialog`-subrole windows eligible for exact background mutations while preserving modal, sheet, and file-dialog protections, and recognize `inspect_ui` as fresh Agent perception in recovery guidance.
 - Keep legacy Agent JSON tool-call arguments privacy-safe and deterministic instead of exposing Swift implementation details and runtime addresses.
+- Report `retry_safe: false` whenever an Agent trace cannot prove whether a mutation dispatched.
 
 ## [4.2.2] - 2026-08-20
 

--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Keep non-modal SwiftUI `AXDialog`-subrole windows eligible for exact background mutations while preserving modal, sheet, and file-dialog protections, and recognize `inspect_ui` as fresh Agent perception in recovery guidance.
 - Keep legacy Agent JSON tool-call arguments privacy-safe and deterministic instead of exposing Swift implementation details and runtime addresses.
 - Report `retry_safe: false` whenever an Agent trace cannot prove whether a mutation dispatched.
+- Replace arbitrary provider-authored Agent trace field names with deterministic ordinal placeholders at every argument nesting level.
 
 ## [4.2.2] - 2026-08-20
 

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/AI/AgentCommand+Execution.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/AI/AgentCommand+Execution.swift
@@ -129,14 +129,27 @@ extension AgentCommand {
     }
 
     func makeAgentJSONResponse(_ result: AgentExecutionResult) -> [String: Any] {
-        let legacyToolCalls: [[String: Any]] = result.messages.flatMap { message in
-            message.content.compactMap { content in
-                guard case let .toolCall(toolCall) = content else { return nil }
-                return [
+        let trace = result.executionTrace()
+        var legacyToolCalls: [[String: Any]] = []
+        var traceIndex = 0
+        for message in result.messages {
+            for content in message.content {
+                guard case let .toolCall(toolCall) = content else { continue }
+                let arguments: String
+                if trace.entries.indices.contains(traceIndex) {
+                    let entry = trace.entries[traceIndex]
+                    arguments = entry.id == toolCall.id && entry.name == toolCall.name
+                        ? Self.safeLegacyArguments(entry.arguments)
+                        : Self.fullyRedactedLegacyArguments
+                } else {
+                    arguments = Self.fullyRedactedLegacyArguments
+                }
+                legacyToolCalls.append([
                     "id": toolCall.id,
                     "name": toolCall.name,
-                    "arguments": String(describing: toolCall.arguments),
-                ]
+                    "arguments": arguments,
+                ])
+                traceIndex += 1
             }
         }
         let usage: Any = result.usage.map { usage in
@@ -150,7 +163,7 @@ extension AgentCommand {
             "content": result.content,
             "sessionId": result.sessionId.map { $0 as Any } ?? NSNull(),
             "toolCalls": legacyToolCalls,
-            "executionTrace": self.executionTraceJSONObject(for: result),
+            "executionTrace": self.executionTraceJSONObject(trace),
             "metadata": [
                 "executionTime": result.metadata.executionTime,
                 "toolCallCount": result.metadata.toolCallCount,
@@ -161,8 +174,20 @@ extension AgentCommand {
         return ["success": true, "result": resultPayload]
     }
 
-    private func executionTraceJSONObject(for result: AgentExecutionResult) -> [String: Any] {
-        let trace = result.executionTrace()
+    private static let fullyRedactedLegacyArguments = #"{"redacted":true}"#
+
+    private static func safeLegacyArguments(_ arguments: [String: AnyAgentToolValue]) -> String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        guard let data = try? encoder.encode(arguments),
+              let text = String(data: data, encoding: .utf8)
+        else {
+            return Self.fullyRedactedLegacyArguments
+        }
+        return text
+    }
+
+    private func executionTraceJSONObject(_ trace: AgentExecutionTrace) -> [String: Any] {
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.sortedKeys]
         guard let data = try? encoder.encode(trace),

--- a/Apps/CLI/Tests/CoreCLITests/AgentCommandJSONOutputTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/AgentCommandJSONOutputTests.swift
@@ -72,7 +72,23 @@ struct AgentCommandJSONOutputTests {
 
         #expect(resultObject["sessionId"] is NSNull)
         #expect(legacyCalls.count == 1)
-        #expect(legacyCalls[0]["arguments"] is String)
+        let legacyArguments = try #require(legacyCalls[0]["arguments"] as? String)
+        let legacyArgumentsData = try #require(legacyArguments.data(using: .utf8))
+        let legacyArgumentsObject = try #require(
+            JSONSerialization.jsonObject(with: legacyArgumentsData) as? [String: Any]
+        )
+        #expect(legacyArgumentsObject["app"] as? String == "TextEdit")
+        #expect(legacyArgumentsObject["foreground"] as? Bool == false)
+        #expect(legacyArgumentsObject["mode"] as? String == "background")
+        #expect(legacyArgumentsObject["snapshot"] as? String == "snapshot-123")
+        #expect(legacyArgumentsObject["window_id"] as? Int == 42)
+        for key in ["text", "value", "url", "custom_number", "custom_boolean"] {
+            #expect((legacyArgumentsObject[key] as? [String: Any])?["redacted"] as? Bool == true)
+        }
+        #expect(!legacyArguments.contains("Tachikoma"))
+        #expect(!legacyArguments.contains("AnyAgentToolValue"))
+        #expect(!legacyArguments.contains("unknown context"))
+        #expect(!legacyArguments.contains("storage:"))
         #expect(entries.count == 1)
         #expect(entries[0]["id"] as? String == call.id)
         #expect(entries[0]["disposition"] as? String == "executed/succeeded")
@@ -96,9 +112,88 @@ struct AgentCommandJSONOutputTests {
         #expect(!text.contains("iVBORw0KGgo"))
         #expect(!text.contains("/Users/example/private/capture.png"))
         #expect(!text.contains("sk-testSECRET123456789"))
+        #expect(!text.contains(privateMessage))
+        #expect(!text.contains(ordinaryPassword))
+        #expect(!text.contains(privateURL))
+        #expect(!text.contains("731991"))
+        #expect(!text.contains("AnyAgentToolValue"))
+        #expect(!text.contains("unknown context"))
         #expect(!traceText.contains(privateMessage))
         #expect(!traceText.contains(ordinaryPassword))
         #expect(!traceText.contains(privateURL))
         #expect(!traceText.contains("731991"))
+    }
+
+    @Test
+    func `Legacy calls beyond the bounded trace stay valid and fully redacted`() throws {
+        let calls = (0...512).map { index in
+            AgentToolCall(
+                id: "call-\(index)",
+                name: "inspect_ui",
+                arguments: [
+                    "app_target": AnyAgentToolValue(string: "PID:42"),
+                    "window_id": AnyAgentToolValue(int: 99),
+                ]
+            )
+        }
+        let result = AgentExecutionResult(
+            content: "complete",
+            messages: [ModelMessage(role: .assistant, content: calls.map { .toolCall($0) })],
+            metadata: AgentMetadata(
+                executionTime: 0.1,
+                toolCallCount: calls.count,
+                modelName: "test-model",
+                startTime: Date(),
+                endTime: Date()
+            )
+        )
+        let command = try AgentCommand.parse(["ephemeral task", "--no-cache"])
+
+        let response = command.makeAgentJSONResponse(result)
+        let resultObject = try #require(response["result"] as? [String: Any])
+        let legacyCalls = try #require(resultObject["toolCalls"] as? [[String: Any]])
+        let firstArguments = try #require(legacyCalls.first?["arguments"] as? String)
+        let lastArguments = try #require(legacyCalls.last?["arguments"] as? String)
+
+        #expect(legacyCalls.count == 513)
+        #expect(firstArguments == #"{"app_target":"PID:42","window_id":99}"#)
+        #expect(lastArguments == #"{"redacted":true}"#)
+    }
+
+    @Test
+    func `Legacy argument JSON is stable across dictionary insertion order`() throws {
+        var forward: [String: AnyAgentToolValue] = [:]
+        forward["app_target"] = AnyAgentToolValue(string: "PID:42")
+        forward["foreground"] = AnyAgentToolValue(bool: false)
+        forward["window_id"] = AnyAgentToolValue(int: 99)
+        var reverse: [String: AnyAgentToolValue] = [:]
+        reverse["window_id"] = AnyAgentToolValue(int: 99)
+        reverse["foreground"] = AnyAgentToolValue(bool: false)
+        reverse["app_target"] = AnyAgentToolValue(string: "PID:42")
+        let calls = [
+            AgentToolCall(id: "forward", name: "inspect_ui", arguments: forward),
+            AgentToolCall(id: "reverse", name: "inspect_ui", arguments: reverse),
+        ]
+        let result = AgentExecutionResult(
+            content: "complete",
+            messages: [ModelMessage(role: .assistant, content: calls.map { .toolCall($0) })],
+            metadata: AgentMetadata(
+                executionTime: 0.1,
+                toolCallCount: calls.count,
+                modelName: "test-model",
+                startTime: Date(),
+                endTime: Date()
+            )
+        )
+        let command = try AgentCommand.parse(["ephemeral task", "--no-cache"])
+
+        let response = command.makeAgentJSONResponse(result)
+        let resultObject = try #require(response["result"] as? [String: Any])
+        let legacyCalls = try #require(resultObject["toolCalls"] as? [[String: Any]])
+        let firstArguments = try #require(legacyCalls.first?["arguments"] as? String)
+        let lastArguments = try #require(legacyCalls.last?["arguments"] as? String)
+
+        #expect(firstArguments == lastArguments)
+        #expect(firstArguments == #"{"app_target":"PID:42","foreground":false,"window_id":99}"#)
     }
 }

--- a/Apps/CLI/Tests/CoreCLITests/AgentCommandJSONOutputTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/AgentCommandJSONOutputTests.swift
@@ -82,9 +82,17 @@ struct AgentCommandJSONOutputTests {
         #expect(legacyArgumentsObject["mode"] as? String == "background")
         #expect(legacyArgumentsObject["snapshot"] as? String == "snapshot-123")
         #expect(legacyArgumentsObject["window_id"] as? Int == 42)
-        for key in ["text", "value", "url", "custom_number", "custom_boolean"] {
+        for key in ["text", "value", "url"] {
             #expect((legacyArgumentsObject[key] as? [String: Any])?["redacted"] as? Bool == true)
         }
+        #expect(
+            (legacyArgumentsObject["__peekaboo_trace_unknown_field_1"] as? [String: Any])?["value_type"]
+                as? String == "boolean"
+        )
+        #expect(
+            (legacyArgumentsObject["__peekaboo_trace_unknown_field_2"] as? [String: Any])?["value_type"]
+                as? String == "integer"
+        )
         #expect(!legacyArguments.contains("Tachikoma"))
         #expect(!legacyArguments.contains("AnyAgentToolValue"))
         #expect(!legacyArguments.contains("unknown context"))
@@ -98,9 +106,17 @@ struct AgentCommandJSONOutputTests {
         #expect(arguments["mode"] as? String == "background")
         #expect(arguments["snapshot"] as? String == "snapshot-123")
         #expect(arguments["window_id"] as? Int == 42)
-        for key in ["text", "value", "url", "custom_number", "custom_boolean"] {
+        for key in ["text", "value", "url"] {
             #expect((arguments[key] as? [String: Any])?["redacted"] as? Bool == true)
         }
+        #expect(
+            (arguments["__peekaboo_trace_unknown_field_1"] as? [String: Any])?["value_type"] as? String ==
+                "boolean"
+        )
+        #expect(
+            (arguments["__peekaboo_trace_unknown_field_2"] as? [String: Any])?["value_type"] as? String ==
+                "integer"
+        )
         #expect(resultSummary["success"] as? Bool == true)
         #expect(entries[0]["mutationDispatch"] as? String == "possibly_dispatched")
         #expect(resultSummary["mutation_dispatched"] == nil)
@@ -116,6 +132,8 @@ struct AgentCommandJSONOutputTests {
         #expect(!text.contains(ordinaryPassword))
         #expect(!text.contains(privateURL))
         #expect(!text.contains("731991"))
+        #expect(!text.contains("custom_boolean"))
+        #expect(!text.contains("custom_number"))
         #expect(!text.contains("AnyAgentToolValue"))
         #expect(!text.contains("unknown context"))
         #expect(!traceText.contains(privateMessage))

--- a/Apps/CLI/Tests/CoreCLITests/AgentCommandJSONOutputTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/AgentCommandJSONOutputTests.swift
@@ -105,7 +105,7 @@ struct AgentCommandJSONOutputTests {
         #expect(entries[0]["mutationDispatch"] as? String == "possibly_dispatched")
         #expect(resultSummary["mutation_dispatched"] == nil)
         #expect(resultSummary["mutation_dispatch"] as? String == "possibly_dispatched")
-        #expect(resultSummary["retry_safe"] == nil)
+        #expect(resultSummary["retry_safe"] as? Bool == false)
         #expect(resultSummary["payload_omitted"] as? Bool == true)
         #expect(trace["totalCallCount"] as? Int == 1)
         #expect(trace["truncated"] as? Bool == false)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Bind signed `set-value` results to the opaque requested element and refuse older Bridge hosts before dispatch.
 - Preserve verified process-generation receipts for background AX-only reads when an app has no actionable WindowServer window, while keeping window mutations exact-window-only.
 - Keep verified non-modal SwiftUI windows eligible for exact background mutation, retain fail-closed file-dialog classification, and recognize `inspect_ui` as fresh Agent perception.
+- Keep legacy Agent JSON tool-call arguments privacy-safe and deterministic instead of exposing Swift implementation details and runtime addresses.
 
 ## [4.2.2] - 2026-08-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Keep verified non-modal SwiftUI windows eligible for exact background mutation, retain fail-closed file-dialog classification, and recognize `inspect_ui` as fresh Agent perception.
 - Keep legacy Agent JSON tool-call arguments privacy-safe and deterministic instead of exposing Swift implementation details and runtime addresses.
 - Report `retry_safe: false` whenever an Agent trace cannot prove whether a mutation dispatched.
+- Replace arbitrary provider-authored Agent trace field names with deterministic ordinal placeholders at every argument nesting level.
 
 ## [4.2.2] - 2026-08-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Preserve verified process-generation receipts for background AX-only reads when an app has no actionable WindowServer window, while keeping window mutations exact-window-only.
 - Keep verified non-modal SwiftUI windows eligible for exact background mutation, retain fail-closed file-dialog classification, and recognize `inspect_ui` as fresh Agent perception.
 - Keep legacy Agent JSON tool-call arguments privacy-safe and deterministic instead of exposing Swift implementation details and runtime addresses.
+- Report `retry_safe: false` whenever an Agent trace cannot prove whether a mutation dispatched.
 
 ## [4.2.2] - 2026-08-20
 

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/Agent/AgentExecutionTrace.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/Agent/AgentExecutionTrace.swift
@@ -354,6 +354,9 @@ private enum AgentExecutionTraceSanitizer {
                 object["retry_safe"] = AnyAgentToolValue(bool: actionOutcome.retrySafe)
             }
         }
+        if mutationDispatch == .possiblyDispatched {
+            object["retry_safe"] = AnyAgentToolValue(bool: false)
+        }
         if let mutationDispatch {
             object["mutation_dispatch"] = AnyAgentToolValue(string: mutationDispatch.rawValue)
         }

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/Agent/AgentExecutionTrace.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/Agent/AgentExecutionTrace.swift
@@ -300,6 +300,141 @@ private enum AgentExecutionTraceSanitizer {
         "success",
     ]
 
+    private struct ArgumentFieldPolicy: OptionSet {
+        let rawValue: UInt8
+
+        static let boolean = Self(rawValue: 1 << 0)
+        static let number = Self(rawValue: 1 << 1)
+        static let string = Self(rawValue: 1 << 2)
+        static let container = Self(rawValue: 1 << 3)
+    }
+
+    private struct ArgumentField {
+        let key: String
+        let policy: ArgumentFieldPolicy
+    }
+
+    /// Closed field-name policy for provider-authored arguments. An empty policy preserves a known
+    /// content-bearing field name while redacting every value type. Unknown names never reach output.
+    private static let argumentFieldPolicies: [String: ArgumentFieldPolicy] = [
+        "action": .string,
+        "amount": .number,
+        "api_key": [],
+        "app": .string,
+        "app_target": .string,
+        "background": .boolean,
+        "base64": [],
+        "blob": [],
+        "bounds": .container,
+        "bundle": .string,
+        "bundle_id": .string,
+        "bundle_identifier": .string,
+        "button": [],
+        "bytes": [],
+        "capture_engine": .string,
+        "clear": .boolean,
+        "command": [],
+        "coordinates": .container,
+        "coords": [.number, .container],
+        "data": [],
+        "dataBase64": [],
+        "data_base64": [],
+        "delay": .number,
+        "delivery_mode": .string,
+        "direction": .string,
+        "display_index": .number,
+        "double": .boolean,
+        "duration": .number,
+        "element": .string,
+        "element_id": [.number, .string],
+        "engine": .string,
+        "expected": .boolean,
+        "expected_value": [],
+        "field": [],
+        "file": [],
+        "filePath": [],
+        "file_path": [],
+        "filename": [],
+        "final_screenshot": .boolean,
+        "foreground": .boolean,
+        "format": .string,
+        "from": .container,
+        "height": .number,
+        "identifier": .string,
+        "image": [],
+        "imagePath": [],
+        "image_data": [],
+        "image_path": [],
+        "index": .number,
+        "item_type": .string,
+        "keys": [],
+        "kind": .string,
+        "label": [],
+        "message": [],
+        "mode": .string,
+        "modifiers": [],
+        "name": .string,
+        "on": .string,
+        "open": [],
+        "openTargets": [],
+        "open_target": [],
+        "open_targets": [],
+        "operator": .string,
+        "outputPath": [],
+        "output_path": [],
+        "path": [],
+        "pid": .number,
+        "position": .container,
+        "predicate": .string,
+        "predicate_kind": .string,
+        "predicates": .container,
+        "press_return": .boolean,
+        "process_id": .number,
+        "prompt": [],
+        "promptText": [],
+        "prompt_text": [],
+        "query": [],
+        "question": [],
+        "region": [],
+        "requestFilePath": [],
+        "request_file_path": [],
+        "responseFilePath": [],
+        "response_file_path": [],
+        "right": .boolean,
+        "roi": [],
+        "role": .string,
+        "screen_index": .number,
+        "screenshot": [],
+        "screenshot_data": [],
+        "selector": .container,
+        "shell": [],
+        "smooth": .boolean,
+        "snapshot": .string,
+        "snapshot_id": [.number, .string],
+        "space_id": .number,
+        "stable_samples": .number,
+        "steps": .number,
+        "target": [],
+        "target_pid": .number,
+        "task": [],
+        "text": [],
+        "timeout": .number,
+        "timeout_ms": .number,
+        "title": [],
+        "to": [.number, .container],
+        "tolerance": .number,
+        "type": .string,
+        "url": [],
+        "value": [],
+        "video_out": [],
+        "web_focus": .boolean,
+        "width": .number,
+        "window_id": .number,
+        "window_title": [],
+        "x": .number,
+        "y": .number,
+    ]
+
     private struct Budget {
         var remainingNodes = AgentExecutionTraceSanitizer.maximumNodes
         var remainingStringScalars = AgentExecutionTraceSanitizer.maximumTotalStringScalars
@@ -487,12 +622,20 @@ private enum AgentExecutionTraceSanitizer {
     {
         var sanitized: [String: AnyAgentToolValue] = [:]
         let keys = object.keys.sorted()
-        for (index, key) in keys.prefix(self.maximumContainerItems).enumerated() {
+        var unknownFieldOrdinal = 0
+        for key in keys.prefix(self.maximumContainerItems) {
             guard let value = object[key] else { continue }
-            let outputKey = self.sanitizedObjectKey(key, index: index, existingKeys: Set(sanitized.keys))
+            let policy = self.argumentFieldPolicy(for: key, toolName: toolName)
+            let outputKey: String
+            if policy == nil {
+                unknownFieldOrdinal += 1
+                outputKey = "__peekaboo_trace_unknown_field_\(unknownFieldOrdinal)"
+            } else {
+                outputKey = key
+            }
             sanitized[outputKey] = self.sanitizeArgument(
                 value,
-                key: key,
+                field: ArgumentField(key: key, policy: policy ?? []),
                 toolName: toolName,
                 depth: depth + 1,
                 budget: &budget)
@@ -506,7 +649,7 @@ private enum AgentExecutionTraceSanitizer {
 
     private static func sanitizeArgument(
         _ value: AnyAgentToolValue,
-        key: String,
+        field: ArgumentField,
         toolName: String,
         depth: Int,
         budget: inout Budget) -> AnyAgentToolValue
@@ -524,31 +667,31 @@ private enum AgentExecutionTraceSanitizer {
             return AnyAgentToolValue(null: ())
         }
         if let bool = value.boolValue {
-            guard self.allowsBoolean(key, toolName: toolName) else {
+            guard field.policy.contains(.boolean) else {
                 return self.redactedSummary(value)
             }
             return AnyAgentToolValue(bool: bool)
         }
         if let int = value.intValue {
-            guard self.allowsNumber(key, toolName: toolName) else {
+            guard field.policy.contains(.number) else {
                 return self.redactedSummary(value)
             }
             return AnyAgentToolValue(int: int)
         }
         if let double = value.doubleValue {
-            guard self.allowsNumber(key, toolName: toolName) else {
+            guard field.policy.contains(.number) else {
                 return self.redactedSummary(value)
             }
             return AnyAgentToolValue(double: double)
         }
         if let string = value.stringValue {
-            guard self.allowsString(key, toolName: toolName) else {
+            guard field.policy.contains(.string) else {
                 return self.redactedSummary(value)
             }
-            return AnyAgentToolValue(string: self.sanitizedString(string, key: key, budget: &budget))
+            return AnyAgentToolValue(string: self.sanitizedString(string, key: field.key, budget: &budget))
         }
         if let array = value.arrayValue {
-            guard self.allowsContainer(key, toolName: toolName) else {
+            guard field.policy.contains(.container) else {
                 return self.redactedSummary(value)
             }
             var sanitized = array.prefix(self.maximumContainerItems).map { item in
@@ -561,7 +704,7 @@ private enum AgentExecutionTraceSanitizer {
                 }
                 return self.sanitizeArgument(
                     item,
-                    key: key,
+                    field: field,
                     toolName: toolName,
                     depth: depth + 1,
                     budget: &budget)
@@ -573,7 +716,7 @@ private enum AgentExecutionTraceSanitizer {
             return AnyAgentToolValue(array: sanitized)
         }
         if let object = value.objectValue {
-            guard self.allowsContainer(key, toolName: toolName) else {
+            guard field.policy.contains(.container) else {
                 return self.redactedSummary(value)
             }
             return AnyAgentToolValue(object: self.sanitizedObject(
@@ -613,108 +756,15 @@ private enum AgentExecutionTraceSanitizer {
         return AnyAgentToolValue(object: summary)
     }
 
-    private static func allowsString(_ key: String, toolName: String) -> Bool {
-        let key = self.normalizedKey(key)
-        let auditStrings: Set = [
-            "action",
-            "app",
-            "app_target",
-            "bundle",
-            "bundle_id",
-            "bundle_identifier",
-            "capture_engine",
-            "delivery_mode",
-            "direction",
-            "element",
-            "element_id",
-            "engine",
-            "format",
-            "identifier",
-            "item_type",
-            "kind",
-            "mode",
-            "on",
-            "operator",
-            "predicate",
-            "predicate_kind",
-            "role",
-            "snapshot",
-            "snapshot_id",
-            "type",
-        ]
-        if auditStrings.contains(key) {
-            return true
+    private static func argumentFieldPolicy(
+        for key: String,
+        toolName: String) -> ArgumentFieldPolicy?
+    {
+        guard var policy = self.argumentFieldPolicies[key] else { return nil }
+        if key == "name", toolName.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() != "app" {
+            policy.remove(.string)
         }
-        return key == "name" && self.normalizedKey(toolName) == "app"
-    }
-
-    private static func allowsNumber(_ key: String, toolName _: String) -> Bool {
-        let key = self.normalizedKey(key)
-        let auditNumbers: Set = [
-            "amount",
-            "coords",
-            "delay",
-            "display_index",
-            "duration",
-            "element_id",
-            "height",
-            "index",
-            "pid",
-            "process_id",
-            "screen_index",
-            "snapshot_id",
-            "space_id",
-            "stable_samples",
-            "steps",
-            "target_pid",
-            "timeout",
-            "timeout_ms",
-            "tolerance",
-            "to",
-            "width",
-            "window_id",
-            "x",
-            "y",
-        ]
-        return auditNumbers.contains(key) || key.hasSuffix("_timeout") || key.hasSuffix("_timeout_ms")
-    }
-
-    private static func allowsBoolean(_ key: String, toolName _: String) -> Bool {
-        let key = self.normalizedKey(key)
-        let auditBooleans: Set = [
-            "background",
-            "clear",
-            "double",
-            "expected",
-            "final_screenshot",
-            "foreground",
-            "press_return",
-            "right",
-            "smooth",
-            "web_focus",
-        ]
-        return auditBooleans.contains(key)
-    }
-
-    private static func allowsContainer(_ key: String, toolName _: String) -> Bool {
-        let key = self.normalizedKey(key)
-        return [
-            "bounds",
-            "coordinates",
-            "coords",
-            "from",
-            "position",
-            "predicates",
-            "selector",
-            "to",
-        ].contains(key)
-    }
-
-    private static func normalizedKey(_ key: String) -> String {
-        key
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-            .replacingOccurrences(of: "-", with: "_")
-            .lowercased()
+        return policy
     }
 
     private static func sanitizedString(_ value: String, key: String?, budget: inout Budget) -> String {
@@ -738,17 +788,6 @@ private enum AgentExecutionTraceSanitizer {
         budget.remainingStringScalars -= prefix.count
         let sanitized = String(prefix)
         return prefix.count < scalars.count ? sanitized + "…" : sanitized
-    }
-
-    private static func sanitizedObjectKey(_ key: String, index: Int, existingKeys: Set<String>) -> String {
-        let base: String
-        if self.containsSecret(key) || self.looksLikeLocalPath(key) || self.looksLikeBinaryPayload(key) {
-            base = "__peekaboo_trace_redacted_key"
-        } else {
-            let prefix = key.unicodeScalars.prefix(self.maximumStringScalars)
-            base = String(prefix) + (prefix.count < key.unicodeScalars.count ? "…" : "")
-        }
-        return existingKeys.contains(base) ? "\(base)_\(index)" : base
     }
 
     private static func isSensitiveKey(_ key: String) -> Bool {

--- a/Core/PeekabooCore/Tests/PeekabooAgentRuntimeTests/AgentExecutionTraceTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooAgentRuntimeTests/AgentExecutionTraceTests.swift
@@ -302,13 +302,14 @@ struct AgentExecutionTraceTests {
         #expect(arguments["mode"] as? String == "background")
         #expect(arguments["snapshot"] as? String == "snapshot-123")
         #expect(arguments["window_id"] as? Int == 42)
-        for key in [
-            "api_key", "path", "image", "text", "value", "url", "query", "custom_string",
-            "custom_number", "custom_boolean", "custom_array",
-        ] {
+        for key in ["api_key", "path", "image", "text", "value", "url", "query"] {
             #expect((arguments[key] as? [String: Any])?["redacted"] as? Bool == true)
         }
-        #expect((arguments["custom_array"] as? [String: Any])?["item_count"] as? Int == 2)
+        let unknownFields = (1...4).map { arguments["__peekaboo_trace_unknown_field_\($0)"] }
+        #expect((unknownFields[0] as? [String: Any])?["item_count"] as? Int == 2)
+        #expect((unknownFields[1] as? [String: Any])?["value_type"] as? String == "boolean")
+        #expect((unknownFields[2] as? [String: Any])?["value_type"] as? String == "integer")
+        #expect((unknownFields[3] as? [String: Any])?["value_type"] as? String == "string")
         #expect(predicates[0]["kind"] as? String == "element_value")
         #expect(predicates[0]["expected"] as? Bool == true)
         #expect((predicates[0]["expected_value"] as? [String: Any])?["redacted"] as? Bool == true)
@@ -327,6 +328,9 @@ struct AgentExecutionTraceTests {
         #expect(!text.contains("ordinary unclassified private value"))
         #expect(!text.contains("731991"))
         #expect(!text.contains("Private diary entry"))
+        for key in ["custom_array", "custom_boolean", "custom_number", "custom_string"] {
+            #expect(!text.contains(key))
+        }
 
         let fullTraceData = try JSONEncoder().encode(result.executionTrace())
         let fullTrace = try #require(JSONSerialization.jsonObject(with: fullTraceData) as? [String: Any])
@@ -334,6 +338,86 @@ struct AgentExecutionTraceTests {
         #expect(fullEntries[1]["disposition"] as? String == "missing-result")
         #expect(fullEntries[1]["isError"] is NSNull)
         #expect(fullEntries[1]["result"] is NSNull)
+    }
+
+    @Test
+    func `Trace replaces arbitrary field names with stable ordinals at every object depth`() throws {
+        let topStringKey = "alpha meet me behind the greenhouse at eleven"
+        let topNumberKey = "beta violet elephant porch"
+        let nestedStringKey = "alpha https private example invite"
+        let nestedBooleanKey = "beta private diary toggle"
+        let privateString = "top-level provider content must not survive"
+        let nestedPrivateString = "nested provider content must not survive"
+
+        let selectorForward = AnyAgentToolValue(object: [
+            "identifier": AnyAgentToolValue(string: "basic-text-field"),
+            nestedStringKey: AnyAgentToolValue(string: nestedPrivateString),
+            nestedBooleanKey: AnyAgentToolValue(bool: true),
+        ])
+        var selectorReverseObject: [String: AnyAgentToolValue] = [:]
+        selectorReverseObject[nestedBooleanKey] = AnyAgentToolValue(bool: true)
+        selectorReverseObject[nestedStringKey] = AnyAgentToolValue(string: nestedPrivateString)
+        selectorReverseObject["identifier"] = AnyAgentToolValue(string: "basic-text-field")
+
+        var forward: [String: AnyAgentToolValue] = [:]
+        forward["app"] = AnyAgentToolValue(string: "TextEdit")
+        forward[topStringKey] = AnyAgentToolValue(string: privateString)
+        forward[topNumberKey] = AnyAgentToolValue(int: 731_991)
+        forward["selector"] = selectorForward
+        forward["window_id"] = AnyAgentToolValue(int: 42)
+        var reverse: [String: AnyAgentToolValue] = [:]
+        reverse["window_id"] = AnyAgentToolValue(int: 42)
+        reverse["selector"] = AnyAgentToolValue(object: selectorReverseObject)
+        reverse[topNumberKey] = AnyAgentToolValue(int: 731_991)
+        reverse[topStringKey] = AnyAgentToolValue(string: privateString)
+        reverse["app"] = AnyAgentToolValue(string: "TextEdit")
+
+        let calls = [
+            AgentToolCall(id: "preserved-forward", name: "verify_state", arguments: forward),
+            AgentToolCall(id: "preserved-reverse", name: "verify_state", arguments: reverse),
+        ]
+        let result = AgentExecutionResult(
+            content: "",
+            messages: [ModelMessage(role: .assistant, content: calls.map(ModelMessage.ContentPart.toolCall))],
+            metadata: AgentMetadata(
+                executionTime: 0,
+                toolCallCount: calls.count,
+                modelName: "test",
+                startTime: Date(),
+                endTime: Date()))
+
+        let trace = result.executionTrace()
+        let first = try #require(trace.entries.first)
+        let second = try #require(trace.entries.last)
+        let selector = try #require(first.arguments["selector"]?.objectValue)
+        let data = try JSONEncoder().encode(trace)
+        let text = try #require(String(data: data, encoding: .utf8))
+
+        #expect(first.id == "preserved-forward")
+        #expect(second.id == "preserved-reverse")
+        #expect(first.name == "verify_state")
+        #expect(second.name == "verify_state")
+        #expect(first.arguments == second.arguments)
+        #expect(first.arguments["app"]?.stringValue == "TextEdit")
+        #expect(first.arguments["window_id"]?.intValue == 42)
+        #expect(first.arguments["__peekaboo_trace_unknown_field_1"]?.objectValue?["value_type"]?.stringValue ==
+            "string")
+        #expect(first.arguments["__peekaboo_trace_unknown_field_2"]?.objectValue?["value_type"]?.stringValue ==
+            "integer")
+        #expect(selector["identifier"]?.stringValue == "basic-text-field")
+        #expect(selector["__peekaboo_trace_unknown_field_1"]?.objectValue?["value_type"]?.stringValue == "string")
+        #expect(selector["__peekaboo_trace_unknown_field_2"]?.objectValue?["value_type"]?.stringValue == "boolean")
+        for privateContent in [
+            topStringKey,
+            topNumberKey,
+            nestedStringKey,
+            nestedBooleanKey,
+            privateString,
+            nestedPrivateString,
+            "731991",
+        ] {
+            #expect(!text.contains(privateContent))
+        }
     }
 }
 

--- a/Core/PeekabooCore/Tests/PeekabooAgentRuntimeTests/AgentExecutionTraceTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooAgentRuntimeTests/AgentExecutionTraceTests.swift
@@ -84,7 +84,7 @@ struct AgentExecutionTraceTests {
         #expect(trace.entries[1].mutationDispatch == .possiblyDispatched)
         #expect(trace.entries[1].result?.objectValue?["mutation_dispatched"] == nil)
         #expect(trace.entries[1].result?.objectValue?["mutation_dispatch"]?.stringValue == "possibly_dispatched")
-        #expect(trace.entries[1].result?.objectValue?["retry_safe"] == nil)
+        #expect(trace.entries[1].result?.objectValue?["retry_safe"]?.boolValue == false)
         #expect(trace.entries[2].result?.objectValue?["skipped"]?.boolValue == true)
         #expect(trace.entries[2].result?.objectValue?["mutation_dispatched"]?.boolValue == false)
         #expect(trace.entries[2].mutationDispatch == .notDispatched)
@@ -92,6 +92,7 @@ struct AgentExecutionTraceTests {
         #expect(trace.entries[4].result?.objectValue?["mutation_dispatched"]?.boolValue == false)
         #expect(trace.entries[6].mutationDispatch == .possiblyDispatched)
         #expect(trace.entries[6].result?.objectValue?["mutation_dispatched"] == nil)
+        #expect(trace.entries[6].result?.objectValue?["retry_safe"]?.boolValue == false)
         #expect(!trace.truncated)
         #expect(trace.totalCallCount == 7)
     }

--- a/Core/PeekabooCore/Tests/PeekabooTests/AgentToolMCPBridgeTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/AgentToolMCPBridgeTests.swift
@@ -180,7 +180,7 @@ struct AgentToolMCPBridgeTests {
         #expect(traceEntry.mutationDispatch == .possiblyDispatched)
         #expect(traceEntry.result?.objectValue?["mutation_dispatched"] == nil)
         #expect(traceEntry.result?.objectValue?["mutation_dispatch"]?.stringValue == "possibly_dispatched")
-        #expect(traceEntry.result?.objectValue?["retry_safe"] == nil)
+        #expect(traceEntry.result?.objectValue?["retry_safe"]?.boolValue == false)
     }
 
     @Test

--- a/Core/PeekabooCore/Tests/PeekabooTests/AgentToolMCPFailureSemanticsTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/AgentToolMCPFailureSemanticsTests.swift
@@ -115,7 +115,7 @@ struct AgentToolMCPFailureSemanticsTests {
         #expect(AgentToolResultSemantics.actionOutcome(from: conflict) == nil)
         #expect(conflictEntry.disposition == .executedFailed)
         #expect(conflictEntry.mutationDispatch == .possiblyDispatched)
-        #expect(conflictEntry.result?.objectValue?["retry_safe"] == nil)
+        #expect(conflictEntry.result?.objectValue?["retry_safe"]?.boolValue == false)
         #expect(!AgentToolResultSemantics.isFailure(identical))
         #expect(AgentToolResultSemantics.actionOutcome(from: identical) == confirmed.projection)
 
@@ -128,7 +128,7 @@ struct AgentToolMCPFailureSemanticsTests {
         #expect(malformedEntry.mutationDispatch == .possiblyDispatched)
         #expect(malformedSummary["mutation_dispatched"] == nil)
         #expect(malformedSummary["requires_fresh_observation"] == nil)
-        #expect(malformedSummary["retry_safe"] == nil)
+        #expect(malformedSummary["retry_safe"]?.boolValue == false)
     }
 
     @Test
@@ -188,7 +188,7 @@ struct AgentToolMCPFailureSemanticsTests {
         #expect(entry.mutationDispatch == .possiblyDispatched)
         #expect(summary["mutation_dispatched"]?.boolValue == true)
         #expect(summary["requires_fresh_observation"]?.boolValue == true)
-        #expect(summary["retry_safe"] == nil)
+        #expect(summary["retry_safe"]?.boolValue == false)
         #expect(summary["success"] == nil)
     }
 
@@ -250,7 +250,7 @@ struct AgentToolMCPFailureSemanticsTests {
         #expect(entry.mutationDispatch == .possiblyDispatched)
         #expect(summary["mutation_dispatched"] == nil)
         #expect(summary["requires_fresh_observation"] == nil)
-        #expect(summary["retry_safe"] == nil)
+        #expect(summary["retry_safe"]?.boolValue == false)
     }
 
     @Test
@@ -382,7 +382,7 @@ struct AgentToolMCPFailureSemanticsTests {
         #expect(disputedCanonicalSkipEntry.actionOutcome == nil)
         #expect(disputedCanonicalSkipEntry.result?.objectValue?["skipped"] == nil)
         #expect(disputedCanonicalSkipEntry.result?.objectValue?["mutation_dispatched"] == nil)
-        #expect(disputedCanonicalSkipEntry.result?.objectValue?["retry_safe"] == nil)
+        #expect(disputedCanonicalSkipEntry.result?.objectValue?["retry_safe"]?.boolValue == false)
     }
 
     @Test
@@ -405,7 +405,11 @@ struct AgentToolMCPFailureSemanticsTests {
             #expect(claims.boolean(key) == .invalid, "Expected conflict for \(key)")
             #expect(AgentToolResultSemantics.isFailure(result))
             #expect(entry.disposition == .executedFailed)
-            #expect(summary[key] == nil, "Trace published disputed \(key)")
+            if key == "retry_safe" {
+                #expect(summary[key]?.boolValue == false, "Trace did not project conservative retry safety")
+            } else {
+                #expect(summary[key] == nil, "Trace published disputed \(key)")
+            }
             #expect(entry.mutationDispatch == .possiblyDispatched)
             if key == "skipped" {
                 #expect(entry.disposition != .skippedBeforeDispatch)
@@ -456,7 +460,7 @@ struct AgentToolMCPFailureSemanticsTests {
         let coupledEntry = try #require(
             Self.execution(call: call, result: coupledConflict).executionTrace().entries.first)
         #expect(coupledEntry.mutationDispatch == .possiblyDispatched)
-        #expect(coupledEntry.result?.objectValue?["retry_safe"] == nil)
+        #expect(coupledEntry.result?.objectValue?["retry_safe"]?.boolValue == false)
     }
 
     @Test
@@ -671,7 +675,7 @@ struct AgentToolMCPFailureSemanticsTests {
         #expect(mutatingEntry.mutationDispatch == .possiblyDispatched)
         #expect(summary["mutation_dispatched"] == nil)
         #expect(summary["requires_fresh_observation"] == nil)
-        #expect(summary["retry_safe"] == nil)
+        #expect(summary["retry_safe"]?.boolValue == false)
         #expect(summary["success"] == nil)
         #expect(summary["mutation_dispatch"]?.stringValue == "possibly_dispatched")
     }

--- a/docs/commands/agent.md
+++ b/docs/commands/agent.md
@@ -91,6 +91,11 @@ read_when:
 four dispositions: `executed/succeeded`, `executed/failed`, `skipped-before-dispatch`, or `missing-result`. This lets a
 validator distinguish a model's attempted calls from mutations Peekaboo actually dispatched.
 
+Legacy `result.toolCalls[].arguments` remains a string for compatibility, but that string is now deterministic JSON
+derived from the same bounded, privacy-safe argument projection as the execution trace. It never contains Swift type
+descriptions or runtime addresses. Calls beyond the trace limit and any call/trace mismatch use
+`{"redacted":true}` rather than raw provider arguments.
+
 `executionTrace.entries[].arguments` is a JSON object rather than the legacy string preview. Trace arguments are
 bounded and allowlist only audit-relevant targeting, delivery modes, action enums, timeouts, predicate kinds, and safe
 boolean controls. Content-bearing and unknown values are represented by typed redaction summaries, including typed or

--- a/docs/commands/agent.md
+++ b/docs/commands/agent.md
@@ -100,7 +100,9 @@ descriptions or runtime addresses. Calls beyond the trace limit and any call/tra
 bounded and allowlist only audit-relevant targeting, delivery modes, action enums, timeouts, predicate kinds, and safe
 boolean controls. Content-bearing and unknown values are represented by typed redaction summaries, including typed or
 pasted text, expected values, messages, prompts, shell commands, URLs, open targets, queries, labels, paths, and binary
-image data. Each `result` is a bounded status summary, not the raw tool payload; screenshot bytes and arbitrary output
+image data. Field names also follow one closed policy at the top level and inside allowed containers; unknown
+provider-authored names become deterministic `__peekaboo_trace_unknown_field_<n>` placeholders in sorted order. Each
+`result` is a bounded status summary, not the raw tool payload; screenshot bytes and arbitrary output
 text are intentionally omitted. The trace is capped at 512 entries and reports `totalCallCount` plus `truncated` when
 calls were omitted.
 


### PR DESCRIPTION
## Summary

- replace legacy Swift debug descriptions in Agent JSON with deterministic JSON from the bounded execution-trace projection
- redact unknown provider-authored argument field names at every object depth using stable ordinal placeholders
- restore explicit `retry_safe: false` whenever a mutation is only known to be possibly dispatched

## Why

A physical two-app Agent proof exposed implementation details and content-bearing provider arguments in `result.toolCalls[].arguments`, including Swift storage descriptions, runtime context text, addresses, and unstable dictionary ordering. The same run also showed that trace projection had stopped publishing the conservative retry verdict for uncertain mutation dispatch. This keeps the legacy public string type while making its contents deterministic, bounded, and privacy-safe, and restores the documented fail-closed retry semantics.

## Validation

- focused Agent runtime tests (6/6)
- focused CLI JSON tests (3/3)
- `pnpm run test:safe`
- SwiftFormat and SwiftLint (zero serious violations)
- `pnpm run lint:docs`
- `git diff --check`
- P2 Autoreview: no actionable findings
- Developer-ID-signed read-only Calendar probe: legacy arguments parsed as deterministic JSON with no Swift storage/context text
