### PR TITLE
fix(cli): clarify incomplete accessibility recovery

### DIFF
--- a/Apps/CLI/Sources/PeekabooCLI/Commands/AI/SeeCommand+DetectionPipeline.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/AI/SeeCommand+DetectionPipeline.swift
@@ -182,7 +182,8 @@ extension SeeCommand {
             throw CaptureError.detectionTimedOut(self.overallTimeoutSeconds)
         }
         let message = truncationInfo.remediationMessage(
-            budget: result.metadata.windowContext?.traversalBudget
+            budget: result.metadata.windowContext?.traversalBudget,
+            applicationScopedFallback: result.metadata.isApplicationScopedAccessibilityFallback
         )
         if truncationInfo.incompleteAccessibilityRead,
            result.metadata.windowContext?.windowID != nil ||

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/AI/SeeCommand+Output.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/AI/SeeCommand+Output.swift
@@ -199,9 +199,11 @@ extension SeeCommand {
             : 0
         print("⚙️  Interactable elements: \(interactableCount)")
         if let truncationInfo = context.metadata.truncationInfo, truncationInfo.isTruncated {
-            print(
-                "⚠️  \(truncationInfo.remediationMessage(budget: context.metadata.windowContext?.traversalBudget))"
+            let remediation = truncationInfo.remediationMessage(
+                budget: context.metadata.windowContext?.traversalBudget,
+                applicationScopedFallback: context.metadata.isApplicationScopedAccessibilityFallback
             )
+            print("⚠️  \(remediation)")
         }
         let formattedDuration = String(format: "%.2f", context.executionTime)
         print("⏱️  Execution time: \(formattedDuration)s")

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/AI/SeeCommand+Types.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/AI/SeeCommand+Types.swift
@@ -407,7 +407,8 @@ struct SeeTruncationSummary: Codable {
         self.deadline_reached = truncationInfo.deadlineReached
         self.incomplete_accessibility_read = truncationInfo.incompleteAccessibilityRead
         self.warning = truncationInfo.remediationMessage(
-            budget: metadata.windowContext?.traversalBudget
+            budget: metadata.windowContext?.traversalBudget,
+            applicationScopedFallback: metadata.isApplicationScopedAccessibilityFallback
         )
     }
 }

--- a/Apps/CLI/Tests/CLIAutomationTests/SeeCommandApplicationPartialTests.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/SeeCommandApplicationPartialTests.swift
@@ -70,6 +70,11 @@ extension SeeCommandRuntimeTests {
             #expect(data["snapshot_reusable"] as? Bool == false)
             #expect(data["semantic_scope"] as? String == "application_partial")
             #expect(data["mutation_targeting_available"] as? Bool == false)
+            let truncation = try #require(data["truncation"] as? [String: Any])
+            let warning = try #require(truncation["warning"] as? String)
+            #expect(warning.contains("already inspected the owning process or app tree"))
+            #expect(warning.contains("Do not repeat that fallback"))
+            #expect(!warning.contains("inspect its owning process or app tree"))
             let elements = try #require(data["ui_elements"] as? [[String: Any]])
             #expect(elements.count == 1)
             #expect(elements.first?["is_actionable"] as? Bool == false)
@@ -92,6 +97,9 @@ extension SeeCommandRuntimeTests {
             #expect(human.exitStatus == 0)
             #expect(human.stdout.contains("Interactable elements: 0"))
             #expect(human.stdout.contains("no reusable snapshot or mutation authority"))
+            #expect(human.stdout.contains("already inspected the owning process or app tree"))
+            #expect(human.stdout.contains("Do not repeat that fallback"))
+            #expect(!human.stdout.contains("inspect its owning process or app tree"))
 
             automation.inspectAccessibilityTreeHandler = { _ in fallbackResult(DetectedElements()) }
             let empty = try await InProcessCommandRunner.run(
@@ -111,6 +119,10 @@ extension SeeCommandRuntimeTests {
             let emptyError = try #require(emptyEnvelope["error"] as? [String: Any])
             #expect(empty.exitStatus == 1)
             #expect(emptyError["code"] as? String == "ACCESSIBILITY_INCOMPLETE")
+            #expect((emptyError["message"] as? String)?.contains(
+                "already inspected the owning process or app tree"
+            ) == true)
+            #expect((emptyError["message"] as? String)?.contains("Do not repeat that fallback") == true)
         }
     }
 }

