### PR TITLE
fix(automation): isolate exact-window owner lookup

### DIFF
--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Skip provider discovery and Agent construction for caller-local commands that cannot invoke the Agent, reducing cold startup while preserving full Agent and MCP initialization.
 
 ### Fixed
+- Let exact-window background mutations ignore unrelated incomplete application rows while still refusing ambiguous, incomplete, stale, or mismatched selected owners.
 - Use the canonical MCP mutation policy for Agent visual verification, including conditional browser and foreground menu actions.
 - Bind signed `set-value` results to the opaque requested element and refuse older Bridge hosts before dispatch.
 - Keep non-modal SwiftUI `AXDialog`-subrole windows eligible for exact background mutations while preserving modal, sheet, and file-dialog protections, and recognize `inspect_ui` as fresh Agent perception in recovery guidance.

--- a/Apps/CLI/Tests/CLIAutomationTests/TargetedInteractionDefaultDeliveryTests.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/TargetedInteractionDefaultDeliveryTests.swift
@@ -174,6 +174,81 @@ struct TargetedInteractionDefaultDeliveryTests {
     }
 
     @Test
+    func `exact Calculator window ignores unrelated unpinnable system application row`() async throws {
+        let fixture = AutomationTestFixtures.linkedDesktopTarget(
+            processIdentity: .init(processIdentifier: 2468, processStartIdentity: 7),
+            applicationName: "Calculator",
+            windowID: 42
+        )
+        let unpinnableSystemRow = AutomationTestFixtures.application(
+            processIdentifier: 1,
+            processStartIdentity: nil,
+            bundleIdentifier: nil,
+            name: "WindowServer",
+            isHiddenKnown: false,
+            activationPolicy: .prohibited
+        )
+        let candidates = [fixture.application, unpinnableSystemRow]
+            .map(ApplicationIdentifierMatcher.Candidate.init)
+        let resolution = try #require(try ApplicationIdentifierMatcher.resolution(
+            for: "Calculator",
+            in: candidates
+        ))
+        let calculator = fixture.application.withSelectorResolutionProofs([
+            resolution.proof(selectedProcessIdentity: fixture.processIdentity),
+        ])
+        let applications = StubApplicationService(applications: [calculator, unpinnableSystemRow])
+        applications.inventoryCompleteness = .partial
+        applications.inventoryWarnings = [
+            "Application PID 1 lacked process-generation identity and was omitted.",
+        ]
+        let automation = OutcomeStubAutomationService()
+        automation.actionOutcome = .confirmedChange(
+            delivery: .init(mechanism: .windowTargetedEvents, mode: .background),
+            unitCount: .one
+        )
+        automation.actionOutcomeTargetIdentity = fixture.windowTargetIdentity
+        automation.targetedFocusedElement = UIFocusInfo(
+            role: "AXTextField",
+            title: nil,
+            value: nil,
+            frame: fixture.window.bounds.insetBy(dx: 40, dy: 40),
+            applicationName: fixture.application.name,
+            bundleIdentifier: fixture.application.bundleIdentifier ?? "com.apple.calculator",
+            processId: Int(fixture.processIdentity.processIdentifier),
+            windowID: fixture.window.windowID,
+            identifier: "calculator-display"
+        )
+        let services = TestServicesFactory.makePeekabooServices(
+            applications: applications,
+            windows: StubWindowService(windowsByApp: [fixture.application.name: [fixture.window]]),
+            clipboard: StubClipboardService(),
+            automation: automation
+        )
+
+        for arguments in [
+            ["type", "12345"],
+            ["press", "return"],
+        ] {
+            let result = try await InProcessCommandRunner.run(
+                arguments + [
+                    "--app", "Calculator",
+                    "--window-id", String(fixture.window.windowID),
+                    "--json", "--no-remote",
+                ],
+                services: services
+            )
+            #expect(result.exitStatus == 0, "Unexpected exact-window refusal: \(result.combinedOutput)")
+        }
+
+        #expect(automation.exactTypeActionsCalls.count == 1)
+        #expect(automation.exactTypeActionsCalls.first?.target.windowIdentity == fixture.windowIdentity)
+        #expect(automation.exactHotkeyCalls.count == 1)
+        #expect(automation.exactHotkeyCalls.first?.target.windowIdentity == fixture.windowIdentity)
+        #expect(automation.hotkeyCalls.isEmpty)
+    }
+
+    @Test
     func `foreground explicitly preserves intentional global keyboard delivery`() async throws {
         let automation = StubAutomationService()
         let services = TestServicesFactory.makePeekabooServices(

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Fixed
 - Restore terminal echo around credential-prompt job-control stops and common termination signals, then re-disable echo only after a stopped prompt continues.
+- Let exact-window background mutations ignore unrelated incomplete application rows while still refusing ambiguous, incomplete, stale, or mismatched selected owners.
 - Keep provider dry-run, validation, error, and JSON output free of credential values, and reject special, symlinked, permissive, wrong-owner, or extended-ACL credential files on the opened descriptor before reading.
 - Use the canonical MCP mutation policy for Agent visual verification, including conditional browser and foreground menu actions.
 - Let background certification pin Activity Monitor's exact source-declared window title while refusing unsafe partial, duplicate, or drifting title evidence.

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Strategy/DesktopTargetPlanning+MutationPlanners.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Strategy/DesktopTargetPlanning+MutationPlanners.swift
@@ -188,6 +188,51 @@ extension DesktopTargetPlanning {
             }
         }
 
+        /// Resolves an application constraint through an authoritative direct lookup.
+        ///
+        /// This path is reserved for an already-selected exact window. The direct provider must
+        /// carry a complete selector proof, so omitted broad-inventory rows cannot hide ambiguity.
+        func resolveAuthoritativeWindowOwner(
+            selector: InteractionTargetSelector) async throws -> ApplicationMutationPlan
+        {
+            do {
+                try selector.validate(policy: .mutationSafe)
+            } catch let error as InteractionTargetSelector.ValidationError {
+                throw DesktopTargetPlanningError.invalidSelector(error)
+            }
+            guard selector.hasOwnerInput,
+                  let normalizedTarget = try selector.normalizedApplicationTarget(policy: .mutationSafe).map({
+                      try ApplicationMutationSelector.normalizedIdentifier($0)
+                  }),
+                  let exactIdentifierProvider
+            else {
+                throw DesktopTargetPlanningError.missingApplicationTarget
+            }
+
+            let application = try await self.exactApplication(
+                identifier: normalizedTarget,
+                staleIdentity: nil,
+                provider: exactIdentifierProvider)
+            let processIdentity = try Self.validatedIdentity(application)
+            _ = try ApplicationMutationSelector.select(
+                identifier: normalizedTarget,
+                applications: [application])
+            let candidate = ApplicationIdentifierMatcher.Candidate(application)
+            guard let proof = application.selectorResolutionProofs?.first(where: {
+                $0.applicationMismatch(
+                    identifier: normalizedTarget,
+                    selectedCandidate: candidate,
+                    processIdentity: processIdentity) == nil
+            })
+            else {
+                throw DesktopTargetPlanningError.applicationInventoryUnavailable(identifier: normalizedTarget)
+            }
+            return ApplicationMutationPlan(
+                application: application,
+                processIdentity: processIdentity,
+                selectorProof: proof)
+        }
+
         func frontmost() async throws -> ServiceApplicationInfo {
             guard let frontmostProvider else {
                 throw DesktopTargetPlanningError.unsupportedFrontmostTarget
@@ -209,6 +254,11 @@ extension DesktopTargetPlanning {
             } catch let error as DesktopTargetPlanningError {
                 throw error
             } catch let error as PeekabooError {
+                if case .ambiguousAppIdentifier = error {
+                    throw DesktopTargetPlanningError.ambiguousApplication(
+                        identifier: identifier,
+                        candidatePIDs: [])
+                }
                 guard case .appNotFound = error else {
                     throw DesktopTargetPlanningError.applicationInventoryUnavailable(identifier: identifier)
                 }
@@ -335,8 +385,14 @@ extension DesktopTargetPlanning {
                 throw DesktopTargetPlanningError.invalidSelector(error)
             }
 
+            let isDirectWindowIDLookup = if case .id = windowSelector {
+                true
+            } else {
+                false
+            }
+
             var owner: ApplicationMutationPlan?
-            if selector.hasOwnerInput {
+            if selector.hasOwnerInput, !isDirectWindowIDLookup {
                 owner = try await self.applications.resolve(
                     selector: selector,
                     expectedIdentity: nil,
@@ -364,13 +420,6 @@ extension DesktopTargetPlanning {
                     }
                     return nil
                 }())
-            let isDirectWindowIDLookup = if case .id = windowSelector,
-                                            case .windowId = inventoryTarget
-            {
-                true
-            } else {
-                false
-            }
             guard inventory.isComplete || isDirectWindowIDLookup else {
                 throw DesktopTargetPlanningError.incompleteWindowInventory(
                     selector: selectorDescription,
@@ -394,11 +443,24 @@ extension DesktopTargetPlanning {
             }
 
             if owner == nil {
-                owner = try await self.applications.resolve(
-                    selector: InteractionTargetSelector(
-                        processIdentifier: Int(selectedIdentity.ownerProcessIdentifier)),
-                    expectedIdentity: selectedIdentity.processIdentity,
-                    revalidateBeforeReturn: false)
+                if selector.hasOwnerInput {
+                    do {
+                        owner = try await self.applications.resolve(
+                            selector: selector,
+                            expectedIdentity: nil,
+                            revalidateBeforeReturn: false)
+                    } catch let error as DesktopTargetPlanningError {
+                        guard case .incompleteApplicationInventory = error else { throw error }
+                        owner = try await self.applications.resolveAuthoritativeWindowOwner(
+                            selector: selector)
+                    }
+                } else {
+                    owner = try await self.applications.resolve(
+                        selector: InteractionTargetSelector(
+                            processIdentifier: Int(selectedIdentity.ownerProcessIdentifier)),
+                        expectedIdentity: selectedIdentity.processIdentity,
+                        revalidateBeforeReturn: false)
+                }
             }
             guard let owner else {
                 preconditionFailure("Window planning must resolve an owner")

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKitTestSupport/MutationAuthorityCatalogScript.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKitTestSupport/MutationAuthorityCatalogScript.swift
@@ -65,19 +65,23 @@ public final class MutationAuthorityCatalogScript {
 
     private func exactApplication(identifier: String) throws -> ServiceApplicationInfo {
         self.exactApplicationRequests.append(identifier)
-        let normalized = identifier.trimmingCharacters(in: .whitespacesAndNewlines)
-        let pid = normalized.uppercased().hasPrefix("PID:")
-            ? Int32(normalized.dropFirst(4))
-            : nil
-        let matches = self.currentApplications.filter { application in
-            pid.map { application.processIdentifier == $0 } == true ||
-                application.bundleIdentifier?.caseInsensitiveCompare(normalized) == .orderedSame ||
-                application.name.caseInsensitiveCompare(normalized) == .orderedSame
-        }
-        guard matches.count == 1, let application = matches.first else {
+        let candidates = self.currentApplications.map(ApplicationIdentifierMatcher.Candidate.init)
+        guard let resolution = try ApplicationIdentifierMatcher.resolution(
+            for: identifier,
+            in: candidates)
+        else {
             throw PeekabooError.appNotFound(identifier)
         }
-        return application
+        guard !resolution.hasWinningTie else {
+            throw PeekabooError.ambiguousAppIdentifier(
+                identifier,
+                suggestions: self.currentApplications.map(\.name))
+        }
+        let application = self.currentApplications[resolution.index]
+        guard let processIdentity = application.processIdentity else { return application }
+        return application.withSelectorResolutionProofs([
+            resolution.proof(selectedProcessIdentity: processIdentity),
+        ])
     }
 
     private static func step<Element: Sendable>(

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/MutationAuthorityPlannerTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/MutationAuthorityPlannerTests.swift
@@ -278,6 +278,84 @@ struct MutationAuthorityPlannerTests {
             requirement: .exactWindow(automaticSelection: .preferredMutationWindow(.general)))
 
         #expect(direct.window?.identity == fixture.windowIdentity)
+        #expect(directScript.applicationInventoryRequestCount == 0)
+        #expect(directScript.exactApplicationRequests == ["PID:101", "PID:101"])
+    }
+
+    @Test
+    func `exact window owner ignores unrelated incomplete application rows`() async throws {
+        let fixture = AutomationTestFixtures.linkedDesktopTarget(
+            processIdentity: .init(processIdentifier: 2468, processStartIdentity: 7),
+            applicationName: "Calculator",
+            windowID: 42)
+        let unpinnableSystemRow = AutomationTestFixtures.application(
+            processIdentifier: 1,
+            processStartIdentity: nil,
+            bundleIdentifier: nil,
+            name: "WindowServer",
+            isHiddenKnown: false,
+            activationPolicy: .prohibited)
+        let warning = "Application PID 1 lacked process-generation identity and was omitted."
+        let script = MutationAuthorityCatalogScript(
+            applicationInventories: [
+                .partial([fixture.application, unpinnableSystemRow], warnings: [warning]),
+            ],
+            windowInventories: [.complete([fixture.window])])
+
+        let authority = try await script.planner().plan(selector: InteractionTargetSelector(
+            applicationIdentifier: "Calculator",
+            windowID: fixture.window.windowID))
+
+        #expect(authority.window?.identity == fixture.windowIdentity)
+        #expect(authority.application.processIdentity == fixture.processIdentity)
+        #expect(authority.application.selectorProof.matchKind == .exactName)
+        #expect(script.applicationInventoryRequestCount == 1)
+        #expect(script.exactApplicationRequests == ["Calculator", "PID:2468"])
+        #expect(script.windowInventoryTargets == [.windowId(fixture.window.windowID)])
+    }
+
+    @Test
+    func `exact window owner still refuses known application ambiguity and selected row incompleteness`() async throws {
+        let fixture = AutomationTestFixtures.linkedDesktopTarget(
+            processIdentity: .init(processIdentifier: 2468, processStartIdentity: 7),
+            applicationName: "Calculator",
+            windowID: 42)
+        let duplicate = AutomationTestFixtures.application(
+            processIdentifier: 2469,
+            processStartIdentity: 8,
+            bundleIdentifier: "com.example.OtherCalculator",
+            name: "Calculator")
+        let ambiguous = MutationAuthorityCatalogScript(
+            applicationInventories: [
+                .partial([fixture.application, duplicate], warnings: ["unrelated row omitted"]),
+            ],
+            windowInventories: [.complete([fixture.window])])
+
+        await #expect(throws: DesktopTargetPlanningError.ambiguousApplication(
+            identifier: "Calculator",
+            candidatePIDs: []))
+        {
+            _ = try await ambiguous.planner().plan(selector: InteractionTargetSelector(
+                applicationIdentifier: "Calculator",
+                windowID: fixture.window.windowID))
+        }
+
+        let incompleteApplication = AutomationTestFixtures.application(
+            processIdentifier: fixture.processIdentity.processIdentifier,
+            processStartIdentity: nil,
+            bundleIdentifier: fixture.application.bundleIdentifier,
+            name: fixture.application.name)
+        let incomplete = MutationAuthorityCatalogScript(
+            applicationInventories: [
+                .partial([incompleteApplication], warnings: ["selected row was incomplete"]),
+            ],
+            windowInventories: [.complete([fixture.window])])
+
+        await #expect(throws: DesktopTargetPlanningError.missingProcessIdentity(processIdentifier: 2468)) {
+            _ = try await incomplete.planner().plan(selector: InteractionTargetSelector(
+                applicationIdentifier: "Calculator",
+                windowID: fixture.window.windowID))
+        }
     }
 
     @Test

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/WindowMutationPlannerTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/WindowMutationPlannerTests.swift
@@ -318,6 +318,80 @@ struct WindowMutationPlannerTests {
     }
 
     @Test
+    func `exact window owner revalidation refuses generation drift after partial discovery`() async throws {
+        let fixture = AutomationTestFixtures.linkedDesktopTarget(
+            processIdentity: .init(processIdentifier: 2468, processStartIdentity: 7),
+            applicationName: "Calculator",
+            windowID: 42)
+        let resolution = try #require(try ApplicationIdentifierMatcher.resolution(
+            for: "Calculator",
+            in: [ApplicationIdentifierMatcher.Candidate(fixture.application)]))
+        let authoritativeApplication = fixture.application.withSelectorResolutionProofs([
+            resolution.proof(selectedProcessIdentity: fixture.processIdentity),
+        ])
+        let currentApplication = AutomationTestLockedValue(authoritativeApplication)
+        let applications = DesktopTargetPlanning.ApplicationMutationPlanner(
+            inventoryProvider: {
+                .partial([fixture.application], warnings: ["unrelated system row was omitted"])
+            },
+            exactIdentifierProvider: { _ in currentApplication.value })
+        let planner = DesktopTargetPlanning.WindowMutationPlanner(
+            applicationPlanner: applications,
+            windowInventoryProvider: { _ in .complete([fixture.window]) })
+        let plan = try await planner.plan(selector: InteractionTargetSelector(
+            applicationIdentifier: "Calculator",
+            windowID: fixture.window.windowID))
+        currentApplication.value = AutomationTestFixtures.application(
+            processIdentifier: fixture.processIdentity.processIdentifier,
+            processStartIdentity: fixture.processIdentity.processStartIdentity + 1,
+            bundleIdentifier: fixture.application.bundleIdentifier,
+            name: fixture.application.name)
+
+        await #expect(throws: DesktopTargetPlanningError.staleApplication(expected: fixture.processIdentity)) {
+            _ = try await planner.revalidate(plan)
+        }
+    }
+
+    @Test
+    func `exact Calculator window refuses a mismatched window owner after partial discovery`() async throws {
+        let fixture = AutomationTestFixtures.linkedDesktopTarget(
+            processIdentity: .init(processIdentifier: 2468, processStartIdentity: 7),
+            applicationName: "Calculator",
+            windowID: 42)
+        let resolution = try #require(try ApplicationIdentifierMatcher.resolution(
+            for: "Calculator",
+            in: [ApplicationIdentifierMatcher.Candidate(fixture.application)]))
+        let authoritativeApplication = fixture.application.withSelectorResolutionProofs([
+            resolution.proof(selectedProcessIdentity: fixture.processIdentity),
+        ])
+        let wrongOwner = ApplicationProcessIdentity(
+            processIdentifier: 2469,
+            processStartIdentity: 8)
+        let mismatchedWindow = AutomationTestFixtures.window(
+            windowID: fixture.window.windowID,
+            title: fixture.window.title,
+            bounds: fixture.window.bounds,
+            processIdentity: wrongOwner)
+        let applications = DesktopTargetPlanning.ApplicationMutationPlanner(
+            inventoryProvider: {
+                .partial([fixture.application], warnings: ["unrelated system row was omitted"])
+            },
+            exactIdentifierProvider: { _ in authoritativeApplication })
+        let planner = DesktopTargetPlanning.WindowMutationPlanner(
+            applicationPlanner: applications,
+            windowInventoryProvider: { _ in .complete([mismatchedWindow]) })
+
+        await #expect(throws: DesktopTargetPlanningError.windowOwnerMismatch(
+            windowID: fixture.window.windowID,
+            expected: fixture.processIdentity))
+        {
+            _ = try await planner.plan(selector: InteractionTargetSelector(
+                applicationIdentifier: "Calculator",
+                windowID: fixture.window.windowID))
+        }
+    }
+
+    @Test
     func `selection failures revalidate an already selected owner before returning`() async throws {
         let original = AutomationTestFixtures.application()
         let changed = AutomationTestFixtures.wrongGenerationApplication()


### PR DESCRIPTION
## Summary

- let app plus exact-window-ID background mutations resolve the selected owner through an authoritative direct lookup when unrelated broad application rows are incomplete
- retain fail-closed ambiguity, missing selected generation, stale owner generation, and window-owner mismatch checks
- prove ownerless exact-window resolution uses the exact PID provider rather than broad application inventory

## Proof

- MutationAuthorityPlannerTests: 15/15
- WindowMutationPlannerTests: 20/20
- TargetedInteractionDefaultDeliveryTests: 14/14
- complete safe suite passed before the final rebase; focused suites reran on exact current main
- SwiftFormat and diff checks clean
- strict lint on planner/fixture/test owners: 0 findings
- full SwiftLint: 0 serious findings
- final P2 Autoreview: no actionable findings

## Scope

This is separate from composed-input parity and does not change Bridge protocol versions. No live UI automation, foreground interaction, AppleScript/JXA, cursor assertion, virtualization, install, or release was used.
