### PR TITLE
docs: keep quickstart automation background-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,18 +57,21 @@ Peekaboo 4.2.2 adds exact-window background middle and triple clicks, restores e
 
 ## Automate an app
 
-Target an element by its accessible label, then send text to the same app:
+List Safari's windows, copy the intended `window_id` (`12345` below), then keep the entire interaction pinned to
+that exact window:
 
 ```sh
-peekaboo click "Address and search bar" --app Safari
-peekaboo type "github.com/openclaw/Peekaboo" --app Safari
-peekaboo press Return --app Safari --foreground
+peekaboo window list --app Safari --json
+peekaboo click "Address and search bar" --app Safari --window-id 12345
+peekaboo type "github.com/openclaw/Peekaboo" --app Safari --window-id 12345
+peekaboo press Return --app Safari --window-id 12345
 ```
 
 Targeted semantic and typed CLI input uses background delivery when Peekaboo can resolve the process, so the app does
-not have to become frontmost. Raw `press` chords can also stay background with a fresh exact non-dialog snapshot
-receipt; app/PID-only, window-selector-only under Agent/MCP policy, and targetless chords require explicit foreground
-consent. Prefer a semantic action such as `menu click` when one exists. See the
+not have to become frontmost. Raw CLI `press` chords can also stay background with an exact window selector. The CLI
+also accepts a fresh exact non-dialog snapshot; that snapshot is required by background-only Agent/MCP policy.
+App/PID-only and targetless chords require explicit foreground consent, as do window-selector-only Agent/MCP chords.
+Prefer a semantic action such as `menu click` when one exists. See the
 [automation guide](docs/automation.md) for element IDs, coordinates, snapshots, waits, and input behavior.
 
 ## Agent and MCP

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -46,8 +46,8 @@ Examples:
 
 ```bash
 # Background: use semantic controls without activating Safari
-peekaboo click "Address and search bar" --app Safari
-peekaboo type "github.com/openclaw/Peekaboo" --app Safari
+peekaboo click "Address and search bar" --app Safari --window-id 12345
+peekaboo type "github.com/openclaw/Peekaboo" --app Safari --window-id 12345
 
 # Exact-window raw chords can stay background; app-only chords require foreground consent
 peekaboo press cmd+l --window-id 12345

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -61,10 +61,14 @@ Each element has `id`, `role`, `label`, `frame`, and `actions`. Pass an `id` to 
 
 ## 4. Click and type
 
+List Safari's windows and copy the intended `window_id` (`12345` below). Keeping every step pinned to that exact
+window makes the primary workflow background-safe even when Safari has multiple windows:
+
 ```bash
-peekaboo click "Address and search bar" --app Safari
-peekaboo type "github.com/openclaw/Peekaboo" --app Safari
-peekaboo press Return --app Safari --foreground
+peekaboo window list --app Safari --json
+peekaboo click "Address and search bar" --app Safari --window-id 12345
+peekaboo type "github.com/openclaw/Peekaboo" --app Safari --window-id 12345
+peekaboo press Return --app Safari --window-id 12345
 ```
 
 Coordinate clicks need a fresh capture receipt and an exact target in the default background mode. First run

--- a/tests/background-capability-guidance.test.mjs
+++ b/tests/background-capability-guidance.test.mjs
@@ -34,6 +34,24 @@ const isTargetedRawPress = (line) => /^peekaboo press\b.*--(?:app|pid)\b/.test(l
 const hasSafeRawPressRoute = (line) =>
   /--(?:foreground|snapshot|window-(?:id|title|index))\b/.test(line);
 
+test('primary app automation examples stay exact-window and background-only', () => {
+  for (const path of ['README.md', 'docs/quickstart.md']) {
+    const source = read(path);
+    assert.match(source, /^peekaboo window list --app Safari --json$/m);
+    assert.match(source, /^peekaboo click .*--app Safari --window-id 12345$/m);
+    assert.match(source, /^peekaboo type .*--app Safari --window-id 12345$/m);
+    assert.match(source, /^peekaboo press Return --app Safari --window-id 12345$/m);
+    assert.doesNotMatch(source, /^peekaboo press Return --app Safari --foreground$/m);
+  }
+
+  assert.match(read('README.md'), /Raw CLI `press` chords.*exact window selector/s);
+  assert.match(read('README.md'), /snapshot.*required by background-only Agent\/MCP policy/s);
+
+  const automation = read('docs/automation.md');
+  assert.match(automation, /^peekaboo click .*--app Safari --window-id 12345$/m);
+  assert.match(automation, /^peekaboo type .*--app Safari --window-id 12345$/m);
+});
+
 test('bundled skill never advertises app/PID-only background press', () => {
   const skill = read('skills/peekaboo/SKILL.md');
   const targetedPressExamples = skill


### PR DESCRIPTION
## Summary

- make the README and quickstart Safari workflow resolve a window first
- pin click, type, and Return to the same exact `--window-id` so the primary path stays background-only
- align the automation guide's semantic examples and preserve the stricter Agent/MCP snapshot requirement
- add guidance coverage preventing the primary workflow from drifting back to foreground or ambiguous app-only targeting

## Validation

- `pnpm run test:guidance` (11/11)
- `pnpm run lint:docs`
- `git diff --check`
- Autoreview: clean after rebasing onto #587
