### PR TITLE
perf(cli): defer historical daemon probes

### DIFF
--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/RuntimeHostResolver+Resolution.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/RuntimeHostResolver+Resolution.swift
@@ -82,7 +82,6 @@ extension RuntimeHostResolver {
         let daemonSocketPath: String
         let runtimeBuildIdentity: String
         let buildScopedDaemonSocketPath: String?
-        let historicalBuildScopedDaemonTargets: [DaemonControlTarget]
         let historicalBuildScopedDaemonSocketPaths: [String]
         let candidates: [ImplicitRemoteCandidate]
     }

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/RuntimeHostResolver.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/RuntimeHostResolver.swift
@@ -232,7 +232,7 @@ enum RuntimeHostResolver {
                 requiredOwner: preferredScreenCaptureKitOwner,
                 permissionRejections: &permissionRejections
             ) {
-                return await self.finalizeExactBuildScopedResolution(resolved, candidatePlan: candidatePlan)
+                return resolved
             }
             if prefersExactBuildScopedHost, let buildScopedDaemonSocketPath {
                 throw self.ownerExactBuildConflict(
@@ -264,7 +264,7 @@ enum RuntimeHostResolver {
                 requiredProtocolVersion: PeekabooBridgeConstants.protocolVersion,
                 permissionRejections: &permissionRejections
             ) {
-                return await self.finalizeExactBuildScopedResolution(resolved, candidatePlan: candidatePlan)
+                return resolved
             }
 
             let exactHostExists = await DaemonControlClient(socketPath: buildScopedDaemonSocketPath)
@@ -285,7 +285,7 @@ enum RuntimeHostResolver {
                    requiredProtocolVersion: PeekabooBridgeConstants.protocolVersion,
                    permissionRejections: &permissionRejections
                ) {
-                return await self.finalizeExactBuildScopedResolution(resolved, candidatePlan: candidatePlan)
+                return resolved
             }
         }
 
@@ -293,7 +293,7 @@ enum RuntimeHostResolver {
             candidates: candidatePlan.candidates,
             permissionRejections: &permissionRejections
         ) {
-            return await self.finalizeExactBuildScopedResolution(resolved, candidatePlan: candidatePlan)
+            return resolved
         }
 
         if let explicitSocket,
@@ -329,7 +329,7 @@ enum RuntimeHostResolver {
                     )],
                     permissionRejections: &permissionRejections
                 ) {
-                return await self.finalizeExactBuildScopedResolution(resolved, candidatePlan: candidatePlan)
+                return resolved
             }
         }
 
@@ -430,20 +430,29 @@ enum RuntimeHostResolver {
             daemonSocketPath: daemonSocketPath,
             runtimeBuildIdentity: runtimeBuildIdentity
         )
