### PR TITLE
refactor(agent): unify mutation verification policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Skip provider discovery and Agent construction for caller-local CLI commands that cannot invoke the Agent, reducing cold startup while preserving full Agent and MCP initialization.
 
 ### Fixed
+- Use the canonical MCP mutation policy for Agent verification, keeping browser page selection/tracing, foreground menu listing, and app launches aligned without a duplicate action registry.
 - Let background certification pin Activity Monitor's exact source-declared window title while refusing unsafe partial, duplicate, or drifting title evidence.
 - Fail closed instead of generating or accepting a release-qualification manifest until final-cycle liveness witnesses have a cryptographic trust anchor.
 - Add receipt-required Bridge protocol 1.32 observation of exact process generations for signed liveness and absence evidence.

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/Agent/AgentEnhancementOptions.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/Agent/AgentEnhancementOptions.swift
@@ -112,25 +112,6 @@ public enum VerifiableActionType: String, Sendable, Hashable, CaseIterable {
     case type
     case window
 
-    private static let appReadOnlyActions: Set<String> = ["list"]
-    private static let browserReadOnlyActions: Set<String> = [
-        "status",
-        "connect",
-        "disconnect",
-        "list_pages",
-        "snapshot",
-        "console",
-        "network",
-        "screenshot",
-        "performance_trace",
-        "wait_for",
-    ]
-    private static let dialogReadOnlyActions: Set<String> = ["list"]
-    private static let dockReadOnlyActions: Set<String> = ["list"]
-    private static let menuReadOnlyActions: Set<String> = ["list"]
-    private static let spaceReadOnlyActions: Set<String> = ["list"]
-    private static let windowReadOnlyActions: Set<String> = ["list"]
-
     /// Whether this tool can modify state and should be verified by default when action details are unavailable.
     public var isMutating: Bool {
         true
@@ -138,27 +119,8 @@ public enum VerifiableActionType: String, Sendable, Hashable, CaseIterable {
 
     /// Whether this invocation modifies state and should be verified by default.
     public func isMutating(arguments: [String: String]) -> Bool {
-        switch self {
-        case .app:
-            !Self.appReadOnlyActions.contains(Self.actionName(in: arguments))
-        case .browser:
-            !Self.browserReadOnlyActions.contains(Self.actionName(in: arguments))
-        case .dialog:
-            !Self.dialogReadOnlyActions.contains(Self.actionName(in: arguments))
-        case .dock:
-            !Self.dockReadOnlyActions.contains(Self.actionName(in: arguments))
-        case .menu:
-            !Self.menuReadOnlyActions.contains(Self.actionName(in: arguments))
-        case .space:
-            !Self.spaceReadOnlyActions.contains(Self.actionName(in: arguments))
-        case .window:
-            !Self.windowReadOnlyActions.contains(Self.actionName(in: arguments))
-        default:
-            true
-        }
-    }
-
-    private static func actionName(in arguments: [String: String]) -> String {
-        arguments["action"]?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() ?? ""
+        MCPToolSnapshotMutationPolicy.isMutating(
+            toolName: self.rawValue,
+            stringArguments: arguments)
     }
 }

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/MCPToolSnapshotMutation.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/MCPToolSnapshotMutation.swift
@@ -283,6 +283,22 @@ extension MCPToolSnapshotMutationCoordinating {
 }
 
 enum MCPToolSnapshotMutationPolicy {
+    static func isMutating(toolName: String, stringArguments: [String: String]) -> Bool {
+        // Verification historically treats a tool without invocation details as broadly mutating.
+        guard !stringArguments.isEmpty else { return true }
+
+        let mappedToolName = toolName == "launch_app" ? "app" : toolName
+        var arguments = stringArguments
+        if let action = arguments["action"] {
+            arguments["action"] = action.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        } else if toolName == "launch_app" {
+            arguments["action"] = "launch"
+        }
+        return self.effect(
+            toolName: mappedToolName,
+            arguments: ToolArguments(raw: arguments)) != .none
+    }
+
     static func effect(toolName: String, arguments: ToolArguments) -> MCPToolSnapshotEffect {
         self.explicitEffect(toolName: toolName, arguments: arguments) ?? .none
     }

--- a/Core/PeekabooCore/Tests/PeekabooAgentRuntimeTests/AgentEnhancementIntegrationTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooAgentRuntimeTests/AgentEnhancementIntegrationTests.swift
@@ -216,7 +216,32 @@ struct AgentEnhancementIntegrationTests {
         #expect(ActionVerifier.shouldVerify(toolName: "space", arguments: ["action": "switch"], options: options))
         #expect(!ActionVerifier.shouldVerify(toolName: "browser", arguments: ["action": "snapshot"], options: options))
         #expect(!ActionVerifier.shouldVerify(toolName: "browser", arguments: ["action": "wait_for"], options: options))
+        #expect(ActionVerifier.shouldVerify(toolName: "browser", arguments: ["action": "connect"], options: options))
+        #expect(!ActionVerifier.shouldVerify(
+            toolName: "browser",
+            arguments: ["action": "select_page", "bring_to_front": "false"],
+            options: options))
+        #expect(ActionVerifier.shouldVerify(
+            toolName: "browser",
+            arguments: ["action": "select_page", "bring_to_front": "true"],
+            options: options))
+        #expect(!ActionVerifier.shouldVerify(
+            toolName: "browser",
+            arguments: ["action": "performance_trace", "trace_action": "start", "reload": "false"],
+            options: options))
+        #expect(ActionVerifier.shouldVerify(
+            toolName: "browser",
+            arguments: ["action": "performance_trace", "trace_action": "start", "reload": "true"],
+            options: options))
         #expect(ActionVerifier.shouldVerify(toolName: "browser", arguments: ["action": "click"], options: options))
