### PR TITLE
perf(capture): retain validated classic PNG bytes

### DIFF
--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Read `config credential set` secrets from no-echo prompts, stdin, or owner-only files; let `config provider add` also accept non-secret references; retain deprecated argv compatibility.
 - Skip provider discovery and Agent construction for caller-local commands that cannot invoke the Agent.
 - Skip the ScreenCaptureKit post-capture settlement delay for classic captures that never enter ScreenCaptureKit.
+- Reuse validated classic PNG bytes when capture performs no transform instead of encoding the same image twice.
 
 ### Fixed
 - Downscale straight-alpha legacy screenshots to logical 1x instead of silently returning Retina-sized pixels.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Read `config credential set` secrets from no-echo prompts, stdin, or owner-only files; let `config provider add` also accept non-secret references; retain deprecated argv compatibility.
 - Skip provider discovery and Agent construction for caller-local commands that cannot invoke the Agent.
 - Skip the ScreenCaptureKit post-capture settlement delay for classic captures that never enter ScreenCaptureKit.
+- Reuse validated classic PNG bytes when capture performs no transform instead of encoding the same image twice.
 
 ### Fixed
 - Downscale straight-alpha legacy screenshots to logical 1x instead of silently returning Retina-sized pixels.

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/LegacyPNGValidator.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/LegacyPNGValidator.swift
@@ -1,0 +1,138 @@
+import Foundation
+import zlib
+
+enum LegacyPNGValidator {
+    private static let signature: [UInt8] = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]
+    private static let ihdr: UInt32 = 0x4948_4452
+    private static let plte: UInt32 = 0x504C_5445
+    private static let idat: UInt32 = 0x4944_4154
+    private static let iend: UInt32 = 0x4945_4E44
+
+    static func hasValidStructureAndCRC(_ data: Data) -> Bool {
+        data.withUnsafeBytes { bytes in
+            guard bytes.count >= self.signature.count + 12,
+                  self.signature.indices.allSatisfy({ bytes[$0] == self.signature[$0] })
+            else { return false }
+
+            var offset = self.signature.count
+            var sawIDAT = false
+            var idatSequenceEnded = false
+            var sawPLTE = false
+            var colorType: UInt8?
+            var totalIDATBytes: UInt64 = 0
+
+            while offset < bytes.count {
+                let remaining = bytes.count - offset
+                guard remaining >= 12 else { return false }
+
+                let declaredLength = self.uint32(bytes, at: offset)
+                guard let length = Int(exactly: declaredLength),
+                      length <= remaining - 12
+                else { return false }
+
+                let typeOffset = offset + 4
+                let dataOffset = typeOffset + 4
+                let crcOffset = dataOffset + length
+                let chunkEnd = crcOffset + 4
+                let type = self.uint32(bytes, at: typeOffset)
+                guard self.isValidChunkType(bytes, at: typeOffset),
+                      self.crc32(bytes, from: typeOffset, count: length + 4) == self.uint32(bytes, at: crcOffset)
+                else { return false }
+
+                if offset == self.signature.count {
+                    guard type == self.ihdr,
+                          length == 13,
+                          self.validIHDR(bytes, at: dataOffset)
+                    else { return false }
+                    colorType = bytes[dataOffset + 9]
+                } else if type == self.ihdr {
+                    return false
+                }
+
+                switch type {
+                case self.ihdr:
+                    break
+
+                case self.plte:
+                    guard !sawPLTE,
+                          !sawIDAT,
+                          (3...768).contains(length),
+                          length.isMultiple(of: 3),
+                          colorType != 0,
+                          colorType != 4
+                    else { return false }
+                    sawPLTE = true
+
+                case self.idat:
+                    guard !idatSequenceEnded else { return false }
+                    let (updatedTotal, overflow) = totalIDATBytes.addingReportingOverflow(UInt64(length))
+                    guard !overflow else { return false }
+                    totalIDATBytes = updatedTotal
+                    sawIDAT = true
+
+                case self.iend:
+                    guard sawIDAT,
+                          totalIDATBytes > 0,
+                          length == 0,
+                          chunkEnd == bytes.count,
+                          colorType != 3 || sawPLTE
+                    else { return false }
+                    return true
+
+                default:
+                    // Unknown critical chunks cannot be safely ignored.
+                    guard bytes[typeOffset] >= 0x61 else { return false }
+                    if sawIDAT {
+                        idatSequenceEnded = true
+                    }
+                }
+
+                offset = chunkEnd
+            }
+            return false
+        }
+    }
+
+    private static func validIHDR(_ bytes: UnsafeRawBufferPointer, at offset: Int) -> Bool {
+        let width = self.uint32(bytes, at: offset)
+        let height = self.uint32(bytes, at: offset + 4)
+        let bitDepth = bytes[offset + 8]
+        let colorType = bytes[offset + 9]
+        let compression = bytes[offset + 10]
+        let filter = bytes[offset + 11]
+        let interlace = bytes[offset + 12]
+        let validBitDepth = switch colorType {
+        case 0: [1, 2, 4, 8, 16].contains(bitDepth)
+        case 2, 4, 6: [8, 16].contains(bitDepth)
+        case 3: [1, 2, 4, 8].contains(bitDepth)
+        default: false
+        }
+        return width > 0 && height > 0 && validBitDepth && compression == 0 && filter == 0 && interlace <= 1
+    }
+
+    private static func isValidChunkType(_ bytes: UnsafeRawBufferPointer, at offset: Int) -> Bool {
+        for index in 0..<4 {
+            let byte = bytes[offset + index]
+            guard (0x41...0x5A).contains(byte) || (0x61...0x7A).contains(byte) else { return false }
+        }
+        // The PNG reserved bit must remain zero, represented by an uppercase third letter.
+        return (0x41...0x5A).contains(bytes[offset + 2])
+    }
+
+    private static func crc32(
+        _ bytes: UnsafeRawBufferPointer,
+        from offset: Int,
+        count: Int) -> UInt32
+    {
+        guard count > 0, let baseAddress = bytes.baseAddress else { return 0 }
+        let pointer = baseAddress.advanced(by: offset).assumingMemoryBound(to: Bytef.self)
+        return UInt32(truncatingIfNeeded: zlib.crc32_z(0, pointer, count))
+    }
+
+    private static func uint32(_ bytes: UnsafeRawBufferPointer, at offset: Int) -> UInt32 {
+        UInt32(bytes[offset]) << 24 |
+            UInt32(bytes[offset + 1]) << 16 |
+            UInt32(bytes[offset + 2]) << 8 |
+            UInt32(bytes[offset + 3])
+    }
+}

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/LegacyScreenCaptureOperator+ScreenArea.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/LegacyScreenCaptureOperator+ScreenArea.swift
@@ -35,9 +35,9 @@ extension LegacyScreenCaptureOperator {
             screenBackingScaleFactor: targetScreen.backingScaleFactor,
             fallbackPixelWidth: Int(screenBounds.width * targetScreen.backingScaleFactor),
             frameWidth: screenBounds.width)