--- a/Apps/CLI/Tests/CLIAutomationTests/SeeCommandTests.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/SeeCommandTests.swift
@@ -100,7 +100,9 @@ struct SeeCommandTests {
 
         #expect(!summary.deadline_reached)
         #expect(summary.incomplete_accessibility_read)
-        #expect(summary.warning.contains("may not expose a readable Accessibility tree"))
+        #expect(summary.warning.contains("transient sheet"))
+        #expect(summary.warning.contains("owning process or app tree"))
+        #expect(summary.warning.contains("does not provide a reusable snapshot or mutation authority"))
         #expect(summary.warning.contains("increase the timeout only when the app is slow"))
     }
 
@@ -1228,7 +1230,14 @@ extension SeeCommandRuntimeTests {
             #expect(error["retry_safe"] as? Bool == true)
             #expect(error["mutation_dispatched"] as? Bool == false)
             #expect((error["message"] as? String)?.contains("fresh observation") == true)
+            #expect((error["message"] as? String)?.contains("transient sheet") == true)
+            #expect((error["message"] as? String)?.contains("owning process or app tree") == true)
+            #expect((error["message"] as? String)?.contains("read-only dialog elements") == true)
+            #expect((error["message"] as? String)?.contains(
+                "does not provide a reusable snapshot or mutation authority"
+            ) == true)
             #expect((error["hint"] as? String)?.contains("screenshot/OCR") == true)
+            #expect((error["hint"] as? String)?.contains("increase the timeout only when the app is slow") == true)
             #expect(!result.stdout.contains("snapshot_id"))
             #expect(try await context.snapshots.listSnapshots().isEmpty)
         }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 - Restore terminal echo when credential prompts receive signals and reject background prompts or insecure credential files.
 - Deduplicate runtime flags and improve unknown-command, browser reconnect, help, `learn`, schema, and background-automation guidance.
 - Validate contradictory window and Space selectors before runtime-host discovery so malformed requests cannot start support services or mask the actionable error.
