### PR TITLE
docs: require exact window for background press

### DIFF
--- a/skills/peekaboo/SKILL.md
+++ b/skills/peekaboo/SKILL.md
@@ -90,7 +90,7 @@ peekaboo permissions request screen-recording
 peekaboo app focus Safari
 peekaboo config provider list --json
 peekaboo agent sessions --json
-peekaboo press cmd+shift+t --app Safari
+peekaboo press cmd+shift+t --app Safari --window-id 12345
 peekaboo verify --app Safari --window-exists --timeout 2s --json
 ```
 

--- a/tests/background-capability-guidance.test.mjs
+++ b/tests/background-capability-guidance.test.mjs
@@ -40,7 +40,7 @@ test('bundled skill never advertises app-only background press', () => {
   for (const example of appTargetedPressExamples) {
     assert.match(
       example,
-      /--(?:foreground|window-id|snapshot)\b/,
+      /--(?:foreground|snapshot|window-(?:id|title|index))\b/,
       `app-only background press is not a valid route: ${example}`
     );
   }

--- a/tests/background-capability-guidance.test.mjs
+++ b/tests/background-capability-guidance.test.mjs
@@ -30,6 +30,22 @@ test('press guidance preserves the snapshot-pinned background route', () => {
   assert.match(press, /Background-only Agent\/MCP.*explicit fresh exact non-dialog snapshot/s);
 });
 
+test('bundled skill never advertises app-only background press', () => {
+  const skill = read('skills/peekaboo/SKILL.md');
+  const appTargetedPressExamples = skill
+    .split('\n')
+    .filter((line) => /^peekaboo press\b.*--app\b/.test(line));
+
+  assert.ok(appTargetedPressExamples.length > 0);
+  for (const example of appTargetedPressExamples) {
+    assert.match(
+      example,
+      /--(?:foreground|window-id|snapshot)\b/,
+      `app-only background press is not a valid route: ${example}`
+    );
+  }
+});
+
 test('background Agent type guidance requires an explicit non-dialog snapshot', () => {
   for (const path of ['docs/commands/agent.md', 'docs/MCP.md']) {
     const source = read(path);


### PR DESCRIPTION
## Summary

- make the bundled Peekaboo skill use exact `--window-id` targeting for its background `press` example
- add a regression that rejects app/PID-only background `press` examples unless they carry an exact route or explicit foreground consent

App/PID-only raw `press` is refused by the CLI. Exact `--window-id` targeting keeps the example background-safe and consistent with the execution policy.

## Validation

- `pnpm run test:guidance` (9/9)
- `pnpm run lint:docs`
- `git diff --check`
- Autoreview: clean
