### PR TITLE
refactor(bridge): unify target evidence adapters

### DIFF
--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Strategy/DesktopTargetEvidenceAdapter.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Strategy/DesktopTargetEvidenceAdapter.swift
@@ -30,6 +30,23 @@ public enum DesktopTargetEvidenceAdapter {
     }
 
     public static func evidence(
+        windowTarget: WindowTarget,
+        windowIdentity: WindowMutationIdentity?) -> DesktopTargetIdentity.Evidence
+    {
+        let requestedWindowID: Int? = if case let .windowId(windowID) = windowTarget {
+            windowID
+        } else {
+            nil
+        }
+        return .init(
+            processIdentifier: windowIdentity?.ownerProcessIdentifier,
+            processIdentity: windowIdentity?.processIdentity,
+            windowID: requestedWindowID ?? windowIdentity?.windowID,
+            windowIdentity: windowIdentity,
+            windowBounds: windowIdentity?.capturedBounds)
+    }
+
+    public static func evidence(
         windowIdentity: WindowMutationIdentity,
         bounds: CGRect? = nil,
         focusedElement: FocusedElementIdentity? = nil) -> DesktopTargetIdentity.Evidence
@@ -55,6 +72,20 @@ public enum DesktopTargetEvidenceAdapter {
             windowIdentity: exactWindowIdentity,
             windowBounds: exactWindowIdentity.flatMap { context.windowBounds ?? $0.capturedBounds },
             focusedElement: exactWindowIdentity == nil ? nil : context.focusedElement)
