### PR TITLE
perf(capture): skip idle SCK settlement

### DIFF
--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Read `config credential set` secrets from no-echo prompts, stdin, or owner-only files; let `config provider add` also accept non-secret references; retain deprecated argv compatibility.
 - Skip provider discovery and Agent construction for caller-local commands that cannot invoke the Agent.
+- Skip the ScreenCaptureKit post-capture settlement delay for classic captures that never enter ScreenCaptureKit.
 
 ### Fixed
 - Bound modern capture transaction-lock waits inside the Bridge request envelope so a wedged peer fails clearly instead of hanging indefinitely. Thanks @SebTardif for #599.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 ### Changed
 - Read `config credential set` secrets from no-echo prompts, stdin, or owner-only files; let `config provider add` also accept non-secret references; retain deprecated argv compatibility.
 - Skip provider discovery and Agent construction for caller-local commands that cannot invoke the Agent.
+- Skip the ScreenCaptureKit post-capture settlement delay for classic captures that never enter ScreenCaptureKit.
 
 ### Fixed
 - Bound exclusive ScreenCaptureKit transaction-lock waits inside the Bridge request envelope so a wedged peer fails clearly instead of hanging capture indefinitely. Thanks @SebTardif for #599.

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/ScreenCaptureKitCaptureGate.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/ScreenCaptureKitCaptureGate.swift
@@ -8,8 +8,10 @@ enum ScreenCaptureKitCaptureGate {
     static let defaultExclusiveWaitNanoseconds: UInt64 = 8_000_000_000
 
     @TaskLocal private static var isInsideCaptureOperation = false
+    @TaskLocal private static var captureTransactionUsage: CaptureTransactionUsage?
     @TaskLocal static var processOwnerClaimOverride:
         (@MainActor @Sendable () throws -> ScreenCaptureKitOwnerLease.OwnerReceipt)?
+    @TaskLocal static var postCaptureSettleOverride: (@MainActor @Sendable () async -> Void)?
     private static let processOwnerLease = Result { try ScreenCaptureKitOwnerLease() }
     @MainActor private static let captureCoordinator = ScreenCaptureKitOperationCoordinator(
         lockFilePath: (NSTemporaryDirectory() as NSString)
@@ -52,6 +54,7 @@ enum ScreenCaptureKitCaptureGate {
         try await self.withProcessOwner(operationName: operationName) {
             try await self.captureCoordinator.run(seconds: seconds, operationName: operationName) {
                 try self.requireProcessOwner(operationName: operationName)
+                self.captureTransactionUsage?.recordScreenCaptureKitUse()
                 return try await operation()
             }
         }
@@ -98,17 +101,30 @@ enum ScreenCaptureKitCaptureGate {
         }
         defer { flock(fd, LOCK_UN) }
 
-        return try await self.$isInsideCaptureOperation.withValue(true) {
-            do {
-                let value = try await operation()
-                // replayd can report transient TCC/capture failures when another CLI grabs SCK immediately after
-                // a screenshot completes. Keep the transaction lock briefly so the system service can settle.
-                try? await Task.sleep(nanoseconds: 100_000_000)
-                return value
-            } catch {
-                try? await Task.sleep(nanoseconds: 100_000_000)
-                throw error
+        let usage = CaptureTransactionUsage()
+        return try await self.$captureTransactionUsage.withValue(usage) {
+            try await self.$isInsideCaptureOperation.withValue(true) {
+                do {
+                    let value = try await operation()
+                    await self.settleAfterScreenCaptureKitUseIfNeeded(usage)
+                    return value
+                } catch {
+                    await self.settleAfterScreenCaptureKitUseIfNeeded(usage)
+                    throw error
+                }
             }
+        }
+    }
+
+    @MainActor
+    private static func settleAfterScreenCaptureKitUseIfNeeded(_ usage: CaptureTransactionUsage) async {
+        guard usage.usedScreenCaptureKit else { return }
+        // replayd can report transient TCC/capture failures when another CLI grabs SCK immediately after a
+        // screenshot completes. Keep the transaction lock briefly only when this transaction entered SCK.
+        if let postCaptureSettleOverride {
+            await postCaptureSettleOverride()
+        } else {
+            try? await Task.sleep(nanoseconds: 100_000_000)
         }
     }
 
@@ -170,6 +186,15 @@ enum ScreenCaptureKitCaptureGate {
         return OperationError.captureFailed(
             reason: "ScreenCaptureKit owner validation failed before \(operationName): " +
                 "\(error.localizedDescription). No ScreenCaptureKit operation was dispatched.")
+    }
+}
+
+@MainActor
+private final class CaptureTransactionUsage {
+    private(set) var usedScreenCaptureKit = false
+
+    func recordScreenCaptureKitUse() {
+        self.usedScreenCaptureKit = true
     }
 }
 

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ScreenCaptureKitExclusiveLockDeadlineTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ScreenCaptureKitExclusiveLockDeadlineTests.swift
@@ -31,13 +31,19 @@ struct ScreenCaptureKitExclusiveLockDeadlineTests {
         }
 
         var leafCalls = 0
+        var settleCalls = 0
+        let settle: @MainActor @Sendable () async -> Void = {
+            settleCalls += 1
+        }
         do {
-            _ = try await ScreenCaptureKitCaptureGate.withExclusiveCaptureOperation(
-                operationName: "exclusiveLockDeadline",
-                exclusiveWaitNanoseconds: 80_000_000)
-            {
-                leafCalls += 1
-                return 1
+            _ = try await ScreenCaptureKitCaptureGate.$postCaptureSettleOverride.withValue(settle) {
+                try await ScreenCaptureKitCaptureGate.withExclusiveCaptureOperation(
+                    operationName: "exclusiveLockDeadline",
+                    exclusiveWaitNanoseconds: 80_000_000)
+                {
+                    leafCalls += 1
+                    return 1
+                }
             }
             Issue.record("A live exclusive holder should time out the waiter")
         } catch let error as PeekabooError {
@@ -47,5 +53,6 @@ struct ScreenCaptureKitExclusiveLockDeadlineTests {
             Issue.record("Unexpected error: \(error)")
         }
         #expect(leafCalls == 0)
+        #expect(settleCalls == 0)
     }
 }

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ScreenCaptureKitOwnerLeafTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ScreenCaptureKitOwnerLeafTests.swift
@@ -6,6 +6,73 @@ import Testing
 @MainActor
 struct ScreenCaptureKitOwnerLeafTests {
     @Test
+    func `classic transaction skips ScreenCaptureKit settlement`() async throws {
+        var steps: [String] = []
+        let settle: @MainActor @Sendable () async -> Void = {
+            steps.append("settle")
+        }
+
+        let value = try await ScreenCaptureKitCaptureGate.$postCaptureSettleOverride.withValue(settle) {
+            try await ScreenCaptureKitCaptureGate.withExclusiveCaptureOperation(operationName: "classic") {
+                steps.append("capture")
+                return 42
+            }
+        }
+
+        #expect(value == 42)
+        #expect(steps == ["capture"])
+    }
+
+    @Test
+    func `ScreenCaptureKit transaction settles before returning`() async throws {
+        var steps: [String] = []
+        let receipt = Self.receipt(processIdentifier: 100, processStartIdentity: 200)
+        let claim: @MainActor @Sendable () throws -> ScreenCaptureKitOwnerLease.OwnerReceipt = { receipt }
+        let settle: @MainActor @Sendable () async -> Void = {
+            steps.append("settle")
+        }
+
+        let operation: () async throws -> Int = {
+            try await ScreenCaptureKitCaptureGate.$postCaptureSettleOverride.withValue(settle) {
+                try await ScreenCaptureKitCaptureGate.withExclusiveCaptureOperation(operationName: "modern") {
+                    steps.append("transaction")
+                    return try await ScreenCaptureKitCaptureGate.runOwnedOperation(
+                        seconds: 1,
+                        operationName: "leaf")
+                    {
+                        steps.append("leaf")
+                        return 42
+                    }
+                }
+            }
+        }
+
+        let value = try await ScreenCaptureKitCaptureGate.$processOwnerClaimOverride.withValue(
+            claim,
+            operation: operation)
+
+        #expect(value == 42)
+        #expect(steps == ["transaction", "leaf", "settle"])
+    }
+
+    @Test
+    func `cancelled classic transaction skips settlement and preserves cancellation`() async {
+        var settleCalls = 0
+        let settle: @MainActor @Sendable () async -> Void = {
+            settleCalls += 1
+        }
+
+        await #expect(throws: CancellationError.self) {
+            try await ScreenCaptureKitCaptureGate.$postCaptureSettleOverride.withValue(settle) {
+                try await ScreenCaptureKitCaptureGate.withExclusiveCaptureOperation(operationName: "classic") {
+                    throw CancellationError()
+                }
+            }
+        }
+        #expect(settleCalls == 0)
+    }
+
+    @Test
     func `owner claim completes before the ScreenCaptureKit leaf`() async throws {
         var steps: [String] = []
         let receipt = Self.receipt(processIdentifier: 100, processStartIdentity: 200)


### PR DESCRIPTION
## Summary

- track whether a capture transaction actually entered ScreenCaptureKit
- retain the 100 ms replayd settlement only for transactions that used ScreenCaptureKit
- let classic captures return immediately after their protected capture work
- extend the #599 contention regression to prove timeout runs neither the capture leaf nor settlement

## Why

`withExclusiveCaptureOperation` currently sleeps for 100 ms after every protected transaction, even when the request used the classic capture engine and never entered ScreenCaptureKit. That adds a fixed delay to persistent classic `see` calls without protecting replayd or an SCK operation.

The transaction now records SCK use only at the owned SCK leaf. Success and failure still settle before releasing the cross-process lock when SCK ran; classic success, classic cancellation, and pre-leaf lock timeout skip the irrelevant delay.

## Exact-head signed behavior proof

The final head `73592cdf934cb4d2be9f82379df8055a94e21021` was built, timestamped, Foundation-signed, transactionally installed, and exercised through one persistent MCP process pinned to the explicit GUI Bridge socket. Every `see` request selected the classic engine; no local/ad-hoc or fallback route was used.

- Foundation-signed CLI CDHash: `dcbb7e8b19092b113f91ff3dfe91baa5a9805678`
- Foundation-signed GUI host CDHash: `5391ee989d6877a100c7c235483bfd746c70a7db`
- GUI source identity: exact final head, protocol 1.33, all three permissions granted, AppleScript disabled
- 30/30 reads succeeded across TextEdit, Calculator, Calendar, Safari, and System Settings
- overall p50: 206.3 ms; warm p50: 195.8 ms
- warm per-app p50: 185.6 ms TextEdit, 164.9 ms Calculator, 162.8 ms Calendar, 256.0 ms Safari, 206.3 ms Settings
- the exact foreground app/process generation was unchanged; the physical cursor was not used or assumed stable
- all temporary screenshots were deleted unseen; none were retained, viewed, or uploaded
- no input, cursor, foreground, AppleScript/JXA, virtualization, or account interaction was used

Direct `/usr/sbin/screencapture` remains a roughly 98–101 ms floor, so external process and PNG work—not AX or this lock—is the next bounded optimization target.

## Verification

- focused settlement/owner/deadline tests: 8/8
- full AutomationKit serialized: 1,272/1,272
- exact CLI build: green
- SwiftFormat: clean
- SwiftLint: zero serious findings
- docs lint and diff hygiene: clean
- exact whole-branch P2 review: clean
- changelog-only P2 review: clean


The mirrored 4.2.3 changelog bullet is intentionally retained under this repository's user-visible-change policy and explicit maintainer direction. This is the maintainer resolution of ClawSweeper's release-note P3.
