### PR TITLE
refactor(cli): centralize action result validation

### DIFF
--- a/Apps/CLI/Sources/PeekabooCLI/CLI/Output/JSONOutput.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/CLI/Output/JSONOutput.swift
@@ -545,26 +545,17 @@ func validateSuccessfulActionOutcome(
     targetIdentity: DesktopTargetIdentity?,
     operation: String
 ) throws {
-    guard let outcome else {
-        let failure = DesktopActionFailure.indeterminate(
-            evidence: .completionUnknown,
-            message: "\(operation) returned without a canonical outcome.",
-            hint: "Observe the target before retrying and update the runtime host."
+    do {
+        _ = try UIAutomationActionResultSemantics.requireAcceptedOutcome(
+            outcome,
+            policy: .confirmedOrDispatched,
+            operation: operation,
+            targetReceipt: targetIdentity?.actionTargetReceipt,
+            rejectedOutcomeMessage: "\(operation) did not return a successful outcome."
         )
-        .attributed(to: targetIdentity?.actionTargetReceipt)
+    } catch let failure as DesktopActionFailure {
         throw ActionResultEnvelopeFailure(failure: failure, targetIdentity: targetIdentity)
     }
-    guard !outcome.isAccepted(by: .confirmedOrDispatched) else { return }
-    guard let failure = DesktopActionFailure(
-        outcome: outcome,
-        message: "\(operation) did not return a successful outcome.",
-        hint: "Follow the canonical escalation metadata before deciding whether to retry.",
-        targetReceipt: targetIdentity?.actionTargetReceipt
-    )
-    else {
-        return
-    }
-    throw ActionResultEnvelopeFailure(failure: failure, targetIdentity: targetIdentity)
 }
 
 func outputJSONCodable(_ response: ResultEnvelope<some Encodable>, logger: Logger) {

--- a/Apps/CLI/Tests/CLIAutomationTests/CLIActionResultConsumerTests.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/CLIActionResultConsumerTests.swift
@@ -827,6 +827,37 @@ struct CLIActionResultConsumerTests {
     }
 
     @Test
+    func `successful result validation preserves rejected canonical outcome`() throws {
+        let target = try DesktopTargetIdentity(processIdentity: ApplicationProcessIdentity(
+            processIdentifier: 42,
+            processStartIdentity: 420
+        ))
+        let outcome = DesktopActionOutcome.partial(
+            route: .bridge,
+            delivery: .init(mechanism: .accessibilityAction, mode: .background),
+            unitCount: .one
+        )
+
+        do {
+            try validateSuccessfulActionOutcome(
+                outcome,
+                targetIdentity: target,
+                operation: "Result-aware mutation"
+            )
+            Issue.record("Expected rejected outcome validation failure")
+        } catch {
+            let metadata = actionErrorEnvelopeMetadata(for: error, isActionCommand: true)
+            #expect(metadata.outcome == outcome)
+            #expect(metadata.effect == outcome.effect)
+            #expect(metadata.retrySafe == false)
+            #expect(metadata.mutationDispatched == true)
+            #expect(metadata.targetIdentity == target)
+            #expect(metadata.failure?.message == "Result-aware mutation did not return a successful outcome.")
+            #expect(metadata.failure?.targetReceipt == target.actionTargetReceipt)
+        }
+    }
+
+    @Test
     func `menu Quit keeps its completed result after the application disappears`() async throws {
         let fixture = Self.menuFixture()
         let applications = StubApplicationService(applications: [fixture.application])

--- a/Apps/CLI/Tests/CoreCLITests/ResultEnvelopeTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/ResultEnvelopeTests.swift
@@ -137,6 +137,36 @@ struct ResultEnvelopeTests {
         #expect(envelope.outcome == failure.outcome.projection)
     }
 
+    @Test func `successful action validation keeps the CLI envelope wrapper`() throws {
+        let targetIdentity = try DesktopTargetIdentity(processIdentity: ApplicationProcessIdentity(
+            processIdentifier: 42,
+            processStartIdentity: 9_007_199_254_740_993
+        ))
+        let outcome = DesktopActionOutcome.refused(
+            route: .bridge,
+            reason: .permissionDenied
+        )
+
+        do {
+            try validateSuccessfulActionOutcome(
+                outcome,
+                targetIdentity: targetIdentity,
+                operation: "Fixture mutation"
+            )
+            Issue.record("Expected successful action validation to reject the refusal")
+        } catch {
+            let envelopeError = try #require(error as? any ResultEnvelopeError)
+            let failure = try #require(envelopeError.envelopeActionFailure)
+            #expect(envelopeError.envelopeCode == .INTERACTION_FAILED)
+            #expect(envelopeError.envelopeEffect == .refused)
+            #expect(envelopeError.envelopeRetrySafe == true)
+            #expect(envelopeError.envelopeMutationDispatched == false)
+            #expect(envelopeError.envelopeTargetIdentity == targetIdentity)
+            #expect(failure.outcome == outcome)
+            #expect(failure.targetReceipt == targetIdentity.actionTargetReceipt)
+        }
+    }
+
     @Test func `success and error envelopes publish process-only target receipts`() throws {
         let identity = ApplicationProcessIdentity(
             processIdentifier: 42,

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/UIAutomationActionResultSemanticsTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/UIAutomationActionResultSemanticsTests.swift
@@ -126,4 +126,43 @@ struct UIAutomationActionResultSemanticsTests {
             #expect(failure.targetReceipt == nil)
         }
     }
+
+    @Test
+    func `outcome-only validation preserves failure context for consumers`() throws {
+        let receipt = DesktopActionTargetReceipt(
+            processIdentifier: 42,
+            processStartIdentity: 1001,
+            windowID: 71)
+
+        do {
+            _ = try UIAutomationActionResultSemantics.requireAcceptedOutcome(
+                nil,
+                policy: .confirmedOrDispatched,
+                operation: "Fixture action",
+                targetReceipt: receipt)
+            Issue.record("Expected missing outcome validation to fail")
+        } catch let failure as DesktopActionFailure {
+            #expect(failure.outcome.state == .indeterminate)
+            #expect(failure.outcome.evidence == .completionUnknown)
+            #expect(failure.message == "Fixture action returned without a canonical outcome.")
+            #expect(failure.targetReceipt == receipt)
+        }
+
+        let refusal = DesktopActionOutcome.refused(
+            route: .bridge,
+            reason: .permissionDenied)
+        do {
+            _ = try UIAutomationActionResultSemantics.requireAcceptedOutcome(
+                refusal,
+                policy: .confirmedOrDispatched,
+                operation: "Fixture action",
+                targetReceipt: receipt,
+                rejectedOutcomeMessage: "Fixture action did not return a successful outcome.")
+            Issue.record("Expected rejected outcome validation to fail")
+        } catch let failure as DesktopActionFailure {
+            #expect(failure.outcome == refusal)
+            #expect(failure.message == "Fixture action did not return a successful outcome.")
+            #expect(failure.targetReceipt == receipt)
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- Delegate CLI success-outcome acceptance to the canonical `UIAutomationActionResultSemantics` owner.
- Preserve the CLI-specific `ResultEnvelopeError` wrapper, exact target identity, and canonical failure metadata.
- Cover missing outcomes, rejected outcomes, target receipts, and envelope projection at the canonical and CLI boundaries.

## Proof

- `swift test --package-path Core/PeekabooAutomationKit --filter UIAutomationActionResultSemanticsTests` (6/6)
- `PEEKABOO_INCLUDE_AUTOMATION_TESTS=true PEEKABOO_INCLUDE_AMBIENT_STATE_TESTS=false swift test --package-path Apps/CLI -Xswiftc -DPEEKABOO_SKIP_AUTOMATION --no-parallel --filter 'CLIActionResultConsumerTests|ResultEnvelopeTests'` (68/68)
- `pnpm run format`
- `pnpm run lint` (0 serious violations)
- `git diff --check`
- Autoreview through P2: clean, no actionable findings

No changelog entry: this is an internal, behavior-preserving ownership consolidation.
