### PR TITLE
refactor(agent): centralize visual mutation policy

### DIFF
--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [4.2.3] - Unreleased
 
 ### Fixed
+- Use the canonical MCP mutation policy for Agent visual verification, including conditional browser and foreground menu actions.
 - Bind signed `set-value` results to the opaque requested element and refuse older Bridge hosts before dispatch.
 - Keep non-modal SwiftUI `AXDialog`-subrole windows eligible for exact background mutations while preserving modal, sheet, and file-dialog protections, and recognize `inspect_ui` as fresh Agent perception in recovery guidance.
 - Keep legacy Agent JSON tool-call arguments privacy-safe and deterministic instead of exposing Swift implementation details and runtime addresses.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [4.2.3] - Unreleased
 
 ### Fixed
+- Use the canonical MCP mutation policy for Agent visual verification, including conditional browser and foreground menu actions.
 - Let background certification pin Activity Monitor's exact source-declared window title while refusing unsafe partial, duplicate, or drifting title evidence.
 - Fail closed instead of generating or accepting a release-qualification manifest until final-cycle liveness witnesses have a cryptographic trust anchor.
 - Add receipt-required Bridge protocol 1.32 observation of exact process generations for signed liveness and absence evidence.

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/Agent/AgentEnhancementOptions.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/Agent/AgentEnhancementOptions.swift
@@ -112,25 +112,6 @@ public enum VerifiableActionType: String, Sendable, Hashable, CaseIterable {
     case type
     case window
 
-    private static let appReadOnlyActions: Set<String> = ["list"]
-    private static let browserReadOnlyActions: Set<String> = [
-        "status",
-        "connect",
-        "disconnect",
-        "list_pages",
-        "snapshot",
-        "console",
-        "network",
-        "screenshot",
-        "performance_trace",
-        "wait_for",
-    ]
-    private static let dialogReadOnlyActions: Set<String> = ["list"]
-    private static let dockReadOnlyActions: Set<String> = ["list"]
-    private static let menuReadOnlyActions: Set<String> = ["list"]
-    private static let spaceReadOnlyActions: Set<String> = ["list"]
-    private static let windowReadOnlyActions: Set<String> = ["list"]
-
     /// Whether this tool can modify state and should be verified by default when action details are unavailable.
     public var isMutating: Bool {
         true
@@ -138,27 +119,16 @@ public enum VerifiableActionType: String, Sendable, Hashable, CaseIterable {
 
     /// Whether this invocation modifies state and should be verified by default.
     public func isMutating(arguments: [String: String]) -> Bool {
-        switch self {
-        case .app:
-            !Self.appReadOnlyActions.contains(Self.actionName(in: arguments))
-        case .browser:
-            !Self.browserReadOnlyActions.contains(Self.actionName(in: arguments))
-        case .dialog:
-            !Self.dialogReadOnlyActions.contains(Self.actionName(in: arguments))
-        case .dock:
-            !Self.dockReadOnlyActions.contains(Self.actionName(in: arguments))
-        case .menu:
-            !Self.menuReadOnlyActions.contains(Self.actionName(in: arguments))
-        case .space:
-            !Self.spaceReadOnlyActions.contains(Self.actionName(in: arguments))
-        case .window:
-            !Self.windowReadOnlyActions.contains(Self.actionName(in: arguments))
-        default:
-            true
+        var normalizedArguments = arguments
+        let toolName: String
+        if self == .launchApp {
+            toolName = VerifiableActionType.app.rawValue
+            normalizedArguments["action"] = "launch"
+        } else {
+            toolName = self.rawValue
         }
-    }
-
-    private static func actionName(in arguments: [String: String]) -> String {
-        arguments["action"]?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() ?? ""
+        return MCPToolVisualVerificationPolicy.requiresVerification(
+            toolName: toolName,
+            stringArguments: normalizedArguments)
     }
 }

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/MCPToolSnapshotMutation.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/MCPToolSnapshotMutation.swift
@@ -393,7 +393,7 @@ enum MCPToolSnapshotMutationPolicy {
 enum MCPToolVisualVerificationPolicy {
     static func requiresVerification(toolName: String, stringArguments: [String: String]) -> Bool {
         guard !stringArguments.isEmpty else { return true }
-        let arguments = ToolArguments(raw: stringArguments.mapValues { $0 as Any })
+        let arguments = ToolArguments(raw: stringArguments.mapValues(Self.typedArgumentValue))
         if toolName == "browser",
            let actionName = arguments.getString("action"),
            let action = BrowserAction(rawValue: actionName)
@@ -406,5 +406,13 @@ enum MCPToolVisualVerificationPolicy {
             }
         }
         return MCPToolSnapshotMutationPolicy.effect(toolName: toolName, arguments: arguments) != .none
+    }
+
+    private static func typedArgumentValue(_ value: String) -> Any {
+        switch value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+        case "true": true
+        case "false": false
+        default: value
+        }
     }
 }

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/MCPToolSnapshotMutation.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/MCPToolSnapshotMutation.swift
@@ -385,3 +385,26 @@ enum MCPToolSnapshotMutationPolicy {
             : .none
     }
 }
+
+/// Invocation-level visual verification derived from the canonical mutation effect.
+///
+/// Browser connection state is intentionally nonvisual even though connecting mutates the session.
+/// Empty arguments preserve broad verification for tools whose concrete action is unavailable.
+enum MCPToolVisualVerificationPolicy {
+    static func requiresVerification(toolName: String, stringArguments: [String: String]) -> Bool {
+        guard !stringArguments.isEmpty else { return true }
+        let arguments = ToolArguments(raw: stringArguments.mapValues { $0 as Any })
+        if toolName == "browser",
+           let actionName = arguments.getString("action"),
+           let action = BrowserAction(rawValue: actionName)
+        {
+            switch action {
+            case .status, .connect, .disconnect:
+                return false
+            default:
+                break
+            }
+        }
+        return MCPToolSnapshotMutationPolicy.effect(toolName: toolName, arguments: arguments) != .none
+    }
+}

--- a/Core/PeekabooCore/Tests/PeekabooAgentRuntimeTests/AgentEnhancementIntegrationTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooAgentRuntimeTests/AgentEnhancementIntegrationTests.swift
@@ -178,6 +178,7 @@ struct AgentEnhancementIntegrationTests {
             "click",
             "dock",
             "drag",
+            "launch_app",
             "press",
             "paste",
             "action",
@@ -203,19 +204,49 @@ struct AgentEnhancementIntegrationTests {
 
         #expect(!ActionVerifier.shouldVerify(toolName: "app", arguments: ["action": "list"], options: options))
         #expect(ActionVerifier.shouldVerify(toolName: "app", arguments: ["action": "launch"], options: options))
+        #expect(ActionVerifier.shouldVerify(
+            toolName: "launch_app",
+            arguments: ["name": "Calendar"],
+            options: options))
         #expect(!ActionVerifier.shouldVerify(toolName: "clipboard", arguments: ["action": "set"], options: options))
         #expect(!ActionVerifier.shouldVerify(toolName: "dialog", arguments: ["action": "list"], options: options))
         #expect(ActionVerifier.shouldVerify(toolName: "dialog", arguments: ["action": "click"], options: options))
         #expect(!ActionVerifier.shouldVerify(toolName: "dock", arguments: ["action": "list"], options: options))
         #expect(ActionVerifier.shouldVerify(toolName: "dock", arguments: ["action": "hide"], options: options))
         #expect(!ActionVerifier.shouldVerify(toolName: "menu", arguments: ["action": "list"], options: options))
+        #expect(ActionVerifier.shouldVerify(
+            toolName: "menu",
+            arguments: ["action": "list", "foreground": "true"],
+            options: options))
         #expect(ActionVerifier.shouldVerify(toolName: "menu", arguments: ["action": "click"], options: options))
         #expect(!ActionVerifier.shouldVerify(toolName: "move", arguments: ["to": "100,100"], options: options))
         #expect(!ActionVerifier.shouldVerify(toolName: "space", arguments: ["action": "list"], options: options))
         #expect(!ActionVerifier.shouldVerify(toolName: "window", arguments: ["action": "list"], options: options))