-        let image: CGImage
+        let raster: LegacyCapturedRaster
         do {
-            image = try await self.captureScreenWithSystemScreencapture(
+            raster = try await self.captureScreenWithSystemScreencapture(
                 screen: targetScreen,
                 correlationId: correlationId)
         } catch {
@@ -48,6 +48,7 @@ extension LegacyScreenCaptureOperator {
             throw error
         }
 
+        let image = raster.image
         let scaledImage = ScreenCaptureImageScaler.maybeDownscale(
             image,
             scale: scale,
@@ -55,7 +56,7 @@ extension LegacyScreenCaptureOperator {
 
         let imageData: Data
         do {
-            imageData = try scaledImage.pngData()
+            imageData = try raster.pngData(for: scaledImage)
         } catch {
             throw OperationError.captureFailed(reason: "Failed to convert image to PNG format")
         }
@@ -103,14 +104,15 @@ extension LegacyScreenCaptureOperator {
             displayID: display.id,
             fallbackPixelWidth: CGDisplayPixelsWide(display.id),
             frameWidth: display.bounds.width)
-        let image = try await self.captureAreaWithSystemScreencapture(
+        let raster = try await self.captureAreaWithSystemScreencapture(
             rect,
             correlationId: correlationId)
+        let image = raster.image
         let scaledImage = ScreenCaptureImageScaler.maybeDownscale(
             image,
             scale: scale,
             fallbackScale: scalePlan.nativeScale)
-        let imageData = try scaledImage.pngData()
+        let imageData = try raster.pngData(for: scaledImage)
         let metadata = CaptureMetadata(
             size: CGSize(width: scaledImage.width, height: scaledImage.height),
             mode: .area,

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/LegacyScreenCaptureOperator+Support.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/LegacyScreenCaptureOperator+Support.swift
@@ -9,15 +9,16 @@ extension LegacyScreenCaptureOperator {
     func captureWindowWithCGWindowList(
         windowID: CGWindowID,
         correlationId: String,
-        scale: CaptureScalePreference) async throws -> CGImage
+        scale: CaptureScalePreference) async throws -> LegacyCapturedRaster
     {
         let allowsPrivateSCKLookup = ScreenCaptureService.captureEnginePreference != .legacy
         if Self.privateScreenCaptureKitWindowLookupEnabled(), allowsPrivateSCKLookup {
             do {
-                return try await self.captureWindowWithPrivateScreenCaptureKit(
+                let image = try await self.captureWindowWithPrivateScreenCaptureKit(
                     windowID: windowID,
                     correlationId: correlationId,
                     scale: scale)
+                return LegacyCapturedRaster(image: image)
             } catch {
                 guard PrivateScreenCaptureKitWindowLookupPolicy.allowsSystemFallback(
                     after: error,

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/LegacyScreenCaptureOperator+SystemScreencapture.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/LegacyScreenCaptureOperator+SystemScreencapture.swift
@@ -15,8 +15,17 @@ struct LegacyCapturedRaster {
 
     init(systemScreencapturePNG data: Data) throws {
         guard
+            LegacyPNGValidator.hasValidStructureAndCRC(data),
             let source = CGImageSourceCreateWithData(data as CFData, nil),
-            let image = CGImageSourceCreateImageAtIndex(source, 0, nil)
+            let image = CGImageSourceCreateImageAtIndex(source, 0, nil),
+            let providerData = image.dataProvider?.data
+        else {
+            throw OperationError.captureFailed(reason: "Failed to decode screencapture output")
+        }
+        let (requiredPixelBytes, overflow) = image.bytesPerRow.multipliedReportingOverflow(by: image.height)
+        guard !overflow,
+              requiredPixelBytes > 0,
+              CFDataGetLength(providerData) >= requiredPixelBytes
         else {
             throw OperationError.captureFailed(reason: "Failed to decode screencapture output")
         }

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/LegacyScreenCaptureOperator+SystemScreencapture.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/LegacyScreenCaptureOperator+SystemScreencapture.swift
@@ -4,10 +4,39 @@ import Foundation
 import ImageIO
 import PeekabooFoundation
 
+struct LegacyCapturedRaster {
+    let image: CGImage
+    let sourcePNG: Data?
+
+    init(image: CGImage) {
+        self.image = image
+        self.sourcePNG = nil
+    }
+
+    init(systemScreencapturePNG data: Data) throws {
+        guard
+            let source = CGImageSourceCreateWithData(data as CFData, nil),
+            let image = CGImageSourceCreateImageAtIndex(source, 0, nil)
+        else {
+            throw OperationError.captureFailed(reason: "Failed to decode screencapture output")
+        }
+        self.image = image
+        self.sourcePNG = data
+    }
+
+    func pngData(for deliveredImage: CGImage) throws -> Data {
+        // Object identity is the scaler's no-transform receipt; pixel equality alone is insufficient.
+        if deliveredImage === self.image, let sourcePNG {
+            return sourcePNG
+        }
+        return try deliveredImage.pngData()
+    }
+}
+
 extension LegacyScreenCaptureOperator {
     func captureScreenWithSystemScreencapture(
         screen: NSScreen,
-        correlationId: String) async throws -> CGImage
+        correlationId: String) async throws -> LegacyCapturedRaster
     {
         guard let displayID = self.displayID(for: screen) else {
             throw OperationError.captureFailed(reason: "Could not resolve the selected NSScreen display ID")
@@ -44,7 +73,7 @@ extension LegacyScreenCaptureOperator {
 
     func captureAreaWithSystemScreencapture(
         _ rect: CGRect,
-        correlationId: String) async throws -> CGImage
+        correlationId: String) async throws -> LegacyCapturedRaster
     {
         try await self.captureImageWithSystemScreencapture(
             arguments: [
@@ -59,7 +88,7 @@ extension LegacyScreenCaptureOperator {
 
     func captureWindowWithSystemScreencapture(
         windowID: CGWindowID,
-        correlationId: String) async throws -> CGImage
+        correlationId: String) async throws -> LegacyCapturedRaster
     {
         // Match Apple's native window capture path; Hopper shows `screencapture -l` using
         // private window-id lookup before building its SCScreenshotManager content filter.
@@ -81,7 +110,7 @@ extension LegacyScreenCaptureOperator {
         outputPrefix: String,
         logMessage: String,
         metadata: [String: String],
-        correlationId: String) async throws -> CGImage
+        correlationId: String) async throws -> LegacyCapturedRaster
     {
         let url = URL(fileURLWithPath: NSTemporaryDirectory())
             .appendingPathComponent("\(outputPrefix)-\(UUID().uuidString).png")
@@ -106,21 +135,15 @@ extension LegacyScreenCaptureOperator {
                 reason: "screencapture exited with \(process.terminationStatus)\(detail)")
         }
 
-        let data = try Data(contentsOf: url)
-        guard
-            let source = CGImageSourceCreateWithData(data as CFData, nil),
-            let image = CGImageSourceCreateImageAtIndex(source, 0, nil)
-        else {
-            throw OperationError.captureFailed(reason: "Failed to decode screencapture output")
-        }
+        let raster = try LegacyCapturedRaster(systemScreencapturePNG: Data(contentsOf: url))
 
         var logMetadata = metadata
-        logMetadata["imageSize"] = "\(image.width)x\(image.height)"
+        logMetadata["imageSize"] = "\(raster.image.width)x\(raster.image.height)"
         self.logger.debug(
             logMessage,
             metadata: logMetadata,
             correlationId: correlationId)
-        return image
+        return raster
     }
 
     nonisolated static func waitForSystemScreencaptureExit(

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/LegacyScreenCaptureOperator+Window.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/LegacyScreenCaptureOperator+Window.swift
@@ -73,10 +73,11 @@ extension LegacyScreenCaptureOperator {
             ],
             correlationId: correlationId)
 
-        let image = try await self.captureWindowImage(
+        let raster = try await self.captureWindowImage(
             windowID: windowID,
             correlationId: correlationId,
             scale: scale)
+        let image = raster.image
         let mutationIdentity: WindowMutationIdentity? = mutationSnapshot.flatMap { snapshot in
             guard snapshot.ownerProcessStartIdentity == app.processStartIdentity else { return nil }
             return Self.validatedMutationIdentity(snapshot)
@@ -97,7 +98,7 @@ extension LegacyScreenCaptureOperator {
             scale: scale,
             fallbackScale: scalePlan.nativeScale)
         do {
-            imageData = try scaledImage.pngData()
+            imageData = try raster.pngData(for: scaledImage)
         } catch {
             throw OperationError.captureFailed(reason: "Failed to convert image to PNG format")
         }
@@ -184,10 +185,11 @@ extension LegacyScreenCaptureOperator {
             ],
             correlationId: correlationId)
 
-        let image = try await self.captureWindowImage(
+        let raster = try await self.captureWindowImage(
             windowID: windowID,
             correlationId: correlationId,
             scale: scale)
+        let image = raster.image
         let mutationIdentity = mutationSnapshot.flatMap(Self.validatedMutationIdentity)
 
         let bounds = Self.windowBounds(from: targetWindow, fallbackImage: image)
@@ -198,7 +200,7 @@ extension LegacyScreenCaptureOperator {
             scale: scale,
             fallbackScale: scalePlan.nativeScale)
         do {
-            imageData = try scaledImage.pngData()
+            imageData = try raster.pngData(for: scaledImage)
         } catch {
             throw OperationError.captureFailed(reason: "Failed to convert image to PNG format")
         }
@@ -286,9 +288,9 @@ extension LegacyScreenCaptureOperator {
     private func captureWindowImage(
         windowID: CGWindowID,
         correlationId: String,
-        scale: CaptureScalePreference) async throws -> CGImage
+        scale: CaptureScalePreference) async throws -> LegacyCapturedRaster
     {
-        let image = try await self.captureWindowWithCGWindowList(
+        let raster = try await self.captureWindowWithCGWindowList(
             windowID: windowID,
             correlationId: correlationId,
             scale: scale)
@@ -296,7 +298,7 @@ extension LegacyScreenCaptureOperator {
             "Captured window via isolated legacy path",
             metadata: ["windowID": String(windowID)],
             correlationId: correlationId)
-        return image
+        return raster
     }
 
     private static func windowBounds(

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/LegacyCapturedRasterTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/LegacyCapturedRasterTests.swift
@@ -4,6 +4,7 @@ import ImageIO
 import PeekabooFoundation
 import Testing
 import UniformTypeIdentifiers
+import zlib
 @testable import PeekabooAutomationKit
 
 struct LegacyCapturedRasterTests {
@@ -51,14 +52,49 @@ struct LegacyCapturedRasterTests {
     }
 
     @Test
-    func `corrupt and truncated system PNGs fail the full decode gate`() throws {
-        let validPNG = try Self.pngData(image: Self.makeImage(width: 4, height: 3))
-        let invalidInputs = [
-            Data([0x89, 0x50, 0x4E, 0x47]),
-            Data(validPNG.prefix(16)),
-        ]
+    func `bad CRC and invalid IDAT fail before source bytes can be retained`() throws {
+        let validPNG = try Self.pngData(image: Self.makeImage(width: 64, height: 48))
+        let idatChunks = Self.chunks(ofType: Self.idat, in: validPNG)
+        let firstIDAT = try #require(idatChunks.first)
+
+        var badCRC = validPNG
+        badCRC[firstIDAT.crcOffset] ^= 0x01
+        #expect(CGImageSourceCreateWithData(badCRC as CFData, nil) != nil)
+        #expect(!LegacyPNGValidator.hasValidStructureAndCRC(badCRC))
+        #expect(throws: PeekabooError.self) {
+            try LegacyCapturedRaster(systemScreencapturePNG: badCRC)
+        }
+
+        var invalidIDAT = validPNG
+        for chunk in idatChunks {
+            for index in chunk.dataRange {
+                invalidIDAT[index] = 0
+            }
+            Self.rewriteCRC(for: chunk, in: &invalidIDAT)
+        }
+        #expect(CGImageSourceCreateWithData(invalidIDAT as CFData, nil) != nil)
+        #expect(LegacyPNGValidator.hasValidStructureAndCRC(invalidIDAT))
+        #expect(throws: PeekabooError.self) {
+            try LegacyCapturedRaster(systemScreencapturePNG: invalidIDAT)
+        }
+    }
+
+    @Test
+    func `missing IEND truncation and overflowing chunk lengths fail structurally`() throws {
+        let validPNG = try Self.pngData(image: Self.makeImage(width: 8, height: 6))
+        let iend = try #require(Self.chunks(ofType: Self.iend, in: validPNG).first)
+        let idat = try #require(Self.chunks(ofType: Self.idat, in: validPNG).first)
+        let missingIEND = Data(validPNG[..<iend.offset])
+        let truncatedIDAT = Data(validPNG.prefix(idat.dataRange.lowerBound + max(idat.dataRange.count / 2, 1)))
+        let overflowingLength = Data([
+            0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A,
+            0xFF, 0xFF, 0xFF, 0xFF, 0x49, 0x44, 0x41, 0x54,
+            0x00, 0x00, 0x00, 0x00,
+        ])
+        let invalidInputs = [missingIEND, truncatedIDAT, overflowingLength]
 
         for data in invalidInputs {
+            #expect(!LegacyPNGValidator.hasValidStructureAndCRC(data))
             #expect(throws: PeekabooError.self) {
                 try LegacyCapturedRaster(systemScreencapturePNG: data)
             }
@@ -116,5 +152,60 @@ struct LegacyCapturedRasterTests {
     private static func decodedImage(_ data: Data) throws -> CGImage {
         let source = try #require(CGImageSourceCreateWithData(data as CFData, nil))
         return try #require(CGImageSourceCreateImageAtIndex(source, 0, nil))
+    }
+
+    private struct PNGChunk {
+        let offset: Int
+        let typeOffset: Int
+        let dataRange: Range<Int>
+        let crcOffset: Int
+    }
+
+    private static let idat: UInt32 = 0x4944_4154
+    private static let iend: UInt32 = 0x4945_4E44
+
+    private static func chunks(ofType expectedType: UInt32, in data: Data) -> [PNGChunk] {
+        data.withUnsafeBytes { bytes in
+            var chunks: [PNGChunk] = []
+            var offset = 8
+            while offset < bytes.count {
+                guard bytes.count - offset >= 12 else { break }
+                let length = Int(Self.uint32(bytes, at: offset))
+                guard length <= bytes.count - offset - 12 else { break }
+                let typeOffset = offset + 4
+                let dataOffset = typeOffset + 4
+                let crcOffset = dataOffset + length
+                if Self.uint32(bytes, at: typeOffset) == expectedType {
+                    chunks.append(PNGChunk(
+                        offset: offset,
+                        typeOffset: typeOffset,
+                        dataRange: dataOffset..<crcOffset,
+                        crcOffset: crcOffset))
+                }
+                offset = crcOffset + 4
+            }
+            return chunks
+        }
+    }
+
+    private static func rewriteCRC(for chunk: PNGChunk, in data: inout Data) {
+        let checksum = data.withUnsafeBytes { bytes -> UInt32 in
+            let count = chunk.dataRange.count + 4
+            let pointer = bytes.baseAddress!
+                .advanced(by: chunk.typeOffset)
+                .assumingMemoryBound(to: Bytef.self)
+            return UInt32(truncatingIfNeeded: zlib.crc32_z(0, pointer, count))
+        }
+        data[chunk.crcOffset] = UInt8(truncatingIfNeeded: checksum >> 24)
+        data[chunk.crcOffset + 1] = UInt8(truncatingIfNeeded: checksum >> 16)
+        data[chunk.crcOffset + 2] = UInt8(truncatingIfNeeded: checksum >> 8)
+        data[chunk.crcOffset + 3] = UInt8(truncatingIfNeeded: checksum)
+    }
+
+    private static func uint32(_ bytes: UnsafeRawBufferPointer, at offset: Int) -> UInt32 {
+        UInt32(bytes[offset]) << 24 |
+            UInt32(bytes[offset + 1]) << 16 |
+            UInt32(bytes[offset + 2]) << 8 |
+            UInt32(bytes[offset + 3])
     }
 }

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/LegacyCapturedRasterTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/LegacyCapturedRasterTests.swift
@@ -1,0 +1,120 @@
+import CoreGraphics
+import Foundation
+import ImageIO
+import PeekabooFoundation
+import Testing
+import UniformTypeIdentifiers
+@testable import PeekabooAutomationKit
+
+struct LegacyCapturedRasterTests {
+    @Test
+    func `native and true 1x delivery retain exact source PNG bytes`() throws {
+        let sourceImage = try Self.makeImage(width: 8, height: 6)
+        let sourcePNG = try Self.pngData(image: sourceImage, marker: "peekaboo-source-marker")
+        let raster = try LegacyCapturedRaster(systemScreencapturePNG: sourcePNG)
+
+        let native = ScreenCaptureImageScaler.maybeDownscale(
+            raster.image,
+            scale: .native,
+            fallbackScale: 2)
+        let logicalOne = ScreenCaptureImageScaler.maybeDownscale(
+            raster.image,
+            scale: .logical1x,
+            fallbackScale: 1)
+
+        #expect(native === raster.image)
+        #expect(logicalOne === raster.image)
+        #expect(raster.sourcePNG == sourcePNG)
+        #expect(try raster.pngData(for: native) == sourcePNG)
+        #expect(try raster.pngData(for: logicalOne) == sourcePNG)
+        #expect(sourcePNG.range(of: Data("peekaboo-source-marker".utf8)) != nil)
+    }
+
+    @Test
+    func `Retina logical 1x delivery discards source bytes and encodes transformed dimensions`() throws {
+        let sourceImage = try Self.makeImage(width: 8, height: 6)
+        let sourcePNG = try Self.pngData(image: sourceImage, marker: "must-not-survive-transform")
+        let raster = try LegacyCapturedRaster(systemScreencapturePNG: sourcePNG)
+
+        let logicalOne = ScreenCaptureImageScaler.maybeDownscale(
+            raster.image,
+            scale: .logical1x,
+            fallbackScale: 2)
+        let deliveredPNG = try raster.pngData(for: logicalOne)
+        let deliveredImage = try Self.decodedImage(deliveredPNG)
+
+        #expect(logicalOne !== raster.image)
+        #expect(deliveredPNG != sourcePNG)
+        #expect(deliveredPNG.range(of: Data("must-not-survive-transform".utf8)) == nil)
+        #expect(deliveredImage.width == 4)
+        #expect(deliveredImage.height == 3)
+    }
+
+    @Test
+    func `corrupt and truncated system PNGs fail the full decode gate`() throws {
+        let validPNG = try Self.pngData(image: Self.makeImage(width: 4, height: 3))
+        let invalidInputs = [
+            Data([0x89, 0x50, 0x4E, 0x47]),
+            Data(validPNG.prefix(16)),
+        ]
+
+        for data in invalidInputs {
+            #expect(throws: PeekabooError.self) {
+                try LegacyCapturedRaster(systemScreencapturePNG: data)
+            }
+        }
+    }
+
+    @Test
+    func `image-only private SCK raster has no source bytes and encodes the image`() throws {
+        let sourceImage = try Self.makeImage(width: 5, height: 3)
+        let raster = LegacyCapturedRaster(image: sourceImage)
+        let encoded = try raster.pngData(for: sourceImage)
+        let decoded = try Self.decodedImage(encoded)
+
+        #expect(raster.sourcePNG == nil)
+        #expect(!encoded.isEmpty)
+        #expect(decoded.width == 5)
+        #expect(decoded.height == 3)
+    }
+
+    private static func makeImage(width: Int, height: Int) throws -> CGImage {
+        let colorSpace = CGColorSpace(name: CGColorSpace.sRGB) ?? CGColorSpaceCreateDeviceRGB()
+        let bitmapInfo = CGBitmapInfo(rawValue: CGImageAlphaInfo.premultipliedLast.rawValue)
+        let context = try #require(CGContext(
+            data: nil,
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bytesPerRow: 0,
+            space: colorSpace,
+            bitmapInfo: bitmapInfo.rawValue))
+        context.setFillColor(CGColor(red: 0.2, green: 0.4, blue: 0.8, alpha: 1))
+        context.fill(CGRect(x: 0, y: 0, width: width, height: height))
+        return try #require(context.makeImage())
+    }
+
+    private static func pngData(image: CGImage, marker: String? = nil) throws -> Data {
+        let data = NSMutableData()
+        let destination = try #require(CGImageDestinationCreateWithData(
+            data,
+            UTType.png.identifier as CFString,
+            1,
+            nil))
+        let properties: CFDictionary? = marker.map { marker in
+            [
+                kCGImagePropertyPNGDictionary: [
+                    kCGImagePropertyPNGDescription: marker,
+                ],
+            ] as CFDictionary
+        }
+        CGImageDestinationAddImage(destination, image, properties)
+        try #require(CGImageDestinationFinalize(destination))
+        return data as Data
+    }
+
+    private static func decodedImage(_ data: Data) throws -> CGImage {
+        let source = try #require(CGImageSourceCreateWithData(data as CFData, nil))
+        return try #require(CGImageSourceCreateImageAtIndex(source, 0, nil))
+    }
+}


### PR DESCRIPTION
## Summary

- retain the exact PNG bytes produced by system `screencapture` after strict validation and full pixel consumption
- reuse those bytes only when the capture scaler returns the identical untransformed `CGImage`
- preserve the existing encoder for logical-1x transforms, private ScreenCaptureKit images, and every other derived output

## Why

The classic capture path currently reads and decodes the child PNG, then encodes the same pixels back to PNG even when native/true-1x delivery performs no transform. This adds redundant CPU and latency before digesting, publishing, and base64 transport.

`LegacyCapturedRaster` now carries validated source bytes alongside the decoded image. Object identity is the no-transform receipt: pixel equality is deliberately insufficient. Transformed images and image-only private-SCK results continue through the existing encoder.

## Integrity boundary

Raw bytes are retained only after:

- PNG signature, chunk type/order, IHDR/IDAT/IEND, checked lengths, and structural validation
- system-zlib CRC verification for every chunk without per-chunk allocation
- ImageIO image creation
- checked `bytesPerRow * height`
- full `CGDataProvider` pixel materialization

Adversarial tests reject bad CRC, valid-CRC invalid compressed IDAT, missing IEND, truncation, and a `UInt32.max` chunk length. Valid ancillary chunks remain byte-for-byte intact.

## Performance

Synthetic validation after the integrity fix:

- 13.5 KB PNG: validated retention 0.165 ms vs decode/re-encode 0.304 ms
- 6.02 MB PNG: validated retention 18.657 ms vs decode/re-encode 125.249 ms
- large eligible capture saving: about 106.6 ms

This does not claim a win for the common Retina logical-1x path, which transforms and still re-encodes.

## Verification

- focused retention/adversarial tests: 5/5
- serialized AutomationKit: 1,282/1,282
- See ownership + signed output/digest + exact-window See: 15/15
- SwiftFormat: clean
- SwiftLint: zero serious/new violations
- docs lint and diff hygiene: clean
- exact whole-branch P2 review: clean

There are no Bridge/result-projection/public API, ROI, annotation, JPEG, output-path, quarantine, digest, or base64 changes. No live UI, input, screenshots, AppleScript/JXA, virtualization, or account interaction was used.

The mirrored 4.2.3 changelog bullet is intentionally retained under the repository's user-visible-change policy and explicit maintainer direction.


## Exact-head signed native capture proof

The exact final head was Foundation-signed and transactionally installed on the verified personal Retina Studio. CLI CDHash `c70d74c0a134b0e761874785826866998fb39b9a`; GUI CDHash `f5ad75d2c98e257fe292fa89f38f6fb4ba85fede`; source `7c41df28a7786c64e6f14778f8e0c159b13a4441`; protocol 1.33; all three permissions granted.

Two real classic screen captures ran through one explicit GUI Bridge while the exact Chrome foreground PID/generation stayed unchanged:

- native/Retina: 6400×3600, 8,920,307 bytes, 0.73s, every PNG chunk CRC valid
- logical1x: 3200×1800, 3,668,393 bytes, 0.81s, every PNG chunk CRC valid
- native output retained the system-only ancillary sequence `pHYs`, `iTXt`, and `iDOT`, proving the validated source PNG reached publication unchanged
- logical1x output omitted those chunks and carried the requested half dimensions, proving the transformed image used the encoder path
- both images were moved unseen to Trash; none was viewed or uploaded

Private text/JSON evidence is sealed by manifest SHA-256 `fc06904ad3c2d6f154a940c4ffdb9c4ba4ab9fe33e10b60f2f3614817e024f41`.

The first hosted CLI attempt failed only the known secure-prompt timing test; the exact focused suite passed 14/14 locally, and the unchanged failed job was rerun. No PNG/capture test failed.
