### PR TITLE
feat(mcp): allow explicit foreground authority

### DIFF
--- a/Apps/CLI/Sources/PeekabooCLI/Commands/MCP/MCPCommand+CommanderMetadata.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/MCP/MCPCommand+CommanderMetadata.swift
@@ -14,6 +14,13 @@ extension MCPCommand.Serve: CommanderSignatureProviding {
                     help: "Reserved port for future HTTP/SSE transport support",
                     long: "port"
                 ),
+            ],
+            flags: [
+                .commandFlag(
+                    "allowForeground",
+                    help: "Authorize foreground/global UI for this MCP server",
+                    long: "allow-foreground"
+                ),
             ]
         )
     }

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/MCP/MCPCommand+Serve.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/MCP/MCPCommand+Serve.swift
@@ -18,8 +18,8 @@ extension MCPCommand {
             discussion: """
             Starts Peekaboo as an MCP server, exposing all its tools via the
             Model Context Protocol. This allows AI clients like Claude to use
-            Peekaboo's automation capabilities. The server is always background-only:
-            foreground actions and ambient browser auto-connect are refused before dispatch.
+            Peekaboo's automation capabilities. The server is background-only by default;
+            pass --allow-foreground to authorize foreground actions for this server process.
 
             USAGE WITH CLAUDE CODE:
               claude mcp add peekaboo -- peekaboo mcp
@@ -34,6 +34,12 @@ extension MCPCommand {
 
         @Option(help: "Reserved port for future HTTP/SSE transport support")
         var port: Int = 8080
+
+        @Flag(
+            name: .customLong("allow-foreground"),
+            help: "Authorize foreground/global UI for this MCP server"
+        )
+        var allowForeground = false
 
         @MainActor
         mutating func run(using runtime: CommandRuntime) async throws {
@@ -73,6 +79,7 @@ extension MCPCommand {
                 let toolContext = Self.makeToolContext(
                     services: runtime.services,
                     snapshotMutationCoordinator: mutationCoordinator,
+                    executionPolicy: self.allowForeground ? .foregroundAllowed : .backgroundOnly,
                     capturePreflightRefusal: runtime.toolCapturePreflightRefusal
                 )
                 let server = try await PeekabooMCPServer(toolContext: toolContext)
@@ -96,6 +103,7 @@ extension MCPCommand {
         static func makeToolContext(
             services: any PeekabooServiceProviding,
             snapshotMutationCoordinator: (any MCPToolSnapshotMutationCoordinating)?,
+            executionPolicy: MCPToolExecutionPolicy = .backgroundOnly,
             capturePreflightRefusal: MCPToolCapturePreflightRefusal? = nil
         ) -> MCPToolContext {
             let snapshotExecutionGate: MCPToolSnapshotExecutionGate
@@ -111,7 +119,7 @@ extension MCPCommand {
                 services: services,
                 snapshotMutationCoordinator: snapshotMutationCoordinator,
                 snapshotExecutionGate: snapshotExecutionGate,
-                executionPolicy: .backgroundOnly,
+                executionPolicy: executionPolicy,
                 capturePreflightRefusal: capturePreflightRefusal
             )
         }
@@ -139,5 +147,6 @@ extension MCPCommand.Serve: CommanderBindableCommand {
         if let portOption = try values.decodeOption("port", as: Int.self) {
             self.port = portOption
         }
+        self.allowForeground = values.flag("allowForeground")
     }
 }

--- a/Apps/CLI/Tests/CLIAutomationTests/MCPCommandTests.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/MCPCommandTests.swift
@@ -26,14 +26,16 @@ struct MCPCommandTests {
 
         #expect(serve.transport == "stdio")
         #expect(serve.port == 8080)
+        #expect(serve.allowForeground == false)
     }
 
     @Test
     func `MCP serve command custom options`() throws {
-        let serve = try MCPCommand.Serve.parse(["--transport", "http", "--port", "9000"])
+        let serve = try MCPCommand.Serve.parse(["--transport", "http", "--port", "9000", "--allow-foreground"])
 
         #expect(serve.transport == "http")
         #expect(serve.port == 9000)
+        #expect(serve.allowForeground == true)
     }
 
     // MARK: - Help Text Tests
@@ -55,6 +57,7 @@ struct MCPCommandTests {
         #expect(helpText.contains("npx @modelcontextprotocol/inspector"))
         #expect(helpText.contains("--transport"))
         #expect(helpText.contains("--port"))
+        #expect(helpText.contains("--allow-foreground"))
         #expect(helpText.contains("reserved but not implemented"))
     }
 

--- a/Apps/CLI/Tests/CoreCLITests/MCPWrapperCommandBindingTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/MCPWrapperCommandBindingTests.swift
@@ -144,5 +144,12 @@ struct MCPWrapperCommandBindingTests {
         #expect(context.executionPolicy == .backgroundOnly)
         #expect(nestedAgentContext.capturePreflightRefusal == refusal)
         #expect(nestedAgentContext.executionPolicy == .backgroundOnly)
+
+        let foregroundContext = MCPCommand.Serve.makeToolContext(
+            services: services,
+            snapshotMutationCoordinator: nil,
+            executionPolicy: .foregroundAllowed
+        )
+        #expect(foregroundContext.executionPolicy == .foregroundAllowed)
     }
 }

--- a/Apps/CLI/Tests/CoreCLITests/MCPWrapperCommandBindingTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/MCPWrapperCommandBindingTests.swift
@@ -6,6 +6,24 @@ import Testing
 
 struct MCPWrapperCommandBindingTests {
     @Test
+    func `MCP server runtime binding exposes foreground opt in`() throws {
+        let flag = try #require(MCPCommand.Serve.commanderSignature().flags.first {
+            $0.label == "allowForeground"
+        })
+        let command = try CommanderCLIBinder.instantiateCommand(
+            ofType: MCPCommand.Serve.self,
+            parsedValues: ParsedValues(
+                positional: [],
+                options: [:],
+                flags: ["allowForeground"]
+            )
+        )
+
+        #expect(flag.names.contains(.long("allow-foreground")))
+        #expect(command.allowForeground)
+    }
+
+    @Test
     func `Browser command binding`() throws {
         let parsed = ParsedValues(
             positional: ["navigate"],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - **CLI and MCP workflows start faster and recover more clearly.** Deferred Agent startup, Bridge-bound capture, and precise browser, help, locked-session, and window-close guidance keep routine automation moving.
 
 ### Added
+- Let trusted MCP hosts explicitly authorize foreground UI for one server process while keeping background-only as the default. Thanks @Austin1serb for #612.
 - Report per-window `combined_eligible`, `pixels_only`, or `unknown` observation eligibility in CLI and MCP, including screenshot-only recovery.
 - Add an embedding-only Bridge protocol 1.32 API for signed, process-generation-bound observation.
 - Add atomic exact-window pixel-focus typing to CLI, MCP, Agent, and Bridge, keeping the focus-only Accessibility write and every background keyboard unit under one target receipt and retry-safe prefix accounting.


### PR DESCRIPTION
Closes #611. Supersedes #612 while retaining Austin Serb's original authored commit; the maintainer push to the contributor fork was rejected with HTTP 403.

## Summary

- add explicit `peekaboo mcp serve --allow-foreground` process-level authority for trusted MCP hosts
- keep the default server background-only and preserve every tool's existing operation-level foreground consent
- expose the flag through the real Commander runtime signature, not only the legacy parser
- document the opt-in in 4.2.3 and thank @Austin1serb for the original contribution

## Exact-head proof

Source: `e7f7c8ea22af7fab32de1e9b88872468e783242b`

Foundation-signed debug CLI SHA-256: `5598fd99b9dfbcb21eb29223a81c5ef8ef8ccc27f1a2d22366c7a5af29cb2fa7`

The real executable help contains both the background-only default and `--allow-foreground`. Two separate one-shot JSON-RPC clients then called `app.focus` for the same controlled Playground process generation on the physical Mac:

- default server: refused before dispatch with `AGENT_EXECUTION_POLICY_REFUSAL`, `background_only`, `dispatch_state=none`, `mutation_dispatched=false`, and `retry_safe=true`; the foreground sentinel and hidden Playground state were unchanged
- opted-in server: returned `confirmed_change`, `native_framework`, `foreground`, one dispatched unit, and exact target `PID 1705` / generation `1787657922333519`
- cleanup: restored exact sentinel `PID 28611` / generation `1787493920650462`, quit the task-owned Playground generation exactly, and verified it was absent

No AppleScript/JXA, virtualization, account login, clipboard mutation, or pointer movement was used.

## Tests

- `PEEKABOO_INCLUDE_AUTOMATION_TESTS=true PEEKABOO_INCLUDE_AMBIENT_STATE_TESTS=false swift test --package-path Apps/CLI --filter 'MCPWrapperCommandBindingTests|MCPCommandTests'` (20 passed)
- `pnpm run format`
- `pnpm run lint` (zero serious violations; inherited warnings only)
- full branch Autoreview clean at 0.99
