### PR TITLE
refactor(results): centralize application result semantics

### DIFF
--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Core/Protocols/ApplicationServiceProtocol.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Core/Protocols/ApplicationServiceProtocol.swift
@@ -201,13 +201,11 @@ public enum ApplicationActionResultSemantics {
         operation: String) throws
     {
         guard let outcome else { return }
-        guard !outcome.isAccepted(by: .confirmedOrDispatched) else { return }
-        guard let failure = DesktopActionFailure(
-            outcome: outcome,
-            message: "\(operation) did not return a successful application outcome.",
-            hint: "Follow the canonical escalation metadata before deciding whether to retry.")
-        else { return }
-        throw failure
+        _ = try UIAutomationActionResultSemantics.requireAcceptedOutcome(
+            outcome,
+            policy: .confirmedOrDispatched,
+            operation: operation,
+            rejectedOutcomeMessage: "\(operation) did not return a successful application outcome.")
     }
 
     public static func requireSuccessfulExactProcessResult(
@@ -215,40 +213,17 @@ public enum ApplicationActionResultSemantics {
         expectedIdentity: ApplicationProcessIdentity,
         operation: String) throws
     {
-        guard let outcome = result.outcome else {
-            throw DesktopActionFailure.indeterminate(
-                evidence: .completionUnknown,
-                message: "\(operation) returned without a canonical outcome.",
-                hint: "Observe the selected application before retrying and update the runtime host.")
-        }
-        if outcome.state == .refused, outcome.dispatchState == .none {
-            try self.requireSuccessfulOutcome(outcome, operation: operation)
-        }
-        if let returnedIdentity = result.targetIdentity?.processIdentity,
-           returnedIdentity != expectedIdentity
-        {
-            throw DesktopActionFailure.indeterminate(
-                route: outcome.route,
-                delivery: outcome.delivery,
-                evidence: .completionUnknown,
-                unitCount: outcome.dispatchState.unitCount,
-                message: "\(operation) returned a different process-generation target.",
-                hint: "Observe the selected application before retrying and update the runtime host.")
-        }
-        do {
-            try self.requireSuccessfulOutcome(outcome, operation: operation)
-        } catch let failure as DesktopActionFailure {
-            throw failure.attributed(to: expectedIdentity.actionTargetReceipt)
-        }
-        guard result.targetIdentity?.processIdentity == expectedIdentity else {
-            throw DesktopActionFailure.indeterminate(
-                route: outcome.route,
-                delivery: outcome.delivery,
-                evidence: .completionUnknown,
-                unitCount: outcome.dispatchState.unitCount,
-                message: "\(operation) returned without the exact process-generation target.",
-                hint: "Observe the selected application before retrying and update the runtime host.")
-        }
+        _ = try UIAutomationActionResultSemantics.requireAcceptedExactProcessResult(
+            result,
+            expectedIdentity: expectedIdentity,
+            policy: .confirmedOrDispatched,
+            operation: operation,
+            missingOutcomeMessage: "\(operation) returned without a canonical outcome.",
+            missingTargetMessage: "\(operation) returned without the exact process-generation target.",
+            contradictoryTargetMessage: "\(operation) returned a different process-generation target.",
+            rejectedOutcomeMessage: "\(operation) did not return a successful application outcome.",
+            missingOutcomeHint: "Observe the selected application before retrying and update the runtime host.",
+            targetHint: "Observe the selected application before retrying and update the runtime host.")
     }
 
     public static func requireConsistentQuitResult(

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Strategy/UIAutomationActionResultSemantics.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Strategy/UIAutomationActionResultSemantics.swift
@@ -43,6 +43,75 @@ public enum UIAutomationActionResultSemantics {
         target.keyboardDelivery
     }
 
+    /// Applies one acceptance policy to a result pinned to an exact process generation.
+    ///
+    /// A provider refusal before dispatch remains authoritative even when target evidence is absent
+    /// or contradictory. After dispatch, contradictory target evidence takes precedence over the
+    /// provider outcome, while a missing target is reported only after accepting the outcome.
+    @discardableResult
+    public static func requireAcceptedExactProcessResult(
+        _ result: UIAutomationActionResult<some Sendable>,
+        expectedIdentity: ApplicationProcessIdentity,
+        policy: DesktopActionOutcome.SuccessPolicy,
+        operation: String,
+        missingOutcomeMessage: String? = nil,
+        missingTargetMessage: String? = nil,
+        contradictoryTargetMessage: String? = nil,
+        rejectedOutcomeMessage: String? = nil,
+        missingOutcomeHint: String = "Observe the target before retrying and update the runtime host.",
+        targetHint: String = "Observe the target before retrying and update the runtime host.",
+        rejectedOutcomeHint: String =
+            "Follow the canonical escalation metadata before deciding whether to retry.") throws
+        -> DesktopActionOutcome
+    {
+        guard let outcome = result.outcome else {
+            return try self.requireAcceptedOutcome(
+                result.outcome,
+                policy: policy,
+                operation: operation,
+                missingOutcomeMessage: missingOutcomeMessage,
+                missingOutcomeHint: missingOutcomeHint,
+                rejectedOutcomeHint: rejectedOutcomeHint)
+        }
+        if outcome.state == .refused, outcome.dispatchState == .none {
+            return try self.requireAcceptedOutcome(
+                outcome,
+                policy: policy,
+                operation: operation,
+                rejectedOutcomeMessage: rejectedOutcomeMessage,
+                rejectedOutcomeHint: rejectedOutcomeHint)
+        }
+        if let returnedIdentity = result.targetIdentity?.processIdentity,
+           returnedIdentity != expectedIdentity
+        {
+            throw DesktopActionFailure.indeterminate(
+                route: outcome.route,
+                delivery: outcome.delivery,
+                evidence: .completionUnknown,
+                unitCount: outcome.dispatchState.unitCount,
+                message: contradictoryTargetMessage ?? "\(operation) returned a contradictory process target.",
+                hint: targetHint)
+        }
+
+        let acceptedOutcome = try self.requireAcceptedOutcome(
+            outcome,
+            policy: policy,
+            operation: operation,
+            targetReceipt: expectedIdentity.actionTargetReceipt,
+            rejectedOutcomeMessage: rejectedOutcomeMessage,
+            rejectedOutcomeHint: rejectedOutcomeHint)
+        guard result.targetIdentity?.processIdentity == expectedIdentity else {
+            throw DesktopActionFailure.indeterminate(
+                route: outcome.route,
+                delivery: outcome.delivery,
+                evidence: .completionUnknown,
+                unitCount: outcome.dispatchState.unitCount,
+                message: missingTargetMessage ?? "\(operation) returned without its exact process target.",
+                hint: targetHint)
+        }
+        return acceptedOutcome
+    }
+
     public static func requireAcceptedOutcome(
         _ result: UIAutomationActionResult<some Sendable>,
         policy: DesktopActionOutcome.SuccessPolicy,

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ApplicationServiceProtocolTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ApplicationServiceProtocolTests.swift
@@ -32,6 +32,145 @@ struct ApplicationServiceProtocolTests {
     }
 
     @Test
+    func `application outcome policy retains legacy nil compatibility`() throws {
+        try ApplicationActionResultSemantics.requireSuccessfulOutcome(
+            nil,
+            operation: "Application action")
+    }
+
+    @Test
+    func `application outcome policy delegates reported results to canonical acceptance`() throws {
+        let delivery = DesktopActionOutcome.Delivery(
+            mechanism: .nativeFramework,
+            mode: .background)
+        try ApplicationActionResultSemantics.requireSuccessfulOutcome(
+            .confirmedChange(delivery: delivery),
+            operation: "Application action")
+        try ApplicationActionResultSemantics.requireSuccessfulOutcome(
+            .dispatchedUnverified(
+                delivery: delivery,
+                evidence: .deliveryAccepted),
+            operation: "Application action")
+
+        let rejected = DesktopActionOutcome.suspectedNoop(delivery: delivery)
+        do {
+            try ApplicationActionResultSemantics.requireSuccessfulOutcome(
+                rejected,
+                operation: "Application action")
+            Issue.record("Expected canonical provider failure")
+        } catch let failure as DesktopActionFailure {
+            #expect(failure.outcome == rejected)
+            #expect(failure.message == "Application action did not return a successful application outcome.")
+            #expect(failure.hint == "Follow the canonical escalation metadata before deciding whether to retry.")
+            #expect(failure.causeDescription == nil)
+            #expect(failure.targetReceipt == nil)
+        }
+    }
+
+    @Test
+    func `exact application result rejects missing outcome without inventing target evidence`() throws {
+        let identity = ApplicationProcessIdentity(processIdentifier: 42, processStartIdentity: 7)
+
+        do {
+            try ApplicationActionResultSemantics.requireSuccessfulExactProcessResult(
+                UIAutomationActionResult<Void>(payload: (), outcome: nil, targetIdentity: nil),
+                expectedIdentity: identity,
+                operation: "Application hide")
+            Issue.record("Expected missing-outcome failure")
+        } catch let failure as DesktopActionFailure {
+            #expect(failure.outcome == .indeterminate(
+                evidence: .completionUnknown))
+            #expect(failure.message == "Application hide returned without a canonical outcome.")
+            #expect(failure.hint == "Observe the selected application before retrying and update the runtime host.")
+            #expect(failure.causeDescription == nil)
+            #expect(failure.targetReceipt == nil)
+        }
+    }
+
+    @Test
+    func `exact application result distinguishes missing and contradictory targets`() throws {
+        let identity = ApplicationProcessIdentity(processIdentifier: 42, processStartIdentity: 7)
+        let delivery = DesktopActionOutcome.Delivery(
+            mechanism: .accessibilityAction,
+            mode: .background)
+        let outcome = DesktopActionOutcome.confirmedChange(
+            route: .bridge,
+            delivery: delivery)
+        let replacement = try DesktopTargetIdentity(processIdentity: .init(
+            processIdentifier: identity.processIdentifier,
+            processStartIdentity: identity.processStartIdentity + 1))
+
+        let cases: [(DesktopTargetIdentity?, String)] = [
+            (nil, "Application hide returned without the exact process-generation target."),
+            (replacement, "Application hide returned a different process-generation target."),
+        ]
+        for (targetIdentity, expectedMessage) in cases {
+            do {
+                try ApplicationActionResultSemantics.requireSuccessfulExactProcessResult(
+                    UIAutomationActionResult(payload: (), outcome: outcome, targetIdentity: targetIdentity),
+                    expectedIdentity: identity,
+                    operation: "Application hide")
+                Issue.record("Expected exact-target failure")
+            } catch let failure as DesktopActionFailure {
+                #expect(failure.outcome == .indeterminate(
+                    route: .bridge,
+                    delivery: delivery,
+                    evidence: .completionUnknown))
+                #expect(failure.message == expectedMessage)
+                #expect(failure.hint ==
+                    "Observe the selected application before retrying and update the runtime host.")
+                #expect(failure.causeDescription == nil)
+                #expect(failure.targetReceipt == nil)
+            }
+        }
+    }
+
+    @Test
+    func `exact application result preserves provider failure before requiring a missing target`() throws {
+        let identity = ApplicationProcessIdentity(processIdentifier: 42, processStartIdentity: 7)
+        let outcome = DesktopActionOutcome.suspectedNoop(
+            route: .bridge,
+            delivery: .init(mechanism: .accessibilityAction, mode: .background))
+
+        do {
+            try ApplicationActionResultSemantics.requireSuccessfulExactProcessResult(
+                UIAutomationActionResult<Void>(payload: (), outcome: outcome, targetIdentity: nil),
+                expectedIdentity: identity,
+                operation: "Application hide")
+            Issue.record("Expected provider failure")
+        } catch let failure as DesktopActionFailure {
+            #expect(failure.outcome == outcome)
+            #expect(failure.message == "Application hide did not return a successful application outcome.")
+            #expect(failure.hint == "Follow the canonical escalation metadata before deciding whether to retry.")
+            #expect(failure.causeDescription == nil)
+            #expect(failure.targetReceipt == identity.actionTargetReceipt)
+        }
+    }
+
+    @Test
+    func `exact application result preserves pre-dispatch refusal ahead of contradictory target evidence`() throws {
+        let identity = ApplicationProcessIdentity(processIdentifier: 42, processStartIdentity: 7)
+        let replacement = try DesktopTargetIdentity(processIdentity: .init(
+            processIdentifier: identity.processIdentifier,
+            processStartIdentity: identity.processStartIdentity + 1))
+        let refusal = DesktopActionOutcome.refused(route: .bridge, reason: .targetUnavailable)
+
+        do {
+            try ApplicationActionResultSemantics.requireSuccessfulExactProcessResult(
+                UIAutomationActionResult(payload: (), outcome: refusal, targetIdentity: replacement),
+                expectedIdentity: identity,
+                operation: "Application hide")
+            Issue.record("Expected provider refusal")
+        } catch let failure as DesktopActionFailure {
+            #expect(failure.outcome == refusal)
+            #expect(failure.message == "Application hide did not return a successful application outcome.")
+            #expect(failure.hint == "Follow the canonical escalation metadata before deciding whether to retry.")
+            #expect(failure.causeDescription == nil)
+            #expect(failure.targetReceipt == nil)
+        }
+    }
+
+    @Test
     func `exact quit rejects missing canonical outcome`() {
         let identity = ApplicationProcessIdentity(processIdentifier: 42, processStartIdentity: 7)
 

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/UIAutomationActionResultSemanticsTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/UIAutomationActionResultSemanticsTests.swift
@@ -81,6 +81,88 @@ struct UIAutomationActionResultSemanticsTests {
     }
 
     @Test
+    func `exact process validator accepts process and window refinements from the same generation`() throws {
+        let fixture = AutomationTestFixtures.linkedDesktopTarget(
+            processIdentity: .init(processIdentifier: 42, processStartIdentity: 1001),
+            windowID: 71,
+            bounds: Self.windowBounds)
+        let outcome = DesktopActionOutcome.confirmedChange(delivery: self.backgroundDelivery)
+
+        for target in [fixture.processTargetIdentity, fixture.windowTargetIdentity] {
+            let accepted = try UIAutomationActionResultSemantics.requireAcceptedExactProcessResult(
+                UIAutomationActionResult(payload: (), outcome: outcome, targetIdentity: target),
+                expectedIdentity: fixture.processIdentity,
+                policy: .confirmedOrDispatched,
+                operation: "Fixture action")
+            #expect(accepted == outcome)
+        }
+    }
+
+    @Test
+    func `exact process validator preserves target and provider failure ordering`() throws {
+        let expected = AutomationTestFixtures.linkedDesktopTarget(
+            processIdentity: .init(processIdentifier: 42, processStartIdentity: 1001))
+        let replacement = AutomationTestFixtures.linkedDesktopTarget(
+            processIdentity: .init(processIdentifier: 42, processStartIdentity: 1002))
+        let providerFailure = DesktopActionOutcome.suspectedNoop(delivery: self.backgroundDelivery)
+
+        do {
+            _ = try UIAutomationActionResultSemantics.requireAcceptedExactProcessResult(
+                UIAutomationActionResult<Void>(
+                    payload: (),
+                    outcome: providerFailure,
+                    targetIdentity: nil),
+                expectedIdentity: expected.processIdentity,
+                policy: .confirmedOrDispatched,
+                operation: "Fixture action",
+                contradictoryTargetMessage: "contradictory target",
+                rejectedOutcomeMessage: "provider failure")
+            Issue.record("Expected provider failure before missing-target validation")
+        } catch let failure as DesktopActionFailure {
+            #expect(failure.outcome == providerFailure)
+            #expect(failure.message == "provider failure")
+            #expect(failure.targetReceipt == expected.processTargetReceipt)
+        }
+
+        do {
+            _ = try UIAutomationActionResultSemantics.requireAcceptedExactProcessResult(
+                UIAutomationActionResult(
+                    payload: (),
+                    outcome: providerFailure,
+                    targetIdentity: replacement.processTargetIdentity),
+                expectedIdentity: expected.processIdentity,
+                policy: .confirmedOrDispatched,
+                operation: "Fixture action",
+                contradictoryTargetMessage: "contradictory target",
+                rejectedOutcomeMessage: "provider failure")
+            Issue.record("Expected target contradiction before provider failure")
+        } catch let failure as DesktopActionFailure {
+            #expect(failure.outcome.state == .indeterminate)
+            #expect(failure.message == "contradictory target")
+            #expect(failure.targetReceipt == nil)
+        }
+
+        let refusal = DesktopActionOutcome.refused(reason: .targetUnavailable)
+        do {
+            _ = try UIAutomationActionResultSemantics.requireAcceptedExactProcessResult(
+                UIAutomationActionResult(
+                    payload: (),
+                    outcome: refusal,
+                    targetIdentity: replacement.processTargetIdentity),
+                expectedIdentity: expected.processIdentity,
+                policy: .confirmedOrDispatched,
+                operation: "Fixture action",
+                contradictoryTargetMessage: "contradictory target",
+                rejectedOutcomeMessage: "provider refusal")
+            Issue.record("Expected pre-dispatch refusal before target validation")
+        } catch let failure as DesktopActionFailure {
+            #expect(failure.outcome == refusal)
+            #expect(failure.message == "provider refusal")
+            #expect(failure.targetReceipt == nil)
+        }
+    }
+
+    @Test
     func `shared validator rejects delivery drift and attributes the target`() throws {
         let target = AutomationTestFixtures.linkedDesktopTarget(
             processIdentity: .init(processIdentifier: 42, processStartIdentity: 1001))


### PR DESCRIPTION
## Summary

- make `UIAutomationActionResultSemantics` the single owner of exact-process result acceptance
- keep application lifecycle adapters thin while preserving legacy nil-outcome compatibility and quit consistency checks
- lock the existing failure ordering, wording, target attribution, route, delivery, dispatch count, hint, and cause semantics

## Proof

- application and shared-result semantics tests: 26 passed
- relevant app lifecycle exact-target tests: 4 passed
- `pnpm run format`
- `pnpm run lint` (zero serious findings)
- `git diff --check`
- P0-P2 structured review: clean

The five failures in the broader lifecycle suite reproduce unchanged on `main`; they are stale inventory fixtures outside this refactor.
