### PR TITLE
refactor(targeting): centralize selector admission

### DIFF
--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Shared/InteractionTargetOptions.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Shared/InteractionTargetOptions.swift
@@ -52,14 +52,6 @@ struct InteractionTargetOptions: CommanderParsable, ApplicationResolvable {
 
     func validate() throws {
         try self.validateSelectorCombination()
-
-        if let windowIndex = self.windowIndex, windowIndex < 0 {
-            throw ValidationError("--window-index must be 0 or greater")
-        }
-
-        if let windowId = self.windowId, windowId <= 0 || UInt32(exactly: windowId) == nil {
-            throw ValidationError("--window-id must be between 1 and \(UInt32.max)")
-        }
     }
 
     func resolveApplicationIdentifierOptional() throws -> String? {

--- a/Apps/CLI/Tests/CoreCLITests/InteractionTargetSelectorValidationTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/InteractionTargetSelectorValidationTests.swift
@@ -44,6 +44,40 @@ struct InteractionTargetSelectorValidationTests {
     }
 
     @Test
+    func `interaction numeric failures retain CLI wording`() {
+        let cases: [(InteractionTargetOptions, String)] = [
+            (Self.makeTarget(Selectors(
+                app: nil,
+                pid: 0,
+                windowTitle: nil,
+                windowIndex: nil,
+                windowID: nil
+            )), "--pid must be greater than 0"),
+            (Self.makeTarget(Selectors(
+                app: nil,
+                pid: nil,
+                windowTitle: nil,
+                windowIndex: nil,
+                windowID: 0
+            )), "--window-id must be between 1 and \(UInt32.max)"),
+            (Self.makeTarget(Selectors(
+                app: "TextEdit",
+                pid: nil,
+                windowTitle: nil,
+                windowIndex: -1,
+                windowID: nil
+            )), "--window-index must be 0 or greater"),
+        ]
+
+        for (target, expectedMessage) in cases {
+            let error = #expect(throws: ValidationError.self) {
+                try target.validate()
+            }
+            #expect(error?.localizedDescription == expectedMessage)
+        }
+    }
+
+    @Test
     func `every phase 3 interaction surface rejects app and pid while binding`() {
         let targetOptions = ["app": ["TextEdit"], "pid": ["42"]]
 

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/MCPToolContext+BackgroundApplicationTarget.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/MCPToolContext+BackgroundApplicationTarget.swift
@@ -184,25 +184,16 @@ extension MCPToolContext {
         }
 
         let pid = try keys.pid.flatMap { try arguments.validatedInt($0) }
-        guard pid.map({ $0 > 0 && Int32(exactly: $0) != nil }) ?? true else {
-            throw BackgroundTargetResolutionError("pid must be a valid positive process identifier")
-        }
-        guard applicationSelector.value == nil || pid == nil else {
-            throw BackgroundTargetResolutionError("app and pid are mutually exclusive")
-        }
         let windowID = try arguments.validatedInt("window_id")
         let windowIndex = try arguments.validatedInt(keys.index)
-        guard windowID.map({ $0 > 0 && UInt32(exactly: $0) != nil }) ?? true else {
-            throw BackgroundTargetResolutionError("window_id must be a valid positive WindowServer identifier")
-        }
-        guard windowIndex.map({ $0 >= 0 }) ?? true else {
-            throw BackgroundTargetResolutionError("\(keys.index) must be zero or greater")
-        }
-        let selectorCount = [windowID != nil, titleSelector.value != nil, windowIndex != nil].count(where: { $0 })
-        guard selectorCount <= 1 else {
-            throw BackgroundTargetResolutionError("window_id, \(keys.title), and \(keys.index) are mutually exclusive")
-        }
-        if toolName == "paste", selectorCount == 0 {
+        let selector = InteractionTargetSelector(
+            applicationIdentifier: applicationSelector.value,
+            processIdentifier: pid,
+            windowID: windowID,
+            windowTitle: titleSelector.value,
+            windowIndex: windowIndex)
+        try self.validateBackgroundInteractionSelector(selector, keys: keys)
+        if toolName == "paste", !selector.hasWindowInput {
             return nil
         }
         guard windowID != nil || applicationSelector.value != nil || pid != nil else {
@@ -211,12 +202,38 @@ extension MCPToolContext {
         }
         return BackgroundExactWindowSelector(
             keys: keys,
-            selector: InteractionTargetSelector(
-                applicationIdentifier: applicationSelector.value,
-                processIdentifier: pid,
-                windowID: windowID,
-                windowTitle: titleSelector.value,
-                windowIndex: windowIndex))
+            selector: selector)
+    }
+
+    private static func validateBackgroundInteractionSelector(
+        _ selector: InteractionTargetSelector,
+        keys: BackgroundExactWindowSelectorKeys) throws
+    {
+        do {
+            try selector.validate(policy: .interaction)
+        } catch let error as InteractionTargetSelector.ValidationError {
+            let detail = switch error {
+            case .applicationAndProcessIdentifier:
+                "app and pid are mutually exclusive"
+            case .multipleWindowSelectors:
+                "window_id, \(keys.title), and \(keys.index) are mutually exclusive"
+            case .windowSelectorRequiresApplication:
+                "background window mutation requires an application or exact window_id owner"
+            case .invalidProcessIdentifier:
+                "pid must be a valid positive process identifier"
+            case .invalidWindowID:
+                "window_id must be a valid positive WindowServer identifier"
+            case .invalidWindowIndex:
+                "\(keys.index) must be zero or greater"
+            case .conflictingProcessIdentifiers,
+                 .invalidApplicationProcessIdentifier,
+                 .missingTarget,
+                 .emptyApplication,
+                 .emptyWindowTitle:
+                preconditionFailure("Interaction policy does not emit \(error)")
+            }
+            throw BackgroundTargetResolutionError(detail)
+        }
     }
 
     private static func backgroundExactWindowSelectorKeys(
@@ -248,6 +265,7 @@ extension MCPToolContext {
         schema: BackgroundApplicationTargetSchema) throws -> [String]
     {
         var identifiers: [String] = []
+        var stringSelectors: [String] = []
         for key in schema.stringKeys {
             let selector = Self.strictString(arguments, key: key)
             guard !selector.isInvalid else {
@@ -255,12 +273,27 @@ extension MCPToolContext {
             }
             if let value = selector.value {
                 identifiers.append(value)
+                stringSelectors.append(value)
             }
         }
+        var processIdentifiers: [Int] = []
         for key in schema.pidKeys {
-            if let pid = arguments.getInt(key), pid > 0 {
+            if let pid = try arguments.validatedInt(key) {
                 identifiers.append("PID:\(pid)")
+                processIdentifiers.append(pid)
             }
+        }
+        if schema.stringKeys.count == 1, schema.pidKeys.count == 1 {
+            let selector = InteractionTargetSelector(
+                applicationIdentifier: stringSelectors.first,
+                processIdentifier: processIdentifiers.first)
+            try self.validateBackgroundInteractionSelector(
+                selector,
+                keys: BackgroundExactWindowSelectorKeys(
+                    application: schema.stringKeys[0],
+                    pid: schema.pidKeys[0],
+                    title: "window_title",
+                    index: "window_index"))
         }
         return identifiers
     }
@@ -271,7 +304,14 @@ extension MCPToolContext {
     {
         var identities: [DesktopTargetIdentity] = []
         for key in keys {
-            guard let windowID = arguments.getInt(key) else { continue }
+            guard let windowID = try arguments.validatedInt(key) else { continue }
+            try Self.validateBackgroundInteractionSelector(
+                InteractionTargetSelector(windowID: windowID),
+                keys: BackgroundExactWindowSelectorKeys(
+                    application: "app",
+                    pid: "pid",
+                    title: "window_title",
+                    index: "window_index"))
             let windows: [ServiceWindowInfo]
             do {
                 windows = try await self.windows.listWindows(target: .windowId(windowID))

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/MCPInteractionTarget.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/MCPInteractionTarget.swift
@@ -295,18 +295,6 @@ struct MCPInteractionTarget {
                 preconditionFailure("Interaction policy does not emit \(error)")
             }
         }
-
-        if let pid, pid <= 0 || Int32(exactly: pid) == nil {
-            throw MCPInteractionTargetError.invalidProcessIdentifier
-        }
-
-        if let windowId, windowId <= 0 || CGWindowID(exactly: windowId) == nil {
-            throw MCPInteractionTargetError.invalidWindowId
-        }
-
-        if let windowIndex, windowIndex < 0 {
-            throw MCPInteractionTargetError.invalidWindowIndex
-        }
     }
 
     func toWindowTarget() throws -> WindowTarget? {

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPInteractionTargetTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPInteractionTargetTests.swift
@@ -414,6 +414,9 @@ struct MCPInteractionTargetTests {
         case windowIDAndTitle
         case titleWithoutOwner
         case indexWithoutOwner
+        case invalidPID
+        case invalidWindowID
+        case invalidWindowIndex
 
         var arguments: [String: Any] {
             switch self {
@@ -425,6 +428,12 @@ struct MCPInteractionTargetTests {
                 ["window_title": "Main"]
             case .indexWithoutOwner:
                 ["window_index": 2]
+            case .invalidPID:
+                ["pid": 0]
+            case .invalidWindowID:
+                ["window_id": 0]
+            case .invalidWindowIndex:
+                ["app": "Preview", "window_index": -1]
             }
         }
 
@@ -436,6 +445,12 @@ struct MCPInteractionTargetTests {
                 "window_id, window_title, and window_index are mutually exclusive"
             case .titleWithoutOwner, .indexWithoutOwner:
                 "require app or pid"
+            case .invalidPID:
+                "pid must be a positive 32-bit integer"
+            case .invalidWindowID:
+                "window_id must be between 1 and \(UInt32.max)"
+            case .invalidWindowIndex:
+                "window_index must be 0 or greater"
             }
         }
     }
@@ -570,6 +585,31 @@ struct MCPInteractionTargetTests {
             try MCPToolTestHelpers.expectCanonicalOutcomeMetadata(
                 .refused(reason: .invalidRequest),
                 in: response)
+        }
+    }
+
+    @MainActor
+    @Test
+    func `background dialog admission maps canonical owner and range errors`() async throws {
+        let context = await MCPToolTestHelpers.makeContext(executionPolicy: .backgroundOnly)
+        for fixture in [
+            InvalidConsumerFixture.applicationAndPID,
+            .invalidPID,
+            .invalidWindowID,
+        ] {
+            let response = try await context.execute(
+                tool: DialogTool(context: context),
+                arguments: ToolArguments(raw: fixture.arguments.merging([
+                    "action": "click",
+                    "button": "OK",
+                ]) { current, _ in current }))
+
+            #expect(response.isError)
+            guard case let .text(text, _, _)? = response.content.first else {
+                Issue.record("Expected background selector admission error")
+                continue
+            }
+            #expect(text.contains(fixture.message))
         }
     }
 

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/WindowToolExactRoutingTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/WindowToolExactRoutingTests.swift
@@ -8,6 +8,11 @@ import Testing
 @testable import PeekabooCore
 
 struct WindowToolExactRoutingTests {
+    struct InvalidSelectorFixture: Sendable {
+        let arguments: [String: Int]
+        let expectedMessage: String
+    }
+
     @Test
     @MainActor
     func `background window mutation retains exact authorized window through dispatch`() async throws {
@@ -162,6 +167,44 @@ struct WindowToolExactRoutingTests {
         #expect(service.mutationDispatchCount == 1)
         #expect(service.closeTargets.map(\.description) == ["windowId(924)"])
         #expect(service.receivedIdentities.map(\.ownerProcessStartIdentity) == [7])
+    }
+
+    @Test(arguments: [
+        InvalidSelectorFixture(
+            arguments: ["window_id": 0],
+            expectedMessage: "window_id must be a valid positive WindowServer identifier"),
+        InvalidSelectorFixture(
+            arguments: ["index": -1],
+            expectedMessage: "index must be zero or greater"),
+    ])
+    @MainActor
+    func `background window numeric admission maps canonical selector errors`(
+        fixture: InvalidSelectorFixture) async throws
+    {
+        let service = ExactRoutingWindowService()
+        let context = await MCPToolTestHelpers.makeContext(
+            applications: Self.fixtureApplications(),
+            windows: service,
+            executionPolicy: .backgroundOnly)
+        var arguments: [String: Any] = [
+            "action": "close",
+            "app": "Fixture",
+        ]
+        for (key, value) in fixture.arguments {
+            arguments[key] = value
+        }
+
+        let response = try await context.execute(
+            tool: WindowTool(context: context),
+            arguments: ToolArguments(raw: arguments))
+
+        #expect(response.isError)
+        #expect(service.mutationDispatchCount == 0)
+        guard case let .text(message, _, _)? = response.content.first else {
+            Issue.record("Expected canonical selector admission refusal")
+            return
+        }
+        #expect(message.contains(fixture.expectedMessage))
     }
 
     @Test

--- a/Core/PeekabooFoundation/Sources/PeekabooFoundation/InteractionTargetSelector.swift
+++ b/Core/PeekabooFoundation/Sources/PeekabooFoundation/InteractionTargetSelector.swift
@@ -143,6 +143,7 @@ public struct InteractionTargetSelector: Equatable, Sendable {
         switch policy {
         case .interaction:
             try self.validateInteractionGrammar(allowsGlobalTitle: false, rejectsEmptyStrings: false)
+            try self.validateNumericRanges()
 
         case .dialogOwnerRequired:
             try self.validateInteractionGrammar(allowsGlobalTitle: false, rejectsEmptyStrings: true)

--- a/Core/PeekabooFoundation/Tests/PeekabooFoundationTests/InteractionTargetSelectorValidationTests.swift
+++ b/Core/PeekabooFoundation/Tests/PeekabooFoundationTests/InteractionTargetSelectorValidationTests.swift
@@ -75,19 +75,24 @@ struct InteractionTargetSelectorValidationTests {
     }
 
     @Test
-    func `canonical mutation-safe policy validates numeric ranges`() {
-        #expect(throws: InteractionTargetSelector.ValidationError.invalidProcessIdentifier) {
-            try InteractionTargetSelector(processIdentifier: 0).validate(policy: .mutationSafe)
-        }
-        #expect(throws: InteractionTargetSelector.ValidationError.invalidProcessIdentifier) {
-            try InteractionTargetSelector(processIdentifier: Int(Int32.max) + 1).validate(policy: .mutationSafe)
-        }
-        #expect(throws: InteractionTargetSelector.ValidationError.invalidWindowID) {
-            try InteractionTargetSelector(windowID: Int(UInt32.max) + 1).validate(policy: .mutationSafe)
-        }
-        #expect(throws: InteractionTargetSelector.ValidationError.invalidWindowIndex) {
-            try InteractionTargetSelector(applicationIdentifier: "Preview", windowIndex: -1)
-                .validate(policy: .mutationSafe)
+    func `canonical interaction policies validate numeric ranges`() {
+        for policy in [InteractionTargetSelector.Policy.interaction, .mutationSafe] {
+            #expect(throws: InteractionTargetSelector.ValidationError.invalidProcessIdentifier) {
+                try InteractionTargetSelector(processIdentifier: 0).validate(policy: policy)
+            }
+            #expect(throws: InteractionTargetSelector.ValidationError.invalidProcessIdentifier) {
+                try InteractionTargetSelector(processIdentifier: Int(Int32.max) + 1).validate(policy: policy)
+            }
+            #expect(throws: InteractionTargetSelector.ValidationError.invalidWindowID) {
+                try InteractionTargetSelector(windowID: 0).validate(policy: policy)
+            }
+            #expect(throws: InteractionTargetSelector.ValidationError.invalidWindowID) {
+                try InteractionTargetSelector(windowID: Int(UInt32.max) + 1).validate(policy: policy)
+            }
+            #expect(throws: InteractionTargetSelector.ValidationError.invalidWindowIndex) {
+                try InteractionTargetSelector(applicationIdentifier: "Preview", windowIndex: -1)
+                    .validate(policy: policy)
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

- make `InteractionTargetSelector` the single owner of interaction PID, window ID, and window-index range validation
- remove duplicate CLI and MCP admission guards while preserving each adapter's existing error wording
- route background application/window admission through the same canonical selector policy
- add focused Foundation, CLI, and MCP regressions for canonical validation and adapter error projection

## Tests

- `swift test --package-path Core/PeekabooFoundation --filter InteractionTargetSelectorValidationTests`
- `swift test --package-path Apps/CLI --filter InteractionTargetSelectorValidationTests`
- `swift test --package-path Core/PeekabooCore --filter 'MCPInteractionTargetTests|WindowToolExactRoutingTests' --no-parallel`
- `pnpm run format`
- `pnpm run lint` (118 existing warnings, 0 serious)
- `git diff --check`
- Autoreview: clean, no actionable findings

No changelog entry: this is an internal ownership consolidation with unchanged accepted selector behavior and public error wording.
