### PR TITLE
fix(cli): make command recovery actionable

### DIFF
--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Let exact-window background mutations ignore unrelated incomplete application rows while still refusing ambiguous, incomplete, stale, or mismatched selected owners.
+- Give unknown commands a current-help recovery hint and remove source-checkout rebuild advice from installed help.
 - Use the canonical MCP mutation policy for Agent visual verification, including conditional browser and foreground menu actions.
 - Bind signed `set-value` results to the opaque requested element and refuse older Bridge hosts before dispatch.
 - Keep non-modal SwiftUI `AXDialog`-subrole windows eligible for exact background mutations while preserving modal, sheet, and file-dialog protections, and recognize `inspect_ui` as fresh Agent perception in recovery guidance.

--- a/Apps/CLI/Sources/PeekabooCLI/CLI/CommanderRuntimeRouter+Help.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/CLI/CommanderRuntimeRouter+Help.swift
@@ -22,9 +22,6 @@ extension CommanderRuntimeRouter {
         var lines: [String] = []
         lines.append(theme.heading("Usage"))
         lines.append("  \(theme.accent("peekaboo <command> [options] [runtime flags]"))")
-        lines.append("")
-        lines.append(theme.heading("Tip"))
-        lines.append("  When developing locally, rebuild via \(theme.accent("pnpm run build:cli")) to test fresh bits.")
         return lines.joined(separator: "\n")
     }
 
@@ -46,9 +43,6 @@ extension CommanderRuntimeRouter {
             lines.append("  \(abstract)")
         }
 
-        lines.append("")
-        lines.append(theme.heading("Tip"))
-        lines.append("  When developing locally, rebuild via \(theme.accent("pnpm run build:cli")) to test fresh bits.")
         return lines.joined(separator: "\n")
     }
 

--- a/Apps/CLI/Sources/PeekabooCLI/CLI/PeekabooEntryPoint.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/CLI/PeekabooEntryPoint.swift
@@ -59,17 +59,32 @@ func commanderErrorMessage(_ error: CommanderProgramError) -> String {
     error.description
 }
 
+func commanderErrorHint(_ error: CommanderProgramError) -> String? {
+    switch error {
+    case .missingCommand, .unknownCommand:
+        "Run 'peekaboo --help' to list current commands."
+    case let .missingSubcommand(command), let .unknownSubcommand(command, _):
+        "Run 'peekaboo help \(command)' to list current subcommands."
+    default:
+        nil
+    }
+}
+
 private func printCommanderError(_ error: CommanderProgramError, jsonOutput: Bool) {
     let message = commanderErrorMessage(error)
+    let hint = commanderErrorHint(error)
     guard jsonOutput else {
         fputs("Error: \(message)\n", stderr)
+        if let hint {
+            fputs("Hint: \(hint)\n", stderr)
+        }
         return
     }
 
     let logger = Logger.shared
     logger.setJsonOutputMode(true)
     ResultEnvelopeContext.$isPreDispatchFailure.withValue(true) {
-        outputError(message: message, code: .INVALID_ARGUMENT, logger: logger)
+        outputError(message: message, code: .INVALID_ARGUMENT, hint: hint, logger: logger)
     }
 }
 

--- a/Apps/CLI/Tests/CLIRuntimeTests/RootEarlyExitRuntimeTests.swift
+++ b/Apps/CLI/Tests/CLIRuntimeTests/RootEarlyExitRuntimeTests.swift
@@ -96,6 +96,59 @@ struct RootEarlyExitRuntimeTests {
         }
     }
 
