### PR TITLE
refactor(targeting): consolidate explicit window selection

### DIFF
--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommandUtilities.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommandUtilities.swift
@@ -389,13 +389,18 @@ enum ExactWindowSelectorResolver {
         windows: [ServiceWindowInfo],
         operation: String) -> ExactWindowSelectorResolutionError
     {
-        switch (selection, error) {
+        if case let .conflictingWindowEntries(windowID) = error {
+            return self.inventoryConflictError(
+                windowID: windowID,
+                windows: windows,
+                operation: operation)
+        }
+        return switch (selection, error) {
         case let (.id(windowID), .windowNotFound):
             ExactWindowSelectorResolutionError(
                 message: "\(operation) --window-id \(windowID) does not identify a window. " +
                     "Refresh the window inventory before retrying.")
-        case let (.id(windowID), .ambiguousWindow),
-             let (.id(windowID), .conflictingWindowEntries):
+        case let (.id(windowID), .ambiguousWindow):
             ExactWindowSelectorResolutionError(
                 message: "\(operation) --window-id \(windowID) identifies multiple windows. " +
                     "Refresh the window inventory before retrying.")
@@ -409,18 +414,11 @@ enum ExactWindowSelectorResolver {
                 windowIDs: windowIDs,
                 windows: windows,
                 operation: operation)
-        case let (.title(title), .conflictingWindowEntries(windowID)):
-            self.titleAmbiguityError(
-                title: title,
-                windowIDs: [windowID],
-                windows: windows,
-                operation: operation)
         case let (.index(index), .windowNotFound):
             ExactWindowSelectorResolutionError(
                 message: "\(operation) --window-index \(index) is not present. " +
                     "Refresh the inventory and select a --window-id.")
-        case let (.index(index), .ambiguousWindow),
-             let (.index(index), .conflictingWindowEntries):
+        case let (.index(index), .ambiguousWindow):
             ExactWindowSelectorResolutionError(
                 message: "\(operation) --window-index \(index) is ambiguous. " +
                     "Refresh the inventory and select a --window-id.")
@@ -436,8 +434,29 @@ enum ExactWindowSelectorResolver {
         windows: [ServiceWindowInfo],
         operation: String) -> ExactWindowSelectorResolutionError
     {
+        let candidates = self.candidateSummary(windowIDs: windowIDs, windows: windows)
+        return ExactWindowSelectorResolutionError(
+            message: "\(operation) window title '\(title)' is ambiguous (\(candidates)). " +
+                "Select one --window-id or --window-index explicitly.")
+    }
+
+    private static func inventoryConflictError(
+        windowID: Int,
+        windows: [ServiceWindowInfo],
+        operation: String) -> ExactWindowSelectorResolutionError
+    {
+        let candidates = self.candidateSummary(windowIDs: [windowID], windows: windows)
+        return ExactWindowSelectorResolutionError(
+            message: "\(operation) found conflicting inventory rows for window ID \(windowID) (\(candidates)). " +
+                "Refresh the window inventory before retrying.")
+    }
+
+    private static func candidateSummary(
+        windowIDs: [Int],
+        windows: [ServiceWindowInfo]) -> String
+    {
         let candidateIDs = Set(windowIDs)
-        let candidates = windows.lazy.filter { candidateIDs.contains($0.windowID) }
+        return windows.lazy.filter { candidateIDs.contains($0.windowID) }
             .sorted { lhs, rhs in
                 if lhs.windowID != rhs.windowID {
                     return lhs.windowID < rhs.windowID
@@ -450,9 +469,6 @@ enum ExactWindowSelectorResolver {
             .prefix(5)
             .map { "id=\($0.windowID) index=\($0.index) '\($0.title)'" }
             .joined(separator: "; ")
-        return ExactWindowSelectorResolutionError(
-            message: "\(operation) window title '\(title)' is ambiguous (\(candidates)). " +
-                "Select one --window-id or --window-index explicitly.")
     }
 }
 

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommandUtilities.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommandUtilities.swift
@@ -368,65 +368,81 @@ enum ExactWindowSelectorResolver {
                 )
             }
             return window
-
-        case let .id(windowID):
-            let matches = windows.filter { $0.windowID == windowID }
-            guard matches.count == 1, let window = matches.first else {
-                let detail = matches.isEmpty ? "does not identify a window" : "identifies multiple windows"
-                throw ExactWindowSelectorResolutionError(
-                    message: "\(operation) --window-id \(windowID) \(detail). " +
-                        "Refresh the window inventory before retrying."
-                )
+        case let selection?:
+            do {
+                return try DesktopTargetPlanning.WindowCandidateSelector.selectExplicitCandidate(
+                    candidates: windows,
+                    selector: selection)
+            } catch let error as DesktopTargetPlanningError {
+                throw Self.presentationError(
+                    error,
+                    selection: selection,
+                    windows: windows,
+                    operation: operation)
             }
-            return window
-
-        case let .title(title):
-            let exactMatches = windows.filter {
-                $0.title.compare(title, options: .caseInsensitive) == .orderedSame
-            }
-            if exactMatches.count == 1, let window = exactMatches.first {
-                return window
-            }
-            if exactMatches.count > 1 {
-                throw Self.ambiguousTitle(title, matches: exactMatches, operation: operation)
-            }
-
-            let partialMatches = windows.filter { $0.title.localizedCaseInsensitiveContains(title) }
-            guard partialMatches.count == 1, let window = partialMatches.first else {
-                if partialMatches.isEmpty {
-                    throw ExactWindowSelectorResolutionError(
-                        message: "\(operation) found no window whose title matches '\(title)'. " +
-                            "Refresh the inventory and select a --window-id or valid --window-index."
-                    )
-                }
-                throw Self.ambiguousTitle(title, matches: partialMatches, operation: operation)
-            }
-            return window
-
-        case let .index(index):
-            let matches = windows.filter { $0.index == index }
-            guard matches.count == 1, let window = matches.first else {
-                let detail = matches.isEmpty ? "is not present" : "is ambiguous"
-                throw ExactWindowSelectorResolutionError(
-                    message: "\(operation) --window-index \(index) \(detail). " +
-                        "Refresh the inventory and select a --window-id."
-                )
-            }
-            return window
         }
     }
 
-    private static func ambiguousTitle(
-        _ title: String,
-        matches: [ServiceWindowInfo],
-        operation: String
-    ) -> ExactWindowSelectorResolutionError {
-        let candidates = matches.prefix(5).map { "id=\($0.windowID) index=\($0.index) '\($0.title)'" }
+    private static func presentationError(
+        _ error: DesktopTargetPlanningError,
+        selection: InteractionTargetSelector.WindowSelector,
+        windows: [ServiceWindowInfo],
+        operation: String) -> ExactWindowSelectorResolutionError
+    {
+        switch (selection, error) {
+        case let (.id(windowID), .windowNotFound):
+            ExactWindowSelectorResolutionError(
+                message: "\(operation) --window-id \(windowID) does not identify a window. " +
+                    "Refresh the window inventory before retrying.")
+        case let (.id(windowID), .ambiguousWindow),
+             let (.id(windowID), .conflictingWindowEntries):
+            ExactWindowSelectorResolutionError(
+                message: "\(operation) --window-id \(windowID) identifies multiple windows. " +
+                    "Refresh the window inventory before retrying.")
+        case let (.title(title), .windowNotFound):
+            ExactWindowSelectorResolutionError(
+                message: "\(operation) found no window whose title matches '\(title)'. " +
+                    "Refresh the inventory and select a --window-id or valid --window-index.")
+        case let (.title(title), .ambiguousWindow(_, windowIDs)):
+            self.titleAmbiguityError(
+                title: title,
+                windowIDs: windowIDs,
+                windows: windows,
+                operation: operation)
+        case let (.title(title), .conflictingWindowEntries(windowID)):
+            self.titleAmbiguityError(
+                title: title,
+                windowIDs: [windowID],
+                windows: windows,
+                operation: operation)
+        case let (.index(index), .windowNotFound):
+            ExactWindowSelectorResolutionError(
+                message: "\(operation) --window-index \(index) is not present. " +
+                    "Refresh the inventory and select a --window-id.")
+        case let (.index(index), .ambiguousWindow),
+             let (.index(index), .conflictingWindowEntries):
+            ExactWindowSelectorResolutionError(
+                message: "\(operation) --window-index \(index) is ambiguous. " +
+                    "Refresh the inventory and select a --window-id.")
+        default:
+            ExactWindowSelectorResolutionError(
+                message: "\(operation) could not resolve one exact window. \(error.localizedDescription)")
+        }
+    }
+
+    private static func titleAmbiguityError(
+        title: String,
+        windowIDs: [Int],
+        windows: [ServiceWindowInfo],
+        operation: String) -> ExactWindowSelectorResolutionError
+    {
+        let candidateIDs = Set(windowIDs)
+        let candidates = windows.lazy.filter { candidateIDs.contains($0.windowID) }.prefix(5)
+            .map { "id=\($0.windowID) index=\($0.index) '\($0.title)'" }
             .joined(separator: "; ")
         return ExactWindowSelectorResolutionError(
             message: "\(operation) window title '\(title)' is ambiguous (\(candidates)). " +
-                "Select one --window-id or --window-index explicitly."
-        )
+                "Select one --window-id or --window-index explicitly.")
     }
 }
 

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommandUtilities.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommandUtilities.swift
@@ -437,7 +437,17 @@ enum ExactWindowSelectorResolver {
         operation: String) -> ExactWindowSelectorResolutionError
     {
         let candidateIDs = Set(windowIDs)
-        let candidates = windows.lazy.filter { candidateIDs.contains($0.windowID) }.prefix(5)
+        let candidates = windows.lazy.filter { candidateIDs.contains($0.windowID) }
+            .sorted { lhs, rhs in
+                if lhs.windowID != rhs.windowID {
+                    return lhs.windowID < rhs.windowID
+                }
+                if lhs.index != rhs.index {
+                    return lhs.index < rhs.index
+                }
+                return lhs.title < rhs.title
+            }
+            .prefix(5)
             .map { "id=\($0.windowID) index=\($0.index) '\($0.title)'" }
             .joined(separator: "; ")
         return ExactWindowSelectorResolutionError(

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommandUtilities.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommandUtilities.swift
@@ -372,13 +372,15 @@ enum ExactWindowSelectorResolver {
             do {
                 return try DesktopTargetPlanning.WindowCandidateSelector.selectExplicitCandidate(
                     candidates: windows,
-                    selector: selection)
+                    selector: selection
+                )
             } catch let error as DesktopTargetPlanningError {
                 throw Self.presentationError(
                     error,
                     selection: selection,
                     windows: windows,
-                    operation: operation)
+                    operation: operation
+                )
             }
         }
     }
@@ -387,44 +389,52 @@ enum ExactWindowSelectorResolver {
         _ error: DesktopTargetPlanningError,
         selection: InteractionTargetSelector.WindowSelector,
         windows: [ServiceWindowInfo],
-        operation: String) -> ExactWindowSelectorResolutionError
-    {
+        operation: String
+    ) -> ExactWindowSelectorResolutionError {
         if case let .conflictingWindowEntries(windowID) = error {
             return self.inventoryConflictError(
                 windowID: windowID,
                 windows: windows,
-                operation: operation)
+                operation: operation
+            )
         }
         return switch (selection, error) {
         case let (.id(windowID), .windowNotFound):
             ExactWindowSelectorResolutionError(
                 message: "\(operation) --window-id \(windowID) does not identify a window. " +
-                    "Refresh the window inventory before retrying.")
+                    "Refresh the window inventory before retrying."
+            )
         case let (.id(windowID), .ambiguousWindow):
             ExactWindowSelectorResolutionError(
                 message: "\(operation) --window-id \(windowID) identifies multiple windows. " +
-                    "Refresh the window inventory before retrying.")
+                    "Refresh the window inventory before retrying."
+            )
         case let (.title(title), .windowNotFound):
             ExactWindowSelectorResolutionError(
                 message: "\(operation) found no window whose title matches '\(title)'. " +
-                    "Refresh the inventory and select a --window-id or valid --window-index.")
+                    "Refresh the inventory and select a --window-id or valid --window-index."
+            )
         case let (.title(title), .ambiguousWindow(_, windowIDs)):
             self.titleAmbiguityError(
                 title: title,
                 windowIDs: windowIDs,
                 windows: windows,
-                operation: operation)
+                operation: operation
+            )
         case let (.index(index), .windowNotFound):
             ExactWindowSelectorResolutionError(
                 message: "\(operation) --window-index \(index) is not present. " +
-                    "Refresh the inventory and select a --window-id.")
+                    "Refresh the inventory and select a --window-id."
+            )
         case let (.index(index), .ambiguousWindow):
             ExactWindowSelectorResolutionError(
                 message: "\(operation) --window-index \(index) is ambiguous. " +
-                    "Refresh the inventory and select a --window-id.")
+                    "Refresh the inventory and select a --window-id."
+            )
         default:
             ExactWindowSelectorResolutionError(
-                message: "\(operation) could not resolve one exact window. \(error.localizedDescription)")
+                message: "\(operation) could not resolve one exact window. \(error.localizedDescription)"
+            )
         }
     }
 