+        #expect(ActionVerifier.shouldVerify(
+            toolName: "menu",
+            arguments: ["action": "list", "foreground": "true"],
+            options: options))
+        #expect(ActionVerifier.shouldVerify(
+            toolName: "launch_app",
+            arguments: ["foreground": "false"],
+            options: options))
     }
 
     @Test

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPToolSnapshotMutationTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPToolSnapshotMutationTests.swift
@@ -52,6 +52,31 @@ struct MCPToolSnapshotMutationTests {
     }
 
     @Test
+    func `Verification string arguments delegate to canonical mutation semantics`() {
+        #expect(!MCPToolSnapshotMutationPolicy.isMutating(
+            toolName: "app",
+            stringArguments: ["action": " LIST "]))
+        #expect(MCPToolSnapshotMutationPolicy.isMutating(
+            toolName: "launch_app",
+            stringArguments: ["foreground": "false"]))
+        #expect(MCPToolSnapshotMutationPolicy.isMutating(
+            toolName: "browser",
+            stringArguments: ["action": "connect"]))
+        #expect(!MCPToolSnapshotMutationPolicy.isMutating(
+            toolName: "browser",
+            stringArguments: ["action": "select_page", "bring_to_front": "false"]))
+        #expect(MCPToolSnapshotMutationPolicy.isMutating(
+            toolName: "browser",
+            stringArguments: ["action": "select_page", "bring_to_front": "true"]))
+        #expect(MCPToolSnapshotMutationPolicy.isMutating(
+            toolName: "menu",
+            stringArguments: ["action": "list", "foreground": "true"]))
+        #expect(MCPToolSnapshotMutationPolicy.isMutating(
+            toolName: "browser",
+            stringArguments: [:]))
+    }
+
+    @Test
     func `Every cataloged MCP tool has an explicit snapshot effect classification`() {
         let context = MCPToolContext(services: PeekabooServices())
         let tools = MCPToolCatalog.unfilteredTools(context: context)


### PR DESCRIPTION
## Summary

- delete Agent enhancement's duplicate read-only and mutating tool registries
- delegate invocation classification to the shared MCP snapshot-mutation policy
- preserve broad verification for empty argument maps and the launch-app compatibility mapping
- add parity regressions for browser and foreground menu operations that had drifted

## Proof

- Agent enhancement integration: 15/15
- MCP mutation policy: 37/37
- SwiftFormat and strict focused SwiftLint
- diff hygiene
- Autoreview: no actionable findings
