### PR TITLE
fix(cli): honor default save path for pixel captures

### DIFF
--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bind Bridge 1.34 Chrome channel connections to an exact live Chrome bundle, native process-owned DevTools listener, and approval-gated WebSocket under one 90-second deadline, verifying `Browser.getVersion` once without legacy HTTP discovery or repeated permission probes and failing closed on helper-service names, file, socket, generation, or endpoint drift.
 - Authenticate native Chrome channels against Google Team ID `EQHXZ8M8AV`, pin the exact signed identifier and CDHash for the process generation, and enumerate the target process's complete listener inventory independently of Peekaboo's file-descriptor limit.
+- Honor the configured default save directory for pathless pixel-only `see` captures and add collision-resistant generated filenames for concurrent callers, while preserving explicit paths and stdout streaming. Thanks @PollyBot13 for #607.
 - Emit one lossless target identity and process-generation receipt across CLI envelopes and App MCP responses, preventing extra metadata from overriding the canonical target.
 - Let exact `dialog` targeting prefer one active child sheet or alert beneath its structural parent, retain ambiguity for multiple children, and preserve actionable parent-window recovery hints through Bridge routing.
 

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/AI/SeeCommand+CommanderMetadata.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/AI/SeeCommand+CommanderMetadata.swift
@@ -58,7 +58,8 @@ extension SeeCommand: CommanderSignatureProviding {
                         .aliasLong("output"),
                         .short("o"),
                     ],
-                    help: "Output path for screenshot (aliases: --save, --output, -o)",
+                    help: "Output screenshot path; pixel-only captures default to the configured save directory "
+                        + "(aliases: --save, --output, -o)",
                     parsing: .singleValue
                 ),
                 .commandOption(

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/AI/SeeCommand+PixelCaptureFiles.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/AI/SeeCommand+PixelCaptureFiles.swift
@@ -34,7 +34,13 @@ extension SeeCommand {
         }
     }
 
