### PR TITLE
refactor(targeting): consolidate exact window resolution

### DIFF
--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommandUtilities.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommandUtilities.swift
@@ -319,7 +319,8 @@ extension WindowIdentificationOptions {
         try ExactWindowSelectorResolver.select(
             from: windows,
             selector: self.selector,
-            operation: operation
+            operation: operation,
+            vocabulary: .commandLine
         )
     }
 
@@ -348,147 +349,6 @@ extension WindowIdentificationOptions {
             logger.warn("Failed to refetch window info (\(context)): \(error.localizedDescription)")
             return nil
         }
-    }
-}
-
-/// Shared strict selector used by CLI surfaces that must freeze one exact window before work starts.
-enum ExactWindowSelectorResolver {
-    @MainActor
-    static func select(
-        from windows: [ServiceWindowInfo],
-        selector: InteractionTargetSelector,
-        operation: String
-    ) throws -> ServiceWindowInfo {
-        let selection = try selector.normalizedWindowSelector(policy: .mutationSafe)
-        switch selection {
-        case nil:
-            guard let window = ObservationTargetResolver.bestWindow(from: windows) else {
-                throw ExactWindowSelectorResolutionError(
-                    message: "\(operation) found no eligible window. Refresh the window inventory before retrying."
-                )
-            }
-            return window
-        case let selection?:
-            do {
-                return try DesktopTargetPlanning.WindowCandidateSelector.selectExplicitCandidate(
-                    candidates: windows,
-                    selector: selection
-                )
-            } catch let error as DesktopTargetPlanningError {
-                throw Self.presentationError(
-                    error,
-                    selection: selection,
-                    windows: windows,
-                    operation: operation
-                )
-            }
-        }
-    }
-
-    private static func presentationError(
-        _ error: DesktopTargetPlanningError,
-        selection: InteractionTargetSelector.WindowSelector,
-        windows: [ServiceWindowInfo],
-        operation: String
-    ) -> ExactWindowSelectorResolutionError {
-        if case let .conflictingWindowEntries(windowID) = error {
-            return self.inventoryConflictError(
-                windowID: windowID,
-                windows: windows,
-                operation: operation
-            )
-        }
-        return switch (selection, error) {
-        case let (.id(windowID), .windowNotFound):
-            ExactWindowSelectorResolutionError(
-                message: "\(operation) --window-id \(windowID) does not identify a window. " +
-                    "Refresh the window inventory before retrying."
-            )
-        case let (.id(windowID), .ambiguousWindow):
-            ExactWindowSelectorResolutionError(
-                message: "\(operation) --window-id \(windowID) identifies multiple windows. " +
-                    "Refresh the window inventory before retrying."
-            )
-        case let (.title(title), .windowNotFound):
-            ExactWindowSelectorResolutionError(
-                message: "\(operation) found no window whose title matches '\(title)'. " +
-                    "Refresh the inventory and select a --window-id or valid --window-index."
-            )
-        case let (.title(title), .ambiguousWindow(_, windowIDs)):
-            self.titleAmbiguityError(
-                title: title,
-                windowIDs: windowIDs,
-                windows: windows,
-                operation: operation
-            )
-        case let (.index(index), .windowNotFound):
-            ExactWindowSelectorResolutionError(
-                message: "\(operation) --window-index \(index) is not present. " +
-                    "Refresh the inventory and select a --window-id."
-            )
-        case let (.index(index), .ambiguousWindow):
-            ExactWindowSelectorResolutionError(
-                message: "\(operation) --window-index \(index) is ambiguous. " +
-                    "Refresh the inventory and select a --window-id."
-            )
-        default:
-            ExactWindowSelectorResolutionError(
-                message: "\(operation) could not resolve one exact window. \(error.localizedDescription)"
-            )
-        }
-    }
-
-    private static func titleAmbiguityError(
-        title: String,
-        windowIDs: [Int],
-        windows: [ServiceWindowInfo],
-        operation: String
-    ) -> ExactWindowSelectorResolutionError {
-        let candidates = self.candidateSummary(windowIDs: windowIDs, windows: windows)
-        return ExactWindowSelectorResolutionError(
-            message: "\(operation) window title '\(title)' is ambiguous (\(candidates)). " +
-                "Select one --window-id or --window-index explicitly."
-        )
-    }
-
-    private static func inventoryConflictError(
-        windowID: Int,
-        windows: [ServiceWindowInfo],
-        operation: String
-    ) -> ExactWindowSelectorResolutionError {
-        let candidates = self.candidateSummary(windowIDs: [windowID], windows: windows)
-        return ExactWindowSelectorResolutionError(
-            message: "\(operation) found conflicting inventory rows for window ID \(windowID) (\(candidates)). " +
-                "Refresh the window inventory before retrying."
-        )
-    }
-
-    private static func candidateSummary(
-        windowIDs: [Int],
-        windows: [ServiceWindowInfo]
-    ) -> String {
-        let candidateIDs = Set(windowIDs)
-        return windows.lazy.filter { candidateIDs.contains($0.windowID) }
-            .sorted { lhs, rhs in
-                if lhs.windowID != rhs.windowID {
-                    return lhs.windowID < rhs.windowID
-                }
-                if lhs.index != rhs.index {
-                    return lhs.index < rhs.index
-                }
-                return lhs.title < rhs.title
-            }
-            .prefix(5)
-            .map { "id=\($0.windowID) index=\($0.index) '\($0.title)'" }
-            .joined(separator: "; ")
-    }
-}
-
-struct ExactWindowSelectorResolutionError: Error, LocalizedError, Sendable, Equatable {
-    let message: String
-
-    var errorDescription: String? {
-        self.message
     }
 }
 

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Core/CaptureCommand+LiveScope.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Core/CaptureCommand+LiveScope.swift
@@ -48,7 +48,8 @@ func resolveExactCaptureWindowReference(
         selectedWindow = try ExactWindowSelectorResolver.select(
             from: renderable,
             selector: selector,
-            operation: operation
+            operation: operation,
+            vocabulary: .commandLine
         )
     } catch {
         throw ValidationError(error.localizedDescription)

--- a/Apps/CLI/Tests/CoreCLITests/CaptureLiveBehaviorTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/CaptureLiveBehaviorTests.swift
@@ -1,6 +1,7 @@
 import Commander
 import CoreGraphics
 import Foundation
+import PeekabooAutomationKitTestSupport
 import PeekabooCore
 import PeekabooFoundation
 import Testing
@@ -91,8 +92,8 @@ struct CaptureLiveBehaviorTests {
     @MainActor
     func `capture live and action reject duplicate exact title matches`() throws {
         let windows = [
-            Self.window(id: 101, title: "Draft", index: 0),
-            Self.window(id: 102, title: "Draft", index: 1),
+            AutomationTestFixtures.window(windowID: 101, title: "Draft", index: 0),
+            AutomationTestFixtures.window(windowID: 102, title: "Draft", index: 1),
         ]
         let expectedMessage =
             "Capture selector test window title 'Draft' is ambiguous " +
@@ -106,100 +107,14 @@ struct CaptureLiveBehaviorTests {
                     _ = try ExactWindowSelectorResolver.select(
                         from: inventory,
                         selector: selector,
-                        operation: "Capture selector test"
+                        operation: "Capture selector test",
+                        vocabulary: .commandLine
                     )
                     Issue.record("Expected duplicate exact title selection to fail")
                 } catch let error as ExactWindowSelectorResolutionError {
                     #expect(error.message == expectedMessage)
                 }
             }
-        }
-    }
-
-    @Test
-    @MainActor
-    func `capture live and action reject duplicate partial title matches`() throws {
-        let windows = [
-            Self.window(id: 101, title: "Draft One", index: 0),
-            Self.window(id: 102, title: "Draft Two", index: 1),
-        ]
-        let expectedMessage =
-            "Capture selector test window title 'Draft' is ambiguous " +
-            "(id=101 index=0 'Draft One'; id=102 index=1 'Draft Two'). " +
-            "Select one --window-id or --window-index explicitly."
-
-        for surface in SelectorSurface.allCases {
-            let selector = try Self.selector(for: surface, title: "Draft")
-            for inventory in [windows, Array(windows.reversed())] {
-                do {
-                    _ = try ExactWindowSelectorResolver.select(
-                        from: inventory,
-                        selector: selector,
-                        operation: "Capture selector test"
-                    )
-                    Issue.record("Expected duplicate partial title selection to fail")
-                } catch let error as ExactWindowSelectorResolutionError {
-                    #expect(error.message == expectedMessage)
-                }
-            }
-        }
-    }
-
-    @Test
-    @MainActor
-    func `capture selectors ignore unrelated conflicting duplicates`() throws {
-        let selected = Self.window(id: 101, title: "Draft", index: 0)
-        let firstConflict = Self.window(id: 202, title: "Other A", index: 1)
-        let secondConflict = Self.window(id: 202, title: "Other B", index: 2)
-        let inventories = [
-            [selected, firstConflict, secondConflict],
-            [secondConflict, firstConflict, selected],
-        ]
-        for surface in SelectorSurface.allCases {
-            let selector = try Self.selector(for: surface, title: "Draft")
-            for inventory in inventories {
-                let result = try ExactWindowSelectorResolver.select(
-                    from: inventory,
-                    selector: selector,
-                    operation: "Capture selector test"
-                )
-                #expect(result == selected)
-            }
-        }
-    }
-
-    @Test
-    @MainActor
-    func `capture selectors canonicalize repeated stable inventory rows`() throws {
-        let window = Self.window(id: 101, title: "Draft", index: 0)
-
-        for surface in SelectorSurface.allCases {
-            let selector = try Self.selector(for: surface, title: "Draft")
-            let selected = try ExactWindowSelectorResolver.select(
-                from: [window, window],
-                selector: selector,
-                operation: "Capture selector test"
-            )
-            #expect(selected == window)
-        }
-    }
-
-    @Test
-    @MainActor
-    func `capture live and action resolve one unique partial title match`() throws {
-        let windows = [
-            Self.window(id: 101, title: "Draft One", index: 0),
-            Self.window(id: 102, title: "Release Notes", index: 1),
-        ]
-
-        for surface in SelectorSurface.allCases {
-            let selector = try Self.selector(for: surface, title: "Notes")
-            let selected = try ExactWindowSelectorResolver.select(
-                from: windows,
-                selector: selector,
-                operation: "Capture selector test"
-            )
-            #expect(selected.windowID == 102)
         }
     }
 
