### PR TITLE
fix(mcp): advertise only policy-reachable actions

### DIFF
--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Authenticate native Chrome channels against Google Team ID `EQHXZ8M8AV`, pin the exact signed identifier and CDHash for the process generation, and enumerate the target process's complete listener inventory independently of Peekaboo's file-descriptor limit.
 - Honor the configured default save directory for pathless pixel-only `see` captures and add collision-resistant generated filenames for concurrent callers, while preserving explicit paths and stdout streaming. Thanks @PollyBot13 for #607.
 - Preserve the exact browser target-lock refusal so reconnecting to a different live Chrome channel or endpoint tells callers to disconnect first instead of reporting a generic unavailable target.
+- Advertise only actions and input shapes reachable under immutable background-only authority, while keeping foreground-capable app, Dock, Space, dialog, menu, browser, clipboard, and paste workflows explicit.
 - Emit one lossless target identity and process-generation receipt across CLI envelopes and App MCP responses, preventing extra metadata from overriding the canonical target.
 - Let exact `dialog` targeting prefer one active child sheet or alert beneath its structural parent, retain ambiguity for multiple children, and preserve actionable parent-window recovery hints through Bridge routing.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Authenticate native Chrome channels against Google Team ID `EQHXZ8M8AV`, pin the exact signed identifier and CDHash for the process generation, and enumerate the target process's complete listener inventory independently of Peekaboo's file-descriptor limit.
 - Honor the configured default save directory for pathless pixel-only `see` captures and add collision-resistant generated filenames for concurrent callers, while preserving explicit paths and stdout streaming. Thanks @PollyBot13 for #607.
 - Preserve the exact browser target-lock refusal so reconnecting to a different live Chrome channel or endpoint tells callers to disconnect first instead of reporting a generic unavailable target.
