### PR TITLE
docs(cli): clarify exact-build host routing

### DIFF
--- a/docs/bridge-host.md
+++ b/docs/bridge-host.md
@@ -15,9 +15,13 @@ This replaces the previous XPC-based helper approach.
 ## Hosts and discovery
 
 Most CLI automation commands first reuse a healthy Peekaboo daemon. If none can satisfy the operation, they try a
-capable Peekaboo.app GUI Bridge host before starting a daemon on demand. Operations that permit process-local fallback
-can use it when no compatible host is available. Application inventory and launch prefer the GUI host, while relaunch
-and quit require a reusable daemon that survives the caller.
+capable Peekaboo.app GUI Bridge host before starting a daemon on demand. Implicit screen-capture observation, AX-tree
+inspection, browser, and snapshot-state commands additionally prefer the current CLI build's deterministic
+`daemon-<build>.sock` and may start that exact-build daemon before considering the GUI host. This keeps in-memory state
+and host capabilities on the same executable generation. An explicit Bridge socket, a custom daemon socket, and
+`--no-remote` bypass that preference.
+Operations that permit process-local fallback can use it when no compatible host is available. Application inventory
+and launch prefer the GUI host, while relaunch and quit require a reusable daemon that survives the caller.
 
 Bridge diagnostics inspect sockets in this order:
 
@@ -360,7 +364,10 @@ Bridge hosts are intended to be long-lived and keep automation state **in memory
 ## CLI behavior
 
 - By default, automation-oriented CLI commands use a healthy reusable daemon, then a capable Peekaboo.app GUI host,
-  then auto-start a daemon, with process-local execution as the final operation-dependent fallback.
+  then auto-start a daemon, with process-local execution as the final operation-dependent fallback. Implicit
+  screen-capture observation, AX-tree inspection, browser, and snapshot-state work first prefers—and may auto-start—the
+  current CLI build's build-scoped daemon so an older compatible host does not become the owner of build-sensitive
+  in-memory state.
 - Use `--no-remote` to force local execution.
 - Use `--bridge-socket <path>` or `PEEKABOO_BRIDGE_SOCKET` to override host discovery.
 - Use `PEEKABOO_DAEMON_SOCKET` only to change the auto-start daemon socket without treating it as an explicit Bridge override.

--- a/docs/commands/bridge.md
+++ b/docs/commands/bridge.md
@@ -14,13 +14,16 @@ read_when:
 ## Subcommands
 | Name | Purpose |
 | --- | --- |
-| `status` (default) | Probes configured sockets and reports the selected reusable daemon, healthy Peekaboo.app GUI host, auto-start daemon plan, or final operation-dependent local fallback. |
+| `status` (default) | Probes configured sockets and reports reusable and build-scoped daemons, the healthy Peekaboo.app GUI host, auto-start plans, or final operation-dependent local fallback. |
 | `receipt validate` | Authenticates one exact live listener and verifies one private exported protocol 1.29 terminal bundle against it. |
 
 ## Notes
 - Normal automation routing reuses a healthy daemon, then tries a capable Peekaboo.app host before starting a daemon
   on demand; operation-specific requirements can prefer the GUI host or require a surviving daemon. The complete host
   discovery order is documented in `docs/bridge-host.md`.
+- Implicit screen-capture observation, AX-tree inspection, browser, and snapshot-state commands first prefer the exact
+  CLI build's build-scoped daemon and may auto-start it before considering the GUI host. Use the command's actual
+  requirements—not the generic status ordering—to interpret which reported host it will select.
 - `--no-remote` (or `PEEKABOO_NO_REMOTE`) skips remote probing and forces local execution.
 - `--bridge-socket <path>` (or `PEEKABOO_BRIDGE_SOCKET`) overrides host discovery and probes only that socket.
   The override is strict: an unavailable or incompatible host fails non-zero instead of silently using the local

--- a/docs/commands/daemon.md
+++ b/docs/commands/daemon.md
@@ -18,8 +18,12 @@ commands detect that legacy daemon by its daemon status. Peekaboo.app is never t
 Normal automation commands migrate legacy auto or manual daemons that advertise atomic conditional stop. The daemon
 keeps its prior lifecycle mode, poll interval, and auto idle timeout, so a manually started daemon remains manual after
 migration. MCP sessions remain process-owned and are never migrated.
-When `bridge.sock` belongs to a healthy Peekaboo.app GUI host instead, normal commands keep using that app-held TCC
-context and start the reusable daemon only if the app host is unavailable or lacks the required capability.
+When `bridge.sock` belongs to a healthy Peekaboo.app GUI host instead, commands outside the exact-build preference keep
+using that app-held TCC context and start the reusable daemon only if the app host is unavailable or lacks the required
+capability. Implicit commands that require screen capture, inspect the AX tree, use browser MCP, or consume/invalidate
+snapshot state first prefer the current CLI build's deterministic `daemon-<build>.sock` and may auto-start it before
+considering the GUI host. Explicit Bridge paths, custom daemon paths, application inventory or launch, and local-only
+execution bypass that preference.
 Automatic migration defers while operational requests are active and keeps using the legacy daemon for that invocation.
 Older daemons without conditional stop remain on `bridge.sock` until they exit or are explicitly stopped. Explicit
 `daemon start` asks the user to stop those older daemons first, and asks for a retry when supported daemons are busy.
