### PR TITLE
fix(cli): hide foreground-only tools from background catalogs

### DIFF
--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Skip provider discovery and Agent construction for caller-local commands that cannot invoke the Agent, reducing cold startup while preserving full Agent and MCP initialization.
 
 ### Fixed
+- Hide shared-pointer-only tools from background MCP and Agent catalogs, and keep CLI follow-up guidance explicit about foreground consent.
 - Let exact-window background mutations ignore unrelated incomplete application rows while still refusing ambiguous, incomplete, stale, or mismatched selected owners.
 - Give unknown commands a current-help recovery hint and remove source-checkout rebuild advice from installed help.
 - Return explicitly application-scoped, observation-only AX semantics for tree-only reads of exact pixel-only windows while withholding snapshot and mutation authority.

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Core/LearnCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Core/LearnCommand.swift
@@ -9,6 +9,9 @@ typealias PeekabooToolParameter = ParameterDefinition
 
 @MainActor
 struct LearnCommand {
+    static let foregroundDragExample =
+        "peekaboo drag --from <id|x,y> --to <id|x,y> --foreground"
+
     @RuntimeStorage private var runtime: CommandRuntime?
 
     private var resolvedRuntime: CommandRuntime {
@@ -57,8 +60,8 @@ struct LearnCommand {
         - Exact targeted `dialog input` defaults to background AXValue; targetless/global input, file actions, and
           forced dismiss require explicit foreground consent.
         - Use `verify` instead of fixed sleeps to wait for stable window and element predicates.
-        - Invoke accessibility actions with `action`; drag from elements or coordinates with
-          `drag --from <id|x,y> --to <id|x,y>`.
+        - Invoke accessibility actions with `action`. Drag changes the shared physical cursor and requires explicit
+          foreground consent: `\(Self.foregroundDragExample)`.
         - Management commands are subcommand trees: `clipboard get|set|clear|save|restore`,
           `menubar list|click`, `agent run|resume|sessions|chat`, `config provider ...`, and
           `permissions request <kind>`.
@@ -162,7 +165,8 @@ struct LearnCommand {
         print("""
         ## MCP / Agent Tool Quick Reference
         - **Vision**: see, image
-        - **UI Automation**: click, type, press, scroll, drag
+        - **UI Automation**: click, type, press, scroll
+        - **Foreground-only CLI pointer**: move and drag require explicit `--foreground` consent
         - **Window Management**: window, space
         - **Applications**: app
         - **Elements**: inspect_ui, verify_state, set_value, action

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/AppCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/AppCommand.swift
@@ -11,8 +11,10 @@ struct AppCommand: ParsableCommand {
         abstract: "Control applications - launch, quit, relaunch, hide/unhide, switch, focus, and list apps",
         discussion: """
         EXAMPLES:
-          # Launch an application
+          # Verify an already-running application without dispatching a launch
           peekaboo app launch "Visual Studio Code"
+
+          # Launch or open an application with explicit foreground consent
           peekaboo app launch --bundle-id com.microsoft.VSCode --wait-ready --foreground
           peekaboo app launch "Safari" --open https://example.com --open ~/Desktop/notes.txt --foreground
           peekaboo app launch "Safari" --foreground

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/MenuBarCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/MenuBarCommand.swift
@@ -90,7 +90,10 @@ InjectedRuntimeBackedCommand {
             } else {
                 MenuBarItemListOutput.display(menuBarItems)
                 if !menuBarItems.isEmpty {
-                    print("\n💡 Tip: Use 'peekaboo menubar click --index <index>' or click by name")
+                    print(
+                        "\n💡 Tip: Use 'peekaboo menubar click --index <index> --foreground' " +
+                            "or 'peekaboo menubar click \"<name>\" --foreground'"
+                    )
                 }
             }
         } catch {

--- a/Apps/CLI/Tests/CLIAutomationTests/MenuBarCommandConsentTests.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/MenuBarCommandConsentTests.swift
@@ -115,6 +115,23 @@ struct MenuBarCommandConsentTests {
 
     @Test
     @MainActor
+    func `human list follow-up includes foreground consent for both selectors`() async throws {
+        let menu = RecordingMenuBarService(items: [Self.item])
+        let result = try await InProcessCommandRunner.run(
+            ["menubar", "list"],
+            services: TestServicesFactory.makePeekabooServices(menu: menu)
+        )
+
+        #expect(result.exitStatus == 0)
+        #expect(result.stdout.contains("peekaboo menubar click --index <index> --foreground"))
+        #expect(result.stdout.contains("peekaboo menubar click \"<name>\" --foreground"))
+        #expect(menu.listCallCount == 1)
+        #expect(menu.namedClickCalls.isEmpty)
+        #expect(menu.indexClickCalls.isEmpty)
+    }
+
+    @Test
+    @MainActor
     func `foreground named click preserves name-based dispatch`() async throws {
         let menu = RecordingMenuBarService(items: [Self.item])
         let result = try await InProcessCommandRunner.run(

--- a/Apps/CLI/Tests/CoreCLITests/CommandHelpRendererTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/CommandHelpRendererTests.swift
@@ -31,6 +31,22 @@ struct CommandHelpRendererTests {
     }
 
     @Test
+    func `root app help distinguishes a background readiness probe from foreground launch`() {
+        let help = AppCommand.helpMessage()
+
+        #expect(help.contains("Verify an already-running application without dispatching a launch"))
+        #expect(help.contains("Launch or open an application with explicit foreground consent"))
+    }
+
+    @Test
+    func `learn drag guidance carries explicit foreground consent`() {
+        #expect(
+            LearnCommand.foregroundDragExample ==
+                "peekaboo drag --from <id|x,y> --to <id|x,y> --foreground"
+        )
+    }
+
+    @Test
     func `V4 generated help uses canonical commands and explicit duration units`() {
         let help = [
             AppCommand.helpMessage(),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Read credentials for `config credential set` and `config provider add` from piped stdin, owner-only files, or no-echo prompts by default; keep argv input as a documented deprecated compatibility path.
 
 ### Fixed
+- Hide shared-pointer-only tools from background MCP and Agent catalogs, and keep CLI follow-up guidance explicit about foreground consent.
 - Restore terminal echo around credential-prompt job-control stops and common termination signals, then re-disable echo only after a stopped prompt continues.
 - Let exact-window background mutations ignore unrelated incomplete application rows while still refusing ambiguous, incomplete, stale, or mismatched selected owners.
 - Give unknown CLI commands a current-help recovery hint and remove source-checkout rebuild advice from installed help.

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/Agent/PeekabooAgentService+Toolset.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/Agent/PeekabooAgentService+Toolset.swift
@@ -40,12 +40,7 @@ extension PeekabooAgentService {
                 self.createAgentTools()
             }
         }
-        let authorityFiltered: [AgentTool] = switch executionPolicy {
-        case .unrestricted:
-            tools
-        case .backgroundOnly, .foregroundAllowed:
-            tools.filter { $0.name != "shell" }
-        }
+        let authorityFiltered = tools.filter { executionPolicy.exposesToolInCatalog(named: $0.name) }
 
         let filters = ToolFiltering.currentFilters()
         return ToolFiltering.applyInputStrategyAvailability(

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/MCPToolExecutionPolicy.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/MCPToolExecutionPolicy.swift
@@ -16,6 +16,21 @@ public enum MCPToolExecutionPolicy: String, Codable, Sendable {
 
     static let refusalErrorCode = "AGENT_EXECUTION_POLICY_REFUSAL"
 
+    private static let nonUnrestrictedCatalogExclusions: Set<String> = ["shell"]
+    private static let backgroundOnlyCatalogExclusions: Set<String> = ["drag", "move"]
+
+    func exposesToolInCatalog(named toolName: String) -> Bool {
+        switch self {
+        case .unrestricted:
+            true
+        case .foregroundAllowed:
+            !Self.nonUnrestrictedCatalogExclusions.contains(toolName)
+        case .backgroundOnly:
+            !Self.nonUnrestrictedCatalogExclusions.contains(toolName) &&
+                !Self.backgroundOnlyCatalogExclusions.contains(toolName)
+        }
+    }
+
     func rejection(toolName: String, arguments: ToolArguments) -> ToolResponse? {
         let refusal: (message: String, reason: DesktopActionOutcome.RefusalReason)? = switch self {
         case .unrestricted:

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Server/MCPToolCatalog.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Server/MCPToolCatalog.swift
@@ -10,8 +10,15 @@ public enum MCPToolCatalog {
         filters: ToolFilters = ToolFiltering.currentFilters(),
         log: ((String) -> Void)? = nil) -> [any MCPTool]
     {
+        let authorityFilteredTools = self.unfilteredTools(context: context).filter { tool in
+            let isExposed = context.executionPolicy.exposesToolInCatalog(named: tool.name)
+            if !isExposed {
+                log?("Tool '\(tool.name)' not exposed under \(context.executionPolicy.rawValue) authority.")
+            }
+            return isExposed
+        }
         let filteredTools = ToolFiltering.apply(
-            self.unfilteredTools(context: context),
+            authorityFilteredTools,
             filters: filters,
             log: log)
 

--- a/Core/PeekabooCore/Tests/PeekabooAgentRuntimeTests/ToolRegistryContractTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooAgentRuntimeTests/ToolRegistryContractTests.swift
@@ -24,19 +24,22 @@ struct ToolRegistryContractTests {
             "scroll",
             "press",
             "action",
-            "drag",
-            "move",
             "app",
             "window",
         ]))
-        #expect(!names.contains("shell"))
-        #expect(names.isDisjoint(with: ["hotkey", "launch_app", "list"]))
+        #expect(names.isDisjoint(with: ["drag", "move", "shell", "hotkey", "launch_app", "list"]))
 
         let agent = try PeekabooAgentService(services: services)
         let sessionNames = await Set(agent.buildToolset(for: .anthropic(.sonnet45)).map(\.name))
         let publicFactoryNames = Set(agent.publicAgentTools().map(\.name))
         #expect(names == sessionNames)
         #expect(names == publicFactoryNames)
+
+        let foregroundNames = await Set(agent.buildToolset(
+            for: .anthropic(.sonnet45),
+            executionPolicy: .foregroundAllowed).map(\.name))
+        #expect(foregroundNames.isSuperset(of: ["drag", "move"]))
+        #expect(!foregroundNames.contains("shell"))
     }
 
     @Test

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPToolRegistryTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPToolRegistryTests.swift
@@ -183,7 +183,7 @@ struct MCPToolRegistryIntegrationTests {
             filters: noToolFilters)
         let names = Set(tools.map(\.name))
 
-        #expect(tools.count == 26)
+        #expect(tools.count == 24)
         #expect(names.contains("clipboard"))
         #expect(names.contains("paste"))
         #expect(names.contains("set_value"))
@@ -195,6 +195,14 @@ struct MCPToolRegistryIntegrationTests {
         #expect(names.contains("verify_state"))
         #expect(names.contains("capture"))
         #expect(!names.contains("shell"))
+        #expect(names.isDisjoint(with: ["drag", "move"]))
+
+        let foregroundContext = MCPToolContext(services: services, executionPolicy: .foregroundAllowed)
+        let foregroundNames = Set(MCPToolCatalog.tools(
+            context: foregroundContext,
+            inputPolicy: services.configuration.getUIInputPolicy(),
+            filters: noToolFilters).map(\.name))
+        #expect(foregroundNames.isSuperset(of: ["drag", "move"]))
     }
 
     @Test
@@ -209,7 +217,7 @@ struct MCPToolRegistryIntegrationTests {
             filters: noToolFilters))
 
         let tools = registry.allTools()
-        #expect(tools.count == 26)
+        #expect(tools.count == 24)
 
         // Verify some key tools are present
         let imageToolExists = registry.tool(named: "image") != nil

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/PeekabooMCPServerTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/PeekabooMCPServerTests.swift
@@ -18,7 +18,7 @@ struct PeekabooMCPServerTests {
         let server = try await makeServer()
         let names = await server.registeredToolNamesForTesting()
 
-        #expect(names.count == 26)
+        #expect(names.count == 24)
         #expect(names == names.sorted())
         #expect(names.contains("capture"))
         #expect(names.contains("image"))
@@ -30,6 +30,7 @@ struct PeekabooMCPServerTests {
         #expect(names.contains("set_value"))
         #expect(names.contains("action"))
         #expect(names.contains("press"))
+        #expect(Set(names).isDisjoint(with: ["drag", "move"]))
         #expect(!names.contains("hotkey"))
         #expect(!names.contains("swipe"))
     }
@@ -498,7 +499,7 @@ struct PeekabooMCPServerTests {
 
         do {
             let (tools, _) = try await session.client.listTools()
-            #expect(tools.count == 26)
+            #expect(tools.count == 24)
 
             for (index, tool) in tools.sorted(by: { $0.name < $1.name }).enumerated() {
                 guard case let .object(schema) = tool.inputSchema else {

--- a/docs/commands/tools.md
+++ b/docs/commands/tools.md
@@ -7,7 +7,7 @@ read_when:
 
 # `peekaboo tools`
 
-`peekaboo tools` prints the background-only MCP tool catalog that `peekaboo mcp` exposes (Image, See, Click, Press, Action, Window, Browser, Inspect UI, etc.). `peekaboo tools describe <name>` prints one tool's policy-aware JSON input schema for token-cheap, on-demand discovery. Guaranteed-refused foreground shapes are omitted from background-only schemas and their descriptions explain the required human-authorized foreground Agent or standalone CLI route. The public Agent catalog is a separate Shell-free surface; run `peekaboo learn` for that exact guide. The CLI keeps `browser` as a dedicated wrapper and exposes AX-only inspection through `peekaboo see --tree --no-screenshot`; run `peekaboo --help` for the full CLI command list.
+`peekaboo tools` prints the background-only MCP tool catalog that `peekaboo mcp` exposes (Image, See, Click, Press, Action, Window, Browser, Inspect UI, etc.). `peekaboo tools describe <name>` prints one tool's policy-aware JSON input schema for token-cheap, on-demand discovery. Tools with no background-safe form, such as `move` and `drag`, are omitted. Mixed-capability tools retain their background-safe actions and describe which foreground shapes require a human-authorized foreground Agent or standalone CLI route. The public Agent catalog is a separate Shell-free surface; run `peekaboo learn` for that exact guide. The CLI keeps `browser` as a dedicated wrapper and exposes AX-only inspection through `peekaboo see --tree --no-screenshot`; run `peekaboo --help` for the full CLI command list.
 
 ## Key options
 | Flag | Description |

--- a/tests/background-capability-guidance.test.mjs
+++ b/tests/background-capability-guidance.test.mjs
@@ -139,6 +139,8 @@ test('generated guidance sources retain CLI and policy distinctions', () => {
 
   assert.match(learn, /fresh exact non-dialog snapshot form/);
   assert.match(learn, /dialog input.*background AXValue/);
+  assert.match(learn, /Foreground-only CLI pointer.*move and drag require explicit `--foreground` consent/);
+  assert.doesNotMatch(learn, /\*\*UI Automation\*\*:.*\bdrag\b/);
   assert.doesNotMatch(learn, /\*\*System\*\*:\s*shell/);
   assert.doesNotMatch(learn, /type --app/);
   assert.doesNotMatch(toolRegistry, /peekaboo type .*--app/);


### PR DESCRIPTION
## Summary

- omit shared-pointer-only `move` and `drag` from background-only MCP and Agent catalogs while retaining them for foreground-authorized sessions
- keep the existing Shell restriction and pre-dispatch refusal checks as defense in depth
- make menubar follow-up tips, app launch/probe help, Learn guidance, command docs, and changelogs explicit about foreground consent

## Tests

- `swift test --package-path Core/PeekabooCore --filter 'ToolRegistryContractTests|MCPToolRegistryIntegrationTests' --no-parallel`
- exact MCP server catalog and closed-schema tests
- `PEEKABOO_INCLUDE_AUTOMATION_TESTS=true swift test --package-path Apps/CLI --filter 'MenuBarCommandConsentTests|CommandHelpRendererTests|ToolsCommandTests|ToolsCommandStructureTests' --no-parallel`
- `pnpm run test:guidance`
- `pnpm run lint:docs`
- `pnpm run format`
- `pnpm run lint`
- whole-branch P2 autoreview
