### PR TITLE
build: refresh trusted release helper pin

### DIFF
--- a/scripts/build-terminal-artifacts.sh
+++ b/scripts/build-terminal-artifacts.sh
@@ -82,9 +82,9 @@ EXPECTED_IDENTITY='Developer ID Application: OpenClaw Foundation (FWJYW4S8P8)'
 EXPECTED_TEAM_ID=FWJYW4S8P8
 EXPECTED_REQUIREMENT="anchor apple generic and certificate leaf[subject.OU] = \"$EXPECTED_TEAM_ID\""
 TIMESTAMP_URL=http://timestamp.apple.com/ts01
-EXPECTED_RELEASE_HELPER_COMMIT=ee69e9516e61901c02abd1a71456d5f1fd9f1d5f
+EXPECTED_RELEASE_HELPER_COMMIT=20ab9a5e6bb1107788366726868f1a9b4c16d953
 EXPECTED_RELEASE_HELPER_SHA=e65e06ef89ec90ebfc537d28748a3c4de8ce89bd09b51e4d67ba4bdd95427255
-EXPECTED_RELEASE_HELPER_LIB_SHA=6be67a85c4b83d8968bfcf3697451dc21544614a4318e49a3534b219026ee842
+EXPECTED_RELEASE_HELPER_LIB_SHA=c29d3c46506c2d0bd2db7ab688bd3108d54e8824074a4fe800de6e3fe17284c9
 CANONICAL_LOCK_RELATIVE=Apps/Peekaboo.xcworkspace/xcshareddata/swiftpm/Package.resolved
 CANONICAL_LOCK="$ROOT_DIR/$CANONICAL_LOCK_RELATIVE"
 
