### PR TITLE
fix(bridge): accept missing closed-window readback

### DIFF
--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Keep legacy Agent JSON tool-call arguments privacy-safe and deterministic instead of exposing Swift implementation details and runtime addresses.
 - Report `retry_safe: false` whenever an Agent trace cannot prove whether a mutation dispatched.
 - Replace arbitrary provider-authored Agent trace field names with deterministic ordinal placeholders at every argument nesting level.
+- Treat an exact missing-window readback after `window close` as confirmed closure instead of a retry-unsafe failure.
 
 ## [4.2.2] - 2026-08-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Keep legacy Agent JSON tool-call arguments privacy-safe and deterministic instead of exposing Swift implementation details and runtime addresses.
 - Report `retry_safe: false` whenever an Agent trace cannot prove whether a mutation dispatched.
 - Replace arbitrary provider-authored Agent trace field names with deterministic ordinal placeholders at every argument nesting level.
+- Treat an exact missing-window readback after `window close` as confirmed closure instead of a retry-unsafe failure.
 
 ## [4.2.2] - 2026-08-20
 

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer+MutationProof.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer+MutationProof.swift
@@ -100,8 +100,20 @@ extension PeekabooBridgeServer {
             guard let identity = request.pinnedWindowMutation?.identity else {
                 throw DesktopTargetIdentityError.incompleteExactWindow
             }
-            let rawReadback = try await self.services.windows
-                .listWindows(target: .windowId(identity.windowID)).first
+            let rawReadback: ServiceWindowInfo?
+            do {
+                rawReadback = try await self.services.windows
+                    .listWindows(target: .windowId(identity.windowID)).first
+            } catch let error as PeekabooError {
+                if [.closeWindow, .backgroundCloseWindow].contains(request.operation),
+                   case .windowNotFound = error
+                {
+                    // Exact-window lookup reports a successful close as target absence.
+                    rawReadback = nil
+                } else {
+                    throw error
+                }
+            }
             if request.operation == .maximizeWindow, let rawReadback {
                 let visibleWorkArea = self.maximizedVisibleWorkAreaProvider(rawReadback.bounds)
                 readback = rawReadback.withMutationPostconditionEvidence(.init(

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeHandlerMutationSemanticsTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeHandlerMutationSemanticsTests.swift
@@ -982,6 +982,68 @@ struct PeekabooBridgeHandlerMutationSemanticsTests {
 
     @Test
     @MainActor
+    func `current close treats a window not found readback as a proved absent target`() async throws {
+        let cases: [(request: PeekabooBridgeRequest, mode: DesktopActionOutcome.Delivery.Mode, fallback: Bool)] = [
+            (
+                .closeWindow(.init(target: .windowId(77), expectedIdentity: Self.windowIdentity)),
+                .foreground,
+                true),
+            (
+                .backgroundCloseWindow(.init(target: .windowId(77), expectedIdentity: Self.windowIdentity)),
+                .background,
+                false),
+        ]
+
+        for testCase in cases {
+            let windows = HandlerMutationWindowService(
+                readbackError: .windowNotFound(criteria: "windowId 77"))
+            let handled = try await Self.handleCurrent(
+                testCase.request,
+                with: Self.server(services: StubServices(windows: windows)))
+
+            guard case .window(nil) = handled.response else {
+                Issue.record("Expected the missing post-close window to be returned as nil")
+                continue
+            }
+            #expect(handled.outcome?.state == .confirmedChange)
+            #expect(handled.outcome?.delivery?.mode == testCase.mode)
+            guard case .requestPinned? = handled.mutation?.target else {
+                Issue.record("Expected current close to retain its request-pinned window")
+                continue
+            }
+            #expect(await windows.recordedClose()?.allowForegroundFallback == testCase.fallback)
+        }
+    }
+
+    @Test
+    @MainActor
+    func `current window mutations keep other readback failures indeterminate`() async throws {
+        let cases: [(request: PeekabooBridgeRequest, error: PeekabooError)] = [
+            (
+                .closeWindow(.init(target: .windowId(77), expectedIdentity: Self.windowIdentity)),
+                .commandFailed("fixture readback failure")),
+            (
+                .maximizeWindow(.init(target: .windowId(77), expectedIdentity: Self.windowIdentity)),
+                .windowNotFound(criteria: "windowId 77")),
+        ]
+
+        for testCase in cases {
+            let windows = HandlerMutationWindowService(readbackError: testCase.error)
+            do {
+                _ = try await Self.handleCurrent(
+                    testCase.request,
+                    with: Self.server(services: StubServices(windows: windows)))
+                Issue.record("Expected an unrecognized post-mutation readback failure to be indeterminate")
+            } catch let failure as DesktopActionFailure {
+                #expect(failure.outcome.state == .indeterminate)
+                #expect(failure.outcome.evidence == .completionUnknown)
+                #expect(failure.outcome.retrySafety == .unsafe)
+            }
+        }
+    }
+
+    @Test
+    @MainActor
     func `current close refuses receiptless provider before dispatch`() async throws {
         let windows = ReceiptlessCloseWindowService()
         let server = Self.server(services: StubServices(windows: windows))
@@ -1290,13 +1352,16 @@ private final class HandlerMutationWindowService: WindowManagementServiceProtoco
     private let recorder = HandlerMutationWindowRecorder()
     private let maximizeOutcome: DesktopActionOutcome
     private let readback: ServiceWindowInfo?
+    private let readbackError: PeekabooError?
 
     init(
         maximizeOutcome: DesktopActionOutcome = .confirmedNoChange(),
-        readback: ServiceWindowInfo? = nil)
+        readback: ServiceWindowInfo? = nil,
+        readbackError: PeekabooError? = nil)
     {
         self.maximizeOutcome = maximizeOutcome
         self.readback = readback
+        self.readbackError = readbackError
     }
 
     func closeWindow(target _: WindowTarget) async throws {}
@@ -1321,9 +1386,12 @@ private final class HandlerMutationWindowService: WindowManagementServiceProtoco
             target: target,
             expectedIdentity: expectedIdentity,
             allowForegroundFallback: allowForegroundFallback)
+        let delivery: DesktopActionOutcome.Delivery = allowForegroundFallback
+            ? .init(mechanism: .composite, mode: .foreground)
+            : .init(mechanism: .accessibilityAction, mode: .background)
         return DesktopActionResult(outcome: .confirmedChange(
-            delivery: .init(mechanism: .composite, mode: .foreground),
-            unitCount: DesktopActionOutcome.DispatchUnitCount(2)))
+            delivery: delivery,
+            unitCount: DesktopActionOutcome.DispatchUnitCount(allowForegroundFallback ? 2 : 1)))
     }
 
     func minimizeWindowActionResult(
@@ -1412,7 +1480,10 @@ private final class HandlerMutationWindowService: WindowManagementServiceProtoco
     }
 
     func listWindows(target _: WindowTarget) async throws -> [ServiceWindowInfo] {
-        self.readback.map { [$0] } ?? []
+        if let readbackError {
+            throw readbackError
+        }
+        return self.readback.map { [$0] } ?? []
     }
 
     func getFocusedWindow() async throws -> ServiceWindowInfo? {


### PR DESCRIPTION
## Summary

- treat exact window absence after foreground or background close as a confirmed postcondition
- preserve fail-closed behavior for every other close lookup error and for non-close missing-window readbacks
- add current-semantics regression and control coverage

## Proof

- focused 36-test Bridge handler mutation-semantics suite
- `pnpm run test:safe` (including the final 505-test CLI suite)
- `pnpm run format`
- `pnpm run lint` (0 serious findings)
- docs lint
- Autoreview: no actionable findings

## Behavior

Before this change, the exact target window disappeared successfully but the CLI returned exit 1 with `mutation_dispatched: true`, `retry_safe: false`, and `Window not found`. The Bridge now translates only that expected exact post-close readback into absence, which the existing mutation validator already defines as successful closure.
