### PR TITLE
fix(browser): preserve target lock guidance

### DIFF
--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bind Bridge 1.34 Chrome channel connections to an exact live Chrome bundle, native process-owned DevTools listener, and approval-gated WebSocket under one 90-second deadline, verifying `Browser.getVersion` once without legacy HTTP discovery or repeated permission probes and failing closed on helper-service names, file, socket, generation, or endpoint drift.
 - Authenticate native Chrome channels against Google Team ID `EQHXZ8M8AV`, pin the exact signed identifier and CDHash for the process generation, and enumerate the target process's complete listener inventory independently of Peekaboo's file-descriptor limit.
 - Honor the configured default save directory for pathless pixel-only `see` captures and add collision-resistant generated filenames for concurrent callers, while preserving explicit paths and stdout streaming. Thanks @PollyBot13 for #607.
+- Preserve the exact browser target-lock refusal so reconnecting to a different live Chrome channel or endpoint tells callers to disconnect first instead of reporting a generic unavailable target.
 - Emit one lossless target identity and process-generation receipt across CLI envelopes and App MCP responses, preventing extra metadata from overriding the canonical target.
 - Let exact `dialog` targeting prefer one active child sheet or alert beneath its structural parent, retain ambiguity for multiple children, and preserve actionable parent-window recovery hints through Bridge routing.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Bind Bridge 1.34 Chrome channel connections to an exact live Chrome bundle, native process-owned DevTools listener, and approval-gated WebSocket under one 90-second deadline, verifying `Browser.getVersion` once without legacy HTTP discovery or repeated permission probes and failing closed on helper-service names, file, socket, generation, or endpoint drift.
 - Authenticate native Chrome channels against Google Team ID `EQHXZ8M8AV`, pin the exact signed identifier and CDHash for the process generation, and enumerate the target process's complete listener inventory independently of Peekaboo's file-descriptor limit.
 - Honor the configured default save directory for pathless pixel-only `see` captures and add collision-resistant generated filenames for concurrent callers, while preserving explicit paths and stdout streaming. Thanks @PollyBot13 for #607.
