### PR TITLE
fix(mcp): bind persistent capture to selected Bridge

### DIFF
--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommandRuntime.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommandRuntime.swift
@@ -75,6 +75,7 @@ struct CommandRuntimeOptions {
     var usesPersistentDynamicToolRuntime: Bool {
         self.requiresAgentService && self.usesPerToolSnapshotInvalidation
     }
+
     var requiresExactWindowTargetedClicks = false
     /// Protocol 1.30 is required before encoding middle/triple click cases.
     var requiresStatelessClickVariants = false

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommandRuntime.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommandRuntime.swift
@@ -70,6 +70,11 @@ struct CommandRuntimeOptions {
     var requiresExplicitSnapshotPublication = false
     var requiresCallerDesktopMutationBarrier = false
     var usesPerToolSnapshotInvalidation = false
+    /// MCP and Agent keep one dynamic tool runtime alive across multiple calls. An explicit
+    /// Bridge route therefore owns capture preflight for that runtime's authenticated generation.
+    var usesPersistentDynamicToolRuntime: Bool {
+        self.requiresAgentService && self.usesPerToolSnapshotInvalidation
+    }
     var requiresExactWindowTargetedClicks = false
     /// Protocol 1.30 is required before encoding middle/triple click cases.
     var requiresStatelessClickVariants = false

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/RuntimeHostResolver+ScreenCaptureKitOwner.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/RuntimeHostResolver+ScreenCaptureKitOwner.swift
@@ -65,7 +65,10 @@ extension RuntimeHostResolver {
                         options: options,
                         environment: environment
                     )
-                    resolvedCandidates = RuntimeHostResolver.screenCaptureKitSafetyCandidates(from: plan)
+                    resolvedCandidates = RuntimeHostResolver.screenCaptureKitSafetyCandidates(
+                        from: plan,
+                        options: options
+                    )
                 }
                 return try await RuntimeHostResolver.firstScreenCaptureKitOwnerUnawareHost(
                     candidates: resolvedCandidates,
@@ -299,9 +302,17 @@ extension RuntimeHostResolver {
     }
 
     static func screenCaptureKitSafetyCandidates(
-        from plan: RemoteCandidatePlan
+        from plan: RemoteCandidatePlan,
+        options: CommandRuntimeOptions
     ) -> [ImplicitRemoteCandidate] {
         var paths = plan.candidates.map(\.socketPath)
+        if options.usesPersistentDynamicToolRuntime,
+           plan.explicitSocket?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false {
+            // A persistent MCP/Agent runtime with an explicit Bridge route retains the authenticated
+            // client from this handshake. Its listener generation is revalidated for every request,
+            // so unrelated global sockets cannot contribute capture authority or poison the session.
+            return self.screenCaptureKitSafetyCandidates(paths: paths)
+        }
         paths.append(plan.daemonSocketPath)
         if let buildScopedDaemonSocketPath = plan.buildScopedDaemonSocketPath {
             paths.append(buildScopedDaemonSocketPath)
@@ -313,6 +324,12 @@ extension RuntimeHostResolver {
             PeekabooBridgeConstants.clawdbotSocketPath,
         ])
 
+        return self.screenCaptureKitSafetyCandidates(paths: paths)
+    }
+
+    private static func screenCaptureKitSafetyCandidates(
+        paths: [String]
+    ) -> [ImplicitRemoteCandidate] {
         var seen = Set<String>()
         return paths.compactMap { path in
             let standardized = NSString(string: path).standardizingPath
@@ -411,7 +428,8 @@ extension RuntimeHostResolver {
     ) -> MCPToolCapturePreflightRefusal {
         let refusal = self.ownerCapabilityRefusal(host: host, selectedSocket: selectedSocket)
         let sessionGuidance = "This capture refusal is fixed for the lifetime of this MCP or Agent session; " +
-            "after the owner is updated or stopped, start a fresh session before retrying capture."
+            "after the owner is updated or stopped, start a fresh session before retrying auto or modern capture. " +
+            "The see tool can instead use capture_engine 'classic' in this session without entering ScreenCaptureKit."
         return MCPToolCapturePreflightRefusal(
             message: refusal.localizedDescription,
             hint: [refusal.hint, sessionGuidance].compactMap(\.self).joined(separator: " ")

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/RuntimeHostResolver+ScreenCaptureKitOwner.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/RuntimeHostResolver+ScreenCaptureKitOwner.swift
@@ -308,9 +308,10 @@ extension RuntimeHostResolver {
         var paths = plan.candidates.map(\.socketPath)
         if options.usesPersistentDynamicToolRuntime,
            plan.explicitSocket?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false {
-            // A persistent MCP/Agent runtime with an explicit Bridge route retains the authenticated
-            // client from this handshake. Its listener generation is revalidated for every request,
-            // so unrelated global sockets cannot contribute capture authority or poison the session.
+            // Scope only caller-side socket discovery. The selected host must advertise process
+            // ownership here, and every real SCK leaf then rescans all same-user potential Peekaboo
+            // processes through ScreenCaptureKitOwnerLease before dispatch. Omitted sockets therefore
+            // cannot contribute authority or escape the canonical process-level safety scan.
             return self.screenCaptureKitSafetyCandidates(paths: paths)
         }
         paths.append(plan.daemonSocketPath)

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/RuntimeHostResolver.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/RuntimeHostResolver.swift
@@ -49,7 +49,7 @@ enum RuntimeHostResolver {
             if let oldHost = try await dependencies.inspectScreenCaptureKitSafety(
                 options,
                 environment,
-                self.screenCaptureKitSafetyCandidates(from: plan),
+                self.screenCaptureKitSafetyCandidates(from: plan, options: options),
                 resolvedHandshakeCache
             ) {
                 // The live recorder installs an irreversible process-lifetime tombstone. One

--- a/Apps/CLI/Tests/CoreCLITests/ScreenCaptureKitDynamicToolRuntimeTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/ScreenCaptureKitDynamicToolRuntimeTests.swift
@@ -1,6 +1,7 @@
 import Commander
 import Foundation
 import MCP
+import PeekabooBridge
 import PeekabooCore
 import TachikomaMCP
 import Testing
@@ -8,15 +9,97 @@ import Testing
 
 extension ScreenCaptureKitOwnerRuntimeTests {
     @Test
-    func `explicit dynamic host starts while unrelated legacy owner blocks only capture tools`() async throws {
+    func `explicit persistent capture safety is scoped to its selected socket`() {
+        let selectedSocket = "/tmp/persistent-selected.sock"
+        let plan = RuntimeHostResolver.RemoteCandidatePlan(
+            explicitSocket: selectedSocket,
+            daemonSocketPath: "/tmp/unrelated-daemon.sock",
+            runtimeBuildIdentity: "fixture-build",
+            buildScopedDaemonSocketPath: "/tmp/unrelated-build-daemon.sock",
+            historicalBuildScopedDaemonTargets: [],
+            historicalBuildScopedDaemonSocketPaths: ["/tmp/unrelated-historical.sock"],
+            candidates: [.init(
+                socketPath: selectedSocket,
+                requireReusableDaemon: false,
+                requiredHostKind: nil,
+                requiresValidatedHistoricalDaemon: false
+            )]
+        )
+        var options = CommandRuntimeOptions()
+        options.requiresAgentService = true
+        options.usesPerToolSnapshotInvalidation = true
+
+        let candidates = RuntimeHostResolver.screenCaptureKitSafetyCandidates(
+            from: plan,
+            options: options
+        )
+
+        #expect(candidates.map(\.socketPath) == [selectedSocket])
+    }
+
+    @Test
+    func `one-shot and implicit capture safety retain broad legacy-owner discovery`() {
+        let selectedSocket = "/tmp/one-shot-selected.sock"
+        let daemonSocket = "/tmp/one-shot-daemon.sock"
+        let buildSocket = "/tmp/one-shot-build-daemon.sock"
+        let historicalSocket = "/tmp/one-shot-historical.sock"
+        let plan = RuntimeHostResolver.RemoteCandidatePlan(
+            explicitSocket: selectedSocket,
+            daemonSocketPath: daemonSocket,
+            runtimeBuildIdentity: "fixture-build",
+            buildScopedDaemonSocketPath: buildSocket,
+            historicalBuildScopedDaemonTargets: [],
+            historicalBuildScopedDaemonSocketPaths: [historicalSocket],
+            candidates: [.init(
+                socketPath: selectedSocket,
+                requireReusableDaemon: false,
+                requiredHostKind: nil,
+                requiresValidatedHistoricalDaemon: false
+            )]
+        )
+
+        let candidates = RuntimeHostResolver.screenCaptureKitSafetyCandidates(
+            from: plan,
+            options: CommandRuntimeOptions()
+        ).map(\.socketPath)
+
+        #expect(candidates.first == selectedSocket)
+        #expect(candidates.contains(daemonSocket))
+        #expect(candidates.contains(buildSocket))
+        #expect(candidates.contains(historicalSocket))
+        #expect(candidates.contains(PeekabooBridgeConstants.peekabooSocketPath))
+        #expect(candidates.contains(PeekabooBridgeConstants.claudeSocketPath))
+        #expect(candidates.contains(PeekabooBridgeConstants.clawdbotSocketPath))
+        #expect(Set(candidates).count == candidates.count)
+    }
+
+    @Test
+    func `explicit dynamic host ignores unrelated legacy owner and reuses selected generation`() async throws {
         let selectedSocket = "/tmp/peekaboo-dynamic-selected-\(UUID().uuidString).sock"
+        let unrelatedSocket = "/tmp/peekaboo-dynamic-unrelated-\(UUID().uuidString).sock"
+        var selectedHandshakeCount = 0
+        var unrelatedHandshakeCount = 0
         let selectedHost = try await Self.startHost(
             socketPath: selectedSocket,
             processIdentifier: 4242,
             processStartIdentity: 9001,
-            codeSignatureHash: "selected-build"
+            codeSignatureHash: "selected-build",
+            permissionEvaluationObserver: { selectedHandshakeCount += 1 }
         )
-        defer { Task { await selectedHost.stop() } }
+        let unrelatedHost = try await Self.startHost(
+            socketPath: unrelatedSocket,
+            processIdentifier: 5151,
+            processStartIdentity: 6161,
+            codeSignatureHash: "legacy-build",
+            ownerAware: false,
+            permissionEvaluationObserver: { unrelatedHandshakeCount += 1 }
+        )
+        defer {
+            Task {
+                await selectedHost.stop()
+                await unrelatedHost.stop()
+            }
+        }
 
         let options = try CommanderCLIBinder.makeRuntimeOptions(
             from: ParsedValues(
@@ -28,16 +111,11 @@ extension ScreenCaptureKitOwnerRuntimeTests {
         )
         #expect(options.bridgeSocketPath == selectedSocket)
         #expect(options.usesPerToolSnapshotInvalidation)
-        #expect(!options.requiresScreenCaptureKitOwnerCapability)
+        #expect(options.usesPersistentDynamicToolRuntime)
         #expect(!options.requiresScreenCaptureKitOwnerCapability)
         var inspectOwnerCalls = 0
         var localFactoryCalls = 0
-        let legacyOwner = RuntimeHostResolver.ScreenCaptureKitOwnerUnawareHost(
-            socketPath: "/tmp/unrelated-legacy-owner.sock",
-            processIdentifier: nil,
-            processStartIdentity: nil,
-            buildIdentity: "legacy-build"
-        )
+        var inspectedCandidates: [String] = []
 
         let resolution = try await RuntimeHostResolver.resolveServices(
             options: options,
@@ -53,7 +131,16 @@ extension ScreenCaptureKitOwnerRuntimeTests {
                     inspectOwnerCalls += 1
                     return nil
                 },
-                inspectScreenCaptureKitSafety: { _, _, _, _ in legacyOwner },
+                inspectScreenCaptureKitSafety: { _, _, candidates, handshakeCache in
+                    let candidates = try #require(candidates)
+                    inspectedCandidates = candidates.map(\.socketPath)
+                    return try await RuntimeHostResolver.firstScreenCaptureKitOwnerUnawareHost(
+                        candidates: candidates,
+                        identity: handshakeCache.identity,
+                        handshakeCache: handshakeCache,
+                        externalHostPresence: { _ in .absent }
+                    )
+                },
                 remoteCandidatePlan: { _, _ in
                     RuntimeHostResolver.RemoteCandidatePlan(
                         explicitSocket: selectedSocket,
@@ -76,13 +163,17 @@ extension ScreenCaptureKitOwnerRuntimeTests {
         #expect(resolution.selectedRemoteSocketPath == selectedSocket)
         #expect(inspectOwnerCalls == 1)
         #expect(localFactoryCalls == 0)
-        let refusal = try #require(resolution.toolCapturePreflightRefusal)
-        #expect(refusal.message.contains(selectedSocket))
-        #expect(refusal.message.contains(legacyOwner.socketPath))
-        #expect(refusal.message.contains("No capture was dispatched"))
-        #expect(refusal.hint?.contains("Do not stop any process") == true)
-        #expect(refusal.hint?.contains("start a fresh session") == true)
+        #expect(resolution.toolCapturePreflightRefusal == nil)
+        #expect(inspectedCandidates == [selectedSocket])
+        #expect(selectedHandshakeCount == 1)
+        #expect(unrelatedHandshakeCount == 0)
+
+        let permissions = try await resolution.services.permissionsStatus()
+        #expect(permissions.screenRecording)
+        #expect(selectedHandshakeCount == 2)
+        #expect(unrelatedHandshakeCount == 0)
         await selectedHost.stop()
+        await unrelatedHost.stop()
     }
 
     @Test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Restore terminal echo around credential-prompt job-control stops and common termination signals, then re-disable echo only after a stopped prompt continues.
 - Let exact-window background mutations ignore unrelated incomplete application rows while still refusing ambiguous, incomplete, stale, or mismatched selected owners.
 - Give unknown CLI commands a current-help recovery hint and remove source-checkout rebuild advice from installed help.
+- Bind persistent MCP capture preflight to its explicitly selected Bridge socket and authenticated process generation, ignoring unrelated legacy-owner sockets while exposing safe request-local classic `see` capture.
 - Keep provider dry-run, validation, error, and JSON output free of credential values, and reject special, symlinked, permissive, wrong-owner, or extended-ACL credential files on the opened descriptor before reading.
 - Use the canonical MCP mutation policy for Agent visual verification, including conditional browser and foreground menu actions.
 - Let background certification pin Activity Monitor's exact source-declared window title while refusing unsafe partial, duplicate, or drifting title evidence.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 - Restore terminal echo around credential-prompt job-control stops and common termination signals, then re-disable echo only after a stopped prompt continues.
 - Let exact-window background mutations ignore unrelated incomplete application rows while still refusing ambiguous, incomplete, stale, or mismatched selected owners.
 - Give unknown CLI commands a current-help recovery hint and remove source-checkout rebuild advice from installed help.
-- Bind persistent MCP capture preflight to its explicitly selected Bridge socket and authenticated process generation, ignoring unrelated legacy-owner sockets while exposing safe request-local classic `see` capture.
+- Bind persistent MCP capture preflight to its explicitly selected Bridge generation, preserve precise signed capture refusals, retain an exact generation's canonical ScreenCaptureKit lease across later legacy-process discovery, and expose safe request-local classic `see` capture.
 - Keep provider dry-run, validation, error, and JSON output free of credential values, and reject special, symlinked, permissive, wrong-owner, or extended-ACL credential files on the opened descriptor before reading.
 - Use the canonical MCP mutation policy for Agent visual verification, including conditional browser and foreground menu actions.
 - Let background certification pin Activity Monitor's exact source-declared window title while refusing unsafe partial, duplicate, or drifting title evidence.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 - Restore terminal echo around credential-prompt job-control stops and common termination signals, then re-disable echo only after a stopped prompt continues.
 - Let exact-window background mutations ignore unrelated incomplete application rows while still refusing ambiguous, incomplete, stale, or mismatched selected owners.
 - Give unknown CLI commands a current-help recovery hint and remove source-checkout rebuild advice from installed help.
-- Bind persistent MCP capture preflight to its explicitly selected Bridge generation, preserve precise signed capture refusals, retain an exact generation's canonical ScreenCaptureKit lease across later legacy-process discovery, and expose safe request-local classic `see` capture.
+- Bind persistent MCP capture preflight to its explicitly selected Bridge generation, preserve precise signed capture refusals, and expose safe request-local classic `see` capture.
 - Keep provider dry-run, validation, error, and JSON output free of credential values, and reject special, symlinked, permissive, wrong-owner, or extended-ACL credential files on the opened descriptor before reading.
 - Use the canonical MCP mutation policy for Agent visual verification, including conditional browser and foreground menu actions.
 - Let background certification pin Activity Monitor's exact source-declared window title while refusing unsafe partial, duplicate, or drifting title evidence.

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/ScreenCaptureKitOwnerLease.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/ScreenCaptureKitOwnerLease.swift
@@ -325,6 +325,9 @@ public final class ScreenCaptureKitOwnerLease: Sendable {
 
     /// Makes exactly one nonblocking `flock` attempt. A live contender is reported immediately.
     public func claim() throws -> ClaimResult {
+        if let receipt = try Self.currentProcessHeldReceipt(path: self.lockPath) {
+            return .alreadyOwnedByCurrentProcess(receipt)
+        }
         let uncoordinatedHosts = self.uncoordinatedHosts()
         guard uncoordinatedHosts.isEmpty else {
             throw LeaseError.uncoordinatedHosts(uncoordinatedHosts)
@@ -332,9 +335,6 @@ public final class ScreenCaptureKitOwnerLease: Sendable {
         let uncoordinatedProcesses = try self.uncoordinatedProcesses()
         guard uncoordinatedProcesses.isEmpty else {
             throw LeaseError.uncoordinatedProcesses(uncoordinatedProcesses)
-        }
-        if let receipt = try Self.currentProcessHeldReceipt(path: self.lockPath) {
-            return .alreadyOwnedByCurrentProcess(receipt)
         }
         if let receipt = try Self.currentOwnerReceiptIfHeld(
             lockURL: URL(fileURLWithPath: self.lockPath),

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/ScreenCaptureKitOwnerLease.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/ScreenCaptureKitOwnerLease.swift
@@ -325,9 +325,6 @@ public final class ScreenCaptureKitOwnerLease: Sendable {
 
     /// Makes exactly one nonblocking `flock` attempt. A live contender is reported immediately.
     public func claim() throws -> ClaimResult {
-        if let receipt = try Self.currentProcessHeldReceipt(path: self.lockPath) {
-            return .alreadyOwnedByCurrentProcess(receipt)
-        }
         let uncoordinatedHosts = self.uncoordinatedHosts()
         guard uncoordinatedHosts.isEmpty else {
             throw LeaseError.uncoordinatedHosts(uncoordinatedHosts)
@@ -335,6 +332,9 @@ public final class ScreenCaptureKitOwnerLease: Sendable {
         let uncoordinatedProcesses = try self.uncoordinatedProcesses()
         guard uncoordinatedProcesses.isEmpty else {
             throw LeaseError.uncoordinatedProcesses(uncoordinatedProcesses)
+        }
+        if let receipt = try Self.currentProcessHeldReceipt(path: self.lockPath) {
+            return .alreadyOwnedByCurrentProcess(receipt)
         }
         if let receipt = try Self.currentOwnerReceiptIfHeld(
             lockURL: URL(fileURLWithPath: self.lockPath),

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Strategy/UIAutomationActionResultSequenceAccumulator.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Strategy/UIAutomationActionResultSequenceAccumulator.swift
@@ -493,6 +493,7 @@ public struct UIAutomationActionResultSequenceAccumulator: Sendable {
             message: composed.message,
             hint: composed.hint,
             causeDescription: composed.causeDescription,
+            standardErrorCode: leafFailure.standardErrorCode,
             targetReceipt: targetReceipt,
             selectedLeafEvidence: evidence)
         else {
@@ -510,7 +511,8 @@ public struct UIAutomationActionResultSequenceAccumulator: Sendable {
                 outcome: failure.outcome,
                 message: failure.message,
                 hint: failure.hint,
-                causeDescription: failure.causeDescription)
+                causeDescription: failure.causeDescription,
+                standardErrorCode: failure.standardErrorCode)
             else {
                 preconditionFailure("A reconciled desktop action failure must remain non-confirmed")
             }

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ScreenCaptureKitOwnerLeaseTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ScreenCaptureKitOwnerLeaseTests.swift
@@ -314,7 +314,7 @@ struct ScreenCaptureKitOwnerLeaseTests {
     }
 
     @Test
-    func `Exact current owner reentry precedes late uncoordinated process discovery`() throws {
+    func `Same-process reentry rescans late-starting uncoordinated hosts`() throws {
         let fixture = try LeaseFixture(name: "reentry-rescan")
         defer { fixture.removeLockPath() }
         let conflict = ScreenCaptureKitOwnerLease.UncoordinatedProcess(
@@ -332,7 +332,7 @@ struct ScreenCaptureKitOwnerLeaseTests {
                 scanCount.increment()
                 return []
             })
-        let first = try firstLease.claim()
+        _ = try firstLease.claim()
         let reentrantLease = ScreenCaptureKitOwnerLease(
             lockURL: fixture.lockURL,
             ownerIdentity: .init(
@@ -344,12 +344,10 @@ struct ScreenCaptureKitOwnerLeaseTests {
                 return [conflict]
             })
 
-        guard case let .acquired(receipt) = first else {
-            Issue.record("Expected the first exact generation to acquire the lease")
-            return
+        #expect(throws: ScreenCaptureKitOwnerLease.LeaseError.uncoordinatedProcesses([conflict])) {
+            try reentrantLease.claim()
         }
-        #expect(try reentrantLease.claim() == .alreadyOwnedByCurrentProcess(receipt))
-        #expect(scanCount.value == 1)
+        #expect(scanCount.value == 2)
     }
 
     @Test

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ScreenCaptureKitOwnerLeaseTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ScreenCaptureKitOwnerLeaseTests.swift
@@ -314,7 +314,7 @@ struct ScreenCaptureKitOwnerLeaseTests {
     }
 
     @Test
-    func `Same-process reentry rescans late-starting uncoordinated hosts`() throws {
+    func `Exact current owner reentry precedes late uncoordinated process discovery`() throws {
         let fixture = try LeaseFixture(name: "reentry-rescan")
         defer { fixture.removeLockPath() }
         let conflict = ScreenCaptureKitOwnerLease.UncoordinatedProcess(
@@ -332,7 +332,7 @@ struct ScreenCaptureKitOwnerLeaseTests {
                 scanCount.increment()
                 return []
             })
-        _ = try firstLease.claim()
+        let first = try firstLease.claim()
         let reentrantLease = ScreenCaptureKitOwnerLease(
             lockURL: fixture.lockURL,
             ownerIdentity: .init(
@@ -344,10 +344,12 @@ struct ScreenCaptureKitOwnerLeaseTests {
                 return [conflict]
             })
 
-        #expect(throws: ScreenCaptureKitOwnerLease.LeaseError.uncoordinatedProcesses([conflict])) {
-            try reentrantLease.claim()
+        guard case let .acquired(receipt) = first else {
+            Issue.record("Expected the first exact generation to acquire the lease")
+            return
         }
-        #expect(scanCount.value == 2)
+        #expect(try reentrantLease.claim() == .alreadyOwnedByCurrentProcess(receipt))
+        #expect(scanCount.value == 1)
     }
 
     @Test

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/MCPToolContext.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/MCPToolContext.swift
@@ -437,7 +437,7 @@ public struct MCPToolContext: @unchecked Sendable {
         arguments: ToolArguments) -> ToolResponse?
     {
         guard let capturePreflightRefusal else { return nil }
-        guard let requiresPixels = MCPToolCaptureRequirement.requiresPixels(
+        guard let requiresOwnerPreflight = MCPToolCaptureRequirement.requiresScreenCaptureKitOwnerPreflight(
             toolName: tool.name,
             arguments: arguments)
         else {
@@ -447,7 +447,7 @@ public struct MCPToolContext: @unchecked Sendable {
                 reason: .runtimeIncompatible,
                 additionalFields: ["error_code": .string("CAPTURE_POLICY_UNCLASSIFIED")])
         }
-        guard requiresPixels else { return nil }
+        guard requiresOwnerPreflight else { return nil }
         return MCPToolResponseMetadataProjector.preDispatchRefusalResponse(
             message: capturePreflightRefusal.diagnostic,
             reason: .runtimeIncompatible,

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/MCPToolSnapshotMutation.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/MCPToolSnapshotMutation.swift
@@ -94,6 +94,22 @@ enum MCPToolCaptureRequirement: Sendable, Equatable {
             nil
         }
     }
+
+    static func requiresScreenCaptureKitOwnerPreflight(
+        toolName: String,
+        arguments: ToolArguments) -> Bool?
+    {
+        guard let requiresPixels = self.requiresPixels(toolName: toolName, arguments: arguments) else { return nil }
+        guard requiresPixels else { return false }
+        if toolName == "see",
+           arguments.getString("capture_engine")?
+               .trimmingCharacters(in: .whitespacesAndNewlines)
+               .lowercased() == "classic"
+        {
+            return false
+        }
+        return true
+    }
 }
 
 struct MCPToolPendingSnapshotInvalidation: Sendable, Equatable {

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/ObservationActionResultSupport.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/ObservationActionResultSupport.swift
@@ -30,6 +30,11 @@ enum ObservationActionResultSupport {
     }
 
     static func standardErrorFields(_ error: any Error) -> [String: Value] {
+        if let error = error as? DesktopActionFailure,
+           let code = error.standardErrorCode
+        {
+            return ["error_code": .string(code.rawValue)]
+        }
         guard let error = error as? PeekabooError else { return [:] }
         let code: StandardErrorCode? = switch error {
         case .accessibilityIncomplete:

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/SeeTool+Types.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/SeeTool+Types.swift
@@ -8,6 +8,7 @@ struct SeeRequest {
     let appTarget: String?
     let windowIDValue: Value?
     let path: String?
+    let captureEngine: CaptureEnginePreference
     let snapshotId: String?
     let annotate: Bool
     let ocr: Bool
@@ -19,6 +20,7 @@ struct SeeRequest {
         self.appTarget = arguments.getString("app_target")
         self.windowIDValue = arguments.getValue(for: "window_id")
         self.path = arguments.getString("path")
+        self.captureEngine = try Self.captureEngine(arguments.getString("capture_engine"))
         self.snapshotId = arguments.getString("snapshot")
         self.annotate = arguments.getBool("annotate") ?? false
         self.ocr = arguments.getBool("ocr") ?? false
@@ -48,6 +50,20 @@ struct SeeRequest {
             throw PeekabooError.invalidInput("\(key) must be a positive integer")
         }
         return value
+    }
+
+    private static func captureEngine(_ rawValue: String?) throws -> CaptureEnginePreference {
+        switch rawValue?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+        case nil, "", "auto":
+            .auto
+        case "modern":
+            .modern
+        case "classic":
+            .legacy
+        case let value?:
+            throw PeekabooError.invalidInput(
+                "Invalid capture_engine '\(value)'. Expected auto, modern, or classic.")
+        }
     }
 }
 

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/SeeTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/SeeTool.swift
@@ -52,6 +52,13 @@ public struct SeeTool: MCPTool {
                     description: """
                     Optional. Path to save the screenshot. If omitted, a temporary file is used.
                     """),
+                "capture_engine": SchemaBuilder.string(
+                    description: """
+                    Optional. auto (default), modern (ScreenCaptureKit), or classic (no ScreenCaptureKit).
+                    Use classic to recover safely from a ScreenCaptureKit owner refusal.
+                    """,
+                    enum: ["auto", "modern", "classic"],
+                    default: "auto"),
                 "snapshot": SchemaBuilder.string(
                     description: """
                     Optional. Snapshot ID for UI automation tracking. A new snapshot is created when absent.
@@ -237,7 +244,10 @@ public struct SeeTool: MCPTool {
         try await self.context.desktopObservation.observeResult(
             DesktopObservationRequest(
                 target: target.observationTarget,
-                capture: DesktopCaptureOptions(visualizerMode: .none, roi: request.roi),
+                capture: DesktopCaptureOptions(
+                    engine: request.captureEngine,
+                    visualizerMode: .none,
+                    roi: request.roi),
                 detection: DesktopDetectionOptions(
                     mode: request.ocr ? .accessibilityAndOCR : .accessibility,
                     allowWebFocusFallback: request.webFocus,

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeModels.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeModels.swift
@@ -687,6 +687,7 @@ public struct PeekabooBridgeErrorEnvelope: Codable, Sendable, LocalizedError {
             message: self.message,
             hint: self.actionFailureHint,
             causeDescription: self.actionFailureCauseDescription,
+            standardErrorCode: self.standardizedErrorCode,
             targetReceipt: self.actionTargetReceipt,
             selectedLeafEvidence: self.actionSelectedLeafEvidence)
     }

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer+OperationReceipts.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer+OperationReceipts.swift
@@ -116,13 +116,7 @@ extension PeekabooBridgeServer {
                 context: encodingContext)
         }
 
-        let handled = await PeekabooBridgeRequestContext.$negotiatedSessionCapabilities.withValue(
-            claim.negotiatedCapabilities)
-        {
-            await PeekabooBridgeRequestContext.$usesAttestedOperationResultSemantics.withValue(true) {
-                await self.terminalResponse(for: plan, peer: peer)
-            }
-        }
+        let handled = await self.executeAttestedOperation(plan: plan, claim: claim, peer: peer)
         let response: PeekabooBridgeResponse
         let target: PeekabooBridgeOperationTargetReceipt?
         let focusedElement: FocusedElementIdentity?
@@ -185,6 +179,21 @@ extension PeekabooBridgeServer {
                 failureEvidence: targetFailureEvidence),
             selectedLeafEvidence: targetFailure == nil ? handled.selectedLeafEvidence : nil,
             context: encodingContext)
+    }
+
+    private func executeAttestedOperation(
+        plan: PeekabooBridgeOperationResultSemantics.PeekabooBridgeRequestPlan,
+        claim: PeekabooBridgeOperationSessionClaim,
+        peer: PeekabooBridgePeer) async -> PeekabooBridgeHandledResponse
+    {
+        let handled = await PeekabooBridgeRequestContext.$negotiatedSessionCapabilities.withValue(
+            claim.negotiatedCapabilities)
+        {
+            await PeekabooBridgeRequestContext.$usesAttestedOperationResultSemantics.withValue(true) {
+                await self.terminalResponse(for: plan, peer: peer)
+            }
+        }
+        return Self.normalizingTargetlessReadOnlyFailure(handled, plan: plan)
     }
 
     static func operationReceiptClaimErrorCode(
@@ -353,6 +362,7 @@ extension PeekabooBridgeServer {
         do {
             return try await self.route(plan, peer: peer)
         } catch let envelope as PeekabooBridgeErrorEnvelope {
+            let envelope = Self.targetlessReadOnlyFailureEnvelope(envelope, plan: plan)
             return .init(
                 response: .error(envelope.legacyCompatible),
                 selectedLeafEvidence: envelope.actionSelectedLeafEvidence)
@@ -367,12 +377,72 @@ extension PeekabooBridgeServer {
                     details: "\(failure)")),
                 selectedLeafEvidence: routed.selectedLeafEvidence)
         } catch is CancellationError {
-            return .init(response: .error(.init(code: .timeout, message: "Bridge request was cancelled")))
+            let envelope = Self.targetlessReadOnlyFailureEnvelope(
+                .init(code: .timeout, message: "Bridge request was cancelled"),
+                plan: plan)
+            return .init(response: .error(envelope))
         } catch {
-            return .init(response: .error(.init(
+            let envelope = Self.targetlessReadOnlyFailureEnvelope(.init(
                 code: .internalError,
                 message: error.localizedDescription,
-                details: "\(error)")))
+                details: "\(error)"), plan: plan)
+            return .init(response: .error(envelope))
+        }
+    }
+
+    private static func targetlessReadOnlyFailureEnvelope(
+        _ envelope: PeekabooBridgeErrorEnvelope,
+        plan: PeekabooBridgeOperationResultSemantics.PeekabooBridgeRequestPlan) -> PeekabooBridgeErrorEnvelope
+    {
+        guard !plan.result.completion.mutatesDesktop,
+              !envelope.operationMayHaveCompleted,
+              envelope.actionOutcome == nil,
+              envelope.actionTargetReceipt == nil,
+              envelope.actionSelectedLeafEvidence == nil
+        else {
+            return envelope
+        }
+        let failure = DesktopActionFailure.preDispatchRefusal(
+            route: .bridge,
+            reason: self.readOnlyFailureReason(envelope.code),
+            message: envelope.message,
+            hint: envelope.actionFailureHint,
+            causeDescription: envelope.details)
+        return PeekabooBridgeErrorEnvelope(
+            code: envelope.code,
+            actionFailure: failure,
+            details: envelope.details,
+            permission: envelope.permission,
+            kind: envelope.kind,
+            context: envelope.context)
+    }
+
+    private static func normalizingTargetlessReadOnlyFailure(
+        _ handled: PeekabooBridgeHandledResponse,
+        plan: PeekabooBridgeOperationResultSemantics.PeekabooBridgeRequestPlan) -> PeekabooBridgeHandledResponse
+    {
+        guard case let .error(envelope) = handled.response else { return handled }
+        return handled.replacingResponse(.error(self.targetlessReadOnlyFailureEnvelope(envelope, plan: plan)))
+    }
+
+    private static func readOnlyFailureReason(
+        _ code: PeekabooBridgeErrorCode) -> DesktopActionOutcome.RefusalReason
+    {
+        switch code {
+        case .permissionDenied:
+            .permissionDenied
+        case .notFound:
+            .targetUnavailable
+        case .timeout:
+            .requestCancelled
+        case .invalidRequest, .decodingFailed:
+            .invalidRequest
+        case .operationNotSupported:
+            .operationUnsupported
+        case .serverBusy, .unauthorizedClient:
+            .transportSessionUnavailable
+        case .versionMismatch, .internalError:
+            .runtimeIncompatible
         }
     }
 

--- a/Core/PeekabooCore/Tests/PeekabooAgentRuntimeTests/MCPToolContextTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooAgentRuntimeTests/MCPToolContextTests.swift
@@ -6,6 +6,7 @@ import Testing
 @testable import PeekabooAgentRuntime
 @testable import PeekabooBridge
 @testable import PeekabooCore
+@testable import PeekabooFoundation
 
 @Suite(.serialized)
 struct MCPToolContextTests {
@@ -164,6 +165,22 @@ struct MCPToolContextTests {
 
         #expect(refusedContext.capturePreflightRefusal == refusal)
         #expect(agent.makeToolContext().capturePreflightRefusal == nil)
+    }
+
+    @Test
+    func `Bridge action failure preserves its standardized capture code for MCP metadata`() throws {
+        let failure = try #require(DesktopActionFailure(
+            outcome: .refused(route: .bridge, reason: .runtimeIncompatible),
+            message: "Capture failed before dispatch",
+            standardErrorCode: .captureFailed))
+
+        #expect(ObservationActionResultSupport.standardErrorFields(failure) == [
+            "error_code": .string("CAPTURE_FAILED"),
+        ])
+        let roundTrip = try JSONDecoder().decode(
+            DesktopActionFailure.self,
+            from: JSONEncoder().encode(failure))
+        #expect(roundTrip == failure)
     }
 
     @Test

--- a/Core/PeekabooCore/Tests/PeekabooAgentRuntimeTests/MCPToolContextTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooAgentRuntimeTests/MCPToolContextTests.swift
@@ -130,6 +130,7 @@ struct MCPToolContextTests {
 
         for (name, arguments) in [
             ("inspect_ui", ToolArguments(value: .object([:]))),
+            ("see", ToolArguments(value: .object(["capture_engine": .string(" CLASSIC ")]))),
             ("capture", ToolArguments(value: .object(["source": .string(" VIDEO ")]))),
             ("verify_state", ToolArguments(value: .object(["final_screenshot": .bool(false)]))),
         ] {
@@ -287,6 +288,7 @@ private struct MCPToolInvocationProbe: MCPTool {
         SchemaBuilder.object(
             properties: [
                 "app_target": SchemaBuilder.string(),
+                "capture_engine": SchemaBuilder.string(),
                 "capture_focus": SchemaBuilder.string(),
                 "final_screenshot": SchemaBuilder.boolean(),
                 "source": SchemaBuilder.string(),

--- a/Core/PeekabooCore/Tests/PeekabooAgentRuntimeTests/ToolRegistryContractTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooAgentRuntimeTests/ToolRegistryContractTests.swift
@@ -1,5 +1,8 @@
+import MCP
 import PeekabooAutomation
+import PeekabooAutomationKit
 import PeekabooCore
+import TachikomaMCP
 import Testing
 @testable import PeekabooAgentRuntime
 
@@ -72,5 +75,41 @@ struct ToolRegistryContractTests {
         let unclassified = names.filter { MCPToolCaptureRequirement.profile(toolName: $0) == nil }
 
         #expect(unclassified.isEmpty, "MCP tools missing capture profiles: \(unclassified.sorted())")
+    }
+
+    @Test
+    func `See exposes a closed capture engine and maps classic without ScreenCaptureKit`() throws {
+        let tool = SeeTool(context: MCPToolContext(services: PeekabooServices()))
+        guard case let .object(schema) = tool.inputSchema,
+              case let .object(properties)? = schema["properties"],
+              case let .object(captureEngine)? = properties["capture_engine"],
+              case let .array(values)? = captureEngine["enum"]
+        else {
+            Issue.record("Expected see.capture_engine schema")
+            return
+        }
+
+        #expect(values == ["auto", "modern", "classic"].map(Value.string))
+        #expect(captureEngine["default"] == .string("auto"))
+
+        let automatic = try SeeRequest(arguments: ToolArguments(value: .object([:])))
+        let modern = try SeeRequest(arguments: ToolArguments(value: .object([
+            "capture_engine": .string("modern"),
+        ])))
+        let classic = try SeeRequest(arguments: ToolArguments(value: .object([
+            "capture_engine": .string("classic"),
+        ])))
+        #expect(automatic.captureEngine == .auto)
+        #expect(modern.captureEngine == .modern)
+        #expect(classic.captureEngine == .legacy)
+
+        do {
+            _ = try SeeRequest(arguments: ToolArguments(value: .object([
+                "capture_engine": .string("sckit"),
+            ])))
+            Issue.record("Expected closed capture_engine validation")
+        } catch {
+            #expect(error.localizedDescription.contains("Expected auto, modern, or classic"))
+        }
     }
 }

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeDesktopObservationResultTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeDesktopObservationResultTests.swift
@@ -235,6 +235,62 @@ struct PeekabooBridgeDesktopObservationResultTests {
         await host.stop()
     }
 
+    @Test
+    func `signed read-only handler error keeps targetless refusal metadata`() async throws {
+        let provider = FailingObservationProvider()
+        let root = URL(fileURLWithPath: "/tmp/pb-ob-targetless-error-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let socketPath = root.appendingPathComponent("bridge.sock").path
+        let host = PeekabooBridgeHost(
+            socketPath: socketPath,
+            server: Self.server(provider: provider),
+            allowedTeamIDs: [],
+            requestTimeoutSec: 2)
+        try await host.startChecked()
+        defer { Task { await host.stop() } }
+
+        let client = TrustedBridgeClientFixture.make(socketPath: socketPath, requestTimeoutSec: 2)
+        _ = try await client.handshake(client: Self.clientIdentity)
+        let request = DesktopObservationRequest(
+            target: .app(identifier: "Fixture", window: .automatic),
+            capture: .init(engine: .modern, focus: .background),
+            detection: .init(mode: .accessibility))
+
+        do {
+            _ = try await client.desktopObservationWithOutcome(request)
+            Issue.record("Expected the read-only capture failure")
+        } catch let failure as DesktopActionFailure {
+            #expect(failure.message.contains("fixture modern owner refusal"))
+            #expect(failure.outcome.state == .refused)
+            #expect(failure.outcome.refusalReason == .runtimeIncompatible)
+            #expect(failure.outcome.dispatchState == .none)
+            #expect(failure.outcome.retrySafety == .safe)
+            #expect(failure.standardErrorCode == .captureFailed)
+            #expect(failure.targetReceipt == nil)
+        }
+
+        let bundle = try #require(await client.lastOperationReceiptBundle())
+        try bundle.validate()
+        #expect(bundle.receipt.payload.target == nil)
+        #expect(bundle.receipt.payload.targetAttributionFailure == nil)
+        #expect(bundle.receipt.payload.targetAttributionEvidence == nil)
+        #expect(bundle.receipt.payload.outcome?.outcome.state == .refused)
+        let response = try JSONDecoder.peekabooBridgeDecoder().decode(
+            PeekabooBridgeResponse.self,
+            from: bundle.canonicalResponse)
+        guard case let .error(envelope) = response else {
+            Issue.record("Expected the original error response")
+            return
+        }
+        #expect(envelope.context == "standard_error:CAPTURE_FAILED")
+        #expect(envelope.message.contains("fixture modern owner refusal"))
+        #expect(!envelope.operationMayHaveCompleted)
+        #expect(envelope.actionOutcome?.outcome.refusalReason == .runtimeIncompatible)
+        #expect(envelope.actionTargetReceipt == nil)
+        #expect(provider.actionResultCount == 1)
+        await host.stop()
+    }
+
     private static let delivery = DesktopActionOutcome.Delivery(
         mechanism: .capturePipeline,
         mode: .background)
@@ -411,5 +467,21 @@ private final class LegacyObservationProvider: DesktopObservationServiceProtocol
     func observe(_: DesktopObservationRequest) async throws -> DesktopObservationResult {
         self.observeCount += 1
         return self.result
+    }
+}
+
+@MainActor
+private final class FailingObservationProvider: DesktopObservationActionResultProviding {
+    private(set) var actionResultCount = 0
+
+    func observe(_: DesktopObservationRequest) async throws -> DesktopObservationResult {
+        throw OperationError.captureFailed(reason: "fixture modern owner refusal")
+    }
+
+    func observeActionResult(
+        _: DesktopObservationRequest) async throws -> UIAutomationActionResult<DesktopObservationResult>
+    {
+        self.actionResultCount += 1
+        throw OperationError.captureFailed(reason: "fixture modern owner refusal")
     }
 }

--- a/Core/PeekabooFoundation/Sources/PeekabooFoundation/DesktopActionOutcome.swift
+++ b/Core/PeekabooFoundation/Sources/PeekabooFoundation/DesktopActionOutcome.swift
@@ -685,6 +685,7 @@ public struct DesktopActionFailure: Codable, Equatable, LocalizedError, Sendable
     public let message: String
     public let hint: String?
     public let causeDescription: String?
+    public let standardErrorCode: StandardErrorCode?
     public let targetReceipt: DesktopActionTargetReceipt?
     public let selectedLeafEvidence: [DesktopSelectedLeafEvidence]?
 
@@ -693,6 +694,7 @@ public struct DesktopActionFailure: Codable, Equatable, LocalizedError, Sendable
         message: String,
         hint: String? = nil,
         causeDescription: String? = nil,
+        standardErrorCode: StandardErrorCode? = nil,
         targetReceipt: DesktopActionTargetReceipt? = nil,
         selectedLeafEvidence: [DesktopSelectedLeafEvidence]? = nil)
     {
@@ -705,6 +707,7 @@ public struct DesktopActionFailure: Codable, Equatable, LocalizedError, Sendable
         self.message = message
         self.hint = hint
         self.causeDescription = causeDescription
+        self.standardErrorCode = standardErrorCode
         self.targetReceipt = targetReceipt
         self.selectedLeafEvidence = selectedLeafEvidence
     }
@@ -830,6 +833,7 @@ public struct DesktopActionFailure: Codable, Equatable, LocalizedError, Sendable
         message: String,
         hint: String?,
         causeDescription: String?,
+        standardErrorCode: StandardErrorCode? = nil,
         targetReceipt: DesktopActionTargetReceipt? = nil,
         selectedLeafEvidence: [DesktopSelectedLeafEvidence]? = nil)
     {
@@ -837,6 +841,7 @@ public struct DesktopActionFailure: Codable, Equatable, LocalizedError, Sendable
         self.message = message
         self.hint = hint
         self.causeDescription = causeDescription
+        self.standardErrorCode = standardErrorCode
         self.targetReceipt = targetReceipt
         self.selectedLeafEvidence = outcome.dispatchState.mutationDispatched ? selectedLeafEvidence : nil
     }
@@ -860,6 +865,7 @@ public struct DesktopActionFailure: Codable, Equatable, LocalizedError, Sendable
             message: self.message,
             hint: self.hint,
             causeDescription: self.causeDescription,
+            standardErrorCode: self.standardErrorCode,
             targetReceipt: self.targetReceipt,
             selectedLeafEvidence: self.selectedLeafEvidence)
     }
@@ -872,6 +878,7 @@ public struct DesktopActionFailure: Codable, Equatable, LocalizedError, Sendable
             message: self.message,
             hint: self.hint,
             causeDescription: self.causeDescription,
+            standardErrorCode: self.standardErrorCode,
             targetReceipt: targetReceipt,
             selectedLeafEvidence: self.selectedLeafEvidence)
     }
@@ -888,6 +895,7 @@ public struct DesktopActionFailure: Codable, Equatable, LocalizedError, Sendable
             message: self.message,
             hint: self.hint,
             causeDescription: self.causeDescription,
+            standardErrorCode: self.standardErrorCode,
             targetReceipt: self.targetReceipt,
             selectedLeafEvidence: evidence)
     }
@@ -897,6 +905,7 @@ public struct DesktopActionFailure: Codable, Equatable, LocalizedError, Sendable
         case message
         case hint
         case causeDescription = "cause_description"
+        case standardErrorCode = "standard_error_code"
         case targetReceipt = "target_receipt"
         case selectedLeafEvidence = "selected_leaf_evidence"
     }
@@ -914,6 +923,7 @@ public struct DesktopActionFailure: Codable, Equatable, LocalizedError, Sendable
         self.message = try container.decode(String.self, forKey: .message)
         self.hint = try container.decodeIfPresent(String.self, forKey: .hint)
         self.causeDescription = try container.decodeIfPresent(String.self, forKey: .causeDescription)
+        self.standardErrorCode = try container.decodeIfPresent(StandardErrorCode.self, forKey: .standardErrorCode)
         self.targetReceipt = try container.decodeIfPresent(DesktopActionTargetReceipt.self, forKey: .targetReceipt)
         self.selectedLeafEvidence = try container.decodeIfPresent(
             [DesktopSelectedLeafEvidence].self,

--- a/Core/PeekabooFoundation/Sources/PeekabooFoundation/StandardizedErrors.swift
+++ b/Core/PeekabooFoundation/Sources/PeekabooFoundation/StandardizedErrors.swift
@@ -3,7 +3,7 @@ import Foundation
 // MARK: - Error Code Protocol
 
 /// Standard error codes used across Peekaboo
-public enum StandardErrorCode: String, Sendable, Equatable {
+public enum StandardErrorCode: String, Codable, Sendable, Equatable {
     // Permission errors
     case screenRecordingPermissionDenied = "PERMISSION_DENIED_SCREEN_RECORDING"
     case accessibilityPermissionDenied = "PERMISSION_DENIED_ACCESSIBILITY"

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -16,6 +16,9 @@ Peekaboo no longer hosts or manages external MCP servers; configure your MCP cli
 By default, the MCP process owns its lifecycle and keeps support services process-local. An explicit
 `--bridge-socket <path>` instead attaches MCP tools to that existing Bridge host and skips the embedded support daemon.
 In both modes, MCP never publishes `daemon.sock`, `bridge.sock`, or another Bridge listener itself.
+The explicit route also owns capture preflight for the server lifetime: Peekaboo reuses one authenticated client bound
+to that listener's process generation and does not consult unrelated global Bridge sockets. Caller-local MCP retains
+the broader legacy-owner scan because no external Bridge generation owns its capture path.
 
 Action-oriented UI tools include:
 
@@ -160,6 +163,12 @@ real owner before using the ID. Do not combine `window_id` with a window title o
 one window selector so stale inputs cannot redirect work to a sibling window from the same process. `window_id` is a
 positive 32-bit integer; strings, fractional numbers, zero, negative values, and out-of-range values fail before
 capture or Accessibility traversal begins.
+
+`see` also accepts the closed `capture_engine` values `auto` (default), `modern`, and `classic`. The choice is carried
+in that observation request to the selected host; incapable hosts refuse it before capture. `classic` never enters
+ScreenCaptureKit, so it is the safe request-local recovery path when the selected legacy host blocks auto/modern
+capture. A selected-host owner refusal remains fixed for the MCP process lifetime; update or relaunch that exact host
+and start a fresh MCP process before retrying auto/modern capture.
 
 Every successful MCP `see` response includes the selected raw or annotated screenshot as inline image content. When
 multiple calls intentionally share the same `path`, each response still returns pixels owned by its own capture; the

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -17,8 +17,10 @@ By default, the MCP process owns its lifecycle and keeps support services proces
 `--bridge-socket <path>` instead attaches MCP tools to that existing Bridge host and skips the embedded support daemon.
 In both modes, MCP never publishes `daemon.sock`, `bridge.sock`, or another Bridge listener itself.
 The explicit route also owns capture preflight for the server lifetime: Peekaboo reuses one authenticated client bound
-to that listener's process generation and does not consult unrelated global Bridge sockets. Caller-local MCP retains
-the broader legacy-owner scan because no external Bridge generation owns its capture path.
+to that listener's process generation and does not consult unrelated auxiliary Bridge sockets during caller routing.
+The selected host independently enforces the canonical ScreenCaptureKit lease: first acquisition still refuses live
+owner-unaware processes, while an exact generation that already holds the lease retains it across later process
+discovery. Caller-local MCP retains the broader legacy-owner scan because no external Bridge generation owns its path.
 
 Action-oriented UI tools include:
 

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -18,9 +18,10 @@ By default, the MCP process owns its lifecycle and keeps support services proces
 In both modes, MCP never publishes `daemon.sock`, `bridge.sock`, or another Bridge listener itself.
 The explicit route also owns capture preflight for the server lifetime: Peekaboo reuses one authenticated client bound
 to that listener's process generation and does not consult unrelated auxiliary Bridge sockets during caller routing.
-The selected host independently enforces the canonical ScreenCaptureKit lease: first acquisition still refuses live
-owner-unaware processes, while an exact generation that already holds the lease retains it across later process
-discovery. Caller-local MCP retains the broader legacy-owner scan because no external Bridge generation owns its path.
+Startup verifies that the selected host advertises process ownership. The host then enforces the canonical
+ScreenCaptureKit lease at every real SCK leaf by rescanning all same-user potential Peekaboo processes, including
+owner-unaware processes that started after acquisition. Caller-local MCP retains the broader legacy-socket scan because
+no external Bridge generation owns its capture path.
 
 Action-oriented UI tools include:
 

--- a/docs/commands/mcp.md
+++ b/docs/commands/mcp.md
@@ -25,10 +25,12 @@ read_when:
 - HTTP/SSE server transports are reserved but not implemented. Selecting either fails before daemon startup and emits a structured error in JSON mode.
 - The MCP process owns its stdio lifecycle and never hosts a Bridge listener. Support stays process-local by default;
   an explicit `--bridge-socket <path>` uses that existing Bridge host and skips the embedded daemon.
-- If an unrelated legacy Bridge is still a possible ScreenCaptureKit owner, startup and non-capturing tools remain
-  available through an explicitly selected current host, but pixel-producing calls fail before dispatch with the
-  exact owner diagnostic. That capture refusal is immutable for the connection; after fixing the owner, start a fresh
-  MCP process before retrying capture.
+- An explicit `--bridge-socket` binds capture preflight and every later request to that socket's authenticated process
+  generation. Unrelated Claude, OpenClaw, or other global Bridge sockets cannot poison the persistent session. If the
+  selected host itself predates safe ScreenCaptureKit ownership, auto/modern pixel calls fail before dispatch with its
+  exact owner diagnostic; `see` can use `capture_engine: "classic"` without entering ScreenCaptureKit. After updating
+  or relaunching the selected owner, start a fresh MCP process before retrying auto/modern capture. Caller-local MCP
+  keeps the broader process-owner scan because it has no external Bridge generation to own capture.
 - The native tool catalog includes bounded `capture` for live screen/window/region recording or video ingest. It writes retained frames, `contact.png`, `metadata.json`, and optional MP4 output, so use tool allow/deny filters when exposing MCP to untrusted clients.
 - UI automation tools include action-first additions: `set_value` directly mutates a settable accessibility value, and `action` invokes a named accessibility action on an element from `see`.
 - `verify_state` replaces fixed sleeps with bounded native polling. It resolves an app or PID to one exact window, evaluates 1–8 AND predicates for window existence/bounds or exact AX element existence/value/enabled/selected state every 100 ms, and reports `satisfied`, `unsatisfied`, or conservative `unknown` after at most 10 seconds. Explicit PIDs and app-name selectors are pinned to the first resolved PID/process-start generation for the whole invocation; relaunch, PID reuse, and selector drift are `unknown`. Exact-window ownership is rechecked on every sample and before an optional screenshot, whose capture metadata must confirm the same PID and window ID. A directly read value matching a unique exact AX identifier can satisfy an `element_value` predicate when unrelated AX siblings are unreadable; missing, mismatched, non-identifier, or ambiguous partial-tree evidence remains `unknown`. A WindowServer miss is corroborated with a complete app-scoped window inventory before Peekaboo reports absence, preserving minimized AX windows. Ownership ambiguity, partial enumeration, or identity changes are `unknown`. It never focuses or replays actions.
@@ -45,6 +47,9 @@ peekaboo mcp serve --transport stdio
 # Route MCP tools through an existing Bridge host
 peekaboo mcp serve --bridge-socket "$HOME/Library/Application Support/Peekaboo/bridge.sock"
 ```
+
+The `see` tool publishes a closed `capture_engine` choice: `auto` (default), `modern`, or `classic`. `classic` is the
+request-local no-ScreenCaptureKit recovery path and remains bound to the same selected Bridge host.
 
 An MCP client can wait for stable native state without interrupting the user:
 

--- a/docs/commands/mcp.md
+++ b/docs/commands/mcp.md
@@ -27,12 +27,12 @@ read_when:
   an explicit `--bridge-socket <path>` uses that existing Bridge host and skips the embedded daemon.
 - An explicit `--bridge-socket` binds caller-side capture preflight and every later request to that socket's
   authenticated process generation; unrelated auxiliary sockets cannot freeze the MCP session. The selected host still
-  enforces the canonical process-lifetime ScreenCaptureKit lease. Its first modern acquisition refuses any live
-  owner-unaware process, while an exact generation that already holds the lease keeps that authority across processes
-  discovered later. Modern refusal remains a signed `CAPTURE_FAILED` / `runtime_incompatible`, retry-safe,
-  not-dispatched result instead of being rewritten as a target-attribution error. `see` can use
-  `capture_engine: "classic"` without entering ScreenCaptureKit. Caller-local MCP keeps the broader startup scan because
-  it has no external Bridge generation to own capture.
+  must advertise process ownership, then enforces the canonical process-lifetime ScreenCaptureKit lease at every SCK
+  leaf by scanning all same-user potential Peekaboo processes. Reentry refuses owner-unaware processes discovered later.
+  Modern refusal remains a signed `CAPTURE_FAILED` / `runtime_incompatible`, retry-safe, not-dispatched result instead
+  of being rewritten as a target-attribution error. `see` can use `capture_engine: "classic"` without entering
+  ScreenCaptureKit. Caller-local MCP keeps the broader startup scan because it has no external Bridge generation to own
+  capture.
 - The native tool catalog includes bounded `capture` for live screen/window/region recording or video ingest. It writes retained frames, `contact.png`, `metadata.json`, and optional MP4 output, so use tool allow/deny filters when exposing MCP to untrusted clients.
 - UI automation tools include action-first additions: `set_value` directly mutates a settable accessibility value, and `action` invokes a named accessibility action on an element from `see`.
 - `verify_state` replaces fixed sleeps with bounded native polling. It resolves an app or PID to one exact window, evaluates 1–8 AND predicates for window existence/bounds or exact AX element existence/value/enabled/selected state every 100 ms, and reports `satisfied`, `unsatisfied`, or conservative `unknown` after at most 10 seconds. Explicit PIDs and app-name selectors are pinned to the first resolved PID/process-start generation for the whole invocation; relaunch, PID reuse, and selector drift are `unknown`. Exact-window ownership is rechecked on every sample and before an optional screenshot, whose capture metadata must confirm the same PID and window ID. A directly read value matching a unique exact AX identifier can satisfy an `element_value` predicate when unrelated AX siblings are unreadable; missing, mismatched, non-identifier, or ambiguous partial-tree evidence remains `unknown`. A WindowServer miss is corroborated with a complete app-scoped window inventory before Peekaboo reports absence, preserving minimized AX windows. Ownership ambiguity, partial enumeration, or identity changes are `unknown`. It never focuses or replays actions.

--- a/docs/commands/mcp.md
+++ b/docs/commands/mcp.md
@@ -25,12 +25,14 @@ read_when:
 - HTTP/SSE server transports are reserved but not implemented. Selecting either fails before daemon startup and emits a structured error in JSON mode.
 - The MCP process owns its stdio lifecycle and never hosts a Bridge listener. Support stays process-local by default;
   an explicit `--bridge-socket <path>` uses that existing Bridge host and skips the embedded daemon.
-- An explicit `--bridge-socket` binds capture preflight and every later request to that socket's authenticated process
-  generation. Unrelated Claude, OpenClaw, or other global Bridge sockets cannot poison the persistent session. If the
-  selected host itself predates safe ScreenCaptureKit ownership, auto/modern pixel calls fail before dispatch with its
-  exact owner diagnostic; `see` can use `capture_engine: "classic"` without entering ScreenCaptureKit. After updating
-  or relaunching the selected owner, start a fresh MCP process before retrying auto/modern capture. Caller-local MCP
-  keeps the broader process-owner scan because it has no external Bridge generation to own capture.
+- An explicit `--bridge-socket` binds caller-side capture preflight and every later request to that socket's
+  authenticated process generation; unrelated auxiliary sockets cannot freeze the MCP session. The selected host still
+  enforces the canonical process-lifetime ScreenCaptureKit lease. Its first modern acquisition refuses any live
+  owner-unaware process, while an exact generation that already holds the lease keeps that authority across processes
+  discovered later. Modern refusal remains a signed `CAPTURE_FAILED` / `runtime_incompatible`, retry-safe,
+  not-dispatched result instead of being rewritten as a target-attribution error. `see` can use
+  `capture_engine: "classic"` without entering ScreenCaptureKit. Caller-local MCP keeps the broader startup scan because
+  it has no external Bridge generation to own capture.
 - The native tool catalog includes bounded `capture` for live screen/window/region recording or video ingest. It writes retained frames, `contact.png`, `metadata.json`, and optional MP4 output, so use tool allow/deny filters when exposing MCP to untrusted clients.
 - UI automation tools include action-first additions: `set_value` directly mutates a settable accessibility value, and `action` invokes a named accessibility action on an element from `see`.
 - `verify_state` replaces fixed sleeps with bounded native polling. It resolves an app or PID to one exact window, evaluates 1–8 AND predicates for window existence/bounds or exact AX element existence/value/enabled/selected state every 100 ms, and reports `satisfied`, `unsatisfied`, or conservative `unknown` after at most 10 seconds. Explicit PIDs and app-name selectors are pinned to the first resolved PID/process-start generation for the whole invocation; relaunch, PID reuse, and selector drift are `unknown`. Exact-window ownership is rechecked on every sample and before an optional screenshot, whose capture metadata must confirm the same PID and window ID. A directly read value matching a unique exact AX identifier can satisfy an `element_value` predicate when unrelated AX siblings are unreadable; missing, mismatched, non-identifier, or ambiguous partial-tree evidence remains `unknown`. A WindowServer miss is corroborated with a complete app-scoped window inventory before Peekaboo reports absence, preserving minimized AX windows. Ownership ambiguity, partial enumeration, or identity changes are `unknown`. It never focuses or replays actions.

--- a/docs/engine.md
+++ b/docs/engine.md
@@ -39,9 +39,8 @@ macOS can strand a second process's ScreenCaptureKit screenshot request after an
 when no capture is in flight. Peekaboo therefore gives the first process that explicitly preclaims caller-local modern
 capture or enters a real SCK API a per-user, process-lifetime owner lease. Later remote `modern` requests prefer the
 compatible Bridge host whose PID, process generation, and signed build match that lease.
-First acquisition always scans and refuses owner-unaware live processes. Once an exact process generation holds the
-canonical lease, reentrant SCK leaves validate and return that same held receipt before scanning processes that started
-later; a late legacy process cannot retroactively displace already-proven ownership.
+Every claim scans and refuses owner-unaware live processes, including processes discovered after the current generation
+acquired the canonical lease.
 
 Every transported engine requires the additive `screenCaptureKitProcessOwnership` host capability. For `auto` and
 `modern`, it proves the host enforces the owner lease; for `classic`, it proves a false CoreGraphics permission preflight

--- a/docs/engine.md
+++ b/docs/engine.md
@@ -39,6 +39,9 @@ macOS can strand a second process's ScreenCaptureKit screenshot request after an
 when no capture is in flight. Peekaboo therefore gives the first process that explicitly preclaims caller-local modern
 capture or enters a real SCK API a per-user, process-lifetime owner lease. Later remote `modern` requests prefer the
 compatible Bridge host whose PID, process generation, and signed build match that lease.
+First acquisition always scans and refuses owner-unaware live processes. Once an exact process generation holds the
+canonical lease, reentrant SCK leaves validate and return that same held receipt before scanning processes that started
+later; a late legacy process cannot retroactively displace already-proven ownership.
 
 Every transported engine requires the additive `screenCaptureKitProcessOwnership` host capability. For `auto` and
 `modern`, it proves the host enforces the owner lease; for `classic`, it proves a false CoreGraphics permission preflight


### PR DESCRIPTION
## Summary

Bind persistent MCP/Agent capture preflight to the explicitly selected Bridge socket and its authenticated listener generation.

The persistent runtime previously expanded its ScreenCaptureKit safety scan to unrelated auxiliary Bridge sockets even when `--bridge-socket` selected one exact host. A stale auxiliary owner could therefore install an immutable capture refusal before the healthy selected handshake was used, making every later pixel-producing MCP call fail against an owner unrelated to the configured route.

This change keeps broad owner discovery for one-shot commands, Verify, and implicit/caller-local runtimes. An explicit persistent route instead reuses the selected host's authenticated handshake and client, revalidates its listener generation, and rescans late legacy processes before capture. Fail-closed capture refusals retain their signed no-dispatch receipt and are no longer misattributed to an observation target.

MCP/Agent `see` also exposes a closed request-local `capture_engine` enum:

- `auto` (default)
- `modern` (ScreenCaptureKit)
- `classic` (no ScreenCaptureKit)

`classic` bypasses only the ScreenCaptureKit-owner preflight. Schema, selected-host capability, authenticated transport, target, permission, observation, and receipt validation still apply.

## Proof

- `pnpm run test:safe`: passed at exact head `5aefb741a`.
- Focused CLI owner-runtime suite: 36/36 passed.
- Focused Core MCP context/catalog suite: 16/16 passed.
- `pnpm run format`, `pnpm run lint`, `pnpm run lint:docs`, and `git diff --check`: passed with no serious findings.
- Whole-branch P2 Autoreview: no accepted/actionable findings.

The exact source produced a timestamped Developer ID CLI:

- source commit: `5aefb741a`
- executable SHA-256: `95d3fcc361aabeb7a1732d97fdb9b5517b1a48ef08972d10fafc26ddf6add27d`
- CDHash: `99f46a409d006a32c732a4ee2b5541698d673b67`

### Persistent default replay

One signed MCP process, one initialize request, and 15 sequential background-only `see` calls through the selected current-source Bridge:

| App | Passed | Median wall time |
| --- | ---: | ---: |
| System Settings | 3/3 | 553.343 ms |
| Safari | 3/3 | 643.450 ms |
| TextEdit | 3/3 | 427.115 ms |
| Calendar | 3/3 | 579.210 ms |
| Calculator | 3/3 | 429.558 ms |

Result: 15/15 successful, 15 inline images, 15 requested screenshots observed and immediately deleted, zero retained screenshots, zero stderr bytes, server exit 0, and 15/15 listener-authenticated `desktopObservation` receipts valid.

### Explicit classic replay

The same persistent 15-call matrix with `capture_engine: "classic"`:

| App | Passed | Median wall time |
| --- | ---: | ---: |
| System Settings | 3/3 | 530.908 ms |
| Safari | 3/3 | 633.250 ms |
| TextEdit | 3/3 | 395.147 ms |
| Calendar | 3/3 | 442.279 ms |
| Calculator | 3/3 | 398.526 ms |

Result: 15/15 successful, zero retained screenshots, zero stderr bytes, server exit 0, and 15/15 listener-authenticated receipts valid.

### Explicit modern refusal

With a distinct live ScreenCaptureKit owner, the same signed runtime returns the expected pre-dispatch `CAPTURE_FAILED` / `runtime_incompatible` refusal: dispatch `none`, retry safe, no screenshot, server exit 0, and a valid signed targetless receipt with no attribution failure.

All replays were read-only and background-only. They did not activate apps, dispatch input, move the cursor, use AppleScript/JXA, or use virtualization.
