### PR TITLE
fix(release): isolate preflight tests from signing

### DIFF
--- a/scripts/prepare-release.js
+++ b/scripts/prepare-release.js
@@ -286,8 +286,16 @@ function checkSwift() {
     logSuccess('No Swift compiler warnings found');
   }
 
-  // Run Swift tests
-  if (!execWithOutput('pnpm test', 'Swift CLI tests (safe)')) {
+  // Tests include fixture modes that must never inherit live signing authority.
+  const testCommand = [
+    '/usr/bin/env',
+    '-u MAC_RELEASE_CODESIGN_KEYCHAIN',
+    '-u MAC_RELEASE_CODESIGN_KEYCHAIN_PASSWORD',
+    '-u CODESIGN_KEYCHAIN',
+    '-u CODESIGN_IDENTITY',
+    'pnpm test'
+  ].join(' ');
+  if (!execWithOutput(testCommand, 'Swift CLI tests (safe)')) {
     logError('Swift tests failed');
     return false;
   }

--- a/tests/release-preflight-contract.test.mjs
+++ b/tests/release-preflight-contract.test.mjs
@@ -188,6 +188,19 @@ test('npm version availability accepts valid registry lists and rejects an alrea
   }
 });
 
+test('publication preflight isolates tests from live signing authority', () => {
+  const source = readFileSync(new URL('../scripts/prepare-release.js', import.meta.url), 'utf8');
+  for (const variable of [
+    'MAC_RELEASE_CODESIGN_KEYCHAIN',
+    'MAC_RELEASE_CODESIGN_KEYCHAIN_PASSWORD',
+    'CODESIGN_KEYCHAIN',
+    'CODESIGN_IDENTITY'
+  ]) {
+    assert.match(source, new RegExp(`-u ${variable}`));
+  }
+  assert.match(source, /pnpm test/);
+});
+
 test('repository release source surfaces remain internally consistent', () => {
   const packageVersion = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8')).version;
   const versionResult = validateVersionConsistency(projectRoot);


### PR DESCRIPTION
## Summary

Credentialed release preflight leaked managed signing authority into fixture-mode tests. Run only the `pnpm test` subprocess without `MAC_RELEASE_CODESIGN_KEYCHAIN`, `MAC_RELEASE_CODESIGN_KEYCHAIN_PASSWORD`, `CODESIGN_KEYCHAIN`, and `CODESIGN_IDENTITY`, while retaining that signing authority for the later signed universal build and package phase.

Add a release-preflight contract that verifies the live signing variables are removed from the test subprocess.

## Proof

- `node --test tests/release-preflight-contract.test.mjs` — 10 contract tests passed.
- `node --check scripts/prepare-release.js` — passed.
- `git diff --check` — passed.
- Independent autoreview clean.

No changelog entry: release-internal behavior only.