@@ -432,29 +442,31 @@ enum ExactWindowSelectorResolver {
         title: String,
         windowIDs: [Int],
         windows: [ServiceWindowInfo],
-        operation: String) -> ExactWindowSelectorResolutionError
-    {
+        operation: String
+    ) -> ExactWindowSelectorResolutionError {
         let candidates = self.candidateSummary(windowIDs: windowIDs, windows: windows)
         return ExactWindowSelectorResolutionError(
             message: "\(operation) window title '\(title)' is ambiguous (\(candidates)). " +
-                "Select one --window-id or --window-index explicitly.")
+                "Select one --window-id or --window-index explicitly."
+        )
     }
 
     private static func inventoryConflictError(
         windowID: Int,
         windows: [ServiceWindowInfo],
-        operation: String) -> ExactWindowSelectorResolutionError
-    {
+        operation: String
+    ) -> ExactWindowSelectorResolutionError {
         let candidates = self.candidateSummary(windowIDs: [windowID], windows: windows)
         return ExactWindowSelectorResolutionError(
             message: "\(operation) found conflicting inventory rows for window ID \(windowID) (\(candidates)). " +
-                "Refresh the window inventory before retrying.")
+                "Refresh the window inventory before retrying."
+        )
     }
 
     private static func candidateSummary(
         windowIDs: [Int],
-        windows: [ServiceWindowInfo]) -> String
-    {
+        windows: [ServiceWindowInfo]
+    ) -> String {
         let candidateIDs = Set(windowIDs)
         return windows.lazy.filter { candidateIDs.contains($0.windowID) }
             .sorted { lhs, rhs in

--- a/Apps/CLI/Tests/CoreCLITests/CaptureLiveBehaviorTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/CaptureLiveBehaviorTests.swift
@@ -106,7 +106,8 @@ struct CaptureLiveBehaviorTests {
                     _ = try ExactWindowSelectorResolver.select(
                         from: inventory,
                         selector: selector,
-                        operation: "Capture selector test")
+                        operation: "Capture selector test"
+                    )
                     Issue.record("Expected duplicate exact title selection to fail")
                 } catch let error as ExactWindowSelectorResolutionError {
                     #expect(error.message == expectedMessage)
@@ -134,7 +135,8 @@ struct CaptureLiveBehaviorTests {
                     _ = try ExactWindowSelectorResolver.select(
                         from: inventory,
                         selector: selector,
-                        operation: "Capture selector test")
+                        operation: "Capture selector test"
+                    )
                     Issue.record("Expected duplicate partial title selection to fail")
                 } catch let error as ExactWindowSelectorResolutionError {
                     #expect(error.message == expectedMessage)
@@ -145,7 +147,7 @@ struct CaptureLiveBehaviorTests {
 
     @Test
     @MainActor
-    func `capture selectors deterministically report unrelated conflicting duplicates`() throws {
+    func `capture selectors ignore unrelated conflicting duplicates`() throws {
         let selected = Self.window(id: 101, title: "Draft", index: 0)
         let firstConflict = Self.window(id: 202, title: "Other A", index: 1)
         let secondConflict = Self.window(id: 202, title: "Other B", index: 2)
@@ -153,23 +155,15 @@ struct CaptureLiveBehaviorTests {
             [selected, firstConflict, secondConflict],
             [secondConflict, firstConflict, selected],
         ]
-        let expectedMessage =
-            "Capture selector test found conflicting inventory rows for window ID 202 " +
-            "(id=202 index=1 'Other A'; id=202 index=2 'Other B'). " +
-            "Refresh the window inventory before retrying."
-
         for surface in SelectorSurface.allCases {
             let selector = try Self.selector(for: surface, title: "Draft")
             for inventory in inventories {
-                do {
-                    _ = try ExactWindowSelectorResolver.select(
-                        from: inventory,
-                        selector: selector,
-                        operation: "Capture selector test")
-                    Issue.record("Expected conflicting inventory selection to fail")
-                } catch let error as ExactWindowSelectorResolutionError {
-                    #expect(error.message == expectedMessage)
-                }
+                let result = try ExactWindowSelectorResolver.select(
+                    from: inventory,
+                    selector: selector,
+                    operation: "Capture selector test"
+                )
+                #expect(result == selected)
             }
         }
     }
@@ -184,7 +178,8 @@ struct CaptureLiveBehaviorTests {
             let selected = try ExactWindowSelectorResolver.select(
                 from: [window, window],
                 selector: selector,
-                operation: "Capture selector test")
+                operation: "Capture selector test"
+            )
             #expect(selected == window)
         }
     }

--- a/Apps/CLI/Tests/CoreCLITests/CaptureLiveBehaviorTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/CaptureLiveBehaviorTests.swift
@@ -97,12 +97,17 @@ struct CaptureLiveBehaviorTests {
 
         for surface in SelectorSurface.allCases {
             let selector = try Self.selector(for: surface, title: "Draft")
-            #expect(throws: ExactWindowSelectorResolutionError.self) {
+            do {
                 _ = try ExactWindowSelectorResolver.select(
                     from: windows,
                     selector: selector,
-                    operation: "Capture selector test"
-                )
+                    operation: "Capture selector test")
+                Issue.record("Expected duplicate exact title selection to fail")
+            } catch let error as ExactWindowSelectorResolutionError {
+                #expect(error.message ==
+                    "Capture selector test window title 'Draft' is ambiguous " +
+                    "(id=101 index=0 'Draft'; id=102 index=1 'Draft'). " +
+                    "Select one --window-id or --window-index explicitly.")
             }
         }
     }