+    }
+
+    /// Converts request selector constraints without promoting them to stable mutation authority.
+    ///
+    /// Unlike `evidence(context:)`, this preserves unreceipted window hints so a response-resolved
+    /// operation can reject a response that contradicts the signed request.
+    public static func evidence(selectorContext context: WindowContext) -> DesktopTargetIdentity.Evidence {
+        .init(
+            processIdentifier: context.applicationProcessId,
+            processIdentity: context.windowMutationIdentity?.processIdentity,
+            windowID: context.windowID,
+            windowIdentity: context.windowMutationIdentity,
+            windowBounds: context.windowBounds,
+            focusedElement: context.focusedElement)
     }
 
     public static func evidence(snapshot: UIAutomationSnapshot) -> DesktopTargetIdentity.Evidence {

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/SnapshotTargetReceiptPlannerTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/SnapshotTargetReceiptPlannerTests.swift
@@ -55,6 +55,50 @@ struct SnapshotTargetReceiptPlannerTests {
     }
 
     @Test
+    func `window target evidence preserves exact receipts and selector-only identifiers`() {
+        let fixture = AutomationTestFixtures.linkedSnapshotTarget()
+        let identity = fixture.desktopTarget.windowIdentity
+
+        let exact = DesktopTargetEvidenceAdapter.evidence(
+            windowTarget: .windowId(identity.windowID),
+            windowIdentity: identity)
+        let selectorOnly = DesktopTargetEvidenceAdapter.evidence(
+            windowTarget: .title("Editor"),
+            windowIdentity: nil)
+        let identifierOnly = DesktopTargetEvidenceAdapter.evidence(
+            windowTarget: .windowId(identity.windowID),
+            windowIdentity: nil)
+
+        #expect(exact.processIdentifier == identity.ownerProcessIdentifier)
+        #expect(exact.processIdentity == identity.processIdentity)
+        #expect(exact.windowID == identity.windowID)
+        #expect(exact.windowIdentity == identity)
+        #expect(exact.windowBounds == identity.capturedBounds)
+        #expect(selectorOnly == .init())
+        #expect(identifierOnly == .init(windowID: identity.windowID))
+    }
+
+    @Test
+    func `selector context evidence retains constraints without changing stable context policy`() {
+        let context = WindowContext(
+            applicationProcessId: 42,
+            applicationProcessStartIdentity: 1001,
+            windowID: 73,
+            windowBounds: .init(x: 20, y: 30, width: 640, height: 480))
+
+        let selectorEvidence = DesktopTargetEvidenceAdapter.evidence(selectorContext: context)
+        let stableEvidence = DesktopTargetEvidenceAdapter.evidence(context: context)
+
+        #expect(selectorEvidence.processIdentifier == 42)
+        #expect(selectorEvidence.processIdentity == nil)
+        #expect(selectorEvidence.windowID == 73)
+        #expect(selectorEvidence.windowBounds == context.windowBounds)
+        #expect(stableEvidence.processIdentity == .init(processIdentifier: 42, processStartIdentity: 1001))
+        #expect(stableEvidence.windowID == nil)
+        #expect(stableEvidence.windowBounds == nil)
+    }
+
+    @Test
     func `planner merges linked sources and preserves coordinate authority`() throws {
         let fixture = AutomationTestFixtures.linkedSnapshotTarget()
 

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeOperationReceiptModels.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeOperationReceiptModels.swift
@@ -270,8 +270,8 @@ public struct PeekabooBridgeOperationReceiptPayload: Codable, Equatable, Sendabl
             return try DesktopTargetIdentity(processIdentity: process)
         case let .window(window):
             return try DesktopTargetPlanning.DesktopTargetIdentityCoalescer.resolve([
-                PeekabooBridgeOperationTargetEvidenceAdapter.exactWindow(
-                    identity: window,
+                DesktopTargetEvidenceAdapter.evidence(
+                    windowIdentity: window,
                     bounds: window.capturedBounds ?? .null,
                     focusedElement: self.focusedElement),
             ])

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeOperationReceipts.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeOperationReceipts.swift
@@ -1977,23 +1977,23 @@ extension PeekabooBridgeRequest {
         case let .attestedOperation(payload):
             payload.request.operationTargetEvidence
         case let .exactWindowTargetedTypeActions(payload):
-            [PeekabooBridgeOperationTargetEvidenceAdapter.exactWindow(
-                identity: payload.expectedWindowIdentity,
+            [DesktopTargetEvidenceAdapter.evidence(
+                windowIdentity: payload.expectedWindowIdentity,
                 bounds: payload.expectedWindowBounds,
                 focusedElement: payload.expectedFocusedElement)]
         case let .exactWindowTargetedHotkey(payload):
-            [PeekabooBridgeOperationTargetEvidenceAdapter.exactWindow(
-                identity: payload.expectedWindowIdentity,
+            [DesktopTargetEvidenceAdapter.evidence(
+                windowIdentity: payload.expectedWindowIdentity,
                 bounds: payload.expectedWindowBounds,
                 focusedElement: payload.expectedFocusedElement)]
         case let .beginExactWindowHeldPointer(payload):
-            [PeekabooBridgeOperationTargetEvidenceAdapter.exactWindow(
-                identity: payload.request.windowIdentity,
+            [DesktopTargetEvidenceAdapter.evidence(
+                windowIdentity: payload.request.windowIdentity,
                 bounds: payload.request.windowBounds)]
         case let .releaseExactWindowHeldPointer(payload),
              let .revokeExactWindowHeldPointer(payload):
-            [PeekabooBridgeOperationTargetEvidenceAdapter.exactWindow(
-                identity: payload.receipt.windowIdentity,
+            [DesktopTargetEvidenceAdapter.evidence(
+                windowIdentity: payload.receipt.windowIdentity,
                 bounds: payload.receipt.windowBounds)]
         case let .targetedTypeActions(payload):
             [.init(
@@ -2015,26 +2015,26 @@ extension PeekabooBridgeRequest {
                 windowIdentity: payload.expectedWindowIdentity,
                 windowBounds: payload.expectedWindowBounds)]
         case let .moveWindow(payload):
-            [PeekabooBridgeOperationTargetEvidenceAdapter.window(
-                target: payload.target,
-                identity: payload.expectedIdentity)]
+            [DesktopTargetEvidenceAdapter.evidence(
+                windowTarget: payload.target,
+                windowIdentity: payload.expectedIdentity)]
         case let .resizeWindow(payload):
-            [PeekabooBridgeOperationTargetEvidenceAdapter.window(
-                target: payload.target,
-                identity: payload.expectedIdentity)]
+            [DesktopTargetEvidenceAdapter.evidence(
+                windowTarget: payload.target,
+                windowIdentity: payload.expectedIdentity)]
         case let .setWindowBounds(payload):
-            [PeekabooBridgeOperationTargetEvidenceAdapter.window(
-                target: payload.target,
-                identity: payload.expectedIdentity)]
+            [DesktopTargetEvidenceAdapter.evidence(
+                windowTarget: payload.target,
+                windowIdentity: payload.expectedIdentity)]
         case let .focusWindow(payload),
              let .closeWindow(payload),
              let .backgroundCloseWindow(payload),
              let .minimizeWindow(payload),
              let .restoreWindow(payload),
              let .maximizeWindow(payload):
-            [PeekabooBridgeOperationTargetEvidenceAdapter.window(
-                target: payload.target,
-                identity: payload.expectedIdentity)]
+            [DesktopTargetEvidenceAdapter.evidence(
+                windowTarget: payload.target,
+                windowIdentity: payload.expectedIdentity)]
         case let .quitApplication(payload):
             payload.expectedIdentity.map {
                 [.init(processIdentifier: $0.processIdentifier, processIdentity: $0)]
@@ -2064,53 +2064,10 @@ extension PeekabooBridgeRequest {
         case let .exactDialogClickButton(receipt), let .exactDialogDismiss(receipt):
             [.init(target: DesktopTargetIdentity(exactWindow: receipt.target))]
         case let .inspectAccessibilityTree(payload):
-            payload.windowContext.map(PeekabooBridgeOperationTargetEvidenceAdapter.windowContext).map { [$0] } ?? []
+            payload.windowContext.map(DesktopTargetEvidenceAdapter.evidence(selectorContext:)).map { [$0] } ?? []
         default:
             []
         }
-    }
-}
-
-enum PeekabooBridgeOperationTargetEvidenceAdapter {
-    static func exactWindow(
-        identity: WindowMutationIdentity,
-        bounds: CGRect,
-        focusedElement: FocusedElementIdentity? = nil) -> DesktopTargetIdentity.Evidence
-    {
-        .init(
-            processIdentifier: identity.ownerProcessIdentifier,
-            processIdentity: identity.processIdentity,
-            windowID: identity.windowID,
-            windowIdentity: identity,
-            windowBounds: bounds,
-            focusedElement: focusedElement)
-    }
-
-    static func window(
-        target: WindowTarget,
-        identity: WindowMutationIdentity?) -> DesktopTargetIdentity.Evidence
-    {
-        let targetWindowID: Int? = if case let .windowId(windowID) = target {
-            windowID
-        } else {
-            nil
-        }
-        return .init(
-            processIdentifier: identity?.ownerProcessIdentifier,
-            processIdentity: identity?.processIdentity,
-            windowID: targetWindowID ?? identity?.windowID,
-            windowIdentity: identity,
-            windowBounds: identity?.capturedBounds)
-    }
-
-    static func windowContext(_ context: WindowContext) -> DesktopTargetIdentity.Evidence {
-        .init(
-            processIdentifier: context.applicationProcessId,
-            processIdentity: context.windowMutationIdentity?.processIdentity,
-            windowID: context.windowID,
-            windowIdentity: context.windowMutationIdentity,
-            windowBounds: context.windowBounds,
-            focusedElement: context.focusedElement)
     }
 }
 

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeOperationReceiptTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeOperationReceiptTests.swift
@@ -2148,6 +2148,42 @@ extension PeekabooBridgeOperationReceiptTests {
     }
 
     @Test
+    func `request target evidence delegates without changing selector constraints`() throws {
+        let bounds = CGRect(x: 20, y: 30, width: 640, height: 480)
+        let identity = WindowMutationIdentity(
+            windowID: 73,
+            ownerProcessIdentifier: 42,
+            ownerProcessStartIdentity: 1001,
+            capturedBounds: bounds)
+        let moveRequest = PeekabooBridgeRequest.moveWindow(.init(
+            target: .windowId(identity.windowID),
+            expectedIdentity: identity,
+            position: .zero))
+        #expect(moveRequest.operationTargetEvidence == [DesktopTargetEvidenceAdapter.evidence(
+            windowTarget: .windowId(identity.windowID),
+            windowIdentity: identity)])
+        #expect(try PeekabooBridgeOperationTargetAttribution.resolveRequest(moveRequest)?.exactWindow?
+            .identity == identity)
+
+        let selectorContext = WindowContext(
+            applicationProcessId: identity.ownerProcessIdentifier,
+            applicationProcessStartIdentity: identity.ownerProcessStartIdentity,
+            windowID: identity.windowID,
+            windowBounds: bounds)
+        let inspectRequest = PeekabooBridgeRequest.inspectAccessibilityTree(.init(windowContext: selectorContext))
+        let selectorEvidence = try #require(inspectRequest.operationTargetEvidence.first)
+
+        #expect(inspectRequest.operationTargetEvidence == [
+            DesktopTargetEvidenceAdapter.evidence(selectorContext: selectorContext),
+        ])
+        #expect(selectorEvidence.processIdentifier == identity.ownerProcessIdentifier)
+        #expect(selectorEvidence.processIdentity == nil)
+        #expect(selectorEvidence.windowID == identity.windowID)
+        #expect(selectorEvidence.windowBounds == bounds)
+        #expect(try PeekabooBridgeOperationTargetAttribution.resolveRequest(inspectRequest) == nil)
+    }
+
+    @Test
     func `observation and capture receipts use resolved stable targets without widening`() throws {
         let bounds = CGRect(x: 20, y: 30, width: 640, height: 480)
         let identity = WindowMutationIdentity(


### PR DESCRIPTION
## Summary

- remove the parallel Bridge-only target-evidence adapter
- route exact keyboard, held-pointer, window mutation, tree inspection, and receipt decoding through the canonical AutomationKit adapter
- add canonical WindowTarget/identity projection and parity regressions

## Proof

- AutomationKit planner: 10/10
- Bridge adapter parity: 2/2
- window mutation and typed receipt binding: 18/18
- SwiftFormat, diff hygiene, and Autoreview clean
- strict lint has only the existing warnings in already-oversized touched files

One aggregate observation/capture receipt test is independently red on clean main with `incompleteExactWindow`; the focused changed surfaces are green and this patch neither causes nor suppresses that baseline failure.
