### PR TITLE
fix(capture): downscale straight-alpha legacy images

### DIFF
--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Skip the ScreenCaptureKit post-capture settlement delay for classic captures that never enter ScreenCaptureKit.
 
 ### Fixed
+- Downscale straight-alpha legacy screenshots to logical 1x instead of silently returning Retina-sized pixels.
 - Bound modern capture transaction-lock waits inside the Bridge request envelope so a wedged peer fails clearly instead of hanging indefinitely. Thanks @SebTardif for #599.
 - Send Gemini API keys in request headers, require HTTPS OAuth endpoints, and redact OAuth state. Thanks Vincent Koc for #575 and Tachikoma #73.
 - Enforce a race-safe 10 MiB limit for clipboard and paste file payloads. Thanks @SebTardif for #561.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Skip the ScreenCaptureKit post-capture settlement delay for classic captures that never enter ScreenCaptureKit.
 
 ### Fixed
+- Downscale straight-alpha legacy screenshots to logical 1x instead of silently returning Retina-sized pixels.
 - Bound exclusive ScreenCaptureKit transaction-lock waits inside the Bridge request envelope so a wedged peer fails clearly instead of hanging capture indefinitely. Thanks @SebTardif for #599.
 - Send Gemini API keys in request headers, require HTTPS OAuth endpoints, and redact OAuth state. Thanks Vincent Koc for #575 and Tachikoma #73.
 - Enforce a 10 MiB clipboard and paste file payload limit on the opened descriptor to prevent file-replacement races. Thanks @SebTardif for #561.

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/ScreenCaptureImageScaler.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/ScreenCaptureImageScaler.swift
@@ -41,8 +41,7 @@ enum ScreenCaptureImageScaler {
         guard alphaInfo != image.alphaInfo else { return image.bitmapInfo }
 
         // ImageIO can decode PNGs with straight alpha, which is invalid as a bitmap-context destination format.
-        let alphaInfoMask: UInt32 = 0x1F
-        let rawValue = (image.bitmapInfo.rawValue & ~alphaInfoMask) | alphaInfo.rawValue
+        let rawValue = (image.bitmapInfo.rawValue & ~CGBitmapInfo.alphaInfoMask.rawValue) | alphaInfo.rawValue
         return CGBitmapInfo(rawValue: rawValue)
     }
 }

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/ScreenCaptureImageScaler.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/ScreenCaptureImageScaler.swift
@@ -15,6 +15,7 @@ enum ScreenCaptureImageScaler {
             width: CGFloat(image.width) / fallbackScale,
             height: CGFloat(image.height) / fallbackScale)
         let colorSpace = image.colorSpace ?? CGColorSpaceCreateDeviceRGB()
+        let bitmapInfo = Self.contextBitmapInfo(for: image)
         guard let context = CGContext(
             data: nil,
             width: Int(targetSize.width.rounded()),
@@ -22,12 +23,26 @@ enum ScreenCaptureImageScaler {
             bitsPerComponent: image.bitsPerComponent,
             bytesPerRow: 0,
             space: colorSpace,
-            bitmapInfo: image.bitmapInfo.rawValue)
+            bitmapInfo: bitmapInfo.rawValue)
         else {
             return image
         }
         context.interpolationQuality = .high
         context.draw(image, in: CGRect(origin: .zero, size: targetSize))
         return context.makeImage() ?? image