+        #expect(ActionVerifier.shouldVerify(toolName: "window", arguments: ["action": "move"], options: options))
         #expect(ActionVerifier.shouldVerify(toolName: "space", arguments: ["action": "switch"], options: options))
         #expect(!ActionVerifier.shouldVerify(toolName: "browser", arguments: ["action": "snapshot"], options: options))
         #expect(!ActionVerifier.shouldVerify(toolName: "browser", arguments: ["action": "wait_for"], options: options))
+        #expect(!ActionVerifier.shouldVerify(toolName: "browser", arguments: ["action": "connect"], options: options))
+        #expect(!ActionVerifier.shouldVerify(
+            toolName: "browser",
+            arguments: ["action": "select_page", "bring_to_front": "false"],
+            options: options))
+        #expect(ActionVerifier.shouldVerify(
+            toolName: "browser",
+            arguments: ["action": "select_page", "bring_to_front": "true"],
+            options: options))
+        #expect(ActionVerifier.shouldVerify(
+            toolName: "browser",
+            arguments: ["action": "performance_trace", "trace_action": "start", "reload": "true"],
+            options: options))
+        #expect(!ActionVerifier.shouldVerify(
+            toolName: "browser",
+            arguments: ["action": "performance_trace", "trace_action": "start", "reload": "false"],
+            options: options))
+        #expect(!ActionVerifier.shouldVerify(
+            toolName: "browser",
+            arguments: ["action": "performance_trace", "trace_action": "stop"],
+            options: options))
         #expect(ActionVerifier.shouldVerify(toolName: "browser", arguments: ["action": "click"], options: options))
     }
 

