### PR TITLE
test(qualification): timestamp restore readback after owner

### DIFF
--- a/scripts/final-qualification/test/qualification-tools.test.mjs
+++ b/scripts/final-qualification/test/qualification-tools.test.mjs
@@ -2342,7 +2342,7 @@ test('marker publication is run-bound, readback-gated, atomic, and no-overwrite'
     const restoreReadback = writeJSON(path.join(root, 'restore-readback.json'), {
       version: 1, execution_nonce: NONCE, monitor_instance_id: UUID, phase: 'restore',
       window_path: windowPath, emitter: emitter(), target: target(203, '203001', 303),
-      observed_at_milliseconds: now, passed: true,
+      observed_at_milliseconds: Date.now(), passed: true,
       baseline_value_sha256: sha256(Buffer.from(baseline)),
       observed_value_sha256: sha256(Buffer.from(baseline)),
       sentinel,


### PR DESCRIPTION
## Summary

- The synthetic restore observation reused the timestamp captured before the perform phase.
- Compiling the Swift atomic-publication helper can take longer than the owner window's 1,000 ms timing tolerance.
- Capture the restore observation with `Date.now()` after the restore owner window is written; the production timing invariant remains unchanged.

## Verification

- Marker-publication regression test: 10 consecutive stress runs passed.
- Full final-qualification suite: 51 tests passed.
- `node --check scripts/final-qualification/test/qualification-tools.test.mjs`
- `node --check scripts/final-qualification/publish-coordinator-marker.mjs`
- `git diff --check`
- Codex autoreview: no actionable findings.
