### PR TITLE
fix(cli): validate system selectors before runtime

### DIFF
--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommandUtilities.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommandUtilities.swift
@@ -287,7 +287,7 @@ func validatedMutationSelector(
         case .invalidApplicationProcessIdentifier:
             throw Commander.ValidationError("Invalid PID format in --app")
         case .applicationAndProcessIdentifier:
-            throw Commander.ValidationError("Provide the application either with --app or --pid, not both")
+            throw InteractionTargetOptions.validationError(for: error)
         case .multipleWindowSelectors:
             throw Commander.ValidationError(multipleWindowSelectorsMessage)
         case .windowSelectorRequiresApplication:

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/SpaceCommand+MoveWindow.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/SpaceCommand+MoveWindow.swift
@@ -40,7 +40,7 @@ struct MoveWindowSubcommand: ActionOutputFormattable, ErrorHandlingCommand,
     var foreground = false
     @RuntimeStorage var runtime: CommandRuntime?
 
-    mutating func validate() throws {
+    func validateBeforeRuntime() throws {
         try self.makeWindowOptions().validateMutation()
 
         guard self.to != nil || self.toCurrent else {
@@ -49,6 +49,21 @@ struct MoveWindowSubcommand: ActionOutputFormattable, ErrorHandlingCommand,
         guard !(self.to != nil && self.toCurrent) else {
             throw ValidationError("Cannot specify both --to and --to-current")
         }
+
+        if self.follow, !self.foreground {
+            throw PreDispatchActionError(
+                message: "Space move-window --follow changes the visible desktop and requires explicit " +
+                    "--foreground consent.",
+                code: .VALIDATION_ERROR,
+                hint: "Omit --follow for background window placement, or add --foreground when following is " +
+                    "intentional.",
+                reason: .foregroundConsentRequired
+            )
+        }
+    }
+
+    mutating func validate() throws {
+        try self.validateBeforeRuntime()
     }
 
     @MainActor
@@ -57,21 +72,11 @@ struct MoveWindowSubcommand: ActionOutputFormattable, ErrorHandlingCommand,
         self.logger.setJsonOutputMode(self.jsonOutput)
 
         do {
-            if self.follow, !self.foreground {
-                throw PreDispatchActionError(
-                    message: "Space move-window --follow changes the visible desktop and requires explicit " +
-                        "--foreground consent.",
-                    code: .VALIDATION_ERROR,
-                    hint: "Omit --follow for background window placement, or add --foreground when following is " +
-                        "intentional.",
-                    reason: .foregroundConsentRequired
-                )
-            }
+            try self.validateBeforeRuntime()
             try SpaceCommandHostOwnership.requireLocalMutation(
                 services: self.services,
                 operation: "move a window between Spaces"
             )
-            try self.validate()
             let windowOptions = self.makeWindowOptions()
             let appInfo = try await windowOptions.resolveApplicationInfoIfNeeded(services: self.services)
 
@@ -313,6 +318,7 @@ extension MoveWindowSubcommand: ParsableCommand {
 }
 
 extension MoveWindowSubcommand: AsyncRuntimeCommand {}
+extension MoveWindowSubcommand: PreRuntimeValidatingCommand {}
 
 @MainActor
 extension MoveWindowSubcommand: CommanderBindableCommand {

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/WindowCommand+Bindings.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/WindowCommand+Bindings.swift
@@ -93,7 +93,7 @@ extension WindowCommand.WindowListSubcommand: PreRuntimeValidatingCommand {
             applicationIdentifier: self.app,
             processIdentifier: self.pid.map(Int.init)
         )
-        _ = try validatedMutationSelector(selector)
+        _ = try validatedMutationSelector(selector, allowMissingTarget: true)
     }
 }
 

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/WindowCommand+Bindings.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/WindowCommand+Bindings.swift
@@ -1,6 +1,7 @@
 import Commander
 import Foundation
 import PeekabooCore
+import PeekabooFoundation
 
 struct WindowActionResult: Codable {
     let action: String
@@ -12,6 +13,17 @@ struct WindowActionResult: Codable {
     let requested_bounds: WindowBounds?
     /// Set when the achieved geometry differs from the requested one or could not be verified.
     let warning: String?
+}
+
+@MainActor
+private protocol WindowMutationPreRuntimeValidatingCommand: PreRuntimeValidatingCommand {
+    var windowOptions: WindowIdentificationOptions { get }
+}
+
+extension WindowMutationPreRuntimeValidatingCommand {
+    func validateBeforeRuntime() throws {
+        try self.windowOptions.validateMutation()
+    }
 }
 
 // MARK: - Subcommand Conformances
@@ -27,6 +39,8 @@ extension WindowCommand.MoveSubcommand: ParsableCommand {
 
 extension WindowCommand.MoveSubcommand: AsyncRuntimeCommand {}
 
+extension WindowCommand.MoveSubcommand: WindowMutationPreRuntimeValidatingCommand {}
+
 @MainActor
 extension WindowCommand.ResizeSubcommand: ParsableCommand {
     nonisolated(unsafe) static var commandDescription: CommandDescription {
@@ -38,6 +52,8 @@ extension WindowCommand.ResizeSubcommand: ParsableCommand {
 
 extension WindowCommand.ResizeSubcommand: AsyncRuntimeCommand {}
 
+extension WindowCommand.ResizeSubcommand: WindowMutationPreRuntimeValidatingCommand {}
+
 @MainActor
 extension WindowCommand.SetBoundsSubcommand: ParsableCommand {
     nonisolated(unsafe) static var commandDescription: CommandDescription {
@@ -48,6 +64,8 @@ extension WindowCommand.SetBoundsSubcommand: ParsableCommand {
 }
 
 extension WindowCommand.SetBoundsSubcommand: AsyncRuntimeCommand {}
+
+extension WindowCommand.SetBoundsSubcommand: WindowMutationPreRuntimeValidatingCommand {}
 
 @MainActor
 extension WindowCommand.WindowListSubcommand: ParsableCommand {
@@ -69,6 +87,16 @@ extension WindowCommand.WindowListSubcommand: ParsableCommand {
 
 extension WindowCommand.WindowListSubcommand: AsyncRuntimeCommand {}
 
+extension WindowCommand.WindowListSubcommand: PreRuntimeValidatingCommand {
+    func validateBeforeRuntime() throws {
+        let selector = InteractionTargetSelector(
+            applicationIdentifier: self.app,
+            processIdentifier: self.pid.map(Int.init)
+        )
+        _ = try validatedMutationSelector(selector)
+    }
+}
+
 @MainActor
 extension WindowCommand.CloseSubcommand: ParsableCommand {
     nonisolated(unsafe) static var commandDescription: CommandDescription {
@@ -80,6 +108,8 @@ extension WindowCommand.CloseSubcommand: ParsableCommand {
 
 extension WindowCommand.CloseSubcommand: AsyncRuntimeCommand {}
 
+extension WindowCommand.CloseSubcommand: WindowMutationPreRuntimeValidatingCommand {}
+
 @MainActor
 extension WindowCommand.MinimizeSubcommand: ParsableCommand {
     nonisolated(unsafe) static var commandDescription: CommandDescription {
@@ -90,6 +120,8 @@ extension WindowCommand.MinimizeSubcommand: ParsableCommand {
 }
 
 extension WindowCommand.MinimizeSubcommand: AsyncRuntimeCommand {}
+
+extension WindowCommand.MinimizeSubcommand: WindowMutationPreRuntimeValidatingCommand {}
 
 @MainActor
 extension WindowCommand.RestoreSubcommand: ParsableCommand {
@@ -105,6 +137,8 @@ extension WindowCommand.RestoreSubcommand: ParsableCommand {
 
 extension WindowCommand.RestoreSubcommand: AsyncRuntimeCommand {}
 
+extension WindowCommand.RestoreSubcommand: WindowMutationPreRuntimeValidatingCommand {}
+
 @MainActor
 extension WindowCommand.MaximizeSubcommand: ParsableCommand {
     nonisolated(unsafe) static var commandDescription: CommandDescription {
@@ -118,6 +152,8 @@ extension WindowCommand.MaximizeSubcommand: ParsableCommand {
 }
 
 extension WindowCommand.MaximizeSubcommand: AsyncRuntimeCommand {}
+
+extension WindowCommand.MaximizeSubcommand: WindowMutationPreRuntimeValidatingCommand {}
 
 @MainActor
 extension WindowCommand.FocusSubcommand: ParsableCommand {
@@ -145,6 +181,12 @@ extension WindowCommand.FocusSubcommand: ParsableCommand {
 }
 
 extension WindowCommand.FocusSubcommand: AsyncRuntimeCommand {}
+
+extension WindowCommand.FocusSubcommand: PreRuntimeValidatingCommand {
+    func validateBeforeRuntime() throws {
+        try self.windowOptions.validateMutation(allowMissingTarget: self.snapshot?.isEmpty == false)
+    }
+}
 
 // MARK: - Commander Binding
 

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/WindowCommand+Support.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/WindowCommand+Support.swift
@@ -71,7 +71,7 @@ struct WindowIdentificationOptions: CommanderParsable, ApplicationResolvable {
             case .invalidApplicationProcessIdentifier:
                 throw PeekabooError.invalidInput("Invalid PID format in --app: '\(self.app ?? "")'")
             case .applicationAndProcessIdentifier:
-                throw PeekabooError.invalidInput("Provide the application either with --app or --pid, not both")
+                throw InteractionTargetOptions.validationError(for: error)
             case .multipleWindowSelectors,
                  .windowSelectorRequiresApplication,
                  .invalidProcessIdentifier,

--- a/Apps/CLI/Tests/CLIRuntimeTests/InvalidInputOrderingCLITests.swift
+++ b/Apps/CLI/Tests/CLIRuntimeTests/InvalidInputOrderingCLITests.swift
@@ -21,6 +21,18 @@ struct InvalidInputOrderingCLITests {
         let hint: String?
     }
 
+    struct SystemSelectorCase: Sendable {
+        let arguments: [String]
+    }
+
+    private struct ErrorEnvelope {
+        let code: String
+        let message: String
+        let hint: String?
+        let debugLogs: [String]
+        let mutationDispatched: Bool?
+    }
+
     @Test(arguments: [
         MissingSemanticInputCase(command: "type"),
         MissingSemanticInputCase(command: "press"),
@@ -130,6 +142,33 @@ struct InvalidInputOrderingCLITests {
         #expect(envelope.hint == testCase.hint)
         #expect(envelope.debugLogs.isEmpty)
         #expect(elapsed < .seconds(2))
+    }
+
+    @Test(arguments: [
+        SystemSelectorCase(arguments: [
+            "window", "restore", "--app", "TextEdit", "--pid", "123",
+        ]),
+        SystemSelectorCase(arguments: [
+            "space", "move-window", "--app", "TextEdit", "--pid", "123", "--to", "2",
+        ]),
+    ])
+    func `invalid system selectors refuse before runtime-host discovery`(
+        _ testCase: SystemSelectorCase
+    ) async throws {
+        let result = try await TestChildProcess.runPeekaboo(
+            testCase.arguments + [
+                "--bridge-socket", "/tmp/peekaboo-system-selector-preflight-missing.sock", "--json",
+            ],
+            isolateFromRemoteHosts: false
+        )
+
+        #expect(result.status == .exited(1))
+        #expect(result.standardError.isEmpty)
+        let envelope = try Self.errorEnvelope(from: result.standardOutput)
+        #expect(envelope.code == "VALIDATION_ERROR")
+        #expect(envelope.message == "Use either --app or --pid, not both.")
+        #expect(envelope.debugLogs.isEmpty)
+        #expect(envelope.mutationDispatched == false)
     }
 
     @Test
@@ -270,22 +309,18 @@ struct InvalidInputOrderingCLITests {
         }
     }
 
-    private static func errorEnvelope(from output: String) throws -> (
-        code: String,
-        message: String,
-        hint: String?,
-        debugLogs: [String]
-    ) {
+    private static func errorEnvelope(from output: String) throws -> ErrorEnvelope {
         let object = try #require(
             JSONSerialization.jsonObject(with: Data(output.utf8)) as? [String: Any]
         )
         #expect(object["success"] as? Bool == false)
         let error = try #require(object["error"] as? [String: Any])
-        return try (
+        return try ErrorEnvelope(
             code: #require(error["code"] as? String),
             message: #require(error["message"] as? String),
             hint: error["hint"] as? String,
-            debugLogs: #require(object["debug_logs"] as? [String])
+            debugLogs: #require(object["debug_logs"] as? [String]),
+            mutationDispatched: error["mutation_dispatched"] as? Bool
         )
     }
 }

--- a/Apps/CLI/Tests/CoreCLITests/PreRuntimeInvalidInputOrderingTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/PreRuntimeInvalidInputOrderingTests.swift
@@ -22,6 +22,71 @@ struct PreRuntimeInvalidInputOrderingTests {
             "Invalid --browser-url. Expected http://127.0.0.1:<port>, " +
                 "http://[::1]:<port>, or http://localhost:<port>."
         ),
+        (
+            ["peekaboo", "window", "list", "--app", "TextEdit", "--pid", "123", "--json"],
+            "Use either --app or --pid, not both."
+        ),
+        (
+            ["peekaboo", "window", "close", "--app", "TextEdit", "--pid", "123", "--json"],
+            "Use either --app or --pid, not both."
+        ),
+        (
+            ["peekaboo", "window", "minimize", "--app", "TextEdit", "--pid", "123", "--json"],
+            "Use either --app or --pid, not both."
+        ),
+        (
+            ["peekaboo", "window", "restore", "--app", "TextEdit", "--pid", "123", "--json"],
+            "Use either --app or --pid, not both."
+        ),
+        (
+            ["peekaboo", "window", "maximize", "--app", "TextEdit", "--pid", "123", "--json"],
+            "Use either --app or --pid, not both."
+        ),
+        (
+            [
+                "peekaboo", "window", "move", "--app", "TextEdit", "--pid", "123", "--x", "10", "--y", "20",
+                "--json",
+            ],
+            "Use either --app or --pid, not both."
+        ),
+        (
+            [
+                "peekaboo", "window", "resize", "--app", "TextEdit", "--pid", "123", "--width", "100",
+                "--height", "100", "--json",
+            ],
+            "Use either --app or --pid, not both."
+        ),
+        (
+            [
+                "peekaboo", "window", "set-bounds", "--app", "TextEdit", "--pid", "123", "--x", "10", "--y",
+                "20", "--width", "100", "--height", "100", "--json",
+            ],
+            "Use either --app or --pid, not both."
+        ),
+        (
+            ["peekaboo", "window", "focus", "--app", "TextEdit", "--pid", "123", "--json"],
+            "Use either --app or --pid, not both."
+        ),
+        (
+            [
+                "peekaboo", "space", "move-window", "--app", "TextEdit", "--pid", "123", "--to", "2", "--json",
+            ],
+            "Use either --app or --pid, not both."
+        ),
+        (
+            [
+                "peekaboo", "window", "restore", "--app", "TextEdit", "--window-id", "42", "--window-title",
+                "Document", "--json",
+            ],
+            "Provide only one of --window-id, --window-title, or --window-index"
+        ),
+        (
+            [
+                "peekaboo", "space", "move-window", "--app", "TextEdit", "--window-id", "42", "--window-index",
+                "0", "--to", "2", "--json",
+            ],
+            "Provide only one of --window-id, --window-title, or --window-index"
+        ),
     ])
     func `semantic-invalid commands refuse before runtime construction`(
         arguments: [String],

--- a/Apps/CLI/Tests/CoreCLITests/PreRuntimeInvalidInputOrderingTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/PreRuntimeInvalidInputOrderingTests.swift
@@ -178,6 +178,7 @@ struct PreRuntimeInvalidInputOrderingTests {
     @Test(arguments: [
         ["peekaboo", "type", "alpha", "--foreground", "--json"],
         ["peekaboo", "browser", "status", "--json"],
+        ["peekaboo", "window", "list", "--json"],
     ])
     func `valid request shapes continue to runtime construction`(arguments: [String]) async throws {
         let resolved = try CommanderRuntimeRouter.resolve(argv: arguments)

--- a/Apps/CLI/Tests/CoreCLITests/ToolsCommandTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/ToolsCommandTests.swift
@@ -1,6 +1,8 @@
 import Foundation
+import MCP
 import PeekabooAgentRuntime
 import PeekabooCore
+import TachikomaMCP
 import Testing
 @testable import PeekabooCLI
 
@@ -78,6 +80,36 @@ struct ToolsCommandTests {
         #expect(json.contains("\"input_schema\""))
         #expect(json.contains("\"properties\""))
         #expect(ToolsCommand.DescribeSubcommand.payload(named: "nonexistent", tools: tools) == nil)
+    }
+
+    @Test
+    @MainActor
+    func `Default tools catalog exposes only background-safe authority`() throws {
+        let services = PeekabooServices()
+        let context = MCPToolContext(services: services)
+        let tools = MCPToolCatalog.tools(
+            context: context,
+            inputPolicy: services.configuration.getUIInputPolicy(),
+            filters: ToolFilters(allow: [], deny: [], allowSource: .none, denySources: [:])
+        )
+        let names = Set(tools.map(\.name))
+
+        #expect(names.isSuperset(of: ["click", "type", "press", "paste", "clipboard", "app", "window"]))
+        #expect(names.isDisjoint(with: ["move", "drag"]))
+
+        let clipboard = try #require(tools.first { $0.name == "clipboard" })
+        guard case let .object(schema) = clipboard.inputSchema,
+              case let .object(properties)? = schema["properties"],
+              case let .object(action)? = properties["action"],
+              case let .array(actions)? = action["enum"]
+        else {
+            Issue.record("Expected the policy-filtered clipboard action schema")
+            return
+        }
+        #expect(actions == ["get", "save"].map(Value.string))
+        #expect(properties["text"] == nil)
+        #expect(properties["file_path"] == nil)
+        #expect(properties["data_base64"] == nil)
     }
 }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 - Explain why locked macOS sessions cannot be captured even when `screen list` still reports connected displays.
 - Restore terminal echo when credential prompts receive signals and reject background prompts or insecure credential files.
 - Deduplicate runtime flags and improve unknown-command, browser reconnect, help, `learn`, schema, and background-automation guidance.
+- Validate contradictory window and Space selectors before runtime-host discovery so malformed requests cannot start support services or mask the actionable error.
 
 ## [4.2.2] - 2026-08-20
 


### PR DESCRIPTION
## Summary

- validate every window leaf and Space window movement before runtime-host discovery
- return the shared canonical app/PID conflict error without starting or selecting a support host
- lock the default tools catalog to background-safe pointer and clipboard authority
- document the user-visible validation-order fix

## Tests

- `swift test --package-path Apps/CLI --no-parallel --filter 'PreRuntimeInvalidInputOrderingTests|ToolsCommandTests|InvalidInputOrderingCLITests'`
- `swift test --package-path Apps/CLI --no-parallel --filter 'CommanderBinderProgramResolutionSpaceTests|PreRuntimeSemanticValidationTests|SpaceCommandActionTests|WindowTargetCreationTests|CommanderBinderCommandBindingTests'`
- `pnpm run format` (0 files changed)
- `pnpm run lint` (118 existing warnings, 0 serious)
- `git diff --check`

No UI automation or foreground interaction was used for validation.