+- Preserve the exact browser target-lock refusal so reconnecting to a different live Chrome channel or endpoint tells callers to disconnect first instead of reporting a generic unavailable target.
 - Emit one lossless target identity and process-generation receipt across CLI envelopes and App MCP responses, preventing extra metadata from overriding the canonical target.
 - Prefer a sole live child sheet or alert beneath its exact structural parent window, preserve multi-child ambiguity, and keep parent-window recovery guidance intact across remote dialog reads.
 

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/Browser/BrowserMCPSessionManager.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/Browser/BrowserMCPSessionManager.swift
@@ -283,6 +283,8 @@ final class BrowserMCPSessionManager: @unchecked Sendable {
             throw failure
         } catch is CancellationError where !attempt.state.didStartAnyDispatch {
             throw Self.preDispatchConnectionFailure(CancellationError())
+        } catch BrowserMCPConnectionError.targetLocked {
+            throw BrowserMCPConnectionError.targetLocked
         } catch {
             if attempt.state.didStartAnyDispatch {
                 throw Self.indeterminateConnectionFailure(error)

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/BrowserTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/BrowserTool.swift
@@ -201,6 +201,10 @@ public struct BrowserTool: MCPTool {
             return ToolResponse.error(error.localizedDescription)
         } catch let error as BrowserMCPUploadStagingError {
             return ToolResponse.error(error.localizedDescription)
+        } catch BrowserMCPConnectionError.targetLocked {
+            return try MCPToolResponseMetadataProjector.errorResponse(
+                for: self.targetLockedFailure(),
+                invalidatedSnapshotID: nil)
         } catch let failure as DesktopActionFailure
             where failure.outcome.state == .refused &&
             failure.outcome.refusalReason == .requestCancelled &&
@@ -466,6 +470,19 @@ public struct BrowserTool: MCPTool {
         var lines = ["Chrome DevTools MCP failed: \(error.localizedDescription)", ""]
         lines.append(contentsOf: self.permissionInstructions())
         return lines.joined(separator: "\n")
+    }
+
+    private func targetLockedFailure() -> DesktopActionFailure {
+        let hint = switch self.instructionAudience {
+        case .mcp:
+            "Run browser { \"action\": \"disconnect\" }, then connect to the intended channel or endpoint."
+        case .commandLine:
+            "Run `peekaboo browser disconnect`, then connect to the intended channel or endpoint."
+        }
+        return .preDispatchRefusal(
+            reason: .transportSessionUnavailable,
+            message: BrowserMCPConnectionError.targetLocked.localizedDescription,
+            hint: hint)
     }
 
     private func permissionInstructions() -> [String] {

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeModels.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeModels.swift
@@ -585,7 +585,9 @@ public struct PeekabooBridgeErrorEnvelope: Codable, Sendable, LocalizedError {
         self.details = details
         self.permission = permission
         self.kind = kind
-        self.context = context
+        self.context = context ?? actionFailure.standardErrorCode.map {
+            Self.standardizedErrorContextPrefix + $0.rawValue
+        }
         self.operationMayHaveCompleted = actionFailure.outcome.projection.mutationDispatched
         self.actionOutcome = actionFailure.outcome.projection
         self.actionFailureHint = actionFailure.hint

--- a/Core/PeekabooCore/Sources/PeekabooCore/Support/PeekabooServices+BrowserBridge.swift
+++ b/Core/PeekabooCore/Sources/PeekabooCore/Support/PeekabooServices+BrowserBridge.swift
@@ -22,10 +22,14 @@ extension PeekabooServices: PeekabooBridgeBrowserConnectionResultProviding {
     }
 
     public func browserConnect(channel: String?, browserURL: String?) async throws -> PeekabooBridgeBrowserStatus {
-        let status = try await self.browser.connect(
-            channel: Self.browserChannel(from: channel),
-            browserURL: browserURL)
-        return Self.bridgeStatus(from: status)
+        do {
+            let status = try await self.browser.connect(
+                channel: Self.browserChannel(from: channel),
+                browserURL: browserURL)
+            return Self.bridgeStatus(from: status)
+        } catch BrowserMCPConnectionError.targetLocked {
+            throw Self.browserTargetLockedFailure()
+        }
     }
 
     public func browserConnectResult(
@@ -38,12 +42,16 @@ extension PeekabooServices: PeekabooBridgeBrowserConnectionResultProviding {
                 message: "The browser provider cannot report canonical connection outcomes.",
                 hint: "Update the runtime host before retrying browser connect.")
         }
-        let result = try await resultBrowser.connectWithOutcome(
-            channel: Self.browserChannel(from: channel),
-            browserURL: browserURL)
-        return DesktopActionResult(
-            payload: Self.bridgeStatus(from: result.payload),
-            outcome: result.outcome)
+        do {
+            let result = try await resultBrowser.connectWithOutcome(
+                channel: Self.browserChannel(from: channel),
+                browserURL: browserURL)
+            return DesktopActionResult(
+                payload: Self.bridgeStatus(from: result.payload),
+                outcome: result.outcome)
+        } catch BrowserMCPConnectionError.targetLocked {
+            throw Self.browserTargetLockedFailure()
+        }
     }
 
     public func browserDisconnect() async throws {
@@ -145,6 +153,14 @@ extension PeekabooServices: PeekabooBridgeBrowserConnectionResultProviding {
                 hint: "Use one of: stable, beta, dev, or canary.")
         }
         return channel
+    }
+
+    private static func browserTargetLockedFailure() -> DesktopActionFailure {
+        .preDispatchRefusal(
+            reason: .transportSessionUnavailable,
+            message: BrowserMCPConnectionError.targetLocked.localizedDescription,
+            hint: "Disconnect the current browser connection before selecting another channel or endpoint.",
+            standardErrorCode: .browserTargetLocked)
     }
 
     private static func bridgeStatus(from status: BrowserMCPStatus) -> PeekabooBridgeBrowserStatus {

--- a/Core/PeekabooCore/Sources/PeekabooCore/Support/RemoteBrowserMCPClient.swift
+++ b/Core/PeekabooCore/Sources/PeekabooCore/Support/RemoteBrowserMCPClient.swift
@@ -42,12 +42,16 @@ public final class RemoteBrowserMCPClient: BrowserMCPClientProviding, BrowserMCP
         channel: BrowserMCPChannel?,
         browserURL: String?) async throws -> DesktopActionResult<BrowserMCPStatus>
     {
-        let result = try await self.client.browserConnectResult(
-            channel: channel?.rawValue,
-            browserURL: browserURL)
-        return try DesktopActionResult(
-            payload: Self.status(from: result.payload),
-            outcome: result.outcome)
+        do {
+            let result = try await self.client.browserConnectResult(
+                channel: channel?.rawValue,
+                browserURL: browserURL)
+            return try DesktopActionResult(
+                payload: Self.status(from: result.payload),
+                outcome: result.outcome)
+        } catch let failure as DesktopActionFailure where Self.isBrowserTargetLockedFailure(failure) {
+            throw BrowserMCPConnectionError.targetLocked
+        }
     }
 
     @MainActor
@@ -167,6 +171,14 @@ public final class RemoteBrowserMCPClient: BrowserMCPClientProviding, BrowserMCP
             detectedBrowsers: detectedBrowsers,
             connectionReceipt: connectionReceipt,
             error: bridgeStatus.error)
+    }
+
+    private static func isBrowserTargetLockedFailure(_ failure: DesktopActionFailure) -> Bool {
+        failure.standardErrorCode == .browserTargetLocked &&
+            failure.outcome.state == .refused &&
+            failure.outcome.refusalReason == .transportSessionUnavailable &&
+            failure.outcome.dispatchState == .none &&
+            failure.outcome.retrySafety == .safe
     }
 
     private static func bridgeReceipt(

--- a/Core/PeekabooCore/Tests/PeekabooAgentRuntimeTests/BrowserMCPSessionManagerAuthorityValidationTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooAgentRuntimeTests/BrowserMCPSessionManagerAuthorityValidationTests.swift
@@ -350,7 +350,7 @@ struct BrowserMCPSessionManagerAuthorityValidationTests {
             browserURL: "http://127.0.0.1:9222").connectionReceipt)
         manager.executedTools.removeAll()
 
