### PR TITLE
refactor(semantics): centralize action result transforms

### DIFF
--- a/Apps/CLI/Sources/PeekabooCLI/CLI/Output/JSONOutput.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/CLI/Output/JSONOutput.swift
@@ -431,24 +431,7 @@ func canonicalActionOutcomeAfterSuccessfulVerification(
     _ outcome: DesktopActionOutcome?,
     observedChange: Bool? = nil
 ) -> DesktopActionOutcome? {
-    guard let outcome else { return nil }
-    switch outcome.state {
-    case .dispatchedUnverified:
-        guard let observedChange else { return outcome }
-        guard let delivery = outcome.delivery else { return outcome }
-        if observedChange {
-            return .confirmedChange(
-                route: outcome.route,
-                delivery: delivery,
-                unitCount: outcome.dispatchState.unitCount
-            )
-        }
-        return .confirmedNoChange(route: outcome.route)
-    case .confirmedChange, .confirmedNoChange:
-        return outcome
-    case .refused, .partial, .suspectedNoop, .indeterminate:
-        return outcome
-    }
+    outcome?.confirmingDispatchedOutcome(observedChange: observedChange)
 }
 
 func postDispatchActionResultError(

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/AI/SeeCommand+CapturePipeline.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/AI/SeeCommand+CapturePipeline.swift
@@ -35,7 +35,7 @@ extension SeeCommand {
                 message: "Element detection timed out after web-content focus may have been dispatched.",
                 hint: "Observe the target before retrying with --web-focus.",
                 causeDescription: CaptureError.detectionTimedOut(timeoutSeconds).localizedDescription
-            ).attributed(to: SeeExecutionReceipt.targetReceipt(from: windowContext))
+            ).attributed(to: windowContext?.windowMutationIdentity?.validActionTargetReceipt)
         } catch is TimeoutError {
             throw CaptureError.detectionTimedOut(timeoutSeconds)
         }

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/AI/SeeCommand+Types.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/AI/SeeCommand+Types.swift
@@ -27,7 +27,7 @@ struct SeeExecutionReceipt: Equatable, Sendable {
     ) {
         let targetReceipt: DesktopActionTargetReceipt? =
             if let targetIdentity = result.targetIdentity {
-                Self.targetReceipt(from: targetIdentity)
+                targetIdentity.actionTargetReceipt
             } else {
                 fallbackTargetReceipt
             }
@@ -58,7 +58,7 @@ struct SeeExecutionReceipt: Equatable, Sendable {
         )
         return Self(
             outcome: result.outcome,
-            targetReceipt: Self.targetReceipt(from: target)
+            targetReceipt: target?.actionTargetReceipt
         )
     }
 
@@ -83,7 +83,7 @@ struct SeeExecutionReceipt: Equatable, Sendable {
         )
         return Self(
             outcome: result.outcome,
-            targetReceipt: Self.targetReceipt(from: target)
+            targetReceipt: target?.actionTargetReceipt
         )
     }
 
@@ -146,38 +146,6 @@ struct SeeExecutionReceipt: Equatable, Sendable {
             operation: operation,
             message: "\(operation) failed after its conditional desktop mutation result was returned.",
             hint: "Observe the target before deciding whether to retry \(operation)."
-        )
-    }
-
-    static func targetReceipt(from identity: DesktopTargetIdentity?) -> DesktopActionTargetReceipt? {
-        identity?.actionTargetReceipt
-    }
-
-    static func targetReceipt(from result: DesktopObservationResult) -> DesktopActionTargetReceipt? {
-        self.targetReceipt(from: result.capture.metadata.windowInfo?.mutationIdentity)
-            ?? result.elements.flatMap(self.targetReceipt(from:))
-    }
-
-    static func targetReceipt(from result: ElementDetectionResult) -> DesktopActionTargetReceipt? {
-        self.targetReceipt(from: result.metadata.windowContext)
-    }
-
-    static func targetReceipt(from context: WindowContext?) -> DesktopActionTargetReceipt? {
-        self.targetReceipt(from: context?.windowMutationIdentity)
-    }
-
-    private static func targetReceipt(
-        from identity: WindowMutationIdentity?
-    ) -> DesktopActionTargetReceipt? {
-        guard let identity,
-              identity.ownerProcessIdentifier > 0,
-              identity.ownerProcessStartIdentity > 0,
-              identity.windowID > 0
-        else { return nil }
-        return DesktopActionTargetReceipt(
-            processIdentifier: identity.ownerProcessIdentifier,
-            processStartIdentity: identity.ownerProcessStartIdentity,
-            windowID: identity.windowID
         )
     }
 }

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/PasteCommand+BackgroundTextResult.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/PasteCommand+BackgroundTextResult.swift
@@ -6,10 +6,6 @@ extension PasteCommand {
         UIAutomationActionResultSemantics.keyboardDelivery(for: target)
     }
 
-    static func pasteTargetReceipt(for target: UIAutomationTarget) -> DesktopActionTargetReceipt? {
-        try? UIAutomationActionResultSemantics.actionTargetReceipt(for: target)
-    }
-
     static func validateBackgroundTextResult(
         _ result: UIAutomationActionResult<TypeResult>,
         authorizedTarget: UIAutomationTarget

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/PasteCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/PasteCommand.swift
@@ -663,7 +663,7 @@ struct PasteCommand: ActionOutputFormattable, ErrorHandlingCommand, OutputFormat
                 causeDescription: error.causeDescription
             )
         }
-        return failure.attributed(to: Self.pasteTargetReceipt(for: target))
+        return failure.attributed(to: try? UIAutomationActionResultSemantics.actionTargetReceipt(for: target))
     }
 
     private func ensureForegroundFocus(

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Shared/FocusCommandUtilities.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Shared/FocusCommandUtilities.swift
@@ -463,7 +463,7 @@ func validatedConfirmedForegroundFocusResult(
     _ result: UIAutomationActionResult<Void>,
     operation: String
 ) throws -> UIAutomationActionResult<Void> {
-    let targetReceipt = result.targetIdentity.flatMap(focusTargetReceipt)
+    let targetReceipt = result.targetIdentity?.actionTargetReceipt
     guard let targetIdentity = result.targetIdentity,
           targetIdentity.exactWindow != nil
     else {
@@ -481,14 +481,14 @@ func validatedConfirmedForegroundFocusResult(
             evidence: .completionUnknown,
             message: "\(operation) returned without a canonical focus outcome.",
             hint: "Observe the target before retrying and update the runtime host."
-        ).attributed(to: focusTargetReceipt(targetIdentity))
+        ).attributed(to: targetIdentity.actionTargetReceipt)
     }
     guard outcome.isConfirmed else {
         guard let failure = DesktopActionFailure(
             outcome: outcome,
             message: "\(operation) did not confirm exact foreground focus.",
             hint: "Do not send global input until the exact target focus is confirmed.",
-            targetReceipt: focusTargetReceipt(targetIdentity)
+            targetReceipt: targetIdentity.actionTargetReceipt
         ) else {
             preconditionFailure("A non-confirmed focus outcome must construct a failure")
         }
@@ -503,13 +503,9 @@ func validatedConfirmedForegroundFocusResult(
             unitCount: outcome.dispatchState.unitCount,
             message: "\(operation) confirmed a dispatched focus without foreground delivery.",
             hint: "Do not send global input until the exact target focus is confirmed in the foreground."
-        ).attributed(to: focusTargetReceipt(targetIdentity))
+        ).attributed(to: targetIdentity.actionTargetReceipt)
     }
     return result