@@ -404,9 +404,9 @@ verify_unsigned_stage() {
       .dependency_lock_path == $lockPath and .dependency_lock_sha256 == $lockSHA and
       .toolchain == {developer_dir: $developerDir, xcodebuild_version: $xcodebuildVersion,
         sdk_version: $sdkVersion, swiftc_version: $swiftcVersion} and
-      .release_helper == {commit: "ee69e9516e61901c02abd1a71456d5f1fd9f1d5f",
+      .release_helper == {commit: "20ab9a5e6bb1107788366726868f1a9b4c16d953",
         executable_sha256: "e65e06ef89ec90ebfc537d28748a3c4de8ce89bd09b51e4d67ba4bdd95427255",
-        library_sha256: "6be67a85c4b83d8968bfcf3697451dc21544614a4318e49a3534b219026ee842"} and
+        library_sha256: "c29d3c46506c2d0bd2db7ab688bd3108d54e8824074a4fe800de6e3fe17284c9"} and
       (.unsigned_inputs | keys == ["cli_inventory_sha256", "peekaboo_inventory_sha256",
         "playground_inventory_sha256", "qualification_inventory_sha256",
         "qualification_node_inventory_sha256", "qualification_source_inventory_sha256"] and
@@ -614,9 +614,9 @@ EOF
     --arg qualificationSourceInventory "$(/usr/bin/shasum -a 256 "$SOURCE_TREE_MANIFEST" | /usr/bin/awk '{print $1}')" '
       {version: 1, build_mode: $buildMode, source_commit: $sourceCommit, marketing_version: $version,
        dependency_lock_path: $lockPath, dependency_lock_sha256: $lockSHA,
-       release_helper: {commit: "ee69e9516e61901c02abd1a71456d5f1fd9f1d5f",
+       release_helper: {commit: "20ab9a5e6bb1107788366726868f1a9b4c16d953",
          executable_sha256: "e65e06ef89ec90ebfc537d28748a3c4de8ce89bd09b51e4d67ba4bdd95427255",
-         library_sha256: "6be67a85c4b83d8968bfcf3697451dc21544614a4318e49a3534b219026ee842"},
+         library_sha256: "c29d3c46506c2d0bd2db7ab688bd3108d54e8824074a4fe800de6e3fe17284c9"},
        toolchain: {developer_dir: $developerDir, xcodebuild_version: $xcodebuildVersion,
          sdk_version: $sdkVersion, swiftc_version: $swiftcVersion},
        unsigned_inputs: {cli_inventory_sha256: $cliInventory,
@@ -1210,9 +1210,9 @@ publish_phase() {
        toolchain: {developer_dir: $developerDir, xcodebuild_version: $xcodebuildVersion,
          sdk_version: $sdkVersion, swiftc_version: $swiftcVersion},
        signing: {authority: "Developer ID Application: OpenClaw Foundation (FWJYW4S8P8)", team_id: "FWJYW4S8P8",
-         release_helper: {commit: "ee69e9516e61901c02abd1a71456d5f1fd9f1d5f",
+         release_helper: {commit: "20ab9a5e6bb1107788366726868f1a9b4c16d953",
            executable_sha256: "e65e06ef89ec90ebfc537d28748a3c4de8ce89bd09b51e4d67ba4bdd95427255",
-           library_sha256: "6be67a85c4b83d8968bfcf3697451dc21544614a4318e49a3534b219026ee842"}},
+           library_sha256: "c29d3c46506c2d0bd2db7ab688bd3108d54e8824074a4fe800de6e3fe17284c9"}},
        notarization: {cli: $cliNotary[0], peekaboo_app: $appNotary[0],
          playground_app: $playgroundNotary[0], peekaboo_dmg: $dmgNotary[0],
          qualification_node_app: $nodeNotary[0], certification_controller: $controllerNotary[0]},

--- a/scripts/test-terminal-artifact-env.sh
+++ b/scripts/test-terminal-artifact-env.sh
@@ -183,7 +183,7 @@ rg -Fq 'qualification_source_inventory_sha256' "$wrapper" || \
   fail 'build provenance omits the commit-materialized source snapshot'
 rg -Fq 'qualification_monitor:' "$wrapper" || fail 'portable manifest omits the rich monitor record'
 rg -Fq 'materialize_committed_file' "$wrapper" || fail 'published source/tools still come from the mutable worktree'
-rg -Fq 'ee69e9516e61901c02abd1a71456d5f1fd9f1d5f' "$wrapper" || \
+rg -Fq '20ab9a5e6bb1107788366726868f1a9b4c16d953' "$wrapper" || \
   fail 'terminal pipeline does not pin the package-run helper contract'
 rg -Fq 'scripts/build-terminal-artifacts.sh check-helper' "$ROOT_DIR/docs/RELEASING.md" || \
   fail 'manual release flow does not preflight the credential runner'

--- a/scripts/test-terminal-manifest-portability.sh
+++ b/scripts/test-terminal-manifest-portability.sh
@@ -237,7 +237,7 @@ jq -n --arg version "$VERSION" --arg source "$SOURCE_COMMIT" --arg lockSHA "$loc
   dependency_lock_path:"Apps/Peekaboo.xcworkspace/xcshareddata/swiftpm/Package.resolved",dependency_lock_sha256:$lockSHA,
   toolchain:{developer_dir:"/Fixture/Xcode",xcodebuild_version:"Xcode Fixture",sdk_version:"99.0",swiftc_version:"Swift Fixture"},
   signing:{authority:"Developer ID Application: OpenClaw Foundation (FWJYW4S8P8)",team_id:"FWJYW4S8P8",
-   release_helper:{commit:"ee69e9516e61901c02abd1a71456d5f1fd9f1d5f",executable_sha256:"e65e06ef89ec90ebfc537d28748a3c4de8ce89bd09b51e4d67ba4bdd95427255",library_sha256:"6be67a85c4b83d8968bfcf3697451dc21544614a4318e49a3534b219026ee842"}},
+   release_helper:{commit:"20ab9a5e6bb1107788366726868f1a9b4c16d953",executable_sha256:"e65e06ef89ec90ebfc537d28748a3c4de8ce89bd09b51e4d67ba4bdd95427255",library_sha256:"c29d3c46506c2d0bd2db7ab688bd3108d54e8824074a4fe800de6e3fe17284c9"}},
   notarization:{cli:$cliNotary[0],peekaboo_app:$appNotary[0],peekaboo_dmg:$dmgNotary[0],playground_app:$playgroundNotary[0],qualification_node_app:$nodeNotary[0],certification_controller:$controllerNotary[0]},
   cli:{sha256:$cliExecutableSHA,cdhash:"1111111111111111111111111111111111111111"},app:{source_commit:$source,zip_sha256:$appSHA,cdhash:"1111111111111111111111111111111111111111"},
   playground:{source_commit:$source,zip_sha256:$playgroundSHA,cdhash:"1111111111111111111111111111111111111111"},

--- a/scripts/validate-terminal-artifact-manifest.mjs
+++ b/scripts/validate-terminal-artifact-manifest.mjs
@@ -457,11 +457,11 @@ exactKeys(manifest.signing, ['authority', 'team_id', 'release_helper'], 'signing
 exactKeys(manifest.signing.release_helper, ['commit', 'executable_sha256', 'library_sha256'], 'release helper');
 if (manifest.signing.authority !== 'Developer ID Application: OpenClaw Foundation (FWJYW4S8P8)' ||
     manifest.signing.team_id !== 'FWJYW4S8P8' ||
-    manifest.signing.release_helper.commit !== 'ee69e9516e61901c02abd1a71456d5f1fd9f1d5f' ||
+    manifest.signing.release_helper.commit !== '20ab9a5e6bb1107788366726868f1a9b4c16d953' ||
     manifest.signing.release_helper.executable_sha256 !==
       'e65e06ef89ec90ebfc537d28748a3c4de8ce89bd09b51e4d67ba4bdd95427255' ||
     manifest.signing.release_helper.library_sha256 !==
-      '6be67a85c4b83d8968bfcf3697451dc21544614a4318e49a3534b219026ee842') {
+      'c29d3c46506c2d0bd2db7ab688bd3108d54e8824074a4fe800de6e3fe17284c9') {
   throw new Error('signing identity or release helper mismatch');
 }
 exactKeys(manifest.portable, ['validator', 'tree_generator', 'archive_policy', 'dmg_policy', 'source_tree'],


### PR DESCRIPTION
## Summary

- refresh the trusted `agent-scripts` release-helper commit to the current clean canonical checkout
- retain the unchanged helper executable hash and pin the updated library hash
- update every independent validator and hostile fixture without adding fallback trust

## Proof

- full `pnpm run test:safe`: release gates, preflight, certification, Foundation 77, CLI 1069, controller 50, runtime 527
- terminal artifact environment and portability mutation matrix
- release signing, source provenance, package resolution, and app-signing fixtures
- SwiftFormat, SwiftLint with zero serious findings, Bash/Node syntax, ShellCheck, and `git diff --check`
- P0-P2 structured review: clean
