### PR TITLE
fix(bridge): preserve precise read-only failures

### DIFF
--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer+OperationReceipts.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer+OperationReceipts.swift
@@ -193,6 +193,8 @@ extension PeekabooBridgeServer {
                 await self.terminalResponse(for: plan, peer: peer)
             }
         }
+        // This is the single enrichment boundary for attested read-only errors. Existing precise
+        // envelopes pass through unchanged; only metadata-less targetless failures are normalized.
         return Self.normalizingTargetlessReadOnlyFailure(handled, plan: plan)
     }
 
@@ -362,10 +364,12 @@ extension PeekabooBridgeServer {
         do {
             return try await self.route(plan, peer: peer)
         } catch let envelope as PeekabooBridgeErrorEnvelope {
-            let envelope = Self.targetlessReadOnlyFailureEnvelope(envelope, plan: plan)
+            let responseEnvelope = PeekabooBridgeRequestContext.usesAttestedOperationResultSemantics
+                ? envelope
+                : envelope.legacyCompatible
             return .init(
-                response: .error(envelope.legacyCompatible),
-                selectedLeafEvidence: envelope.actionSelectedLeafEvidence)
+                response: .error(responseEnvelope),
+                selectedLeafEvidence: responseEnvelope.actionSelectedLeafEvidence)
         } catch let failure as DesktopActionFailure
             where PeekabooBridgeRequestContext.usesAttestedOperationResultSemantics
         {
@@ -377,16 +381,12 @@ extension PeekabooBridgeServer {
                     details: "\(failure)")),
                 selectedLeafEvidence: routed.selectedLeafEvidence)
         } catch is CancellationError {
-            let envelope = Self.targetlessReadOnlyFailureEnvelope(
-                .init(code: .timeout, message: "Bridge request was cancelled"),
-                plan: plan)
-            return .init(response: .error(envelope))
+            return .init(response: .error(.init(code: .timeout, message: "Bridge request was cancelled")))
         } catch {
-            let envelope = Self.targetlessReadOnlyFailureEnvelope(.init(
+            return .init(response: .error(.init(
                 code: .internalError,
                 message: error.localizedDescription,
-                details: "\(error)"), plan: plan)
-            return .init(response: .error(envelope))
+                details: "\(error)")))
         }
     }
 

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeDesktopObservationResultTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeDesktopObservationResultTests.swift
@@ -291,6 +291,63 @@ struct PeekabooBridgeDesktopObservationResultTests {
         await host.stop()
     }
 
