### PR TITLE
fix(dialog): prefer active sheets beneath structural parents

### DIFF
--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bind Bridge 1.34 Chrome channel connections to an exact live Chrome bundle, native process-owned DevTools listener, and approval-gated WebSocket under one 90-second deadline, verifying `Browser.getVersion` once without legacy HTTP discovery or repeated permission probes and failing closed on helper-service names, file, socket, generation, or endpoint drift.
 - Authenticate native Chrome channels against Google Team ID `EQHXZ8M8AV`, pin the exact signed identifier and CDHash for the process generation, and enumerate the target process's complete listener inventory independently of Peekaboo's file-descriptor limit.
+- Let exact `dialog` targeting prefer one active child sheet or alert beneath its structural parent, retain ambiguity for multiple children, and preserve actionable parent-window recovery hints through Bridge routing.
 
 ## [4.2.3] - 2026-08-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Bind Bridge 1.34 Chrome channel connections to an exact live Chrome bundle, native process-owned DevTools listener, and approval-gated WebSocket under one 90-second deadline, verifying `Browser.getVersion` once without legacy HTTP discovery or repeated permission probes and failing closed on helper-service names, file, socket, generation, or endpoint drift.
 - Authenticate native Chrome channels against Google Team ID `EQHXZ8M8AV`, pin the exact signed identifier and CDHash for the process generation, and enumerate the target process's complete listener inventory independently of Peekaboo's file-descriptor limit.
+- Prefer a sole live child sheet or alert beneath its exact structural parent window, preserve multi-child ambiguity, and keep parent-window recovery guidance intact across remote dialog reads.
 
 ## [4.2.3] - 2026-08-23
 

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/DialogService+PreparedActions.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/DialogService+PreparedActions.swift
@@ -473,7 +473,9 @@ extension DialogService {
             stack.append(contentsOf: traversal.elements.reversed())
         }
         return FreshDialogElements(
-            structural: structuralDialogs,
+            structural: DialogTraversal.preferredStructuralDialogs(
+                in: window,
+                candidates: structuralDialogs),
             legacy: legacyDialogs,
             readable: readable)
     }
@@ -708,17 +710,31 @@ extension DialogService {
     }
 
     func dialogCandidateRefusal(
-        target _: DialogTargetSelector,
+        target: DialogTargetSelector,
         candidates: [TargetedDialogCandidate]) -> DesktopActionFailure
     {
         let candidateIDs = Self.candidateWindowIDs(candidates.map(\.target))
         let message = candidates.isEmpty
             ? "No dialog matched the selected target."
             : "Dialog target is ambiguous across \(candidates.count) eligible dialogs."
+        let hint: String
+        if let windowID = target.windowID {
+            if candidates.isEmpty {
+                let owner = target.processIdentifier.map { " for PID \($0)" } ?? ""
+                hint = "Window ID \(windowID) did not retain a structural dialog. " +
+                    "If it is a blank-title transient sheet CGWindow, use the titled parent AX window ID\(owner) " +
+                    "from window list."
+            } else {
+                hint = "Window ID \(windowID) contains \(candidates.count) simultaneous structural dialogs or " +
+                    "sheets. Wait for or dismiss the extra dialog, then list the retained parent window again."
+            }
+        } else {
+            hint = "Candidate window IDs: \(candidateIDs). Add --window-id or a more exact selector."
+        }
         return .preDispatchRefusal(
             reason: .targetUnavailable,
             message: message,
-            hint: "Candidate window IDs: \(candidateIDs). Add --window-id or a more exact selector.")
+            hint: hint)
     }
 
     func targetUnavailable(_ message: String) -> DesktopActionFailure {

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/DialogService+Traversal.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/DialogService+Traversal.swift
@@ -79,6 +79,17 @@ enum DialogTraversal {
 
         return ordered
     }
+
+    /// A window can itself expose a structural dialog role while hosting a transient sheet or alert.
+    /// In that shape the descendants are the active dialogs; retaining the parent as a second candidate
+    /// makes an exact parent-window selector permanently ambiguous.
+    static func preferredStructuralDialogs<Node: Hashable>(
+        in root: Node,
+        candidates: [Node]) -> [Node]
+    {
+        let descendants = candidates.filter { $0 != root }
+        return descendants.isEmpty ? candidates : descendants
+    }
 }
 
 @MainActor

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/DialogElementTraversalTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/DialogElementTraversalTests.swift
@@ -75,6 +75,55 @@ struct DialogElementTraversalTests {
     }
 
     @Test