-}
-
-private func focusTargetReceipt(_ identity: DesktopTargetIdentity) -> DesktopActionTargetReceipt {
-    identity.actionTargetReceipt
 }
 
 @MainActor

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/DialogCommand+Click.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/DialogCommand+Click.swift
@@ -65,7 +65,7 @@ extension DialogCommand {
                     do {
                         outcome = try result.requiredPreparedOutcome(kind: .clickButton)
                     } catch let failure as DesktopActionFailure {
-                        throw failure.attributed(to: DialogCommand.targetReceipt(receipt.target))
+                        throw failure.attributed(to: receipt.target.actionTargetReceipt)
                     }
                     let resultTarget: DesktopTargetIdentity
                     do {

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/DialogCommand+DismissList.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/DialogCommand+DismissList.swift
@@ -122,7 +122,7 @@ extension DialogCommand {
                         do {
                             outcome = try result.requiredPreparedOutcome(kind: .dismiss)
                         } catch let failure as DesktopActionFailure {
-                            throw failure.attributed(to: DialogCommand.targetReceipt(receipt.target))
+                            throw failure.attributed(to: receipt.target.actionTargetReceipt)
                         }
                         do {
                             guard let exactTarget = try DialogCommand.exactResultTargetIdentity(

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/DialogCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/DialogCommand.swift
@@ -20,14 +20,6 @@ struct DialogCommand: ParsableCommand {
         let actionSequence: CommandActionSequenceAccumulator
     }
 
-    static func targetReceipt(_ target: UIAutomationTarget.ExactWindow) -> DesktopActionTargetReceipt {
-        DesktopActionTargetReceipt(
-            processIdentifier: target.identity.ownerProcessIdentifier,
-            processStartIdentity: target.identity.ownerProcessStartIdentity,
-            windowID: target.identity.windowID
-        )
-    }
-
     static func exactResultTargetIdentity(
         from result: DialogActionResult,
         matching selector: DialogTargetSelector? = nil,

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/SpaceCommand+MoveWindow.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/SpaceCommand+MoveWindow.swift
@@ -189,11 +189,7 @@ struct MoveWindowSubcommand: ActionOutputFormattable, ErrorHandlingCommand,
                         message: "Space move-window follow could not compose its two canonical outcomes.",
                         hint: "Observe both the exact window and active Space before retrying."
                     )
-                    .attributed(to: DesktopActionTargetReceipt(
-                        processIdentifier: expectedWindow.identity.ownerProcessIdentifier,
-                        processStartIdentity: expectedWindow.identity.ownerProcessStartIdentity,
-                        windowID: expectedWindow.identity.windowID
-                    ))
+                    .attributed(to: expectedWindow.actionTargetReceipt)
                 }
                 outcome = combinedOutcome
             } else {

--- a/Apps/CLI/Tests/CLIAutomationTests/DialogCommandTests.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/DialogCommandTests.swift
@@ -513,7 +513,7 @@ struct DialogCommandTests {
                 delivery: .init(mechanism: .accessibilityValue, mode: .background),
                 unitCount: .one
             ),
-            targetReceipt: DialogCommand.targetReceipt(exactTarget),
+            targetReceipt: exactTarget.actionTargetReceipt,
             targetWindowIdentity: identity,
             targetWindowBounds: bounds,
             focusedElement: nil,

--- a/Apps/CLI/Tests/CLIAutomationTests/Support/TestServices.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/Support/TestServices.swift
@@ -1383,7 +1383,7 @@ final class StubDialogService: DialogServiceProtocol {
                 delivery: .init(mechanism: .accessibilityAction, mode: .background),
                 unitCount: .one
             ),
-            targetReceipt: provided?.targetReceipt ?? DialogCommand.targetReceipt(receipt.target),
+            targetReceipt: provided?.targetReceipt ?? receipt.target.actionTargetReceipt,
             targetWindowIdentity: provided?.targetWindowIdentity ?? receipt.target.identity,
             targetWindowBounds: provided?.targetWindowBounds ?? receipt.target.bounds,
             focusedElement: provided?.focusedElement,

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Core/Protocols/ApplicationServiceProtocol.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Core/Protocols/ApplicationServiceProtocol.swift
@@ -238,7 +238,7 @@ public enum ApplicationActionResultSemantics {
         do {
             try self.requireSuccessfulOutcome(outcome, operation: operation)
         } catch let failure as DesktopActionFailure {
-            throw failure.attributed(to: expectedIdentity)
+            throw failure.attributed(to: expectedIdentity.actionTargetReceipt)
         }
         guard result.targetIdentity?.processIdentity == expectedIdentity else {
             throw DesktopActionFailure.indeterminate(
@@ -265,7 +265,7 @@ public enum ApplicationActionResultSemantics {
                 evidence: .completionUnknown,
                 message: "\(operation) returned without a canonical outcome.",
                 hint: "Observe the pinned application before retrying and update the runtime host.")
-                .attributed(to: expectedIdentity)
+                .attributed(to: expectedIdentity.actionTargetReceipt)
         }
         if !result.payload, outcome.isAccepted(by: .confirmedOrDispatched) {
             throw DesktopActionFailure.indeterminate(
@@ -275,12 +275,12 @@ public enum ApplicationActionResultSemantics {
                 unitCount: outcome.dispatchState.unitCount,
                 message: "\(operation) returned false with a successful canonical outcome.",
                 hint: "Observe the pinned application before retrying and update the runtime host.")
-                .attributed(to: expectedIdentity)
+                .attributed(to: expectedIdentity.actionTargetReceipt)
         }
         do {
             try self.requireSuccessfulOutcome(outcome, operation: operation)
         } catch let failure as DesktopActionFailure {
-            throw failure.attributed(to: expectedIdentity)
+            throw failure.attributed(to: expectedIdentity.actionTargetReceipt)
         }
     }
 }
@@ -864,21 +864,6 @@ public struct WindowMutationIdentity: Sendable, Codable, Equatable {
         self.windowID == other.windowID &&
             self.processIdentity == other.processIdentity &&
             self.capturedBounds == other.capturedBounds
-    }
-}
-
-extension DesktopActionFailure {
-    func attributed(to processIdentity: ApplicationProcessIdentity) -> DesktopActionFailure {
-        self.attributed(to: DesktopActionTargetReceipt(
-            processIdentifier: processIdentity.processIdentifier,
-            processStartIdentity: processIdentity.processStartIdentity))
-    }
-
-    func attributed(to windowIdentity: WindowMutationIdentity) -> DesktopActionFailure {
-        self.attributed(to: DesktopActionTargetReceipt(
-            processIdentifier: windowIdentity.ownerProcessIdentifier,
-            processStartIdentity: windowIdentity.ownerProcessStartIdentity,
-            windowID: windowIdentity.windowID))
     }
 }
 

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Core/Protocols/MenuServiceProtocol.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Core/Protocols/MenuServiceProtocol.swift
@@ -310,7 +310,8 @@ extension MenuServiceProtocol {
                 reason: .targetUnavailable,
                 message: "Application PID \(request.expectedIdentity.processIdentifier) changed generation " +
                     "while listing its menu.",
-                hint: "Refresh the application inventory before retrying.").attributed(to: request.expectedIdentity)
+                hint: "Refresh the application inventory before retrying.")
+                .attributed(to: request.expectedIdentity.actionTargetReceipt)
         }
         return structure
     }
@@ -320,9 +321,7 @@ extension MenuServiceProtocol {
         expectedIdentity: ApplicationProcessIdentity,
         operation: String) throws -> UIAutomationActionResult<Void>
     {
-        let receipt = DesktopActionTargetReceipt(
-            processIdentifier: expectedIdentity.processIdentifier,
-            processStartIdentity: expectedIdentity.processStartIdentity)
+        let receipt = expectedIdentity.actionTargetReceipt
         guard let outcome = result.outcome else {
             throw DesktopActionFailure.indeterminate(
                 evidence: .completionUnknown,

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Core/Protocols/WindowManagementServiceProtocol.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Core/Protocols/WindowManagementServiceProtocol.swift
@@ -295,10 +295,7 @@ extension WindowManagementServiceProtocol {
         expectedIdentity: WindowMutationIdentity,
         operation: String) throws -> UIAutomationActionResult<Void>
     {
-        let receipt = DesktopActionTargetReceipt(
-            processIdentifier: expectedIdentity.ownerProcessIdentifier,
-            processStartIdentity: expectedIdentity.ownerProcessStartIdentity,
-            windowID: expectedIdentity.windowID)
+        let receipt = expectedIdentity.actionTargetReceipt
         guard let outcome = result.outcome else {
             throw DesktopActionFailure.indeterminate(
                 evidence: .completionUnknown,

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Observation/DesktopObservationService.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Observation/DesktopObservationService.swift
@@ -905,41 +905,7 @@ public final class DesktopObservationService: DesktopObservationActionResultProv
         request: DesktopObservationRequest) -> DesktopActionOutcome
     {
         let delivery = self.pipelineDelivery(for: request)
-        switch outcome.state {
-        case .confirmedChange:
-            return .confirmedChange(
-                route: outcome.route,
-                delivery: delivery,
-                unitCount: outcome.dispatchState.unitCount)
-        case .confirmedNoChange:
-            return .confirmedNoChange(route: outcome.route)
-        case .partial:
-            return .partial(
-                route: outcome.route,
-                delivery: delivery,
-                unitCount: outcome.dispatchState.unitCount)
-        case .dispatchedUnverified:
-            return .dispatchedUnverified(
-                route: outcome.route,
-                delivery: delivery,
-                evidence: outcome.evidence == .operationStillRunning ? .operationStillRunning : .deliveryAccepted,
-                unitCount: outcome.dispatchState.unitCount)
-        case .suspectedNoop:
-            return .suspectedNoop(
-                route: outcome.route,
-                delivery: delivery,
-                unitCount: outcome.dispatchState.unitCount)
-        case .refused:
-            return .refused(
-                route: outcome.route,
-                reason: outcome.refusalReason ?? .operationUnsupported)
-        case .indeterminate:
-            return .indeterminate(
-                route: outcome.route,
-                delivery: outcome.delivery == nil ? nil : delivery,
-                evidence: outcome.evidence == .responseLost ? .responseLost : .completionUnknown,
-                unitCount: outcome.dispatchState.unitCount)
-        }
+        return outcome.reprojectingDelivery(delivery)
     }
 
     private static func projectingPipelineFailure(

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/System/ApplicationService+ActionOutcomes.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/System/ApplicationService+ActionOutcomes.swift
@@ -23,7 +23,7 @@ extension ApplicationService {
                 try await self.performApplicationRelaunchWithOutcomeOwnedLane(request)
             }
         } catch let failure as DesktopActionFailure {
-            throw failure.attributed(to: request.expectedTargetIdentity.map(Self.applicationTargetReceipt))
+            throw failure.attributed(to: request.expectedTargetIdentity?.actionTargetReceipt)
         }
     }
 
@@ -41,7 +41,7 @@ extension ApplicationService {
                 return DesktopActionResult(outcome: outcome)
             }
         } catch let failure as DesktopActionFailure {
-            throw failure.attributed(to: request.expectedIdentity.map(Self.applicationTargetReceipt))
+            throw failure.attributed(to: request.expectedIdentity?.actionTargetReceipt)
         }
     }
 
@@ -62,7 +62,7 @@ extension ApplicationService {
                 identifier: "PID:\(identity.processIdentifier)",
                 expectedIdentity: identity))
         } catch let failure as DesktopActionFailure {
-            throw failure.attributed(to: Self.applicationTargetReceipt(identity))
+            throw failure.attributed(to: identity.actionTargetReceipt)
         }
         return try UIAutomationActionResult(
             payload: result.payload,
@@ -107,7 +107,7 @@ extension ApplicationService {
                 return DesktopActionResult(payload: attempt.terminated, outcome: outcome)
             }
         } catch let failure as DesktopActionFailure {
-            throw failure.attributed(to: Self.applicationTargetReceipt(expectedIdentity))
+            throw failure.attributed(to: expectedIdentity.actionTargetReceipt)
         }
     }
 
@@ -146,7 +146,7 @@ extension ApplicationService {
                 hidden: true,
                 expectedIdentity: request.expectedIdentity)
         } catch let failure as DesktopActionFailure {
-            throw failure.attributed(to: Self.applicationTargetReceipt(request.expectedIdentity))
+            throw failure.attributed(to: request.expectedIdentity.actionTargetReceipt)
         }
         return try UIAutomationActionResult(
             payload: result.payload,
@@ -311,14 +311,6 @@ extension ApplicationService {
         DesktopActionOutcome.Delivery(mechanism: .nativeFramework, mode: mode)
     }
 
-    private static func applicationTargetReceipt(
-        _ identity: ApplicationProcessIdentity) -> DesktopActionTargetReceipt
-    {
-        DesktopActionTargetReceipt(
-            processIdentifier: identity.processIdentifier,
-            processStartIdentity: identity.processStartIdentity)
-    }
-
     static func checkApplicationDispatchCancellation(
         operation: String,
         _ checkCancellation: () throws -> Void = { try Task.checkCancellation() }) throws
@@ -423,7 +415,7 @@ extension ApplicationService {
                     "process generation before visibility dispatch.",
                 hint: "Refresh the application inventory before retrying.",
                 causeDescription: String(describing: error))
-                .attributed(to: expectedIdentity)
+                .attributed(to: expectedIdentity.actionTargetReceipt)
         }
     }
 
@@ -464,7 +456,7 @@ extension ApplicationService {
                 reason: .targetUnavailable,
                 message: "The application visibility target changed process generation before dispatch.",
                 hint: "Refresh the application inventory before retrying.")
-                .attributed(to: processIdentity)
+                .attributed(to: processIdentity.actionTargetReceipt)
         }
         try self.validateApplicationVisibilityIdentity(processIdentity, resolvedApplication: app)
 

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/DialogService+FileDialogVerification.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/DialogService+FileDialogVerification.swift
@@ -271,7 +271,7 @@ extension DialogService {
                 "button": refreshed.button.title() ?? "Replace",
             ]) { _, new in new },
             outcome: outcome,
-            targetReceipt: Self.desktopActionTargetReceipt(refreshed.target),
+            targetReceipt: refreshed.target.actionTargetReceipt,
             targetWindowIdentity: refreshed.target.identity,
             targetWindowBounds: refreshed.target.bounds,
             focusedElement: nil)

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/DialogService+FileDialogs.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/DialogService+FileDialogs.swift
@@ -158,7 +158,7 @@ extension DialogService {
                     action: .handleFileDialog,
                     details: details,
                     outcome: actionSequence.successResolution().outcome,
-                    targetReceipt: Self.desktopActionTargetReceipt(retainedTarget),
+                    targetReceipt: retainedTarget.actionTargetReceipt,
                     targetWindowIdentity: retainedTarget.identity,
                     targetWindowBounds: retainedTarget.bounds,
                     focusedElement: nil)
