### PR TITLE
fix(cli): deduplicate runtime flags in help

### DIFF
--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Replace arbitrary provider-authored Agent trace field names with deterministic ordinal placeholders at every argument nesting level.
 - Treat an exact missing-window readback after `window close` as confirmed closure instead of a retry-unsafe failure.
 - Explain that locked macOS GUI sessions cannot be captured even when `screen list` still reports connected displays.
+- Show global runtime flags once in generated leaf and nested command help while retaining root-level discovery.
 
 ## [4.2.2] - 2026-08-20
 

--- a/Apps/CLI/Sources/PeekabooCLI/CLI/CommanderRuntimeRouter+Help.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/CLI/CommanderRuntimeRouter+Help.swift
@@ -51,6 +51,43 @@ extension CommanderRuntimeRouter {
         return lines.joined(separator: "\n")
     }
 
+    static func renderCommandHelp(
+        _ descriptor: CommanderCommandDescriptor,
+        path: [String],
+        theme: HelpTheme
+    ) -> String {
+        var sections = [
+            self.renderUsageCard(for: descriptor, path: path, theme: theme),
+            CommandHelpRenderer.renderHelp(for: descriptor.type, theme: theme),
+        ]
+
+        // Registry descriptors already inject the runtime signature into OPTIONS and FLAGS.
+        // Keep the standalone section only for descriptors that do not expose those entries.
+        if !self.signatureContainsRuntimeOptions(descriptor.metadata.signature) {
+            sections.append(self.renderGlobalFlagsSection(theme: theme))
+        }
+
+        if !descriptor.subcommands.isEmpty {
+            var lines = ["Subcommands:"]
+            lines.append(contentsOf: self.renderCommandList(for: descriptor.subcommands, theme: theme))
+            if let defaultName = descriptor.metadata.defaultSubcommandName {
+                lines.append("")
+                lines.append("Default subcommand: \(theme.command(defaultName))")
+            }
+            sections.append(lines.joined(separator: "\n"))
+        }
+
+        return sections.joined(separator: "\n\n")
+    }
+
+    static func signatureContainsRuntimeOptions(_ signature: CommandSignature) -> Bool {
+        let runtimeSignature = CommandSignature().withPeekabooRuntimeFlags().flattened()
+        let optionLabels = Set(signature.options.map(\.label))
+        let flagLabels = Set(signature.flags.map(\.label))
+        return Set(runtimeSignature.options.map(\.label)).isSubset(of: optionLabels) &&
+            Set(runtimeSignature.flags.map(\.label)).isSubset(of: flagLabels)
+    }
+
     static func globalFlagSummaries(theme: HelpTheme) -> [String] {
         [
             theme.bullet(label: "--json/-j (alias: --json-output)", description: "Emit machine-readable JSON output"),

--- a/Apps/CLI/Sources/PeekabooCLI/CLI/CommanderRuntimeRouter.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/CLI/CommanderRuntimeRouter.swift
@@ -311,19 +311,6 @@ enum CommanderRuntimeRouter {
 
     private static func printCommandHelp(_ descriptor: CommanderCommandDescriptor, path: [String]) {
         let theme = self.makeHelpTheme()
-        let usageCard = self.renderUsageCard(for: descriptor, path: path, theme: theme)
-        let helpText = CommandHelpRenderer.renderHelp(for: descriptor.type, theme: theme)
-        print(usageCard)
-        print("")
-        print(helpText)
-        print("")
-        print(self.renderGlobalFlagsSection(theme: theme))
-        guard !descriptor.subcommands.isEmpty else { return }
-        print("\nSubcommands:")
-        let subcommandRows = self.renderCommandList(for: descriptor.subcommands, theme: theme)
-        subcommandRows.forEach { print($0) }
-        if let defaultName = descriptor.metadata.defaultSubcommandName {
-            print("\nDefault subcommand: \(theme.command(defaultName))")
-        }
+        print(self.renderCommandHelp(descriptor, path: path, theme: theme))
     }
 }

--- a/Apps/CLI/Tests/CLIAutomationTests/HelpCommandTests.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/HelpCommandTests.swift
@@ -61,16 +61,13 @@ struct HelpCommandTests {
         for subcommand in subcommands {
             let output = try await runPeekaboo(["help", subcommand]).stdout
 
-            // Each subcommand help should contain a usage card + global flags.
+            // Each subcommand help should contain a usage card and one injected runtime signature.
             #expect(output.contains("Usage"), "Help for \(subcommand) should contain Usage")
             #expect(
                 output.contains("peekaboo \(subcommand)"),
                 "Help for \(subcommand) should contain usage line"
             )
-            #expect(
-                output.contains("Global Runtime Flags"),
-                "Help for \(subcommand) should mention global runtime flags"
-            )
+            #expect(!output.contains("Global Runtime Flags"), "Help for \(subcommand) should not duplicate flags")
             #expect(output.contains("--json"), "Help for \(subcommand) should include JSON flag")
 
             // Should not show agent execution output
@@ -140,6 +137,7 @@ struct HelpCommandTests {
 
         let pressHelp = try await runPeekaboo(["press", "--help"])
         #expect(pressHelp.stdout.contains("peekaboo press [<chord> ...]"))
+        #expect(!pressHelp.stdout.contains("Global Runtime Flags"))
     }
 
     @Test
@@ -151,7 +149,7 @@ struct HelpCommandTests {
             let output = try await runPeekaboo([subcommand, "--help"]).stdout
 
             #expect(output.contains("Usage"), "\(subcommand) --help should show usage")
-            #expect(output.contains("Global Runtime Flags"), "\(subcommand) --help should mention global flags")
+            #expect(!output.contains("Global Runtime Flags"), "\(subcommand) --help should not duplicate flags")
             #expect(!output.contains("[info] Peekaboo Agent"), "\(subcommand) --help should not invoke agent")
         }
     }

--- a/Apps/CLI/Tests/CLIRuntimeTests/RootEarlyExitRuntimeTests.swift
+++ b/Apps/CLI/Tests/CLIRuntimeTests/RootEarlyExitRuntimeTests.swift
@@ -40,6 +40,34 @@ struct RootEarlyExitRuntimeTests {
         #expect(result.standardError.isEmpty)
         #expect(result.standardOutput.contains("Usage"))
         #expect(result.standardOutput.contains("Global Runtime Flags"))
+        #expect(self.helpEntryCount("- --bridge-socket <path>", in: result.standardOutput) == 1)
+    }
+
+    @Test
+    func `leaf and nested help do not duplicate runtime flags`() async throws {
+        guard TestChildProcess.canLocatePeekabooBinary() else {
+            Issue.record("Build peekaboo before running CLI runtime tests.")
+            return
+        }
+
+        let cases = [
+            (["click", "--help"], "peekaboo click"),
+            (["app", "list", "--help"], "peekaboo app list"),
+            (["bridge", "receipt", "validate", "--help"], "peekaboo bridge receipt validate"),
+        ]
+        for (arguments, usage) in cases {
+            let result = try await TestChildProcess.runPeekaboo(arguments, isolateFromRemoteHosts: false)
+
+            #expect(result.status == .exited(0))
+            #expect(result.standardError.isEmpty)
+            #expect(result.standardOutput.contains("Usage\n  \(usage)"))
+            #expect(!result.standardOutput.contains("Global Runtime Flags"))
+            #expect(self.helpEntryCount("--bridge-socket <bridge-socket>", in: result.standardOutput) == 1)
+            #expect(self.helpEntryCount("--input-strategy <input-strategy>", in: result.standardOutput) == 1)
+            #expect(self.helpEntryCount("--no-remote", in: result.standardOutput) == 1)
+            #expect(self.helpEntryCount("--json, -j", in: result.standardOutput) == 1)
+            #expect(self.helpEntryCount("-v, --verbose", in: result.standardOutput) == 1)
+        }
     }
 
     @Test(arguments: [
@@ -139,5 +167,11 @@ struct RootEarlyExitRuntimeTests {
         #expect(result.standardOutput.isEmpty)
         #expect(result.standardError.contains("Error: Unknown command '--junk'"))
         #expect(!result.standardError.contains("\"success\""))
+    }
+
+    private func helpEntryCount(_ option: String, in help: String) -> Int {
+        help.split(separator: "\n").count { line in
+            line.trimmingCharacters(in: .whitespaces).hasPrefix(option)
+        }
     }
 }

--- a/Apps/CLI/Tests/CoreCLITests/CommandHelpRendererTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/CommandHelpRendererTests.swift
@@ -85,6 +85,44 @@ struct CommandHelpRendererTests {
     }
 
     @Test
+    func `router help keeps one canonical runtime presentation for leaf and nested commands`() {
+        let cases: [(any ParsableCommand.Type, [String])] = [
+            (ClickCommand.self, ["click"]),
+            (AppCommand.ListSubcommand.self, ["app", "list"]),
+            (BridgeCommand.ValidateSubcommand.self, ["bridge", "receipt", "validate"]),
+        ]
+
+        for (type, path) in cases {
+            let descriptor = CommanderRegistryBuilder.buildDescriptor(for: type)
+            let help = CommanderRuntimeRouter.renderCommandHelp(
+                descriptor,
+                path: path,
+                theme: HelpTheme(useColors: false)
+            )
+
+            #expect(help.contains("Usage\n  peekaboo \(path.joined(separator: " "))"))
+            #expect(!help.contains("Global Runtime Flags"))
+            #expect(self.helpEntryCount("--bridge-socket <bridge-socket>", in: help) == 1)
+            #expect(self.helpEntryCount("--input-strategy <input-strategy>", in: help) == 1)
+            #expect(self.helpEntryCount("--no-remote", in: help) == 1)
+            #expect(self.helpEntryCount("--json, -j", in: help) == 1)
+            #expect(self.helpEntryCount("-v, --verbose", in: help) == 1)
+        }
+    }
+
+    @Test
+    func `root help retains one standalone global runtime section`() {
+        let help = CommanderRuntimeRouter.renderGlobalFlagsSection(theme: HelpTheme(useColors: false))
+
+        #expect(help.components(separatedBy: "Global Runtime Flags").count - 1 == 1)
+        #expect(self.helpEntryCount("- --bridge-socket <path>", in: help) == 1)
+        #expect(self.helpEntryCount("- --input-strategy <mode>", in: help) == 1)
+        #expect(self.helpEntryCount("- --no-remote", in: help) == 1)
+        #expect(self.helpEntryCount("- --json/-j", in: help) == 1)
+        #expect(self.helpEntryCount("- --verbose/-v", in: help) == 1)
+    }
+
+    @Test
     func `click help makes the background coordinate receipt contract explicit`() {
         let help = ClickCommand.helpMessage()
 
@@ -128,6 +166,12 @@ struct CommandHelpRendererTests {
         #expect(help.contains("Expected element value"))
         #expect(!help.contains("Required x,y,width,height"))
         #expect(!help.contains("Required element value"))
+    }
+
+    private func helpEntryCount(_ option: String, in help: String) -> Int {
+        help.split(separator: "\n").count { line in
+            line.trimmingCharacters(in: .whitespaces).hasPrefix(option)
+        }
     }
 }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Treat an exact missing-window readback after `window close` as confirmed closure instead of a retry-unsafe failure.
 - Refuse capture before permission or backend dispatch when the macOS GUI session is locked, while explaining that `screen list` can still report connected displays.
 - Show CLI-native recovery commands in disconnected browser status output while preserving MCP guidance.
+- Show global runtime flags once in generated leaf and nested command help while retaining root-level discovery.
 
 ## [4.2.2] - 2026-08-20
 


### PR DESCRIPTION
## Summary

- make Commander-generated OPTIONS/FLAGS the single runtime-flag presentation for leaf and nested help
- keep the standalone Global Runtime Flags catalog on root help for discovery
- cover pure rendering plus real child-process leaf, nested, root, ordering, and JSON routing

## Proof

- CLI build
- focused help/runtime suites
- formatting and SwiftLint with zero serious findings
- docs lint
- Autoreview: no actionable findings
