### PR TITLE
perf(capture): avoid redundant Bridge artifact verification

### DIFF
--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Read `config credential set` secrets from no-echo prompts, stdin, or owner-only files; let `config provider add` also accept non-secret references; retain deprecated argv compatibility.
 - Skip provider discovery and Agent construction for caller-local commands that cannot invoke the Agent.
+- Avoid reopening and hashing Bridge screenshot artifacts twice before CLI or MCP consumption while retaining signed client verification and use-time publication checks.
 - Skip the ScreenCaptureKit post-capture settlement delay for classic captures that never enter ScreenCaptureKit.
 - Reuse validated classic PNG bytes when capture performs no transform instead of encoding the same image twice.
 

--- a/Apps/CLI/Tests/CLIAutomationTests/SeeCommandTests.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/SeeCommandTests.swift
@@ -9,6 +9,34 @@ import Testing
 @Suite(.serialized, .tags(.safe))
 struct SeeCommandTests {
     @Test
+    @MainActor
+    func `pixel publication rejects an artifact replaced after capture verification`() throws {
+        let artifactURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("peekaboo-see-publication-\(UUID().uuidString).png")
+        defer { try? FileManager.default.removeItem(at: artifactURL) }
+        let verifiedData = Data("verified-pixels".utf8)
+        let replacement = Data("replaced-pixels".utf8)
+        #expect(verifiedData.count == replacement.count)
+        try verifiedData.write(to: artifactURL, options: .atomic)
+        let capture = ImageCapturedFile(
+            file: SavedFile(path: artifactURL.path, mime_type: "image/png"),
+            imageData: verifiedData,
+            observation: ImageObservationDiagnostics(
+                timings: ObservationTimings(),
+                diagnostics: DesktopObservationDiagnostics()
+            ),
+            snapshotID: nil,
+            receipt: .none
+        )
+
+        try replacement.write(to: artifactURL, options: .atomic)
+
+        #expect(throws: DesktopObservationContentVerificationError.digestMismatch) {
+            try SeeCommand.requireCurrentCaptureArtifacts([capture])
+        }
+    }
+
+    @Test
     func `CLI truncation output includes deadline reached explicitly`() throws {
         let metadata = DetectionMetadata(
             detectionTime: 0,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 ### Changed
 - Read `config credential set` secrets from no-echo prompts, stdin, or owner-only files; let `config provider add` also accept non-secret references; retain deprecated argv compatibility.
 - Skip provider discovery and Agent construction for caller-local commands that cannot invoke the Agent.
+- Avoid reopening and hashing Bridge screenshot artifacts twice before CLI or MCP consumption while retaining signed client verification and use-time publication checks.
 - Skip the ScreenCaptureKit post-capture settlement delay for classic captures that never enter ScreenCaptureKit.
 - Reuse validated classic PNG bytes when capture performs no transform instead of encoding the same image twice.
 

--- a/Core/PeekabooCore/Sources/PeekabooCore/Support/RemoteDesktopObservationService.swift
+++ b/Core/PeekabooCore/Sources/PeekabooCore/Support/RemoteDesktopObservationService.swift
@@ -93,12 +93,10 @@ public final class RemoteDesktopObservationService: DesktopObservationActionResu
         guard request.capture.roi != nil else {
             let actionResult = try await self.client.desktopObservationWithOutcome(request)
             do {
-                if actionResult.payload.files.rawScreenshotPath != nil {
-                    _ = try actionResult.payload.verifiedRawScreenshotData()
-                }
-                if actionResult.payload.files.annotatedScreenshotPath != nil {
-                    _ = try actionResult.payload.verifiedAnnotatedScreenshotData()
-                }
+                // The Bridge client verifies every returned artifact under the negotiated content
+                // policy before it yields the result. Consumers still revalidate the file at the
+                // point where they use or publish its pixels; reopening it here only repeated the
+                // same whole-file I/O.
                 try DesktopObservationEvidencePolicy.requireUsableAccessibilityEvidence(
                     actionResult.payload.elements,
                     target: actionResult.payload.target,

--- a/Core/PeekabooCore/Tests/PeekabooTests/RemoteCaptureGateOwnershipTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/RemoteCaptureGateOwnershipTests.swift
@@ -258,6 +258,46 @@ extension RemoteCaptureGateOwnershipTests {
     }
 
     @Test
+    func `non ROI remote observation retains use time artifact verification`() async throws {
+        let root = URL(
+            fileURLWithPath: "/tmp/pb-remote-content-\(UUID().uuidString.prefix(8))",
+            isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: false)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let socketPath = root.appendingPathComponent("bridge.sock").path
+        let artifactURL = root.appendingPathComponent("capture.png")
+        let observation = NonROIFileObservationService()
+        let server = self.makeROIServer(services: StubServices(desktopObservation: observation))
+        let host = PeekabooBridgeHost(
+            socketPath: socketPath,
+            server: server,
+            allowedTeamIDs: [],
+            requestTimeoutSec: 2)
+        try await host.startChecked()
+        defer { Task { await host.stop() } }
+        let remote = try await RemoteDesktopObservationService(
+            client: self.makeNegotiatedClient(socketPath: socketPath, requestTimeoutSec: 2))
+
+        let result = try await remote.observe(DesktopObservationRequest(
+            target: .screen(index: 0),
+            detection: DesktopDetectionOptions(mode: .none),
+            output: DesktopObservationOutputOptions(
+                path: artifactURL.path,
+                saveRawScreenshot: true)))
+
+        #expect(result.capture.imageData.isEmpty)
+        #expect(result.captureContentDigest != nil)
+        #expect(try result.verifiedRawScreenshotData(requirement: .requireDigest) == observation.imageData)
+        var replacement = observation.imageData
+        replacement[replacement.startIndex] ^= 0x01
+        try replacement.write(to: artifactURL, options: .atomic)
+        #expect(throws: DesktopObservationContentVerificationError.digestMismatch) {
+            try result.verifiedRawScreenshotData(requirement: .requireDigest)
+        }
+        await host.stop()
+    }
+
+    @Test
     func `remote ROI rejects an exhausted overall deadline before transport`() async {
         let remote = RemoteDesktopObservationService(
             client: PeekabooBridgeClient(
@@ -905,6 +945,39 @@ private final class PathlessTrackingObservationService: DesktopObservationServic
                 imageData: StubScreenCaptureService.sampleData,
                 metadata: CaptureMetadata(size: .init(width: 1, height: 1), mode: .screen)),
             elements: nil)
+    }
+}
+
+@MainActor
+private final class NonROIFileObservationService: DesktopObservationServiceProtocol {
+    let imageData = makeROITestImageData(width: 1, height: 1, red: 0.2, green: 0.4, blue: 0.8)
+
+    func observe(_ request: DesktopObservationRequest) async throws -> DesktopObservationResult {
+        let path = try #require(request.output.path)
+        try self.imageData.write(to: URL(fileURLWithPath: path), options: .atomic)
+        let size = CGSize(width: 1, height: 1)
+        return DesktopObservationResult(
+            target: ResolvedObservationTarget(kind: .screen(index: 0)),
+            capture: CaptureResult(
+                imageData: self.imageData,
+                savedPath: path,
+                metadata: CaptureMetadata(
+                    size: size,
+                    mode: .screen,
+                    displayInfo: DisplayInfo(
+                        index: 0,
+                        name: "Fixture",
+                        bounds: CGRect(origin: .zero, size: size),
+                        scaleFactor: 1),
+                    diagnostics: CaptureDiagnostics(
+                        requestedScale: request.capture.scale,
+                        nativeScale: 1,
+                        outputScale: 1,
+                        scaleSource: "fixture",
+                        finalPixelSize: size,
+                        engine: "ScreenCaptureKit"))),
+            elements: nil,
+            files: DesktopObservationFiles(rawScreenshotPath: path))
     }
 }
 


### PR DESCRIPTION
## Summary

- remove the redundant non-ROI screenshot read and SHA-256 pass in `RemoteDesktopObservationService`
- keep the Bridge client's negotiated signed/legacy content verification as the transport trust boundary
- retain consumer use-time verification in CLI publication and MCP response ownership paths
- add signed remote and CLI replacement regressions, plus matched root and CLI 4.2.3 changelog entries

## Ownership trace

The Bridge host reads each artifact to create the response content digest, and the Bridge client reads it again to authenticate that signed response before returning. The non-ROI remote service then immediately performed the same whole-file verification and discarded the bytes. It has no suspension or ownership transfer between those two checks, while CLI and MCP consumers independently read verified bytes at their actual consumption/publication boundary.

ROI remains unchanged because it uses the verified bytes for raster-dimension validation, quarantine, owner-side republishing, and snapshot publication.

## Performance

An owner-private source-only benchmark over a representative 32 MiB artifact measured median read+SHA-256 time across seven samples:

- one pass: 11.44 ms
- two passes: 22.95 ms
- removed redundant pass: 11.51 ms

## Verification

- `swift test --package-path Core/PeekabooCore --no-parallel --filter RemoteCaptureGateOwnershipTests` (24 passed)
- `swift test --package-path Core/PeekabooCore --no-parallel --filter 'signed observation authenticates exact file bytes and rejects same-size replacement'` (1 passed)
- `swift test --package-path Core/PeekabooCore --no-parallel --filter SeeToolImageOwnershipTests` (8 passed)
- `PEEKABOO_INCLUDE_AUTOMATION_TESTS=true swift test --package-path Apps/CLI --no-parallel --filter 'pixel publication rejects an artifact replaced after capture verification' -Xswiftc -DPEEKABOO_SKIP_AUTOMATION` (1 passed)
- `pnpm run format`
- `pnpm run lint` (0 serious violations; baseline warnings remain)
- `pnpm run lint:docs`
- structured autoreview: clean on both the implementation and matched CLI changelog follow-up

No UI, input, foreground, AppleScript/JXA, virtualization, or screenshot upload was used.