-        let historicalBuildScopedDaemonTargets: [DaemonControlTarget] = if self.shouldDiscoverHistoricalDaemons(
+        // Read-only routing needs only same-owner socket candidates from the canonical daemon directory;
+        // candidate admission authenticates their status and identity if fallback reaches them. Mutation
+        // barriers keep the stricter prevalidated inventory because they must invalidate sibling snapshots.
+        let historicalBuildScopedDaemonSocketPaths: [String] = if self.shouldDiscoverHistoricalDaemons(
             explicitSocket: explicitSocket,
             daemonSocketPath: daemonSocketPath
         ) {
-            await DaemonControlResolver.validatedHistoricalTargets(
-                daemonSocketPath: daemonSocketPath,
-                currentBuildScopedSocketPath: buildScopedDaemonSocketPath
-            )
+            if self.requiresValidatedHistoricalDaemonInventory(options: options) {
+                await DaemonControlResolver.validatedHistoricalTargets(
+                    daemonSocketPath: daemonSocketPath,
+                    currentBuildScopedSocketPath: buildScopedDaemonSocketPath
+                )
+                .filter { DaemonControlPlanner.supportsCurrentDaemon($0.status) }
+                .map(\.client.socketPath)
+            } else {
+                DaemonControlResolver.discoveredHistoricalBuildScopedSocketPaths(
+                    daemonSocketPath: daemonSocketPath,
+                    currentBuildScopedSocketPath: buildScopedDaemonSocketPath
+                )
+            }
         } else {
             []
         }
-        let historicalBuildScopedDaemonSocketPaths = historicalBuildScopedDaemonTargets
-            .filter { DaemonControlPlanner.supportsCurrentDaemon($0.status) }
-            .map(\.client.socketPath)
 
         let candidates: [ImplicitRemoteCandidate] = if let explicitSocket, !explicitSocket.isEmpty {
             [ImplicitRemoteCandidate(
@@ -466,32 +475,9 @@ enum RuntimeHostResolver {
             daemonSocketPath: daemonSocketPath,
             runtimeBuildIdentity: runtimeBuildIdentity,
             buildScopedDaemonSocketPath: buildScopedDaemonSocketPath,
-            historicalBuildScopedDaemonTargets: historicalBuildScopedDaemonTargets,
             historicalBuildScopedDaemonSocketPaths: historicalBuildScopedDaemonSocketPaths,
             candidates: candidates
         )
-    }
-
-    private static func finalizeExactBuildScopedResolution(
-        _ resolution: Resolution,
-        candidatePlan: RemoteCandidatePlan
-    ) async -> Resolution {
-        guard candidatePlan.explicitSocket == nil,
-              let currentSocketPath = candidatePlan.buildScopedDaemonSocketPath,
-              resolution.selectedRemoteSocketPath == NSString(string: currentSocketPath).standardizingPath
-        else {
-            return resolution
-        }
-
-        // Debug builds get generation-specific hosts. Once the current generation is usable,
-        // retire only safely identified auto hosts already past their idle deadline so
-        // ScreenCaptureKit state cannot pile up without interrupting long-lived clients.
-        await DaemonControlResolver.stopIdleHistoricalAutoDaemons(
-            candidatePlan.historicalBuildScopedDaemonTargets,
-            daemonSocketPath: candidatePlan.daemonSocketPath,
-            currentBuildScopedSocketPath: currentSocketPath
-        )
-        return resolution
     }
 
     static func initialRoutingDecision(
@@ -579,6 +565,10 @@ enum RuntimeHostResolver {
         daemonSocketPath: String
     ) -> Bool {
         explicitSocket == nil && DaemonLaunchPolicy.shouldMigrateLegacyDaemon(targetSocketPath: daemonSocketPath)
+    }
+
+    static func requiresValidatedHistoricalDaemonInventory(options: CommandRuntimeOptions) -> Bool {
+        options.requiresImplicitSnapshotInvalidation || options.usesPerToolSnapshotInvalidation
     }
 
     static func prefersExactBuildScopedHost(

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/DaemonCommand+Run.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/DaemonCommand+Run.swift
@@ -43,13 +43,44 @@ extension DaemonCommand {
             )
 
             let daemon = PeekabooDaemon(configuration: config)
+            let historicalCleanupTask: Task<Void, Never>? = if Self.shouldScheduleHistoricalCleanup(config) {
+                Task { @MainActor in
+                    try? await Task.sleep(for: .seconds(1))
+                    guard !Task.isCancelled else { return }
+                    let targets = await DaemonControlResolver.validatedHistoricalTargets(
+                        daemonSocketPath: PeekabooBridgeConstants.daemonSocketPath,
+                        currentBuildScopedSocketPath: config.bridgeSocketPath
+                    )
+                    guard !Task.isCancelled else { return }
+                    await DaemonControlResolver.stopIdleHistoricalAutoDaemons(
+                        targets,
+                        daemonSocketPath: PeekabooBridgeConstants.daemonSocketPath,
+                        currentBuildScopedSocketPath: config.bridgeSocketPath
+                    )
+                }
+            } else {
+                nil
+            }
             let terminationSignalSource = ProcessTerminationSignalSource { [weak daemon] _ in
                 Task { @MainActor in
                     _ = await daemon?.requestStop()
                 }
             }
-            defer { terminationSignalSource.cancel() }
+            defer {
+                historicalCleanupTask?.cancel()
+                terminationSignalSource.cancel()
+            }
             try await daemon.runUntilStopChecked()
+        }
+
+        static func shouldScheduleHistoricalCleanup(_ configuration: PeekabooDaemon.Configuration) -> Bool {
+            let socketURL = URL(fileURLWithPath: configuration.bridgeSocketPath).standardizedFileURL
+            let defaultSocketURL = URL(
+                fileURLWithPath: PeekabooBridgeConstants.daemonSocketPath
+            ).standardizedFileURL
+            return configuration.mode == .auto &&
+                socketURL.deletingLastPathComponent() == defaultSocketURL.deletingLastPathComponent() &&
+                DaemonControlResolver.isBuildScopedSocketName(socketURL.lastPathComponent)
         }
 
         static func configuration(

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/DaemonCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/DaemonCommand.swift
@@ -534,7 +534,7 @@ enum DaemonControlResolver {
         }
     }
 
-    private static func discoveredHistoricalBuildScopedSocketPaths(
+    static func discoveredHistoricalBuildScopedSocketPaths(
         daemonSocketPath: String,
         currentBuildScopedSocketPath: String?
     ) -> [String] {

--- a/Apps/CLI/Tests/CoreCLITests/CaptureVideoLocalIngestTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/CaptureVideoLocalIngestTests.swift
@@ -121,7 +121,6 @@ struct CaptureVideoLocalIngestTests {
                         daemonSocketPath: "/tmp/peekaboo-video-ingest-daemon.sock",
                         runtimeBuildIdentity: "video-ingest-test",
                         buildScopedDaemonSocketPath: "/tmp/peekaboo-video-ingest-current.sock",
-                        historicalBuildScopedDaemonTargets: [],
                         historicalBuildScopedDaemonSocketPaths: [],
                         candidates: []
                     )

--- a/Apps/CLI/Tests/CoreCLITests/DaemonHistoricalCleanupTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/DaemonHistoricalCleanupTests.swift
@@ -1,0 +1,27 @@
+import Foundation
+import PeekabooBridge
+import Testing
+@testable import PeekabooCLI
+
+@Suite(.tags(.safe))
+struct DaemonHistoricalCleanupTests {
+    @Test
+    func `only automatic build scoped daemons own deferred historical cleanup`() {
+        let defaultSocketURL = URL(fileURLWithPath: PeekabooBridgeConstants.daemonSocketPath)
+        let buildSocketPath = defaultSocketURL.deletingLastPathComponent()
+            .appendingPathComponent("daemon-aaaaaaaaaaaaaaaa.sock").path
+
+        #expect(DaemonCommand.Run.shouldScheduleHistoricalCleanup(.auto(
+            bridgeSocketPath: buildSocketPath
+        )))
+        #expect(!DaemonCommand.Run.shouldScheduleHistoricalCleanup(.manual(
+            bridgeSocketPath: buildSocketPath
+        )))
+        #expect(!DaemonCommand.Run.shouldScheduleHistoricalCleanup(.auto(
+            bridgeSocketPath: PeekabooBridgeConstants.daemonSocketPath
+        )))
+        #expect(!DaemonCommand.Run.shouldScheduleHistoricalCleanup(.auto(
+            bridgeSocketPath: "/tmp/daemon-aaaaaaaaaaaaaaaa.sock"
+        )))
+    }
+}

