### PR TITLE
fix(capture): bound exclusive SCK flock wait

### DIFF
--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Skip provider discovery and Agent construction for caller-local commands that cannot invoke the Agent.
 
 ### Fixed
+- Bound modern capture transaction-lock waits inside the Bridge request envelope so a wedged peer fails clearly instead of hanging indefinitely. Thanks @SebTardif for #599.
 - Send Gemini API keys in request headers, require HTTPS OAuth endpoints, and redact OAuth state. Thanks Vincent Koc for #575 and Tachikoma #73.
 - Enforce a race-safe 10 MiB limit for clipboard and paste file payloads. Thanks @SebTardif for #561.
 - Prevent configured editors from injecting command-line options. Thanks @SebTardif for #562.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Skip provider discovery and Agent construction for caller-local commands that cannot invoke the Agent.
 
 ### Fixed
+- Bound exclusive ScreenCaptureKit transaction-lock waits inside the Bridge request envelope so a wedged peer fails clearly instead of hanging capture indefinitely. Thanks @SebTardif for #599.
 - Send Gemini API keys in request headers, require HTTPS OAuth endpoints, and redact OAuth state. Thanks Vincent Koc for #575 and Tachikoma #73.
 - Enforce a 10 MiB clipboard and paste file payload limit on the opened descriptor to prevent file-replacement races. Thanks @SebTardif for #561.
 - Prevent configured editors from injecting command-line options. Thanks @SebTardif for #562.

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/ScreenCaptureKitCaptureGate.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/ScreenCaptureKitCaptureGate.swift
@@ -5,6 +5,8 @@ import PeekabooFoundation
 @preconcurrency import ScreenCaptureKit
 
 enum ScreenCaptureKitCaptureGate {
+    static let defaultExclusiveWaitNanoseconds: UInt64 = 8_000_000_000
+
     @TaskLocal private static var isInsideCaptureOperation = false
     @TaskLocal static var processOwnerClaimOverride:
         (@MainActor @Sendable () throws -> ScreenCaptureKitOwnerLease.OwnerReceipt)?
@@ -63,7 +65,7 @@ enum ScreenCaptureKitCaptureGate {
     @MainActor
     static func withExclusiveCaptureOperation<T: Sendable>(
         operationName: String,
-        exclusiveWaitNanoseconds: UInt64 = 15_000_000_000,
+        exclusiveWaitNanoseconds: UInt64 = Self.defaultExclusiveWaitNanoseconds,
         _ operation: @escaping @MainActor @Sendable () async throws -> T) async throws -> T
     {
         guard !self.isInsideCaptureOperation else {

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/ScreenCaptureKitCaptureGate.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/ScreenCaptureKitCaptureGate.swift
@@ -62,7 +62,8 @@ enum ScreenCaptureKitCaptureGate {
 
     @MainActor
     static func withExclusiveCaptureOperation<T: Sendable>(
-        operationName _: String,
+        operationName: String,
+        exclusiveWaitNanoseconds: UInt64 = 15_000_000_000,
         _ operation: @escaping @MainActor @Sendable () async throws -> T) async throws -> T
     {
         guard !self.isInsideCaptureOperation else {
@@ -79,12 +80,18 @@ enum ScreenCaptureKitCaptureGate {
         }
         defer { close(fd) }
 
+        let deadline = DispatchTime.now().uptimeNanoseconds + exclusiveWaitNanoseconds
         while flock(fd, LOCK_EX | LOCK_NB) != 0 {
             guard errno == EWOULDBLOCK || errno == EAGAIN || errno == EINTR else {
                 return try await operation()
             }
 
             try Task.checkCancellation()
+            if DispatchTime.now().uptimeNanoseconds >= deadline {
+                throw OperationError.captureFailed(
+                    reason: "Timed out waiting for the exclusive ScreenCaptureKit " +
+                        "operation lock before \(operationName).")
+            }
             try await Task.sleep(nanoseconds: 10_000_000)
         }
         defer { flock(fd, LOCK_UN) }

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ScreenCaptureKitExclusiveLockDeadlineTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ScreenCaptureKitExclusiveLockDeadlineTests.swift
@@ -1,0 +1,45 @@
+import Darwin
+import Foundation
+import PeekabooFoundation
+import Testing
+@testable import PeekabooAutomationKit
+
+@MainActor
+struct ScreenCaptureKitExclusiveLockDeadlineTests {
+    @Test
+    func `exclusive capture wait fails when another holder never unlocks`() async {
+        let path = (NSTemporaryDirectory() as NSString)
+            .appendingPathComponent("boo.peekaboo.sckit-operation.lock")
+        let holder = open(path, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR)
+        guard holder >= 0 else {
+            Issue.record("Could not create exclusive lock file")
+            return
+        }
+        defer {
+            flock(holder, LOCK_UN)
+            close(holder)
+        }
+        guard flock(holder, LOCK_EX | LOCK_NB) == 0 else {
+            Issue.record("Could not take exclusive lock for the fixture holder")
+            return
+        }
+
+        var leafCalls = 0
+        do {
+            _ = try await ScreenCaptureKitCaptureGate.withExclusiveCaptureOperation(
+                operationName: "exclusiveLockDeadline",
+                exclusiveWaitNanoseconds: 80_000_000)
+            {
+                leafCalls += 1
+                return 1
+            }
+            Issue.record("A live exclusive holder should time out the waiter")
+        } catch let error as PeekabooError {
+            #expect(error.code == StandardErrorCode.captureFailed)
+            #expect(error.localizedDescription.contains("exclusive ScreenCaptureKit operation lock"))
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+        #expect(leafCalls == 0)
+    }
+}

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ScreenCaptureKitExclusiveLockDeadlineTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ScreenCaptureKitExclusiveLockDeadlineTests.swift
@@ -7,6 +7,12 @@ import Testing
 @MainActor
 struct ScreenCaptureKitExclusiveLockDeadlineTests {
     @Test
+    func `default exclusive wait fits inside the standard Bridge request envelope`() {
+        #expect(ScreenCaptureKitCaptureGate.defaultExclusiveWaitNanoseconds == 8_000_000_000)
+        #expect(ScreenCaptureKitCaptureGate.defaultExclusiveWaitNanoseconds < 10_000_000_000)
+    }
+
+    @Test
     func `exclusive capture wait fails when another holder never unlocks`() async {
         let path = (NSTemporaryDirectory() as NSString)
             .appendingPathComponent("boo.peekaboo.sckit-operation.lock")


### PR DESCRIPTION
## Summary

- bound the cross-process exclusive ScreenCaptureKit transaction-lock wait instead of spinning until cancellation
- keep the default wait at 8 seconds, inside the standard 10-second Bridge request envelope
- fail before the protected capture leaf with a clear lock-timeout message
- add focused deadline and Bridge-envelope regression coverage

## Why

`withExclusiveCaptureOperation` previously retried `flock(LOCK_EX | LOCK_NB)` forever while another live process held `boo.peekaboo.sckit-operation.lock`. A wedged holder could therefore block every later modern screenshot, `see`, or MCP capture indefinitely.

The first version of this patch used 15 seconds. Real signed CLI proof exposed that the standard Bridge request timed out first, hiding the typed lock failure behind a generic transport timeout. The default is now 8 seconds so callers receive the actual capture error while the request is still live.

## Exact-head live behavior proof

The final source head `50525ce4d46bd0cdf935af5ba54c74da5066eff4` was built, timestamped, Foundation-signed, installed, and exercised through the explicit GUI Bridge without weakening signing policy.

- Foundation-signed CLI CDHash: `38ed29575416bced4706b1effdb5876c6fce66db`
- Foundation-signed GUI host CDHash: `8b2955e30ca49981c5c9a4bb488c91fd3c771069`
- GUI source identity: exact final head, protocol 1.33, Screen Recording, Accessibility, and Event Synthesizing granted
- baseline: a real signed CLI modern 1920×1080 screen capture completed in 0.53s
- contention: an owned process held the exact production transaction lock while a second signed CLI issued the same real capture through the GUI Bridge
- result: the second capture failed in 8.23s with `Timed out waiting for the exclusive ScreenCaptureKit operation lock before desktopObservation`; no output PNG was created
- recovery: after stopping the exact owned holder, modern capture completed in 0.51s at 1920×1080
- cleanup: the holder stopped and both successful proof PNGs were moved to Trash; private text/JSON evidence remains local

## Verification

- `ScreenCaptureKitExclusiveLockDeadlineTests`: 2/2
- adjacent ScreenCaptureKit suites: 57/57
- docs lint: clean
- scoped SwiftFormat and SwiftLint: clean
- final whole-branch P2 review: clean
- hosted CI run `32578371615`: Core, CLI, Tachikoma, macOS apps/Inspector, and SwiftLint all green on exact head
- Cursor: green on exact head
- ClawSweeper: exact-head review found no code defect and accepted the live proof as sufficient

The two mirrored unreleased 4.2.3 changelog bullets are intentionally retained under the repository's user-visible-fix policy and explicit maintainer direction. This is the maintainer resolution of ClawSweeper's release-note P3.

Thanks @SebTardif for finding and fixing the unbounded wait.
