### PR TITLE
fix(app): make background hide outcome truthful

### DIFF
--- a/Apps/CLI/Tests/CLIRuntimeTests/DaemonLaunchPolicyTests.swift
+++ b/Apps/CLI/Tests/CLIRuntimeTests/DaemonLaunchPolicyTests.swift
@@ -182,7 +182,9 @@ struct DaemonLaunchPolicyTests {
             _ = try await DaemonLaunchPolicy.launchDaemon(
                 socketPath: "/tmp/peekaboo-daemon-term-\(UUID().uuidString).sock",
                 arguments: ["-c", "trap '' TERM; \(Self.writePIDCommand(to: pidURL)); exec /bin/sleep 30"],
-                timeout: 0.05,
+                // Give the child one scheduler slice to install its TERM trap and publish the PID.
+                // A 50 ms readiness deadline can expire before a loaded hosted runner schedules it.
+                timeout: 1,
                 executableURL: URL(fileURLWithPath: "/bin/sh"),
                 logHandle: .nullDevice
             )
@@ -196,7 +198,7 @@ struct DaemonLaunchPolicyTests {
             Issue.record("Unexpected daemon launch error: \(error)")
         }
 
-        #expect(clock.now - startedAt < .seconds(3))
+        #expect(clock.now - startedAt < .seconds(4))
         childPID = try await Self.waitForPID(at: pidURL)
         let stoppedPID = try #require(childPID)
         #expect(kill(stoppedPID, 0) == -1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - Keep Agent traces privacy-safe and deterministic, and mark unknown mutation dispatch as unsafe to retry.
 - Hide foreground-only pointer tools and unsupported input shapes from background Agent and MCP catalogs while preserving explicit CLI foreground consent.
 - Reject foreground delivery reported by background CLI paste and preserve canonical target receipts for missing or conflicting results.
+- Fall back to native app hiding when Accessibility proves `AXHide` was rejected before dispatch.
 - Keep verified non-modal SwiftUI actions available, isolate exact targets from unrelated incomplete inventory, and recognize fresh `inspect_ui` observations.
 - Preserve process-scoped Accessibility receipts and return read-only `application_partial` trees without reusable snapshots or mutation authority.
 - Bind persistent MCP capture to its selected Bridge, keep classic capture request-local, and preserve precise signed refusals, causes, and recovery hints.

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/System/ApplicationService+Lifecycle.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/System/ApplicationService+Lifecycle.swift
@@ -1127,6 +1127,20 @@ extension ApplicationService {
                     mechanism: .nativeFramework,
                     mode: .background),
                 unitCount: .one))
