### PR TITLE
feat(mcp): allow explicit foreground authority

### DIFF
--- a/Apps/CLI/Sources/PeekabooCLI/Commands/MCP/MCPCommand+Serve.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/MCP/MCPCommand+Serve.swift
@@ -18,8 +18,8 @@ extension MCPCommand {
             discussion: """
             Starts Peekaboo as an MCP server, exposing all its tools via the
             Model Context Protocol. This allows AI clients like Claude to use
-            Peekaboo's automation capabilities. The server is always background-only:
-            foreground actions and ambient browser auto-connect are refused before dispatch.
+            Peekaboo's automation capabilities. The server is background-only by default;
+            pass --allow-foreground to authorize foreground actions for this server process.
 
             USAGE WITH CLAUDE CODE:
               claude mcp add peekaboo -- peekaboo mcp
@@ -34,6 +34,12 @@ extension MCPCommand {
 
         @Option(help: "Reserved port for future HTTP/SSE transport support")
         var port: Int = 8080
+
+        @Flag(
+            name: .customLong("allow-foreground"),
+            help: "Authorize foreground/global UI for this MCP server"
+        )
+        var allowForeground = false
 
         @MainActor
         mutating func run(using runtime: CommandRuntime) async throws {
@@ -73,6 +79,7 @@ extension MCPCommand {
                 let toolContext = Self.makeToolContext(
                     services: runtime.services,
                     snapshotMutationCoordinator: mutationCoordinator,
+                    executionPolicy: self.allowForeground ? .foregroundAllowed : .backgroundOnly,
                     capturePreflightRefusal: runtime.toolCapturePreflightRefusal
                 )
                 let server = try await PeekabooMCPServer(toolContext: toolContext)
@@ -96,6 +103,7 @@ extension MCPCommand {
         static func makeToolContext(
             services: any PeekabooServiceProviding,
             snapshotMutationCoordinator: (any MCPToolSnapshotMutationCoordinating)?,
+            executionPolicy: MCPToolExecutionPolicy = .backgroundOnly,
             capturePreflightRefusal: MCPToolCapturePreflightRefusal? = nil
         ) -> MCPToolContext {
             let snapshotExecutionGate: MCPToolSnapshotExecutionGate
@@ -111,7 +119,7 @@ extension MCPCommand {
                 services: services,
                 snapshotMutationCoordinator: snapshotMutationCoordinator,
                 snapshotExecutionGate: snapshotExecutionGate,
-                executionPolicy: .backgroundOnly,
+                executionPolicy: executionPolicy,
                 capturePreflightRefusal: capturePreflightRefusal
             )
         }
@@ -139,5 +147,6 @@ extension MCPCommand.Serve: CommanderBindableCommand {
         if let portOption = try values.decodeOption("port", as: Int.self) {
             self.port = portOption
         }
+        self.allowForeground = values.flag("allowForeground")
     }
 }

--- a/Apps/CLI/Tests/CLIAutomationTests/MCPCommandTests.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/MCPCommandTests.swift
@@ -26,14 +26,16 @@ struct MCPCommandTests {
 
         #expect(serve.transport == "stdio")
         #expect(serve.port == 8080)
+        #expect(serve.allowForeground == false)
     }
 
     @Test
     func `MCP serve command custom options`() throws {
-        let serve = try MCPCommand.Serve.parse(["--transport", "http", "--port", "9000"])
+        let serve = try MCPCommand.Serve.parse(["--transport", "http", "--port", "9000", "--allow-foreground"])
 
         #expect(serve.transport == "http")
         #expect(serve.port == 9000)
+        #expect(serve.allowForeground == true)
     }
 
     // MARK: - Help Text Tests
@@ -55,6 +57,7 @@ struct MCPCommandTests {
         #expect(helpText.contains("npx @modelcontextprotocol/inspector"))
         #expect(helpText.contains("--transport"))
         #expect(helpText.contains("--port"))
+        #expect(helpText.contains("--allow-foreground"))
         #expect(helpText.contains("reserved but not implemented"))
     }
 

--- a/Apps/CLI/Tests/CoreCLITests/MCPWrapperCommandBindingTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/MCPWrapperCommandBindingTests.swift
@@ -144,5 +144,12 @@ struct MCPWrapperCommandBindingTests {
         #expect(context.executionPolicy == .backgroundOnly)
         #expect(nestedAgentContext.capturePreflightRefusal == refusal)
         #expect(nestedAgentContext.executionPolicy == .backgroundOnly)
+
+        let foregroundContext = MCPCommand.Serve.makeToolContext(
+            services: services,
+            snapshotMutationCoordinator: nil,
+            executionPolicy: .foregroundAllowed
+        )
+        #expect(foregroundContext.executionPolicy == .foregroundAllowed)
     }
 }


### PR DESCRIPTION
Closes #611

Peekaboo's MCP schemas expose foreground-capable operations, but `mcp serve` always starts with background-only authority, so those operations are guaranteed to be refused.

This adds an explicit `--allow-foreground` startup opt-in for trusted MCP hosts. The default remains background-only. Enabling the flag only raises the server's authority ceiling; individual tools still require explicit foreground requests where applicable.

Tested against a live MCP client with foreground operations enabled. Focused CLI coverage verifies the default, flag parsing, help output, and resulting execution policy.