+    }
+
+    private static func contextBitmapInfo(for image: CGImage) -> CGBitmapInfo {
+        let alphaInfo: CGImageAlphaInfo = switch image.alphaInfo {
+        case .first: .premultipliedFirst
+        case .last: .premultipliedLast
+        default: image.alphaInfo
+        }
+        guard alphaInfo != image.alphaInfo else { return image.bitmapInfo }
+
+        // ImageIO can decode PNGs with straight alpha, which is invalid as a bitmap-context destination format.
+        let alphaInfoMask: UInt32 = 0x1F
+        let rawValue = (image.bitmapInfo.rawValue & ~alphaInfoMask) | alphaInfo.rawValue
+        return CGBitmapInfo(rawValue: rawValue)
     }
 }

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ScreenCaptureImageScalerTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ScreenCaptureImageScalerTests.swift
@@ -117,7 +117,6 @@ struct ScreenCaptureImageScalerTests {
 
     private static let sRGB = CGColorSpace(name: CGColorSpace.sRGB)!
     private static let displayP3 = CGColorSpace(name: CGColorSpace.displayP3)!
-    private static let alphaInfoMask: UInt32 = 0x1F
     private static let byteOrderMask: UInt32 = 0x7000
 
     private static func makeImage(
@@ -201,7 +200,8 @@ struct ScreenCaptureImageScalerTests {
         case .last: .premultipliedLast
         default: image.alphaInfo
         }
-        let rawBitmapInfo = (image.bitmapInfo.rawValue & ~Self.alphaInfoMask) | normalizedAlpha.rawValue
+        let rawBitmapInfo =
+            (image.bitmapInfo.rawValue & ~CGBitmapInfo.alphaInfoMask.rawValue) | normalizedAlpha.rawValue
         let context = try #require(CGContext(
             data: nil,
             width: Int(targetSize.width.rounded()),

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ScreenCaptureImageScalerTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ScreenCaptureImageScalerTests.swift
@@ -1,0 +1,230 @@
+import CoreGraphics
+import Foundation
+import Testing
+@testable import PeekabooAutomationKit
+
+struct ScreenCaptureImageScalerTests {
+    @Test
+    func `logical 1x normalizes straight alpha and preserves exact dimensions`() throws {
+        let cases: [(CGImageAlphaInfo, CGImageAlphaInfo, CGBitmapInfo)] = [
+            (.last, .premultipliedLast, .byteOrder32Big),
+            (.first, .premultipliedFirst, .byteOrder32Little),
+        ]
+
+        for (sourceAlpha, expectedAlpha, byteOrder) in cases {
+            let image = try Self.makeImage(
+                width: 8,
+                height: 6,
+                colorSpace: Self.sRGB,
+                alphaInfo: sourceAlpha,
+                byteOrder: byteOrder)
+
+            let scaled = ScreenCaptureImageScaler.maybeDownscale(
+                image,
+                scale: .logical1x,
+                fallbackScale: 2)
+
+            #expect(scaled.width == 4)
+            #expect(scaled.height == 3)
+            #expect(scaled.alphaInfo == expectedAlpha)
+            #expect(Self.byteOrder(of: scaled) == byteOrder.rawValue)
+            #expect(scaled.colorSpace?.name == Self.sRGB.name)
+            #expect(try Self.pixelData(scaled) == Self.pixelData(Self.trustedDownscale(image, fallbackScale: 2)))
+        }
+    }
+
+    @Test
+    func `even opaque Display P3 output remains byte equivalent to the current path`() throws {
+        let image = try Self.makeImage(
+            width: 10,
+            height: 8,
+            colorSpace: Self.displayP3,
+            alphaInfo: .noneSkipLast,
+            byteOrder: .byteOrder32Big)
+        let expected = try Self.trustedDownscale(image, fallbackScale: 2)
+
+        let scaled = ScreenCaptureImageScaler.maybeDownscale(
+            image,
+            scale: .logical1x,
+            fallbackScale: 2)
+
+        #expect(scaled.width == 5)
+        #expect(scaled.height == 4)
+        #expect(scaled.alphaInfo == image.alphaInfo)
+        #expect(Self.byteOrder(of: scaled) == Self.byteOrder(of: image))
+        #expect(scaled.colorSpace?.name == Self.displayP3.name)
+        #expect(Self.pixelData(scaled) == Self.pixelData(expected))
+    }
+
+    @Test
+    func `odd straight alpha input retains the current fractional draw geometry`() throws {
+        let image = try Self.makeImage(
+            width: 7,
+            height: 5,
+            colorSpace: Self.sRGB,
+            alphaInfo: .last,
+            byteOrder: .byteOrder32Big)
+        let expected = try Self.trustedDownscale(image, fallbackScale: 2)
+
+        let scaled = ScreenCaptureImageScaler.maybeDownscale(
+            image,
+            scale: .logical1x,
+            fallbackScale: 2)
+
+        #expect(scaled.width == 4)
+        #expect(scaled.height == 3)
+        #expect(Self.pixelData(scaled) == Self.pixelData(expected))
+    }
+
+    @Test
+    func `unsupported destination bitmap retains the original image`() throws {
+        let image = try Self.makeIndexedImage(width: 7, height: 5)
+
+        let scaled = ScreenCaptureImageScaler.maybeDownscale(
+            image,
+            scale: .logical1x,
+            fallbackScale: 2)
+
+        #expect(scaled === image)
+    }
+
+    @Test
+    func `native scale and non Retina logical scale return the original image`() throws {
+        let image = try Self.makeImage(
+            width: 8,
+            height: 6,
+            colorSpace: Self.sRGB,
+            alphaInfo: .last,
+            byteOrder: .byteOrder32Big)
+
+        let native = ScreenCaptureImageScaler.maybeDownscale(
+            image,
+            scale: .native,
+            fallbackScale: 2)
+        let logicalOne = ScreenCaptureImageScaler.maybeDownscale(
+            image,
+            scale: .logical1x,
+            fallbackScale: 1)
+        let logicalSubOne = ScreenCaptureImageScaler.maybeDownscale(
+            image,
+            scale: .logical1x,
+            fallbackScale: 0.5)
+
+        #expect(native === image)
+        #expect(logicalOne === image)
+        #expect(logicalSubOne === image)
+    }
+
+    private static let sRGB = CGColorSpace(name: CGColorSpace.sRGB)!
+    private static let displayP3 = CGColorSpace(name: CGColorSpace.displayP3)!
+    private static let alphaInfoMask: UInt32 = 0x1F
+    private static let byteOrderMask: UInt32 = 0x7000
+
+    private static func makeImage(
+        width: Int,
+        height: Int,
+        colorSpace: CGColorSpace,
+        alphaInfo: CGImageAlphaInfo,
+        byteOrder: CGBitmapInfo) throws -> CGImage
+    {
+        var pixels = [UInt8](repeating: 0, count: width * height * 4)
+        for y in 0..<height {
+            for x in 0..<width {
+                let offset = (y * width + x) * 4
+                let red = UInt8((x * 31 + y * 7) % 256)
+                let green = UInt8((x * 11 + y * 43) % 256)
+                let blue = UInt8((x * 53 + y * 17) % 256)
+                let alpha = UInt8(64 + (x * 19 + y * 23) % 192)
+                if alphaInfo == .first || alphaInfo == .premultipliedFirst {
+                    pixels[offset] = alpha
+                    pixels[offset + 1] = red
+                    pixels[offset + 2] = green
+                    pixels[offset + 3] = blue
+                } else {
+                    pixels[offset] = red
+                    pixels[offset + 1] = green
+                    pixels[offset + 2] = blue
+                    pixels[offset + 3] = alphaInfo == .noneSkipLast ? 255 : alpha
+                }
+            }
+        }
+
+        let provider = try #require(CGDataProvider(data: Data(pixels) as CFData))
+        let bitmapInfo = CGBitmapInfo(rawValue: alphaInfo.rawValue).union(byteOrder)
+        return try #require(CGImage(
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bitsPerPixel: 32,
+            bytesPerRow: width * 4,
+            space: colorSpace,
+            bitmapInfo: bitmapInfo,
+            provider: provider,
+            decode: nil,
+            shouldInterpolate: true,
+            intent: .defaultIntent))
+    }
+
+    private static func makeIndexedImage(width: Int, height: Int) throws -> CGImage {
+        let data = Data((0..<(width * height)).map { UInt8(($0 * 29) % 256) })
+        let provider = try #require(CGDataProvider(data: data as CFData))
+        let colorTable: [UInt8] = [
+            0, 0, 0,
+            255, 255, 255,
+        ]
+        let colorSpace = try #require(colorTable.withUnsafeBufferPointer { buffer in
+            CGColorSpace(
+                indexedBaseSpace: Self.sRGB,
+                last: 1,
+                colorTable: buffer.baseAddress!)
+        })
+        return try #require(CGImage(
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bitsPerPixel: 8,
+            bytesPerRow: width,
+            space: colorSpace,
+            bitmapInfo: CGBitmapInfo(rawValue: CGImageAlphaInfo.none.rawValue),
+            provider: provider,
+            decode: nil,
+            shouldInterpolate: true,
+            intent: .defaultIntent))
+    }
+
+    private static func trustedDownscale(_ image: CGImage, fallbackScale: CGFloat) throws -> CGImage {
+        let targetSize = CGSize(
+            width: CGFloat(image.width) / fallbackScale,
+            height: CGFloat(image.height) / fallbackScale)
+        let normalizedAlpha: CGImageAlphaInfo = switch image.alphaInfo {
+        case .first: .premultipliedFirst
+        case .last: .premultipliedLast
+        default: image.alphaInfo
+        }
+        let rawBitmapInfo = (image.bitmapInfo.rawValue & ~Self.alphaInfoMask) | normalizedAlpha.rawValue
+        let context = try #require(CGContext(
+            data: nil,
+            width: Int(targetSize.width.rounded()),
+            height: Int(targetSize.height.rounded()),
+            bitsPerComponent: image.bitsPerComponent,
+            bytesPerRow: 0,
+            space: image.colorSpace ?? CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: rawBitmapInfo))
+        context.interpolationQuality = .high
+        context.draw(image, in: CGRect(origin: .zero, size: targetSize))
+        return try #require(context.makeImage())
+    }
+
+    private static func byteOrder(of image: CGImage) -> UInt32 {
+        image.bitmapInfo.rawValue & self.byteOrderMask
+    }
+
+    private static func pixelData(_ image: CGImage) -> Data {
+        guard let provider = image.dataProvider,
+              let data = provider.data
+        else {
+            return Data()
+        }
+        return data as Data
+    }
+}