-    func makeOutputURL(preferredName: String?, index: Int?) -> URL {
+    func makeOutputURL(
+        preferredName: String?,
+        index: Int?,
+        defaultDirectory: String? = nil,
+        timestamp: Date = Date(),
+        uniqueToken: UUID = UUID()
+    ) -> URL {
         if self.streamsImageToStdout {
             let suffix = index.map { "-\($0)" } ?? ""
             return FileManager.default.temporaryDirectory
@@ -47,7 +53,12 @@ extension SeeCommand {
             if ObservationOutputPathResolver.isDirectoryLike(expanded) {
                 return URL(fileURLWithPath: expanded, isDirectory: true)
                     .appendingPathComponent(
-                        self.defaultOutputFilename(preferredName: preferredName, index: index)
+                        self.defaultOutputFilename(
+                            preferredName: preferredName,
+                            index: index,
+                            timestamp: timestamp,
+                            uniqueToken: uniqueToken
+                        )
                     )
             }
 
@@ -68,9 +79,16 @@ extension SeeCommand {
             return url
         }
 
-        return URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+        let configuredDirectory = defaultDirectory
+            ?? ConfigurationManager.shared.getDefaultSavePath(cliValue: nil)
+        return URL(fileURLWithPath: configuredDirectory, isDirectory: true)
             .appendingPathComponent(
-                self.defaultOutputFilename(preferredName: preferredName, index: index)
+                self.defaultOutputFilename(
+                    preferredName: preferredName,
+                    index: index,
+                    timestamp: timestamp,
+                    uniqueToken: uniqueToken
+                )
             )
     }
 
@@ -94,8 +112,13 @@ extension SeeCommand {
         )
     }
 
-    private func defaultOutputFilename(preferredName: String?, index: Int?) -> String {
-        let timestamp = Self.imageFilenameDateFormatter.string(from: Date())
+    private func defaultOutputFilename(
+        preferredName: String?,
+        index: Int?,
+        timestamp: Date,
+        uniqueToken: UUID
+    ) -> String {
+        let readableTimestamp = Self.imageFilenameDateFormatter.string(from: timestamp)
         var components: [String] = []
         if let preferred = preferredName {
             components.append(self.sanitizeFilenameComponent(preferred))
@@ -106,10 +129,11 @@ extension SeeCommand {
         } else {
             components.append("capture")
         }
-        components.append(timestamp)
+        components.append(readableTimestamp)
         if let index, index > 0 {
             components.append(String(index))
         }
+        components.append(uniqueToken.uuidString.lowercased())
 
         return components.joined(separator: "_") + ".\(self.format.fileExtension)"
     }

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/AI/SeeCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/AI/SeeCommand.swift
@@ -51,7 +51,8 @@ RuntimeBackedCommand {
             .automatic, .customLong("save"), .customLong("output"),
             .customShort("o", allowingJoined: false),
         ],
-        help: "Output path for screenshot (aliases: --save, --output, -o)"
+        help: "Output screenshot path; pixel-only captures default to the configured save directory "
+            + "(aliases: --save, --output, -o)"
     )
     var path: String?
 

--- a/Apps/CLI/Tests/CLIAutomationTests/HelpCommandTests.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/HelpCommandTests.swift
@@ -166,6 +166,12 @@ struct HelpCommandTests {
     }
 
     @Test
+    func `See help explains the pathless pixel capture destination`() async throws {
+        let help = try await runPeekaboo(["see", "--help"]).stdout
+        #expect(help.contains("pixel-only captures default to the configured save directory"))
+    }
+
+    @Test
     func `V4 inventory and interaction help omit removed CLI forms`() async throws {
         let helpPaths = [
             ["app", "list", "--help"],

--- a/Apps/CLI/Tests/CoreCLITests/CommanderBinderProgramResolutionTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/CommanderBinderProgramResolutionTests.swift
@@ -110,6 +110,8 @@ struct CommanderBinderProgramResolutionTests {
         }
         let modeHelp = SeeCommand.commanderSignature().options.first { $0.label == "mode" }?.help
         #expect(modeHelp?.contains("multi") == true)
+        let pathHelp = SeeCommand.commanderSignature().options.first { $0.label == "path" }?.help
+        #expect(pathHelp?.contains("pixel-only captures default to the configured save directory") == true)
     }
 
     @Test

--- a/Apps/CLI/Tests/CoreCLITests/ImageCaptureLogicTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/ImageCaptureLogicTests.swift
@@ -65,6 +65,66 @@ struct ImageCaptureLogicTests {
 
     @Test(.tags(.fast))
     @MainActor
+    func `Implicit output path uses configured save directory`() throws {
+        let command = try SeeCommand.parse(["--mode", "screen", "--screen-index", "0"])
+        let directory = "/tmp/peekaboo configured captures"
+
+        let output = command.makeOutputURL(
+            preferredName: "screen0",
+            index: nil,
+            defaultDirectory: directory
+        )
+
+        #expect(output.deletingLastPathComponent().path == directory)
+        #expect(output.lastPathComponent.hasPrefix("screen0_"))
+        #expect(output.pathExtension == "png")
+    }
+
+    @Test(.tags(.fast))
+    @MainActor
+    func `Concurrent implicit outputs stay unique and immutable`() async throws {
+        let command = try SeeCommand.parse(["--mode", "screen", "--screen-index", "0"])
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+
+        let timestamp = Date(timeIntervalSince1970: 1_735_689_600)
+        let firstToken = try #require(UUID(uuidString: "00000000-0000-4000-8000-000000000001"))
+        let secondToken = try #require(UUID(uuidString: "00000000-0000-4000-8000-000000000002"))
+        let firstURL = command.makeOutputURL(
+            preferredName: "screen0",
+            index: nil,
+            defaultDirectory: directory.path,
+            timestamp: timestamp,
+            uniqueToken: firstToken
+        )
+        let secondURL = command.makeOutputURL(
+            preferredName: "screen0",
+            index: nil,
+            defaultDirectory: directory.path,
+            timestamp: timestamp,
+            uniqueToken: secondToken
+        )
+
+        #expect(firstURL != secondURL)
+        #expect(firstURL.lastPathComponent.contains("2025-01-01T00:00:00Z"))
+        #expect(secondURL.lastPathComponent.contains("2025-01-01T00:00:00Z"))
+
+        let firstPixels = Data("first-capture-pixels".utf8)
+        let secondPixels = Data("second-capture-pixels".utf8)
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            group.addTask { try firstPixels.write(to: firstURL, options: .atomic) }
+            group.addTask { try secondPixels.write(to: secondURL, options: .atomic) }
+            try await group.waitForAll()
+        }
+
+        #expect(try Data(contentsOf: firstURL) == firstPixels)
+        #expect(try Data(contentsOf: secondURL) == secondPixels)
+    }
+
+    @Test(.tags(.fast))
+    @MainActor
     func `Stdout image streaming rejects structured or text output`() throws {
         let jsonCommand = try SeeCommand.parse(["--path", "-", "--json"])
         #expect(throws: ValidationError.self) {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Bind Bridge 1.34 Chrome channel connections to an exact live Chrome bundle, native process-owned DevTools listener, and approval-gated WebSocket under one 90-second deadline, verifying `Browser.getVersion` once without legacy HTTP discovery or repeated permission probes and failing closed on helper-service names, file, socket, generation, or endpoint drift.
 - Authenticate native Chrome channels against Google Team ID `EQHXZ8M8AV`, pin the exact signed identifier and CDHash for the process generation, and enumerate the target process's complete listener inventory independently of Peekaboo's file-descriptor limit.
+- Honor the configured default save directory for pathless pixel-only `see` captures and add collision-resistant generated filenames for concurrent callers, while preserving explicit paths and stdout streaming. Thanks @PollyBot13 for #607.
 - Emit one lossless target identity and process-generation receipt across CLI envelopes and App MCP responses, preventing extra metadata from overriding the canonical target.
 - Prefer a sole live child sheet or alert beneath its exact structural parent window, preserve multi-child ambiguity, and keep parent-window recovery guidance intact across remote dialog reads.
 

--- a/docs/commands/see.md
+++ b/docs/commands/see.md
@@ -52,7 +52,7 @@ peekaboo see --app Calendar --window-id 12345 --ocr --json --path /tmp/calendar.
 | `--tree` | Print the accessibility text tree. For an explicit WindowServer ID with no matching AX window, tree-only read-only observation may return application-scoped partial semantics instead of relabeling another window as the requested target. |
 | `--no-screenshot` | Skip pixel capture; requires `--tree` and rejects `--capture-engine` because no backend runs. Ambient engine configuration is ignored so it cannot reroute this AX-only form. Element IDs and a snapshot publish only after pinning the exact process generation, window, and bounds; target drift or a missing receipt fails before publication. |
 | `--annotate` | Overlay element bounds/IDs on the output image. |
-| `--path <file>` / `--save` / `--output` / `-o` | Save the screenshot/annotation to disk. |
+| `--path <file>` / `--save` / `--output` / `-o` | Save the screenshot/annotation to disk. Pixel-only `--no-elements` captures otherwise use the configured default save directory; pass `-` for raw screenshot bytes on stdout. |
 | `--json` | Emit structured metadata (recommended for scripting). |
 | `--menubar` | Capture menu bar popovers via window list + OCR (useful for status-item settings panels). When `--app` is set, the app name is used as an OCR hint for popover selection. |
 | `--timeout <duration>` | Increase overall timeout for large/complex windows (defaults to `20s`, or `60s` with `--analyze`; bare values are milliseconds). |
@@ -74,11 +74,11 @@ relaunch that host, or pass `--no-remote` to explicitly run Vision OCR in the ca
 preferred-OCR path retains its legacy Bridge contract. Incomplete AX warnings remain in the successful result so OCR
 text never turns missing Accessibility evidence into a false completeness claim.
 
-For agent and automation runs, pass `--path` to a known temporary file when using `see` so capture artifacts land where expected. Use `peekaboo see --tree --no-screenshot --json` when you need AX metadata without a screenshot artifact.
+For agent and automation runs, pass `--path` to a known temporary file when using `see` so capture artifacts land at one exact caller-owned path. Use `peekaboo see --tree --no-screenshot --json` when you need AX metadata without a screenshot artifact.
 
 Passive background observations retry one resolve-and-capture transaction when the target's exact receipt changes during capture, then fail closed if it changes again. Foreground capture, explicit web-focus fallback, and menu-opening observations never retry because they can mutate visible desktop state.
 
-When `--json` is used without `--path`, Peekaboo retains the raw image only in managed snapshot storage and returns empty `screenshot_raw` and `screenshot_annotated` fields. Pass `--path` when the caller needs a directly accessible image file.
+Pixel-only `see --no-elements` captures without `--path` write a generated file beneath `PEEKABOO_DEFAULT_SAVE_PATH`, `defaults.savePath`, or the built-in `~/Desktop` default, in that order. Generated names retain a readable timestamp and include a unique token so concurrent callers do not share a path. This also applies with `--json`; `data.files[].path` reports the saved file. Ordinary element-producing `--json` observations without `--path` instead retain the raw image only in managed snapshot storage and return empty `screenshot_raw` and `screenshot_annotated` fields.
 
 ## Exact-window ROI capture
 


### PR DESCRIPTION
Closes #606.

## Summary

- save pathless pixel-only captures beneath the effective default save directory
- allocate readable timestamp-plus-UUID filenames so concurrent same-target captures never collide
- preserve explicit file paths and `--path -` stdout streaming
- clarify JSON artifact behavior in help/docs and add release-owned notes

Thanks @PollyBot13 for the original report and patch.

## Root cause

Pathless pixel capture bypassed `ConfigurationManager` and fell back to the caller's working directory. Moving every caller to one configured directory exposed a second issue: second-precision filenames alias concurrent captures. The final implementation centralizes allocation under the configured directory and adds a UUID while retaining the timestamp and target label.

## Proof

- deterministic concurrent uniqueness/content-isolation regression
- focused image tests: 31 passed
- Commander/background tests: 37 passed
- help/See tests: 50 passed
- full `pnpm run test:safe`: background certification; Foundation 77; CLI 1069; controller 50; runtime 527
- SwiftFormat, docs lint, `git diff --check`, and SwiftLint with zero serious findings
- P0-P2 structured review: clean

Signed live proof covered normal on-demand Bridge classic capture, explicit local classic capture, and two simultaneous processes from distinct working directories writing stable, distinct PNGs into one configured destination. Automatic modern capture correctly refused an older unattested GUI owner rather than falling back unsafely.
