### PR TITLE
fix(cli): align discovery with execution policy

### DIFF
--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Treat an exact missing-window readback after `window close` as confirmed closure instead of a retry-unsafe failure.
 - Explain that locked macOS GUI sessions cannot be captured even when `screen list` still reports connected displays.
 - Show global runtime flags once in generated leaf and nested command help while retaining root-level discovery.
+- Keep `learn`, policy-aware tool schemas, and default-subcommand parent help aligned with the actual public Agent and CLI surfaces.
 
 ## [4.2.2] - 2026-08-20
 

--- a/Apps/CLI/Sources/PeekabooCLI/CLI/CommanderRuntimeRouter+Help.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/CLI/CommanderRuntimeRouter+Help.swift
@@ -31,9 +31,10 @@ extension CommanderRuntimeRouter {
     static func renderUsageCard(
         for descriptor: CommanderCommandDescriptor,
         path: [String],
+        signature: CommandSignature? = nil,
         theme: HelpTheme
     ) -> String {
-        let usageLine = self.buildUsageLine(path: path, signature: descriptor.metadata.signature)
+        let usageLine = self.buildUsageLine(path: path, signature: signature ?? descriptor.metadata.signature)
         var lines: [String] = []
         lines.append(theme.heading("Usage"))
         lines.append("  \(theme.accent(usageLine))")
@@ -56,14 +57,15 @@ extension CommanderRuntimeRouter {
         path: [String],
         theme: HelpTheme
     ) -> String {
+        let helpSignature = self.helpSignature(for: descriptor)
         var sections = [
-            self.renderUsageCard(for: descriptor, path: path, theme: theme),
-            CommandHelpRenderer.renderHelp(for: descriptor.type, theme: theme),
+            self.renderUsageCard(for: descriptor, path: path, signature: helpSignature, theme: theme),
+            CommandHelpRenderer.renderHelp(for: descriptor.type, signature: helpSignature, theme: theme),
         ]
 
         // Registry descriptors already inject the runtime signature into OPTIONS and FLAGS.
         // Keep the standalone section only for descriptors that do not expose those entries.
-        if !self.signatureContainsRuntimeOptions(descriptor.metadata.signature) {
+        if !self.signatureContainsRuntimeOptions(helpSignature) {
             sections.append(self.renderGlobalFlagsSection(theme: theme))
         }
 
@@ -78,6 +80,52 @@ extension CommanderRuntimeRouter {
         }
 
         return sections.joined(separator: "\n\n")
+    }
+
+    /// Parent help for a default-subcommand tree must describe the forms accepted by the bare parent invocation.
+    /// Merge only for presentation: parsing still resolves through Commander's normal default-subcommand path.
+    static func helpSignature(for descriptor: CommanderCommandDescriptor) -> CommandSignature {
+        guard let defaultName = descriptor.metadata.defaultSubcommandName,
+              let defaultDescriptor = descriptor.subcommands.first(where: { $0.metadata.name == defaultName })
+        else {
+            return descriptor.metadata.signature
+        }
+        return self.mergingHelpSignatures(
+            parent: descriptor.metadata.signature,
+            defaultLeaf: defaultDescriptor.metadata.signature
+        )
+    }
+
+    private static func mergingHelpSignatures(
+        parent: CommandSignature,
+        defaultLeaf: CommandSignature
+    ) -> CommandSignature {
+        let parent = parent.flattened()
+        let defaultLeaf = defaultLeaf.flattened()
+        var arguments = parent.arguments
+        var options = parent.options
+        var flags = parent.flags
+        var argumentLabels = Set(arguments.map(\.label))
+        var optionTokens = Set(options.flatMap { $0.names.map(\.commandLineToken) })
+        var flagTokens = Set(flags.flatMap { $0.names.map(\.commandLineToken) })
+
+        for argument in defaultLeaf.arguments where argumentLabels.insert(argument.label).inserted {
+            arguments.append(argument)
+        }
+        for option in defaultLeaf.options {
+            let tokens = Set(option.names.map(\.commandLineToken))
+            guard optionTokens.isDisjoint(with: tokens) else { continue }
+            options.append(option)
+            optionTokens.formUnion(tokens)
+        }
+        for flag in defaultLeaf.flags {
+            let tokens = Set(flag.names.map(\.commandLineToken))
+            guard flagTokens.isDisjoint(with: tokens) else { continue }
+            flags.append(flag)
+            flagTokens.formUnion(tokens)
+        }
+
+        return CommandSignature(arguments: arguments, options: options, flags: flags)
     }
 
     static func signatureContainsRuntimeOptions(_ signature: CommandSignature) -> Bool {

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommandHelpRenderer.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommandHelpRenderer.swift
@@ -27,6 +27,21 @@ struct CommandHelpRenderer {
         )
     }
 
+    static func renderHelp(
+        for type: (some ParsableCommand).Type,
+        signature: CommandSignature,
+        theme: HelpTheme? = nil
+    ) -> String {
+        let description = type.commandDescription
+        return self.renderHelp(
+            abstract: description.abstract,
+            discussion: description.discussion,
+            signature: signature,
+            usageExamples: description.usageExamples,
+            theme: theme
+        )
+    }
+
     private static func renderHelp(
         abstract: String,
         discussion: String?,

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Core/LearnCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Core/LearnCommand.swift
@@ -119,7 +119,7 @@ struct LearnCommand {
 
     private func appendParameters(_ parameters: [PeekabooToolParameter], to output: inout String) {
         print("**Parameters:**", to: &output)
-        for param in parameters where param.cliOptions?.argumentType != .argument {
+        for param in parameters {
             var line = "- `\(param.name)` (\(param.type)"
             if param.required {
                 line += ", **required**"

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Core/LearnCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Core/LearnCommand.swift
@@ -80,7 +80,7 @@ struct LearnCommand {
     }
 
     private func appendToolCatalog(tools: [PeekabooToolDefinition], to output: inout String) {
-        let groupedTools = ToolRegistry.toolsByCategory()
+        let groupedTools = Dictionary(grouping: tools, by: \.category)
         for category in ToolCategory.allCases {
             guard let categoryTools = groupedTools[category], !categoryTools.isEmpty else { continue }
             self.appendToolCategory(category, tools: categoryTools, to: &output)
@@ -150,7 +150,8 @@ struct LearnCommand {
         6. Common workflows:
            - Screenshot: `see --no-elements` with `--app`, `--window-id`, or `--mode screen`.
            - AX tree: `see --tree --no-screenshot` with an exact app/window target.
-           - Typing: `click` the field, then `type --app ...` the text; add `--foreground` only if needed.
+           - Typing: background-click the field, observe again, then call `type` with that fresh exact non-dialog
+             snapshot. App/PID/window-selector-only Agent typing is refused.
            - Menus: `menu click --path ...`.
            - Keyboard shortcuts: `press --snapshot <fresh-exact-snapshot> cmd+shift+t` in background, or
              `press cmd+shift+t --foreground` with explicit foreground consent.
@@ -166,7 +167,8 @@ struct LearnCommand {
         - **Applications**: app
         - **Elements**: inspect_ui, verify_state, set_value, action
         - **Menu/Dialog**: menu, dialog
-        - **System**: shell, done, need_info
+        - **System**: permissions, sleep, clipboard, paste
+        - **Completion**: done, need_info
 
         The MCP-only `image` and `inspect_ui` tools remain separate; their CLI equivalents are
         `see --no-elements` and `see --tree --no-screenshot`.

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Core/ToolsCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Core/ToolsCommand.swift
@@ -12,8 +12,9 @@ struct ToolsCommand: ParsableCommand {
         abstract: "List the MCP tool catalog",
         discussion: """
         Display the native tools exposed to `peekaboo mcp` clients (e.g. Codex,
-        Claude Code, Cursor). The built-in Peekaboo Agent adds agent-only capabilities,
-        including `shell`; run `peekaboo learn` for the combined guidance. Some MCP
+        Claude Code, Cursor). The public Agent catalog is a separate background-first surface
+        derived from the same implementations and never exposes `shell`; run `peekaboo learn`
+        for its exact policy-aware guidance. Some MCP
         tools also have dedicated CLI wrappers, such as `peekaboo browser`.
         Run `peekaboo --help` for the CLI command list.
 

--- a/Apps/CLI/Tests/CLIRuntimeTests/CLIRuntimeSmokeTests.swift
+++ b/Apps/CLI/Tests/CLIRuntimeTests/CLIRuntimeSmokeTests.swift
@@ -650,7 +650,18 @@ struct CLIRuntimeSmokeTests {
         #expect(!result.standardOutput.contains("#### `shell`"))
         #expect(!result.standardOutput.contains("- **System**: shell"))
         #expect(!result.standardOutput.contains("type --app"))
-        #expect(result.standardOutput.contains(#""snapshot": "$SNAPSHOT_ID""#))
+        #expect(result.standardOutput.contains("explicit fresh exact non-dialog snapshot receipt"))
+
+        let clipboardMarker = try #require(result.standardOutput.range(of: "#### `clipboard`"))
+        let clipboardTail = result.standardOutput[clipboardMarker.lowerBound...]
+        let nextTool = clipboardTail.dropFirst().range(of: "\n#### `")?.lowerBound ?? clipboardTail.endIndex
+        let clipboardSection = clipboardTail[..<nextTool]
+        let compactClipboard = clipboardSection.split(whereSeparator: \.isWhitespace).joined(separator: " ")
+        #expect(compactClipboard.contains("Available actions are `get` and `save`"))
+        #expect(compactClipboard.contains("Options: `get`, `save`"))
+        #expect(!clipboardSection.contains("**Examples:**"))
+        #expect(!clipboardSection.contains(#""action": "set""#))
+        #expect(!clipboardSection.contains("peekaboo clipboard set"))
 
         let registeredRoots = Set(CommandRegistry.definitions().map(\.name))
         let expression = try NSRegularExpression(pattern: #"\bpeekaboo ([a-z][a-z0-9-]*)"#)

--- a/Apps/CLI/Tests/CLIRuntimeTests/CLIRuntimeSmokeTests.swift
+++ b/Apps/CLI/Tests/CLIRuntimeTests/CLIRuntimeSmokeTests.swift
@@ -650,6 +650,7 @@ struct CLIRuntimeSmokeTests {
         #expect(!result.standardOutput.contains("#### `shell`"))
         #expect(!result.standardOutput.contains("- **System**: shell"))
         #expect(!result.standardOutput.contains("type --app"))
+        #expect(!result.standardOutput.contains("****"))
         #expect(result.standardOutput.contains("explicit fresh exact non-dialog snapshot receipt"))
 
         let clipboardMarker = try #require(result.standardOutput.range(of: "#### `clipboard`"))

--- a/Apps/CLI/Tests/CLIRuntimeTests/CLIRuntimeSmokeTests.swift
+++ b/Apps/CLI/Tests/CLIRuntimeTests/CLIRuntimeSmokeTests.swift
@@ -647,6 +647,10 @@ struct CLIRuntimeSmokeTests {
         #expect(result.status == .exited(0))
         #expect(result.standardOutput.contains("# Peekaboo Comprehensive Guide"))
         #expect(result.standardOutput.contains("## Commander Command Signatures"))
+        #expect(!result.standardOutput.contains("#### `shell`"))
+        #expect(!result.standardOutput.contains("- **System**: shell"))
+        #expect(!result.standardOutput.contains("type --app"))
+        #expect(result.standardOutput.contains(#""snapshot": "$SNAPSHOT_ID""#))
 
         let registeredRoots = Set(CommandRegistry.definitions().map(\.name))
         let expression = try NSRegularExpression(pattern: #"\bpeekaboo ([a-z][a-z0-9-]*)"#)
@@ -661,6 +665,49 @@ struct CLIRuntimeSmokeTests {
 
         #expect(documentedRoots.contains("click"))
         #expect(unavailableRoots.isEmpty, "Learn documents unavailable CLI roots: \(unavailableRoots)")
+    }
+
+    @Test
+    func `tools describe emits policy-usable background schemas`() async throws {
+        guard Self.ensureLocalRuntimeAvailable() else { return }
+
+        for toolName in ["app", "window", "clipboard"] {
+            let result = try await TestChildProcess.runPeekaboo([
+                "tools",
+                "describe",
+                toolName,
+                "--json",
+                "--no-remote",
+            ])
+            #expect(result.status == .exited(0))
+            #expect(result.standardError.isEmpty)
+            let payload = try Self.jsonDataPayload(from: result.standardOutput)
+            let description = try #require(payload["description"] as? String)
+            let schema = try #require(payload["input_schema"] as? [String: Any])
+            let properties = try #require(schema["properties"] as? [String: Any])
+            let action = try #require(properties["action"] as? [String: Any])
+            let actions = try Set(#require(action["enum"] as? [String]))
+
+            switch toolName {
+            case "app":
+                #expect(actions == Set(["launch", "quit", "hide", "list"]))
+                #expect(properties["foreground"] == nil)
+                #expect(!description.contains(#""action": "focus""#))
+                #expect(!description.contains(#""action": "switch""#))
+                #expect(description.contains("foreground-capable Agent session"))
+            case "window":
+                #expect(!actions.contains("focus"))
+                #expect(properties["foreground"] == nil)
+                #expect(description.contains("focus: Unavailable under background-only authority"))
+            case "clipboard":
+                #expect(actions == Set(["get", "save"]))
+                #expect(properties["text"] == nil)
+                #expect(description.contains("persistently"))
+                #expect(description.contains("shared clipboard state"))
+            default:
+                Issue.record("Unexpected tool \(toolName)")
+            }
+        }
     }
 
     @Test

--- a/Apps/CLI/Tests/CLIRuntimeTests/RootEarlyExitRuntimeTests.swift
+++ b/Apps/CLI/Tests/CLIRuntimeTests/RootEarlyExitRuntimeTests.swift
@@ -70,6 +70,32 @@ struct RootEarlyExitRuntimeTests {
         }
     }
 
+    @Test
+    func `default-subcommand parent help surfaces accepted leaf flags once`() async throws {
+        guard TestChildProcess.canLocatePeekabooBinary() else {
+            Issue.record("Build peekaboo before running CLI runtime tests.")
+            return
+        }
+
+        let cases: [([String], [String])] = [
+            (["agent", "--help"], ["--model <model>", "--allow-foreground", "--dry-run"]),
+            (["permissions", "--help"], ["--all-sources"]),
+            (["tools", "--help"], ["--no-sort"]),
+        ]
+        for (arguments, leafFlags) in cases {
+            let result = try await TestChildProcess.runPeekaboo(arguments, isolateFromRemoteHosts: false)
+
+            #expect(result.status == .exited(0))
+            #expect(result.standardError.isEmpty)
+            #expect(!result.standardOutput.contains("Global Runtime Flags"))
+            for flag in leafFlags {
+                #expect(self.helpEntryCount(flag, in: result.standardOutput) == 1)
+            }
+            #expect(self.helpEntryCount("--bridge-socket <bridge-socket>", in: result.standardOutput) == 1)
+            #expect(self.helpEntryCount("--no-remote", in: result.standardOutput) == 1)
+        }
+    }
+
     @Test(arguments: [
         ["--log-level", "debug", "--version"],
         ["--logLevel=debug", "-V"],

--- a/Apps/CLI/Tests/CoreCLITests/CommandHelpRendererTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/CommandHelpRendererTests.swift
@@ -111,6 +111,31 @@ struct CommandHelpRendererTests {
     }
 
     @Test
+    func `router parent help merges the default leaf signature without duplicates`() {
+        let cases: [(any ParsableCommand.Type, [String], [String])] = [
+            (AgentRootCommand.self, ["agent"], ["--model <model>", "--allow-foreground", "--dry-run"]),
+            (PermissionsCommand.self, ["permissions"], ["--all-sources"]),
+            (ToolsCommand.self, ["tools"], ["--no-sort"]),
+        ]
+
+        for (type, path, leafFlags) in cases {
+            let descriptor = CommanderRegistryBuilder.buildDescriptor(for: type)
+            let help = CommanderRuntimeRouter.renderCommandHelp(
+                descriptor,
+                path: path,
+                theme: HelpTheme(useColors: false)
+            )
+
+            for flag in leafFlags {
+                #expect(self.helpEntryCount(flag, in: help) == 1)
+            }
+            #expect(self.helpEntryCount("--bridge-socket <bridge-socket>", in: help) == 1)
+            #expect(self.helpEntryCount("--no-remote", in: help) == 1)
+            #expect(!help.contains("Global Runtime Flags"))
+        }
+    }
+
+    @Test
     func `root help retains one standalone global runtime section`() {
         let help = CommanderRuntimeRouter.renderGlobalFlagsSection(theme: HelpTheme(useColors: false))
 

--- a/Apps/CLI/Tests/CoreCLITests/ToolsCommandTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/ToolsCommandTests.swift
@@ -15,8 +15,8 @@ struct ToolsCommandTests {
         #expect(config.abstract == "List the MCP tool catalog")
         #expect(config.discussion != nil)
         let discussion = config.discussion ?? ""
-        #expect(discussion.contains("built-in Peekaboo Agent adds agent-only capabilities"))
-        #expect(discussion.contains("including `shell`"))
+        #expect(discussion.contains("public Agent catalog is a separate background-first surface"))
+        #expect(discussion.contains("never exposes `shell`"))
         #expect(discussion.contains("Examples:"))
         #expect(discussion.contains("peekaboo tools"))
         #expect(discussion.contains("--verbose"))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Refuse capture before permission or backend dispatch when the macOS GUI session is locked, while explaining that `screen list` can still report connected displays.
 - Show CLI-native recovery commands in disconnected browser status output while preserving MCP guidance.
 - Show global runtime flags once in generated leaf and nested command help while retaining root-level discovery.
+- Keep `learn`, policy-aware tool schemas, and default-subcommand parent help aligned with the actual public Agent and CLI surfaces.
 
 ## [4.2.2] - 2026-08-20
 

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/Agent/PeekabooAgentService+Toolset.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/Agent/PeekabooAgentService+Toolset.swift
@@ -40,9 +40,12 @@ extension PeekabooAgentService {
                 self.createAgentTools()
             }
         }
-        let authorityFiltered = executionPolicy == .unrestricted
-            ? tools
-            : tools.filter { $0.name != "shell" }
+        let authorityFiltered: [AgentTool] = switch executionPolicy {
+        case .unrestricted:
+            tools
+        case .backgroundOnly, .foregroundAllowed:
+            tools.filter { $0.name != "shell" }
+        }
 
         let filters = ToolFiltering.currentFilters()
         return ToolFiltering.applyInputStrategyAvailability(

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/Agent/PeekabooAgentService+Toolset.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/Agent/PeekabooAgentService+Toolset.swift
@@ -13,6 +13,28 @@ extension PeekabooAgentService {
         snapshotOwner: MCPToolSnapshotOwner = MCPToolSnapshotOwner(),
         executionPolicy: MCPToolExecutionPolicy = .backgroundOnly) async -> [AgentTool]
     {
+        let filtered = self.filteredAgentTools(
+            snapshotOwner: snapshotOwner,
+            executionPolicy: executionPolicy)
+
+        self.logToolsetDetails(filtered, model: model)
+        return filtered
+    }
+
+    /// The exact tool catalog exposed by a normal public Agent session.
+    /// Public Agent entry points are background-only by default and never expose Shell.
+    public func publicAgentTools(
+        snapshotOwner: MCPToolSnapshotOwner = MCPToolSnapshotOwner()) -> [AgentTool]
+    {
+        self.filteredAgentTools(
+            snapshotOwner: snapshotOwner,
+            executionPolicy: .backgroundOnly)
+    }
+
+    private func filteredAgentTools(
+        snapshotOwner: MCPToolSnapshotOwner,
+        executionPolicy: MCPToolExecutionPolicy) -> [AgentTool]
+    {
         let tools = Self.$toolConstructionSnapshotOwner.withValue(snapshotOwner) {
             Self.$toolConstructionExecutionPolicy.withValue(executionPolicy) {
                 self.createAgentTools()
@@ -23,7 +45,7 @@ extension PeekabooAgentService {
             : tools.filter { $0.name != "shell" }
 
         let filters = ToolFiltering.currentFilters()
-        let filtered = ToolFiltering.applyInputStrategyAvailability(
+        return ToolFiltering.applyInputStrategyAvailability(
             ToolFiltering.apply(
                 authorityFiltered,
                 filters: filters,
@@ -34,9 +56,6 @@ extension PeekabooAgentService {
             log: { [logger] message in
                 logger.notice("\(message, privacy: .public)")
             })
-
-        self.logToolsetDetails(filtered, model: model)
-        return filtered
     }
 
     private func runtimeInputPolicy() -> UIInputPolicy {

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/AppTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/AppTool.swift
@@ -13,10 +13,28 @@ public struct AppTool: MCPTool {
     public let name = "app"
 
     public var description: String {
-        """
-        Control applications - verify an already-running app in the background, or explicitly launch/open/relaunch,
-        unhide, focus, switch, quit, hide, and list apps. Cold launch, open, new-instance, relaunch, and unhide require
-        foreground=true because macOS cannot guarantee those operations will preserve the user's foreground work.
+        if self.context.executionPolicy == .backgroundOnly {
+            return """
+            Control applications under immutable background-only authority. Available actions are `list`, `quit`,
+            `hide`, and `launch`; background `launch` is only an exact already-running readiness probe and never cold
+            starts an app. Focus, switch, open, relaunch, unhide, new-instance, and `foreground=true` are unavailable
+            here because they can activate shared desktop UI. A human must start a foreground-capable Agent session or
+            use the standalone CLI with explicit foreground consent for those operations.
+
+            Process-generation chaining must use `target_identity.process_start_identity_decimal`; the numeric
+            `process_start_identity` field remains compatibility-only and can lose precision above 2^53.
+
+            Always include the `action` field in your JSON payload. Examples:
+            - { "action": "list" }
+            - { "action": "launch", "name": "Finder" }
+            - { "action": "quit", "name": "Slack", "force": false }
+            """
+        }
+
+        return """
+        Control applications with explicit foreground-capable authority. Focus and switch activate shared desktop UI;
+        cold launch, open, new-instance, relaunch, and unhide require `foreground=true` because macOS cannot guarantee
+        those operations preserve the user's foreground work. Prefer background targeting after foreground setup.
         Process-generation chaining must use `target_identity.process_start_identity_decimal`; the numeric
         `process_start_identity` field remains compatibility-only and can lose precision above 2^53.
 
@@ -24,7 +42,6 @@ public struct AppTool: MCPTool {
         - { "action": "launch", "name": "Finder" }
         - { "action": "launch", "name": "TextEdit", "newInstance": true, "foreground": true }
         - { "action": "open", "name": "Safari", "openTargets": ["https://example.com"], "foreground": true }
-        - { "action": "launch", "name": "Calendar", "foreground": true }
         - { "action": "switch", "to": "Safari" }
         - { "action": "focus", "name": "Google Chrome" }
         - { "action": "quit", "name": "Slack", "force": false }
@@ -32,46 +49,56 @@ public struct AppTool: MCPTool {
     }
 
     public var inputSchema: Value {
-        SchemaBuilder.object(
-            properties: [
-                "action": SchemaBuilder.string(
-                    description: "Action to perform",
-                    enum: ["launch", "open", "quit", "relaunch", "focus", "hide", "unhide", "switch", "list"]),
-                "name": SchemaBuilder.string(
-                    description: "App name/bundle ID/PID (e.g., 'Safari', 'com.apple.Safari', 'PID:663')"),
-                "bundleId": SchemaBuilder.string(
-                    description: "Bundle identifier when launching"),
-                "openTargets": SchemaBuilder.array(
-                    items: SchemaBuilder.string(),
-                    description: "URL or file paths to open; required for open, optional for launch"),
-                "foreground": SchemaBuilder.boolean(
-                    description: "Required for cold launch, open, new-instance, relaunch, and unhide",
-                    default: false),
-                "force": SchemaBuilder.boolean(
-                    description: "Force quit application",
-                    default: false),
-                "wait": SchemaBuilder.number(
-                    description: "Wait time (seconds) between quit/launch for relaunch",
-                    default: 2.0),
-                "waitUntilReady": SchemaBuilder.boolean(
-                    description: "Wait until LaunchServices reports startup complete",
-                    default: false),
-                "waitForWindow": SchemaBuilder.boolean(
-                    description: "Wait until the launched app exposes an exact WindowServer window",
-                    default: false),
-                "newInstance": SchemaBuilder.boolean(
-                    description: "Launch a distinct process even if the app is already running",
-                    default: false),
-                "all": SchemaBuilder.boolean(
-                    description: "Quit all applications",
-                    default: false),
-                "except": SchemaBuilder.string(
-                    description: "Comma-separated list of apps to exclude when quitting all"),
-                "to": SchemaBuilder.string(description: "Target application when switching"),
-                "cycle": SchemaBuilder.boolean(
-                    description: "Cycle to the next application (like Cmd+Tab)",
-                    default: false),
-            ],
+        let foregroundCapable = self.context.executionPolicy != .backgroundOnly
+        let actions = foregroundCapable
+            ? ["launch", "open", "quit", "relaunch", "focus", "hide", "unhide", "switch", "list"]
+            : ["launch", "quit", "hide", "list"]
+        var properties: [String: Value] = [
+            "action": SchemaBuilder.string(
+                description: foregroundCapable
+                    ? "Action to perform; focus and switch use the session's explicit foreground authority"
+                    : "Background-only action; foreground lifecycle, focus, and switch actions are unavailable",
+                enum: actions),
+            "name": SchemaBuilder.string(
+                description: "App name/bundle ID/PID (e.g., 'Safari', 'com.apple.Safari', 'PID:663')"),
+            "bundleId": SchemaBuilder.string(
+                description: "Bundle identifier when launching"),
+            "force": SchemaBuilder.boolean(
+                description: "Force quit application",
+                default: false),
+            "waitUntilReady": SchemaBuilder.boolean(
+                description: "Wait until LaunchServices reports startup complete",
+                default: false),
+            "waitForWindow": SchemaBuilder.boolean(
+                description: "Wait until the launched app exposes an exact WindowServer window",
+                default: false),
+            "all": SchemaBuilder.boolean(
+                description: "Quit all applications",
+                default: false),
+            "except": SchemaBuilder.string(
+                description: "Comma-separated list of apps to exclude when quitting all"),
+        ]
+        if foregroundCapable {
+            properties["openTargets"] = SchemaBuilder.array(
+                items: SchemaBuilder.string(),
+                description: "URL or file paths to open; required for open, optional for launch")
+            properties["foreground"] = SchemaBuilder.boolean(
+                description: "Required for cold launch, open, new-instance, relaunch, and unhide",
+                default: false)
+            properties["wait"] = SchemaBuilder.number(
+                description: "Wait time (seconds) between quit/launch for relaunch",
+                default: 2.0)
+            properties["newInstance"] = SchemaBuilder.boolean(
+                description: "Launch a distinct process even if the app is already running",
+                default: false)
+            properties["to"] = SchemaBuilder.string(description: "Target application when switching")
+            properties["cycle"] = SchemaBuilder.boolean(
+                description: "Cycle to the next application (like Cmd+Tab)",
+                default: false)
+        }
+
+        return SchemaBuilder.object(
+            properties: properties,
             required: ["action"])
     }
 

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/ClipboardTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/ClipboardTool.swift
@@ -15,8 +15,23 @@ public struct ClipboardTool: MCPTool {
     }
 
     public var description: String {
-        """
+        if self.context.executionPolicy == .backgroundOnly {
+            return """
+            Read or snapshot the macOS clipboard under immutable background-only authority. Available actions are
+            `get` and `save`. The `set`, `clear`, and `restore` actions are unavailable because they persistently
+            change the user's shared clipboard state; use exact targeted transactional `paste`, or ask the human to
+            start a foreground-capable Agent session or use the standalone CLI when that user-state change is intended.
+
+            - get: read the clipboard; optionally prefer a UTI and/or write binary data to a filesystem path.
+              MCP stdout is reserved for JSON-RPC, so outputPath '-' is rejected.
+            - save: snapshot clipboard contents to a named slot without changing the shared clipboard.
+            """
+        }
+
+        return """
         Work with the macOS clipboard (pasteboard). Actions: get, set, clear, save, restore.
+        The `set`, `clear`, and `restore` actions persistently change the user's shared clipboard state. Use them only
+        when the human-authorized workflow intends that state change; prefer save/restore around temporary mutation.
         - get: read the clipboard; optionally prefer a UTI and/or write binary data to a filesystem path.
           MCP stdout is reserved for JSON-RPC, so outputPath '-' is rejected.
         - set: write text, file, image, or base64+UTI data to the clipboard (optionally also set plain text).
@@ -26,24 +41,34 @@ public struct ClipboardTool: MCPTool {
     }
 
     public var inputSchema: Value {
-        SchemaBuilder.object(
-            properties: [
-                "action": SchemaBuilder.string(
-                    description: "Action to perform",
-                    enum: ["get", "set", "clear", "save", "restore"]),
-                "text": SchemaBuilder.string(description: "Plain text to set on the clipboard"),
-                "file_path": SchemaBuilder.string(description: "Path to a file to copy (binary or text)"),
-                "data_base64": SchemaBuilder.string(description: "Base64-encoded data to copy"),
-                "uti": SchemaBuilder.string(description: "Uniform Type Identifier for data_base64 or to force type"),
-                "prefer": SchemaBuilder.string(description: "Preferred UTI when reading clipboard"),
-                "outputPath": SchemaBuilder
-                    .string(description: "When reading, filesystem path to write binary data. " +
-                        "The '-' stdout sentinel is not supported because MCP stdout carries JSON-RPC; " +
-                        "omit outputPath to receive UTF-8 text in the tool response."),
-                "slot": SchemaBuilder.string(description: "Save/restore slot name (default: \"0\")"),
-                "alsoText": SchemaBuilder.string(description: "Optional plain text companion when setting binary data"),
-                "allowLarge": SchemaBuilder.boolean(description: "Allow writes larger than the 10 MB guard"),
-            ],
+        let foregroundCapable = self.context.executionPolicy != .backgroundOnly
+        let actions = foregroundCapable ? ["get", "set", "clear", "save", "restore"] : ["get", "save"]
+        var properties: [String: Value] = [
+            "action": SchemaBuilder.string(
+                description: foregroundCapable
+                    ? "Action to perform; set, clear, and restore persistently change the user's clipboard"
+                    : "Background-safe action; persistent clipboard mutation is unavailable",
+                enum: actions),
+            "prefer": SchemaBuilder.string(description: "Preferred UTI when reading clipboard"),
+            "outputPath": SchemaBuilder
+                .string(description: "When reading, filesystem path to write binary data. " +
+                    "The '-' stdout sentinel is not supported because MCP stdout carries JSON-RPC; " +
+                    "omit outputPath to receive UTF-8 text in the tool response."),
+            "slot": SchemaBuilder.string(description: "Save/restore slot name (default: \"0\")"),
+        ]
+        if foregroundCapable {
+            properties["text"] = SchemaBuilder.string(description: "Plain text to set on the clipboard")
+            properties["file_path"] = SchemaBuilder.string(description: "Path to a file to copy (binary or text)")
+            properties["data_base64"] = SchemaBuilder.string(description: "Base64-encoded data to copy")
+            properties["uti"] = SchemaBuilder.string(
+                description: "Uniform Type Identifier for data_base64 or to force type")
+            properties["alsoText"] = SchemaBuilder.string(
+                description: "Optional plain text companion when setting binary data")
+            properties["allowLarge"] = SchemaBuilder.boolean(description: "Allow writes larger than the 10 MB guard")
+        }
+
+        return SchemaBuilder.object(
+            properties: properties,
             required: ["action"])
     }
 

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/WindowTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/WindowTool.swift
@@ -13,7 +13,14 @@ public struct WindowTool: MCPTool {
     public let name = "window"
 
     public var description: String {
-        """
+        let foregroundCapable = self.context.executionPolicy != .backgroundOnly
+        let focusGuidance = foregroundCapable
+            ? "- focus: Bring a window to the foreground using the session's explicit foreground authority"
+            : "- focus: Unavailable under background-only authority; use a human-authorized foreground session or CLI"
+        let focusExample = foregroundCapable
+            ? "\n- { \"action\": \"focus\", \"app\": \"Google Chrome\" }"
+            : ""
+        return """
         List and manipulate application windows.
 
         Actions:
@@ -25,7 +32,10 @@ public struct WindowTool: MCPTool {
         - move: Move a window to specific coordinates (requires x, y)
         - resize: Resize a window to specific dimensions (requires width, height)
         - set-bounds: Set both position and size (requires x, y, width, height)
-        - focus: Bring a window to the foreground
+        \(focusGuidance)
+
+        Background-only close uses Accessibility and fails rather than focusing the app for a global fallback.
+        A focused/global close fallback is available only to a foreground-capable session with `foreground=true`.
 
         Target windows by application name and optionally by window title or index.
         For deterministic targeting, prefer `window_id` (from `peekaboo window list`).
@@ -33,54 +43,63 @@ public struct WindowTool: MCPTool {
 
         JSON Examples (ALWAYS include `action`):
         - { "action": "list", "app": "Safari" }
-        - { "action": "focus", "app": "Google Chrome" }
         - { "action": "move", "app": "TextEdit", "x": 100, "y": 100 }
         - { "action": "restore", "app": "PID:1234", "window_id": 5678 }
         - { "action": "set-bounds", "app": "Terminal", "x": 0, "y": 0, "width": 1280, "height": 720 }
-        - { "action": "close", "app": "Safari", "title": "Grindr Web" }
+        - { "action": "close", "app": "Safari", "title": "Document" }\(focusExample)
         \(PeekabooMCPVersion.banner) using openai/gpt-5.6, anthropic/claude-opus-5
         """
     }
 
     public var inputSchema: Value {
-        SchemaBuilder.object(
-            properties: [
-                "action": SchemaBuilder.string(
-                    description: "The action to perform on the window",
-                    enum: [
-                        "list",
-                        "close",
-                        "minimize",
-                        "restore",
-                        "maximize",
-                        "move",
-                        "resize",
-                        "set-bounds",
-                        "focus",
-                    ]),
-                "app": SchemaBuilder.string(
-                    description: "Target application name, bundle ID, or process ID"),
-                "title": SchemaBuilder.string(
-                    description: "Window title to target (partial matching supported)"),
-                "index": SchemaBuilder.integer(
-                    description: "Window index (0-based) for multi-window applications"),
-                "window_id": SchemaBuilder.integer(
-                    description: "Window ID (from window list); preferred stable selector"),
-                "x": SchemaBuilder.number(
-                    description: "X coordinate for move or set-bounds action"),
-                "y": SchemaBuilder.number(
-                    description: "Y coordinate for move or set-bounds action"),
-                "width": SchemaBuilder.number(
-                    description: "Width for resize or set-bounds action"),
-                "height": SchemaBuilder.number(
-                    description: "Height for resize or set-bounds action"),
-                "foreground": SchemaBuilder.boolean(
-                    description: "For close only: allow focused/global fallback after AX close fails.",
-                    default: false),
-                "include_window_details": SchemaBuilder.array(
-                    items: SchemaBuilder.string(enum: WindowDetail.allCases.map(\.rawValue)),
-                    description: "Details for list results. Defaults to ids, bounds, and off_screen."),
-            ],
+        let foregroundCapable = self.context.executionPolicy != .backgroundOnly
+        var actions = [
+            "list",
+            "close",
+            "minimize",
+            "restore",
+            "maximize",
+            "move",
+            "resize",
+            "set-bounds",
+        ]
+        if foregroundCapable {
+            actions.append("focus")
+        }
+        var properties: [String: Value] = [
+            "action": SchemaBuilder.string(
+                description: foregroundCapable
+                    ? "The action to perform; focus uses the session's explicit foreground authority"
+                    : "The background-safe action to perform; focus is unavailable",
+                enum: actions),
+            "app": SchemaBuilder.string(
+                description: "Target application name, bundle ID, or process ID"),
+            "title": SchemaBuilder.string(
+                description: "Window title to target (partial matching supported)"),
+            "index": SchemaBuilder.integer(
+                description: "Window index (0-based) for multi-window applications"),
+            "window_id": SchemaBuilder.integer(
+                description: "Window ID (from window list); preferred stable selector"),
+            "x": SchemaBuilder.number(
+                description: "X coordinate for move or set-bounds action"),
+            "y": SchemaBuilder.number(
+                description: "Y coordinate for move or set-bounds action"),
+            "width": SchemaBuilder.number(
+                description: "Width for resize or set-bounds action"),
+            "height": SchemaBuilder.number(
+                description: "Height for resize or set-bounds action"),
+            "include_window_details": SchemaBuilder.array(
+                items: SchemaBuilder.string(enum: WindowDetail.allCases.map(\.rawValue)),
+                description: "Details for list results. Defaults to ids, bounds, and off_screen."),
+        ]
+        if foregroundCapable {
+            properties["foreground"] = SchemaBuilder.boolean(
+                description: "For close only: allow focused/global fallback after AX close fails.",
+                default: false)
+        }
+
+        return SchemaBuilder.object(
+            properties: properties,
             required: ["action"])
     }
 

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/ToolRegistry/ToolRegistry.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/ToolRegistry/ToolRegistry.swift
@@ -1,5 +1,4 @@
 import Foundation
-import os.log
 import PeekabooAutomation
 import Tachikoma
 
@@ -86,24 +85,26 @@ public enum ToolRegistry {
                 "reference the new element id."),
         "type": ToolOverride(
             category: .automation,
-            abstract: "Types text into a targeted app or element with configurable cadence.",
+            abstract: "Types text through an explicit snapshot-pinned Agent target with configurable cadence.",
             discussion: """
-            Types raw text into the targeted app or focused element. Escape sequences are supported:
+            Background-only Agent typing requires a fresh exact non-dialog snapshot. An optional element ID must come
+            from that snapshot; app, PID, window-selector-only, targetless, and implicit-latest forms are refused.
+            Escape sequences are supported:
             - Use "\\n" for newline
             - Use "\\t" for tab
             - Use "\\\\" or the word "escape" to send a literal backslash
 
             EXAMPLE
-            peekaboo type \"Hello\\nWorld\" --app TextEdit
-            peekaboo type --text \"Press\\tescape\" --app TextEdit --delay 50ms
+            { "text": "Hello\\nWorld", "snapshot": "$SNAPSHOT_ID" }
+            { "text": "Name:\\tJohn", "snapshot": "$SNAPSHOT_ID", "delay": 25 }
 
             TROUBLESHOOTING
-            If the text appears in the wrong place, pass `--app`, `--pid`, `--window-id`, or `--snapshot` so
-            Peekaboo can resolve a background target process. Use `--foreground` for apps that require focused input.
+            Background-click the field, observe the exact window again, and pass that new snapshot to `type`.
+            A foreground-capable Agent session may use its separately authorized foreground targeting forms.
             """,
             examples: [
-                "peekaboo type \"Hello\\nWorld\" --app TextEdit",
-                "peekaboo type --text \"Name:\\tJohn\" --app TextEdit --delay 25ms",
+                "{ \"text\": \"Hello\\nWorld\", \"snapshot\": \"$SNAPSHOT_ID\" }",
+                "{ \"text\": \"Name:\\tJohn\", \"snapshot\": \"$SNAPSHOT_ID\", \"delay\": 25 }",
             ],
             agentGuidance: "Remember to escape newline/tab characters when providing prompts; " +
                 "literal newlines may be interpreted by the shell."),
@@ -168,19 +169,11 @@ public enum ToolRegistry {
             return []
         }
 
-        // Get all agent tools
-        let agentTools = agentService.createAgentTools()
-        let filters = ToolFiltering.currentFilters()
-        let filteredTools = ToolFiltering.apply(
-            agentTools,
-            filters: filters,
-            log: { message in
-                Logger(subsystem: "boo.peekaboo.tools", category: "registry")
-                    .notice("\(message, privacy: .public)")
-            })
+        // Use the same background-only, Shell-free catalog that a public Agent session receives.
+        let agentTools = agentService.publicAgentTools()
 
         // Convert AgentTools to PeekabooToolDefinitions
-        return filteredTools.compactMap { agentTool in
+        return agentTools.compactMap { agentTool in
             self.convertAgentToolToDefinition(agentTool)
         }
     }

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/ToolRegistry/ToolRegistry.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/ToolRegistry/ToolRegistry.swift
@@ -9,143 +9,6 @@ public enum ToolRegistry {
     @MainActor
     private static var defaultServicesFactory: (() -> any PeekabooServiceProviding)?
 
-    private struct ToolOverride {
-        let category: ToolCategory?
-        let abstract: String?
-        let discussion: String?
-        let examples: [String]?
-        let agentGuidance: String?
-    }
-
-    /// Runtime tool names carrying curated copy. Exposed so a contract test can
-    /// keep this table synchronized with the agent/MCP tool surface.
-    static var overriddenToolNames: Set<String> {
-        Set(self.toolOverrides.keys)
-    }
-
-    private static let toolOverrides: [String: ToolOverride] = [
-        "see": ToolOverride(
-            category: .vision,
-            abstract: "Capture and analyze UI contexts, returning snapshot-aware element maps.",
-            discussion: """
-            Capture a screenshot, analyze every visible UI element, and write the results to the snapshot cache
-            so later tools can reference the same IDs. The command automatically handles full screen,
-            frontmost window, or app-specific captures.
-
-            EXAMPLE
-            peekaboo see --app Safari --path ~/Desktop/safari.png --annotate
-
-            SNAPSHOT MANAGEMENT
-            - Each capture stores a snapshot id (returned in CLI output)
-            - Pass --snapshot <id> to reuse the same map in follow-up interaction commands
-
-            TROUBLESHOOTING
-            If a window is missing, try `--mode screen` so Peekaboo can discover all windows before filtering.
-            """,
-            examples: [
-                "peekaboo see --app Safari --path ~/Shots/safari.png --annotate",
-                "peekaboo see --mode screen --json",
-            ],
-            agentGuidance: "Run `inspect_ui` for AX-only element IDs, or `see` when a screenshot/visual " +
-                "element map is needed; both responses contain snapshot ids."),
-        "click": ToolOverride(
-            category: .automation,
-            abstract: "High-precision UI clicking with fuzzy matching and snapshot-aware targeting.",
-            discussion: """
-            Clicks on UI elements or coordinates. CLI interactions use IDs from `see`;
-            agent/MCP interactions may also use IDs from `inspect_ui`,
-            fuzzy text queries, or raw coordinates. Clicks use background delivery by default;
-            pass `--foreground` only when the target must receive a foreground mouse event.
-
-            ELEMENT MATCHING
-            - Fuzzy matching on element titles and labels
-            - Smart waiting keeps checking until the element is reachable
-            - Snapshot-aware IDs avoid ambiguity when multiple matches exist
-
-            CLICK KIND
-            - `--double`, `--triple`, `--right`, or `--middle` select one alternate click kind
-            - `--long-press` presses and holds, and requires `--foreground`
-
-            EXAMPLE
-            peekaboo see --app Safari --json
-            peekaboo click \"Submit\" --app Safari --snapshot "$SNAPSHOT_ID" --wait-for 1500ms
-            peekaboo click --on "$ELEMENT_ID" --snapshot "$SNAPSHOT_ID" --double
-
-            TROUBLESHOOTING
-            If the element isn't found, refresh the snapshot with a fresh observation (`peekaboo see`
-            in CLI, or `see`/`inspect_ui` in MCP), or provide a more precise query.
-            """,
-            examples: [
-                "peekaboo click \"Submit\" --app Safari --snapshot \"$SNAPSHOT_ID\" --wait-for 1500ms",
-                "peekaboo click --on \"$ELEMENT_ID\" --snapshot \"$SNAPSHOT_ID\"",
-                "peekaboo click --on \"$ELEMENT_ID\" --snapshot \"$SNAPSHOT_ID\" --double",
-            ],
-            agentGuidance: "Prefer ID-based clicks when possible. Use default background delivery, and add " +
-                "`--foreground` only when the app requires focused input. If fuzzy text fails, capture again and " +
-                "reference the new element id."),
-        "type": ToolOverride(
-            category: .automation,
-            abstract: "Types text through an explicit snapshot-pinned Agent target with configurable cadence.",
-            discussion: """
-            Background-only Agent typing requires a fresh exact non-dialog snapshot. An optional element ID must come
-            from that snapshot; app, PID, window-selector-only, targetless, and implicit-latest forms are refused.
-            Escape sequences are supported:
-            - Use "\\n" for newline
-            - Use "\\t" for tab
-            - Use "\\\\" or the word "escape" to send a literal backslash
-
-            EXAMPLE
-            { "text": "Hello\\nWorld", "snapshot": "$SNAPSHOT_ID" }
-            { "text": "Name:\\tJohn", "snapshot": "$SNAPSHOT_ID", "delay": 25 }
-
-            TROUBLESHOOTING
-            Background-click the field, observe the exact window again, and pass that new snapshot to `type`.
-            A foreground-capable Agent session may use its separately authorized foreground targeting forms.
-            """,
-            examples: [
-                "{ \"text\": \"Hello\\nWorld\", \"snapshot\": \"$SNAPSHOT_ID\" }",
-                "{ \"text\": \"Name:\\tJohn\", \"snapshot\": \"$SNAPSHOT_ID\", \"delay\": 25 }",
-            ],
-            agentGuidance: "Remember to escape newline/tab characters when providing prompts; " +
-                "literal newlines may be interpreted by the shell."),
-        "clipboard": ToolOverride(
-            category: .system,
-            abstract: "Read/write the macOS clipboard (text, images, files) with save/restore slots.",
-            discussion: """
-            Use `action: set` with text, file_path, or data_base64+uti to write the clipboard.
-            Use `action: get` to read it (optionally prefer a UTI or write binary to a filesystem outputPath).
-            MCP stdout carries JSON-RPC, so outputPath `-` is rejected; omit it to receive UTF-8 text.
-            `save`/`restore` keep user content safe while automating; `clear` empties the pasteboard.
-            """,
-            examples: [
-                "peekaboo clipboard set --text \"hello world\"",
-                "peekaboo clipboard get --output /tmp/clip.bin",
-                "peekaboo clipboard save --slot original && " +
-                    "peekaboo clipboard clear && " +
-                    "peekaboo clipboard restore --slot original",
-            ],
-            agentGuidance: "Use save/restore when a workflow might overwrite the user's clipboard."),
-        "browser": ToolOverride(
-            category: .browser,
-            abstract: "Control and inspect Chrome page content through Chrome DevTools MCP.",
-            discussion: """
-            Brokers Chrome DevTools MCP for page-level browser automation: snapshots, clicks, fills,
-            navigation, console, network, screenshots, and performance traces.
-
-            PERMISSIONS
-            - Requires Chrome 144+.
-            - The user must enable remote debugging at chrome://inspect/#remote-debugging.
-            - The user must accept Chrome's remote debugging prompt.
-            - Peekaboo disables Chrome DevTools MCP usage statistics and CrUX lookups.
-            """,
-            examples: [
-                "browser { \"action\": \"status\" }",
-                "browser { \"action\": \"connect\" }",
-                "browser { \"action\": \"snapshot\" }",
-            ],
-            agentGuidance: "Use for Chrome web page content. Use native Peekaboo tools for macOS UI and dialogs."),
-    ]
-
     // MARK: - Registry Access
 
     /// All registered tools collected from various definition structs
@@ -173,7 +36,7 @@ public enum ToolRegistry {
         let agentTools = agentService.publicAgentTools()
 
         // Convert AgentTools to PeekabooToolDefinitions
-        return agentTools.compactMap { agentTool in
+        return agentTools.map { agentTool in
             self.convertAgentToolToDefinition(agentTool)
         }
     }
@@ -199,26 +62,28 @@ public enum ToolRegistry {
     // MARK: - Private Helpers
 
     /// Convert an AgentTool to PeekabooToolDefinition
-    private static func convertAgentToolToDefinition(_ tool: AgentTool) -> PeekabooToolDefinition? {
+    private static func convertAgentToolToDefinition(_ tool: AgentTool) -> PeekabooToolDefinition {
         // Map common tool names to categories
         let category: ToolCategory = switch tool.name {
-        case "see", "screenshot", "window_capture":
+        case "see", "image", "capture", "analyze":
             .vision
         case "inspect_ui", "verify_state":
             .element
-        case "click", "type", "press", "scroll", "drag", "move", "action":
+        case "click", "type", "press", "scroll", "drag", "move", "action", "set_value", "paste":
             .automation
+        case "window", "space":
+            .window
         case "app":
             .app
-        case "menu_click", "list_menus":
+        case "menu":
             .menu
-        case "dialog_click", "dialog_input":
+        case "dialog":
             .dialog
-        case "dock_launch", "list_dock":
+        case "dock":
             .dock
         case "browser":
             .browser
-        case "shell", "clipboard", "copy_to_clipboard", "paste_from_clipboard":
+        case "shell", "clipboard", "permissions", "sleep":
             .system
         case "done", "need_info":
             .completion
@@ -229,7 +94,7 @@ public enum ToolRegistry {
         // Convert parameters from agent tool schema
         let parameters = self.convertAgentParameters(tool.parameters)
 
-        let baseDefinition = PeekabooToolDefinition(
+        return PeekabooToolDefinition(
             name: tool.name,
             commandName: tool.name.replacingOccurrences(of: "_", with: "-"),
             abstract: tool.description,
@@ -238,20 +103,6 @@ public enum ToolRegistry {
             parameters: parameters,
             examples: [],
             agentGuidance: "")
-
-        if let override = self.toolOverrides[tool.name] {
-            return PeekabooToolDefinition(
-                name: baseDefinition.name,
-                commandName: baseDefinition.commandName,
-                abstract: override.abstract ?? baseDefinition.abstract,
-                discussion: override.discussion ?? baseDefinition.discussion,
-                category: override.category ?? baseDefinition.category,
-                parameters: baseDefinition.parameters,
-                examples: override.examples ?? baseDefinition.examples,
-                agentGuidance: override.agentGuidance ?? baseDefinition.agentGuidance)
-        }
-
-        return baseDefinition
     }
 
     /// Convert agent tool parameters to parameter definitions

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/ToolRegistry/ToolRegistry.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/ToolRegistry/ToolRegistry.swift
@@ -101,8 +101,7 @@ public enum ToolRegistry {
             discussion: tool.description,
             category: category,
             parameters: parameters,
-            examples: [],
-            agentGuidance: "")
+            examples: [])
     }
 
     /// Convert agent tool parameters to parameter definitions

--- a/Core/PeekabooCore/Tests/PeekabooAgentRuntimeTests/ToolRegistryContractTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooAgentRuntimeTests/ToolRegistryContractTests.swift
@@ -37,15 +37,20 @@ struct ToolRegistryContractTests {
     }
 
     @Test
-    func `Curated copy only overrides tools the runtime exposes`() {
+    func `Final definitions preserve policy-filtered source descriptions without widening`() throws {
         let services = PeekabooServices()
         services.installAgentRuntimeDefaults()
 
-        let exposed = Set(ToolRegistry.allTools(using: services).map(\.name))
-        let documented = ToolRegistry.overriddenToolNames
-        let orphaned = documented.subtracting(exposed).sorted()
+        let sourceTools = try PeekabooAgentService(services: services).publicAgentTools()
+        let sourceByName = Dictionary(uniqueKeysWithValues: sourceTools.map { ($0.name, $0) })
+        let definitions = ToolRegistry.allTools(using: services)
 
-        #expect(orphaned.isEmpty, "Curated copy overrides unavailable runtime tools: \(orphaned)")
+        for definition in definitions {
+            let source = try #require(sourceByName[definition.name])
+            #expect(definition.abstract == source.description)
+            #expect(definition.discussion == source.description)
+            #expect(definition.examples.isEmpty)
+        }
     }
 
     @Test

--- a/Core/PeekabooCore/Tests/PeekabooAgentRuntimeTests/ToolRegistryContractTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooAgentRuntimeTests/ToolRegistryContractTests.swift
@@ -6,7 +6,7 @@ import Testing
 @MainActor
 struct ToolRegistryContractTests {
     @Test
-    func `Default services expose automation tools`() {
+    func `Default services expose the public background Agent catalog`() async throws {
         let services = PeekabooServices()
         services.installAgentRuntimeDefaults()
 
@@ -23,11 +23,17 @@ struct ToolRegistryContractTests {
             "action",
             "drag",
             "move",
-            "shell",
             "app",
             "window",
         ]))
+        #expect(!names.contains("shell"))
         #expect(names.isDisjoint(with: ["hotkey", "launch_app", "list"]))
+
+        let agent = try PeekabooAgentService(services: services)
+        let sessionNames = await Set(agent.buildToolset(for: .anthropic(.sonnet45)).map(\.name))
+        let publicFactoryNames = Set(agent.publicAgentTools().map(\.name))
+        #expect(names == sessionNames)
+        #expect(names == publicFactoryNames)
     }
 
     @Test

--- a/Core/PeekabooCore/Tests/PeekabooTests/AgentToolDescriptionTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/AgentToolDescriptionTests.swift
@@ -167,13 +167,9 @@ struct AgentToolDescriptionTests {
 
     @Test
     @MainActor
-    func `Shell tool has quoting examples`() {
-        guard let shellTool = makeAgentTools().first(where: { $0.name == "shell" }) else {
-            Issue.record("Shell tool not found")
-            return
-        }
-
-        let discussion = shellTool.discussion
+    func `Raw privileged Shell factory retains quoting examples`() throws {
+        let service = try PeekabooAgentService(services: PeekabooServices())
+        let discussion = service.createShellTool().description
 
         // Shell tool should have examples
         #expect(discussion.contains("EXAMPLE") || discussion.contains("shell"))
@@ -362,7 +358,7 @@ struct AgentToolDescriptionTests {
 
             // Examples should demonstrate various options
             if tool.parameters.count > 2 {
-                let hasOptionExample = tool.discussion.contains("--")
+                let hasOptionExample = tool.discussion.contains("--") || tool.examples.contains { $0.contains("\"") }
                 #expect(
                     hasOptionExample,
                     "Tool '\(tool.name)' with multiple parameters should show option examples")

--- a/Core/PeekabooCore/Tests/PeekabooTests/AgentToolDescriptionTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/AgentToolDescriptionTests.swift
@@ -31,16 +31,7 @@ struct AgentToolDescriptionTests {
         for tool in allTools {
             let discussion = tool.discussion
 
-            // Check for common sections in enhanced descriptions
-            if discussion.count > 200 { // Only check substantial descriptions
-                // Many enhanced tools include EXAMPLES section
-                if tool.name == "click" || tool.name == "type" || tool.name == "see" {
-                    #expect(
-                        discussion.contains("EXAMPLE"),
-                        "Tool '\(tool.name)' should include examples")
-                }
-
-                // UI tools should mention relevant keywords
+            if discussion.count > 200 {
                 if tool.category == .automation {
                     let hasUIGuidance = discussion.contains("element") ||
                         discussion.contains("UI") ||
@@ -61,7 +52,7 @@ struct AgentToolDescriptionTests {
 
     @Test
     @MainActor
-    func `Click tool has enhanced element matching description`() {
+    func `Click tool preserves native receipt and background guidance`() {
         guard let clickTool = makeAgentTools().first(where: { $0.name == "click" }) else {
             Issue.record("Click tool not found")
             return
@@ -69,21 +60,14 @@ struct AgentToolDescriptionTests {
 
         let discussion = clickTool.discussion
 
-        // Verify enhanced features are documented
-        #expect(discussion.contains("Fuzzy matching"))
-        #expect(discussion.contains("Smart waiting"))
-        #expect(discussion.contains("ELEMENT MATCHING"))
-        #expect(discussion.contains("TROUBLESHOOTING"))
-
-        // Check for specific examples
-        #expect(discussion.contains("peekaboo click"))
-        #expect(discussion.contains("--wait-for"))
-        #expect(discussion.contains("--double"))
+        #expect(discussion.contains("specific IDs from `see` or `inspect_ui`"))
+        #expect(discussion.contains("fresh exact-window `see`"))
+        #expect(discussion.contains("Background delivery is the default"))
     }
 
     @Test
     @MainActor
-    func `Type tool includes escape sequence documentation`() {
+    func `Type tool preserves native background policy documentation`() {
         guard let typeTool = makeAgentTools().first(where: { $0.name == "type" }) else {
             Issue.record("Type tool not found")
             return
@@ -91,10 +75,9 @@ struct AgentToolDescriptionTests {
 
         let discussion = typeTool.discussion
 
-        // Check for escape sequence documentation
-        #expect(discussion.contains("\\n") || discussion.contains("newline"))
-        #expect(discussion.contains("\\t") || discussion.contains("tab"))
-        #expect(discussion.contains("escape") || discussion.contains("\\"))
+        #expect(discussion.contains("explicit fresh exact non-dialog snapshot receipt"))
+        #expect(discussion.contains("App/PID/window-only"))
+        #expect(discussion.contains("implicit-latest"))
     }
 
     @Test
@@ -109,7 +92,8 @@ struct AgentToolDescriptionTests {
 
         // Verify see tool features are documented
         #expect(discussion.contains("screenshot") || discussion.contains("capture"))
-        #expect(discussion.contains("app") || discussion.contains("window"))
+        #expect(discussion.contains("background-only"))
+        #expect(discussion.contains("opaque Peekaboo element IDs"))
 
         // Check for snapshot management info
         #expect(discussion.contains("snapshot"))
@@ -276,93 +260,20 @@ struct AgentToolDescriptionTests {
 
     @Test
     @MainActor
-    func `Tools provide helpful error guidance`() {
-        // Only check tools that are expected to have error guidance
-        // Based on actual tool definitions, only 'click' has TROUBLESHOOTING section
-        let toolsWithErrorGuidance = ["click"]
-
-        for toolName in toolsWithErrorGuidance {
-            guard let tool = makeAgentTools().first(where: { $0.name == toolName }) else {
-                continue
-            }
-
-            let discussion = tool.discussion
-
-            // Check for troubleshooting or error handling guidance
-            let hasErrorGuidance = discussion.contains("TROUBLESHOOTING") ||
-                discussion.contains("If") ||
-                discussion.contains("not found") ||
-                discussion.contains("fail") ||
-                discussion.contains("error") ||
-                discussion.contains("try")
-
-            #expect(
-                hasErrorGuidance,
-                "Tool '\(toolName)' should include error guidance")
-        }
-
-        // Additionally, verify that tools that need error guidance have it
-        // This is more of a design guideline check
-        let interactionTools = ["click", "type", "see", "app"]
-        var toolsWithGuidance = 0
-        var toolsWithoutGuidance: [String] = []
-
-        for toolName in interactionTools {
-            guard let tool = makeAgentTools().first(where: { $0.name == toolName }) else {
-                continue
-            }
-
-            let discussion = tool.discussion
-            let hasGuidance = discussion.contains("TROUBLESHOOTING") ||
-                discussion.contains("If") ||
-                discussion.contains("not found") ||
-                discussion.contains("fail") ||
-                discussion.contains("error") ||
-                discussion.contains("try")
-
-            if hasGuidance {
-                toolsWithGuidance += 1
-            } else {
-                toolsWithoutGuidance.append(toolName)
-            }
-        }
-
-        // At least some interaction tools should have error guidance
-        #expect(toolsWithGuidance > 0, "At least some interaction tools should have error guidance")
-
-        // This is informational - not a hard requirement
-        if !toolsWithoutGuidance.isEmpty {
-            // Note: Tools without explicit error guidance: \(toolsWithoutGuidance)
-            // This is OK as long as they have clear descriptions
-        }
+    func `Policy-sensitive tools preserve native refusal guidance`() throws {
+        let tools = Dictionary(uniqueKeysWithValues: makeAgentTools().map { ($0.name, $0) })
+        #expect(try #require(tools["app"]).discussion.contains("unavailable"))
+        #expect(try #require(tools["window"]).discussion.contains("Unavailable under background-only authority"))
+        #expect(try #require(tools["clipboard"]).discussion.contains("persistently"))
     }
 
     // MARK: - Example Quality Tests
 
     @Test
     @MainActor
-    func `Tool examples are realistic and helpful`() {
-        let allTools = makeAgentTools()
-
-        for tool in allTools where tool.discussion.contains("EXAMPLE") {
-            // Examples should reference the tool somehow
-            let toolNameParts = tool.name.split(separator: "_")
-            let hasReference = tool.discussion.contains("peekaboo") ||
-                tool.discussion.contains(tool.name) ||
-                toolNameParts.contains { part in
-                    tool.discussion.lowercased().contains(part.lowercased())
-                }
-            #expect(
-                hasReference,
-                "Examples for '\(tool.name)' should reference the tool")
-
-            // Examples should demonstrate various options
-            if tool.parameters.count > 2 {
-                let hasOptionExample = tool.discussion.contains("--") || tool.examples.contains { $0.contains("\"") }
-                #expect(
-                    hasOptionExample,
-                    "Tool '\(tool.name)' with multiple parameters should show option examples")
-            }
+    func `Final public definitions do not layer examples over policy-filtered schemas`() {
+        for tool in makeAgentTools() {
+            #expect(tool.examples.isEmpty, "Tool '\(tool.name)' should use only its policy-aware native description")
         }
     }
 }

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPSpecificToolTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPSpecificToolTests.swift
@@ -32,7 +32,7 @@ private func makeTestTool<T>(
 @MainActor
 struct MCPSpecificToolTests {
     @Test
-    func `Clipboard schema uses snake case payload names and excludes load`() {
+    func `Clipboard schemas expose only policy-usable actions and warn about user state`() {
         let tool = makeTestTool(ClipboardTool.init)
         guard case let .object(schema) = tool.inputSchema,
               case let .object(properties)? = schema["properties"],
@@ -45,15 +45,33 @@ struct MCPSpecificToolTests {
             return
         }
 
-        #expect(properties["file_path"] != nil)
-        #expect(properties["data_base64"] != nil)
+        #expect(properties["file_path"] == nil)
+        #expect(properties["data_base64"] == nil)
         #expect(properties["filePath"] == nil)
         #expect(properties["imagePath"] == nil)
         #expect(properties["dataBase64"] == nil)
         #expect(!actions.contains(.string("load")))
-        #expect(actions == ["get", "set", "clear", "save", "restore"].map(Value.string))
+        #expect(actions == ["get", "save"].map(Value.string))
         #expect(outputPathDescription.contains("'-' stdout sentinel is not supported"))
         #expect(outputPathDescription.contains("JSON-RPC"))
+        #expect(tool.description.contains("persistently"))
+        #expect(tool.description.contains("shared clipboard state"))
+
+        let foregroundTool = makeTestTool(executionPolicy: .foregroundAllowed, ClipboardTool.init)
+        guard case let .object(foregroundSchema) = foregroundTool.inputSchema,
+              case let .object(foregroundProperties)? = foregroundSchema["properties"],
+              case let .object(foregroundAction)? = foregroundProperties["action"],
+              case let .array(foregroundActions)? = foregroundAction["enum"]
+        else {
+            Issue.record("Expected foreground-capable clipboard schema")
+            return
+        }
+        #expect(foregroundActions == ["get", "set", "clear", "save", "restore"].map(Value.string))
+        #expect(foregroundProperties["file_path"] != nil)
+        #expect(foregroundProperties["data_base64"] != nil)
+        #expect(foregroundProperties["filePath"] == nil)
+        #expect(foregroundProperties["dataBase64"] == nil)
+        #expect(foregroundTool.description.contains("persistently change the user's shared clipboard state"))
     }
 
     @Test
@@ -398,7 +416,7 @@ struct MCPSpecificToolTests {
     }
 
     @Test
-    func `Window tool complex action schema`() {
+    func `Window tool schema omits background-refused focus and foreground fallback`() {
         let tool = makeTestTool(WindowTool.init)
 
         guard case let .object(schema) = tool.inputSchema,
@@ -415,7 +433,7 @@ struct MCPSpecificToolTests {
         #expect(props["index"] != nil)
         #expect(props["width"] != nil)
         #expect(props["height"] != nil)
-        #expect(props["foreground"] != nil)
+        #expect(props["foreground"] == nil)
 
         // Check action types include all window operations
         if let actionSchema = props["action"],
@@ -427,8 +445,60 @@ struct MCPSpecificToolTests {
             #expect(actions.contains(.string("close")))
             #expect(actions.contains(.string("minimize")))
             #expect(actions.contains(.string("maximize")))
-            #expect(actions.contains(.string("focus")))
+            #expect(!actions.contains(.string("focus")))
         }
+        #expect(tool.description.contains("focus: Unavailable under background-only authority"))
+
+        let foregroundTool = makeTestTool(executionPolicy: .foregroundAllowed, WindowTool.init)
+        guard case let .object(foregroundSchema) = foregroundTool.inputSchema,
+              case let .object(foregroundProperties)? = foregroundSchema["properties"],
+              case let .object(foregroundAction)? = foregroundProperties["action"],
+              case let .array(foregroundActions)? = foregroundAction["enum"]
+        else {
+            Issue.record("Expected foreground-capable window schema")
+            return
+        }
+        #expect(foregroundActions.contains(.string("focus")))
+        #expect(foregroundProperties["foreground"] != nil)
+        #expect(foregroundTool.description.contains("session's explicit foreground authority"))
+    }
+
+    @Test
+    func `App tool schema omits guaranteed-refused background lifecycle and focus actions`() {
+        let tool = makeTestTool(AppTool.init)
+        guard case let .object(schema) = tool.inputSchema,
+              case let .object(properties)? = schema["properties"],
+              case let .object(action)? = properties["action"],
+              case let .array(actions)? = action["enum"]
+        else {
+            Issue.record("Expected background app schema")
+            return
+        }
+
+        #expect(actions == ["launch", "quit", "hide", "list"].map(Value.string))
+        #expect(properties["foreground"] == nil)
+        #expect(properties["openTargets"] == nil)
+        #expect(properties["to"] == nil)
+        #expect(properties["cycle"] == nil)
+        #expect(tool.description.contains("Focus, switch, open, relaunch, unhide"))
+        #expect(tool.description.contains("foreground-capable Agent session"))
+
+        let foregroundTool = makeTestTool(executionPolicy: .foregroundAllowed, AppTool.init)
+        guard case let .object(foregroundSchema) = foregroundTool.inputSchema,
+              case let .object(foregroundProperties)? = foregroundSchema["properties"],
+              case let .object(foregroundAction)? = foregroundProperties["action"],
+              case let .array(foregroundActions)? = foregroundAction["enum"]
+        else {
+            Issue.record("Expected foreground-capable app schema")
+            return
+        }
+        #expect(foregroundActions.contains(.string("focus")))
+        #expect(foregroundActions.contains(.string("switch")))
+        #expect(foregroundActions.contains(.string("open")))
+        #expect(foregroundProperties["foreground"] != nil)
+        #expect(foregroundProperties["openTargets"] != nil)
+        #expect(foregroundProperties["to"] != nil)
+        #expect(foregroundProperties["cycle"] != nil)
     }
 
     // MARK: - Move Tool Tests

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPSpecificToolTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPSpecificToolTests.swift
@@ -448,6 +448,7 @@ struct MCPSpecificToolTests {
             #expect(!actions.contains(.string("focus")))
         }
         #expect(tool.description.contains("focus: Unavailable under background-only authority"))
+        #expect(tool.description.contains("combined-observation eligibility"))
 
         let foregroundTool = makeTestTool(executionPolicy: .foregroundAllowed, WindowTool.init)
         guard case let .object(foregroundSchema) = foregroundTool.inputSchema,
@@ -461,6 +462,7 @@ struct MCPSpecificToolTests {
         #expect(foregroundActions.contains(.string("focus")))
         #expect(foregroundProperties["foreground"] != nil)
         #expect(foregroundTool.description.contains("session's explicit foreground authority"))
+        #expect(foregroundTool.description.contains("combined-observation eligibility"))
     }
 
     @Test

--- a/docs/commands/learn.md
+++ b/docs/commands/learn.md
@@ -7,18 +7,19 @@ read_when:
 
 # `peekaboo learn`
 
-`peekaboo learn` prints the canonical “agent guide” that powers Peekaboo’s AI flows. It stitches together the generated system prompt, every tool definition from `ToolRegistry`, best-practice checklists, common workflows, and the full Commander signature table so other runtimes can stay in sync with the CLI release.
+`peekaboo learn` prints the canonical background-only public Agent guide. It stitches together the matching generated system prompt and Shell-free Agent tool registry, best-practice checklists, common workflows, and the full Commander signature table so other runtimes can stay in sync with the CLI release.
 
 ## What it emits
-- **System instructions** straight from `AgentSystemPrompt.generate()`, including communication rules and safety guidance.
-- **Tool catalog** grouped by category with each tool’s abstract, required/optional parameters, and JSON examples (if available).
+- **System instructions** straight from background-only `AgentSystemPrompt.generate()`, including communication rules and safety guidance.
+- **Tool catalog** grouped by category with each public Agent tool’s abstract, required/optional parameters, and JSON examples (if available). Shell is not a public Agent tool.
 - **Best practices + quick reference**: long-form guidance for automation patterns, then a condensed cheat sheet.
 - **Commander section**: a programmatic dump of every CLI command’s positional arguments, options, and flags (built by `CommanderRegistryBuilder.buildCommandSummaries()`).
 
 ## Implementation notes
 - The command is intentionally text-only—`--json` is ignored—so downstream systems should capture stdout if they want to cache the content.
-- Everything runs on the main actor because it pulls live data from `ToolRegistry` and Commander; no stale handwritten docs are involved.
+- Everything runs on the main actor because it pulls the same background-only, policy-filtered toolset as a normal Agent session plus live Commander metadata; no parallel discovery catalog is involved.
 - Because it reuses the same builders the CLI uses at runtime, new commands/tools automatically show up here as soon as they land.
+- Background-only typing examples use a fresh exact non-dialog snapshot; app/PID/window-selector-only Agent typing is intentionally absent because policy refuses it.
 - When stdout is a rich TTY, output is rendered with Swiftdansi for ANSI color and table/box formatting; piped output stays plain Markdown for downstream tools.
 
 ## Examples

--- a/docs/commands/tools.md
+++ b/docs/commands/tools.md
@@ -1,5 +1,5 @@
 ---
-summary: 'List the MCP/agent tool catalog via peekaboo tools'
+summary: 'List the MCP tool catalog via peekaboo tools'
 read_when:
   - 'deciding which automation tool to call from agents or scripts'
   - 'debugging missing tool registrations'
@@ -7,7 +7,7 @@ read_when:
 
 # `peekaboo tools`
 
-`peekaboo tools` prints the MCP/agent tool catalog that `peekaboo mcp` exposes (Image, See, Click, Press, Action, Window, Browser, Inspect UI, etc.). `peekaboo tools describe <name>` prints one tool's complete JSON input schema for token-cheap, on-demand discovery. These names are the tools available to agents and MCP clients. The CLI keeps `browser` as a dedicated wrapper and exposes AX-only inspection through `peekaboo see --tree --no-screenshot`; run `peekaboo --help` for the full CLI command list.
+`peekaboo tools` prints the background-only MCP tool catalog that `peekaboo mcp` exposes (Image, See, Click, Press, Action, Window, Browser, Inspect UI, etc.). `peekaboo tools describe <name>` prints one tool's policy-aware JSON input schema for token-cheap, on-demand discovery. Guaranteed-refused foreground shapes are omitted from background-only schemas and their descriptions explain the required human-authorized foreground Agent or standalone CLI route. The public Agent catalog is a separate Shell-free surface; run `peekaboo learn` for that exact guide. The CLI keeps `browser` as a dedicated wrapper and exposes AX-only inspection through `peekaboo see --tree --no-screenshot`; run `peekaboo --help` for the full CLI command list.
 
 ## Key options
 | Flag | Description |
@@ -24,6 +24,8 @@ read_when:
 
 ## Implementation notes
 - The command and MCP server both use `MCPToolCatalog`, so tool additions only need to be registered once.
+- Tool schemas receive the same execution policy as the catalog. Background `app`/`window` descriptions omit focus and switch actions, while foreground-capable Agent schemas expose them under explicit human authority.
+- Background clipboard discovery exposes only `get` and `save`. `set`, `clear`, and `restore` persistently change the user's shared clipboard state and require a foreground-authorized workflow; prefer exact targeted transactional paste when possible.
 - Allow/deny filtering happens before formatting (`ToolFiltering.apply`), so the output matches MCP server behavior.
 - Input-strategy availability filtering also runs before formatting, so action-only tools are hidden when the current policy cannot support them.
 - The command runs locally by default because it only reports the static native catalog; use per-tool wrappers or an attached MCP client to execute tools.

--- a/tests/background-capability-guidance.test.mjs
+++ b/tests/background-capability-guidance.test.mjs
@@ -77,6 +77,9 @@ test('generated guidance sources retain CLI and policy distinctions', () => {
   const toolRegistry = read(
     'Core/PeekabooCore/Sources/PeekabooAgentRuntime/ToolRegistry/ToolRegistry.swift'
   );
+  const typeTool = read(
+    'Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/TypeTool.swift'
+  );
   const pressMetadata = read(
     'Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/PressCommand+CommanderMetadata.swift'
   );
@@ -86,8 +89,9 @@ test('generated guidance sources retain CLI and policy distinctions', () => {
   assert.doesNotMatch(learn, /\*\*System\*\*:\s*shell/);
   assert.doesNotMatch(learn, /type --app/);
   assert.doesNotMatch(toolRegistry, /peekaboo type .*--app/);
-  assert.match(toolRegistry, /"snapshot": "\$SNAPSHOT_ID"/);
+  assert.doesNotMatch(toolRegistry, /ToolOverride|toolOverrides/);
   assert.match(toolRegistry, /publicAgentTools\(\)/);
+  assert.match(typeTool, /explicit fresh exact non-dialog snapshot receipt/);
   assert.match(pressMetadata, /Agent\/MCP background-only policy/);
   assert.match(pressMetadata, /never infers latest/);
 });

--- a/tests/background-capability-guidance.test.mjs
+++ b/tests/background-capability-guidance.test.mjs
@@ -74,12 +74,20 @@ test('foreground-exposing action examples include consent', () => {
 
 test('generated guidance sources retain CLI and policy distinctions', () => {
   const learn = read('Apps/CLI/Sources/PeekabooCLI/Commands/Core/LearnCommand.swift');
+  const toolRegistry = read(
+    'Core/PeekabooCore/Sources/PeekabooAgentRuntime/ToolRegistry/ToolRegistry.swift'
+  );
   const pressMetadata = read(
     'Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/PressCommand+CommanderMetadata.swift'
   );
 
   assert.match(learn, /fresh exact non-dialog snapshot form/);
   assert.match(learn, /dialog input.*background AXValue/);
+  assert.doesNotMatch(learn, /\*\*System\*\*:\s*shell/);
+  assert.doesNotMatch(learn, /type --app/);
+  assert.doesNotMatch(toolRegistry, /peekaboo type .*--app/);
+  assert.match(toolRegistry, /"snapshot": "\$SNAPSHOT_ID"/);
+  assert.match(toolRegistry, /publicAgentTools\(\)/);
   assert.match(pressMetadata, /Agent\/MCP background-only policy/);
   assert.match(pressMetadata, /never infers latest/);
 });


### PR DESCRIPTION
## Problem

`peekaboo learn` and `tools describe` presented a false authority map: discovery could advertise Shell, selector-only Agent typing, foreground app/window actions, and persistent clipboard writes that the public background execution policy refuses. At the same time, parent help for default-subcommand commands hid valid leaf flags such as Agent model/foreground/dry-run controls, permission source selection, and tool ordering.

## Changes

- derive `learn` from the same canonical Shell-free public Agent toolset used at runtime
- replace Agent-incompatible `type --app` examples with exact snapshot-pinned background guidance
- make app, window, and clipboard descriptions/schemas policy-aware, including explicit user-state warnings for persistent clipboard mutation
- merge default-leaf signatures into parent help while deduplicating runtime flags by actual CLI spelling, preserving #571
- keep browser and daemon behavior unchanged

## Proof

- full `pnpm run test:safe`
- current-main CLI build, docs lint, guidance, and release-preflight contracts
- 97 focused Core policy/schema/registry tests
- 56 CLI and real child-process help/schema/guidance tests
- format stable and SwiftLint with zero serious findings
- exact-head P2 Autoreview clean against `main` with no accepted/actionable P0-P2 findings