@@ -299,22 +214,5 @@ struct CaptureLiveBehaviorTests {
             command.windowIndex = index
             return try command.validatedCaptureWindowSelector()
         }
-    }
-
-    private static func window(id: Int, title: String, index: Int) -> ServiceWindowInfo {
-        let position = CGFloat(index * 20)
-        let bounds = CGRect(x: position, y: position, width: 640, height: 480)
-        return ServiceWindowInfo(
-            windowID: id,
-            title: title,
-            bounds: bounds,
-            index: index,
-            mutationIdentity: WindowMutationIdentity(
-                windowID: id,
-                ownerProcessIdentifier: 42,
-                ownerProcessStartIdentity: 7,
-                capturedBounds: bounds
-            )
-        )
     }
 }

--- a/Apps/CLI/Tests/CoreCLITests/WindowTargetCreationTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/WindowTargetCreationTests.swift
@@ -56,62 +56,6 @@ struct WindowTargetCreationTests {
     }
 
     @Test
-    @MainActor
-    func `exact window resolver rejects duplicate exact titles`() throws {
-        var options = WindowIdentificationOptions()
-        options.app = "Fixture"
-        options.windowTitle = "Draft"
-        try options.validateMutation()
-
-        #expect(throws: ExactWindowSelectorResolutionError.self) {
-            _ = try options.selectMutationWindow(
-                from: [
-                    Self.window(id: 101, title: "Draft", index: 0),
-                    Self.window(id: 102, title: "Draft", index: 1),
-                ],
-                operation: "Window test"
-            )
-        }
-    }
-
-    @Test
-    @MainActor
-    func `exact window resolver rejects duplicate partial titles`() throws {
-        var options = WindowIdentificationOptions()
-        options.app = "Fixture"
-        options.windowTitle = "Draft"
-        try options.validateMutation()
-
-        #expect(throws: ExactWindowSelectorResolutionError.self) {
-            _ = try options.selectMutationWindow(
-                from: [
-                    Self.window(id: 101, title: "Draft One", index: 0),
-                    Self.window(id: 102, title: "Draft Two", index: 1),
-                ],
-                operation: "Window test"
-            )
-        }
-    }
-
-    @Test
-    @MainActor
-    func `exact window resolver returns one unique partial title match`() throws {
-        var options = WindowIdentificationOptions()
-        options.app = "Fixture"
-        options.windowTitle = "Notes"
-        try options.validateMutation()
-
-        let selected = try options.selectMutationWindow(
-            from: [
-                Self.window(id: 101, title: "Draft One", index: 0),
-                Self.window(id: 102, title: "Release Notes", index: 1),
-            ],
-            operation: "Window test"
-        )
-        #expect(selected.windowID == 102)
-    }
-
-    @Test
     func `app + windowTitle creates .applicationAndTitle`() throws {
         var options = WindowIdentificationOptions()
         options.app = "Safari"
@@ -436,15 +380,5 @@ struct WindowTargetCreationTests {
         )
 
         #expect(windowDisplayName(from: snapshot, snapshotId: "snapshot-1") == "Example")
-    }
-
-    private static func window(id: Int, title: String, index: Int) -> ServiceWindowInfo {
-        let position = CGFloat(index * 20)
-        return ServiceWindowInfo(
-            windowID: id,
-            title: title,
-            bounds: CGRect(x: position, y: position, width: 640, height: 480),
-            index: index
-        )
     }
 }

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Strategy/ExactWindowSelectorResolver.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Strategy/ExactWindowSelectorResolver.swift
@@ -1,24 +1,51 @@
 import Foundation
