### PR TITLE
test(bridge): keep receipt evidence families aligned

### DIFF
--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeOperationReceiptTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeOperationReceiptTests.swift
@@ -2214,10 +2214,10 @@ extension PeekabooBridgeOperationReceiptTests {
             imageData: Data(),
             metadata: .init(size: bounds.size, mode: .window))
         let observation = DesktopObservationResult(target: resolved, capture: capture, elements: nil)
-        let request = PeekabooBridgeRequest.desktopObservation(.init(target: .windowID(73)))
+        let observationRequest = PeekabooBridgeRequest.desktopObservation(.init(target: .windowID(73)))
 
         #expect(try PeekabooBridgeOperationTargetAttribution.resolveReceipt(
-            request: request,
+            request: observationRequest,
             response: .desktopObservation(observation)).target == .window(identity))
 
         let windowInfo = ServiceWindowInfo(
@@ -2237,9 +2237,20 @@ extension PeekabooBridgeOperationReceiptTests {
                 mode: .window,
                 applicationInfo: applicationInfo,
                 windowInfo: windowInfo))
+        let captureRequest = PeekabooBridgeRequest.captureWindow(.init(
+            appIdentifier: "",
+            windowIndex: nil,
+            windowId: identity.windowID,
+            visualizerMode: .none,
+            scale: .logical1x))
         #expect(try PeekabooBridgeOperationTargetAttribution.resolveReceipt(
-            request: request,
+            request: captureRequest,
             response: .capture(exactCapture)).target == .window(identity))
+        #expect(throws: DesktopTargetIdentityError.incompleteExactWindow) {
+            _ = try PeekabooBridgeOperationTargetAttribution.resolveReceipt(
+                request: observationRequest,
+                response: .capture(exactCapture))
+        }
 
         let contradictoryCapture = CaptureResult(
             imageData: Data(),
@@ -2254,7 +2265,7 @@ extension PeekabooBridgeOperationReceiptTests {
                 windowInfo: windowInfo))
         #expect(throws: DesktopTargetIdentityError.contradictoryProcessGeneration) {
             _ = try PeekabooBridgeOperationTargetAttribution.resolveReceipt(
-                request: request,
+                request: captureRequest,
                 response: .capture(contradictoryCapture))
         }
 
@@ -2264,7 +2275,7 @@ extension PeekabooBridgeOperationReceiptTests {
             elements: nil)
         #expect(throws: DesktopTargetIdentityError.incompleteExactWindow) {
             _ = try PeekabooBridgeOperationTargetAttribution.resolveReceipt(
-                request: request,
+                request: observationRequest,
                 response: .desktopObservation(processOnly))
         }
         let differentIdentity = WindowMutationIdentity(
@@ -2277,7 +2288,7 @@ extension PeekabooBridgeOperationReceiptTests {
             bounds: bounds))
         #expect(throws: DesktopTargetIdentityError.contradictoryWindowIdentifier) {
             _ = try PeekabooBridgeOperationTargetAttribution.resolveReceipt(
-                request: request,
+                request: observationRequest,
                 response: .desktopObservation(processOnly),
                 handledTarget: differentTarget)
         }
@@ -2305,7 +2316,7 @@ extension PeekabooBridgeOperationReceiptTests {
             elements: nil)
         #expect(throws: DesktopTargetIdentityError.incompleteExactWindow) {
             _ = try PeekabooBridgeOperationTargetAttribution.resolveReceipt(
-                request: request,
+                request: observationRequest,
                 response: .desktopObservation(unresolved))
         }
 


### PR DESCRIPTION
## Summary

- pair observation and capture receipt fixtures with their matching request families
- keep an explicit regression proving cross-family response evidence is refused
- test-only change; no runtime behavior or changelog entry

## Clean-main reproduction

On `e9be6cf8464ee5b8d67e02d94b8a434ae7076510`:

```sh
swift test --package-path Core/PeekabooCore --filter 'observation and capture receipts use resolved stable targets without widening'
```

The test fails with `DesktopTargetIdentityError.incompleteExactWindow` because its capture phase reuses a desktop-observation request. Capture evidence is correctly ignored for a desktop-observation response-evidence plan.

## Proof

- exact regression: 1/1 passing
- `PeekabooBridgeOperationReceiptTests`: 34/34 passing
- SwiftFormat and diff hygiene clean
- SwiftLint: 0 serious violations
- P2 Autoreview: no actionable findings