-        await #expect(throws: DesktopActionFailure.self) {
+        await #expect(throws: BrowserMCPConnectionError.targetLocked) {
             _ = try await session.connect(channel: .stable)
         }
 
@@ -407,7 +407,7 @@ struct BrowserMCPSessionManagerAuthorityValidationTests {
         manager.executedTools.removeAll()
         isolated.value = false
 
-        await #expect(throws: DesktopActionFailure.self) {
+        await #expect(throws: BrowserMCPConnectionError.targetLocked) {
             _ = try await session.connect(channel: .stable)
         }
 

--- a/Core/PeekabooCore/Tests/PeekabooAgentRuntimeTests/BrowserMCPSessionManagerTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooAgentRuntimeTests/BrowserMCPSessionManagerTests.swift
@@ -1044,7 +1044,7 @@ extension BrowserMCPSessionManagerTests {
         #expect(manager.addedConfigs[0].args.contains(
             "--wsEndpoint=ws://127.0.0.1:9222/devtools/browser/browser-a"))
 
-        await #expect(throws: DesktopActionFailure.self) {
+        await #expect(throws: BrowserMCPConnectionError.targetLocked) {
             _ = try await session.connect(
                 channel: .stable,
                 browserURL: "http://127.0.0.1:9333")

--- a/Core/PeekabooCore/Tests/PeekabooAgentRuntimeTests/BrowserToolConnectOutcomeTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooAgentRuntimeTests/BrowserToolConnectOutcomeTests.swift
@@ -48,6 +48,42 @@ struct BrowserToolConnectOutcomeTests {
     }
 
     @Test