### PR DESCRIPTION
## Summary

- normalize straight-alpha `.first` and `.last` legacy images to valid premultiplied CGContext destination formats
- preserve byte order, color space, target geometry, and existing unsupported-format fallback
- add focused coverage for RGBA, wide-gamut opaque, odd-size, unsupported, and no-op scale cases

## Why

ImageIO can decode PNGs with straight alpha. Core Graphics accepts those as source images but not as bitmap-context destination formats. The logical-1x scaler passed the decoded bitmap flags through unchanged, so `CGContext` creation failed and the fallback silently returned the original Retina-sized image.

The scaler now changes only the alpha-info bits to the corresponding premultiplied form before creating the destination context. Other bitmap flags and color-space behavior remain unchanged.

## Validation

- focused scaler suite: 5/5
- serialized AutomationKit: 1,277/1,277 across 119 suites
- straight-alpha first/last layouts produce exact logical-1x dimensions
- byte order and sRGB color space are preserved
- opaque Display P3 output remains byte-equivalent to the previous valid path
- odd fractional geometry matches the existing CGContext draw behavior
- unsupported indexed color still returns the original image
- native and non-Retina scale paths remain identity no-ops
- SwiftFormat and scoped SwiftLint: clean
- repository lint: zero serious findings
- docs lint and diff hygiene: clean
- exact whole-branch P2 review: clean

A numeric-only synthetic benchmark rejected ImageIO thumbnailing as a speed optimization; it was slightly slower than the existing path. Core Image was faster but materially increased memory and changed edge/alpha quality, so neither is included here. No live UI, input, screenshots, AppleScript/JXA, virtualization, or account interaction was used.

The mirrored 4.2.3 changelog bullet is intentionally retained under the repository's user-visible-fix policy and explicit maintainer direction.
