### PR TITLE
ci(codeql): add advanced multi-language analysis

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -46,6 +46,7 @@ jobs:
   analyze-swift:
     name: Analyze Swift
     runs-on: macos-26
+    timeout-minutes: 330
     steps:
       - uses: actions/checkout@v7
         with:
@@ -76,7 +77,7 @@ jobs:
           build-mode: manual
 
       - name: Build CLI
-        run: swift build --package-path Apps/CLI --arch arm64 --configuration debug
+        run: swift build --package-path Apps/CLI --configuration debug
 
       - name: Build Peekaboo
         run: |
@@ -85,14 +86,11 @@ jobs:
             -scheme Peekaboo \
             -configuration Debug \
             -sdk macosx \
-            -destination "platform=macOS,arch=arm64" \
             -derivedDataPath "$RUNNER_TEMP/codeql-peekaboo" \
             -disableAutomaticPackageResolution \
             -onlyUsePackageVersionsFromResolvedFile \
             -skipPackageUpdates \
             build \
-            ARCHS=arm64 \
-            ONLY_ACTIVE_ARCH=YES \
             CODE_SIGNING_ALLOWED=NO \
             CODE_SIGNING_REQUIRED=NO \
             CODE_SIGN_IDENTITY="" \
@@ -105,11 +103,8 @@ jobs:
             -scheme Playground \
             -configuration Debug \
             -sdk macosx \
-            -destination "platform=macOS,arch=arm64" \
             -derivedDataPath "$RUNNER_TEMP/codeql-playground" \
             build \
-            ARCHS=arm64 \
-            ONLY_ACTIVE_ARCH=YES \
             CODE_SIGNING_ALLOWED=NO \
             CODE_SIGNING_REQUIRED=NO \
             CODE_SIGN_IDENTITY="" \
@@ -122,11 +117,8 @@ jobs:
             -scheme Inspector \
             -configuration Debug \
             -sdk macosx \
-            -destination "platform=macOS,arch=arm64" \
             -derivedDataPath "$RUNNER_TEMP/codeql-inspector" \
             build \
-            ARCHS=arm64 \
-            ONLY_ACTIVE_ARCH=YES \
             CODE_SIGNING_ALLOWED=NO \
             CODE_SIGNING_REQUIRED=NO \
             CODE_SIGN_IDENTITY="" \

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,138 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "31 14 * * 2"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
+
+concurrency:
+  group: codeql-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze-source:
+    name: Analyze ${{ matrix.language }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - actions
+          - javascript-typescript
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: recursive
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: none
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: /language:${{ matrix.language }}
+
+  analyze-swift:
+    name: Analyze Swift
+    runs-on: macos-26
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: recursive
+
+      - name: Select Xcode 26
+        run: |
+          set -euo pipefail
+          for candidate in \
+            /Applications/Xcode_26.6.app \
+            /Applications/Xcode_26.5.app \
+            /Applications/Xcode_26.4.1.app \
+            /Applications/Xcode_26.3.app \
+            /Applications/Xcode_26.2.app \
+            /Applications/Xcode.app; do
+            if [[ -d "$candidate" ]]; then
+              sudo xcode-select -s "$candidate"
+              echo "DEVELOPER_DIR=${candidate}/Contents/Developer" >> "$GITHUB_ENV"
+              break
+            fi
+          done
+          xcodebuild -version
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: swift
+          build-mode: manual
+
+      - name: Build CLI
+        run: swift build --package-path Apps/CLI --arch arm64 --configuration debug
+
+      - name: Build Peekaboo
+        run: |
+          xcodebuild \
+            -workspace Apps/Peekaboo.xcworkspace \
+            -scheme Peekaboo \
+            -configuration Debug \
+            -sdk macosx \
+            -destination "platform=macOS,arch=arm64" \
+            -derivedDataPath "$RUNNER_TEMP/codeql-peekaboo" \
+            -disableAutomaticPackageResolution \
+            -onlyUsePackageVersionsFromResolvedFile \
+            -skipPackageUpdates \
+            build \
+            ARCHS=arm64 \
+            ONLY_ACTIVE_ARCH=YES \
+            CODE_SIGNING_ALLOWED=NO \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGN_IDENTITY="" \
+            DEVELOPMENT_TEAM=""
+
+      - name: Build Playground
+        run: |
+          xcodebuild \
+            -project Apps/Playground/Playground.xcodeproj \
+            -scheme Playground \
+            -configuration Debug \
+            -sdk macosx \
+            -destination "platform=macOS,arch=arm64" \
+            -derivedDataPath "$RUNNER_TEMP/codeql-playground" \
+            build \
+            ARCHS=arm64 \
+            ONLY_ACTIVE_ARCH=YES \
+            CODE_SIGNING_ALLOWED=NO \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGN_IDENTITY="" \
+            DEVELOPMENT_TEAM=""
+
+      - name: Build Inspector
+        run: |
+          xcodebuild \
+            -project Apps/PeekabooInspector/Inspector.xcodeproj \
+            -scheme Inspector \
+            -configuration Debug \
+            -sdk macosx \
+            -destination "platform=macOS,arch=arm64" \
+            -derivedDataPath "$RUNNER_TEMP/codeql-inspector" \
+            build \
+            ARCHS=arm64 \
+            ONLY_ACTIVE_ARCH=YES \
+            CODE_SIGNING_ALLOWED=NO \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGN_IDENTITY="" \
+            DEVELOPMENT_TEAM=""
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: /language:swift


### PR DESCRIPTION
## Summary

- add advanced CodeQL analysis for GitHub Actions and JavaScript/TypeScript on Ubuntu
- build Swift manually on `macos-26` in one database across the CLI, Peekaboo, Playground, and Inspector
- let Swift and Xcode select the hosted runner architecture instead of forcing an unavailable arm64 destination
- keep signing disabled and preserve the workspace package-resolution constraints

## Validation

- `actionlint .github/workflows/codeql.yml`
- Ruby YAML parse
- `git diff --check`
- exact grep confirms no `--arch arm64`, forced Xcode destination, `ARCHS=arm64`, or command-line `ONLY_ACTIVE_ARCH=YES` remains
- signed correction commit `a7b0ab6ff52dcc89a838c89ca2292327c534ce1d`

## Failure evidence

- the prior Swift run reached the Peekaboo build, then failed because `macos-26` exposed only an x86_64 `My Mac` destination while the workflow required `platform=macOS,arch=arm64`: https://github.com/openclaw/Peekaboo/actions/runs/32888545508/job/97934691605
- the corrected sequential Swift run is allowed up to 330 minutes; it remains a single CodeQL initialization and analysis database

## Residual exclusions

- release packaging, signing, notarization, publishing, and live UI/permission tests are not run
- standalone submodule builds and Swift sources not reached by the four explicit build commands are not included in the Swift database
- dependency caches, DYLD environment rewriting, and Swift Argument Parser fork bootstrapping are intentionally excluded
- organization security configuration `268172` is not attached by this PR and remains a post-merge activation step