+    func `Target lock projects exact session recovery without permission guidance`() async throws {
+        let cases: [(BrowserToolInstructionAudience, String)] = [
+            (.mcp, "Run browser { \"action\": \"disconnect\" }"),
+            (.commandLine, "Run `peekaboo browser disconnect`"),
+        ]
+
+        for (audience, expectedHint) in cases {
+            let client = ConnectOutcomeBrowserClient(error: BrowserMCPConnectionError.targetLocked)
+            let response = try await BrowserTool(
+                client: client,
+                executionPolicy: .unrestricted,
+                instructionAudience: audience).execute(
+                arguments: ToolArguments(raw: ["action": "connect", "channel": "canary"]))
+
+            #expect(response.isError)
+            let meta = try #require(response.meta?.objectValue)
+            #expect(meta["state"] == .string("refused"))
+            #expect(meta["dispatch_state"] == .string("none"))
+            #expect(meta["mutation_dispatched"] == .bool(false))
+            #expect(meta["retry_safe"] == .bool(true))
+            #expect(meta["refusal_reason"] == .string("transport_session_unavailable"))
+            #expect(meta["escalation"] == .string("reconnect_session"))
+
+            guard case let .text(text: text, annotations: _, _meta: _) = response.content.first else {
+                Issue.record("Expected a text error response")
+                continue
+            }
+            #expect(text.contains(BrowserMCPConnectionError.targetLocked.localizedDescription))
+            #expect(text.contains(expectedHint))
+            #expect(!text.contains("enable remote debugging"))
+            #expect(!text.contains("Run browser { \"action\": \"connect\" }"))
+            #expect(client.connectCount == 1)
+        }
+    }
+
+    @Test
     func `Browser tool keeps uncancelled raw provider cancellation indeterminate`() async throws {
         let client = ConnectOutcomeBrowserClient(error: CancellationError())
 

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooServicesBrowserBridgeTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooServicesBrowserBridgeTests.swift
@@ -1,6 +1,7 @@
 import Foundation
 import MCP
 import PeekabooAutomationKit
+import PeekabooBridgeTestSupport
 import PeekabooFoundation
 import TachikomaMCP
 import Testing
@@ -9,6 +10,73 @@ import Testing
 @testable import PeekabooCore
 
 struct PeekabooServicesBrowserBridgeTests {
+    @Test
+    @MainActor
+    func `target lock stays retry safe through Bridge remote client and Browser tool`() async throws {
+        let browser = TargetLockedBrowserMCPClient()
+        let services = Self.services(browser: browser)
+        let socketPath = "/tmp/peekaboo-browser-target-lock-\(UUID().uuidString).sock"
+        let server = PeekabooBridgeServer(
+            services: services,
+            hostKind: .onDemand,
+            allowlistedTeams: [],
+            allowlistedBundles: [])
+        let host = PeekabooBridgeHost(
+            socketPath: socketPath,
+            server: server,
+            allowedTeamIDs: [],
+            requestTimeoutSec: 2)
+        try await host.startChecked()
+        defer { Task { await host.stop() } }
+
+        let bridge = TrustedBridgeClientFixture.make(socketPath: socketPath, requestTimeoutSec: 2)
+        _ = try await bridge.handshake(client: .init(
+            bundleIdentifier: "dev.peekaboo.browser-target-lock",
+            teamIdentifier: nil,
+            processIdentifier: getpid()))
+        let response = try await BrowserTool(
+            client: RemoteBrowserMCPClient(client: bridge),
+            executionPolicy: .unrestricted,
+            instructionAudience: .commandLine).execute(
+            arguments: ToolArguments(raw: ["action": "connect", "channel": "canary"]))
+
+        #expect(response.isError)
+        let metadata = try #require(response.meta?.objectValue)
+        #expect(metadata["state"] == .string("refused"))
+        #expect(metadata["dispatch_state"] == .string("none"))
+        #expect(metadata["mutation_dispatched"] == .bool(false))
+        #expect(metadata["retry_safe"] == .bool(true))
+        #expect(metadata["refusal_reason"] == .string("transport_session_unavailable"))
+        #expect(metadata["escalation"] == .string("reconnect_session"))
+
+        guard case let .text(text: text, annotations: _, _meta: _) = response.content.first else {
+            Issue.record("Expected a text error response")
+            return
+        }
+        #expect(text.contains(BrowserMCPConnectionError.targetLocked.localizedDescription))
+        #expect(text.contains("Run `peekaboo browser disconnect`"))
+        #expect(!text.contains("enable remote debugging"))
+        #expect(browser.connectCount == 1)
+
+        let bundle = try #require(await bridge.lastOperationReceiptBundle())
+        try bundle.validate()
+        #expect(bundle.receipt.payload.operation == .browserConnect)
+        #expect(bundle.receipt.payload.outcome?.state == .refused)
+        #expect(bundle.receipt.payload.outcome?.refusalReason == .transportSessionUnavailable)
+        #expect(bundle.receipt.payload.outcome?.dispatchState == DesktopActionOutcome.DispatchState.none)
+        let certifiedResponse = try JSONDecoder.peekabooBridgeDecoder().decode(
+            PeekabooBridgeResponse.self,
+            from: bundle.canonicalResponse)
+        guard case let .projectedAction(projected) = certifiedResponse,
+              case let .error(envelope) = projected.response
+        else {
+            Issue.record("Expected the target lock refusal envelope")
+            return
+        }
+        #expect(envelope.standardizedErrorCode == .browserTargetLocked)
+        await host.stop()
+    }
+
     @Test
     @MainActor
     func `legacy injected browser omits native binding capability and refuses channel connect`() async throws {
@@ -542,6 +610,49 @@ struct PeekabooServicesBrowserBridgeTests {
         screenRecording: true,
         accessibility: true,
         postEvent: true)
+}
+
+@MainActor
+private final class TargetLockedBrowserMCPClient: BrowserMCPClientProviding,
+    BrowserMCPConnectionResultProviding, @unchecked Sendable
+{
+    nonisolated var supportsNativeBrowserConnectionBinding: Bool {
+        true
+    }
+
+    private(set) var connectCount = 0
+
+    func status(channel _: BrowserMCPChannel?) async -> BrowserMCPStatus {
+        BrowserMCPStatus(isConnected: false, toolCount: 0, detectedBrowsers: [])
+    }
+
+    func connect(channel _: BrowserMCPChannel?) async throws -> BrowserMCPStatus {
+        self.connectCount += 1
+        throw BrowserMCPConnectionError.targetLocked
+    }
+
+    func connect(channel _: BrowserMCPChannel?, browserURL _: String?) async throws -> BrowserMCPStatus {
+        self.connectCount += 1
+        throw BrowserMCPConnectionError.targetLocked
+    }
+
+    func connectWithOutcome(
+        channel _: BrowserMCPChannel?,
+        browserURL _: String?) async throws -> DesktopActionResult<BrowserMCPStatus>
+    {
+        self.connectCount += 1
+        throw BrowserMCPConnectionError.targetLocked
+    }
+
+    func disconnect() async {}
+
+    func execute(
+        toolName _: String,
+        arguments _: [String: Any],
+        channel _: BrowserMCPChannel?) async throws -> ToolResponse
+    {
+        .error("unexpected")
+    }
 }
 
 @MainActor

--- a/Core/PeekabooFoundation/Sources/PeekabooFoundation/DesktopActionOutcome.swift
+++ b/Core/PeekabooFoundation/Sources/PeekabooFoundation/DesktopActionOutcome.swift
@@ -857,14 +857,15 @@ public struct DesktopActionFailure: Codable, Equatable, LocalizedError, Sendable
         reason: DesktopActionOutcome.RefusalReason,
         message: String,
         hint: String? = nil,
-        causeDescription: String? = nil) -> DesktopActionFailure
+        causeDescription: String? = nil,
+        standardErrorCode: StandardErrorCode? = nil) -> DesktopActionFailure
     {
-        .refused(
-            route: route,
-            reason: reason,
+        Self(
+            validatedOutcome: .refused(route: route, reason: reason),
             message: message,
             hint: hint,
-            causeDescription: causeDescription)
+            causeDescription: causeDescription,
+            standardErrorCode: standardErrorCode)
     }
 
     /// Fails a step only when its implementation reported a non-confirmed canonical outcome.