@@ -117,13 +122,33 @@ struct CaptureLiveBehaviorTests {
 
         for surface in SelectorSurface.allCases {
             let selector = try Self.selector(for: surface, title: "Draft")
-            #expect(throws: ExactWindowSelectorResolutionError.self) {
+            do {
                 _ = try ExactWindowSelectorResolver.select(
                     from: windows,
                     selector: selector,
-                    operation: "Capture selector test"
-                )
+                    operation: "Capture selector test")
+                Issue.record("Expected duplicate partial title selection to fail")
+            } catch let error as ExactWindowSelectorResolutionError {
+                #expect(error.message ==
+                    "Capture selector test window title 'Draft' is ambiguous " +
+                    "(id=101 index=0 'Draft One'; id=102 index=1 'Draft Two'). " +
+                    "Select one --window-id or --window-index explicitly.")
             }
+        }
+    }
+
+    @Test
+    @MainActor
+    func `capture selectors canonicalize repeated stable inventory rows`() throws {
+        let window = Self.window(id: 101, title: "Draft", index: 0)
+
+        for surface in SelectorSurface.allCases {
+            let selector = try Self.selector(for: surface, title: "Draft")
+            let selected = try ExactWindowSelectorResolver.select(
+                from: [window, window],
+                selector: selector,
+                operation: "Capture selector test")
+            #expect(selected == window)
         }
     }
 

--- a/Apps/CLI/Tests/CoreCLITests/CaptureLiveBehaviorTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/CaptureLiveBehaviorTests.swift
@@ -94,20 +94,23 @@ struct CaptureLiveBehaviorTests {
             Self.window(id: 101, title: "Draft", index: 0),
             Self.window(id: 102, title: "Draft", index: 1),
         ]
+        let expectedMessage =
+            "Capture selector test window title 'Draft' is ambiguous " +
+            "(id=101 index=0 'Draft'; id=102 index=1 'Draft'). " +
+            "Select one --window-id or --window-index explicitly."
 
         for surface in SelectorSurface.allCases {
             let selector = try Self.selector(for: surface, title: "Draft")
-            do {
-                _ = try ExactWindowSelectorResolver.select(
-                    from: windows,
-                    selector: selector,
-                    operation: "Capture selector test")
-                Issue.record("Expected duplicate exact title selection to fail")
-            } catch let error as ExactWindowSelectorResolutionError {
-                #expect(error.message ==
-                    "Capture selector test window title 'Draft' is ambiguous " +
-                    "(id=101 index=0 'Draft'; id=102 index=1 'Draft'). " +
-                    "Select one --window-id or --window-index explicitly.")
+            for inventory in [windows, Array(windows.reversed())] {
+                do {
+                    _ = try ExactWindowSelectorResolver.select(
+                        from: inventory,
+                        selector: selector,
+                        operation: "Capture selector test")
+                    Issue.record("Expected duplicate exact title selection to fail")
+                } catch let error as ExactWindowSelectorResolutionError {
+                    #expect(error.message == expectedMessage)
+                }
             }
         }
     }
@@ -119,20 +122,54 @@ struct CaptureLiveBehaviorTests {
             Self.window(id: 101, title: "Draft One", index: 0),
             Self.window(id: 102, title: "Draft Two", index: 1),
         ]
+        let expectedMessage =
+            "Capture selector test window title 'Draft' is ambiguous " +
+            "(id=101 index=0 'Draft One'; id=102 index=1 'Draft Two'). " +
+            "Select one --window-id or --window-index explicitly."
 
         for surface in SelectorSurface.allCases {
             let selector = try Self.selector(for: surface, title: "Draft")
-            do {
-                _ = try ExactWindowSelectorResolver.select(
-                    from: windows,
-                    selector: selector,
-                    operation: "Capture selector test")
-                Issue.record("Expected duplicate partial title selection to fail")
-            } catch let error as ExactWindowSelectorResolutionError {
-                #expect(error.message ==
-                    "Capture selector test window title 'Draft' is ambiguous " +
-                    "(id=101 index=0 'Draft One'; id=102 index=1 'Draft Two'). " +
-                    "Select one --window-id or --window-index explicitly.")
+            for inventory in [windows, Array(windows.reversed())] {
+                do {
+                    _ = try ExactWindowSelectorResolver.select(
+                        from: inventory,
+                        selector: selector,
+                        operation: "Capture selector test")
+                    Issue.record("Expected duplicate partial title selection to fail")
+                } catch let error as ExactWindowSelectorResolutionError {
+                    #expect(error.message == expectedMessage)
+                }
+            }
+        }
+    }
+
+    @Test
+    @MainActor
+    func `capture selectors deterministically report unrelated conflicting duplicates`() throws {
+        let selected = Self.window(id: 101, title: "Draft", index: 0)
+        let firstConflict = Self.window(id: 202, title: "Other A", index: 1)
+        let secondConflict = Self.window(id: 202, title: "Other B", index: 2)
+        let inventories = [
+            [selected, firstConflict, secondConflict],
+            [secondConflict, firstConflict, selected],
+        ]
+        let expectedMessage =
+            "Capture selector test window title 'Draft' is ambiguous " +
+            "(id=202 index=1 'Other A'; id=202 index=2 'Other B'). " +
+            "Select one --window-id or --window-index explicitly."
+
+        for surface in SelectorSurface.allCases {
+            let selector = try Self.selector(for: surface, title: "Draft")
+            for inventory in inventories {
+                do {
+                    _ = try ExactWindowSelectorResolver.select(
+                        from: inventory,
+                        selector: selector,
+                        operation: "Capture selector test")
+                    Issue.record("Expected conflicting inventory selection to fail")
+                } catch let error as ExactWindowSelectorResolutionError {
+                    #expect(error.message == expectedMessage)
+                }
             }
         }
     }