+- Explain that exact transient sheets may require read-only owning-process Accessibility inspection before screenshot/OCR fallback, without granting partial app trees mutation authority.
 
 ## [4.2.2] - 2026-08-20
 

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Observation/DesktopObservationEvidencePolicy.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Observation/DesktopObservationEvidencePolicy.swift
@@ -40,7 +40,8 @@ public enum DesktopObservationEvidencePolicy {
 
         if let truncationInfo = elements.metadata.truncationInfo, truncationInfo.isTruncated {
             let message = truncationInfo.remediationMessage(
-                budget: elements.metadata.windowContext?.traversalBudget ?? request.detection.traversalBudget)
+                budget: elements.metadata.windowContext?.traversalBudget ?? request.detection.traversalBudget,
+                applicationScopedFallback: elements.metadata.isApplicationScopedAccessibilityFallback)
             if truncationInfo.deadlineReached {
                 return PeekabooError.timeout(message)
             }

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Observation/DesktopObservationRequestModels.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Observation/DesktopObservationRequestModels.swift
@@ -162,17 +162,30 @@ extension DetectionTruncationInfo {
             self.deadlineReached || self.incompleteAccessibilityRead
     }
 
-    public func remediationMessage(budget: AXTraversalBudget?) -> String {
-        self.remediationMessage(budget: budget, style: .commandLine)
+    public func remediationMessage(
+        budget: AXTraversalBudget?,
+        applicationScopedFallback: Bool = false) -> String
+    {
+        self.remediationMessage(
+            budget: budget,
+            style: .commandLine,
+            applicationScopedFallback: applicationScopedFallback)
     }
 
-    public func automationToolRemediationMessage(budget: AXTraversalBudget?) -> String {
-        self.remediationMessage(budget: budget, style: .automationTool)
+    public func automationToolRemediationMessage(
+        budget: AXTraversalBudget?,
+        applicationScopedFallback: Bool = false) -> String
+    {
+        self.remediationMessage(
+            budget: budget,
+            style: .automationTool,
+            applicationScopedFallback: applicationScopedFallback)
     }
 
     private func remediationMessage(
         budget: AXTraversalBudget?,
-        style: DetectionRemediationStyle) -> String
+        style: DetectionRemediationStyle,
+        applicationScopedFallback: Bool) -> String
     {
         let budget = budget ?? AXTraversalBudget()
         var limits: [String] = []
@@ -194,6 +207,20 @@ extension DetectionTruncationInfo {
 
         let limitSummary = limits.isEmpty ? "the AX traversal budget" : limits.joined(separator: ", ")
         if self.incompleteAccessibilityRead {
+            if applicationScopedFallback {
+                return switch style {
+                case .commandLine:
+                    "Warning: AX tree incomplete at \(limitSummary). The exact-window fallback already " +
+                        "inspected the owning process or app tree. Do not repeat that fallback. Partial app-tree " +
+                        "evidence does not provide a reusable snapshot or mutation authority; use screenshot/OCR " +
+                        "evidence instead."
+                case .automationTool:
+                    "Warning: AX tree incomplete at \(limitSummary). The exact-window fallback already " +
+                        "inspected the owning app_target without window_id. Do not repeat that fallback. Partial " +
+                        "app-tree evidence does not provide a reusable snapshot or mutation authority; use " +
+                        "screenshot/OCR evidence instead."
+                }
+            }
             return switch style {
             case .commandLine:
                 "Warning: AX tree incomplete at \(limitSummary). Retry once to obtain a fresh observation. " +

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Observation/DesktopObservationRequestModels.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Observation/DesktopObservationRequestModels.swift
@@ -196,15 +196,18 @@ extension DetectionTruncationInfo {
         if self.incompleteAccessibilityRead {
             return switch style {
             case .commandLine:
-                "Warning: AX tree incomplete at \(limitSummary). Retry once to obtain a fresh observation; " +
-                    "if this persists, the target may " +
-                    "not expose a readable Accessibility tree. Use a narrower window target or screenshot/OCR; " +
+                "Warning: AX tree incomplete at \(limitSummary). Retry once to obtain a fresh observation. " +
+                    "If the exact target is a transient sheet without an independent AX-window identity, " +
+                    "inspect its owning process or app tree for read-only dialog elements. Partial app-tree " +
+                    "evidence does not provide a reusable snapshot or mutation authority. Use screenshot/OCR " +
+                    "evidence for other persistent failures; " +
                     "increase the timeout only when the app is slow to respond."
             case .automationTool:
-                "Warning: AX tree incomplete at \(limitSummary). Retry once with an exact app_target and " +
-                    "window_id to obtain a fresh observation. If this persists, the target may not expose a " +
-                    "readable Accessibility tree; " +
-                    "use screenshot/OCR evidence instead."
+                "Warning: AX tree incomplete at \(limitSummary). Retry once with the same exact app_target and " +
+                    "window_id. If the exact target is a transient sheet without an independent AX-window " +
+                    "identity, inspect the owning app_target without window_id for read-only dialog elements. " +
+                    "Partial app-tree evidence does not provide a reusable snapshot or mutation authority. " +
+                    "Use screenshot/OCR evidence for other persistent failures."
             }
         }
         if self.deadlineReached {

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/AXTreeCollectorBudgetTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/AXTreeCollectorBudgetTests.swift
@@ -144,10 +144,30 @@ final class AXTreeCollectorBudgetTests: XCTestCase {
 
         let message = info.automationToolRemediationMessage(budget: nil)
 
+        XCTAssertTrue(message.contains("Retry once"))
         XCTAssertTrue(message.contains("app_target"))
         XCTAssertTrue(message.contains("window_id"))
+        XCTAssertTrue(message.contains("transient sheet"))
+        XCTAssertTrue(message.contains("without window_id"))
+        XCTAssertTrue(message.contains("read-only dialog elements"))
+        XCTAssertTrue(message.contains("does not provide a reusable snapshot or mutation authority"))
+        XCTAssertTrue(message.contains("screenshot/OCR evidence"))
         XCTAssertFalse(message.contains("increase the timeout"))
         XCTAssertFalse(message.contains("--"))
+    }
+
+    func testCommandLineIncompleteRemediationDistinguishesTransientSheetsFromOtherFailures() {
+        let info = DetectionTruncationInfo(incompleteAccessibilityRead: true)
+
+        let message = info.remediationMessage(budget: nil)
+
+        XCTAssertTrue(message.contains("Retry once"))
+        XCTAssertTrue(message.contains("transient sheet"))
+        XCTAssertTrue(message.contains("owning process or app tree"))
+        XCTAssertTrue(message.contains("read-only dialog elements"))
+        XCTAssertTrue(message.contains("does not provide a reusable snapshot or mutation authority"))
+        XCTAssertTrue(message.contains("screenshot/OCR evidence"))
+        XCTAssertTrue(message.contains("increase the timeout only when the app is slow"))
     }
 
     func testMaxDepthOneStopsAtRoot() throws {

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/AXTreeCollectorBudgetTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/AXTreeCollectorBudgetTests.swift
@@ -170,6 +170,24 @@ final class AXTreeCollectorBudgetTests: XCTestCase {
         XCTAssertTrue(message.contains("increase the timeout only when the app is slow"))
     }
 
+    func testIncompleteApplicationScopedFallbackDoesNotRecommendRepeatingTheAppTreeRead() {
+        let info = DetectionTruncationInfo(incompleteAccessibilityRead: true)
+
+        let commandLine = info.remediationMessage(budget: nil, applicationScopedFallback: true)
+        let automation = info.automationToolRemediationMessage(
+            budget: nil,
+            applicationScopedFallback: true)
+
+        XCTAssertTrue(commandLine.contains("already inspected the owning process or app tree"))
+        XCTAssertTrue(commandLine.contains("Do not repeat that fallback"))
+        XCTAssertTrue(commandLine.contains("screenshot/OCR evidence instead"))
+        XCTAssertFalse(commandLine.contains("inspect its owning process or app tree"))
+        XCTAssertTrue(automation.contains("already inspected the owning app_target without window_id"))
+        XCTAssertTrue(automation.contains("Do not repeat that fallback"))
+        XCTAssertTrue(automation.contains("screenshot/OCR evidence instead"))
+        XCTAssertFalse(automation.contains("inspect the owning app_target without window_id"))
+    }
+
     func testMaxDepthOneStopsAtRoot() throws {
         guard let window = self.frontmostWindowElement() else {
             throw XCTSkip("No frontmost window available for AX testing")

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/InspectUITool+Types.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/InspectUITool+Types.swift
@@ -102,7 +102,8 @@ struct InspectUISummaryBuilder {
             return []
         }
         return [truncationInfo.automationToolRemediationMessage(
-            budget: self.result.metadata.windowContext?.traversalBudget)]
+            budget: self.result.metadata.windowContext?.traversalBudget,
+            applicationScopedFallback: self.result.metadata.isApplicationScopedAccessibilityFallback)]
     }
 
     private func roleHeader(role: String, elements: [DetectedElement]) -> String {

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/InspectUITool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/InspectUITool.swift
@@ -194,7 +194,8 @@ public struct InspectUITool: MCPTool {
         else { return }
 
         let message = truncationInfo.automationToolRemediationMessage(
-            budget: result.metadata.windowContext?.traversalBudget)
+            budget: result.metadata.windowContext?.traversalBudget,
+            applicationScopedFallback: result.metadata.isApplicationScopedAccessibilityFallback)
         if truncationInfo.deadlineReached {
             throw PeekabooError.timeout(message)
         }

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/InspectUIToolExecutionTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/InspectUIToolExecutionTests.swift
@@ -445,8 +445,13 @@ extension InspectUIToolExecutionTests {
             Issue.record("Expected structured inspect_ui failure")
             return
         }
-        #expect(output.contains("fresh observation"))
+        #expect(output.contains("Retry once"))
+        #expect(output.contains("transient sheet"))
+        #expect(output.contains("app_target without window_id"))
+        #expect(output.contains("read-only dialog elements"))
+        #expect(output.contains("does not provide a reusable snapshot or mutation authority"))
         #expect(output.contains("screenshot/OCR"))
+        #expect(!output.contains("increase the timeout"))
         #expect(meta["error_code"] == .string("ACCESSIBILITY_INCOMPLETE"))
         #expect(meta["retry_safe"] == .bool(true))
         #expect(meta["mutation_dispatched"] == .bool(false))


### PR DESCRIPTION
## Summary

- replace the misleading narrower-window advice for incomplete exact-sheet Accessibility observations
- direct callers to retry once, then inspect the owning process/app tree only for read-only dialog evidence when a transient sheet lacks independent AX-window identity
- keep partial app-tree results explicitly non-reusable and without mutation authority before screenshot/OCR fallback
- preserve command-line timeout guidance without inventing a timeout control for automation tools

## Tests

- `swift test --package-path Core/PeekabooAutomationKit --filter AXTreeCollectorBudgetTests` (28 tests, 4 environment skips)
- `PEEKABOO_INCLUDE_AUTOMATION_TESTS=true PEEKABOO_INCLUDE_AMBIENT_STATE_TESTS=false swift test --package-path Apps/CLI --filter SeeCommandTests` (38 passed)
- `swift test --package-path Core/PeekabooCore --filter InspectUIToolExecutionTests` (29 passed)
- `pnpm run format` (0 files changed)
- `git diff --check`
- full branch Autoreview clean at 0.99

No UI mutation, AppleScript, virtualization, protected-install, release, or artifact operation was performed.