@@ -60,7 +64,9 @@ Options:
 - `--wait <duration>` how long to wait for shutdown (default `12s`, above the Bridge request deadline).
 
 ## Notes
-- Normal automation commands auto-start the daemon in `auto` mode when the default daemon socket is unavailable.
+- Normal automation commands auto-start the daemon in `auto` mode when the selected reusable socket is unavailable;
+  exact-build routing for the command categories above can select `daemon-<build>.sock` before the default socket or
+  GUI host.
 - Auto-started daemons exit after an idle timeout (default 300 seconds), while explicit `peekaboo daemon start` remains manual and stays up until stopped.
 - The daemon uses an in-memory snapshot store for speed.
 - Set `PEEKABOO_DAEMON_IDLE_TIMEOUT_SECONDS` to tune the auto-start idle timeout.

--- a/docs/commands/see.md
+++ b/docs/commands/see.md
@@ -10,6 +10,10 @@ read_when:
 `peekaboo see` captures the current macOS UI, extracts accessibility metadata, and (optionally) saves annotated screenshots. CLI and agent flows rely on these UI maps to find fresh element IDs, bounds, labels, and snapshot IDs.
 
 Observation is read-only with respect to focus: targeting a background app does not activate it or move its windows.
+With implicit host discovery and the standard daemon path, `see` prefers the current CLI build's deterministic
+build-scoped daemon and may auto-start it before considering a healthy Peekaboo.app host. This applies to pixel and
+AX-tree-only forms because their snapshots and capability decisions are host-memory state. An explicit
+`--bridge-socket`, a custom daemon socket, or `--no-remote` remains authoritative.
 
 ```bash
 # Capture frontmost window, print JSON, and save an annotated PNG

--- a/docs/daemon.md
+++ b/docs/daemon.md
@@ -26,9 +26,9 @@ Each long-lived host has one distinct role and socket:
 | Peekaboo.app Bridge | `~/Library/Application Support/Peekaboo/bridge.sock` | Owned by the GUI app and its TCC grants. |
 | MCP server | stdio | Owned by the MCP client; no Bridge listener or published socket. |
 
-Normal automation commands prefer the reusable daemon when it is healthy. If it is unavailable, they use a healthy
-Peekaboo.app host with the required capability before auto-starting a daemon. If no remote host is usable, the command
-falls back to process-local services when that operation permits it.
+Commands outside the exact-build preference below prefer the reusable daemon when it is healthy. If it is unavailable,
+they use a healthy Peekaboo.app host with the required capability before auto-starting a daemon. If no remote host is
+usable, the command falls back to process-local services when that operation permits it.
 
 Implicit commands that require screen capture, inspect the AX tree, use browser MCP, or consume/invalidate snapshot
 state first prefer the current CLI build's deterministic `daemon-<build>.sock`. They may auto-start that exact-build

--- a/docs/daemon.md
+++ b/docs/daemon.md
@@ -30,11 +30,17 @@ Normal automation commands prefer the reusable daemon when it is healthy. If it 
 Peekaboo.app host with the required capability before auto-starting a daemon. If no remote host is usable, the command
 falls back to process-local services when that operation permits it.
 
-If another build owns `daemon.sock` but lacks a required capability, the current universal binary reuses a deterministic
-`daemon-<build>.sock` fallback shared by native and Rosetta invocations. Daemon status prefers the compatible host and
-warns when another daemon also exists; explicit daemon start safely promotes a compatible auto fallback to manual mode.
-After executable upgrades, implicit routing rediscovers compatible same-user fallback sockets and validates their
-daemon identity before reuse. Explicit Bridge paths and custom daemon paths do not scan sibling sockets.
+Implicit commands that require screen capture, inspect the AX tree, use browser MCP, or consume/invalidate snapshot
+state first prefer the current CLI build's deterministic `daemon-<build>.sock`. They may auto-start that exact-build
+daemon before considering an otherwise healthy Peekaboo.app host, because protocol compatibility alone does not make
+build-sensitive in-memory state interchangeable. This preference does not apply to explicit Bridge paths, custom
+daemon paths, application inventory or launch, or local-only execution.
+
+The same build-scoped socket is the compatibility fallback when another build owns `daemon.sock` but lacks a required
+capability. Native and Rosetta invocations of the same universal binary share it. Daemon status prefers the compatible
+host and warns when another daemon also exists; explicit daemon start safely promotes a compatible auto fallback to
+manual mode. After executable upgrades, implicit routing rediscovers compatible same-user fallback sockets and validates
+their daemon identity before reuse. Explicit Bridge paths and custom daemon paths do not scan sibling sockets.
 
 Explicit `--bridge-socket` or `PEEKABOO_BRIDGE_SOCKET` selects only that Bridge path and disables daemon auto-start.
 `PEEKABOO_DAEMON_SOCKET` changes the reusable daemon path without becoming an explicit Bridge override.


### PR DESCRIPTION
## Summary

- document the exact-build daemon preference used by implicit screen-capture observation, AX-tree inspection, browser MCP, and snapshot-state commands
- distinguish that stateful route from the ordinary reusable-daemon → GUI Bridge → auto-start fallback order
- document the explicit socket, custom daemon path, application inventory/launch, and local-only exceptions

## Validation

- `pnpm run lint:docs`
- `swift test --package-path Apps/CLI --filter RuntimeHostResolverTests` (21/21)
- `git diff --check`
- P2 Autoreview: clean

No runtime behavior changes; this corrects public documentation to match the existing resolver.