+- Advertise only actions and input shapes reachable under immutable background-only authority, while keeping foreground-capable app, Dock, Space, dialog, menu, browser, clipboard, and paste workflows explicit.
 - Emit one lossless target identity and process-generation receipt across CLI envelopes and App MCP responses, preventing extra metadata from overriding the canonical target.
 - Prefer a sole live child sheet or alert beneath its exact structural parent window, preserve multi-child ambiguity, and keep parent-window recovery guidance intact across remote dialog reads.
 

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/AppTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/AppTool.swift
@@ -26,7 +26,7 @@ public struct AppTool: MCPTool {
 
             Always include the `action` field in your JSON payload. Examples:
             - { "action": "list" }
-            - { "action": "launch", "name": "Finder" }
+            - Already-running readiness probe: { "action": "launch", "name": "Finder" }
             - { "action": "quit", "name": "Slack", "force": false }
             """
         }
@@ -39,7 +39,8 @@ public struct AppTool: MCPTool {
         `process_start_identity` field remains compatibility-only and can lose precision above 2^53.
 
         Always include the `action` field in your JSON payload. Examples:
-        - { "action": "launch", "name": "Finder" }
+        - Already-running readiness probe: { "action": "launch", "name": "PID:1234" }
+        - Cold launch with foreground consent: { "action": "launch", "name": "Calendar", "foreground": true }
         - { "action": "launch", "name": "TextEdit", "newInstance": true, "foreground": true }
         - { "action": "open", "name": "Safari", "openTargets": ["https://example.com"], "foreground": true }
         - { "action": "switch", "to": "Safari" }

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/BrowserTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/BrowserTool.swift
@@ -15,102 +15,114 @@ public struct BrowserTool: MCPTool {
     private let instructionAudience: BrowserToolInstructionAudience
 
     public let name = "browser"
-    public let description = """
-    Controls and inspects Chrome web pages through Chrome DevTools MCP.
+    public var description: String {
+        if self.executionPolicy == .backgroundOnly {
+            return """
+            Controls and inspects Chrome web pages through one existing exact DevTools connection under immutable
+            background-only authority. Use `status` to inspect its receipt, then page-scoped actions with explicit
+            page IDs. Connect is unavailable because Chrome may surface remote-debugging setup or approval UI; use a
+            human-authorized foreground-capable session or standalone CLI to establish the connection first.
+            """
+        }
 
-    Use this for browser page content: DOM/accessibility snapshots, web forms, navigation,
-    console messages, network requests, screenshots, and performance traces. Use Peekaboo's
-    native tools for macOS chrome, menus, dialogs, permissions, and non-browser applications.
+        return """
+        Controls and inspects Chrome web pages through Chrome DevTools MCP.
 
-    Chrome DevTools MCP requires Chrome 144+ with remote debugging enabled at
-    chrome://inspect/#remote-debugging. The user must accept Chrome's remote debugging prompt.
-    Peekaboo starts chrome-devtools-mcp with usage statistics and CrUX lookups disabled.
-    Background-only Agent sessions reuse an existing exact connection and never auto-connect;
-    ask the user to connect explicitly when status reports no live connection receipt.
-    """
+        Use this for browser page content: DOM/accessibility snapshots, web forms, navigation,
+        console messages, network requests, screenshots, and performance traces. Use Peekaboo's
+        native tools for macOS chrome, menus, dialogs, permissions, and non-browser applications.
+
+        Chrome DevTools MCP requires Chrome 144+ with remote debugging enabled at
+        chrome://inspect/#remote-debugging. The user must accept Chrome's remote debugging prompt.
+        Peekaboo starts chrome-devtools-mcp with usage statistics and CrUX lookups disabled.
+        """
+    }
 
     public var inputSchema: Value {
-        SchemaBuilder.object(
-            properties: [
-                "action": SchemaBuilder.string(
-                    description: """
-                    Browser action to perform. Use `status` before connecting. Use `connect` after the user
-                    enables remote debugging and accepts Chrome's prompt. Connect is a foreground-consent action
-                    and is refused by background-only contexts.
-                    """,
-                    enum: BrowserAction.allCases.map(\.rawValue)),
-                "channel": SchemaBuilder.string(
-                    description: """
-                    Chrome channel selected by explicit connect. Defaults to the running Chrome channel, then stable.
-                    Other actions never auto-connect in a background-only context.
-                    """,
-                    enum: BrowserMCPChannel.allCases.map(\.rawValue)),
-                "browser_url": SchemaBuilder.string(description: """
-                Exact loopback DevTools HTTP endpoint for connect, for example http://127.0.0.1:9222.
-                Peekaboo resolves and pins its browser WebSocket identity. Required when multiple Chrome
-                processes share one channel.
-                """),
-                "page_id": SchemaBuilder.integer(description: """
-                Chrome DevTools page ID. Required for every page-scoped action so concurrent clients cannot
-                redirect one another by changing the shared selected page. Use list_pages to discover IDs.
-                """, minimum: 0),
-                "url": SchemaBuilder.string(description: "URL for navigate/new_page."),
-                "navigation_type": SchemaBuilder.string(
-                    description: "Navigation type for navigate.",
-                    enum: ["url", "back", "forward", "reload"]),
-                "uid": SchemaBuilder.string(description: """
-                Element uid from the latest browser snapshot. Required for element actions, including type and
-                press_key so keyboard input cannot inherit an unrelated focused element.
-                """),
-                "to_uid": SchemaBuilder.string(description: "Drop target uid for drag."),
-                "text": SchemaBuilder.string(description: "Text for type or wait_for."),
-                "value": SchemaBuilder.string(description: "Value for fill."),
-                "key": SchemaBuilder.string(description: "Key or key combination for press_key."),
-                "submit_key": SchemaBuilder.string(description: "Optional key pressed after type_text."),
-                "dialog_action": SchemaBuilder.string(
-                    description: "Browser dialog action.",
-                    enum: ["accept", "dismiss"]),
-                "include_snapshot": SchemaBuilder.boolean(
-                    description: "Ask Chrome DevTools MCP to include a fresh snapshot when supported.",
-                    default: false),
-                "double": SchemaBuilder.boolean(description: "Double-click for click.", default: false),
-                "bring_to_front": SchemaBuilder.boolean(description: "Bring selected page to front.", default: false),
-                "background": SchemaBuilder.boolean(description: "Open new page in the background.", default: true),
-                "timeout": SchemaBuilder.integer(description: "Timeout in milliseconds for navigation/waits."),
-                "page_size": SchemaBuilder.integer(description: "Pagination size for console/network listings."),
-                "page_index": SchemaBuilder.integer(description: "Zero-based page index for console/network listings."),
-                "types": SchemaBuilder.array(
-                    items: SchemaBuilder.string(),
-                    description: "Console message types to include."),
-                "resource_types": SchemaBuilder.array(
-                    items: SchemaBuilder.string(),
-                    description: "Network resource types to include."),
-                "include_preserved": SchemaBuilder.boolean(
-                    description: "Include preserved console/network data from recent navigations.",
-                    default: false),
-                "message_id": SchemaBuilder.integer(description: "Console message ID for get_console_message."),
-                "request_id": SchemaBuilder.integer(description: "Network request ID for get_network_request."),
-                "request_file_path": SchemaBuilder.string(description: "Path for saving a network request body."),
-                "response_file_path": SchemaBuilder.string(description: "Path for saving a network response body."),
-                "path": SchemaBuilder.string(description: "Absolute input file for upload_file; output path for " +
-                    "snapshots, screenshots, or traces. Uploads accept current-user regular files up to 100 MiB."),
-                "format": SchemaBuilder.string(
-                    description: "Screenshot format.",
-                    enum: ["png", "jpeg", "webp"]),
-                "quality": SchemaBuilder.integer(description: "Screenshot quality for jpeg/webp."),
-                "full_page": SchemaBuilder.boolean(description: "Capture a full-page screenshot.", default: false),
-                "trace_action": SchemaBuilder.string(
-                    description: "Performance trace operation.",
-                    enum: ["start", "stop", "analyze"]),
-                "reload": SchemaBuilder.boolean(description: "Reload page when starting a trace.", default: true),
-                "auto_stop": SchemaBuilder.boolean(description: "Auto-stop trace after capture.", default: true),
-                "insight_set_id": SchemaBuilder.string(description: "Insight set id from trace summary."),
-                "insight_name": SchemaBuilder.string(description: "Insight name from trace summary."),
-                "mcp_tool": SchemaBuilder.string(
-                    description: "Advanced: audited Chrome DevTools MCP v1.6.0 tool name for call."),
-                "mcp_args_json": SchemaBuilder.string(description: "Advanced: JSON object args for raw MCP call. " +
-                    "Page-targeted tools require top-level page_id; nested pageId cannot select the page."),
-            ],
+        let foregroundCapable = self.executionPolicy != .backgroundOnly
+        let actions = BrowserAction.allCases.filter { foregroundCapable || $0 != .connect }
+        var properties: [String: Value] = [
+            "action": SchemaBuilder.string(
+                description: foregroundCapable
+                    ? "Browser action. Use status before explicit connect; connect may present Chrome approval UI."
+                    : "Background-safe action against an existing exact connection; connect is unavailable.",
+                enum: actions.map(\.rawValue)),
+            "channel": SchemaBuilder.string(
+                description: """
+                Chrome channel selected by explicit connect. Defaults to the running Chrome channel, then stable.
+                Other actions never auto-connect in a background-only context.
+                """,
+                enum: BrowserMCPChannel.allCases.map(\.rawValue)),
+            "page_id": SchemaBuilder.integer(description: """
+            Chrome DevTools page ID. Required for every page-scoped action so concurrent clients cannot
+            redirect one another by changing the shared selected page. Use list_pages to discover IDs.
+            """, minimum: 0),
+            "url": SchemaBuilder.string(description: "URL for navigate/new_page."),
+            "navigation_type": SchemaBuilder.string(
+                description: "Navigation type for navigate.",
+                enum: ["url", "back", "forward", "reload"]),
+            "uid": SchemaBuilder.string(description: """
+            Element uid from the latest browser snapshot. Required for element actions, including type and
+            press_key so keyboard input cannot inherit an unrelated focused element.
+            """),
+            "to_uid": SchemaBuilder.string(description: "Drop target uid for drag."),
+            "text": SchemaBuilder.string(description: "Text for type or wait_for."),
+            "value": SchemaBuilder.string(description: "Value for fill."),
+            "key": SchemaBuilder.string(description: "Key or key combination for press_key."),
+            "submit_key": SchemaBuilder.string(description: "Optional key pressed after type_text."),
+            "dialog_action": SchemaBuilder.string(
+                description: "Browser dialog action.",
+                enum: ["accept", "dismiss"]),
+            "include_snapshot": SchemaBuilder.boolean(
+                description: "Ask Chrome DevTools MCP to include a fresh snapshot when supported.",
+                default: false),
+            "double": SchemaBuilder.boolean(description: "Double-click for click.", default: false),
+            "bring_to_front": SchemaBuilder.boolean(description: "Bring selected page to front.", default: false),
+            "background": SchemaBuilder.boolean(description: "Open new page in the background.", default: true),
+            "timeout": SchemaBuilder.integer(description: "Timeout in milliseconds for navigation/waits."),
+            "page_size": SchemaBuilder.integer(description: "Pagination size for console/network listings."),
+            "page_index": SchemaBuilder.integer(description: "Zero-based page index for console/network listings."),
+            "types": SchemaBuilder.array(
+                items: SchemaBuilder.string(),
+                description: "Console message types to include."),
+            "resource_types": SchemaBuilder.array(
+                items: SchemaBuilder.string(),
+                description: "Network resource types to include."),
+            "include_preserved": SchemaBuilder.boolean(
+                description: "Include preserved console/network data from recent navigations.",
+                default: false),
+            "message_id": SchemaBuilder.integer(description: "Console message ID for get_console_message."),
+            "request_id": SchemaBuilder.integer(description: "Network request ID for get_network_request."),
+            "request_file_path": SchemaBuilder.string(description: "Path for saving a network request body."),
+            "response_file_path": SchemaBuilder.string(description: "Path for saving a network response body."),
+            "path": SchemaBuilder.string(description: "Absolute input file for upload_file; output path for " +
+                "snapshots, screenshots, or traces. Uploads accept current-user regular files up to 100 MiB."),
+            "format": SchemaBuilder.string(
+                description: "Screenshot format.",
+                enum: ["png", "jpeg", "webp"]),
+            "quality": SchemaBuilder.integer(description: "Screenshot quality for jpeg/webp."),
+            "full_page": SchemaBuilder.boolean(description: "Capture a full-page screenshot.", default: false),
+            "trace_action": SchemaBuilder.string(
+                description: "Performance trace operation.",
+                enum: ["start", "stop", "analyze"]),
+            "reload": SchemaBuilder.boolean(description: "Reload page when starting a trace.", default: true),
+            "auto_stop": SchemaBuilder.boolean(description: "Auto-stop trace after capture.", default: true),
+            "insight_set_id": SchemaBuilder.string(description: "Insight set id from trace summary."),
+            "insight_name": SchemaBuilder.string(description: "Insight name from trace summary."),
+            "mcp_tool": SchemaBuilder.string(
+                description: "Advanced: audited Chrome DevTools MCP v1.6.0 tool name for call."),
+            "mcp_args_json": SchemaBuilder.string(description: "Advanced: JSON object args for raw MCP call. " +
+                "Page-targeted tools require top-level page_id; nested pageId cannot select the page."),
+        ]
+        if foregroundCapable {
+            properties["browser_url"] = SchemaBuilder.string(description: """
+            Exact loopback DevTools HTTP endpoint for connect, for example http://127.0.0.1:9222.
+            Peekaboo resolves and pins its browser WebSocket identity. Required when multiple Chrome
+            processes share one channel.
+            """)
+        }
+        return SchemaBuilder.object(
+            properties: properties,
             required: ["action"])
     }
 

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/DialogTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/DialogTool.swift
@@ -21,7 +21,21 @@ public struct DialogTool: MCPTool {
     public let name = "dialog"
 
     public var description: String {
-        """
+        if self.context.executionPolicy == .backgroundOnly {
+            return """
+            Inspect and interact with system dialogs under immutable background-only authority. Available actions are
+            `list`, targeted `click`, targeted `input`, and targeted non-forced `dismiss`. Every mutation requires an
+            explicit app, PID, or exact window target. File-dialog keyboard navigation, forced dismissal, targetless
+            input, and foreground fallback are unavailable; use a human-authorized foreground-capable session or CLI.
+
+            Examples:
+            - Click OK: { "action": "click", "button": "OK", "app": "TextEdit" }
+            - Background input: { "action": "input", "text": "hello", "field": "Name", "app": "TextEdit" }
+            - Dismiss: { "action": "dismiss", "app": "TextEdit" }
+            """
+        }
+
+        return """
         Interact with system dialogs and alerts (alerts, sheets, NSSavePanel/NSOpenPanel).
 
         Actions:
@@ -49,46 +63,43 @@ public struct DialogTool: MCPTool {
     }
 
     public var inputSchema: Value {
-        SchemaBuilder.object(
-            properties: [
-                "action": SchemaBuilder.string(
-                    description: "Action to perform",
-                    enum: DialogToolAction.allCases.map(\.rawValue)),
-
-                // Targeting
-                "app": SchemaBuilder.string(description: "Target app name/bundle ID, or 'PID:<n>'."),
-                "pid": SchemaBuilder.integer(description: "Target process ID (alternative to app)."),
-                "window_id": SchemaBuilder.integer(description: "Window ID (preferred stable selector)."),
-                "window_title": SchemaBuilder.string(description: "Window title (substring match)."),
-                "window_index": SchemaBuilder.integer(description: "Window index (0-based); requires app/pid."),
-                "foreground": SchemaBuilder.boolean(
-                    description: "Allow focus/global input. Required for targetless input, file, and forced dismiss.",
-                    default: false),
-
-                // click
-                "button": SchemaBuilder.string(description: "Button text to click. Use 'default' to click OKButton."),
-
-                // input
-                "text": SchemaBuilder.string(description: "Text to input (for input action)."),
-                "field": SchemaBuilder.string(description: "Field label/placeholder to target (for input action)."),
-                "field_index": SchemaBuilder.integer(
-                    description: "Field index (0-based) to target (for input action)."),
-                "clear": SchemaBuilder.boolean(description: "Clear existing text first.", default: false),
-
-                // file
-                "path": SchemaBuilder.string(description: "Directory (or full path) to navigate to (for file action)."),
-                "name": SchemaBuilder.string(description: "Filename to enter (for save dialogs)."),
-                "select": SchemaBuilder.string(
-                    description: """
-                    Button to click after setting path/name. Omit (or pass 'default') to click OKButton.
-                    """),
-                "ensure_expanded": SchemaBuilder.boolean(
-                    description: "Ensure file dialogs are expanded (Show Details) before applying path navigation.",
-                    default: false),
-
-                // dismiss
-                "force": SchemaBuilder.boolean(description: "Force dismiss (sends Escape).", default: false),
-            ],
+        let foregroundCapable = self.context.executionPolicy != .backgroundOnly
+        let actions = foregroundCapable
+            ? DialogToolAction.allCases.map(\.rawValue)
+            : [DialogToolAction.list, .click, .input, .dismiss].map(\.rawValue)
+        var properties: [String: Value] = [
+            "action": SchemaBuilder.string(
+                description: foregroundCapable
+                    ? "Action to perform"
+                    : "Background-safe dialog action; file and global input are unavailable",
+                enum: actions),
+            "app": SchemaBuilder.string(description: "Target app name/bundle ID, or 'PID:<n>'."),
+            "pid": SchemaBuilder.integer(description: "Target process ID (alternative to app)."),
+            "window_id": SchemaBuilder.integer(description: "Window ID (preferred stable selector)."),
+            "window_title": SchemaBuilder.string(description: "Window title (substring match)."),
+            "window_index": SchemaBuilder.integer(description: "Window index (0-based); requires app/pid."),
+            "button": SchemaBuilder.string(description: "Button text to click. Use 'default' to click OKButton."),
+            "text": SchemaBuilder.string(description: "Text to input (for input action)."),
+            "field": SchemaBuilder.string(description: "Field label/placeholder to target (for input action)."),
+            "field_index": SchemaBuilder.integer(description: "Field index (0-based) to target (for input action)."),
+            "clear": SchemaBuilder.boolean(description: "Clear existing text first.", default: false),
+        ]
+        if foregroundCapable {
+            properties["foreground"] = SchemaBuilder.boolean(
+                description: "Allow focus/global input. Required for targetless input, file, and forced dismiss.",
+                default: false)
+            properties["path"] = SchemaBuilder.string(
+                description: "Directory (or full path) to navigate to (for file action).")
+            properties["name"] = SchemaBuilder.string(description: "Filename to enter (for save dialogs).")
+            properties["select"] = SchemaBuilder.string(
+                description: "Button to click after setting path/name; default clicks OKButton.")
+            properties["ensure_expanded"] = SchemaBuilder.boolean(
+                description: "Ensure file dialogs are expanded (Show Details) before applying path navigation.",
+                default: false)
+            properties["force"] = SchemaBuilder.boolean(description: "Force dismiss (sends Escape).", default: false)
+        }
+        return SchemaBuilder.object(
+            properties: properties,
             required: ["action"])
     }
 

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/DockTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/DockTool.swift
@@ -19,7 +19,7 @@ public struct DockTool: MCPTool {
             Inspect the macOS Dock under immutable background-only authority. The available action is `list`.
             Dock launch, context menus, hide, and show mutate shared desktop UI and require a human-authorized
             foreground-capable Agent session or the standalone CLI.
-            \(PeekabooMCPVersion.banner) using openai/gpt-5.6 and anthropic/claude-opus-5
+            \(PeekabooMCPVersion.banner)
             """
         }
 

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/DockTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/DockTool.swift
@@ -14,7 +14,16 @@ public struct DockTool: MCPTool {
     public let name = "dock"
 
     public var description: String {
-        """
+        if self.context.executionPolicy == .backgroundOnly {
+            return """
+            Inspect the macOS Dock under immutable background-only authority. The available action is `list`.
+            Dock launch, context menus, hide, and show mutate shared desktop UI and require a human-authorized
+            foreground-capable Agent session or the standalone CLI.
+            \(PeekabooMCPVersion.banner) using openai/gpt-5.6 and anthropic/claude-opus-5
+            """
+        }
+
+        return """
         Interact with the macOS Dock - launch apps, show context menus, hide/show dock.
         Actions: launch, right-click (with menu selection), hide, show, list
         launch and right-click activate global Dock UI and require foreground=true.
@@ -25,22 +34,29 @@ public struct DockTool: MCPTool {
     }
 
     public var inputSchema: Value {
-        SchemaBuilder.object(
-            properties: [
-                "action": SchemaBuilder.string(
-                    description: "Action to perform on the dock",
-                    enum: ["launch", "right-click", "hide", "show", "list"]),
-                "app": SchemaBuilder.string(
-                    description: "Application name for launch/right-click actions"),
-                "select": SchemaBuilder.string(
-                    description: "Menu item to select after right-clicking"),
-                "foreground": SchemaBuilder.boolean(
-                    description: "Confirm foreground/global Dock UI for launch and right-click actions.",
-                    default: false),
-                "include_all": SchemaBuilder.boolean(
-                    description: "Include all items when listing (default: false)",
-                    default: false),
-            ],
+        let foregroundCapable = self.context.executionPolicy != .backgroundOnly
+        let actions = foregroundCapable ? ["launch", "right-click", "hide", "show", "list"] : ["list"]
+        var properties: [String: Value] = [
+            "action": SchemaBuilder.string(
+                description: foregroundCapable
+                    ? "Action to perform on the Dock"
+                    : "Background-safe Dock action; mutations are unavailable",
+                enum: actions),
+            "include_all": SchemaBuilder.boolean(
+                description: "Include all items when listing (default: false)",
+                default: false),
+        ]
+        if foregroundCapable {
+            properties["app"] = SchemaBuilder.string(
+                description: "Application name for launch/right-click actions")
+            properties["select"] = SchemaBuilder.string(
+                description: "Menu item to select after right-clicking")
+            properties["foreground"] = SchemaBuilder.boolean(
+                description: "Confirm foreground/global Dock UI for launch and right-click actions.",
+                default: false)
+        }
+        return SchemaBuilder.object(
+            properties: properties,
             required: ["action"])
     }
 

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/MenuTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/MenuTool.swift
@@ -25,7 +25,20 @@ public struct MenuTool: MCPTool {
     private let context: MCPToolContext
 
     public var description: String {
-        """
+        if self.context.executionPolicy == .backgroundOnly {
+            return """
+            Inspect or click application menu items under immutable background-only authority. Available actions are
+            `list` and `click`; neither activates the application. Click requires an exact app name, bundle ID, or PID,
+            while read-only list retains fuzzy name matching. Foreground menu expansion is unavailable in this session.
+
+            Examples:
+            - List Chrome menus: { "action": "list", "app": "Google Chrome" }
+            - Save document: { "action": "click", "app": "TextEdit", "path": "File > Save" }
+            \(PeekabooMCPVersion.banner)
+            """
+        }
+
+        return """
         Interact with application menu bars - list available menus and menu items
         for an application, or click on a specific menu item using path notation.
 
@@ -47,25 +60,25 @@ public struct MenuTool: MCPTool {
     }
 
     public var inputSchema: Value {
-        SchemaBuilder.object(
-            properties: [
-                "action": SchemaBuilder.string(
-                    description: """
-                    Action to perform. Use 'list' to discover menus or 'click' to
-                    interact with menu items.
-                    """.trimmingCharacters(in: .whitespacesAndNewlines),
-                    enum: ["list", "click"]),
-                "app": SchemaBuilder.string(
-                    description: "Target application name, bundle ID, or process ID. Click and foreground list " +
-                        "require an exact selector; background list permits fuzzy names."),
-                "path": SchemaBuilder.string(
-                    description: "Menu path for nested items (e.g., 'File > Save As...' or 'Edit > Copy')"),
-                "item": SchemaBuilder.string(
-                    description: "Simple menu item to click (for non-nested items)"),
-                "foreground": SchemaBuilder.boolean(
-                    description: "Focus the target before list/click. Defaults to background AX access.",
-                    default: false),
-            ],
+        let foregroundCapable = self.context.executionPolicy != .backgroundOnly
+        var properties: [String: Value] = [
+            "action": SchemaBuilder.string(
+                description: "Use 'list' to discover menus or 'click' to interact with menu items.",
+                enum: ["list", "click"]),
+            "app": SchemaBuilder.string(
+                description: "Target application name, bundle ID, or process ID. Click and foreground list " +
+                    "require an exact selector; background list permits fuzzy names."),
+            "path": SchemaBuilder.string(
+                description: "Menu path for nested items (e.g., 'File > Save As...' or 'Edit > Copy')"),
+            "item": SchemaBuilder.string(description: "Simple menu item to click (for non-nested items)"),
+        ]
+        if foregroundCapable {
+            properties["foreground"] = SchemaBuilder.boolean(
+                description: "Focus the target before list/click. Defaults to background AX access.",
+                default: false)
+        }
+        return SchemaBuilder.object(
+            properties: properties,
             required: ["action"])
     }
 

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/PasteTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/PasteTool.swift
@@ -18,10 +18,10 @@ public struct PasteTool: MCPTool {
     public var description: String {
         if self.context.executionPolicy == .backgroundOnly {
             return """
-            Deliver one direct text payload to an explicit app, PID, or exact window under immutable background-only
-            authority. This route does not touch the shared clipboard. Current-clipboard, binary/file/image payloads,
-            targetless input, and foreground delivery are unavailable. If delivery fails after it begins, a prefix may
-            already be present; observe the exact target before retrying.
+            Deliver one direct text payload to an explicit app, PID, or exact-window UI target under immutable
+            background-only authority. This route does not touch the shared clipboard. Current-clipboard,
+            binary/file/image payloads, targetless input, and foreground delivery are unavailable. If delivery fails
+            after it begins, a prefix may already be present; observe the exact target before retrying.
             """
         }
 

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/PasteTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/PasteTool.swift
@@ -7,6 +7,7 @@ import PeekabooFoundation
 import TachikomaMCP
 import UniformTypeIdentifiers
 
+// swiftlint:disable type_body_length
 /// MCP tool for atomic clipboard+paste+restore.
 public struct PasteTool: MCPTool {
     private let logger = os.Logger(subsystem: "boo.peekaboo.mcp", category: "PasteTool")
@@ -15,7 +16,16 @@ public struct PasteTool: MCPTool {
     public let name = "paste"
 
     public var description: String {
-        """
+        if self.context.executionPolicy == .backgroundOnly {
+            return """
+            Deliver one direct text payload to an explicit app, PID, or exact window under immutable background-only
+            authority. This route does not touch the shared clipboard. Current-clipboard, binary/file/image payloads,
+            targetless input, and foreground delivery are unavailable. If delivery fails after it begins, a prefix may
+            already be present; observe the exact target before retrying.
+            """
+        }
+
+        return """
         Paste the current clipboard, or atomically set the clipboard, paste (Cmd+V), then restore it.
 
         Use this when you want fewer steps than:
@@ -44,40 +54,50 @@ public struct PasteTool: MCPTool {
     }
 
     public var inputSchema: Value {
-        SchemaBuilder.object(
-            properties: [
-                // Targeting
-                "app": SchemaBuilder.string(description: "Target app name/bundle ID, or 'PID:<n>'."),
-                "pid": SchemaBuilder.integer(description: "Target process ID (alternative to app)."),
-                "window_id": SchemaBuilder.integer(
-                    description: "Exact window ID for atomic background delivery, or foreground focus when requested."),
-                "window_title": SchemaBuilder
-                    .string(description: "Window title substring for atomic exact-window background delivery."),
-                "window_index": SchemaBuilder
-                    .integer(description: "Window index (0-based); requires app/pid and pins that exact window."),
-
-                // Payload
-                "text": SchemaBuilder.string(
-                    description: "Plain text. Background delivery leaves the clipboard untouched; a failure after " +
-                        "dispatch begins is retry-unsafe because a prefix may already be present."),
-                "filePath": SchemaBuilder
-                    .string(description: "Path to a file to paste (file bytes placed on clipboard)."),
-                "imagePath": SchemaBuilder.string(description: "Path to an image to paste (alias of filePath)."),
-                "dataBase64": SchemaBuilder.string(description: "Base64-encoded payload to paste."),
-                "uti": SchemaBuilder.string(description: "UTI for dataBase64, or to force type when pasting a file."),
-                "alsoText": SchemaBuilder.string(description: "Optional plain-text companion when pasting binary."),
-                "allowLarge": SchemaBuilder.boolean(description: "Allow payloads larger than 10 MB.", default: false),
-
-                // Restore timing
-                "restore_delay_ms": SchemaBuilder.integer(
-                    description: "Delay before restoring the previous clipboard (ms). Default: 150.",
-                    minimum: 0,
-                    default: 150),
-                "foreground": SchemaBuilder.boolean(
-                    description: "Optional. Focus a target or intentionally send foreground/global Cmd+V.",
-                    default: false),
-            ],
-            required: [])
+        let foregroundCapable = self.context.executionPolicy != .backgroundOnly
+        var properties: [String: Value] = [
+            "app": SchemaBuilder.string(description: "Target app name/bundle ID, or 'PID:<n>'."),
+            "pid": SchemaBuilder.integer(description: "Target process ID (alternative to app)."),
+            "window_id": SchemaBuilder.integer(
+                description: "Exact window ID for atomic background delivery, or foreground focus when requested."),
+            "window_title": SchemaBuilder
+                .string(description: "Window title substring for atomic exact-window background delivery."),
+            "window_index": SchemaBuilder
+                .integer(description: "Window index (0-based); requires app/pid and pins that exact window."),
+            "text": SchemaBuilder.string(
+                description: "Plain text. Background delivery leaves the clipboard untouched; a failure after " +
+                    "dispatch begins is retry-unsafe because a prefix may already be present."),
+        ]
+        if foregroundCapable {
+            properties["filePath"] = SchemaBuilder.string(
+                description: "Path to a file to paste (file bytes placed on clipboard).")
+            properties["imagePath"] = SchemaBuilder
+                .string(description: "Path to an image to paste (alias of filePath).")
+            properties["dataBase64"] = SchemaBuilder.string(description: "Base64-encoded payload to paste.")
+            properties["uti"] = SchemaBuilder.string(
+                description: "UTI for dataBase64, or to force type when pasting a file.")
+            properties["alsoText"] = SchemaBuilder.string(
+                description: "Optional plain-text companion when pasting binary.")
+            properties["allowLarge"] = SchemaBuilder.boolean(
+                description: "Allow payloads larger than 10 MB.",
+                default: false)
+            properties["restore_delay_ms"] = SchemaBuilder.integer(
+                description: "Delay before restoring the previous clipboard (ms). Default: 150.",
+                minimum: 0,
+                default: 150)
+            properties["foreground"] = SchemaBuilder.boolean(
+                description: "Optional. Focus a target or intentionally send foreground/global Cmd+V.",
+                default: false)
+        }
+        let base = SchemaBuilder.object(
+            properties: properties,
+            required: foregroundCapable ? [] : ["text"])
+        guard !foregroundCapable, case let .object(fields) = base else { return base }
+        var backgroundSchema = fields
+        backgroundSchema["anyOf"] = .array(["app", "pid", "window_id", "window_title", "window_index"].map {
+            .object(["required": .array([.string($0)])])
+        })
+        return .object(backgroundSchema)
     }
 
     public init(context: MCPToolContext = .shared) {
@@ -1077,6 +1097,8 @@ public struct PasteTool: MCPTool {
             operation: "Background text paste").target
     }
 }
+
+// swiftlint:enable type_body_length
 
 extension PasteTool: MCPToolArgumentSemanticValidating {}
 

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/SpaceTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/SpaceTool.swift
@@ -40,7 +40,21 @@ public struct SpaceTool: MCPTool {
     public let name = "space"
 
     public var description: String {
-        """
+        if self.context.executionPolicy == .backgroundOnly {
+            return """
+            Inspect macOS Spaces or move an exact window without following it under immutable background-only
+            authority. Available actions are `list` and `move-window`. Space switching and `follow=true` change the
+            user's visible desktop and require a human-authorized foreground-capable Agent session or standalone CLI.
+
+            Examples:
+            - List spaces: { "action": "list" }
+            - Move window to space 3: { "action": "move-window", "app": "Safari", "to": 3 }
+            - Move window to current space: { "action": "move-window", "app": "TextEdit", "to_current": true }
+            \(PeekabooMCPVersion.banner) using openai/gpt-5.6, anthropic/claude-opus-5
+            """
+        }
+
+        return """
         Manage macOS Spaces (virtual desktops).
 
         Actions:
@@ -64,34 +78,41 @@ public struct SpaceTool: MCPTool {
     }
 
     public var inputSchema: Value {
-        SchemaBuilder.object(
-            properties: [
-                "action": SchemaBuilder.string(
-                    description: "The action to perform",
-                    enum: ["list", "switch", "move-window"]),
-                "to": SchemaBuilder.integer(
-                    description: "Space number to switch to (for switch action)"),
-                "app": SchemaBuilder.string(
-                    description: "Application name for move-window action"),
-                "window_id": SchemaBuilder.integer(
-                    description: "Exact window ID for move-window action"),
-                "window_title": SchemaBuilder.string(
-                    description: "Window title to move"),
-                "window_index": SchemaBuilder.integer(
-                    description: "Window index for multi-window apps"),
-                "to_current": SchemaBuilder.boolean(
-                    description: "Move window to current space (for move-window action)",
-                    default: false),
-                "follow": SchemaBuilder.boolean(
-                    description: "Follow the window to the new space; requires foreground=true",
-                    default: false),
-                "foreground": SchemaBuilder.boolean(
-                    description: "Explicit consent for switch and move-window follow actions",
-                    default: false),
-                "detailed": SchemaBuilder.boolean(
-                    description: "Show detailed space information (for list action)",
-                    default: false),
-            ],
+        let foregroundCapable = self.context.executionPolicy != .backgroundOnly
+        let actions = foregroundCapable ? ["list", "switch", "move-window"] : ["list", "move-window"]
+        var properties: [String: Value] = [
+            "action": SchemaBuilder.string(
+                description: foregroundCapable
+                    ? "The action to perform"
+                    : "Background-safe Space action; switching is unavailable",
+                enum: actions),
+            "to": SchemaBuilder.integer(
+                description: "Space number to switch or move a window to"),
+            "app": SchemaBuilder.string(
+                description: "Application name for move-window action"),
+            "window_id": SchemaBuilder.integer(
+                description: "Exact window ID for move-window action"),
+            "window_title": SchemaBuilder.string(
+                description: "Window title to move"),
+            "window_index": SchemaBuilder.integer(
+                description: "Window index for multi-window apps"),
+            "to_current": SchemaBuilder.boolean(
+                description: "Move window to current space (for move-window action)",
+                default: false),
+            "detailed": SchemaBuilder.boolean(
+                description: "Show detailed space information (for list action)",
+                default: false),
+        ]
+        if foregroundCapable {
+            properties["follow"] = SchemaBuilder.boolean(
+                description: "Follow the window to the new space; requires foreground=true",
+                default: false)
+            properties["foreground"] = SchemaBuilder.boolean(
+                description: "Explicit consent for switch and move-window follow actions",
+                default: false)
+        }
+        return SchemaBuilder.object(
+            properties: properties,
             required: ["action"])
     }
 

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/SpaceTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/SpaceTool.swift
@@ -50,7 +50,7 @@ public struct SpaceTool: MCPTool {
             - List spaces: { "action": "list" }
             - Move window to space 3: { "action": "move-window", "app": "Safari", "to": 3 }
             - Move window to current space: { "action": "move-window", "app": "TextEdit", "to_current": true }
-            \(PeekabooMCPVersion.banner) using openai/gpt-5.6, anthropic/claude-opus-5
+            \(PeekabooMCPVersion.banner)
             """
         }
 

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPBackgroundPolicyExecutionTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPBackgroundPolicyExecutionTests.swift
@@ -274,13 +274,27 @@ struct MCPBackgroundPolicyExecutionTests {
 
     @Test
     func `App tool lifecycle examples include required foreground consent`() async {
-        let context = await MCPToolTestHelpers.makeContext(snapshotOwner: Self.uiSnapshots.owner)
+        let backgroundContext = await MCPToolTestHelpers.makeContext(snapshotOwner: Self.uiSnapshots.owner)
+        let backgroundDescription = AppTool(context: backgroundContext).description
+        let context = await MCPToolTestHelpers.makeContext(
+            snapshotOwner: Self.uiSnapshots.owner,
+            executionPolicy: .foregroundAllowed)
         let description = AppTool(context: context).description
+        let backgroundOnlyProbeExample =
+            #"Already-running readiness probe: { "action": "launch", "name": "Finder" }"#
+        let backgroundProbeExample =
+            #"Already-running readiness probe: { "action": "launch", "name": "PID:1234" }"#
+        let coldLaunchExample =
+            #"Cold launch with foreground consent: { "action": "launch", "name": "Calendar", "foreground": true }"#
         let newInstanceExample =
             #"{ "action": "launch", "name": "TextEdit", "newInstance": true, "foreground": true }"#
         let openExample =
             #"{ "action": "open", "name": "Safari", "openTargets": ["https://example.com"], "foreground": true }"#
 
+        #expect(backgroundDescription.contains(backgroundOnlyProbeExample))
+        #expect(!backgroundDescription.contains("Cold launch with foreground consent"))
+        #expect(description.contains(backgroundProbeExample))
+        #expect(description.contains(coldLaunchExample))
         #expect(description.contains(newInstanceExample))
         #expect(description.contains(openExample))
     }

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPPolicyAwareCatalogTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPPolicyAwareCatalogTests.swift
@@ -5,6 +5,39 @@ import Testing
 
 struct MCPPolicyAwareCatalogTests {
     @Test
+    func `Browser tool hides connection setup under background authority`() async {
+        let backgroundContext = await MCPToolTestHelpers.makeContext(executionPolicy: .backgroundOnly)
+        let tool = BrowserTool(context: backgroundContext)
+        guard case let .object(schema) = tool.inputSchema,
+              case let .object(properties)? = schema["properties"],
+              case let .object(action)? = properties["action"],
+              case let .array(actions)? = action["enum"]
+        else {
+            Issue.record("Expected background-only Browser schema")
+            return
+        }
+        #expect(!actions.contains(.string(BrowserAction.connect.rawValue)))
+        #expect(actions.contains(.string(BrowserAction.status.rawValue)))
+        #expect(actions.contains(.string(BrowserAction.listPages.rawValue)))
+        #expect(properties["browser_url"] == nil)
+        #expect(tool.description.contains("Connect is unavailable"))
+
+        let foregroundContext = await MCPToolTestHelpers.makeContext(executionPolicy: .foregroundAllowed)
+        let foregroundTool = BrowserTool(context: foregroundContext)
+        guard case let .object(foregroundSchema) = foregroundTool.inputSchema,
+              case let .object(foregroundProperties)? = foregroundSchema["properties"],
+              case let .object(foregroundAction)? = foregroundProperties["action"],
+              case let .array(foregroundActions)? = foregroundAction["enum"]
+        else {
+            Issue.record("Expected foreground-capable Browser schema")
+            return
+        }
+        #expect(foregroundActions.contains(.string(BrowserAction.connect.rawValue)))
+        #expect(foregroundProperties["browser_url"] != nil)
+        #expect(foregroundTool.description.contains("accept Chrome's remote debugging prompt"))
+    }
+
+    @Test
     func `Dialog tool omits foreground-only actions and inputs under background authority`() async {
         let backgroundContext = await MCPToolTestHelpers.makeContext(executionPolicy: .backgroundOnly)
         let tool = DialogTool(context: backgroundContext)

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPPolicyAwareCatalogTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPPolicyAwareCatalogTests.swift
@@ -1,0 +1,96 @@
+import MCP
+import TachikomaMCP
+import Testing
+@testable import PeekabooAgentRuntime
+
+struct MCPPolicyAwareCatalogTests {
+    @Test
+    func `Space tool schema advertises only policy reachable actions`() async {
+        let backgroundContext = await MCPToolTestHelpers.makeContext(executionPolicy: .backgroundOnly)
+        let tool = SpaceTool(context: backgroundContext)
+        guard case let .object(schema) = tool.inputSchema,
+              case let .object(properties)? = schema["properties"],
+              case let .object(action)? = properties["action"],
+              case let .array(actions)? = action["enum"]
+        else {
+            Issue.record("Expected background-only Space schema")
+            return
+        }
+
+        #expect(properties["to"] != nil)
+        #expect(properties["app"] != nil)
+        #expect(properties["window_title"] != nil)
+        #expect(properties["window_index"] != nil)
+        #expect(properties["to_current"] != nil)
+        #expect(properties["follow"] == nil)
+        #expect(properties["foreground"] == nil)
+        #expect(properties["detailed"] != nil)
+        #expect(actions == ["list", "move-window"].map(Value.string))
+        #expect(tool.description.contains("immutable background-only"))
+
+        let foregroundContext = await MCPToolTestHelpers.makeContext(executionPolicy: .foregroundAllowed)
+        let foregroundTool = SpaceTool(context: foregroundContext)
+        guard case let .object(foregroundSchema) = foregroundTool.inputSchema,
+              case let .object(foregroundProperties)? = foregroundSchema["properties"],
+              case let .object(foregroundAction)? = foregroundProperties["action"],
+              case let .array(foregroundActions)? = foregroundAction["enum"]
+        else {
+            Issue.record("Expected foreground-capable Space schema")
+            return
+        }
+        #expect(foregroundActions == ["list", "switch", "move-window"].map(Value.string))
+        #expect(foregroundProperties["follow"] != nil)
+        #expect(foregroundProperties["foreground"] != nil)
+        #expect(foregroundTool.description.contains("Switch to space 2"))
+    }
+
+    @Test
+    func `Dock tool schema advertises only policy reachable actions`() async throws {
+        let backgroundContext = await MCPToolTestHelpers.makeContext(executionPolicy: .backgroundOnly)
+        let tool = DockTool(context: backgroundContext)
+        guard case let .object(schema) = tool.inputSchema,
+              case let .object(properties)? = schema["properties"],
+              case let .object(action)? = properties["action"],
+              case let .array(actions)? = action["enum"]
+        else {
+            Issue.record("Expected background-only Dock schema")
+            return
+        }
+        #expect(actions == [Value.string("list")])
+        #expect(properties["app"] == nil)
+        #expect(properties["select"] == nil)
+        #expect(properties["foreground"] == nil)
+        #expect(properties["include_all"] != nil)
+        #expect(tool.description.contains("available action is `list`"))
+
+        let foregroundContext = await MCPToolTestHelpers.makeContext(executionPolicy: .foregroundAllowed)
+        let foregroundTool = DockTool(context: foregroundContext)
+        guard case let .object(foregroundSchema) = foregroundTool.inputSchema,
+              case let .object(foregroundProperties)? = foregroundSchema["properties"],
+              case let .object(foregroundAction)? = foregroundProperties["action"],
+              case let .array(foregroundActions)? = foregroundAction["enum"],
+              case let .object(foreground)? = foregroundProperties["foreground"],
+              case .bool(false)? = foreground["default"]
+        else {
+            Issue.record("Expected foreground-capable Dock schema")
+            return
+        }
+        #expect(foregroundActions == ["launch", "right-click", "hide", "show", "list"].map(Value.string))
+        #expect(foregroundProperties["app"] != nil)
+        #expect(foregroundProperties["select"] != nil)
+        #expect(foregroundTool.description.contains("launch and right-click activate global Dock UI"))
+
+        for action in ["launch", "right-click"] {
+            let response = try await foregroundTool.execute(arguments: ToolArguments(raw: [
+                "action": action,
+                "app": "Finder",
+            ]))
+            #expect(response.isError)
+            guard case let .text(text: message, annotations: _, _meta: _) = response.content.first else {
+                Issue.record("Expected Dock foreground validation error")
+                continue
+            }
+            #expect(message.contains("foreground=true"))
+        }
+    }
+}

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPPolicyAwareCatalogTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPPolicyAwareCatalogTests.swift
@@ -37,6 +37,7 @@ struct MCPPolicyAwareCatalogTests {
         #expect(properties["allowLarge"] == nil)
         #expect(properties["restore_delay_ms"] == nil)
         #expect(properties["foreground"] == nil)
+        #expect(tool.description.contains("explicit app, PID, or exact-window UI target"))
         #expect(tool.description.contains("does not touch the shared clipboard"))
         let targetless = try await backgroundContext.execute(
             tool: tool,

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPPolicyAwareCatalogTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPPolicyAwareCatalogTests.swift
@@ -5,6 +5,67 @@ import Testing
 
 struct MCPPolicyAwareCatalogTests {
     @Test
+    func `Paste tool advertises only direct targeted text under background authority`() async throws {
+        let backgroundContext = await MCPToolTestHelpers.makeContext(executionPolicy: .backgroundOnly)
+        let tool = PasteTool(context: backgroundContext)
+        guard case let .object(schema) = tool.inputSchema,
+              case let .object(properties)? = schema["properties"],
+              case let .array(required)? = schema["required"],
+              case let .array(targetAlternatives)? = schema["anyOf"]
+        else {
+            Issue.record("Expected background-only Paste schema")
+            return
+        }
+        #expect(required == [Value.string("text")])
+        let requiredTargets = targetAlternatives.compactMap { alternative -> String? in
+            guard case let .object(fields) = alternative,
+                  case let .array(required)? = fields["required"],
+                  case let .string(target)? = required.first
+            else { return nil }
+            return target
+        }
+        #expect(Set(requiredTargets) == Set(["app", "pid", "window_id", "window_title", "window_index"]))
+        #expect(properties["text"] != nil)
+        #expect(properties["app"] != nil)
+        #expect(properties["pid"] != nil)
+        #expect(properties["window_id"] != nil)
+        #expect(properties["filePath"] == nil)
+        #expect(properties["imagePath"] == nil)
+        #expect(properties["dataBase64"] == nil)
+        #expect(properties["uti"] == nil)
+        #expect(properties["alsoText"] == nil)
+        #expect(properties["allowLarge"] == nil)
+        #expect(properties["restore_delay_ms"] == nil)
+        #expect(properties["foreground"] == nil)
+        #expect(tool.description.contains("does not touch the shared clipboard"))
+        let targetless = try await backgroundContext.execute(
+            tool: tool,
+            arguments: ToolArguments(raw: ["text": "must not dispatch"]))
+        #expect(targetless.isError)
+        #expect(targetless.meta?.objectValue?["refusal_reason"] == .string("foreground_consent_required"))
+        #expect(targetless.meta?.objectValue?["mutation_dispatched"] == .bool(false))
+
+        let foregroundContext = await MCPToolTestHelpers.makeContext(executionPolicy: .foregroundAllowed)
+        let foregroundTool = PasteTool(context: foregroundContext)
+        guard case let .object(foregroundSchema) = foregroundTool.inputSchema,
+              case let .object(foregroundProperties)? = foregroundSchema["properties"]
+        else {
+            Issue.record("Expected foreground-capable Paste schema")
+            return
+        }
+        #expect(foregroundSchema["required"] == nil)
+        #expect(foregroundProperties["filePath"] != nil)
+        #expect(foregroundProperties["imagePath"] != nil)
+        #expect(foregroundProperties["dataBase64"] != nil)
+        #expect(foregroundProperties["uti"] != nil)
+        #expect(foregroundProperties["alsoText"] != nil)
+        #expect(foregroundProperties["allowLarge"] != nil)
+        #expect(foregroundProperties["restore_delay_ms"] != nil)
+        #expect(foregroundProperties["foreground"] != nil)
+        #expect(foregroundTool.description.contains("Paste the current clipboard"))
+    }
+
+    @Test
     func `Browser tool hides connection setup under background authority`() async {
         let backgroundContext = await MCPToolTestHelpers.makeContext(executionPolicy: .backgroundOnly)
         let tool = BrowserTool(context: backgroundContext)

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPPolicyAwareCatalogTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPPolicyAwareCatalogTests.swift
@@ -5,6 +5,79 @@ import Testing
 
 struct MCPPolicyAwareCatalogTests {
     @Test
+    func `Dialog tool omits foreground-only actions and inputs under background authority`() async {
+        let backgroundContext = await MCPToolTestHelpers.makeContext(executionPolicy: .backgroundOnly)
+        let tool = DialogTool(context: backgroundContext)
+        guard case let .object(schema) = tool.inputSchema,
+              case let .object(properties)? = schema["properties"],
+              case let .object(action)? = properties["action"],
+              case let .array(actions)? = action["enum"]
+        else {
+            Issue.record("Expected background-only Dialog schema")
+            return
+        }
+        #expect(actions == ["list", "click", "input", "dismiss"].map(Value.string))
+        #expect(properties["button"] != nil)
+        #expect(properties["text"] != nil)
+        #expect(properties["field"] != nil)
+        #expect(properties["path"] == nil)
+        #expect(properties["name"] == nil)
+        #expect(properties["select"] == nil)
+        #expect(properties["ensure_expanded"] == nil)
+        #expect(properties["force"] == nil)
+        #expect(properties["foreground"] == nil)
+        #expect(tool.description.contains("targeted non-forced `dismiss`"))
+
+        let foregroundContext = await MCPToolTestHelpers.makeContext(executionPolicy: .foregroundAllowed)
+        let foregroundTool = DialogTool(context: foregroundContext)
+        guard case let .object(foregroundSchema) = foregroundTool.inputSchema,
+              case let .object(foregroundProperties)? = foregroundSchema["properties"],
+              case let .object(foregroundAction)? = foregroundProperties["action"],
+              case let .array(foregroundActions)? = foregroundAction["enum"]
+        else {
+            Issue.record("Expected foreground-capable Dialog schema")
+            return
+        }
+        #expect(foregroundActions == DialogToolAction.allCases.map { Value.string($0.rawValue) })
+        #expect(foregroundProperties["path"] != nil)
+        #expect(foregroundProperties["name"] != nil)
+        #expect(foregroundProperties["select"] != nil)
+        #expect(foregroundProperties["ensure_expanded"] != nil)
+        #expect(foregroundProperties["force"] != nil)
+        #expect(foregroundProperties["foreground"] != nil)
+        #expect(foregroundTool.description.contains("targeted input defaults to background AXValue"))
+        #expect(foregroundTool.description.contains(#""foreground": true"#))
+    }
+
+    @Test
+    func `Menu tool omits impossible foreground control under background authority`() async {
+        let backgroundContext = await MCPToolTestHelpers.makeContext(executionPolicy: .backgroundOnly)
+        let tool = MenuTool(context: backgroundContext)
+        guard case let .object(schema) = tool.inputSchema,
+              case let .object(properties)? = schema["properties"],
+              case let .object(path)? = properties["path"],
+              case let .string(pathDescription)? = path["description"]
+        else {
+            Issue.record("Expected background-only Menu schema")
+            return
+        }
+        #expect(properties["foreground"] == nil)
+        #expect(pathDescription.contains(">"))
+        #expect(tool.description.contains("Foreground menu expansion is unavailable"))
+
+        let foregroundContext = await MCPToolTestHelpers.makeContext(executionPolicy: .foregroundAllowed)
+        let foregroundTool = MenuTool(context: foregroundContext)
+        guard case let .object(foregroundSchema) = foregroundTool.inputSchema,
+              case let .object(foregroundProperties)? = foregroundSchema["properties"]
+        else {
+            Issue.record("Expected foreground-capable Menu schema")
+            return
+        }
+        #expect(foregroundProperties["foreground"] != nil)
+        #expect(foregroundTool.description.contains("foreground-list actions require an exact"))
+    }
+
+    @Test
     func `Space tool schema advertises only policy reachable actions`() async {
         let backgroundContext = await MCPToolTestHelpers.makeContext(executionPolicy: .backgroundOnly)
         let tool = SpaceTool(context: backgroundContext)

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPSpecificToolTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPSpecificToolTests.swift
@@ -320,42 +320,6 @@ struct MCPSpecificToolTests {
         }
     }
 
-    // MARK: - Space Tool Tests
-
-    @Test
-    func `Space tool schema includes Mission Control actions`() {
-        let tool = makeTestTool(SpaceTool.init)
-
-        guard case let .object(schema) = tool.inputSchema,
-              let properties = schema["properties"],
-              case let .object(props) = properties
-        else {
-            Issue.record("Expected object schema with properties")
-            return
-        }
-
-        #expect(props["action"] != nil)
-        #expect(props["to"] != nil)
-        #expect(props["app"] != nil)
-        #expect(props["window_title"] != nil)
-        #expect(props["window_index"] != nil)
-        #expect(props["to_current"] != nil)
-        #expect(props["follow"] != nil)
-        #expect(props["foreground"] != nil)
-        #expect(props["detailed"] != nil)
-
-        // Check action types
-        if let actionSchema = props["action"],
-           case let .object(actionDict) = actionSchema,
-           let enumValue = actionDict["enum"],
-           case let .array(actions) = enumValue
-        {
-            #expect(actions.contains(.string("list")))
-            #expect(actions.contains(.string("switch")))
-            #expect(actions.contains(.string("move-window")))
-        }
-    }
-
     // MARK: - Drag Tool Tests
 
     @Test
@@ -388,32 +352,6 @@ struct MCPSpecificToolTests {
     }
 
     // MARK: - Window Tool Tests
-
-    @Test
-    func `Dock tool requires foreground consent for global UI actions`() async throws {
-        let tool = makeTestTool(DockTool.init)
-        guard case let .object(schema) = tool.inputSchema,
-              case let .object(properties)? = schema["properties"],
-              case let .object(foreground)? = properties["foreground"],
-              case .bool(false)? = foreground["default"]
-        else {
-            Issue.record("Expected Dock foreground schema default")
-            return
-        }
-
-        for action in ["launch", "right-click"] {
-            let response = try await tool.execute(arguments: ToolArguments(raw: [
-                "action": action,
-                "app": "Finder",
-            ]))
-            #expect(response.isError)
-            guard case let .text(text: message, annotations: _, _meta: _) = response.content.first else {
-                Issue.record("Expected Dock foreground validation error")
-                continue
-            }
-            #expect(message.contains("foreground=true"))
-        }
-    }
 
     @Test
     func `Window tool schema omits background-refused focus and foreground fallback`() {

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPSpecificToolTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPSpecificToolTests.swift
@@ -212,49 +212,6 @@ struct MCPSpecificToolTests {
     // MARK: - Dialog Tool Tests
 
     @Test
-    func `Dialog tool schema validation`() {
-        let tool = makeTestTool(DialogTool.init)
-
-        guard case let .object(schema) = tool.inputSchema,
-              let properties = schema["properties"],
-              case let .object(props) = properties
-        else {
-            Issue.record("Expected object schema with properties")
-            return
-        }
-
-        // Dialog tool should have action and optional parameters
-        #expect(props["action"] != nil)
-        #expect(props["button"] != nil)
-        #expect(props["text"] != nil)
-        #expect(props["field"] != nil)
-        #expect(props["clear"] != nil)
-        #expect(props["path"] != nil)
-        #expect(props["select"] != nil)
-        #expect(props["window_title"] != nil)
-        #expect(props["window_index"] != nil)
-        #expect(props["window_id"] != nil)
-        #expect(props["name"] != nil)
-        #expect(props["force"] != nil)
-        #expect(props["field_index"] != nil)
-        #expect(props["foreground"] != nil)
-        #expect(tool.description.contains("targeted input defaults to background AXValue"))
-        #expect(tool.description.contains(#""action": "input""#))
-        #expect(tool.description.contains(#""foreground": true"#))
-
-        // Check action enum values
-        if let actionSchema = props["action"],
-           case let .object(actionDict) = actionSchema,
-           let enumValue = actionDict["enum"],
-           case let .array(actions) = enumValue
-        {
-            #expect(actions.contains(.string("list")))
-            #expect(actions.contains(.string("click")))
-            #expect(actions.contains(.string("input")))
-        }
-    }
-
-    @Test
     func `Dialog tool requires foreground for global input paths`() async throws {
         let tool = makeTestTool(DialogTool.init)
         let requests: [([String: Any], String)] = [
@@ -289,35 +246,6 @@ struct MCPSpecificToolTests {
             return
         }
         #expect(text.contains("always read-only/background"))
-    }
-
-    // MARK: - Menu Tool Tests
-
-    @Test
-    func `Menu tool schema includes path format`() {
-        let tool = makeTestTool(MenuTool.init)
-
-        guard case let .object(schema) = tool.inputSchema,
-              let properties = schema["properties"],
-              case let .object(props) = properties
-        else {
-            Issue.record("Expected object schema with properties")
-            return
-        }
-
-        #expect(props["action"] != nil)
-        #expect(props["path"] != nil)
-        #expect(props["app"] != nil)
-        #expect(props["foreground"] != nil)
-
-        // Verify path description includes format examples
-        if let pathSchema = props["path"],
-           case let .object(pathDict) = pathSchema,
-           let description = pathDict["description"],
-           case let .string(desc) = description
-        {
-            #expect(desc.contains(">") || desc.contains("separator"))
-        }
     }
 
     // MARK: - Drag Tool Tests


### PR DESCRIPTION
## Summary

- make App, Dock, Space, Dialog, Menu, Browser, Clipboard, and Paste schemas reflect immutable background-only authority
- remove actions and inputs that policy will always refuse while retaining every foreground-capable workflow
- clarify background launch as an already-running readiness probe and require direct background Paste to carry text plus one explicit target
- move policy-catalog coverage out of the oversized legacy specific-tool fixture

## Verification

- `swift test --package-path Core/PeekabooCore --no-parallel --filter 'MCPPolicyAwareCatalogTests|MCPSpecificToolTests|MCPBackgroundPolicyExecutionTests'` (63 tests)
- `swift test --package-path Core/PeekabooCore --no-parallel --filter Browser` (67 Core + 157 AgentRuntime tests)
- `swift test --package-path Core/PeekabooCore --no-parallel --filter 'MCPPolicyAwareCatalogTests|Paste'` (42 tests)
- `pnpm run build:cli`
- real built CLI `tools describe` schema audit for all seven changed tool families
- strict touched SwiftLint, SwiftFormat, docs lint, release-version check, and release preflight (10/10)
- P0-P2 Autoreview clean after accepted catalog-contract corrections