--- a/Core/PeekabooFoundation/Sources/PeekabooFoundation/StandardizedErrors.swift
+++ b/Core/PeekabooFoundation/Sources/PeekabooFoundation/StandardizedErrors.swift
@@ -21,6 +21,7 @@ public enum StandardErrorCode: String, Codable, Sendable, Equatable {
     // Operation errors
     case captureFailed = "CAPTURE_FAILED"
     case interactionFailed = "INTERACTION_FAILED"
+    case browserTargetLocked = "BROWSER_TARGET_LOCKED"
     case accessibilityIncomplete = "ACCESSIBILITY_INCOMPLETE"
     case timeout = "TIMEOUT"
     case cancelled = "CANCELLED"


### PR DESCRIPTION
## Summary

- preserve `targetLocked` through the outer browser-connect deadline wrapper
- keep the exact disconnect-first recovery contract for conflicting existing sessions
- project tool-level conflicts as canonical zero-dispatch, retry-safe reconnect-session refusals
- carry stable `BROWSER_TARGET_LOCKED` identity through the signed Bridge and reconstruct the typed session error remotely
- cover endpoint-to-endpoint, explicit-to-native, and isolated-to-native conflicts

## Proof

- focused BrowserTool/session tests: 10 passed
- broader serial Browser tests: 157 passed
- Foundation error-code tests: 77 passed
- real-socket Bridge-to-tool regression: 1 passed
- SwiftFormat and strict touched-file SwiftLint
- `git diff --check`
- P0-P2 structured review: clean