+        } catch let error as AccessibilitySystemError
+            where error.axError == .actionUnsupported || error.axError == .apiDisabled
+        {
+            // These AX errors prove the action was rejected before dispatch, so native AppKit
+            // fallback cannot duplicate a hide that may already have happened.
+            try Self.checkApplicationDispatchCancellation(operation: "Hide application fallback")
+            guard self.applicationNativeVisibilityHandler(application, true) else {
+                return .rejected
+            }
+            return .accepted(ApplicationActionDispatch(
+                delivery: DesktopActionOutcome.Delivery(
+                    mechanism: .nativeFramework,
+                    mode: .background),
+                unitCount: .one))
         } catch {
             _ = error.asPeekabooError(context: "AX hide action failed")
             // A generic AX error does not prove that dispatch was rejected. Replaying the hide

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/System/ApplicationService+Lifecycle.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/System/ApplicationService+Lifecycle.swift
@@ -1074,6 +1074,26 @@ extension ApplicationService {
         _ = try await self.unhideApplicationResult(identifier: identifier)
     }
 
+    static func dispatchApplicationAccessibilityHide(
+        isSupported: () -> Bool,
+        submit: () throws -> Void) throws
+    {
+        guard isSupported() else {
+            throw DesktopActionFailure.preDispatchRefusal(
+                reason: .operationUnsupported,
+                message: "The application does not expose an AXHide action.")
+        }
+        try submit()
+    }
+
+    static func submitNativeApplicationVisibility(_ submit: () -> Bool) -> Bool {
+        // NSRunningApplication can return false even though the asynchronous visibility request
+        // takes effect. The invocation is therefore a dispatched unit; exact state polling owns
+        // the terminal outcome instead of the immediate advisory Boolean.
+        _ = submit()
+        return true
+    }
+
     func requestApplicationVisibility(
         _ application: NSRunningApplication,
         hidden: Bool) throws -> ApplicationVisibilityAttempt

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/System/ApplicationService+Lifecycle.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/System/ApplicationService+Lifecycle.swift
@@ -1076,6 +1076,7 @@ extension ApplicationService {
 
     static func dispatchApplicationAccessibilityHide(
         isSupported: () -> Bool,
+        checkCancellation: () throws -> Void = { try Task.checkCancellation() },
         submit: () throws -> Void) throws
     {
         guard isSupported() else {
@@ -1083,6 +1084,9 @@ extension ApplicationService {
                 reason: .operationUnsupported,
                 message: "The application does not expose an AXHide action.")
         }
+        try self.checkApplicationDispatchCancellation(
+            operation: "Hide application",
+            checkCancellation)
         try submit()
     }
 

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/System/ApplicationService.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/System/ApplicationService.swift
@@ -261,10 +261,15 @@ public final class ApplicationService: ApplicationServiceProtocol, ApplicationMu
         },
         applicationHiddenProvider: @escaping ApplicationHiddenProvider = { $0.isHidden },
         applicationAccessibilityHideHandler: @escaping ApplicationAccessibilityHideHandler = { application in
-            try AXApp(application).element.performAction(Attribute<String>("AXHide"))
+            let element = AXApp(application).element
+            try ApplicationService.dispatchApplicationAccessibilityHide(
+                isSupported: { element.isActionSupported("AXHide") },
+                submit: { try element.performAction(Attribute<String>("AXHide")) })
         },
         applicationNativeVisibilityHandler: @escaping ApplicationNativeVisibilityHandler = { application, hidden in
-            hidden ? application.hide() : application.unhide()
+            ApplicationService.submitNativeApplicationVisibility {
+                hidden ? application.hide() : application.unhide()
+            }
         },
         applicationVisibilityHandler: ApplicationVisibilityHandler? = nil,
         applicationVisibilitySleepHandler: @escaping ApplicationVisibilitySleepHandler = { duration in

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ApplicationServiceVisibilityLifecycleTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ApplicationServiceVisibilityLifecycleTests.swift
@@ -28,6 +28,35 @@ struct ApplicationServiceVisibilityLifecycleTests {
 
     @Test
     @MainActor
+    func `AX hide cancellation after support preflight refuses before submission`() {
+        var events: [String] = []
+
+        do {
+            try ApplicationService.dispatchApplicationAccessibilityHide(
+                isSupported: {
+                    events.append("support")
+                    return true
+                },
+                checkCancellation: {
+                    events.append("cancellation")
+                    throw CancellationError()
+                },
+                submit: { events.append("submission") })
+            Issue.record("Expected typed AXHide cancellation")
+        } catch let failure as DesktopActionFailure {
+            #expect(failure.outcome.state == .refused)
+            #expect(failure.outcome.refusalReason == .requestCancelled)
+            #expect(failure.outcome.dispatchState == .none)
+            #expect(failure.outcome.retrySafety == .safe)
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+
+        #expect(events == ["support", "cancellation"])
+    }
+
+    @Test
+    @MainActor
     func `native visibility invocation is dispatched when AppKit returns false`() {
         var submissionCount = 0
 

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ApplicationServiceVisibilityLifecycleTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ApplicationServiceVisibilityLifecycleTests.swift
@@ -7,6 +7,41 @@ import Testing
 struct ApplicationServiceVisibilityLifecycleTests {
     @Test
     @MainActor
+    func `AX hide preflight refuses unsupported action before submission`() {
+        var submissionCount = 0
+
+        do {
+            try ApplicationService.dispatchApplicationAccessibilityHide(
+                isSupported: { false },
+                submit: { submissionCount += 1 })
+            Issue.record("Expected unsupported AXHide refusal")
+        } catch let failure as DesktopActionFailure {
+            #expect(failure.outcome.state == .refused)
+            #expect(failure.outcome.refusalReason == .operationUnsupported)
+            #expect(failure.outcome.dispatchState == .none)
+            #expect(failure.outcome.retrySafety == .safe)
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+        #expect(submissionCount == 0)
+    }
+
+    @Test
+    @MainActor
+    func `native visibility invocation is dispatched when AppKit returns false`() {
+        var submissionCount = 0
+
+        let dispatched = ApplicationService.submitNativeApplicationVisibility {
+            submissionCount += 1
+            return false
+        }
+
+        #expect(dispatched)
+        #expect(submissionCount == 1)
+    }
+
+    @Test
+    @MainActor
     func `show all cancellation immediately before AX submission is typed and dispatches nothing`() {
         var submissionCount = 0
 

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ApplicationServiceVisibilityLifecycleTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ApplicationServiceVisibilityLifecycleTests.swift
@@ -1,4 +1,5 @@
 import AppKit
+import AXorcist
 import PeekabooFoundation
 import Testing
 @testable import PeekabooAutomationKit
@@ -496,6 +497,65 @@ struct ApplicationServiceVisibilityLifecycleTests {
         #expect(result.outcome?.delivery == .init(mechanism: .nativeFramework, mode: .background))
         #expect(result.outcome?.dispatchState == .dispatched(unitCount: .one))
         #expect(nativeFallbackCount == 1)
+    }
+
+    @Test
+    @MainActor
+    func `proven AX system hide refusals may use native fallback`() async throws {
+        for axError in [AXError.actionUnsupported, .apiDisabled] {
+            let runningApplication = try self.runningApplication()
+            var isHidden = false
+            var nativeFallbackCount = 0
+            let service = ApplicationService(
+                applicationOpenHandler: { _, _, _ in runningApplication },
+                applicationHiddenProvider: { _ in isHidden },
+                applicationAccessibilityHideHandler: { _ in
+                    throw AccessibilitySystemError(axError)
+                },
+                applicationNativeVisibilityHandler: { _, hidden in
+                    nativeFallbackCount += 1
+                    isHidden = hidden
+                    return true
+                },
+                applicationVisibilityTimeout: 0)
+
+            let result = try await service.hideApplicationResult(
+                identifier: "PID:\(runningApplication.processIdentifier)")
+
+            #expect(result.outcome?.state == .confirmedChange)
+            #expect(result.outcome?.delivery == .init(mechanism: .nativeFramework, mode: .background))
+            #expect(result.outcome?.dispatchState == .dispatched(unitCount: .one))
+            #expect(nativeFallbackCount == 1)
+        }
+    }
+
+    @Test
+    @MainActor
+    func `ambiguous AX system hide error never replays through native fallback`() async throws {
+        let runningApplication = try self.runningApplication()
+        var nativeFallbackCount = 0
+        let service = ApplicationService(
+            applicationOpenHandler: { _, _, _ in runningApplication },
+            applicationHiddenProvider: { _ in false },
+            applicationAccessibilityHideHandler: { _ in
+                throw AccessibilitySystemError(.cannotComplete)
+            },
+            applicationNativeVisibilityHandler: { _, _ in
+                nativeFallbackCount += 1
+                return true
+            },
+            applicationVisibilityTimeout: 0)
+
+        do {
+            _ = try await service.hideApplicationResult(
+                identifier: "PID:\(runningApplication.processIdentifier)")
+            Issue.record("Expected ambiguous AX delivery")
+        } catch let failure as DesktopActionFailure {
+            #expect(failure.outcome.state == .indeterminate)
+            #expect(failure.outcome.delivery == .init(mechanism: .accessibilityAction, mode: .background))
+            #expect(failure.outcome.dispatchState == .mayHaveDispatched(unitCount: .one))
+        }
+        #expect(nativeFallbackCount == 0)
     }
 
     @Test


### PR DESCRIPTION
## Summary

- preflight whether the target application exposes `AXHide` before attempting Accessibility dispatch
- use native AppKit fallback only after a proven zero-dispatch Accessibility refusal; ambiguous AX failures still never replay
- treat the nonthrowing native visibility invocation as one submitted unit even when AppKit's immediate advisory Boolean is false
- keep exact process-generation state polling as the owner of confirmed change versus retry-unsafe suspected no-op

## Root cause

The published 4.2.2 path attempted `AXHide` without checking whether the application exposed that action. Playground returned an AX failure, so Peekaboo correctly avoided blind native replay but could only report indeterminate. After adding the preflight, live testing exposed a second issue: `NSRunningApplication.hide()` returned `false` even though fresh exact observation showed the app had become hidden. Treating that Boolean as a pre-dispatch rejection produced a retry-safe error after a real mutation.

## Tests

- `swift test --package-path Core/PeekabooAutomationKit --filter ApplicationServiceVisibilityLifecycleTests` (21 passed)
- `pnpm run format`
- `pnpm run lint` (zero serious violations; inherited warnings only)
- full branch Autoreview clean at 0.99

## Physical-Mac proof

Source: `48cf63f831603c3b169351898ddf3858b152975d`

Foundation-signed debug CLI SHA-256: `b0bb4ce7f322a13d1cd601b9f714ca66d8ac82055e0cb8da47df75c499cb2f47`

- prepared task-owned Playground `PID 14032` / generation `1787658666375824` as visible but inactive, with Peekaboo `PID 28611` / generation `1787493920650462` as the foreground sentinel
- exact local `app hide --pid 14032 --no-remote --json` returned `confirmed_change`, `native_framework`, `background`, one dispatched unit, and the exact process-generation target receipt
- fresh observation confirmed Playground hidden and inactive while the sentinel generation remained active
- exact-generation quit succeeded and removed the task-owned app

No AppleScript/JXA, virtualization, account login, clipboard mutation, or pointer movement was used.