+    @Test
+    func `signed read-only precise failure keeps its reason hint and cause`() async throws {
+        let expected = DesktopActionFailure.preDispatchRefusal(
+            route: .bridge,
+            reason: .permissionDenied,
+            message: "Fixture precise read-only refusal",
+            hint: "Retain this exact recovery hint.",
+            causeDescription: "Fixture precise cause")
+        let provider = PreciseFailingObservationProvider(envelope: .init(
+            code: .permissionDenied,
+            actionFailure: expected,
+            details: "Fixture envelope details"))
+        let root = URL(fileURLWithPath: "/tmp/pb-ob-precise-error-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let socketPath = root.appendingPathComponent("bridge.sock").path
+        let host = PeekabooBridgeHost(
+            socketPath: socketPath,
+            server: Self.server(provider: provider),
+            allowedTeamIDs: [],
+            requestTimeoutSec: 2)
+        try await host.startChecked()
+        defer { Task { await host.stop() } }
+
+        let client = TrustedBridgeClientFixture.make(socketPath: socketPath, requestTimeoutSec: 2)
+        _ = try await client.handshake(client: Self.clientIdentity)
+
+        do {
+            _ = try await client.desktopObservationWithOutcome(Self.readOnlyRequest)
+            Issue.record("Expected the precise read-only refusal")
+        } catch let failure as DesktopActionFailure {
+            #expect(failure.outcome == expected.outcome)
+            #expect(failure.message == expected.message)
+            #expect(failure.hint == expected.hint)
+            #expect(failure.causeDescription == expected.causeDescription)
+            #expect(failure.targetReceipt == nil)
+        }
+
+        let bundle = try #require(await client.lastOperationReceiptBundle())
+        try bundle.validate()
+        #expect(bundle.receipt.payload.target == nil)
+        #expect(bundle.receipt.payload.targetAttributionFailure == nil)
+        #expect(bundle.receipt.payload.outcome == expected.outcome.projection)
+        let response = try JSONDecoder.peekabooBridgeDecoder().decode(
+            PeekabooBridgeResponse.self,
+            from: bundle.canonicalResponse)
+        guard case let .error(envelope) = response else {
+            Issue.record("Expected the precise error response")
+            return
+        }
+        #expect(envelope.actionOutcome == expected.outcome.projection)
+        #expect(envelope.actionFailureHint == expected.hint)
+        #expect(envelope.actionFailureCauseDescription == expected.causeDescription)
+        #expect(envelope.details == "Fixture envelope details")
+        #expect(provider.actionResultCount == 1)
+        await host.stop()
+    }
+
     private static let delivery = DesktopActionOutcome.Delivery(
         mechanism: .capturePipeline,
         mode: .background)
@@ -483,5 +540,26 @@ private final class FailingObservationProvider: DesktopObservationActionResultPr
     {
         self.actionResultCount += 1
         throw OperationError.captureFailed(reason: "fixture modern owner refusal")
+    }
+}
+
+@MainActor
+private final class PreciseFailingObservationProvider: DesktopObservationActionResultProviding {
+    private let envelope: PeekabooBridgeErrorEnvelope
+    private(set) var actionResultCount = 0
+
+    init(envelope: PeekabooBridgeErrorEnvelope) {
+        self.envelope = envelope
+    }
+
+    func observe(_: DesktopObservationRequest) async throws -> DesktopObservationResult {
+        throw self.envelope
+    }
+
+    func observeActionResult(
+        _: DesktopObservationRequest) async throws -> UIAutomationActionResult<DesktopObservationResult>
+    {
+        self.actionResultCount += 1
+        throw self.envelope
     }
 }


### PR DESCRIPTION
## Summary

Fix forward from #592 so an attested read-only Bridge error that already carries a precise `DesktopActionFailure` keeps its exact outcome, hint, cause, details, and selected-leaf evidence.

The merged path normalized the envelope before passing it through `legacyCompatible`, which stripped those canonical fields. The outer attested-response boundary then reconstructed a generic refusal from the Bridge error code alone. Capture-owner failures still produced the intended `CAPTURE_FAILED`, but a sibling precise failure such as `permissionDenied` could be remapped and lose its recovery hint.

This change makes `executeAttestedOperation` the single read-only enrichment boundary:

- already-precise attested envelopes pass through unchanged;
- metadata-less targetless errors are normalized once after routing;
- legacy callers still receive `legacyCompatible` projection;
- cancellation and unexpected errors still reach the same final normalization step.

## Proof

- `swift test --package-path Core/PeekabooCore --filter 'PeekabooBridgeDesktopObservationResultTests|PeekabooBridgeOperationReceiptTests' --no-parallel`: 41/41 passed.
- The existing signed capture regression still proves targetless `CAPTURE_FAILED` / `runtime_incompatible` preservation.
- A new listener-signed sibling regression proves exact `permissionDenied` reason, hint, cause, details, targetless outcome, and client-visible failure survive together.
- `pnpm run format`: zero files changed.
- `pnpm run lint:docs`: passed.
- `pnpm run lint`: passed with zero serious findings (96 inherited warnings).
- `git diff --check`: passed.
- Final structured P2 review: clean, no accepted/actionable finding.

No changelog entry: this is a narrow correctness fix for the just-landed unreleased failure-normalization path, whose user-visible capture behavior is already covered by the #592 changelog entry.
