### PR TITLE
refactor(bridge): centralize request planning

### DIFF
--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeClient+Transport.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeClient+Transport.swift
@@ -30,13 +30,17 @@ extension PeekabooBridgeClient {
         -> PeekabooBridgeTransportReply
     {
         try self.requireNegotiatedInputCapabilities(for: request)
+        let plan = PeekabooBridgeOperationResultSemantics.requestPlan(
+            for: request,
+            vocabulary: self.actionProjectionEnabled ? .current : .legacy)
+        let mayMutateDesktop = plan.result.completion.mutatesDesktop
         let explicitlyProjected = if case .projectedAction = request {
             true
         } else {
             false
         }
         let expectsProjectedResponse = explicitlyProjected ||
-            (automaticallyProjectsActions && self.actionProjectionEnabled && request.mayMutateDesktop)
+            (automaticallyProjectsActions && self.actionProjectionEnabled && mayMutateDesktop)
         let projectedRequest = expectsProjectedResponse && !explicitlyProjected
             ? PeekabooBridgeRequest.projectedAction(.init(request: request))
             : request
@@ -53,16 +57,16 @@ extension PeekabooBridgeClient {
         while true {
             let preparedRequest = try await self.prepareWireRequestForSend(
                 projectedRequest,
-                originalRequest: request,
+                plan: plan,
                 operation: op,
                 deadline: deadline,
                 operationReceiptRequirement: operationReceiptRequirement)
             try self.checkCancellationBeforeTransport(
-                request: request,
+                plan: plan,
                 preparedRequest: preparedRequest)
             let verified = try await self.exchange(
                 preparedRequest,
-                originalRequest: request,
+                plan: plan,
                 deadline: deadline)
             switch verified {
             case let .terminal(verifiedWireResponse, bundle, connectedHost):
@@ -94,7 +98,7 @@ extension PeekabooBridgeClient {
                     verifiedWireResponse,
                     expectsProjectedResponse: expectsProjectedResponse,
                     hasVerifiedOperationReceipt: bundle != nil,
-                    request: request)
+                    plan: plan)
                 let reply = PeekabooBridgeTransportReply(
                     response: unwrappedReply.response,
                     outcome: unwrappedReply.outcome,
@@ -105,7 +109,7 @@ extension PeekabooBridgeClient {
                     operationReceiptBundle: bundle)
                 let response = reply.response
                 if case let .error(envelope) = response,
-                   request.mayMutateDesktop,
+                   mayMutateDesktop,
                    throwsActionFailures
                 {
                     if let failure = envelope.desktopActionFailure {
@@ -130,7 +134,7 @@ extension PeekabooBridgeClient {
                     self.invalidateOperationSession(for: context)
                     try Self.throwVerifiedRolloverUnavailable(
                         operation: op,
-                        mutating: request.mayMutateDesktop)
+                        mutating: mayMutateDesktop)
                 }
                 do {
                     try self.installOperationSession(
@@ -141,16 +145,16 @@ extension PeekabooBridgeClient {
                 } catch {
                     try Self.throwVerifiedRolloverInstallationFailure(
                         operation: op,
-                        mutating: request.mayMutateDesktop,
+                        mutating: mayMutateDesktop,
                         cause: error)
                 }
                 guard rolloverRetryCount == 0 else {
-                    try Self.throwRepeatedRolloverRefusal(operation: op, mutating: request.mayMutateDesktop)
+                    try Self.throwRepeatedRolloverRefusal(operation: op, mutating: mayMutateDesktop)
                 }
                 rolloverRetryCount += 1
                 try Self.checkCancellationBeforeRolloverRetry(
                     operation: op,
-                    mutating: request.mayMutateDesktop)
+                    mutating: mayMutateDesktop)
             }
         }
     }
@@ -163,12 +167,13 @@ extension PeekabooBridgeClient {
 
     private func prepareWireRequestForSend(
         _ projectedRequest: PeekabooBridgeRequest,
-        originalRequest: PeekabooBridgeRequest,
+        plan: PeekabooBridgeOperationResultSemantics.PeekabooBridgeRequestPlan,
         operation: PeekabooBridgeOperation,
         deadline: Date,
         operationReceiptRequirement: PeekabooBridgeOperationReceiptRequirement) async throws
         -> PeekabooBridgePreparedRequest
     {
+        let originalRequest = plan.request
         try self.requireNegotiatedInputCapabilities(for: originalRequest)
         let preparedRequest: PeekabooBridgePreparedRequest
         do {
@@ -177,12 +182,12 @@ extension PeekabooBridgeClient {
                 throw PeekabooBridgeClientOperationSessionError.handshakeRequired
             }
         } catch let cancellation as CancellationError {
-            guard originalRequest.mayMutateDesktop,
+            guard plan.result.completion.mutatesDesktop,
                   !self.usesExplicitReceiptlessTransport()
             else { throw cancellation }
             throw Self.preTransportRequestCancelledFailure(operation: operation)
         } catch {
-            guard originalRequest.mayMutateDesktop else { throw error }
+            guard plan.result.completion.mutatesDesktop else { throw error }
             throw Self.preTransportSessionUnavailableFailure(operation: operation, cause: error)
         }
         try self.requireNegotiatedInputCapabilities(for: originalRequest)
@@ -260,25 +265,26 @@ extension PeekabooBridgeClient {
     }
 
     private func checkCancellationBeforeTransport(
-        request: PeekabooBridgeRequest,
+        plan: PeekabooBridgeOperationResultSemantics.PeekabooBridgeRequestPlan,
         preparedRequest: PeekabooBridgePreparedRequest) throws
     {
         do {
             try Task.checkCancellation()
         } catch let cancellation as CancellationError {
             self.invalidateOperationSession(for: preparedRequest.context)
-            guard request.mayMutateDesktop,
+            guard plan.result.completion.mutatesDesktop,
                   preparedRequest.context != nil
             else { throw cancellation }
-            throw Self.preTransportRequestCancelledFailure(operation: request.operation)
+            throw Self.preTransportRequestCancelledFailure(operation: plan.operation)
         }
     }
 
     private func exchange(
         _ preparedRequest: PeekabooBridgePreparedRequest,
-        originalRequest: PeekabooBridgeRequest,
+        plan: PeekabooBridgeOperationResultSemantics.PeekabooBridgeRequestPlan,
         deadline: Date) async throws -> PeekabooBridgeVerifiedResponse
     {
+        let originalRequest = plan.request
         let attestedContext = preparedRequest.context
         let payload: Data
         do {
@@ -335,7 +341,7 @@ extension PeekabooBridgeClient {
             self.invalidateOperationSession(for: attestedContext)
             self.invalidateReceiptlessAuthenticatedHost(
                 reservation: preparedRequest.receiptlessHostReservation)
-            guard originalRequest.mayMutateDesktop else {
+            guard plan.result.completion.mutatesDesktop else {
                 throw failure.underlying
             }
             throw Self.responseLostFailure(
@@ -347,12 +353,12 @@ extension PeekabooBridgeClient {
             self.invalidateReceiptlessAuthenticatedHost(
                 reservation: preparedRequest.receiptlessHostReservation)
             if error is CancellationError,
-               originalRequest.mayMutateDesktop,
+               plan.result.completion.mutatesDesktop,
                attestedContext != nil
             {
                 throw Self.preTransportRequestCancelledFailure(operation: op)
             }
-            if originalRequest.mayMutateDesktop,
+            if plan.result.completion.mutatesDesktop,
                attestedContext != nil || preparedRequest.receiptlessHostReservation != nil
             {
                 throw Self.preTransportSessionUnavailableFailure(operation: op, cause: error)
@@ -374,7 +380,7 @@ extension PeekabooBridgeClient {
             self.invalidateOperationSession(for: attestedContext)
             self.invalidateReceiptlessAuthenticatedHost(
                 reservation: preparedRequest.receiptlessHostReservation)
-            guard originalRequest.mayMutateDesktop else {
+            guard plan.result.completion.mutatesDesktop else {
                 throw PeekabooBridgeErrorEnvelope(
                     code: .internalError,
                     message: "Bridge host returned no response",
@@ -393,7 +399,7 @@ extension PeekabooBridgeClient {
             self.invalidateOperationSession(for: attestedContext)
             self.invalidateReceiptlessAuthenticatedHost(
                 reservation: preparedRequest.receiptlessHostReservation)
-            guard originalRequest.mayMutateDesktop else {
+            guard plan.result.completion.mutatesDesktop else {
                 throw PeekabooBridgeErrorEnvelope(
                     code: .decodingFailed,
                     message: "Bridge host returned an invalid response",
@@ -423,7 +429,7 @@ extension PeekabooBridgeClient {
             }
             self.invalidateReceiptlessAuthenticatedHost(
                 reservation: preparedRequest.receiptlessHostReservation)
-            guard originalRequest.mayMutateDesktop else { throw error }
+            guard plan.result.completion.mutatesDesktop else { throw error }
             throw Self.responseLostFailure(
                 operation: op,
                 causeDescription: "Bridge operation receipt validation failed: \(error.localizedDescription)",
@@ -515,14 +521,16 @@ extension PeekabooBridgeClient {
         _ response: PeekabooBridgeResponse,
         expectsProjectedResponse: Bool,
         hasVerifiedOperationReceipt: Bool,
-        request: PeekabooBridgeRequest) throws -> PeekabooBridgeTransportReply
+        plan: PeekabooBridgeOperationResultSemantics.PeekabooBridgeRequestPlan) throws
+        -> PeekabooBridgeTransportReply
     {
+        let request = plan.request
         let needsStandaloneReceiptlessFamilyValidation = if case let .projectedAction(projected) = response {
             projected.outcome == nil
         } else {
             true
         }
-        if request.mayMutateDesktop,
+        if plan.result.completion.mutatesDesktop,
            !hasVerifiedOperationReceipt,
            needsStandaloneReceiptlessFamilyValidation
         {
@@ -533,7 +541,7 @@ extension PeekabooBridgeClient {
             }
             guard PeekabooBridgeOperationResultSemantics.responseMatchesContract(
                 semanticResponse,
-                request: request)
+                plan: plan)
             else {
                 throw Self.responseLostFailure(
                     operation: request.operation,
@@ -559,7 +567,7 @@ extension PeekabooBridgeClient {
                     causeDescription: "Bridge action response and error envelope carried contradictory outcomes")
             }
             if payload.outcome != nil, !hasVerifiedOperationReceipt {
-                try Self.validateReceiptlessProjectedResponse(payload, request: request)
+                try Self.validateReceiptlessProjectedResponse(payload, plan: plan)
             }
             return PeekabooBridgeTransportReply(
                 response: payload.response,
@@ -569,7 +577,7 @@ extension PeekabooBridgeClient {
         guard case .projectedAction = response else {
             return PeekabooBridgeTransportReply(response: response, outcome: nil)
         }
-        if request.mayMutateDesktop {
+        if plan.result.completion.mutatesDesktop {
             throw self.responseLostFailure(
                 operation: request.operation,
                 causeDescription: "Bridge host returned unrequested action projection carriage")
@@ -581,13 +589,14 @@ extension PeekabooBridgeClient {
 
     private nonisolated static func validateReceiptlessProjectedResponse(
         _ projected: PeekabooBridgeProjectedActionResponse,
-        request: PeekabooBridgeRequest) throws
+        plan: PeekabooBridgeOperationResultSemantics.PeekabooBridgeRequestPlan) throws
     {
+        let request = plan.request
         guard let projection = projected.outcome else { return }
         let outcome = projection.outcome
         guard PeekabooBridgeOperationResultSemantics.responseMatchesContract(
             projected.response,
-            request: request)
+            plan: plan)
         else {
             try Self.throwReceiptlessProjectionMismatch(
                 request: request,
@@ -599,21 +608,21 @@ extension PeekabooBridgeClient {
             projection == envelope.actionOutcome &&
                 PeekabooBridgeOperationResultSemantics.failureOutcomeMatchesContract(
                     outcome,
-                    request: request)
+                    plan: plan)
         case let .browserToolResponse(browserResponse):
             Self.receiptlessBrowserProjectionMatches(
                 browserResponse,
                 projection: projection,
-                request: request)
+                plan: plan)
         default:
             PeekabooBridgeOperationResultSemantics.successfulOutcomeMatchesContract(
                 outcome,
                 response: projected.response,
-                request: request) ||
+                plan: plan) ||
                 PeekabooBridgeOperationResultSemantics.nonErrorResponseAllowsFailureOutcome(
                     projected.response,
                     outcome: outcome,
-                    request: request)
+                    plan: plan)
         }
         guard outcomeMatches else {
             try Self.throwReceiptlessProjectionMismatch(
@@ -627,7 +636,7 @@ extension PeekabooBridgeClient {
         else { return }
         do {
             try Self.validateReceiptlessProjectedTarget(
-                request: request,
+                plan: plan,
                 response: wrappedResponse)
         } catch {
             try Self.throwReceiptlessProjectionMismatch(
@@ -637,9 +646,10 @@ extension PeekabooBridgeClient {
     }
 
     private nonisolated static func validateReceiptlessProjectedTarget(
-        request: PeekabooBridgeRequest,
+        plan: PeekabooBridgeOperationResultSemantics.PeekabooBridgeRequestPlan,
         response: PeekabooBridgeResponse) throws
     {
+        let request = plan.request
         switch request {
         case let .activateApplication(payload) where payload.expectedIdentity == nil:
             return
@@ -648,7 +658,7 @@ extension PeekabooBridgeClient {
         default:
             break
         }
-        let policy = PeekabooBridgeOperationResultSemantics.semanticPlan(for: request).contract.targetPolicy
+        let policy = plan.target.policy
         if policy == .external,
            request.operation == .browserExecute
         {
@@ -676,14 +686,14 @@ extension PeekabooBridgeClient {
         }
 
         let resolved = try PeekabooBridgeOperationTargetAttribution.resolve(
-            request: request,
+            plan: plan,
             response: response,
             handledTarget: nil)
         switch policy {
         case .global:
             guard resolved == nil else { throw DesktopTargetIdentityError.incompleteExactWindow }
         case .requestPinned:
-            let requested = try PeekabooBridgeOperationTargetAttribution.resolveRequest(request)
+            let requested = try PeekabooBridgeOperationTargetAttribution.resolveRequest(plan)
             guard requested != nil, resolved == requested else {
                 throw DesktopTargetIdentityError.incompleteExactWindow
             }
@@ -699,8 +709,9 @@ extension PeekabooBridgeClient {
     private nonisolated static func receiptlessBrowserProjectionMatches(
         _ response: PeekabooBridgeBrowserToolResponse,
         projection: DesktopActionOutcome.Projection,
-        request: PeekabooBridgeRequest) -> Bool
+        plan: PeekabooBridgeOperationResultSemantics.PeekabooBridgeRequestPlan) -> Bool
     {
+        let request = plan.request
         guard let browserRequest = request.browserExecutionRequest,
               response.isError == (response.actionFailure != nil)
         else { return false }
@@ -721,7 +732,7 @@ extension PeekabooBridgeClient {
             else { return false }
             return PeekabooBridgeOperationResultSemantics.failureOutcomeMatchesContract(
                 failure.outcome,
-                request: request)
+                plan: plan)
         }
         guard completed >= 0,
               dispatched >= completed,
@@ -735,7 +746,7 @@ extension PeekabooBridgeClient {
             else { return false }
             return PeekabooBridgeOperationResultSemantics.failureOutcomeMatchesContract(
                 failure.outcome,
-                request: request)
+                plan: plan)
         }
         guard let units = DesktopActionOutcome.DispatchUnitCount(dispatched),
               projection.outcome.dispatchState.unitCount == units
@@ -744,14 +755,14 @@ extension PeekabooBridgeClient {
             return failure.outcome.projection == projection &&
                 PeekabooBridgeOperationResultSemantics.failureOutcomeMatchesContract(
                     failure.outcome,
-                    request: request)
+                    plan: plan)
         }
         return completed == callCount &&
             dispatched == callCount &&
             PeekabooBridgeOperationResultSemantics.successfulOutcomeMatchesContract(
                 projection.outcome,
                 response: .browserToolResponse(response),
-                request: request)
+                plan: plan)
     }
 
     private nonisolated static func throwReceiptlessProjectionMismatch(

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeOperationDescriptor.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeOperationDescriptor.swift
@@ -1,0 +1,623 @@
+import Foundation
+import PeekabooFoundation
+
+extension PeekabooBridgeOperationResultSemantics {
+    // The single exhaustive owner for static Bridge operation semantics.
+    // swiftlint:disable:next cyclomatic_complexity function_body_length
+    static func operationDescriptor(for operation: PeekabooBridgeOperation) -> OperationDescriptor {
+        let axForeground = DesktopActionOutcome.Delivery(mechanism: .accessibilityAction, mode: .foreground)
+        let axBackground = DesktopActionOutcome.Delivery(mechanism: .accessibilityAction, mode: .background)
+        let valueBackground = DesktopActionOutcome.Delivery(mechanism: .accessibilityValue, mode: .background)
+        let globalForeground = DesktopActionOutcome.Delivery(mechanism: .globalEvents, mode: .foreground)
+        let processBackground = DesktopActionOutcome.Delivery(mechanism: .processTargetedEvents, mode: .background)
+        let windowBackground = DesktopActionOutcome.Delivery(mechanism: .windowTargetedEvents, mode: .background)
+        let nativeForeground = DesktopActionOutcome.Delivery(mechanism: .nativeFramework, mode: .foreground)
+        let nativeBackground = DesktopActionOutcome.Delivery(mechanism: .nativeFramework, mode: .background)
+        let compositeForeground = DesktopActionOutcome.Delivery(mechanism: .composite, mode: .foreground)
+        let clipboardForeground = DesktopActionOutcome.Delivery(
+            mechanism: .clipboardTransaction,
+            mode: .foreground)
+        let browserForeground = DesktopActionOutcome.Delivery(mechanism: .browserProtocol, mode: .foreground)
+        let browserBackground = DesktopActionOutcome.Delivery(mechanism: .browserProtocol, mode: .background)
+
+        func descriptor(
+            ownership: NativeLaneOwnership = .bridge,
+            read: ReadLanePolicy = .none,
+            pinnedWindow: PinnedWindowPolicy = .unavailable,
+            typedResponse: TypedResponseBinding = .familyOnly,
+            completion: Completion,
+            targetPolicy: TargetPolicy,
+            responseFamilies: Set<ResponseFamily>,
+            responseTargetEvidence: ResponseTargetEvidenceSource = .none) -> OperationDescriptor
+        {
+            OperationDescriptor(
+                operation: operation,
+                lane: .init(nativeOwnership: ownership, readPolicy: read),
+                pinnedWindow: pinnedWindow,
+                typedResponse: typedResponse,
+                windowResponseProof: typedResponse == .postMutationWindow ? .postMutationState : .none,
+                contract: .init(completion: completion, targetPolicy: targetPolicy),
+                responseFamilies: responseFamilies,
+                responseTargetEvidence: responseTargetEvidence)
+        }
+
+        return switch operation {
+        case .permissionsStatus:
+            descriptor(
+                completion: .readOnly,
+                targetPolicy: .notApplicable,
+                responseFamilies: [.permissionsStatus])
+        case .requestPostEventPermission:
+            descriptor(
+                completion: .dispatchedUnverified(nativeForeground),
+                targetPolicy: .global,
+                responseFamilies: [.bool])
+        case .daemonStatus:
+            descriptor(
+                completion: .readOnly,
+                targetPolicy: .notApplicable,
+                responseFamilies: [.daemonStatus])
+        case .daemonStop:
+            descriptor(
+                completion: .readOnly,
+                targetPolicy: .notApplicable,
+                responseFamilies: [.bool])
+        case .agentExecutionTrace:
+            descriptor(
+                typedResponse: .agentExecutionTrace,
+                completion: .externalProcessDispatch(nativeBackground),
+                targetPolicy: .responseResolved,
+                responseFamilies: [.agentExecutionTrace],
+                responseTargetEvidence: .agentProcess)
+        case .observeProcessGeneration:
+            descriptor(
+                typedResponse: .processGenerationObservation,
+                completion: .readOnly,
+                targetPolicy: .notApplicable,
+                responseFamilies: [.processGenerationObservation])
+        case .certificationProducerAttestation:
+            descriptor(
+                typedResponse: .certificationProducerAttestation,
+                completion: .readOnly,
+                targetPolicy: .notApplicable,
+                responseFamilies: [.certificationProducerAttestation])
+        case .browserStatus:
+            descriptor(
+                completion: .readOnly,
+                targetPolicy: .notApplicable,
+                responseFamilies: [.browserStatus])
+        case .browserConnect:
+            descriptor(
+                completion: .dispatchedUnverified(browserForeground),
+                targetPolicy: .external,
+                responseFamilies: [.browserStatus],
+                responseTargetEvidence: .browserConnection)
+        case .browserDisconnect:
+            descriptor(
+                completion: .readOnly,
+                targetPolicy: .notApplicable,
+                responseFamilies: [.ok])
+        case .browserExecute:
+            descriptor(
+                completion: .dispatchedUnverified(browserBackground),
+                targetPolicy: .external,
+                responseFamilies: [.browserToolResponse],
+                responseTargetEvidence: .browserConnection)
+        case .captureScreen, .captureFrontmost, .captureArea:
+            descriptor(
+                read: .globalExclusive,
+                typedResponse: .capture,
+                completion: .requestDependent(mutatesDesktop: false),
+                targetPolicy: .requestDependent,
+                responseFamilies: [.capture],
+                responseTargetEvidence: .capture)
+        case .captureWindow:
+            descriptor(
+                read: .exactTargetOrGlobalExclusive,
+                typedResponse: .capture,
+                completion: .requestDependent(mutatesDesktop: false),
+                targetPolicy: .requestDependent,
+                responseFamilies: [.capture],
+                responseTargetEvidence: .capture)
+        case .detectElements:
+            descriptor(
+                read: .globalExclusive,
+                typedResponse: .elementDetection,
+                completion: .requestDependent(mutatesDesktop: false),
+                targetPolicy: .requestDependent,
+                responseFamilies: [.elementDetection])
+        case .inspectAccessibilityTree:
+            descriptor(
+                read: .exactTargetOrGlobalExclusive,
+                typedResponse: .elementDetection,
+                completion: .requestDependent(mutatesDesktop: false),
+                targetPolicy: .requestDependent,
+                responseFamilies: [.elementDetection],
+                responseTargetEvidence: .inspectWindowContext)
+        case .getFocusedElement:
+            descriptor(
+                read: .globalExclusive,
+                typedResponse: .focusedElement,
+                completion: .readOnly,
+                targetPolicy: .notApplicable,
+                responseFamilies: [.focusedElement])
+        case .desktopObservation:
+            descriptor(
+                ownership: .service,
+                read: .exactTargetOrGlobalExclusive,
+                typedResponse: .desktopObservation,
+                completion: .requestDependent(mutatesDesktop: false),
+                targetPolicy: .requestDependent,
+                responseFamilies: [.desktopObservation],
+                responseTargetEvidence: .desktopObservation)
+        case .click, .type, .scroll:
+            descriptor(
+                ownership: .service,
+                completion: .requestDependent(mutatesDesktop: true),
+                targetPolicy: .requestDependent,
+                responseFamilies: [.ok])
+        case .typeActions:
+            descriptor(
+                ownership: .service,
+                typedResponse: .typeActions,
+                completion: .dispatchedUnverified(globalForeground),
+                targetPolicy: .global,
+                responseFamilies: [.typeResult])
+        case .targetedTypeActions:
+            descriptor(
+                ownership: .service,
+                typedResponse: .typeActions,
+                completion: .dispatchedUnverified(processBackground),
+                targetPolicy: .requestPinned,
+                responseFamilies: [.typeResult])
+        case .exactWindowTargetedTypeActions:
+            descriptor(
+                ownership: .service,
+                typedResponse: .typeActions,
+                completion: .dispatchedUnverified(windowBackground),
+                targetPolicy: .requestPinned,
+                responseFamilies: [.typeResult])
+        case .setValue:
+            descriptor(
+                ownership: .service,
+                typedResponse: .setValue,
+                completion: .dispatchedUnverified(valueBackground),
+                targetPolicy: .handlerRequired,
+                responseFamilies: [.elementActionResult])
+        case .performAction:
+            descriptor(
+                ownership: .service,
+                typedResponse: .performAction,
+                completion: .dispatchedUnverified(axBackground),
+                targetPolicy: .handlerRequired,
+                responseFamilies: [.elementActionResult])
+        case .targetedScroll:
+            descriptor(
+                ownership: .service,
+                completion: .dispatchedUnverified(axBackground),
+                targetPolicy: .handlerRequired,
+                responseFamilies: [.ok])
+        case .hotkey, .swipe, .drag, .moveMouse:
+            descriptor(
+                ownership: .service,
+                completion: .dispatchedUnverified(globalForeground),
+                targetPolicy: .global,
+                responseFamilies: [.ok])
+        case .targetedHotkey:
+            descriptor(
+                ownership: .service,
+                completion: .dispatchedUnverified(processBackground),
+                targetPolicy: .requestPinned,
+                responseFamilies: [.ok])
+        case .exactWindowTargetedHotkey:
+            descriptor(
+                ownership: .service,
+                completion: .dispatchedUnverified(windowBackground),
+                targetPolicy: .requestPinned,
+                responseFamilies: [.ok])
+        case .createExactWindowHeldPointerOwner:
+            descriptor(
+                completion: .readOnly,
+                targetPolicy: .notApplicable,
+                responseFamilies: [.heldPointerOwner])
+        case .beginExactWindowHeldPointer:
+            descriptor(
+                ownership: .service,
+                completion: .dispatchedUnverified(windowBackground),
+                targetPolicy: .requestPinned,
+                responseFamilies: [.heldPointerReceipt])
+        case .releaseExactWindowHeldPointer, .revokeExactWindowHeldPointer:
+            descriptor(
+                ownership: .service,
+                completion: .requestDependent(mutatesDesktop: true),
+                targetPolicy: .requestPinned,
+                responseFamilies: [.heldPointerTermination],
+                responseTargetEvidence: .heldPointerTermination)
+        case .disconnectExactWindowHeldPointerOwner:
+            descriptor(
+                ownership: .service,
+                completion: .requestDependent(mutatesDesktop: true),
+                targetPolicy: .handlerResolvedOrGlobal,
+                responseFamilies: [.heldPointerTermination],
+                responseTargetEvidence: .heldPointerTermination)
+        case .targetedClick, .exactWindowTargetedClick:
+            descriptor(
+                ownership: .service,
+                completion: .dispatchedUnverified(axBackground),
+                targetPolicy: .requestPinned,
+                responseFamilies: [.ok])
+        case .waitForElement:
+            descriptor(
+                read: .globalExclusive,
+                typedResponse: .waitElementSelector,
+                completion: .readOnly,
+                targetPolicy: .notApplicable,
+                responseFamilies: [.waitResult])
+        case .listWindows:
+            descriptor(
+                read: .globalExclusive,
+                completion: .readOnly,
+                targetPolicy: .notApplicable,
+                responseFamilies: [.windows])
+        case .focusWindow:
+            descriptor(
+                ownership: .service,
+                pinnedWindow: .legacyOptionalCurrentRequired,
+                typedResponse: .postMutationWindow,
+                completion: .dispatchedUnverified(compositeForeground),
+                targetPolicy: .requestPinned,
+                responseFamilies: [.ok, .window],
+                responseTargetEvidence: .window)
+        case .moveWindow, .resizeWindow, .setWindowBounds, .minimizeWindow, .restoreWindow, .maximizeWindow:
+            descriptor(
+                ownership: .service,
+                pinnedWindow: .required,
+                typedResponse: .postMutationWindow,
+                completion: .dispatchedUnverified(valueBackground),
+                targetPolicy: .requestPinned,
+                responseFamilies: [.ok, .window],
+                responseTargetEvidence: .window)
+        case .closeWindow:
+            descriptor(
+                ownership: .service,
+                pinnedWindow: .required,
+                typedResponse: .postMutationWindow,
+                completion: .dispatchedUnverified(compositeForeground),
+                targetPolicy: .requestPinned,
+                responseFamilies: [.ok, .window],
+                responseTargetEvidence: .window)
+        case .backgroundCloseWindow:
+            descriptor(
+                ownership: .service,
+                pinnedWindow: .required,
+                typedResponse: .postMutationWindow,
+                completion: .dispatchedUnverified(axBackground),
+                targetPolicy: .requestPinned,
+                responseFamilies: [.ok, .window],
+                responseTargetEvidence: .window)
+        case .getFocusedWindow:
+            descriptor(
+                read: .globalExclusive,
+                completion: .readOnly,
+                targetPolicy: .notApplicable,
+                responseFamilies: [.window],
+                responseTargetEvidence: .window)
+        case .listApplications:
+            descriptor(
+                read: .globalExclusive,
+                completion: .readOnly,
+                targetPolicy: .notApplicable,
+                responseFamilies: [.applications])
+        case .findApplication:
+            descriptor(
+                read: .globalExclusive,
+                typedResponse: .applicationIdentifier,
+                completion: .readOnly,
+                targetPolicy: .notApplicable,
+                responseFamilies: [.application],
+                responseTargetEvidence: .application)
+        case .getFrontmostApplication:
+            descriptor(
+                read: .globalExclusive,
+                completion: .readOnly,
+                targetPolicy: .notApplicable,
+                responseFamilies: [.application],
+                responseTargetEvidence: .application)
+        case .isApplicationRunning:
+            descriptor(
+                read: .globalExclusive,
+                completion: .readOnly,
+                targetPolicy: .notApplicable,
+                responseFamilies: [.bool])
+        case .launchApplication:
+            descriptor(
+                ownership: .service,
+                typedResponse: .applicationIdentifier,
+                completion: .dispatchedUnverified(nativeForeground),
+                targetPolicy: .responseResolved,
+                responseFamilies: [.application],
+                responseTargetEvidence: .application)
+        case .launchApplicationWithOptions:
+            descriptor(
+                ownership: .service,
+                typedResponse: .applicationLaunch,
+                completion: .requestDependent(mutatesDesktop: false),
+                targetPolicy: .requestDependent,
+                responseFamilies: [.application],
+                responseTargetEvidence: .application)
+        case .relaunchApplicationWithOptions:
+            descriptor(
+                ownership: .service,
+                typedResponse: .applicationRelaunch,
+                completion: .requestDependent(mutatesDesktop: true),
+                targetPolicy: .responseResolved,
+                responseFamilies: [.application],
+                responseTargetEvidence: .application)
+        case .activateApplication:
+            descriptor(
+                ownership: .service,
+                completion: .dispatchedUnverified(nativeForeground),
+                targetPolicy: .requestPinned,
+                responseFamilies: [.ok])
+        case .quitApplication:
+            descriptor(
+                ownership: .service,
+                completion: .dispatchedUnverified(nativeBackground),
+                targetPolicy: .requestPinned,
+                responseFamilies: [.bool])
+        case .hideApplication:
+            descriptor(
+                ownership: .service,
+                completion: .dispatchedUnverified(nativeBackground),
+                targetPolicy: .requestPinned,
+                responseFamilies: [.ok])
+        case .unhideApplication:
+            descriptor(
+                ownership: .service,
+                completion: .dispatchedUnverified(nativeBackground),
+                targetPolicy: .handlerRequired,
+                responseFamilies: [.ok])
+        case .hideOtherApplications, .showAllApplications:
+            descriptor(
+                ownership: .service,
+                completion: .dispatchedUnverified(axBackground),
+                targetPolicy: .global,
+                responseFamilies: [.ok])
+        case .listMenus:
+            descriptor(
+                read: .globalExclusive,
+                typedResponse: .menuStructureApplication,
+                completion: .readOnly,
+                targetPolicy: .notApplicable,
+                responseFamilies: [.menuStructure])
+        case .listFrontmostMenus:
+            descriptor(
+                read: .globalExclusive,
+                completion: .readOnly,
+                targetPolicy: .notApplicable,
+                responseFamilies: [.menuStructure])
+        case .clickMenuItem, .clickMenuItemByName:
+            descriptor(
+                ownership: .service,
+                completion: .dispatchedUnverified(axBackground),
+                targetPolicy: .requestPinned,
+                responseFamilies: [.ok])
+        case .listMenuExtras:
+            descriptor(
+                read: .globalExclusive,
+                completion: .readOnly,
+                targetPolicy: .notApplicable,
+                responseFamilies: [.menuExtras])
+        case .clickMenuExtra:
+            descriptor(
+                ownership: .service,
+                completion: .dispatchedUnverified(axForeground),
+                targetPolicy: .external,
+                responseFamilies: [.ok])
+        case .menuExtraOpenMenuFrame:
+            descriptor(
+                read: .globalExclusive,
+                completion: .readOnly,
+                targetPolicy: .notApplicable,
+                responseFamilies: [.rect])
+        case .listMenuBarItems:
+            descriptor(
+                read: .globalExclusive,
+                completion: .readOnly,
+                targetPolicy: .notApplicable,
+                responseFamilies: [.menuBarItems])
+        case .clickMenuBarItemNamed:
+            descriptor(
+                ownership: .service,
+                completion: .dispatchedUnverified(axForeground),
+                targetPolicy: .external,
+                responseFamilies: [.clickResult])
+        case .clickMenuBarItemIndex:
+            descriptor(
+                ownership: .service,
+                completion: .dispatchedUnverified(globalForeground),
+                targetPolicy: .external,
+                responseFamilies: [.clickResult])
+        case .listDockItems:
+            descriptor(
+                read: .globalExclusive,
+                completion: .readOnly,
+                targetPolicy: .notApplicable,
+                responseFamilies: [.dockItems])
+        case .launchDockItem:
+            descriptor(
+                ownership: .service,
+                completion: .dispatchedUnverified(axForeground),
+                targetPolicy: .external,
+                responseFamilies: [.ok])
+        case .rightClickDockItem:
+            descriptor(
+                ownership: .service,
+                completion: .dispatchedUnverified(globalForeground),
+                targetPolicy: .external,
+                responseFamilies: [.ok])
+        case .hideDock, .showDock:
+            descriptor(
+                ownership: .service,
+                completion: .dispatchedUnverified(nativeBackground),
+                targetPolicy: .global,
+                responseFamilies: [.ok])
+        case .isDockHidden:
+            descriptor(
+                read: .globalExclusive,
+                completion: .readOnly,
+                targetPolicy: .notApplicable,
+                responseFamilies: [.bool])
+        case .findDockItem:
+            descriptor(
+                read: .globalExclusive,
+                typedResponse: .dockItemSelector,
+                completion: .readOnly,
+                targetPolicy: .notApplicable,
+                responseFamilies: [.dockItem])
+        case .dialogFindActive:
+            descriptor(
+                ownership: .service,
+                read: .globalExclusive,
+                completion: .readOnly,
+                targetPolicy: .notApplicable,
+                responseFamilies: [.dialogInfo])
+        case .dialogClickButton, .dialogDismiss:
+            descriptor(
+                ownership: .service,
+                typedResponse: .dialogResult,
+                completion: .dispatchedUnverified(axForeground),
+                targetPolicy: .responseResolved,
+                responseFamilies: [.dialogResult],
+                responseTargetEvidence: .dialog)
+        case .backgroundDialogClickButton:
+            descriptor(
+                ownership: .service,
+                typedResponse: .dialogResult,
+                completion: .dispatchedUnverified(axBackground),
+                targetPolicy: .responseResolved,
+                responseFamilies: [.dialogResult],
+                responseTargetEvidence: .dialog)
+        case .dialogEnterText:
+            descriptor(
+                ownership: .service,
+                typedResponse: .dialogResult,
+                completion: .dispatchedUnverified(globalForeground),
+                targetPolicy: .responseResolved,
+                responseFamilies: [.dialogResult],
+                responseTargetEvidence: .dialog)
+        case .dialogHandleFile:
+            descriptor(
+                ownership: .service,
+                typedResponse: .dialogResult,
+                completion: .dispatchedUnverified(clipboardForeground),
+                targetPolicy: .responseResolved,
+                responseFamilies: [.dialogResult],
+                responseTargetEvidence: .dialog)
+        case .dialogListElements:
+            descriptor(
+                ownership: .service,
+                read: .globalExclusive,
+                completion: .readOnly,
+                targetPolicy: .notApplicable,
+                responseFamilies: [.dialogElements])
+        case .targetedDialogListElements:
+            descriptor(
+                ownership: .service,
+                read: .globalExclusive,
+                typedResponse: .targetedDialogElements,
+                completion: .readOnly,
+                targetPolicy: .notApplicable,
+                responseFamilies: [.dialogElements],
+                responseTargetEvidence: .targetedDialog)
+        case .prepareDialogAction:
+            descriptor(
+                ownership: .service,
+                read: .globalExclusive,
+                typedResponse: .preparedDialogAction,
+                completion: .readOnly,
+                targetPolicy: .notApplicable,
+                responseFamilies: [.preparedDialogAction],
+                responseTargetEvidence: .preparedDialog)
+        case .exactDialogClickButton, .exactDialogDismiss:
+            descriptor(
+                ownership: .service,
+                typedResponse: .dialogResult,
+                completion: .dispatchedUnverified(axBackground),
+                targetPolicy: .requestPinned,
+                responseFamilies: [.dialogResult],
+                responseTargetEvidence: .dialog)
+        case .exactDialogEnterText:
+            descriptor(
+                ownership: .service,
+                typedResponse: .dialogResult,
+                completion: .dispatchedUnverified(valueBackground),
+                targetPolicy: .responseResolved,
+                responseFamilies: [.dialogResult],
+                responseTargetEvidence: .dialog)
+        case .exactDialogForceDismiss:
+            descriptor(
+                ownership: .service,
+                typedResponse: .dialogResult,
+                completion: .dispatchedUnverified(globalForeground),
+                targetPolicy: .responseResolved,
+                responseFamilies: [.dialogResult],
+                responseTargetEvidence: .dialog)
+        case .createSnapshot:
+            descriptor(
+                completion: .readOnly,
+                targetPolicy: .notApplicable,
+                responseFamilies: [.snapshotID])
+        case .storeDetectionResult:
+            descriptor(
+                typedResponse: .storedDetection,
+                completion: .readOnly,
+                targetPolicy: .notApplicable,
+                responseFamilies: [.ok])
+        case .getDetectionResult:
+            descriptor(
+                typedResponse: .detectionSnapshot,
+                completion: .readOnly,
+                targetPolicy: .notApplicable,
+                responseFamilies: [.detection])
+        case .storeScreenshot, .storeObservationSnapshot, .storeAnnotatedScreenshot,
+             .finishSnapshotMutation, .cleanSnapshot:
+            descriptor(
+                completion: .readOnly,
+                targetPolicy: .notApplicable,
+                responseFamilies: [.ok])
+        case .listSnapshots:
+            descriptor(
+                completion: .readOnly,
+                targetPolicy: .notApplicable,
+                responseFamilies: [.snapshots])
+        case .getMostRecentSnapshot:
+            descriptor(
+                completion: .readOnly,
+                targetPolicy: .notApplicable,
+                responseFamilies: [.snapshotID])
+        case .invalidateImplicitLatestSnapshot:
+            descriptor(
+                completion: .readOnly,
+                targetPolicy: .notApplicable,
+                responseFamilies: [.ok, .snapshotID])
+        case .beginSnapshotMutation:
+            descriptor(
+                typedResponse: .snapshotMutationLease,
+                completion: .readOnly,
+                targetPolicy: .notApplicable,
+                responseFamilies: [.snapshotMutationLease])
+        case .cleanSnapshotsOlderThan, .cleanAllSnapshots:
+            descriptor(
+                completion: .readOnly,
+                targetPolicy: .notApplicable,
+                responseFamilies: [.int])
+        case ._appleScriptProbe:
+            descriptor(
+                typedResponse: .noSuccessResponse,
+                completion: .readOnly,
+                targetPolicy: .notApplicable,
+                responseFamilies: [])
+        }
+    }
+}

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeOperationReceiptModels.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeOperationReceiptModels.swift
@@ -49,8 +49,39 @@ public struct PeekabooBridgeAttestedOperationRequest: Codable, Sendable {
     }
 }
 
+extension PeekabooBridgeOperationReceiptSemantics {
+    static func validateTargetAttribution(
+        _ payload: PeekabooBridgeOperationReceiptPayload,
+        request: PeekabooBridgeRequest,
+        response: PeekabooBridgeResponse) throws
+    {
+        try self.validateTargetAttribution(
+            payload,
+            plan: PeekabooBridgeOperationResultSemantics.semanticPlan(for: request),
+            response: response)
+    }
+
+    static func validateReceiptCarriage(
+        _ payload: PeekabooBridgeOperationReceiptPayload,
+        request: PeekabooBridgeRequest,
+        response: PeekabooBridgeResponse) throws
+    {
+        try self.validateReceiptCarriage(
+            payload,
+            plan: PeekabooBridgeOperationResultSemantics.semanticPlan(for: request),
+            response: response)
+    }
+}
+
 extension PeekabooBridgeRequest {
     fileprivate func validateAttestedOperationCarriage() throws {
+        try self.validateAttestedOperationCarriage(
+            plan: PeekabooBridgeOperationResultSemantics.semanticPlan(for: self))
+    }
+
+    fileprivate func validateAttestedOperationCarriage(
+        plan: PeekabooBridgeOperationResultSemantics.PeekabooBridgeRequestPlan) throws
+    {
         switch self {
         case .attestedOperation:
             throw PeekabooBridgeErrorEnvelope(
@@ -67,7 +98,7 @@ extension PeekabooBridgeRequest {
                     code: .invalidRequest,
                     message: "Attested Bridge operation requests cannot be nested inside action carriage")
             }
-        case _ where self.mayMutateDesktop:
+        case _ where plan.result.completion.mutatesDesktop:
             throw PeekabooBridgeErrorEnvelope(
                 code: .invalidRequest,
                 message: "Mutating attested Bridge operations require action outcome carriage")
@@ -461,11 +492,11 @@ enum PeekabooBridgeOperationReceiptSemantics {
 
     static func validateTargetAttribution(
         _ payload: PeekabooBridgeOperationReceiptPayload,
-        request: PeekabooBridgeRequest,
+        plan: PeekabooBridgeOperationResultSemantics.PeekabooBridgeRequestPlan,
         response: PeekabooBridgeResponse) throws
     {
         try payload.validateTargetState()
-        try self.validateReceiptCarriage(payload, request: request, response: response)
+        try self.validateReceiptCarriage(payload, plan: plan, response: response)
         guard let failure = payload.targetAttributionFailure else {
             if self.errorEnvelope(in: response)?.context?.hasPrefix("bridge_target_attribution:") == true {
                 throw PeekabooBridgeOperationReceiptError.receiptMismatch(
@@ -473,24 +504,25 @@ enum PeekabooBridgeOperationReceiptSemantics {
             }
             try self.validateSuccessfulTargetAttribution(
                 payload,
-                request: request,
+                plan: plan,
                 response: response)
             return
         }
         try self.validateFailedTargetAttribution(
             payload,
             failure: failure,
-            request: request,
+            plan: plan,
             response: response)
     }
 
     static func validateReceiptCarriage(
         _ payload: PeekabooBridgeOperationReceiptPayload,
-        request: PeekabooBridgeRequest,
+        plan: PeekabooBridgeOperationResultSemantics.PeekabooBridgeRequestPlan,
         response: PeekabooBridgeResponse) throws
     {
+        let request = plan.carriageRequest
         do {
-            try request.validateAttestedOperationCarriage()
+            try request.validateAttestedOperationCarriage(plan: plan)
         } catch {
             try self.validateInvalidRequestCarriageRefusal(
                 payload,
@@ -505,11 +537,11 @@ enum PeekabooBridgeOperationReceiptSemantics {
         }
         guard PeekabooBridgeOperationResultSemantics.responseMatchesContract(
             semanticResponse,
-            request: request)
+            plan: plan)
         else {
             throw PeekabooBridgeOperationReceiptError.receiptMismatch("operation response family")
         }
-        if request.mayMutateDesktop {
+        if plan.result.completion.mutatesDesktop {
             guard case .projectedAction = request,
                   case let .projectedAction(projected) = response,
                   let outcome = projected.outcome,
@@ -534,7 +566,7 @@ enum PeekabooBridgeOperationReceiptSemantics {
                       !outcome.isConfirmed,
                       PeekabooBridgeOperationResultSemantics.failureOutcomeMatchesContract(
                           outcome,
-                          request: request)
+                          plan: plan)
                 else {
                     throw PeekabooBridgeOperationReceiptError.receiptMismatch(
                         "read-only action outcome semantics")
@@ -553,8 +585,8 @@ enum PeekabooBridgeOperationReceiptSemantics {
                 }
             }
         }
-        try self.validateTypedResponseSemantics(semanticResponse, outerResponse: response, request: request)
-        try self.validateResponseOutcomeConsistency(response, request: request)
+        try self.validateTypedResponseSemantics(semanticResponse, outerResponse: response, plan: plan)
+        try self.validateResponseOutcomeConsistency(response, plan: plan)
         try self.validateSelectedLeafEvidence(payload, request: request, response: semanticResponse)
     }
 
@@ -785,9 +817,10 @@ enum PeekabooBridgeOperationReceiptSemantics {
 
     private static func validateSuccessfulTargetAttribution(
         _ payload: PeekabooBridgeOperationReceiptPayload,
-        request: PeekabooBridgeRequest,
+        plan: PeekabooBridgeOperationResultSemantics.PeekabooBridgeRequestPlan,
         response: PeekabooBridgeResponse) throws
     {
+        let request = plan.carriageRequest
         if self.allowsTargetlessFailureReceipt(for: response) {
             guard payload.target == nil else {
                 throw PeekabooBridgeOperationReceiptError.receiptMismatch("no-dispatch failure target")
@@ -798,13 +831,13 @@ enum PeekabooBridgeOperationReceiptSemantics {
             throw PeekabooBridgeOperationReceiptError.receiptMismatch("targetless successful attribution")
         }
         do {
-            _ = try PeekabooBridgeOperationTargetAttribution.resolveRequest(request)
+            _ = try PeekabooBridgeOperationTargetAttribution.resolveRequest(plan)
         } catch {
             throw PeekabooBridgeOperationReceiptError.receiptMismatch(
                 "successful request target contract")
         }
         if [.browserConnect, .browserExecute].contains(request.operation),
-           PeekabooBridgeOperationResultSemantics.semanticPlan(for: request).contract.completion.mutatesDesktop,
+           plan.result.completion.mutatesDesktop,
            !PeekabooBridgeOperationResultSemantics.isNoDispatchFailure(response)
         {
             guard let responseReceipt = response.browserExecutionConnectionReceipt,
@@ -853,7 +886,7 @@ enum PeekabooBridgeOperationReceiptSemantics {
                 "browser target used outside external browser execution")
         }
         let signedIdentity = try payload.resolvedTargetIdentity()
-        let targetPolicy = PeekabooBridgeOperationResultSemantics.semanticPlan(for: request).contract.targetPolicy
+        let targetPolicy = plan.target.policy
         let handledTarget: DesktopTargetIdentity? = switch targetPolicy {
         case .handlerRequired, .handlerResolvedOrGlobal, .external:
             signedIdentity
@@ -865,7 +898,7 @@ enum PeekabooBridgeOperationReceiptSemantics {
         let resolvedIdentity: DesktopTargetIdentity?
         do {
             resolvedIdentity = try PeekabooBridgeOperationTargetAttribution.resolve(
-                request: request,
+                plan: plan,
                 response: response,
                 handledTarget: handledTarget)
         } catch {
@@ -884,9 +917,10 @@ enum PeekabooBridgeOperationReceiptSemantics {
     private static func validateFailedTargetAttribution(
         _ payload: PeekabooBridgeOperationReceiptPayload,
         failure: PeekabooBridgeTargetAttributionFailure,
-        request: PeekabooBridgeRequest,
+        plan: PeekabooBridgeOperationResultSemantics.PeekabooBridgeRequestPlan,
         response: PeekabooBridgeResponse) throws
     {
+        let request = plan.carriageRequest
         let envelope = self.errorEnvelope(in: response)
         guard envelope?.context == "bridge_target_attribution:\(failure.code.rawValue)" else {
             throw PeekabooBridgeOperationReceiptError.receiptMismatch("target attribution failure response")
@@ -896,7 +930,7 @@ enum PeekabooBridgeOperationReceiptSemantics {
         }
         try self.validateFailureResponseSemantics(
             failure,
-            request: request,
+            plan: plan,
             envelope: envelope)
         guard let signedEvidence = payload.targetAttributionEvidence else {
             throw PeekabooBridgeOperationReceiptError.receiptMismatch("target attribution failure evidence")
@@ -911,7 +945,7 @@ enum PeekabooBridgeOperationReceiptSemantics {
                 throw PeekabooBridgeOperationReceiptError.receiptMismatch("pre-dispatch target evidence")
             }
             do {
-                _ = try PeekabooBridgeOperationTargetAttribution.resolveRequest(request)
+                _ = try PeekabooBridgeOperationTargetAttribution.resolveRequest(plan)
                 throw PeekabooBridgeOperationReceiptError.receiptMismatch(
                     "claimed pre-dispatch target attribution failure")
             } catch let error as DesktopTargetIdentityError {
@@ -922,7 +956,7 @@ enum PeekabooBridgeOperationReceiptSemantics {
             return
         case .postExecution:
             do {
-                _ = try PeekabooBridgeOperationTargetAttribution.resolveRequest(request)
+                _ = try PeekabooBridgeOperationTargetAttribution.resolveRequest(plan)
             } catch {
                 throw PeekabooBridgeOperationReceiptError.receiptMismatch(
                     "post-execution request target evidence")
@@ -930,7 +964,7 @@ enum PeekabooBridgeOperationReceiptSemantics {
         }
         do {
             _ = try PeekabooBridgeOperationTargetAttribution.resolveEvidence(
-                request: request,
+                plan: plan,
                 evidence: signedEvidence.map(\.desktopEvidence))
             throw PeekabooBridgeOperationReceiptError.receiptMismatch(
                 "claimed target attribution failure")
@@ -943,10 +977,10 @@ enum PeekabooBridgeOperationReceiptSemantics {
 
     private static func validateFailureResponseSemantics(
         _ failure: PeekabooBridgeTargetAttributionFailure,
-        request: PeekabooBridgeRequest,
+        plan: PeekabooBridgeOperationResultSemantics.PeekabooBridgeRequestPlan,
         envelope: PeekabooBridgeErrorEnvelope) throws
     {
-        guard request.mayMutateDesktop else {
+        guard plan.result.completion.mutatesDesktop else {
             guard envelope.code == .invalidRequest,
                   envelope.actionOutcome == nil
             else {
@@ -980,7 +1014,7 @@ enum PeekabooBridgeOperationReceiptSemantics {
                   outcome.retrySafety == .unsafe,
                   PeekabooBridgeOperationResultSemantics.failureOutcomeMatchesContract(
                       outcome,
-                      request: request)
+                      plan: plan)
             else {
                 throw PeekabooBridgeOperationReceiptError.receiptMismatch(
                     "retry-unsafe target attribution failure")
@@ -1006,10 +1040,9 @@ enum PeekabooBridgeOperationReceiptSemantics {
     private static func validateTypedResponseSemantics(
         _ response: PeekabooBridgeResponse,
         outerResponse: PeekabooBridgeResponse,
-        request: PeekabooBridgeRequest) throws
+        plan: PeekabooBridgeOperationResultSemantics.PeekabooBridgeRequestPlan) throws
     {
-        let request = request.unwrappedOperationRequest
-        let plan = PeekabooBridgeOperationResultSemantics.semanticPlan(for: request)
+        let request = plan.request
         let outerOutcome = self.outcome(in: outerResponse)?.outcome
         try plan.validateBoundTypedResponse(response, outcome: outerOutcome)
         if plan.responseCarriesPostMutationWindowState,
@@ -1091,7 +1124,7 @@ enum PeekabooBridgeOperationReceiptSemantics {
         case let (.postMutationWindow, _, .window(window)):
             try self.validatePostMutationWindow(
                 window,
-                request: request,
+                plan: plan,
                 outcome: outerOutcome)
         case let (.menuStructureApplication, .listMenus(expected), .menuStructure(actual)):
             try self.validateApplication(
@@ -1331,7 +1364,19 @@ enum PeekabooBridgeOperationReceiptSemantics {
         request: PeekabooBridgeRequest,
         outcome: DesktopActionOutcome?) throws
     {
-        guard let expected = request.pinnedWindowMutation?.identity else {
+        try self.validatePostMutationWindow(
+            window,
+            plan: PeekabooBridgeOperationResultSemantics.semanticPlan(for: request),
+            outcome: outcome)
+    }
+
+    static func validatePostMutationWindow(
+        _ window: ServiceWindowInfo?,
+        plan: PeekabooBridgeOperationResultSemantics.PeekabooBridgeRequestPlan,
+        outcome: DesktopActionOutcome?) throws
+    {
+        let request = plan.request
+        guard let expected = plan.pinnedWindowMutation?.identity else {
             throw PeekabooBridgeOperationReceiptError.receiptMismatch("post-mutation window request target")
         }
         guard let window else {
@@ -1508,8 +1553,9 @@ enum PeekabooBridgeOperationReceiptSemantics {
 
     private static func validateResponseOutcomeConsistency(
         _ response: PeekabooBridgeResponse,
-        request: PeekabooBridgeRequest) throws
+        plan: PeekabooBridgeOperationResultSemantics.PeekabooBridgeRequestPlan) throws
     {
+        let request = plan.request
         guard case let .projectedAction(projected) = response else { return }
         if case let .browserToolResponse(browserResponse) = projected.response {
             guard let browserRequest = request.browserExecutionRequest else {
@@ -1542,7 +1588,7 @@ enum PeekabooBridgeOperationReceiptSemantics {
                       outcome.retrySafety == .unsafe,
                       PeekabooBridgeOperationResultSemantics.failureOutcomeMatchesContract(
                           failure.outcome,
-                          request: request)
+                          plan: plan)
                 else {
                     throw PeekabooBridgeOperationReceiptError.receiptMismatch(
                         "browser response unknown progress")
@@ -1571,7 +1617,7 @@ enum PeekabooBridgeOperationReceiptSemantics {
                       outcome.refusalReason != nil,
                       PeekabooBridgeOperationResultSemantics.failureOutcomeMatchesContract(
                           failure.outcome,
-                          request: request)
+                          plan: plan)
                 else {
                     throw PeekabooBridgeOperationReceiptError.receiptMismatch(
                         "browser response zero progress refusal")
@@ -1588,7 +1634,7 @@ enum PeekabooBridgeOperationReceiptSemantics {
                 guard failure.outcome.projection == projected.outcome,
                       PeekabooBridgeOperationResultSemantics.failureOutcomeMatchesContract(
                           failure.outcome,
-                          request: request)
+                          plan: plan)
                 else {
                     throw PeekabooBridgeOperationReceiptError.receiptMismatch(
                         "browser response action failure")
@@ -1608,7 +1654,7 @@ enum PeekabooBridgeOperationReceiptSemantics {
             return
         }
         guard let outcome = projected.outcome?.outcome else {
-            guard !request.mayMutateDesktop else {
+            guard !plan.result.completion.mutatesDesktop else {
                 throw PeekabooBridgeOperationReceiptError.receiptMismatch(
                     "projected response outcome")
             }
@@ -1625,7 +1671,7 @@ enum PeekabooBridgeOperationReceiptSemantics {
                   !outcome.isConfirmed,
                   PeekabooBridgeOperationResultSemantics.failureOutcomeMatchesContract(
                       outcome,
-                      request: request)
+                      plan: plan)
             else {
                 throw PeekabooBridgeOperationReceiptError.receiptMismatch(
                     "projected error outcome")
@@ -1635,10 +1681,10 @@ enum PeekabooBridgeOperationReceiptSemantics {
         guard PeekabooBridgeOperationResultSemantics.successfulOutcomeMatchesContract(
             outcome,
             response: projected.response,
-            request: request) || PeekabooBridgeOperationResultSemantics.nonErrorResponseAllowsFailureOutcome(
+            plan: plan) || PeekabooBridgeOperationResultSemantics.nonErrorResponseAllowsFailureOutcome(
             projected.response,
             outcome: outcome,
-            request: request)
+            plan: plan)
         else {
             throw PeekabooBridgeOperationReceiptError.receiptMismatch(
                 "successful projected response outcome")

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeOperationReceipts.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeOperationReceipts.swift
@@ -2131,18 +2131,24 @@ struct PeekabooBridgeResolvedOperationTarget: Sendable {
 
 enum PeekabooBridgeOperationTargetAttribution {
     static func resolveRequest(_ request: PeekabooBridgeRequest) throws -> DesktopTargetIdentity? {
-        let targetPolicy = PeekabooBridgeOperationResultSemantics.contract(for: request).targetPolicy
+        try self.resolveRequest(PeekabooBridgeOperationResultSemantics.semanticPlan(for: request))
+    }
+
+    static func resolveRequest(
+        _ plan: PeekabooBridgeOperationResultSemantics.PeekabooBridgeRequestPlan) throws
+        -> DesktopTargetIdentity?
+    {
         let identity: DesktopTargetIdentity?
         do {
             identity = try DesktopTargetPlanning.DesktopTargetIdentityCoalescer.resolve(
-                request.operationTargetEvidence)
+                plan.target.requestEvidence)
         } catch let error as DesktopTargetIdentityError {
-            guard targetPolicy == .responseResolved,
+            guard plan.target.policy == .responseResolved,
                   error == .missingProcessGeneration || error == .incompleteExactWindow
             else { throw error }
             identity = nil
         }
-        if request.requiresStableOperationTarget, identity == nil {
+        if plan.target.requiresStableIdentity, identity == nil {
             throw DesktopTargetIdentityError.incompleteExactWindow
         }
         return identity
@@ -2153,13 +2159,24 @@ enum PeekabooBridgeOperationTargetAttribution {
         response: PeekabooBridgeResponse,
         handledTarget: DesktopTargetIdentity?) throws -> DesktopTargetIdentity?
     {
+        try self.resolve(
+            plan: PeekabooBridgeOperationResultSemantics.semanticPlan(for: request),
+            response: response,
+            handledTarget: handledTarget)
+    }
+
+    static func resolve(
+        plan: PeekabooBridgeOperationResultSemantics.PeekabooBridgeRequestPlan,
+        response: PeekabooBridgeResponse,
+        handledTarget: DesktopTargetIdentity?) throws -> DesktopTargetIdentity?
+    {
         if PeekabooBridgeOperationResultSemantics.isNoDispatchFailure(response) {
             return nil
         }
         return try self.resolveEvidence(
-            request: request,
+            plan: plan,
             evidence: self.evidence(
-                request: request,
+                plan: plan,
                 response: response,
                 handledTarget: handledTarget))
     }
@@ -2168,11 +2185,20 @@ enum PeekabooBridgeOperationTargetAttribution {
         request: PeekabooBridgeRequest,
         evidence: [DesktopTargetIdentity.Evidence]) throws -> DesktopTargetIdentity?
     {
+        try self.resolveEvidence(
+            plan: PeekabooBridgeOperationResultSemantics.semanticPlan(for: request),
+            evidence: evidence)
+    }
+
+    static func resolveEvidence(
+        plan: PeekabooBridgeOperationResultSemantics.PeekabooBridgeRequestPlan,
+        evidence: [DesktopTargetIdentity.Evidence]) throws -> DesktopTargetIdentity?
+    {
         let identity = try DesktopTargetPlanning.DesktopTargetIdentityCoalescer.resolve(evidence)
-        if request.requiresResolvedOperationTarget, identity == nil {
+        if plan.target.requiresResolvedIdentity, identity == nil {
             throw DesktopTargetIdentityError.incompleteExactWindow
         }
-        try request.validateResolvedOperationTarget(identity)
+        try plan.request.validateResolvedOperationTarget(identity)
         return identity
     }
 
@@ -2181,15 +2207,25 @@ enum PeekabooBridgeOperationTargetAttribution {
         response: PeekabooBridgeResponse,
         handledTarget: DesktopTargetIdentity?) -> [DesktopTargetIdentity.Evidence]
     {
-        var evidence = request.operationTargetEvidence
-        let targetPolicy = PeekabooBridgeOperationResultSemantics.contract(for: request).targetPolicy
+        self.evidence(
+            plan: PeekabooBridgeOperationResultSemantics.semanticPlan(for: request),
+            response: response,
+            handledTarget: handledTarget)
+    }
+
+    static func evidence(
+        plan: PeekabooBridgeOperationResultSemantics.PeekabooBridgeRequestPlan,
+        response: PeekabooBridgeResponse,
+        handledTarget: DesktopTargetIdentity?) -> [DesktopTargetIdentity.Evidence]
+    {
+        var evidence = plan.target.requestEvidence
         if let handledTarget,
-           request.requiresResolvedOperationTarget || targetPolicy == .handlerResolvedOrGlobal ||
-           !request.operationTargetEvidence.isEmpty
+           plan.target.requiresResolvedIdentity || plan.target.policy == .handlerResolvedOrGlobal ||
+           !plan.target.requestEvidence.isEmpty
         {
             evidence.append(.init(target: handledTarget))
         }
-        evidence.append(contentsOf: response.operationTargetEvidence(for: request.operation))
+        evidence.append(contentsOf: response.operationTargetEvidence(for: plan))
         return evidence
     }
 
@@ -2198,27 +2234,25 @@ enum PeekabooBridgeOperationTargetAttribution {
         response: PeekabooBridgeResponse,
         handledTarget: DesktopTargetIdentity? = nil) throws -> PeekabooBridgeResolvedOperationTarget
     {
+        try self.resolveReceipt(
+            plan: PeekabooBridgeOperationResultSemantics.semanticPlan(for: request),
+            response: response,
+            handledTarget: handledTarget)
+    }
+
+    static func resolveReceipt(
+        plan: PeekabooBridgeOperationResultSemantics.PeekabooBridgeRequestPlan,
+        response: PeekabooBridgeResponse,
+        handledTarget: DesktopTargetIdentity? = nil) throws -> PeekabooBridgeResolvedOperationTarget
+    {
         try PeekabooBridgeResolvedOperationTarget(self.resolve(
-            request: request,
+            plan: plan,
             response: response,
             handledTarget: handledTarget))
     }
 }
 
 extension PeekabooBridgeRequest {
-    fileprivate var requiresStableOperationTarget: Bool {
-        PeekabooBridgeOperationResultSemantics.contract(for: self).targetPolicy == .requestPinned
-    }
-
-    fileprivate var requiresResolvedOperationTarget: Bool {
-        switch PeekabooBridgeOperationResultSemantics.contract(for: self).targetPolicy {
-        case .requestPinned, .handlerRequired, .responseResolved, .external:
-            true
-        case .handlerResolvedOrGlobal, .notApplicable, .requestDependent, .global:
-            false
-        }
-    }
-
     fileprivate func validateResolvedOperationTarget(_ identity: DesktopTargetIdentity?) throws {
         switch self {
         case let .attestedOperation(payload):

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeOperationResponseTargetEvidence.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeOperationResponseTargetEvidence.swift
@@ -63,14 +63,15 @@ extension PeekabooBridgeResponse {
     }
 
     func operationTargetEvidence(
-        for operation: PeekabooBridgeOperation) -> [DesktopTargetIdentity.Evidence]
+        for plan: PeekabooBridgeOperationResultSemantics.PeekabooBridgeRequestPlan)
+        -> [DesktopTargetIdentity.Evidence]
     {
         switch self {
         case let .attestedOperation(payload):
-            return payload.response.operationTargetEvidence(for: operation)
+            return payload.response.operationTargetEvidence(for: plan)
         case let .projectedAction(payload):
-            return payload.response.operationTargetEvidence(for: operation)
-        case let .desktopObservation(result):
+            return payload.response.operationTargetEvidence(for: plan)
+        case let .desktopObservation(result) where plan.target.responseEvidenceSource == .desktopObservation:
             if let mutationTargetIdentity = result.target.mutationTargetIdentity {
                 return [DesktopTargetEvidenceAdapter.evidence(
                     processIdentity: mutationTargetIdentity.processIdentity,
@@ -82,55 +83,89 @@ extension PeekabooBridgeResponse {
                 result.target.app.map { DesktopTargetEvidenceAdapter.evidence(application: $0) },
                 result.target.window.map { DesktopTargetEvidenceAdapter.evidence(window: $0) },
             ].compactMap(\.self) + DesktopTargetEvidenceAdapter.fragments(captureMetadata: result.capture.metadata)
-        case let .capture(result):
+        case let .capture(result) where plan.target.responseEvidenceSource == .capture:
             return DesktopTargetEvidenceAdapter.fragments(captureMetadata: result.metadata)
-        case let .elementDetection(result):
-            return operation == .inspectAccessibilityTree
-                ? result.metadata.windowContext.map { [DesktopTargetEvidenceAdapter.evidence(context: $0)] } ?? []
-                : []
-        case let .window(window):
-            return PeekabooBridgeOperationResultSemantics.operationPolicy(for: operation)
-                .windowResponseProof == .postMutationState
+        case let .elementDetection(result) where plan.target.responseEvidenceSource == .inspectWindowContext:
+            return result.metadata.windowContext.map { [DesktopTargetEvidenceAdapter.evidence(context: $0)] } ?? []
+        case let .window(window) where plan.target.responseEvidenceSource == .window:
+            return plan.responseCarriesPostMutationWindowState
                 ? []
                 : window.map { [DesktopTargetEvidenceAdapter.evidence(window: $0)] } ?? []
-        case let .application(application):
+        case let .application(application) where plan.target.responseEvidenceSource == .application:
             return [DesktopTargetEvidenceAdapter.evidence(application: application)]
-        case let .agentExecutionTrace(result):
-            guard operation == .agentExecutionTrace else { return [] }
+        case let .agentExecutionTrace(result) where plan.target.responseEvidenceSource == .agentProcess:
             let process = result.process.processIdentity
             return [.init(
                 processIdentifier: process.processIdentifier,
                 processIdentity: .init(
                     processIdentifier: process.processIdentifier,
                     processStartIdentity: process.processStartIdentity))]
-        case let .browserToolResponse(result):
-            return operation == .browserExecute
-                ? [Self.browserEvidence(result.connectionReceipt)].compactMap(\.self)
-                : []
-        case let .browserStatus(status):
-            return operation == .browserConnect
-                ? [Self.browserEvidence(status.connectionReceipt)].compactMap(\.self)
-                : []
-        case let .preparedDialogAction(receipt):
+        case let .browserToolResponse(result)
+            where plan.operation == .browserExecute && plan.target.responseEvidenceSource == .browserConnection:
+            return [Self.browserEvidence(result.connectionReceipt)].compactMap(\.self)
+        case let .browserStatus(status)
+            where plan.operation == .browserConnect && plan.target.responseEvidenceSource == .browserConnection:
+            return [Self.browserEvidence(status.connectionReceipt)].compactMap(\.self)
+        case let .preparedDialogAction(receipt) where plan.target.responseEvidenceSource == .preparedDialog:
             return [.init(target: DesktopTargetIdentity(exactWindow: receipt.target))]
-        case let .dialogElements(elements):
-            guard operation == .targetedDialogListElements,
-                  let target = elements.resolvedTarget?.target
+        case let .dialogElements(elements) where plan.target.responseEvidenceSource == .targetedDialog:
+            guard let target = elements.resolvedTarget?.target
             else {
                 return []
             }
             return [.init(target: DesktopTargetIdentity(exactWindow: target))]
-        case let .dialogResult(result):
+        case let .dialogResult(result) where plan.target.responseEvidenceSource == .dialog:
             return DesktopTargetEvidenceAdapter.fragments(dialogResult: result)
-        case let .exactWindowHeldPointerTermination(termination?):
+        case let .exactWindowHeldPointerTermination(termination?)
+            where plan.target.responseEvidenceSource == .heldPointerTermination:
             return [DesktopTargetEvidenceAdapter.evidence(
                 windowIdentity: termination.receipt.windowIdentity,
                 bounds: termination.receipt.windowBounds)]
-        case .focusedElement:
-            return []
         case let .error(envelope):
             return envelope.actionTargetReceipt.map { [DesktopTargetEvidenceAdapter.evidence(receipt: $0)] } ?? []
-        default:
+        case .operationSessionRollover,
+             .handshake,
+             .permissionsStatus,
+             .daemonStatus,
+             .agentExecutionTrace,
+             .processGenerationObservation,
+             .certificationProducerAttestation,
+             .browserStatus,
+             .browserToolResponse,
+             .capture,
+             .elementDetection,
+             .focusedElement,
+             .desktopObservation,
+             .ok,
+             .waitResult,
+             .windows,
+             .windowMutationInventory,
+             .window,
+             .applications,
+             .applicationMutationInventory,
+             .application,
+             .bool,
+             .typeResult,
+             .exactWindowHeldPointerOwner,
+             .exactWindowHeldPointerReceipt,
+             .exactWindowHeldPointerTermination,
+             .elementActionResult,
+             .clickResult,
+             .menuStructure,
+             .menuExtras,
+             .menuBarItems,
+             .dockItems,
+             .dockItem,
+             .rect,
+             .dialogInfo,
+             .dialogElements,
+             .dialogResult,
+             .preparedDialogAction,
+             .snapshotId,
+             .snapshotMutationLease,
+             .snapshots,
+             .detection,
+             .int:
             return []
         }
     }

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeOperationResultSemantics.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeOperationResultSemantics.swift
@@ -345,13 +345,35 @@ enum PeekabooBridgeOperationResultSemantics {
         case postMutationState
     }
 
-    /// Static policy that every wire operation must classify explicitly.
-    struct OperationPolicy: Equatable, Sendable {
+    /// Where a successful response can contribute target-attribution evidence.
+    enum ResponseTargetEvidenceSource: Equatable, Sendable {
+        case none
+        case agentProcess
+        case application
+        case browserConnection
+        case capture
+        case desktopObservation
+        case dialog
+        case heldPointerTermination
+        case inspectWindowContext
+        case preparedDialog
+        case targetedDialog
+        case window
+    }
+
+    /// Static policy that every wire operation must classify in one descriptor.
+    struct OperationDescriptor: Equatable, Sendable {
+        let operation: PeekabooBridgeOperation
         let lane: LanePolicy
         let pinnedWindow: PinnedWindowPolicy
         let typedResponse: TypedResponseBinding
         let windowResponseProof: WindowResponseProofPolicy
+        let contract: Contract
+        let responseFamilies: Set<ResponseFamily>
+        let responseTargetEvidence: ResponseTargetEvidenceSource
     }
+
+    typealias OperationPolicy = OperationDescriptor
 
     enum ExactReadTarget: Equatable, Sendable {
         case process(pid_t)
@@ -364,20 +386,112 @@ enum PeekabooBridgeOperationResultSemantics {
         let identity: WindowMutationIdentity
     }
 
-    struct SemanticPlan: Sendable {
-        let operation: PeekabooBridgeOperation
-        let operationPolicy: OperationPolicy
-        let contract: Contract
+    struct TargetPlan: Sendable {
+        let policy: TargetPolicy
+        let responseEvidenceSource: ResponseTargetEvidenceSource
+        let requestEvidence: [DesktopTargetIdentity.Evidence]
+        let desktopOperationScope: DesktopOperationScope
+        let desktopReadOperationLane: (scope: DesktopOperationScope, access: DesktopOperationAccess)?
+        let exactReadTarget: ExactReadTarget?
+        let pinnedWindowMutation: PinnedWindowMutation?
+        let requiresPinnedWindowMutation: Bool
+
+        var requiresStableIdentity: Bool {
+            self.policy == .requestPinned
+        }
+
+        var requiresResolvedIdentity: Bool {
+            switch self.policy {
+            case .requestPinned, .handlerRequired, .responseResolved, .external:
+                true
+            case .handlerResolvedOrGlobal, .notApplicable, .requestDependent, .global:
+                false
+            }
+        }
+    }
+
+    struct ResultPlan: Sendable {
+        let completion: Completion
         let responseFamilies: Set<ResponseFamily>
         let deliveryRules: [DeliveryRule]
         let allowedSuccessStates: [DesktopActionOutcome.State]
         let successResponsePolicy: SuccessResponsePolicy
         let deliveryAgnosticFailureUnits: UnitPolicy?
         let typedResponseRule: TypedResponseRule
-        let desktopOperationScope: DesktopOperationScope
-        let desktopReadOperationLane: (scope: DesktopOperationScope, access: DesktopOperationAccess)?
-        let exactReadTarget: ExactReadTarget?
-        let pinnedWindowMutation: PinnedWindowMutation?
+    }
+
+    struct PeekabooBridgeRequestPlan: Sendable {
+        enum Vocabulary: Equatable, Sendable {
+            case legacy
+            case current
+
+            init(usesCurrentResultSemantics: Bool) {
+                self = usesCurrentResultSemantics ? .current : .legacy
+            }
+
+            var usesCurrentResultSemantics: Bool {
+                self == .current
+            }
+        }
+
+        let request: PeekabooBridgeRequest
+        let carriageRequest: PeekabooBridgeRequest
+        let descriptor: OperationDescriptor
+        let vocabulary: Vocabulary
+        let target: TargetPlan
+        let result: ResultPlan
+
+        var operation: PeekabooBridgeOperation {
+            self.descriptor.operation
+        }
+
+        var operationPolicy: OperationPolicy {
+            self.descriptor
+        }
+
+        var contract: Contract {
+            .init(completion: self.result.completion, targetPolicy: self.target.policy)
+        }
+
+        var responseFamilies: Set<ResponseFamily> {
+            self.result.responseFamilies
+        }
+
+        var deliveryRules: [DeliveryRule] {
+            self.result.deliveryRules
+        }
+
+        var allowedSuccessStates: [DesktopActionOutcome.State] {
+            self.result.allowedSuccessStates
+        }
+
+        var successResponsePolicy: SuccessResponsePolicy {
+            self.result.successResponsePolicy
+        }
+
+        var deliveryAgnosticFailureUnits: UnitPolicy? {
+            self.result.deliveryAgnosticFailureUnits
+        }
+
+        var typedResponseRule: TypedResponseRule {
+            self.result.typedResponseRule
+        }
+
+        var desktopOperationScope: DesktopOperationScope {
+            self.target.desktopOperationScope
+        }
+
+        var desktopReadOperationLane: (scope: DesktopOperationScope, access: DesktopOperationAccess)? {
+            self.target.desktopReadOperationLane
+        }
+
+        var exactReadTarget: ExactReadTarget? {
+            self.target.exactReadTarget
+        }
+
+        var pinnedWindowMutation: PinnedWindowMutation? {
+            self.target.pinnedWindowMutation
+        }
 
         func responseMatches(_ response: PeekabooBridgeResponse) -> Bool {
             if case .error = response {
@@ -467,22 +581,15 @@ enum PeekabooBridgeOperationResultSemantics {
         }
 
         var nativeServiceOwnsDesktopOperationLane: Bool {
-            self.operationPolicy.lane.nativeOwnership == .service
+            self.descriptor.lane.nativeOwnership == .service
         }
 
         var requiresPinnedWindowMutation: Bool {
-            switch self.operationPolicy.pinnedWindow {
-            case .required:
-                true
-            case .legacyOptionalCurrentRequired:
-                PeekabooBridgeRequestContext.usesAttestedOperationResultSemantics
-            case .unavailable:
-                false
-            }
+            self.target.requiresPinnedWindowMutation
         }
 
         var responseCarriesPostMutationWindowState: Bool {
-            self.operationPolicy.windowResponseProof == .postMutationState
+            self.descriptor.windowResponseProof == .postMutationState
         }
 
         func defaultSuccessfulDispatchUnitCount(
@@ -499,678 +606,16 @@ enum PeekabooBridgeOperationResultSemantics {
     }
 }
 
+typealias PeekabooBridgeRequestPlan =
+    PeekabooBridgeOperationResultSemantics.PeekabooBridgeRequestPlan
+
 extension PeekabooBridgeOperationResultSemantics {
     static func operationPolicy(for operation: PeekabooBridgeOperation) -> OperationPolicy {
-        let typedResponse = self.typedResponseBinding(for: operation)
-        return OperationPolicy(
-            lane: .init(
-                nativeOwnership: self.nativeLaneOwnership(for: operation),
-                readPolicy: self.readLanePolicy(for: operation)),
-            pinnedWindow: self.pinnedWindowPolicy(for: operation),
-            typedResponse: typedResponse,
-            windowResponseProof: typedResponse == .postMutationWindow ? .postMutationState : .none)
+        self.operationDescriptor(for: operation)
     }
 
-    private static func nativeLaneOwnership(for operation: PeekabooBridgeOperation) -> NativeLaneOwnership {
-        switch operation {
-        case .click,
-             .type,
-             .typeActions,
-             .targetedTypeActions,
-             .exactWindowTargetedTypeActions,
-             .setValue,
-             .performAction,
-             .scroll,
-             .targetedScroll,
-             .hotkey,
-             .targetedHotkey,
-             .exactWindowTargetedHotkey,
-             .beginExactWindowHeldPointer,
-             .releaseExactWindowHeldPointer,
-             .revokeExactWindowHeldPointer,
-             .disconnectExactWindowHeldPointerOwner,
-             .targetedClick,
-             .exactWindowTargetedClick,
-             .swipe,
-             .drag,
-             .moveMouse,
-             .focusWindow,
-             .moveWindow,
-             .resizeWindow,
-             .setWindowBounds,
-             .closeWindow,
-             .backgroundCloseWindow,
-             .minimizeWindow,
-             .restoreWindow,
-             .maximizeWindow,
-             .launchApplication,
-             .launchApplicationWithOptions,
-             .relaunchApplicationWithOptions,
-             .activateApplication,
-             .quitApplication,
-             .hideApplication,
-             .unhideApplication,
-             .hideOtherApplications,
-             .showAllApplications,
-             .clickMenuItem,
-             .clickMenuItemByName,
-             .clickMenuExtra,
-             .clickMenuBarItemNamed,
-             .clickMenuBarItemIndex,
-             .launchDockItem,
-             .rightClickDockItem,
-             .hideDock,
-             .showDock,
-             .dialogFindActive,
-             .dialogClickButton,
-             .backgroundDialogClickButton,
-             .dialogEnterText,
-             .dialogHandleFile,
-             .dialogDismiss,
-             .dialogListElements,
-             .targetedDialogListElements,
-             .prepareDialogAction,
-             .exactDialogClickButton,
-             .exactDialogDismiss,
-             .exactDialogEnterText,
-             .exactDialogForceDismiss,
-             .desktopObservation:
-            .service
-        case .permissionsStatus,
-             .agentExecutionTrace,
-             .observeProcessGeneration,
-             .certificationProducerAttestation,
-             .createExactWindowHeldPointerOwner,
-             .requestPostEventPermission,
-             .daemonStatus,
-             .daemonStop,
-             .browserStatus,
-             .browserConnect,
-             .browserDisconnect,
-             .browserExecute,
-             .captureScreen,
-             .captureWindow,
-             .captureFrontmost,
-             .captureArea,
-             .detectElements,
-             .inspectAccessibilityTree,
-             .getFocusedElement,
-             .waitForElement,
-             .listWindows,
-             .getFocusedWindow,
-             .listApplications,
-             .findApplication,
-             .getFrontmostApplication,
-             .isApplicationRunning,
-             .listMenus,
-             .listFrontmostMenus,
-             .listMenuExtras,
-             .menuExtraOpenMenuFrame,
-             .listMenuBarItems,
-             .listDockItems,
-             .isDockHidden,
-             .findDockItem,
-             .createSnapshot,
-             .storeDetectionResult,
-             .getDetectionResult,
-             .storeScreenshot,
-             .storeObservationSnapshot,
-             .storeAnnotatedScreenshot,
-             .listSnapshots,
-             .getMostRecentSnapshot,
-             .invalidateImplicitLatestSnapshot,
-             .beginSnapshotMutation,
-             .finishSnapshotMutation,
-             .cleanSnapshot,
-             .cleanSnapshotsOlderThan,
-             .cleanAllSnapshots,
-             ._appleScriptProbe:
-            .bridge
-        }
-    }
-
-    private static func readLanePolicy(for operation: PeekabooBridgeOperation) -> ReadLanePolicy {
-        switch operation {
-        case .captureWindow, .desktopObservation, .inspectAccessibilityTree:
-            .exactTargetOrGlobalExclusive
-        case .captureScreen,
-             .captureFrontmost,
-             .captureArea,
-             .detectElements,
-             .getFocusedElement,
-             .waitForElement,
-             .listWindows,
-             .getFocusedWindow,
-             .listApplications,
-             .findApplication,
-             .getFrontmostApplication,
-             .isApplicationRunning,
-             .listMenus,
-             .listFrontmostMenus,
-             .listMenuExtras,
-             .menuExtraOpenMenuFrame,
-             .listMenuBarItems,
-             .listDockItems,
-             .isDockHidden,
-             .findDockItem,
-             .dialogFindActive,
-             .dialogListElements,
-             .targetedDialogListElements,
-             .prepareDialogAction:
-            .globalExclusive
-        case .permissionsStatus,
-             .agentExecutionTrace,
-             .observeProcessGeneration,
-             .certificationProducerAttestation,
-             .requestPostEventPermission,
-             .daemonStatus,
-             .daemonStop,
-             .browserStatus,
-             .browserConnect,
-             .browserDisconnect,
-             .browserExecute,
-             .click,
-             .type,
-             .typeActions,
-             .targetedTypeActions,
-             .exactWindowTargetedTypeActions,
-             .setValue,
-             .performAction,
-             .scroll,
-             .targetedScroll,
-             .hotkey,
-             .targetedHotkey,
-             .exactWindowTargetedHotkey,
-             .createExactWindowHeldPointerOwner,
-             .beginExactWindowHeldPointer,
-             .releaseExactWindowHeldPointer,
-             .revokeExactWindowHeldPointer,
-             .disconnectExactWindowHeldPointerOwner,
-             .targetedClick,
-             .exactWindowTargetedClick,
-             .swipe,
-             .drag,
-             .moveMouse,
-             .focusWindow,
-             .moveWindow,
-             .resizeWindow,
-             .setWindowBounds,
-             .closeWindow,
-             .backgroundCloseWindow,
-             .minimizeWindow,
-             .restoreWindow,
-             .maximizeWindow,
-             .launchApplication,
-             .launchApplicationWithOptions,
-             .relaunchApplicationWithOptions,
-             .activateApplication,
-             .quitApplication,
-             .hideApplication,
-             .unhideApplication,
-             .hideOtherApplications,
-             .showAllApplications,
-             .clickMenuItem,
-             .clickMenuItemByName,
-             .clickMenuExtra,
-             .clickMenuBarItemNamed,
-             .clickMenuBarItemIndex,
-             .launchDockItem,
-             .rightClickDockItem,
-             .hideDock,
-             .showDock,
-             .dialogClickButton,
-             .backgroundDialogClickButton,
-             .dialogEnterText,
-             .dialogHandleFile,
-             .dialogDismiss,
-             .exactDialogClickButton,
-             .exactDialogDismiss,
-             .exactDialogEnterText,
-             .exactDialogForceDismiss,
-             .createSnapshot,
-             .storeDetectionResult,
-             .getDetectionResult,
-             .storeScreenshot,
-             .storeObservationSnapshot,
-             .storeAnnotatedScreenshot,
-             .listSnapshots,
-             .getMostRecentSnapshot,
-             .invalidateImplicitLatestSnapshot,
-             .beginSnapshotMutation,
-             .finishSnapshotMutation,
-             .cleanSnapshot,
-             .cleanSnapshotsOlderThan,
-             .cleanAllSnapshots,
-             ._appleScriptProbe:
-            .none
-        }
-    }
-
-    private static func pinnedWindowPolicy(for operation: PeekabooBridgeOperation) -> PinnedWindowPolicy {
-        switch operation {
-        case .focusWindow:
-            .legacyOptionalCurrentRequired
-        case .moveWindow,
-             .resizeWindow,
-             .setWindowBounds,
-             .closeWindow,
-             .backgroundCloseWindow,
-             .minimizeWindow,
-             .restoreWindow,
-             .maximizeWindow:
-            .required
-        case .permissionsStatus,
-             .agentExecutionTrace,
-             .observeProcessGeneration,
-             .certificationProducerAttestation,
-             .requestPostEventPermission,
-             .daemonStatus,
-             .daemonStop,
-             .browserStatus,
-             .browserConnect,
-             .browserDisconnect,
-             .browserExecute,
-             .captureScreen,
-             .captureWindow,
-             .captureFrontmost,
-             .captureArea,
-             .detectElements,
-             .inspectAccessibilityTree,
-             .getFocusedElement,
-             .desktopObservation,
-             .click,
-             .type,
-             .typeActions,
-             .targetedTypeActions,
-             .exactWindowTargetedTypeActions,
-             .setValue,
-             .performAction,
-             .scroll,
-             .targetedScroll,
-             .hotkey,
-             .targetedHotkey,
-             .exactWindowTargetedHotkey,
-             .createExactWindowHeldPointerOwner,
-             .beginExactWindowHeldPointer,
-             .releaseExactWindowHeldPointer,
-             .revokeExactWindowHeldPointer,
-             .disconnectExactWindowHeldPointerOwner,
-             .targetedClick,
-             .exactWindowTargetedClick,
-             .swipe,
-             .drag,
-             .moveMouse,
-             .waitForElement,
-             .listWindows,
-             .getFocusedWindow,
-             .listApplications,
-             .findApplication,
-             .getFrontmostApplication,
-             .isApplicationRunning,
-             .launchApplication,
-             .launchApplicationWithOptions,
-             .relaunchApplicationWithOptions,
-             .activateApplication,
-             .quitApplication,
-             .hideApplication,
-             .unhideApplication,
-             .hideOtherApplications,
-             .showAllApplications,
-             .listMenus,
-             .listFrontmostMenus,
-             .clickMenuItem,
-             .clickMenuItemByName,
-             .listMenuExtras,
-             .clickMenuExtra,
-             .menuExtraOpenMenuFrame,
-             .listMenuBarItems,
-             .clickMenuBarItemNamed,
-             .clickMenuBarItemIndex,
-             .listDockItems,
-             .launchDockItem,
-             .rightClickDockItem,
-             .hideDock,
-             .showDock,
-             .isDockHidden,
-             .findDockItem,
-             .dialogFindActive,
-             .dialogClickButton,
-             .backgroundDialogClickButton,
-             .dialogEnterText,
-             .dialogHandleFile,
-             .dialogDismiss,
-             .dialogListElements,
-             .targetedDialogListElements,
-             .prepareDialogAction,
-             .exactDialogClickButton,
-             .exactDialogDismiss,
-             .exactDialogEnterText,
-             .exactDialogForceDismiss,
-             .createSnapshot,
-             .storeDetectionResult,
-             .getDetectionResult,
-             .storeScreenshot,
-             .storeObservationSnapshot,
-             .storeAnnotatedScreenshot,
-             .listSnapshots,
-             .getMostRecentSnapshot,
-             .invalidateImplicitLatestSnapshot,
-             .beginSnapshotMutation,
-             .finishSnapshotMutation,
-             .cleanSnapshot,
-             .cleanSnapshotsOlderThan,
-             .cleanAllSnapshots,
-             ._appleScriptProbe:
-            .unavailable
-        }
-    }
-
-    // swiftlint:disable:next cyclomatic_complexity
-    private static func typedResponseBinding(for operation: PeekabooBridgeOperation) -> TypedResponseBinding {
-        switch operation {
-        case .agentExecutionTrace:
-            .agentExecutionTrace
-        case .observeProcessGeneration:
-            .processGenerationObservation
-        case .certificationProducerAttestation:
-            .certificationProducerAttestation
-        case .typeActions, .targetedTypeActions, .exactWindowTargetedTypeActions:
-            .typeActions
-        case .setValue:
-            .setValue
-        case .performAction:
-            .performAction
-        case .getFocusedElement:
-            .focusedElement
-        case .findApplication, .launchApplication:
-            .applicationIdentifier
-        case .launchApplicationWithOptions:
-            .applicationLaunch
-        case .relaunchApplicationWithOptions:
-            .applicationRelaunch
-        case .captureScreen, .captureWindow, .captureFrontmost, .captureArea:
-            .capture
-        case .detectElements, .inspectAccessibilityTree:
-            .elementDetection
-        case .desktopObservation:
-            .desktopObservation
-        case .focusWindow,
-             .moveWindow,
-             .resizeWindow,
-             .setWindowBounds,
-             .closeWindow,
-             .backgroundCloseWindow,
-             .minimizeWindow,
-             .restoreWindow,
-             .maximizeWindow:
-            .postMutationWindow
-        case .dialogClickButton,
-             .backgroundDialogClickButton,
-             .dialogEnterText,
-             .dialogHandleFile,
-             .dialogDismiss,
-             .exactDialogClickButton,
-             .exactDialogDismiss,
-             .exactDialogEnterText,
-             .exactDialogForceDismiss:
-            .dialogResult
-        case .prepareDialogAction:
-            .preparedDialogAction
-        case .targetedDialogListElements:
-            .targetedDialogElements
-        case .listMenus:
-            .menuStructureApplication
-        case .waitForElement:
-            .waitElementSelector
-        case .findDockItem:
-            .dockItemSelector
-        case .storeDetectionResult:
-            .storedDetection
-        case .getDetectionResult:
-            .detectionSnapshot
-        case .beginSnapshotMutation:
-            .snapshotMutationLease
-        case .permissionsStatus,
-             .requestPostEventPermission,
-             .daemonStatus,
-             .daemonStop,
-             .browserStatus,
-             .browserConnect,
-             .browserDisconnect,
-             .browserExecute,
-             .click,
-             .type,
-             .scroll,
-             .targetedScroll,
-             .hotkey,
-             .targetedHotkey,
-             .exactWindowTargetedHotkey,
-             .createExactWindowHeldPointerOwner,
-             .beginExactWindowHeldPointer,
-             .releaseExactWindowHeldPointer,
-             .revokeExactWindowHeldPointer,
-             .disconnectExactWindowHeldPointerOwner,
-             .targetedClick,
-             .exactWindowTargetedClick,
-             .swipe,
-             .drag,
-             .moveMouse,
-             .listWindows,
-             .getFocusedWindow,
-             .listApplications,
-             .getFrontmostApplication,
-             .isApplicationRunning,
-             .activateApplication,
-             .quitApplication,
-             .hideApplication,
-             .unhideApplication,
-             .hideOtherApplications,
-             .showAllApplications,
-             .listFrontmostMenus,
-             .clickMenuItem,
-             .clickMenuItemByName,
-             .listMenuExtras,
-             .clickMenuExtra,
-             .menuExtraOpenMenuFrame,
-             .listMenuBarItems,
-             .clickMenuBarItemNamed,
-             .clickMenuBarItemIndex,
-             .listDockItems,
-             .launchDockItem,
-             .rightClickDockItem,
-             .hideDock,
-             .showDock,
-             .isDockHidden,
-             .dialogFindActive,
-             .dialogListElements,
-             .createSnapshot,
-             .storeScreenshot,
-             .storeObservationSnapshot,
-             .storeAnnotatedScreenshot,
-             .listSnapshots,
-             .getMostRecentSnapshot,
-             .invalidateImplicitLatestSnapshot,
-             .finishSnapshotMutation,
-             .cleanSnapshot,
-             .cleanSnapshotsOlderThan,
-             .cleanAllSnapshots:
-            .familyOnly
-        case ._appleScriptProbe:
-            .noSuccessResponse
-        }
-    }
-
-    // One exhaustive wire-operation matrix is intentionally more useful here than scattered
-    // low-complexity partial switches that can silently drift apart.
-    // swiftlint:disable:next cyclomatic_complexity function_body_length
     static func contract(for operation: PeekabooBridgeOperation) -> Contract {
-        let accessibilityForeground = DesktopActionOutcome.Delivery(
-            mechanism: .accessibilityAction,
-            mode: .foreground)
-        let accessibilityBackground = DesktopActionOutcome.Delivery(
-            mechanism: .accessibilityAction,
-            mode: .background)
-        let accessibilityValueBackground = DesktopActionOutcome.Delivery(
-            mechanism: .accessibilityValue,
-            mode: .background)
-        let globalForeground = DesktopActionOutcome.Delivery(
-            mechanism: .globalEvents,
-            mode: .foreground)
-        let processBackground = DesktopActionOutcome.Delivery(
-            mechanism: .processTargetedEvents,
-            mode: .background)
-        let windowBackground = DesktopActionOutcome.Delivery(
-            mechanism: .windowTargetedEvents,
-            mode: .background)
-        let nativeForeground = DesktopActionOutcome.Delivery(
-            mechanism: .nativeFramework,
-            mode: .foreground)
-        let nativeBackground = DesktopActionOutcome.Delivery(
-            mechanism: .nativeFramework,
-            mode: .background)
-        let compositeForeground = DesktopActionOutcome.Delivery(
-            mechanism: .composite,
-            mode: .foreground)
-
-        return switch operation {
-        case .agentExecutionTrace:
-            .init(completion: .externalProcessDispatch(nativeBackground), targetPolicy: .responseResolved)
-        case .requestPostEventPermission:
-            .init(completion: .dispatchedUnverified(nativeForeground), targetPolicy: .global)
-        case .browserConnect:
-            .init(
-                completion: .dispatchedUnverified(.init(
-                    mechanism: .browserProtocol,
-                    mode: .foreground)),
-                targetPolicy: .external)
-        case .browserExecute:
-            .init(
-                completion: .dispatchedUnverified(.init(
-                    mechanism: .browserProtocol,
-                    mode: .background)),
-                targetPolicy: .external)
-        case .click, .type, .scroll:
-            .init(completion: .requestDependent(mutatesDesktop: true), targetPolicy: .requestDependent)
-        case .typeActions, .hotkey, .swipe, .drag, .moveMouse:
-            .init(completion: .dispatchedUnverified(globalForeground), targetPolicy: .global)
-        case .targetedTypeActions, .targetedHotkey:
-            .init(completion: .dispatchedUnverified(processBackground), targetPolicy: .requestPinned)
-        case .exactWindowTargetedTypeActions, .exactWindowTargetedHotkey:
-            .init(completion: .dispatchedUnverified(windowBackground), targetPolicy: .requestPinned)
-        case .beginExactWindowHeldPointer:
-            .init(completion: .dispatchedUnverified(windowBackground), targetPolicy: .requestPinned)
-        case .releaseExactWindowHeldPointer, .revokeExactWindowHeldPointer:
-            .init(completion: .requestDependent(mutatesDesktop: true), targetPolicy: .requestPinned)
-        case .disconnectExactWindowHeldPointerOwner:
-            .init(completion: .requestDependent(mutatesDesktop: true), targetPolicy: .handlerResolvedOrGlobal)
-        case .setValue:
-            .init(completion: .dispatchedUnverified(accessibilityValueBackground), targetPolicy: .handlerRequired)
-        case .performAction, .targetedScroll:
-            .init(completion: .dispatchedUnverified(accessibilityBackground), targetPolicy: .handlerRequired)
-        case .targetedClick, .exactWindowTargetedClick:
-            .init(completion: .dispatchedUnverified(accessibilityBackground), targetPolicy: .requestPinned)
-        case .focusWindow, .closeWindow:
-            .init(completion: .dispatchedUnverified(compositeForeground), targetPolicy: .requestPinned)
-        case .moveWindow, .resizeWindow, .setWindowBounds:
-            .init(completion: .dispatchedUnverified(accessibilityValueBackground), targetPolicy: .requestPinned)
-        case .backgroundCloseWindow:
-            .init(completion: .dispatchedUnverified(accessibilityBackground), targetPolicy: .requestPinned)
-        case .minimizeWindow, .restoreWindow, .maximizeWindow:
-            .init(completion: .dispatchedUnverified(accessibilityValueBackground), targetPolicy: .requestPinned)
-        case .launchApplication:
-            .init(completion: .dispatchedUnverified(nativeForeground), targetPolicy: .responseResolved)
-        case .launchApplicationWithOptions:
-            .init(completion: .requestDependent(mutatesDesktop: false), targetPolicy: .requestDependent)
-        case .relaunchApplicationWithOptions:
-            .init(completion: .requestDependent(mutatesDesktop: true), targetPolicy: .responseResolved)
-        case .activateApplication:
-            .init(completion: .dispatchedUnverified(nativeForeground), targetPolicy: .requestPinned)
-        case .quitApplication:
-            .init(completion: .dispatchedUnverified(nativeBackground), targetPolicy: .requestPinned)
-        case .hideApplication:
-            .init(completion: .dispatchedUnverified(nativeBackground), targetPolicy: .requestPinned)
-        case .unhideApplication:
-            .init(completion: .dispatchedUnverified(nativeBackground), targetPolicy: .handlerRequired)
-        case .hideOtherApplications, .showAllApplications:
-            .init(completion: .dispatchedUnverified(accessibilityBackground), targetPolicy: .global)
-        case .clickMenuItem, .clickMenuItemByName:
-            .init(completion: .dispatchedUnverified(accessibilityBackground), targetPolicy: .requestPinned)
-        case .clickMenuExtra, .clickMenuBarItemNamed:
-            .init(completion: .dispatchedUnverified(accessibilityForeground), targetPolicy: .external)
-        case .clickMenuBarItemIndex:
-            .init(completion: .dispatchedUnverified(globalForeground), targetPolicy: .external)
-        case .launchDockItem:
-            .init(completion: .dispatchedUnverified(accessibilityForeground), targetPolicy: .external)
-        case .rightClickDockItem:
-            .init(completion: .dispatchedUnverified(globalForeground), targetPolicy: .external)
-        case .hideDock, .showDock:
-            .init(completion: .dispatchedUnverified(nativeBackground), targetPolicy: .global)
-        case .dialogClickButton, .dialogDismiss:
-            .init(completion: .dispatchedUnverified(accessibilityForeground), targetPolicy: .responseResolved)
-        case .backgroundDialogClickButton:
-            .init(completion: .dispatchedUnverified(accessibilityBackground), targetPolicy: .responseResolved)
-        case .dialogEnterText:
-            .init(completion: .dispatchedUnverified(globalForeground), targetPolicy: .responseResolved)
-        case .dialogHandleFile:
-            .init(completion: .dispatchedUnverified(.init(
-                mechanism: .clipboardTransaction,
-                mode: .foreground)), targetPolicy: .responseResolved)
-        case .exactDialogClickButton, .exactDialogDismiss:
-            .init(completion: .dispatchedUnverified(accessibilityBackground), targetPolicy: .requestPinned)
-        case .exactDialogEnterText:
-            .init(completion: .dispatchedUnverified(.init(
-                mechanism: .accessibilityValue,
-                mode: .background)), targetPolicy: .responseResolved)
-        case .exactDialogForceDismiss:
-            .init(completion: .dispatchedUnverified(globalForeground), targetPolicy: .responseResolved)
-        case .desktopObservation, .detectElements, .inspectAccessibilityTree,
-             .captureScreen, .captureWindow, .captureFrontmost, .captureArea:
-            .init(completion: .requestDependent(mutatesDesktop: false), targetPolicy: .requestDependent)
-        case .permissionsStatus,
-             .createExactWindowHeldPointerOwner,
-             .observeProcessGeneration,
-             .certificationProducerAttestation,
-             .daemonStatus,
-             .daemonStop,
-             .browserStatus,
-             .browserDisconnect,
-             .getFocusedElement,
-             .waitForElement,
-             .listWindows,
-             .getFocusedWindow,
-             .listApplications,
-             .findApplication,
-             .getFrontmostApplication,
-             .isApplicationRunning,
-             .listMenus,
-             .listFrontmostMenus,
-             .listMenuExtras,
-             .menuExtraOpenMenuFrame,
-             .listMenuBarItems,
-             .listDockItems,
-             .isDockHidden,
-             .findDockItem,
-             .dialogFindActive,
-             .dialogListElements,
-             .targetedDialogListElements,
-             .prepareDialogAction,
-             .createSnapshot,
-             .storeDetectionResult,
-             .getDetectionResult,
-             .storeScreenshot,
-             .storeObservationSnapshot,
-             .storeAnnotatedScreenshot,
-             .listSnapshots,
-             .getMostRecentSnapshot,
-             .invalidateImplicitLatestSnapshot,
-             .beginSnapshotMutation,
-             .finishSnapshotMutation,
-             .cleanSnapshot,
-             .cleanSnapshotsOlderThan,
-             .cleanAllSnapshots,
-             ._appleScriptProbe:
-            .init(completion: .readOnly, targetPolicy: .notApplicable)
-        }
+        self.operationDescriptor(for: operation).contract
     }
 
     // swiftlint:disable:next cyclomatic_complexity
@@ -1331,62 +776,111 @@ extension PeekabooBridgeOperationResultSemantics {
             targetPolicy: mutationTargetPolicy)
     }
 
-    static func semanticPlan(for request: PeekabooBridgeRequest) -> SemanticPlan {
+    static func semanticPlan(for request: PeekabooBridgeRequest) -> PeekabooBridgeRequestPlan {
+        self.requestPlan(
+            for: request,
+            vocabulary: .init(usesCurrentResultSemantics:
+                PeekabooBridgeRequestContext.usesAttestedOperationResultSemantics))
+    }
+
+    static func requestPlan(
+        for request: PeekabooBridgeRequest,
+        vocabulary: PeekabooBridgeRequestPlan.Vocabulary) -> PeekabooBridgeRequestPlan
+    {
+        let carriageRequest = request
         let request = request.unwrappedOperationRequest
         let operation = request.operation
         if case .attestedOperation = request {
-            return self.invalidCarriageSemanticPlan(operation: operation)
+            return self.invalidCarriageSemanticPlan(
+                request: request,
+                operation: operation,
+                vocabulary: vocabulary)
         }
         if case .projectedAction = request {
-            return self.invalidCarriageSemanticPlan(operation: operation)
+            return self.invalidCarriageSemanticPlan(
+                request: request,
+                operation: operation,
+                vocabulary: vocabulary)
         }
-        let operationPolicy = self.operationPolicy(for: operation)
+        let descriptor = self.operationPolicy(for: operation)
         let typedResponseRule = self.typedResponseRule(for: request)
         precondition(
-            typedResponseRule.isConsistent(with: operationPolicy.typedResponse),
+            typedResponseRule.isConsistent(with: descriptor.typedResponse),
             "Typed response rule must match the exhaustive operation binding")
         let contract = self.contract(for: request)
         let exactReadTarget = self.exactReadTarget(for: request)
         let readLane = self.desktopReadOperationLane(
             contract: contract,
-            policy: operationPolicy.lane.readPolicy,
+            policy: descriptor.lane.readPolicy,
             exactTarget: exactReadTarget)
-        return SemanticPlan(
-            operation: operation,
-            operationPolicy: operationPolicy,
-            contract: contract,
-            responseFamilies: self.responseFamilies(for: request),
-            deliveryRules: self.deliveryRules(for: request),
-            allowedSuccessStates: self.allowedSuccessStates(for: request),
-            successResponsePolicy: self.successResponsePolicy(for: request),
-            deliveryAgnosticFailureUnits: self.deliveryAgnosticFailureUnits(for: request),
-            typedResponseRule: typedResponseRule,
-            desktopOperationScope: self.desktopOperationScope(for: request),
-            desktopReadOperationLane: readLane,
-            exactReadTarget: exactReadTarget,
-            pinnedWindowMutation: self.pinnedWindowMutation(for: request))
+        let requiresPinnedWindowMutation = switch descriptor.pinnedWindow {
+        case .required: true
+        case .legacyOptionalCurrentRequired: vocabulary == .current
+        case .unavailable: false
+        }
+        return PeekabooBridgeRequestPlan(
+            request: request,
+            carriageRequest: carriageRequest,
+            descriptor: descriptor,
+            vocabulary: vocabulary,
+            target: .init(
+                policy: contract.targetPolicy,
+                responseEvidenceSource: descriptor.responseTargetEvidence,
+                requestEvidence: request.operationTargetEvidence,
+                desktopOperationScope: self.desktopOperationScope(for: request),
+                desktopReadOperationLane: readLane,
+                exactReadTarget: exactReadTarget,
+                pinnedWindowMutation: self.pinnedWindowMutation(for: request),
+                requiresPinnedWindowMutation: requiresPinnedWindowMutation),
+            result: .init(
+                completion: contract.completion,
+                responseFamilies: self.responseFamilies(for: request),
+                deliveryRules: self.deliveryRules(for: request, contract: contract),
+                allowedSuccessStates: self.allowedSuccessStates(
+                    for: request,
+                    completion: contract.completion),
+                successResponsePolicy: self.successResponsePolicy(for: request),
+                deliveryAgnosticFailureUnits: self.deliveryAgnosticFailureUnits(for: request),
+                typedResponseRule: typedResponseRule))
     }
 
-    private static func invalidCarriageSemanticPlan(operation: PeekabooBridgeOperation) -> SemanticPlan {
+    private static func invalidCarriageSemanticPlan(
+        request: PeekabooBridgeRequest,
+        operation: PeekabooBridgeOperation,
+        vocabulary: PeekabooBridgeRequestPlan.Vocabulary) -> PeekabooBridgeRequestPlan
+    {
         let lane = LanePolicy(nativeOwnership: .bridge, readPolicy: .globalExclusive)
-        return SemanticPlan(
+        let descriptor = OperationDescriptor(
             operation: operation,
-            operationPolicy: .init(
-                lane: lane,
-                pinnedWindow: .unavailable,
-                typedResponse: .noSuccessResponse,
-                windowResponseProof: .none),
+            lane: lane,
+            pinnedWindow: .unavailable,
+            typedResponse: .noSuccessResponse,
+            windowResponseProof: .none,
             contract: .init(completion: .readOnly, targetPolicy: .notApplicable),
             responseFamilies: [],
-            deliveryRules: [],
-            allowedSuccessStates: [],
-            successResponsePolicy: .errorOnly,
-            deliveryAgnosticFailureUnits: nil,
-            typedResponseRule: .none,
-            desktopOperationScope: .global,
-            desktopReadOperationLane: (.global, .write),
-            exactReadTarget: nil,
-            pinnedWindowMutation: nil)
+            responseTargetEvidence: .none)
+        return PeekabooBridgeRequestPlan(
+            request: request,
+            carriageRequest: request,
+            descriptor: descriptor,
+            vocabulary: vocabulary,
+            target: .init(
+                policy: .notApplicable,
+                responseEvidenceSource: .none,
+                requestEvidence: [],
+                desktopOperationScope: .global,
+                desktopReadOperationLane: (.global, .write),
+                exactReadTarget: nil,
+                pinnedWindowMutation: nil,
+                requiresPinnedWindowMutation: false),
+            result: .init(
+                completion: .readOnly,
+                responseFamilies: [],
+                deliveryRules: [],
+                allowedSuccessStates: [],
+                successResponsePolicy: .errorOnly,
+                deliveryAgnosticFailureUnits: nil,
+                typedResponseRule: .none))
     }
 
     private static func desktopOperationScope(for request: PeekabooBridgeRequest) -> DesktopOperationScope {
@@ -1679,9 +1173,10 @@ extension PeekabooBridgeOperationResultSemantics {
     }
 
     private static func allowedSuccessStates(
-        for request: PeekabooBridgeRequest) -> [DesktopActionOutcome.State]
+        for request: PeekabooBridgeRequest,
+        completion: Completion) -> [DesktopActionOutcome.State]
     {
-        guard self.contract(for: request).completion.mutatesDesktop else { return [] }
+        guard completion.mutatesDesktop else { return [] }
         let verifiedOrAccepted: [DesktopActionOutcome.State] = [
             .confirmedChange,
             .confirmedNoChange,
@@ -1782,78 +1277,8 @@ extension PeekabooBridgeOperationResultSemantics {
         }
     }
 
-    // Every wire operation has exactly one success-response family set here. Errors are admitted
-    // separately and still have to satisfy the operation's outcome and target rules.
-    // swiftlint:disable:next cyclomatic_complexity
     static func responseFamilies(for operation: PeekabooBridgeOperation) -> Set<ResponseFamily> {
-        switch operation {
-        case .permissionsStatus: [.permissionsStatus]
-        case .agentExecutionTrace: [.agentExecutionTrace]
-        case .observeProcessGeneration: [.processGenerationObservation]
-        case .certificationProducerAttestation: [.certificationProducerAttestation]
-        case .requestPostEventPermission: [.bool]
-        case .daemonStatus: [.daemonStatus]
-        case .daemonStop: [.bool]
-        case .browserStatus, .browserConnect: [.browserStatus]
-        case .browserDisconnect: [.ok]
-        case .browserExecute: [.browserToolResponse]
-        case .captureScreen, .captureWindow, .captureFrontmost, .captureArea: [.capture]
-        case .detectElements, .inspectAccessibilityTree: [.elementDetection]
-        case .getFocusedElement: [.focusedElement]
-        case .createExactWindowHeldPointerOwner: [.heldPointerOwner]
-        case .beginExactWindowHeldPointer: [.heldPointerReceipt]
-        case .releaseExactWindowHeldPointer, .revokeExactWindowHeldPointer,
-             .disconnectExactWindowHeldPointerOwner:
-            [.heldPointerTermination]
-        case .desktopObservation: [.desktopObservation]
-        case .click, .type, .scroll, .targetedScroll, .hotkey, .targetedHotkey,
-             .exactWindowTargetedHotkey, .targetedClick, .exactWindowTargetedClick,
-             .swipe, .drag, .moveMouse:
-            [.ok]
-        case .typeActions, .targetedTypeActions, .exactWindowTargetedTypeActions: [.typeResult]
-        case .setValue, .performAction: [.elementActionResult]
-        case .waitForElement: [.waitResult]
-        case .listWindows: [.windows]
-        case .focusWindow, .moveWindow, .resizeWindow, .setWindowBounds, .closeWindow,
-             .backgroundCloseWindow, .minimizeWindow, .restoreWindow, .maximizeWindow:
-            [.ok, .window]
-        case .getFocusedWindow: [.window]
-        case .listApplications: [.applications]
-        case .findApplication, .getFrontmostApplication, .launchApplication,
-             .launchApplicationWithOptions, .relaunchApplicationWithOptions:
-            [.application]
-        case .isApplicationRunning, .quitApplication: [.bool]
-        case .activateApplication, .hideApplication, .unhideApplication,
-             .hideOtherApplications, .showAllApplications:
-            [.ok]
-        case .listMenus, .listFrontmostMenus: [.menuStructure]
-        case .clickMenuItem, .clickMenuItemByName, .clickMenuExtra: [.ok]
-        case .listMenuExtras: [.menuExtras]
-        case .menuExtraOpenMenuFrame: [.rect]
-        case .listMenuBarItems: [.menuBarItems]
-        case .clickMenuBarItemNamed, .clickMenuBarItemIndex: [.clickResult]
-        case .listDockItems: [.dockItems]
-        case .launchDockItem, .rightClickDockItem, .hideDock, .showDock: [.ok]
-        case .isDockHidden: [.bool]
-        case .findDockItem: [.dockItem]
-        case .dialogFindActive: [.dialogInfo]
-        case .dialogClickButton, .backgroundDialogClickButton, .dialogEnterText,
-             .dialogHandleFile, .dialogDismiss, .exactDialogClickButton, .exactDialogDismiss,
-             .exactDialogEnterText, .exactDialogForceDismiss:
-            [.dialogResult]
-        case .dialogListElements, .targetedDialogListElements: [.dialogElements]
-        case .prepareDialogAction: [.preparedDialogAction]
-        case .createSnapshot, .getMostRecentSnapshot: [.snapshotID]
-        case .storeDetectionResult, .storeScreenshot, .storeObservationSnapshot,
-             .storeAnnotatedScreenshot, .finishSnapshotMutation, .cleanSnapshot:
-            [.ok]
-        case .getDetectionResult: [.detection]
-        case .listSnapshots: [.snapshots]
-        case .invalidateImplicitLatestSnapshot: [.ok, .snapshotID]
-        case .beginSnapshotMutation: [.snapshotMutationLease]
-        case .cleanSnapshotsOlderThan, .cleanAllSnapshots: [.int]
-        case ._appleScriptProbe: []
-        }
+        self.operationDescriptor(for: operation).responseFamilies
     }
 
     private static func responseFamilies(for request: PeekabooBridgeRequest) -> Set<ResponseFamily> {
@@ -1870,7 +1295,10 @@ extension PeekabooBridgeOperationResultSemantics {
     // Delivery is a route result, not just an operation property: several operations have bounded
     // native/AX or AX/window-targeted alternatives. Keep each alternative paired with its unit rule.
     // swiftlint:disable:next cyclomatic_complexity function_body_length
-    private static func deliveryRules(for request: PeekabooBridgeRequest) -> [DeliveryRule] {
+    private static func deliveryRules(
+        for request: PeekabooBridgeRequest,
+        contract: Contract) -> [DeliveryRule]
+    {
         let axForeground = DesktopActionOutcome.Delivery(mechanism: .accessibilityAction, mode: .foreground)
         let axBackground = DesktopActionOutcome.Delivery(mechanism: .accessibilityAction, mode: .background)
         let valueForeground = DesktopActionOutcome.Delivery(mechanism: .accessibilityValue, mode: .foreground)
@@ -2076,7 +1504,7 @@ extension PeekabooBridgeOperationResultSemantics {
                 : .foreground
             return [rule(.init(mechanism: .capturePipeline, mode: mode), .variable)]
         case .captureScreen, .captureWindow, .captureFrontmost, .captureArea:
-            guard self.contract(for: request).completion.mutatesDesktop else { return [] }
+            guard contract.completion.mutatesDesktop else { return [] }
             return [rule(.init(mechanism: .capturePipeline, mode: .background), .exact(1))]
         case .detectElements, .inspectAccessibilityTree:
             return [rule(axBackground, .exact(1))]
@@ -2089,7 +1517,6 @@ extension PeekabooBridgeOperationResultSemantics {
         case .browserExecute:
             return [rule(browserBackground, .variable)]
         default:
-            let contract = self.contract(for: request)
             guard let delivery = contract.completion.fixedDelivery else { return [] }
             return [rule(delivery, .exact(1))]
         }
@@ -2163,7 +1590,17 @@ extension PeekabooBridgeOperationResultSemantics {
         response: PeekabooBridgeResponse? = nil,
         request: PeekabooBridgeRequest) -> Bool
     {
-        let plan = self.semanticPlan(for: request)
+        self.successfulOutcomeMatchesContract(
+            outcome,
+            response: response,
+            plan: self.semanticPlan(for: request))
+    }
+
+    static func successfulOutcomeMatchesContract(
+        _ outcome: DesktopActionOutcome,
+        response: PeekabooBridgeResponse? = nil,
+        plan: PeekabooBridgeRequestPlan) -> Bool
+    {
         guard outcome.route == .bridge,
               plan.contract.completion.mutatesDesktop,
               plan.allowsSuccessState(outcome.state),
@@ -2181,7 +1618,7 @@ extension PeekabooBridgeOperationResultSemantics {
     private static func successResponseMatchesPolicy(
         _ response: PeekabooBridgeResponse?,
         outcome: DesktopActionOutcome,
-        plan: SemanticPlan) -> Bool
+        plan: PeekabooBridgeRequestPlan) -> Bool
     {
         switch plan.successResponsePolicy {
         case .ordinary:
@@ -2215,11 +1652,17 @@ extension PeekabooBridgeOperationResultSemantics {
         _ outcome: DesktopActionOutcome,
         request: PeekabooBridgeRequest) -> Bool
     {
+        self.failureOutcomeMatchesContract(outcome, plan: self.semanticPlan(for: request))
+    }
+
+    static func failureOutcomeMatchesContract(
+        _ outcome: DesktopActionOutcome,
+        plan: PeekabooBridgeRequestPlan) -> Bool
+    {
         guard outcome.route == .bridge, !outcome.isConfirmed else { return false }
         if outcome.state == .refused {
             return outcome.delivery == nil && outcome.dispatchState == .none
         }
-        let plan = self.semanticPlan(for: request)
         guard let delivery = outcome.delivery else {
             guard outcome.state == .indeterminate else { return false }
             guard let unitCount = outcome.dispatchState.unitCount else { return true }
@@ -2239,31 +1682,57 @@ extension PeekabooBridgeOperationResultSemantics {
         self.semanticPlan(for: request).responseMatches(response)
     }
 
+    static func responseMatchesContract(
+        _ response: PeekabooBridgeResponse,
+        plan: PeekabooBridgeRequestPlan) -> Bool
+    {
+        plan.responseMatches(response)
+    }
+
     static func nonErrorResponseAllowsFailureOutcome(
         _ response: PeekabooBridgeResponse,
         outcome: DesktopActionOutcome,
         request: PeekabooBridgeRequest) -> Bool
     {
-        guard self.semanticPlan(for: request).successResponsePolicy == .quitBoolean,
+        self.nonErrorResponseAllowsFailureOutcome(
+            response,
+            outcome: outcome,
+            plan: self.semanticPlan(for: request))
+    }
+
+    static func nonErrorResponseAllowsFailureOutcome(
+        _ response: PeekabooBridgeResponse,
+        outcome: DesktopActionOutcome,
+        plan: PeekabooBridgeRequestPlan) -> Bool
+    {
+        guard plan.successResponsePolicy == .quitBoolean,
               case let .bool(terminated) = response,
               !terminated,
               outcome.state == .refused,
               outcome.refusalReason == .targetUnavailable,
               outcome.dispatchState == .none
         else { return false }
-        return self.failureOutcomeMatchesContract(outcome, request: request)
+        return self.failureOutcomeMatchesContract(outcome, plan: plan)
     }
 
     static func finalizeSuccessful(
         request: PeekabooBridgeRequest,
         handled: PeekabooBridgeHandledResponse) throws -> PeekabooBridgeHandledResponse
     {
-        guard PeekabooBridgeRequestContext.usesAttestedOperationResultSemantics else { return handled }
-        guard request.mayMutateDesktop else { return handled }
+        try self.finalizeSuccessful(plan: self.semanticPlan(for: request), handled: handled)
+    }
+
+    static func finalizeSuccessful(
+        plan: PeekabooBridgeRequestPlan,
+        handled: PeekabooBridgeHandledResponse) throws -> PeekabooBridgeHandledResponse
+    {
+        let request = plan.request
+        guard plan.vocabulary.usesCurrentResultSemantics else { return handled }
+        guard plan.result.completion.mutatesDesktop else { return handled }
         if let mutation = handled.mutation {
             let outcome = self.fillingExpectedSuccessfulDispatchUnitCount(
                 mutation.outcome,
-                request: request)
+                plan: plan)
             let normalized = outcome == mutation.outcome
                 ? handled
                 : handled.finalizingMutation(outcome: outcome, target: mutation.target)
@@ -2271,7 +1740,7 @@ extension PeekabooBridgeOperationResultSemantics {
                 return normalized
             }
             guard [.partial, .refused, .indeterminate].contains(outcome.state),
-                  self.failureOutcomeMatchesContract(outcome.routed(to: .bridge), request: request),
+                  self.failureOutcomeMatchesContract(outcome.routed(to: .bridge), plan: plan),
                   let failure = DesktopActionFailure(
                       outcome: outcome.routed(to: .bridge),
                       message: "The desktop action provider returned a non-success result.",
@@ -2285,7 +1754,7 @@ extension PeekabooBridgeOperationResultSemantics {
                outcome.dispatchState.mutationDispatched
             {
                 guard let target = try PeekabooBridgeOperationTargetAttribution.resolve(
-                    request: request,
+                    plan: plan,
                     response: normalized.response,
                     handledTarget: normalized.targetIdentity)
                 else {
@@ -2309,7 +1778,6 @@ extension PeekabooBridgeOperationResultSemantics {
         if let failure = self.actionFailure(in: handled.response) {
             throw failure.routed(to: .bridge)
         }
-        let plan = self.semanticPlan(for: request)
         let contract = plan.contract
         guard contract.completion.fixedDelivery != nil else {
             preconditionFailure("Mutating Bridge request has no successful result contract: \(request.operation)")
@@ -2380,12 +1848,11 @@ extension PeekabooBridgeOperationResultSemantics {
 
     private static func fillingExpectedSuccessfulDispatchUnitCount(
         _ outcome: DesktopActionOutcome,
-        request: PeekabooBridgeRequest) -> DesktopActionOutcome
+        plan: PeekabooBridgeRequestPlan) -> DesktopActionOutcome
     {
         guard outcome.dispatchState.unitCount == nil,
               let delivery = outcome.delivery,
-              let unitCount = self.semanticPlan(for: request)
-                  .defaultSuccessfulDispatchUnitCount(for: delivery)
+              let unitCount = plan.defaultSuccessfulDispatchUnitCount(for: delivery)
         else { return outcome }
         switch outcome.state {
         case .confirmedChange:
@@ -2411,7 +1878,18 @@ extension PeekabooBridgeOperationResultSemantics {
         request: PeekabooBridgeRequest,
         stage: FailureStage) -> PeekabooBridgeErrorEnvelope
     {
-        let usesCurrentVocabulary = PeekabooBridgeRequestContext.usesAttestedOperationResultSemantics
+        self.canonicalFailure(
+            envelope,
+            plan: self.semanticPlan(for: request),
+            stage: stage)
+    }
+
+    static func canonicalFailure(
+        _ envelope: PeekabooBridgeErrorEnvelope,
+        plan: PeekabooBridgeRequestPlan,
+        stage: FailureStage) -> PeekabooBridgeErrorEnvelope
+    {
+        let usesCurrentVocabulary = plan.vocabulary.usesCurrentResultSemantics
         let compatibleEnvelope = usesCurrentVocabulary
             ? envelope
             : self.removingReceiptOnlyFailureVocabulary(from: envelope)
@@ -2434,7 +1912,7 @@ extension PeekabooBridgeOperationResultSemantics {
                 stage
             }
         }
-        guard request.mayMutateDesktop, compatibleEnvelope.actionOutcome == nil else {
+        guard plan.result.completion.mutatesDesktop, compatibleEnvelope.actionOutcome == nil else {
             return compatibleEnvelope
         }
         let failure: DesktopActionFailure = switch compatibleStage {
@@ -2479,9 +1957,18 @@ extension PeekabooBridgeOperationResultSemantics {
         request: PeekabooBridgeRequest,
         handled: PeekabooBridgeHandledResponse) throws
     {
-        guard request.mayMutateDesktop else { return }
+        try self.validateSuccessfulTargetDisposition(
+            plan: self.semanticPlan(for: request),
+            handled: handled)
+    }
+
+    static func validateSuccessfulTargetDisposition(
+        plan: PeekabooBridgeRequestPlan,
+        handled: PeekabooBridgeHandledResponse) throws
+    {
+        guard plan.result.completion.mutatesDesktop else { return }
         guard !self.isNoDispatchFailure(handled.response) else { return }
-        let policy = self.semanticPlan(for: request).contract.targetPolicy
+        let policy = plan.target.policy
         guard let mutation = handled.mutation else {
             guard self.isDispatchedFailure(handled.response) else {
                 throw DesktopTargetIdentityError.incompleteExactWindow
@@ -2490,7 +1977,7 @@ extension PeekabooBridgeOperationResultSemantics {
             case .global:
                 break
             case .requestPinned:
-                guard try PeekabooBridgeOperationTargetAttribution.resolveRequest(request) != nil else {
+                guard try PeekabooBridgeOperationTargetAttribution.resolveRequest(plan) != nil else {
                     throw DesktopTargetIdentityError.incompleteExactWindow
                 }
             case .handlerRequired, .handlerResolvedOrGlobal, .responseResolved, .external:

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer+DesktopReadLane.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer+DesktopReadLane.swift
@@ -13,7 +13,10 @@ extension PeekabooBridgeServer {
         proposed: (scope: DesktopOperationScope, access: DesktopOperationAccess))
         -> (scope: DesktopOperationScope, access: DesktopOperationAccess)
     {
-        switch self.desktopReadLaneResolution(for: request, proposed: proposed) {
+        switch self.desktopReadLaneResolution(
+            for: PeekabooBridgeOperationResultSemantics.semanticPlan(for: request),
+            proposed: proposed)
+        {
         case let .lane(scope, access, validatesIdentity):
             if validatesIdentity, !self.desktopReadScopeIsCurrent(scope) {
                 return (.global, .write)
@@ -30,19 +33,29 @@ extension PeekabooBridgeServer {
         operation: () async throws -> T) async throws -> T
     {
         try await self.withValidatedDesktopReadOperationLane(
-            for: request,
+            for: PeekabooBridgeOperationResultSemantics.semanticPlan(for: request),
             proposed: proposed)
         { _ in
             try await operation()
         }
     }
 
+    func withValidatedDesktopReadOperationLane<T: Sendable>(
+        for plan: PeekabooBridgeOperationResultSemantics.PeekabooBridgeRequestPlan,
+        proposed: (scope: DesktopOperationScope, access: DesktopOperationAccess),
+        operation: () async throws -> T) async throws -> T
+    {
+        try await self.withValidatedDesktopReadOperationLane(for: plan, proposed: proposed) { _ in
+            try await operation()
+        }
+    }
+
     private func withValidatedDesktopReadOperationLane<T: Sendable>(
-        for request: PeekabooBridgeRequest,
+        for plan: PeekabooBridgeOperationResultSemantics.PeekabooBridgeRequestPlan,
         proposed: (scope: DesktopOperationScope, access: DesktopOperationAccess),
         operation: (DesktopOperationScope) async throws -> T) async throws -> T
     {
-        let resolution = self.desktopReadLaneResolution(for: request, proposed: proposed)
+        let resolution = self.desktopReadLaneResolution(for: plan, proposed: proposed)
         guard case let .lane(scope, access, validatesIdentity) = resolution else {
             throw Self.exactDesktopReadTargetChangedError()
         }
@@ -61,10 +74,9 @@ extension PeekabooBridgeServer {
     }
 
     private func desktopReadLaneResolution(
-        for request: PeekabooBridgeRequest,
+        for plan: PeekabooBridgeOperationResultSemantics.PeekabooBridgeRequestPlan,
         proposed: (scope: DesktopOperationScope, access: DesktopOperationAccess)) -> DesktopReadLaneResolution
     {
-        let plan = PeekabooBridgeOperationResultSemantics.semanticPlan(for: request)
         if let exactTarget = plan.exactReadTarget,
            let exactScope = self.exactDesktopReadScope(for: exactTarget)
         {

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer+OperationReceipts.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer+OperationReceipts.swift
@@ -4,6 +4,7 @@ import PeekabooFoundation
 
 private struct OperationReceiptEncodingContext {
     let request: PeekabooBridgeRequest
+    let plan: PeekabooBridgeOperationResultSemantics.PeekabooBridgeRequestPlan
     let requestPayload: PeekabooBridgeAttestedOperationRequest
     let authority: PeekabooBridgeOperationReceiptAuthority
     let claim: PeekabooBridgeOperationSessionClaim
@@ -69,18 +70,20 @@ extension PeekabooBridgeServer {
         }
         let encodingContext = OperationReceiptEncodingContext(
             request: request,
+            plan: PeekabooBridgeOperationResultSemantics.requestPlan(for: request, vocabulary: .current),
             requestPayload: payload,
             authority: authority,
             claim: claim,
             startedAt: startedAt)
-        let requestEvidence = request.operationTargetEvidence
+        let plan = encodingContext.plan
+        let requestEvidence = plan.target.requestEvidence
         let requestTarget: DesktopTargetIdentity?
         do {
-            requestTarget = try PeekabooBridgeOperationTargetAttribution.resolveRequest(request)
+            requestTarget = try PeekabooBridgeOperationTargetAttribution.resolveRequest(plan)
         } catch let error as DesktopTargetIdentityError {
             let failure = PeekabooBridgeTargetAttributionFailure(error, stage: .preDispatch)
             let response = Self.targetAttributionFailureResponse(
-                request: request,
+                plan: plan,
                 failure: failure,
                 originalOutcome: nil,
                 afterExecution: false)
@@ -117,7 +120,7 @@ extension PeekabooBridgeServer {
             claim.negotiatedCapabilities)
         {
             await PeekabooBridgeRequestContext.$usesAttestedOperationResultSemantics.withValue(true) {
-                await self.terminalResponse(for: request, peer: peer)
+                await self.terminalResponse(for: plan, peer: peer)
             }
         }
         let response: PeekabooBridgeResponse
@@ -126,12 +129,12 @@ extension PeekabooBridgeServer {
         let targetFailure: PeekabooBridgeTargetAttributionFailure?
         let targetFailureEvidence: [PeekabooBridgeOperationTargetEvidence]?
         let attributionEvidence = PeekabooBridgeOperationTargetAttribution.evidence(
-            request: request,
+            plan: plan,
             response: handled.response,
             handledTarget: handled.targetIdentity ?? requestTarget)
         do {
             try PeekabooBridgeOperationResultSemantics.validateSuccessfulTargetDisposition(
-                request: request,
+                plan: plan,
                 handled: handled)
             if PeekabooBridgeOperationReceiptSemantics.allowsTargetlessFailureReceipt(for: handled.response) {
                 response = handled.response
@@ -150,7 +153,7 @@ extension PeekabooBridgeServer {
                 focusedElement = nil
             } else {
                 let resolved = try PeekabooBridgeOperationTargetAttribution.resolve(
-                    request: request,
+                    plan: plan,
                     response: handled.response,
                     handledTarget: handled.targetIdentity ?? requestTarget)
                 let receiptTarget = PeekabooBridgeResolvedOperationTarget(resolved)
@@ -163,7 +166,7 @@ extension PeekabooBridgeServer {
         } catch let error as DesktopTargetIdentityError {
             let failure = PeekabooBridgeTargetAttributionFailure(error, stage: .postExecution)
             response = Self.targetAttributionFailureResponse(
-                request: request,
+                plan: plan,
                 failure: failure,
                 originalOutcome: handled.outcome?.projection ??
                     PeekabooBridgeOperationReceiptSemantics.outcome(in: handled.response),
@@ -232,7 +235,7 @@ extension PeekabooBridgeServer {
                 PeekabooBridgeOperationReceiptCoding.unixMilliseconds()))
         try PeekabooBridgeOperationReceiptSemantics.validateReceiptCarriage(
             receiptPayload,
-            request: context.request,
+            plan: context.plan,
             response: response)
         let receipt: PeekabooBridgeOperationReceipt
         do {
@@ -242,7 +245,7 @@ extension PeekabooBridgeServer {
                 code: .internalError,
                 message: "Bridge operation completed, but its signed receipt could not be archived",
                 details: error.localizedDescription,
-                operationMayHaveCompleted: context.request.mayMutateDesktop)
+                operationMayHaveCompleted: context.plan.result.completion.mutatesDesktop)
         }
         return try self.encoder.encode(PeekabooBridgeResponse.attestedOperation(.init(
             response: response,
@@ -276,6 +279,9 @@ extension PeekabooBridgeServer {
                 failureEvidence: nil),
             context: .init(
                 request: payload.request,
+                plan: PeekabooBridgeOperationResultSemantics.requestPlan(
+                    for: payload.request,
+                    vocabulary: .current),
                 requestPayload: payload,
                 authority: authority,
                 claim: claim,
@@ -300,13 +306,17 @@ extension PeekabooBridgeServer {
     }
 
     private func terminalResponse(
-        for request: PeekabooBridgeRequest,
+        for plan: PeekabooBridgeOperationResultSemantics.PeekabooBridgeRequestPlan,
         peer: PeekabooBridgePeer) async -> PeekabooBridgeHandledResponse
     {
+        let request = plan.carriageRequest
         if case let .projectedAction(payload) = request {
             do {
                 let nestedRequest = try payload.validatedRequest()
-                let handled = try await self.route(nestedRequest, peer: peer)
+                let nestedPlan = PeekabooBridgeOperationResultSemantics.requestPlan(
+                    for: nestedRequest,
+                    vocabulary: plan.vocabulary)
+                let handled = try await self.route(nestedPlan, peer: peer)
                 return .init(
                     response: .projectedActionForCurrentRequestVocabulary(
                         response: handled.response,
@@ -315,25 +325,33 @@ extension PeekabooBridgeServer {
                     targetIdentity: handled.targetIdentity,
                     selectedLeafEvidence: handled.selectedLeafEvidence)
             } catch let envelope as PeekabooBridgeErrorEnvelope {
-                return Self.projectedFailure(envelope, for: payload.request)
+                return Self.projectedFailure(
+                    envelope,
+                    mayMutateDesktop: plan.result.completion.mutatesDesktop)
             } catch let failure as DesktopActionFailure {
-                return Self.projectedFailure(.init(
-                    code: .internalError,
-                    actionFailure: failure.routed(to: .bridge),
-                    details: "\(failure)"), for: payload.request)
+                return Self.projectedFailure(
+                    .init(
+                        code: .internalError,
+                        actionFailure: failure.routed(to: .bridge),
+                        details: "\(failure)"),
+                    mayMutateDesktop: plan.result.completion.mutatesDesktop)
             } catch is CancellationError {
-                return Self.projectedFailure(.init(
-                    code: .timeout,
-                    message: "Bridge request was cancelled"), for: payload.request)
+                return Self.projectedFailure(
+                    .init(
+                        code: .timeout,
+                        message: "Bridge request was cancelled"),
+                    mayMutateDesktop: plan.result.completion.mutatesDesktop)
             } catch {
-                return Self.projectedFailure(.init(
-                    code: .internalError,
-                    message: error.localizedDescription,
-                    details: "\(error)"), for: payload.request)
+                return Self.projectedFailure(
+                    .init(
+                        code: .internalError,
+                        message: error.localizedDescription,
+                        details: "\(error)"),
+                    mayMutateDesktop: plan.result.completion.mutatesDesktop)
             }
         }
         do {
-            return try await self.route(request, peer: peer)
+            return try await self.route(plan, peer: peer)
         } catch let envelope as PeekabooBridgeErrorEnvelope {
             return .init(
                 response: .error(envelope.legacyCompatible),
@@ -360,9 +378,11 @@ extension PeekabooBridgeServer {
 
     private static func projectedFailure(
         _ unprojectedEnvelope: PeekabooBridgeErrorEnvelope,
-        for request: PeekabooBridgeRequest) -> PeekabooBridgeHandledResponse
+        mayMutateDesktop: Bool) -> PeekabooBridgeHandledResponse
     {
-        let envelope = self.canonicalMutationFailureEnvelope(unprojectedEnvelope, for: request)
+        let envelope = self.canonicalMutationFailureEnvelope(
+            unprojectedEnvelope,
+            mayMutateDesktop: mayMutateDesktop)
         return .init(
             response: .projectedActionForCurrentRequestVocabulary(
                 response: .error(envelope),
@@ -372,9 +392,9 @@ extension PeekabooBridgeServer {
 
     private static func canonicalMutationFailureEnvelope(
         _ envelope: PeekabooBridgeErrorEnvelope,
-        for request: PeekabooBridgeRequest) -> PeekabooBridgeErrorEnvelope
+        mayMutateDesktop: Bool) -> PeekabooBridgeErrorEnvelope
     {
-        guard request.mayMutateDesktop, envelope.actionOutcome == nil else { return envelope }
+        guard mayMutateDesktop, envelope.actionOutcome == nil else { return envelope }
         let failure = DesktopActionFailure.indeterminate(
             route: .bridge,
             evidence: .completionUnknown,
@@ -391,13 +411,13 @@ extension PeekabooBridgeServer {
     }
 
     private static func targetAttributionFailureResponse(
-        request: PeekabooBridgeRequest,
+        plan: PeekabooBridgeOperationResultSemantics.PeekabooBridgeRequestPlan,
         failure: PeekabooBridgeTargetAttributionFailure,
         originalOutcome: DesktopActionOutcome.Projection?,
         afterExecution: Bool) -> PeekabooBridgeResponse
     {
         let context = "bridge_target_attribution:\(failure.code.rawValue)"
-        guard request.mayMutateDesktop else {
+        guard plan.result.completion.mutatesDesktop else {
             return .error(.init(
                 code: .invalidRequest,
                 message: "Bridge operation target attribution failed",
@@ -428,7 +448,7 @@ extension PeekabooBridgeServer {
             code: mayHaveDispatched ? .internalError : .invalidRequest,
             actionFailure: actionFailure,
             context: context)
-        if case .projectedAction = request {
+        if case .projectedAction = plan.carriageRequest {
             return .projectedActionForCurrentRequestVocabulary(
                 response: .error(envelope),
                 outcome: actionFailure.outcome.projection,

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer+Routing.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer+Routing.swift
@@ -8,12 +8,24 @@ extension PeekabooBridgeServer {
         _ request: PeekabooBridgeRequest,
         peer: PeekabooBridgePeer?) async throws -> PeekabooBridgeHandledResponse
     {
+        let plan = PeekabooBridgeOperationResultSemantics.requestPlan(
+            for: request,
+            vocabulary: .init(usesCurrentResultSemantics:
+                PeekabooBridgeRequestContext.usesAttestedOperationResultSemantics))
+        return try await self.route(plan, peer: peer)
+    }
+
+    func route(
+        _ plan: PeekabooBridgeOperationResultSemantics.PeekabooBridgeRequestPlan,
+        peer: PeekabooBridgePeer?) async throws -> PeekabooBridgeHandledResponse
+    {
+        let request = plan.request
         do {
             try self.validatePeerAuthorization(peer)
         } catch let envelope as PeekabooBridgeErrorEnvelope {
             throw PeekabooBridgeOperationResultSemantics.canonicalFailure(
                 envelope,
-                request: request,
+                plan: plan,
                 stage: .preDispatch(.transportSessionUnavailable))
         }
         do {
@@ -21,7 +33,7 @@ extension PeekabooBridgeServer {
         } catch {
             throw PeekabooBridgeOperationResultSemantics.canonicalFailure(
                 .init(code: .timeout, message: "Bridge request was cancelled before dispatch"),
-                request: request,
+                plan: plan,
                 stage: .preDispatch(.requestCancelled))
         }
 
@@ -47,7 +59,7 @@ extension PeekabooBridgeServer {
         do {
             try request.validatePlatformIdentifierBounds()
             try self.validateOperationAccess(
-                for: request,
+                for: plan,
                 peer: peer,
                 permissions: permissions,
                 effectiveOps: effectiveOps)
@@ -62,18 +74,18 @@ extension PeekabooBridgeServer {
                 """)
             throw PeekabooBridgeOperationResultSemantics.canonicalFailure(
                 envelope,
-                request: request,
+                plan: plan,
                 stage: .preDispatch(PeekabooBridgeOperationResultSemantics.preDispatchReason(for: envelope)))
         }
 
         do {
-            return try await self.withDaemonActivity(for: request) {
+            return try await self.withDaemonActivity(for: plan) {
                 let response = try await self.handleAuthorizedWithDesktopMutationBarrier(
-                    request,
+                    plan,
                     peer: peer,
                     permissions: permissions)
                 return try PeekabooBridgeOperationResultSemantics.finalizeSuccessful(
-                    request: request,
+                    plan: plan,
                     handled: response)
             }
         } catch let envelope as PeekabooBridgeErrorEnvelope {
@@ -87,7 +99,7 @@ extension PeekabooBridgeServer {
                 """)
             throw PeekabooBridgeOperationResultSemantics.canonicalFailure(
                 envelope,
-                request: request,
+                plan: plan,
                 stage: .executionMayHaveStarted)
         } catch {
             failed = true
@@ -101,15 +113,16 @@ extension PeekabooBridgeServer {
 
             throw PeekabooBridgeOperationResultSemantics.canonicalFailure(
                 Self.bridgeErrorEnvelope(for: error, operation: op),
-                request: request,
+                plan: plan,
                 stage: .executionMayHaveStarted)
         }
     }
 
     private func withDaemonActivity<Value>(
-        for request: PeekabooBridgeRequest,
+        for plan: PeekabooBridgeOperationResultSemantics.PeekabooBridgeRequestPlan,
         operation: () async throws -> Value) async throws -> Value
     {
+        let request = plan.request
         let op = request.operation
         guard let daemonControl = self.daemonControl,
               op != .daemonStatus,
@@ -122,7 +135,7 @@ extension PeekabooBridgeServer {
             guard await conditionalControl.admitActivity(operation: op) else {
                 throw PeekabooBridgeOperationResultSemantics.canonicalFailure(
                     .init(code: .serverBusy, message: "Daemon is shutting down"),
-                    request: request,
+                    plan: plan,
                     stage: .preDispatch(.transportSessionUnavailable))
             }
         } else {

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer.swift
@@ -565,62 +565,64 @@ public final class PeekabooBridgeServer {
     }
 
     func handleAuthorizedWithDesktopMutationBarrier(
-        _ request: PeekabooBridgeRequest,
+        _ plan: PeekabooBridgeOperationResultSemantics.PeekabooBridgeRequestPlan,
         peer: PeekabooBridgePeer?,
         permissions: PermissionsStatus) async throws -> PeekabooBridgeHandledResponse
     {
+        let request = plan.request
         if request.bypassesOuterDesktopMutationLane {
             return try await self.handleAuthorized(request, peer: peer, permissions: permissions)
         }
-        let nativeLeafOwnsLane = request.nativeLeafOwnsDesktopOperationLane &&
+        let nativeLeafOwnsLane = plan.nativeServiceOwnsDesktopOperationLane &&
             self.services.ownsDesktopOperationLane(for: request.operation)
-        if let proposedReadLane = request.desktopReadOperationLane, !nativeLeafOwnsLane {
+        if let proposedReadLane = plan.desktopReadOperationLane, !nativeLeafOwnsLane {
             return try await self.withValidatedDesktopReadOperationLane(
-                for: request,
+                for: plan,
                 proposed: proposedReadLane)
             {
                 try await self.handleAuthorizedWithOwnedDesktopOperationLane(
-                    request,
+                    plan,
                     peer: peer,
                     permissions: permissions)
             }
         }
 
-        if request.mayMutateDesktop, !nativeLeafOwnsLane {
+        if plan.result.completion.mutatesDesktop, !nativeLeafOwnsLane {
             return try await self.desktopOperationLaneCoordinator.run(
-                scope: request.desktopOperationScope,
+                scope: plan.desktopOperationScope,
                 access: .write)
             {
                 try await self.handleAuthorizedWithOwnedDesktopOperationLane(
-                    request,
+                    plan,
                     peer: peer,
                     permissions: permissions)
             }
         }
         return try await self.handleAuthorizedWithOwnedDesktopOperationLane(
-            request,
+            plan,
             peer: peer,
             permissions: permissions)
     }
 
     private func handleAuthorizedWithOwnedDesktopOperationLane(
-        _ request: PeekabooBridgeRequest,
+        _ plan: PeekabooBridgeOperationResultSemantics.PeekabooBridgeRequestPlan,
         peer: PeekabooBridgePeer?,
         permissions: PermissionsStatus) async throws -> PeekabooBridgeHandledResponse
     {
-        guard request.mayMutateDesktop else {
+        let request = plan.request
+        guard plan.result.completion.mutatesDesktop else {
             return try await self.handleAuthorized(request, peer: peer, permissions: permissions)
         }
 
         guard let desktopMutationWatermarkStore else {
-            try self.validatePreDispatchState(for: request)
+            try self.validatePreDispatchState(for: plan)
             return try await self.handleAuthorized(request, peer: peer, permissions: permissions)
         }
-        try self.validatePreDispatchState(for: request)
+        try self.validatePreDispatchState(for: plan)
         let mutation: DesktopMutationWatermarkStore.PendingMutation
         do {
             mutation = try await desktopMutationWatermarkStore.beginMutationCancellable(
-                target: request.desktopOperationScope)
+                target: plan.desktopOperationScope)
         } catch {
             throw PeekabooBridgeErrorEnvelope(
                 code: .internalError,
@@ -629,7 +631,7 @@ public final class PeekabooBridgeServer {
         }
 
         do {
-            try self.validatePreDispatchState(for: request)
+            try self.validatePreDispatchState(for: plan)
         } catch {
             do {
                 try desktopMutationWatermarkStore.cancelMutation(mutation)
@@ -688,25 +690,29 @@ public final class PeekabooBridgeServer {
         return completedLegacyResponse.map(response.replacingResponse) ?? response
     }
 
-    private func validatePreDispatchState(for request: PeekabooBridgeRequest) throws {
+    private func validatePreDispatchState(
+        for plan: PeekabooBridgeOperationResultSemantics.PeekabooBridgeRequestPlan) throws
+    {
         do {
             try PeekabooBridgeRequestContext.checkRequestIsActive()
-            try self.validatePinnedWindowMutation(request)
+            try self.validatePinnedWindowMutation(plan)
         } catch is CancellationError {
             throw PeekabooBridgeOperationResultSemantics.canonicalFailure(
                 .init(code: .timeout, message: "Bridge request was cancelled before dispatch"),
-                request: request,
+                plan: plan,
                 stage: .preDispatch(.requestCancelled))
         } catch let envelope as PeekabooBridgeErrorEnvelope {
             throw PeekabooBridgeOperationResultSemantics.canonicalFailure(
                 envelope,
-                request: request,
+                plan: plan,
                 stage: .preDispatch(PeekabooBridgeOperationResultSemantics.preDispatchReason(for: envelope)))
         }
     }
 
-    private func validatePinnedWindowMutation(_ request: PeekabooBridgeRequest) throws {
-        guard let pinned = request.pinnedWindowMutation else { return }
+    private func validatePinnedWindowMutation(
+        _ plan: PeekabooBridgeOperationResultSemantics.PeekabooBridgeRequestPlan) throws
+    {
+        guard let pinned = plan.pinnedWindowMutation else { return }
         let identity = pinned.identity
         guard identity.capturedBounds != nil else {
             throw PeekabooBridgeErrorEnvelope(
@@ -835,6 +841,20 @@ public final class PeekabooBridgeServer {
         permissions: PermissionsStatus,
         effectiveOps: Set<PeekabooBridgeOperation>) throws
     {
+        try self.validateOperationAccess(
+            for: PeekabooBridgeOperationResultSemantics.semanticPlan(for: request),
+            peer: peer,
+            permissions: permissions,
+            effectiveOps: effectiveOps)
+    }
+
+    func validateOperationAccess(
+        for plan: PeekabooBridgeOperationResultSemantics.PeekabooBridgeRequestPlan,
+        peer: PeekabooBridgePeer? = nil,
+        permissions: PermissionsStatus,
+        effectiveOps: Set<PeekabooBridgeOperation>) throws
+    {
+        let request = plan.request
         let op = request.operation
         if case .handshake = request {
             return
@@ -877,7 +897,7 @@ public final class PeekabooBridgeServer {
                 message: "Operation \(op.rawValue) is not supported by this host's background dialog provider")
         }
 
-        if request.requiresPinnedWindowMutationReceipt, request.pinnedWindowMutation == nil {
+        if plan.requiresPinnedWindowMutation, plan.pinnedWindowMutation == nil {
             throw PeekabooBridgeErrorEnvelope(
                 code: .invalidRequest,
                 message: "Operation \(op.rawValue) requires a process-generation window mutation receipt")

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeOperationResultSemanticsTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeOperationResultSemanticsTests.swift
@@ -269,6 +269,7 @@ struct PeekabooBridgeOperationResultSemanticsTests {
     @Test
     func `Every unconditionally mutating wire operation has one explicit result contract`() {
         let expected: Set<PeekabooBridgeOperation> = [
+            .agentExecutionTrace,
             .requestPostEventPermission,
             .browserConnect,
             .browserExecute,

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeRequestPlanTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeRequestPlanTests.swift
@@ -1,0 +1,98 @@
+import PeekabooAutomationKitTestSupport
+import Testing
+@testable import PeekabooBridge
+
+@Suite(.serialized)
+struct PeekabooBridgeRequestPlanTests {
+    typealias Semantics = PeekabooBridgeOperationResultSemantics
+
+    @Test
+    func `Every wire operation has one complete static descriptor`() {
+        let operations = PeekabooBridgeOperation.allCases
+        #expect(operations.count == 111)
+
+        let descriptors = operations.map(Semantics.operationDescriptor(for:))
+        #expect(descriptors.map(\.operation) == operations)
+        #expect(Set(descriptors.map(\.operation)) == Set(operations))
+        #expect(descriptors.allSatisfy {
+            !$0.responseFamilies.isEmpty || $0.operation == ._appleScriptProbe
+        })
+        #expect(descriptors.allSatisfy {
+            $0.windowResponseProof == ($0.typedResponse == .postMutationWindow ? .postMutationState : .none)
+        })
+
+        let evidenceSources: [Semantics.ResponseTargetEvidenceSource] = [
+            .none,
+            .agentProcess,
+            .application,
+            .browserConnection,
+            .capture,
+            .desktopObservation,
+            .dialog,
+            .heldPointerTermination,
+            .inspectWindowContext,
+            .preparedDialog,
+            .targetedDialog,
+            .window,
+        ]
+        let partition = evidenceSources.map { source in
+            Set(descriptors.filter { $0.responseTargetEvidence == source }.map(\.operation))
+        }
+        #expect(partition.reduce(0) { $0 + $1.count } == operations.count)
+        #expect(partition.reduce(into: Set<PeekabooBridgeOperation>()) { $0.formUnion($1) } == Set(operations))
+    }
+
+    @Test
+    func `Linked exact window plan captures legacy and current vocabulary immutably`() throws {
+        let fixture = AutomationTestFixtures.linkedDesktopTarget()
+        let request = PeekabooBridgeRequest.focusWindow(.init(
+            target: .windowId(fixture.windowIdentity.windowID),
+            expectedIdentity: fixture.windowIdentity))
+        let legacy = Semantics.requestPlan(for: request, vocabulary: .legacy)
+        let current = Semantics.requestPlan(for: request, vocabulary: .current)
+
+        #expect(legacy.vocabulary == .legacy)
+        #expect(current.vocabulary == .current)
+        #expect(!legacy.target.requiresPinnedWindowMutation)
+        #expect(current.target.requiresPinnedWindowMutation)
+        #expect(legacy.target.policy == .requestPinned)
+        #expect(current.target.policy == .requestPinned)
+        #expect(legacy.target.desktopOperationScope == .global)
+        #expect(current.target.desktopOperationScope == .global)
+        #expect(Semantics.operationPolicy(for: request.operation) == current.descriptor)
+        #expect(try PeekabooBridgeOperationTargetAttribution.resolveRequest(legacy) == fixture.windowTargetIdentity)
+        #expect(try PeekabooBridgeOperationTargetAttribution.resolveRequest(current) == fixture.windowTargetIdentity)
+    }
+
+    @Test(arguments: [Semantics.PeekabooBridgeRequestPlan.Vocabulary.legacy, .current])
+    func `Invalid nested carriage remains a fail closed plan`(
+        vocabulary: Semantics.PeekabooBridgeRequestPlan.Vocabulary)
+    {
+        let inner = PeekabooBridgeRequest.setValue(.init(
+            target: "B1",
+            value: .string("fixture"),
+            snapshotId: "snapshot"))
+        let malformed = PeekabooBridgeRequest.projectedAction(.init(
+            request: .projectedAction(.init(request: inner))))
+        let plan = Semantics.requestPlan(for: malformed, vocabulary: vocabulary)
+
+        #expect(plan.operation == .setValue)
+        #expect(plan.vocabulary == vocabulary)
+        #expect(plan.result.completion == .readOnly)
+        #expect(plan.result.responseFamilies.isEmpty)
+        #expect(plan.result.deliveryRules.isEmpty)
+        #expect(plan.result.allowedSuccessStates.isEmpty)
+        #expect(plan.result.successResponsePolicy == .errorOnly)
+        #expect(plan.result.typedResponseRule == .none)
+        #expect(plan.target.policy == .notApplicable)
+        #expect(plan.target.requestEvidence.isEmpty)
+        #expect(plan.target.responseEvidenceSource == .none)
+        #expect(plan.target.desktopOperationScope == .global)
+        #expect(plan.target.desktopReadOperationLane?.scope == .global)
+        #expect(plan.target.desktopReadOperationLane?.access == .write)
+        #expect(!plan.target.requiresPinnedWindowMutation)
+        #expect(plan.descriptor.lane.nativeOwnership == .bridge)
+        #expect(plan.descriptor.lane.readPolicy == .globalExclusive)
+        #expect(plan.descriptor.typedResponse == .noSuccessResponse)
+    }
+}


### PR DESCRIPTION
## Summary

- centralize all 111 static Bridge operation policies and response target evidence in one exhaustive `OperationDescriptor`
- build one immutable `PeekabooBridgeRequestPlan` with explicit legacy/current vocabulary, `TargetPlan`, and `ResultPlan`
- reuse that plan through client transport, server routing/read lanes, target attribution, and signed receipt validation

## Why

The background safety stack had accumulated parallel policy switches and repeated plan construction across result semantics, mutation classification, target evidence, response evidence, routing, and receipt validation. Adding one operation could require synchronized edits across many owners. This moves the static contract to one compiler-exhaustive switch while keeping genuinely request-dependent rules in the request overlay.

The plan captures protocol vocabulary when it is constructed, preserves the original carriage separately from the validated inner request, and treats invalid nested projected/attested carriage as a read-only error-only plan. It does not change Codable shapes, canonical bytes, signatures, or public APIs.

## Scope

- production: +1,376/-1,075 (net +301)
- tests: +99

The positive production delta establishes the request-scoped ownership boundary and removes 863 lines from the former 2,616-line result-semantics owner. A follow-up can split request overlay/delivery tables and the remaining large receipt validator into plan extensions, then migrate the few compatibility leaf adapters still reading `mayMutateDesktop`.

## Validation

- focused semantic/receipt/canonical suites: 49 + 76 tests
- exhaustive descriptor coverage for all 111 operations
- legacy/current vocabulary capture and invalid-carriage refusal tests
- `pnpm run test:safe` — final 505 tests in 64 suites plus release/certification gates
- `pnpm run format`
- `pnpm run lint` — zero serious violations
- `git diff --check`
- Autoreview: no actionable findings