+    @Test
+    func `release-style help omits source checkout rebuild advice`() async throws {
+        guard TestChildProcess.canLocatePeekabooBinary() else {
+            Issue.record("Build peekaboo before running CLI runtime tests.")
+            return
+        }
+
+        let workingDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("peekaboo-help-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: workingDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: workingDirectory) }
+
+        for arguments in [[], ["--help"], ["click", "--help"], ["window", "list", "--help"]] {
+            let result = try await TestChildProcess.runPeekaboo(
+                arguments,
+                workingDirectory: workingDirectory,
+                isolateFromRemoteHosts: false
+            )
+
+            #expect(result.status == .exited(0))
+            #expect(result.standardError.isEmpty)
+            #expect(!result.standardOutput.contains("When developing locally"))
+            #expect(!result.standardOutput.contains("pnpm run build:cli"))
+        }
+    }
+
+    @Test
+    func `unknown command includes current help recovery in text and JSON`() async throws {
+        guard TestChildProcess.canLocatePeekabooBinary() else {
+            Issue.record("Build peekaboo before running CLI runtime tests.")
+            return
+        }
+
+        let human = try await TestChildProcess.runPeekaboo(["frobnicate"], isolateFromRemoteHosts: false)
+        #expect(human.status == .exited(1))
+        #expect(human.standardOutput.isEmpty)
+        #expect(human.standardError.contains("Error: Unknown command 'frobnicate'"))
+        #expect(human.standardError.contains("Hint: Run 'peekaboo --help' to list current commands."))
+
+        let json = try await TestChildProcess.runPeekaboo(
+            ["frobnicate", "--json"],
+            isolateFromRemoteHosts: false
+        )
+        #expect(json.status == .exited(1))
+        #expect(json.standardError.isEmpty)
+        let object = try JSONSerialization.jsonObject(with: Data(json.standardOutput.utf8))
+        let envelope = try #require(object as? [String: Any])
+        let error = try #require(envelope["error"] as? [String: Any])
+        #expect(error["code"] as? String == "INVALID_ARGUMENT")
+        #expect(error["message"] as? String == "Unknown command 'frobnicate'")
+        #expect(error["hint"] as? String == "Run 'peekaboo --help' to list current commands.")
+    }
+
     @Test(arguments: [
         ["--log-level", "debug", "--version"],
         ["--logLevel=debug", "-V"],

--- a/Apps/CLI/Tests/CoreCLITests/CommanderBinderProgramResolutionTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/CommanderBinderProgramResolutionTests.swift
@@ -28,6 +28,23 @@ struct CommanderBinderProgramResolutionTests {
     }
 
     @Test
+    func `Commander path failures retain current help recovery`() {
+        #expect(
+            commanderErrorHint(.unknownCommand("frobnicate")) ==
+                "Run 'peekaboo --help' to list current commands."
+        )
+        #expect(
+            commanderErrorHint(.missingSubcommand(command: "window")) ==
+                "Run 'peekaboo help window' to list current subcommands."
+        )
+        #expect(
+            commanderErrorHint(.unknownSubcommand(command: "window", name: "frobnicate")) ==
+                "Run 'peekaboo help window' to list current subcommands."
+        )
+        #expect(commanderErrorHint(.duplicateCommand("see")) == nil)
+    }
+
+    @Test
     @MainActor
     func `Commander program resolves screenshot-only see options`() throws {
         let descriptors = CommanderRegistryBuilder.buildDescriptors()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Fixed
 - Restore terminal echo around credential-prompt job-control stops and common termination signals, then re-disable echo only after a stopped prompt continues.
 - Let exact-window background mutations ignore unrelated incomplete application rows while still refusing ambiguous, incomplete, stale, or mismatched selected owners.
+- Give unknown CLI commands a current-help recovery hint and remove source-checkout rebuild advice from installed help.
 - Keep provider dry-run, validation, error, and JSON output free of credential values, and reject special, symlinked, permissive, wrong-owner, or extended-ACL credential files on the opened descriptor before reading.
 - Use the canonical MCP mutation policy for Agent visual verification, including conditional browser and foreground menu actions.
 - Let background certification pin Activity Monitor's exact source-declared window title while refusing unsafe partial, duplicate, or drifting title evidence.


### PR DESCRIPTION
## Summary

- add actionable current-help hints for unknown and missing root/subcommand errors
- preserve those hints in both human stderr and structured JSON error envelopes
- remove the source-checkout-only `pnpm run build:cli` tip from shared root and leaf help
- add neutral-working-directory child-process and source-level regressions

## Before / after

Before, `peekaboo frobnicate --json` returned `INVALID_ARGUMENT` with only `Unknown command 'frobnicate'`, and every installed help page advertised a developer rebuild command.

After, human and JSON errors direct users to `peekaboo --help` (or the current parent command's help), while root and leaf help remain distribution-appropriate.

## Validation

- current-source before/after repro for `frobnicate` text and JSON output
- 27/27 `CommanderBinderProgramResolutionTests`
- 11/11 `RootEarlyExitRuntimeTests`
- neutral-working-directory root/leaf help coverage
- `pnpm run lint:docs`
- `pnpm run format`
- `git diff --check`
- `pnpm run lint` (0 serious findings)
- Autoreview: clean
