### PR TITLE
refactor(bridge): centralize operation permissions

### DIFF
--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeOperation+Policy.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeOperation+Policy.swift
@@ -22,78 +22,9 @@ extension PeekabooBridgeOperation {
             .windowResponseProof == .postMutationState
     }
 
-    /// TCC permissions an operation relies on. Used to gate advertisement/handling.
+    /// The operation's static/current TCC permissions. Protocol- and request-specific modifiers stay server-owned.
     public var requiredPermissions: Set<PeekabooBridgePermissionKind> {
-        switch self {
-        case .captureScreen, .captureWindow, .captureFrontmost, .captureArea, .detectElements,
-             .desktopObservation:
-            [.screenRecording]
-        case .targetedHotkey, .targetedTypeActions, .click, .scroll, .swipe, .drag, .moveMouse,
-             .beginExactWindowHeldPointer:
-            [.postEvent]
-        case .exactWindowTargetedHotkey, .exactWindowTargetedTypeActions,
-             .exactDialogForceDismiss, .clickMenuBarItemIndex:
-            [.postEvent, .accessibility]
-        case .inspectAccessibilityTree,
-             .getFocusedElement,
-             .type, .typeActions, .setValue, .performAction, .hotkey,
-             .waitForElement, .listWindows, .focusWindow, .moveWindow, .resizeWindow, .setWindowBounds, .closeWindow,
-             .backgroundCloseWindow,
-             .minimizeWindow, .restoreWindow, .maximizeWindow, .getFocusedWindow, .listMenus, .listFrontmostMenus,
-             .clickMenuItem, .clickMenuItemByName, .listMenuExtras, .clickMenuExtra, .menuExtraOpenMenuFrame,
-             .listMenuBarItems, .clickMenuBarItemNamed, .listDockItems, .launchDockItem,
-             .rightClickDockItem, .hideDock, .showDock, .isDockHidden, .findDockItem, .dialogFindActive,
-             .dialogClickButton, .backgroundDialogClickButton, .dialogEnterText, .dialogHandleFile, .dialogDismiss,
-             .dialogListElements, .targetedDialogListElements, .prepareDialogAction,
-             .exactDialogClickButton, .exactDialogDismiss, .exactDialogEnterText:
-            [.accessibility]
-        case .targetedClick, .exactWindowTargetedClick, .targetedScroll:
-            [.accessibility]
-        case ._appleScriptProbe,
-             .agentExecutionTrace,
-             .observeProcessGeneration,
-             .certificationProducerAttestation,
-             .createExactWindowHeldPointerOwner,
-             .releaseExactWindowHeldPointer,
-             .revokeExactWindowHeldPointer,
-             .disconnectExactWindowHeldPointerOwner,
-             .permissionsStatus,
-             .requestPostEventPermission,
-             .daemonStatus,
-             .daemonStop,
-             .browserStatus,
-             .browserConnect,
-             .browserDisconnect,
-             .browserExecute,
-             .createSnapshot,
-             .storeDetectionResult,
-             .getDetectionResult,
-             .storeScreenshot,
-             .storeObservationSnapshot,
-             .storeAnnotatedScreenshot,
-             .listSnapshots,
-             .getMostRecentSnapshot,
-             .invalidateImplicitLatestSnapshot,
-             .beginSnapshotMutation,
-             .finishSnapshotMutation,
-             .cleanSnapshot,
-             .cleanSnapshotsOlderThan,
-             .cleanAllSnapshots,
-             .listApplications,
-             .findApplication,
-             .getFrontmostApplication,
-             .isApplicationRunning,
-             .launchApplication,
-             .launchApplicationWithOptions,
-             .relaunchApplicationWithOptions,
-             .activateApplication,
-             .quitApplication,
-             .hideApplication,
-             .unhideApplication,
-             .hideOtherApplications,
-             .showAllApplications:
-            []
-        }
+        PeekabooBridgeOperationResultSemantics.operationPolicy(for: self).requiredPermissions
     }
 
     /// Operations enabled by default for remote helper hosts.

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeOperationDescriptor.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeOperationDescriptor.swift
@@ -25,6 +25,7 @@ extension PeekabooBridgeOperationResultSemantics {
             read: ReadLanePolicy = .none,
             pinnedWindow: PinnedWindowPolicy = .unavailable,
             typedResponse: TypedResponseBinding = .familyOnly,
+            requiredPermissions: Set<PeekabooBridgePermissionKind> = [],
             completion: Completion,
             targetPolicy: TargetPolicy,
             responseFamilies: Set<ResponseFamily>,
@@ -32,6 +33,7 @@ extension PeekabooBridgeOperationResultSemantics {
         {
             OperationDescriptor(
                 operation: operation,
+                requiredPermissions: requiredPermissions,
                 lane: .init(nativeOwnership: ownership, readPolicy: read),
                 pinnedWindow: pinnedWindow,
                 typedResponse: typedResponse,
@@ -107,6 +109,7 @@ extension PeekabooBridgeOperationResultSemantics {
             descriptor(
                 read: .globalExclusive,
                 typedResponse: .capture,
+                requiredPermissions: [.screenRecording],
                 completion: .requestDependent(mutatesDesktop: false),
                 targetPolicy: .requestDependent,
                 responseFamilies: [.capture],
@@ -115,6 +118,7 @@ extension PeekabooBridgeOperationResultSemantics {
             descriptor(
                 read: .exactTargetOrGlobalExclusive,
                 typedResponse: .capture,
+                requiredPermissions: [.screenRecording],
                 completion: .requestDependent(mutatesDesktop: false),
                 targetPolicy: .requestDependent,
                 responseFamilies: [.capture],
@@ -123,6 +127,7 @@ extension PeekabooBridgeOperationResultSemantics {
             descriptor(
                 read: .globalExclusive,
                 typedResponse: .elementDetection,
+                requiredPermissions: [.screenRecording],
                 completion: .requestDependent(mutatesDesktop: false),
                 targetPolicy: .requestDependent,
                 responseFamilies: [.elementDetection])
@@ -130,6 +135,7 @@ extension PeekabooBridgeOperationResultSemantics {
             descriptor(
                 read: .exactTargetOrGlobalExclusive,
                 typedResponse: .elementDetection,
+                requiredPermissions: [.accessibility],
                 completion: .requestDependent(mutatesDesktop: false),
                 targetPolicy: .requestDependent,
                 responseFamilies: [.elementDetection],
@@ -138,6 +144,7 @@ extension PeekabooBridgeOperationResultSemantics {
             descriptor(
                 read: .globalExclusive,
                 typedResponse: .focusedElement,
+                requiredPermissions: [.accessibility],
                 completion: .readOnly,
                 targetPolicy: .notApplicable,
                 responseFamilies: [.focusedElement])
@@ -146,13 +153,22 @@ extension PeekabooBridgeOperationResultSemantics {
                 ownership: .service,
                 read: .exactTargetOrGlobalExclusive,
                 typedResponse: .desktopObservation,
+                requiredPermissions: [.screenRecording],
                 completion: .requestDependent(mutatesDesktop: false),
                 targetPolicy: .requestDependent,
                 responseFamilies: [.desktopObservation],
                 responseTargetEvidence: .desktopObservation)
-        case .click, .type, .scroll:
+        case .click, .scroll:
             descriptor(
                 ownership: .service,
+                requiredPermissions: [.postEvent],
+                completion: .requestDependent(mutatesDesktop: true),
+                targetPolicy: .requestDependent,
+                responseFamilies: [.ok])
+        case .type:
+            descriptor(
+                ownership: .service,
+                requiredPermissions: [.accessibility],
                 completion: .requestDependent(mutatesDesktop: true),
                 targetPolicy: .requestDependent,
                 responseFamilies: [.ok])
@@ -160,6 +176,7 @@ extension PeekabooBridgeOperationResultSemantics {
             descriptor(
                 ownership: .service,
                 typedResponse: .typeActions,
+                requiredPermissions: [.accessibility],
                 completion: .dispatchedUnverified(globalForeground),
                 targetPolicy: .global,
                 responseFamilies: [.typeResult])
@@ -167,6 +184,7 @@ extension PeekabooBridgeOperationResultSemantics {
             descriptor(
                 ownership: .service,
                 typedResponse: .typeActions,
+                requiredPermissions: [.postEvent],
                 completion: .dispatchedUnverified(processBackground),
                 targetPolicy: .requestPinned,
                 responseFamilies: [.typeResult])
@@ -174,6 +192,7 @@ extension PeekabooBridgeOperationResultSemantics {
             descriptor(
                 ownership: .service,
                 typedResponse: .typeActions,
+                requiredPermissions: [.accessibility, .postEvent],
                 completion: .dispatchedUnverified(windowBackground),
                 targetPolicy: .requestPinned,
                 responseFamilies: [.typeResult])
@@ -181,6 +200,7 @@ extension PeekabooBridgeOperationResultSemantics {
             descriptor(
                 ownership: .service,
                 typedResponse: .setValue,
+                requiredPermissions: [.accessibility],
                 completion: .dispatchedUnverified(valueBackground),
                 targetPolicy: .handlerRequired,
                 responseFamilies: [.elementActionResult])
@@ -188,30 +208,42 @@ extension PeekabooBridgeOperationResultSemantics {
             descriptor(
                 ownership: .service,
                 typedResponse: .performAction,
+                requiredPermissions: [.accessibility],
                 completion: .dispatchedUnverified(axBackground),
                 targetPolicy: .handlerRequired,
                 responseFamilies: [.elementActionResult])
         case .targetedScroll:
             descriptor(
                 ownership: .service,
+                requiredPermissions: [.accessibility],
                 completion: .dispatchedUnverified(axBackground),
                 targetPolicy: .handlerRequired,
                 responseFamilies: [.ok])
-        case .hotkey, .swipe, .drag, .moveMouse:
+        case .hotkey:
             descriptor(
                 ownership: .service,
+                requiredPermissions: [.accessibility],
+                completion: .dispatchedUnverified(globalForeground),
+                targetPolicy: .global,
+                responseFamilies: [.ok])
+        case .swipe, .drag, .moveMouse:
+            descriptor(
+                ownership: .service,
+                requiredPermissions: [.postEvent],
                 completion: .dispatchedUnverified(globalForeground),
                 targetPolicy: .global,
                 responseFamilies: [.ok])
         case .targetedHotkey:
             descriptor(
                 ownership: .service,
+                requiredPermissions: [.postEvent],
                 completion: .dispatchedUnverified(processBackground),
                 targetPolicy: .requestPinned,
                 responseFamilies: [.ok])
         case .exactWindowTargetedHotkey:
             descriptor(
                 ownership: .service,
+                requiredPermissions: [.accessibility, .postEvent],
                 completion: .dispatchedUnverified(windowBackground),
                 targetPolicy: .requestPinned,
                 responseFamilies: [.ok])
@@ -223,6 +255,7 @@ extension PeekabooBridgeOperationResultSemantics {
         case .beginExactWindowHeldPointer:
             descriptor(
                 ownership: .service,
+                requiredPermissions: [.postEvent],
                 completion: .dispatchedUnverified(windowBackground),
                 targetPolicy: .requestPinned,
                 responseFamilies: [.heldPointerReceipt])
@@ -243,6 +276,7 @@ extension PeekabooBridgeOperationResultSemantics {
         case .targetedClick, .exactWindowTargetedClick:
             descriptor(
                 ownership: .service,
+                requiredPermissions: [.accessibility],
                 completion: .dispatchedUnverified(axBackground),
                 targetPolicy: .requestPinned,
                 responseFamilies: [.ok])
@@ -250,12 +284,14 @@ extension PeekabooBridgeOperationResultSemantics {
             descriptor(
                 read: .globalExclusive,
                 typedResponse: .waitElementSelector,
+                requiredPermissions: [.accessibility],
                 completion: .readOnly,
                 targetPolicy: .notApplicable,
                 responseFamilies: [.waitResult])
         case .listWindows:
             descriptor(
                 read: .globalExclusive,
+                requiredPermissions: [.accessibility],
                 completion: .readOnly,
                 targetPolicy: .notApplicable,
                 responseFamilies: [.windows])
@@ -264,6 +300,7 @@ extension PeekabooBridgeOperationResultSemantics {
                 ownership: .service,
                 pinnedWindow: .legacyOptionalCurrentRequired,
                 typedResponse: .postMutationWindow,
+                requiredPermissions: [.accessibility],
                 completion: .dispatchedUnverified(compositeForeground),
                 targetPolicy: .requestPinned,
                 responseFamilies: [.ok, .window],
@@ -273,6 +310,7 @@ extension PeekabooBridgeOperationResultSemantics {
                 ownership: .service,
                 pinnedWindow: .required,
                 typedResponse: .postMutationWindow,
+                requiredPermissions: [.accessibility],
                 completion: .dispatchedUnverified(valueBackground),
                 targetPolicy: .requestPinned,
                 responseFamilies: [.ok, .window],
@@ -282,6 +320,7 @@ extension PeekabooBridgeOperationResultSemantics {
                 ownership: .service,
                 pinnedWindow: .required,
                 typedResponse: .postMutationWindow,
+                requiredPermissions: [.accessibility],
                 completion: .dispatchedUnverified(compositeForeground),
                 targetPolicy: .requestPinned,
                 responseFamilies: [.ok, .window],
@@ -291,6 +330,7 @@ extension PeekabooBridgeOperationResultSemantics {
                 ownership: .service,
                 pinnedWindow: .required,
                 typedResponse: .postMutationWindow,
+                requiredPermissions: [.accessibility],
                 completion: .dispatchedUnverified(axBackground),
                 targetPolicy: .requestPinned,
                 responseFamilies: [.ok, .window],
@@ -298,6 +338,7 @@ extension PeekabooBridgeOperationResultSemantics {
         case .getFocusedWindow:
             descriptor(
                 read: .globalExclusive,
+                requiredPermissions: [.accessibility],
                 completion: .readOnly,
                 targetPolicy: .notApplicable,
                 responseFamilies: [.window],
@@ -387,84 +428,98 @@ extension PeekabooBridgeOperationResultSemantics {
             descriptor(
                 read: .globalExclusive,
                 typedResponse: .menuStructureApplication,
+                requiredPermissions: [.accessibility],
                 completion: .readOnly,
                 targetPolicy: .notApplicable,
                 responseFamilies: [.menuStructure])
         case .listFrontmostMenus:
             descriptor(
                 read: .globalExclusive,
+                requiredPermissions: [.accessibility],
                 completion: .readOnly,
                 targetPolicy: .notApplicable,
                 responseFamilies: [.menuStructure])
         case .clickMenuItem, .clickMenuItemByName:
             descriptor(
                 ownership: .service,
+                requiredPermissions: [.accessibility],
                 completion: .dispatchedUnverified(axBackground),
                 targetPolicy: .requestPinned,
                 responseFamilies: [.ok])
         case .listMenuExtras:
             descriptor(
                 read: .globalExclusive,
+                requiredPermissions: [.accessibility],
                 completion: .readOnly,
                 targetPolicy: .notApplicable,
                 responseFamilies: [.menuExtras])
         case .clickMenuExtra:
             descriptor(
                 ownership: .service,
+                requiredPermissions: [.accessibility],
                 completion: .dispatchedUnverified(axForeground),
                 targetPolicy: .external,
                 responseFamilies: [.ok])
         case .menuExtraOpenMenuFrame:
             descriptor(
                 read: .globalExclusive,
+                requiredPermissions: [.accessibility],
                 completion: .readOnly,
                 targetPolicy: .notApplicable,
                 responseFamilies: [.rect])
         case .listMenuBarItems:
             descriptor(
                 read: .globalExclusive,
+                requiredPermissions: [.accessibility],
                 completion: .readOnly,
                 targetPolicy: .notApplicable,
                 responseFamilies: [.menuBarItems])
         case .clickMenuBarItemNamed:
             descriptor(
                 ownership: .service,
+                requiredPermissions: [.accessibility],
                 completion: .dispatchedUnverified(axForeground),
                 targetPolicy: .external,
                 responseFamilies: [.clickResult])
         case .clickMenuBarItemIndex:
             descriptor(
                 ownership: .service,
+                requiredPermissions: [.accessibility, .postEvent],
                 completion: .dispatchedUnverified(globalForeground),
                 targetPolicy: .external,
                 responseFamilies: [.clickResult])
         case .listDockItems:
             descriptor(
                 read: .globalExclusive,
+                requiredPermissions: [.accessibility],
                 completion: .readOnly,
                 targetPolicy: .notApplicable,
                 responseFamilies: [.dockItems])
         case .launchDockItem:
             descriptor(
                 ownership: .service,
+                requiredPermissions: [.accessibility],
                 completion: .dispatchedUnverified(axForeground),
                 targetPolicy: .external,
                 responseFamilies: [.ok])
         case .rightClickDockItem:
             descriptor(
                 ownership: .service,
+                requiredPermissions: [.accessibility],
                 completion: .dispatchedUnverified(globalForeground),
                 targetPolicy: .external,
                 responseFamilies: [.ok])
         case .hideDock, .showDock:
             descriptor(
                 ownership: .service,
+                requiredPermissions: [.accessibility],
                 completion: .dispatchedUnverified(nativeBackground),
                 targetPolicy: .global,
                 responseFamilies: [.ok])
         case .isDockHidden:
             descriptor(
                 read: .globalExclusive,
+                requiredPermissions: [.accessibility],
                 completion: .readOnly,
                 targetPolicy: .notApplicable,
                 responseFamilies: [.bool])
@@ -472,6 +527,7 @@ extension PeekabooBridgeOperationResultSemantics {
             descriptor(
                 read: .globalExclusive,
                 typedResponse: .dockItemSelector,
+                requiredPermissions: [.accessibility],
                 completion: .readOnly,
                 targetPolicy: .notApplicable,
                 responseFamilies: [.dockItem])
@@ -479,6 +535,7 @@ extension PeekabooBridgeOperationResultSemantics {
             descriptor(
                 ownership: .service,
                 read: .globalExclusive,
+                requiredPermissions: [.accessibility],
                 completion: .readOnly,
                 targetPolicy: .notApplicable,
                 responseFamilies: [.dialogInfo])
@@ -486,6 +543,7 @@ extension PeekabooBridgeOperationResultSemantics {
             descriptor(
                 ownership: .service,
                 typedResponse: .dialogResult,
+                requiredPermissions: [.accessibility],
                 completion: .dispatchedUnverified(axForeground),
                 targetPolicy: .responseResolved,
                 responseFamilies: [.dialogResult],
@@ -494,6 +552,7 @@ extension PeekabooBridgeOperationResultSemantics {
             descriptor(
                 ownership: .service,
                 typedResponse: .dialogResult,
+                requiredPermissions: [.accessibility],
                 completion: .dispatchedUnverified(axBackground),
                 targetPolicy: .responseResolved,
                 responseFamilies: [.dialogResult],
@@ -502,6 +561,7 @@ extension PeekabooBridgeOperationResultSemantics {
             descriptor(
                 ownership: .service,
                 typedResponse: .dialogResult,
+                requiredPermissions: [.accessibility],
                 completion: .dispatchedUnverified(globalForeground),
                 targetPolicy: .responseResolved,
                 responseFamilies: [.dialogResult],
@@ -510,6 +570,7 @@ extension PeekabooBridgeOperationResultSemantics {
             descriptor(
                 ownership: .service,
                 typedResponse: .dialogResult,
+                requiredPermissions: [.accessibility],
                 completion: .dispatchedUnverified(clipboardForeground),
                 targetPolicy: .responseResolved,
                 responseFamilies: [.dialogResult],
@@ -518,6 +579,7 @@ extension PeekabooBridgeOperationResultSemantics {
             descriptor(
                 ownership: .service,
                 read: .globalExclusive,
+                requiredPermissions: [.accessibility],
                 completion: .readOnly,
                 targetPolicy: .notApplicable,
                 responseFamilies: [.dialogElements])
@@ -526,6 +588,7 @@ extension PeekabooBridgeOperationResultSemantics {
                 ownership: .service,
                 read: .globalExclusive,
                 typedResponse: .targetedDialogElements,
+                requiredPermissions: [.accessibility],
                 completion: .readOnly,
                 targetPolicy: .notApplicable,
                 responseFamilies: [.dialogElements],
@@ -535,6 +598,7 @@ extension PeekabooBridgeOperationResultSemantics {
                 ownership: .service,
                 read: .globalExclusive,
                 typedResponse: .preparedDialogAction,
+                requiredPermissions: [.accessibility],
                 completion: .readOnly,
                 targetPolicy: .notApplicable,
                 responseFamilies: [.preparedDialogAction],
@@ -543,6 +607,7 @@ extension PeekabooBridgeOperationResultSemantics {
             descriptor(
                 ownership: .service,
                 typedResponse: .dialogResult,
+                requiredPermissions: [.accessibility],
                 completion: .dispatchedUnverified(axBackground),
                 targetPolicy: .requestPinned,
                 responseFamilies: [.dialogResult],
@@ -551,6 +616,7 @@ extension PeekabooBridgeOperationResultSemantics {
             descriptor(
                 ownership: .service,
                 typedResponse: .dialogResult,
+                requiredPermissions: [.accessibility],
                 completion: .dispatchedUnverified(valueBackground),
                 targetPolicy: .responseResolved,
                 responseFamilies: [.dialogResult],
@@ -559,6 +625,7 @@ extension PeekabooBridgeOperationResultSemantics {
             descriptor(
                 ownership: .service,
                 typedResponse: .dialogResult,
+                requiredPermissions: [.accessibility, .postEvent],
                 completion: .dispatchedUnverified(globalForeground),
                 targetPolicy: .responseResolved,
                 responseFamilies: [.dialogResult],

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeOperationResultSemantics.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeOperationResultSemantics.swift
@@ -364,6 +364,7 @@ enum PeekabooBridgeOperationResultSemantics {
     /// Static policy that every wire operation must classify in one descriptor.
     struct OperationDescriptor: Equatable, Sendable {
         let operation: PeekabooBridgeOperation
+        let requiredPermissions: Set<PeekabooBridgePermissionKind>
         let lane: LanePolicy
         let pinnedWindow: PinnedWindowPolicy
         let typedResponse: TypedResponseBinding
@@ -852,6 +853,7 @@ extension PeekabooBridgeOperationResultSemantics {
         let lane = LanePolicy(nativeOwnership: .bridge, readPolicy: .globalExclusive)
         let descriptor = OperationDescriptor(
             operation: operation,
+            requiredPermissions: [],
             lane: lane,
             pinnedWindow: .unavailable,
             typedResponse: .noSuccessResponse,

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeOperationSemanticPlanTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeOperationSemanticPlanTests.swift
@@ -78,6 +78,16 @@ struct PeekabooBridgeOperationSemanticPlanTests {
         partition(
             [.none, .postMutationState],
             by: \Semantics.OperationPolicy.windowResponseProof)
+        let permissionSets: [Set<PeekabooBridgePermissionKind>] = [
+            [],
+            [.screenRecording],
+            [.accessibility],
+            [.postEvent],
+            [.accessibility, .postEvent],
+        ]
+        partition(
+            permissionSets,
+            by: \Semantics.OperationPolicy.requiredPermissions)
 
         let postWindow = Set(operations.filter {
             Semantics.operationPolicy(for: $0).windowResponseProof == .postMutationState

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeRequestPlanTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeRequestPlanTests.swift
@@ -43,6 +43,107 @@ struct PeekabooBridgeRequestPlanTests {
     }
 
     @Test
+    func `Static descriptors own the exact base permission partition`() {
+        let allOperations = PeekabooBridgeOperation.allCases
+        let descriptors = allOperations.map(Semantics.operationDescriptor(for:))
+
+        func operationSet(requiring permissions: Set<PeekabooBridgePermissionKind>) -> Set<PeekabooBridgeOperation> {
+            Set(descriptors.filter { $0.requiredPermissions == permissions }.map(\.operation))
+        }
+
+        let screenRecording: Set<PeekabooBridgeOperation> = [
+            .captureScreen,
+            .captureWindow,
+            .captureFrontmost,
+            .captureArea,
+            .detectElements,
+            .desktopObservation,
+        ]
+        let postEvent: Set<PeekabooBridgeOperation> = [
+            .targetedHotkey,
+            .targetedTypeActions,
+            .click,
+            .scroll,
+            .swipe,
+            .drag,
+            .moveMouse,
+            .beginExactWindowHeldPointer,
+        ]
+        let accessibilityAndPostEvent: Set<PeekabooBridgeOperation> = [
+            .exactWindowTargetedHotkey,
+            .exactWindowTargetedTypeActions,
+            .exactDialogForceDismiss,
+            .clickMenuBarItemIndex,
+        ]
+        let accessibility: Set<PeekabooBridgeOperation> = [
+            .inspectAccessibilityTree,
+            .getFocusedElement,
+            .type,
+            .typeActions,
+            .setValue,
+            .performAction,
+            .hotkey,
+            .waitForElement,
+            .listWindows,
+            .focusWindow,
+            .moveWindow,
+            .resizeWindow,
+            .setWindowBounds,
+            .closeWindow,
+            .backgroundCloseWindow,
+            .minimizeWindow,
+            .restoreWindow,
+            .maximizeWindow,
+            .getFocusedWindow,
+            .listMenus,
+            .listFrontmostMenus,
+            .clickMenuItem,
+            .clickMenuItemByName,
+            .listMenuExtras,
+            .clickMenuExtra,
+            .menuExtraOpenMenuFrame,
+            .listMenuBarItems,
+            .clickMenuBarItemNamed,
+            .listDockItems,
+            .launchDockItem,
+            .rightClickDockItem,
+            .hideDock,
+            .showDock,
+            .isDockHidden,
+            .findDockItem,
+            .dialogFindActive,
+            .dialogClickButton,
+            .backgroundDialogClickButton,
+            .dialogEnterText,
+            .dialogHandleFile,
+            .dialogDismiss,
+            .dialogListElements,
+            .targetedDialogListElements,
+            .prepareDialogAction,
+            .exactDialogClickButton,
+            .exactDialogDismiss,
+            .exactDialogEnterText,
+            .targetedClick,
+            .exactWindowTargetedClick,
+            .targetedScroll,
+        ]
+
+        #expect(operationSet(requiring: [.screenRecording]) == screenRecording)
+        #expect(operationSet(requiring: [.postEvent]) == postEvent)
+        #expect(operationSet(requiring: [.accessibility, .postEvent]) == accessibilityAndPostEvent)
+        #expect(operationSet(requiring: [.accessibility]) == accessibility)
+
+        let nonempty = screenRecording
+            .union(postEvent)
+            .union(accessibilityAndPostEvent)
+            .union(accessibility)
+        #expect(operationSet(requiring: []) == Set(allOperations).subtracting(nonempty))
+        #expect(allOperations.allSatisfy {
+            $0.requiredPermissions == Semantics.operationDescriptor(for: $0).requiredPermissions
+        })
+    }
+
+    @Test
     func `Linked exact window plan captures legacy and current vocabulary immutably`() throws {
         let fixture = AutomationTestFixtures.linkedDesktopTarget()
         let request = PeekabooBridgeRequest.focusWindow(.init(
@@ -94,5 +195,6 @@ struct PeekabooBridgeRequestPlanTests {
         #expect(plan.descriptor.lane.nativeOwnership == .bridge)
         #expect(plan.descriptor.lane.readPolicy == .globalExclusive)
         #expect(plan.descriptor.typedResponse == .noSuccessResponse)
+        #expect(plan.descriptor.requiredPermissions.isEmpty)
     }
 }


### PR DESCRIPTION
## Summary

- make the exhaustive Bridge operation descriptor own each operation's static/current TCC permission set
- preserve protocol- and request-aware permission modifiers and remote/embedded exposure policy unchanged
- add a closed five-set partition, exact operation mapping, public projection, and invalid-carriage regression coverage

This is an internal ownership refactor with no user-facing or wire behavior change, so it does not require a changelog or documentation update.

## Proof

- `swift test --package-path Core/PeekabooCore --filter 'PeekabooBridge(RequestPlan|OperationSemanticPlan)Tests'` — 41 passed
- dynamic exact-dialog, targeted-click, capability, held-pointer, and embedded-runtime suites — 80 passed
- `pnpm run format` — zero files changed
- `pnpm run lint` — zero serious findings
- `pnpm run test:safe` — complete safe gate passed, including background certification and 506 final CLI tests
- P2 Autoreview — clean, zero findings, 0.99 confidence