-import PeekabooAutomationKit
 import PeekabooFoundation
 
-struct ExactWindowSelectorResolutionError: Error, LocalizedError, Sendable, Equatable {
-    let message: String
+public struct ExactWindowSelectorResolutionError: Error, LocalizedError, Sendable, Equatable {
+    public let message: String
 
-    var errorDescription: String? {
+    public var errorDescription: String? {
         self.message
     }
 }
 
 /// Resolves compatibility window selectors without silently choosing among ambiguous matches.
-enum ExactWindowSelectorResolver {
-    enum Selection: Sendable, Equatable {
+public enum ExactWindowSelectorResolver {
+    /// Surface-specific names used in selector errors.
+    public struct Vocabulary: Sendable, Equatable {
+        public static let commandLine = Self(
+            windowIDSelector: "--window-id",
+            windowIndexSelector: "--window-index",
+            windowIndexAlternative: "--window-index")
+
+        public static let mcp = Self(
+            windowIDSelector: "window_id",
+            windowIndexSelector: "window index",
+            windowIndexAlternative: "index")
+
+        let windowIDSelector: String
+        let windowIndexSelector: String
+        let windowIndexAlternative: String
+    }
+
+    public enum Selection: Sendable, Equatable {
         case automatic
         case id(Int)
         case title(String)
         case index(Int)
 
-        var explicitSelector: InteractionTargetSelector.WindowSelector? {
+        fileprivate init(_ selector: InteractionTargetSelector.WindowSelector) {
+            switch selector {
+            case let .id(windowID):
+                self = .id(windowID)
+            case let .title(title):
+                self = .title(title)
+            case let .index(index):
+                self = .index(index)
+            }
+        }
+
+        fileprivate var explicitSelector: InteractionTargetSelector.WindowSelector? {
             switch self {
             case .automatic: nil
             case let .id(windowID): .id(windowID)
@@ -28,23 +55,40 @@ enum ExactWindowSelectorResolver {
         }
     }
 
-    static func select(
+    public static func select(
+        from windows: [ServiceWindowInfo],
+        selector: InteractionTargetSelector,
+        operation: String,
+        vocabulary: Vocabulary) throws -> ServiceWindowInfo
+    {
+        let selector = try selector.normalizedWindowSelector(policy: .mutationSafe)
+        return try self.select(
+            from: windows,
+            selection: selector.map(Selection.init) ?? .automatic,
+            operation: operation,
+            vocabulary: vocabulary)
+    }
+
+    public static func select(
         from windows: [ServiceWindowInfo],
         selection: Selection,
-        operation: String) throws -> ServiceWindowInfo
+        operation: String,
+        vocabulary: Vocabulary) throws -> ServiceWindowInfo
     {
         guard let explicitSelector = selection.explicitSelector else {
             guard let window = ObservationTargetResolver.bestWindow(from: windows) else {
                 throw ExactWindowSelectorResolutionError(
-                    message: "\(operation) found no eligible window. Refresh the window inventory before retrying.")
+                    message: "\(operation) found no eligible window. " +
+                        "Refresh the window inventory before retrying.")
             }
             return window
         }
         if case let .index(index) = explicitSelector, index < 0 {
             throw ExactWindowSelectorResolutionError(
-                message: "\(operation) window index must be zero or greater.")
+                message: "\(operation) \(vocabulary.windowIndexSelector) must be zero or greater.")
         }
         do {
+            // Compatibility and read-only capture paths intentionally select without requiring a mutation receipt.
             return try DesktopTargetPlanning.WindowCandidateSelector.selectExplicitCandidate(
                 candidates: windows,
                 selector: explicitSelector)
@@ -53,11 +97,12 @@ enum ExactWindowSelectorResolver {
                 error,
                 selector: explicitSelector,
                 windows: windows,
-                operation: operation)
+                operation: operation,
+                vocabulary: vocabulary)
         }
     }
 
-    static func selection(for target: WindowTarget) -> Selection {
+    public static func selection(for target: WindowTarget) -> Selection {
         switch target {
         case .application, .frontmost:
             .automatic
@@ -74,7 +119,8 @@ enum ExactWindowSelectorResolver {
         _ error: DesktopTargetPlanningError,
         selector: InteractionTargetSelector.WindowSelector,
         windows: [ServiceWindowInfo],
-        operation: String) -> ExactWindowSelectorResolutionError
+        operation: String,
+        vocabulary: Vocabulary) -> ExactWindowSelectorResolutionError
     {
         if case let .conflictingWindowEntries(windowID) = error {
             return self.inventoryConflictError(
@@ -85,30 +131,32 @@ enum ExactWindowSelectorResolver {
         return switch (selector, error) {
         case let (.id(windowID), .windowNotFound):
             ExactWindowSelectorResolutionError(
-                message: "\(operation) window_id \(windowID) does not identify a window. " +
+                message: "\(operation) \(vocabulary.windowIDSelector) \(windowID) does not identify a window. " +
                     "Refresh the window inventory before retrying.")
         case let (.id(windowID), .ambiguousWindow):
             ExactWindowSelectorResolutionError(
-                message: "\(operation) window_id \(windowID) identifies multiple windows. " +
+                message: "\(operation) \(vocabulary.windowIDSelector) \(windowID) identifies multiple windows. " +
                     "Refresh the window inventory before retrying.")
         case let (.title(title), .windowNotFound):
             ExactWindowSelectorResolutionError(
                 message: "\(operation) found no window whose title matches '\(title)'. " +
-                    "Refresh the inventory and select a window_id or valid index.")
+                    "Refresh the inventory and select a \(vocabulary.windowIDSelector) or valid " +
+                    "\(vocabulary.windowIndexAlternative).")
         case let (.title(title), .ambiguousWindow(_, windowIDs)):
             self.titleAmbiguityError(
                 title: title,
                 windowIDs: windowIDs,
                 windows: windows,
-                operation: operation)
+                operation: operation,
+                vocabulary: vocabulary)
         case let (.index(index), .windowNotFound):
             ExactWindowSelectorResolutionError(
-                message: "\(operation) window index \(index) is not present. " +
-                    "Refresh the inventory and select a window_id.")
+                message: "\(operation) \(vocabulary.windowIndexSelector) \(index) is not present. " +
+                    "Refresh the inventory and select a \(vocabulary.windowIDSelector).")
         case let (.index(index), .ambiguousWindow):
             ExactWindowSelectorResolutionError(
-                message: "\(operation) window index \(index) is ambiguous. " +
-                    "Refresh the inventory and select a window_id.")
+                message: "\(operation) \(vocabulary.windowIndexSelector) \(index) is ambiguous. " +
+                    "Refresh the inventory and select a \(vocabulary.windowIDSelector).")
         default:
             ExactWindowSelectorResolutionError(
                 message: "\(operation) could not resolve one exact window. \(error.localizedDescription)")
@@ -119,12 +167,13 @@ enum ExactWindowSelectorResolver {
         title: String,
         windowIDs: [Int],
         windows: [ServiceWindowInfo],
-        operation: String) -> ExactWindowSelectorResolutionError
+        operation: String,
+        vocabulary: Vocabulary) -> ExactWindowSelectorResolutionError
     {
         let candidates = self.candidateSummary(windowIDs: windowIDs, windows: windows)
         return ExactWindowSelectorResolutionError(
             message: "\(operation) window title '\(title)' is ambiguous (\(candidates)). " +
-                "Select one window_id or index explicitly.")
+                "Select one \(vocabulary.windowIDSelector) or \(vocabulary.windowIndexAlternative) explicitly.")
     }
 
     private static func inventoryConflictError(

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ExactWindowSelectorResolverTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ExactWindowSelectorResolverTests.swift
@@ -1,0 +1,153 @@
+import PeekabooAutomationKitTestSupport
+import PeekabooFoundation
+import Testing
+@testable import PeekabooAutomationKit
+
+struct ExactWindowSelectorResolverTests {
+    @Test
+    func `explicit resolution preserves receiptless compatibility selection`() throws {
+        let receiptless = AutomationTestFixtures.window(includesMutationIdentity: false)
+
+        let selected = try ExactWindowSelectorResolver.select(
+            from: [receiptless],
+            selection: .id(receiptless.windowID),
+            operation: "Capture window selection",
+            vocabulary: .mcp)
+
+        #expect(selected == receiptless)
+    }
+
+    @Test
+    func `automatic resolution uses the canonical observation ranking`() throws {
+        let secondary = AutomationTestFixtures.window(
+            windowID: 202,
+            title: "Secondary",
+            isMainWindow: false,
+            isKeyWindow: false,
+            index: 1)
+        let primary = AutomationTestFixtures.window(
+            windowID: 201,
+            title: "Primary",
+            isMainWindow: true,
+            isKeyWindow: true,
+            index: 0)
+
+        let selected = try ExactWindowSelectorResolver.select(
+            from: [secondary, primary],
+            selection: .automatic,
+            operation: "Capture window selection",
+            vocabulary: .mcp)
+
+        #expect(selected == primary)
+    }
+
+    @Test
+    func `explicit resolution delegates canonical rows and selector semantics`() throws {
+        let selected = AutomationTestFixtures.window(windowID: 201, title: "Project Notes", index: 4)
+        let unrelated = AutomationTestFixtures.window(windowID: 202, title: "Other", index: 5)
+        let conflicting = AutomationTestFixtures.window(windowID: 202, title: "Conflict", index: 6)
+
+        for inventory in [
+            [selected, selected, unrelated, conflicting],
+            [conflicting, unrelated, selected, selected],
+        ] {
+            for selection: ExactWindowSelectorResolver.Selection in [
+                .id(selected.windowID),
+                .title("Notes"),
+                .index(selected.index),
+            ] {
+                #expect(try ExactWindowSelectorResolver.select(
+                    from: inventory,
+                    selection: selection,
+                    operation: "Capture window selection",
+                    vocabulary: .mcp) == selected)
+            }
+        }
+    }
+
+    @Test
+    func `command line vocabulary preserves title ambiguity wording`() {
+        let first = AutomationTestFixtures.window(windowID: 101, title: "Draft One", index: 0)
+        let second = AutomationTestFixtures.window(windowID: 102, title: "Draft Two", index: 1)
+
+        let error = #expect(throws: ExactWindowSelectorResolutionError.self) {
+            _ = try ExactWindowSelectorResolver.select(
+                from: [second, first],
+                selection: .title("Draft"),
+                operation: "Capture selector test",
+                vocabulary: .commandLine)
+        }
+        #expect(error?.message ==
+            "Capture selector test window title 'Draft' is ambiguous " +
+            "(id=101 index=0 'Draft One'; id=102 index=1 'Draft Two'). " +
+            "Select one --window-id or --window-index explicitly.")
+    }
+
+    @Test
+    func `MCP vocabulary preserves title ambiguity wording`() {
+        let first = AutomationTestFixtures.window(windowID: 41, title: "Project Notes", index: 0)
+        let second = AutomationTestFixtures.window(windowID: 42, title: "Project Plan", index: 1)
+
+        let error = #expect(throws: ExactWindowSelectorResolutionError.self) {
+            _ = try ExactWindowSelectorResolver.select(
+                from: [second, first],
+                selection: .title("Project"),
+                operation: "Capture window selection",
+                vocabulary: .mcp)
+        }
+        #expect(error?.message ==
+            "Capture window selection window title 'Project' is ambiguous " +
+            "(id=41 index=0 'Project Notes'; id=42 index=1 'Project Plan'). " +
+            "Select one window_id or index explicitly.")
+    }
+
+    @Test
+    func `surface vocabulary preserves missing selector wording`() {
+        let window = AutomationTestFixtures.window(windowID: 201, title: "Available", index: 4)
+
+        let cliID = #expect(throws: ExactWindowSelectorResolutionError.self) {
+            _ = try ExactWindowSelectorResolver.select(
+                from: [window],
+                selection: .id(999),
+                operation: "Window test",
+                vocabulary: .commandLine)
+        }
+        #expect(cliID?.message ==
+            "Window test --window-id 999 does not identify a window. " +
+            "Refresh the window inventory before retrying.")
+
+        let mcpIndex = #expect(throws: ExactWindowSelectorResolutionError.self) {
+            _ = try ExactWindowSelectorResolver.select(
+                from: [window],
+                selection: .index(7),
+                operation: "Window test",
+                vocabulary: .mcp)
+        }
+        #expect(mcpIndex?.message ==
+            "Window test window index 7 is not present. Refresh the inventory and select a window_id.")
+    }
+
+    @Test
+    func `negative index refuses before candidate selection`() {
+        let error = #expect(throws: ExactWindowSelectorResolutionError.self) {
+            _ = try ExactWindowSelectorResolver.select(
+                from: [],
+                selection: .index(-1),
+                operation: "Capture window selection",
+                vocabulary: .mcp)
+        }
+
+        #expect(error?.message == "Capture window selection window index must be zero or greater.")
+    }
+
+    @Test
+    func `WindowTarget adapter retains compatibility selection`() {
+        #expect(ExactWindowSelectorResolver.selection(for: .application("Preview")) == .automatic)
+        #expect(ExactWindowSelectorResolver.selection(for: .frontmost) == .automatic)
+        #expect(ExactWindowSelectorResolver.selection(for: .title("Draft")) == .title("Draft"))
+        #expect(ExactWindowSelectorResolver.selection(
+            for: .applicationAndTitle(app: "Preview", title: "Draft")) == .title("Draft"))
+        #expect(ExactWindowSelectorResolver.selection(for: .index(app: "Preview", index: 3)) == .index(3))
+        #expect(ExactWindowSelectorResolver.selection(for: .windowId(42)) == .id(42))
+    }
+}

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/CaptureTool+WindowResolution.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/CaptureTool+WindowResolution.swift
@@ -91,7 +91,8 @@ enum CaptureToolWindowResolver {
             return try ExactWindowSelectorResolver.select(
                 from: windows,
                 selection: selection,
-                operation: operation)
+                operation: operation,
+                vocabulary: .mcp)
         } catch {
             throw PeekabooError.windowNotFound(criteria: error.localizedDescription)
         }

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/ImageTool+Capture.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/ImageTool+Capture.swift
@@ -146,7 +146,8 @@ extension ImageTool {
         let window = try ExactWindowSelectorResolver.select(
             from: windows,
             selection: .id(windowID),
-            operation: "Image foreground capture")
+            operation: "Image foreground capture",
+            vocabulary: .mcp)
         guard let identity = window.mutationIdentity,
               identity.windowID == window.windowID,
               identity.capturedBounds == window.bounds,

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/SpaceTool+Handlers.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/SpaceTool+Handlers.swift
@@ -163,7 +163,8 @@ extension SpaceTool {
                 windowInfo = try ExactWindowSelectorResolver.select(
                     from: windows,
                     selection: ExactWindowSelectorResolver.selection(for: windowTarget),
-                    operation: operation)
+                    operation: operation,
+                    vocabulary: .mcp)
             } catch {
                 throw DesktopActionFailure.preDispatchRefusal(
                     reason: .targetUnavailable,

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/WindowTool+Handlers.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/WindowTool+Handlers.swift
@@ -393,7 +393,8 @@ extension WindowTool {
             return try ExactWindowSelectorResolver.select(
                 from: windows,
                 selection: ExactWindowSelectorResolver.selection(for: target.target),
-                operation: operation)
+                operation: operation,
+                vocabulary: .mcp)
         } catch {
             throw DesktopActionFailure.preDispatchRefusal(
                 reason: .targetUnavailable,
@@ -457,7 +458,8 @@ extension WindowTool {
             let windowInfo = try ExactWindowSelectorResolver.select(
                 from: windows,
                 selection: ExactWindowSelectorResolver.selection(for: target),
-                operation: "\(action) post-action readback")
+                operation: "\(action) post-action readback",
+                vocabulary: .mcp)
             let targetIdentity = try Self.coalescedPostMutationWindowTargetIdentity(
                 windowInfo: windowInfo,
                 actionResultTarget: actionResult.targetIdentity)

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/CaptureToolPathResolverTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/CaptureToolPathResolverTests.swift
@@ -2,6 +2,7 @@ import Foundation
 import MCP
 import PeekabooAutomation
 import PeekabooAutomationKit
+import PeekabooAutomationKitTestSupport
 import PeekabooFoundation
 import TachikomaMCP
 import Testing
@@ -164,8 +165,12 @@ struct CaptureToolPathResolverTests {
     @Test
     func `window resolver maps app title selection to stable window id`() async throws {
         let windows = CaptureWindowResolverWindowService(windows: [
-            Self.window(id: 7, title: "", index: 0, bounds: CGRect(x: 0, y: 0, width: 500, height: 30)),
-            Self.window(id: 42, title: "Main Document", index: 1),
+            AutomationTestFixtures.window(
+                windowID: 7,
+                title: "",
+                bounds: CGRect(x: 0, y: 0, width: 500, height: 30),
+                index: 0),
+            AutomationTestFixtures.window(windowID: 42, title: "Main Document", index: 1),
         ])
 
         let scope = try await CaptureToolWindowResolver.scope(
@@ -185,9 +190,18 @@ struct CaptureToolPathResolverTests {
     @Test
     func `window resolver freezes automatic app selection to exact identity`() async throws {
         let selectedBounds = CGRect(x: 20, y: 30, width: 800, height: 600)
+        let selected = AutomationTestFixtures.window(
+            windowID: 42,
+            title: "Main Document",
+            bounds: selectedBounds,
+            index: 1)
         let windows = CaptureWindowResolverWindowService(windows: [
-            Self.window(id: 7, title: "", index: 0, bounds: CGRect(x: 0, y: 0, width: 500, height: 30)),
-            Self.window(id: 42, title: "Main Document", index: 1, bounds: selectedBounds),
+            AutomationTestFixtures.window(
+                windowID: 7,
+                title: "",
+                bounds: CGRect(x: 0, y: 0, width: 500, height: 30),
+                index: 0),
+            selected,
         ])
 
         let scope = try await CaptureToolWindowResolver.scope(
@@ -198,11 +212,7 @@ struct CaptureToolPathResolverTests {
             windows: windows)
 
         #expect(scope.windowId == 42)
-        #expect(scope.windowMutationIdentity == WindowMutationIdentity(
-            windowID: 42,
-            ownerProcessIdentifier: 42,
-            ownerProcessStartIdentity: 7,
-            capturedBounds: selectedBounds))
+        #expect(scope.windowMutationIdentity == selected.mutationIdentity)
         #expect(scope.applicationIdentifier == "Preview")
         #expect(windows.requestedTargets.map(\.description) == ["application(Preview)"])
     }
@@ -211,7 +221,7 @@ struct CaptureToolPathResolverTests {
     func `window resolver freezes untargeted automatic selection to exact frontmost candidate`() async throws {
         let bounds = CGRect(x: 40, y: 50, width: 700, height: 500)
         let windows = CaptureWindowResolverWindowService(windows: [
-            Self.window(id: 77, title: "Frontmost", index: 0, bounds: bounds),
+            AutomationTestFixtures.window(windowID: 77, title: "Frontmost", bounds: bounds, index: 0),
         ])
 
         let scope = try await CaptureToolWindowResolver.scope(
@@ -230,7 +240,7 @@ struct CaptureToolPathResolverTests {
     @Test
     func `window resolver maps title-only selection to stable window id`() async throws {
         let windows = CaptureWindowResolverWindowService(windows: [
-            Self.window(id: 99, title: "Inspector", index: 4),
+            AutomationTestFixtures.window(windowID: 99, title: "Inspector", index: 4),
         ])
 
         let scope = try await CaptureToolWindowResolver.scope(
@@ -246,25 +256,9 @@ struct CaptureToolPathResolverTests {
     }
 
     @Test
-    func `window resolver canonicalizes repeated stable inventory rows`() async throws {
-        let window = Self.window(id: 99, title: "Inspector", index: 4)
-        let windows = CaptureWindowResolverWindowService(windows: [window, window])
-
-        let scope = try await CaptureToolWindowResolver.scope(
-            app: "Preview",
-            pid: nil,
-            windowTitle: "Inspector",
-            windowIndex: nil,
-            windows: windows)
-
-        #expect(scope.windowId == 99)
-        #expect(scope.windowMutationIdentity == window.mutationIdentity)
-    }
-
-    @Test
     func `window resolver refuses ambiguous partial titles instead of pinning the first result`() async {
-        let first = Self.window(id: 41, title: "Project Notes", index: 0)
-        let second = Self.window(id: 42, title: "Project Plan", index: 1)
+        let first = AutomationTestFixtures.window(windowID: 41, title: "Project Notes", index: 0)
+        let second = AutomationTestFixtures.window(windowID: 42, title: "Project Plan", index: 1)
         let expectedMessage =
             "window title 'Project' is ambiguous " +
             "(id=41 index=0 'Project Notes'; id=42 index=1 'Project Plan'). " +
@@ -290,51 +284,9 @@ struct CaptureToolPathResolverTests {
     }
 
     @Test
-    func `window resolver ignores unrelated conflicting duplicates`() throws {
-        let selected = Self.window(id: 41, title: "Project", index: 0)
-        let firstConflict = Self.window(id: 50, title: "Other A", index: 1)
-        let secondConflict = Self.window(id: 50, title: "Other B", index: 2)
-
-        for inventory in [
-            [selected, firstConflict, secondConflict],
-            [secondConflict, firstConflict, selected],
-        ] {
-            for selection: ExactWindowSelectorResolver.Selection in [
-                .id(selected.windowID),
-                .title(selected.title),
-                .index(selected.index),
-            ] {
-                let result = try ExactWindowSelectorResolver.select(
-                    from: inventory,
-                    selection: selection,
-                    operation: "Capture window selection")
-                #expect(result == selected)
-            }
-        }
-    }
-
-    @Test
-    func `window resolver exact title remains stable when inventory order differs`() async throws {
-        let windows = CaptureWindowResolverWindowService(windows: [
-            Self.window(id: 42, title: "Project Plan", index: 1),
-            Self.window(id: 41, title: "Project", index: 0),
-        ])
-
-        let scope = try await CaptureToolWindowResolver.scope(
-            app: "Preview",
-            pid: nil,
-            windowTitle: "Project",
-            windowIndex: nil,
-            windows: windows)
-
-        #expect(scope.windowId == 41)
-        #expect(scope.windowIndex == 0)
-    }
-
-    @Test
     func `window resolver rejects index without app or pid`() async {
         let windows = CaptureWindowResolverWindowService(windows: [
-            Self.window(id: 99, title: "Inspector", index: 4),
+            AutomationTestFixtures.window(windowID: 99, title: "Inspector", index: 4),
         ])
 
         await #expect(throws: PeekabooError.self) {
@@ -415,7 +367,7 @@ struct CaptureToolPathResolverTests {
             unitCount: .one,
             message: "focus verification failed after dispatch")
         let windows = CaptureWindowResolverWindowService(
-            windows: [Self.window(id: 42, title: "Main Document", index: 0)],
+            windows: [AutomationTestFixtures.window(windowID: 42, title: "Main Document", index: 0)],
             focusError: focusError)
         let services = PeekabooServices()
         let context = MCPToolContext(
@@ -603,24 +555,6 @@ struct CaptureToolPathResolverTests {
     private static func meta(from response: ToolResponse) -> [String: Value]? {
         guard case let .object(meta) = response.meta else { return nil }
         return meta
-    }
-
-    private static func window(
-        id: Int,
-        title: String,
-        index: Int,
-        bounds: CGRect = CGRect(x: 0, y: 0, width: 500, height: 400)) -> ServiceWindowInfo
-    {
-        ServiceWindowInfo(
-            windowID: id,
-            title: title,
-            bounds: bounds,
-            index: index,
-            mutationIdentity: WindowMutationIdentity(
-                windowID: id,
-                ownerProcessIdentifier: 42,
-                ownerProcessStartIdentity: 7,
-                capturedBounds: bounds))
     }
 }
 


### PR DESCRIPTION
## Summary

- move exact-window selection into one AutomationKit resolver shared by CLI and MCP callers
- preserve surface-specific diagnostics while centralizing normalization, ambiguity, ranking, and compatibility behavior
- remove duplicate resolver implementations and local window-fixture builders

## Proof

- AutomationKit exact-window resolver: 8 tests
- CLI capture/window targeting: 35 tests
- CLI focus targeting: 12 tests
- Core MCP capture path resolver: 20 tests
- strict SwiftLint on all touched files
- `git diff --check`
- P0-P2 Autoreview clean

This is an internal consolidation with no user-visible command or schema change.
