### PR TITLE
docs: keep Peekaboo skill examples read-only

### DIFF
--- a/skills/peekaboo/SKILL.md
+++ b/skills/peekaboo/SKILL.md
@@ -84,10 +84,10 @@ peekaboo browser status --json
 # Browser toolbar, menus, permission prompts, and native app chrome still belong to Peekaboo.
 peekaboo menu list --app Safari --json
 
-# Management commands use noun/verb subcommands.
-peekaboo clipboard set --text "hello" --verify
-peekaboo permissions request screen-recording
-peekaboo app focus Safari
+# Routine management examples stay read-only by default.
+peekaboo clipboard get --json
+peekaboo permissions status --all-sources --json
+peekaboo app list --include-hidden --include-background --json
 peekaboo config provider list --json
 peekaboo agent sessions --json
 peekaboo press cmd+shift+t --app Safari --window-id 12345

--- a/tests/background-capability-guidance.test.mjs
+++ b/tests/background-capability-guidance.test.mjs
@@ -46,6 +46,17 @@ test('bundled skill never advertises app-only background press', () => {
   }
 });
 
+test('bundled skill keeps routine management examples read-only', () => {
+  const skill = read('skills/peekaboo/SKILL.md');
+
+  assert.doesNotMatch(skill, /^peekaboo clipboard (?:set|clear|restore)\b/m);
+  assert.doesNotMatch(skill, /^peekaboo permissions request\b/m);
+  assert.doesNotMatch(skill, /^peekaboo app focus\b/m);
+  assert.match(skill, /^peekaboo clipboard get --json$/m);
+  assert.match(skill, /^peekaboo permissions status --all-sources --json$/m);
+  assert.match(skill, /^peekaboo app list --include-hidden --include-background --json$/m);
+});
+
 test('background Agent type guidance requires an explicit non-dialog snapshot', () => {
   for (const path of ['docs/commands/agent.md', 'docs/MCP.md']) {
     const source = read(path);


### PR DESCRIPTION
## Summary

- replace routine bundled-skill examples that overwrite the clipboard, prompt for macOS permissions, or activate an app
- use read-only clipboard, permission-status, and app-inventory examples instead
- add a guidance regression that keeps those three mutating forms out of routine skill guidance

The command references still document these operations when explicitly needed. The bundled agent skill now models the background-first, non-interrupting default.

## Validation

- `pnpm run test:guidance` (10/10)
- `pnpm run lint:docs`
- `git diff --check`
- Autoreview: clean