+    func `one active sheet supersedes its structural dialog parent`() {
+        let parent = TraversalNode(name: "Dialog Fixture", isMatch: true)
+        let sheet = TraversalNode(name: "Alert", isMatch: true, isSheet: true)
+
+        let preferred = DialogTraversal.preferredStructuralDialogs(
+            in: parent,
+            candidates: [parent, sheet])
+
+        #expect(preferred == [sheet])
+    }
+
+    @Test
+    func `simultaneous sheets and nested alerts remain ambiguous under one parent`() {
+        let parent = TraversalNode(name: "Dialog Fixture", isMatch: true)
+        let firstSheet = TraversalNode(name: "First sheet", isMatch: true, isSheet: true)
+        let secondAlert = TraversalNode(name: "Nested alert", isMatch: true)
+
+        let preferred = DialogTraversal.preferredStructuralDialogs(
+            in: parent,
+            candidates: [parent, firstSheet, secondAlert])
+
+        #expect(preferred == [firstSheet, secondAlert])
+    }
+
+    @Test
+    func `ordinary AXDialog fixture window remains eligible without a sheet`() {
+        let fixture = TraversalNode(name: "Dialog Fixture", isMatch: true)
+
+        let preferred = DialogTraversal.preferredStructuralDialogs(
+            in: fixture,
+            candidates: [fixture])
+
+        #expect(preferred == [fixture])
+    }
+
+    @Test
+    func `multiple ordinary AXDialog fixture windows remain distinct candidates`() {
+        let first = TraversalNode(name: "Dialog Fixture 1", isMatch: true)
+        let second = TraversalNode(name: "Dialog Fixture 2", isMatch: true)
+
+        let candidates = [
+            DialogTraversal.preferredStructuralDialogs(in: first, candidates: [first]),
+            DialogTraversal.preferredStructuralDialogs(in: second, candidates: [second]),
+        ].flatMap(\.self)
+
+        #expect(candidates == [first, second])
+    }
+
+    @Test
     func `deep hierarchies do not consume the call stack`() {
         let root = TraversalNode(name: "0")
         var nodes = [root]

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/DialogExactInputContractTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/DialogExactInputContractTests.swift
@@ -235,6 +235,82 @@ struct DialogExactInputContractTests {
     }
 
     @Test
+    func `blank sheet CGWindow refusal points to the retained parent instead of repeating its selector`() throws {
+        let service = DialogService()
+        let refusal = try service.dialogCandidateRefusal(
+            target: DialogTargetSelector(processIdentifier: 42, windowID: 21723),
+            candidates: [])
+
+        #expect(refusal.outcome.state == .refused)
+        #expect(refusal.outcome.dispatchState == .none)
+        #expect(refusal.hint?.contains("blank-title transient sheet CGWindow") == true)
+        #expect(refusal.hint?.contains("parent AX window ID") == true)
+        #expect(refusal.hint?.contains("Add --window-id") == false)
+    }
+
+    @Test
+    func `multiple sheets under an exact parent produce a resolvable state hint`() throws {
+        let service = DialogService()
+        let target = try self.target()
+        let application = ServiceApplicationInfo(
+            processIdentifier: target.identity.ownerProcessIdentifier,
+            processStartIdentity: target.identity.ownerProcessStartIdentity,
+            bundleIdentifier: "dev.peekaboo.fixture",
+            name: "Fixture")
+        let window = self.window(
+            id: target.identity.windowID,
+            title: "Dialog Fixture",
+            generation: target.identity.ownerProcessStartIdentity)
+        let evidence = try ResolvedDialogTargetEvidence(
+            target: target,
+            application: application,
+            window: window)
+        let candidates = [0, 1].map { _ in
+            DialogService.TargetedDialogCandidate(
+                target: target,
+                resolvedTarget: evidence,
+                window: Element.systemWide(),
+                dialog: Element.systemWide())
+        }
+
+        let refusal = try service.dialogCandidateRefusal(
+            target: DialogTargetSelector(processIdentifier: 42, windowID: target.identity.windowID),
+            candidates: candidates)
+
+        #expect(refusal.message.contains("ambiguous across 2"))
+        #expect(refusal.hint?.contains("simultaneous structural dialogs or sheets") == true)
+        #expect(refusal.hint?.contains("Add --window-id") == false)
+    }
+
+    @Test
+    func `parent sheet selection does not relax generation or retained parent checks`() throws {
+        let target = try self.target()
+        let staleGeneration = DialogService.DialogTargetRevalidationObservation(
+            applicationIdentity: ApplicationProcessIdentity(processIdentifier: 42, processStartIdentity: 9999),
+            windowIdentity: target.identity,
+            windowBounds: target.bounds,
+            retainedWindowMatches: true,
+            hierarchyReadable: true,
+            structuralDialogCount: 1,
+            retainedDialogMatches: true)
+        let staleParent = DialogService.DialogTargetRevalidationObservation(
+            applicationIdentity: target.identity.processIdentity,
+            windowIdentity: target.identity,
+            windowBounds: target.bounds,
+            retainedWindowMatches: false,
+            hierarchyReadable: true,
+            structuralDialogCount: 1,
+            retainedDialogMatches: true)
+
+        #expect(!DialogService.isValidDialogTargetRevalidation(
+            expected: target,
+            observation: staleGeneration))
+        #expect(!DialogService.isValidDialogTargetRevalidation(
+            expected: target,
+            observation: staleParent))
+    }
+
+    @Test
     func `resolved dialog proof preserves prohibited helper fuzzy eligibility`() throws {
         let window = self.window(id: 700, title: "Helper Dialog", generation: 1234)
         let target = try UIAutomationTarget.ExactWindow(window: window)

--- a/Core/PeekabooCore/Sources/PeekabooCore/Support/RemoteDialogService.swift
+++ b/Core/PeekabooCore/Sources/PeekabooCore/Support/RemoteDialogService.swift
@@ -255,7 +255,13 @@ public final class RemoteDialogService: DialogServiceProtocol {
             throw Self.capabilityRefusal(
                 "Remote host does not advertise uniquely targeted dialog listing; update the host.")
         }
-        return try await self.client.targetedDialogListElements(target: target)
+        do {
+            return try await self.client.targetedDialogListElements(target: target)
+        } catch let failure as DesktopActionFailure {
+            throw failure
+        } catch let envelope as PeekabooBridgeErrorEnvelope {
+            throw Self.preDispatchFailure(for: envelope)
+        }
     }
 
     private func supportsAction(_ kind: DialogPreparedActionKind) -> Bool {
@@ -277,6 +283,12 @@ public final class RemoteDialogService: DialogServiceProtocol {
     }
 
     static func preDispatchFailure(for envelope: PeekabooBridgeErrorEnvelope) -> DesktopActionFailure {
+        if let failure = envelope.desktopActionFailure,
+           failure.outcome.state == .refused,
+           !failure.outcome.dispatchState.mutationDispatched
+        {
+            return failure.routed(to: .bridge)
+        }
         let reason: DesktopActionOutcome.RefusalReason = switch envelope.code {
         case .permissionDenied:
             .permissionDenied

--- a/Core/PeekabooCore/Tests/PeekabooTests/BridgeStrictBackgroundOperationTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/BridgeStrictBackgroundOperationTests.swift
@@ -1,9 +1,10 @@
 import CoreGraphics
 import Foundation
 import PeekabooAutomationKit
-import PeekabooBridge
+import PeekabooBridgeTestSupport
 import PeekabooFoundation
 import Testing
+@testable import PeekabooBridge
 @testable import PeekabooCore
 
 @MainActor
@@ -287,7 +288,7 @@ struct BridgeStrictBackgroundOperationTests {
     }
 
     @Test
-    func `remote blank child recovery hint survives structured bridge refusal`() {
+    func `remote blank child recovery hint survives server envelope and bridge wire`() async throws {
         let hint = "Window ID 21723 did not retain a structural dialog. " +
             "If it is a blank-title transient sheet CGWindow, use the titled parent AX window ID for PID 42 " +
             "from window list."
@@ -295,11 +296,37 @@ struct BridgeStrictBackgroundOperationTests {
             reason: .targetUnavailable,
             message: "No dialog matched the selected target.",
             hint: hint)
-        let envelope = PeekabooBridgeErrorEnvelope(
-            code: .internalError,
-            actionFailure: localFailure)
+        let serverEnvelope = PeekabooBridgeServer.bridgeErrorEnvelope(
+            for: localFailure,
+            operation: .targetedDialogListElements)
+        let protocolVersion = PeekabooBridgeProtocolVersion(major: 1, minor: 28)
+        let peer = try ScriptedBridgePeer(responses: [
+            .handshake(BridgeTestFixtures.handshake(
+                negotiatedVersion: protocolVersion,
+                supportedOperations: [.targetedDialogListElements])),
+            .error(serverEnvelope),
+        ])
+        let client = PeekabooBridgeClient(socketPath: peer.socketPath, requestTimeoutSec: 1)
+        _ = try await client.handshake(
+            client: .init(
+                bundleIdentifier: "dev.peekaboo.dialog-recovery-test",
+                teamIdentifier: nil,
+                processIdentifier: getpid()),
+            protocolVersion: protocolVersion)
+        let remote = RemoteDialogService(
+            client: client,
+            capabilities: .init(targetedList: true))
 
-        let failure = RemoteDialogService.preDispatchFailure(for: envelope)
+        let failure: DesktopActionFailure
+        do {
+            _ = try await remote.listDialogElements(target: .init(processIdentifier: 42, windowID: 21723))
+            Issue.record("Expected the server refusal to survive the Bridge wire")
+            await peer.stop()
+            return
+        } catch let error as DesktopActionFailure {
+            failure = error
+        }
+        await peer.waitUntilFinished()
 
         #expect(failure.outcome.route == .bridge)
         #expect(failure.outcome.state == .refused)

--- a/Core/PeekabooCore/Tests/PeekabooTests/BridgeStrictBackgroundOperationTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/BridgeStrictBackgroundOperationTests.swift
@@ -287,6 +287,28 @@ struct BridgeStrictBackgroundOperationTests {
     }
 
     @Test
+    func `remote blank child recovery hint survives structured bridge refusal`() {
+        let hint = "Window ID 21723 did not retain a structural dialog. " +
+            "If it is a blank-title transient sheet CGWindow, use the titled parent AX window ID for PID 42 " +
+            "from window list."
+        let localFailure = DesktopActionFailure.preDispatchRefusal(
+            reason: .targetUnavailable,
+            message: "No dialog matched the selected target.",
+            hint: hint)
+        let envelope = PeekabooBridgeErrorEnvelope(
+            code: .internalError,
+            actionFailure: localFailure)
+
+        let failure = RemoteDialogService.preDispatchFailure(for: envelope)
+
+        #expect(failure.outcome.route == .bridge)
+        #expect(failure.outcome.state == .refused)
+        #expect(failure.outcome.refusalReason == .targetUnavailable)
+        #expect(failure.outcome.dispatchState == .none)
+        #expect(failure.hint == hint)
+    }
+
+    @Test
     func `remote authority errors retain transport-session refusal semantics`() {
         for code in [PeekabooBridgeErrorCode.unauthorizedClient, .serverBusy, .timeout] {
             let failure = RemoteDialogService.preDispatchFailure(for: .init(

--- a/docs/commands/dialog.md
+++ b/docs/commands/dialog.md
@@ -23,6 +23,7 @@ require `--foreground`.
 
 ## Implementation notes
 - Every `dialog list` form is read-only/background and creates no mutation or snapshot debt. A targeted list must resolve exactly one dialog; ambiguity reports candidate window IDs.
+- When an exact titled parent AX window contains one structural child sheet or alert, Peekaboo treats that child as the active dialog while retaining the parent window receipt. The parent remains targetable when it has no structural child, and multiple child dialogs remain ambiguous. If a blank-title transient sheet CGWindow ID does not resolve, use the titled parent AX window ID reported by `window list`.
 - Default background click and non-forced dismiss use Bridge protocol 1.25's two-phase contract: a read-only prepare operation uniquely upgrades app/PID/title selectors to one exact process-generation/window receipt and retains the raw AX window, dialog, and button identities under a short-lived one-shot token.
 - Immediately before AXPress, Peekaboo consumes the token, reacquires the exact-window write lane, re-enumerates and compares all three raw AX identities, and rechecks owner generation, window bounds, enabled state, and AXPress support. It never falls back to the physical pointer, clipboard, focus, or global input.
 - Success is confirmed only after the retained dialog or sheet disappears. An accepted press without a verified postcondition is retry-unsafe and requires fresh observation; planning or identity ambiguity is a retry-safe pre-dispatch refusal.


### PR DESCRIPTION
## Summary

- prefer the sole live child sheet or alert when an exact structural parent window owns one active dialog
- preserve ambiguity when multiple active child dialogs exist and retain the ordinary parent when no child is active
- keep the exact parent PID, process generation, window ID, and bounds as mutation authority while treating the descendant sheet/alert only as Accessibility identity
- preserve actionable blank-child/parent-window recovery hints through server envelope, Bridge socket serialization, client decoding, and `RemoteDialogService`

This fixes the common macOS sheet shape where the WindowServer parent is the stable exact target but the actionable controls live under one transient Accessibility child.

## Proof

- AutomationKit dialog traversal and exact-input contract: 30 tests
- Bridge strict-background and real serialized recovery-hint roundtrip: 17 tests
- broader Bridge/receipt/dialog set: 75 tests
- SwiftFormat unchanged
- SwiftLint: no new serious violations
- docs lint and `git diff --check` clean
- independent P0–P2 review clean

Two unrelated load-sensitive AutomationKit cases pass independently; one unrelated legacy set-value Bridge expectation is stale on the corrected result base and is excluded.

## Documentation

- document exact parent-window → sole child sheet/alert selection, no-child behavior, multiple-child ambiguity, and blank-title CG sheet recovery
- add matching root and CLI 4.2.4 Unreleased changelog bullets