--- a/Core/PeekabooCore/Tests/PeekabooAgentRuntimeTests/AgentEnhancementIntegrationTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooAgentRuntimeTests/AgentEnhancementIntegrationTests.swift
@@ -214,6 +214,10 @@ struct AgentEnhancementIntegrationTests {
         #expect(!ActionVerifier.shouldVerify(toolName: "dock", arguments: ["action": "list"], options: options))
         #expect(ActionVerifier.shouldVerify(toolName: "dock", arguments: ["action": "hide"], options: options))
         #expect(!ActionVerifier.shouldVerify(toolName: "menu", arguments: ["action": "list"], options: options))
+        #expect(!ActionVerifier.shouldVerify(
+            toolName: "menu",
+            arguments: ["action": "list", "foreground": "false"],
+            options: options))
         #expect(ActionVerifier.shouldVerify(
             toolName: "menu",
             arguments: ["action": "list", "foreground": "true"],


### PR DESCRIPTION
## Summary

- make Agent screenshot verification derive UI-mutating invocations from the canonical MCP mutation policy
- preserve nonvisual browser connection/status behavior while handling foreground page selection, reload tracing, and foreground menu listing consistently
- remove seven parallel read-only action registries from `VerifiableActionType`

## Tests

- `swift test --package-path Core/PeekabooCore --filter 'MCPToolSnapshotMutationTests|BrowserToolTests|AgentEnhancementIntegrationTests'` (92 tests)
- `PEEKABOO_INCLUDE_AUTOMATION_TESTS=true PEEKABOO_INCLUDE_AMBIENT_STATE_TESTS=false swift test --package-path Apps/CLI --filter VerifiableActionTypeTests --no-parallel` (3 tests)
- `pnpm run lint` (0 serious findings)
- `pnpm run test:safe` (complete release, certification, Foundation, controller, CLI, and runtime gate)
- `node scripts/docs-lint.mjs`
- SwiftFormat and diff checks
- Autoreview clean
