### PR TITLE
perf(cli): defer unused agent bootstrap

### DIFF
--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [4.2.3] - Unreleased
 
+### Changed
+- Skip provider discovery and Agent construction for caller-local commands that cannot invoke the Agent, reducing cold startup while preserving full Agent and MCP initialization.
+
 ### Fixed
 - Bind signed `set-value` results to the opaque requested element and refuse older Bridge hosts before dispatch.
 - Keep non-modal SwiftUI `AXDialog`-subrole windows eligible for exact background mutations while preserving modal, sheet, and file-dialog protections, and recognize `inspect_ui` as fresh Agent perception in recovery guidance.

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/AI/AgentCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/AI/AgentCommand.swift
@@ -154,6 +154,7 @@ struct AgentCommand: RuntimeBackedCommand {
         // Remote GUI bridge mode is optional and can fail to expose auth state.
         // Keep agent execution local by default unless an explicit runtime option overrides it.
         options.preferRemote = false
+        options.requiresAgentService = true
         return options
     }()
 

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommandRuntime.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommandRuntime.swift
@@ -104,6 +104,10 @@ struct CommandRuntimeOptions {
     /// Set for interactive permission-request commands, which must be able to reach a host that
     /// still lacks the permission being requested.
     var requestsHostPermissionGrant = false
+    /// Only Agent execution and the long-lived MCP server need provider discovery during
+    /// process bootstrap. Other commands construct the native service graph without eagerly
+    /// reloading provider credentials or creating an Agent that they cannot call.
+    var requiresAgentService = false
 
     func makeConfiguration() -> CommandRuntime.Configuration {
         CommandRuntime.Configuration(

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommanderBinder.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommanderBinder.swift
@@ -97,6 +97,7 @@ enum CommanderCLIBinder {
         options.requiresProcessGenerationPinnedClicks = commandType == ClickCommand.self && usesBackgroundInput &&
             !options.requiresExactWindowTargetedClicks
         let servesDynamicTools = Self.isAgentExecutionCommand(commandType) || commandType == MCPCommand.Serve.self
+        options.requiresAgentService = servesDynamicTools
         if servesDynamicTools {
             options.requiresSafeBackgroundApplicationLaunchNoOp = true
             options.requiresProcessGenerationPinnedApplicationActivation = true

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/RuntimeServiceFactory.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/RuntimeServiceFactory.swift
@@ -10,7 +10,8 @@ enum RuntimeServiceFactory {
             ),
             inputPolicy: PeekabooAutomation.ConfigurationManager.shared.getUIInputPolicy(
                 cliStrategy: options.inputStrategy
-            )
+            ),
+            initializeAgentService: options.requiresAgentService
         )
     }
 }

--- a/Apps/CLI/Tests/CoreCLITests/CommanderBinderTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/CommanderBinderTests.swift
@@ -24,6 +24,21 @@ struct CommanderBinderTests {
     }
 
     @Test
+    func `Only dynamic Agent runtimes eagerly construct the Agent service`() throws {
+        let parsed = ParsedValues(positional: [], options: [:], flags: [])
+
+        for commandType in [AgentRunSubcommand.self, MCPCommand.Serve.self] as [any ParsableCommand.Type] {
+            let options = try CommanderCLIBinder.makeRuntimeOptions(from: parsed, commandType: commandType)
+            #expect(options.requiresAgentService, "Missing Agent service for \(commandType)")
+        }
+
+        for commandType in [ToolsListSubcommand.self, SeeCommand.self] as [any ParsableCommand.Type] {
+            let options = try CommanderCLIBinder.makeRuntimeOptions(from: parsed, commandType: commandType)
+            #expect(!options.requiresAgentService, "Eager Agent service for \(commandType)")
+        }
+    }
+
+    @Test
     func `Runtime options map log level option`() throws {
         let parsed = ParsedValues(positional: [], options: ["logLevel": ["error"]], flags: [])
         let options = try CommanderCLIBinder.makeRuntimeOptions(from: parsed)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [4.2.3] - Unreleased
 
+### Changed
+- Skip provider discovery and Agent construction for caller-local CLI commands that cannot invoke the Agent, reducing cold startup while preserving full Agent and MCP initialization.
+
 ### Fixed
 - Let background certification pin Activity Monitor's exact source-declared window title while refusing unsafe partial, duplicate, or drifting title evidence.
 - Fail closed instead of generating or accepting a release-qualification manifest until final-cycle liveness witnesses have a cryptographic trust anchor.

--- a/Core/PeekabooCore/Sources/PeekabooCore/Support/PeekabooServices.swift
+++ b/Core/PeekabooCore/Sources/PeekabooCore/Support/PeekabooServices.swift
@@ -126,9 +126,13 @@ public final class PeekabooServices {
     /// Lock for thread-safe agent updates
     let agentLock = NSLock()
 
-    /// Initialize with default service implementations
+    /// Initialize with default service implementations.
+    /// - Parameter initializeAgentService: When false, leaves `agent` unset until `refreshAgentService()` is called.
     @MainActor
-    public init(inputPolicy: UIInputPolicy? = nil) {
+    public init(
+        inputPolicy: UIInputPolicy? = nil,
+        initializeAgentService: Bool = true)
+    {
         self.logger.debug("🚀 Initializing PeekabooServices with default implementations")
 
         let logging = LoggingService()
@@ -218,12 +222,19 @@ public final class PeekabooServices {
         self.nativeDesktopOperationLaneOperations = PeekabooBridgeOperation.nativeDesktopOperationLaneOperations
 
         self.logger.debug("✨ PeekabooServices initialization complete")
-        self.refreshAgentService()
+        if initializeAgentService {
+            self.refreshAgentService()
+        }
     }
 
     /// Initialize with default services but a custom snapshot manager (e.g. in-memory for long-lived host apps).
+    /// - Parameter initializeAgentService: When false, leaves `agent` unset until `refreshAgentService()` is called.
     @MainActor
-    public convenience init(snapshotManager: any SnapshotManagerProtocol, inputPolicy: UIInputPolicy? = nil) {
+    public convenience init(
+        snapshotManager: any SnapshotManagerProtocol,
+        inputPolicy: UIInputPolicy? = nil,
+        initializeAgentService: Bool = true)
+    {
         let logger = SystemLogger(subsystem: "boo.peekaboo.core", category: "Services")
         logger.debug("🚀 Initializing PeekabooServices with default implementations (custom snapshots)")
 
@@ -302,7 +313,9 @@ public final class PeekabooServices {
             nativeDesktopOperationLaneOperations: PeekabooBridgeOperation.nativeDesktopOperationLaneOperations)
 
         logger.debug("✨ PeekabooServices initialization complete (custom snapshots)")
-        self.refreshAgentService()
+        if initializeAgentService {
+            self.refreshAgentService()
+        }
     }
 
     /// Initialize with custom service implementations (for testing)


### PR DESCRIPTION
## Summary

- add an explicit runtime requirement for commands that need the Agent service
- skip provider discovery and Agent construction for caller-local commands that cannot invoke Agent
- preserve full Agent initialization for Agent commands and the long-lived MCP server
- document the startup optimization in both changelogs

## Why

`PeekabooServices` refreshed provider configuration and constructed an Agent during every local CLI bootstrap, even for commands such as `tools` that cannot execute Agent. This reloaded configuration and provider state without contributing to the command result.

The CLI binder now marks Agent execution and MCP serving as requiring Agent initialization. Direct `AgentCommand` construction carries the same requirement. Other local command runtimes build the native service graph with `agent` unset; callers can still explicitly initialize it through the existing `refreshAgentService()` API.

The default `PeekabooServices` initializer behavior remains unchanged for app and library consumers. Remote-host resolution, candidate order, explicit socket authority, ScreenCaptureKit ownership, TCC selection, daemon auto-start, cancellation, and transport deadlines are untouched.

## Performance

Release binaries were benchmarked with `tools --json-output`, 2 warmups, and 20 measured process launches on the same machine.

| Wall time | `15d413162` baseline | Final patch | Change |
| --- | ---: | ---: | ---: |
| Mean | 86.417 ms | 82.202 ms | -4.9% |
| Median | 85.414 ms | 82.613 ms | -3.3% |
| p95 | 90.894 ms | 85.242 ms | -6.2% |

The baseline and final binaries were both built in release mode from the exact source states under comparison.

## Probe experiment intentionally excluded

I also prototyped bounded, ordered hedged probes for runtime-host and ScreenCaptureKit-owner discovery. A release `mcp serve` EOF benchmark showed no useful improvement:

| Wall time | Serial baseline | Hedged prototype |
| --- | ---: | ---: |
| Median | 680.544 ms | 695.297 ms |
| p95 | 723.778 ms | 722.122 ms |

The median regressed while p95 was effectively unchanged, so the probe implementation and its tests were removed rather than adding concurrency and cancellation complexity without a measured benefit. This PR contains no runtime-host probing changes.

## Tests

- `pnpm run build:cli:release`
- `pnpm run format`
- `pnpm run lint` (passes with existing non-serious repository warnings)
- `swift test --package-path Apps/CLI --filter 'CommanderBinderTests|ScreenCaptureKitOwnerRuntimeTests|RuntimeHostHandshakeReuseTests|RuntimeHostResolverTests|RuntimeHostApplicationSelectionTests'` (131 tests)
- `pnpm run test:safe`
- Autoreview: clean