--- a/Apps/CLI/Tests/CoreCLITests/CaptureLiveBehaviorTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/CaptureLiveBehaviorTests.swift
@@ -154,9 +154,9 @@ struct CaptureLiveBehaviorTests {
             [secondConflict, firstConflict, selected],
         ]
         let expectedMessage =
-            "Capture selector test window title 'Draft' is ambiguous " +
+            "Capture selector test found conflicting inventory rows for window ID 202 " +
             "(id=202 index=1 'Other A'; id=202 index=2 'Other B'). " +
-            "Select one --window-id or --window-index explicitly."
+            "Refresh the window inventory before retrying."
 
         for surface in SelectorSurface.allCases {
             let selector = try Self.selector(for: surface, title: "Draft")

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,6 @@
 - Reuse validated classic PNG bytes when capture performs no transform instead of encoding the same image twice.
 
 ### Fixed
-- Resolve repeated stable window inventory rows consistently across CLI and MCP instead of falsely reporting ambiguity.
 - Downscale straight-alpha legacy screenshots to logical 1x instead of silently returning Retina-sized pixels.
 - Bound exclusive ScreenCaptureKit transaction-lock waits inside the Bridge request envelope so a wedged peer fails clearly instead of hanging capture indefinitely. Thanks @SebTardif for #599.
 - Send Gemini API keys in request headers, require HTTPS OAuth endpoints, and redact OAuth state. Thanks Vincent Koc for #575 and Tachikoma #73.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,5 @@
 # Changelog
 
-## Unreleased
-
-### Fixed
-- Resolve repeated stable window inventory rows consistently across CLI and MCP instead of falsely reporting ambiguity.
-
 ## [4.2.3] - 2026-08-23
 
 ### Highlights
@@ -28,6 +23,7 @@
 - Reuse validated classic PNG bytes when capture performs no transform instead of encoding the same image twice.
 
 ### Fixed
+- Resolve repeated stable window inventory rows consistently across CLI and MCP instead of falsely reporting ambiguity.
 - Downscale straight-alpha legacy screenshots to logical 1x instead of silently returning Retina-sized pixels.
 - Bound exclusive ScreenCaptureKit transaction-lock waits inside the Bridge request envelope so a wedged peer fails clearly instead of hanging capture indefinitely. Thanks @SebTardif for #599.
 - Send Gemini API keys in request headers, require HTTPS OAuth endpoints, and redact OAuth state. Thanks Vincent Koc for #575 and Tachikoma #73.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Reuse validated classic PNG bytes when capture performs no transform instead of encoding the same image twice.
 
 ### Fixed
+- Resolve repeated stable window inventory rows consistently across CLI and MCP instead of falsely reporting ambiguity.
 - Downscale straight-alpha legacy screenshots to logical 1x instead of silently returning Retina-sized pixels.
 - Bound exclusive ScreenCaptureKit transaction-lock waits inside the Bridge request envelope so a wedged peer fails clearly instead of hanging capture indefinitely. Thanks @SebTardif for #599.
 - Send Gemini API keys in request headers, require HTTPS OAuth endpoints, and redact OAuth state. Thanks Vincent Koc for #575 and Tachikoma #73.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+- Resolve repeated stable window inventory rows consistently across CLI and MCP instead of falsely reporting ambiguity.
+
 ## [4.2.3] - 2026-08-23
 
 ### Highlights

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Strategy/DesktopTargetPlanning+Candidates.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Strategy/DesktopTargetPlanning+Candidates.swift
@@ -298,7 +298,7 @@ extension DesktopTargetPlanning {
         {
             try self.selectExplicit(
                 selector,
-                from: self.canonicalizedCandidates(candidates))
+                from: self.canonicalizedCandidates(self.candidates(relevantTo: selector, in: candidates)))
         }
 
         public static func select(
@@ -307,11 +307,14 @@ extension DesktopTargetPlanning {
             policy: WindowSelectionPolicy,
             expectedOwner: ApplicationProcessIdentity? = nil) throws -> ServiceWindowInfo
         {
-            let canonical = try self.canonicalizedCandidates(candidates)
             let selected: ServiceWindowInfo
             if let selector {
+                let canonical = try self.canonicalizedCandidates(self.candidates(
+                    relevantTo: selector,
+                    in: candidates))
                 selected = try self.selectExplicit(selector, from: canonical)
             } else {
+                let canonical = try self.canonicalizedCandidates(candidates)
                 guard case let .preferredMutationWindow(intent) = policy else {
                     throw DesktopTargetPlanningError.windowNotFound(
                         selector: "an explicit window selector",
@@ -328,6 +331,31 @@ extension DesktopTargetPlanning {
             }
             try self.validate(selected, expectedOwner: expectedOwner)
             return selected
+        }
+
+        private static func candidates(
+            relevantTo selector: InteractionTargetSelector.WindowSelector,
+            in candidates: [ServiceWindowInfo]) -> [ServiceWindowInfo]
+        {
+            let relevantWindowIDs: Set<Int> = switch selector {
+            case let .id(windowID):
+                [windowID]
+            case let .title(title):
+                {
+                    let exact = Set(candidates.lazy.filter {
+                        $0.title.compare(title, options: .caseInsensitive) == .orderedSame
+                    }.map(\.windowID))
+                    if !exact.isEmpty {
+                        return exact
+                    }
+                    return Set(candidates.lazy.filter {
+                        $0.title.localizedCaseInsensitiveContains(title)
+                    }.map(\.windowID))
+                }()
+            case let .index(index):
+                Set(candidates.lazy.filter { $0.index == index }.map(\.windowID))
+            }
+            return candidates.filter { relevantWindowIDs.contains($0.windowID) }
         }
 
         private static func selectExplicit(

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Strategy/DesktopTargetPlanning+Candidates.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Strategy/DesktopTargetPlanning+Candidates.swift
@@ -288,6 +288,19 @@ extension DesktopTargetPlanning {
     }
 
     public enum WindowCandidateSelector {
+        /// Selects one explicit compatibility candidate without requiring a mutation receipt.
+        ///
+        /// Read-only surfaces use the same deterministic ID, title, index, and duplicate-row
+        /// semantics as mutation planning, then apply their own capability requirements.
+        public static func selectExplicitCandidate(
+            candidates: [ServiceWindowInfo],
+            selector: InteractionTargetSelector.WindowSelector) throws -> ServiceWindowInfo
+        {
+            try self.selectExplicit(
+                selector,
+                from: self.canonicalizedCandidates(candidates))
+        }
+
         public static func select(
             candidates: [ServiceWindowInfo],
             selector: InteractionTargetSelector.WindowSelector?,
@@ -296,17 +309,9 @@ extension DesktopTargetPlanning {
         {
             let canonical = try self.canonicalizedCandidates(candidates)
             let selected: ServiceWindowInfo
-            switch selector {
-            case let .id(windowID):
-                selected = try self.selectUniqueID(
-                    windowID,
-                    from: canonical,
-                    selector: "window ID \(windowID)")
-            case let .title(title):
-                selected = try self.selectTitle(title, from: canonical)
-            case let .index(index):
-                selected = try self.selectIndex(index, from: canonical)
-            case nil:
+            if let selector {
+                selected = try self.selectExplicit(selector, from: canonical)
+            } else {
                 guard case let .preferredMutationWindow(intent) = policy else {
                     throw DesktopTargetPlanningError.windowNotFound(
                         selector: "an explicit window selector",
@@ -323,6 +328,23 @@ extension DesktopTargetPlanning {
             }
             try self.validate(selected, expectedOwner: expectedOwner)
             return selected
+        }
+
+        private static func selectExplicit(
+            _ selector: InteractionTargetSelector.WindowSelector,
+            from candidates: [ServiceWindowInfo]) throws -> ServiceWindowInfo
+        {
+            switch selector {
+            case let .id(windowID):
+                try self.selectUniqueID(
+                    windowID,
+                    from: candidates,
+                    selector: "window ID \(windowID)")
+            case let .title(title):
+                try self.selectTitle(title, from: candidates)
+            case let .index(index):
+                try self.selectIndex(index, from: candidates)
+            }
         }
 
         private static func selectTitle(

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Strategy/DesktopTargetPlanning+Candidates.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Strategy/DesktopTargetPlanning+Candidates.swift
@@ -333,7 +333,7 @@ extension DesktopTargetPlanning {
             return selected
         }
 
-        private static func candidates(
+        static func candidates(
             relevantTo selector: InteractionTargetSelector.WindowSelector,
             in candidates: [ServiceWindowInfo]) -> [ServiceWindowInfo]
         {

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Strategy/DesktopTargetPlanning+MutationPlanners.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Strategy/DesktopTargetPlanning+MutationPlanners.swift
@@ -613,20 +613,25 @@ extension DesktopTargetPlanning {
             processIdentity: ApplicationProcessIdentity) throws -> SelectorResolutionProof?
         {
             let proofSelection: WindowSelection
+            let explicitSelector: InteractionTargetSelector.WindowSelector
             switch selection {
             case .automatic:
                 return nil
             case let .id(windowID):
                 proofSelection = .id(CGWindowID(windowID))
+                explicitSelector = .id(windowID)
             case let .title(title):
                 proofSelection = .title(title)
+                explicitSelector = .title(title)
             case let .index(index):
                 proofSelection = .index(index)
+                explicitSelector = .index(index)
             }
             do {
                 return try WindowSelectorResolutionProof.make(
                     selection: proofSelection,
-                    candidates: WindowCandidateSelector.canonicalizedCandidates(candidates),
+                    candidates: WindowCandidateSelector.canonicalizedCandidates(
+                        WindowCandidateSelector.candidates(relevantTo: explicitSelector, in: candidates)),
                     selected: selected,
                     processIdentity: processIdentity)
             } catch let error as WindowSelectorResolutionProof.ResolutionError {

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/WindowCandidateSelectorTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/WindowCandidateSelectorTests.swift
@@ -23,20 +23,27 @@ struct WindowCandidateSelectorTests {
     }
 
     @Test
-    func `unrelated conflicting duplicate poisons explicit compatibility selection`() {
+    func `unrelated conflicting duplicate does not poison explicit selection`() throws {
         let selected = AutomationTestFixtures.window(windowID: 201, title: "Selected", index: 0)
         let unrelated = AutomationTestFixtures.window(windowID: 202, title: "Other", index: 1)
         let conflicting = AutomationTestFixtures.window(windowID: 202, title: "Conflict", index: 2)
-        let expected = DesktopTargetPlanningError.conflictingWindowEntries(windowID: 202)
 
         for candidates in [
             [selected, unrelated, conflicting],
             [conflicting, unrelated, selected],
         ] {
-            #expect(throws: expected) {
-                _ = try DesktopTargetPlanning.WindowCandidateSelector.selectExplicitCandidate(
+            for selector: InteractionTargetSelector.WindowSelector in [
+                .id(selected.windowID),
+                .title(selected.title),
+                .index(selected.index),
+            ] {
+                #expect(try DesktopTargetPlanning.WindowCandidateSelector.selectExplicitCandidate(
                     candidates: candidates,
-                    selector: .id(selected.windowID))
+                    selector: selector) == selected)
+                #expect(try DesktopTargetPlanning.WindowCandidateSelector.select(
+                    candidates: candidates,
+                    selector: selector,
+                    policy: .explicit) == selected)
             }
         }
     }
@@ -233,6 +240,11 @@ struct WindowCandidateSelectorTests {
                     selector: .title(matching.title),
                     policy: .explicit)
             }
+            #expect(throws: expected) {
+                _ = try DesktopTargetPlanning.WindowCandidateSelector.selectExplicitCandidate(
+                    candidates: candidates,
+                    selector: .title(matching.title))
+            }
         }
     }
 
@@ -248,6 +260,11 @@ struct WindowCandidateSelectorTests {
                     candidates: candidates,
                     selector: .index(matching.index),
                     policy: .explicit)
+            }
+            #expect(throws: expected) {
+                _ = try DesktopTargetPlanning.WindowCandidateSelector.selectExplicitCandidate(
+                    candidates: candidates,
+                    selector: .index(matching.index))
             }
         }
     }

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/WindowCandidateSelectorTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/WindowCandidateSelectorTests.swift
@@ -6,6 +6,23 @@ import Testing
 
 struct WindowCandidateSelectorTests {
     @Test
+    func `explicit compatibility selection does not require a mutation receipt`() throws {
+        let receiptless = AutomationTestFixtures.window(includesMutationIdentity: false)
+
+        let selected = try DesktopTargetPlanning.WindowCandidateSelector.selectExplicitCandidate(
+            candidates: [receiptless],
+            selector: .id(receiptless.windowID))
+
+        #expect(selected == receiptless)
+        #expect(throws: DesktopTargetPlanningError.missingWindowIdentity(windowID: receiptless.windowID)) {
+            _ = try DesktopTargetPlanning.WindowCandidateSelector.select(
+                candidates: [receiptless],
+                selector: .id(receiptless.windowID),
+                policy: .explicit)
+        }
+    }
+
+    @Test
     func `unique exact title wins before partial while duplicate exact refuses deterministically`() throws {
         let windows = AutomationTestFixtures.duplicateTitleWindows()
         let selected = try DesktopTargetPlanning.WindowCandidateSelector.select(

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/WindowCandidateSelectorTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/WindowCandidateSelectorTests.swift
@@ -23,6 +23,25 @@ struct WindowCandidateSelectorTests {
     }
 
     @Test
+    func `unrelated conflicting duplicate poisons explicit compatibility selection`() {
+        let selected = AutomationTestFixtures.window(windowID: 201, title: "Selected", index: 0)
+        let unrelated = AutomationTestFixtures.window(windowID: 202, title: "Other", index: 1)
+        let conflicting = AutomationTestFixtures.window(windowID: 202, title: "Conflict", index: 2)
+        let expected = DesktopTargetPlanningError.conflictingWindowEntries(windowID: 202)
+
+        for candidates in [
+            [selected, unrelated, conflicting],
+            [conflicting, unrelated, selected],
+        ] {
+            #expect(throws: expected) {
+                _ = try DesktopTargetPlanning.WindowCandidateSelector.selectExplicitCandidate(
+                    candidates: candidates,
+                    selector: .id(selected.windowID))
+            }
+        }
+    }
+
+    @Test
     func `unique exact title wins before partial while duplicate exact refuses deterministically`() throws {
         let windows = AutomationTestFixtures.duplicateTitleWindows()
         let selected = try DesktopTargetPlanning.WindowCandidateSelector.select(

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/WindowMutationPlannerTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/WindowMutationPlannerTests.swift
@@ -7,6 +7,37 @@ import Testing
 @MainActor
 struct WindowMutationPlannerTests {
     @Test
+    func `explicit mutation proof ignores unrelated conflicting duplicate rows`() async throws {
+        let fixture = AutomationTestFixtures.linkedDesktopTarget()
+        let unrelated = AutomationTestFixtures.window(windowID: 202, title: "Other", index: 1)
+        let conflicting = AutomationTestFixtures.window(windowID: 202, title: "Conflict", index: 2)
+        let applications = DesktopTargetPlanning.ApplicationMutationPlanner(
+            inventoryProvider: { .complete([fixture.application]) })
+        let planner = DesktopTargetPlanning.WindowMutationPlanner(
+            applicationPlanner: applications,
+            windowInventoryProvider: { _ in
+                .complete([fixture.window, unrelated, conflicting])
+            })
+        let selectors = [
+            InteractionTargetSelector(windowID: fixture.window.windowID),
+            InteractionTargetSelector(
+                applicationIdentifier: fixture.application.name,
+                windowTitle: fixture.window.title),
+            InteractionTargetSelector(
+                applicationIdentifier: fixture.application.name,
+                windowIndex: fixture.window.index),
+        ]
+
+        for selector in selectors {
+            let plan = try await planner.plan(selector: selector)
+            let proof = try #require(plan.selectorProof)
+
+            #expect(plan.selectionWindow == fixture.window)
+            #expect(proof.selectedWindowIdentity == fixture.windowIdentity)
+        }
+    }
+
+    @Test
     func `partial window inventory refuses title and index uniqueness`() async {
         let fixture = AutomationTestFixtures.linkedDesktopTarget()
         let application = fixture.application
@@ -219,7 +250,7 @@ struct WindowMutationPlannerTests {
     }
 
     @Test
-    func `nonfinite unrelated candidate evidence becomes a canonical invalid inventory`() async {
+    func `nonfinite unrelated candidate evidence does not poison explicit mutation proof`() async throws {
         let application = AutomationTestFixtures.application()
         let selected = AutomationTestFixtures.window(title: "Target")
         let invalid = ServiceWindowInfo(
@@ -230,14 +261,12 @@ struct WindowMutationPlannerTests {
             applicationInventories: [[application], [application]],
             windows: [.application("PID:101"): [selected, invalid]])
 
-        await #expect(throws: DesktopTargetPlanningError.invalidWindowInventory(
-            selector: "window title 'Target'",
-            reason: "candidate evidence could not be encoded"))
-        {
-            _ = try await spy.planner().plan(selector: InteractionTargetSelector(
-                applicationIdentifier: "Test App",
-                windowTitle: "Target"))
-        }
+        let plan = try await spy.planner().plan(selector: InteractionTargetSelector(
+            applicationIdentifier: "Test App",
+            windowTitle: "Target"))
+
+        #expect(plan.selectionWindow == selected)
+        #expect(plan.selectorProof?.selectedWindowIdentity == selected.mutationIdentity)
     }
 
     @Test

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/ExactWindowSelectorResolver.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/ExactWindowSelectorResolver.swift
@@ -1,5 +1,6 @@
 import Foundation
 import PeekabooAutomationKit
+import PeekabooFoundation
 
 struct ExactWindowSelectorResolutionError: Error, LocalizedError, Sendable, Equatable {
     let message: String
@@ -16,6 +17,15 @@ enum ExactWindowSelectorResolver {
         case id(Int)
         case title(String)
         case index(Int)
+
+        var explicitSelector: InteractionTargetSelector.WindowSelector? {
+            switch self {
+            case .automatic: nil
+            case let .id(windowID): .id(windowID)
+            case let .title(title): .title(title)
+            case let .index(index): .index(index)
+            }
+        }
     }
 
     static func select(
@@ -23,59 +33,27 @@ enum ExactWindowSelectorResolver {
         selection: Selection,
         operation: String) throws -> ServiceWindowInfo
     {
-        switch selection {
-        case .automatic:
+        guard let explicitSelector = selection.explicitSelector else {
             guard let window = ObservationTargetResolver.bestWindow(from: windows) else {
                 throw ExactWindowSelectorResolutionError(
                     message: "\(operation) found no eligible window. Refresh the window inventory before retrying.")
             }
             return window
-
-        case let .id(windowID):
-            let matches = windows.filter { $0.windowID == windowID }
-            guard matches.count == 1, let window = matches.first else {
-                let detail = matches.isEmpty ? "does not identify a window" : "identifies multiple windows"
-                throw ExactWindowSelectorResolutionError(
-                    message: "\(operation) window_id \(windowID) \(detail). " +
-                        "Refresh the window inventory before retrying.")
-            }
-            return window
-
-        case let .title(title):
-            let exactMatches = windows.filter {
-                $0.title.compare(title, options: .caseInsensitive) == .orderedSame
-            }
-            if exactMatches.count == 1, let window = exactMatches.first {
-                return window
-            }
-            if exactMatches.count > 1 {
-                throw self.ambiguousTitle(title, matches: exactMatches, operation: operation)
-            }
-
-            let partialMatches = windows.filter { $0.title.localizedCaseInsensitiveContains(title) }
-            guard partialMatches.count == 1, let window = partialMatches.first else {
-                if partialMatches.isEmpty {
-                    throw ExactWindowSelectorResolutionError(
-                        message: "\(operation) found no window whose title matches '\(title)'. " +
-                            "Refresh the inventory and select a window_id or valid index.")
-                }
-                throw self.ambiguousTitle(title, matches: partialMatches, operation: operation)
-            }
-            return window
-
-        case let .index(index):
-            guard index >= 0 else {
-                throw ExactWindowSelectorResolutionError(
-                    message: "\(operation) window index must be zero or greater.")
-            }
-            let matches = windows.filter { $0.index == index }
-            guard matches.count == 1, let window = matches.first else {
-                let detail = matches.isEmpty ? "is not present" : "is ambiguous"
-                throw ExactWindowSelectorResolutionError(
-                    message: "\(operation) window index \(index) \(detail). " +
-                        "Refresh the inventory and select a window_id.")
-            }
-            return window
+        }
+        if case let .index(index) = explicitSelector, index < 0 {
+            throw ExactWindowSelectorResolutionError(
+                message: "\(operation) window index must be zero or greater.")
+        }
+        do {
+            return try DesktopTargetPlanning.WindowCandidateSelector.selectExplicitCandidate(
+                candidates: windows,
+                selector: explicitSelector)
+        } catch let error as DesktopTargetPlanningError {
+            throw self.presentationError(
+                error,
+                selector: explicitSelector,
+                windows: windows,
+                operation: operation)
         }
     }
 
@@ -92,12 +70,62 @@ enum ExactWindowSelectorResolver {
         }
     }
 
-    private static func ambiguousTitle(
-        _ title: String,
-        matches: [ServiceWindowInfo],
+    private static func presentationError(
+        _ error: DesktopTargetPlanningError,
+        selector: InteractionTargetSelector.WindowSelector,
+        windows: [ServiceWindowInfo],
         operation: String) -> ExactWindowSelectorResolutionError
     {
-        let candidates = matches.prefix(5).map { "id=\($0.windowID) index=\($0.index) '\($0.title)'" }
+        switch (selector, error) {
+        case let (.id(windowID), .windowNotFound):
+            ExactWindowSelectorResolutionError(
+                message: "\(operation) window_id \(windowID) does not identify a window. " +
+                    "Refresh the window inventory before retrying.")
+        case let (.id(windowID), .ambiguousWindow),
+             let (.id(windowID), .conflictingWindowEntries):
+            ExactWindowSelectorResolutionError(
+                message: "\(operation) window_id \(windowID) identifies multiple windows. " +
+                    "Refresh the window inventory before retrying.")
+        case let (.title(title), .windowNotFound):
+            ExactWindowSelectorResolutionError(
+                message: "\(operation) found no window whose title matches '\(title)'. " +
+                    "Refresh the inventory and select a window_id or valid index.")
+        case let (.title(title), .ambiguousWindow(_, windowIDs)):
+            self.titleAmbiguityError(
+                title: title,
+                windowIDs: windowIDs,
+                windows: windows,
+                operation: operation)
+        case let (.title(title), .conflictingWindowEntries(windowID)):
+            self.titleAmbiguityError(
+                title: title,
+                windowIDs: [windowID],
+                windows: windows,
+                operation: operation)
+        case let (.index(index), .windowNotFound):
+            ExactWindowSelectorResolutionError(
+                message: "\(operation) window index \(index) is not present. " +
+                    "Refresh the inventory and select a window_id.")
+        case let (.index(index), .ambiguousWindow),
+             let (.index(index), .conflictingWindowEntries):
+            ExactWindowSelectorResolutionError(
+                message: "\(operation) window index \(index) is ambiguous. " +
+                    "Refresh the inventory and select a window_id.")
+        default:
+            ExactWindowSelectorResolutionError(
+                message: "\(operation) could not resolve one exact window. \(error.localizedDescription)")
+        }
+    }
+
+    private static func titleAmbiguityError(
+        title: String,
+        windowIDs: [Int],
+        windows: [ServiceWindowInfo],
+        operation: String) -> ExactWindowSelectorResolutionError
+    {
+        let candidateIDs = Set(windowIDs)
+        let candidates = windows.lazy.filter { candidateIDs.contains($0.windowID) }.prefix(5)
+            .map { "id=\($0.windowID) index=\($0.index) '\($0.title)'" }
             .joined(separator: "; ")
         return ExactWindowSelectorResolutionError(
             message: "\(operation) window title '\(title)' is ambiguous (\(candidates)). " +

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/ExactWindowSelectorResolver.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/ExactWindowSelectorResolver.swift
@@ -76,13 +76,18 @@ enum ExactWindowSelectorResolver {
         windows: [ServiceWindowInfo],
         operation: String) -> ExactWindowSelectorResolutionError
     {
-        switch (selector, error) {
+        if case let .conflictingWindowEntries(windowID) = error {
+            return self.inventoryConflictError(
+                windowID: windowID,
+                windows: windows,
+                operation: operation)
+        }
+        return switch (selector, error) {
         case let (.id(windowID), .windowNotFound):
             ExactWindowSelectorResolutionError(
                 message: "\(operation) window_id \(windowID) does not identify a window. " +
                     "Refresh the window inventory before retrying.")
-        case let (.id(windowID), .ambiguousWindow),
-             let (.id(windowID), .conflictingWindowEntries):
+        case let (.id(windowID), .ambiguousWindow):
             ExactWindowSelectorResolutionError(
                 message: "\(operation) window_id \(windowID) identifies multiple windows. " +
                     "Refresh the window inventory before retrying.")
@@ -96,18 +101,11 @@ enum ExactWindowSelectorResolver {
                 windowIDs: windowIDs,
                 windows: windows,
                 operation: operation)
-        case let (.title(title), .conflictingWindowEntries(windowID)):
-            self.titleAmbiguityError(
-                title: title,
-                windowIDs: [windowID],
-                windows: windows,
-                operation: operation)
         case let (.index(index), .windowNotFound):
             ExactWindowSelectorResolutionError(
                 message: "\(operation) window index \(index) is not present. " +
                     "Refresh the inventory and select a window_id.")
-        case let (.index(index), .ambiguousWindow),
-             let (.index(index), .conflictingWindowEntries):
+        case let (.index(index), .ambiguousWindow):
             ExactWindowSelectorResolutionError(
                 message: "\(operation) window index \(index) is ambiguous. " +
                     "Refresh the inventory and select a window_id.")
@@ -123,8 +121,29 @@ enum ExactWindowSelectorResolver {
         windows: [ServiceWindowInfo],
         operation: String) -> ExactWindowSelectorResolutionError
     {
+        let candidates = self.candidateSummary(windowIDs: windowIDs, windows: windows)
+        return ExactWindowSelectorResolutionError(
+            message: "\(operation) window title '\(title)' is ambiguous (\(candidates)). " +
+                "Select one window_id or index explicitly.")
+    }
+
+    private static func inventoryConflictError(
+        windowID: Int,
+        windows: [ServiceWindowInfo],
+        operation: String) -> ExactWindowSelectorResolutionError
+    {
+        let candidates = self.candidateSummary(windowIDs: [windowID], windows: windows)
+        return ExactWindowSelectorResolutionError(
+            message: "\(operation) found conflicting inventory rows for window ID \(windowID) (\(candidates)). " +
+                "Refresh the window inventory before retrying.")
+    }
+
+    private static func candidateSummary(
+        windowIDs: [Int],
+        windows: [ServiceWindowInfo]) -> String
+    {
         let candidateIDs = Set(windowIDs)
-        let candidates = windows.lazy.filter { candidateIDs.contains($0.windowID) }
+        return windows.lazy.filter { candidateIDs.contains($0.windowID) }
             .sorted { lhs, rhs in
                 if lhs.windowID != rhs.windowID {
                     return lhs.windowID < rhs.windowID
@@ -137,8 +156,5 @@ enum ExactWindowSelectorResolver {
             .prefix(5)
             .map { "id=\($0.windowID) index=\($0.index) '\($0.title)'" }
             .joined(separator: "; ")
-        return ExactWindowSelectorResolutionError(
-            message: "\(operation) window title '\(title)' is ambiguous (\(candidates)). " +
-                "Select one window_id or index explicitly.")
     }
 }

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/ExactWindowSelectorResolver.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/ExactWindowSelectorResolver.swift
@@ -124,7 +124,17 @@ enum ExactWindowSelectorResolver {
         operation: String) -> ExactWindowSelectorResolutionError
     {
         let candidateIDs = Set(windowIDs)
-        let candidates = windows.lazy.filter { candidateIDs.contains($0.windowID) }.prefix(5)
+        let candidates = windows.lazy.filter { candidateIDs.contains($0.windowID) }
+            .sorted { lhs, rhs in
+                if lhs.windowID != rhs.windowID {
+                    return lhs.windowID < rhs.windowID
+                }
+                if lhs.index != rhs.index {
+                    return lhs.index < rhs.index
+                }
+                return lhs.title < rhs.title
+            }
+            .prefix(5)
             .map { "id=\($0.windowID) index=\($0.index) '\($0.title)'" }
             .joined(separator: "; ")
         return ExactWindowSelectorResolutionError(

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/CaptureToolPathResolverTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/CaptureToolPathResolverTests.swift
@@ -246,19 +246,41 @@ struct CaptureToolPathResolverTests {
     }
 
     @Test
+    func `window resolver canonicalizes repeated stable inventory rows`() async throws {
+        let window = Self.window(id: 99, title: "Inspector", index: 4)
+        let windows = CaptureWindowResolverWindowService(windows: [window, window])
+
+        let scope = try await CaptureToolWindowResolver.scope(
+            app: "Preview",
+            pid: nil,
+            windowTitle: "Inspector",
+            windowIndex: nil,
+            windows: windows)
+
+        #expect(scope.windowId == 99)
+        #expect(scope.windowMutationIdentity == window.mutationIdentity)
+    }
+
+    @Test
     func `window resolver refuses ambiguous partial titles instead of pinning the first result`() async {
         let windows = CaptureWindowResolverWindowService(windows: [
             Self.window(id: 41, title: "Project Notes", index: 0),
             Self.window(id: 42, title: "Project Plan", index: 1),
         ])
 
-        await #expect(throws: PeekabooError.self) {
+        do {
             _ = try await CaptureToolWindowResolver.scope(
                 app: "Preview",
                 pid: nil,
                 windowTitle: "Project",
                 windowIndex: nil,
                 windows: windows)
+            Issue.record("Expected ambiguous partial title selection to fail")
+        } catch let error as PeekabooError {
+            #expect(error.localizedDescription.contains(
+                "Select one window_id or index explicitly."))
+        } catch {
+            Issue.record("Expected PeekabooError, received \(error)")
         }
         #expect(windows.requestedTargets.map(\.description) == ["application(Preview)"])
     }

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/CaptureToolPathResolverTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/CaptureToolPathResolverTests.swift
@@ -290,29 +290,25 @@ struct CaptureToolPathResolverTests {
     }
 
     @Test
-    func `window resolver deterministically reports unrelated conflicting duplicates`() {
+    func `window resolver ignores unrelated conflicting duplicates`() throws {
         let selected = Self.window(id: 41, title: "Project", index: 0)
         let firstConflict = Self.window(id: 50, title: "Other A", index: 1)
         let secondConflict = Self.window(id: 50, title: "Other B", index: 2)
-        let expectedMessage =
-            "found conflicting inventory rows for window ID 50 " +
-            "(id=50 index=1 'Other A'; id=50 index=2 'Other B'). " +
-            "Refresh the window inventory before retrying."
 
         for inventory in [
             [selected, firstConflict, secondConflict],
             [secondConflict, firstConflict, selected],
         ] {
-            do {
-                _ = try ExactWindowSelectorResolver.select(
+            for selection: ExactWindowSelectorResolver.Selection in [
+                .id(selected.windowID),
+                .title(selected.title),
+                .index(selected.index),
+            ] {
+                let result = try ExactWindowSelectorResolver.select(
                     from: inventory,
-                    selection: .title("Project"),
+                    selection: selection,
                     operation: "Capture window selection")
-                Issue.record("Expected conflicting inventory selection to fail")
-            } catch let error as ExactWindowSelectorResolutionError {
-                #expect(error.message == "Capture window selection \(expectedMessage)")
-            } catch {
-                Issue.record("Expected ExactWindowSelectorResolutionError, received \(error)")
+                #expect(result == selected)
             }
         }
     }

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/CaptureToolPathResolverTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/CaptureToolPathResolverTests.swift
@@ -295,9 +295,9 @@ struct CaptureToolPathResolverTests {
         let firstConflict = Self.window(id: 50, title: "Other A", index: 1)
         let secondConflict = Self.window(id: 50, title: "Other B", index: 2)
         let expectedMessage =
-            "window title 'Project' is ambiguous " +
+            "found conflicting inventory rows for window ID 50 " +
             "(id=50 index=1 'Other A'; id=50 index=2 'Other B'). " +
-            "Select one window_id or index explicitly."
+            "Refresh the window inventory before retrying."
 
         for inventory in [
             [selected, firstConflict, secondConflict],

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/CaptureToolPathResolverTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/CaptureToolPathResolverTests.swift
@@ -263,26 +263,58 @@ struct CaptureToolPathResolverTests {
 
     @Test
     func `window resolver refuses ambiguous partial titles instead of pinning the first result`() async {
-        let windows = CaptureWindowResolverWindowService(windows: [
-            Self.window(id: 41, title: "Project Notes", index: 0),
-            Self.window(id: 42, title: "Project Plan", index: 1),
-        ])
+        let first = Self.window(id: 41, title: "Project Notes", index: 0)
+        let second = Self.window(id: 42, title: "Project Plan", index: 1)
+        let expectedMessage =
+            "window title 'Project' is ambiguous " +
+            "(id=41 index=0 'Project Notes'; id=42 index=1 'Project Plan'). " +
+            "Select one window_id or index explicitly."
 
-        do {
-            _ = try await CaptureToolWindowResolver.scope(
-                app: "Preview",
-                pid: nil,
-                windowTitle: "Project",
-                windowIndex: nil,
-                windows: windows)
-            Issue.record("Expected ambiguous partial title selection to fail")
-        } catch let error as PeekabooError {
-            #expect(error.localizedDescription.contains(
-                "Select one window_id or index explicitly."))
-        } catch {
-            Issue.record("Expected PeekabooError, received \(error)")
+        for inventory in [[first, second], [second, first]] {
+            let windows = CaptureWindowResolverWindowService(windows: inventory)
+            do {
+                _ = try await CaptureToolWindowResolver.scope(
+                    app: "Preview",
+                    pid: nil,
+                    windowTitle: "Project",
+                    windowIndex: nil,
+                    windows: windows)
+                Issue.record("Expected ambiguous partial title selection to fail")
+            } catch let error as PeekabooError {
+                #expect(error.localizedDescription.contains(expectedMessage))
+            } catch {
+                Issue.record("Expected PeekabooError, received \(error)")
+            }
+            #expect(windows.requestedTargets.map(\.description) == ["application(Preview)"])
         }
-        #expect(windows.requestedTargets.map(\.description) == ["application(Preview)"])
+    }
+
+    @Test
+    func `window resolver deterministically reports unrelated conflicting duplicates`() {
+        let selected = Self.window(id: 41, title: "Project", index: 0)
+        let firstConflict = Self.window(id: 50, title: "Other A", index: 1)
+        let secondConflict = Self.window(id: 50, title: "Other B", index: 2)
+        let expectedMessage =
+            "window title 'Project' is ambiguous " +
+            "(id=50 index=1 'Other A'; id=50 index=2 'Other B'). " +
+            "Select one window_id or index explicitly."
+
+        for inventory in [
+            [selected, firstConflict, secondConflict],
+            [secondConflict, firstConflict, selected],
+        ] {
+            do {
+                _ = try ExactWindowSelectorResolver.select(
+                    from: inventory,
+                    selection: .title("Project"),
+                    operation: "Capture window selection")
+                Issue.record("Expected conflicting inventory selection to fail")
+            } catch let error as ExactWindowSelectorResolutionError {
+                #expect(error.message == "Capture window selection \(expectedMessage)")
+            } catch {
+                Issue.record("Expected ExactWindowSelectorResolutionError, received \(error)")
+            }
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary

- make `WindowCandidateSelector` the single owner for explicit window ID, title, and index matching
- canonicalize all repeated rows for the selected window IDs, while ignoring contradictory rows for unrelated windows
- build mutation selector proof from the same explicit-selection scope instead of re-reading unrelated inventory
- keep selected-window contradictions fail-closed and keep CLI/MCP automatic window ranking and recovery wording unchanged
- document the user-visible repeated-row fix in the unpublished 4.2.3 changelog

## Tests

- `swift test --package-path Core/PeekabooAutomationKit --filter WindowCandidateSelectorTests` (15 passed)
- `swift test --package-path Core/PeekabooAutomationKit --filter WindowMutationPlannerTests` (21 passed)
- `swift test --package-path Apps/CLI --filter CaptureLiveBehaviorTests` (18 passed)
- `swift test --package-path Core/PeekabooCore --filter CaptureToolPathResolverTests` (23 passed)
- `pnpm run format`
- `pnpm run lint` (zero serious violations; inherited warnings only)
- Autoreview clean at 0.99

## Review fixes

- explicit ID, title, and index regressions prove unrelated conflicting rows no longer poison a valid request
- planner regressions prove mutation selection and proof use the same scoped rows, including unrelated malformed evidence
- selected title/index conflicts remain deterministic refusals in both mutation and compatibility selection

The changelog note is intentional: this is a maintainer-authored user-visible compatibility fix, and repository policy requires maintainer-owned user-facing fixes to update the still-unpublished release notes.