--- a/Apps/CLI/Tests/CoreCLITests/RuntimeHostResolverTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/RuntimeHostResolverTests.swift
@@ -9,6 +9,25 @@ import Testing
 @MainActor
 struct RuntimeHostResolverTests {
     @Test
+    func `only mutation barriers prevalidate historical daemon inventory`() {
+        #expect(!RuntimeHostResolver.requiresValidatedHistoricalDaemonInventory(
+            options: CommandRuntimeOptions()
+        ))
+
+        var implicitInvalidation = CommandRuntimeOptions()
+        implicitInvalidation.requiresImplicitSnapshotInvalidation = true
+        #expect(RuntimeHostResolver.requiresValidatedHistoricalDaemonInventory(
+            options: implicitInvalidation
+        ))
+
+        var perToolInvalidation = CommandRuntimeOptions()
+        perToolInvalidation.usesPerToolSnapshotInvalidation = true
+        #expect(RuntimeHostResolver.requiresValidatedHistoricalDaemonInventory(
+            options: perToolInvalidation
+        ))
+    }
+
+    @Test
     func `Policy-local click retains known snapshot invalidation endpoints`() throws {
         let parsed = ParsedValues(
             positional: [],

--- a/Apps/CLI/Tests/CoreCLITests/ScreenCaptureKitDynamicToolRuntimeTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/ScreenCaptureKitDynamicToolRuntimeTests.swift
@@ -16,7 +16,6 @@ extension ScreenCaptureKitOwnerRuntimeTests {
             daemonSocketPath: "/tmp/unrelated-daemon.sock",
             runtimeBuildIdentity: "fixture-build",
             buildScopedDaemonSocketPath: "/tmp/unrelated-build-daemon.sock",
-            historicalBuildScopedDaemonTargets: [],
             historicalBuildScopedDaemonSocketPaths: ["/tmp/unrelated-historical.sock"],
             candidates: [.init(
                 socketPath: selectedSocket,
@@ -48,7 +47,6 @@ extension ScreenCaptureKitOwnerRuntimeTests {
             daemonSocketPath: daemonSocket,
             runtimeBuildIdentity: "fixture-build",
             buildScopedDaemonSocketPath: buildSocket,
-            historicalBuildScopedDaemonTargets: [],
             historicalBuildScopedDaemonSocketPaths: [historicalSocket],
             candidates: [.init(
                 socketPath: selectedSocket,
@@ -147,7 +145,6 @@ extension ScreenCaptureKitOwnerRuntimeTests {
                         daemonSocketPath: "/tmp/peekaboo-unused-daemon.sock",
                         runtimeBuildIdentity: "current-build",
                         buildScopedDaemonSocketPath: nil,
-                        historicalBuildScopedDaemonTargets: [],
                         historicalBuildScopedDaemonSocketPaths: [],
                         candidates: [.init(
                             socketPath: selectedSocket,
@@ -215,7 +212,6 @@ extension ScreenCaptureKitOwnerRuntimeTests {
                             daemonSocketPath: "/tmp/peekaboo-unused-daemon.sock",
                             runtimeBuildIdentity: "current-build",
                             buildScopedDaemonSocketPath: nil,
-                            historicalBuildScopedDaemonTargets: [],
                             historicalBuildScopedDaemonSocketPaths: [],
                             candidates: [.init(
                                 socketPath: selectedSocket,
@@ -280,7 +276,6 @@ extension ScreenCaptureKitOwnerRuntimeTests {
                         daemonSocketPath: "/tmp/peekaboo-unused-daemon.sock",
                         runtimeBuildIdentity: "current-build",
                         buildScopedDaemonSocketPath: nil,
-                        historicalBuildScopedDaemonTargets: [],
                         historicalBuildScopedDaemonSocketPaths: [],
                         candidates: [.init(
                             socketPath: selectedSocket,

--- a/Apps/CLI/Tests/CoreCLITests/ScreenCaptureKitOwnerRuntimeTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/ScreenCaptureKitOwnerRuntimeTests.swift
@@ -764,7 +764,6 @@ struct ScreenCaptureKitOwnerRuntimeTests {
                         daemonSocketPath: "/tmp/peekaboo-dynamic-daemon.sock",
                         runtimeBuildIdentity: "current-build",
                         buildScopedDaemonSocketPath: "/tmp/peekaboo-dynamic-current-build.sock",
-                        historicalBuildScopedDaemonTargets: [],
                         historicalBuildScopedDaemonSocketPaths: [],
                         candidates: [.init(
                             socketPath: ownerSocket,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Add explicit foreground modifier-click with exact target preflight and compare-and-swap cursor and focus restoration, preserving newer user or application state instead of overwriting it.
 
 ### Changed
+- Defer authenticated historical-daemon RPCs until a fallback is actually needed instead of serially probing every stale socket before ordinary CLI commands.
 - Read `config credential set` secrets from no-echo prompts, stdin, or owner-only files; let `config provider add` also accept non-secret references; retain deprecated argv compatibility.
 - Skip provider discovery and Agent construction for caller-local commands that cannot invoke the Agent.
 - Avoid reopening and hashing Bridge screenshot artifacts twice before CLI or MCP consumption while retaining signed client verification and use-time publication checks.


### PR DESCRIPTION
## Summary

- keep historical build-scoped daemon discovery off ordinary read-only CLI startup by listing only same-owner sockets from the canonical daemon directory
- retain authenticated status and identity admission before any historical fallback is selected
- preserve eager historical prevalidation for mutation barriers that must invalidate sibling snapshots
- move idle historical-daemon cleanup into the long-lived automatic daemon one second after startup instead of blocking every short-lived client
- document the user-visible startup improvement in 4.2.3

## Root cause

Runtime host planning synchronously requested status from every historical build-scoped daemon before considering the already-healthy current host. A machine with accumulated stale sockets therefore paid the sum of those bounded RPC probes on every read-only command. Explicitly selecting the exact daemon removed roughly half of the wall time, isolating host discovery as the cold-path owner.

## Proof

- 130 focused routing, daemon, ScreenCaptureKit-owner, dynamic-tool, and local-ingest tests passed
- `pnpm run format` changed zero files on the final tree
- `pnpm run lint` completed with zero serious violations
- final Autoreview reported no actionable finding at 0.99 confidence
- signed optimized release build passed strict code-signature validation under the OpenClaw Foundation Developer ID

### Interleaved physical-Mac benchmark

Baseline: current `main@42b8096fbce59f0f9606891d4f7ed4e9f2c5cb35`  
Optimized: `1f2198edba5c5015eb5964b865a580592e1a220d`

Both binaries were Foundation-signed release builds, alternated under the same load against the same running apps and Bridge state. Finder remained the exact frontmost process generation throughout.

- TextEdit AX-only `see`: median 844 ms to 417 ms, 50.6% faster
- app inventory: median 1,161 ms to 653 ms, 43.8% faster

No AppleScript/JXA, virtualization, account action, foreground interaction, clipboard mutation, or pointer movement was used.