@@ -222,7 +222,7 @@ extension DialogService {
         after sequence: DesktopActionSequenceAccumulator,
         target: UIAutomationTarget.ExactWindow?) -> any Error
     {
-        let targetReceipt = target.map(Self.desktopActionTargetReceipt)
+        let targetReceipt = target?.actionTargetReceipt
         if let failure = error as? DesktopActionFailure {
             return sequence.failure(
                 combining: failure,

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/DialogService+ForegroundOutcomes.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/DialogService+ForegroundOutcomes.swift
@@ -35,7 +35,7 @@ extension DialogService {
         _ failure: DesktopActionFailure,
         target: UIAutomationTarget.ExactWindow) -> DesktopActionFailure
     {
-        failure.attributed(to: self.desktopActionTargetReceipt(target))
+        failure.attributed(to: target.actionTargetReceipt)
     }
 
     public func enterText(
@@ -340,7 +340,7 @@ extension DialogService {
             action: .enterText,
             details: details,
             outcome: outcome,
-            targetReceipt: Self.desktopActionTargetReceipt(plan.target),
+            targetReceipt: plan.target.actionTargetReceipt,
             targetWindowIdentity: plan.target.identity,
             targetWindowBounds: plan.target.bounds,
             focusedElement: plan.target.focusedElement,
@@ -508,7 +508,7 @@ extension DialogService {
                     valueVerified: false,
                     focusPolicy: focusPolicy),
                 outcome: .confirmedNoChange(),
-                targetReceipt: execution.publishTargetReceipt ? Self.desktopActionTargetReceipt(plan.target) : nil,
+                targetReceipt: execution.publishTargetReceipt ? plan.target.actionTargetReceipt : nil,
                 targetWindowIdentity: plan.target.identity,
                 targetWindowBounds: plan.target.bounds,
                 focusedElement: plan.target.focusedElement,
@@ -612,7 +612,7 @@ extension DialogService {
                 valueVerified: retainedValueMatchesRequest,
                 focusPolicy: focusPolicy),
             outcome: outcome,
-            targetReceipt: execution.publishTargetReceipt ? Self.desktopActionTargetReceipt(plan.target) : nil,
+            targetReceipt: execution.publishTargetReceipt ? plan.target.actionTargetReceipt : nil,
             targetWindowIdentity: plan.target.identity,
             targetWindowBounds: plan.target.bounds,
             focusedElement: plan.target.focusedElement,
@@ -754,7 +754,7 @@ extension DialogService {
                 action: .dismiss,
                 details: details,
                 outcome: outcome,
-                targetReceipt: Self.desktopActionTargetReceipt(plan.target),
+                targetReceipt: plan.target.actionTargetReceipt,
                 targetWindowIdentity: plan.target.identity,
                 targetWindowBounds: plan.target.bounds,
                 focusedElement: plan.target.focusedElement,

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/DialogService+PreparedActions.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/DialogService+PreparedActions.swift
@@ -671,15 +671,6 @@ extension DialogService {
         ]
     }
 
-    static func desktopActionTargetReceipt(
-        _ target: UIAutomationTarget.ExactWindow) -> DesktopActionTargetReceipt
-    {
-        DesktopActionTargetReceipt(
-            processIdentifier: target.identity.ownerProcessIdentifier,
-            processStartIdentity: target.identity.ownerProcessStartIdentity,
-            windowID: target.identity.windowID)
-    }
-
     func dialogElements(
         for dialog: Element,
         resolvedTarget: ResolvedDialogTargetEvidence? = nil) -> DialogElements

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/DockService.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/DockService.swift
@@ -149,7 +149,7 @@ public final class DockService: DockServiceProtocol, DockServiceActionResultProv
         } catch let failure as DesktopActionFailure {
             let combinedEvidence = (selectedLeafEvidence ?? []) + (failure.selectedLeafEvidence ?? [])
             throw failure
-                .attributed(to: processIdentity)
+                .attributed(to: processIdentity.actionTargetReceipt)
                 .selectingLeaves(combinedEvidence.isEmpty ? nil : combinedEvidence)
         }
     }

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/MenuService+Actions.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/MenuService+Actions.swift
@@ -174,7 +174,7 @@ extension MenuService {
         do {
             return try await operation()
         } catch let failure as DesktopActionFailure {
-            throw failure.attributed(to: processIdentity)
+            throw failure.attributed(to: processIdentity.actionTargetReceipt)
         }
     }
 

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/MenuService+Extras.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/MenuService+Extras.swift
@@ -192,7 +192,7 @@ extension MenuService {
                 press: { try refreshed.snapshot.element.performAction(.press) })
         } catch let failure as DesktopActionFailure {
             throw failure
-                .attributed(to: refreshed.snapshot.processIdentity)
+                .attributed(to: refreshed.snapshot.processIdentity.actionTargetReceipt)
                 .selectingLeaves([refreshed.evidence])
         }
         return refreshed
@@ -680,19 +680,19 @@ extension MenuService {
                 allowedWindowLayers: Self.menuBarRoutableWindowLayers)
         } catch let failure as DesktopActionFailure {
             throw failure
-                .attributed(to: route.identity)
+                .attributed(to: route.identity.actionTargetReceipt)
                 .selectingLeaves([resultEvidence])
         } catch let error as InputDeliveryIndeterminateError {
             throw error.desktopActionFailure(
                 delivery: .init(mechanism: .windowTargetedEvents, mode: .background))
-                .attributed(to: route.identity)
+                .attributed(to: route.identity.actionTargetReceipt)
                 .selectingLeaves([resultEvidence])
         } catch is CancellationError {
             throw DesktopActionFailure.preDispatchRefusal(
                 reason: .requestCancelled,
                 message: "Menu bar click was cancelled before routed event submission.",
                 hint: "Submit a new request only if the menu bar action is still wanted.")
-                .attributed(to: route.identity)
+                .attributed(to: route.identity.actionTargetReceipt)
                 .selectingLeaves([resultEvidence])
         } catch let error as PeekabooError {
             let reason: DesktopActionOutcome.RefusalReason = switch error {
@@ -705,7 +705,7 @@ extension MenuService {
                 message: "Menu bar background routing refused before dispatch.",
                 hint: "Refresh the target or grant Event Synthesizing permission; global fallback is disabled.",
                 causeDescription: error.localizedDescription)
-                .attributed(to: route.identity)
+                .attributed(to: route.identity.actionTargetReceipt)
                 .selectingLeaves([resultEvidence])
         }
 

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/WindowManagementService+Focus.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/WindowManagementService+Focus.swift
@@ -28,10 +28,7 @@ extension WindowManagementService {
         }
         let exactWindow = try UIAutomationTarget.ExactWindow(identity: expectedIdentity, bounds: bounds)
         let targetIdentity = DesktopTargetIdentity(exactWindow: exactWindow)
-        let targetReceipt = DesktopActionTargetReceipt(
-            processIdentifier: expectedIdentity.ownerProcessIdentifier,
-            processStartIdentity: expectedIdentity.ownerProcessStartIdentity,
-            windowID: expectedIdentity.windowID)
+        let targetReceipt = expectedIdentity.actionTargetReceipt
         var sequence = DesktopActionSequenceAccumulator()
 
         do {

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/WindowManagementService+ForegroundClose.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/WindowManagementService+ForegroundClose.swift
@@ -10,10 +10,7 @@ extension WindowManagementService {
         target: WindowTarget,
         expectedIdentity: WindowMutationIdentity) async throws -> DesktopActionResult<Void>
     {
-        let targetReceipt = DesktopActionTargetReceipt(
-            processIdentifier: expectedIdentity.ownerProcessIdentifier,
-            processStartIdentity: expectedIdentity.ownerProcessStartIdentity,
-            windowID: expectedIdentity.windowID)
+        let targetReceipt = expectedIdentity.actionTargetReceipt
         var sequence = DesktopActionSequenceAccumulator()
 
         do {

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Strategy/DesktopActionTargetReceipt+Identity.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Strategy/DesktopActionTargetReceipt+Identity.swift
@@ -1,0 +1,43 @@
+import PeekabooFoundation
+
+extension ApplicationProcessIdentity {
+    public var actionTargetReceipt: DesktopActionTargetReceipt {
+        DesktopActionTargetReceipt(
+            processIdentifier: self.processIdentifier,
+            processStartIdentity: self.processStartIdentity)
+    }
+}
+
+extension WindowMutationIdentity {
+    public var actionTargetReceipt: DesktopActionTargetReceipt {
+        DesktopActionTargetReceipt(
+            processIdentifier: self.ownerProcessIdentifier,
+            processStartIdentity: self.ownerProcessStartIdentity,
+            windowID: self.windowID)
+    }
+
+    /// A projection for optional or partially decoded evidence that must not synthesize an
+    /// actionable receipt from zero-valued identity fields.
+    public var validActionTargetReceipt: DesktopActionTargetReceipt? {
+        guard self.ownerProcessIdentifier > 0,
+              self.ownerProcessStartIdentity > 0,
+              self.windowID > 0,
+              self.windowID <= Int(UInt32.max)
+        else {
+            return nil
+        }
+        return self.actionTargetReceipt
+    }
+}
+
+extension UIAutomationTarget.ExactWindow {
+    public var actionTargetReceipt: DesktopActionTargetReceipt {
+        self.identity.actionTargetReceipt
+    }
+}
+
+extension DesktopTargetIdentity {
+    public var actionTargetReceipt: DesktopActionTargetReceipt {
+        self.exactWindow?.actionTargetReceipt ?? self.processIdentity.actionTargetReceipt
+    }
+}

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Strategy/UIAutomationActionResultSemantics.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Strategy/UIAutomationActionResultSemantics.swift
@@ -232,20 +232,6 @@ public enum UIAutomationActionResultSemantics {
     }
 }
 
-extension DesktopTargetIdentity {
-    public var actionTargetReceipt: DesktopActionTargetReceipt {
-        if let exactWindow = self.exactWindow {
-            return DesktopActionTargetReceipt(
-                processIdentifier: exactWindow.identity.ownerProcessIdentifier,
-                processStartIdentity: exactWindow.identity.ownerProcessStartIdentity,
-                windowID: exactWindow.identity.windowID)
-        }
-        return DesktopActionTargetReceipt(
-            processIdentifier: self.processIdentity.processIdentifier,
-            processStartIdentity: self.processIdentity.processStartIdentity)
-    }
-}
-
 extension UIAutomationActionResult {
     public var actionTargetReceipt: DesktopActionTargetReceipt? {
         self.targetIdentity?.actionTargetReceipt

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Utilities/FocusUtilities.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Utilities/FocusUtilities.swift
@@ -417,10 +417,7 @@ enum FocusDispatchAccounting {
         requiredDeliveryMode: DesktopActionOutcome.Delivery.Mode,
         operation: String) throws -> DesktopActionOutcome
     {
-        let targetReceipt = DesktopActionTargetReceipt(
-            processIdentifier: expectedIdentity.ownerProcessIdentifier,
-            processStartIdentity: expectedIdentity.ownerProcessStartIdentity,
-            windowID: expectedIdentity.windowID)
+        let targetReceipt = expectedIdentity.actionTargetReceipt
         let expectedWindow: UIAutomationTarget.ExactWindow
         do {
             guard let capturedBounds = expectedIdentity.capturedBounds else {

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Utilities/SpaceWindowMutationDispatcher.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Utilities/SpaceWindowMutationDispatcher.swift
@@ -272,10 +272,7 @@ enum SpaceWindowMutationDispatcher {
         window: UIAutomationTarget.ExactWindow,
         receipt: DesktopActionTargetReceipt)
     {
-        let receipt = DesktopActionTargetReceipt(
-            processIdentifier: expectedIdentity.ownerProcessIdentifier,
-            processStartIdentity: expectedIdentity.ownerProcessStartIdentity,
-            windowID: expectedIdentity.windowID)
+        let receipt = expectedIdentity.actionTargetReceipt
         guard expectedIdentity.windowID == Int(windowID),
               let capturedBounds = expectedIdentity.capturedBounds
         else {

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/DesktopActionTargetReceiptIdentityTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/DesktopActionTargetReceiptIdentityTests.swift
@@ -1,0 +1,143 @@
+import CoreGraphics
+import Foundation
+import PeekabooFoundation
+import Testing
+@testable import PeekabooAutomationKit
+
+struct DesktopActionTargetReceiptIdentityTests {
+    private static let bounds = CGRect(x: 10, y: 20, width: 300, height: 200)
+
+    @Test
+    func `identity projections preserve legacy receipt bytes`() throws {
+        let process = ApplicationProcessIdentity(
+            processIdentifier: 42,
+            processStartIdentity: 9_007_199_254_740_993)
+        let processReceipt = DesktopActionTargetReceipt(
+            processIdentifier: process.processIdentifier,
+            processStartIdentity: process.processStartIdentity)
+        try self.expectByteParity(process.actionTargetReceipt, processReceipt)
+
+        let windowIdentity = WindowMutationIdentity(
+            windowID: 71,
+            ownerProcessIdentifier: process.processIdentifier,
+            ownerProcessStartIdentity: process.processStartIdentity,
+            capturedBounds: Self.bounds,
+            isMinimized: true)
+        let windowReceipt = DesktopActionTargetReceipt(
+            processIdentifier: windowIdentity.ownerProcessIdentifier,
+            processStartIdentity: windowIdentity.ownerProcessStartIdentity,
+            windowID: windowIdentity.windowID)
+        try self.expectByteParity(windowIdentity.actionTargetReceipt, windowReceipt)
+        try self.expectByteParity(#require(windowIdentity.validActionTargetReceipt), windowReceipt)
+
+        let exactWindow = try UIAutomationTarget.ExactWindow(
+            identity: windowIdentity,
+            bounds: Self.bounds)
+        try self.expectByteParity(exactWindow.actionTargetReceipt, windowReceipt)
+
+        let processTarget = try DesktopTargetIdentity(processIdentity: process)
+        try self.expectByteParity(processTarget.actionTargetReceipt, processReceipt)
+
+        let windowTarget = DesktopTargetIdentity(exactWindow: exactWindow)
+        try self.expectByteParity(windowTarget.actionTargetReceipt, windowReceipt)
+    }
+
+    @Test
+    func `exact window receipt takes precedence over its process receipt`() throws {
+        let process = ApplicationProcessIdentity(processIdentifier: 42, processStartIdentity: 1001)
+        let processTarget = try DesktopTargetIdentity(processIdentity: process)
+        #expect(processTarget.actionTargetReceipt == DesktopActionTargetReceipt(
+            processIdentifier: 42,
+            processStartIdentity: 1001))
+
+        let windowIdentity = WindowMutationIdentity(
+            windowID: 71,
+            ownerProcessIdentifier: process.processIdentifier,
+            ownerProcessStartIdentity: process.processStartIdentity,
+            capturedBounds: Self.bounds)
+        let exactWindow = try UIAutomationTarget.ExactWindow(
+            identity: windowIdentity,
+            bounds: Self.bounds)
+        let windowTarget = DesktopTargetIdentity(exactWindow: exactWindow)
+
+        #expect(windowTarget.processIdentity == process)
+        #expect(windowTarget.actionTargetReceipt == DesktopActionTargetReceipt(
+            processIdentifier: 42,
+            processStartIdentity: 1001,
+            windowID: 71))
+    }
+
+    @Test
+    func `valid window receipt rejects invalid identity fields and window IDs`() throws {
+        let aboveWindowServerRange = try #require(Int(exactly: UInt64(UInt32.max) + 1))
+        let invalidIdentities = [
+            WindowMutationIdentity(
+                windowID: 71,
+                ownerProcessIdentifier: 0,
+                ownerProcessStartIdentity: 1001),
+            WindowMutationIdentity(
+                windowID: 71,
+                ownerProcessIdentifier: -1,
+                ownerProcessStartIdentity: 1001),
+            WindowMutationIdentity(
+                windowID: 71,
+                ownerProcessIdentifier: 42,
+                ownerProcessStartIdentity: 0),
+            WindowMutationIdentity(
+                windowID: 0,
+                ownerProcessIdentifier: 42,
+                ownerProcessStartIdentity: 1001),
+            WindowMutationIdentity(
+                windowID: -1,
+                ownerProcessIdentifier: 42,
+                ownerProcessStartIdentity: 1001),
+            WindowMutationIdentity(
+                windowID: aboveWindowServerRange,
+                ownerProcessIdentifier: 42,
+                ownerProcessStartIdentity: 1001),
+        ]
+
+        for identity in invalidIdentities {
+            #expect(identity.validActionTargetReceipt == nil)
+            let legacyReceipt = DesktopActionTargetReceipt(
+                processIdentifier: identity.ownerProcessIdentifier,
+                processStartIdentity: identity.ownerProcessStartIdentity,
+                windowID: identity.windowID)
+            try self.expectByteParity(identity.actionTargetReceipt, legacyReceipt)
+        }
+    }
+
+    @Test
+    func `valid receipt ignores mutable window metadata`() throws {
+        let identity = WindowMutationIdentity(
+            windowID: Int(UInt32.max),
+            ownerProcessIdentifier: Int32.max,
+            ownerProcessStartIdentity: UInt64.max,
+            capturedBounds: Self.bounds,
+            isMinimized: false)
+        let changedMetadata = WindowMutationIdentity(
+            windowID: identity.windowID,
+            ownerProcessIdentifier: identity.ownerProcessIdentifier,
+            ownerProcessStartIdentity: identity.ownerProcessStartIdentity,
+            capturedBounds: nil,
+            isMinimized: true)
+
+        let receipt = try #require(identity.validActionTargetReceipt)
+        #expect(changedMetadata.validActionTargetReceipt == receipt)
+        try self.expectByteParity(changedMetadata.actionTargetReceipt, receipt)
+    }
+
+    private func expectByteParity(
+        _ projected: DesktopActionTargetReceipt,
+        _ legacy: DesktopActionTargetReceipt) throws
+    {
+        #expect(projected == legacy)
+        #expect(try self.encoded(projected) == self.encoded(legacy))
+    }
+
+    private func encoded(_ value: some Encodable) throws -> Data {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        return try encoder.encode(value)
+    }
+}

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/DialogExactInputContractTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/DialogExactInputContractTests.swift
@@ -543,14 +543,14 @@ struct DialogExactInputContractTests {
             action: .enterText,
             details: ["window_id": "700"],
             outcome: .confirmedNoChange(),
-            targetReceipt: DialogService.desktopActionTargetReceipt(target),
+            targetReceipt: target.actionTargetReceipt,
             targetWindowIdentity: target.identity,
             targetWindowBounds: target.bounds,
             focusedElement: target.focusedElement)
         let roundTrip = try JSONDecoder().decode(
             DialogActionResult.self,
             from: JSONEncoder().encode(result))
-        #expect(roundTrip.targetReceipt == DialogService.desktopActionTargetReceipt(target))
+        #expect(roundTrip.targetReceipt == target.actionTargetReceipt)
         #expect(roundTrip.targetWindowIdentity == target.identity)
         #expect(roundTrip.targetWindowBounds == target.bounds)
         #expect(roundTrip.focusedElement == target.focusedElement)

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/Browser/BrowserMCPService.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/Browser/BrowserMCPService.swift
@@ -556,10 +556,7 @@ public final class BrowserMCPService: BrowserMCPClientProviding, BrowserMCPActio
 
         var sequence = DesktopActionSequenceAccumulator()
         sequence.record(.outcome(connection))
-        let isSuccessfulExecution = switch execution.state {
-        case .confirmedChange, .confirmedNoChange, .dispatchedUnverified: true
-        case .partial, .suspectedNoop, .refused, .indeterminate: false
-        }
+        let isSuccessfulExecution = execution.isAccepted(by: .confirmedOrDispatched)
         if !isSuccessfulExecution,
            let failure = DesktopActionFailure(
                outcome: execution,

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/AppTool+Lifecycle.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/AppTool+Lifecycle.swift
@@ -79,7 +79,7 @@ extension AppToolActions {
                 reason: .targetUnavailable,
                 message: "Background application readiness returned no process-generation identity.",
                 hint: "Refresh the application inventory before retrying.")
-                .attributed(to: Self.targetReceipt(authorizedIdentity))
+                .attributed(to: authorizedIdentity.actionTargetReceipt)
         }
         _ = try context.coalesceAuthorizedDesktopTarget(
             DesktopTargetIdentity(processIdentity: returnedIdentity),
@@ -90,7 +90,7 @@ extension AppToolActions {
                 evidence: .completionUnknown,
                 message: "Background application readiness returned without a canonical no-dispatch outcome.",
                 hint: "Inspect the selected application before retrying and update the runtime host.")
-                .attributed(to: Self.targetReceipt(authorizedIdentity))
+                .attributed(to: authorizedIdentity.actionTargetReceipt)
         }
         guard outcome.state == .confirmedNoChange,
               outcome.dispatchState == .none,
@@ -103,15 +103,9 @@ extension AppToolActions {
                 unitCount: outcome.dispatchState.unitCount,
                 message: "Background application readiness did not prove an exact read-only no-op.",
                 hint: "Inspect the selected application before retrying and update the runtime host.")
-                .attributed(to: Self.targetReceipt(authorizedIdentity))
+                .attributed(to: authorizedIdentity.actionTargetReceipt)
         }
         return outcome
-    }
-
-    private static func targetReceipt(_ identity: ApplicationProcessIdentity) -> DesktopActionTargetReceipt {
-        DesktopActionTargetReceipt(
-            processIdentifier: identity.processIdentifier,
-            processStartIdentity: identity.processStartIdentity)
     }
 
     func handleOpen(request: AppToolRequest) async throws -> ToolResponse {

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/BrowserTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/BrowserTool.swift
@@ -359,27 +359,19 @@ public struct BrowserTool: MCPTool {
                 message: "Browser connect returned without a canonical action outcome.",
                 hint: "Check browser status before deciding whether to reconnect.")
         }
-        switch outcome.state {
-        case .confirmedNoChange:
-            guard outcome.delivery == nil,
-                  outcome.dispatchState == .none
-            else { break }
-            return outcome
-        case .dispatchedUnverified:
-            guard outcome.delivery == .init(mechanism: .browserProtocol, mode: .foreground),
-                  outcome.dispatchState.unitCount == .one
-            else { break }
-            return outcome
-        case .confirmedChange, .partial, .suspectedNoop, .refused, .indeterminate:
-            break
+        let policy = DesktopActionOutcome.SuccessPolicy.confirmedNoChangeOrDispatched(
+            requiring: .init(mechanism: .browserProtocol, mode: .foreground),
+            unitCount: .exact(.one))
+        guard outcome.isAccepted(by: policy) else {
+            throw DesktopActionFailure.indeterminate(
+                route: outcome.route,
+                delivery: outcome.delivery,
+                evidence: .completionUnknown,
+                unitCount: outcome.dispatchState.unitCount,
+                message: "Browser connect returned contradictory canonical action semantics.",
+                hint: "Check browser status before deciding whether to reconnect and update the runtime host.")
         }
-        throw DesktopActionFailure.indeterminate(
-            route: outcome.route,
-            delivery: outcome.delivery,
-            evidence: .completionUnknown,
-            unitCount: outcome.dispatchState.unitCount,
-            message: "Browser connect returned contradictory canonical action semantics.",
-            hint: "Check browser status before deciding whether to reconnect and update the runtime host.")
+        return outcome
     }
 
     private func formatStatus(

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/CaptureTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/CaptureTool.swift
@@ -235,10 +235,7 @@ public struct CaptureTool: MCPTool {
                 expectedIdentity: identity,
                 operation: "Live capture focus")
         } catch let failure as DesktopActionFailure {
-            throw failure.attributed(to: DesktopActionTargetReceipt(
-                processIdentifier: identity.ownerProcessIdentifier,
-                processStartIdentity: identity.ownerProcessStartIdentity,
-                windowID: identity.windowID))
+            throw failure.attributed(to: identity.actionTargetReceipt)
         }
         try await Task.sleep(nanoseconds: 50_000_000)
     }

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/ImageTool+Capture.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/ImageTool+Capture.swift
@@ -194,9 +194,7 @@ extension ImageTool {
             throw PeekabooError.serviceUnavailable(
                 "Image target activation did not retain its process-generation identity")
         }
-        let receipt = DesktopActionTargetReceipt(
-            processIdentifier: expectedIdentity.processIdentifier,
-            processStartIdentity: expectedIdentity.processStartIdentity)
+        let receipt = expectedIdentity.actionTargetReceipt
         let result: UIAutomationActionResult<Void>
         do {
             result = try await self.context.applications.activateApplicationTargetedResult(
@@ -451,9 +449,7 @@ extension ImageTool {
                 outcome,
                 expectedDelivery: expectedDelivery,
                 message: "Image target activation returned incomplete or contradictory action semantics.")
-                .attributed(to: DesktopActionTargetReceipt(
-                    processIdentifier: target.processIdentifier,
-                    processStartIdentity: target.processStartIdentity))
+                .attributed(to: target.actionTargetReceipt)
         }
         return outcome
     }

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/MenuTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/MenuTool.swift
@@ -327,10 +327,7 @@ public struct MenuTool: MCPTool {
                 message: "Foreground menu focus may have changed desktop state before failing.",
                 hint: "Observe the exact window before retrying foreground menu access.",
                 causeDescription: error.localizedDescription)
-                .attributed(to: DesktopActionTargetReceipt(
-                    processIdentifier: window.identity.ownerProcessIdentifier,
-                    processStartIdentity: window.identity.ownerProcessStartIdentity,
-                    windowID: window.identity.windowID))
+                .attributed(to: window.identity.actionTargetReceipt)
         }
     }
 

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/SpaceTool+Handlers.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/SpaceTool+Handlers.swift
@@ -294,7 +294,7 @@ extension SpaceTool {
                     message: "The window moved, but following it to the target Space failed.",
                     hint: "Observe both the exact window and active Space before retrying.",
                     causeDescription: switchFailure.causeDescription ?? error.localizedDescription)
-                throw combinedFailure.attributed(to: Self.targetReceipt(expectedIdentity))
+                throw combinedFailure.attributed(to: expectedIdentity.actionTargetReceipt)
             }
             let resolution = sequence.successResolution()
             guard let outcome = resolution.outcome else {
@@ -304,7 +304,7 @@ extension SpaceTool {
                     unitCount: resolution.mutationDisposition.unitCount,
                     message: "Space move-window follow returned incompatible canonical outcomes.",
                     hint: "Observe both the exact window and active Space before retrying.")
-                    .attributed(to: Self.targetReceipt(expectedIdentity))
+                    .attributed(to: expectedIdentity.actionTargetReceipt)
             }
             actionResult = UIAutomationActionResult(
                 payload: (),
@@ -429,7 +429,7 @@ extension SpaceTool {
     private static func expectedTargetIdentity(
         _ identity: WindowMutationIdentity) throws -> DesktopTargetIdentity
     {
-        let receipt = self.targetReceipt(identity)
+        let receipt = identity.actionTargetReceipt
         guard let bounds = identity.capturedBounds else {
             throw DesktopActionFailure.preDispatchRefusal(
                 reason: .targetUnavailable,
@@ -449,15 +449,6 @@ extension SpaceTool {
                 causeDescription: error.localizedDescription)
                 .attributed(to: receipt)
         }
-    }
-
-    private static func targetReceipt(
-        _ identity: WindowMutationIdentity) -> DesktopActionTargetReceipt
-    {
-        DesktopActionTargetReceipt(
-            processIdentifier: identity.ownerProcessIdentifier,
-            processStartIdentity: identity.ownerProcessStartIdentity,
-            windowID: identity.windowID)
     }
 
     private func createWindowTarget(

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/WindowTool+Handlers.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/WindowTool+Handlers.swift
@@ -485,12 +485,7 @@ extension WindowTool {
                 message: "\(action) was dispatched, but the exact window could not be read back.",
                 hint: "Observe the exact window before deciding whether to retry.",
                 causeDescription: error.localizedDescription)
-            let receipt = actionResult.targetIdentity?.exactWindow.map {
-                DesktopActionTargetReceipt(
-                    processIdentifier: $0.identity.ownerProcessIdentifier,
-                    processStartIdentity: $0.identity.ownerProcessStartIdentity,
-                    windowID: $0.identity.windowID)
-            }
+            let receipt = actionResult.targetIdentity?.exactWindow?.actionTargetReceipt
             throw failure.attributed(to: receipt)
         }
     }

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeClient+Transport.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeClient+Transport.swift
@@ -113,7 +113,7 @@ extension PeekabooBridgeClient {
                    throwsActionFailures
                 {
                     if let failure = envelope.desktopActionFailure {
-                        throw failure.attributed(to: Self.actionTargetReceipt(verifiedTargetIdentity))
+                        throw failure.attributed(to: verifiedTargetIdentity?.actionTargetReceipt)
                     }
                     if envelope.operationMayHaveCompleted {
                         throw Self.legacyCompletionUnknownFailure(envelope: envelope)
@@ -157,12 +157,6 @@ extension PeekabooBridgeClient {
                     mutating: mayMutateDesktop)
             }
         }
-    }
-
-    private nonisolated static func actionTargetReceipt(
-        _ targetIdentity: DesktopTargetIdentity?) -> DesktopActionTargetReceipt?
-    {
-        targetIdentity?.actionTargetReceipt
     }
 
     private func prepareWireRequestForSend(

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeOperationResultSemantics.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeOperationResultSemantics.swift
@@ -1810,10 +1810,7 @@ extension PeekabooBridgeOperationResultSemantics {
                 failureResult = normalized.finalizingMutation(
                     outcome: outcome,
                     target: .handlerResolved(target))
-                attributedFailure = failure.attributed(to: DesktopActionTargetReceipt(
-                    processIdentifier: target.processIdentity.processIdentifier,
-                    processStartIdentity: target.processIdentity.processStartIdentity,
-                    windowID: target.exactWindow?.identity.windowID))
+                attributedFailure = failure.attributed(to: target.actionTargetReceipt)
             } else {
                 failureResult = normalized
                 attributedFailure = failure
@@ -1901,23 +1898,7 @@ extension PeekabooBridgeOperationResultSemantics {
               let delivery = outcome.delivery,
               let unitCount = plan.defaultSuccessfulDispatchUnitCount(for: delivery)
         else { return outcome }
-        switch outcome.state {
-        case .confirmedChange:
-            return .confirmedChange(route: outcome.route, delivery: delivery, unitCount: unitCount)
-        case .dispatchedUnverified:
-            guard let evidence = DesktopActionOutcome.DispatchedUnverifiedEvidence(
-                rawValue: outcome.evidence.rawValue)
-            else { return outcome }
-            return .dispatchedUnverified(
-                route: outcome.route,
-                delivery: delivery,
-                evidence: evidence,
-                unitCount: unitCount)
-        case .suspectedNoop:
-            return .suspectedNoop(route: outcome.route, delivery: delivery, unitCount: unitCount)
-        case .confirmedNoChange, .partial, .indeterminate, .refused:
-            return outcome
-        }
+        return outcome.fillingSuccessfulDispatchUnitCount(unitCount)
     }
 
     static func canonicalFailure(

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer+BrowserConnect.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer+BrowserConnect.swift
@@ -27,18 +27,10 @@ extension PeekabooBridgeServer {
                 message: "Browser connect returned a connection receipt for a different endpoint or channel.",
                 hint: "Check browser status before deciding whether to reconnect and update the runtime host.")
         }
-        switch outcome.state {
-        case .confirmedNoChange:
-            guard outcome.delivery == nil, outcome.dispatchState == .none else {
-                throw Self.invalidBrowserConnectOutcome(outcome)
-            }
-        case .dispatchedUnverified:
-            guard outcome.delivery == .init(mechanism: .browserProtocol, mode: .foreground),
-                  outcome.dispatchState.unitCount == .one
-            else {
-                throw Self.invalidBrowserConnectOutcome(outcome)
-            }
-        case .confirmedChange, .partial, .suspectedNoop, .refused, .indeterminate:
+        let policy = DesktopActionOutcome.SuccessPolicy.confirmedNoChangeOrDispatched(
+            requiring: .init(mechanism: .browserProtocol, mode: .foreground),
+            unitCount: .exact(.one))
+        guard outcome.isAccepted(by: policy) else {
             throw Self.invalidBrowserConnectOutcome(outcome)
         }
         return try .init(

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer+Handlers.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer+Handlers.swift
@@ -538,7 +538,7 @@ extension PeekabooBridgeServer {
         _ result: UIAutomationActionResult<DesktopObservationResult>) -> DesktopActionFailure?
     {
         guard let outcome = result.outcome else { return nil }
-        let targetReceipt = self.observationTargetReceipt(result.targetIdentity)
+        let targetReceipt = result.targetIdentity?.actionTargetReceipt
         if outcome.state == .confirmedNoChange,
            outcome.delivery == nil,
            outcome.dispatchState == .none

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer+HeldPointer.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer+HeldPointer.swift
@@ -78,7 +78,7 @@ extension PeekabooBridgeServer {
                     unitCount: result.outcome?.dispatchState.unitCount,
                     message: "Held pointer owner disconnected before its begin receipt could be delivered.",
                     hint: "Treat the hold as terminal and observe the target before retrying.")
-                    .attributed(to: Self.actionTargetReceipt(result.payload))
+                    .attributed(to: result.payload.windowIdentity.actionTargetReceipt)
             }
             binding.pendingBeginTarget = nil
             binding.activeReceipt = result.payload
@@ -125,7 +125,7 @@ extension PeekabooBridgeServer {
                 self.markHeldPointerOwnerClosed(payload.owner)
                 guard let operationTarget else { throw failure }
                 let routed = failure
-                    .attributed(to: Self.actionTargetReceipt(operationTarget))
+                    .attributed(to: operationTarget.actionTargetReceipt)
                     .routed(to: .bridge)
                 return PeekabooBridgeHandledResponse(
                     response: .error(.init(
@@ -279,24 +279,6 @@ extension PeekabooBridgeServer {
         for (owner, _) in closedOwners.dropLast(Self.heldPointerClosedOwnerCapacity) {
             self.heldPointerBridgeOwners.removeValue(forKey: owner)
         }
-    }
-
-    private static func actionTargetReceipt(
-        _ receipt: ExactWindowHeldPointerReceipt) -> DesktopActionTargetReceipt
-    {
-        DesktopActionTargetReceipt(
-            processIdentifier: receipt.windowIdentity.ownerProcessIdentifier,
-            processStartIdentity: receipt.windowIdentity.ownerProcessStartIdentity,
-            windowID: receipt.windowIdentity.windowID)
-    }
-
-    private static func actionTargetReceipt(
-        _ target: DesktopTargetIdentity) -> DesktopActionTargetReceipt
-    {
-        DesktopActionTargetReceipt(
-            processIdentifier: target.processIdentity.processIdentifier,
-            processStartIdentity: target.processIdentity.processStartIdentity,
-            windowID: target.exactWindow?.identity.windowID)
     }
 
     #if DEBUG

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer+MutationProof.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer+MutationProof.swift
@@ -25,7 +25,7 @@ extension PeekabooBridgeServer {
             outcome: outcome,
             message: "The desktop observation provider reported a non-success action outcome.",
             hint: "Follow the canonical outcome before retrying.",
-            targetReceipt: self.observationTargetReceipt(result.targetIdentity))
+            targetReceipt: result.targetIdentity?.actionTargetReceipt)
     }
 
     static func observationFallbackTarget(
@@ -39,12 +39,6 @@ extension PeekabooBridgeServer {
         case .menubarPopover:
             .responseResolved
         }
-    }
-
-    static func observationTargetReceipt(
-        _ target: DesktopTargetIdentity?) -> DesktopActionTargetReceipt?
-    {
-        target?.actionTargetReceipt
     }
 
     static func validateAttestedWebFocusTarget(

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer+ServiceHandlers.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer+ServiceHandlers.swift
@@ -42,7 +42,7 @@ extension PeekabooBridgeServer {
                 resultAware: resultAware,
                 mode: .foreground,
                 operation: "Launch application",
-                targetReceipt: Self.applicationTargetReceipt(result.payload.processIdentity))
+                targetReceipt: result.payload.processIdentity?.actionTargetReceipt)
             return .init(
                 response: .application(result.payload),
                 mutation: .init(
@@ -67,7 +67,7 @@ extension PeekabooBridgeServer {
                 resultAware: self.services.applications is any ApplicationServiceActionResultProviding,
                 mode: payload.launchRequest.activates ? .foreground : .background,
                 operation: "Relaunch application",
-                targetReceipt: Self.applicationTargetReceipt(result.payload.processIdentity))
+                targetReceipt: result.payload.processIdentity?.actionTargetReceipt)
             try Self.validateRelaunchResponse(
                 result.payload,
                 differsFrom: expectedTargetIdentity,
@@ -102,7 +102,7 @@ extension PeekabooBridgeServer {
                     self.services.applications is any ApplicationServiceTargetedActionResultProviding,
                 mode: .foreground,
                 operation: "Activate application",
-                targetReceipt: Self.applicationTargetReceipt(result.targetIdentity?.processIdentity))
+                targetReceipt: result.targetIdentity?.processIdentity.actionTargetReceipt)
             let target = try Self.requireActionTarget(
                 result.targetIdentity,
                 outcome: outcome,
@@ -137,7 +137,7 @@ extension PeekabooBridgeServer {
                     resultAware: self.services.applications is any ApplicationServiceActionResultProviding,
                     mode: .background,
                     operation: "Quit application",
-                    targetReceipt: Self.applicationTargetReceipt(expectedIdentity))
+                    targetReceipt: expectedIdentity.actionTargetReceipt)
                 return .init(
                     response: .bool(result.payload),
                     mutation: .init(
@@ -222,7 +222,7 @@ extension PeekabooBridgeServer {
             resultAware: self.services.applications is any ApplicationServiceTargetedActionResultProviding,
             mode: .background,
             operation: "Hide application",
-            targetReceipt: Self.applicationTargetReceipt(result.targetIdentity?.processIdentity))
+            targetReceipt: result.targetIdentity?.processIdentity.actionTargetReceipt)
         let target = try Self.requireActionTarget(
             result.targetIdentity,
             outcome: outcome,
@@ -259,7 +259,7 @@ extension PeekabooBridgeServer {
             try Self.requireAttestedSafeBackgroundLaunchOutcome(
                 result.outcome,
                 resultAware: resultAware,
-                targetReceipt: Self.applicationTargetReceipt(result.payload.processIdentity))
+                targetReceipt: result.payload.processIdentity?.actionTargetReceipt)
             return .init(response: .application(result.payload))
         }
         let outcome = try Self.applicationMutationOutcome(
@@ -267,7 +267,7 @@ extension PeekabooBridgeServer {
             resultAware: resultAware,
             mode: request.activates ? .foreground : .background,
             operation: "Launch application",
-            targetReceipt: Self.applicationTargetReceipt(result.payload.processIdentity))
+            targetReceipt: result.payload.processIdentity?.actionTargetReceipt)
         return .init(
             response: .application(result.payload),
             mutation: .init(
@@ -365,15 +365,6 @@ extension PeekabooBridgeServer {
             message: "\(operation) result provider returned without a canonical outcome.",
             hint: "Observe the application before retrying and update the runtime host.")
             .attributed(to: targetReceipt)
-    }
-
-    private static func applicationTargetReceipt(
-        _ identity: ApplicationProcessIdentity?) -> DesktopActionTargetReceipt?
-    {
-        guard let identity else { return nil }
-        return DesktopActionTargetReceipt(
-            processIdentifier: identity.processIdentifier,
-            processStartIdentity: identity.processStartIdentity)
     }
 
     private static func requireRelaunchTargetIdentity(
@@ -986,15 +977,9 @@ extension PeekabooBridgeServer {
     }
 
     private static func isCanonicalBackgroundExactDialogInputOutcome(_ outcome: DesktopActionOutcome) -> Bool {
-        switch outcome.state {
-        case .confirmedNoChange:
-            outcome.delivery == nil && outcome.dispatchState == .none
-        case .dispatchedUnverified:
-            outcome.delivery == .init(mechanism: .accessibilityValue, mode: .background) &&
-                outcome.dispatchState.unitCount != nil
-        case .confirmedChange, .partial, .suspectedNoop, .refused, .indeterminate:
-            false
-        }
+        outcome.isAccepted(by: .confirmedNoChangeOrDispatched(
+            requiring: .init(mechanism: .accessibilityValue, mode: .background),
+            unitCount: .required))
     }
 
     private static func throwExactDialogRefusalIfReported(

--- a/Core/PeekabooCore/Tests/PeekabooTests/ExactDialogInputBridgeIntegrationTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/ExactDialogInputBridgeIntegrationTests.swift
@@ -9,6 +9,52 @@ import Testing
 struct ExactDialogInputBridgeIntegrationTests {
     @Test
     @MainActor
+    func `current exact dialog input accepts canonical no change`() async throws {
+        let bounds = CGRect(x: 10, y: 20, width: 480, height: 320)
+        let identity = WindowMutationIdentity(
+            windowID: 700,
+            ownerProcessIdentifier: 4242,
+            ownerProcessStartIdentity: 99,
+            capturedBounds: bounds)
+        let receipt = identity.actionTargetReceipt
+        let dialogs = ExactDialogInputBridgeStub(
+            receipt: receipt,
+            windowIdentity: identity,
+            windowBounds: bounds,
+            exactInputOutcome: .confirmedNoChange())
+        let server = PeekabooBridgeServer(
+            services: ExactDialogInputBridgeServices(dialogs: dialogs),
+            hostKind: .gui,
+            allowlistedTeams: [],
+            allowlistedBundles: [],
+            allowedOperations: [.exactDialogEnterText])
+        let request = try DialogInputExecutionRequest(
+            target: DialogTargetSelector(processIdentifier: 4242, windowID: 700),
+            text: "",
+            fieldIdentifier: "Name",
+            clearExisting: false,
+            focus: DialogForegroundFocusPolicy(autoFocus: false))
+
+        let handled = try await PeekabooBridgeRequestContext.$negotiatedSessionCapabilities.withValue(.current) {
+            try await PeekabooBridgeRequestContext.$usesAttestedOperationResultSemantics.withValue(true) {
+                try await server.handleAuthorized(
+                    .exactDialogEnterText(request),
+                    peer: nil,
+                    permissions: .init(screenRecording: false, accessibility: true, postEvent: true))
+            }
+        }
+
+        #expect(handled.outcome?.state == .confirmedNoChange)
+        #expect(handled.outcome?.delivery == nil)
+        #expect(handled.outcome?.dispatchState == DesktopActionOutcome.DispatchState.none)
+        guard case .responseResolved? = handled.mutation?.target else {
+            Issue.record("Expected the no-change dialog result to retain its resolved exact target")
+            return
+        }
+    }
+
+    @Test
+    @MainActor
     func `legacy exact dialog input refuses missing PostEvent before dispatch`() throws {
         let receipt = DesktopActionTargetReceipt(
             processIdentifier: 4242,
@@ -825,6 +871,7 @@ private final class ExactDialogInputBridgeStub: DialogServiceProtocol {
     private let windowIdentity: WindowMutationIdentity?
     private let windowBounds: CGRect?
     private let resolvedTarget: ResolvedDialogTargetEvidence?
+    private let exactInputOutcome: DesktopActionOutcome
     private let foregroundCompatibleInputOutcome: DesktopActionOutcome
     private(set) var legacyTexts: [String] = []
     private(set) var lastExactRequest: DialogInputExecutionRequest?
@@ -840,6 +887,10 @@ private final class ExactDialogInputBridgeStub: DialogServiceProtocol {
         windowIdentity: WindowMutationIdentity? = nil,
         windowBounds: CGRect? = nil,
         resolvedTarget: ResolvedDialogTargetEvidence? = nil,
+        exactInputOutcome: DesktopActionOutcome = .dispatchedUnverified(
+            delivery: .init(mechanism: .accessibilityValue, mode: .background),
+            evidence: .deliveryAccepted,
+            unitCount: .one),
         foregroundCompatibleInputOutcome: DesktopActionOutcome = .dispatchedUnverified(
             delivery: .init(mechanism: .globalEvents, mode: .foreground),
             evidence: .deliveryAccepted,
@@ -850,6 +901,7 @@ private final class ExactDialogInputBridgeStub: DialogServiceProtocol {
         self.windowIdentity = windowIdentity
         self.windowBounds = windowBounds
         self.resolvedTarget = resolvedTarget
+        self.exactInputOutcome = exactInputOutcome
         self.foregroundCompatibleInputOutcome = foregroundCompatibleInputOutcome
         self.supportsBackgroundExactDialogInput = supportsBackgroundExactDialogInput
     }
@@ -895,10 +947,7 @@ private final class ExactDialogInputBridgeStub: DialogServiceProtocol {
                 "process_start_identity_decimal": "99",
                 "window_id": "700",
             ],
-            outcome: .dispatchedUnverified(
-                delivery: .init(mechanism: .accessibilityValue, mode: .background),
-                evidence: .deliveryAccepted,
-                unitCount: .one),
+            outcome: self.exactInputOutcome,
             targetReceipt: self.receipt,
             targetWindowIdentity: self.windowIdentity,
             targetWindowBounds: self.windowBounds,

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeBrowserClientTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeBrowserClientTests.swift
@@ -833,9 +833,6 @@ extension StubServices: PeekabooBridgeBrowserConnectionResultProviding {
         }
         return try await DesktopActionResult(
             payload: self.browserConnect(channel: channel, browserURL: browserURL),
-            outcome: .dispatchedUnverified(
-                delivery: .init(mechanism: .browserProtocol, mode: .foreground),
-                evidence: .deliveryAccepted,
-                unitCount: .one))
+            outcome: self.browserConnectOutcome)
     }
 }

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeClientTransportOutcomeTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeClientTransportOutcomeTests.swift
@@ -628,7 +628,7 @@ struct PeekabooBridgeClientTransportOutcomeTests {
         profile: .linear))
 
     private static let browserConnectionReceipt = PeekabooBridgeBrowserConnectionReceipt(
-        channel: "chrome",
+        channel: "stable",
         processIdentifier: 42,
         processStartIdentity: 9001,
         bundleIdentifier: "com.google.Chrome")

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeClientTransportSafetyTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeClientTransportSafetyTests.swift
@@ -299,7 +299,7 @@ struct PeekabooBridgeClientTransportSafetyTests {
         profile: .linear))
 
     private static let browserConnectionReceipt = PeekabooBridgeBrowserConnectionReceipt(
-        channel: "chrome",
+        channel: "stable",
         processIdentifier: 42,
         processStartIdentity: 9001,
         bundleIdentifier: "com.google.Chrome")

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeHandlerMutationSemanticsTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeHandlerMutationSemanticsTests.swift
@@ -63,6 +63,25 @@ struct PeekabooBridgeHandlerMutationSemanticsTests {
 
     @Test
     @MainActor
+    func `browser connect accepts canonical existing connection no change`() async throws {
+        let services = StubServices()
+        services.browserConnectOutcome = .confirmedNoChange()
+        let handled = try await Self.handleCurrent(
+            .browserConnect(.init(channel: "stable")),
+            with: Self.server(services: services))
+
+        #expect(handled.outcome?.state == .confirmedNoChange)
+        #expect(handled.outcome?.delivery == nil)
+        #expect(handled.outcome?.dispatchState == DesktopActionOutcome.DispatchState.none)
+        guard case let .handlerResolved(target)? = handled.mutation?.target else {
+            Issue.record("Expected the existing browser connection to retain its exact process target")
+            return
+        }
+        #expect(target.processIdentity == .init(processIdentifier: 42, processStartIdentity: 10042))
+    }
+
+    @Test
+    @MainActor
     func `browser execution binds every accepted call and response to one exact browser receipt`() async throws {
         let services = StubServices()
         let server = Self.server(services: services)

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeOperationResultSemanticsTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeOperationResultSemanticsTests.swift
@@ -278,6 +278,8 @@ struct PeekabooBridgeOperationResultSemanticsTests {
             .typeActions,
             .targetedTypeActions,
             .exactWindowTargetedTypeActions,
+            .exactWindowPixelFocusType,
+            .foregroundModifierClick,
             .setValue,
             .performAction,
             .scroll,
@@ -333,10 +335,23 @@ struct PeekabooBridgeOperationResultSemanticsTests {
         let classified = Set(PeekabooBridgeOperation.allCases.filter(\.mutatesDesktop))
         #expect(classified == expected)
 
+        let exactContracts: [
+            PeekabooBridgeOperation: PeekabooBridgeOperationResultSemantics.Contract
+        ] = [
+            .exactWindowPixelFocusType: .init(
+                completion: .dispatchedUnverified(.init(mechanism: .composite, mode: .background)),
+                targetPolicy: .requestPinned),
+            .foregroundModifierClick: .init(
+                completion: .dispatchedUnverified(.init(mechanism: .composite, mode: .foreground)),
+                targetPolicy: .requestPinned),
+        ]
         for operation in expected {
             let contract = PeekabooBridgeOperationResultSemantics.contract(for: operation)
             #expect(contract.completion != .readOnly, "Missing completion contract for \(operation)")
             #expect(contract.targetPolicy != .notApplicable, "Missing target contract for \(operation)")
+            if let exactContract = exactContracts[operation] {
+                #expect(contract == exactContract, "Incorrect explicit result contract for \(operation)")
+            }
         }
     }
 

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeTests.swift
@@ -1990,6 +1990,10 @@ final class StubServices: PeekabooBridgeServiceProviding {
     var browserStatusError: (any Error)?
     var browserConnectFailure: DesktopActionFailure?
     var browserConnectError: (any Error)?
+    var browserConnectOutcome = DesktopActionOutcome.dispatchedUnverified(
+        delivery: .init(mechanism: .browserProtocol, mode: .foreground),
+        evidence: .deliveryAccepted,
+        unitCount: .one)
     var browserExecutionError: (any Error)?
     var browserExecutionErrorAfterDispatch: (any Error)?
     var browserExecutionReceiptOverride: PeekabooBridgeBrowserConnectionReceipt?

--- a/Core/PeekabooFoundation/Sources/PeekabooFoundation/DesktopActionOutcome+Transforms.swift
+++ b/Core/PeekabooFoundation/Sources/PeekabooFoundation/DesktopActionOutcome+Transforms.swift
@@ -1,0 +1,91 @@
+import Foundation
+
+extension DesktopActionOutcome {
+    /// Promotes an accepted but unverified dispatch after a caller completes an exact readback.
+    /// All other states and an unavailable readback remain byte-for-byte unchanged.
+    public func confirmingDispatchedOutcome(observedChange: Bool?) -> Self {
+        guard self.state == .dispatchedUnverified,
+              let observedChange,
+              let delivery = self.delivery
+        else {
+            return self
+        }
+        if observedChange {
+            return .confirmedChange(
+                route: self.route,
+                delivery: delivery,
+                unitCount: self.dispatchState.unitCount)
+        }
+        return .confirmedNoChange(route: self.route)
+    }
+
+    /// Reprojects one validated outcome through a different concrete delivery route without
+    /// changing its state, route, dispatch count, or evidence meaning.
+    public func reprojectingDelivery(_ delivery: Delivery) -> Self {
+        switch self.state {
+        case .confirmedChange:
+            return .confirmedChange(
+                route: self.route,
+                delivery: delivery,
+                unitCount: self.dispatchState.unitCount)
+        case .confirmedNoChange, .refused:
+            return self
+        case .partial:
+            return .partial(
+                route: self.route,
+                delivery: delivery,
+                unitCount: self.dispatchState.unitCount)
+        case .dispatchedUnverified:
+            guard let evidence = DispatchedUnverifiedEvidence(rawValue: self.evidence.rawValue) else {
+                return self
+            }
+            return .dispatchedUnverified(
+                route: self.route,
+                delivery: delivery,
+                evidence: evidence,
+                unitCount: self.dispatchState.unitCount)
+        case .suspectedNoop:
+            return .suspectedNoop(
+                route: self.route,
+                delivery: delivery,
+                unitCount: self.dispatchState.unitCount)
+        case .indeterminate:
+            guard self.delivery != nil else { return self }
+            guard let evidence = IndeterminateEvidence(rawValue: self.evidence.rawValue) else {
+                return self
+            }
+            return .indeterminate(
+                route: self.route,
+                delivery: delivery,
+                evidence: evidence,
+                unitCount: self.dispatchState.unitCount)
+        }
+    }
+
+    /// Fills a missing unit count only for states that can represent a successful accepted
+    /// dispatch at compatibility boundaries. Existing counts and every other state are unchanged.
+    public func fillingSuccessfulDispatchUnitCount(_ unitCount: DispatchUnitCount) -> Self {
+        guard self.dispatchState.unitCount == nil,
+              let delivery = self.delivery
+        else {
+            return self
+        }
+        switch self.state {
+        case .confirmedChange:
+            return .confirmedChange(route: self.route, delivery: delivery, unitCount: unitCount)
+        case .dispatchedUnverified:
+            guard let evidence = DispatchedUnverifiedEvidence(rawValue: self.evidence.rawValue) else {
+                return self
+            }
+            return .dispatchedUnverified(
+                route: self.route,
+                delivery: delivery,
+                evidence: evidence,
+                unitCount: unitCount)
+        case .suspectedNoop:
+            return .suspectedNoop(route: self.route, delivery: delivery, unitCount: unitCount)
+        case .confirmedNoChange, .partial, .refused, .indeterminate:
+            return self
+        }
+    }
+}

--- a/Core/PeekabooFoundation/Sources/PeekabooFoundation/DesktopActionOutcome.swift
+++ b/Core/PeekabooFoundation/Sources/PeekabooFoundation/DesktopActionOutcome.swift
@@ -217,9 +217,27 @@ public struct DesktopActionOutcome: Codable, Equatable, Sendable {
     /// dispatch. A delivery-mode requirement applies only to states that dispatched work;
     /// `confirmedNoChange` remains valid because it proves that no dispatch was necessary.
     public struct SuccessPolicy: Equatable, Sendable {
+        public enum DispatchedUnitCountRequirement: Equatable, Sendable {
+            case required
+            case exact(DispatchUnitCount)
+
+            fileprivate func accepts(_ unitCount: DispatchUnitCount?) -> Bool {
+                switch self {
+                case .required:
+                    unitCount != nil
+                case let .exact(expected):
+                    unitCount == expected
+                }
+            }
+        }
+
         public let acceptsDispatchedUnverified: Bool
         public let acceptsSuspectedNoop: Bool
         public let requiredDeliveryMode: Delivery.Mode?
+        private let acceptsConfirmedChange: Bool
+        private let acceptsConfirmedNoChange: Bool
+        private let requiredDelivery: Delivery?
+        private let dispatchedUnitCountRequirement: DispatchedUnitCountRequirement?
 
         public init(
             acceptsDispatchedUnverified: Bool,
@@ -229,6 +247,28 @@ public struct DesktopActionOutcome: Codable, Equatable, Sendable {
             self.acceptsDispatchedUnverified = acceptsDispatchedUnverified
             self.acceptsSuspectedNoop = acceptsSuspectedNoop
             self.requiredDeliveryMode = requiredDeliveryMode
+            self.acceptsConfirmedChange = true
+            self.acceptsConfirmedNoChange = true
+            self.requiredDelivery = nil
+            self.dispatchedUnitCountRequirement = nil
+        }
+
+        private init(
+            acceptsConfirmedChange: Bool,
+            acceptsConfirmedNoChange: Bool,
+            acceptsDispatchedUnverified: Bool,
+            acceptsSuspectedNoop: Bool,
+            requiredDeliveryMode: Delivery.Mode?,
+            requiredDelivery: Delivery?,
+            dispatchedUnitCountRequirement: DispatchedUnitCountRequirement?)
+        {
+            self.acceptsConfirmedChange = acceptsConfirmedChange
+            self.acceptsConfirmedNoChange = acceptsConfirmedNoChange
+            self.acceptsDispatchedUnverified = acceptsDispatchedUnverified
+            self.acceptsSuspectedNoop = acceptsSuspectedNoop
+            self.requiredDeliveryMode = requiredDeliveryMode
+            self.requiredDelivery = requiredDelivery
+            self.dispatchedUnitCountRequirement = dispatchedUnitCountRequirement
         }
 
         public static let confirmed = Self(acceptsDispatchedUnverified: false)
@@ -262,10 +302,31 @@ public struct DesktopActionOutcome: Codable, Equatable, Sendable {
                 requiredDeliveryMode: deliveryMode)
         }
 
+        /// Accepts an idempotent no-change result or one exact unverified dispatch shape.
+        ///
+        /// This policy is intentionally stricter than ``confirmedOrDispatched``: a reported
+        /// confirmed change is contradictory at connection/setup boundaries that can only prove
+        /// no work was necessary or that one delivery was accepted.
+        public static func confirmedNoChangeOrDispatched(
+            requiring delivery: Delivery,
+            unitCount: DispatchedUnitCountRequirement) -> Self
+        {
+            Self(
+                acceptsConfirmedChange: false,
+                acceptsConfirmedNoChange: true,
+                acceptsDispatchedUnverified: true,
+                acceptsSuspectedNoop: false,
+                requiredDeliveryMode: nil,
+                requiredDelivery: delivery,
+                dispatchedUnitCountRequirement: unitCount)
+        }
+
         public func accepts(_ outcome: DesktopActionOutcome) -> Bool {
             let acceptedState = switch outcome.state {
-            case .confirmedChange, .confirmedNoChange:
-                true
+            case .confirmedChange:
+                self.acceptsConfirmedChange
+            case .confirmedNoChange:
+                self.acceptsConfirmedNoChange
             case .dispatchedUnverified:
                 self.acceptsDispatchedUnverified
             case .suspectedNoop:
@@ -274,12 +335,26 @@ public struct DesktopActionOutcome: Codable, Equatable, Sendable {
                 false
             }
             guard acceptedState else { return false }
-            guard outcome.state != .confirmedNoChange,
-                  let requiredDeliveryMode = self.requiredDeliveryMode
-            else {
-                return true
+            guard outcome.state != .confirmedNoChange else {
+                return outcome.delivery == nil && outcome.dispatchState == .none
             }
-            return outcome.delivery?.mode == requiredDeliveryMode
+            if let requiredDelivery = self.requiredDelivery,
+               outcome.delivery != requiredDelivery
+            {
+                return false
+            }
+            if let requiredDeliveryMode = self.requiredDeliveryMode,
+               outcome.delivery?.mode != requiredDeliveryMode
+            {
+                return false
+            }
+            if outcome.state == .dispatchedUnverified,
+               let dispatchedUnitCountRequirement = self.dispatchedUnitCountRequirement,
+               !dispatchedUnitCountRequirement.accepts(outcome.dispatchState.unitCount)
+            {
+                return false
+            }
+            return true
         }
     }
 

--- a/Core/PeekabooFoundation/Tests/PeekabooFoundationTests/DesktopActionOutcomeTests.swift
+++ b/Core/PeekabooFoundation/Tests/PeekabooFoundationTests/DesktopActionOutcomeTests.swift
@@ -136,6 +136,30 @@ struct DesktopActionOutcomeTests {
     }
 
     @Test
+    func `confirmed no change requires canonical zero dispatch shape`() throws {
+        let outcome = DesktopActionOutcome.confirmedNoChange(route: .bridge)
+        #expect(outcome.delivery == nil)
+        #expect(outcome.dispatchState == .none)
+        #expect(outcome.isAccepted(by: .confirmed))
+        #expect(outcome.isAccepted(by: .confirmedOrDispatched))
+        #expect(outcome.isAccepted(by: .observation))
+
+        let contradictoryDelivery = try self.mutatedJSON(outcome) { object in
+            object["delivery_mechanism"] = "browser_protocol"
+            object["delivery_mode"] = "foreground"
+        }
+        let contradictoryDispatch = try self.mutatedJSON(outcome) { object in
+            object["dispatch_state"] = "dispatched"
+            object["dispatched_unit_count"] = 1
+        }
+        for data in [contradictoryDelivery, contradictoryDispatch] {
+            #expect(throws: DecodingError.self) {
+                try JSONDecoder().decode(DesktopActionOutcome.self, from: data)
+            }
+        }
+    }
+
+    @Test
     func `decoder rejects incomplete delivery and invalid unit counts`() throws {
         #expect(DesktopActionOutcome.DispatchUnitCount(0) == nil)
         #expect(DesktopActionOutcome.DispatchUnitCount(-1) == nil)

--- a/Core/PeekabooFoundation/Tests/PeekabooFoundationTests/DesktopActionOutcomeTransformTests.swift
+++ b/Core/PeekabooFoundation/Tests/PeekabooFoundationTests/DesktopActionOutcomeTransformTests.swift
@@ -1,0 +1,296 @@
+import Foundation
+import PeekabooFoundation
+import Testing
+
+struct DesktopActionOutcomeTransformTests {
+    private typealias UnverifiedDispatchCase = (
+        evidence: DesktopActionOutcome.DispatchedUnverifiedEvidence,
+        unitCount: DesktopActionOutcome.DispatchUnitCount?)
+
+    private let originalDelivery = DesktopActionOutcome.Delivery(
+        mechanism: .browserProtocol,
+        mode: .background)
+    private let replacementDelivery = DesktopActionOutcome.Delivery(
+        mechanism: .nativeFramework,
+        mode: .foreground)
+
+    @Test
+    func `dispatch confirmation transforms only unverified dispatches`() throws {
+        let one = try self.unitCount(1)
+        let unchanged: [DesktopActionOutcome] = [
+            .confirmedChange(route: .bridge, delivery: self.originalDelivery, unitCount: one),
+            .confirmedNoChange(route: .bridge),
+            .partial(route: .bridge, delivery: self.originalDelivery, unitCount: one),
+            .suspectedNoop(route: .bridge, delivery: self.originalDelivery, unitCount: one),
+            .refused(route: .bridge, reason: .targetUnavailable),
+            .indeterminate(
+                route: .bridge,
+                delivery: self.originalDelivery,
+                evidence: .responseLost,
+                unitCount: one),
+        ]
+
+        for outcome in unchanged {
+            for observedChange: Bool? in [nil, false, true] {
+                let transformed = outcome.confirmingDispatchedOutcome(observedChange: observedChange)
+                #expect(try self.encoded(transformed) == self.encoded(outcome))
+            }
+        }
+
+        let dispatchedCases: [UnverifiedDispatchCase] = [
+            (.deliveryAccepted, nil),
+            (.operationStillRunning, one),
+        ]
+        for (evidence, unitCount) in dispatchedCases {
+            let outcome = DesktopActionOutcome.dispatchedUnverified(
+                route: .bridge,
+                delivery: self.originalDelivery,
+                evidence: evidence,
+                unitCount: unitCount)
+
+            #expect(try self.encoded(outcome.confirmingDispatchedOutcome(observedChange: nil)) == self.encoded(outcome))
+            #expect(outcome.confirmingDispatchedOutcome(observedChange: true) == .confirmedChange(
+                route: .bridge,
+                delivery: self.originalDelivery,
+                unitCount: unitCount))
+            #expect(outcome.confirmingDispatchedOutcome(observedChange: false) == .confirmedNoChange(route: .bridge))
+        }
+    }
+
+    @Test
+    func `delivery reprojection covers every state and evidence case`() throws {
+        let one = try self.unitCount(1)
+        let transformedCases: [(DesktopActionOutcome, DesktopActionOutcome)] = [
+            (
+                .confirmedChange(route: .bridge, delivery: self.originalDelivery, unitCount: one),
+                .confirmedChange(route: .bridge, delivery: self.replacementDelivery, unitCount: one)),
+            (
+                .partial(route: .bridge, delivery: self.originalDelivery, unitCount: one),
+                .partial(route: .bridge, delivery: self.replacementDelivery, unitCount: one)),
+            (
+                .dispatchedUnverified(
+                    route: .bridge,
+                    delivery: self.originalDelivery,
+                    evidence: .deliveryAccepted),
+                .dispatchedUnverified(
+                    route: .bridge,
+                    delivery: self.replacementDelivery,
+                    evidence: .deliveryAccepted)),
+            (
+                .dispatchedUnverified(
+                    route: .bridge,
+                    delivery: self.originalDelivery,
+                    evidence: .operationStillRunning,
+                    unitCount: one),
+                .dispatchedUnverified(
+                    route: .bridge,
+                    delivery: self.replacementDelivery,
+                    evidence: .operationStillRunning,
+                    unitCount: one)),
+            (
+                .suspectedNoop(route: .bridge, delivery: self.originalDelivery, unitCount: one),
+                .suspectedNoop(route: .bridge, delivery: self.replacementDelivery, unitCount: one)),
+            (
+                .indeterminate(
+                    route: .bridge,
+                    delivery: self.originalDelivery,
+                    evidence: .responseLost),
+                .indeterminate(
+                    route: .bridge,
+                    delivery: self.replacementDelivery,
+                    evidence: .responseLost)),
+            (
+                .indeterminate(
+                    route: .bridge,
+                    delivery: self.originalDelivery,
+                    evidence: .completionUnknown,
+                    unitCount: one),
+                .indeterminate(
+                    route: .bridge,
+                    delivery: self.replacementDelivery,
+                    evidence: .completionUnknown,
+                    unitCount: one)),
+        ]
+
+        for (outcome, expected) in transformedCases {
+            #expect(outcome.reprojectingDelivery(self.replacementDelivery) == expected)
+        }
+
+        let unchanged: [DesktopActionOutcome] = [
+            .confirmedNoChange(route: .bridge),
+            .refused(route: .bridge, reason: .permissionDenied),
+            .indeterminate(route: .bridge, evidence: .responseLost, unitCount: one),
+            .indeterminate(route: .bridge, evidence: .completionUnknown),
+        ]
+        for outcome in unchanged {
+            #expect(try self.encoded(outcome.reprojectingDelivery(self.replacementDelivery)) == self.encoded(outcome))
+        }
+    }
+
+    @Test
+    func `unit count filling covers every state and preserves existing counts`() throws {
+        let one = try self.unitCount(1)
+        let two = try self.unitCount(2)
+        let missingCountCases: [(DesktopActionOutcome, DesktopActionOutcome)] = [
+            (
+                .confirmedChange(route: .bridge, delivery: self.originalDelivery),
+                .confirmedChange(route: .bridge, delivery: self.originalDelivery, unitCount: two)),
+            (
+                .confirmedNoChange(route: .bridge),
+                .confirmedNoChange(route: .bridge)),
+            (
+                .partial(route: .bridge, delivery: self.originalDelivery),
+                .partial(route: .bridge, delivery: self.originalDelivery)),
+            (
+                .dispatchedUnverified(
+                    route: .bridge,
+                    delivery: self.originalDelivery,
+                    evidence: .deliveryAccepted),
+                .dispatchedUnverified(
+                    route: .bridge,
+                    delivery: self.originalDelivery,
+                    evidence: .deliveryAccepted,
+                    unitCount: two)),
+            (
+                .dispatchedUnverified(
+                    route: .bridge,
+                    delivery: self.originalDelivery,
+                    evidence: .operationStillRunning),
+                .dispatchedUnverified(
+                    route: .bridge,
+                    delivery: self.originalDelivery,
+                    evidence: .operationStillRunning,
+                    unitCount: two)),
+            (
+                .suspectedNoop(route: .bridge, delivery: self.originalDelivery),
+                .suspectedNoop(route: .bridge, delivery: self.originalDelivery, unitCount: two)),
+            (
+                .refused(route: .bridge, reason: .invalidRequest),
+                .refused(route: .bridge, reason: .invalidRequest)),
+            (
+                .indeterminate(
+                    route: .bridge,
+                    delivery: self.originalDelivery,
+                    evidence: .responseLost),
+                .indeterminate(
+                    route: .bridge,
+                    delivery: self.originalDelivery,
+                    evidence: .responseLost)),
+            (
+                .indeterminate(route: .bridge, evidence: .completionUnknown),
+                .indeterminate(route: .bridge, evidence: .completionUnknown)),
+        ]
+
+        for (outcome, expected) in missingCountCases {
+            #expect(outcome.fillingSuccessfulDispatchUnitCount(two) == expected)
+        }
+
+        let existingCountCases: [DesktopActionOutcome] = [
+            .confirmedChange(route: .bridge, delivery: self.originalDelivery, unitCount: one),
+            .partial(route: .bridge, delivery: self.originalDelivery, unitCount: one),
+            .dispatchedUnverified(
+                route: .bridge,
+                delivery: self.originalDelivery,
+                evidence: .deliveryAccepted,
+                unitCount: one),
+            .dispatchedUnverified(
+                route: .bridge,
+                delivery: self.originalDelivery,
+                evidence: .operationStillRunning,
+                unitCount: one),
+            .suspectedNoop(route: .bridge, delivery: self.originalDelivery, unitCount: one),
+            .indeterminate(
+                route: .bridge,
+                delivery: self.originalDelivery,
+                evidence: .responseLost,
+                unitCount: one),
+            .indeterminate(route: .bridge, evidence: .completionUnknown, unitCount: one),
+        ]
+        for outcome in existingCountCases {
+            #expect(try self.encoded(outcome.fillingSuccessfulDispatchUnitCount(two)) == self.encoded(outcome))
+        }
+    }
+
+    @Test
+    func `exact dispatch policy enforces state delivery and unit count`() throws {
+        let one = try self.unitCount(1)
+        let two = try self.unitCount(2)
+        let requiredCount = DesktopActionOutcome.SuccessPolicy.confirmedNoChangeOrDispatched(
+            requiring: self.originalDelivery,
+            unitCount: .required)
+        let exactlyOne = DesktopActionOutcome.SuccessPolicy.confirmedNoChangeOrDispatched(
+            requiring: self.originalDelivery,
+            unitCount: .exact(one))
+
+        for outcome in [
+            DesktopActionOutcome.confirmedNoChange(),
+            DesktopActionOutcome.confirmedNoChange(route: .bridge),
+        ] {
+            #expect(requiredCount.accepts(outcome))
+            #expect(exactlyOne.accepts(outcome))
+        }
+
+        for evidence in [
+            DesktopActionOutcome.DispatchedUnverifiedEvidence.deliveryAccepted,
+            .operationStillRunning,
+        ] {
+            let oneUnit = DesktopActionOutcome.dispatchedUnverified(
+                route: .bridge,
+                delivery: self.originalDelivery,
+                evidence: evidence,
+                unitCount: one)
+            let twoUnits = DesktopActionOutcome.dispatchedUnverified(
+                delivery: self.originalDelivery,
+                evidence: evidence,
+                unitCount: two)
+            let missingCount = DesktopActionOutcome.dispatchedUnverified(
+                delivery: self.originalDelivery,
+                evidence: evidence)
+
+            #expect(requiredCount.accepts(oneUnit))
+            #expect(requiredCount.accepts(twoUnits))
+            #expect(!requiredCount.accepts(missingCount))
+            #expect(exactlyOne.accepts(oneUnit))
+            #expect(!exactlyOne.accepts(twoUnits))
+            #expect(!exactlyOne.accepts(missingCount))
+        }
+
+        let wrongDeliveryCases = [
+            DesktopActionOutcome.Delivery(mechanism: .capturePipeline, mode: .background),
+            DesktopActionOutcome.Delivery(mechanism: .browserProtocol, mode: .foreground),
+        ]
+        for delivery in wrongDeliveryCases {
+            let outcome = DesktopActionOutcome.dispatchedUnverified(
+                delivery: delivery,
+                evidence: .deliveryAccepted,
+                unitCount: one)
+            #expect(!requiredCount.accepts(outcome))
+            #expect(!exactlyOne.accepts(outcome))
+        }
+
+        let rejectedStates: [DesktopActionOutcome] = [
+            .confirmedChange(delivery: self.originalDelivery, unitCount: one),
+            .partial(delivery: self.originalDelivery, unitCount: one),
+            .suspectedNoop(delivery: self.originalDelivery, unitCount: one),
+            .refused(reason: .targetUnavailable),
+            .indeterminate(
+                delivery: self.originalDelivery,
+                evidence: .completionUnknown,
+                unitCount: one),
+        ]
+        for outcome in rejectedStates {
+            #expect(!requiredCount.accepts(outcome))
+            #expect(!exactlyOne.accepts(outcome))
+        }
+    }
+
+    private func encoded(_ value: some Encodable) throws -> Data {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        return try encoder.encode(value)
+    }
+
+    private func unitCount(_ value: Int) throws -> DesktopActionOutcome.DispatchUnitCount {
+        try #require(DesktopActionOutcome.DispatchUnitCount(value))
+    }
+}


### PR DESCRIPTION
## Summary

- centralize accepted `DesktopActionResult` transformations and strict-success policy in PeekabooFoundation
- centralize identity-to-target receipt projection in PeekabooAutomationKit
- remove duplicated CLI/Core/Bridge outcome switches and thin receipt adapters while keeping surface-specific presentation local
- reduce raw production target-receipt construction from 28 sites to 4 canonical semantic owners
- preserve #622's protocol 1.34 browser receipt, cancellation, and receipt-bound read semantics
- enforce the canonical `confirmed_no_change` shape centrally: delivery must be absent and dispatch must be none

This is the first post-safety architecture consolidation: target/result meaning now has one owner instead of drifting across CLI, MCP, Browser, Bridge, and runtime adapters.

## Proof

- Foundation full: 76 tests; post-commit exact slice 17
- AutomationKit focused 23; full package 1,320 Swift Testing tests across 125 suites plus XCTest
- affected receiptless/transport suites 34/34
- post-commit Core exact slice 49 plus BrowserTool 9
- Apps/CLI full package passed; final tranche 527 tests across 66 suites
- SwiftFormat: 0 changed across 1,678 files
- SwiftLint: 0 serious violations
- `git diff --check` clean
- integrated Autoreview clean, confidence 0.98
- post-review no-change guard proof: Foundation 16/16, exact migrated Core caller set 62/62, CLI outcome 30/30, focused Autoreview clean at 0.97

Three unrelated full-Core baseline failures reproduce identically on clean `main` and are excluded: CaptureWindowIDValidation, CertificationProducerTransport, and MCPToolExecutionPolicy.

## Notes

- The two browser fixture updates replace the now-invalid synthetic channel `chrome` with canonical `stable`; production #622 behavior is unchanged.
- Exhaustive mutating-operation coverage now includes pixel-focus typing and foreground modifier-click with their exact completion, delivery, and request-pinned target contracts.
- This is an internal consolidation with exhaustive parity tests, so it does not add a changelog or user documentation entry.
