### PR TITLE
fix(snapshots): bind references to producer hosts

### DIFF
--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -7,18 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-### Fixed
-
-- Bind Bridge 1.34 Chrome channel connections to an exact live Chrome bundle, native process-owned DevTools listener, and approval-gated WebSocket under one 90-second deadline, verifying `Browser.getVersion` once without legacy HTTP discovery or repeated permission probes and failing closed on helper-service names, file, socket, generation, or endpoint drift.
-- Authenticate native Chrome channels against Google Team ID `EQHXZ8M8AV`, pin the exact signed identifier and CDHash for the process generation, and enumerate the target process's complete listener inventory independently of Peekaboo's file-descriptor limit.
-- Honor the configured default save directory for pathless pixel-only `see` captures and add collision-resistant generated filenames for concurrent callers, while preserving explicit paths and stdout streaming. Thanks @PollyBot13 for #607.
-- Preserve the exact browser target-lock refusal so reconnecting to a different live Chrome channel or endpoint tells callers to disconnect first instead of reporting a generic unavailable target.
-- Advertise only actions and input shapes reachable under immutable background-only authority, while keeping foreground-capable app, Dock, Space, dialog, menu, browser, clipboard, and paste workflows explicit.
-- Emit one lossless target identity and process-generation receipt across CLI envelopes and App MCP responses, preventing extra metadata from overriding the canonical target.
-- Let exact `dialog` targeting prefer one active child sheet or alert beneath its structural parent, retain ambiguity for multiple children, and preserve actionable parent-window recovery hints through Bridge routing.
-
-## [4.2.3] - 2026-08-23
-
 ### Highlights
 
 - **Credentials and provider authentication are safer.** Secure prompts, stdin, and owner-only files keep secrets out of process lists, with additional Gemini, OAuth, clipboard, and editor hardening.
@@ -39,6 +27,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reuse validated classic PNG bytes when capture performs no transform instead of encoding the same image twice.
 
 ### Fixed
+- Bind Bridge 1.34 Chrome channel connections to an exact live Chrome bundle, native process-owned DevTools listener, and approval-gated WebSocket under one 90-second deadline, verifying `Browser.getVersion` once without legacy HTTP discovery or repeated permission probes and failing closed on helper-service names, file, socket, generation, or endpoint drift.
+- Authenticate native Chrome channels against Google Team ID `EQHXZ8M8AV`, pin the exact signed identifier and CDHash for the process generation, and enumerate the target process's complete listener inventory independently of Peekaboo's file-descriptor limit.
+- Honor the configured default save directory for pathless pixel-only `see` captures and add collision-resistant generated filenames for concurrent callers, while preserving explicit paths and stdout streaming. Thanks @PollyBot13 for #607.
+- Preserve the exact browser target-lock refusal so reconnecting to a different live Chrome channel or endpoint tells callers to disconnect first instead of reporting a generic unavailable target.
+- Advertise only actions and input shapes reachable under immutable background-only authority, while keeping foreground-capable app, Dock, Space, dialog, menu, browser, clipboard, and paste workflows explicit.
+- Emit one lossless target identity and process-generation receipt across CLI envelopes and App MCP responses, preventing extra metadata from overriding the canonical target.
+- Let exact `dialog` targeting prefer one active child sheet or alert beneath its structural parent, retain ambiguity for multiple children, and preserve actionable parent-window recovery hints through Bridge routing.
+- Bind snapshots to strict producer-owned `ps1_` references, route concrete IDs to their unique authenticated local or Bridge host before normal preference, and fail closed on malformed, stale, duplicate, incapable, or explicitly misrouted hosts while keeping legacy timestamp directories cleanup-only.
 - Downscale straight-alpha legacy screenshots to logical 1x instead of silently returning Retina-sized pixels.
 - Bound modern capture transaction-lock waits inside the Bridge request envelope so a wedged peer fails clearly instead of hanging indefinitely. Thanks @SebTardif for #599.
 - Send Gemini API keys in request headers, require HTTPS OAuth endpoints, and redact OAuth state. Thanks Vincent Koc for #575 and Tachikoma #73.

--- a/Apps/CLI/Package.swift
+++ b/Apps/CLI/Package.swift
@@ -87,6 +87,7 @@ var targets: [Target] = [
             .product(name: "PeekabooFoundationTestSupport", package: "PeekabooFoundation"),
             .product(name: "PeekabooAutomation", package: "PeekabooCore"),
             .product(name: "PeekabooAgentRuntime", package: "PeekabooCore"),
+            .product(name: "PeekabooBridge", package: "PeekabooCore"),
             .product(name: "PeekabooCore", package: "PeekabooCore"),
         ],
         path: "Tests/CoreCLITests",

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommandRuntime.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommandRuntime.swift
@@ -65,6 +65,9 @@ struct CommandRuntimeOptions {
     /// Protocol 1.22 carries a process-generation receipt with targeted click requests.
     var requiresProcessGenerationPinnedClicks = false
     var requiresHostApplicationInventory = false
+    /// A concrete snapshot reference is host-local state. Runtime selection must authenticate
+    /// the live host that owns it instead of replaying the ID against the ordinary preferred host.
+    var explicitSnapshotID: String?
     var requiresImplicitSnapshotInvalidation = false
     /// Protocol 1.26 publishes a receipt that is addressable by ID without replacing implicit latest elements.
     var requiresExplicitSnapshotPublication = false

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommandRuntime.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommandRuntime.swift
@@ -64,10 +64,14 @@ struct CommandRuntimeOptions {
     var requiresProcessGenerationPinnedTypeActions = false
     /// Protocol 1.22 carries a process-generation receipt with targeted click requests.
     var requiresProcessGenerationPinnedClicks = false
+    /// Current background clicks must carry an explicit AX-value allow/deny policy to the selected host.
+    var requiresTargetedClickAccessibilityValueDelivery = false
     var requiresHostApplicationInventory = false
     /// A concrete snapshot reference is host-local state. Runtime selection must authenticate
     /// the live host that owns it instead of replaying the ID against the ordinary preferred host.
     var explicitSnapshotID: String?
+    /// Snapshot-producing commands require canonical producer ownership before selecting a host.
+    var requiresProducerBoundSnapshotReferences = false
     var requiresImplicitSnapshotInvalidation = false
     /// Protocol 1.26 publishes a receipt that is addressable by ID without replacing implicit latest elements.
     var requiresExplicitSnapshotPublication = false

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommandServiceBridges.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommandServiceBridges.swift
@@ -65,6 +65,8 @@ enum AutomationServiceBridge {
             guard targetedClickService.supportsTargetedClicks else {
                 throw self.targetedClickUnavailableError(service: targetedClickService)
             }
+            let allowsAccessibilityValueDelivery =
+                targetedClickService.supportsTargetedClickAccessibilityValueDelivery
 
             if let targetWindowID {
                 guard let exactWindowService = targetedClickService as? any ExactWindowTargetedClickServiceProtocol
@@ -90,7 +92,8 @@ enum AutomationServiceBridge {
                         clickType: clickType,
                         snapshotId: snapshotId,
                         expectedWindowIdentity: expectedWindowIdentity,
-                        expectedWindowBounds: expectedWindowBounds
+                        expectedWindowBounds: expectedWindowBounds,
+                        allowsAccessibilityValueDelivery: allowsAccessibilityValueDelivery
                     )
                 }
                 try await exactWindowService.click(
@@ -98,7 +101,8 @@ enum AutomationServiceBridge {
                     clickType: clickType,
                     snapshotId: snapshotId,
                     expectedWindowIdentity: expectedWindowIdentity,
-                    expectedWindowBounds: expectedWindowBounds
+                    expectedWindowBounds: expectedWindowBounds,
+                    allowsAccessibilityValueDelivery: allowsAccessibilityValueDelivery
                 )
             } else {
                 guard targetedClickService.supportsProcessGenerationPinnedClicks else {
@@ -111,14 +115,16 @@ enum AutomationServiceBridge {
                         target: target,
                         clickType: clickType,
                         snapshotId: snapshotId,
-                        expectedProcessIdentity: expectedProcessIdentity
+                        expectedProcessIdentity: expectedProcessIdentity,
+                        allowsAccessibilityValueDelivery: allowsAccessibilityValueDelivery
                     )
                 }
                 try await targetedClickService.click(
                     target: target,
                     clickType: clickType,
                     snapshotId: snapshotId,
-                    expectedProcessIdentity: expectedProcessIdentity
+                    expectedProcessIdentity: expectedProcessIdentity,
+                    allowsAccessibilityValueDelivery: allowsAccessibilityValueDelivery
                 )
             }
             return UIAutomationActionResult(payload: (), outcome: nil)

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommanderBinder.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommanderBinder.swift
@@ -81,6 +81,12 @@ enum CommanderCLIBinder {
             commandType,
             parsedValues: parsedValues
         )
+        if options.requiresImplicitSnapshotInvalidation,
+           InteractionSnapshotReference.isConcrete(commandValues.singleOption("snapshot")) {
+            options.explicitSnapshotID = InteractionSnapshotReference.normalized(
+                commandValues.singleOption("snapshot")
+            )
+        }
         let clipboardMayMutate = Self.clipboardMayMutate(commandType)
         options.requiresCallerDesktopMutationBarrier = commandType == SwitchSubcommand.self ||
             commandType == MoveWindowSubcommand.self ||

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommanderBinder.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommanderBinder.swift
@@ -81,11 +81,19 @@ enum CommanderCLIBinder {
             commandType,
             parsedValues: parsedValues
         )
+        let resolvedSnapshotOption = commandValues.singleOption("snapshot").flatMap { value in
+            value.isEmpty ? nil : value
+        } ?? parsedValues.options["snapshot"]?.last
         if options.requiresImplicitSnapshotInvalidation,
-           InteractionSnapshotReference.isConcrete(commandValues.singleOption("snapshot")) {
-            options.explicitSnapshotID = InteractionSnapshotReference.normalized(
-                commandValues.singleOption("snapshot")
-            )
+           let snapshotID = resolvedSnapshotOption,
+           !InteractionSnapshotReference.isLatestAlias(snapshotID) {
+            guard SnapshotReference(rawValue: snapshotID) != nil else {
+                throw ValidationError(
+                    "Invalid snapshot reference '\(snapshotID)'; expected ps1_ followed by 32 lowercase " +
+                        "hexadecimal digits"
+                )
+            }
+            options.explicitSnapshotID = snapshotID
         }
         let clipboardMayMutate = Self.clipboardMayMutate(commandType)
         options.requiresCallerDesktopMutationBarrier = commandType == SwitchSubcommand.self ||
@@ -106,6 +114,8 @@ enum CommanderCLIBinder {
             commandValues.singleOption("at") != nil
         options.requiresProcessGenerationPinnedClicks = commandType == ClickCommand.self && usesBackgroundInput &&
             !options.requiresExactWindowTargetedClicks
+        options.requiresTargetedClickAccessibilityValueDelivery = commandType == ClickCommand.self &&
+            usesBackgroundInput
         let servesDynamicTools = Self.isAgentExecutionCommand(commandType) || commandType == MCPCommand.Serve.self
         options.requiresAgentService = servesDynamicTools
         if servesDynamicTools {
@@ -114,6 +124,7 @@ enum CommanderCLIBinder {
             options.requiresProcessGenerationPinnedHotkeys = true
             options.requiresProcessGenerationPinnedTypeActions = true
             options.requiresProcessGenerationPinnedClicks = true
+            options.requiresTargetedClickAccessibilityValueDelivery = true
         }
         options.requiresTargetedScroll = commandType == ScrollCommand.self &&
             !commandValues.flag("foreground")
@@ -143,6 +154,9 @@ enum CommanderCLIBinder {
         options.usesPerToolSnapshotInvalidation = Self.isAgentExecutionCommand(commandType) ||
             commandType == MCPCommand.Serve.self ||
             commandType == VerifyCommand.self
+        options.requiresProducerBoundSnapshotReferences = commandType == SeeCommand.self ||
+            options.requiresSilentCapture ||
+            options.usesPerToolSnapshotInvalidation
         options.verbose = parsedValues.flags.contains("verbose")
         options.jsonOutput = parsedValues.flags.contains("jsonOutput")
         let values = CommanderBindableValues(parsedValues: parsedValues)

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/BridgeCapabilityPolicy.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/BridgeCapabilityPolicy.swift
@@ -105,12 +105,22 @@ enum BridgeCapabilityPolicy {
             return false
         }
 
+        if options.requiresTargetedClickAccessibilityValueDelivery,
+           !self.supportsTargetedClickAccessibilityValueDelivery(for: handshake) {
+            return false
+        }
+
         if options.requiresHostApplicationInventory, !self.supportsHostApplicationInventory(for: handshake) {
             return false
         }
 
         if options.requiresImplicitSnapshotInvalidation || options.usesPerToolSnapshotInvalidation,
            !self.supportsImplicitSnapshotInvalidation(for: handshake) {
+            return false
+        }
+
+        if options.requiresProducerBoundSnapshotReferences,
+           !self.supportsProducerBoundSnapshotReferences(for: handshake) {
             return false
         }
 
@@ -475,6 +485,26 @@ enum BridgeCapabilityPolicy {
     static func supportsExplicitSnapshotPublication(for handshake: PeekabooBridgeHandshakeResponse) -> Bool {
         handshake.negotiatedVersion >= PeekabooBridgeConstants.explicitSnapshotPublicationVersion &&
             handshake.hostCapabilities?.contains(PeekabooBridgeHostCapability.explicitSnapshotPublication) == true
+    }
+
+    static func supportsProducerBoundSnapshotReferences(for handshake: PeekabooBridgeHandshakeResponse) -> Bool {
+        handshake.negotiatedVersion >= PeekabooBridgeConstants.producerBoundSnapshotReferencesVersion &&
+            handshake.hostCapabilities?.contains(PeekabooBridgeHostCapability.attestedOperationReceipts) == true &&
+            handshake.hostCapabilities?.contains(
+                PeekabooBridgeHostCapability.producerBoundSnapshotReferences
+            ) == true &&
+            self.supportsOperation(.ownsSnapshot, for: handshake)
+    }
+
+    static func supportsTargetedClickAccessibilityValueDelivery(
+        for handshake: PeekabooBridgeHandshakeResponse
+    ) -> Bool {
+        handshake.negotiatedVersion >= PeekabooBridgeConstants.targetedClickAccessibilityValueDeliveryVersion &&
+            handshake.hostCapabilities?.contains(PeekabooBridgeHostCapability.attestedOperationReceipts) == true &&
+            handshake.hostCapabilities?.contains(
+                PeekabooBridgeHostCapability.targetedClickAccessibilityValueDelivery
+            ) == true &&
+            self.supportsOperation(.targetedClick, for: handshake)
     }
 
     static func supportsElementActions(for handshake: PeekabooBridgeHandshakeResponse) -> Bool {

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/RuntimeHostResolver+Resolution.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/RuntimeHostResolver+Resolution.swift
@@ -70,7 +70,7 @@ extension RuntimeHostResolver {
         }
     }
 
-    struct ImplicitRemoteCandidate: Equatable {
+    struct ImplicitRemoteCandidate: Equatable, Sendable {
         let socketPath: String
         let requireReusableDaemon: Bool
         let requiredHostKind: PeekabooBridgeHostKind?

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/RuntimeHostResolver+Resolution.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/RuntimeHostResolver+Resolution.swift
@@ -16,6 +16,8 @@ extension RuntimeHostResolver {
         }
 
         let identity: PeekabooBridgeClientIdentity
+        let trustedHostTeamIDs: Set<String>?
+        let clientFactory: (@MainActor (String) -> PeekabooBridgeClient)?
         private var entriesBySocketPath: [String: Entry] = [:]
 
         convenience init() {
@@ -27,8 +29,14 @@ extension RuntimeHostResolver {
             ))
         }
 
-        init(identity: PeekabooBridgeClientIdentity) {
+        init(
+            identity: PeekabooBridgeClientIdentity,
+            trustedHostTeamIDs: Set<String>? = nil,
+            clientFactory: (@MainActor (String) -> PeekabooBridgeClient)? = nil
+        ) {
             self.identity = identity
+            self.trustedHostTeamIDs = trustedHostTeamIDs
+            self.clientFactory = clientFactory
         }
 
         func handshake(
@@ -43,7 +51,10 @@ extension RuntimeHostResolver {
                 return entry
             }
 
-            let client = PeekabooBridgeClient(socketPath: candidate.socketPath)
+            let client = self.clientFactory?(candidate.socketPath) ?? PeekabooBridgeClient(
+                socketPath: candidate.socketPath,
+                trustedHostTeamIDs: self.trustedHostTeamIDs
+            )
             let response = try await client.handshake(client: self.identity, requestedHost: nil)
             let entry = Entry(client: client, response: response)
             self.entriesBySocketPath[socketPath] = entry

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/RuntimeHostResolver+ScreenCaptureKitOwner.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/RuntimeHostResolver+ScreenCaptureKitOwner.swift
@@ -27,6 +27,7 @@ extension RuntimeHostResolver {
     ) async throws -> PeekabooBridgeHandshakeResponse
     typealias ScreenCaptureKitExternalHostInspector = @MainActor @Sendable (String) ->
         ScreenCaptureKitExternalHostPresence
+    typealias RemoteHandshakeCacheFactory = @MainActor () -> RemoteHandshakeCache
 
     struct Dependencies {
         let makeLocalServices: LocalServiceFactory
@@ -35,6 +36,8 @@ extension RuntimeHostResolver {
         let inspectScreenCaptureKitSafety: ScreenCaptureKitSafetyInspector
         let recordScreenCaptureKitSafetyBlocker: ScreenCaptureKitSafetyRecorder
         let remoteCandidatePlan: RemoteCandidatePlanner
+        let snapshotAffinityProbe: SnapshotAffinityProbe
+        let makeRemoteHandshakeCache: RemoteHandshakeCacheFactory
 
         init(
             makeLocalServices: @escaping LocalServiceFactory,
@@ -42,7 +45,9 @@ extension RuntimeHostResolver {
             inspectScreenCaptureKitOwner: @escaping ScreenCaptureKitOwnerInspector,
             inspectScreenCaptureKitSafety: @escaping ScreenCaptureKitSafetyInspector = { _, _, _, _ in nil },
             recordScreenCaptureKitSafetyBlocker: @escaping ScreenCaptureKitSafetyRecorder = { _ in },
-            remoteCandidatePlan: @escaping RemoteCandidatePlanner = RuntimeHostResolver.remoteCandidatePlan
+            remoteCandidatePlan: @escaping RemoteCandidatePlanner = RuntimeHostResolver.remoteCandidatePlan,
+            snapshotAffinityProbe: @escaping SnapshotAffinityProbe = RuntimeHostResolver.liveSnapshotAffinityProbe,
+            makeRemoteHandshakeCache: @escaping RemoteHandshakeCacheFactory = { RemoteHandshakeCache() }
         ) {
             self.makeLocalServices = makeLocalServices
             self.claimScreenCaptureKitOwner = claimScreenCaptureKitOwner
@@ -50,6 +55,8 @@ extension RuntimeHostResolver {
             self.inspectScreenCaptureKitSafety = inspectScreenCaptureKitSafety
             self.recordScreenCaptureKitSafetyBlocker = recordScreenCaptureKitSafetyBlocker
             self.remoteCandidatePlan = remoteCandidatePlan
+            self.snapshotAffinityProbe = snapshotAffinityProbe
+            self.makeRemoteHandshakeCache = makeRemoteHandshakeCache
         }
 
         static let live = Dependencies(

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/RuntimeHostResolver+SnapshotAffinity.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/RuntimeHostResolver+SnapshotAffinity.swift
@@ -1,12 +1,24 @@
 import Foundation
+import PeekabooAgentRuntime
 import PeekabooBridge
 import PeekabooFoundation
 
 extension RuntimeHostResolver {
+    private enum SnapshotAffinityRemoteOwnerKey: Hashable {
+        case attestedProcess(pid_t, UInt64, String)
+        case endpoint(String)
+    }
+
     enum SnapshotAffinityProbeResult: Equatable, Sendable {
         case owner
         case missing
+        case incompatible
         case unavailable
+    }
+
+    enum SnapshotAffinityOwner: Equatable, Sendable {
+        case local
+        case remote([ImplicitRemoteCandidate])
     }
 
     typealias SnapshotAffinityProbe = @MainActor @Sendable (
@@ -43,6 +55,18 @@ extension RuntimeHostResolver {
                 requiredHostKind: .gui,
                 requiresValidatedHistoricalDaemon: false
             ),
+            ImplicitRemoteCandidate(
+                socketPath: PeekabooBridgeConstants.claudeSocketPath,
+                requireReusableDaemon: false,
+                requiredHostKind: nil,
+                requiresValidatedHistoricalDaemon: false
+            ),
+            ImplicitRemoteCandidate(
+                socketPath: PeekabooBridgeConstants.clawdbotSocketPath,
+                requireReusableDaemon: false,
+                requiredHostKind: nil,
+                requiresValidatedHistoricalDaemon: false
+            ),
         ].compactMap(\.self))
         candidates.append(contentsOf: plan.historicalBuildScopedDaemonSocketPaths.map {
             ImplicitRemoteCandidate(
@@ -67,12 +91,32 @@ extension RuntimeHostResolver {
         probe: @escaping SnapshotAffinityProbe = RuntimeHostResolver
             .liveSnapshotAffinityProbe
     ) async throws -> ImplicitRemoteCandidate {
-        guard self.isSafeSnapshotReference(snapshotID) else {
-            throw self.snapshotAffinityRefusal(
-                snapshotID: snapshotID,
-                message: "Snapshot reference is not one safe opaque snapshot ID.",
-                reason: .invalidRequest
-            )
+        let owner = try await self.resolveSnapshotAffinityOwner(
+            snapshotID: snapshotID,
+            localServices: nil,
+            candidates: candidates,
+            identity: identity,
+            handshakeCache: handshakeCache,
+            probe: probe
+        )
+        guard case let .remote(candidates) = owner,
+              let candidate = candidates.first
+        else {
+            preconditionFailure("Remote-only snapshot affinity unexpectedly selected local services")
+        }
+        return candidate
+    }
+
+    static func resolveSnapshotAffinityOwner(
+        snapshotID: String,
+        localServices: (any PeekabooServiceProviding)?,
+        candidates: [ImplicitRemoteCandidate],
+        identity: PeekabooBridgeClientIdentity,
+        handshakeCache: RemoteHandshakeCache,
+        probe: @escaping SnapshotAffinityProbe = RuntimeHostResolver.liveSnapshotAffinityProbe
+    ) async throws -> SnapshotAffinityOwner {
+        guard SnapshotReference(rawValue: snapshotID) != nil else {
+            throw self.invalidSnapshotReferenceRefusal(snapshotID)
         }
 
         let tasks = candidates.enumerated().map { index, candidate in
@@ -98,24 +142,53 @@ extension RuntimeHostResolver {
         }
         try Task.checkCancellation()
 
-        var owners: [ImplicitRemoteCandidate] = []
+        let localOwnsSnapshot = if let localServices {
+            try await localServices.snapshots.ownsSnapshot(snapshotId: snapshotID)
+        } else {
+            false
+        }
         var unavailableCount = 0
+        var incompatibleCount = 0
+        var remoteOwnerOrder: [SnapshotAffinityRemoteOwnerKey] = []
+        var remoteOwnerCandidates: [SnapshotAffinityRemoteOwnerKey: [ImplicitRemoteCandidate]] = [:]
         for (_, candidate, result) in observations {
             switch result {
             case .owner:
-                owners.append(candidate)
+                let key = self.snapshotAffinityRemoteOwnerKey(
+                    candidate: candidate,
+                    identity: identity,
+                    handshakeCache: handshakeCache
+                )
+                if remoteOwnerCandidates[key] == nil {
+                    remoteOwnerOrder.append(key)
+                }
+                remoteOwnerCandidates[key, default: []].append(candidate)
             case .missing:
                 break
+            case .incompatible:
+                incompatibleCount += 1
             case .unavailable:
                 unavailableCount += 1
             }
         }
-        if owners.count == 1, let owner = owners.first {
-            return owner
+        let ownerCount = (localOwnsSnapshot ? 1 : 0) + remoteOwnerOrder.count
+        if ownerCount == 1 {
+            if localOwnsSnapshot {
+                return .local
+            }
+            if let key = remoteOwnerOrder.first,
+               let candidates = remoteOwnerCandidates[key] {
+                return .remote(candidates)
+            }
         }
-        if owners.count > 1 {
-            let paths = owners
-                .map { NSString(string: $0.socketPath).standardizingPath }
+        if ownerCount > 1 {
+            let localPaths = localOwnsSnapshot ? ["local"] : []
+            let remotePaths = remoteOwnerOrder.flatMap { key in
+                remoteOwnerCandidates[key, default: []].map {
+                    NSString(string: $0.socketPath).standardizingPath
+                }
+            }
+            let paths = (localPaths + remotePaths)
                 .sorted()
                 .joined(separator: ", ")
             throw self.snapshotAffinityRefusal(
@@ -125,9 +198,23 @@ extension RuntimeHostResolver {
             )
         }
 
-        let availability = unavailableCount == 0
-            ? "No authenticated live Peekaboo host owns it; it may be expired, cleaned, or unknown."
-            : "Its producing host may be stopped or unreachable, and no authenticated live host owns it."
+        let soleCandidatePath = candidates.count == 1
+            ? candidates.first.map { NSString(string: $0.socketPath).standardizingPath }
+            : nil
+        let availability = if let soleCandidatePath, incompatibleCount > 0 {
+            "The authenticated host at \(soleCandidatePath) cannot prove producer-bound snapshot ownership; update it."
+        } else if let soleCandidatePath, unavailableCount > 0 {
+            "The selected host at \(soleCandidatePath) is stopped or unreachable, and no other authenticated live " +
+                "host may claim this reference."
+        } else if let soleCandidatePath {
+            "The authenticated host at \(soleCandidatePath) does not own it; it may be expired, cleaned, or unknown."
+        } else if incompatibleCount > 0 {
+            "One or more live hosts cannot prove producer-bound snapshot ownership; update them."
+        } else if unavailableCount == 0 {
+            "No authenticated live Peekaboo host owns it; it may be expired, cleaned, or unknown."
+        } else {
+            "Its producing host may be stopped or unreachable, and no authenticated live host owns it."
+        }
         throw self.snapshotAffinityRefusal(
             snapshotID: snapshotID,
             message: availability,
@@ -135,27 +222,66 @@ extension RuntimeHostResolver {
         )
     }
 
-    static func resolveSnapshotAffinityServices(
-        snapshotID: String,
-        context: RemoteResolutionContext,
-        permissionRejections: inout [String]
-    ) async throws -> Resolution {
-        let owner = try await self.resolveSnapshotAffinity(
-            snapshotID: snapshotID,
-            candidates: self.snapshotAffinityCandidates(from: context.candidatePlan),
-            identity: context.identity,
-            handshakeCache: context.handshakeCache
-        )
-        if let resolved = try await context.resolveRemoteServices(
-            candidates: [owner],
-            permissionRejections: &permissionRejections
-        ) {
-            return resolved
+    private static func snapshotAffinityRemoteOwnerKey(
+        candidate: ImplicitRemoteCandidate,
+        identity: PeekabooBridgeClientIdentity,
+        handshakeCache: RemoteHandshakeCache
+    ) -> SnapshotAffinityRemoteOwnerKey {
+        if let host = handshakeCache.entry(for: candidate, identity: identity)?.response.operationAttestation?.host {
+            return .attestedProcess(
+                host.processIdentifier,
+                host.processStartIdentity,
+                host.codeSignatureHash
+            )
         }
-        throw self.snapshotOwnerIncompatibleRefusal(snapshotID: snapshotID, candidate: owner)
+        return .endpoint(NSString(string: candidate.socketPath).standardizingPath)
     }
 
-    private static func liveSnapshotAffinityProbe(
+    static func resolveSnapshotAffinityServices(
+        snapshotID: String,
+        localServices: (any PeekabooServiceProviding)?,
+        context: RemoteResolutionContext,
+        permissionRejections: inout [String],
+        probe: @escaping SnapshotAffinityProbe = RuntimeHostResolver.liveSnapshotAffinityProbe
+    ) async throws -> Resolution {
+        let owner = try await self.resolveSnapshotAffinityOwner(
+            snapshotID: snapshotID,
+            localServices: localServices,
+            candidates: self.snapshotAffinityCandidates(from: context.candidatePlan),
+            identity: context.identity,
+            handshakeCache: context.handshakeCache,
+            probe: probe
+        )
+        switch owner {
+        case .local:
+            guard let localServices else {
+                throw self.snapshotAffinityRefusal(
+                    snapshotID: snapshotID,
+                    message: "Local ownership was selected without local services.",
+                    reason: .runtimeIncompatible
+                )
+            }
+            return Resolution(
+                services: localServices,
+                hostDescription: "local (snapshot producer)",
+                selectedRemoteSocketPath: nil,
+                selectedRemoteHostProcessIdentifier: nil,
+                snapshotInvalidationRemoteSocketPaths: context.snapshotInvalidationRemoteSocketPaths,
+                applicationRelaunchAllowed: true,
+                requiredHostFailure: nil
+            )
+        case let .remote(candidates):
+            if let resolved = try await context.resolveRemoteServices(
+                candidates: candidates,
+                permissionRejections: &permissionRejections
+            ) {
+                return resolved
+            }
+            throw self.snapshotOwnerIncompatibleRefusal(snapshotID: snapshotID, candidates: candidates)
+        }
+    }
+
+    static func liveSnapshotAffinityProbe(
         _ candidate: ImplicitRemoteCandidate,
         _ snapshotID: String,
         _ identity: PeekabooBridgeClientIdentity,
@@ -163,26 +289,30 @@ extension RuntimeHostResolver {
     ) async throws -> SnapshotAffinityProbeResult {
         do {
             let entry = try await handshakeCache.handshake(candidate, identity: identity)
-            guard BridgeCapabilityPolicy.supportsOperation(.getDetectionResult, for: entry.response) else {
-                return .unavailable
+            guard BridgeCapabilityPolicy.supportsProducerBoundSnapshotReferences(for: entry.response) else {
+                return .incompatible
             }
-            let result = try await entry.client.getDetectionResult(snapshotId: snapshotID)
-            return result.snapshotId == snapshotID ? .owner : .unavailable
-        } catch let envelope as PeekabooBridgeErrorEnvelope where envelope.code == .notFound {
-            return .missing
+            return try await entry.client.ownsSnapshot(snapshotId: snapshotID) ? .owner : .missing
         } catch let error as CancellationError {
             throw error
+        } catch let envelope as PeekabooBridgeErrorEnvelope
+            where envelope.code == .operationNotSupported ||
+            envelope.code == .invalidRequest ||
+            envelope.code == .decodingFailed ||
+            envelope.code == .versionMismatch {
+            return .incompatible
         } catch {
             return .unavailable
         }
     }
 
-    private static func isSafeSnapshotReference(_ snapshotID: String) -> Bool {
-        !snapshotID.isEmpty &&
-            snapshotID != "." &&
-            snapshotID != ".." &&
-            !snapshotID.contains("/") &&
-            !snapshotID.unicodeScalars.contains { CharacterSet.controlCharacters.contains($0) }
+    private static func invalidSnapshotReferenceRefusal(_ snapshotID: String) -> PreDispatchActionError {
+        PreDispatchActionError(
+            message: "Snapshot reference '\(snapshotID)' is invalid. No action was dispatched.",
+            code: .VALIDATION_ERROR,
+            hint: "Use the exact ps1_ reference returned by a fresh 'peekaboo see'.",
+            reason: .invalidRequest
+        )
     }
 
     private static func snapshotAffinityRefusal(
@@ -200,12 +330,13 @@ extension RuntimeHostResolver {
 
     private static func snapshotOwnerIncompatibleRefusal(
         snapshotID: String,
-        candidate: ImplicitRemoteCandidate
+        candidates: [ImplicitRemoteCandidate]
     ) -> PreDispatchActionError {
-        let socketPath = NSString(string: candidate.socketPath).standardizingPath
+        let socketPaths = candidates.map { NSString(string: $0.socketPath).standardizingPath }
+            .joined(separator: ", ")
         return PreDispatchActionError(
-            message: "Snapshot '\(snapshotID)' is owned by the authenticated host at \(socketPath), but that " +
-                "host cannot satisfy this command. No action was dispatched.",
+            message: "Snapshot '\(snapshotID)' is owned by the authenticated host through \(socketPaths), but " +
+                "none of those endpoints can satisfy this command. No action was dispatched.",
             code: .BRIDGE_UNAVAILABLE,
             hint: "Update or relaunch that exact host, then run 'peekaboo see' again before retrying.",
             reason: .runtimeIncompatible

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/RuntimeHostResolver+SnapshotAffinity.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/RuntimeHostResolver+SnapshotAffinity.swift
@@ -1,0 +1,214 @@
+import Foundation
+import PeekabooBridge
+import PeekabooFoundation
+
+extension RuntimeHostResolver {
+    enum SnapshotAffinityProbeResult: Equatable, Sendable {
+        case owner
+        case missing
+        case unavailable
+    }
+
+    typealias SnapshotAffinityProbe = @MainActor @Sendable (
+        _ candidate: ImplicitRemoteCandidate,
+        _ snapshotID: String,
+        _ identity: PeekabooBridgeClientIdentity,
+        _ handshakeCache: RemoteHandshakeCache
+    ) async throws -> SnapshotAffinityProbeResult
+
+    static func snapshotAffinityCandidates(from plan: RemoteCandidatePlan) -> [ImplicitRemoteCandidate] {
+        if plan.explicitSocket != nil {
+            return plan.candidates
+        }
+
+        var candidates = plan.candidates
+        candidates.append(contentsOf: [
+            plan.buildScopedDaemonSocketPath.map {
+                ImplicitRemoteCandidate(
+                    socketPath: $0,
+                    requireReusableDaemon: true,
+                    requiredHostKind: .onDemand,
+                    requiresValidatedHistoricalDaemon: false
+                )
+            },
+            ImplicitRemoteCandidate(
+                socketPath: plan.daemonSocketPath,
+                requireReusableDaemon: true,
+                requiredHostKind: nil,
+                requiresValidatedHistoricalDaemon: false
+            ),
+            ImplicitRemoteCandidate(
+                socketPath: PeekabooBridgeConstants.peekabooSocketPath,
+                requireReusableDaemon: false,
+                requiredHostKind: .gui,
+                requiresValidatedHistoricalDaemon: false
+            ),
+        ].compactMap(\.self))
+        candidates.append(contentsOf: plan.historicalBuildScopedDaemonSocketPaths.map {
+            ImplicitRemoteCandidate(
+                socketPath: $0,
+                requireReusableDaemon: true,
+                requiredHostKind: .onDemand,
+                requiresValidatedHistoricalDaemon: true
+            )
+        })
+
+        var seen = Set<String>()
+        return candidates.filter {
+            seen.insert(NSString(string: $0.socketPath).standardizingPath).inserted
+        }
+    }
+
+    static func resolveSnapshotAffinity(
+        snapshotID: String,
+        candidates: [ImplicitRemoteCandidate],
+        identity: PeekabooBridgeClientIdentity,
+        handshakeCache: RemoteHandshakeCache,
+        probe: @escaping SnapshotAffinityProbe = RuntimeHostResolver
+            .liveSnapshotAffinityProbe
+    ) async throws -> ImplicitRemoteCandidate {
+        guard self.isSafeSnapshotReference(snapshotID) else {
+            throw self.snapshotAffinityRefusal(
+                snapshotID: snapshotID,
+                message: "Snapshot reference is not one safe opaque snapshot ID.",
+                reason: .invalidRequest
+            )
+        }
+
+        let tasks = candidates.enumerated().map { index, candidate in
+            Task { @MainActor in
+                try await (index, candidate, probe(candidate, snapshotID, identity, handshakeCache))
+            }
+        }
+        let observations = try await withTaskCancellationHandler {
+            defer {
+                for task in tasks {
+                    task.cancel()
+                }
+            }
+            var results: [(Int, ImplicitRemoteCandidate, SnapshotAffinityProbeResult)] = []
+            for task in tasks {
+                try await results.append(task.value)
+            }
+            return results.sorted { $0.0 < $1.0 }
+        } onCancel: {
+            for task in tasks {
+                task.cancel()
+            }
+        }
+        try Task.checkCancellation()
+
+        var owners: [ImplicitRemoteCandidate] = []
+        var unavailableCount = 0
+        for (_, candidate, result) in observations {
+            switch result {
+            case .owner:
+                owners.append(candidate)
+            case .missing:
+                break
+            case .unavailable:
+                unavailableCount += 1
+            }
+        }
+        if owners.count == 1, let owner = owners.first {
+            return owner
+        }
+        if owners.count > 1 {
+            let paths = owners
+                .map { NSString(string: $0.socketPath).standardizingPath }
+                .sorted()
+                .joined(separator: ", ")
+            throw self.snapshotAffinityRefusal(
+                snapshotID: snapshotID,
+                message: "Multiple authenticated Peekaboo hosts claim this snapshot: \(paths).",
+                reason: .runtimeIncompatible
+            )
+        }
+
+        let availability = unavailableCount == 0
+            ? "No authenticated live Peekaboo host owns it; it may be expired, cleaned, or unknown."
+            : "Its producing host may be stopped or unreachable, and no authenticated live host owns it."
+        throw self.snapshotAffinityRefusal(
+            snapshotID: snapshotID,
+            message: availability,
+            reason: .targetUnavailable
+        )
+    }
+
+    static func resolveSnapshotAffinityServices(
+        snapshotID: String,
+        context: RemoteResolutionContext,
+        permissionRejections: inout [String]
+    ) async throws -> Resolution {
+        let owner = try await self.resolveSnapshotAffinity(
+            snapshotID: snapshotID,
+            candidates: self.snapshotAffinityCandidates(from: context.candidatePlan),
+            identity: context.identity,
+            handshakeCache: context.handshakeCache
+        )
+        if let resolved = try await context.resolveRemoteServices(
+            candidates: [owner],
+            permissionRejections: &permissionRejections
+        ) {
+            return resolved
+        }
+        throw self.snapshotOwnerIncompatibleRefusal(snapshotID: snapshotID, candidate: owner)
+    }
+
+    private static func liveSnapshotAffinityProbe(
+        _ candidate: ImplicitRemoteCandidate,
+        _ snapshotID: String,
+        _ identity: PeekabooBridgeClientIdentity,
+        _ handshakeCache: RemoteHandshakeCache
+    ) async throws -> SnapshotAffinityProbeResult {
+        do {
+            let entry = try await handshakeCache.handshake(candidate, identity: identity)
+            guard BridgeCapabilityPolicy.supportsOperation(.getDetectionResult, for: entry.response) else {
+                return .unavailable
+            }
+            let result = try await entry.client.getDetectionResult(snapshotId: snapshotID)
+            return result.snapshotId == snapshotID ? .owner : .unavailable
+        } catch let envelope as PeekabooBridgeErrorEnvelope where envelope.code == .notFound {
+            return .missing
+        } catch let error as CancellationError {
+            throw error
+        } catch {
+            return .unavailable
+        }
+    }
+
+    private static func isSafeSnapshotReference(_ snapshotID: String) -> Bool {
+        !snapshotID.isEmpty &&
+            snapshotID != "." &&
+            snapshotID != ".." &&
+            !snapshotID.contains("/") &&
+            !snapshotID.unicodeScalars.contains { CharacterSet.controlCharacters.contains($0) }
+    }
+
+    private static func snapshotAffinityRefusal(
+        snapshotID: String,
+        message: String,
+        reason: DesktopActionOutcome.RefusalReason
+    ) -> PreDispatchActionError {
+        PreDispatchActionError(
+            message: "Snapshot '\(snapshotID)' has no unique live host affinity. \(message) No action was dispatched.",
+            code: .SNAPSHOT_NOT_FOUND,
+            hint: "Run 'peekaboo see' again and use the fresh snapshot without changing Bridge hosts.",
+            reason: reason
+        )
+    }
+
+    private static func snapshotOwnerIncompatibleRefusal(
+        snapshotID: String,
+        candidate: ImplicitRemoteCandidate
+    ) -> PreDispatchActionError {
+        let socketPath = NSString(string: candidate.socketPath).standardizingPath
+        return PreDispatchActionError(
+            message: "Snapshot '\(snapshotID)' is owned by the authenticated host at \(socketPath), but that " +
+                "host cannot satisfy this command. No action was dispatched.",
+            code: .BRIDGE_UNAVAILABLE,
+            hint: "Update or relaunch that exact host, then run 'peekaboo see' again before retrying.",
+            reason: .runtimeIncompatible
+        )
+    }
+}

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/RuntimeHostResolver.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/RuntimeHostResolver.swift
@@ -252,6 +252,14 @@ enum RuntimeHostResolver {
             )
         }
 
+        if let snapshotID = options.explicitSnapshotID {
+            return try await self.resolveSnapshotAffinityServices(
+                snapshotID: snapshotID,
+                context: context,
+                permissionRejections: &permissionRejections
+            )
+        }
+
         if prefersExactBuildScopedHost, let buildScopedDaemonSocketPath {
             let exactCandidate = ImplicitRemoteCandidate(
                 socketPath: buildScopedDaemonSocketPath,

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/RuntimeHostResolver.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/RuntimeHostResolver.swift
@@ -4,6 +4,7 @@ import PeekabooAutomation
 import PeekabooAutomationKit
 import PeekabooBridge
 import PeekabooCore
+import PeekabooFoundation
 
 @MainActor
 enum RuntimeHostResolver {
@@ -44,7 +45,7 @@ enum RuntimeHostResolver {
         if self.requiresCallerLocalScreenCaptureKitSafetyCheck(options: options, environment: environment) {
             let plan = await dependencies.remoteCandidatePlan(options, environment)
             safetyPlan = plan
-            let resolvedHandshakeCache = RemoteHandshakeCache()
+            let resolvedHandshakeCache = dependencies.makeRemoteHandshakeCache()
             handshakeCache = resolvedHandshakeCache
             if let oldHost = try await dependencies.inspectScreenCaptureKitSafety(
                 options,
@@ -88,14 +89,29 @@ enum RuntimeHostResolver {
             }
         }
 
+        let concreteSnapshotID = options.explicitSnapshotID
+        let localSnapshotServices = concreteSnapshotID.map { _ in dependencies.makeLocalServices(options) }
         guard self.shouldResolveKnownRemoteEndpoints(
             options: options,
             environment: environment,
             configurationInput: configurationInput
         )
         else {
+            if let concreteSnapshotID, let localSnapshotServices {
+                let resolvedHandshakeCache = dependencies.makeRemoteHandshakeCache()
+                let owner = try await self.resolveSnapshotAffinityOwner(
+                    snapshotID: concreteSnapshotID,
+                    localServices: localSnapshotServices,
+                    candidates: [],
+                    identity: resolvedHandshakeCache.identity,
+                    handshakeCache: resolvedHandshakeCache
+                )
+                guard owner == .local else {
+                    preconditionFailure("Local-only snapshot affinity selected a remote owner")
+                }
+            }
             return Resolution(
-                services: dependencies.makeLocalServices(options),
+                services: localSnapshotServices ?? dependencies.makeLocalServices(options),
                 hostDescription: "local (in-process)",
                 selectedRemoteSocketPath: nil,
                 selectedRemoteHostProcessIdentifier: nil,
@@ -122,6 +138,33 @@ enum RuntimeHostResolver {
             buildScopedDaemonSocketPath: buildScopedDaemonSocketPath,
             historicalBuildScopedDaemonSocketPaths: historicalBuildScopedDaemonSocketPaths
         )
+
+        if let concreteSnapshotID {
+            let resolvedHandshakeCache = handshakeCache ?? dependencies.makeRemoteHandshakeCache()
+            let context = RemoteResolutionContext(
+                options: options,
+                environment: environment,
+                candidatePlan: candidatePlan,
+                identity: resolvedHandshakeCache.identity,
+                handshakeCache: resolvedHandshakeCache,
+                snapshotInvalidationRemoteSocketPaths: snapshotInvalidationRemoteSocketPaths,
+                preferredScreenCaptureKitOwner: nil,
+                makeLocalServices: dependencies.makeLocalServices,
+                inspectScreenCaptureKitSafety: dependencies.inspectScreenCaptureKitSafety,
+                recordScreenCaptureKitSafetyBlocker: dependencies.recordScreenCaptureKitSafetyBlocker
+            )
+            var permissionRejections: [String] = []
+            var resolution = try await self.resolveSnapshotAffinityServices(
+                snapshotID: concreteSnapshotID,
+                localServices: explicitSocket == nil ? localSnapshotServices : nil,
+                context: context,
+                permissionRejections: &permissionRejections,
+                probe: dependencies.snapshotAffinityProbe
+            )
+            resolution.captureEngineSafetyOverride = captureEngineSafetyOverride
+            resolution.toolCapturePreflightRefusal = toolCapturePreflightRefusal
+            return resolution
+        }
 
         if deferredScreenCaptureKitSafetyBlocker {
             return Resolution(
@@ -169,7 +212,7 @@ enum RuntimeHostResolver {
             )
         }
 
-        let resolvedHandshakeCache = handshakeCache ?? RemoteHandshakeCache()
+        let resolvedHandshakeCache = handshakeCache ?? dependencies.makeRemoteHandshakeCache()
         var resolution = try await self.resolveRemoteRouting(context: RemoteResolutionContext(
             options: options,
             environment: environment,
@@ -249,14 +292,6 @@ enum RuntimeHostResolver {
             throw self.ownerRefusal(
                 owner: preferredScreenCaptureKitOwner,
                 callerLocal: false
-            )
-        }
-
-        if let snapshotID = options.explicitSnapshotID {
-            return try await self.resolveSnapshotAffinityServices(
-                snapshotID: snapshotID,
-                context: context,
-                permissionRejections: &permissionRejections
             )
         }
 
@@ -793,6 +828,8 @@ enum RuntimeHostResolver {
             targetedTypeRequiresEventSynthesizingPermission: targetedType.missingPermissions.contains(.postEvent),
             supportsTargetedClicks: targetedClick.isEnabled,
             supportsStatelessClickVariants: BridgeCapabilityPolicy.supportsStatelessClickVariants(for: handshake),
+            supportsTargetedClickAccessibilityValueDelivery:
+            BridgeCapabilityPolicy.supportsTargetedClickAccessibilityValueDelivery(for: handshake),
             targetedClickUnavailableReason: targetedClick.unavailableReason,
             targetedClickRequiresEventSynthesizingPermission: targetedClick.missingPermissions.contains(.postEvent),
             supportsExactWindowTargetedClicks: BridgeCapabilityPolicy.supportsExactWindowTargetedClicks(for: handshake),
@@ -834,6 +871,8 @@ enum RuntimeHostResolver {
             supportsExplicitSnapshotPublication: BridgeCapabilityPolicy.supportsExplicitSnapshotPublication(
                 for: handshake
             ),
+            supportsProducerBoundSnapshotReferences:
+            BridgeCapabilityPolicy.supportsProducerBoundSnapshotReferences(for: handshake),
             supportsApplicationLaunchOptions: BridgeCapabilityPolicy.supportsApplicationLaunchOptions(for: handshake),
             supportsSafeBackgroundApplicationLaunchNoOp:
             BridgeCapabilityPolicy.supportsSafeBackgroundApplicationLaunchNoOp(for: handshake),

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/ClickCommand+SnapshotWindowSelection.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/ClickCommand+SnapshotWindowSelection.swift
@@ -1,0 +1,63 @@
+import Commander
+import Foundation
+import PeekabooCore
+import PeekabooFoundation
+
+extension ClickCommand {
+    func resolveSnapshotBackedWindowSelection(
+        observation: InteractionObservationContext
+    ) async throws -> InteractionWindowResolution {
+        let snapshotID = try observation.requireSnapshot()
+        let detection = try await observation.requireDetectionResult(using: self.services.snapshots)
+        let context = detection.metadata.windowContext
+        guard let requestedWindowID = self.target.windowId,
+              let snapshotWindowID = context?.windowID
+        else {
+            throw ValidationError(
+                "Snapshot '\(snapshotID)' does not identify an exact window; " +
+                    "capture a fresh snapshot for the selected window"
+            )
+        }
+        guard let snapshotBounds = context?.windowBounds,
+              let snapshotIdentity = context?.windowMutationIdentity,
+              snapshotIdentity.windowID == snapshotWindowID,
+              snapshotIdentity.ownerProcessIdentifier == context?.applicationProcessId,
+              snapshotIdentity.capturedBounds == snapshotBounds
+        else {
+            throw ValidationError(
+                "Snapshot '\(snapshotID)' has no capture-time process-generation receipt for window " +
+                    "\(snapshotWindowID)."
+            )
+        }
+        guard requestedWindowID == snapshotWindowID else {
+            throw ValidationError(
+                "Snapshot '\(snapshotID)' belongs to window \(snapshotWindowID), but the explicit selector " +
+                    "requested window \(requestedWindowID)"
+            )
+        }
+
+        let targetApplication: ServiceApplicationInfo? = if let identifier = try self.target
+            .resolveApplicationIdentifierOptional() {
+            try await self.services.applications.findApplication(identifier: identifier)
+        } else {
+            nil
+        }
+        if let targetApplication,
+           targetApplication.processIdentifier != snapshotIdentity.ownerProcessIdentifier {
+            throw ValidationError(
+                "Snapshot '\(snapshotID)' belongs to PID \(snapshotIdentity.ownerProcessIdentifier), but " +
+                    "the explicit application selector resolved PID \(targetApplication.processIdentifier)"
+            )
+        }
+
+        return InteractionWindowResolution(
+            windowInfo: ServiceWindowInfo(
+                windowID: snapshotWindowID,
+                title: context?.windowTitle ?? "",
+                bounds: snapshotBounds,
+                mutationIdentity: snapshotIdentity
+            ),
+            targetApplication: targetApplication
+        )
+    }
+}

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/ClickCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/ClickCommand.swift
@@ -525,6 +525,12 @@ struct ClickCommand: ActionOutputFormattable, ErrorHandlingCommand, OutputFormat
             return nil
         }
 
+        if self.usesBackgroundDelivery,
+           self.target.windowId != nil,
+           observation.source == .explicit {
+            return try await self.resolveSnapshotBackedWindowSelection(observation: observation)
+        }
+
         let resolution = try await InteractionCoordinateResolver.resolveTargetWindow(
             target: self.target,
             services: self.services

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Shared/InteractionObservationContext.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Shared/InteractionObservationContext.swift
@@ -11,8 +11,7 @@ enum InteractionSnapshotSource: String {
 
 enum InteractionSnapshotReference {
     static func normalized(_ snapshotId: String?) -> String? {
-        let trimmed = snapshotId?.trimmingCharacters(in: .whitespacesAndNewlines)
-        return trimmed?.isEmpty == false ? trimmed : nil
+        snapshotId?.isEmpty == false ? snapshotId : nil
     }
 
     static func isConcrete(_ snapshotId: String?) -> Bool {

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/CleanCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/CleanCommand.swift
@@ -14,7 +14,7 @@ struct CleanCommand: OutputFormattable, RuntimeBackedCommand {
             EXAMPLES:
               peekaboo clean --all-snapshots      # Remove all snapshot data
               peekaboo clean --older-than 24      # Remove snapshots older than 24 hours
-              peekaboo clean --snapshot 12345     # Remove specific snapshot
+              peekaboo clean --snapshot ps1_0123456789abcdef0123456789abcdef
               peekaboo clean --dry-run            # Preview what would be deleted
 
             SNAPSHOT CACHE:
@@ -24,6 +24,9 @@ struct CleanCommand: OutputFormattable, RuntimeBackedCommand {
 
               --snapshot only checks the on-disk cache. If the ID exists only in the
               daemon's memory backend, the command reports not_found and removes nothing.
+              Current IDs are ps1_ plus 32 lowercase hexadecimal digits. Exact legacy
+              13-digit-timestamp-4-digit directories remain cleanup-only when they contain
+              a regular snapshot.json; legacy IDs cannot drive automation.
         """,
 
         showHelpOnEmptyInvocation: true

--- a/Apps/CLI/Tests/CLIAutomationTests/ActionOutcomeCommandTests.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/ActionOutcomeCommandTests.swift
@@ -834,6 +834,7 @@ struct ActionOutcomeCommandTests {
         #expect(firstOutcome["requires_fresh_observation"] as? Bool == true)
         #expect(firstOutcome["retry_safe"] as? Bool == false)
         #expect(automation.targetedClickCalls.count == 1)
+        #expect(automation.targetedClickCalls.first?.allowsAccessibilityValueDelivery == true)
 
         let second = try await InProcessCommandRunner.run(arguments, services: services)
         let secondObject = try Self.jsonObject(second.stdout)

--- a/Apps/CLI/Tests/CLIAutomationTests/CleanCommandSimpleTests.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/CleanCommandSimpleTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import PeekabooCore
+import PeekabooFoundationTestSupport
 import Testing
 @testable import PeekabooCLI
 
@@ -102,9 +103,10 @@ struct CleanCommandSimpleTests {
     @MainActor
     func `Clean snapshot miss reports disk not found in JSON and text`() async throws {
         let services = TestServicesFactory.makePeekabooServices(files: StubFileService())
+        let missingSnapshotID = SnapshotReferenceFixtures.first.rawValue
 
         let jsonResult = try await InProcessCommandRunner.run(
-            ["clean", "--snapshot", "memory-only", "--json"],
+            ["clean", "--snapshot", missingSnapshotID, "--json"],
             services: services
         )
 
@@ -116,7 +118,7 @@ struct CleanCommandSimpleTests {
         #expect(payloadData["not_found"] as? Bool == true)
 
         let textResult = try await InProcessCommandRunner.run(
-            ["clean", "--snapshot", "memory-only"],
+            ["clean", "--snapshot", missingSnapshotID],
             services: services
         )
 
@@ -144,6 +146,6 @@ struct CleanCommandSimpleTests {
         )
         #expect(response.success == false)
         #expect(response.error?.code == ErrorCode.VALIDATION_ERROR.rawValue)
-        #expect(response.error?.message == "Invalid snapshot ID: expected one folder name")
+        #expect(response.error?.message == FileServiceError.invalidSnapshotID.localizedDescription)
     }
 }

--- a/Apps/CLI/Tests/CLIAutomationTests/ClickCommandTests.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/ClickCommandTests.swift
@@ -248,16 +248,20 @@ struct ClickCommandTests {
 
     @Test
     func `Click command refuses PID only background coordinates without snapshot`() async throws {
-        for snapshotArguments in [[], ["--snapshot", ""]] {
+        let cases = [
+            (snapshotArguments: [String](), expectedMessage: "require --snapshot"),
+            (snapshotArguments: ["--snapshot", ""], expectedMessage: "Invalid snapshot reference"),
+        ]
+        for testCase in cases {
             let context = await makeContext()
             let result = try await InProcessCommandRunner.run(
                 ["click", "--at", "100,200", "--pid", "12345", "--global"] +
-                    snapshotArguments + ["--json"],
+                    testCase.snapshotArguments + ["--json"],
                 services: context.services
             )
 
             #expect(result.exitStatus == 1)
-            #expect(result.combinedOutput.contains("require --snapshot"))
+            #expect(result.combinedOutput.contains(testCase.expectedMessage))
             let calls = await automationState(context) { $0.targetedClickCalls }
             #expect(calls.isEmpty)
             #expect(context.snapshots.invalidationCutoffs.isEmpty)

--- a/Apps/CLI/Tests/CLIAutomationTests/ClickCommandTests.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/ClickCommandTests.swift
@@ -202,7 +202,7 @@ struct ClickCommandTests {
     }
 
     @Test
-    func `Background stateless click rejects same ID generation and bounds drift`() async throws {
+    func `Background stateless click rejects same ID generation and bounds drift atomically`() async throws {
         let application = Self.makeApplication()
         let snapshotWindow = Self.makeWindow(id: 42, title: "Editor", index: 0)
         let mismatchedWindows = [
@@ -217,6 +217,9 @@ struct ClickCommandTests {
 
         for selectedWindow in mismatchedWindows {
             let context = await makeContext(application: application, windows: [selectedWindow])
+            context.automation.clickError = PeekabooError.snapshotStale(
+                "Exact-window click receipt no longer matches current identity and bounds"
+            )
             let snapshotId = try await storeSnapshot(
                 element: DetectedElement(
                     id: "B1",
@@ -239,7 +242,7 @@ struct ClickCommandTests {
 
             #expect(result.exitStatus == 1)
             #expect(result.combinedOutput.contains("no longer matches"))
-            #expect(await self.automationState(context) { $0.targetedClickCalls }.isEmpty)
+            #expect(await self.automationState(context) { $0.targetedClickCalls }.count == 1)
         }
     }
 

--- a/Apps/CLI/Tests/CLIAutomationTests/ClickSnapshotWindowSelectionTests.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/ClickSnapshotWindowSelectionTests.swift
@@ -1,0 +1,153 @@
+import Foundation
+import PeekabooCore
+import PeekabooFoundation
+import Testing
+@testable import PeekabooCLI
+
+@Suite(.tags(.automation), .enabled(if: CLITestEnvironment.runAutomationRead))
+struct ClickSnapshotWindowSelectionTests {
+    @Test
+    @MainActor
+    func `Explicit exact-window snapshot does not depend on a second broad window lookup`() async throws {
+        let application = Self.makeApplication()
+        let window = Self.makeWindow()
+        let windows = SnapshotReceiptOnlyWindowService(windowsByApp: [application.name: [window]])
+        let fixture = Self.makeFixture(application: application, window: window, windows: windows)
+        let snapshotID = try await Self.storeSnapshot(window: window, in: fixture.snapshots)
+
+        let result = try await InProcessCommandRunner.run(
+            [
+                "click", "--on", "B1", "--snapshot", snapshotID,
+                "--app", application.name, "--window-id", "42", "--json",
+            ],
+            services: fixture.services
+        )
+
+        #expect(result.exitStatus == 0, "\(result.combinedOutput)")
+        #expect(windows.exactWindowLookupCount == 0)
+        #expect(fixture.automation.targetedClickCalls.count == 1)
+        #expect(fixture.automation.targetedClickCalls.first?.targetWindowID == 42)
+    }
+
+    @Test
+    @MainActor
+    func `Stale exact-window receipt refuses once without selector fallback`() async throws {
+        let application = Self.makeApplication()
+        let window = Self.makeWindow()
+        let windows = StubWindowService(windowsByApp: [application.name: [window]])
+        let fixture = Self.makeFixture(application: application, window: window, windows: windows)
+        fixture.automation.clickError = PeekabooError.snapshotStale("window identity changed")
+        let snapshotID = try await Self.storeSnapshot(window: window, in: fixture.snapshots)
+
+        let result = try await InProcessCommandRunner.run(
+            ["click", "--on", "B1", "--snapshot", snapshotID, "--window-id", "42", "--json"],
+            services: fixture.services
+        )
+
+        #expect(result.exitStatus == 1)
+        #expect(result.combinedOutput.contains("window identity changed"))
+        #expect(fixture.automation.targetedClickCalls.count == 1)
+    }
+
+    @MainActor
+    private static func makeFixture(
+        application: ServiceApplicationInfo,
+        window: ServiceWindowInfo,
+        windows: any WindowManagementServiceProtocol
+    ) -> TestServicesFactory.AutomationTestContext {
+        let automation = OutcomeStubAutomationService()
+        automation.actionOutcome = .dispatchedUnverified(
+            delivery: .init(mechanism: .accessibilityAction, mode: .background),
+            evidence: .deliveryAccepted,
+            unitCount: .one
+        )
+        return TestServicesFactory.makeAutomationTestContext(
+            automation: automation,
+            applications: StubApplicationService(
+                applications: [application],
+                windowsByApp: [application.name: [window]]
+            ),
+            windows: windows
+        )
+    }
+
+    @MainActor
+    private static func storeSnapshot(
+        window: ServiceWindowInfo,
+        in snapshots: StubSnapshotManager
+    ) async throws -> String {
+        let snapshotID = try await snapshots.createSnapshot()
+        let identity = try #require(window.mutationIdentity)
+        try await snapshots.storeDetectionResult(
+            snapshotId: snapshotID,
+            result: ElementDetectionResult(
+                snapshotId: snapshotID,
+                screenshotPath: "/tmp/screenshot.png",
+                elements: DetectedElements(buttons: [DetectedElement(
+                    id: "B1",
+                    type: .button,
+                    label: "Save",
+                    bounds: CGRect(x: 20, y: 30, width: 80, height: 30)
+                )]),
+                metadata: DetectionMetadata(
+                    detectionTime: 0,
+                    elementCount: 1,
+                    method: "stub",
+                    windowContext: WindowContext(
+                        applicationName: "TestApp",
+                        applicationBundleId: "com.example.test",
+                        applicationProcessId: 12345,
+                        windowTitle: window.title,
+                        windowID: window.windowID,
+                        windowBounds: window.bounds,
+                        windowMutationIdentity: identity
+                    ),
+                    truncationInfo: nil
+                )
+            )
+        )
+        return snapshotID
+    }
+
+    private static func makeApplication() -> ServiceApplicationInfo {
+        ServiceApplicationInfo(
+            processIdentifier: 12345,
+            processStartIdentity: 7,
+            bundleIdentifier: "com.example.test",
+            name: "TestApp",
+            isActive: false,
+            windowCount: 1,
+            activationPolicy: .regular
+        )
+    }
+
+    private static func makeWindow() -> ServiceWindowInfo {
+        let bounds = CGRect(x: 10, y: 20, width: 400, height: 300)
+        return ServiceWindowInfo(
+            windowID: 42,
+            title: "Editor",
+            bounds: bounds,
+            isMainWindow: true,
+            index: 0,
+            mutationIdentity: WindowMutationIdentity(
+                windowID: 42,
+                ownerProcessIdentifier: 12345,
+                ownerProcessStartIdentity: 7,
+                capturedBounds: bounds
+            )
+        )
+    }
+}
+
+@MainActor
+private final class SnapshotReceiptOnlyWindowService: StubWindowService {
+    private(set) var exactWindowLookupCount = 0
+
+    override func listWindows(target: WindowTarget) async throws -> [ServiceWindowInfo] {
+        if case .windowId = target {
+            self.exactWindowLookupCount += 1
+            throw PeekabooError.windowNotFound(criteria: "fixture rejects redundant exact-window enumeration")
+        }
+        return try await super.listWindows(target: target)
+    }
+}

--- a/Apps/CLI/Tests/CLIAutomationTests/ComposedInputParityValidationTests.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/ComposedInputParityValidationTests.swift
@@ -3,19 +3,21 @@ import CoreGraphics
 import Foundation
 import PeekabooCore
 import PeekabooFoundation
+import PeekabooFoundationTestSupport
 import Testing
 @testable import PeekabooCLI
 
 @Suite(.tags(.safe))
 struct ComposedInputParityValidationTests {
     private typealias Fixture = (services: PeekabooServices, snapshots: StubSnapshotManager, snapshotID: String)
+    private static let canonicalSnapshotID = SnapshotReferenceFixtures.first.rawValue
 
     @Test(arguments: [
         "invalid", "10", "10,20,30", "nan,20", "10,inf", ",10,20", "10,,20", "10,20,",
     ])
     func `pixel focus type requires one finite coordinate pair`(_ point: String) throws {
         var command = try TypeCommand.parse([
-            "hello", "--at", point, "--snapshot", "snap",
+            "hello", "--at", point, "--snapshot", Self.canonicalSnapshotID,
         ])
 
         let error = #expect(throws: ValidationError.self) {
@@ -29,8 +31,8 @@ struct ComposedInputParityValidationTests {
         let invalidArguments = [
             ["hello", "--at", "10,20"],
             ["hello", "--at", "10,20", "--snapshot", "latest"],
-            ["hello", "--at", "10,20", "--snapshot", "snap", "--foreground"],
-            ["hello", "--at", "10,20", "--snapshot", "snap", "--app", "TextEdit"],
+            ["hello", "--at", "10,20", "--snapshot", Self.canonicalSnapshotID, "--foreground"],
+            ["hello", "--at", "10,20", "--snapshot", Self.canonicalSnapshotID, "--app", "TextEdit"],
         ]
 
         for arguments in invalidArguments {
@@ -41,7 +43,8 @@ struct ComposedInputParityValidationTests {
         }
 
         var accepted = try TypeCommand.parse([
-            "hello", "--at", "10,20", "--coordinate-space", "image_pixels", "--snapshot", "snap",
+            "hello", "--at", "10,20", "--coordinate-space", "image_pixels", "--snapshot",
+            Self.canonicalSnapshotID,
             "--focus-background",
         ])
         try accepted.validate()
@@ -56,7 +59,7 @@ struct ComposedInputParityValidationTests {
     ])
     func `pixel focus type rejects foreground focus overrides`(_ focusArguments: [String]) throws {
         var command = try TypeCommand.parse([
-            "hello", "--at", "10,20", "--snapshot", "snap",
+            "hello", "--at", "10,20", "--snapshot", Self.canonicalSnapshotID,
         ] + focusArguments)
 
         let error = #expect(throws: ValidationError.self) {
@@ -69,14 +72,23 @@ struct ComposedInputParityValidationTests {
     @Test
     func `modifier click requires explicit foreground and exact snapshot authority`() throws {
         let invalidArguments = [
-            ["--on", "B1", "--modifiers", "cmd", "--snapshot", "snap"],
+            ["--on", "B1", "--modifiers", "cmd", "--snapshot", Self.canonicalSnapshotID],
             ["--on", "B1", "--modifiers", "cmd", "--foreground"],
             ["--on", "B1", "--modifiers", "cmd", "--foreground", "--snapshot", "latest"],
-            ["--on", "B1", "--modifiers", "fn", "--foreground", "--snapshot", "snap"],
-            ["--on", "B1", "--modifiers", "ctrl", "--foreground", "--snapshot", "snap"],
-            ["--on", "B1", "--modifiers", "cmd", "--right", "--foreground", "--snapshot", "snap"],
-            ["--on", "B1", "--modifiers", "cmd", "--foreground", "--snapshot", "snap", "--app", "Safari"],
-            ["--on", "B1", "--modifiers", "cmd", "--foreground", "--snapshot", "snap", "--space-switch"],
+            ["--on", "B1", "--modifiers", "fn", "--foreground", "--snapshot", Self.canonicalSnapshotID],
+            ["--on", "B1", "--modifiers", "ctrl", "--foreground", "--snapshot", Self.canonicalSnapshotID],
+            [
+                "--on", "B1", "--modifiers", "cmd", "--right", "--foreground", "--snapshot",
+                Self.canonicalSnapshotID,
+            ],
+            [
+                "--on", "B1", "--modifiers", "cmd", "--foreground", "--snapshot", Self.canonicalSnapshotID,
+                "--app", "Safari",
+            ],
+            [
+                "--on", "B1", "--modifiers", "cmd", "--foreground", "--snapshot", Self.canonicalSnapshotID,
+                "--space-switch",
+            ],
         ]
 
         for arguments in invalidArguments {
@@ -87,7 +99,7 @@ struct ComposedInputParityValidationTests {
         }
 
         var accepted = try ClickCommand.parse([
-            "--on", "B1", "--modifiers", "cmd,shift", "--foreground", "--snapshot", "snap",
+            "--on", "B1", "--modifiers", "cmd,shift", "--foreground", "--snapshot", Self.canonicalSnapshotID,
         ])
         try accepted.validate()
     }

--- a/Apps/CLI/Tests/CLIAutomationTests/DragCommandTests.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/DragCommandTests.swift
@@ -149,7 +149,11 @@ struct DragCommandTests {
 
     @Test
     func `Drag from element to coordinates scenario`() async throws {
-        let snapshotId = "test-snapshot"
+        let windows = await MainActor.run {
+            InputFocusWindowService(focusOutcome: InputFocusFixtures.focusOutcome)
+        }
+        let context = await self.makeAutomationContext(windows: windows)
+        let snapshotId = try await context.snapshots.createSnapshot()
         let element = DetectedElement(
             id: "B1",
             type: .button,
@@ -165,10 +169,6 @@ struct DragCommandTests {
             "--foreground",
         ]
 
-        let windows = await MainActor.run {
-            InputFocusWindowService(focusOutcome: InputFocusFixtures.focusOutcome)
-        }
-        let context = await self.makeAutomationContext(windows: windows)
         let services = await MainActor.run {
             InputExecutionHostServices(host: .remote, base: context.services)
         }

--- a/Apps/CLI/Tests/CLIAutomationTests/MoveCommandTests.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/MoveCommandTests.swift
@@ -61,6 +61,7 @@ struct MoveCommandTests {
     @Test
     func `Move by element ID resolves using stored detection results`() async throws {
         let (context, services) = await self.makeExactElementContext()
+        let snapshotID = try await context.snapshots.createSnapshot()
         let element = DetectedElement(
             id: "B1",
             type: .button,
@@ -68,7 +69,7 @@ struct MoveCommandTests {
             bounds: CGRect(x: 50, y: 70, width: 120, height: 40)
         )
         let detection = ElementDetectionResult(
-            snapshotId: "snapshot-id",
+            snapshotId: snapshotID,
             screenshotPath: "/tmp/screenshot.png",
             elements: DetectedElements(buttons: [element]),
             metadata: DetectionMetadata(
@@ -78,10 +79,10 @@ struct MoveCommandTests {
                 windowContext: Self.inputFocusWindowContext
             )
         )
-        try await context.snapshots.storeDetectionResult(snapshotId: "snapshot-id", result: detection)
+        try await context.snapshots.storeDetectionResult(snapshotId: snapshotID, result: detection)
 
         let result = try await InProcessCommandRunner.run(
-            ["move", "--on", "B1", "--snapshot", "snapshot-id", "--json", "--foreground"],
+            ["move", "--on", "B1", "--snapshot", snapshotID, "--json", "--foreground"],
             services: services
         )
 
@@ -96,6 +97,7 @@ struct MoveCommandTests {
     @Test
     func `Move by element ID is repeatable`() async throws {
         let (context, services) = await self.makeExactElementContext()
+        let snapshotID = try await context.snapshots.createSnapshot()
         let element = DetectedElement(
             id: "B1",
             type: .button,
@@ -103,7 +105,7 @@ struct MoveCommandTests {
             bounds: CGRect(x: 50, y: 70, width: 120, height: 40)
         )
         let detection = ElementDetectionResult(
-            snapshotId: "snapshot-id",
+            snapshotId: snapshotID,
             screenshotPath: "/tmp/screenshot.png",
             elements: DetectedElements(buttons: [element]),
             metadata: DetectionMetadata(
@@ -113,10 +115,10 @@ struct MoveCommandTests {
                 windowContext: Self.inputFocusWindowContext
             )
         )
-        try await context.snapshots.storeDetectionResult(snapshotId: "snapshot-id", result: detection)
+        try await context.snapshots.storeDetectionResult(snapshotId: snapshotID, result: detection)
 
         let result = try await InProcessCommandRunner.run(
-            ["move", "--on", "B1", "--snapshot", "snapshot-id", "--json", "--foreground"],
+            ["move", "--on", "B1", "--snapshot", snapshotID, "--json", "--foreground"],
             services: services
         )
 

--- a/Apps/CLI/Tests/CLIAutomationTests/PreDispatchActionEnvelopeTests.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/PreDispatchActionEnvelopeTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import PeekabooFoundation
+import PeekabooFoundationTestSupport
 import Testing
 @testable import PeekabooCLI
 
@@ -118,13 +119,19 @@ struct PreDispatchActionEnvelopeTests {
                 ),
                 (
                     "missing explicit type snapshot",
-                    ["type", "hello", "--snapshot", "synthetic-missing-snapshot", "--json", "--no-remote"],
+                    [
+                        "type", "hello", "--snapshot", SnapshotReferenceFixtures.first.rawValue,
+                        "--json", "--no-remote",
+                    ],
                     .SNAPSHOT_NOT_FOUND,
                     .targetUnavailable
                 ),
                 (
                     "missing explicit press snapshot",
-                    ["press", "return", "--snapshot", "synthetic-missing-snapshot", "--json", "--no-remote"],
+                    [
+                        "press", "return", "--snapshot", SnapshotReferenceFixtures.first.rawValue,
+                        "--json", "--no-remote",
+                    ],
                     .SNAPSHOT_NOT_FOUND,
                     .targetUnavailable
                 ),

--- a/Apps/CLI/Tests/CLIAutomationTests/PressCommandTests.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/PressCommandTests.swift
@@ -373,8 +373,8 @@ struct PressCommandTests {
 
     @Test
     func `Foreground snapshot without an exact target refuses before global input`() async throws {
-        let snapshotId = "snapshot-42"
         let context = await self.makeContext()
+        let snapshotId = try await context.snapshots.createSnapshot()
         let detection = ElementDetectionResult(
             snapshotId: snapshotId,
             screenshotPath: "/tmp/screenshot.png",

--- a/Apps/CLI/Tests/CLIAutomationTests/ScrollCommandTests.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/ScrollCommandTests.swift
@@ -260,7 +260,6 @@ struct ScrollCommandTests {
 
     @Test
     func `partial scroll failure preserves exact accepted units in JSON`() async throws {
-        let snapshotID = "partial-scroll-snapshot"
         let automation = await MainActor.run { OutcomeStubAutomationService() }
         await MainActor.run {
             automation.uiAutomationOutcomeScript.appendFailure(
@@ -273,6 +272,7 @@ struct ScrollCommandTests {
             )
         }
         let snapshots = StubSnapshotManager()
+        let snapshotID = try await snapshots.createSnapshot()
         try await snapshots.storeDetectionResult(
             snapshotId: snapshotID,
             result: Self.detectionResult(snapshotId: snapshotID, element: Self.buttonElement(id: "B1"))
@@ -302,12 +302,12 @@ struct ScrollCommandTests {
 
     @Test
     func `stale background scroll reports canonical retry-safe refusal`() async throws {
-        let snapshotId = "stale-scroll-snapshot"
         let context = await self.makeContext { automation, _ in
             automation.scrollError = PeekabooError.snapshotStale(
                 "target window owner, process generation, or bounds changed"
             )
         }
+        let snapshotId = try await context.snapshots.createSnapshot()
         try await context.snapshots.storeDetectionResult(
             snapshotId: snapshotId,
             result: Self.detectionResult(snapshotId: snapshotId, element: Self.buttonElement(id: "B1"))
@@ -336,12 +336,12 @@ struct ScrollCommandTests {
 
     @Test
     func `unsupported background scroll reports canonical retry-safe refusal`() async throws {
-        let snapshotId = "unsupported-scroll-snapshot"
         let context = await self.makeContext { automation, _ in
             automation.scrollError = PeekabooError.invalidInput(
                 "Background scroll is unavailable for this target"
             )
         }
+        let snapshotId = try await context.snapshots.createSnapshot()
         try await context.snapshots.storeDetectionResult(
             snapshotId: snapshotId,
             result: Self.detectionResult(snapshotId: snapshotId, element: Self.buttonElement(id: "B1"))

--- a/Apps/CLI/Tests/CLIAutomationTests/SeeCommandTests.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/SeeCommandTests.swift
@@ -1295,7 +1295,7 @@ extension SeeCommandRuntimeTests {
     }
 
     static func makeSeeCommandRuntimeFixture() -> RuntimeFixture {
-        let snapshotId = UUID().uuidString
+        let snapshotId = SnapshotReference.generate().rawValue
         let windowBounds = CGRect(x: 10, y: 20, width: 800, height: 600)
         let applicationInfo = Self.makeSeeFixtureApplicationInfo()
         let windowInfo = Self.makeSeeFixtureWindowInfo(windowBounds: windowBounds)

--- a/Apps/CLI/Tests/CLIAutomationTests/SnapshotNotFoundRegressionTests.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/SnapshotNotFoundRegressionTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import PeekabooCore
+import PeekabooFoundation
 import Testing
 @testable import PeekabooCLI
 
@@ -150,6 +151,44 @@ struct SnapshotNotFoundRegressionTests {
         let response = try ExternalCommandRunner.decodeJSONResponse(from: result, as: JSONResponse.self)
         #expect(response.success == false)
         #expect(response.error?.code == ErrorCode.SNAPSHOT_NOT_FOUND.rawValue)
+    }
+
+    @Test
+    @MainActor
+    func `shared snapshot fixture refuses storage before producer creation`() async throws {
+        let snapshots = StubSnapshotManager()
+        let unownedSnapshotID = SnapshotReference.generate().rawValue
+        let detection = ElementDetectionResult(
+            snapshotId: unownedSnapshotID,
+            screenshotPath: "/tmp/screenshot.png",
+            elements: DetectedElements(),
+            metadata: DetectionMetadata(detectionTime: 0, elementCount: 0, method: "stub")
+        )
+
+        #expect(try await !snapshots.ownsSnapshot(snapshotId: unownedSnapshotID))
+        await #expect(throws: SnapshotError.self) {
+            try await snapshots.storeDetectionResult(snapshotId: unownedSnapshotID, result: detection)
+        }
+        await #expect(throws: SnapshotError.self) {
+            try await snapshots.storeScreenshot(.init(
+                snapshotId: unownedSnapshotID,
+                screenshotPath: "/tmp/screenshot.png",
+                applicationBundleId: nil,
+                applicationProcessId: nil,
+                applicationName: nil,
+                windowTitle: nil,
+                windowBounds: nil
+            ))
+        }
+        await #expect(throws: SnapshotError.self) {
+            try await snapshots.storeAnnotatedScreenshot(
+                snapshotId: unownedSnapshotID,
+                annotatedScreenshotPath: "/tmp/annotated.png"
+            )
+        }
+
+        let ownedSnapshotID = try await snapshots.createSnapshot()
+        #expect(try await snapshots.ownsSnapshot(snapshotId: ownedSnapshotID))
     }
 
     private func makeSnapshot(with snapshots: StubSnapshotManager) async throws -> String {

--- a/Apps/CLI/Tests/CLIAutomationTests/Support/TestServices+PinnedInput.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/Support/TestServices+PinnedInput.swift
@@ -24,6 +24,52 @@ extension StubAutomationService {
         }
     }
 
+    func click(
+        target: ClickTarget,
+        clickType: ClickType,
+        snapshotId: String?,
+        expectedProcessIdentity: ApplicationProcessIdentity,
+        allowsAccessibilityValueDelivery: Bool
+    ) async throws {
+        self.targetedClickCalls.append(TargetedClickCall(
+            target: target,
+            clickType: clickType,
+            snapshotId: snapshotId,
+            targetProcessIdentifier: expectedProcessIdentity.processIdentifier,
+            targetWindowID: nil,
+            expectedProcessIdentity: expectedProcessIdentity,
+            allowsAccessibilityValueDelivery: allowsAccessibilityValueDelivery
+        ))
+        if let clickError {
+            throw clickError
+        }
+    }
+
+    func click(
+        target: ClickTarget,
+        clickType: ClickType,
+        snapshotId: String?,
+        expectedWindowIdentity: WindowMutationIdentity,
+        expectedWindowBounds _: CGRect,
+        allowsAccessibilityValueDelivery: Bool
+    ) async throws {
+        self.targetedClickCalls.append(TargetedClickCall(
+            target: target,
+            clickType: clickType,
+            snapshotId: snapshotId,
+            targetProcessIdentifier: expectedWindowIdentity.ownerProcessIdentifier,
+            targetWindowID: expectedWindowIdentity.windowID,
+            expectedProcessIdentity: ApplicationProcessIdentity(
+                processIdentifier: expectedWindowIdentity.ownerProcessIdentifier,
+                processStartIdentity: expectedWindowIdentity.ownerProcessStartIdentity
+            ),
+            allowsAccessibilityValueDelivery: allowsAccessibilityValueDelivery
+        ))
+        if let clickError {
+            throw clickError
+        }
+    }
+
     func typeActions(
         _ actions: [TypeAction],
         cadence: TypingCadence,

--- a/Apps/CLI/Tests/CLIAutomationTests/Support/TestServices.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/Support/TestServices.swift
@@ -188,6 +188,25 @@ ExactWindowTargetedClickServiceProtocol, ElementActionAutomationServiceProtocol 
         let targetProcessIdentifier: pid_t
         let targetWindowID: Int?
         let expectedProcessIdentity: ApplicationProcessIdentity?
+        let allowsAccessibilityValueDelivery: Bool?
+
+        init(
+            target: ClickTarget,
+            clickType: ClickType,
+            snapshotId: String?,
+            targetProcessIdentifier: pid_t,
+            targetWindowID: Int?,
+            expectedProcessIdentity: ApplicationProcessIdentity?,
+            allowsAccessibilityValueDelivery: Bool? = nil
+        ) {
+            self.target = target
+            self.clickType = clickType
+            self.snapshotId = snapshotId
+            self.targetProcessIdentifier = targetProcessIdentifier
+            self.targetWindowID = targetWindowID
+            self.expectedProcessIdentity = expectedProcessIdentity
+            self.allowsAccessibilityValueDelivery = allowsAccessibilityValueDelivery
+        }
     }
 
     struct WaitForElementCall {
@@ -246,6 +265,7 @@ ExactWindowTargetedClickServiceProtocol, ElementActionAutomationServiceProtocol 
     var supportsTargetedClicks = true
     var supportsProcessGenerationPinnedClicks = true
     var supportsStatelessClickVariants = true
+    var supportsTargetedClickAccessibilityValueDelivery = true
     var targetedClickUnavailableReason: String?
     var targetedClickRequiresEventSynthesizingPermission = false
     var clickError: (any Error)?
@@ -693,6 +713,7 @@ class StubApplicationService: ScriptedApplicationInventoryService {
 final class StubSnapshotManager: SnapshotManagerProtocol, @unchecked Sendable {
     let supportsImplicitLatestSnapshotInvalidation = true
     let supportsSnapshotMutationLeases = true
+    let supportsProducerBoundSnapshotReferences = true
     var copiesScreenshotArtifactsIntoStorage = false
     var effectiveImplicitLatestInvalidationWatermark: Date?
     private(set) var detectionResults: [String: ElementDetectionResult] = [:]
@@ -737,7 +758,7 @@ final class StubSnapshotManager: SnapshotManagerProtocol, @unchecked Sendable {
     }
 
     private func createSnapshotImpl(pendingAt observationStartedAt: Date?) -> String {
-        let snapshotId = UUID().uuidString
+        let snapshotId = SnapshotReference.generate().rawValue
         let now = observationStartedAt ?? Date()
         self.snapshotInfos[snapshotId] = SnapshotInfo(
             id: snapshotId,
@@ -757,6 +778,7 @@ final class StubSnapshotManager: SnapshotManagerProtocol, @unchecked Sendable {
     }
 
     func storeDetectionResult(snapshotId: String, result: ElementDetectionResult) async throws {
+        try self.requireCreatedSnapshot(snapshotId)
         if self.pendingSnapshotIDs.contains(snapshotId), self.mostRecentSnapshotId == snapshotId {
             self.exposedPendingSnapshotDuringWrite = true
         }
@@ -812,6 +834,13 @@ final class StubSnapshotManager: SnapshotManagerProtocol, @unchecked Sendable {
 
     func getMostRecentSnapshot(applicationBundleId _: String) async -> String? {
         self.mostRecentSnapshotId
+    }
+
+    func ownsSnapshot(snapshotId: String) async throws -> Bool {
+        guard SnapshotReference(rawValue: snapshotId) != nil else {
+            throw SnapshotError.invalidSnapshotReference(snapshotId)
+        }
+        return self.snapshotInfos[snapshotId] != nil
     }
 
     func beginSnapshotMutation(snapshotId: String) async throws -> SnapshotMutationLease {
@@ -935,6 +964,7 @@ final class StubSnapshotManager: SnapshotManagerProtocol, @unchecked Sendable {
     }
 
     func storeScreenshot(_ request: SnapshotScreenshotRequest) async throws {
+        try self.requireCreatedSnapshot(request.snapshotId)
         if self.pendingSnapshotIDs.contains(request.snapshotId), self.mostRecentSnapshotId == request.snapshotId {
             self.exposedPendingSnapshotDuringWrite = true
         }
@@ -965,9 +995,19 @@ final class StubSnapshotManager: SnapshotManagerProtocol, @unchecked Sendable {
     }
 
     func storeAnnotatedScreenshot(snapshotId: String, annotatedScreenshotPath: String) async throws {
+        try self.requireCreatedSnapshot(snapshotId)
         var records = self.storedAnnotatedScreenshots[snapshotId] ?? []
         records.append(annotatedScreenshotPath)
         self.storedAnnotatedScreenshots[snapshotId] = records
+    }
+
+    private func requireCreatedSnapshot(_ snapshotId: String) throws {
+        guard SnapshotReference(rawValue: snapshotId) != nil else {
+            throw SnapshotError.invalidSnapshotReference(snapshotId)
+        }
+        guard self.snapshotInfos[snapshotId] != nil else {
+            throw SnapshotError.snapshotNotFound
+        }
     }
 
     func getElement(snapshotId: String, elementId: String) async throws -> PeekabooCore.UIElement? {

--- a/Apps/CLI/Tests/CLIAutomationTests/TargetedInteractionDefaultDeliveryTests.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/TargetedInteractionDefaultDeliveryTests.swift
@@ -720,6 +720,7 @@ struct TargetedInteractionDefaultDeliveryTests {
         #expect(call.targetProcessIdentifier == 2468)
         #expect(call.targetWindowID == targetWindow.windowID)
         #expect(call.snapshotId == snapshotId)
+        #expect(call.allowsAccessibilityValueDelivery == true)
         if case let .coordinates(point) = call.target {
             #expect(point == CGPoint(x: 10, y: 20))
         } else {

--- a/Apps/CLI/Tests/CLIRuntimeTests/AgentExecutionProcessLimitRuntimeTests.swift
+++ b/Apps/CLI/Tests/CLIRuntimeTests/AgentExecutionProcessLimitRuntimeTests.swift
@@ -99,7 +99,7 @@ struct AgentExecutionProcessLimitRuntimeTests {
     }
 
     @Test
-    func `Real gated Agent completes a provider tool provider loop through nested Bridge`() async throws {
+    func `Real gated Agent refuses receiptless custom Bridge before provider execution`() async throws {
         let bridge = try ConcurrentGatedBridgePeer()
         let binaryPath = try TestChildProcess.peekabooBinaryURL().path
         let challenge = String(repeating: "b", count: 64)
@@ -141,29 +141,13 @@ struct AgentExecutionProcessLimitRuntimeTests {
         responder.cancel()
         _ = try? await responder.value
 
-        #expect(
-            result.waitStatus == 0,
-            """
-            Agent stdout: \(String(data: result.output, encoding: .utf8) ?? "<non-UTF8>"); \
-            stderr: \(String(data: result.standardError, encoding: .utf8) ?? "<non-UTF8>"); \
-            accepted: \(acceptedConnections); requests: \(requestBodies)
-            """
-        )
+        #expect(result.waitStatus != 0)
         let response = try #require(JSONSerialization.jsonObject(with: result.output) as? [String: Any])
-        let payload = try #require(response["result"] as? [String: Any])
-        let trace = try #require(payload["executionTrace"] as? [String: Any])
-        let entries = try #require(trace["entries"] as? [[String: Any]])
-        #expect(response["success"] as? Bool == true)
-        #expect(
-            payload["content"] as? String == "agent-provider-tool-ok",
-            "Bridge requests: \(requestBodies)"
-        )
-        #expect(entries.map { $0["name"] as? String } == ["app"])
-        #expect(
-            entries.map { $0["disposition"] as? String } == ["executed/succeeded"],
-            "Agent stdout: \(String(data: result.output, encoding: .utf8) ?? "<non-UTF8>")"
-        )
-        #expect(trace["totalCallCount"] as? Int == 1)
+        let error = try #require(response["error"] as? [String: Any])
+        #expect(response["success"] as? Bool == false)
+        #expect(error["code"] as? String == "BRIDGE_UNAVAILABLE")
+        #expect((error["message"] as? String)?.contains(bridge.socketPath) == true)
+        #expect(result.standardError.isEmpty)
 
         let decodedRequests = try requests.map {
             try JSONDecoder.peekabooBridgeDecoder().decode(PeekabooBridgeRequest.self, from: $0)
@@ -182,13 +166,11 @@ struct AgentExecutionProcessLimitRuntimeTests {
             return request.operation
         }
         let invalidationCount = operations.count(where: { $0 == .invalidateImplicitLatestSnapshot })
-        // SCK safety inspection and runtime selection retain one authenticated client/session.
         #expect(handshakeCount == 1, "Bridge requests: \(requestBodies)")
-        #expect((0...1).contains(invalidationCount), "Bridge requests: \(requestBodies)")
-        #expect(operations.count(where: { $0 == .getFrontmostApplication }) == 2)
-        #expect(operations.count(where: { $0 == .getFocusedWindow }) == 2)
-        #expect(operations.count(where: { $0 == .listApplications }) == 3)
-        #expect(requests.count == 8 + invalidationCount, "Bridge requests: \(requestBodies)")
+        #expect(invalidationCount == 0)
+        #expect(operations.isEmpty)
+        #expect(acceptedConnections == 1)
+        #expect(requests.count == 1)
     }
 
     private static func response(for request: PeekabooBridgeRequest) -> PeekabooBridgeResponse {

--- a/Apps/CLI/Tests/CLIRuntimeTests/BridgeStatusCLITests.swift
+++ b/Apps/CLI/Tests/CLIRuntimeTests/BridgeStatusCLITests.swift
@@ -317,7 +317,7 @@ struct BridgeStatusCLITests {
             .appendingPathComponent("peekaboo-missing-middle-click-\(UUID().uuidString).sock").path
         let result = try await TestChildProcess.runPeekaboo(
             [
-                "click", "--on", "B1", "--snapshot", "fixture", "--middle",
+                "click", "--on", "B1", "--snapshot", "ps1_00000000000000000000000000000001", "--middle",
                 "--bridge-socket", socketPath,
                 "--json",
             ],
@@ -331,10 +331,9 @@ struct BridgeStatusCLITests {
         let json = try #require(object as? [String: Any])
         let error = try #require(json["error"] as? [String: Any])
         #expect(json["success"] as? Bool == false)
-        #expect(error["code"] as? String == "BRIDGE_UNAVAILABLE")
+        #expect(error["code"] as? String == "SNAPSHOT_NOT_FOUND")
         #expect((error["message"] as? String)?.contains(socketPath) == true)
         #expect(!result.standardOutput.contains("Runtime host: local"))
-        #expect(!result.standardOutput.contains("SNAPSHOT_NOT_FOUND"))
     }
 
     @Test

--- a/Apps/CLI/Tests/CLIRuntimeTests/InvalidInputOrderingCLITests.swift
+++ b/Apps/CLI/Tests/CLIRuntimeTests/InvalidInputOrderingCLITests.swift
@@ -99,7 +99,8 @@ struct InvalidInputOrderingCLITests {
         ),
         JSONCase(
             arguments: [
-                "type", "alpha", "--at", "nan,20", "--snapshot", "snapshot-1", "--json",
+                "type", "alpha", "--at", "nan,20", "--snapshot",
+                "ps1_00000000000000000000000000000001", "--json",
             ],
             code: "VALIDATION_ERROR",
             message: "Invalid coordinates format. Use: x,y",
@@ -107,7 +108,8 @@ struct InvalidInputOrderingCLITests {
         ),
         JSONCase(
             arguments: [
-                "type", "alpha", "--at", "10,,20", "--snapshot", "snapshot-1", "--json",
+                "type", "alpha", "--at", "10,,20", "--snapshot",
+                "ps1_00000000000000000000000000000001", "--json",
             ],
             code: "VALIDATION_ERROR",
             message: "Invalid coordinates format. Use: x,y",

--- a/Apps/CLI/Tests/CoreCLITests/AXOnlySeeRuntimeRoutingTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/AXOnlySeeRuntimeRoutingTests.swift
@@ -36,7 +36,7 @@ struct AXOnlySeeRuntimeRoutingTests {
                 permissionTags: [
                     PeekabooBridgeOperation.inspectAccessibilityTree.rawValue: [.accessibility],
                 ]
-            )
+            ).withProducerBoundSnapshotFixture()
         }
 
         #expect(!options.requiresDesktopObservation)

--- a/Apps/CLI/Tests/CoreCLITests/CommanderBinderCommandBindingMenuTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/CommanderBinderCommandBindingMenuTests.swift
@@ -1,4 +1,5 @@
 import Commander
+import PeekabooFoundationTestSupport
 import Testing
 @testable import PeekabooCLI
 
@@ -11,7 +12,7 @@ struct CommanderBinderMenuDockTests {
                 "direction": ["down"],
                 "amount": ["7"],
                 "on": ["B4"],
-                "snapshot": ["sess-5"],
+                "snapshot": [SnapshotReferenceFixtures.first.rawValue],
                 "delay": ["5"],
                 "app": ["Mail"]
             ],
@@ -24,7 +25,7 @@ struct CommanderBinderMenuDockTests {
         #expect(command.direction == "down")
         #expect(command.amount == 7)
         #expect(command.on == "B4")
-        #expect(command.snapshot == "sess-5")
+        #expect(command.snapshot == SnapshotReferenceFixtures.first.rawValue)
         #expect(command.delay.roundedMilliseconds == 5)
         #expect(command.target.app == "Mail")
         #expect(command.smooth == true)

--- a/Apps/CLI/Tests/CoreCLITests/CommanderBinderCommandBindingTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/CommanderBinderCommandBindingTests.swift
@@ -1,4 +1,5 @@
 import Commander
+import PeekabooFoundationTestSupport
 import Testing
 @testable import PeekabooCLI
 
@@ -175,7 +176,7 @@ struct CommanderBinderCommandBindingTests {
             positional: [],
             options: [
                 "app": ["Safari"],
-                "snapshot": ["snapshot-123"],
+                "snapshot": [SnapshotReferenceFixtures.first.rawValue],
             ],
             flags: ["verify"]
         )
@@ -184,7 +185,7 @@ struct CommanderBinderCommandBindingTests {
             parsedValues: parsed
         )
         #expect(command.verify == true)
-        #expect(command.snapshot == "snapshot-123")
+        #expect(command.snapshot == SnapshotReferenceFixtures.first.rawValue)
     }
 
     @Test
@@ -350,7 +351,7 @@ struct CommanderBinderCommandBindingTests {
         let parsed = ParsedValues(
             positional: ["Submit"],
             options: [
-                "snapshot": ["abc"],
+                "snapshot": [SnapshotReferenceFixtures.first.rawValue],
                 "on": ["B1"],
                 "app": ["Safari"],
                 "waitFor": ["2500"],
@@ -360,7 +361,7 @@ struct CommanderBinderCommandBindingTests {
         )
         let command = try CommanderCLIBinder.instantiateCommand(ofType: ClickCommand.self, parsedValues: parsed)
         #expect(command.query == "Submit")
-        #expect(command.snapshot == "abc")
+        #expect(command.snapshot == SnapshotReferenceFixtures.first.rawValue)
         #expect(command.on == "B1")
         #expect(command.target.app == "Safari")
         #expect(command.waitFor.roundedMilliseconds == 2500)
@@ -374,7 +375,7 @@ struct CommanderBinderCommandBindingTests {
         let parsed = ParsedValues(
             positional: ["Hello"],
             options: [
-                "snapshot": ["xyz"],
+                "snapshot": [SnapshotReferenceFixtures.second.rawValue],
                 "delay": ["10"],
                 "wpm": ["150"],
                 "app": ["Notes"],
@@ -385,7 +386,7 @@ struct CommanderBinderCommandBindingTests {
         )
         let command = try CommanderCLIBinder.instantiateCommand(ofType: TypeCommand.self, parsedValues: parsed)
         #expect(command.text == "Hello")
-        #expect(command.snapshot == "xyz")
+        #expect(command.snapshot == SnapshotReferenceFixtures.second.rawValue)
         #expect(command.delay.roundedMilliseconds == 10)
         #expect(command.profileOption == nil)
         #expect(command.wordsPerMinute == 150)
@@ -402,14 +403,14 @@ struct CommanderBinderCommandBindingTests {
             positional: [],
             options: [
                 "text": ["OptionText"],
-                "snapshot": ["abc"]
+                "snapshot": [SnapshotReferenceFixtures.first.rawValue]
             ],
             flags: []
         )
         let command = try CommanderCLIBinder.instantiateCommand(ofType: TypeCommand.self, parsedValues: parsed)
         #expect(command.text == nil)
         #expect(command.textOption == "OptionText")
-        #expect(command.snapshot == "abc")
+        #expect(command.snapshot == SnapshotReferenceFixtures.first.rawValue)
     }
 
     @Test
@@ -418,14 +419,14 @@ struct CommanderBinderCommandBindingTests {
             positional: ["Hello"],
             options: [
                 "on": ["T1"],
-                "snapshot": ["abc"],
+                "snapshot": [SnapshotReferenceFixtures.first.rawValue],
             ],
             flags: []
         )
         let command = try CommanderCLIBinder.instantiateCommand(ofType: SetValueCommand.self, parsedValues: parsed)
         #expect(command.value == "Hello")
         #expect(command.on == "T1")
-        #expect(command.snapshot == "abc")
+        #expect(command.snapshot == SnapshotReferenceFixtures.first.rawValue)
     }
 
     @Test
@@ -435,7 +436,7 @@ struct CommanderBinderCommandBindingTests {
             options: [
                 "on": ["B1"],
                 "action": ["AXPress"],
-                "snapshot": ["abc"],
+                "snapshot": [SnapshotReferenceFixtures.first.rawValue],
             ],
             flags: []
         )
@@ -443,7 +444,7 @@ struct CommanderBinderCommandBindingTests {
         #expect(command.on == "B1")
         #expect(command.action == "AXPress")
         #expect(command.actionName == nil)
-        #expect(command.snapshot == "abc")
+        #expect(command.snapshot == SnapshotReferenceFixtures.first.rawValue)
     }
 
     @Test
@@ -454,7 +455,7 @@ struct CommanderBinderCommandBindingTests {
                 "count": ["3"],
                 "delay": ["25"],
                 "hold": ["75"],
-                "snapshot": ["sess-123"]
+                "snapshot": [SnapshotReferenceFixtures.third.rawValue]
             ],
             flags: ["noAutoFocus"]
         )
@@ -463,7 +464,7 @@ struct CommanderBinderCommandBindingTests {
         #expect(command.count == 3)
         #expect(command.delay.roundedMilliseconds == 25)
         #expect(command.hold.roundedMilliseconds == 75)
-        #expect(command.snapshot == "sess-123")
+        #expect(command.snapshot == SnapshotReferenceFixtures.third.rawValue)
         #expect(command.focusOptions.noAutoFocus == true)
     }
 
@@ -648,7 +649,7 @@ struct CommanderBinderCommandBindingTests {
                 "duration": ["750"],
                 "steps": ["30"],
                 "profile": ["human"],
-                "snapshot": ["sess-1"]
+                "snapshot": [SnapshotReferenceFixtures.first.rawValue]
             ],
             flags: ["smooth", "foreground"]
         )
@@ -657,7 +658,7 @@ struct CommanderBinderCommandBindingTests {
         #expect(command.duration?.roundedMilliseconds == 750)
         #expect(command.steps == 30)
         #expect(command.profile == "human")
-        #expect(command.snapshot == "sess-1")
+        #expect(command.snapshot == SnapshotReferenceFixtures.first.rawValue)
         #expect(command.smooth == true)
         #expect(command.focusOptions.foreground)
     }
@@ -668,13 +669,13 @@ struct CommanderBinderCommandBindingTests {
             positional: [],
             options: [
                 "on": ["B1"],
-                "snapshot": ["sess-1"]
+                "snapshot": [SnapshotReferenceFixtures.first.rawValue]
             ],
             flags: []
         )
         let command = try CommanderCLIBinder.instantiateCommand(ofType: MoveCommand.self, parsedValues: parsed)
         #expect(command.on == "B1")
-        #expect(command.snapshot == "sess-1")
+        #expect(command.snapshot == SnapshotReferenceFixtures.first.rawValue)
     }
 
     @Test
@@ -710,7 +711,7 @@ struct CommanderBinderCommandBindingTests {
                 "steps": ["15"],
                 "modifiers": ["cmd,shift"],
                 "profile": ["human"],
-                "snapshot": ["sess-drag"]
+                "snapshot": [SnapshotReferenceFixtures.second.rawValue]
             ],
             flags: ["spaceSwitch", "foreground"]
         )
@@ -721,7 +722,7 @@ struct CommanderBinderCommandBindingTests {
         #expect(command.steps == 15)
         #expect(command.modifiers?.description == "cmd,shift")
         #expect(command.profile == "human")
-        #expect(command.snapshot == "sess-drag")
+        #expect(command.snapshot == SnapshotReferenceFixtures.second.rawValue)
         #expect(command.focusOptions.spaceSwitch == true)
         #expect(command.focusOptions.foreground)
     }

--- a/Apps/CLI/Tests/CoreCLITests/CommanderBinderTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/CommanderBinderTests.swift
@@ -488,7 +488,7 @@ struct CommanderBinderTests {
             build: nil,
             supportedOperations: [.captureScreen, .desktopObservation],
             hostCapabilities: [PeekabooBridgeHostCapability.screenCaptureKitProcessOwnership]
-        )
+        ).withProducerBoundSnapshotFixture()
 
         let readOnlyCaptures: [(any ParsableCommand.Type, ParsedValues)] = [
             (SeeCommand.self, ParsedValues(positional: [], options: [:], flags: [])),
@@ -708,10 +708,24 @@ struct CommanderBinderTests {
             permissions: PermissionsStatus(screenRecording: true, accessibility: true, postEvent: true),
             enabledOperations: operations
         )
+        let policyCapable = BridgeTestFixtures.handshake(
+            negotiatedVersion: PeekabooBridgeConstants.targetedClickAccessibilityValueDeliveryVersion,
+            hostKind: .onDemand,
+            build: nil,
+            supportedOperations: operations,
+            permissions: PermissionsStatus(screenRecording: true, accessibility: true, postEvent: true),
+            enabledOperations: operations,
+            hostCapabilities: [
+                PeekabooBridgeHostCapability.attestedOperationReceipts,
+                PeekabooBridgeHostCapability.targetedClickAccessibilityValueDelivery,
+            ]
+        )
 
         #expect(type.requiresProcessGenerationPinnedTypeActions)
         #expect(click.requiresProcessGenerationPinnedClicks)
+        #expect(click.requiresTargetedClickAccessibilityValueDelivery)
         #expect(!exactClick.requiresProcessGenerationPinnedClicks)
+        #expect(exactClick.requiresTargetedClickAccessibilityValueDelivery)
         #expect(paste.requiresProcessGenerationPinnedTypeActions)
         #expect(paste.requiresProcessGenerationPinnedHotkeys)
         #expect(!foreground.requiresProcessGenerationPinnedTypeActions)
@@ -719,9 +733,11 @@ struct CommanderBinderTests {
         #expect(!CommandRuntime.supportsRemoteRequirements(for: legacy, options: click))
         #expect(!CommandRuntime.supportsRemoteRequirements(for: legacy, options: paste))
         #expect(CommandRuntime.supportsRemoteRequirements(for: current, options: type))
-        #expect(CommandRuntime.supportsRemoteRequirements(for: current, options: click))
+        #expect(!CommandRuntime.supportsRemoteRequirements(for: current, options: click))
         #expect(CommandRuntime.supportsRemoteRequirements(for: current, options: paste))
-        #expect(CommandRuntime.supportsRemoteRequirements(for: legacy, options: exactClick))
+        #expect(!CommandRuntime.supportsRemoteRequirements(for: legacy, options: exactClick))
+        #expect(CommandRuntime.supportsRemoteRequirements(for: policyCapable, options: click))
+        #expect(CommandRuntime.supportsRemoteRequirements(for: policyCapable, options: exactClick))
         #expect(CommandRuntime.supportsRemoteRequirements(for: legacy, options: foreground))
     }
 
@@ -841,7 +857,7 @@ struct CommanderBinderTests {
             .targetedClick,
         ]
         let accessibilityOnly = BridgeTestFixtures.handshake(
-            negotiatedVersion: PeekabooBridgeConstants.processGenerationPinnedInteractionVersion,
+            negotiatedVersion: PeekabooBridgeConstants.targetedClickAccessibilityValueDeliveryVersion,
             hostKind: .onDemand,
             build: nil,
             supportedOperations: operations,
@@ -851,10 +867,14 @@ struct CommanderBinderTests {
                 postEvent: false
             ),
             enabledOperations: operations,
-            permissionTags: [PeekabooBridgeOperation.targetedClick.rawValue: []]
+            permissionTags: [PeekabooBridgeOperation.targetedClick.rawValue: []],
+            hostCapabilities: [
+                PeekabooBridgeHostCapability.attestedOperationReceipts,
+                PeekabooBridgeHostCapability.targetedClickAccessibilityValueDelivery,
+            ]
         )
         let fullyPermitted = BridgeTestFixtures.handshake(
-            negotiatedVersion: PeekabooBridgeConstants.processGenerationPinnedInteractionVersion,
+            negotiatedVersion: PeekabooBridgeConstants.targetedClickAccessibilityValueDeliveryVersion,
             hostKind: .onDemand,
             build: nil,
             supportedOperations: operations,
@@ -864,7 +884,11 @@ struct CommanderBinderTests {
                 postEvent: true
             ),
             enabledOperations: operations,
-            permissionTags: [PeekabooBridgeOperation.targetedClick.rawValue: []]
+            permissionTags: [PeekabooBridgeOperation.targetedClick.rawValue: []],
+            hostCapabilities: [
+                PeekabooBridgeHostCapability.attestedOperationReceipts,
+                PeekabooBridgeHostCapability.targetedClickAccessibilityValueDelivery,
+            ]
         )
 
         #expect(CommandRuntime.supportsRemoteRequirements(for: accessibilityOnly, options: singleClick))
@@ -918,7 +942,7 @@ extension CommanderBinderTests {
             enabledOperations: [.captureScreen, .scroll, .invalidateImplicitLatestSnapshot]
         )
         let current = BridgeTestFixtures.handshake(
-            negotiatedVersion: .init(major: 1, minor: 12),
+            negotiatedVersion: PeekabooBridgeConstants.protocolVersion,
             hostKind: .onDemand,
             build: nil,
             supportedOperations: [.captureScreen, .scroll, .targetedScroll, .invalidateImplicitLatestSnapshot],
@@ -928,7 +952,7 @@ extension CommanderBinderTests {
                 postEvent: true
             ),
             enabledOperations: [.captureScreen, .scroll, .targetedScroll, .invalidateImplicitLatestSnapshot]
-        )
+        ).withProducerBoundSnapshotFixture()
 
         #expect(!CommandRuntime.supportsRemoteRequirements(for: legacy, options: background))
         #expect(CommandRuntime.supportsRemoteRequirements(for: current, options: background))

--- a/Apps/CLI/Tests/CoreCLITests/DesktopObservationCaptureEngineRuntimeCapabilityTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/DesktopObservationCaptureEngineRuntimeCapabilityTests.swift
@@ -205,13 +205,13 @@ struct DesktopObservationCaptureEngineRuntimeCapabilityTests {
         permissions: PermissionsStatus? = nil
     ) -> PeekabooBridgeHandshakeResponse {
         BridgeTestFixtures.handshake(
-            negotiatedVersion: PeekabooBridgeProtocolVersion(major: 1, minor: 22),
+            negotiatedVersion: PeekabooBridgeConstants.protocolVersion,
             hostKind: .onDemand,
             build: nil,
             supportedOperations: operations,
             permissions: permissions,
             enabledOperations: enabledOperations,
             hostCapabilities: capabilities
-        )
+        ).withProducerBoundSnapshotFixture()
     }
 }

--- a/Apps/CLI/Tests/CoreCLITests/DesktopObservationOCRRuntimeCapabilityTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/DesktopObservationOCRRuntimeCapabilityTests.swift
@@ -131,12 +131,12 @@ struct DesktopObservationOCRRuntimeCapabilityTests {
         capabilities: [String]?
     ) -> PeekabooBridgeHandshakeResponse {
         BridgeTestFixtures.handshake(
-            negotiatedVersion: PeekabooBridgeProtocolVersion(major: 1, minor: 22),
+            negotiatedVersion: PeekabooBridgeConstants.protocolVersion,
             hostKind: .gui,
             build: nil,
             supportedOperations: operations,
             enabledOperations: enabledOperations,
             hostCapabilities: capabilities
-        )
+        ).withProducerBoundSnapshotFixture()
     }
 }

--- a/Apps/CLI/Tests/CoreCLITests/ExactWindowROIRuntimeCapabilityTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/ExactWindowROIRuntimeCapabilityTests.swift
@@ -55,7 +55,7 @@ struct ExactWindowROIRuntimeCapabilityTests {
     }
 
     @Test
-    func `See ROI requires protocol 1_21 while ordinary see remains compatible`() throws {
+    func `See ROI and ordinary observation require a producer capable current host`() throws {
         let roi = try CommanderCLIBinder.makeRuntimeOptions(
             from: ParsedValues(
                 positional: [],
@@ -74,7 +74,12 @@ struct ExactWindowROIRuntimeCapabilityTests {
         )
         let operations = [PeekabooBridgeOperation.captureScreen] + Self.roiOperations
         let older = Self.handshake(minor: 20, hostKind: .onDemand, operations: operations)
-        let current = Self.handshake(minor: 21, hostKind: .onDemand, operations: operations)
+        let roiOnly = Self.handshake(minor: 21, hostKind: .onDemand, operations: operations)
+        let current = Self.handshake(
+            minor: PeekabooBridgeConstants.protocolVersion.minor,
+            hostKind: .onDemand,
+            operations: operations
+        ).withProducerBoundSnapshotFixture()
         let disabledOperations = operations.filter { $0 != .desktopObservation }
         let disabled = Self.handshake(
             minor: 21,
@@ -86,9 +91,11 @@ struct ExactWindowROIRuntimeCapabilityTests {
         #expect(roi.requiresExactWindowROIObservation)
         #expect(!ordinary.requiresExactWindowROIObservation)
         #expect(!CommandRuntime.supportsRemoteRequirements(for: older, options: roi))
+        #expect(!CommandRuntime.supportsRemoteRequirements(for: roiOnly, options: roi))
         #expect(CommandRuntime.supportsRemoteRequirements(for: current, options: roi))
         #expect(!CommandRuntime.supportsRemoteRequirements(for: disabled, options: roi))
-        #expect(CommandRuntime.supportsRemoteRequirements(for: older, options: ordinary))
+        #expect(!CommandRuntime.supportsRemoteRequirements(for: older, options: ordinary))
+        #expect(CommandRuntime.supportsRemoteRequirements(for: current, options: ordinary))
     }
 
     @Test

--- a/Apps/CLI/Tests/CoreCLITests/ExplicitSnapshotPublicationRuntimeTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/ExplicitSnapshotPublicationRuntimeTests.swift
@@ -40,7 +40,7 @@ struct ExplicitSnapshotPublicationRuntimeTests {
             enabledOperations: operations,
             hostCapabilities: [PeekabooBridgeHostCapability.screenCaptureKitProcessOwnership]
         )
-        let currentHost = BridgeTestFixtures.handshake(
+        let publicationOnlyHost = BridgeTestFixtures.handshake(
             negotiatedVersion: PeekabooBridgeConstants.explicitSnapshotPublicationVersion,
             hostKind: .gui,
             build: "current",
@@ -51,12 +51,24 @@ struct ExplicitSnapshotPublicationRuntimeTests {
                 PeekabooBridgeHostCapability.screenCaptureKitProcessOwnership,
             ]
         )
+        let currentHost = BridgeTestFixtures.handshake(
+            negotiatedVersion: PeekabooBridgeConstants.protocolVersion,
+            hostKind: .gui,
+            build: "current",
+            supportedOperations: operations,
+            enabledOperations: operations,
+            hostCapabilities: [
+                PeekabooBridgeHostCapability.explicitSnapshotPublication,
+                PeekabooBridgeHostCapability.screenCaptureKitProcessOwnership,
+            ]
+        ).withProducerBoundSnapshotFixture()
 
         #expect(exact.requiresExplicitSnapshotPublication)
         #expect(!processOnly.requiresExplicitSnapshotPublication)
         #expect(!streamed.requiresExplicitSnapshotPublication)
         #expect(!CommandRuntime.supportsRemoteRequirements(for: oldHost, options: exact))
-        #expect(CommandRuntime.supportsRemoteRequirements(for: oldHost, options: processOnly))
+        #expect(!CommandRuntime.supportsRemoteRequirements(for: oldHost, options: processOnly))
+        #expect(!CommandRuntime.supportsRemoteRequirements(for: publicationOnlyHost, options: exact))
         #expect(CommandRuntime.supportsRemoteRequirements(for: currentHost, options: exact))
         #expect(RuntimeHostResolver.requiredHostFailure(
             explicitSocket: "/tmp/old.sock",

--- a/Apps/CLI/Tests/CoreCLITests/InteractionObservationContextTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/InteractionObservationContextTests.swift
@@ -5,6 +5,7 @@ import PeekabooAutomationKit
 import PeekabooAutomationKitTestSupport
 import PeekabooCore
 import PeekabooFoundation
+import PeekabooFoundationTestSupport
 import Testing
 @testable import PeekabooCLI
 
@@ -12,19 +13,20 @@ import Testing
 @MainActor
 struct InteractionObservationContextTests {
     @Test
-    func `Explicit snapshot is trimmed and wins over latest`() async throws {
+    func `Explicit canonical snapshot wins over latest`() async throws {
         let snapshots = CoreSnapshotManagerStub()
         let latest = try await snapshots.createSnapshot()
+        let explicit = SnapshotReferenceFixtures.first.rawValue
 
         let context = await InteractionObservationContext.resolve(
-            explicitSnapshot: "  explicit-snapshot  ",
+            explicitSnapshot: explicit,
             fallbackToLatest: true,
             snapshots: snapshots
         )
 
-        #expect(latest != "explicit-snapshot")
-        #expect(context.explicitSnapshotId == "explicit-snapshot")
-        #expect(context.snapshotId == "explicit-snapshot")
+        #expect(latest != explicit)
+        #expect(context.explicitSnapshotId == explicit)
+        #expect(context.snapshotId == explicit)
         #expect(context.source == .explicit)
     }
 
@@ -53,10 +55,10 @@ struct InteractionObservationContextTests {
     @Test
     func `Explicit latest alias resolves to most recent snapshot`() async throws {
         let snapshots = CoreSnapshotManagerStub()
-        let latest = try await snapshots.createSnapshot(id: "fresh-snapshot")
+        let latest = try await snapshots.createSnapshot(id: SnapshotReferenceFixtures.second.rawValue)
 
         let context = await InteractionObservationContext.resolve(
-            explicitSnapshot: " latest ",
+            explicitSnapshot: "latest",
             fallbackToLatest: true,
             snapshots: snapshots
         )
@@ -69,7 +71,7 @@ struct InteractionObservationContextTests {
     @Test
     func `Explicit latest alias resolves even when omitted fallback is disabled`() async throws {
         let snapshots = CoreSnapshotManagerStub()
-        let latest = try await snapshots.createSnapshot(id: "fresh-snapshot")
+        let latest = try await snapshots.createSnapshot(id: SnapshotReferenceFixtures.second.rawValue)
 
         let context = await InteractionObservationContext.resolve(
             explicitSnapshot: "most-recent",

--- a/Apps/CLI/Tests/CoreCLITests/InteractionSnapshotCaptureRequirementTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/InteractionSnapshotCaptureRequirementTests.swift
@@ -36,11 +36,27 @@ struct InteractionSnapshotCaptureRequirementTests {
                 options: ["on": ["B1"], "snapshot": ["receipt-1"], "pid": ["123"]],
                 flags: []
             )),
+            (TypeCommand.self, ParsedValues(
+                positional: ["text"],
+                options: ["snapshot": ["receipt-1"]],
+                flags: []
+            )),
+            (PressCommand.self, ParsedValues(
+                positional: ["return"],
+                options: ["snapshot": ["receipt-1"]],
+                flags: []
+            )),
+            (PasteCommand.self, ParsedValues(
+                positional: ["text"],
+                options: ["snapshot": ["receipt-1"]],
+                flags: []
+            )),
         ]
 
         for (commandType, values) in concreteCases {
             let options = try CommanderCLIBinder.makeRuntimeOptions(from: values, commandType: commandType)
             #expect(!options.requiresSilentCapture, "Concrete snapshot unexpectedly captured for \(commandType)")
+            #expect(options.explicitSnapshotID == "receipt-1")
         }
 
         let refreshableCases: [(any ParsableCommand.Type, ParsedValues)] = [
@@ -91,8 +107,24 @@ struct InteractionSnapshotCaptureRequirementTests {
                     options.requiresSilentCapture,
                     "Refreshable snapshot was treated as concrete for \(commandType): \(snapshot ?? "nil")"
                 )
+                #expect(options.explicitSnapshotID == nil)
             }
         }
+    }
+
+    @Test
+    func `Nonmutating snapshot argument does not request host affinity`() throws {
+        let options = try CommanderCLIBinder.makeRuntimeOptions(
+            from: ParsedValues(
+                positional: [],
+                options: ["snapshot": ["receipt-1"]],
+                flags: []
+            ),
+            commandType: CleanCommand.self
+        )
+
+        #expect(!options.requiresImplicitSnapshotInvalidation)
+        #expect(options.explicitSnapshotID == nil)
     }
 
     @Test
@@ -110,8 +142,8 @@ struct InteractionSnapshotCaptureRequirementTests {
                 let options = try CommanderCLIBinder.makeRuntimeOptions(
                     from: ParsedValues(
                         positional: ["value-or-action"],
-                        options: ["on": ["B1"]].merging(snapshot.map { ["snapshot": [$0]] } ?? [:]) {
-                            _, latest in latest
+                        options: ["on": ["B1"]].merging(snapshot.map { ["snapshot": [$0]] } ?? [:]) { _, latest in
+                            latest
                         },
                         flags: []
                     ),

--- a/Apps/CLI/Tests/CoreCLITests/InteractionSnapshotCaptureRequirementTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/InteractionSnapshotCaptureRequirementTests.swift
@@ -1,4 +1,5 @@
 import Commander
+import PeekabooFoundationTestSupport
 import Testing
 @testable import PeekabooCLI
 
@@ -8,55 +9,61 @@ struct InteractionSnapshotCaptureRequirementTests {
         let concreteCases: [(any ParsableCommand.Type, ParsedValues)] = [
             (ClickCommand.self, ParsedValues(
                 positional: [],
-                options: ["on": ["B1"], "snapshot": ["receipt-1"]],
+                options: ["on": ["B1"], "snapshot": [SnapshotReferenceFixtures.first.rawValue]],
                 flags: ["foreground"]
             )),
             (ScrollCommand.self, ParsedValues(
                 positional: [],
-                options: ["on": ["S1"], "snapshot": ["receipt-1"]],
+                options: ["on": ["S1"], "snapshot": [SnapshotReferenceFixtures.first.rawValue]],
                 flags: []
             )),
             (MoveCommand.self, ParsedValues(
                 positional: [],
-                options: ["on": ["B1"], "snapshot": ["receipt-1"]],
+                options: ["on": ["B1"], "snapshot": [SnapshotReferenceFixtures.first.rawValue]],
                 flags: ["foreground"]
             )),
             (DragCommand.self, ParsedValues(
                 positional: [],
-                options: ["from": ["B1"], "to": ["B2"], "snapshot": ["receipt-1"]],
+                options: ["from": ["B1"], "to": ["B2"], "snapshot": [SnapshotReferenceFixtures.first.rawValue]],
                 flags: ["foreground"]
             )),
             (ActionCommand.self, ParsedValues(
                 positional: ["AXPress"],
-                options: ["on": ["B1"], "snapshot": ["receipt-1"], "app": ["TextEdit"]],
+                options: ["on": ["B1"], "snapshot": [SnapshotReferenceFixtures.first.rawValue], "app": ["TextEdit"]],
                 flags: []
             )),
             (SetValueCommand.self, ParsedValues(
                 positional: ["value"],
-                options: ["on": ["B1"], "snapshot": ["receipt-1"], "pid": ["123"]],
+                options: ["on": ["B1"], "snapshot": [SnapshotReferenceFixtures.first.rawValue], "pid": ["123"]],
                 flags: []
             )),
             (TypeCommand.self, ParsedValues(
                 positional: ["text"],
-                options: ["snapshot": ["receipt-1"]],
+                options: ["snapshot": [SnapshotReferenceFixtures.first.rawValue]],
                 flags: []
             )),
             (PressCommand.self, ParsedValues(
                 positional: ["return"],
-                options: ["snapshot": ["receipt-1"]],
+                options: ["snapshot": [SnapshotReferenceFixtures.first.rawValue]],
                 flags: []
             )),
             (PasteCommand.self, ParsedValues(
                 positional: ["text"],
-                options: ["snapshot": ["receipt-1"]],
+                options: ["snapshot": [SnapshotReferenceFixtures.first.rawValue]],
                 flags: []
             )),
         ]
 
         for (commandType, values) in concreteCases {
-            let options = try CommanderCLIBinder.makeRuntimeOptions(from: values, commandType: commandType)
+            let options: CommandRuntimeOptions
+            do {
+                options = try CommanderCLIBinder.makeRuntimeOptions(from: values, commandType: commandType)
+            } catch {
+                Issue.record("\(commandType) rejected canonical snapshot: \(error)")
+                continue
+            }
             #expect(!options.requiresSilentCapture, "Concrete snapshot unexpectedly captured for \(commandType)")
-            #expect(options.explicitSnapshotID == "receipt-1")
+            #expect(options.explicitSnapshotID == SnapshotReferenceFixtures.first.rawValue)
         }
 
         let refreshableCases: [(any ParsableCommand.Type, ParsedValues)] = [
@@ -92,7 +99,7 @@ struct InteractionSnapshotCaptureRequirementTests {
             )),
         ]
 
-        for snapshot in [nil, "", " ", "latest", "most-recent", "most_recent"] {
+        for snapshot in [nil, "latest", "most-recent", "most_recent"] {
             let snapshotOptions = snapshot.map { ["snapshot": [$0]] } ?? [:]
             for (commandType, values) in refreshableCases {
                 let options = try CommanderCLIBinder.makeRuntimeOptions(
@@ -117,7 +124,7 @@ struct InteractionSnapshotCaptureRequirementTests {
         let options = try CommanderCLIBinder.makeRuntimeOptions(
             from: ParsedValues(
                 positional: [],
-                options: ["snapshot": ["receipt-1"]],
+                options: ["snapshot": [SnapshotReferenceFixtures.first.rawValue]],
                 flags: []
             ),
             commandType: CleanCommand.self
@@ -133,6 +140,33 @@ struct InteractionSnapshotCaptureRequirementTests {
         #expect(InteractionSnapshotReference.isConcrete(" receipt-1 "))
         #expect(!InteractionSnapshotReference.isConcrete("latest"))
         #expect(!InteractionSnapshotReference.isConcrete(nil))
+    }
+
+    @Test
+    func `Mutating commands reject malformed concrete snapshot references before runtime`() {
+        for snapshotID in ["", " ", "1787675983803-1514", "PS1_00000000000000000000000000000000"] {
+            #expect(throws: ValidationError.self) {
+                _ = try CommanderCLIBinder.makeRuntimeOptions(
+                    from: ParsedValues(
+                        positional: [],
+                        options: ["snapshot": [snapshotID], "on": ["B1"]],
+                        flags: []
+                    ),
+                    commandType: ClickCommand.self
+                )
+            }
+        }
+
+        let canonical = SnapshotReferenceFixtures.first.rawValue
+        let options = try? CommanderCLIBinder.makeRuntimeOptions(
+            from: ParsedValues(
+                positional: [],
+                options: ["snapshot": [canonical], "on": ["B1"]],
+                flags: []
+            ),
+            commandType: ClickCommand.self
+        )
+        #expect(options?.explicitSnapshotID == canonical)
     }
 
     @Test
@@ -215,7 +249,9 @@ struct InteractionSnapshotCaptureRequirementTests {
 
                 let concreteValues = ParsedValues(
                     positional: positional,
-                    options: values.options.merging(["snapshot": ["receipt-1"]]) { _, latest in latest },
+                    options: values.options.merging(
+                        ["snapshot": [SnapshotReferenceFixtures.first.rawValue]]
+                    ) { _, latest in latest },
                     flags: []
                 )
                 let concreteOptions = try CommanderCLIBinder.makeRuntimeOptions(

--- a/Apps/CLI/Tests/CoreCLITests/Phase3CommandParsingTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/Phase3CommandParsingTests.swift
@@ -1,6 +1,7 @@
 import Commander
 import CoreGraphics
 import PeekabooAutomationKit
+import PeekabooFoundationTestSupport
 import Testing
 @testable import PeekabooCLI
 
@@ -153,7 +154,7 @@ struct Phase3CommandParsingTests {
     func `Click parser delegates nested option groups to Commander`() throws {
         let command = try ClickCommand.parse([
             "Submit",
-            "--snapshot", "snapshot-1",
+            "--snapshot", SnapshotReferenceFixtures.first.rawValue,
             "--window-id", "42",
             "--foreground",
             "--focus-timeout", "750",
@@ -163,7 +164,7 @@ struct Phase3CommandParsingTests {
         ])
 
         #expect(command.query == "Submit")
-        #expect(command.snapshot == "snapshot-1")
+        #expect(command.snapshot == SnapshotReferenceFixtures.first.rawValue)
         #expect(command.target.windowId == 42)
         #expect(command.focusOptions.foreground)
         #expect(command.focusOptions.focusTimeoutDuration == .milliseconds(750))

--- a/Apps/CLI/Tests/CoreCLITests/PreRuntimeSemanticValidationTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/PreRuntimeSemanticValidationTests.swift
@@ -1,5 +1,6 @@
 import Commander
 import PeekabooFoundation
+import PeekabooFoundationTestSupport
 import Testing
 @testable import PeekabooCLI
 
@@ -29,7 +30,8 @@ struct PreRuntimeSemanticValidationTests {
         ),
         Case(
             arguments: [
-                "peekaboo", "scroll", "--direction", "sideways", "--on", "elem_6", "--snapshot", "stale-valid",
+                "peekaboo", "scroll", "--direction", "sideways", "--on", "elem_6", "--snapshot",
+                SnapshotReferenceFixtures.first.rawValue,
                 "--no-remote", "--json",
             ],
             expectedMessage: "Invalid direction. Use: up, down, left, or right"
@@ -118,13 +120,18 @@ struct PreRuntimeSemanticValidationTests {
     @Test
     func `direct element actions reject concrete snapshots with explicit targets before runtime selection`() throws {
         let cases = [
-            ["action", "AXIncrement", "--on", "B1", "--snapshot", "receipt-1", "--window-id", "42"],
             [
-                "set-value", "hello", "--on", "T1", "--snapshot", "receipt-1", "--app", "TextEdit",
+                "action", "AXIncrement", "--on", "B1", "--snapshot",
+                SnapshotReferenceFixtures.first.rawValue, "--window-id", "42",
+            ],
+            [
+                "set-value", "hello", "--on", "T1", "--snapshot", SnapshotReferenceFixtures.first.rawValue,
+                "--app", "TextEdit",
                 "--window-title", "Document",
             ],
             [
-                "action", "AXIncrement", "--on", "B1", "--snapshot", "receipt-1", "--pid", "123",
+                "action", "AXIncrement", "--on", "B1", "--snapshot", SnapshotReferenceFixtures.first.rawValue,
+                "--pid", "123",
                 "--window-index", "0",
             ],
         ]

--- a/Apps/CLI/Tests/CoreCLITests/RuntimeHostApplicationSelectionTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/RuntimeHostApplicationSelectionTests.swift
@@ -23,7 +23,7 @@ struct RuntimeHostApplicationSelectionTests {
                 PeekabooBridgeHostCapability.desktopObservationCaptureEngine,
                 PeekabooBridgeHostCapability.screenCaptureKitProcessOwnership,
             ]
-        )
+        ).withProducerBoundSnapshotFixture()
         let captureOnly = BridgeTestFixtures.handshake(
             negotiatedVersion: PeekabooBridgeConstants.protocolVersion,
             hostKind: .onDemand,

--- a/Apps/CLI/Tests/CoreCLITests/RuntimeHostResolverTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/RuntimeHostResolverTests.swift
@@ -285,6 +285,57 @@ struct RuntimeHostResolverTests {
     }
 
     @Test
+    func `snapshot-producing command skips old same-minor host for a capable peer`() async throws {
+        let oldCandidate = RuntimeHostResolver.ImplicitRemoteCandidate(
+            socketPath: "/tmp/old-snapshot-host.sock",
+            requireReusableDaemon: false,
+            requiredHostKind: nil,
+            requiresValidatedHistoricalDaemon: false
+        )
+        let currentCandidate = RuntimeHostResolver.ImplicitRemoteCandidate(
+            socketPath: "/tmp/current-snapshot-host.sock",
+            requireReusableDaemon: false,
+            requiredHostKind: nil,
+            requiresValidatedHistoricalDaemon: false
+        )
+        let oldHandshake = BridgeTestFixtures.handshake(
+            negotiatedVersion: .init(major: 1, minor: 34),
+            supportedOperations: [.desktopObservation],
+            hostCapabilities: [PeekabooBridgeHostCapability.attestedOperationReceipts]
+        )
+        let currentHandshake = BridgeTestFixtures.handshake(
+            negotiatedVersion: .init(major: 1, minor: 34),
+            supportedOperations: [.desktopObservation, .ownsSnapshot],
+            hostCapabilities: [
+                PeekabooBridgeHostCapability.attestedOperationReceipts,
+                PeekabooBridgeHostCapability.producerBoundSnapshotReferences,
+            ]
+        )
+        var options = CommandRuntimeOptions()
+        options.requiresDesktopObservation = true
+        options.requiresProducerBoundSnapshotReferences = true
+        var permissionRejections: [String] = []
+
+        let resolution = try await RuntimeHostResolver.resolveRemoteServices(
+            candidates: [oldCandidate, currentCandidate],
+            identity: PeekabooBridgeClientIdentity(
+                bundleIdentifier: "boo.peekaboo.snapshot-selection-tests",
+                teamIdentifier: nil,
+                processIdentifier: 42
+            ),
+            options: options,
+            snapshotInvalidationRemoteSocketPaths: [],
+            permissionRejections: &permissionRejections,
+            handshake: { candidate, _ in
+                candidate == oldCandidate ? oldHandshake : currentHandshake
+            }
+        )
+
+        #expect(resolution?.selectedRemoteSocketPath == currentCandidate.socketPath)
+        #expect(permissionRejections.isEmpty)
+    }
+
+    @Test
     func `Candidate validation rejects pre-long-press bridge hosts`() async {
         let candidate = RuntimeHostResolver.ImplicitRemoteCandidate(
             socketPath: "/tmp/bridge.sock",

--- a/Apps/CLI/Tests/CoreCLITests/ScreenCaptureKitDynamicToolRuntimeTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/ScreenCaptureKitDynamicToolRuntimeTests.swift
@@ -2,6 +2,7 @@ import Commander
 import Foundation
 import MCP
 import PeekabooBridge
+import PeekabooBridgeTestSupport
 import PeekabooCore
 import TachikomaMCP
 import Testing
@@ -82,6 +83,8 @@ extension ScreenCaptureKitOwnerRuntimeTests {
             processIdentifier: 4242,
             processStartIdentity: 9001,
             codeSignatureHash: "selected-build",
+            maximumProtocolVersion: PeekabooBridgeConstants.protocolVersion,
+            usesCurrentHostIdentity: true,
             permissionEvaluationObserver: { selectedHandshakeCount += 1 }
         )
         let unrelatedHost = try await Self.startHost(
@@ -153,7 +156,8 @@ extension ScreenCaptureKitOwnerRuntimeTests {
                             requiresValidatedHistoricalDaemon: false
                         )]
                     )
-                }
+                },
+                makeRemoteHandshakeCache: { Self.authenticatedHandshakeCache() }
             )
         )
 
@@ -236,7 +240,9 @@ extension ScreenCaptureKitOwnerRuntimeTests {
             socketPath: selectedSocket,
             processIdentifier: 4242,
             processStartIdentity: 9001,
-            codeSignatureHash: "selected-build"
+            codeSignatureHash: "selected-build",
+            maximumProtocolVersion: PeekabooBridgeConstants.protocolVersion,
+            usesCurrentHostIdentity: true
         )
         defer { Task { await selectedHost.stop() } }
 
@@ -254,6 +260,13 @@ extension ScreenCaptureKitOwnerRuntimeTests {
         )
         #expect(options.bridgeSocketPath == selectedSocket)
         #expect(options.usesPerToolSnapshotInvalidation)
+        let handshakeCache = Self.authenticatedHandshakeCache()
+        let selectedCandidate = RuntimeHostResolver.ImplicitRemoteCandidate(
+            socketPath: selectedSocket,
+            requireReusableDaemon: false,
+            requiredHostKind: nil,
+            requiresValidatedHistoricalDaemon: false
+        )
 
         let legacyOwner = RuntimeHostResolver.ScreenCaptureKitOwnerUnawareHost(
             socketPath: "/tmp/unrelated-legacy-owner.sock",
@@ -269,7 +282,10 @@ extension ScreenCaptureKitOwnerRuntimeTests {
                 makeLocalServices: { _ in PeekabooServices() },
                 claimScreenCaptureKitOwner: { Self.ownerReceipt() },
                 inspectScreenCaptureKitOwner: { nil },
-                inspectScreenCaptureKitSafety: { _, _, _, _ in legacyOwner },
+                inspectScreenCaptureKitSafety: { _, _, _, cache in
+                    _ = try await cache.handshake(selectedCandidate, identity: cache.identity)
+                    return legacyOwner
+                },
                 remoteCandidatePlan: { _, _ in
                     RuntimeHostResolver.RemoteCandidatePlan(
                         explicitSocket: selectedSocket,
@@ -277,14 +293,10 @@ extension ScreenCaptureKitOwnerRuntimeTests {
                         runtimeBuildIdentity: "current-build",
                         buildScopedDaemonSocketPath: nil,
                         historicalBuildScopedDaemonSocketPaths: [],
-                        candidates: [.init(
-                            socketPath: selectedSocket,
-                            requireReusableDaemon: false,
-                            requiredHostKind: nil,
-                            requiresValidatedHistoricalDaemon: false
-                        )]
+                        candidates: [selectedCandidate]
                     )
-                }
+                },
+                makeRemoteHandshakeCache: { handshakeCache }
             )
         )
         let refusal = try #require(resolution.toolCapturePreflightRefusal)
@@ -322,6 +334,17 @@ extension ScreenCaptureKitOwnerRuntimeTests {
         #expect(!nonCapture.isError)
         #expect(await nonCaptureCounter.wasInvoked)
         await selectedHost.stop()
+    }
+
+    private static func authenticatedHandshakeCache() -> RuntimeHostResolver.RemoteHandshakeCache {
+        RuntimeHostResolver.RemoteHandshakeCache(
+            identity: PeekabooBridgeClientIdentity(
+                bundleIdentifier: "boo.peekaboo.dynamic-snapshot-tests",
+                teamIdentifier: nil,
+                processIdentifier: getpid()
+            ),
+            clientFactory: { BridgeTestFixtures.authenticatedClient(socketPath: $0) }
+        )
     }
 }
 

--- a/Apps/CLI/Tests/CoreCLITests/ScreenCaptureKitOwnerRuntimeTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/ScreenCaptureKitOwnerRuntimeTests.swift
@@ -153,10 +153,13 @@ struct ScreenCaptureKitOwnerRuntimeTests {
 
     @Test
     func `caller-local explicit snapshot scroll skips capture ownership and old-host discovery`() async throws {
+        let snapshots = InMemorySnapshotManager()
+        let snapshotID = try await snapshots.createSnapshot()
+        let localServices = PeekabooServices(snapshotManager: snapshots)
         var options = try CommanderCLIBinder.makeRuntimeOptions(
             from: ParsedValues(
                 positional: [],
-                options: ["on": ["elem_3"], "snapshot": ["explicit-receipt"]],
+                options: ["on": ["elem_3"], "snapshot": [snapshotID]],
                 flags: ["no-remote"]
             ),
             commandType: ScrollCommand.self
@@ -175,7 +178,7 @@ struct ScreenCaptureKitOwnerRuntimeTests {
             dependencies: .init(
                 makeLocalServices: { _ in
                     localFactoryCalls += 1
-                    return PeekabooServices()
+                    return localServices
                 },
                 claimScreenCaptureKitOwner: {
                     claimCalls += 1
@@ -1435,6 +1438,9 @@ extension ScreenCaptureKitOwnerRuntimeTests {
         codeSignatureHash: String,
         ownerAware: Bool = true,
         screenRecording: Bool = true,
+        maximumProtocolVersion: PeekabooBridgeProtocolVersion =
+            PeekabooBridgeConstants.exactForcedDialogDismissExecutionVersion,
+        usesCurrentHostIdentity: Bool = false,
         serviceOverride: (any PeekabooBridgeServiceProviding)? = nil,
         permissionEvaluationObserver: @escaping @MainActor @Sendable () -> Void = {}
     ) async throws -> PeekabooBridgeHost {
@@ -1452,7 +1458,7 @@ extension ScreenCaptureKitOwnerRuntimeTests {
             allowlistedBundles: [],
             supportedVersions: ClosedRange(uncheckedBounds: (
                 lower: PeekabooBridgeConstants.supportedProtocolRange.lowerBound,
-                upper: PeekabooBridgeConstants.exactForcedDialogDismissExecutionVersion
+                upper: maximumProtocolVersion
             )),
             allowedOperations: [
                 .permissionsStatus,
@@ -1460,23 +1466,27 @@ extension ScreenCaptureKitOwnerRuntimeTests {
                 .desktopObservation,
                 .invalidateImplicitLatestSnapshot,
                 .launchApplicationWithOptions,
+                .findApplication,
                 .activateApplication,
                 .targetedHotkey,
                 .targetedTypeActions,
                 .targetedClick,
+                .ownsSnapshot,
                 .targetedDialogListElements,
                 .prepareDialogAction,
                 .exactDialogClickButton,
                 .exactDialogDismiss,
             ],
-            hostIdentity: PeekabooBridgeHostIdentity(
-                processIdentifier: processIdentifier,
-                processStartIdentity: processStartIdentity,
-                bundleIdentifier: "boo.peekaboo.test.host",
-                bundleShortVersion: nil,
-                bundleVersion: nil,
-                codeSignatureHash: codeSignatureHash
-            ),
+            hostIdentity: usesCurrentHostIdentity
+                ? .current()
+                : PeekabooBridgeHostIdentity(
+                    processIdentifier: processIdentifier,
+                    processStartIdentity: processStartIdentity,
+                    bundleIdentifier: "boo.peekaboo.test.host",
+                    bundleShortVersion: nil,
+                    bundleVersion: nil,
+                    codeSignatureHash: codeSignatureHash
+                ),
             permissionStatusEvaluator: { _ in
                 permissionEvaluationObserver()
                 return PermissionsStatus(

--- a/Apps/CLI/Tests/CoreCLITests/ServiceBridgeTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/ServiceBridgeTests.swift
@@ -1,5 +1,7 @@
 import CoreGraphics
 import Foundation
+import PeekabooBridge
+import PeekabooBridgeTestSupport
 import PeekabooCore
 import PeekabooFoundation
 import Testing
@@ -141,6 +143,7 @@ struct ServiceBridgeTests {
         #expect(automation.targetedClickCalls.first?.snapshotId == "snapshot-123")
         #expect(automation.targetedClickCalls.first?.targetProcessIdentifier == 12345)
         #expect(automation.targetedClickCalls.first?.targetWindowID == nil)
+        #expect(automation.targetedClickCalls.first?.allowsAccessibilityValueDelivery == true)
     }
 
     @Test func `automation targeted click forwards exact window`() async throws {
@@ -166,6 +169,70 @@ struct ServiceBridgeTests {
 
         #expect(automation.targetedClickCalls.first?.targetProcessIdentifier == 12345)
         #expect(automation.targetedClickCalls.first?.targetWindowID == 42)
+        #expect(automation.targetedClickCalls.first?.allowsAccessibilityValueDelivery == true)
+    }
+
+    @Test func `automation targeted click refuses policy blind hosts before dispatch`() async throws {
+        let automation = MockTargetedAutomationService()
+        automation.supportsTargetedClickAccessibilityValueDelivery = false
+
+        await #expect(throws: PeekabooError.self) {
+            try await AutomationServiceBridge.click(
+                automation: automation,
+                target: .elementId("field"),
+                clickType: .single,
+                snapshotId: "snapshot-123",
+                expectedProcessIdentity: self.processIdentity
+            )
+        }
+        #expect(automation.targetedClickCalls.isEmpty)
+    }
+
+    @Test func `CLI click refuses old 1 34 value policy before remote provider entry`() async throws {
+        let services = PolicyBlindBridgeServices()
+        let socketPath = "/tmp/peekaboo-cli-old-value-policy-\(UUID().uuidString).sock"
+        let version = PeekabooBridgeProtocolVersion(major: 1, minor: 34)
+        let server = PeekabooBridgeServer(
+            services: services,
+            hostKind: .onDemand,
+            allowlistedTeams: [],
+            allowlistedBundles: [],
+            supportedVersions: version...version
+        )
+        let host = PeekabooBridgeHost(socketPath: socketPath, server: server, allowedTeamIDs: [])
+        try await host.startChecked()
+        defer { Task { await host.stop() } }
+
+        let client = BridgeTestFixtures.authenticatedClient(socketPath: socketPath, requestTimeoutSec: 1)
+        let handshake = try await client.handshake(
+            client: .init(
+                bundleIdentifier: "boo.peekaboo.cli-policy-tests",
+                teamIdentifier: nil,
+                processIdentifier: getpid()
+            ),
+            protocolVersion: version
+        )
+        #expect(handshake.hostCapabilities?.contains(
+            PeekabooBridgeHostCapability.targetedClickAccessibilityValueDelivery
+        ) != true)
+        let remote = RemoteUIAutomationService(
+            client: client,
+            supportsTargetedClicks: true,
+            supportsProcessGenerationPinnedClicks: true
+        )
+
+        await #expect(throws: PeekabooError.self) {
+            try await AutomationServiceBridge.click(
+                automation: remote,
+                target: .elementId("field"),
+                clickType: .single,
+                snapshotId: "snapshot-123",
+                expectedProcessIdentity: self.processIdentity
+            )
+        }
+        #expect(services.automationService.policyAwareClickEntryCount == 0)
+        #expect(services.automationService.targetedClickCalls.isEmpty)
+        await host.stop()
     }
 
     @Test func `automation targeted click maps missing event synthesizing permission`() async throws {
@@ -348,6 +415,7 @@ TargetedTypeServiceProtocol, ExactWindowTargetedClickServiceProtocol {
         let snapshotId: String?
         let targetProcessIdentifier: pid_t
         let targetWindowID: Int?
+        let allowsAccessibilityValueDelivery: Bool?
     }
 
     struct TargetedTypeActionsCall {
@@ -360,6 +428,7 @@ TargetedTypeServiceProtocol, ExactWindowTargetedClickServiceProtocol {
     var targetedHotkeyCalls: [TargetedHotkeyCall] = []
     var targetedTypeActionsCalls: [TargetedTypeActionsCall] = []
     var targetedClickCalls: [TargetedClickCall] = []
+    private(set) var policyAwareClickEntryCount = 0
     var supportsTargetedHotkeys = true
     var targetedHotkeyUnavailableReason: String?
     var targetedHotkeyRequiresEventSynthesizingPermission = false
@@ -369,6 +438,7 @@ TargetedTypeServiceProtocol, ExactWindowTargetedClickServiceProtocol {
     var targetedTypeRequiresEventSynthesizingPermission = false
     var supportsTargetedClicks = true
     var supportsProcessGenerationPinnedClicks = true
+    var supportsTargetedClickAccessibilityValueDelivery = true
     var targetedClickUnavailableReason: String?
     var targetedClickRequiresEventSynthesizingPermission = false
 
@@ -421,7 +491,8 @@ TargetedTypeServiceProtocol, ExactWindowTargetedClickServiceProtocol {
             clickType: clickType,
             snapshotId: snapshotId,
             targetProcessIdentifier: targetProcessIdentifier,
-            targetWindowID: nil
+            targetWindowID: nil,
+            allowsAccessibilityValueDelivery: nil
         ))
     }
 
@@ -436,7 +507,29 @@ TargetedTypeServiceProtocol, ExactWindowTargetedClickServiceProtocol {
             clickType: clickType,
             snapshotId: snapshotId,
             targetProcessIdentifier: expectedProcessIdentity.processIdentifier,
-            targetWindowID: nil
+            targetWindowID: nil,
+            allowsAccessibilityValueDelivery: nil
+        ))
+    }
+
+    func click(
+        target: ClickTarget,
+        clickType: ClickType,
+        snapshotId: String?,
+        expectedProcessIdentity: ApplicationProcessIdentity,
+        allowsAccessibilityValueDelivery: Bool
+    ) async throws {
+        self.policyAwareClickEntryCount += 1
+        guard self.supportsTargetedClickAccessibilityValueDelivery else {
+            throw PeekabooError.serviceUnavailable("Targeted click value-delivery policy is unavailable")
+        }
+        self.targetedClickCalls.append(.init(
+            target: target,
+            clickType: clickType,
+            snapshotId: snapshotId,
+            targetProcessIdentifier: expectedProcessIdentity.processIdentifier,
+            targetWindowID: nil,
+            allowsAccessibilityValueDelivery: allowsAccessibilityValueDelivery
         ))
     }
 
@@ -452,8 +545,81 @@ TargetedTypeServiceProtocol, ExactWindowTargetedClickServiceProtocol {
             clickType: clickType,
             snapshotId: snapshotId,
             targetProcessIdentifier: expectedWindowIdentity.ownerProcessIdentifier,
-            targetWindowID: expectedWindowIdentity.windowID
+            targetWindowID: expectedWindowIdentity.windowID,
+            allowsAccessibilityValueDelivery: nil
         ))
+    }
+
+    func click(
+        target: ClickTarget,
+        clickType: ClickType,
+        snapshotId: String?,
+        expectedWindowIdentity: WindowMutationIdentity,
+        expectedWindowBounds _: CGRect,
+        allowsAccessibilityValueDelivery: Bool
+    ) async throws {
+        self.policyAwareClickEntryCount += 1
+        guard self.supportsTargetedClickAccessibilityValueDelivery else {
+            throw PeekabooError.serviceUnavailable("Targeted click value-delivery policy is unavailable")
+        }
+        self.targetedClickCalls.append(.init(
+            target: target,
+            clickType: clickType,
+            snapshotId: snapshotId,
+            targetProcessIdentifier: expectedWindowIdentity.ownerProcessIdentifier,
+            targetWindowID: expectedWindowIdentity.windowID,
+            allowsAccessibilityValueDelivery: allowsAccessibilityValueDelivery
+        ))
+    }
+}
+
+@MainActor
+private final class PolicyBlindBridgeServices: PeekabooBridgeServiceProviding {
+    let base = PeekabooServices()
+    let automationService = MockTargetedAutomationService()
+
+    var permissions: PermissionsService {
+        self.base.permissions
+    }
+
+    var screenCapture: any ScreenCaptureServiceProtocol {
+        self.base.screenCapture
+    }
+
+    var automation: any UIAutomationServiceProtocol {
+        self.automationService
+    }
+
+    var windows: any WindowManagementServiceProtocol {
+        self.base.windows
+    }
+
+    var applications: any ApplicationServiceProtocol {
+        self.base.applications
+    }
+
+    var menu: any MenuServiceProtocol {
+        self.base.menu
+    }
+
+    var dock: any DockServiceProtocol {
+        self.base.dock
+    }
+
+    var dialogs: any DialogServiceProtocol {
+        self.base.dialogs
+    }
+
+    var snapshots: any SnapshotManagerProtocol {
+        self.base.snapshots
+    }
+
+    var desktopObservation: any DesktopObservationServiceProtocol {
+        self.base.desktopObservation
+    }
+
+    init() {
+        self.automationService.supportsTargetedClickAccessibilityValueDelivery = false
     }
 }
 

--- a/Apps/CLI/Tests/CoreCLITests/SnapshotHostAffinityRuntimeTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/SnapshotHostAffinityRuntimeTests.swift
@@ -1,0 +1,261 @@
+import Darwin
+import Foundation
+import PeekabooAutomationKit
+import PeekabooBridge
+import PeekabooCore
+import Testing
+@testable import PeekabooCLI
+
+@Suite(.tags(.safe))
+@MainActor
+struct SnapshotHostAffinityRuntimeTests {
+    @Test
+    func `live authenticated probes retain the sole snapshot producer`() async throws {
+        let snapshotID = "1787675983803-1514"
+        let missingSnapshots = InMemorySnapshotManager()
+        let ownerSnapshots = InMemorySnapshotManager()
+        let bounds = CGRect(x: 10, y: 20, width: 600, height: 400)
+        let identity = WindowMutationIdentity(
+            windowID: 74,
+            ownerProcessIdentifier: getpid(),
+            ownerProcessStartIdentity: 7,
+            capturedBounds: bounds
+        )
+        let window = ServiceWindowInfo(
+            windowID: identity.windowID,
+            title: "No Elements",
+            bounds: bounds,
+            mutationIdentity: identity
+        )
+        try await ownerSnapshots.storeObservationSnapshot(SnapshotObservationPublicationRequest(
+            screenshot: SnapshotScreenshotRequest(
+                snapshotId: snapshotID,
+                screenshotPath: "/tmp/no-elements.png",
+                applicationBundleId: "boo.peekaboo.fixture",
+                applicationProcessId: identity.ownerProcessIdentifier,
+                applicationName: "Fixture",
+                windowTitle: window.title,
+                windowBounds: bounds,
+                windowID: identity.windowID,
+                windowMutationIdentity: identity,
+                captureCoordinateContext: CaptureCoordinateContext(
+                    metadata: CaptureMetadata(
+                        size: bounds.size,
+                        mode: .window,
+                        windowInfo: window
+                    ),
+                    referenceID: snapshotID
+                )
+            ),
+            detectionResult: nil,
+            annotatedScreenshotPath: nil
+        ))
+        let synthesized = try #require(try await ownerSnapshots.getDetectionResult(snapshotId: snapshotID))
+        #expect(synthesized.elements.all.isEmpty)
+        _ = try SnapshotTargetReceiptPlanner.assemble(
+            snapshotID: snapshotID,
+            detectionResult: synthesized
+        ).receipt.requireCoordinateAuthority()
+
+        let missingSocket = "/tmp/peekaboo-affinity-missing-\(UUID().uuidString).sock"
+        let ownerSocket = "/tmp/peekaboo-affinity-owner-\(UUID().uuidString).sock"
+        let missingHost = try await self.startHost(
+            socketPath: missingSocket,
+            hostKind: .gui,
+            snapshots: missingSnapshots
+        )
+        let ownerHost = try await self.startHost(
+            socketPath: ownerSocket,
+            hostKind: .onDemand,
+            snapshots: ownerSnapshots
+        )
+        defer {
+            Task {
+                await missingHost.stop()
+                await ownerHost.stop()
+            }
+        }
+        let candidates = [self.candidate(missingSocket), self.candidate(ownerSocket)]
+        let cache = RuntimeHostResolver.RemoteHandshakeCache(identity: self.identity)
+
+        let selected = try await RuntimeHostResolver.resolveSnapshotAffinity(
+            snapshotID: snapshotID,
+            candidates: candidates,
+            identity: self.identity,
+            handshakeCache: cache
+        )
+
+        #expect(selected.socketPath == ownerSocket)
+        for candidate in candidates {
+            #expect(cache.entry(for: candidate, identity: self.identity) != nil)
+        }
+        await missingHost.stop()
+        await ownerHost.stop()
+    }
+
+    @Test
+    func `concrete snapshot selects its sole owner among same-version hosts`() async throws {
+        let hosts = [self.candidate("/tmp/current.sock"), self.candidate("/tmp/gui.sock")]
+        var probes: [String] = []
+
+        let selected = try await RuntimeHostResolver.resolveSnapshotAffinity(
+            snapshotID: "1787675983803-1514",
+            candidates: hosts,
+            identity: self.identity,
+            handshakeCache: RuntimeHostResolver.RemoteHandshakeCache(identity: self.identity),
+            probe: { candidate, _, _, _ in
+                probes.append(candidate.socketPath)
+                return candidate.socketPath == "/tmp/gui.sock" ? .owner : .missing
+            }
+        )
+
+        #expect(selected.socketPath == "/tmp/gui.sock")
+        #expect(probes == ["/tmp/current.sock", "/tmp/gui.sock"])
+    }
+
+    @Test
+    func `dead producer never replays snapshot on another live host`() async {
+        let hosts = [self.candidate("/tmp/dead-producer.sock"), self.candidate("/tmp/other-live.sock")]
+
+        await #expect(throws: PreDispatchActionError.self) {
+            _ = try await RuntimeHostResolver.resolveSnapshotAffinity(
+                snapshotID: "1787675983803-1514",
+                candidates: hosts,
+                identity: self.identity,
+                handshakeCache: RuntimeHostResolver.RemoteHandshakeCache(identity: self.identity),
+                probe: { candidate, _, _, _ in
+                    candidate.socketPath == "/tmp/dead-producer.sock" ? .unavailable : .missing
+                }
+            )
+        }
+    }
+
+    @Test
+    func `unknown snapshot fails closed after every host denies ownership`() async {
+        let hosts = [self.candidate("/tmp/current.sock"), self.candidate("/tmp/gui.sock")]
+        var probes = 0
+
+        await #expect(throws: PreDispatchActionError.self) {
+            _ = try await RuntimeHostResolver.resolveSnapshotAffinity(
+                snapshotID: "1787675983803-9999",
+                candidates: hosts,
+                identity: self.identity,
+                handshakeCache: RuntimeHostResolver.RemoteHandshakeCache(identity: self.identity),
+                probe: { _, _, _, _ in
+                    probes += 1
+                    return .missing
+                }
+            )
+        }
+        #expect(probes == hosts.count)
+    }
+
+    @Test
+    func `tampered snapshot reference is rejected before any host probe`() async {
+        var probes = 0
+
+        await #expect(throws: PreDispatchActionError.self) {
+            _ = try await RuntimeHostResolver.resolveSnapshotAffinity(
+                snapshotID: "../1787675983803-1514",
+                candidates: [self.candidate("/tmp/gui.sock")],
+                identity: self.identity,
+                handshakeCache: RuntimeHostResolver.RemoteHandshakeCache(identity: self.identity),
+                probe: { _, _, _, _ in
+                    probes += 1
+                    return .owner
+                }
+            )
+        }
+        #expect(probes == 0)
+    }
+
+    @Test
+    func `duplicate snapshot ownership is ambiguous instead of order dependent`() async {
+        let hosts = [self.candidate("/tmp/current.sock"), self.candidate("/tmp/gui.sock")]
+
+        for candidates in [hosts, Array(hosts.reversed())] {
+            await #expect(throws: PreDispatchActionError.self) {
+                _ = try await RuntimeHostResolver.resolveSnapshotAffinity(
+                    snapshotID: "1787675983803-1514",
+                    candidates: candidates,
+                    identity: self.identity,
+                    handshakeCache: RuntimeHostResolver.RemoteHandshakeCache(identity: self.identity),
+                    probe: { _, _, _, _ in .owner }
+                )
+            }
+        }
+    }
+
+    @Test
+    func `explicit socket affinity stays on the asserted host`() {
+        let explicit = self.candidate("/tmp/explicit.sock")
+        let plan = RuntimeHostResolver.RemoteCandidatePlan(
+            explicitSocket: explicit.socketPath,
+            daemonSocketPath: "/tmp/daemon.sock",
+            runtimeBuildIdentity: "build",
+            buildScopedDaemonSocketPath: "/tmp/build.sock",
+            historicalBuildScopedDaemonSocketPaths: ["/tmp/history.sock"],
+            candidates: [explicit]
+        )
+
+        #expect(RuntimeHostResolver.snapshotAffinityCandidates(from: plan) == [explicit])
+    }
+
+    @Test
+    func `unavailable affinity probes complete concurrently`() async {
+        let hosts = (0..<4).map { self.candidate("/tmp/slow-\($0).sock") }
+        let startedAt = ContinuousClock.now
+
+        await #expect(throws: PreDispatchActionError.self) {
+            _ = try await RuntimeHostResolver.resolveSnapshotAffinity(
+                snapshotID: "1787675983803-1514",
+                candidates: hosts,
+                identity: self.identity,
+                handshakeCache: RuntimeHostResolver.RemoteHandshakeCache(identity: self.identity),
+                probe: { _, _, _, _ in
+                    try await Task.sleep(for: .milliseconds(120))
+                    return .unavailable
+                }
+            )
+        }
+        #expect(startedAt.duration(to: .now) < .milliseconds(350))
+    }
+
+    private var identity: PeekabooBridgeClientIdentity {
+        PeekabooBridgeClientIdentity(
+            bundleIdentifier: "boo.peekaboo.test.client",
+            teamIdentifier: nil,
+            processIdentifier: getpid()
+        )
+    }
+
+    private func candidate(_ socketPath: String) -> RuntimeHostResolver.ImplicitRemoteCandidate {
+        RuntimeHostResolver.ImplicitRemoteCandidate(
+            socketPath: socketPath,
+            requireReusableDaemon: false,
+            requiredHostKind: nil,
+            requiresValidatedHistoricalDaemon: false
+        )
+    }
+
+    private func startHost(
+        socketPath: String,
+        hostKind: PeekabooBridgeHostKind,
+        snapshots: InMemorySnapshotManager
+    ) async throws -> PeekabooBridgeHost {
+        let server = PeekabooBridgeServer(
+            services: PeekabooServices(snapshotManager: snapshots),
+            hostKind: hostKind,
+            allowlistedTeams: [],
+            allowlistedBundles: []
+        )
+        let host = PeekabooBridgeHost(
+            socketPath: socketPath,
+            server: server,
+            allowedTeamIDs: [],
+            requestTimeoutSec: 2
+        )
+        try await host.startChecked()
+        return host
+    }
+}

--- a/Apps/CLI/Tests/CoreCLITests/SnapshotHostAffinityRuntimeTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/SnapshotHostAffinityRuntimeTests.swift
@@ -1,8 +1,11 @@
 import Darwin
 import Foundation
 import PeekabooAutomationKit
+import PeekabooAutomationKitTestSupport
 import PeekabooBridge
+import PeekabooBridgeTestSupport
 import PeekabooCore
+import PeekabooFoundationTestSupport
 import Testing
 @testable import PeekabooCLI
 
@@ -11,9 +14,9 @@ import Testing
 struct SnapshotHostAffinityRuntimeTests {
     @Test
     func `live authenticated probes retain the sole snapshot producer`() async throws {
-        let snapshotID = "1787675983803-1514"
         let missingSnapshots = InMemorySnapshotManager()
         let ownerSnapshots = InMemorySnapshotManager()
+        let snapshotID = try await ownerSnapshots.createSnapshot()
         let bounds = CGRect(x: 10, y: 20, width: 600, height: 400)
         let identity = WindowMutationIdentity(
             windowID: 74,
@@ -76,7 +79,15 @@ struct SnapshotHostAffinityRuntimeTests {
             }
         }
         let candidates = [self.candidate(missingSocket), self.candidate(ownerSocket)]
-        let cache = RuntimeHostResolver.RemoteHandshakeCache(identity: self.identity)
+        let cache = RuntimeHostResolver.RemoteHandshakeCache(
+            identity: self.identity,
+            clientFactory: { BridgeTestFixtures.authenticatedClient(socketPath: $0) }
+        )
+        for candidate in candidates {
+            let handshake = try await cache.handshake(candidate, identity: self.identity).response
+            #expect(handshake.supportedOperations.contains(.ownsSnapshot))
+            #expect(BridgeCapabilityPolicy.supportsProducerBoundSnapshotReferences(for: handshake))
+        }
 
         let selected = try await RuntimeHostResolver.resolveSnapshotAffinity(
             snapshotID: snapshotID,
@@ -99,7 +110,7 @@ struct SnapshotHostAffinityRuntimeTests {
         var probes: [String] = []
 
         let selected = try await RuntimeHostResolver.resolveSnapshotAffinity(
-            snapshotID: "1787675983803-1514",
+            snapshotID: SnapshotReferenceFixtures.first.rawValue,
             candidates: hosts,
             identity: self.identity,
             handshakeCache: RuntimeHostResolver.RemoteHandshakeCache(identity: self.identity),
@@ -114,12 +125,119 @@ struct SnapshotHostAffinityRuntimeTests {
     }
 
     @Test
+    func `candidate aliases count as one snapshot owner`() async throws {
+        let aliases = [
+            self.candidate("/tmp/peekaboo-affinity-alias.sock"),
+            self.candidate("/tmp/../tmp/peekaboo-affinity-alias.sock"),
+        ]
+
+        let selected = try await RuntimeHostResolver.resolveSnapshotAffinity(
+            snapshotID: SnapshotReferenceFixtures.first.rawValue,
+            candidates: aliases,
+            identity: self.identity,
+            handshakeCache: RuntimeHostResolver.RemoteHandshakeCache(identity: self.identity),
+            probe: { _, _, _, _ in .owner }
+        )
+
+        #expect(selected.socketPath == aliases[0].socketPath)
+    }
+
+    @Test
+    func `two authenticated endpoints from one process count as one snapshot owner`() async throws {
+        let snapshots = InMemorySnapshotManager()
+        let snapshotID = try await snapshots.createSnapshot()
+        let firstSocket = "/tmp/peekaboo-affinity-first-\(UUID().uuidString).sock"
+        let secondSocket = "/tmp/peekaboo-affinity-second-\(UUID().uuidString).sock"
+        let firstHost = try await self.startHost(
+            socketPath: firstSocket,
+            hostKind: .onDemand,
+            snapshots: snapshots
+        )
+        let secondHost = try await self.startHost(
+            socketPath: secondSocket,
+            hostKind: .onDemand,
+            snapshots: snapshots
+        )
+        defer {
+            Task {
+                await firstHost.stop()
+                await secondHost.stop()
+            }
+        }
+        let cache = RuntimeHostResolver.RemoteHandshakeCache(
+            identity: self.identity,
+            clientFactory: { BridgeTestFixtures.authenticatedClient(socketPath: $0) }
+        )
+
+        let selected = try await RuntimeHostResolver.resolveSnapshotAffinity(
+            snapshotID: snapshotID,
+            candidates: [self.candidate(firstSocket), self.candidate(secondSocket)],
+            identity: self.identity,
+            handshakeCache: cache
+        )
+
+        #expect(selected.socketPath == firstSocket)
+        await firstHost.stop()
+        await secondHost.stop()
+    }
+
+    @Test
+    func `same-producer affinity tries every alias for command capability`() async throws {
+        let snapshots = InMemorySnapshotManager()
+        let snapshotID = try await snapshots.createSnapshot()
+        let firstSocket = "/tmp/peekaboo-affinity-limited-\(UUID().uuidString).sock"
+        let secondSocket = "/tmp/peekaboo-affinity-capable-\(UUID().uuidString).sock"
+        let firstHost = try await self.startHost(
+            socketPath: firstSocket,
+            hostKind: .onDemand,
+            snapshots: snapshots,
+            allowedOperations: [.ownsSnapshot]
+        )
+        let secondHost = try await self.startHost(
+            socketPath: secondSocket,
+            hostKind: .onDemand,
+            snapshots: snapshots,
+            allowedOperations: [.ownsSnapshot, .targetedClick]
+        )
+        defer {
+            Task {
+                await firstHost.stop()
+                await secondHost.stop()
+            }
+        }
+        var options = CommandRuntimeOptions()
+        options.explicitSnapshotID = snapshotID
+        options.requiresProducerBoundSnapshotReferences = true
+        options.requiresProcessGenerationPinnedClicks = true
+        let dependencies = RuntimeHostResolver.Dependencies(
+            makeLocalServices: { _ in PeekabooServices(snapshotManager: InMemorySnapshotManager()) },
+            claimScreenCaptureKitOwner: { throw POSIXError(.EPERM) },
+            inspectScreenCaptureKitOwner: { nil },
+            remoteCandidatePlan: { _, _ in
+                self.plan(candidates: [self.candidate(firstSocket), self.candidate(secondSocket)])
+            },
+            makeRemoteHandshakeCache: { self.authenticatedHandshakeCache() }
+        )
+
+        let resolution = try await RuntimeHostResolver.resolveServices(
+            options: options,
+            environment: [:],
+            configurationInput: nil,
+            dependencies: dependencies
+        )
+
+        #expect(resolution.selectedRemoteSocketPath == secondSocket)
+        await firstHost.stop()
+        await secondHost.stop()
+    }
+
+    @Test
     func `dead producer never replays snapshot on another live host`() async {
         let hosts = [self.candidate("/tmp/dead-producer.sock"), self.candidate("/tmp/other-live.sock")]
 
         await #expect(throws: PreDispatchActionError.self) {
             _ = try await RuntimeHostResolver.resolveSnapshotAffinity(
-                snapshotID: "1787675983803-1514",
+                snapshotID: SnapshotReferenceFixtures.first.rawValue,
                 candidates: hosts,
                 identity: self.identity,
                 handshakeCache: RuntimeHostResolver.RemoteHandshakeCache(identity: self.identity),
@@ -137,7 +255,7 @@ struct SnapshotHostAffinityRuntimeTests {
 
         await #expect(throws: PreDispatchActionError.self) {
             _ = try await RuntimeHostResolver.resolveSnapshotAffinity(
-                snapshotID: "1787675983803-9999",
+                snapshotID: SnapshotReferenceFixtures.second.rawValue,
                 candidates: hosts,
                 identity: self.identity,
                 handshakeCache: RuntimeHostResolver.RemoteHandshakeCache(identity: self.identity),
@@ -156,7 +274,7 @@ struct SnapshotHostAffinityRuntimeTests {
 
         await #expect(throws: PreDispatchActionError.self) {
             _ = try await RuntimeHostResolver.resolveSnapshotAffinity(
-                snapshotID: "../1787675983803-1514",
+                snapshotID: "../\(SnapshotReferenceFixtures.first.rawValue)",
                 candidates: [self.candidate("/tmp/gui.sock")],
                 identity: self.identity,
                 handshakeCache: RuntimeHostResolver.RemoteHandshakeCache(identity: self.identity),
@@ -176,7 +294,7 @@ struct SnapshotHostAffinityRuntimeTests {
         for candidates in [hosts, Array(hosts.reversed())] {
             await #expect(throws: PreDispatchActionError.self) {
                 _ = try await RuntimeHostResolver.resolveSnapshotAffinity(
-                    snapshotID: "1787675983803-1514",
+                    snapshotID: SnapshotReferenceFixtures.first.rawValue,
                     candidates: candidates,
                     identity: self.identity,
                     handshakeCache: RuntimeHostResolver.RemoteHandshakeCache(identity: self.identity),
@@ -202,13 +320,82 @@ struct SnapshotHostAffinityRuntimeTests {
     }
 
     @Test
+    func `full runtime accepts an explicit socket only when that host owns the snapshot`() async throws {
+        let snapshots = InMemorySnapshotManager()
+        let snapshotID = try await snapshots.createSnapshot()
+        let socketPath = "/tmp/peekaboo-explicit-owner-\(UUID().uuidString).sock"
+        let host = try await self.startHost(
+            socketPath: socketPath,
+            hostKind: .onDemand,
+            snapshots: snapshots
+        )
+        defer { Task { await host.stop() } }
+        var options = CommandRuntimeOptions()
+        options.bridgeSocketPath = socketPath
+        options.explicitSnapshotID = snapshotID
+        let dependencies = RuntimeHostResolver.Dependencies(
+            makeLocalServices: { _ in PeekabooServices(snapshotManager: InMemorySnapshotManager()) },
+            claimScreenCaptureKitOwner: { throw POSIXError(.EPERM) },
+            inspectScreenCaptureKitOwner: { nil },
+            remoteCandidatePlan: { _, _ in self.explicitPlan(socketPath: socketPath) },
+            makeRemoteHandshakeCache: { self.authenticatedHandshakeCache() }
+        )
+
+        let resolution = try await RuntimeHostResolver.resolveServices(
+            options: options,
+            environment: [:],
+            configurationInput: nil,
+            dependencies: dependencies
+        )
+
+        #expect(resolution.selectedRemoteSocketPath == socketPath)
+        #expect(try await resolution.services.snapshots.ownsSnapshot(snapshotId: snapshotID))
+        await host.stop()
+    }
+
+    @Test
+    func `full runtime refuses an explicit socket that does not own the snapshot`() async throws {
+        let socketPath = "/tmp/peekaboo-explicit-nonowner-\(UUID().uuidString).sock"
+        let host = try await self.startHost(
+            socketPath: socketPath,
+            hostKind: .onDemand,
+            snapshots: InMemorySnapshotManager()
+        )
+        defer { Task { await host.stop() } }
+        var options = CommandRuntimeOptions()
+        options.bridgeSocketPath = socketPath
+        options.explicitSnapshotID = SnapshotReferenceFixtures.first.rawValue
+        let dependencies = RuntimeHostResolver.Dependencies(
+            makeLocalServices: { _ in PeekabooServices(snapshotManager: InMemorySnapshotManager()) },
+            claimScreenCaptureKitOwner: { throw POSIXError(.EPERM) },
+            inspectScreenCaptureKitOwner: { nil },
+            remoteCandidatePlan: { _, _ in self.explicitPlan(socketPath: socketPath) },
+            makeRemoteHandshakeCache: { self.authenticatedHandshakeCache() }
+        )
+
+        do {
+            _ = try await RuntimeHostResolver.resolveServices(
+                options: options,
+                environment: [:],
+                configurationInput: nil,
+                dependencies: dependencies
+            )
+            Issue.record("Expected explicit non-owner refusal")
+        } catch let error as PreDispatchActionError {
+            #expect(error.code == .SNAPSHOT_NOT_FOUND)
+            #expect(error.localizedDescription.contains("no unique live host affinity"))
+        }
+        await host.stop()
+    }
+
+    @Test
     func `unavailable affinity probes complete concurrently`() async {
         let hosts = (0..<4).map { self.candidate("/tmp/slow-\($0).sock") }
         let startedAt = ContinuousClock.now
 
         await #expect(throws: PreDispatchActionError.self) {
             _ = try await RuntimeHostResolver.resolveSnapshotAffinity(
-                snapshotID: "1787675983803-1514",
+                snapshotID: SnapshotReferenceFixtures.first.rawValue,
                 candidates: hosts,
                 identity: self.identity,
                 handshakeCache: RuntimeHostResolver.RemoteHandshakeCache(identity: self.identity),
@@ -219,6 +406,146 @@ struct SnapshotHostAffinityRuntimeTests {
             )
         }
         #expect(startedAt.duration(to: .now) < .milliseconds(350))
+    }
+
+    @Test
+    func `dishonest ownership capability is classified as incompatible`() async throws {
+        let snapshots = SnapshotMutationRecordingManager(wrapping: InMemorySnapshotManager())
+        snapshots.ownsSnapshotError = PeekabooBridgeErrorEnvelope(
+            code: .operationNotSupported,
+            message: "Injected dishonest capability"
+        )
+        let socketPath = "/tmp/peekaboo-dishonest-owner-\(UUID().uuidString).sock"
+        let host = try await self.startHost(
+            socketPath: socketPath,
+            hostKind: .onDemand,
+            snapshots: snapshots
+        )
+        defer { Task { await host.stop() } }
+        let candidate = self.candidate(socketPath)
+        let cache = self.authenticatedHandshakeCache()
+
+        let result = try await RuntimeHostResolver.liveSnapshotAffinityProbe(
+            candidate,
+            SnapshotReferenceFixtures.first.rawValue,
+            self.identity,
+            cache
+        )
+
+        #expect(result == .incompatible)
+        #expect(snapshots.ownsCalls == [SnapshotReferenceFixtures.first.rawValue])
+        await host.stop()
+    }
+
+    @Test
+    func `automatic runtime selects a caller-local snapshot owner before remote policy`() async throws {
+        let snapshots = InMemorySnapshotManager()
+        let snapshotID = try await snapshots.createSnapshot()
+        let services = PeekabooServices(snapshotManager: snapshots)
+        var probes: [String] = []
+        var options = CommandRuntimeOptions()
+        options.explicitSnapshotID = snapshotID
+        options.inputStrategy = .actionFirst
+        let remote = self.candidate("/tmp/nonowner.sock")
+        let resolution = try await RuntimeHostResolver.resolveServices(
+            options: options,
+            environment: [:],
+            configurationInput: nil,
+            dependencies: self.dependencies(
+                localServices: services,
+                candidates: [remote],
+                probe: { candidate, _, _, _ in
+                    probes.append(candidate.socketPath)
+                    return .missing
+                }
+            )
+        )
+
+        #expect(resolution.selectedRemoteSocketPath == nil)
+        #expect(resolution.hostDescription == "local (snapshot producer)")
+        #expect(Set(probes) == Set([
+            remote.socketPath,
+            "/tmp/daemon.sock",
+            PeekabooBridgeConstants.peekabooSocketPath,
+            PeekabooBridgeConstants.claudeSocketPath,
+            PeekabooBridgeConstants.clawdbotSocketPath,
+        ]))
+    }
+
+    @Test
+    func `force-local snapshot routing verifies only local ownership`() async throws {
+        let snapshots = InMemorySnapshotManager()
+        let owned = try await snapshots.createSnapshot()
+        let services = PeekabooServices(snapshotManager: snapshots)
+        var probeCount = 0
+        var planCount = 0
+        var options = CommandRuntimeOptions()
+        options.explicitSnapshotID = owned
+        let dependencies = RuntimeHostResolver.Dependencies(
+            makeLocalServices: { _ in services },
+            claimScreenCaptureKitOwner: { throw POSIXError(.EPERM) },
+            inspectScreenCaptureKitOwner: { nil },
+            remoteCandidatePlan: { _, _ in
+                planCount += 1
+                return self.plan(candidates: [self.candidate("/tmp/unused.sock")])
+            },
+            snapshotAffinityProbe: { _, _, _, _ in
+                probeCount += 1
+                return .owner
+            }
+        )
+        let resolution = try await RuntimeHostResolver.resolveServices(
+            options: options,
+            environment: ["PEEKABOO_NO_REMOTE": "1"],
+            configurationInput: nil,
+            dependencies: dependencies
+        )
+
+        #expect(resolution.selectedRemoteSocketPath == nil)
+        #expect(try await resolution.services.snapshots.ownsSnapshot(snapshotId: owned))
+        #expect(planCount == 0)
+        #expect(probeCount == 0)
+
+        options.explicitSnapshotID = SnapshotReferenceFixtures.second.rawValue
+        await #expect(throws: PreDispatchActionError.self) {
+            _ = try await RuntimeHostResolver.resolveServices(
+                options: options,
+                environment: ["PEEKABOO_NO_REMOTE": "1"],
+                configurationInput: nil,
+                dependencies: dependencies
+            )
+        }
+        #expect(planCount == 0)
+        #expect(probeCount == 0)
+    }
+
+    @Test
+    func `malformed concrete runtime reference is validation error before policy or probes`() async {
+        let services = PeekabooServices(snapshotManager: InMemorySnapshotManager())
+        var probeCount = 0
+        var options = CommandRuntimeOptions()
+        options.explicitSnapshotID = "1787675983803-1514"
+        do {
+            _ = try await RuntimeHostResolver.resolveServices(
+                options: options,
+                environment: ["PEEKABOO_NO_REMOTE": "1"],
+                configurationInput: nil,
+                dependencies: self.dependencies(
+                    localServices: services,
+                    candidates: [],
+                    probe: { _, _, _, _ in
+                        probeCount += 1
+                        return .owner
+                    }
+                )
+            )
+            Issue.record("Expected malformed snapshot refusal")
+        } catch let error as PreDispatchActionError {
+            #expect(error.code == .VALIDATION_ERROR)
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+        #expect(probeCount == 0)
     }
 
     private var identity: PeekabooBridgeClientIdentity {
@@ -238,17 +565,75 @@ struct SnapshotHostAffinityRuntimeTests {
         )
     }
 
+    private func plan(
+        candidates: [RuntimeHostResolver.ImplicitRemoteCandidate]
+    ) -> RuntimeHostResolver.RemoteCandidatePlan {
+        RuntimeHostResolver.RemoteCandidatePlan(
+            explicitSocket: nil,
+            daemonSocketPath: "/tmp/daemon.sock",
+            runtimeBuildIdentity: "snapshot-tests",
+            buildScopedDaemonSocketPath: nil,
+            historicalBuildScopedDaemonSocketPaths: [],
+            candidates: candidates
+        )
+    }
+
+    private func explicitPlan(socketPath: String) -> RuntimeHostResolver.RemoteCandidatePlan {
+        let explicit = self.candidate(socketPath)
+        return RuntimeHostResolver.RemoteCandidatePlan(
+            explicitSocket: socketPath,
+            daemonSocketPath: "/tmp/daemon.sock",
+            runtimeBuildIdentity: "snapshot-tests",
+            buildScopedDaemonSocketPath: nil,
+            historicalBuildScopedDaemonSocketPaths: [],
+            candidates: [explicit]
+        )
+    }
+
+    private func authenticatedHandshakeCache() -> RuntimeHostResolver.RemoteHandshakeCache {
+        RuntimeHostResolver.RemoteHandshakeCache(
+            identity: self.identity,
+            clientFactory: { BridgeTestFixtures.authenticatedClient(socketPath: $0) }
+        )
+    }
+
+    private func dependencies(
+        localServices: PeekabooServices,
+        candidates: [RuntimeHostResolver.ImplicitRemoteCandidate],
+        probe: @escaping RuntimeHostResolver.SnapshotAffinityProbe
+    ) -> RuntimeHostResolver.Dependencies {
+        RuntimeHostResolver.Dependencies(
+            makeLocalServices: { _ in localServices },
+            claimScreenCaptureKitOwner: { throw POSIXError(.EPERM) },
+            inspectScreenCaptureKitOwner: { nil },
+            remoteCandidatePlan: { _, _ in self.plan(candidates: candidates) },
+            snapshotAffinityProbe: probe
+        )
+    }
+
     private func startHost(
         socketPath: String,
         hostKind: PeekabooBridgeHostKind,
-        snapshots: InMemorySnapshotManager
+        snapshots: any SnapshotManagerProtocol,
+        allowedOperations: Set<PeekabooBridgeOperation>? = nil
     ) async throws -> PeekabooBridgeHost {
-        let server = PeekabooBridgeServer(
-            services: PeekabooServices(snapshotManager: snapshots),
-            hostKind: hostKind,
-            allowlistedTeams: [],
-            allowlistedBundles: []
-        )
+        let services = PeekabooServices(snapshotManager: snapshots)
+        let server = if let allowedOperations {
+            PeekabooBridgeServer(
+                services: services,
+                hostKind: hostKind,
+                allowlistedTeams: [],
+                allowlistedBundles: [],
+                allowedOperations: allowedOperations
+            )
+        } else {
+            PeekabooBridgeServer(
+                services: services,
+                hostKind: hostKind,
+                allowlistedTeams: [],
+                allowlistedBundles: []
+            )
+        }
         let host = PeekabooBridgeHost(
             socketPath: socketPath,
             server: server,

--- a/Apps/CLI/Tests/CoreCLITests/StatelessClickRuntimeTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/StatelessClickRuntimeTests.swift
@@ -2,6 +2,7 @@ import Commander
 import PeekabooAutomationKit
 import PeekabooBridge
 import PeekabooBridgeTestSupport
+import PeekabooFoundationTestSupport
 import Testing
 @testable import PeekabooCLI
 
@@ -105,7 +106,7 @@ struct StatelessClickRuntimeTests {
         let runtimeOptions = try CommanderCLIBinder.makeRuntimeOptions(
             from: ParsedValues(
                 positional: [],
-                options: ["modifiers": ["cmd"], "snapshot": ["snapshot"]],
+                options: ["modifiers": ["cmd"], "snapshot": [SnapshotReferenceFixtures.first.rawValue]],
                 flags: ["foreground"]
             ),
             commandType: ClickCommand.self
@@ -159,7 +160,7 @@ struct StatelessClickRuntimeTests {
         let runtimeOptions = try CommanderCLIBinder.makeRuntimeOptions(
             from: ParsedValues(
                 positional: ["hello"],
-                options: ["at": ["10,20"], "snapshot": ["snapshot"]],
+                options: ["at": ["10,20"], "snapshot": [SnapshotReferenceFixtures.first.rawValue]],
                 flags: []
             ),
             commandType: TypeCommand.self

--- a/Apps/CLI/Tests/CoreCLITests/TestTags.swift
+++ b/Apps/CLI/Tests/CoreCLITests/TestTags.swift
@@ -1,5 +1,39 @@
 import Foundation
+import PeekabooBridge
 import Testing
+
+extension PeekabooBridgeHandshakeResponse {
+    func withProducerBoundSnapshotFixture() -> PeekabooBridgeHandshakeResponse {
+        var supportedOperations = self.supportedOperations
+        if !supportedOperations.contains(.ownsSnapshot) {
+            supportedOperations.append(.ownsSnapshot)
+        }
+        var enabledOperations = self.enabledOperations
+        if enabledOperations != nil, enabledOperations?.contains(.ownsSnapshot) != true {
+            enabledOperations?.append(.ownsSnapshot)
+        }
+        var hostCapabilities = self.hostCapabilities ?? []
+        for capability in [
+            PeekabooBridgeHostCapability.attestedOperationReceipts,
+            PeekabooBridgeHostCapability.producerBoundSnapshotReferences,
+        ] where !hostCapabilities.contains(capability) {
+            hostCapabilities.append(capability)
+        }
+        return PeekabooBridgeHandshakeResponse(
+            negotiatedVersion: self.negotiatedVersion,
+            hostKind: self.hostKind,
+            build: self.build,
+            supportedOperations: supportedOperations,
+            permissions: self.permissions,
+            enabledOperations: enabledOperations,
+            permissionTags: self.permissionTags,
+            hostIdentity: self.hostIdentity,
+            hostCapabilities: hostCapabilities,
+            operationAttestation: self.operationAttestation,
+            operationSessionAttestation: self.operationSessionAttestation
+        )
+    }
+}
 
 extension Tag {
     // Test categories

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,18 +2,6 @@
 
 ## Unreleased
 
-### Fixed
-
-- Bind Bridge 1.34 Chrome channel connections to an exact live Chrome bundle, native process-owned DevTools listener, and approval-gated WebSocket under one 90-second deadline, verifying `Browser.getVersion` once without legacy HTTP discovery or repeated permission probes and failing closed on helper-service names, file, socket, generation, or endpoint drift.
-- Authenticate native Chrome channels against Google Team ID `EQHXZ8M8AV`, pin the exact signed identifier and CDHash for the process generation, and enumerate the target process's complete listener inventory independently of Peekaboo's file-descriptor limit.
-- Honor the configured default save directory for pathless pixel-only `see` captures and add collision-resistant generated filenames for concurrent callers, while preserving explicit paths and stdout streaming. Thanks @PollyBot13 for #607.
-- Preserve the exact browser target-lock refusal so reconnecting to a different live Chrome channel or endpoint tells callers to disconnect first instead of reporting a generic unavailable target.
-- Advertise only actions and input shapes reachable under immutable background-only authority, while keeping foreground-capable app, Dock, Space, dialog, menu, browser, clipboard, and paste workflows explicit.
-- Emit one lossless target identity and process-generation receipt across CLI envelopes and App MCP responses, preventing extra metadata from overriding the canonical target.
-- Prefer a sole live child sheet or alert beneath its exact structural parent window, preserve multi-child ambiguity, and keep parent-window recovery guidance intact across remote dialog reads.
-
-## [4.2.3] - 2026-08-23
-
 ### Highlights
 
 - **Credentials and provider authentication are safer.** Secure prompts, stdin, and owner-only files keep secrets out of process lists, while Gemini, OAuth, clipboard, and editor workflows receive additional hardening.
@@ -37,6 +25,15 @@
 - Reuse validated classic PNG bytes when capture performs no transform instead of encoding the same image twice.
 
 ### Fixed
+- Bind Bridge 1.34 Chrome channel connections to an exact live Chrome bundle, native process-owned DevTools listener, and approval-gated WebSocket under one 90-second deadline, verifying `Browser.getVersion` once without legacy HTTP discovery or repeated permission probes and failing closed on helper-service names, file, socket, generation, or endpoint drift.
+- Authenticate native Chrome channels against Google Team ID `EQHXZ8M8AV`, pin the exact signed identifier and CDHash for the process generation, and enumerate the target process's complete listener inventory independently of Peekaboo's file-descriptor limit.
+- Honor the configured default save directory for pathless pixel-only `see` captures and add collision-resistant generated filenames for concurrent callers, while preserving explicit paths and stdout streaming. Thanks @PollyBot13 for #607.
+- Preserve the exact browser target-lock refusal so reconnecting to a different live Chrome channel or endpoint tells callers to disconnect first instead of reporting a generic unavailable target.
+- Advertise only actions and input shapes reachable under immutable background-only authority, while keeping foreground-capable app, Dock, Space, dialog, menu, browser, clipboard, and paste workflows explicit.
+- Emit one lossless target identity and process-generation receipt across CLI envelopes and App MCP responses, preventing extra metadata from overriding the canonical target.
+- Prefer a sole live child sheet or alert beneath its exact structural parent window, preserve multi-child ambiguity, and keep parent-window recovery guidance intact across remote dialog reads.
+- Bind snapshots to cryptographically random `ps1_` references owned by their creating local or Bridge host, route concrete references to one authenticated producer before normal host preference, and refuse malformed, stale, duplicated, incapable, or explicitly misrouted hosts before publication or input.
+- Keep Bridge 1.34 snapshot ownership and Accessibility-value click policy independently capability-gated, preserve omitted-policy behavior for old clients, enforce explicit opt-outs before dispatch, and retain cleanup-only removal of legacy timestamp snapshot directories without making their IDs actionable.
 - Resolve repeated stable window inventory rows consistently across CLI and MCP instead of falsely reporting ambiguity.
 - Downscale straight-alpha legacy screenshots to logical 1x instead of silently returning Retina-sized pixels.
 - Bound exclusive ScreenCaptureKit transaction-lock waits inside the Bridge request envelope so a wedged peer fails clearly instead of hanging capture indefinitely. Thanks @SebTardif for #599.

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Core/Models/Snapshot.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Core/Models/Snapshot.swift
@@ -185,6 +185,7 @@ public nonisolated struct MenuBarData: Codable, Sendable {
 
 /// Snapshot storage error types
 public enum SnapshotError: LocalizedError, Sendable {
+    case invalidSnapshotReference(String)
     case snapshotNotFound
     case noValidSnapshotFound
     case versionMismatch(found: Int, expected: Int)
@@ -193,6 +194,8 @@ public enum SnapshotError: LocalizedError, Sendable {
 
     public var errorDescription: String? {
         switch self {
+        case let .invalidSnapshotReference(reference):
+            "Invalid snapshot reference '\(reference)'; expected ps1_ followed by 32 lowercase hexadecimal digits"
         case .snapshotNotFound:
             "Snapshot not found or expired"
         case .noValidSnapshotFound:

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Core/Protocols/FileServiceProtocol.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Core/Protocols/FileServiceProtocol.swift
@@ -147,7 +147,8 @@ public enum FileServiceError: LocalizedError, Sendable {
     public var errorDescription: String? {
         switch self {
         case .invalidSnapshotID:
-            "Invalid snapshot ID: expected one folder name"
+            "Invalid snapshot ID: expected ps1_ plus 32 lowercase hex digits, or a cleanup-only legacy " +
+                "timestamp in 1234567890123-1234 form"
         case let .snapshotNotFound(snapshotId):
             "Snapshot '\(snapshotId)' not found"
         case let .directoryNotFound(url):

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Core/Protocols/SnapshotManagerProtocol.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Core/Protocols/SnapshotManagerProtocol.swift
@@ -2,6 +2,8 @@ import CoreGraphics
 import Foundation
 import PeekabooFoundation
 
+public typealias SnapshotReferenceGenerator = @MainActor @Sendable () -> SnapshotReference
+
 /// Durable, single-use claim acquired immediately before a snapshot-backed UI mutation.
 public struct SnapshotMutationLease: Codable, Equatable, Sendable {
     public let snapshotId: String
@@ -84,6 +86,9 @@ public protocol SnapshotManagerProtocol: Sendable {
     /// Whether this manager can publish snapshots that remain excluded from implicit latest lookup.
     var supportsExplicitSnapshotPublication: Bool { get }
 
+    /// Whether every created snapshot uses a producer-bound `ps1_` authority and strict ownership checks.
+    var supportsProducerBoundSnapshotReferences: Bool { get }
+
     /// Effective desktop-wide cutoff applied to implicit latest-snapshot lookup.
     /// Managers without a shared watermark can rely on the default `nil` implementation.
     var effectiveImplicitLatestInvalidationWatermark: Date? { get }
@@ -100,6 +105,12 @@ public protocol SnapshotManagerProtocol: Sendable {
     /// Explicit-only snapshots participate in normal retention, cleanup, and mutation leasing, but never replace
     /// the element-producing snapshot returned by implicit latest lookup.
     func createExplicitSnapshot() async throws -> String
+
+    /// Return whether this manager created and still owns the canonical snapshot reference.
+    ///
+    /// A syntactically invalid reference throws ``SnapshotError/invalidSnapshotReference(_:)``;
+    /// a canonical reference owned by another producer returns `false`.
+    func ownsSnapshot(snapshotId: String) async throws -> Bool
 
     /// Store element detection results in a snapshot
     /// - Parameters:
@@ -228,6 +239,10 @@ extension SnapshotManagerProtocol {
         false
     }
 
+    public var supportsProducerBoundSnapshotReferences: Bool {
+        false
+    }
+
     public var effectiveImplicitLatestInvalidationWatermark: Date? {
         nil
     }
@@ -240,6 +255,13 @@ extension SnapshotManagerProtocol {
     public func createExplicitSnapshot() async throws -> String {
         throw SnapshotError.storageError(
             "This snapshot manager does not support explicit-reference-only snapshots")
+    }
+
+    public func ownsSnapshot(snapshotId: String) async throws -> Bool {
+        guard SnapshotReference(rawValue: snapshotId) != nil else {
+            throw SnapshotError.invalidSnapshotReference(snapshotId)
+        }
+        return false
     }
 
     public func storeObservationSnapshot(_ request: SnapshotObservationPublicationRequest) async throws {

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Core/Protocols/UIAutomationServiceProtocol.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Core/Protocols/UIAutomationServiceProtocol.swift
@@ -303,8 +303,23 @@ public protocol UIAutomationActionOutcomeProviding: UIAutomationServiceProtocol 
         target: ClickTarget,
         clickType: ClickType,
         snapshotId: String?,
+        expectedProcessIdentity: ApplicationProcessIdentity,
+        allowsAccessibilityValueDelivery: Bool) async throws -> UIAutomationActionResult<Void>
+
+    func clickWithOutcome(
+        target: ClickTarget,
+        clickType: ClickType,
+        snapshotId: String?,
         expectedWindowIdentity: WindowMutationIdentity,
         expectedWindowBounds: CGRect) async throws -> UIAutomationActionResult<Void>
+
+    func clickWithOutcome(
+        target: ClickTarget,
+        clickType: ClickType,
+        snapshotId: String?,
+        expectedWindowIdentity: WindowMutationIdentity,
+        expectedWindowBounds: CGRect,
+        allowsAccessibilityValueDelivery: Bool) async throws -> UIAutomationActionResult<Void>
 
     func typeWithOutcome(
         text: String,
@@ -379,6 +394,46 @@ public protocol UIAutomationActionOutcomeProviding: UIAutomationServiceProtocol 
         target: String,
         actionName: String,
         snapshotId: String?) async throws -> UIAutomationActionResult<ElementActionResult>
+}
+
+extension UIAutomationActionOutcomeProviding {
+    public func clickWithOutcome(
+        target: ClickTarget,
+        clickType: ClickType,
+        snapshotId: String?,
+        expectedProcessIdentity: ApplicationProcessIdentity,
+        allowsAccessibilityValueDelivery: Bool) async throws -> UIAutomationActionResult<Void>
+    {
+        guard allowsAccessibilityValueDelivery else {
+            throw PeekabooError.serviceUnavailable(
+                "This automation service cannot enforce an accessibility-value click opt-out")
+        }
+        return try await self.clickWithOutcome(
+            target: target,
+            clickType: clickType,
+            snapshotId: snapshotId,
+            expectedProcessIdentity: expectedProcessIdentity)
+    }
+
+    public func clickWithOutcome(
+        target: ClickTarget,
+        clickType: ClickType,
+        snapshotId: String?,
+        expectedWindowIdentity: WindowMutationIdentity,
+        expectedWindowBounds: CGRect,
+        allowsAccessibilityValueDelivery: Bool) async throws -> UIAutomationActionResult<Void>
+    {
+        guard allowsAccessibilityValueDelivery else {
+            throw PeekabooError.serviceUnavailable(
+                "This automation service cannot enforce an accessibility-value click opt-out")
+        }
+        return try await self.clickWithOutcome(
+            target: target,
+            clickType: clickType,
+            snapshotId: snapshotId,
+            expectedWindowIdentity: expectedWindowIdentity,
+            expectedWindowBounds: expectedWindowBounds)
+    }
 }
 
 /// Additive result capability for shared-pointer operations.
@@ -629,6 +684,7 @@ public protocol TargetedClickServiceProtocol: UIAutomationServiceProtocol {
     var supportsTargetedClicks: Bool { get }
     var supportsProcessGenerationPinnedClicks: Bool { get }
     var supportsStatelessClickVariants: Bool { get }
+    var supportsTargetedClickAccessibilityValueDelivery: Bool { get }
     var targetedClickUnavailableReason: String? { get }
     var targetedClickRequiresEventSynthesizingPermission: Bool { get }
 
@@ -643,6 +699,13 @@ public protocol TargetedClickServiceProtocol: UIAutomationServiceProtocol {
         clickType: ClickType,
         snapshotId: String?,
         expectedProcessIdentity: ApplicationProcessIdentity) async throws
+
+    func click(
+        target: ClickTarget,
+        clickType: ClickType,
+        snapshotId: String?,
+        expectedProcessIdentity: ApplicationProcessIdentity,
+        allowsAccessibilityValueDelivery: Bool) async throws
 }
 
 /// Optional capability for preserving an exact target window during a background click.
@@ -656,6 +719,14 @@ public protocol ExactWindowTargetedClickServiceProtocol: TargetedClickServicePro
         snapshotId: String?,
         expectedWindowIdentity: WindowMutationIdentity,
         expectedWindowBounds: CGRect) async throws
+
+    func click(
+        target: ClickTarget,
+        clickType: ClickType,
+        snapshotId: String?,
+        expectedWindowIdentity: WindowMutationIdentity,
+        expectedWindowBounds: CGRect,
+        allowsAccessibilityValueDelivery: Bool) async throws
 }
 
 extension ExactWindowTargetedClickServiceProtocol {
@@ -673,6 +744,26 @@ extension ExactWindowTargetedClickServiceProtocol {
         throw PeekabooError.serviceUnavailable(
             "Exact-window clicks require process-generation identity support")
     }
+
+    public func click(
+        target: ClickTarget,
+        clickType: ClickType,
+        snapshotId: String?,
+        expectedWindowIdentity: WindowMutationIdentity,
+        expectedWindowBounds: CGRect,
+        allowsAccessibilityValueDelivery: Bool) async throws
+    {
+        guard allowsAccessibilityValueDelivery else {
+            throw PeekabooError.serviceUnavailable(
+                "This automation service cannot enforce an accessibility-value click opt-out")
+        }
+        try await self.click(
+            target: target,
+            clickType: clickType,
+            snapshotId: snapshotId,
+            expectedWindowIdentity: expectedWindowIdentity,
+            expectedWindowBounds: expectedWindowBounds)
+    }
 }
 
 extension TargetedClickServiceProtocol {
@@ -685,6 +776,10 @@ extension TargetedClickServiceProtocol {
     }
 
     public var supportsStatelessClickVariants: Bool {
+        false
+    }
+
+    public var supportsTargetedClickAccessibilityValueDelivery: Bool {
         false
     }
 
@@ -704,6 +799,24 @@ extension TargetedClickServiceProtocol {
     {
         throw PeekabooError.serviceUnavailable(
             "This automation service does not support process-generation-pinned clicks")
+    }
+
+    public func click(
+        target: ClickTarget,
+        clickType: ClickType,
+        snapshotId: String?,
+        expectedProcessIdentity: ApplicationProcessIdentity,
+        allowsAccessibilityValueDelivery: Bool) async throws
+    {
+        guard allowsAccessibilityValueDelivery else {
+            throw PeekabooError.serviceUnavailable(
+                "This automation service cannot enforce an accessibility-value click opt-out")
+        }
+        try await self.click(
+            target: target,
+            clickType: clickType,
+            snapshotId: snapshotId,
+            expectedProcessIdentity: expectedProcessIdentity)
     }
 }
 

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/GameBridge/GameBridgeDetectionIntegration.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/GameBridge/GameBridgeDetectionIntegration.swift
@@ -82,7 +82,7 @@ extension GameBridgeDetectionService {
             other: other)
 
         return ElementDetectionResult(
-            snapshotId: snapshotId ?? UUID().uuidString,
+            snapshotId: SnapshotPublicationBinding.resultIdentifier(explicit: snapshotId),
             screenshotPath: "",
             elements: elements,
             metadata: DetectionMetadata(

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Observation/DesktopObservationService.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Observation/DesktopObservationService.swift
@@ -461,9 +461,30 @@ public final class DesktopObservationService: DesktopObservationActionResultProv
     }
 
     private func observeWithinOverallDeadline(
+        _ originalRequest: DesktopObservationRequest) async throws -> UIAutomationActionResult<DesktopObservationResult>
+    {
+        try DesktopObservationROIProcessor.validateRequest(originalRequest.capture.roi, target: originalRequest.target)
+        var request = originalRequest
+        let reservation = try await self.outputWriter.reserveSnapshotIfNeeded(options: request.output)
+        request.output.snapshotID = request.output.snapshotID ?? reservation?.snapshotID
+
+        do {
+            let result = try await self.observePreparedRequest(request)
+            if let reservation {
+                try await self.outputWriter.publishReservedSnapshot(reservation)
+            }
+            return result
+        } catch {
+            if let reservation {
+                try? await self.outputWriter.cleanReservedSnapshot(snapshotID: reservation.snapshotID)
+            }
+            throw error
+        }
+    }
+
+    private func observePreparedRequest(
         _ request: DesktopObservationRequest) async throws -> UIAutomationActionResult<DesktopObservationResult>
     {
-        try DesktopObservationROIProcessor.validateRequest(request.capture.roi, target: request.target)
         let tracer = DesktopObservationTraceRecorder()
         let observeStart = ContinuousClock.now
         let serializesDetection =

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Observation/ObservationOCRService.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Observation/ObservationOCRService.swift
@@ -809,7 +809,9 @@ public enum ObservationOCRMapper {
             minConfidence: minConfidence)
         let grouped = DetectedElements(other: elements)
         return ElementDetectionResult(
-            snapshotId: snapshotID ?? "ocr-\(UUID().uuidString)",
+            snapshotId: SnapshotPublicationBinding.resultIdentifier(
+                explicit: snapshotID,
+                transientPrefix: "ocr"),
             screenshotPath: screenshotPath,
             elements: grouped,
             metadata: DetectionMetadata(

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Observation/ObservationOutputWriter.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Observation/ObservationOutputWriter.swift
@@ -2,6 +2,11 @@ import AppKit
 import Foundation
 import PeekabooFoundation
 
+struct ObservationSnapshotReservation: Sendable {
+    let snapshotID: String
+    let observationStartedAt: Date
+}
+
 @MainActor
 public final class ObservationOutputWriter {
     private let snapshotManager: (any SnapshotManagerProtocol)?
@@ -57,6 +62,51 @@ public final class ObservationOutputWriter {
 
     public nonisolated static func annotatedScreenshotPath(forRawScreenshotPath rawPath: String) -> String {
         (rawPath as NSString).deletingPathExtension + "_annotated.png"
+    }
+
+    func reserveSnapshotIfNeeded(options: DesktopObservationOutputOptions) async throws
+        -> ObservationSnapshotReservation?
+    {
+        guard options.saveSnapshot, options.snapshotID == nil, let snapshotManager else {
+            return nil
+        }
+        guard snapshotManager.supportsProducerBoundSnapshotReferences,
+              snapshotManager.supportsImplicitLatestSnapshotInvalidation
+        else {
+            throw SnapshotError.storageError(
+                "This snapshot manager cannot reserve a producer-bound observation until publication")
+        }
+        let observationStartedAt = Date()
+        let snapshotID = try await snapshotManager.createSnapshot(pendingAt: observationStartedAt)
+        guard SnapshotReference(rawValue: snapshotID) != nil else {
+            try? await snapshotManager.cleanSnapshot(snapshotId: snapshotID)
+            throw SnapshotError.invalidSnapshotReference(snapshotID)
+        }
+        guard try await snapshotManager.ownsSnapshot(snapshotId: snapshotID) else {
+            try? await snapshotManager.cleanSnapshot(snapshotId: snapshotID)
+            throw SnapshotError.storageError(
+                "The snapshot manager did not retain ownership of its observation reservation")
+        }
+        return ObservationSnapshotReservation(
+            snapshotID: snapshotID,
+            observationStartedAt: observationStartedAt)
+    }
+
+    func publishReservedSnapshot(_ reservation: ObservationSnapshotReservation) async throws {
+        guard let snapshotManager else {
+            throw SnapshotError.storageError("The snapshot manager disappeared before observation publication")
+        }
+        _ = try await snapshotManager.invalidateImplicitLatestSnapshot(
+            through: reservation.observationStartedAt,
+            preserving: reservation.snapshotID,
+            preservedAt: Date())
+        guard try await snapshotManager.ownsSnapshot(snapshotId: reservation.snapshotID) else {
+            throw SnapshotError.snapshotNotFound
+        }
+    }
+
+    func cleanReservedSnapshot(snapshotID: String) async throws {
+        try await self.snapshotManager?.cleanSnapshot(snapshotId: snapshotID)
     }
 
     private func writeRawScreenshotIfNeeded(

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Support/InMemorySnapshotManager+Lifecycle.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Support/InMemorySnapshotManager+Lifecycle.swift
@@ -1,4 +1,5 @@
 import Foundation
+import PeekabooFoundation
 
 extension InMemorySnapshotManager {
     // MARK: - Snapshot lifecycle
@@ -21,9 +22,7 @@ extension InMemorySnapshotManager {
     {
         self.pruneIfNeeded()
 
-        let timestamp = Int(Date().timeIntervalSince1970 * 1000) // milliseconds
-        let randomSuffix = Int.random(in: 1000...9999)
-        let snapshotId = "\(timestamp)-\(randomSuffix)"
+        let snapshotId = try self.nextSnapshotID()
 
         let now = Date()
         self.entries[snapshotId] = Entry(
@@ -39,17 +38,23 @@ extension InMemorySnapshotManager {
         return snapshotId
     }
 
+    private func nextSnapshotID() throws -> String {
+        for _ in 0..<8 {
+            let snapshotId = self.snapshotReferenceGenerator().rawValue
+            if self.entries[snapshotId] == nil {
+                return snapshotId
+            }
+        }
+        throw SnapshotError.storageError("Could not reserve a unique producer-bound snapshot reference")
+    }
+
     public func storeDetectionResult(snapshotId: String, result: ElementDetectionResult) async throws {
         self.pruneIfNeeded()
-
-        var entry = self.entries[snapshotId] ?? Entry(
-            createdAt: Date(),
-            lastAccessedAt: Date(),
-            processId: getpid(),
-            isPending: false,
-            isImplicitLatestEligible: true,
-            detectionResult: nil,
-            snapshotData: UIAutomationSnapshot(creatorProcessId: getpid()))
+        var entry = try self.requireEntry(for: snapshotId)
+        try SnapshotPublicationBinding.validate(
+            snapshotId: snapshotId,
+            detectionResult: result,
+            captureCoordinateContext: result.metadata.captureCoordinateContext)
 
         entry.lastAccessedAt = Date()
         self.applyDetectionResult(result, to: &entry.snapshotData)
@@ -63,6 +68,7 @@ extension InMemorySnapshotManager {
     }
 
     public func getDetectionResult(snapshotId: String) async throws -> ElementDetectionResult? {
+        try self.validateSnapshotReference(snapshotId)
         guard var entry = self.entries[snapshotId] else { return nil }
         entry.lastAccessedAt = Date()
         self.entries[snapshotId] = entry
@@ -220,8 +226,14 @@ extension InMemorySnapshotManager {
     }
 
     public func cleanSnapshot(snapshotId: String) async throws {
+        try self.validateSnapshotReference(snapshotId)
         self.mutationLeases.removeValue(forKey: snapshotId)
         self.removeEntry(forSnapshotId: snapshotId)
+    }
+
+    public func ownsSnapshot(snapshotId: String) async throws -> Bool {
+        try self.validateSnapshotReference(snapshotId)
+        return self.entries[snapshotId] != nil
     }
 
     public func cleanSnapshotsOlderThan(days: Int) async throws -> Int {

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Support/InMemorySnapshotManager+MutationLease.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Support/InMemorySnapshotManager+MutationLease.swift
@@ -3,9 +3,7 @@ import PeekabooFoundation
 
 extension InMemorySnapshotManager {
     public func beginSnapshotMutation(snapshotId: String) async throws -> SnapshotMutationLease {
-        guard self.entries[snapshotId] != nil else {
-            throw SnapshotError.snapshotNotFound
-        }
+        _ = try self.requireEntry(for: snapshotId)
         guard self.mutationLeases[snapshotId] == nil else {
             throw PeekabooError.snapshotStale(
                 "Snapshot '\(snapshotId)' already drove a mutation whose result requires a fresh observation. " +
@@ -21,6 +19,7 @@ extension InMemorySnapshotManager {
         _ lease: SnapshotMutationLease,
         requiresFreshObservation: Bool) async throws
     {
+        try self.validateSnapshotReference(lease.snapshotId)
         guard let state = self.mutationLeases[lease.snapshotId], state.lease == lease else {
             throw SnapshotError.storageError(
                 "Mutation lease for snapshot '\(lease.snapshotId)' changed before completion")

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Support/InMemorySnapshotManager+Screenshots.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Support/InMemorySnapshotManager+Screenshots.swift
@@ -7,18 +7,14 @@ extension InMemorySnapshotManager {
 
     public func storeScreenshot(_ request: SnapshotScreenshotRequest) async throws {
         self.pruneIfNeeded()
+        var entry = try self.requireEntry(for: request.snapshotId)
+        try SnapshotPublicationBinding.validate(
+            snapshotId: request.snapshotId,
+            captureCoordinateContext: request.captureCoordinateContext)
         let storedPath = try self.storedArtifactPath(
             sourcePath: request.screenshotPath,
             preferredName: "raw")
 
-        var entry = self.entries[request.snapshotId] ?? Entry(
-            createdAt: Date(),
-            lastAccessedAt: Date(),
-            processId: getpid(),
-            isPending: false,
-            isImplicitLatestEligible: true,
-            detectionResult: nil,
-            snapshotData: UIAutomationSnapshot(creatorProcessId: getpid()))
         if self.options.copyArtifactsOnStore {
             self.deleteManagedTemporaryArtifacts(for: entry.snapshotData)
         }
@@ -43,6 +39,11 @@ extension InMemorySnapshotManager {
     }
 
     public func storeObservationSnapshot(_ request: SnapshotObservationPublicationRequest) async throws {
+        var entry = try self.requireEntry(for: request.screenshot.snapshotId)
+        try SnapshotPublicationBinding.validate(
+            snapshotId: request.screenshot.snapshotId,
+            detectionResult: request.detectionResult,
+            captureCoordinateContext: request.screenshot.captureCoordinateContext)
         let storedRawPath = try self.storedArtifactPath(
             sourcePath: request.screenshot.screenshotPath,
             preferredName: "raw")
@@ -58,14 +59,6 @@ extension InMemorySnapshotManager {
             throw error
         }
 
-        var entry = self.entries[request.screenshot.snapshotId] ?? Entry(
-            createdAt: Date(),
-            lastAccessedAt: Date(),
-            processId: getpid(),
-            isPending: false,
-            isImplicitLatestEligible: true,
-            detectionResult: nil,
-            snapshotData: UIAutomationSnapshot(creatorProcessId: getpid()))
         // Pending visibility belongs to the outer mutation coordinator. Ordinary reservations are already visible;
         // web-focus observations must stay pending until their mutation and preservation boundary is published.
         let previousSnapshotData = entry.snapshotData
@@ -104,18 +97,10 @@ extension InMemorySnapshotManager {
 
     public func storeAnnotatedScreenshot(snapshotId: String, annotatedScreenshotPath: String) async throws {
         self.pruneIfNeeded()
+        var entry = try self.requireEntry(for: snapshotId)
         let storedPath = try self.storedArtifactPath(
             sourcePath: annotatedScreenshotPath,
             preferredName: "annotated")
-
-        var entry = self.entries[snapshotId] ?? Entry(
-            createdAt: Date(),
-            lastAccessedAt: Date(),
-            processId: getpid(),
-            isPending: false,
-            isImplicitLatestEligible: true,
-            detectionResult: nil,
-            snapshotData: UIAutomationSnapshot(creatorProcessId: getpid()))
 
         entry.lastAccessedAt = Date()
         if self.options.copyArtifactsOnStore,
@@ -131,18 +116,14 @@ extension InMemorySnapshotManager {
     }
 
     public func getElement(snapshotId: String, elementId: String) async throws -> UIElement? {
-        guard var entry = self.entries[snapshotId] else {
-            throw SnapshotError.snapshotNotFound
-        }
+        var entry = try self.requireEntry(for: snapshotId)
         entry.lastAccessedAt = Date()
         self.entries[snapshotId] = entry
         return entry.snapshotData.uiMap[elementId]
     }
 
     public func findElements(snapshotId: String, matching query: String) async throws -> [UIElement] {
-        guard var entry = self.entries[snapshotId] else {
-            throw SnapshotError.snapshotNotFound
-        }
+        var entry = try self.requireEntry(for: snapshotId)
         entry.lastAccessedAt = Date()
         self.entries[snapshotId] = entry
 
@@ -165,6 +146,7 @@ extension InMemorySnapshotManager {
     }
 
     public func getUIAutomationSnapshot(snapshotId: String) async throws -> UIAutomationSnapshot? {
+        try self.validateSnapshotReference(snapshotId)
         guard var entry = self.entries[snapshotId] else { return nil }
         entry.lastAccessedAt = Date()
         self.entries[snapshotId] = entry

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Support/InMemorySnapshotManager.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Support/InMemorySnapshotManager.swift
@@ -3,6 +3,24 @@ import Foundation
 import os.log
 import PeekabooFoundation
 
+@MainActor
+private final class SeededSnapshotReferenceGenerator {
+    private let initial: SnapshotReference
+    private var usedInitial = false
+
+    init(initial: SnapshotReference) {
+        self.initial = initial
+    }
+
+    func next() -> SnapshotReference {
+        if !self.usedInitial {
+            self.usedInitial = true
+            return self.initial
+        }
+        return SnapshotReference.generate()
+    }
+}
+
 /// In-memory implementation of `SnapshotManagerProtocol`.
 ///
 /// Unlike `SnapshotManager`, this manager does not persist snapshot state to disk and is ideal for long-lived host apps
@@ -12,6 +30,7 @@ public final class InMemorySnapshotManager: SnapshotManagerProtocol {
     public let supportsImplicitLatestSnapshotInvalidation = true
     public let supportsSnapshotMutationLeases = true
     public let supportsExplicitSnapshotPublication = true
+    public let supportsProducerBoundSnapshotReferences = true
     public var copiesScreenshotArtifactsIntoStorage: Bool {
         self.options.copyArtifactsOnStore
     }
@@ -81,32 +100,85 @@ public final class InMemorySnapshotManager: SnapshotManagerProtocol {
     private let logger = Logger(subsystem: "boo.peekaboo.core", category: "InMemorySnapshotManager")
     let options: Options
     let desktopMutationWatermarkStore: DesktopMutationWatermarkStore?
+    let snapshotReferenceGenerator: SnapshotReferenceGenerator
     var entries: [String: Entry] = [:]
     var implicitLatestInvalidatedAt: Date?
     var implicitLatestPreservation: ImplicitLatestPreservation?
     var mutationLeases: [String: MutationLeaseState] = [:]
 
     public init(
-        detectionResult: ElementDetectionResult? = nil,
         options: Options = Options(),
-        desktopMutationWatermarkStore: DesktopMutationWatermarkStore? = nil)
+        desktopMutationWatermarkStore: DesktopMutationWatermarkStore? = nil,
+        snapshotReferenceGenerator: @escaping SnapshotReferenceGenerator = SnapshotReference.generate)
     {
         self.options = options
         self.desktopMutationWatermarkStore = desktopMutationWatermarkStore
+        self.snapshotReferenceGenerator = snapshotReferenceGenerator
+    }
 
-        if let detectionResult {
-            let now = Date()
-            let snapshotId = detectionResult.snapshotId
-            var entry = Entry(
-                createdAt: now,
-                lastAccessedAt: now,
-                processId: getpid(),
-                isPending: false,
-                isImplicitLatestEligible: true,
-                detectionResult: detectionResult,
-                snapshotData: UIAutomationSnapshot(creatorProcessId: getpid()))
-            self.applyDetectionResult(detectionResult, to: &entry.snapshotData)
-            self.entries[snapshotId] = entry
+    @available(*, deprecated, message: "Use await InMemorySnapshotManager.containing(_:) for seeded state")
+    public convenience init(
+        detectionResult: ElementDetectionResult?,
+        options: Options = Options(),
+        desktopMutationWatermarkStore: DesktopMutationWatermarkStore? = nil)
+    {
+        self.init(
+            options: options,
+            desktopMutationWatermarkStore: desktopMutationWatermarkStore)
+        guard let detectionResult else { return }
+        do {
+            try SnapshotPublicationBinding.validate(
+                snapshotId: detectionResult.snapshotId,
+                detectionResult: detectionResult)
+        } catch {
+            self.logger.error("Refusing invalid compatibility snapshot publication: \(error.localizedDescription)")
+            return
         }
+
+        let now = Date()
+        var entry = Entry(
+            createdAt: now,
+            lastAccessedAt: now,
+            processId: getpid(),
+            isPending: false,
+            isImplicitLatestEligible: true,
+            detectionResult: detectionResult,
+            snapshotData: UIAutomationSnapshot(creatorProcessId: getpid()))
+        self.applyDetectionResult(detectionResult, to: &entry.snapshotData)
+        self.entries[detectionResult.snapshotId] = entry
+    }
+
+    /// Creates a manager through the same create-before-store path used by production observation.
+    public static func containing(
+        _ detectionResult: ElementDetectionResult,
+        options: Options = Options(),
+        desktopMutationWatermarkStore: DesktopMutationWatermarkStore? = nil) async throws
+        -> InMemorySnapshotManager
+    {
+        guard let reference = SnapshotReference(rawValue: detectionResult.snapshotId) else {
+            throw SnapshotError.invalidSnapshotReference(detectionResult.snapshotId)
+        }
+        let generator = SeededSnapshotReferenceGenerator(initial: reference)
+        let manager = InMemorySnapshotManager(
+            options: options,
+            desktopMutationWatermarkStore: desktopMutationWatermarkStore,
+            snapshotReferenceGenerator: { generator.next() })
+        let snapshotId = try await manager.createSnapshot()
+        try await manager.storeDetectionResult(snapshotId: snapshotId, result: detectionResult)
+        return manager
+    }
+
+    func validateSnapshotReference(_ snapshotId: String) throws {
+        guard SnapshotReference(rawValue: snapshotId) != nil else {
+            throw SnapshotError.invalidSnapshotReference(snapshotId)
+        }
+    }
+
+    func requireEntry(for snapshotId: String) throws -> Entry {
+        try self.validateSnapshotReference(snapshotId)
+        guard let entry = self.entries[snapshotId] else {
+            throw SnapshotError.snapshotNotFound
+        }
+        return entry
     }
 }

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Support/SnapshotManager+Elements.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Support/SnapshotManager+Elements.swift
@@ -3,7 +3,9 @@ import Foundation
 extension SnapshotManager {
     /// Get element by ID from snapshot
     public func getElement(snapshotId: String, elementId: String) async throws -> UIElement? {
-        let snapshotPath = self.getSnapshotPath(for: snapshotId)
+        guard let snapshotPath = try self.ownedSnapshotURL(for: snapshotId) else {
+            throw SnapshotError.snapshotNotFound
+        }
         guard let snapshotData = await self.snapshotActor.loadSnapshot(snapshotId: snapshotId, from: snapshotPath)
         else {
             throw SnapshotError.snapshotNotFound
@@ -13,7 +15,9 @@ extension SnapshotManager {
 
     /// Find elements matching a query
     public func findElements(snapshotId: String, matching query: String) async throws -> [UIElement] {
-        let snapshotPath = self.getSnapshotPath(for: snapshotId)
+        guard let snapshotPath = try self.ownedSnapshotURL(for: snapshotId) else {
+            throw SnapshotError.snapshotNotFound
+        }
         guard let snapshotData = await self.snapshotActor.loadSnapshot(snapshotId: snapshotId, from: snapshotPath)
         else {
             throw SnapshotError.snapshotNotFound
@@ -38,7 +42,7 @@ extension SnapshotManager {
     }
 
     public func getUIAutomationSnapshot(snapshotId: String) async throws -> UIAutomationSnapshot? {
-        let snapshotPath = self.getSnapshotPath(for: snapshotId)
+        guard let snapshotPath = try self.ownedSnapshotURL(for: snapshotId) else { return nil }
         return await self.snapshotActor.loadSnapshot(snapshotId: snapshotId, from: snapshotPath)
     }
 }

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Support/SnapshotManager+Helpers.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Support/SnapshotManager+Helpers.swift
@@ -49,9 +49,74 @@ extension SnapshotManager {
     }
 
     func makeSnapshotID() -> String {
-        let timestamp = Int(Date().timeIntervalSince1970 * 1000)
-        let randomSuffix = Int.random(in: 1000...9999)
-        return "\(timestamp)-\(randomSuffix)"
+        self.snapshotReferenceGenerator().rawValue
+    }
+
+    func reserveOwnedSnapshotDirectory() throws -> (snapshotId: String, url: URL) {
+        for _ in 0..<8 {
+            let snapshotId = self.makeSnapshotID()
+            // getSnapshotPath creates the storage root; keep only the random child nonrecursive so collisions surface.
+            let snapshotURL = self.getSnapshotPath(for: snapshotId)
+            do {
+                try FileManager.default.createDirectory(
+                    at: snapshotURL,
+                    withIntermediateDirectories: false)
+            } catch {
+                if FileManager.default.fileExists(atPath: snapshotURL.path) {
+                    continue
+                }
+                throw error
+            }
+            do {
+                try self.markSnapshotOwned(at: snapshotURL, snapshotId: snapshotId)
+                return (snapshotId, snapshotURL)
+            } catch {
+                try? FileManager.default.removeItem(at: snapshotURL)
+                throw error
+            }
+        }
+        throw SnapshotError.storageError("Could not reserve a unique producer-bound snapshot reference")
+    }
+
+    func markSnapshotOwned(at snapshotURL: URL, snapshotId: String) throws {
+        try Data(snapshotId.utf8).write(
+            to: snapshotURL.appendingPathComponent(SnapshotPathValidator.producerOwnerMarkerName),
+            options: .atomic)
+    }
+
+    func isOwnedSnapshot(at snapshotURL: URL, snapshotId: String) -> Bool {
+        SnapshotPathValidator.producerOwnedDirectChildURL(
+            for: snapshotId,
+            in: snapshotURL.deletingLastPathComponent()) == snapshotURL.standardizedFileURL
+    }
+
+    func validatedSnapshotReference(_ snapshotId: String) throws -> SnapshotReference {
+        guard let reference = SnapshotReference(rawValue: snapshotId) else {
+            throw SnapshotError.invalidSnapshotReference(snapshotId)
+        }
+        return reference
+    }
+
+    func ownedSnapshotURL(
+        for snapshotId: String,
+        requiringSnapshotData: Bool = true) throws -> URL?
+    {
+        _ = try self.validatedSnapshotReference(snapshotId)
+        guard let candidate = SnapshotPathValidator.directChildURL(
+            for: snapshotId,
+            in: self.getSnapshotStorageURL()),
+            FileManager.default.fileExists(atPath: candidate.path),
+            self.isOwnedSnapshot(at: candidate, snapshotId: snapshotId)
+        else { return nil }
+        if requiringSnapshotData,
+           SnapshotPathValidator.producerOwnedSnapshotPayloadURL(
+               for: snapshotId,
+               in: self.getSnapshotStorageURL(),
+               allowMissing: false) == nil
+        {
+            return nil
+        }
+        return candidate
     }
 
     func getSnapshotStorageURL() -> URL {
@@ -125,6 +190,29 @@ extension SnapshotManager {
         }
     }
 
+    func cleanupEligibleSnapshotDirectoryURLs() throws -> [URL] {
+        do {
+            return try self.withImplicitLatestInvalidationLock(mode: .read) {
+                let storageURL = self.getSnapshotStorageURL()
+                return try FileManager.default.contentsOfDirectory(
+                    at: storageURL,
+                    includingPropertiesForKeys: [.isDirectoryKey],
+                    options: []).filter { url in
+                    guard (try? url.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true else {
+                        return false
+                    }
+                    return SnapshotPathValidator.cleanupEligibleDirectChildURL(
+                        for: url.lastPathComponent,
+                        in: storageURL) == url.standardizedFileURL
+                }
+            }
+        } catch {
+            self.logger.error("Failed to lock snapshot state for cleanup directory read: \(error)")
+            throw SnapshotError.storageError(
+                "Failed to lock snapshot state for directory read: \(error.localizedDescription)")
+        }
+    }
+
     private func snapshotDirectoryURLsUnlocked(
         includingPending: Bool,
         requiringSnapshotData: Bool = true) -> [URL]
@@ -136,12 +224,15 @@ extension SnapshotManager {
         else { return [] }
         return urls.filter { url in
             guard (try? url.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true else { return false }
-            if url.lastPathComponent.hasPrefix(".pending-") {
+            if SnapshotPathValidator.isLegacyPendingSnapshotDirectoryName(url.lastPathComponent) {
                 return includingPending
             }
+            guard self.isOwnedSnapshot(at: url, snapshotId: url.lastPathComponent) else { return false }
             guard includingPending || !self.isPendingSnapshot(at: url) else { return false }
-            return !requiringSnapshotData || FileManager.default.fileExists(
-                atPath: url.appendingPathComponent("snapshot.json").path)
+            return !requiringSnapshotData || SnapshotPathValidator.producerOwnedSnapshotPayloadURL(
+                for: url.lastPathComponent,
+                in: self.getSnapshotStorageURL(),
+                allowMissing: false) != nil
         }
     }
 
@@ -264,21 +355,34 @@ extension SnapshotManager {
     }
 
     private func validPreservationSnapshotURL(for snapshotId: String) -> URL? {
-        guard let candidate = self.safeSnapshotURL(for: snapshotId) else { return nil }
+        guard let candidate = try? self.ownedSnapshotURL(for: snapshotId) else { return nil }
         guard !self.isExplicitOnlySnapshot(at: candidate) else { return nil }
-        guard FileManager.default.fileExists(atPath: candidate.appendingPathComponent("snapshot.json").path)
+        guard SnapshotPathValidator.producerOwnedSnapshotPayloadURL(
+            for: snapshotId,
+            in: self.getSnapshotStorageURL(),
+            allowMissing: false) != nil
         else { return nil }
         return candidate
     }
 
     private func safeSnapshotURL(for snapshotId: String) -> URL? {
-        SnapshotPathValidator.directChildURL(for: snapshotId, in: self.getSnapshotStorageURL())
+        try? self.ownedSnapshotURL(for: snapshotId, requiringSnapshotData: false)
     }
 
     func removeSnapshotAndPreservation(snapshotId: String) throws -> Bool {
-        guard let snapshotURL = self.safeSnapshotURL(for: snapshotId) else {
-            throw SnapshotError.storageError("Invalid snapshot ID")
+        let snapshotURL: URL?
+        if SnapshotReference(rawValue: snapshotId) != nil {
+            snapshotURL = try self.ownedSnapshotURL(for: snapshotId, requiringSnapshotData: false)
+        } else if SnapshotPathValidator.isLegacyTimestampSnapshotID(snapshotId) ||
+            SnapshotPathValidator.isLegacyPendingSnapshotDirectoryName(snapshotId)
+        {
+            snapshotURL = SnapshotPathValidator.cleanupEligibleDirectChildURL(
+                for: snapshotId,
+                in: self.getSnapshotStorageURL())
+        } else {
+            throw SnapshotError.invalidSnapshotReference(snapshotId)
         }
+        guard let snapshotURL else { return false }
         return try self.withImplicitLatestInvalidationLock(mode: .write) {
             let existed = FileManager.default.fileExists(atPath: snapshotURL.path)
             if existed {
@@ -432,9 +536,13 @@ extension SnapshotManager {
                   watermark.map({ createdAt > $0 }) ?? true,
                   latestCreationDate.map({ createdAt <= $0 }) ?? true,
                   url.hasDirectoryPath,
+                  self.isOwnedSnapshot(at: url, snapshotId: url.lastPathComponent),
                   !self.isPendingSnapshot(at: url),
                   !self.isExplicitOnlySnapshot(at: url),
-                  FileManager.default.fileExists(atPath: url.appendingPathComponent("snapshot.json").path)
+                  SnapshotPathValidator.producerOwnedSnapshotPayloadURL(
+                      for: url.lastPathComponent,
+                      in: snapshotDir,
+                      allowMissing: false) != nil
             else {
                 return nil
             }

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Support/SnapshotManager+MutationLease.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Support/SnapshotManager+MutationLease.swift
@@ -2,11 +2,8 @@ import Foundation
 
 extension SnapshotManager {
     public func beginSnapshotMutation(snapshotId: String) async throws -> SnapshotMutationLease {
-        guard let snapshotPath = SnapshotPathValidator.directChildURL(
-            for: snapshotId,
-            in: self.getSnapshotStorageURL())
-        else {
-            throw SnapshotError.storageError("Invalid snapshot ID")
+        guard let snapshotPath = try self.ownedSnapshotURL(for: snapshotId) else {
+            throw SnapshotError.snapshotNotFound
         }
         return try await self.snapshotActor.beginMutation(
             snapshotId: snapshotId,
@@ -17,11 +14,8 @@ extension SnapshotManager {
         _ lease: SnapshotMutationLease,
         requiresFreshObservation: Bool) async throws
     {
-        guard let snapshotPath = SnapshotPathValidator.directChildURL(
-            for: lease.snapshotId,
-            in: self.getSnapshotStorageURL())
-        else {
-            throw SnapshotError.storageError("Invalid snapshot ID")
+        guard let snapshotPath = try self.ownedSnapshotURL(for: lease.snapshotId) else {
+            throw SnapshotError.snapshotNotFound
         }
         try await self.snapshotActor.finishMutation(
             lease,

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Support/SnapshotManager+Screenshots.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Support/SnapshotManager+Screenshots.swift
@@ -5,11 +5,19 @@ import PeekabooFoundation
 extension SnapshotManager {
     /// Store raw screenshot and build UI map
     public func storeScreenshot(_ request: SnapshotScreenshotRequest) async throws {
-        let snapshotPath = self.getSnapshotPath(for: request.snapshotId)
-        try FileManager.default.createDirectory(at: snapshotPath, withIntermediateDirectories: true)
+        guard let snapshotPath = try self.ownedSnapshotURL(for: request.snapshotId) else {
+            throw SnapshotError.snapshotNotFound
+        }
+        try SnapshotPublicationBinding.validate(
+            snapshotId: request.snapshotId,
+            captureCoordinateContext: request.captureCoordinateContext)
 
-        var snapshotData = await self.snapshotActor
-            .loadSnapshot(snapshotId: request.snapshotId, from: snapshotPath) ?? UIAutomationSnapshot()
+        guard var snapshotData = await self.snapshotActor
+            .loadSnapshot(snapshotId: request.snapshotId, from: snapshotPath)
+        else {
+            throw SnapshotError.snapshotNotFound
+        }
+        await self.postLoadBarrier()
         if snapshotData.creatorProcessId == nil {
             snapshotData.creatorProcessId = getpid()
         }
@@ -51,11 +59,16 @@ extension SnapshotManager {
     }
 
     public func storeAnnotatedScreenshot(snapshotId: String, annotatedScreenshotPath: String) async throws {
-        let snapshotPath = self.getSnapshotPath(for: snapshotId)
-        try FileManager.default.createDirectory(at: snapshotPath, withIntermediateDirectories: true)
+        guard let snapshotPath = try self.ownedSnapshotURL(for: snapshotId) else {
+            throw SnapshotError.snapshotNotFound
+        }
 
-        var snapshotData = await self.snapshotActor
-            .loadSnapshot(snapshotId: snapshotId, from: snapshotPath) ?? UIAutomationSnapshot()
+        guard var snapshotData = await self.snapshotActor
+            .loadSnapshot(snapshotId: snapshotId, from: snapshotPath)
+        else {
+            throw SnapshotError.snapshotNotFound
+        }
+        await self.postLoadBarrier()
         if snapshotData.creatorProcessId == nil {
             snapshotData.creatorProcessId = getpid()
         }

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Support/SnapshotManager.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Support/SnapshotManager.swift
@@ -10,6 +10,7 @@ public final class SnapshotManager: SnapshotManagerProtocol {
     public let supportsImplicitLatestSnapshotInvalidation = true
     public let supportsSnapshotMutationLeases = true
     public let supportsExplicitSnapshotPublication = true
+    public let supportsProducerBoundSnapshotReferences = true
     public let copiesScreenshotArtifactsIntoStorage = true
 
     public var effectiveImplicitLatestInvalidationWatermark: Date? {
@@ -22,75 +23,89 @@ public final class SnapshotManager: SnapshotManagerProtocol {
     let snapshotActor = SnapshotStorageActor()
     let snapshotStorageURLOverride: URL?
     let desktopMutationWatermarkStore: DesktopMutationWatermarkStore?
+    let snapshotReferenceGenerator: SnapshotReferenceGenerator
+    let postLoadBarrier: @MainActor @Sendable () async -> Void
 
     /// Snapshot validity window (10 minutes)
     let snapshotValidityWindow: TimeInterval = 600
 
-    public init(desktopMutationWatermarkStore: DesktopMutationWatermarkStore? = nil) {
+    public init(
+        desktopMutationWatermarkStore: DesktopMutationWatermarkStore? = nil,
+        snapshotReferenceGenerator: @escaping SnapshotReferenceGenerator = SnapshotReference.generate)
+    {
         self.snapshotStorageURLOverride = nil
         self.desktopMutationWatermarkStore = desktopMutationWatermarkStore
+        self.snapshotReferenceGenerator = snapshotReferenceGenerator
+        self.postLoadBarrier = {}
     }
 
     init(
         snapshotStorageURL: URL,
-        desktopMutationWatermarkStore: DesktopMutationWatermarkStore? = nil)
+        desktopMutationWatermarkStore: DesktopMutationWatermarkStore? = nil,
+        snapshotReferenceGenerator: @escaping SnapshotReferenceGenerator = SnapshotReference.generate,
+        postLoadBarrier: @escaping @MainActor @Sendable () async -> Void = {})
     {
         self.snapshotStorageURLOverride = snapshotStorageURL
         self.desktopMutationWatermarkStore = desktopMutationWatermarkStore
+        self.snapshotReferenceGenerator = snapshotReferenceGenerator
+        self.postLoadBarrier = postLoadBarrier
     }
 
     public func createSnapshot() async throws -> String {
-        // Generate timestamp-based snapshot ID for cross-process compatibility
-        let snapshotId = self.makeSnapshotID()
-
-        self.logger.debug("Creating new snapshot: \(snapshotId)")
-
-        // Create snapshot directory
-        let snapshotPath = self.getSnapshotPath(for: snapshotId)
-        try FileManager.default.createDirectory(at: snapshotPath, withIntermediateDirectories: true)
-
-        // Initialize empty snapshot data
-        let snapshotData = UIAutomationSnapshot(creatorProcessId: getpid())
-        try await self.snapshotActor.saveSnapshot(snapshotId: snapshotId, data: snapshotData, at: snapshotPath)
-
-        return snapshotId
+        let reservation = try self.reserveOwnedSnapshotDirectory()
+        self.logger.debug("Creating new snapshot: \(reservation.snapshotId)")
+        return try await self.initializeReservedSnapshot(reservation)
     }
 
     public func createSnapshot(pendingAt observationStartedAt: Date) async throws -> String {
-        let snapshotId = self.makeSnapshotID()
-        let storageURL = self.getSnapshotStorageURL()
-        let snapshotPath = self.getSnapshotPath(for: snapshotId)
-        let stagingPath = storageURL.appendingPathComponent(".pending-\(UUID().uuidString)", isDirectory: true)
-
-        self.logger.debug("Reserving pending snapshot: \(snapshotId)")
-        try FileManager.default.createDirectory(at: stagingPath, withIntermediateDirectories: false)
-        defer { try? FileManager.default.removeItem(at: stagingPath) }
-
-        try self.markSnapshotPending(at: stagingPath, observationStartedAt: observationStartedAt)
-        let snapshotData = UIAutomationSnapshot(creatorProcessId: getpid())
-        try await self.snapshotActor.saveSnapshot(snapshotId: snapshotId, data: snapshotData, at: stagingPath)
-        try FileManager.default.moveItem(at: stagingPath, to: snapshotPath)
-        return snapshotId
+        let reservation = try self.reserveOwnedSnapshotDirectory()
+        self.logger.debug("Reserving pending snapshot: \(reservation.snapshotId)")
+        return try await self.initializeReservedSnapshot(reservation) { snapshotPath in
+            try self.markSnapshotPending(at: snapshotPath, observationStartedAt: observationStartedAt)
+        }
     }
 
     public func createExplicitSnapshot() async throws -> String {
-        let snapshotId = self.makeSnapshotID()
-        let snapshotPath = self.getSnapshotPath(for: snapshotId)
+        let reservation = try self.reserveOwnedSnapshotDirectory()
+        self.logger.debug("Creating explicit-only snapshot: \(reservation.snapshotId)")
+        return try await self.initializeReservedSnapshot(reservation) { snapshotPath in
+            try self.markSnapshotExplicitOnly(at: snapshotPath)
+        }
+    }
 
-        self.logger.debug("Creating explicit-only snapshot: \(snapshotId)")
-        try FileManager.default.createDirectory(at: snapshotPath, withIntermediateDirectories: true)
-        try self.markSnapshotExplicitOnly(at: snapshotPath)
-        let snapshotData = UIAutomationSnapshot(creatorProcessId: getpid())
-        try await self.snapshotActor.saveSnapshot(snapshotId: snapshotId, data: snapshotData, at: snapshotPath)
-        return snapshotId
+    func initializeReservedSnapshot(
+        _ reservation: (snapshotId: String, url: URL),
+        configure: (URL) throws -> Void = { _ in }) async throws -> String
+    {
+        do {
+            try configure(reservation.url)
+            let snapshotData = UIAutomationSnapshot(creatorProcessId: getpid())
+            try await self.snapshotActor.saveSnapshot(
+                snapshotId: reservation.snapshotId,
+                data: snapshotData,
+                at: reservation.url)
+            return reservation.snapshotId
+        } catch {
+            try? FileManager.default.removeItem(at: reservation.url)
+            throw error
+        }
     }
 
     public func storeDetectionResult(snapshotId: String, result: ElementDetectionResult) async throws {
-        let snapshotPath = self.getSnapshotPath(for: snapshotId)
+        guard let snapshotPath = try self.ownedSnapshotURL(for: snapshotId) else {
+            throw SnapshotError.snapshotNotFound
+        }
+        try SnapshotPublicationBinding.validate(
+            snapshotId: snapshotId,
+            detectionResult: result,
+            captureCoordinateContext: result.metadata.captureCoordinateContext)
 
-        // Load existing snapshot or create new
-        var snapshotData = await self.snapshotActor
-            .loadSnapshot(snapshotId: snapshotId, from: snapshotPath) ?? UIAutomationSnapshot()
+        guard var snapshotData = await self.snapshotActor
+            .loadSnapshot(snapshotId: snapshotId, from: snapshotPath)
+        else {
+            throw SnapshotError.snapshotNotFound
+        }
+        await self.postLoadBarrier()
         if snapshotData.creatorProcessId == nil {
             snapshotData.creatorProcessId = getpid()
         }
@@ -140,7 +155,7 @@ public final class SnapshotManager: SnapshotManagerProtocol {
     }
 
     public func getDetectionResult(snapshotId: String) async throws -> ElementDetectionResult? {
-        let snapshotPath = self.getSnapshotPath(for: snapshotId)
+        guard let snapshotPath = try self.ownedSnapshotURL(for: snapshotId) else { return nil }
 
         guard let snapshotData = await self.snapshotActor.loadSnapshot(snapshotId: snapshotId, from: snapshotPath)
         else {
@@ -294,11 +309,15 @@ public final class SnapshotManager: SnapshotManagerProtocol {
         }
     }
 
+    public func ownsSnapshot(snapshotId: String) async throws -> Bool {
+        // Disk ownership is the caller-local cache namespace, durable across short-lived CLI manager instances.
+        // Long-lived Bridge hosts use InMemorySnapshotManager, so they do not claim this disk namespace.
+        try self.ownedSnapshotURL(for: snapshotId, requiringSnapshotData: false) != nil
+    }
+
     public func cleanSnapshotsOlderThan(days: Int) async throws -> Int {
         let cutoffDate = Date().addingTimeInterval(-Double(days) * 24 * 3600)
-        let snapshotIDs = try self.snapshotDirectoryURLs(
-            includingPending: true,
-            requiringSnapshotData: false).compactMap { url -> String? in
+        let snapshotIDs = try self.cleanupEligibleSnapshotDirectoryURLs().compactMap { url -> String? in
             guard let createdAt = self.snapshotCreationDate(at: url), createdAt < cutoffDate else { return nil }
             return url.lastPathComponent
         }
@@ -311,9 +330,7 @@ public final class SnapshotManager: SnapshotManagerProtocol {
     }
 
     public func cleanAllSnapshots() async throws -> Int {
-        let snapshotIDs = try self.snapshotDirectoryURLs(
-            includingPending: true,
-            requiringSnapshotData: false).map(\.lastPathComponent)
+        let snapshotIDs = try self.cleanupEligibleSnapshotDirectoryURLs().map(\.lastPathComponent)
 
         for snapshotID in snapshotIDs {
             try await self.cleanSnapshot(snapshotId: snapshotID)

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Support/SnapshotPathValidator.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Support/SnapshotPathValidator.swift
@@ -1,7 +1,11 @@
 import Darwin
 import Foundation
+import PeekabooFoundation
 
 enum SnapshotPathValidator {
+    static let producerOwnerMarkerName = ".producer-bound-reference"
+    static let snapshotPayloadName = "snapshot.json"
+
     static func directChildURL(for snapshotID: String, in rootURL: URL) -> URL? {
         guard !snapshotID.isEmpty,
               snapshotID != ".",
@@ -29,5 +33,73 @@ enum SnapshotPathValidator {
         // Keep the lexical child. Returning a resolved URL could make a later delete target a
         // symlink destination instead of the user-supplied cache entry.
         return candidate
+    }
+
+    static func producerOwnedDirectChildURL(for snapshotID: String, in rootURL: URL) -> URL? {
+        guard SnapshotReference(rawValue: snapshotID) != nil,
+              let candidate = self.directChildURL(for: snapshotID, in: rootURL)
+        else { return nil }
+
+        let markerURL = candidate.appendingPathComponent(self.producerOwnerMarkerName)
+        var markerInfo = stat()
+        guard lstat(markerURL.path, &markerInfo) == 0,
+              markerInfo.st_mode & mode_t(S_IFMT) == mode_t(S_IFREG),
+              let marker = try? Data(contentsOf: markerURL),
+              marker == Data(snapshotID.utf8)
+        else { return nil }
+        return candidate
+    }
+
+    static func producerOwnedSnapshotPayloadURL(
+        for snapshotID: String,
+        in rootURL: URL,
+        allowMissing: Bool) -> URL?
+    {
+        guard let candidate = self.producerOwnedDirectChildURL(for: snapshotID, in: rootURL) else {
+            return nil
+        }
+        let payloadURL = candidate.appendingPathComponent(self.snapshotPayloadName)
+        var payloadInfo = stat()
+        if lstat(payloadURL.path, &payloadInfo) == 0 {
+            guard payloadInfo.st_mode & mode_t(S_IFMT) == mode_t(S_IFREG) else { return nil }
+        } else if !allowMissing || errno != ENOENT {
+            return nil
+        }
+        return payloadURL
+    }
+
+    static func cleanupEligibleDirectChildURL(for snapshotID: String, in rootURL: URL) -> URL? {
+        if let owned = self.producerOwnedDirectChildURL(for: snapshotID, in: rootURL) {
+            return owned
+        }
+        if self.isLegacyPendingSnapshotDirectoryName(snapshotID) {
+            return self.directChildURL(for: snapshotID, in: rootURL)
+        }
+        guard self.isLegacyTimestampSnapshotID(snapshotID),
+              let candidate = self.directChildURL(for: snapshotID, in: rootURL)
+        else { return nil }
+
+        var payloadInfo = stat()
+        let payloadURL = candidate.appendingPathComponent(self.snapshotPayloadName)
+        guard lstat(payloadURL.path, &payloadInfo) == 0,
+              payloadInfo.st_mode & mode_t(S_IFMT) == mode_t(S_IFREG)
+        else { return nil }
+        return candidate
+    }
+
+    static func isLegacyTimestampSnapshotID(_ snapshotID: String) -> Bool {
+        let bytes = Array(snapshotID.utf8)
+        guard bytes.count == 18, bytes[13] == 45 else { return false }
+        return bytes.enumerated().allSatisfy { index, byte in
+            index == 13 || (48...57).contains(byte)
+        }
+    }
+
+    static func isLegacyPendingSnapshotDirectoryName(_ name: String) -> Bool {
+        let prefix = ".pending-"
+        guard name.hasPrefix(prefix) else { return false }
+        let suffix = String(name.dropFirst(prefix.count))
+        guard let identifier = UUID(uuidString: suffix) else { return false }
+        return identifier.uuidString == suffix
     }
 }

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Support/SnapshotPublicationBinding.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Support/SnapshotPublicationBinding.swift
@@ -1,0 +1,44 @@
+import Foundation
+import PeekabooFoundation
+
+enum SnapshotPublicationBinding {
+    /// Detection-only results still need a correlation identifier, but only a snapshot manager may
+    /// mint the canonical `ps1_` authority used for persistence and follow-up actions.
+    static func resultIdentifier(
+        explicit snapshotId: String?,
+        transientPrefix: String? = nil) -> String
+    {
+        if let snapshotId {
+            return snapshotId
+        }
+        let identifier = UUID().uuidString
+        return transientPrefix.map { "\($0)-\(identifier)" } ?? identifier
+    }
+
+    static func validate(
+        snapshotId: String,
+        detectionResult: ElementDetectionResult? = nil,
+        captureCoordinateContext: CaptureCoordinateContext? = nil) throws
+    {
+        guard SnapshotReference(rawValue: snapshotId) != nil else {
+            throw SnapshotError.invalidSnapshotReference(snapshotId)
+        }
+        if let detectionResult, detectionResult.snapshotId != snapshotId {
+            throw SnapshotError.storageError(
+                "Detection result snapshot '\(detectionResult.snapshotId)' does not match owned snapshot " +
+                    "'\(snapshotId)'")
+        }
+        if let referenceID = captureCoordinateContext?.referenceID,
+           referenceID != snapshotId
+        {
+            throw SnapshotError.storageError(
+                "Capture coordinate reference '\(referenceID)' does not match owned snapshot '\(snapshotId)'")
+        }
+        if let referenceID = detectionResult?.metadata.captureCoordinateContext?.referenceID,
+           referenceID != snapshotId
+        {
+            throw SnapshotError.storageError(
+                "Detection coordinate reference '\(referenceID)' does not match owned snapshot '\(snapshotId)'")
+        }
+    }
+}

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Support/SnapshotStorageActor.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Support/SnapshotStorageActor.swift
@@ -12,17 +12,24 @@ actor SnapshotStorageActor {
     }
 
     func saveSnapshot(snapshotId: String, data: UIAutomationSnapshot, at snapshotPath: URL) throws {
-        try FileManager.default.createDirectory(at: snapshotPath, withIntermediateDirectories: true)
+        guard let snapshotFile = SnapshotPathValidator.producerOwnedSnapshotPayloadURL(
+            for: snapshotId,
+            in: snapshotPath.deletingLastPathComponent(),
+            allowMissing: true)
+        else {
+            throw SnapshotError.snapshotNotFound
+        }
 
-        let snapshotFile = snapshotPath.appendingPathComponent("snapshot.json")
         let jsonData = try self.encoder.encode(data)
         try jsonData.write(to: snapshotFile, options: .atomic)
     }
 
     func loadSnapshot(snapshotId: String, from snapshotPath: URL) -> UIAutomationSnapshot? {
-        let snapshotFile = snapshotPath.appendingPathComponent("snapshot.json")
-
-        guard FileManager.default.fileExists(atPath: snapshotFile.path) else {
+        guard let snapshotFile = SnapshotPathValidator.producerOwnedSnapshotPayloadURL(
+            for: snapshotId,
+            in: snapshotPath.deletingLastPathComponent(),
+            allowMissing: false)
+        else {
             return nil
         }
 

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/System/FileService.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/System/FileService.swift
@@ -32,13 +32,17 @@ public final class FileService: FileServiceProtocol {
         let snapshotDirs = try FileManager.default.contentsOfDirectory(
             at: cacheDir,
             includingPropertiesForKeys: [.creationDateKey, .contentModificationDateKey],
-            options: .skipsHiddenFiles)
+            options: [])
 
         for snapshotDir in snapshotDirs {
-            guard snapshotDir.hasDirectoryPath else { continue }
+            let snapshotId = snapshotDir.lastPathComponent
+            guard snapshotDir.hasDirectoryPath,
+                  SnapshotPathValidator.cleanupEligibleDirectChildURL(
+                      for: snapshotId,
+                      in: cacheDir) == snapshotDir.standardizedFileURL
+            else { continue }
 
             let snapshotSize = try await calculateDirectorySize(snapshotDir)
-            let snapshotId = snapshotDir.lastPathComponent
             let resourceValues = try snapshotDir.resourceValues(forKeys: [
                 .creationDateKey,
                 .contentModificationDateKey,
@@ -84,18 +88,21 @@ public final class FileService: FileServiceProtocol {
         let snapshotDirs = try FileManager.default.contentsOfDirectory(
             at: cacheDir,
             includingPropertiesForKeys: [.creationDateKey, .contentModificationDateKey],
-            options: .skipsHiddenFiles)
+            options: [])
 
         for snapshotDir in snapshotDirs {
-            guard snapshotDir.hasDirectoryPath else { continue }
+            let snapshotId = snapshotDir.lastPathComponent
+            guard snapshotDir.hasDirectoryPath,
+                  SnapshotPathValidator.cleanupEligibleDirectChildURL(
+                      for: snapshotId,
+                      in: cacheDir) == snapshotDir.standardizedFileURL
+            else { continue }
 
             let resourceValues = try snapshotDir.resourceValues(forKeys: [.contentModificationDateKey])
             let modificationDate = resourceValues.contentModificationDate
 
             if let modDate = modificationDate, modDate < cutoffDate {
                 let snapshotSize = try await calculateDirectorySize(snapshotDir)
-                let snapshotId = snapshotDir.lastPathComponent
-
                 let detail = SnapshotDetail(
                     snapshotId: snapshotId,
                     path: snapshotDir.path,
@@ -121,12 +128,17 @@ public final class FileService: FileServiceProtocol {
 
     public func cleanSpecificSnapshot(snapshotId: String, dryRun: Bool) async throws -> SnapshotCleanResult {
         let cacheDir = self.getSnapshotCacheDirectory()
-        guard let snapshotDir = SnapshotPathValidator.directChildURL(for: snapshotId, in: cacheDir) else {
+        guard SnapshotReference(rawValue: snapshotId) != nil ||
+            SnapshotPathValidator.isLegacyTimestampSnapshotID(snapshotId) ||
+            SnapshotPathValidator.isLegacyPendingSnapshotDirectoryName(snapshotId)
+        else {
             throw FileServiceError.invalidSnapshotID
         }
 
-        guard FileManager.default.fileExists(atPath: snapshotDir.path) else {
-            // Return empty result instead of throwing error for consistency with original behavior
+        guard let snapshotDir = SnapshotPathValidator.cleanupEligibleDirectChildURL(
+            for: snapshotId,
+            in: cacheDir)
+        else {
             return SnapshotCleanResult(
                 snapshotsRemoved: 0,
                 bytesFreed: 0,
@@ -193,9 +205,12 @@ public final class FileService: FileServiceProtocol {
             options: .skipsHiddenFiles)
 
         for snapshotDir in snapshotDirs {
-            guard snapshotDir.hasDirectoryPath else { continue }
-
             let snapshotId = snapshotDir.lastPathComponent
+            guard snapshotDir.hasDirectoryPath,
+                  SnapshotPathValidator.producerOwnedDirectChildURL(
+                      for: snapshotId,
+                      in: cacheDir) == snapshotDir.standardizedFileURL
+            else { continue }
             let snapshotSize = try await calculateDirectorySize(snapshotDir)
             let resourceValues = try snapshotDir.resourceValues(forKeys: [
                 .creationDateKey,

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/ActionInputDriver.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/ActionInputDriver.swift
@@ -61,6 +61,9 @@ extension ActionInputError: LocalizedError {
 @MainActor
 protocol ActionInputDriving: Sendable {
     func tryClick(element: AutomationElement) throws -> UIInputExecutionResult.Action
+    func tryClick(
+        element: AutomationElement,
+        allowAccessibilityValueFallback: Bool) throws -> UIInputExecutionResult.Action
     func tryFocus(element: any AutomationElementRepresenting) throws -> UIInputExecutionResult.Action
     func tryRightClick(element: any AutomationElementRepresenting) async throws -> UIInputExecutionResult.Action
     func tryScroll(
@@ -74,6 +77,16 @@ protocol ActionInputDriving: Sendable {
 }
 
 extension ActionInputDriving {
+    func tryClick(
+        element: AutomationElement,
+        allowAccessibilityValueFallback: Bool) throws -> UIInputExecutionResult.Action
+    {
+        guard allowAccessibilityValueFallback else {
+            throw ActionInputError.unsupported(.actionUnsupported)
+        }
+        return try self.tryClick(element: element)
+    }
+
     func tryFocus(element _: any AutomationElementRepresenting) throws -> UIInputExecutionResult.Action {
         throw ActionInputError.unsupported(.attributeUnsupported)
     }
@@ -90,10 +103,18 @@ struct ActionInputDriver: ActionInputDriving {
         mode: .background)
 
     func tryClick(element: AutomationElement) throws -> UIInputExecutionResult.Action {
+        try self.tryClick(element: element, allowAccessibilityValueFallback: true)
+    }
+
+    func tryClick(
+        element: AutomationElement,
+        allowAccessibilityValueFallback: Bool) throws -> UIInputExecutionResult.Action
+    {
         do {
             return try self.performAction(AXActionNames.kAXPressAction, on: element)
         } catch let error as ActionInputError
             where error == .unsupported(.actionUnsupported) &&
+            allowAccessibilityValueFallback &&
             Self.canFocusForClick(
                 role: element.role,
                 subrole: element.subrole,
@@ -1097,11 +1118,15 @@ private struct MenuHotkeyChord: Equatable {
 
 #if DEBUG
 extension ActionInputDriver {
-    func tryClickForTesting(element: any AutomationElementRepresenting) throws -> UIInputExecutionResult.Action {
+    func tryClickForTesting(
+        element: any AutomationElementRepresenting,
+        allowAccessibilityValueFallback: Bool = true) throws -> UIInputExecutionResult.Action
+    {
         do {
             return try self.performAction(AXActionNames.kAXPressAction, on: element)
         } catch let error as ActionInputError
             where error == .unsupported(.actionUnsupported) &&
+            allowAccessibilityValueFallback &&
             Self.canFocusForClick(
                 role: element.role,
                 subrole: element.subrole,

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/ClickService.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/ClickService.swift
@@ -26,7 +26,7 @@ import PeekabooFoundation
  * try await clickService.click(
  *     target: .elementId(detectedElement.id),
  *     clickType: .single,
- *     snapshotId: "snapshot_123"
+ *     snapshotId: "ps1_0123456789abcdef0123456789abcdef"
  * )
  *
  * // Click by coordinates
@@ -59,6 +59,7 @@ private struct ClickExecutionRequest: Sendable {
     let snapshotID: String?
     let automationTarget: UIAutomationTarget
     let validatesProcessIdentity: Bool
+    let allowsAccessibilityValueDelivery: Bool
     let acquireLane: Bool
     let lanePreparation: @MainActor @Sendable () async -> Void
     let laneCompletion: @MainActor @Sendable (UIInputExecutionResult) async -> Void
@@ -172,7 +173,8 @@ public final class ClickService {
         clickType: ClickType,
         snapshotId: String?,
         captureReceipt: DesktopOperationPlan.CaptureReceipt,
-        validatesProcessIdentity: Bool) async throws -> UIInputExecutionResult.Action
+        validatesProcessIdentity: Bool,
+        allowsAccessibilityValueDelivery: Bool) async throws -> UIInputExecutionResult.Action
     {
         let targetProcessIdentifier = captureReceipt.processIdentifier
         guard let element = try await self.resolveAutomationElement(
@@ -190,7 +192,9 @@ public final class ClickService {
         switch clickType {
         case .single:
             let valueBefore = element.intAttribute(AXAttributeNames.kAXValueAttribute)
-            let result = try self.actionInputDriver.tryClick(element: element)
+            let result = try self.actionInputDriver.tryClick(
+                element: element,
+                allowAccessibilityValueFallback: allowsAccessibilityValueDelivery)
             if let focusedElement = result.focusedElement,
                let exactWindow = captureReceipt.exactWindow
             {
@@ -1263,7 +1267,8 @@ extension ClickService {
         clickType: ClickType,
         snapshotId: String?,
         automationTarget: UIAutomationTarget,
-        validatesProcessIdentity: Bool = false) async throws -> UIInputExecutionResult
+        validatesProcessIdentity: Bool = false,
+        allowsAccessibilityValueDelivery: Bool = true) async throws -> UIInputExecutionResult
     {
         try await self.executeClick(ClickExecutionRequest(
             target: target,
@@ -1271,6 +1276,7 @@ extension ClickService {
             snapshotID: snapshotId,
             automationTarget: automationTarget,
             validatesProcessIdentity: validatesProcessIdentity,
+            allowsAccessibilityValueDelivery: allowsAccessibilityValueDelivery,
             acquireLane: true,
             lanePreparation: {},
             laneCompletion: { _ in }))
@@ -1290,6 +1296,7 @@ extension ClickService {
             snapshotID: snapshotId,
             automationTarget: .foreground,
             validatesProcessIdentity: false,
+            allowsAccessibilityValueDelivery: true,
             acquireLane: true,
             lanePreparation: lanePreparation,
             laneCompletion: laneCompletion))
@@ -1324,6 +1331,7 @@ extension ClickService {
             snapshotID: snapshotId,
             automationTarget: automationTarget,
             validatesProcessIdentity: validatesProcessIdentity,
+            allowsAccessibilityValueDelivery: true,
             acquireLane: false,
             lanePreparation: {},
             laneCompletion: { _ in }))
@@ -1415,7 +1423,8 @@ extension ClickService {
                             clickType: clickType,
                             snapshotId: snapshotID,
                             captureReceipt: mutationReceipt,
-                            validatesProcessIdentity: validatesProcessIdentity)
+                            validatesProcessIdentity: validatesProcessIdentity,
+                            allowsAccessibilityValueDelivery: request.allowsAccessibilityValueDelivery)
                     } catch let error as ActionInputError
                         where strategy == .actionFirst &&
                         targetProcessIdentifier != nil &&

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/ElementDetectionService.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/ElementDetectionService.swift
@@ -43,7 +43,7 @@ struct DetachedAXObservationOutcome: Sendable {
  *
  * let result = try await detectionService.detectElements(
  *     in: screenshotData,
- *     snapshotId: "snapshot_123",
+ *     snapshotId: "ps1_0123456789abcdef0123456789abcdef",
  *     windowContext: WindowContext(applicationName: "Safari")
  * )
  *
@@ -134,7 +134,7 @@ public final class ElementDetectionService {
     {
         self.logger.info("Starting accessibility tree inspection")
 
-        let effectiveSnapshotId = snapshotId ?? UUID().uuidString
+        let effectiveSnapshotId = SnapshotPublicationBinding.resultIdentifier(explicit: snapshotId)
 
         let targetApp = try await self.windowResolver.resolveApplication(windowContext: windowContext)
         let applicationIdentity = Self.applicationIdentity(

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/UIAutomationService+Operations.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/UIAutomationService+Operations.swift
@@ -50,7 +50,7 @@ extension UIAutomationService {
      *
      * let elements = try await automation.detectElements(
      *     in: captureResult.imageData,
-     *     snapshotId: "snapshot_123",
+     *     snapshotId: "ps1_0123456789abcdef0123456789abcdef",
      *     windowContext: windowContext
      * )
      *
@@ -143,14 +143,14 @@ extension UIAutomationService {
      * try await automation.click(
      *     target: .elementId(detectedElement.id),
      *     clickType: .single,
-     *     snapshotId: "snapshot_123"
+     *     snapshotId: "ps1_0123456789abcdef0123456789abcdef"
      * )
      *
      * // Click by searching for text
      * try await automation.click(
      *     target: .query("Submit"),
      *     clickType: .single,
-     *     snapshotId: "snapshot_123"
+     *     snapshotId: "ps1_0123456789abcdef0123456789abcdef"
      * )
      *
      * // Click at specific coordinates
@@ -255,11 +255,41 @@ extension UIAutomationService {
             expectedProcessIdentity: expectedProcessIdentity)
     }
 
+    public func click(
+        target: ClickTarget,
+        clickType: ClickType,
+        snapshotId: String?,
+        expectedProcessIdentity: ApplicationProcessIdentity,
+        allowsAccessibilityValueDelivery: Bool) async throws
+    {
+        _ = try await self.clickWithOutcome(
+            target: target,
+            clickType: clickType,
+            snapshotId: snapshotId,
+            expectedProcessIdentity: expectedProcessIdentity,
+            allowsAccessibilityValueDelivery: allowsAccessibilityValueDelivery)
+    }
+
     public func clickWithOutcome(
         target: ClickTarget,
         clickType: ClickType,
         snapshotId: String?,
         expectedProcessIdentity: ApplicationProcessIdentity) async throws -> UIAutomationActionResult<Void>
+    {
+        try await self.clickWithOutcome(
+            target: target,
+            clickType: clickType,
+            snapshotId: snapshotId,
+            expectedProcessIdentity: expectedProcessIdentity,
+            allowsAccessibilityValueDelivery: true)
+    }
+
+    public func clickWithOutcome(
+        target: ClickTarget,
+        clickType: ClickType,
+        snapshotId: String?,
+        expectedProcessIdentity: ApplicationProcessIdentity,
+        allowsAccessibilityValueDelivery: Bool) async throws -> UIAutomationActionResult<Void>
     {
         self.logger.debug("Delegating generation-pinned background click to ClickService")
         let automationTarget: UIAutomationTarget = try .process(UIAutomationTarget.Process(
@@ -271,7 +301,8 @@ extension UIAutomationService {
                 clickType: clickType,
                 snapshotId: snapshotId,
                 automationTarget: automationTarget,
-                validatesProcessIdentity: true)
+                validatesProcessIdentity: true,
+                allowsAccessibilityValueDelivery: allowsAccessibilityValueDelivery)
         }
 
         await self.visualizeClick(
@@ -302,12 +333,46 @@ extension UIAutomationService {
             expectedWindowBounds: expectedWindowBounds)
     }
 
+    public func click(
+        target: ClickTarget,
+        clickType: ClickType,
+        snapshotId: String?,
+        expectedWindowIdentity: WindowMutationIdentity,
+        expectedWindowBounds: CGRect,
+        allowsAccessibilityValueDelivery: Bool) async throws
+    {
+        _ = try await self.clickWithOutcome(
+            target: target,
+            clickType: clickType,
+            snapshotId: snapshotId,
+            expectedWindowIdentity: expectedWindowIdentity,
+            expectedWindowBounds: expectedWindowBounds,
+            allowsAccessibilityValueDelivery: allowsAccessibilityValueDelivery)
+    }
+
     public func clickWithOutcome(
         target: ClickTarget,
         clickType: ClickType,
         snapshotId: String?,
         expectedWindowIdentity: WindowMutationIdentity,
         expectedWindowBounds: CGRect) async throws -> UIAutomationActionResult<Void>
+    {
+        try await self.clickWithOutcome(
+            target: target,
+            clickType: clickType,
+            snapshotId: snapshotId,
+            expectedWindowIdentity: expectedWindowIdentity,
+            expectedWindowBounds: expectedWindowBounds,
+            allowsAccessibilityValueDelivery: true)
+    }
+
+    public func clickWithOutcome(
+        target: ClickTarget,
+        clickType: ClickType,
+        snapshotId: String?,
+        expectedWindowIdentity: WindowMutationIdentity,
+        expectedWindowBounds: CGRect,
+        allowsAccessibilityValueDelivery: Bool) async throws -> UIAutomationActionResult<Void>
     {
         let exactWindow = try UIAutomationTarget.ExactWindow(
             identity: expectedWindowIdentity,
@@ -320,7 +385,8 @@ extension UIAutomationService {
                 clickType: clickType,
                 snapshotId: snapshotId,
                 automationTarget: automationTarget,
-                validatesProcessIdentity: true)
+                validatesProcessIdentity: true,
+                allowsAccessibilityValueDelivery: allowsAccessibilityValueDelivery)
         }
 
         await self.visualizeClick(

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/UIAutomationService+TypingOperations.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/UIAutomationService+TypingOperations.swift
@@ -50,7 +50,7 @@ extension UIAutomationService {
      *     target: detectedElement.id,
      *     clearExisting: true,
      *     typingDelay: 50,
-     *     snapshotId: "snapshot_123"
+     *     snapshotId: "ps1_0123456789abcdef0123456789abcdef"
      * )
      *
      * // Type into currently focused element
@@ -68,7 +68,7 @@ extension UIAutomationService {
      *     target: "searchField",
      *     clearExisting: true,
      *     typingDelay: 100,
-     *     snapshotId: "snapshot_123"
+     *     snapshotId: "ps1_0123456789abcdef0123456789abcdef"
      * )
      * ```
      *

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/UIAutomationService.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/UIAutomationService.swift
@@ -29,15 +29,20 @@ struct HotkeyServiceFactoryContext {
  * // Detect elements in screenshot
  * let elements = try await automation.detectElements(
  *     in: imageData,
- *     snapshotId: "snapshot_123",
+ *     snapshotId: "ps1_0123456789abcdef0123456789abcdef",
  *     windowContext: windowContext
  * )
  *
  * // Perform automation
  * try await automation.click(
- *     target: .elementId(button.id), clickType: .single, snapshotId: "snapshot_123")
+ *     target: .elementId(button.id),
+ *     clickType: .single,
+ *     snapshotId: "ps1_0123456789abcdef0123456789abcdef")
  * try await automation.type(
- *     text: "Hello World", target: textField.id, clearExisting: true, snapshotId: "snapshot_123")
+ *     text: "Hello World",
+ *     target: textField.id,
+ *     clearExisting: true,
+ *     snapshotId: "ps1_0123456789abcdef0123456789abcdef")
  * ```
  *
  * - Important: Requires Screen Recording and Accessibility permissions
@@ -56,6 +61,7 @@ public final class UIAutomationService: TargetedHotkeyServiceProtocol, TargetedT
     public let supportsProcessGenerationPinnedTypeActions = true
     public let supportsProcessGenerationPinnedClicks = true
     public let supportsStatelessClickVariants = true
+    public let supportsTargetedClickAccessibilityValueDelivery = true
     public let supportsExactWindowTargetedKeyboard = true
     public let supportsExactWindowFocusedElementFocus = true
     public let supportsExactWindowPixelFocusTyping = true

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKitTestSupport/AutomationTestFixtures.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKitTestSupport/AutomationTestFixtures.swift
@@ -2,6 +2,7 @@ import CoreGraphics
 import Foundation
 import PeekabooAutomationKit
 import PeekabooFoundation
+import PeekabooFoundationTestSupport
 
 /// Canonical deterministic builders for automation tests.
 public enum AutomationTestFixtures {
@@ -152,7 +153,7 @@ public enum AutomationTestFixtures {
     }
 
     public static func captureCoordinateContext(
-        snapshotID: String = "snapshot-1",
+        snapshotID: String = SnapshotReferenceFixtures.first.rawValue,
         window: ServiceWindowInfo = Self.window(),
         deliveredImageSize: CGSize? = nil,
         viewport: CaptureViewport? = nil) -> CaptureCoordinateContext
@@ -246,7 +247,7 @@ public enum AutomationTestFixtures {
     }
 
     public static func detectionResult(
-        snapshotID: String = "snapshot-1",
+        snapshotID: String = SnapshotReferenceFixtures.first.rawValue,
         screenshotPath: String = "/tmp/peekaboo-test.png",
         elements: DetectedElements = DetectedElements(),
         windowContext: WindowContext? = nil,

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKitTestSupport/LinkedSnapshotTargetFixture.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKitTestSupport/LinkedSnapshotTargetFixture.swift
@@ -2,6 +2,7 @@ import CoreGraphics
 import Foundation
 import PeekabooAutomationKit
 import PeekabooFoundation
+import PeekabooFoundationTestSupport
 
 /// Coherent automation-snapshot and detection-result sources for one exact desktop target.
 public struct LinkedSnapshotTargetFixture: Sendable {
@@ -29,7 +30,7 @@ public struct LinkedSnapshotTargetFixture: Sendable {
 
 extension AutomationTestFixtures {
     public static func linkedSnapshotTarget(
-        snapshotID: String = "snapshot-1",
+        snapshotID: String = SnapshotReferenceFixtures.first.rawValue,
         processIdentity: ApplicationProcessIdentity = Self.processIdentity(),
         bundleIdentifier: String? = "com.example.TestApp",
         applicationName: String = "Test App",

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKitTestSupport/SnapshotMutationRecordingManager.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKitTestSupport/SnapshotMutationRecordingManager.swift
@@ -17,12 +17,24 @@ public final class SnapshotMutationRecordingManager: SnapshotManagerProtocol {
 
     public private(set) var beginCalls: [String] = []
     public private(set) var finishCalls: [FinishCall] = []
+    public private(set) var ownsCalls: [String] = []
+    public private(set) var createCalls: [Date?] = []
+    public private(set) var createExplicitCallCount = 0
     public var failFinish = false
+    public var ownsSnapshotError: (any Error)?
 
     private let wrapped: any SnapshotManagerProtocol
+    private let producerBoundSnapshotReferencesOverride: Bool?
+    private let createdSnapshotReferenceOverride: String?
 
-    public init(wrapping wrapped: any SnapshotManagerProtocol) {
+    public init(
+        wrapping wrapped: any SnapshotManagerProtocol,
+        supportsProducerBoundSnapshotReferences: Bool? = nil,
+        createdSnapshotReferenceOverride: String? = nil)
+    {
         self.wrapped = wrapped
+        self.producerBoundSnapshotReferencesOverride = supportsProducerBoundSnapshotReferences
+        self.createdSnapshotReferenceOverride = createdSnapshotReferenceOverride
     }
 
     public var supportsImplicitLatestSnapshotInvalidation: Bool {
@@ -45,20 +57,45 @@ public final class SnapshotMutationRecordingManager: SnapshotManagerProtocol {
         self.wrapped.supportsExplicitSnapshotPublication
     }
 
+    public var supportsProducerBoundSnapshotReferences: Bool {
+        self.producerBoundSnapshotReferencesOverride ?? self.wrapped.supportsProducerBoundSnapshotReferences
+    }
+
     public var effectiveImplicitLatestInvalidationWatermark: Date? {
         self.wrapped.effectiveImplicitLatestInvalidationWatermark
     }
 
     public func createSnapshot() async throws -> String {
-        try await self.wrapped.createSnapshot()
+        self.createCalls.append(nil)
+        if let createdSnapshotReferenceOverride {
+            return createdSnapshotReferenceOverride
+        }
+        return try await self.wrapped.createSnapshot()
     }
 
     public func createSnapshot(pendingAt observationStartedAt: Date) async throws -> String {
-        try await self.wrapped.createSnapshot(pendingAt: observationStartedAt)
+        self.createCalls.append(observationStartedAt)
+        if let createdSnapshotReferenceOverride {
+            return createdSnapshotReferenceOverride
+        }
+        return try await self.wrapped.createSnapshot(pendingAt: observationStartedAt)
     }
 
     public func createExplicitSnapshot() async throws -> String {
-        try await self.wrapped.createExplicitSnapshot()
+        self.createExplicitCallCount += 1
+        if let createdSnapshotReferenceOverride {
+            return createdSnapshotReferenceOverride
+        }
+        return try await self.wrapped.createExplicitSnapshot()
+    }
+
+    public func ownsSnapshot(snapshotId: String) async throws -> Bool {
+        self.ownsCalls.append(snapshotId)
+        if let ownsSnapshotError {
+            throw ownsSnapshotError
+        }
+        guard self.supportsProducerBoundSnapshotReferences else { return false }
+        return try await self.wrapped.ownsSnapshot(snapshotId: snapshotId)
     }
 
     public func storeDetectionResult(snapshotId: String, result: ElementDetectionResult) async throws {

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKitTestSupport/UIAutomationOutcomeScript.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKitTestSupport/UIAutomationOutcomeScript.swift
@@ -193,6 +193,38 @@ extension ScriptedUIAutomationActionOutcomeProviding {
         target: ClickTarget,
         clickType: ClickType,
         snapshotId: String?,
+        expectedProcessIdentity: ApplicationProcessIdentity,
+        allowsAccessibilityValueDelivery: Bool) async throws -> UIAutomationActionResult<Void>
+    {
+        guard let service = self as? any TargetedClickServiceProtocol,
+              service.supportsTargetedClicks,
+              service.supportsProcessGenerationPinnedClicks,
+              allowsAccessibilityValueDelivery || service.supportsTargetedClickAccessibilityValueDelivery
+        else {
+            throw PeekabooError.serviceUnavailable(
+                self.targetedCapabilityReason(
+                    (self as? any TargetedClickServiceProtocol)?.targetedClickUnavailableReason,
+                    fallback: "This automation test double does not support process-generation-pinned clicks"))
+        }
+        let targetIdentity = try self.outcomeTargetIdentity(
+            expectedProcessIdentity: expectedProcessIdentity)
+        let outcome = try self.uiAutomationOutcomeScript.nextOutcome(for: .click)
+        try await service.click(
+            target: target,
+            clickType: clickType,
+            snapshotId: snapshotId,
+            expectedProcessIdentity: expectedProcessIdentity,
+            allowsAccessibilityValueDelivery: allowsAccessibilityValueDelivery)
+        return UIAutomationActionResult(
+            payload: (),
+            outcome: outcome,
+            targetIdentity: targetIdentity)
+    }
+
+    public func clickWithOutcome(
+        target: ClickTarget,
+        clickType: ClickType,
+        snapshotId: String?,
         expectedWindowIdentity: WindowMutationIdentity,
         expectedWindowBounds: CGRect) async throws -> UIAutomationActionResult<Void>
     {
@@ -214,6 +246,40 @@ extension ScriptedUIAutomationActionOutcomeProviding {
             snapshotId: snapshotId,
             expectedWindowIdentity: expectedWindowIdentity,
             expectedWindowBounds: expectedWindowBounds)
+        return UIAutomationActionResult(
+            payload: (),
+            outcome: outcome,
+            targetIdentity: targetIdentity)
+    }
+
+    public func clickWithOutcome(
+        target: ClickTarget,
+        clickType: ClickType,
+        snapshotId: String?,
+        expectedWindowIdentity: WindowMutationIdentity,
+        expectedWindowBounds: CGRect,
+        allowsAccessibilityValueDelivery: Bool) async throws -> UIAutomationActionResult<Void>
+    {
+        guard let service = self as? any ExactWindowTargetedClickServiceProtocol,
+              service.supportsExactWindowTargetedClicks,
+              allowsAccessibilityValueDelivery || service.supportsTargetedClickAccessibilityValueDelivery
+        else {
+            throw PeekabooError.serviceUnavailable(
+                self.targetedCapabilityReason(
+                    (self as? any TargetedClickServiceProtocol)?.targetedClickUnavailableReason,
+                    fallback: "This automation test double does not support exact-window clicks"))
+        }
+        let targetIdentity = try self.outcomeTargetIdentity(
+            expectedWindowIdentity: expectedWindowIdentity,
+            expectedWindowBounds: expectedWindowBounds)
+        let outcome = try self.uiAutomationOutcomeScript.nextOutcome(for: .click)
+        try await service.click(
+            target: target,
+            clickType: clickType,
+            snapshotId: snapshotId,
+            expectedWindowIdentity: expectedWindowIdentity,
+            expectedWindowBounds: expectedWindowBounds,
+            allowsAccessibilityValueDelivery: allowsAccessibilityValueDelivery)
         return UIAutomationActionResult(
             payload: (),
             outcome: outcome,

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ActionInputDriverTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ActionInputDriverTests.swift
@@ -2,6 +2,7 @@ import AppKit
 import ApplicationServices
 import AXorcist
 import PeekabooFoundation
+import PeekabooFoundationTestSupport
 import Testing
 @testable import PeekabooAutomationKit
 
@@ -585,13 +586,14 @@ struct ActionInputDriverTests {
     @MainActor
     @Test
     func `element action facade normalizes stale action driver failures`() async throws {
+        let snapshotID = SnapshotReferenceFixtures.first.rawValue
         let detected = DetectedElement(
             id: "B1",
             type: .button,
             label: "Save",
             bounds: CGRect(x: 10, y: 10, width: 80, height: 24))
         let detectionResult = ElementDetectionResult(
-            snapshotId: "snapshot",
+            snapshotId: snapshotID,
             screenshotPath: "/tmp/shot.png",
             elements: DetectedElements(buttons: [detected]),
             metadata: DetectionMetadata(
@@ -599,21 +601,21 @@ struct ActionInputDriverTests {
                 elementCount: 1,
                 method: "test",
                 windowContext: WindowContext(applicationProcessId: getpid())))
-        let service = UIAutomationService(
-            snapshotManager: InMemorySnapshotManager(detectionResult: detectionResult),
+        let service = try await UIAutomationService(
+            snapshotManager: InMemorySnapshotManager.containing(detectionResult),
             inputPolicy: UIInputPolicy(defaultStrategy: .actionOnly),
             actionInputDriver: RecordingActionInputDriver(elementActionError: .staleElement),
             automationElementResolver: FixedActionAutomationElementResolver())
 
         do {
-            _ = try await service.setValue(target: "B1", value: .string("hello"), snapshotId: "snapshot")
+            _ = try await service.setValue(target: "B1", value: .string("hello"), snapshotId: snapshotID)
             Issue.record("Expected stale snapshot error from setValue")
         } catch let PeekabooError.snapshotStale(reason) {
             #expect(reason.contains("no longer available"))
         }
 
         do {
-            _ = try await service.performAction(target: "B1", actionName: "AXPress", snapshotId: "snapshot")
+            _ = try await service.performAction(target: "B1", actionName: "AXPress", snapshotId: snapshotID)
             Issue.record("Expected stale snapshot error from performAction")
         } catch let PeekabooError.snapshotStale(reason) {
             #expect(reason.contains("no longer available"))
@@ -623,6 +625,7 @@ struct ActionInputDriverTests {
     @MainActor
     @Test
     func `owner pinned element actions refuse OCR evidence before resolution or dispatch`() async throws {
+        let snapshotID = SnapshotReferenceFixtures.second.rawValue
         let processIdentifier = getpid()
         let processStartIdentity: UInt64 = 99
         let bounds = CGRect(x: 100, y: 100, width: 800, height: 600)
@@ -641,7 +644,7 @@ struct ActionInputDriverTests {
                 "confidence": "0.93",
             ])
         let detectionResult = ElementDetectionResult(
-            snapshotId: "snapshot",
+            snapshotId: snapshotID,
             screenshotPath: "/tmp/calendar.png",
             elements: DetectedElements(other: [detected]),
             metadata: DetectionMetadata(
@@ -653,8 +656,8 @@ struct ActionInputDriverTests {
                     windowID: 42,
                     windowBounds: bounds,
                     windowMutationIdentity: identity)))
-        let service = UIAutomationService(
-            snapshotManager: InMemorySnapshotManager(detectionResult: detectionResult),
+        let service = try await UIAutomationService(
+            snapshotManager: InMemorySnapshotManager.containing(detectionResult),
             inputPolicy: UIInputPolicy(defaultStrategy: .actionOnly),
             actionInputDriver: RecordingActionInputDriver(),
             automationElementResolver: FixedActionAutomationElementResolver {
@@ -666,8 +669,8 @@ struct ActionInputDriverTests {
             processStartIdentityProvider: { _ in processStartIdentity })
 
         for operation in [
-            { try await service.performAction(target: "ocr_1", actionName: "AXPress", snapshotId: "snapshot") },
-            { try await service.setValue(target: "ocr_1", value: .string("unsafe"), snapshotId: "snapshot") },
+            { try await service.performAction(target: "ocr_1", actionName: "AXPress", snapshotId: snapshotID) },
+            { try await service.setValue(target: "ocr_1", value: .string("unsafe"), snapshotId: snapshotID) },
         ] {
             do {
                 _ = try await operation()
@@ -693,10 +696,12 @@ struct ActionInputDriverTests {
         let frameRelease = ActionLaneLatch()
         let firstResolved = ActionLaneLatch()
         let secondResolved = ActionLaneLatch()
+        let firstSnapshotID = SnapshotReferenceFixtures.first.rawValue
+        let secondSnapshotID = SnapshotReferenceFixtures.second.rawValue
         let firstIdentity = self.windowIdentity(windowID: 301, process: firstProcess)
         let secondIdentity = self.windowIdentity(windowID: 302, process: secondProcess)
-        let firstService = self.makeScopedElementMutationService(
-            snapshotID: "first",
+        let firstService = try await self.makeScopedElementMutationService(
+            snapshotID: firstSnapshotID,
             identity: firstIdentity,
             coordinator: coordinator,
             currentGeneration: { pid in
@@ -705,8 +710,8 @@ struct ActionInputDriverTests {
                     : secondProcess.processStartIdentity
             },
             onResolve: { Task { await firstResolved.open() } })
-        let secondService = self.makeScopedElementMutationService(
-            snapshotID: "second",
+        let secondService = try await self.makeScopedElementMutationService(
+            snapshotID: secondSnapshotID,
             identity: secondIdentity,
             coordinator: coordinator,
             currentGeneration: { pid in
@@ -724,10 +729,10 @@ struct ActionInputDriverTests {
         }
         await frameStarted.wait()
         let firstMutation = Task {
-            try? await firstService.setValue(target: "B1", value: .string("one"), snapshotId: "first")
+            try? await firstService.setValue(target: "B1", value: .string("one"), snapshotId: firstSnapshotID)
         }
         let secondMutation = Task {
-            try? await secondService.performAction(target: "B1", actionName: "AXPress", snapshotId: "second")
+            try? await secondService.performAction(target: "B1", actionName: "AXPress", snapshotId: secondSnapshotID)
         }
 
         let secondOverlapped = await secondResolved.opensWithin(.seconds(1))
@@ -751,22 +756,23 @@ struct ActionInputDriverTests {
         defer { try? FileManager.default.removeItem(at: root) }
         let process = ApplicationProcessIdentity(processIdentifier: 612, processStartIdentity: 13)
         let identity = self.windowIdentity(windowID: 303, process: process)
-        let service = self.makeScopedElementMutationService(
-            snapshotID: "reused",
+        let snapshotID = SnapshotReferenceFixtures.third.rawValue
+        let service = try await self.makeScopedElementMutationService(
+            snapshotID: snapshotID,
             identity: identity,
             coordinator: DesktopOperationLaneCoordinator(coordinationRootURL: root),
             currentGeneration: { _ in process.processStartIdentity + 1 },
             onResolve: { Issue.record("Stale element mutation reached target resolution") })
 
         do {
-            _ = try await service.performAction(target: "B1", actionName: "AXPress", snapshotId: "reused")
+            _ = try await service.performAction(target: "B1", actionName: "AXPress", snapshotId: snapshotID)
             Issue.record("Expected reused process generation to refuse action")
         } catch let PeekabooError.snapshotStale(reason) {
             #expect(reason.contains("process generation"))
         }
 
         do {
-            _ = try await service.setValue(target: "B1", value: .string("new"), snapshotId: "reused")
+            _ = try await service.setValue(target: "B1", value: .string("new"), snapshotId: snapshotID)
             Issue.record("Expected reused process generation to refuse set-value")
         } catch let PeekabooError.snapshotStale(reason) {
             #expect(reason.contains("process generation"))
@@ -840,6 +846,36 @@ struct ActionInputDriverTests {
         #expect(result.elementRole == AXRoleNames.kAXTextFieldRole)
         #expect(result.outcome.state == .confirmedChange)
         #expect(result.focusedElement?.identifier == nil)
+    }
+
+    @MainActor
+    @Test
+    func `text field click without negotiated value delivery refuses before focus write`() throws {
+        let element = MockAutomationElement(
+            role: AXRoleNames.kAXTextFieldRole,
+            frame: CGRect(x: 10, y: 20, width: 30, height: 40),
+            isValueSettable: true,
+            isFocusedSettable: true)
+
+        #expect(throws: ActionInputError.self) {
+            _ = try ActionInputDriver().tryClickForTesting(
+                element: element,
+                allowAccessibilityValueFallback: false)
+        }
+        #expect(element.performedActions.isEmpty)
+        #expect(element.setFocusedValues.isEmpty)
+    }
+
+    @MainActor
+    @Test
+    func `legacy action driver opt out refuses before invoking an unknown click implementation`() throws {
+        let driver = RecordingActionInputDriver()
+        let element = AutomationElement(Element(AXUIElementCreateApplication(getpid())))
+
+        #expect(throws: ActionInputError.self) {
+            _ = try driver.tryClick(element: element, allowAccessibilityValueFallback: false)
+        }
+        #expect(driver.clickCallCount == 0)
     }
 
     @MainActor
@@ -1085,7 +1121,7 @@ struct ActionInputDriverTests {
         identity: WindowMutationIdentity,
         coordinator: DesktopOperationLaneCoordinator,
         currentGeneration: @escaping @Sendable (pid_t) -> UInt64?,
-        onResolve: @escaping @MainActor () -> Void) -> UIAutomationService
+        onResolve: @escaping @MainActor () -> Void) async throws -> UIAutomationService
     {
         let detected = DetectedElement(
             id: "B1",
@@ -1106,8 +1142,8 @@ struct ActionInputDriverTests {
                 elementCount: 1,
                 method: "test",
                 windowContext: context))
-        return UIAutomationService(
-            snapshotManager: InMemorySnapshotManager(detectionResult: detectionResult),
+        return try await UIAutomationService(
+            snapshotManager: InMemorySnapshotManager.containing(detectionResult),
             inputPolicy: UIInputPolicy(defaultStrategy: .actionOnly),
             actionInputDriver: RecordingActionInputDriver(elementActionError: .staleElement),
             automationElementResolver: FixedActionAutomationElementResolver(onResolve: onResolve),
@@ -1206,12 +1242,14 @@ private final class PhantomSuccessAutomationElement: AutomationElementRepresenti
 @MainActor
 private final class RecordingActionInputDriver: ActionInputDriving {
     private let elementActionError: ActionInputError?
+    private(set) var clickCallCount = 0
 
     init(elementActionError: ActionInputError? = nil) {
         self.elementActionError = elementActionError
     }
 
     func tryClick(element _: AutomationElement) throws -> UIInputExecutionResult.Action {
+        self.clickCallCount += 1
         Issue.record("Action driver should not be called")
         return UIInputExecutionResult.Action(outcome: .confirmedNoChange())
     }

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/AutomationKitTestSupportTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/AutomationKitTestSupportTests.swift
@@ -201,6 +201,33 @@ struct AutomationKitTestSupportTests {
     }
 
     @Test
+    func `legacy targeted click permits value delivery but refuses explicit opt out`() async throws {
+        let script = UIAutomationOutcomeScript(defaultResponse: .outcome(Self.outcome(evidence: .deliveryAccepted)))
+        let service = PlainScriptedAutomationService(outcomeScript: script)
+        let identity = AutomationTestFixtures.processIdentity()
+
+        await #expect(throws: PeekabooError.self) {
+            try await service.clickWithOutcome(
+                target: .elementId("field"),
+                clickType: .single,
+                snapshotId: nil,
+                expectedProcessIdentity: identity,
+                allowsAccessibilityValueDelivery: false)
+        }
+        #expect(service.clickCount == 0)
+        #expect(script.totalCallCount == 0)
+
+        _ = try await service.clickWithOutcome(
+            target: .elementId("field"),
+            clickType: .single,
+            snapshotId: nil,
+            expectedProcessIdentity: identity,
+            allowsAccessibilityValueDelivery: true)
+        #expect(service.clickCount == 1)
+        #expect(script.callCount(for: .click) == 1)
+    }
+
+    @Test
     func `script default outcome is mutable and instance owned`() async throws {
         let script = UIAutomationOutcomeScript()
         let service = PlainScriptedAutomationService(outcomeScript: script)
@@ -232,9 +259,11 @@ private enum OutcomeScriptTestError: Error {
 @MainActor
 private final class PlainScriptedAutomationService:
     UnusedUIAutomationService,
-    ScriptedUIAutomationActionOutcomeProviding
+    ScriptedUIAutomationActionOutcomeProviding,
+    TargetedClickServiceProtocol
 {
     let uiAutomationOutcomeScript: UIAutomationOutcomeScript
+    let supportsProcessGenerationPinnedClicks = true
     private(set) var clickCount = 0
 
     init(outcomeScript: UIAutomationOutcomeScript) {
@@ -242,6 +271,24 @@ private final class PlainScriptedAutomationService:
     }
 
     override func click(target _: ClickTarget, clickType _: ClickType, snapshotId _: String?) async throws {
+        self.clickCount += 1
+    }
+
+    func click(
+        target _: ClickTarget,
+        clickType _: ClickType,
+        snapshotId _: String?,
+        targetProcessIdentifier _: pid_t) async throws
+    {
+        self.clickCount += 1
+    }
+
+    func click(
+        target _: ClickTarget,
+        clickType _: ClickType,
+        snapshotId _: String?,
+        expectedProcessIdentity _: ApplicationProcessIdentity) async throws
+    {
         self.clickCount += 1
     }
 }

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ClickServiceExactWindowTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ClickServiceExactWindowTests.swift
@@ -6,10 +6,14 @@ import enum PeekabooFoundation.ClickType
 import struct PeekabooFoundation.DesktopActionFailure
 import struct PeekabooFoundation.DesktopActionOutcome
 import enum PeekabooFoundation.PeekabooError
+import PeekabooFoundationTestSupport
 import Testing
 @testable import PeekabooAutomationKit
 
 struct ClickServiceExactWindowTests {
+    private static let snapshotID = SnapshotReferenceFixtures.first.rawValue
+    private static let incompleteSnapshotID = SnapshotReferenceFixtures.second.rawValue
+
     @Test
     @MainActor
     func `Middle and triple clicks use only the exact-window routed synthesis owner`() async throws {
@@ -92,7 +96,7 @@ struct ClickServiceExactWindowTests {
             processStartIdentity: 72)
         let bounds = CGRect(x: 0, y: 0, width: 200, height: 100)
         let detection = ElementDetectionResult(
-            snapshotId: "snapshot",
+            snapshotId: Self.snapshotID,
             screenshotPath: "/tmp/shot.png",
             elements: DetectedElements(buttons: [DetectedElement(
                 id: "B1",
@@ -112,8 +116,8 @@ struct ClickServiceExactWindowTests {
                         processIdentity: replacementProcess,
                         bounds: bounds))))
         let synthetic = ClickRecordingSyntheticInputDriver()
-        let service = ClickService(
-            snapshotManager: InMemorySnapshotManager(detectionResult: detection),
+        let service = try await ClickService(
+            snapshotManager: InMemorySnapshotManager.containing(detection),
             inputPolicy: UIInputPolicy(defaultStrategy: .synthOnly),
             syntheticInputDriver: synthetic,
             exactWindowIdentityValidator: { _, _ in true },
@@ -123,7 +127,7 @@ struct ClickServiceExactWindowTests {
             _ = try await service.click(
                 target: .elementId("B1"),
                 clickType: .single,
-                snapshotId: "snapshot",
+                snapshotId: Self.snapshotID,
                 targetProcessIdentifier: pinnedProcess.processIdentifier,
                 expectedProcessIdentity: pinnedProcess)
         }
@@ -142,7 +146,7 @@ struct ClickServiceExactWindowTests {
             processIdentity: process,
             bounds: nil)
         let detection = AutomationTestFixtures.detectionResult(
-            snapshotID: "incomplete",
+            snapshotID: Self.incompleteSnapshotID,
             elements: DetectedElements(buttons: [AutomationTestFixtures.detectedElement(
                 id: "B1",
                 type: .button,
@@ -153,8 +157,8 @@ struct ClickServiceExactWindowTests {
                 windowBounds: bounds,
                 windowMutationIdentity: identity))
         let synthetic = ClickRecordingSyntheticInputDriver()
-        let service = ClickService(
-            snapshotManager: InMemorySnapshotManager(detectionResult: detection),
+        let service = try await ClickService(
+            snapshotManager: InMemorySnapshotManager.containing(detection),
             inputPolicy: UIInputPolicy(defaultStrategy: .synthOnly),
             syntheticInputDriver: synthetic,
             exactWindowIdentityValidator: { _, _ in
@@ -422,7 +426,7 @@ struct ClickServiceExactWindowTests {
 
     @Test
     @MainActor
-    func `Application menu target cannot use a document window`() async {
+    func `Application menu target cannot use a document window`() async throws {
         let pid = getpid()
         let menuItem = DetectedElement(
             id: "M1",
@@ -434,7 +438,7 @@ struct ClickServiceExactWindowTests {
                 DetectedElementRootPolicy.sourceAttribute: DetectedElementRootPolicy.applicationMenuBarSource,
             ])
         let detectionResult = ElementDetectionResult(
-            snapshotId: "snapshot",
+            snapshotId: Self.snapshotID,
             screenshotPath: "/tmp/shot.png",
             elements: DetectedElements(menus: [menuItem]),
             metadata: DetectionMetadata(
@@ -443,8 +447,8 @@ struct ClickServiceExactWindowTests {
                 method: "test",
                 windowContext: WindowContext(applicationProcessId: pid, windowID: 42)))
         let synthetic = ClickRecordingSyntheticInputDriver()
-        let service = ClickService(
-            snapshotManager: InMemorySnapshotManager(detectionResult: detectionResult),
+        let service = try await ClickService(
+            snapshotManager: InMemorySnapshotManager.containing(detectionResult),
             inputPolicy: UIInputPolicy(defaultStrategy: .synthOnly),
             syntheticInputDriver: synthetic)
 
@@ -452,7 +456,7 @@ struct ClickServiceExactWindowTests {
             try await service.click(
                 target: .elementId("M1"),
                 clickType: .single,
-                snapshotId: "snapshot",
+                snapshotId: Self.snapshotID,
                 targetProcessIdentifier: pid,
                 targetWindowID: 42)
         }
@@ -482,7 +486,7 @@ struct ClickServiceExactWindowTests {
 
             for target in targets {
                 let detectionResult = ElementDetectionResult(
-                    snapshotId: "snapshot",
+                    snapshotId: Self.snapshotID,
                     screenshotPath: "/tmp/shot.png",
                     elements: DetectedElements(menus: [target]),
                     metadata: DetectionMetadata(
@@ -498,8 +502,8 @@ struct ClickServiceExactWindowTests {
                                 ownerProcessIdentifier: pid,
                                 ownerProcessStartIdentity: 1))))
                 let synthetic = ClickRecordingSyntheticInputDriver()
-                let service = ClickService(
-                    snapshotManager: InMemorySnapshotManager(detectionResult: detectionResult),
+                let service = try await ClickService(
+                    snapshotManager: InMemorySnapshotManager.containing(detectionResult),
                     inputPolicy: UIInputPolicy(defaultStrategy: .synthOnly),
                     syntheticInputDriver: synthetic,
                     exactWindowIdentityValidator: { _, _ in true })
@@ -507,7 +511,7 @@ struct ClickServiceExactWindowTests {
                 let result = try await service.click(
                     target: .elementId(target.id),
                     clickType: .single,
-                    snapshotId: "snapshot",
+                    snapshotId: Self.snapshotID,
                     targetProcessIdentifier: pid,
                     targetWindowID: 42,
                     expectedWindowIdentity: WindowMutationIdentity(

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ClickServiceTargetResolutionTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ClickServiceTargetResolutionTests.swift
@@ -8,11 +8,14 @@ import struct PeekabooFoundation.DesktopActionFailure
 import struct PeekabooFoundation.DesktopActionOutcome
 import enum PeekabooFoundation.PeekabooError
 import enum PeekabooFoundation.ScrollDirection
+import PeekabooFoundationTestSupport
 import Testing
 @testable import PeekabooAutomationKit
 
 @Suite(.serialized)
 struct ClickServiceTargetResolutionTests {
+    private static let snapshotID = SnapshotReferenceFixtures.first.rawValue
+
     @Test
     @MainActor
     func `generation-pinned click rejects recycled PID before dispatch`() async throws {
@@ -41,7 +44,7 @@ struct ClickServiceTargetResolutionTests {
         let identity = ApplicationProcessIdentity(processIdentifier: getpid(), processStartIdentity: 71)
         let action = ClickSuccessfulActionInputDriver()
         let detection = ElementDetectionResult(
-            snapshotId: "snapshot",
+            snapshotId: Self.snapshotID,
             screenshotPath: "/tmp/shot.png",
             elements: DetectedElements(buttons: [DetectedElement(
                 id: "B1",
@@ -61,8 +64,8 @@ struct ClickServiceTargetResolutionTests {
                         ownerProcessIdentifier: identity.processIdentifier,
                         ownerProcessStartIdentity: identity.processStartIdentity,
                         capturedBounds: Self.testWindowBounds))))
-        let service = UIAutomationService(
-            snapshotManager: InMemorySnapshotManager(detectionResult: detection),
+        let service = try await UIAutomationService(
+            snapshotManager: InMemorySnapshotManager.containing(detection),
             inputPolicy: UIInputPolicy(defaultStrategy: .actionOnly),
             actionInputDriver: action,
             automationElementResolver: ClickFixedAutomationElementResolver(
@@ -74,7 +77,7 @@ struct ClickServiceTargetResolutionTests {
             try await service.click(
                 target: .elementId("B1"),
                 clickType: .single,
-                snapshotId: "snapshot",
+                snapshotId: Self.snapshotID,
                 expectedProcessIdentity: identity)
         }
         #expect(action.performedActionNames.isEmpty)
@@ -89,7 +92,7 @@ struct ClickServiceTargetResolutionTests {
         let tracker = ClickWindowTracker(bounds: Self.testWindowBounds)
         try await WindowMovementTrackingProviderScope.withProvider(tracker) {
             let detection = ElementDetectionResult(
-                snapshotId: "snapshot",
+                snapshotId: Self.snapshotID,
                 screenshotPath: "/tmp/shot.png",
                 elements: DetectedElements(buttons: [DetectedElement(
                     id: "B1",
@@ -109,8 +112,8 @@ struct ClickServiceTargetResolutionTests {
                             ownerProcessIdentifier: identity.processIdentifier,
                             ownerProcessStartIdentity: identity.processStartIdentity,
                             capturedBounds: Self.testWindowBounds))))
-            let service = UIAutomationService(
-                snapshotManager: InMemorySnapshotManager(detectionResult: detection),
+            let service = try await UIAutomationService(
+                snapshotManager: InMemorySnapshotManager.containing(detection),
                 inputPolicy: UIInputPolicy(defaultStrategy: .actionOnly),
                 actionInputDriver: action,
                 automationElementResolver: ClickFixedAutomationElementResolver(),
@@ -121,7 +124,7 @@ struct ClickServiceTargetResolutionTests {
                 try await service.click(
                     target: .elementId("B1"),
                     clickType: .single,
-                    snapshotId: "snapshot",
+                    snapshotId: Self.snapshotID,
                     expectedProcessIdentity: identity)
                 Issue.record("Expected post-dispatch process drift")
             } catch let failure as DesktopActionFailure {
@@ -143,20 +146,20 @@ struct ClickServiceTargetResolutionTests {
             bounds: CGRect(x: 20, y: 30, width: 100, height: 40),
             attributes: ["identifier": "peekaboo-post-validation-never-focused"])
         let detection = ElementDetectionResult(
-            snapshotId: "snapshot",
+            snapshotId: Self.snapshotID,
             screenshotPath: "/tmp/shot.png",
             elements: DetectedElements(buttons: [element]),
             metadata: DetectionMetadata(detectionTime: 0, elementCount: 1, method: "test"))
 
         for target in [ClickTarget.elementId("B1"), .query("Post Validation Target")] {
             let synthetic = ClickRecordingSyntheticInputDriver(failGlobalClickAt: 2)
-            let service = ClickService(
-                snapshotManager: InMemorySnapshotManager(detectionResult: detection),
+            let service = try await ClickService(
+                snapshotManager: InMemorySnapshotManager.containing(detection),
                 inputPolicy: UIInputPolicy(defaultStrategy: .synthOnly),
                 syntheticInputDriver: synthetic)
 
             do {
-                _ = try await service.click(target: target, clickType: .single, snapshotId: "snapshot")
+                _ = try await service.click(target: target, clickType: .single, snapshotId: Self.snapshotID)
                 Issue.record("Expected post-click focus validation failure")
             } catch let failure as DesktopActionFailure {
                 #expect(failure.outcome.state == .dispatchedUnverified)
@@ -226,18 +229,18 @@ struct ClickServiceTargetResolutionTests {
             isSelected: nil,
             attributes: [:])
         let detectionResult = ElementDetectionResult(
-            snapshotId: "snapshot",
+            snapshotId: Self.snapshotID,
             screenshotPath: "/tmp/shot.png",
             elements: DetectedElements(other: [element]),
             metadata: DetectionMetadata(detectionTime: 0.01, elementCount: 1, method: "test"))
         let synthetic = ClickRecordingSyntheticInputDriver()
-        let service = ClickService(
-            snapshotManager: InMemorySnapshotManager(detectionResult: detectionResult),
+        let service = try await ClickService(
+            snapshotManager: InMemorySnapshotManager.containing(detectionResult),
             inputPolicy: UIInputPolicy(defaultStrategy: .actionFirst),
             syntheticInputDriver: synthetic,
             automationElementResolver: ClickMissingAutomationElementResolver())
 
-        let result = try await service.click(target: .elementId("C1"), clickType: .right, snapshotId: "snapshot")
+        let result = try await service.click(target: .elementId("C1"), clickType: .right, snapshotId: Self.snapshotID)
 
         #expect(result.path == .synth)
         #expect(result.fallbackReason == .missingElement)
@@ -248,7 +251,7 @@ struct ClickServiceTargetResolutionTests {
 
     @Test
     @MainActor
-    func `OCR semantic element refuses before exact owner delivery or synthetic fallback`() async {
+    func `OCR semantic element refuses before exact owner delivery or synthetic fallback`() async throws {
         let pid = getpid()
         let element = DetectedElement(
             id: "ocr_1",
@@ -260,7 +263,7 @@ struct ClickServiceTargetResolutionTests {
                 "confidence": "0.93",
             ])
         let detectionResult = ElementDetectionResult(
-            snapshotId: "snapshot",
+            snapshotId: Self.snapshotID,
             screenshotPath: "/tmp/calendar.png",
             elements: DetectedElements(other: [element]),
             metadata: DetectionMetadata(
@@ -271,8 +274,8 @@ struct ClickServiceTargetResolutionTests {
         let action = ClickSuccessfulActionInputDriver()
         let synthetic = ClickRecordingSyntheticInputDriver()
         let resolver = ClickFixedAutomationElementResolver()
-        let service = ClickService(
-            snapshotManager: InMemorySnapshotManager(detectionResult: detectionResult),
+        let service = try await ClickService(
+            snapshotManager: InMemorySnapshotManager.containing(detectionResult),
             inputPolicy: UIInputPolicy(defaultStrategy: .actionFirst),
             actionInputDriver: action,
             syntheticInputDriver: synthetic,
@@ -283,7 +286,7 @@ struct ClickServiceTargetResolutionTests {
             _ = try await service.click(
                 target: .elementId("ocr_1"),
                 clickType: .single,
-                snapshotId: "snapshot",
+                snapshotId: Self.snapshotID,
                 targetProcessIdentifier: pid)
             Issue.record("Expected OCR semantic evidence refusal")
         } catch let PeekabooError.invalidInput(message) {
@@ -316,7 +319,7 @@ struct ClickServiceTargetResolutionTests {
             label: "August",
             bounds: CGRect(x: 10, y: 40, width: 100, height: 20))
         let result = ElementDetectionResult(
-            snapshotId: "snapshot",
+            snapshotId: Self.snapshotID,
             screenshotPath: "/tmp/calendar.png",
             elements: DetectedElements(other: [ocr, ordinary]),
             metadata: DetectionMetadata(detectionTime: 0, elementCount: 2, method: "test"))
@@ -376,7 +379,7 @@ struct ClickServiceTargetResolutionTests {
                 label: "Background Button",
                 bounds: .init(x: 20, y: 30, width: 100, height: 40))
             let detectionResult = ElementDetectionResult(
-                snapshotId: "snapshot",
+                snapshotId: Self.snapshotID,
                 screenshotPath: "/tmp/shot.png",
                 elements: DetectedElements(buttons: [element]),
                 metadata: DetectionMetadata(
@@ -391,8 +394,8 @@ struct ClickServiceTargetResolutionTests {
                 evidence: .deliveryAccepted,
                 unitCount: unitCount)
             let synthetic = ClickRecordingSyntheticInputDriver(targetedClickOutcome: expectedOutcome)
-            let service = ClickService(
-                snapshotManager: InMemorySnapshotManager(detectionResult: detectionResult),
+            let service = try await ClickService(
+                snapshotManager: InMemorySnapshotManager.containing(detectionResult),
                 inputPolicy: UIInputPolicy(defaultStrategy: .actionFirst),
                 actionInputDriver: action,
                 syntheticInputDriver: synthetic,
@@ -402,7 +405,7 @@ struct ClickServiceTargetResolutionTests {
             let result = try await service.click(
                 target: .elementId("B1"),
                 clickType: .double,
-                snapshotId: "snapshot",
+                snapshotId: Self.snapshotID,
                 targetProcessIdentifier: pid)
 
             #expect(result.path == .synth)
@@ -437,7 +440,7 @@ struct ClickServiceTargetResolutionTests {
                 isSelected: nil,
                 attributes: ["identifier": "background-button", "role": "AXButton"])
             let detectionResult = ElementDetectionResult(
-                snapshotId: "snapshot",
+                snapshotId: Self.snapshotID,
                 screenshotPath: "/tmp/shot.png",
                 elements: DetectedElements(buttons: [element]),
                 metadata: DetectionMetadata(
@@ -446,8 +449,8 @@ struct ClickServiceTargetResolutionTests {
                     method: "test",
                     windowContext: Self.exactWindowContext(processIdentifier: pid)))
             let synthetic = ClickRecordingSyntheticInputDriver()
-            let service = ClickService(
-                snapshotManager: InMemorySnapshotManager(detectionResult: detectionResult),
+            let service = try await ClickService(
+                snapshotManager: InMemorySnapshotManager.containing(detectionResult),
                 inputPolicy: UIInputPolicy(defaultStrategy: .actionFirst),
                 syntheticInputDriver: synthetic,
                 exactWindowIdentityValidator: { _, _ in true })
@@ -455,7 +458,7 @@ struct ClickServiceTargetResolutionTests {
             let result = try await service.click(
                 target: .elementId("B1"),
                 clickType: .single,
-                snapshotId: "snapshot",
+                snapshotId: Self.snapshotID,
                 targetProcessIdentifier: pid)
 
             #expect(result.path == .synth)
@@ -484,7 +487,7 @@ struct ClickServiceTargetResolutionTests {
                 label: "Background Button",
                 bounds: .init(x: 20, y: 30, width: 100, height: 40))
             let detectionResult = ElementDetectionResult(
-                snapshotId: "snapshot",
+                snapshotId: Self.snapshotID,
                 screenshotPath: "/tmp/shot.png",
                 elements: DetectedElements(buttons: [element]),
                 metadata: DetectionMetadata(
@@ -495,8 +498,8 @@ struct ClickServiceTargetResolutionTests {
             let action = ClickSuccessfulActionInputDriver()
             let synthetic = ClickRecordingSyntheticInputDriver()
             let resolver = ClickFixedAutomationElementResolver()
-            let service = ClickService(
-                snapshotManager: InMemorySnapshotManager(detectionResult: detectionResult),
+            let service = try await ClickService(
+                snapshotManager: InMemorySnapshotManager.containing(detectionResult),
                 inputPolicy: UIInputPolicy(defaultStrategy: .actionFirst),
                 actionInputDriver: action,
                 syntheticInputDriver: synthetic,
@@ -506,7 +509,7 @@ struct ClickServiceTargetResolutionTests {
             let result = try await service.click(
                 target: .elementId("B1"),
                 clickType: .single,
-                snapshotId: "snapshot",
+                snapshotId: Self.snapshotID,
                 targetProcessIdentifier: pid)
 
             #expect(result.path == .action)
@@ -530,7 +533,7 @@ struct ClickServiceTargetResolutionTests {
                 label: "Background Button",
                 bounds: .init(x: 20, y: 30, width: 100, height: 40))
             let detectionResult = ElementDetectionResult(
-                snapshotId: "snapshot",
+                snapshotId: Self.snapshotID,
                 screenshotPath: "/tmp/shot.png",
                 elements: DetectedElements(buttons: [element]),
                 metadata: DetectionMetadata(
@@ -541,8 +544,8 @@ struct ClickServiceTargetResolutionTests {
             let action = ClickSuccessfulActionInputDriver()
             let synthetic = ClickRecordingSyntheticInputDriver()
             let resolver = ClickFixedAutomationElementResolver()
-            let service = ClickService(
-                snapshotManager: InMemorySnapshotManager(detectionResult: detectionResult),
+            let service = try await ClickService(
+                snapshotManager: InMemorySnapshotManager.containing(detectionResult),
                 inputPolicy: UIInputPolicy(defaultStrategy: .actionFirst),
                 actionInputDriver: action,
                 syntheticInputDriver: synthetic,
@@ -552,7 +555,7 @@ struct ClickServiceTargetResolutionTests {
             let result = try await service.click(
                 target: .elementId("B1"),
                 clickType: .right,
-                snapshotId: "snapshot",
+                snapshotId: Self.snapshotID,
                 targetProcessIdentifier: pid)
 
             #expect(result.path == .action)
@@ -565,17 +568,17 @@ struct ClickServiceTargetResolutionTests {
 
     @Test
     @MainActor
-    func `background element right click reports synthetic permission when AX fallback fails`() async {
+    func `background element right click reports synthetic permission when AX fallback fails`() async throws {
         let pid = getpid()
         let tracker = ClickWindowTracker(bounds: Self.testWindowBounds)
-        await WindowMovementTrackingProviderScope.withProvider(tracker) {
+        try await WindowMovementTrackingProviderScope.withProvider(tracker) {
             let element = DetectedElement(
                 id: "B1",
                 type: .button,
                 label: "Background Button",
                 bounds: .init(x: 20, y: 30, width: 100, height: 40))
             let detectionResult = ElementDetectionResult(
-                snapshotId: "snapshot",
+                snapshotId: Self.snapshotID,
                 screenshotPath: "/tmp/shot.png",
                 elements: DetectedElements(buttons: [element]),
                 metadata: DetectionMetadata(
@@ -586,8 +589,8 @@ struct ClickServiceTargetResolutionTests {
             let synthetic = ClickRecordingSyntheticInputDriver(
                 targetedClickError: PeekabooError.permissionDeniedEventSynthesizing)
             let resolver = ClickFixedAutomationElementResolver()
-            let service = ClickService(
-                snapshotManager: InMemorySnapshotManager(detectionResult: detectionResult),
+            let service = try await ClickService(
+                snapshotManager: InMemorySnapshotManager.containing(detectionResult),
                 inputPolicy: UIInputPolicy(defaultStrategy: .actionFirst),
                 actionInputDriver: ClickFailingActionInputDriver(error: .permissionDenied),
                 syntheticInputDriver: synthetic,
@@ -598,7 +601,7 @@ struct ClickServiceTargetResolutionTests {
                 _ = try await service.click(
                     target: .elementId("B1"),
                     clickType: .right,
-                    snapshotId: "snapshot",
+                    snapshotId: Self.snapshotID,
                     targetProcessIdentifier: pid)
                 Issue.record("Expected Event Synthesizing permission error")
             } catch PeekabooError.permissionDeniedEventSynthesizing {
@@ -622,7 +625,7 @@ struct ClickServiceTargetResolutionTests {
             label: "Background Button",
             bounds: .init(x: 20, y: 30, width: 100, height: 40))
         let detectionResult = ElementDetectionResult(
-            snapshotId: "snapshot",
+            snapshotId: Self.snapshotID,
             screenshotPath: "/tmp/shot.png",
             elements: DetectedElements(buttons: [element]),
             metadata: DetectionMetadata(
@@ -633,8 +636,8 @@ struct ClickServiceTargetResolutionTests {
         let action = ClickSuccessfulActionInputDriver()
         let synthetic = ClickRecordingSyntheticInputDriver()
         let resolver = ClickFixedAutomationElementResolver()
-        let service = ClickService(
-            snapshotManager: InMemorySnapshotManager(detectionResult: detectionResult),
+        let service = try await ClickService(
+            snapshotManager: InMemorySnapshotManager.containing(detectionResult),
             inputPolicy: UIInputPolicy(defaultStrategy: .actionFirst),
             actionInputDriver: action,
             syntheticInputDriver: synthetic,
@@ -644,7 +647,7 @@ struct ClickServiceTargetResolutionTests {
             try await service.click(
                 target: .elementId("B1"),
                 clickType: .single,
-                snapshotId: "snapshot",
+                snapshotId: Self.snapshotID,
                 targetProcessIdentifier: pid)
         }
 
@@ -667,7 +670,7 @@ struct ClickServiceTargetResolutionTests {
                 DetectedElementRootPolicy.sourceAttribute: DetectedElementRootPolicy.applicationMenuBarSource,
             ])
         let detectionResult = ElementDetectionResult(
-            snapshotId: "snapshot",
+            snapshotId: Self.snapshotID,
             screenshotPath: "/tmp/shot.png",
             elements: DetectedElements(menus: [element]),
             metadata: DetectionMetadata(
@@ -678,8 +681,8 @@ struct ClickServiceTargetResolutionTests {
         let action = ClickSuccessfulActionInputDriver()
         let synthetic = ClickRecordingSyntheticInputDriver()
         let resolver = ClickFixedAutomationElementResolver()
-        let service = ClickService(
-            snapshotManager: InMemorySnapshotManager(detectionResult: detectionResult),
+        let service = try await ClickService(
+            snapshotManager: InMemorySnapshotManager.containing(detectionResult),
             inputPolicy: UIInputPolicy(defaultStrategy: .actionFirst),
             actionInputDriver: action,
             syntheticInputDriver: synthetic,
@@ -688,7 +691,7 @@ struct ClickServiceTargetResolutionTests {
         let result = try await service.click(
             target: .elementId("M1"),
             clickType: .single,
-            snapshotId: "snapshot",
+            snapshotId: Self.snapshotID,
             targetProcessIdentifier: pid)
 
         #expect(result.path == .action)
@@ -707,7 +710,7 @@ struct ClickServiceTargetResolutionTests {
             label: "Different Button",
             bounds: .init(x: 20, y: 30, width: 100, height: 40))
         let detectionResult = ElementDetectionResult(
-            snapshotId: "snapshot",
+            snapshotId: Self.snapshotID,
             screenshotPath: "/tmp/shot.png",
             elements: DetectedElements(buttons: [element]),
             metadata: DetectionMetadata(
@@ -717,8 +720,8 @@ struct ClickServiceTargetResolutionTests {
                 windowContext: Self.exactWindowContext(processIdentifier: pid)))
         let action = ClickSuccessfulActionInputDriver()
         let resolver = ClickFixedAutomationElementResolver()
-        let service = ClickService(
-            snapshotManager: InMemorySnapshotManager(detectionResult: detectionResult),
+        let service = try await ClickService(
+            snapshotManager: InMemorySnapshotManager.containing(detectionResult),
             inputPolicy: UIInputPolicy(defaultStrategy: .actionFirst),
             actionInputDriver: action,
             automationElementResolver: resolver,
@@ -727,7 +730,7 @@ struct ClickServiceTargetResolutionTests {
         let result = try await service.click(
             target: .query("Live Button"),
             clickType: .single,
-            snapshotId: "snapshot",
+            snapshotId: Self.snapshotID,
             targetProcessIdentifier: pid)
 
         #expect(result.path == .action)
@@ -738,7 +741,7 @@ struct ClickServiceTargetResolutionTests {
 
     @Test
     @MainActor
-    func `background missing snapshot query never synthesizes outside its window`() async {
+    func `background missing snapshot query never synthesizes outside its window`() async throws {
         let pid = getpid()
         let element = DetectedElement(
             id: "B1",
@@ -746,7 +749,7 @@ struct ClickServiceTargetResolutionTests {
             label: "Different Button",
             bounds: .init(x: 20, y: 30, width: 100, height: 40))
         let detectionResult = ElementDetectionResult(
-            snapshotId: "snapshot",
+            snapshotId: Self.snapshotID,
             screenshotPath: "/tmp/shot.png",
             elements: DetectedElements(buttons: [element]),
             metadata: DetectionMetadata(
@@ -756,8 +759,8 @@ struct ClickServiceTargetResolutionTests {
                 windowContext: Self.exactWindowContext(processIdentifier: pid)))
         let synthetic = ClickRecordingSyntheticInputDriver()
         let resolver = ClickFixedAutomationElementResolver(resolveQueries: false)
-        let service = ClickService(
-            snapshotManager: InMemorySnapshotManager(detectionResult: detectionResult),
+        let service = try await ClickService(
+            snapshotManager: InMemorySnapshotManager.containing(detectionResult),
             inputPolicy: UIInputPolicy(defaultStrategy: .actionFirst),
             syntheticInputDriver: synthetic,
             automationElementResolver: resolver,
@@ -767,7 +770,7 @@ struct ClickServiceTargetResolutionTests {
             try await service.click(
                 target: .query("Missing Button"),
                 clickType: .single,
-                snapshotId: "snapshot",
+                snapshotId: Self.snapshotID,
                 targetProcessIdentifier: pid)
         }
 
@@ -778,17 +781,17 @@ struct ClickServiceTargetResolutionTests {
 
     @Test
     @MainActor
-    func `background element click rejects vanished window without snapshot bounds`() async {
+    func `background element click rejects vanished window without snapshot bounds`() async throws {
         let pid = getpid()
         let tracker = ClickWindowTracker(bounds: nil)
-        await WindowMovementTrackingProviderScope.withProvider(tracker) {
+        try await WindowMovementTrackingProviderScope.withProvider(tracker) {
             let element = DetectedElement(
                 id: "B1",
                 type: .button,
                 label: "Background Button",
                 bounds: .init(x: 20, y: 30, width: 100, height: 40))
             let detectionResult = ElementDetectionResult(
-                snapshotId: "snapshot",
+                snapshotId: Self.snapshotID,
                 screenshotPath: "/tmp/shot.png",
                 elements: DetectedElements(buttons: [element]),
                 metadata: DetectionMetadata(
@@ -800,8 +803,8 @@ struct ClickServiceTargetResolutionTests {
                         windowID: 42)))
             let action = ClickSuccessfulActionInputDriver()
             let synthetic = ClickRecordingSyntheticInputDriver()
-            let service = ClickService(
-                snapshotManager: InMemorySnapshotManager(detectionResult: detectionResult),
+            let service = try await ClickService(
+                snapshotManager: InMemorySnapshotManager.containing(detectionResult),
                 inputPolicy: UIInputPolicy(defaultStrategy: .actionFirst),
                 actionInputDriver: action,
                 syntheticInputDriver: synthetic,
@@ -811,7 +814,7 @@ struct ClickServiceTargetResolutionTests {
                 try await service.click(
                     target: .elementId("B1"),
                     clickType: .single,
-                    snapshotId: "snapshot",
+                    snapshotId: Self.snapshotID,
                     targetProcessIdentifier: pid)
             }
 
@@ -832,7 +835,7 @@ struct ClickServiceTargetResolutionTests {
                 label: "Duplicate",
                 bounds: CGRect(x: 120, y: 140, width: 80, height: 30))
             let detectionResult = ElementDetectionResult(
-                snapshotId: "snapshot",
+                snapshotId: Self.snapshotID,
                 screenshotPath: "/tmp/shot.png",
                 elements: DetectedElements(buttons: [element]),
                 metadata: DetectionMetadata(
@@ -848,8 +851,8 @@ struct ClickServiceTargetResolutionTests {
                             capturedBounds: CGRect(x: 100, y: 100, width: 300, height: 300)))))
             let resolver = ClickFixedAutomationElementResolver()
             let synthetic = ClickRecordingSyntheticInputDriver()
-            let service = ClickService(
-                snapshotManager: InMemorySnapshotManager(detectionResult: detectionResult),
+            let service = try await ClickService(
+                snapshotManager: InMemorySnapshotManager.containing(detectionResult),
                 inputPolicy: UIInputPolicy(defaultStrategy: .actionFirst),
                 actionInputDriver: ClickSuccessfulActionInputDriver(),
                 syntheticInputDriver: synthetic,
@@ -859,7 +862,7 @@ struct ClickServiceTargetResolutionTests {
             let result = try await service.click(
                 target: .elementId("B1"),
                 clickType: .single,
-                snapshotId: "snapshot",
+                snapshotId: Self.snapshotID,
                 targetProcessIdentifier: pid)
 
             #expect(result.path == .action)
@@ -883,7 +886,7 @@ struct ClickServiceTargetResolutionTests {
                 label: "Background Button",
                 bounds: .init(x: 20, y: 30, width: 100, height: 40))
             let detectionResult = ElementDetectionResult(
-                snapshotId: "snapshot",
+                snapshotId: Self.snapshotID,
                 screenshotPath: "/tmp/shot.png",
                 elements: DetectedElements(buttons: [element]),
                 metadata: DetectionMetadata(
@@ -892,8 +895,8 @@ struct ClickServiceTargetResolutionTests {
                     method: "test",
                     windowContext: Self.exactWindowContext(processIdentifier: pid)))
             let synthetic = ClickRecordingSyntheticInputDriver()
-            let service = ClickService(
-                snapshotManager: InMemorySnapshotManager(detectionResult: detectionResult),
+            let service = try await ClickService(
+                snapshotManager: InMemorySnapshotManager.containing(detectionResult),
                 inputPolicy: UIInputPolicy(defaultStrategy: .actionFirst),
                 actionInputDriver: ClickFailingActionInputDriver(error: .permissionDenied),
                 syntheticInputDriver: synthetic,
@@ -903,7 +906,7 @@ struct ClickServiceTargetResolutionTests {
             let result = try await service.click(
                 target: .elementId("B1"),
                 clickType: .single,
-                snapshotId: "snapshot",
+                snapshotId: Self.snapshotID,
                 targetProcessIdentifier: pid)
 
             #expect(result.path == .synth)
@@ -921,7 +924,7 @@ struct ClickServiceTargetResolutionTests {
 
     @Test
     @MainActor
-    func `background element click rejects snapshot from another process`() async {
+    func `background element click rejects snapshot from another process`() async throws {
         let element = DetectedElement(
             id: "B1",
             type: .button,
@@ -929,7 +932,7 @@ struct ClickServiceTargetResolutionTests {
             bounds: .init(x: 20, y: 30, width: 100, height: 40),
             attributes: ["identifier": "background-button", "role": "AXButton"])
         let detectionResult = ElementDetectionResult(
-            snapshotId: "snapshot",
+            snapshotId: Self.snapshotID,
             screenshotPath: "/tmp/shot.png",
             elements: DetectedElements(buttons: [element]),
             metadata: DetectionMetadata(
@@ -938,8 +941,8 @@ struct ClickServiceTargetResolutionTests {
                 method: "test",
                 windowContext: WindowContext(applicationProcessId: 222)))
         let synthetic = ClickRecordingSyntheticInputDriver()
-        let service = ClickService(
-            snapshotManager: InMemorySnapshotManager(detectionResult: detectionResult),
+        let service = try await ClickService(
+            snapshotManager: InMemorySnapshotManager.containing(detectionResult),
             inputPolicy: UIInputPolicy(defaultStrategy: .actionFirst),
             syntheticInputDriver: synthetic)
 
@@ -947,7 +950,7 @@ struct ClickServiceTargetResolutionTests {
             try await service.click(
                 target: .elementId("B1"),
                 clickType: .single,
-                snapshotId: "snapshot",
+                snapshotId: Self.snapshotID,
                 targetProcessIdentifier: 333)
         }
         #expect(synthetic.events.isEmpty)
@@ -955,20 +958,20 @@ struct ClickServiceTargetResolutionTests {
 
     @Test
     @MainActor
-    func `background element click rejects snapshot without process identity`() async {
+    func `background element click rejects snapshot without process identity`() async throws {
         let element = DetectedElement(
             id: "B1",
             type: .button,
             label: "Background Button",
             bounds: .init(x: 20, y: 30, width: 100, height: 40))
         let detectionResult = ElementDetectionResult(
-            snapshotId: "snapshot",
+            snapshotId: Self.snapshotID,
             screenshotPath: "/tmp/shot.png",
             elements: DetectedElements(buttons: [element]),
             metadata: DetectionMetadata(detectionTime: 0.01, elementCount: 1, method: "test"))
         let synthetic = ClickRecordingSyntheticInputDriver()
-        let service = ClickService(
-            snapshotManager: InMemorySnapshotManager(detectionResult: detectionResult),
+        let service = try await ClickService(
+            snapshotManager: InMemorySnapshotManager.containing(detectionResult),
             inputPolicy: UIInputPolicy(defaultStrategy: .actionFirst),
             syntheticInputDriver: synthetic)
 
@@ -976,7 +979,7 @@ struct ClickServiceTargetResolutionTests {
             try await service.click(
                 target: .elementId("B1"),
                 clickType: .single,
-                snapshotId: "snapshot",
+                snapshotId: Self.snapshotID,
                 targetProcessIdentifier: getpid())
         }
         #expect(synthetic.events.isEmpty)
@@ -984,17 +987,17 @@ struct ClickServiceTargetResolutionTests {
 
     @Test
     @MainActor
-    func `targeted action-only permission denial maps to accessibility permission`() async {
+    func `targeted action-only permission denial maps to accessibility permission`() async throws {
         let pid = getpid()
         let tracker = ClickWindowTracker(bounds: Self.testWindowBounds)
-        await WindowMovementTrackingProviderScope.withProvider(tracker) {
+        try await WindowMovementTrackingProviderScope.withProvider(tracker) {
             let element = DetectedElement(
                 id: "B1",
                 type: .button,
                 label: "Background Button",
                 bounds: .init(x: 20, y: 30, width: 100, height: 40))
             let detectionResult = ElementDetectionResult(
-                snapshotId: "snapshot",
+                snapshotId: Self.snapshotID,
                 screenshotPath: "/tmp/shot.png",
                 elements: DetectedElements(buttons: [element]),
                 metadata: DetectionMetadata(
@@ -1002,8 +1005,8 @@ struct ClickServiceTargetResolutionTests {
                     elementCount: 1,
                     method: "test",
                     windowContext: Self.exactWindowContext(processIdentifier: pid)))
-            let service = ClickService(
-                snapshotManager: InMemorySnapshotManager(detectionResult: detectionResult),
+            let service = try await ClickService(
+                snapshotManager: InMemorySnapshotManager.containing(detectionResult),
                 inputPolicy: UIInputPolicy(defaultStrategy: .actionOnly),
                 actionInputDriver: ClickFailingActionInputDriver(error: .permissionDenied),
                 automationElementResolver: ClickFixedAutomationElementResolver(),
@@ -1013,7 +1016,7 @@ struct ClickServiceTargetResolutionTests {
                 try await service.click(
                     target: .elementId("B1"),
                     clickType: .single,
-                    snapshotId: "snapshot",
+                    snapshotId: Self.snapshotID,
                     targetProcessIdentifier: pid)
                 Issue.record("Expected Accessibility permission error")
             } catch PeekabooError.permissionDeniedAccessibility {
@@ -1130,14 +1133,14 @@ struct ClickServiceTargetResolutionTests {
 
     @Test
     @MainActor
-    func `background synth only click rejects snapshot from another process`() async {
+    func `background synth only click rejects snapshot from another process`() async throws {
         let element = DetectedElement(
             id: "B1",
             type: .button,
             label: "Background Button",
             bounds: .init(x: 20, y: 30, width: 100, height: 40))
         let detectionResult = ElementDetectionResult(
-            snapshotId: "snapshot",
+            snapshotId: Self.snapshotID,
             screenshotPath: "/tmp/shot.png",
             elements: DetectedElements(buttons: [element]),
             metadata: DetectionMetadata(
@@ -1146,8 +1149,8 @@ struct ClickServiceTargetResolutionTests {
                 method: "test",
                 windowContext: WindowContext(applicationProcessId: 222)))
         let synthetic = ClickRecordingSyntheticInputDriver()
-        let service = ClickService(
-            snapshotManager: InMemorySnapshotManager(detectionResult: detectionResult),
+        let service = try await ClickService(
+            snapshotManager: InMemorySnapshotManager.containing(detectionResult),
             inputPolicy: UIInputPolicy(defaultStrategy: .synthOnly),
             syntheticInputDriver: synthetic)
 
@@ -1155,7 +1158,7 @@ struct ClickServiceTargetResolutionTests {
             try await service.click(
                 target: .elementId("B1"),
                 clickType: .single,
-                snapshotId: "snapshot",
+                snapshotId: Self.snapshotID,
                 targetProcessIdentifier: 333)
         }
         #expect(synthetic.events.isEmpty)
@@ -1217,7 +1220,7 @@ struct ClickServiceTargetResolutionTests {
             attributes: ["identifier": "basic-text-field", "role": "AXTextField"])
 
         let detectionResult = ElementDetectionResult(
-            snapshotId: "snapshot",
+            snapshotId: Self.snapshotID,
             screenshotPath: "/tmp/shot.png",
             elements: DetectedElements(buttons: [focusButton], textFields: [basicField]),
             metadata: DetectionMetadata(detectionTime: 0.01, elementCount: 2, method: "test"))
@@ -1249,7 +1252,7 @@ struct ClickServiceTargetResolutionTests {
             attributes: ["identifier": "basic-text-field", "role": "AXTextField"])
 
         let detectionResult = ElementDetectionResult(
-            snapshotId: "snapshot",
+            snapshotId: Self.snapshotID,
             screenshotPath: "/tmp/shot.png",
             elements: DetectedElements(textFields: [higher, lower]),
             metadata: DetectionMetadata(detectionTime: 0.01, elementCount: 2, method: "test"))
@@ -1297,7 +1300,7 @@ extension ClickServiceTargetResolutionTests {
                 label: "Settings",
                 bounds: .init(x: 20, y: 30, width: 100, height: 40))
             let detectionResult = ElementDetectionResult(
-                snapshotId: "snapshot",
+                snapshotId: Self.snapshotID,
                 screenshotPath: "/tmp/shot.png",
                 elements: DetectedElements(buttons: [element]),
                 metadata: DetectionMetadata(
@@ -1307,8 +1310,8 @@ extension ClickServiceTargetResolutionTests {
                     windowContext: Self.exactWindowContext(processIdentifier: pid)))
             let action = ClickSuccessfulActionInputDriver()
             let synthetic = ClickRecordingSyntheticInputDriver()
-            let service = ClickService(
-                snapshotManager: InMemorySnapshotManager(detectionResult: detectionResult),
+            let service = try await ClickService(
+                snapshotManager: InMemorySnapshotManager.containing(detectionResult),
                 inputPolicy: UIInputPolicy(defaultStrategy: .actionFirst),
                 actionInputDriver: action,
                 syntheticInputDriver: synthetic,
@@ -1320,7 +1323,7 @@ extension ClickServiceTargetResolutionTests {
                 _ = try await service.click(
                     target: .elementId("TAB1"),
                     clickType: .single,
-                    snapshotId: "snapshot",
+                    snapshotId: Self.snapshotID,
                     targetProcessIdentifier: pid)
                 Issue.record("Expected an indeterminate accepted tab press")
             } catch let failure as DesktopActionFailure {

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/DesktopObservationServiceTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/DesktopObservationServiceTests.swift
@@ -1,6 +1,8 @@
 import AppKit
 import CoreGraphics
+import PeekabooAutomationKitTestSupport
 import PeekabooFoundation
+import PeekabooFoundationTestSupport
 import XCTest
 @testable import PeekabooAutomationKit
 
@@ -396,12 +398,12 @@ extension DesktopObservationServiceTests {
                 mode: .accessibility,
                 allowWebFocusFallback: false,
                 includeMenuBarElements: false),
-            output: DesktopObservationOutputOptions(snapshotID: "snapshot-1"),
+            output: DesktopObservationOutputOptions(snapshotID: SnapshotReferenceFixtures.first.rawValue),
             timeout: DesktopObservationTimeouts(detection: 60)))
 
         XCTAssertNotNil(result.elements)
         XCTAssertEqual(automation.detectCalls, 1)
-        XCTAssertEqual(automation.lastSnapshotID, "snapshot-1")
+        XCTAssertEqual(automation.lastSnapshotID, SnapshotReferenceFixtures.first.rawValue)
         XCTAssertEqual(automation.lastWindowContext?.applicationName, "Fixture")
         XCTAssertEqual(automation.lastWindowContext?.applicationBundleId, "com.example.fixture")
         XCTAssertEqual(automation.lastWindowContext?.windowTitle, "Editor")
@@ -450,8 +452,7 @@ extension DesktopObservationServiceTests {
                 output: DesktopObservationOutputOptions(
                     path: outputURL.path,
                     saveRawScreenshot: true,
-                    saveSnapshot: true,
-                    snapshotID: "empty-incomplete")))
+                    saveSnapshot: true)))
             XCTFail("Expected empty incomplete combined evidence to fail")
         } catch let error as PeekabooError {
             guard case .accessibilityIncomplete = error else {
@@ -461,6 +462,10 @@ extension DesktopObservationServiceTests {
         }
 
         XCTAssertEqual(automation.detectCalls, 1)
+        let reservedSnapshotID = try XCTUnwrap(automation.lastSnapshotID)
+        XCTAssertNotNil(SnapshotReference(rawValue: reservedSnapshotID))
+        let ownsFailedReservation = try await snapshots.ownsSnapshot(snapshotId: reservedSnapshotID)
+        XCTAssertFalse(ownsFailedReservation)
         XCTAssertEqual(try Data(contentsOf: outputURL), Data([9]))
         let publishedSnapshots = try await snapshots.listSnapshots()
         XCTAssertTrue(publishedSnapshots.isEmpty)
@@ -839,6 +844,11 @@ extension DesktopObservationServiceTests {
         let outputURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("peekaboo-snapshot-test-\(UUID().uuidString).png")
         let snapshotManager = InMemorySnapshotManager()
+        let detectionStarted = expectation(description: "snapshot observation reached detection")
+        let allowDetectionToFinish = ObservationDetectionSuspension {
+            detectionStarted.fulfill()
+        }
+        defer { allowDetectionToFinish.release() }
         let automation = RecordingUIAutomationService(elements: DetectedElements(buttons: [
             DetectedElement(
                 id: "B1",
@@ -846,7 +856,7 @@ extension DesktopObservationServiceTests {
                 label: "Save",
                 bounds: CGRect(x: 20, y: 30, width: 40, height: 20),
                 isEnabled: true),
-        ]))
+        ]), detectionSuspension: allowDetectionToFinish)
         let service = try DesktopObservationService(
             screenCapture: RecordingScreenCaptureService(
                 result: Self.captureResult(
@@ -857,21 +867,37 @@ extension DesktopObservationServiceTests {
             applications: applications,
             snapshotManager: snapshotManager)
 
-        let result = try await service.observe(DesktopObservationRequest(
-            target: .app(identifier: "Fixture", window: .automatic),
-            detection: DesktopDetectionOptions(mode: .accessibility),
-            output: DesktopObservationOutputOptions(
-                path: outputURL.path,
-                saveSnapshot: true)))
+        let observation = Task {
+            try await service.observe(DesktopObservationRequest(
+                target: .app(identifier: "Fixture", window: .automatic),
+                detection: DesktopDetectionOptions(mode: .accessibility),
+                output: DesktopObservationOutputOptions(
+                    path: outputURL.path,
+                    saveSnapshot: true)))
+        }
+        await fulfillment(of: [detectionStarted], timeout: 2)
+        let latestDuringDetection = await snapshotManager.getMostRecentSnapshot()
+        let listedDuringDetection = try await snapshotManager.listSnapshots()
+        XCTAssertNil(latestDuringDetection)
+        XCTAssertTrue(listedDuringDetection.isEmpty)
+
+        allowDetectionToFinish.release()
+        let result = try await observation.value
 
         XCTAssertEqual(result.files.rawScreenshotPath, outputURL.path)
-        let snapshotID = try XCTUnwrap(result.elements?.snapshotId)
-        XCTAssertEqual(result.files.publishedSnapshotID, snapshotID)
-        let storedDetection = try await snapshotManager.getDetectionResult(snapshotId: snapshotID)
+        let resultSnapshotID = try XCTUnwrap(result.elements?.snapshotId)
+        XCTAssertNotNil(SnapshotReference(rawValue: resultSnapshotID))
+        XCTAssertEqual(automation.lastSnapshotID, resultSnapshotID)
+        XCTAssertEqual(result.files.publishedSnapshotID, resultSnapshotID)
+        let ownsPublishedSnapshot = try await snapshotManager.ownsSnapshot(snapshotId: resultSnapshotID)
+        XCTAssertTrue(ownsPublishedSnapshot)
+        let latestAfterPublication = await snapshotManager.getMostRecentSnapshot()
+        XCTAssertEqual(latestAfterPublication, resultSnapshotID)
+        let storedDetection = try await snapshotManager.getDetectionResult(snapshotId: resultSnapshotID)
         XCTAssertEqual(storedDetection?.screenshotPath, outputURL.path)
         XCTAssertEqual(storedDetection?.elements.all.first?.id, "B1")
 
-        let storedSnapshot = try await snapshotManager.getUIAutomationSnapshot(snapshotId: snapshotID)
+        let storedSnapshot = try await snapshotManager.getUIAutomationSnapshot(snapshotId: resultSnapshotID)
         XCTAssertEqual(storedSnapshot?.screenshotPath, outputURL.path)
         XCTAssertEqual(storedSnapshot?.applicationBundleId, "com.example.fixture")
         XCTAssertEqual(storedSnapshot?.windowTitle, "Snapshot")
@@ -879,6 +905,48 @@ extension DesktopObservationServiceTests {
         XCTAssertTrue(result.timings.spans.map(\.name).contains("snapshot.write"))
 
         try? FileManager.default.removeItem(at: outputURL)
+    }
+
+    func testSnapshotObservationRequiresProducerBoundManagerBeforeCapture() async throws {
+        let app = Self.app()
+        let window = Self.window(
+            id: 189,
+            title: "Snapshot authority",
+            bounds: CGRect(x: 10, y: 20, width: 160, height: 120))
+
+        for (manager, expectedCreateCalls) in [
+            (
+                SnapshotMutationRecordingManager(
+                    wrapping: InMemorySnapshotManager(),
+                    supportsProducerBoundSnapshotReferences: false),
+                0),
+            (
+                SnapshotMutationRecordingManager(
+                    wrapping: InMemorySnapshotManager(),
+                    supportsProducerBoundSnapshotReferences: true,
+                    createdSnapshotReferenceOverride: "snapshot-legacy"),
+                1),
+        ] {
+            let capture = RecordingScreenCaptureService(result: Self.captureResult(app: app, window: window))
+            let service = DesktopObservationService(
+                screenCapture: capture,
+                automation: RecordingUIAutomationService(),
+                applications: RecordingApplicationService(applications: [app], windows: [window]),
+                snapshotManager: manager)
+
+            do {
+                _ = try await service.observe(DesktopObservationRequest(
+                    target: .app(identifier: "Fixture", window: .automatic),
+                    detection: DesktopDetectionOptions(mode: .accessibility),
+                    output: DesktopObservationOutputOptions(saveSnapshot: true)))
+                XCTFail("Expected an unsupported snapshot authority to fail before capture")
+            } catch is SnapshotError {
+                // Expected: either unsupported producer authority or a malformed claimed reference.
+            }
+
+            XCTAssertEqual(manager.createCalls.count, expectedCreateCalls)
+            XCTAssertTrue(capture.operations.isEmpty)
+        }
     }
 
     func testObservationForwardsCaptureEnginePreferenceWhenSupported() async throws {

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/DesktopOperationExecutorTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/DesktopOperationExecutorTests.swift
@@ -1,11 +1,14 @@
 import CoreGraphics
 import Foundation
 import PeekabooFoundation
+import PeekabooFoundationTestSupport
 import Testing
 @testable import PeekabooAutomationKit
 
 @MainActor
 struct DesktopOperationExecutorTests {
+    private static let snapshotID = SnapshotReferenceFixtures.first.rawValue
+
     @Test
     func `v4 initializer remains conservative and current result round trips`() throws {
         let legacy = UIInputExecutionResult(
@@ -708,14 +711,14 @@ struct DesktopOperationExecutorTests {
             label: "Input",
             bounds: CGRect(x: 20, y: 30, width: 200, height: 30))
         let detectionResult = ElementDetectionResult(
-            snapshotId: "snapshot",
+            snapshotId: Self.snapshotID,
             screenshotPath: "/tmp/type-target.png",
             elements: DetectedElements(textFields: [target]),
             metadata: DetectionMetadata(detectionTime: 0, elementCount: 1, method: "test"))
         let synthetic = ClickRecordingSyntheticInputDriver()
         var finalizerCount = 0
-        let service = TypeService(
-            snapshotManager: InMemorySnapshotManager(detectionResult: detectionResult),
+        let service = try await TypeService(
+            snapshotManager: InMemorySnapshotManager.containing(detectionResult),
             inputPolicy: UIInputPolicy(defaultStrategy: .synthOnly),
             syntheticInputDriver: synthetic,
             desktopOperationExecutor: executor,
@@ -726,7 +729,7 @@ struct DesktopOperationExecutorTests {
             target: "T1",
             clearExisting: false,
             typingDelay: 0,
-            snapshotId: "snapshot")
+            snapshotId: Self.snapshotID)
 
         #expect(summary.result.path == .synth)
         #expect(finalizerCount == 1)

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/FileServiceSnapshotCleanupTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/FileServiceSnapshotCleanupTests.swift
@@ -1,4 +1,6 @@
 import Foundation
+import PeekabooFoundation
+import PeekabooFoundationTestSupport
 import XCTest
 @testable import PeekabooAutomationKit
 
@@ -18,6 +20,7 @@ final class FileServiceSnapshotCleanupTests: XCTestCase {
             fixture.outside.path,
             "nul\0byte",
             "line\nbreak",
+            "12345",
         ]
 
         for snapshotID in invalidIDs {
@@ -30,16 +33,24 @@ final class FileServiceSnapshotCleanupTests: XCTestCase {
         }
     }
 
-    func testLegacyShapedDirectChildIDsSupportDryRunAndDeletion() async throws {
+    func testProducerOwnedCanonicalIDsSupportDryRunAndDeletion() async throws {
         let fixture = try self.makeFixture()
         defer { try? FileManager.default.removeItem(at: fixture.container) }
         let service = FileService(snapshotCacheDirectory: fixture.cacheRoot)
 
-        for snapshotID in ["12345", "abc", "a..b"] {
+        for snapshotID in [
+            SnapshotReferenceFixtures.id(1),
+            SnapshotReferenceFixtures.id(2),
+            SnapshotReferenceFixtures.id(3),
+        ] {
+            let manager = SnapshotManager(
+                snapshotStorageURL: fixture.cacheRoot,
+                snapshotReferenceGenerator: { SnapshotReference(rawValue: snapshotID)! })
+            let createdSnapshotID = try await manager.createSnapshot()
+            XCTAssertEqual(createdSnapshotID, snapshotID)
             let snapshot = fixture.cacheRoot.appendingPathComponent(snapshotID, isDirectory: true)
             let payload = snapshot.appendingPathComponent("snapshot.json")
             let payloadContents = Data("payload-\(snapshotID)".utf8)
-            try FileManager.default.createDirectory(at: snapshot, withIntermediateDirectories: false)
             try payloadContents.write(to: payload)
 
             let preview = try await service.cleanSpecificSnapshot(snapshotId: snapshotID, dryRun: true)
@@ -69,9 +80,9 @@ final class FileServiceSnapshotCleanupTests: XCTestCase {
         try FileManager.default.createDirectory(at: sibling, withIntermediateDirectories: false)
         try siblingContents.write(to: siblingSentinel)
 
-        let outsideLink = fixture.cacheRoot.appendingPathComponent("outside-link")
-        let siblingLink = fixture.cacheRoot.appendingPathComponent("sibling-link")
-        let danglingLink = fixture.cacheRoot.appendingPathComponent("dangling-link")
+        let outsideLink = fixture.cacheRoot.appendingPathComponent(SnapshotReferenceFixtures.id(11))
+        let siblingLink = fixture.cacheRoot.appendingPathComponent(SnapshotReferenceFixtures.id(12))
+        let danglingLink = fixture.cacheRoot.appendingPathComponent(SnapshotReferenceFixtures.id(13))
         let missingTarget = fixture.container.appendingPathComponent("missing-target", isDirectory: true)
         try FileManager.default.createSymbolicLink(at: outsideLink, withDestinationURL: fixture.outside)
         try FileManager.default.createSymbolicLink(at: siblingLink, withDestinationURL: sibling)
@@ -83,7 +94,7 @@ final class FileServiceSnapshotCleanupTests: XCTestCase {
             danglingLink.lastPathComponent,
         ] {
             for dryRun in [true, false] {
-                await self.assertInvalidSnapshotID(snapshotID, dryRun: dryRun, service: service)
+                try await self.assertUnownedSnapshotIgnored(snapshotID, dryRun: dryRun, service: service)
                 XCTAssertNoThrow(try FileManager.default.destinationOfSymbolicLink(
                     atPath: fixture.cacheRoot.appendingPathComponent(snapshotID).path))
                 XCTAssertEqual(try Data(contentsOf: fixture.outsideSentinel), fixture.outsideSentinelContents)
@@ -97,12 +108,12 @@ final class FileServiceSnapshotCleanupTests: XCTestCase {
         let fixture = try self.makeFixture()
         defer { try? FileManager.default.removeItem(at: fixture.container) }
         let service = FileService(snapshotCacheDirectory: fixture.cacheRoot)
-        let regularFile = fixture.cacheRoot.appendingPathComponent("not-a-snapshot")
+        let regularFile = fixture.cacheRoot.appendingPathComponent(SnapshotReferenceFixtures.id(21))
         let contents = Data("ordinary file".utf8)
         try contents.write(to: regularFile)
 
         for dryRun in [true, false] {
-            await self.assertInvalidSnapshotID(
+            try await self.assertUnownedSnapshotIgnored(
                 regularFile.lastPathComponent,
                 dryRun: dryRun,
                 service: service)
@@ -116,12 +127,146 @@ final class FileServiceSnapshotCleanupTests: XCTestCase {
         let service = FileService(snapshotCacheDirectory: fixture.cacheRoot)
 
         for dryRun in [true, false] {
-            let result = try await service.cleanSpecificSnapshot(snapshotId: "missing", dryRun: dryRun)
+            let result = try await service.cleanSpecificSnapshot(
+                snapshotId: SnapshotReferenceFixtures.id(99),
+                dryRun: dryRun)
             XCTAssertEqual(result.snapshotsRemoved, 0)
             XCTAssertEqual(result.bytesFreed, 0)
             XCTAssertTrue(result.snapshotDetails.isEmpty)
             XCTAssertEqual(result.dryRun, dryRun)
         }
+    }
+
+    func testListExposesOnlyCanonicalProducerOwnedSnapshots() async throws {
+        let fixture = try self.makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.container) }
+        let service = FileService(snapshotCacheDirectory: fixture.cacheRoot)
+        let manager = SnapshotManager(
+            snapshotStorageURL: fixture.cacheRoot,
+            snapshotReferenceGenerator: { SnapshotReferenceFixtures.first })
+        let owned = try await manager.createSnapshot()
+
+        for snapshotID in ["1787675983803-1514", SnapshotReferenceFixtures.id(88)] {
+            let directory = fixture.cacheRoot.appendingPathComponent(snapshotID, isDirectory: true)
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: false)
+            try Data("{}".utf8).write(to: directory.appendingPathComponent("snapshot.json"))
+        }
+        let symlink = fixture.cacheRoot.appendingPathComponent(SnapshotReferenceFixtures.id(89))
+        try FileManager.default.createSymbolicLink(at: symlink, withDestinationURL: fixture.outside)
+        let markerSymlinkID = SnapshotReferenceFixtures.id(90)
+        let markerSymlinkDirectory = fixture.cacheRoot.appendingPathComponent(markerSymlinkID, isDirectory: true)
+        try FileManager.default.createDirectory(at: markerSymlinkDirectory, withIntermediateDirectories: false)
+        try Data("{}".utf8).write(to: markerSymlinkDirectory.appendingPathComponent("snapshot.json"))
+        let outsideMarker = fixture.outside.appendingPathComponent("owner-marker")
+        try Data(markerSymlinkID.utf8).write(to: outsideMarker)
+        try FileManager.default.createSymbolicLink(
+            at: markerSymlinkDirectory.appendingPathComponent(SnapshotPathValidator.producerOwnerMarkerName),
+            withDestinationURL: outsideMarker)
+
+        let listed = try await service.listSnapshots()
+
+        XCTAssertEqual(listed.map(\.snapshotId), [owned])
+        XCTAssertNoThrow(try FileManager.default.destinationOfSymbolicLink(atPath: symlink.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: markerSymlinkDirectory.path))
+    }
+
+    func testLegacyTimestampSnapshotsRemainCleanupOnly() async throws {
+        let fixture = try self.makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.container) }
+        let service = FileService(snapshotCacheDirectory: fixture.cacheRoot)
+        let legacyID = "1787675983803-1514"
+        let legacyURL = fixture.cacheRoot.appendingPathComponent(legacyID, isDirectory: true)
+        try FileManager.default.createDirectory(at: legacyURL, withIntermediateDirectories: false)
+        try Data("legacy".utf8).write(to: legacyURL.appendingPathComponent("snapshot.json"))
+
+        let listed = try await service.listSnapshots()
+        XCTAssertTrue(listed.isEmpty)
+        let preview = try await service.cleanSpecificSnapshot(snapshotId: legacyID, dryRun: true)
+        XCTAssertEqual(preview.snapshotDetails.map(\.snapshotId), [legacyID])
+        XCTAssertTrue(FileManager.default.fileExists(atPath: legacyURL.path))
+
+        let result = try await service.cleanSpecificSnapshot(snapshotId: legacyID, dryRun: false)
+        XCTAssertEqual(result.snapshotsRemoved, 1)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: legacyURL.path))
+    }
+
+    func testLegacyPendingSnapshotDirectoriesRemainCleanupOnly() async throws {
+        let fixture = try self.makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.container) }
+        let service = FileService(snapshotCacheDirectory: fixture.cacheRoot)
+        let legacyPendingID = ".pending-\(UUID().uuidString)"
+        let legacyPendingURL = fixture.cacheRoot.appendingPathComponent(legacyPendingID, isDirectory: true)
+        let malformedPendingURL = fixture.cacheRoot.appendingPathComponent(".pending-abandoned", isDirectory: true)
+        try FileManager.default.createDirectory(at: legacyPendingURL, withIntermediateDirectories: false)
+        try FileManager.default.createDirectory(at: malformedPendingURL, withIntermediateDirectories: false)
+        try Data("legacy pending artifact".utf8).write(to: legacyPendingURL.appendingPathComponent("raw.png"))
+
+        let listed = try await service.listSnapshots()
+        XCTAssertTrue(listed.isEmpty)
+        let preview = try await service.cleanAllSnapshots(dryRun: true)
+        XCTAssertEqual(preview.snapshotDetails.map(\.snapshotId), [legacyPendingID])
+        XCTAssertTrue(FileManager.default.fileExists(atPath: legacyPendingURL.path))
+
+        let cleaned = try await service.cleanAllSnapshots(dryRun: false)
+        XCTAssertEqual(cleaned.snapshotDetails.map(\.snapshotId), [legacyPendingID])
+        XCTAssertFalse(FileManager.default.fileExists(atPath: legacyPendingURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: malformedPendingURL.path))
+    }
+
+    func testCleanAllAndAgeCleanupRemoveOnlyOwnedOrLegacySnapshotDirectories() async throws {
+        let fixture = try self.makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.container) }
+        let service = FileService(snapshotCacheDirectory: fixture.cacheRoot)
+        let manager = SnapshotManager(
+            snapshotStorageURL: fixture.cacheRoot,
+            snapshotReferenceGenerator: { SnapshotReferenceFixtures.first })
+        let owned = try await manager.createSnapshot()
+        let legacyID = "1787675983803-1514"
+        let legacyURL = fixture.cacheRoot.appendingPathComponent(legacyID, isDirectory: true)
+        let unownedURL = fixture.cacheRoot.appendingPathComponent(SnapshotReferenceFixtures.id(88), isDirectory: true)
+        for directory in [legacyURL, unownedURL] {
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: false)
+            try Data("{}".utf8).write(to: directory.appendingPathComponent("snapshot.json"))
+        }
+        let oldDate = Date().addingTimeInterval(-48 * 3600)
+        try FileManager.default.setAttributes([.modificationDate: oldDate], ofItemAtPath: legacyURL.path)
+
+        let aged = try await service.cleanOldSnapshots(hours: 24, dryRun: false)
+        XCTAssertEqual(aged.snapshotDetails.map(\.snapshotId), [legacyID])
+        XCTAssertFalse(FileManager.default.fileExists(atPath: legacyURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: unownedURL.path))
+
+        let all = try await service.cleanAllSnapshots(dryRun: false)
+        XCTAssertEqual(all.snapshotDetails.map(\.snapshotId), [owned])
+        XCTAssertFalse(FileManager.default.fileExists(atPath: fixture.cacheRoot.appendingPathComponent(owned).path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: unownedURL.path))
+    }
+
+    func testLegacyShapeWithoutRegularSnapshotPayloadIsNeverListedOrRemoved() async throws {
+        let fixture = try self.makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.container) }
+        let service = FileService(snapshotCacheDirectory: fixture.cacheRoot)
+        let missingPayload = fixture.cacheRoot.appendingPathComponent("1787675983803-1514", isDirectory: true)
+        let directoryPayload = fixture.cacheRoot.appendingPathComponent("1787675983803-1515", isDirectory: true)
+        let symlinkPayload = fixture.cacheRoot.appendingPathComponent("1787675983803-1516", isDirectory: true)
+        for directory in [missingPayload, directoryPayload, symlinkPayload] {
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: false)
+        }
+        try FileManager.default.createDirectory(
+            at: directoryPayload.appendingPathComponent("snapshot.json", isDirectory: true),
+            withIntermediateDirectories: false)
+        try FileManager.default.createSymbolicLink(
+            at: symlinkPayload.appendingPathComponent("snapshot.json"),
+            withDestinationURL: fixture.outsideSentinel)
+
+        let listed = try await service.listSnapshots()
+        XCTAssertTrue(listed.isEmpty)
+        let cleaned = try await service.cleanAllSnapshots(dryRun: false)
+        XCTAssertEqual(cleaned.snapshotsRemoved, 0)
+        for directory in [missingPayload, directoryPayload, symlinkPayload] {
+            XCTAssertTrue(FileManager.default.fileExists(atPath: directory.path))
+        }
+        XCTAssertEqual(try Data(contentsOf: fixture.outsideSentinel), fixture.outsideSentinelContents)
     }
 
     private func assertInvalidSnapshotID(
@@ -137,6 +282,17 @@ final class FileServiceSnapshotCleanupTests: XCTestCase {
         } catch {
             XCTFail("Expected FileServiceError.invalidSnapshotID, got \(error)")
         }
+    }
+
+    private func assertUnownedSnapshotIgnored(
+        _ snapshotID: String,
+        dryRun: Bool,
+        service: FileService) async throws
+    {
+        let result = try await service.cleanSpecificSnapshot(snapshotId: snapshotID, dryRun: dryRun)
+        XCTAssertEqual(result.snapshotsRemoved, 0)
+        XCTAssertEqual(result.bytesFreed, 0)
+        XCTAssertTrue(result.snapshotDetails.isEmpty)
     }
 
     private func makeFixture() throws -> Fixture {

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/InMemorySnapshotManagerTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/InMemorySnapshotManagerTests.swift
@@ -1,12 +1,54 @@
 import Darwin
 import Dispatch
 import Foundation
+import PeekabooAutomationKitTestSupport
 import PeekabooFoundation
+import PeekabooFoundationTestSupport
 import Testing
 @testable import PeekabooAutomationKit
 
 @MainActor
 struct InMemorySnapshotManagerTests {
+    @Test
+    func `detection-only identifiers never claim producer-bound snapshot authority`() {
+        let transient = SnapshotPublicationBinding.resultIdentifier(explicit: nil)
+        let ocrTransient = SnapshotPublicationBinding.resultIdentifier(
+            explicit: nil,
+            transientPrefix: "ocr")
+        let explicit = SnapshotReferenceFixtures.first.rawValue
+
+        #expect(SnapshotReference(rawValue: transient) == nil)
+        #expect(SnapshotReference(rawValue: ocrTransient) == nil)
+        #expect(ocrTransient.hasPrefix("ocr-"))
+        #expect(SnapshotPublicationBinding.resultIdentifier(explicit: explicit) == explicit)
+    }
+
+    @Test
+    func `failed disk snapshot initialization rolls back producer ownership`() async throws {
+        let storageURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("peekaboo-reservation-rollback-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: storageURL) }
+        let manager = SnapshotManager(snapshotStorageURL: storageURL)
+
+        for failure in [SnapshotInitializationFailure.configure, .payload] {
+            let reservation = try manager.reserveOwnedSnapshotDirectory()
+            await #expect(throws: (any Error).self) {
+                _ = try await manager.initializeReservedSnapshot(reservation) { snapshotPath in
+                    switch failure {
+                    case .configure:
+                        throw failure
+                    case .payload:
+                        try FileManager.default.createDirectory(
+                            at: snapshotPath.appendingPathComponent("snapshot.json"),
+                            withIntermediateDirectories: false)
+                    }
+                }
+            }
+            #expect(!FileManager.default.fileExists(atPath: reservation.url.path))
+            #expect(try await !manager.ownsSnapshot(snapshotId: reservation.snapshotId))
+        }
+    }
+
     @Test
     func `legacy protocol conformer gets non-destructive invalidation default`() async throws {
         let legacyManager: any SnapshotManagerProtocol = UnusedSnapshotManager()
@@ -255,22 +297,30 @@ struct InMemorySnapshotManagerTests {
     }
 
     @Test
-    func `disk clean all removes incomplete and corrupt snapshot directories`() async throws {
+    func `disk clean all removes only producer-owned snapshot directories`() async throws {
         let storageURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("peekaboo-incomplete-cleanup-\(UUID().uuidString)", isDirectory: true)
         defer { try? FileManager.default.removeItem(at: storageURL) }
         let corruptURL = storageURL.appendingPathComponent("corrupt-snapshot", isDirectory: true)
-        let stagingURL = storageURL.appendingPathComponent(".pending-abandoned", isDirectory: true)
+        let malformedPendingURL = storageURL.appendingPathComponent(".pending-abandoned", isDirectory: true)
+        let legacyPendingURL = storageURL.appendingPathComponent(
+            ".pending-\(UUID().uuidString)",
+            isDirectory: true)
         try FileManager.default.createDirectory(at: corruptURL, withIntermediateDirectories: true)
-        try FileManager.default.createDirectory(at: stagingURL, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: malformedPendingURL, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: legacyPendingURL, withIntermediateDirectories: true)
         try Data("artifact".utf8).write(to: corruptURL.appendingPathComponent("raw.png"))
+        try Data("legacy pending artifact".utf8).write(to: legacyPendingURL.appendingPathComponent("raw.png"))
 
         let manager = SnapshotManager(snapshotStorageURL: storageURL)
+        let owned = try await manager.createSnapshot()
         let count = try await manager.cleanAllSnapshots()
 
         #expect(count == 2)
-        #expect(!FileManager.default.fileExists(atPath: corruptURL.path))
-        #expect(!FileManager.default.fileExists(atPath: stagingURL.path))
+        #expect(!FileManager.default.fileExists(atPath: storageURL.appendingPathComponent(owned).path))
+        #expect(!FileManager.default.fileExists(atPath: legacyPendingURL.path))
+        #expect(FileManager.default.fileExists(atPath: corruptURL.path))
+        #expect(FileManager.default.fileExists(atPath: malformedPendingURL.path))
     }
 
     @Test
@@ -405,16 +455,18 @@ struct InMemorySnapshotManagerTests {
 
         let first = try await manager.createSnapshot()
         try await Task.sleep(nanoseconds: 1_000_000)
-        try await manager.storeScreenshot(Self.screenshotRequest(snapshotId: "external", path: "/tmp/external.png"))
+        let second = try await manager.createSnapshot()
+        try await manager.storeScreenshot(Self.screenshotRequest(snapshotId: second, path: "/tmp/external.png"))
 
         let snapshots = try await manager.listSnapshots()
-        #expect(snapshots.map(\.id) == ["external"])
+        #expect(snapshots.map(\.id) == [second])
         #expect(snapshots.contains { $0.id == first } == false)
     }
 
     @Test
     func `snapshot cleanup removes managed temporary artifacts`() async throws {
-        let snapshotId = "managed-temp"
+        let manager = InMemorySnapshotManager()
+        let snapshotId = try await manager.createSnapshot()
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("peekaboo-see/\(snapshotId)", isDirectory: true)
         let raw = directory.appendingPathComponent("raw.png")
@@ -423,8 +475,6 @@ struct InMemorySnapshotManagerTests {
         try Data("raw".utf8).write(to: raw)
         try Data("annotated".utf8).write(to: annotated)
 
-        let manager = InMemorySnapshotManager()
-        _ = try await manager.createSnapshot()
         try await manager.storeScreenshot(Self.screenshotRequest(snapshotId: snapshotId, path: raw.path))
         try await manager.storeAnnotatedScreenshot(snapshotId: snapshotId, annotatedScreenshotPath: annotated.path)
 
@@ -433,6 +483,304 @@ struct InMemorySnapshotManagerTests {
         #expect(!FileManager.default.fileExists(atPath: raw.path))
         #expect(!FileManager.default.fileExists(atPath: annotated.path))
         #expect(!FileManager.default.fileExists(atPath: directory.path))
+    }
+
+    @Test
+    func `producer-bound references own only explicitly created snapshots`() async throws {
+        let storageURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("peekaboo-owned-snapshots-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: storageURL) }
+        let managers: [any SnapshotManagerProtocol] = [
+            InMemorySnapshotManager(),
+            SnapshotManager(snapshotStorageURL: storageURL),
+        ]
+
+        for manager in managers {
+            let owned = try await manager.createSnapshot()
+            #expect(SnapshotReference(rawValue: owned) != nil)
+            #expect(try await manager.ownsSnapshot(snapshotId: owned))
+            #expect(try await !manager.ownsSnapshot(snapshotId: SnapshotReferenceFixtures.id(99)))
+            try await manager.cleanSnapshot(snapshotId: owned)
+            #expect(try await !manager.ownsSnapshot(snapshotId: owned))
+            await #expect(throws: SnapshotError.self) {
+                _ = try await manager.ownsSnapshot(snapshotId: "snapshot-1")
+            }
+        }
+    }
+
+    @Test
+    func `disk ownership survives manager restart`() async throws {
+        let storageURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("peekaboo-owned-restart-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: storageURL) }
+
+        let snapshotID = try await SnapshotManager(snapshotStorageURL: storageURL).createSnapshot()
+        let restarted = SnapshotManager(snapshotStorageURL: storageURL)
+
+        #expect(try await restarted.ownsSnapshot(snapshotId: snapshotID))
+        #expect(try await restarted.listSnapshots().map(\.id) == [snapshotID])
+    }
+
+    @Test
+    func `disk caller local namespace is one producer across manager instances`() async throws {
+        let storageURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("peekaboo-owned-namespace-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: storageURL) }
+        let first = SnapshotManager(snapshotStorageURL: storageURL)
+        let second = SnapshotManager(snapshotStorageURL: storageURL)
+        let snapshotID = try await first.createSnapshot()
+
+        #expect(try await first.ownsSnapshot(snapshotId: snapshotID))
+        #expect(try await second.ownsSnapshot(snapshotId: snapshotID))
+
+        let lease = try await first.beginSnapshotMutation(snapshotId: snapshotID)
+        await #expect(throws: PeekabooError.self) {
+            _ = try await second.beginSnapshotMutation(snapshotId: snapshotID)
+        }
+        try await first.finishSnapshotMutation(lease, requiresFreshObservation: false)
+    }
+
+    @Test
+    func `containing factory seeds one fixture and remains reusable`() async throws {
+        let fixture = AutomationTestFixtures.detectionResult(snapshotID: SnapshotReferenceFixtures.first.rawValue)
+        let manager = try await InMemorySnapshotManager.containing(fixture)
+
+        #expect(try await manager.ownsSnapshot(snapshotId: SnapshotReferenceFixtures.first.rawValue))
+        let next = try await manager.createSnapshot()
+        #expect(next != SnapshotReferenceFixtures.first.rawValue)
+        #expect(SnapshotReference(rawValue: next) != nil)
+    }
+
+    @Test
+    func `legacy seeded initializer remains source compatible and rejects malformed authority`() async throws {
+        let fixture = AutomationTestFixtures.detectionResult(snapshotID: SnapshotReferenceFixtures.first.rawValue)
+        let manager = InMemorySnapshotManager(detectionResult: fixture)
+
+        #expect(try await manager.ownsSnapshot(snapshotId: SnapshotReferenceFixtures.first.rawValue))
+        let next = try await manager.createSnapshot()
+        #expect(next != SnapshotReferenceFixtures.first.rawValue)
+
+        let malformed = AutomationTestFixtures.detectionResult(snapshotID: "snapshot-1")
+        let rejected = InMemorySnapshotManager(detectionResult: malformed)
+        #expect(try await rejected.listSnapshots().isEmpty)
+    }
+
+    @Test
+    func `legacy seeded initializer rejects mismatched embedded coordinate authority`() async throws {
+        let snapshotID = SnapshotReferenceFixtures.first.rawValue
+        let malformed = ElementDetectionResult(
+            snapshotId: snapshotID,
+            screenshotPath: "",
+            elements: DetectedElements(),
+            metadata: DetectionMetadata(
+                detectionTime: 0,
+                elementCount: 0,
+                method: "fixture",
+                truncationInfo: nil,
+                captureCoordinateContext: CaptureCoordinateContext(
+                    metadata: CaptureMetadata(size: .init(width: 10, height: 10), mode: .screen),
+                    referenceID: SnapshotReferenceFixtures.second.rawValue)))
+
+        let manager = InMemorySnapshotManager(detectionResult: malformed)
+
+        #expect(try await manager.listSnapshots().isEmpty)
+        #expect(try await !manager.ownsSnapshot(snapshotId: snapshotID))
+    }
+
+    @Test
+    func `stores require prior ownership and exact embedded references`() async throws {
+        let storageURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("peekaboo-store-authority-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: storageURL) }
+        let managers: [any SnapshotManagerProtocol] = [
+            InMemorySnapshotManager(),
+            SnapshotManager(snapshotStorageURL: storageURL),
+        ]
+
+        for manager in managers {
+            let foreign = SnapshotReferenceFixtures.id(81)
+            await #expect(throws: SnapshotError.self) {
+                try await manager.storeScreenshot(Self.screenshotRequest(
+                    snapshotId: foreign,
+                    path: "/tmp/foreign.png"))
+            }
+
+            let owned = try await manager.createSnapshot()
+            let mismatched = ElementDetectionResult(
+                snapshotId: SnapshotReferenceFixtures.id(82),
+                screenshotPath: "",
+                elements: DetectedElements(),
+                metadata: DetectionMetadata(detectionTime: 0, elementCount: 0, method: "fixture"))
+            await #expect(throws: SnapshotError.self) {
+                try await manager.storeDetectionResult(snapshotId: owned, result: mismatched)
+            }
+            await #expect(throws: SnapshotError.self) {
+                try await manager.storeObservationSnapshot(.init(
+                    screenshot: Self.screenshotRequest(snapshotId: owned, path: "/tmp/owned.png"),
+                    detectionResult: mismatched,
+                    annotatedScreenshotPath: nil))
+            }
+            let mismatchedCoordinateResult = ElementDetectionResult(
+                snapshotId: owned,
+                screenshotPath: "",
+                elements: DetectedElements(),
+                metadata: DetectionMetadata(
+                    detectionTime: 0,
+                    elementCount: 0,
+                    method: "fixture",
+                    truncationInfo: nil,
+                    captureCoordinateContext: CaptureCoordinateContext(
+                        metadata: CaptureMetadata(size: .init(width: 10, height: 10), mode: .screen),
+                        referenceID: SnapshotReferenceFixtures.id(83))))
+            await #expect(throws: SnapshotError.self) {
+                try await manager.storeDetectionResult(snapshotId: owned, result: mismatchedCoordinateResult)
+            }
+            let persistedDetection = try await manager.getDetectionResult(snapshotId: owned)
+            #expect(persistedDetection?.snapshotId != mismatched.snapshotId)
+            #expect(persistedDetection?.elements.all.isEmpty ?? true)
+            #expect(try await manager.getUIAutomationSnapshot(snapshotId: owned)?.screenshotPath == nil)
+        }
+    }
+
+    @Test
+    func `reference generators retry collisions and fail after a bounded exhaustion`() async throws {
+        let retrySequence = SnapshotReferenceSequence([
+            SnapshotReferenceFixtures.first,
+            SnapshotReferenceFixtures.first,
+            SnapshotReferenceFixtures.second,
+        ])
+        let retrying = InMemorySnapshotManager(snapshotReferenceGenerator: { retrySequence.next() })
+        #expect(try await retrying.createSnapshot() == SnapshotReferenceFixtures.first.rawValue)
+        #expect(try await retrying.createSnapshot() == SnapshotReferenceFixtures.second.rawValue)
+
+        let exhausted = InMemorySnapshotManager(
+            snapshotReferenceGenerator: { SnapshotReferenceFixtures.third })
+        #expect(try await exhausted.createSnapshot() == SnapshotReferenceFixtures.third.rawValue)
+        await #expect(throws: SnapshotError.self) {
+            _ = try await exhausted.createSnapshot()
+        }
+
+        let storageURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("peekaboo-collision-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: storageURL) }
+        let disk = SnapshotManager(
+            snapshotStorageURL: storageURL,
+            snapshotReferenceGenerator: { SnapshotReferenceFixtures.first })
+        #expect(try await disk.createSnapshot() == SnapshotReferenceFixtures.first.rawValue)
+        await #expect(throws: SnapshotError.self) {
+            _ = try await disk.createSnapshot()
+        }
+
+        let retryStorageURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("peekaboo-disk-collision-retry-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: retryStorageURL) }
+        let diskRetrySequence = SnapshotReferenceSequence([
+            SnapshotReferenceFixtures.first,
+            SnapshotReferenceFixtures.first,
+            SnapshotReferenceFixtures.second,
+        ])
+        let retryingDisk = SnapshotManager(
+            snapshotStorageURL: retryStorageURL,
+            snapshotReferenceGenerator: { diskRetrySequence.next() })
+        #expect(try await retryingDisk.createSnapshot() == SnapshotReferenceFixtures.first.rawValue)
+        #expect(try await retryingDisk.createSnapshot() == SnapshotReferenceFixtures.second.rawValue)
+    }
+
+    @Test
+    func `legacy timestamp directories are cleanup-only for disk managers`() async throws {
+        let storageURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("peekaboo-legacy-cleanup-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: storageURL) }
+        try FileManager.default.createDirectory(at: storageURL, withIntermediateDirectories: true)
+        let legacyID = "1787675983803-1514"
+        let legacyURL = storageURL.appendingPathComponent(legacyID, isDirectory: true)
+        try FileManager.default.createDirectory(at: legacyURL, withIntermediateDirectories: false)
+        try Data("{}".utf8).write(to: legacyURL.appendingPathComponent("snapshot.json"))
+        let manager = SnapshotManager(snapshotStorageURL: storageURL)
+
+        #expect(try await manager.listSnapshots().isEmpty)
+        await #expect(throws: SnapshotError.self) {
+            _ = try await manager.ownsSnapshot(snapshotId: legacyID)
+        }
+        #expect(try await manager.cleanAllSnapshots() == 1)
+        #expect(!FileManager.default.fileExists(atPath: legacyURL.path))
+    }
+
+    @Test
+    func `legacy and unowned directories cannot shadow latest owned snapshot`() async throws {
+        let storageURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("peekaboo-latest-ownership-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: storageURL) }
+        let manager = SnapshotManager(
+            snapshotStorageURL: storageURL,
+            snapshotReferenceGenerator: { SnapshotReferenceFixtures.first })
+        let owned = try await manager.createSnapshot()
+        try await Task.sleep(for: .milliseconds(2))
+
+        for snapshotID in ["1787675983803-1514", SnapshotReferenceFixtures.id(88)] {
+            let directory = storageURL.appendingPathComponent(snapshotID, isDirectory: true)
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: false)
+            try Data("{}".utf8).write(to: directory.appendingPathComponent("snapshot.json"))
+        }
+
+        #expect(await manager.getMostRecentSnapshot() == owned)
+        #expect(try await manager.listSnapshots().map(\.id) == [owned])
+    }
+
+    @Test
+    func `disk payload symlink is never actionable or followed`() async throws {
+        let container = FileManager.default.temporaryDirectory
+            .appendingPathComponent("peekaboo-payload-symlink-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: container) }
+        let storageURL = container.appendingPathComponent("snapshots", isDirectory: true)
+        let outsideURL = container.appendingPathComponent("outside.json")
+        let outsideContents = Data("outside".utf8)
+        try FileManager.default.createDirectory(at: storageURL, withIntermediateDirectories: true)
+        try outsideContents.write(to: outsideURL)
+        let manager = SnapshotManager(snapshotStorageURL: storageURL)
+        let snapshotID = try await manager.createSnapshot()
+        let payloadURL = storageURL.appendingPathComponent(snapshotID).appendingPathComponent("snapshot.json")
+        try FileManager.default.removeItem(at: payloadURL)
+        try FileManager.default.createSymbolicLink(at: payloadURL, withDestinationURL: outsideURL)
+
+        #expect(try await manager.ownsSnapshot(snapshotId: snapshotID))
+        #expect(try await manager.getDetectionResult(snapshotId: snapshotID) == nil)
+        #expect(await manager.getMostRecentSnapshot() == nil)
+        #expect(try await manager.listSnapshots().isEmpty)
+        #expect(try Data(contentsOf: outsideURL) == outsideContents)
+
+        #expect(try await manager.cleanAllSnapshots() == 1)
+        #expect(try Data(contentsOf: outsideURL) == outsideContents)
+    }
+
+    @Test
+    func `disk store cannot resurrect a snapshot cleaned after ownership load`() async throws {
+        let storageURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("peekaboo-store-clean-race-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: storageURL) }
+        let entered = SnapshotTestLatch()
+        let resume = SnapshotTestLatch()
+        let manager = SnapshotManager(
+            snapshotStorageURL: storageURL,
+            postLoadBarrier: {
+                await entered.open()
+                await resume.wait()
+            })
+        let snapshotID = try await manager.createSnapshot()
+        let store = Task { @MainActor in
+            try await manager.storeDetectionResult(
+                snapshotId: snapshotID,
+                result: AutomationTestFixtures.detectionResult(snapshotID: snapshotID))
+        }
+
+        await entered.wait()
+        try FileManager.default.removeItem(at: storageURL.appendingPathComponent(snapshotID))
+        await resume.open()
+        await #expect(throws: SnapshotError.self) {
+            try await store.value
+        }
+        #expect(!FileManager.default.fileExists(atPath: storageURL.appendingPathComponent(snapshotID).path))
+        #expect(try await !manager.ownsSnapshot(snapshotId: snapshotID))
     }
 
     @Test
@@ -804,5 +1152,48 @@ struct InMemorySnapshotManagerTests {
         try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
         try Data("artifact".utf8).write(to: url)
         return url
+    }
+}
+
+private enum SnapshotInitializationFailure: Error {
+    case configure
+    case payload
+}
+
+@MainActor
+private final class SnapshotReferenceSequence: @unchecked Sendable {
+    private let references: [SnapshotReference]
+    private var index = 0
+
+    init(_ references: [SnapshotReference]) {
+        self.references = references
+    }
+
+    func next() -> SnapshotReference {
+        let reference = self.references[min(self.index, self.references.count - 1)]
+        self.index += 1
+        return reference
+    }
+}
+
+private actor SnapshotTestLatch {
+    private var isOpen = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func wait() async {
+        guard !self.isOpen else { return }
+        await withCheckedContinuation { continuation in
+            self.waiters.append(continuation)
+        }
+    }
+
+    func open() {
+        guard !self.isOpen else { return }
+        self.isOpen = true
+        let waiters = self.waiters
+        self.waiters.removeAll()
+        for waiter in waiters {
+            waiter.resume()
+        }
     }
 }

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ScrollServiceTargetResolutionTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ScrollServiceTargetResolutionTests.swift
@@ -8,6 +8,7 @@ import struct PeekabooFoundation.DesktopActionFailure
 import struct PeekabooFoundation.DesktopActionOutcome
 import enum PeekabooFoundation.PeekabooError
 import enum PeekabooFoundation.ScrollDirection
+import PeekabooFoundationTestSupport
 import Testing
 @testable import PeekabooAutomationKit
 
@@ -66,8 +67,8 @@ struct ScrollServiceTargetResolutionTests {
         let detectionResult = Self.exactDetectionResult(element: element)
         let action = ScrollRecordingActionInputDriver()
         let synthetic = ScrollRecordingSyntheticInputDriver()
-        let service = ScrollService(
-            snapshotManager: InMemorySnapshotManager(detectionResult: detectionResult),
+        let service = try await ScrollService(
+            snapshotManager: InMemorySnapshotManager.containing(detectionResult),
             inputPolicy: UIInputPolicy(defaultStrategy: .synthOnly),
             actionInputDriver: action,
             syntheticInputDriver: synthetic,
@@ -79,7 +80,7 @@ struct ScrollServiceTargetResolutionTests {
             direction: .down,
             amount: 3,
             target: "S1",
-            snapshotId: "snapshot"))
+            snapshotId: Self.snapshotID))
 
         #expect(result.path == .action)
         #expect(result.strategy == .actionOnly)
@@ -127,8 +128,8 @@ struct ScrollServiceTargetResolutionTests {
         let action = ScrollRecordingActionInputDriver(
             scrollError: ActionInputError.unsupported(.actionUnsupported))
         let synthetic = ScrollRecordingSyntheticInputDriver()
-        let service = ScrollService(
-            snapshotManager: InMemorySnapshotManager(detectionResult: detectionResult),
+        let service = try await ScrollService(
+            snapshotManager: InMemorySnapshotManager.containing(detectionResult),
             actionInputDriver: action,
             syntheticInputDriver: synthetic,
             automationElementResolver: ScrollFixedAutomationElementResolver(),
@@ -143,7 +144,7 @@ struct ScrollServiceTargetResolutionTests {
             direction: .down,
             amount: 2,
             target: "S1",
-            snapshotId: "snapshot"))
+            snapshotId: Self.snapshotID))
 
         #expect(result.path == .action)
         #expect(result.actionName == "WindowRoutedWheel")
@@ -193,8 +194,8 @@ struct ScrollServiceTargetResolutionTests {
             delivery: .init(mechanism: .accessibilityAction, mode: .background),
             unitCount: .one,
             message: "One of three AX page units was accepted")
-        let service = ScrollService(
-            snapshotManager: InMemorySnapshotManager(detectionResult: detectionResult),
+        let service = try await ScrollService(
+            snapshotManager: InMemorySnapshotManager.containing(detectionResult),
             actionInputDriver: ScrollRecordingActionInputDriver(scrollError: prefixFailure),
             automationElementResolver: ScrollFixedAutomationElementResolver(),
             windowRoutedPointerDriver: routedDriver,
@@ -207,7 +208,7 @@ struct ScrollServiceTargetResolutionTests {
                 direction: .down,
                 amount: 3,
                 target: "S1",
-                snapshotId: "snapshot"))
+                snapshotId: Self.snapshotID))
             Issue.record("Expected the AX prefix failure to remain authoritative")
         } catch let failure as DesktopActionFailure {
             #expect(failure.outcome.state == .partial)
@@ -219,7 +220,7 @@ struct ScrollServiceTargetResolutionTests {
 
     @Test
     @MainActor
-    func `unsupported AX group refuses when application lacks WebKit capability`() async {
+    func `unsupported AX group refuses when application lacks WebKit capability`() async throws {
         let laneRoot = FileManager.default.temporaryDirectory
             .appendingPathComponent("web-scroll-refusal-lane-\(UUID().uuidString)", isDirectory: true)
         defer { try? FileManager.default.removeItem(at: laneRoot) }
@@ -231,8 +232,9 @@ struct ScrollServiceTargetResolutionTests {
             attributes: ["role": "AXGroup"])
         let action = ScrollRecordingActionInputDriver(
             scrollError: ActionInputError.unsupported(.actionUnsupported))
-        let service = ScrollService(
-            snapshotManager: InMemorySnapshotManager(detectionResult: Self.exactDetectionResult(element: element)),
+        let service = try await ScrollService(
+            snapshotManager: InMemorySnapshotManager.containing(
+                Self.exactDetectionResult(element: element)),
             actionInputDriver: action,
             automationElementResolver: ScrollFixedAutomationElementResolver(),
             backgroundWheelCapability: { _ in false },
@@ -282,7 +284,7 @@ struct ScrollServiceTargetResolutionTests {
                 target: "S1",
                 smooth: false,
                 delay: 0,
-                snapshotId: "missing"))
+                snapshotId: SnapshotReferenceFixtures.first.rawValue))
             Issue.record("Expected stale element error for missing action snapshot.")
         } catch let error as PeekabooError {
             #expect(error.localizedDescription.contains("snapshot"))
@@ -320,7 +322,7 @@ struct ScrollServiceTargetResolutionTests {
 
     @Test
     @MainActor
-    func `foreground OCR target refuses before pointer motion or scroll dispatch`() async {
+    func `foreground OCR target refuses before pointer motion or scroll dispatch`() async throws {
         let element = DetectedElement(
             id: "ocr_1",
             type: .staticText,
@@ -331,13 +333,13 @@ struct ScrollServiceTargetResolutionTests {
                 "confidence": "0.93",
             ])
         let result = ElementDetectionResult(
-            snapshotId: "snapshot",
+            snapshotId: Self.snapshotID,
             screenshotPath: "/tmp/calendar.png",
             elements: DetectedElements(other: [element]),
             metadata: DetectionMetadata(detectionTime: 0, elementCount: 1, method: "AXorcist+OCR"))
         let synthetic = ScrollRecordingSyntheticInputDriver()
-        let service = ScrollService(
-            snapshotManager: InMemorySnapshotManager(detectionResult: result),
+        let service = try await ScrollService(
+            snapshotManager: InMemorySnapshotManager.containing(result),
             inputPolicy: UIInputPolicy(defaultStrategy: .synthFirst),
             syntheticInputDriver: synthetic)
 
@@ -347,7 +349,7 @@ struct ScrollServiceTargetResolutionTests {
                 amount: 1,
                 target: "ocr_1",
                 smooth: true,
-                snapshotId: "snapshot",
+                snapshotId: Self.snapshotID,
                 foreground: true))
             Issue.record("Expected OCR semantic evidence refusal")
         } catch let PeekabooError.invalidInput(message) {
@@ -373,8 +375,8 @@ struct ScrollServiceTargetResolutionTests {
             attributes: [:])
         let detectionResult = Self.exactDetectionResult(element: element)
         let synthetic = ScrollRecordingSyntheticInputDriver()
-        let service = ScrollService(
-            snapshotManager: InMemorySnapshotManager(detectionResult: detectionResult),
+        let service = try await ScrollService(
+            snapshotManager: InMemorySnapshotManager.containing(detectionResult),
             inputPolicy: UIInputPolicy(defaultStrategy: .actionFirst),
             syntheticInputDriver: synthetic,
             exactWindowIdentityValidator: { _, _ in true },
@@ -387,7 +389,7 @@ struct ScrollServiceTargetResolutionTests {
                 target: "S1",
                 smooth: false,
                 delay: 0,
-                snapshotId: "snapshot"))
+                snapshotId: Self.snapshotID))
             Issue.record("Expected an explicit foreground-required error")
         } catch let error as PeekabooError {
             #expect(error.localizedDescription.contains("foreground"))
@@ -411,14 +413,14 @@ struct ScrollServiceTargetResolutionTests {
             target: "S1",
             smooth: false,
             delay: 0,
-            snapshotId: "snapshot")))
+            snapshotId: Self.snapshotID)))
         #expect(ScrollService.requiresSyntheticScrollSemantics(ScrollRequest(
             direction: .down,
             amount: 3,
             target: "S1",
             smooth: true,
             delay: 0,
-            snapshotId: "snapshot",
+            snapshotId: Self.snapshotID,
             foreground: true)))
         #expect(!ScrollService.requiresSyntheticScrollSemantics(ScrollRequest(
             direction: .down,
@@ -426,7 +428,7 @@ struct ScrollServiceTargetResolutionTests {
             target: "S1",
             smooth: false,
             delay: 2,
-            snapshotId: "snapshot")))
+            snapshotId: Self.snapshotID)))
     }
 
     @Test
@@ -461,21 +463,21 @@ struct ScrollServiceTargetResolutionTests {
 
     @Test
     @MainActor
-    func `background scroll refuses incomplete exact receipt before dispatch`() async {
+    func `background scroll refuses incomplete exact receipt before dispatch`() async throws {
         let element = DetectedElement(
             id: "S1",
             type: .other,
             label: "List",
             bounds: CGRect(x: 20, y: 30, width: 300, height: 400))
         let detectionResult = ElementDetectionResult(
-            snapshotId: "snapshot",
+            snapshotId: Self.snapshotID,
             screenshotPath: "/tmp/shot.png",
             elements: DetectedElements(other: [element]),
             metadata: DetectionMetadata(detectionTime: 0, elementCount: 1, method: "test"))
         let action = ScrollRecordingActionInputDriver()
         let synthetic = ScrollRecordingSyntheticInputDriver()
-        let service = ScrollService(
-            snapshotManager: InMemorySnapshotManager(detectionResult: detectionResult),
+        let service = try await ScrollService(
+            snapshotManager: InMemorySnapshotManager.containing(detectionResult),
             actionInputDriver: action,
             syntheticInputDriver: synthetic,
             automationElementResolver: ScrollFixedAutomationElementResolver())
@@ -489,14 +491,14 @@ struct ScrollServiceTargetResolutionTests {
 
     @Test
     @MainActor
-    func `background scroll refuses conflicting capture bounds before dispatch`() async {
+    func `background scroll refuses conflicting capture bounds before dispatch`() async throws {
         let element = Self.scrollElement()
         let detectionResult = Self.exactDetectionResult(
             element: element,
             identityBounds: CGRect(x: 0, y: 0, width: 700, height: 600))
         let action = ScrollRecordingActionInputDriver()
-        let service = ScrollService(
-            snapshotManager: InMemorySnapshotManager(detectionResult: detectionResult),
+        let service = try await ScrollService(
+            snapshotManager: InMemorySnapshotManager.containing(detectionResult),
             actionInputDriver: action,
             automationElementResolver: ScrollFixedAutomationElementResolver(),
             exactWindowIdentityValidator: { _, _ in true },
@@ -511,11 +513,11 @@ struct ScrollServiceTargetResolutionTests {
 
     @Test
     @MainActor
-    func `background scroll revalidates generation after element resolution`() async {
+    func `background scroll revalidates generation after element resolution`() async throws {
         let generation = ScrollLockedValue<UInt64>(11)
         let action = ScrollRecordingActionInputDriver()
-        let service = ScrollService(
-            snapshotManager: InMemorySnapshotManager(detectionResult: Self.exactDetectionResult(
+        let service = try await ScrollService(
+            snapshotManager: InMemorySnapshotManager.containing(Self.exactDetectionResult(
                 element: Self.scrollElement())),
             actionInputDriver: action,
             automationElementResolver: ScrollFixedAutomationElementResolver {
@@ -532,11 +534,11 @@ struct ScrollServiceTargetResolutionTests {
 
     @Test
     @MainActor
-    func `background scroll refuses window drift after element resolution`() async {
+    func `background scroll refuses window drift after element resolution`() async throws {
         let windowIsCurrent = ScrollLockedValue(true)
         let action = ScrollRecordingActionInputDriver()
-        let service = ScrollService(
-            snapshotManager: InMemorySnapshotManager(detectionResult: Self.exactDetectionResult(
+        let service = try await ScrollService(
+            snapshotManager: InMemorySnapshotManager.containing(Self.exactDetectionResult(
                 element: Self.scrollElement())),
             actionInputDriver: action,
             automationElementResolver: ScrollFixedAutomationElementResolver {
@@ -553,13 +555,13 @@ struct ScrollServiceTargetResolutionTests {
 
     @Test
     @MainActor
-    func `background scroll reports post-dispatch generation drift as retry unsafe`() async {
+    func `background scroll reports post-dispatch generation drift as retry unsafe`() async throws {
         let generation = ScrollLockedValue<UInt64>(11)
         let action = ScrollRecordingActionInputDriver {
             generation.value = 12
         }
-        let service = ScrollService(
-            snapshotManager: InMemorySnapshotManager(detectionResult: Self.exactDetectionResult(
+        let service = try await ScrollService(
+            snapshotManager: InMemorySnapshotManager.containing(Self.exactDetectionResult(
                 element: Self.scrollElement())),
             actionInputDriver: action,
             automationElementResolver: ScrollFixedAutomationElementResolver(),
@@ -586,8 +588,8 @@ struct ScrollServiceTargetResolutionTests {
         defer { try? FileManager.default.removeItem(at: root) }
         let coordinator = DesktopOperationLaneCoordinator(coordinationRootURL: root)
         let identity = ApplicationProcessIdentity(processIdentifier: getpid(), processStartIdentity: 11)
-        let service = ScrollService(
-            snapshotManager: InMemorySnapshotManager(detectionResult: Self.exactDetectionResult(
+        let service = try await ScrollService(
+            snapshotManager: InMemorySnapshotManager.containing(Self.exactDetectionResult(
                 element: Self.scrollElement())),
             actionInputDriver: ScrollRecordingActionInputDriver(),
             automationElementResolver: ScrollFixedAutomationElementResolver(),
@@ -602,8 +604,10 @@ struct ScrollServiceTargetResolutionTests {
         }
     }
 
+    private static let snapshotID = SnapshotReferenceFixtures.first.rawValue
+
     private static func backgroundRequest() -> ScrollRequest {
-        ScrollRequest(direction: .down, amount: 1, target: "S1", snapshotId: "snapshot")
+        ScrollRequest(direction: .down, amount: 1, target: "S1", snapshotId: self.snapshotID)
     }
 
     private static func scrollElement() -> DetectedElement {
@@ -623,7 +627,7 @@ struct ScrollServiceTargetResolutionTests {
     {
         let capturedBounds = identityBounds ?? bounds
         return ElementDetectionResult(
-            snapshotId: "snapshot",
+            snapshotId: Self.snapshotID,
             screenshotPath: "/tmp/shot.png",
             elements: DetectedElements(other: [element]),
             metadata: DetectionMetadata(

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/TypeServicePixelFocusTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/TypeServicePixelFocusTests.swift
@@ -13,7 +13,7 @@ struct TypeServicePixelFocusTests {
             processIdentity: ApplicationProcessIdentity(
                 processIdentifier: getpid(),
                 processStartIdentity: 42))
-        let manager = InMemorySnapshotManager(detectionResult: fixture.detectionResult)
+        let manager = try await InMemorySnapshotManager.containing(fixture.detectionResult)
         let synthetic = ClickRecordingSyntheticInputDriver()
         var focusRequests: [(point: CGPoint, window: UIAutomationTarget.ExactWindow)] = []
         let executor = DesktopOperationExecutor(laneCoordinator: DesktopOperationLaneCoordinator(
@@ -75,7 +75,7 @@ struct TypeServicePixelFocusTests {
             processIdentity: ApplicationProcessIdentity(
                 processIdentifier: getpid(),
                 processStartIdentity: 45))
-        let manager = InMemorySnapshotManager(detectionResult: fixture.detectionResult)
+        let manager = try await InMemorySnapshotManager.containing(fixture.detectionResult)
         let suspension = PixelFocusDeliverySuspension()
         var focusCount = 0
         var typed: [Character] = []
@@ -133,7 +133,7 @@ struct TypeServicePixelFocusTests {
             processIdentity: ApplicationProcessIdentity(
                 processIdentifier: getpid(),
                 processStartIdentity: 43))
-        let manager = InMemorySnapshotManager(detectionResult: fixture.detectionResult)
+        let manager = try await InMemorySnapshotManager.containing(fixture.detectionResult)
         let synthetic = ClickRecordingSyntheticInputDriver()
         let executor = DesktopOperationExecutor(laneCoordinator: DesktopOperationLaneCoordinator(
             coordinationRootURL: self.temporaryRoot()))
@@ -184,7 +184,7 @@ struct TypeServicePixelFocusTests {
     @Test
     func `stale coordinate authority refuses before click or typing`() async throws {
         let fixture = AutomationTestFixtures.linkedSnapshotTarget()
-        let manager = InMemorySnapshotManager(detectionResult: fixture.detectionResult)
+        let manager = try await InMemorySnapshotManager.containing(fixture.detectionResult)
         let synthetic = ClickRecordingSyntheticInputDriver()
         let exactWindow = try #require(fixture.targetIdentity.exactWindow)
         var focusAttempted = false
@@ -224,7 +224,7 @@ struct TypeServicePixelFocusTests {
     @Test
     func `ordinary snapshot planning failure releases lease before focus`() async throws {
         let fixture = AutomationTestFixtures.linkedSnapshotTarget()
-        let manager = InMemorySnapshotManager(detectionResult: fixture.detectionResult)
+        let manager = try await InMemorySnapshotManager.containing(fixture.detectionResult)
         let exactWindow = try #require(fixture.targetIdentity.exactWindow)
         var focusAttempted = false
         let service = TypeService(
@@ -260,7 +260,7 @@ struct TypeServicePixelFocusTests {
     @Test
     func `snapshot planning cancellation preserves cancellation and releases lease`() async throws {
         let fixture = AutomationTestFixtures.linkedSnapshotTarget()
-        let manager = InMemorySnapshotManager(detectionResult: fixture.detectionResult)
+        let manager = try await InMemorySnapshotManager.containing(fixture.detectionResult)
         let exactWindow = try #require(fixture.targetIdentity.exactWindow)
         var focusAttempted = false
         let service = TypeService(
@@ -296,7 +296,7 @@ struct TypeServicePixelFocusTests {
     @Test
     func `unknown pixel focus failure finalizes snapshot as retry unsafe`() async throws {
         let fixture = AutomationTestFixtures.linkedSnapshotTarget()
-        let storage = InMemorySnapshotManager(detectionResult: fixture.detectionResult)
+        let storage = try await InMemorySnapshotManager.containing(fixture.detectionResult)
         let manager = SnapshotMutationRecordingManager(wrapping: storage)
         let exactWindow = try #require(fixture.targetIdentity.exactWindow)
         let service = TypeService(
@@ -344,7 +344,7 @@ struct TypeServicePixelFocusTests {
     @Test
     func `accessibility refusal before focus releases snapshot lease`() async throws {
         let fixture = AutomationTestFixtures.linkedSnapshotTarget()
-        let manager = InMemorySnapshotManager(detectionResult: fixture.detectionResult)
+        let manager = try await InMemorySnapshotManager.containing(fixture.detectionResult)
         let exactWindow = try #require(fixture.targetIdentity.exactWindow)
         let service = TypeService(
             snapshotManager: manager,
@@ -381,7 +381,7 @@ struct TypeServicePixelFocusTests {
     @Test
     func `cancellation before focus releases snapshot lease`() async throws {
         let fixture = AutomationTestFixtures.linkedSnapshotTarget()
-        let manager = InMemorySnapshotManager(detectionResult: fixture.detectionResult)
+        let manager = try await InMemorySnapshotManager.containing(fixture.detectionResult)
         let exactWindow = try #require(fixture.targetIdentity.exactWindow)
         let service = TypeService(
             snapshotManager: manager,
@@ -413,7 +413,7 @@ struct TypeServicePixelFocusTests {
             processIdentity: ApplicationProcessIdentity(
                 processIdentifier: getpid(),
                 processStartIdentity: 46))
-        let manager = InMemorySnapshotManager(detectionResult: fixture.detectionResult)
+        let manager = try await InMemorySnapshotManager.containing(fixture.detectionResult)
         let exactWindow = try #require(fixture.targetIdentity.exactWindow)
         let root = self.temporaryRoot()
         defer { try? FileManager.default.removeItem(at: root) }
@@ -470,7 +470,7 @@ struct TypeServicePixelFocusTests {
     @Test
     func `raw cancellation after plan entry preserves pending snapshot lease`() async throws {
         let fixture = AutomationTestFixtures.linkedSnapshotTarget()
-        let manager = InMemorySnapshotManager(detectionResult: fixture.detectionResult)
+        let manager = try await InMemorySnapshotManager.containing(fixture.detectionResult)
         let exactWindow = try #require(fixture.targetIdentity.exactWindow)
         var focusAttempted = false
         let service = TypeService(
@@ -511,7 +511,7 @@ struct TypeServicePixelFocusTests {
             processIdentity: ApplicationProcessIdentity(
                 processIdentifier: getpid(),
                 processStartIdentity: 47))
-        let manager = InMemorySnapshotManager(detectionResult: fixture.detectionResult)
+        let manager = try await InMemorySnapshotManager.containing(fixture.detectionResult)
         let exactWindow = try #require(fixture.targetIdentity.exactWindow)
         let root = self.temporaryRoot()
         defer { try? FileManager.default.removeItem(at: root) }
@@ -564,7 +564,7 @@ struct TypeServicePixelFocusTests {
     @Test
     func `cancellation after focus keeps snapshot replay blocked`() async throws {
         let fixture = AutomationTestFixtures.linkedSnapshotTarget()
-        let manager = InMemorySnapshotManager(detectionResult: fixture.detectionResult)
+        let manager = try await InMemorySnapshotManager.containing(fixture.detectionResult)
         let exactWindow = try #require(fixture.targetIdentity.exactWindow)
         let service = TypeService(
             snapshotManager: manager,
@@ -594,7 +594,7 @@ struct TypeServicePixelFocusTests {
     @Test
     func `zero keyboard units refuse before the focus write`() async throws {
         let fixture = AutomationTestFixtures.linkedSnapshotTarget()
-        let manager = InMemorySnapshotManager(detectionResult: fixture.detectionResult)
+        let manager = try await InMemorySnapshotManager.containing(fixture.detectionResult)
         let synthetic = ClickRecordingSyntheticInputDriver()
         let exactWindow = try #require(fixture.targetIdentity.exactWindow)
         var focusAttempted = false
@@ -630,7 +630,7 @@ struct TypeServicePixelFocusTests {
     @Test
     func `malformed exact window refuses before acquiring snapshot lease`() async throws {
         let fixture = AutomationTestFixtures.linkedSnapshotTarget()
-        let manager = InMemorySnapshotManager(detectionResult: fixture.detectionResult)
+        let manager = try await InMemorySnapshotManager.containing(fixture.detectionResult)
         let exactWindow = try #require(fixture.targetIdentity.exactWindow)
         let service = TypeService(snapshotManager: manager)
         let mismatchedBounds = exactWindow.bounds.offsetBy(dx: 1, dy: 0)
@@ -656,7 +656,7 @@ struct TypeServicePixelFocusTests {
             processIdentity: ApplicationProcessIdentity(
                 processIdentifier: getpid(),
                 processStartIdentity: 44))
-        let manager = InMemorySnapshotManager(detectionResult: fixture.detectionResult)
+        let manager = try await InMemorySnapshotManager.containing(fixture.detectionResult)
         let exactWindow = try #require(fixture.targetIdentity.exactWindow)
         var typed: [Character] = []
         var validatedReceipts: [FocusedElementIdentity] = []

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/TypeServiceTargetResolutionTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/TypeServiceTargetResolutionTests.swift
@@ -1,6 +1,7 @@
 import CoreGraphics
 import Foundation
 import PeekabooFoundation
+import PeekabooFoundationTestSupport
 import Testing
 @testable import PeekabooAutomationKit
 
@@ -189,15 +190,15 @@ struct TypeServiceTargetResolutionTests {
     @Test
     @MainActor
     func `action-first type does not escape an explicit snapshot`() async throws {
-        let snapshotId = "snapshot"
+        let snapshotId = SnapshotReferenceFixtures.first.rawValue
         let detectionResult = ElementDetectionResult(
             snapshotId: snapshotId,
             screenshotPath: "/tmp/shot.png",
             elements: DetectedElements(),
             metadata: DetectionMetadata(detectionTime: 0.01, elementCount: 0, method: "test"))
         let resolver = RecordingTypeAutomationElementResolver()
-        let service = TypeService(
-            snapshotManager: InMemorySnapshotManager(detectionResult: detectionResult),
+        let service = try await TypeService(
+            snapshotManager: InMemorySnapshotManager.containing(detectionResult),
             inputPolicy: UIInputPolicy(defaultStrategy: .actionFirst),
             automationElementResolver: resolver)
 
@@ -220,7 +221,7 @@ struct TypeServiceTargetResolutionTests {
 
     @Test
     @MainActor
-    func `direct OCR target refuses before AX resolution or typing`() async {
+    func `direct OCR target refuses before AX resolution or typing`() async throws {
         let element = DetectedElement(
             id: "ocr_1",
             type: .staticText,
@@ -231,14 +232,14 @@ struct TypeServiceTargetResolutionTests {
                 "confidence": "0.93",
             ])
         let result = ElementDetectionResult(
-            snapshotId: "snapshot",
+            snapshotId: SnapshotReferenceFixtures.second.rawValue,
             screenshotPath: "/tmp/calendar.png",
             elements: DetectedElements(other: [element]),
             metadata: DetectionMetadata(detectionTime: 0, elementCount: 1, method: "AXorcist+OCR"))
         let resolver = RecordingTypeAutomationElementResolver()
         var typed: [Character] = []
-        let service = TypeService(
-            snapshotManager: InMemorySnapshotManager(detectionResult: result),
+        let service = try await TypeService(
+            snapshotManager: InMemorySnapshotManager.containing(result),
             inputPolicy: UIInputPolicy(defaultStrategy: .actionFirst),
             automationElementResolver: resolver,
             randomSource: SystemTypingCadenceRandomSource(),
@@ -250,7 +251,7 @@ struct TypeServiceTargetResolutionTests {
                 target: "ocr_1",
                 clearExisting: false,
                 typingDelay: 0,
-                snapshotId: "snapshot")
+                snapshotId: SnapshotReferenceFixtures.second.rawValue)
             Issue.record("Expected OCR semantic evidence refusal")
         } catch let PeekabooError.invalidInput(message) {
             #expect(message.contains("semantic evidence"))

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/UIAutomationActionOutcomeProvidingTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/UIAutomationActionOutcomeProvidingTests.swift
@@ -185,17 +185,17 @@ struct UIAutomationActionOutcomeProvidingTests {
             outcome: expected,
             storedValue: "old",
             setValueAnchorPoint: driverAnchor)
-        let resultService = self.makeElementActionService(actionDriver: resultDriver)
-        let legacyService = self.makeElementActionService(actionDriver: legacyDriver)
+        let resultService = try await self.makeElementActionService(actionDriver: resultDriver)
+        let legacyService = try await self.makeElementActionService(actionDriver: legacyDriver)
 
         let result = try await resultService.setValueWithOutcome(
             target: "E1",
             value: .string("new"),
-            snapshotId: "snapshot")
+            snapshotId: Self.elementSnapshotID)
         let legacy = try await legacyService.setValue(
             target: "E1",
             value: .string("new"),
-            snapshotId: "snapshot")
+            snapshotId: Self.elementSnapshotID)
 
         #expect(result.outcome == expected)
         #expect(result.payload == legacy)
@@ -215,17 +215,17 @@ struct UIAutomationActionOutcomeProvidingTests {
         let expected = Self.outcome(mechanism: .accessibilityAction, mode: .background)
         let resultDriver = OutcomeActionInputDriver(outcome: expected)
         let legacyDriver = OutcomeActionInputDriver(outcome: expected)
-        let resultService = self.makeElementActionService(actionDriver: resultDriver)
-        let legacyService = self.makeElementActionService(actionDriver: legacyDriver)
+        let resultService = try await self.makeElementActionService(actionDriver: resultDriver)
+        let legacyService = try await self.makeElementActionService(actionDriver: legacyDriver)
 
         let result = try await resultService.performActionWithOutcome(
             target: "E1",
             actionName: "AXPress",
-            snapshotId: "snapshot")
+            snapshotId: Self.elementSnapshotID)
         let legacy = try await legacyService.performAction(
             target: "E1",
             actionName: "AXPress",
-            snapshotId: "snapshot")
+            snapshotId: Self.elementSnapshotID)
 
         #expect(result.outcome == expected)
         #expect(result.payload == legacy)
@@ -263,7 +263,7 @@ struct UIAutomationActionOutcomeProvidingTests {
             focusedElement: focused)
         let expectedClick = Self.outcome(mechanism: .windowTargetedEvents, mode: .background)
         let synthetic = OutcomeSyntheticInputDriver(clickOutcome: expectedClick)
-        let service = self.makeTargetedService(
+        let service = try await self.makeTargetedService(
             synthetic: synthetic,
             generation: generation,
             windowIdentity: windowIdentity,
@@ -279,17 +279,17 @@ struct UIAutomationActionOutcomeProvidingTests {
             let pidClick = try await service.clickWithOutcome(
                 target: clickTarget,
                 clickType: .single,
-                snapshotId: "targeted",
+                snapshotId: Self.targetedSnapshotID,
                 targetProcessIdentifier: getpid())
             let processClick = try await service.clickWithOutcome(
                 target: clickTarget,
                 clickType: .single,
-                snapshotId: "targeted",
+                snapshotId: Self.targetedSnapshotID,
                 expectedProcessIdentity: processIdentity)
             let windowClick = try await service.clickWithOutcome(
                 target: clickTarget,
                 clickType: .single,
-                snapshotId: "targeted",
+                snapshotId: Self.targetedSnapshotID,
                 expectedWindowIdentity: windowIdentity,
                 expectedWindowBounds: bounds)
             return [pidClick, processClick, windowClick]
@@ -398,7 +398,10 @@ struct UIAutomationActionOutcomeProvidingTests {
             })
     }
 
-    private func makeElementActionService(actionDriver: OutcomeActionInputDriver) -> UIAutomationService {
+    private static let elementSnapshotID = SnapshotReferenceFixtures.first.rawValue
+    private static let targetedSnapshotID = SnapshotReferenceFixtures.second.rawValue
+
+    private func makeElementActionService(actionDriver: OutcomeActionInputDriver) async throws -> UIAutomationService {
         let detected = AutomationTestFixtures.detectedElement(
             id: "E1",
             type: .textField,
@@ -406,15 +409,15 @@ struct UIAutomationActionOutcomeProvidingTests {
         let processIdentity = AutomationTestFixtures.processIdentity(processIdentifier: getpid())
         let window = AutomationTestFixtures.window(processIdentity: processIdentity)
         let detection = AutomationTestFixtures.detectionResult(
-            snapshotID: "snapshot",
+            snapshotID: Self.elementSnapshotID,
             elements: DetectedElements(textFields: [detected]),
             windowContext: WindowContext(
                 applicationProcessId: getpid(),
                 windowID: window.windowID,
                 windowBounds: window.bounds,
                 windowMutationIdentity: window.mutationIdentity))
-        return UIAutomationService(
-            snapshotManager: InMemorySnapshotManager(detectionResult: detection),
+        return try await UIAutomationService(
+            snapshotManager: InMemorySnapshotManager.containing(detection),
             inputPolicy: UIInputPolicy(defaultStrategy: .actionOnly),
             actionInputDriver: actionDriver,
             automationElementResolver: FixedOutcomeAutomationElementResolver(),
@@ -429,7 +432,7 @@ struct UIAutomationActionOutcomeProvidingTests {
         synthetic: OutcomeSyntheticInputDriver,
         generation: UInt64,
         windowIdentity: WindowMutationIdentity,
-        focused: FocusedElementIdentity) -> UIAutomationService
+        focused: FocusedElementIdentity) async throws -> UIAutomationService
     {
         let detected = AutomationTestFixtures.detectedElement(
             id: "B1",
@@ -445,11 +448,11 @@ struct UIAutomationActionOutcomeProvidingTests {
             windowBounds: windowIdentity.capturedBounds,
             windowMutationIdentity: windowIdentity)
         let detection = AutomationTestFixtures.detectionResult(
-            snapshotID: "targeted",
+            snapshotID: Self.targetedSnapshotID,
             elements: DetectedElements(buttons: [detected]),
             windowContext: context)
-        return UIAutomationService(
-            snapshotManager: InMemorySnapshotManager(detectionResult: detection),
+        return try await UIAutomationService(
+            snapshotManager: InMemorySnapshotManager.containing(detection),
             inputPolicy: UIInputPolicy(defaultStrategy: .synthOnly),
             actionInputDriver: OutcomeActionInputDriver(outcome: Self.backgroundOutcome),
             syntheticInputDriver: synthetic,

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/UIAutomationServiceModifierClickSnapshotTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/UIAutomationServiceModifierClickSnapshotTests.swift
@@ -9,8 +9,8 @@ struct UIAutomationServiceModifierClickSnapshotTests {
     @Test
     func `service owns the modifier click snapshot lease before foreground work`() async throws {
         let fixture = AutomationTestFixtures.linkedSnapshotTarget()
-        let manager = SnapshotMutationRecordingManager(wrapping: InMemorySnapshotManager(
-            detectionResult: fixture.detectionResult))
+        let manager = try await SnapshotMutationRecordingManager(
+            wrapping: InMemorySnapshotManager.containing(fixture.detectionResult))
         let service = UIAutomationService(snapshotManager: manager)
         let exactWindow = try #require(fixture.targetIdentity.exactWindow)
         let heldLease = try await manager.beginSnapshotMutation(snapshotId: fixture.snapshotID)
@@ -34,8 +34,8 @@ struct UIAutomationServiceModifierClickSnapshotTests {
     @Test
     func `mismatched snapshot authority refuses and releases the unused lease`() async throws {
         let fixture = AutomationTestFixtures.linkedSnapshotTarget()
-        let manager = SnapshotMutationRecordingManager(wrapping: InMemorySnapshotManager(
-            detectionResult: fixture.detectionResult))
+        let manager = try await SnapshotMutationRecordingManager(
+            wrapping: InMemorySnapshotManager.containing(fixture.detectionResult))
         let service = UIAutomationService(snapshotManager: manager)
         let exactWindow = try #require(fixture.targetIdentity.exactWindow)
         let otherBounds = CGRect(x: 900, y: 900, width: 200, height: 200)
@@ -67,8 +67,8 @@ struct UIAutomationServiceModifierClickSnapshotTests {
     @Test
     func `blank and consumed modifier click snapshots refuse before foreground work`() async throws {
         let fixture = AutomationTestFixtures.linkedSnapshotTarget()
-        let manager = SnapshotMutationRecordingManager(wrapping: InMemorySnapshotManager(
-            detectionResult: fixture.detectionResult))
+        let manager = try await SnapshotMutationRecordingManager(
+            wrapping: InMemorySnapshotManager.containing(fixture.detectionResult))
         let service = UIAutomationService(snapshotManager: manager)
         let exactWindow = try #require(fixture.targetIdentity.exactWindow)
 
@@ -109,8 +109,8 @@ struct UIAutomationServiceModifierClickSnapshotTests {
     @Test
     func `successful host operation consumes one lease and blocks replay`() async throws {
         let fixture = AutomationTestFixtures.linkedSnapshotTarget()
-        let manager = SnapshotMutationRecordingManager(wrapping: InMemorySnapshotManager(
-            detectionResult: fixture.detectionResult))
+        let manager = try await SnapshotMutationRecordingManager(
+            wrapping: InMemorySnapshotManager.containing(fixture.detectionResult))
         let service = UIAutomationService(snapshotManager: manager)
         let exactWindow = try #require(fixture.targetIdentity.exactWindow)
         var operationCount = 0
@@ -142,8 +142,8 @@ struct UIAutomationServiceModifierClickSnapshotTests {
     @Test
     func `typed predispatch refusal releases the host lease for a safe retry`() async throws {
         let fixture = AutomationTestFixtures.linkedSnapshotTarget()
-        let manager = SnapshotMutationRecordingManager(wrapping: InMemorySnapshotManager(
-            detectionResult: fixture.detectionResult))
+        let manager = try await SnapshotMutationRecordingManager(
+            wrapping: InMemorySnapshotManager.containing(fixture.detectionResult))
         let service = UIAutomationService(snapshotManager: manager)
         let exactWindow = try #require(fixture.targetIdentity.exactWindow)
 
@@ -171,8 +171,8 @@ struct UIAutomationServiceModifierClickSnapshotTests {
     @Test(arguments: [false, true])
     func `raw operation error and cancellation consume the host lease`(cancel: Bool) async throws {
         let fixture = AutomationTestFixtures.linkedSnapshotTarget()
-        let manager = SnapshotMutationRecordingManager(wrapping: InMemorySnapshotManager(
-            detectionResult: fixture.detectionResult))
+        let manager = try await SnapshotMutationRecordingManager(
+            wrapping: InMemorySnapshotManager.containing(fixture.detectionResult))
         let service = UIAutomationService(snapshotManager: manager)
         let exactWindow = try #require(fixture.targetIdentity.exactWindow)
 
@@ -203,8 +203,8 @@ struct UIAutomationServiceModifierClickSnapshotTests {
     @Test
     func `lease finalization failure is exact target indeterminate`() async throws {
         let fixture = AutomationTestFixtures.linkedSnapshotTarget()
-        let manager = SnapshotMutationRecordingManager(wrapping: InMemorySnapshotManager(
-            detectionResult: fixture.detectionResult))
+        let manager = try await SnapshotMutationRecordingManager(
+            wrapping: InMemorySnapshotManager.containing(fixture.detectionResult))
         manager.failFinish = true
         let service = UIAutomationService(snapshotManager: manager)
         let exactWindow = try #require(fixture.targetIdentity.exactWindow)
@@ -236,8 +236,8 @@ struct UIAutomationServiceModifierClickSnapshotTests {
     @Test
     func `predispatch refusal cannot hide lease finalization failure`() async throws {
         let fixture = AutomationTestFixtures.linkedSnapshotTarget()
-        let manager = SnapshotMutationRecordingManager(wrapping: InMemorySnapshotManager(
-            detectionResult: fixture.detectionResult))
+        let manager = try await SnapshotMutationRecordingManager(
+            wrapping: InMemorySnapshotManager.containing(fixture.detectionResult))
         manager.failFinish = true
         let service = UIAutomationService(snapshotManager: manager)
         let exactWindow = try #require(fixture.targetIdentity.exactWindow)
@@ -265,8 +265,8 @@ struct UIAutomationServiceModifierClickSnapshotTests {
     @Test
     func `snapshot mismatch cannot hide lease finalization failure`() async throws {
         let fixture = AutomationTestFixtures.linkedSnapshotTarget()
-        let manager = SnapshotMutationRecordingManager(wrapping: InMemorySnapshotManager(
-            detectionResult: fixture.detectionResult))
+        let manager = try await SnapshotMutationRecordingManager(
+            wrapping: InMemorySnapshotManager.containing(fixture.detectionResult))
         manager.failFinish = true
         let service = UIAutomationService(snapshotManager: manager)
         let exactWindow = try #require(fixture.targetIdentity.exactWindow)

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/UIAutomationServiceVisualizerTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/UIAutomationServiceVisualizerTests.swift
@@ -1,6 +1,7 @@
 import CoreGraphics
 import Foundation
 import PeekabooFoundation
+import PeekabooFoundationTestSupport
 import Testing
 @testable import PeekabooAutomationKit
 
@@ -61,14 +62,15 @@ struct UIAutomationServiceVisualizerTests {
 
     @Test
     @MainActor
-    func `targeted background interactions stay silent with a resolved target window`() async {
+    func `targeted background interactions stay silent with a resolved target window`() async throws {
         let feedback = RecordingAutomationFeedbackClient()
+        let snapshotID = SnapshotReferenceFixtures.first.rawValue
         let target = VisualizerTargetWindow(
             processIdentifier: 42,
             windowID: 7,
             frame: CGRect(x: 0, y: 0, width: 800, height: 600))
         let detectionResult = ElementDetectionResult(
-            snapshotId: "resolved-target",
+            snapshotId: snapshotID,
             screenshotPath: "/tmp/resolved-target.png",
             elements: DetectedElements(),
             metadata: DetectionMetadata(
@@ -79,8 +81,8 @@ struct UIAutomationServiceVisualizerTests {
                     applicationProcessId: target.processIdentifier,
                     windowID: Int(target.windowID),
                     windowBounds: target.frame)))
-        let service = UIAutomationService(
-            snapshotManager: InMemorySnapshotManager(detectionResult: detectionResult),
+        let service = try await UIAutomationService(
+            snapshotManager: InMemorySnapshotManager.containing(detectionResult),
             feedbackClient: feedback)
 
         await service.visualizeClick(

--- a/Core/PeekabooCore/Package.swift
+++ b/Core/PeekabooCore/Package.swift
@@ -135,6 +135,8 @@ let package = Package(
                 "PeekabooAgentRuntime",
                 "PeekabooCore",
                 .product(name: "PeekabooFoundation", package: "PeekabooFoundation"),
+                .product(name: "PeekabooFoundationTestSupport", package: "PeekabooFoundation"),
+                .product(name: "PeekabooAutomationKitTestSupport", package: "PeekabooAutomationKit"),
             ],
             path: "Tests/PeekabooAgentRuntimeTests",
             swiftSettings: testTargetSettings),

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/UISnapshotStore.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/UISnapshotStore.swift
@@ -2,6 +2,7 @@ import Foundation
 import os
 import PeekabooAutomation
 import PeekabooAutomationKit
+import PeekabooFoundation
 
 actor UISnapshot {
     private struct TargetCache: Sendable {
@@ -26,7 +27,7 @@ actor UISnapshot {
     /// Cache readable from any isolation domain without `nonisolated(unsafe)` stored properties.
     private let targetCache = OSAllocatedUnfairLock(initialState: TargetCache())
 
-    init(id: String = UUID().uuidString, createdAt: Date = Date()) {
+    init(id: String = SnapshotReference.generate().rawValue, createdAt: Date = Date()) {
         self.id = id
         self.createdAt = createdAt
         self.lastAccessedAt = createdAt
@@ -374,7 +375,7 @@ struct MCPToolUISnapshotStore: Sendable {
     }
 
     func createSnapshot(
-        id: String = UUID().uuidString,
+        id: String = SnapshotReference.generate().rawValue,
         at creationDate: Date = Date(),
         pending: Bool = false) async -> UISnapshot
     {
@@ -473,7 +474,7 @@ actor UISnapshotManager {
 
     func createSnapshot(
         owner: MCPToolSnapshotOwner,
-        id: String = UUID().uuidString,
+        id: String = SnapshotReference.generate().rawValue,
         at creationDate: Date = Date(),
         pending: Bool = false) -> UISnapshot
     {
@@ -696,7 +697,7 @@ actor UISnapshotManager {
     /// Source-compatible test seams. Production callers use the owner-scoped
     /// store injected by `MCPToolContext`.
     func createSnapshot(
-        id: String = UUID().uuidString,
+        id: String = SnapshotReference.generate().rawValue,
         at creationDate: Date = Date(),
         pending: Bool = false) -> UISnapshot
     {

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeClient+ActionOutcomes.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeClient+ActionOutcomes.swift
@@ -73,13 +73,45 @@ extension PeekabooBridgeClient {
         snapshotId: String?,
         expectedProcessIdentity: ApplicationProcessIdentity) async throws -> UIAutomationActionResult<Void>
     {
+        try await self.clickWithOutcome(
+            target: target,
+            clickType: clickType,
+            snapshotId: snapshotId,
+            expectedProcessIdentity: expectedProcessIdentity,
+            allowsAccessibilityValueDelivery:
+            self.targetedClickAccessibilityValueDeliveryEnabled ? true : nil)
+    }
+
+    public func clickWithOutcome(
+        target: ClickTarget,
+        clickType: ClickType,
+        snapshotId: String?,
+        expectedProcessIdentity: ApplicationProcessIdentity,
+        allowsAccessibilityValueDelivery: Bool) async throws -> UIAutomationActionResult<Void>
+    {
+        try await self.clickWithOutcome(
+            target: target,
+            clickType: clickType,
+            snapshotId: snapshotId,
+            expectedProcessIdentity: expectedProcessIdentity,
+            allowsAccessibilityValueDelivery: Optional(allowsAccessibilityValueDelivery))
+    }
+
+    private func clickWithOutcome(
+        target: ClickTarget,
+        clickType: ClickType,
+        snapshotId: String?,
+        expectedProcessIdentity: ApplicationProcessIdentity,
+        allowsAccessibilityValueDelivery: Bool?) async throws -> UIAutomationActionResult<Void>
+    {
         try await self.actionResult(
             for: .targetedClick(.init(
                 target: target,
                 clickType: clickType,
                 snapshotId: snapshotId,
                 targetProcessIdentifier: expectedProcessIdentity.processIdentifier,
-                expectedProcessIdentity: expectedProcessIdentity)),
+                expectedProcessIdentity: expectedProcessIdentity,
+                allowsAccessibilityValueDelivery: allowsAccessibilityValueDelivery)),
             expectedResponse: "generation-pinned click")
         { response in
             guard case .ok = response else { return nil }
@@ -94,6 +126,41 @@ extension PeekabooBridgeClient {
         expectedWindowIdentity: WindowMutationIdentity,
         expectedWindowBounds: CGRect) async throws -> UIAutomationActionResult<Void>
     {
+        try await self.clickWithOutcome(
+            target: target,
+            clickType: clickType,
+            snapshotId: snapshotId,
+            expectedWindowIdentity: expectedWindowIdentity,
+            expectedWindowBounds: expectedWindowBounds,
+            allowsAccessibilityValueDelivery:
+            self.targetedClickAccessibilityValueDeliveryEnabled ? true : nil)
+    }
+
+    public func clickWithOutcome(
+        target: ClickTarget,
+        clickType: ClickType,
+        snapshotId: String?,
+        expectedWindowIdentity: WindowMutationIdentity,
+        expectedWindowBounds: CGRect,
+        allowsAccessibilityValueDelivery: Bool) async throws -> UIAutomationActionResult<Void>
+    {
+        try await self.clickWithOutcome(
+            target: target,
+            clickType: clickType,
+            snapshotId: snapshotId,
+            expectedWindowIdentity: expectedWindowIdentity,
+            expectedWindowBounds: expectedWindowBounds,
+            allowsAccessibilityValueDelivery: Optional(allowsAccessibilityValueDelivery))
+    }
+
+    private func clickWithOutcome(
+        target: ClickTarget,
+        clickType: ClickType,
+        snapshotId: String?,
+        expectedWindowIdentity: WindowMutationIdentity,
+        expectedWindowBounds: CGRect,
+        allowsAccessibilityValueDelivery: Bool?) async throws -> UIAutomationActionResult<Void>
+    {
         try await self.actionResult(
             for: .targetedClick(.init(
                 target: target,
@@ -102,7 +169,8 @@ extension PeekabooBridgeClient {
                 targetProcessIdentifier: expectedWindowIdentity.ownerProcessIdentifier,
                 targetWindowID: expectedWindowIdentity.windowID,
                 expectedWindowIdentity: expectedWindowIdentity,
-                expectedWindowBounds: expectedWindowBounds)),
+                expectedWindowBounds: expectedWindowBounds,
+                allowsAccessibilityValueDelivery: allowsAccessibilityValueDelivery)),
             expectedResponse: "exact-window click")
         { response in
             guard case .ok = response else { return nil }

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeClient+Interaction.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeClient+Interaction.swift
@@ -200,6 +200,21 @@ extension PeekabooBridgeClient {
         target: ClickTarget,
         clickType: ClickType,
         snapshotId: String?,
+        expectedProcessIdentity: ApplicationProcessIdentity,
+        allowsAccessibilityValueDelivery: Bool) async throws
+    {
+        _ = try await self.clickWithOutcome(
+            target: target,
+            clickType: clickType,
+            snapshotId: snapshotId,
+            expectedProcessIdentity: expectedProcessIdentity,
+            allowsAccessibilityValueDelivery: allowsAccessibilityValueDelivery)
+    }
+
+    public func click(
+        target: ClickTarget,
+        clickType: ClickType,
+        snapshotId: String?,
         expectedWindowIdentity: WindowMutationIdentity,
         expectedWindowBounds: CGRect) async throws
     {
@@ -209,6 +224,23 @@ extension PeekabooBridgeClient {
             snapshotId: snapshotId,
             expectedWindowIdentity: expectedWindowIdentity,
             expectedWindowBounds: expectedWindowBounds)
+    }
+
+    public func click(
+        target: ClickTarget,
+        clickType: ClickType,
+        snapshotId: String?,
+        expectedWindowIdentity: WindowMutationIdentity,
+        expectedWindowBounds: CGRect,
+        allowsAccessibilityValueDelivery: Bool) async throws
+    {
+        _ = try await self.clickWithOutcome(
+            target: target,
+            clickType: clickType,
+            snapshotId: snapshotId,
+            expectedWindowIdentity: expectedWindowIdentity,
+            expectedWindowBounds: expectedWindowBounds,
+            allowsAccessibilityValueDelivery: allowsAccessibilityValueDelivery)
     }
 
     public func swipe(

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeClient+Snapshots.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeClient+Snapshots.swift
@@ -16,11 +16,22 @@ extension PeekabooBridgeClient {
     }
 
     private func createSnapshot(pendingAt: Date?, explicitOnly: Bool?) async throws -> String {
+        guard self.producerBoundSnapshotReferencesEnabled else {
+            throw PeekabooBridgeErrorEnvelope(
+                code: .operationNotSupported,
+                message: "Bridge host did not negotiate producer-bound snapshot references")
+        }
         let response = try await self.send(.createSnapshot(.init(
             pendingAt: pendingAt,
             explicitOnly: explicitOnly)))
         switch response {
-        case let .snapshotId(id): return id
+        case let .snapshotId(id):
+            guard SnapshotReference(rawValue: id) != nil else {
+                throw PeekabooBridgeErrorEnvelope(
+                    code: .invalidRequest,
+                    message: "Bridge host returned a non-canonical snapshot reference")
+            }
+            return id
         case let .error(envelope): throw envelope
         default: throw PeekabooBridgeErrorEnvelope(code: .invalidRequest, message: "Unexpected createSnapshot response")
         }
@@ -43,6 +54,26 @@ extension PeekabooBridgeClient {
         case let .error(envelope): throw envelope
         default:
             throw PeekabooBridgeErrorEnvelope(code: .invalidRequest, message: "Unexpected getDetectionResult response")
+        }
+    }
+
+    public func ownsSnapshot(snapshotId: String) async throws -> Bool {
+        guard SnapshotReference(rawValue: snapshotId) != nil else {
+            throw PeekabooBridgeErrorEnvelope(
+                code: .invalidRequest,
+                message: "Invalid producer-bound snapshot reference")
+        }
+        guard self.producerBoundSnapshotReferencesEnabled else {
+            throw PeekabooBridgeErrorEnvelope(
+                code: .operationNotSupported,
+                message: "Bridge host did not negotiate producer-bound snapshot references")
+        }
+        let response = try await self.send(.ownsSnapshot(.init(snapshotId: snapshotId)))
+        switch response {
+        case let .bool(owns): return owns
+        case let .error(envelope): throw envelope
+        default:
+            throw PeekabooBridgeErrorEnvelope(code: .invalidRequest, message: "Unexpected ownsSnapshot response")
         }
     }
 

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeClient+Transport.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeClient+Transport.swift
@@ -189,6 +189,22 @@ extension PeekabooBridgeClient {
     }
 
     private func requireNegotiatedInputCapabilities(for request: PeekabooBridgeRequest) throws {
+        if request.createsOrPublishesSnapshotState || request.requiresProducerBoundSnapshotReferences,
+           !self.producerBoundSnapshotReferencesEnabled
+        {
+            throw PeekabooBridgeErrorEnvelope(
+                code: .operationNotSupported,
+                message: "Bridge protocol 1.34 producer-bound snapshot ownership is unavailable")
+        }
+        if request.requiresTargetedClickAccessibilityValueDelivery,
+           !self.targetedClickAccessibilityValueDeliveryEnabled
+        {
+            throw DesktopActionFailure.preDispatchRefusal(
+                route: .bridge,
+                reason: .runtimeIncompatible,
+                message: "This Bridge host cannot honor an explicit accessibility-value click policy.",
+                hint: "Update and relaunch Peekaboo before retrying the snapshot-backed click.")
+        }
         if request.unwrappedOperationRequest.operation == .foregroundModifierClick,
            !self.foregroundModifierClickSnapshotLeaseEnabled
         {

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeClient.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeClient.swift
@@ -61,6 +61,8 @@ public actor PeekabooBridgeClient {
     var setValueResultTargetBindingEnabled = false
     var foregroundModifierClickSnapshotLeaseEnabled = false
     var nativeBrowserConnectionBindingEnabled = false
+    var producerBoundSnapshotReferencesEnabled = false
+    var targetedClickAccessibilityValueDeliveryEnabled = false
     var operationAttestation: PeekabooBridgeListenerAttestation?
     var latestVerifiedOperationReceipt: PeekabooBridgeOperationReceipt?
     var latestVerifiedOperationReceiptBundle: PeekabooBridgeOperationReceiptBundle?
@@ -453,6 +455,8 @@ public actor PeekabooBridgeClient {
         self.setValueResultTargetBindingEnabled = false
         self.foregroundModifierClickSnapshotLeaseEnabled = false
         self.nativeBrowserConnectionBindingEnabled = false
+        self.producerBoundSnapshotReferencesEnabled = false
+        self.targetedClickAccessibilityValueDeliveryEnabled = false
     }
 
     /// Creates or joins one successor-session handshake using the most recent successful public inputs.
@@ -703,7 +707,13 @@ public actor PeekabooBridgeClient {
             client: inputs.client,
             requestedHostKind: inputs.requestedHost,
             operationClientInstanceID: self.operationClientInstanceID,
-            replacingOperationSessionID: replacingOperationSessionID)
+            replacingOperationSessionID: replacingOperationSessionID,
+            clientCapabilities: protocolVersion >= PeekabooBridgeConstants.producerBoundSnapshotReferencesVersion
+                ? [
+                    PeekabooBridgeClientCapability.producerBoundSnapshotReferences,
+                    PeekabooBridgeClientCapability.targetedClickAccessibilityValueDelivery,
+                ]
+                : nil)
         let reply = try await self.sendCarryingActionOutcome(.handshake(payload), timeoutSec: timeoutSec)
         try self.validateTrustedConnectedHost(reply.connectedHost)
         let response = reply.response
@@ -890,6 +900,10 @@ public actor PeekabooBridgeClient {
             Self.supportsForegroundModifierClickSnapshotLease(handshake),
             nativeBrowserConnectionBindingEnabled:
             Self.supportsNativeBrowserConnectionBinding(handshake),
+            producerBoundSnapshotReferencesEnabled:
+            Self.supportsProducerBoundSnapshotReferences(handshake),
+            targetedClickAccessibilityValueDeliveryEnabled:
+            Self.supportsTargetedClickAccessibilityValueDelivery(handshake),
             listenerAttestation: listenerAttestation,
             listenerLiveIdentity: listenerLiveIdentity,
             sessionAttestation: sessionAttestation,
@@ -902,6 +916,28 @@ public actor PeekabooBridgeClient {
             handshake.hostCapabilities?.contains(PeekabooBridgeHostCapability.statelessClickVariants) == true &&
             requiredOperations.isSubset(of: Set(handshake.supportedOperations)) &&
             requiredOperations.isSubset(of: Set(handshake.enabledOperations ?? handshake.supportedOperations))
+    }
+
+    private static func supportsProducerBoundSnapshotReferences(
+        _ handshake: PeekabooBridgeHandshakeResponse) -> Bool
+    {
+        handshake.negotiatedVersion >= PeekabooBridgeConstants.producerBoundSnapshotReferencesVersion &&
+            handshake.hostCapabilities?.contains(PeekabooBridgeHostCapability.attestedOperationReceipts) == true &&
+            handshake.hostCapabilities?.contains(
+                PeekabooBridgeHostCapability.producerBoundSnapshotReferences) == true &&
+            handshake.supportedOperations.contains(.ownsSnapshot) &&
+            (handshake.enabledOperations?.contains(.ownsSnapshot) ?? true)
+    }
+
+    private static func supportsTargetedClickAccessibilityValueDelivery(
+        _ handshake: PeekabooBridgeHandshakeResponse) -> Bool
+    {
+        handshake.negotiatedVersion >= PeekabooBridgeConstants.targetedClickAccessibilityValueDeliveryVersion &&
+            handshake.hostCapabilities?.contains(PeekabooBridgeHostCapability.attestedOperationReceipts) == true &&
+            handshake.hostCapabilities?.contains(
+                PeekabooBridgeHostCapability.targetedClickAccessibilityValueDelivery) == true &&
+            handshake.supportedOperations.contains(.targetedClick) &&
+            (handshake.enabledOperations?.contains(.targetedClick) ?? true)
     }
 
     private static func supportsAgentExecutionTrace(_ handshake: PeekabooBridgeHandshakeResponse) -> Bool {
@@ -1010,6 +1046,9 @@ public actor PeekabooBridgeClient {
         self.foregroundModifierClickSnapshotLeaseEnabled =
             candidate.foregroundModifierClickSnapshotLeaseEnabled
         self.nativeBrowserConnectionBindingEnabled = candidate.nativeBrowserConnectionBindingEnabled
+        self.producerBoundSnapshotReferencesEnabled = candidate.producerBoundSnapshotReferencesEnabled
+        self.targetedClickAccessibilityValueDeliveryEnabled =
+            candidate.targetedClickAccessibilityValueDeliveryEnabled
         self.operationAttestation = candidate.listenerAttestation
         self.installReceiptlessAuthenticatedHost(candidate.receiptlessAuthenticatedHost)
         if let listenerAttestation = candidate.listenerAttestation,
@@ -1300,6 +1339,8 @@ private struct PeekabooBridgeClientHandshakeCandidate: Sendable {
     let setValueResultTargetBindingEnabled: Bool
     let foregroundModifierClickSnapshotLeaseEnabled: Bool
     let nativeBrowserConnectionBindingEnabled: Bool
+    let producerBoundSnapshotReferencesEnabled: Bool
+    let targetedClickAccessibilityValueDeliveryEnabled: Bool
     let listenerAttestation: PeekabooBridgeListenerAttestation?
     let listenerLiveIdentity: PeekabooBridgeLivePeerIdentity?
     let sessionAttestation: PeekabooBridgeOperationSessionAttestation?

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeConstants.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeConstants.swift
@@ -71,6 +71,15 @@ public enum PeekabooBridgeConstants {
     public static let nativeBrowserConnectionBindingVersion =
         PeekabooBridgeProtocolVersion(major: 1, minor: 34)
 
+    /// First protocol that can negotiate producer-bound snapshot references without exposing a
+    /// new operation to already-shipped 1.34 clients that did not offer the raw capability.
+    public static let producerBoundSnapshotReferencesVersion =
+        PeekabooBridgeProtocolVersion(major: 1, minor: 34)
+
+    /// First protocol that can explicitly negotiate and enforce the AXFocused value-delivery policy for clicks.
+    public static let targetedClickAccessibilityValueDeliveryVersion =
+        PeekabooBridgeProtocolVersion(major: 1, minor: 34)
+
     /// First protocol with host-atomic exact-window pixel-focus typing and modifier-click payloads.
     public static let composedInputParityVersion = PeekabooBridgeProtocolVersion(major: 1, minor: 33)
 

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeModels.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeModels.swift
@@ -147,6 +147,7 @@ public enum PeekabooBridgeOperation: String, Codable, Sendable, CaseIterable, Ha
     case createSnapshot
     case storeDetectionResult
     case getDetectionResult
+    case ownsSnapshot
     case storeScreenshot
     case storeObservationSnapshot
     case storeAnnotatedScreenshot
@@ -272,6 +273,9 @@ public enum PeekabooBridgeOperation: String, Codable, Sendable, CaseIterable, Ha
         if version < PeekabooBridgeConstants.certificationProducerAttestationVersion {
             compatible.remove(.certificationProducerAttestation)
         }
+        if version < PeekabooBridgeConstants.producerBoundSnapshotReferencesVersion {
+            compatible.remove(.ownsSnapshot)
+        }
         return compatible
     }
     // swiftlint:enable cyclomatic_complexity
@@ -302,19 +306,23 @@ public struct PeekabooBridgeHandshake: Codable, Sendable {
     public let requestedHostKind: PeekabooBridgeHostKind?
     public let operationClientInstanceID: UUID?
     public let replacingOperationSessionID: UUID?
+    /// Additive raw capability offer. Old hosts ignore the field; old clients omit it.
+    public let clientCapabilities: [String]?
 
     public init(
         protocolVersion: PeekabooBridgeProtocolVersion,
         client: PeekabooBridgeClientIdentity,
         requestedHostKind: PeekabooBridgeHostKind? = nil,
         operationClientInstanceID: UUID? = nil,
-        replacingOperationSessionID: UUID? = nil)
+        replacingOperationSessionID: UUID? = nil,
+        clientCapabilities: [String]? = nil)
     {
         self.protocolVersion = protocolVersion
         self.client = client
         self.requestedHostKind = requestedHostKind
         self.operationClientInstanceID = operationClientInstanceID
         self.replacingOperationSessionID = replacingOperationSessionID
+        self.clientCapabilities = clientCapabilities
     }
 }
 
@@ -373,6 +381,8 @@ public enum PeekabooBridgeHostCapability {
     public static let explicitSnapshotPublication = "explicitSnapshotPublication"
     public static let browserConnectionReceipts = "browserConnectionReceipts"
     public static let nativeBrowserConnectionBinding = "nativeBrowserConnectionBinding"
+    public static let producerBoundSnapshotReferences = "producerBoundSnapshotReferences"
+    public static let targetedClickAccessibilityValueDelivery = "targetedClickAccessibilityValueDelivery"
     public static let exactDialogInputExecution = "exactDialogInputExecution"
     public static let exactForcedDialogDismissExecution = "exactForcedDialogDismissExecution"
     public static let dialogInputFocusPolicy = "dialogInputFocusPolicy"
@@ -385,6 +395,14 @@ public enum PeekabooBridgeHostCapability {
     public static let certificationProducerAttestation = "certificationProducerAttestation"
     public static let setValueResultTargetBinding = "setValueResultTargetBinding"
     public static let foregroundModifierClickSnapshotLease = "foregroundModifierClickSnapshotLease"
+}
+
+/// Stable raw capabilities a client may offer during handshake. Raw strings keep additions
+/// decodable by already-shipped hosts while the offer prevents new 1.34 operations or semantics
+/// from being advertised to already-shipped 1.34 clients.
+public enum PeekabooBridgeClientCapability {
+    public static let producerBoundSnapshotReferences = "producerBoundSnapshotReferences"
+    public static let targetedClickAccessibilityValueDelivery = "targetedClickAccessibilityValueDelivery"
 }
 
 public struct PeekabooBridgeHandshakeResponse: Codable, Sendable {

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeOperation+Policy.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeOperation+Policy.swift
@@ -129,6 +129,7 @@ extension PeekabooBridgeOperation {
         .createSnapshot,
         .storeDetectionResult,
         .getDetectionResult,
+        .ownsSnapshot,
         .storeScreenshot,
         .storeObservationSnapshot,
         .storeAnnotatedScreenshot,

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeOperationDescriptor.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeOperationDescriptor.swift
@@ -663,6 +663,11 @@ extension PeekabooBridgeOperationResultSemantics {
                 completion: .readOnly,
                 targetPolicy: .notApplicable,
                 responseFamilies: [.detection])
+        case .ownsSnapshot:
+            descriptor(
+                completion: .readOnly,
+                targetPolicy: .notApplicable,
+                responseFamilies: [.bool])
         case .storeScreenshot, .storeObservationSnapshot, .storeAnnotatedScreenshot,
              .finishSnapshotMutation, .cleanSnapshot:
             descriptor(

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeOperationResultSemantics.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeOperationResultSemantics.swift
@@ -1384,6 +1384,7 @@ extension PeekabooBridgeOperationResultSemantics {
             return self.targetedClickDeliveryRules(
                 payload,
                 axBackground: axBackground,
+                valueBackground: valueBackground,
                 processBackground: processBackground,
                 windowBackground: windowBackground)
         case .targetedHotkey:
@@ -1572,10 +1573,14 @@ extension PeekabooBridgeOperationResultSemantics {
     private static func targetedClickDeliveryRules(
         _ payload: PeekabooBridgeTargetedClickRequest,
         axBackground: DesktopActionOutcome.Delivery,
+        valueBackground: DesktopActionOutcome.Delivery,
         processBackground: DesktopActionOutcome.Delivery,
         windowBackground: DesktopActionOutcome.Delivery) -> [DeliveryRule]
     {
         let ax = DeliveryRule(delivery: axBackground, units: .exact(1))
+        // AXPress is absent on focusable text fields. ClickService truthfully falls back to one
+        // verified AXFocused value write, which is still a single background click action.
+        let value = DeliveryRule(delivery: valueBackground, units: .exact(1))
         let process = DeliveryRule(delivery: processBackground, units: .variable)
         let routedUnits: Int? = switch payload.clickType {
         case .single: 3
@@ -1587,7 +1592,7 @@ extension PeekabooBridgeOperationResultSemantics {
         let window = routedUnits.map { DeliveryRule(delivery: windowBackground, units: .exact($0)) }
         guard payload.targetWindowID != nil else {
             return switch (payload.target, payload.clickType) {
-            case (.elementId, .single), (.query, .single): [ax, process]
+            case (.elementId, .single), (.query, .single): [ax, value, process]
             case (.elementId, .right), (.query, .right):
                 [ax, process] + (window.map { [$0] } ?? [])
             case (.elementId, .double), (.query, .double):
@@ -1603,7 +1608,7 @@ extension PeekabooBridgeOperationResultSemantics {
         case (.coordinates, .right), (.coordinates, .double), (.coordinates, .middle), (.coordinates, .triple):
             window.map { [$0] } ?? []
         case (.coordinates, .longPress): []
-        case (.elementId, .single), (.query, .single): [ax] + (window.map { [$0] } ?? [])
+        case (.elementId, .single), (.query, .single): [ax, value] + (window.map { [$0] } ?? [])
         case (.elementId, .right), (.query, .right): [ax] + (window.map { [$0] } ?? [])
         case (.elementId, .double), (.query, .double),
              (.elementId, .middle), (.query, .middle),

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeOperationResultSemantics.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeOperationResultSemantics.swift
@@ -1159,6 +1159,7 @@ extension PeekabooBridgeOperationResultSemantics {
              .createSnapshot,
              .storeDetectionResult,
              .getDetectionResult,
+             .ownsSnapshot,
              .storeScreenshot,
              .storeObservationSnapshot,
              .storeAnnotatedScreenshot,
@@ -1264,7 +1265,8 @@ extension PeekabooBridgeOperationResultSemantics {
              .listMenus, .listFrontmostMenus, .listMenuExtras, .menuExtraOpenMenuFrame,
              .listMenuBarItems, .listDockItems, .isDockHidden, .findDockItem, .dialogFindActive,
              .dialogListElements, .targetedDialogListElements, .prepareDialogAction, .createSnapshot,
-             .storeDetectionResult, .getDetectionResult, .storeScreenshot, .storeObservationSnapshot,
+             .storeDetectionResult, .getDetectionResult, .ownsSnapshot, .storeScreenshot,
+             .storeObservationSnapshot,
              .storeAnnotatedScreenshot, .listSnapshots, .getMostRecentSnapshot,
              .invalidateImplicitLatestSnapshot, .beginSnapshotMutation, .finishSnapshotMutation,
              .cleanSnapshot, .cleanSnapshotsOlderThan, .cleanAllSnapshots, ._appleScriptProbe:
@@ -1580,7 +1582,9 @@ extension PeekabooBridgeOperationResultSemantics {
         let ax = DeliveryRule(delivery: axBackground, units: .exact(1))
         // AXPress is absent on focusable text fields. ClickService truthfully falls back to one
         // verified AXFocused value write, which is still a single background click action.
-        let value = DeliveryRule(delivery: valueBackground, units: .exact(1))
+        let value = payload.allowsAccessibilityValueDelivery != false
+            ? [DeliveryRule(delivery: valueBackground, units: .exact(1))]
+            : []
         let process = DeliveryRule(delivery: processBackground, units: .variable)
         let routedUnits: Int? = switch payload.clickType {
         case .single: 3
@@ -1592,7 +1596,7 @@ extension PeekabooBridgeOperationResultSemantics {
         let window = routedUnits.map { DeliveryRule(delivery: windowBackground, units: .exact($0)) }
         guard payload.targetWindowID != nil else {
             return switch (payload.target, payload.clickType) {
-            case (.elementId, .single), (.query, .single): [ax, value, process]
+            case (.elementId, .single), (.query, .single): [ax] + value + [process]
             case (.elementId, .right), (.query, .right):
                 [ax, process] + (window.map { [$0] } ?? [])
             case (.elementId, .double), (.query, .double):
@@ -1608,7 +1612,7 @@ extension PeekabooBridgeOperationResultSemantics {
         case (.coordinates, .right), (.coordinates, .double), (.coordinates, .middle), (.coordinates, .triple):
             window.map { [$0] } ?? []
         case (.coordinates, .longPress): []
-        case (.elementId, .single), (.query, .single): [ax, value] + (window.map { [$0] } ?? [])
+        case (.elementId, .single), (.query, .single): [ax] + value + (window.map { [$0] } ?? [])
         case (.elementId, .right), (.query, .right): [ax] + (window.map { [$0] } ?? [])
         case (.elementId, .double), (.query, .double),
              (.elementId, .middle), (.query, .middle),

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeOperationSessionClaim.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeOperationSessionClaim.swift
@@ -5,23 +5,31 @@ struct PeekabooBridgeNegotiatedSessionCapabilities: Hashable, Sendable {
     let statelessClickVariants: Bool
     let exactWindowHeldPointerLifecycle: Bool
     let nativeBrowserConnectionBinding: Bool
+    let producerBoundSnapshotReferences: Bool
+    let targetedClickAccessibilityValueDelivery: Bool
 
     static let current = Self(
         protocolVersion: PeekabooBridgeConstants.protocolVersion,
         statelessClickVariants: true,
         exactWindowHeldPointerLifecycle: true,
-        nativeBrowserConnectionBinding: true)
+        nativeBrowserConnectionBinding: true,
+        producerBoundSnapshotReferences: true,
+        targetedClickAccessibilityValueDelivery: true)
 
     init(
         protocolVersion: PeekabooBridgeProtocolVersion,
         statelessClickVariants: Bool,
         exactWindowHeldPointerLifecycle: Bool,
-        nativeBrowserConnectionBinding: Bool = false)
+        nativeBrowserConnectionBinding: Bool = false,
+        producerBoundSnapshotReferences: Bool = false,
+        targetedClickAccessibilityValueDelivery: Bool = false)
     {
         self.protocolVersion = protocolVersion
         self.statelessClickVariants = statelessClickVariants
         self.exactWindowHeldPointerLifecycle = exactWindowHeldPointerLifecycle
         self.nativeBrowserConnectionBinding = nativeBrowserConnectionBinding
+        self.producerBoundSnapshotReferences = producerBoundSnapshotReferences
+        self.targetedClickAccessibilityValueDelivery = targetedClickAccessibilityValueDelivery
     }
 }
 

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgePayloads.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgePayloads.swift
@@ -280,6 +280,8 @@ public struct PeekabooBridgeTargetedClickRequest: Codable, Sendable {
     public let targetWindowID: Int?
     public let expectedWindowIdentity: WindowMutationIdentity?
     public let expectedWindowBounds: CGRect?
+    /// Explicit same-version offer for a verified AXFocused value write when AXPress is absent.
+    public let allowsAccessibilityValueDelivery: Bool?
 
     public init(
         target: ClickTarget,
@@ -289,7 +291,8 @@ public struct PeekabooBridgeTargetedClickRequest: Codable, Sendable {
         expectedProcessIdentity: ApplicationProcessIdentity? = nil,
         targetWindowID: Int? = nil,
         expectedWindowIdentity: WindowMutationIdentity? = nil,
-        expectedWindowBounds: CGRect? = nil)
+        expectedWindowBounds: CGRect? = nil,
+        allowsAccessibilityValueDelivery: Bool? = nil)
     {
         self.target = target
         self.clickType = clickType
@@ -299,6 +302,7 @@ public struct PeekabooBridgeTargetedClickRequest: Codable, Sendable {
         self.targetWindowID = targetWindowID
         self.expectedWindowIdentity = expectedWindowIdentity
         self.expectedWindowBounds = expectedWindowBounds
+        self.allowsAccessibilityValueDelivery = allowsAccessibilityValueDelivery
     }
 
     /// Whether this request's concrete click route needs native event synthesis.
@@ -672,6 +676,14 @@ public struct PeekabooBridgeStoreDetectionRequest: Codable, Sendable {
 
 public struct PeekabooBridgeGetDetectionRequest: Codable, Sendable {
     public let snapshotId: String
+}
+
+public struct PeekabooBridgeOwnsSnapshotRequest: Codable, Sendable {
+    public let snapshotId: String
+
+    public init(snapshotId: String) {
+        self.snapshotId = snapshotId
+    }
 }
 
 public struct PeekabooBridgeStoreScreenshotRequest: Codable, Sendable {

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeRequest+DesktopMutation.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeRequest+DesktopMutation.swift
@@ -34,6 +34,12 @@ extension PeekabooBridgeRequest {
         if self.requiresStatelessClickVariantSupport {
             return PeekabooBridgeConstants.statelessClickVariantVersion
         }
+        if self.requiresProducerBoundSnapshotReferences {
+            return PeekabooBridgeConstants.producerBoundSnapshotReferencesVersion
+        }
+        if self.requiresTargetedClickAccessibilityValueDelivery {
+            return PeekabooBridgeConstants.targetedClickAccessibilityValueDeliveryVersion
+        }
         switch self.unwrappedOperationRequest.operation {
         case .exactWindowPixelFocusType, .foregroundModifierClick:
             return PeekabooBridgeConstants.composedInputParityVersion
@@ -52,6 +58,35 @@ extension PeekabooBridgeRequest {
         default:
             return nil
         }
+    }
+
+    /// Current clients must not create or publish snapshot state through a host that did not
+    /// negotiate producer-bound references. This client-side predicate intentionally stays
+    /// separate from the server's ownership-probe gate: an already-shipped 1.34 client treats the
+    /// canonical ID returned by a current host as opaque and must still be able to publish it.
+    var createsOrPublishesSnapshotState: Bool {
+        switch self.unwrappedOperationRequest.operation {
+        case .createSnapshot,
+             .storeDetectionResult,
+             .storeScreenshot,
+             .storeObservationSnapshot,
+             .storeAnnotatedScreenshot:
+            true
+        default:
+            false
+        }
+    }
+
+    var requiresProducerBoundSnapshotReferences: Bool {
+        self.unwrappedOperationRequest.operation == .ownsSnapshot
+    }
+
+    var requiresTargetedClickAccessibilityValueDelivery: Bool {
+        guard case let .targetedClick(payload) = self.unwrappedOperationRequest else { return false }
+        // This capability proves that the host understands the additive policy field, not merely
+        // that it can perform value delivery. An old host would ignore an explicit `false` and
+        // retain its legacy AX-value fallback, so both Boolean values require negotiation.
+        return payload.allowsAccessibilityValueDelivery != nil
     }
 
     var requiresNativeBrowserConnectionBinding: Bool {

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeRequestResponse.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeRequestResponse.swift
@@ -109,6 +109,7 @@ public enum PeekabooBridgeRequest: Codable, Sendable {
     case createSnapshot(PeekabooBridgeCreateSnapshotRequest)
     case storeDetectionResult(PeekabooBridgeStoreDetectionRequest)
     case getDetectionResult(PeekabooBridgeGetDetectionRequest)
+    case ownsSnapshot(PeekabooBridgeOwnsSnapshotRequest)
     case storeScreenshot(PeekabooBridgeStoreScreenshotRequest)
     case storeObservationSnapshot(PeekabooBridgeStoreObservationSnapshotRequest)
     case storeAnnotatedScreenshot(PeekabooBridgeStoreAnnotatedScreenshotRequest)
@@ -231,6 +232,7 @@ extension PeekabooBridgeRequest {
         case .createSnapshot: .createSnapshot
         case .storeDetectionResult: .storeDetectionResult
         case .getDetectionResult: .getDetectionResult
+        case .ownsSnapshot: .ownsSnapshot
         case .storeScreenshot: .storeScreenshot
         case .storeObservationSnapshot: .storeObservationSnapshot
         case .storeAnnotatedScreenshot: .storeAnnotatedScreenshot

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer+Handlers.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer+Handlers.swift
@@ -88,7 +88,7 @@ extension PeekabooBridgeServer {
              .exactDialogClickButton, .exactDialogDismiss, .exactDialogEnterText,
              .exactDialogForceDismiss:
             return try await self.handleDialogRequest(request)
-        case .createSnapshot, .storeDetectionResult, .getDetectionResult, .storeScreenshot,
+        case .createSnapshot, .storeDetectionResult, .getDetectionResult, .ownsSnapshot, .storeScreenshot,
              .storeObservationSnapshot, .storeAnnotatedScreenshot, .listSnapshots, .getMostRecentSnapshot,
              .cleanSnapshot,
              .invalidateImplicitLatestSnapshot, .beginSnapshotMutation, .finishSnapshotMutation,
@@ -1039,6 +1039,18 @@ extension PeekabooBridgeServer {
     private func handleTargetedClick(_ payload: PeekabooBridgeTargetedClickRequest) async throws
         -> PeekabooBridgeHandledResponse
     {
+        let usesProcessPinnedRoute = payload.targetWindowID == nil && payload.expectedProcessIdentity != nil
+        let usesExactWindowPinnedRoute = payload.targetWindowID != nil &&
+            payload.expectedWindowIdentity != nil &&
+            payload.expectedWindowBounds != nil
+        guard payload.allowsAccessibilityValueDelivery == nil ||
+            usesProcessPinnedRoute ||
+            usesExactWindowPinnedRoute
+        else {
+            throw PeekabooBridgeErrorEnvelope(
+                code: .invalidRequest,
+                message: "An explicit accessibility-value click policy requires a process- or exact-window identity")
+        }
         guard
             let targetedClickService = self.services.automation as? any TargetedClickServiceProtocol,
             targetedClickService.supportsTargetedClicks
@@ -1106,7 +1118,8 @@ extension PeekabooBridgeServer {
                 clickType: payload.clickType,
                 snapshotId: payload.snapshotId,
                 expectedWindowIdentity: expectedIdentity,
-                expectedWindowBounds: expectedBounds)
+                expectedWindowBounds: expectedBounds,
+                allowsAccessibilityValueDelivery: payload.allowsAccessibilityValueDelivery != false)
             return .init(response: .ok)
         }
         let result = try await outcomeService.clickWithOutcome(
@@ -1114,7 +1127,8 @@ extension PeekabooBridgeServer {
             clickType: payload.clickType,
             snapshotId: payload.snapshotId,
             expectedWindowIdentity: expectedIdentity,
-            expectedWindowBounds: expectedBounds)
+            expectedWindowBounds: expectedBounds,
+            allowsAccessibilityValueDelivery: payload.allowsAccessibilityValueDelivery != false)
         return try Self.handledActionResponse(
             response: .ok,
             result: result,
@@ -1213,7 +1227,8 @@ extension PeekabooBridgeServer {
                 target: payload.target,
                 clickType: payload.clickType,
                 snapshotId: payload.snapshotId,
-                expectedProcessIdentity: expectedIdentity)
+                expectedProcessIdentity: expectedIdentity,
+                allowsAccessibilityValueDelivery: payload.allowsAccessibilityValueDelivery != false)
             return try Self.handledActionResponse(
                 response: .ok,
                 result: result,
@@ -1223,7 +1238,8 @@ extension PeekabooBridgeServer {
             target: payload.target,
             clickType: payload.clickType,
             snapshotId: payload.snapshotId,
-            expectedProcessIdentity: expectedIdentity)
+            expectedProcessIdentity: expectedIdentity,
+            allowsAccessibilityValueDelivery: payload.allowsAccessibilityValueDelivery != false)
         return .init(response: .ok)
     }
 

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer+Handshake.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer+Handshake.swift
@@ -73,6 +73,11 @@ extension PeekabooBridgeServer {
             usesAttestedOperationReceipts: supportsAttestedOperationReceipts)
         var advertisedOps = compatibleOperations.advertised.sorted { $0.rawValue < $1.rawValue }
         var enabledOps = compatibleOperations.enabled
+        let clientCapabilities = Set(payload.clientCapabilities ?? [])
+        if !clientCapabilities.contains(PeekabooBridgeClientCapability.producerBoundSnapshotReferences) {
+            advertisedOps.removeAll { $0 == .ownsSnapshot }
+            enabledOps.remove(.ownsSnapshot)
+        }
         if (try? self.requireCertificationCaller(peer)) == nil {
             advertisedOps.removeAll {
                 $0 == .observeProcessGeneration || $0 == .certificationProducerAttestation
@@ -155,6 +160,23 @@ extension PeekabooBridgeServer {
             advertisedCapabilities.remove(PeekabooBridgeHostCapability.nativeBrowserConnectionBinding)
         }
         if !supportsAttestedOperationReceipts ||
+            negotiated < PeekabooBridgeConstants.producerBoundSnapshotReferencesVersion ||
+            !clientCapabilities.contains(PeekabooBridgeClientCapability.producerBoundSnapshotReferences) ||
+            !self.services.snapshots.supportsProducerBoundSnapshotReferences ||
+            !advertisedOps.contains(.ownsSnapshot)
+        {
+            advertisedCapabilities.remove(PeekabooBridgeHostCapability.producerBoundSnapshotReferences)
+        }
+        if !supportsAttestedOperationReceipts ||
+            negotiated < PeekabooBridgeConstants.targetedClickAccessibilityValueDeliveryVersion ||
+            !clientCapabilities.contains(PeekabooBridgeClientCapability.targetedClickAccessibilityValueDelivery) ||
+            (self.services.automation as? any TargetedClickServiceProtocol)?
+            .supportsTargetedClickAccessibilityValueDelivery != true ||
+            !advertisedOps.contains(.targetedClick)
+        {
+            advertisedCapabilities.remove(PeekabooBridgeHostCapability.targetedClickAccessibilityValueDelivery)
+        }
+        if !supportsAttestedOperationReceipts ||
             negotiated < PeekabooBridgeConstants.statelessClickVariantVersion ||
             (self.services.automation as? any TargetedClickServiceProtocol)?.supportsStatelessClickVariants != true ||
             !advertisedOps.contains(.targetedClick) ||
@@ -232,7 +254,11 @@ extension PeekabooBridgeServer {
                         exactWindowHeldPointerLifecycle: advertisedCapabilities.contains(
                             PeekabooBridgeHostCapability.exactWindowHeldPointerLifecycle),
                         nativeBrowserConnectionBinding: advertisedCapabilities.contains(
-                            PeekabooBridgeHostCapability.nativeBrowserConnectionBinding)),
+                            PeekabooBridgeHostCapability.nativeBrowserConnectionBinding),
+                        producerBoundSnapshotReferences: advertisedCapabilities.contains(
+                            PeekabooBridgeHostCapability.producerBoundSnapshotReferences),
+                        targetedClickAccessibilityValueDelivery: advertisedCapabilities.contains(
+                            PeekabooBridgeHostCapability.targetedClickAccessibilityValueDelivery)),
                     replacing: payload.replacingOperationSessionID)
                 self.clearReceiptlessNegotiation(peer: peer)
             } catch let error as PeekabooBridgeOperationReceiptError {
@@ -399,6 +425,9 @@ extension PeekabooBridgeServer {
         if !self.services.snapshots.supportsSnapshotMutationLeases {
             operations.remove(.beginSnapshotMutation)
             operations.remove(.finishSnapshotMutation)
+        }
+        if !self.services.snapshots.supportsProducerBoundSnapshotReferences {
+            operations.remove(.ownsSnapshot)
         }
         if !self.services.snapshots.supportsAtomicObservationSnapshotPublication {
             operations.remove(.storeObservationSnapshot)

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer+ServiceHandlers.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer+ServiceHandlers.swift
@@ -1056,6 +1056,20 @@ extension PeekabooBridgeServer {
             throw PeekabooBridgeErrorEnvelope(
                 code: .notFound,
                 message: "No detection result for snapshot \(payload.snapshotId)")
+        case let .ownsSnapshot(payload):
+            guard SnapshotReference(rawValue: payload.snapshotId) != nil else {
+                throw PeekabooBridgeErrorEnvelope(
+                    code: .invalidRequest,
+                    message: "Invalid producer-bound snapshot reference")
+            }
+            guard PeekabooBridgeRequestContext.negotiatedSessionCapabilities?
+                .producerBoundSnapshotReferences == true
+            else {
+                throw PeekabooBridgeErrorEnvelope(
+                    code: .operationNotSupported,
+                    message: "Producer-bound snapshot ownership was not negotiated")
+            }
+            return try await .bool(self.services.snapshots.ownsSnapshot(snapshotId: payload.snapshotId))
         case let .storeScreenshot(payload):
             try await self.services.snapshots.storeScreenshot(payload.snapshotRequest)
             return .ok

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer.swift
@@ -164,6 +164,19 @@ public final class PeekabooBridgeServer {
         {
             resolvedHostCapabilities.insert(PeekabooBridgeHostCapability.nativeBrowserConnectionBinding)
         }
+        if supportedVersions.upperBound >= PeekabooBridgeConstants.producerBoundSnapshotReferencesVersion,
+           services.snapshots.supportsProducerBoundSnapshotReferences,
+           self.allowedOperations.contains(.ownsSnapshot)
+        {
+            resolvedHostCapabilities.insert(PeekabooBridgeHostCapability.producerBoundSnapshotReferences)
+        }
+        if supportedVersions.upperBound >= PeekabooBridgeConstants.targetedClickAccessibilityValueDeliveryVersion,
+           (services.automation as? any TargetedClickServiceProtocol)?
+               .supportsTargetedClickAccessibilityValueDelivery == true,
+               self.allowedOperations.contains(.targetedClick)
+        {
+            resolvedHostCapabilities.insert(PeekabooBridgeHostCapability.targetedClickAccessibilityValueDelivery)
+        }
         let registeredScreenCaptureKitOwnership = services.supportsScreenCaptureKitProcessOwnership &&
             (try? ScreenCaptureKitOwnerLease.registerCurrentProcessCapability()) != nil
         if hostIdentity?.processStartIdentity != nil {
@@ -905,6 +918,10 @@ public final class PeekabooBridgeServer {
             guard (negotiatedVersion ?? .init(major: 0, minor: 0)) >= minimumVersion,
                   !request.requiresNativeBrowserConnectionBinding ||
                   session?.nativeBrowserConnectionBinding == true,
+                  !request.requiresProducerBoundSnapshotReferences ||
+                  session?.producerBoundSnapshotReferences == true,
+                  !request.requiresTargetedClickAccessibilityValueDelivery ||
+                  session?.targetedClickAccessibilityValueDelivery == true,
                   !request.requiresBackgroundStatelessClickVariantSupport || session?.statelessClickVariants == true,
                   !request.requiresExactWindowHeldPointerLifecycleSupport ||
                   session?.exactWindowHeldPointerLifecycle == true

--- a/Core/PeekabooCore/Sources/PeekabooCore/Support/RemotePeekabooServices.swift
+++ b/Core/PeekabooCore/Sources/PeekabooCore/Support/RemotePeekabooServices.swift
@@ -43,6 +43,7 @@ public final class RemotePeekabooServices: PeekabooServiceProviding {
         targetedTypeRequiresEventSynthesizingPermission: Bool = false,
         supportsTargetedClicks: Bool = false,
         supportsStatelessClickVariants: Bool = false,
+        supportsTargetedClickAccessibilityValueDelivery: Bool = false,
         targetedClickUnavailableReason: String? = nil,
         targetedClickRequiresEventSynthesizingPermission: Bool = false,
         supportsExactWindowTargetedClicks: Bool = false,
@@ -70,6 +71,7 @@ public final class RemotePeekabooServices: PeekabooServiceProviding {
         supportsImplicitLatestSnapshotInvalidation: Bool = false,
         supportsSnapshotMutationLeases: Bool = false,
         supportsExplicitSnapshotPublication: Bool = false,
+        supportsProducerBoundSnapshotReferences: Bool = false,
         supportsApplicationLaunchOptions: Bool = false,
         supportsSafeBackgroundApplicationLaunchNoOp: Bool = false,
         supportsNewApplicationInstanceLaunch: Bool = false,
@@ -116,6 +118,7 @@ public final class RemotePeekabooServices: PeekabooServiceProviding {
                 supportsProcessGenerationPinnedClicks: supportsProcessGenerationPinnedInteractions &&
                     supportsTargetedClicks,
                 supportsStatelessClickVariants: supportsStatelessClickVariants,
+                supportsTargetedClickAccessibilityValueDelivery: supportsTargetedClickAccessibilityValueDelivery,
                 targetedClickUnavailableReason: targetedClickUnavailableReason,
                 targetedClickRequiresEventSynthesizingPermission: targetedClickRequiresEventSynthesizingPermission,
                 supportsExactWindowTargetedClicks: supportsExactWindowTargetedClicks,
@@ -145,6 +148,7 @@ public final class RemotePeekabooServices: PeekabooServiceProviding {
                 supportsProcessGenerationPinnedClicks: supportsProcessGenerationPinnedInteractions &&
                     supportsTargetedClicks,
                 supportsStatelessClickVariants: supportsStatelessClickVariants,
+                supportsTargetedClickAccessibilityValueDelivery: supportsTargetedClickAccessibilityValueDelivery,
                 targetedClickUnavailableReason: targetedClickUnavailableReason,
                 targetedClickRequiresEventSynthesizingPermission: targetedClickRequiresEventSynthesizingPermission,
                 supportsExactWindowTargetedClicks: supportsExactWindowTargetedClicks,
@@ -169,6 +173,7 @@ public final class RemotePeekabooServices: PeekabooServiceProviding {
             supportsImplicitLatestSnapshotInvalidation: supportsImplicitLatestSnapshotInvalidation,
             supportsSnapshotMutationLeases: supportsSnapshotMutationLeases,
             supportsExplicitSnapshotPublication: supportsExplicitSnapshotPublication,
+            supportsProducerBoundSnapshotReferences: supportsProducerBoundSnapshotReferences,
             desktopMutationWatermarkStore: desktopMutationWatermarkStore)
         let menuService = RemoteMenuService(client: client)
         let screenService = ScreenService()

--- a/Core/PeekabooCore/Sources/PeekabooCore/Support/RemoteSnapshotManager.swift
+++ b/Core/PeekabooCore/Sources/PeekabooCore/Support/RemoteSnapshotManager.swift
@@ -11,6 +11,7 @@ public final class RemoteSnapshotManager: SnapshotManagerProtocol {
     public let supportsImplicitLatestSnapshotInvalidation: Bool
     public let supportsSnapshotMutationLeases: Bool
     public let supportsExplicitSnapshotPublication: Bool
+    public let supportsProducerBoundSnapshotReferences: Bool
 
     public var effectiveImplicitLatestInvalidationWatermark: Date? {
         self.desktopMutationWatermarkStore?.effectiveWatermark()
@@ -24,21 +25,25 @@ public final class RemoteSnapshotManager: SnapshotManagerProtocol {
         supportsImplicitLatestSnapshotInvalidation: Bool = false,
         supportsSnapshotMutationLeases: Bool = false,
         supportsExplicitSnapshotPublication: Bool = false,
+        supportsProducerBoundSnapshotReferences: Bool = false,
         desktopMutationWatermarkStore: DesktopMutationWatermarkStore? = nil)
     {
         self.client = client
         self.supportsImplicitLatestSnapshotInvalidation = supportsImplicitLatestSnapshotInvalidation
         self.supportsSnapshotMutationLeases = supportsSnapshotMutationLeases
         self.supportsExplicitSnapshotPublication = supportsExplicitSnapshotPublication
+        self.supportsProducerBoundSnapshotReferences = supportsProducerBoundSnapshotReferences
         self.desktopMutationWatermarkStore = desktopMutationWatermarkStore
     }
 
     public func createSnapshot() async throws -> String {
-        try await self.client.createSnapshot()
+        try self.requireProducerBoundSnapshotReferences()
+        return try await self.client.createSnapshot()
     }
 
     public func createSnapshot(pendingAt observationStartedAt: Date) async throws -> String {
-        try await self.client.createSnapshot(pendingAt: observationStartedAt)
+        try self.requireProducerBoundSnapshotReferences()
+        return try await self.client.createSnapshot(pendingAt: observationStartedAt)
     }
 
     public func createExplicitSnapshot() async throws -> String {
@@ -48,6 +53,7 @@ public final class RemoteSnapshotManager: SnapshotManagerProtocol {
                 message: "Bridge protocol 1.26 is required for explicit-reference-only snapshot publication. " +
                     "Update and relaunch the selected Peekaboo host.")
         }
+        try self.requireProducerBoundSnapshotReferences()
         return try await self.client.createExplicitSnapshot()
     }
 
@@ -60,6 +66,19 @@ public final class RemoteSnapshotManager: SnapshotManagerProtocol {
             return try await self.client.getDetectionResult(snapshotId: snapshotId)
         } catch let envelope as PeekabooBridgeErrorEnvelope where envelope.code == .notFound {
             return nil
+        }
+    }
+
+    public func ownsSnapshot(snapshotId: String) async throws -> Bool {
+        try self.requireProducerBoundSnapshotReferences()
+        return try await self.client.ownsSnapshot(snapshotId: snapshotId)
+    }
+
+    private func requireProducerBoundSnapshotReferences() throws {
+        guard self.supportsProducerBoundSnapshotReferences else {
+            throw PeekabooBridgeErrorEnvelope(
+                code: .operationNotSupported,
+                message: "Bridge host lacks producer-bound snapshot references")
         }
     }
 

--- a/Core/PeekabooCore/Sources/PeekabooCore/Support/RemoteUIAutomationService+ActionOutcomes.swift
+++ b/Core/PeekabooCore/Sources/PeekabooCore/Support/RemoteUIAutomationService+ActionOutcomes.swift
@@ -50,6 +50,28 @@ UIAutomationGlobalPointerActionResultProviding {
         target: ClickTarget,
         clickType: ClickType,
         snapshotId: String?,
+        expectedProcessIdentity: ApplicationProcessIdentity,
+        allowsAccessibilityValueDelivery: Bool) async throws -> UIAutomationActionResult<Void>
+    {
+        guard self.supportsProcessGenerationPinnedClicks else {
+            throw PeekabooError.serviceUnavailable(
+                "Remote bridge host does not support process-generation-pinned background clicks; update the host")
+        }
+        try self.requireAccessibilityValueDeliveryPolicySupport()
+        return try await self.remoteAction(snapshotId: snapshotId) {
+            try await self.client.clickWithOutcome(
+                target: target,
+                clickType: clickType,
+                snapshotId: snapshotId,
+                expectedProcessIdentity: expectedProcessIdentity,
+                allowsAccessibilityValueDelivery: allowsAccessibilityValueDelivery)
+        }
+    }
+
+    public func clickWithOutcome(
+        target: ClickTarget,
+        clickType: ClickType,
+        snapshotId: String?,
         targetProcessIdentifier: pid_t) async throws -> UIAutomationActionResult<Void>
     {
         try self.requireTargetedClicks()
@@ -59,6 +81,30 @@ UIAutomationGlobalPointerActionResultProviding {
                 clickType: clickType,
                 snapshotId: snapshotId,
                 targetProcessIdentifier: targetProcessIdentifier)
+        }
+    }
+
+    public func clickWithOutcome(
+        target: ClickTarget,
+        clickType: ClickType,
+        snapshotId: String?,
+        expectedWindowIdentity: WindowMutationIdentity,
+        expectedWindowBounds: CGRect,
+        allowsAccessibilityValueDelivery: Bool) async throws -> UIAutomationActionResult<Void>
+    {
+        guard self.supportsExactWindowTargetedClicks else {
+            throw PeekabooError.serviceUnavailable(
+                "Remote bridge host does not support exact-window background clicks")
+        }
+        try self.requireAccessibilityValueDeliveryPolicySupport()
+        return try await self.remoteAction(snapshotId: snapshotId) {
+            try await self.client.clickWithOutcome(
+                target: target,
+                clickType: clickType,
+                snapshotId: snapshotId,
+                expectedWindowIdentity: expectedWindowIdentity,
+                expectedWindowBounds: expectedWindowBounds,
+                allowsAccessibilityValueDelivery: allowsAccessibilityValueDelivery)
         }
     }
 

--- a/Core/PeekabooCore/Sources/PeekabooCore/Support/RemoteUIAutomationService.swift
+++ b/Core/PeekabooCore/Sources/PeekabooCore/Support/RemoteUIAutomationService.swift
@@ -27,6 +27,7 @@ public class RemoteUIAutomationService: DetectElementsRequestTimeoutAdjusting, T
     public let supportsTargetedClicks: Bool
     public let supportsProcessGenerationPinnedClicks: Bool
     public let supportsStatelessClickVariants: Bool
+    public let supportsTargetedClickAccessibilityValueDelivery: Bool
     public let targetedClickUnavailableReason: String?
     public let targetedClickRequiresEventSynthesizingPermission: Bool
     public let supportsExactWindowTargetedClicks: Bool
@@ -55,6 +56,7 @@ public class RemoteUIAutomationService: DetectElementsRequestTimeoutAdjusting, T
         supportsTargetedClicks: Bool = false,
         supportsProcessGenerationPinnedClicks: Bool = false,
         supportsStatelessClickVariants: Bool = false,
+        supportsTargetedClickAccessibilityValueDelivery: Bool = false,
         targetedClickUnavailableReason: String? = nil,
         targetedClickRequiresEventSynthesizingPermission: Bool = false,
         supportsExactWindowTargetedClicks: Bool = false,
@@ -81,6 +83,7 @@ public class RemoteUIAutomationService: DetectElementsRequestTimeoutAdjusting, T
         self.supportsTargetedClicks = supportsTargetedClicks
         self.supportsProcessGenerationPinnedClicks = supportsProcessGenerationPinnedClicks
         self.supportsStatelessClickVariants = supportsStatelessClickVariants
+        self.supportsTargetedClickAccessibilityValueDelivery = supportsTargetedClickAccessibilityValueDelivery
         self.targetedClickUnavailableReason = targetedClickUnavailableReason
         self.targetedClickRequiresEventSynthesizingPermission = targetedClickRequiresEventSynthesizingPermission
         self.supportsExactWindowTargetedClicks = supportsExactWindowTargetedClicks
@@ -230,6 +233,30 @@ public class RemoteUIAutomationService: DetectElementsRequestTimeoutAdjusting, T
         target: ClickTarget,
         clickType: ClickType,
         snapshotId: String?,
+        expectedProcessIdentity: ApplicationProcessIdentity,
+        allowsAccessibilityValueDelivery: Bool) async throws
+    {
+        guard self.supportsProcessGenerationPinnedClicks else {
+            throw PeekabooError.serviceUnavailable(
+                "Remote bridge host does not support process-generation-pinned background clicks; update the host")
+        }
+        try self.requireAccessibilityValueDeliveryPolicySupport()
+        do {
+            try await self.client.click(
+                target: target,
+                clickType: clickType,
+                snapshotId: snapshotId,
+                expectedProcessIdentity: expectedProcessIdentity,
+                allowsAccessibilityValueDelivery: allowsAccessibilityValueDelivery)
+        } catch let envelope as PeekabooBridgeErrorEnvelope {
+            throw Self.automationError(for: envelope, snapshotId: snapshotId)
+        }
+    }
+
+    public func click(
+        target: ClickTarget,
+        clickType: ClickType,
+        snapshotId: String?,
         expectedWindowIdentity: WindowMutationIdentity,
         expectedWindowBounds: CGRect) async throws
     {
@@ -253,6 +280,44 @@ public class RemoteUIAutomationService: DetectElementsRequestTimeoutAdjusting, T
                 expectedWindowBounds: expectedWindowBounds)
         } catch let envelope as PeekabooBridgeErrorEnvelope {
             throw Self.automationError(for: envelope, snapshotId: snapshotId)
+        }
+    }
+
+    public func click(
+        target: ClickTarget,
+        clickType: ClickType,
+        snapshotId: String?,
+        expectedWindowIdentity: WindowMutationIdentity,
+        expectedWindowBounds: CGRect,
+        allowsAccessibilityValueDelivery: Bool) async throws
+    {
+        guard self.supportsExactWindowTargetedClicks else {
+            throw PeekabooError.serviceUnavailable(
+                "Remote bridge host does not support exact-window background clicks")
+        }
+        guard self.supportsTargetedClicks else {
+            throw Self.targetedClickUnavailableError(
+                reason: self.targetedClickUnavailableReason,
+                requiresEventSynthesizingPermission: self.targetedClickRequiresEventSynthesizingPermission)
+        }
+        try self.requireAccessibilityValueDeliveryPolicySupport()
+        do {
+            try await self.client.click(
+                target: target,
+                clickType: clickType,
+                snapshotId: snapshotId,
+                expectedWindowIdentity: expectedWindowIdentity,
+                expectedWindowBounds: expectedWindowBounds,
+                allowsAccessibilityValueDelivery: allowsAccessibilityValueDelivery)
+        } catch let envelope as PeekabooBridgeErrorEnvelope {
+            throw Self.automationError(for: envelope, snapshotId: snapshotId)
+        }
+    }
+
+    func requireAccessibilityValueDeliveryPolicySupport() throws {
+        guard self.supportsTargetedClickAccessibilityValueDelivery else {
+            throw PeekabooError.serviceUnavailable(
+                "Remote bridge host cannot honor an explicit accessibility-value click policy")
         }
     }
 

--- a/Core/PeekabooCore/Tests/PeekabooAgentRuntimeTests/MCPToolExecutionPolicyTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooAgentRuntimeTests/MCPToolExecutionPolicyTests.swift
@@ -1,5 +1,6 @@
 import MCP
 import PeekabooAutomationKit
+import PeekabooAutomationKitTestSupport
 import PeekabooFoundation
 import Tachikoma
 import TachikomaMCP
@@ -355,7 +356,7 @@ struct MCPToolExecutionPolicyTests {
     @Test
     @MainActor
     func `background-only refuses generic AXPress when an exact Dock snapshot lacks its tool mirror`() async throws {
-        let snapshotID = "dock-policy-\(UUID().uuidString)"
+        let snapshotID = SnapshotReference.generate().rawValue
         let processIdentifier = getpid()
         let processStartIdentity: UInt64 = 77
         let bounds = CGRect(x: 0, y: 900, width: 1200, height: 100)
@@ -387,7 +388,7 @@ struct MCPToolExecutionPolicyTests {
                 elementCount: 1,
                 method: "test",
                 windowContext: windowContext))
-        let snapshots = InMemorySnapshotManager(detectionResult: detectionResult)
+        let snapshots = try await InMemorySnapshotManager.containing(detectionResult)
         let services = PeekabooServices(snapshotManager: snapshots)
         let context = MCPToolContext(services: services, executionPolicy: .backgroundOnly)
         let pressCapture = PolicySnapshotArgumentCapture()
@@ -423,7 +424,7 @@ struct MCPToolExecutionPolicyTests {
     @Test
     @MainActor
     func `background-only pins the authorized implicit snapshot into mutation dispatch`() async throws {
-        let snapshotID = "implicit-policy-\(UUID().uuidString)"
+        let snapshotID = SnapshotReference.generate().rawValue
         let processIdentifier = getpid()
         let bounds = CGRect(x: 100, y: 100, width: 800, height: 600)
         let identity = WindowMutationIdentity(
@@ -431,14 +432,14 @@ struct MCPToolExecutionPolicyTests {
             ownerProcessIdentifier: processIdentifier,
             ownerProcessStartIdentity: 78,
             capturedBounds: bounds)
-        let windowContext = WindowContext(
+        let desktopTarget = AutomationTestFixtures.linkedDesktopTarget(
+            processIdentity: identity.processIdentity,
+            bundleIdentifier: "com.apple.TextEdit",
             applicationName: "TextEdit",
-            applicationBundleId: "com.apple.TextEdit",
-            applicationProcessId: processIdentifier,
+            windowID: identity.windowID,
             windowTitle: "Untitled",
-            windowID: 701,
-            windowBounds: bounds,
-            windowMutationIdentity: identity)
+            bounds: bounds)
+        let windowContext = desktopTarget.windowContext
         let detectionResult = ElementDetectionResult(
             snapshotId: snapshotID,
             screenshotPath: "/tmp/implicit-policy.png",
@@ -454,9 +455,8 @@ struct MCPToolExecutionPolicyTests {
                 elementCount: 1,
                 method: "test",
                 windowContext: windowContext))
-        let snapshots = InMemorySnapshotManager(detectionResult: detectionResult)
-        let services = PeekabooServices(snapshotManager: snapshots)
-        let context = MCPToolContext(services: services, executionPolicy: .backgroundOnly)
+        let snapshots = try await InMemorySnapshotManager.containing(detectionResult)
+        let context = try Self.makePolicyContext(snapshots: snapshots, desktopTarget: desktopTarget)
         let toolSnapshot = await UISnapshotManager.shared.createSnapshot(id: snapshotID)
         await toolSnapshot.setTargetMetadata(from: windowContext)
         let capture = PolicySnapshotArgumentCapture()
@@ -477,7 +477,7 @@ struct MCPToolExecutionPolicyTests {
     @MainActor
     // swiftlint:disable:next function_body_length
     func `background-only rejects conflicting snapshot selectors before dispatch`() async throws {
-        let snapshotID = "selector-policy-\(UUID().uuidString)"
+        let snapshotID = SnapshotReference.generate().rawValue
         let processIdentifier = getpid()
         let bounds = CGRect(x: 100, y: 100, width: 800, height: 600)
         let identity = WindowMutationIdentity(
@@ -485,14 +485,14 @@ struct MCPToolExecutionPolicyTests {
             ownerProcessIdentifier: processIdentifier,
             ownerProcessStartIdentity: 79,
             capturedBounds: bounds)
-        let windowContext = WindowContext(
+        let desktopTarget = AutomationTestFixtures.linkedDesktopTarget(
+            processIdentity: identity.processIdentity,
+            bundleIdentifier: "com.apple.TextEdit",
             applicationName: "TextEdit",
-            applicationBundleId: "com.apple.TextEdit",
-            applicationProcessId: processIdentifier,
+            windowID: identity.windowID,
             windowTitle: "Untitled",
-            windowID: 702,
-            windowBounds: bounds,
-            windowMutationIdentity: identity)
+            bounds: bounds)
+        let windowContext = desktopTarget.windowContext
         let detectionResult = ElementDetectionResult(
             snapshotId: snapshotID,
             screenshotPath: "/tmp/selector-policy.png",
@@ -508,9 +508,8 @@ struct MCPToolExecutionPolicyTests {
                 elementCount: 1,
                 method: "test",
                 windowContext: windowContext))
-        let snapshots = InMemorySnapshotManager(detectionResult: detectionResult)
-        let services = PeekabooServices(snapshotManager: snapshots)
-        let context = MCPToolContext(services: services, executionPolicy: .backgroundOnly)
+        let snapshots = try await InMemorySnapshotManager.containing(detectionResult)
+        let context = try Self.makePolicyContext(snapshots: snapshots, desktopTarget: desktopTarget)
         let toolSnapshot = await UISnapshotManager.shared.createSnapshot(id: snapshotID)
         await toolSnapshot.setTargetMetadata(from: windowContext)
         let capture = PolicySnapshotArgumentCapture()
@@ -636,6 +635,32 @@ struct MCPToolExecutionPolicyTests {
         }
         #expect(meta["error_code"] == .string(MCPToolExecutionPolicy.refusalErrorCode))
         #expect(meta["mutation_dispatched"] == .bool(false))
+    }
+
+    @MainActor
+    private static func makePolicyContext(
+        snapshots: any SnapshotManagerProtocol,
+        desktopTarget: LinkedDesktopTargetFixture) throws -> MCPToolContext
+    {
+        let graph = try LinkedApplicationInventoryGraph(linkedTargets: [desktopTarget])
+        let base = PeekabooServices(snapshotManager: snapshots)
+        return MCPToolContext(
+            automation: base.automation,
+            menu: base.menu,
+            windows: ScriptedWindowInventoryService(graph: graph),
+            applications: ScriptedApplicationInventoryService(graph: graph),
+            dialogs: base.dialogs,
+            dock: base.dock,
+            screenCapture: base.screenCapture,
+            desktopObservation: base.desktopObservation,
+            snapshots: snapshots,
+            screens: base.screens,
+            agent: base.agent,
+            permissions: base.permissions,
+            clipboard: base.clipboard,
+            browser: base.browser,
+            permissionsStatusProvider: base,
+            executionPolicy: .backgroundOnly)
     }
 
     @Test

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPBackgroundPolicyExecutionTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPBackgroundPolicyExecutionTests.swift
@@ -247,10 +247,11 @@ struct MCPBackgroundPolicyExecutionTests {
                     method: "AXorcist",
                     windowContext: windowContext,
                     isDialog: isDialog))
+            let snapshots = try await InMemorySnapshotManager.containing(detection)
             let context = await MCPToolTestHelpers.makeContext(
                 applications: applications,
                 windows: PointerPolicyWindowService(window: window),
-                snapshots: InMemorySnapshotManager(detectionResult: detection),
+                snapshots: snapshots,
                 snapshotOwner: Self.uiSnapshots.owner,
                 executionPolicy: .backgroundOnly)
             let counter = BackgroundPolicyInvocationCounter()

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPBackgroundSnapshotAuthorityTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPBackgroundSnapshotAuthorityTests.swift
@@ -2,6 +2,7 @@ import CoreGraphics
 import PeekabooAutomationKit
 import PeekabooAutomationKitTestSupport
 import PeekabooFoundation
+import PeekabooFoundationTestSupport
 import TachikomaMCP
 import Testing
 @testable import PeekabooAgentRuntime
@@ -13,12 +14,12 @@ struct MCPBackgroundSnapshotAuthorityTests {
     @Test
     @MainActor
     func `snapshot mutation uses one shared receipt and live authority`() async throws {
-        let fixture = AutomationTestFixtures.linkedSnapshotTarget(snapshotID: "shared-authority")
+        let fixture = AutomationTestFixtures.linkedSnapshotTarget(snapshotID: SnapshotReferenceFixtures.id(201))
         let graph = try LinkedApplicationInventoryGraph(linkedTargets: [fixture.desktopTarget])
         let applications = ScriptedApplicationInventoryService(graph: graph)
         let windows = ScriptedWindowInventoryService(graph: graph)
         let automation = SnapshotAuthorityAutomationService()
-        let context = await Self.makeContext(
+        let context = try await Self.makeContext(
             fixture: fixture,
             automation: automation,
             applications: applications,
@@ -40,7 +41,7 @@ struct MCPBackgroundSnapshotAuthorityTests {
     @Test
     @MainActor
     func `contradictory snapshot sources refuse before inventory or dispatch`() async throws {
-        let fixture = AutomationTestFixtures.linkedSnapshotTarget(snapshotID: "contradictory-sources")
+        let fixture = AutomationTestFixtures.linkedSnapshotTarget(snapshotID: SnapshotReferenceFixtures.id(202))
         let graph = try LinkedApplicationInventoryGraph(linkedTargets: [fixture.desktopTarget])
         let applications = ScriptedApplicationInventoryService(graph: graph)
         let windows = ScriptedWindowInventoryService(graph: graph)
@@ -66,7 +67,7 @@ struct MCPBackgroundSnapshotAuthorityTests {
                     bundleIdentifier: fixture.desktopTarget.application.bundleIdentifier,
                     name: fixture.desktopTarget.application.name),
                 windowInfo: contradictoryWindow))
-        let snapshots = InMemorySnapshotManager(detectionResult: fixture.detectionResult)
+        let snapshots = try await InMemorySnapshotManager.containing(fixture.detectionResult)
         let context = await MCPToolTestHelpers.makeContext(
             automation: automation,
             applications: applications,
@@ -91,7 +92,7 @@ struct MCPBackgroundSnapshotAuthorityTests {
     @Test
     @MainActor
     func `partial exact-window inventory without the receipt target refuses before dispatch`() async throws {
-        let fixture = AutomationTestFixtures.linkedSnapshotTarget(snapshotID: "partial-inventory")
+        let fixture = AutomationTestFixtures.linkedSnapshotTarget(snapshotID: SnapshotReferenceFixtures.id(203))
         let graph = try LinkedApplicationInventoryGraph(linkedTargets: [fixture.desktopTarget])
         let applications = ScriptedApplicationInventoryService(graph: graph)
         let windows = ScriptedWindowInventoryService(
@@ -102,7 +103,7 @@ struct MCPBackgroundSnapshotAuthorityTests {
                 ],
             ])
         let automation = SnapshotAuthorityAutomationService()
-        let context = await Self.makeContext(
+        let context = try await Self.makeContext(
             fixture: fixture,
             automation: automation,
             applications: applications,
@@ -123,7 +124,7 @@ struct MCPBackgroundSnapshotAuthorityTests {
     @Test
     @MainActor
     func `process generation replacement during final revalidation refuses before dispatch`() async throws {
-        let fixture = AutomationTestFixtures.linkedSnapshotTarget(snapshotID: "replaced-generation")
+        let fixture = AutomationTestFixtures.linkedSnapshotTarget(snapshotID: SnapshotReferenceFixtures.id(204))
         let graph = try LinkedApplicationInventoryGraph(linkedTargets: [fixture.desktopTarget])
         let replacement = AutomationTestFixtures.application(
             processIdentifier: fixture.desktopTarget.processIdentity.processIdentifier,
@@ -137,7 +138,7 @@ struct MCPBackgroundSnapshotAuthorityTests {
             responses: [fixture.desktopTarget.application, fixture.desktopTarget.application, replacement])
         let windows = ScriptedWindowInventoryService(graph: graph)
         let automation = SnapshotAuthorityAutomationService()
-        let context = await Self.makeContext(
+        let context = try await Self.makeContext(
             fixture: fixture,
             automation: automation,
             applications: applications,
@@ -158,7 +159,7 @@ struct MCPBackgroundSnapshotAuthorityTests {
     @Test
     @MainActor
     func `missing capture generation refuses before inventory or dispatch`() async throws {
-        let fixture = AutomationTestFixtures.linkedSnapshotTarget(snapshotID: "missing-generation")
+        let fixture = AutomationTestFixtures.linkedSnapshotTarget(snapshotID: SnapshotReferenceFixtures.id(205))
         let graph = try LinkedApplicationInventoryGraph(linkedTargets: [fixture.desktopTarget])
         let applications = ScriptedApplicationInventoryService(graph: graph)
         let windows = ScriptedWindowInventoryService(graph: graph)
@@ -176,11 +177,12 @@ struct MCPBackgroundSnapshotAuthorityTests {
         let detection = AutomationTestFixtures.detectionResult(
             snapshotID: fixture.snapshotID,
             windowContext: incompleteContext)
+        let snapshots = try await InMemorySnapshotManager.containing(detection)
         let context = await MCPToolTestHelpers.makeContext(
             automation: automation,
             applications: applications,
             windows: windows,
-            snapshots: InMemorySnapshotManager(detectionResult: detection),
+            snapshots: snapshots,
             snapshotOwner: owner)
 
         let response = try await context.execute(
@@ -200,12 +202,12 @@ struct MCPBackgroundSnapshotAuthorityTests {
     @Test
     @MainActor
     func `snapshot authority preserves cancellation`() async throws {
-        let fixture = AutomationTestFixtures.linkedSnapshotTarget(snapshotID: "cancelled-authority")
+        let fixture = AutomationTestFixtures.linkedSnapshotTarget(snapshotID: SnapshotReferenceFixtures.id(206))
         let graph = try LinkedApplicationInventoryGraph(linkedTargets: [fixture.desktopTarget])
         let applications = CancellingSnapshotAuthorityApplicationService(graph: graph)
         let windows = ScriptedWindowInventoryService(graph: graph)
         let automation = SnapshotAuthorityAutomationService()
-        let context = await Self.makeContext(
+        let context = try await Self.makeContext(
             fixture: fixture,
             automation: automation,
             applications: applications,
@@ -255,7 +257,7 @@ struct MCPBackgroundSnapshotAuthorityTests {
         fixture: LinkedSnapshotTargetFixture,
         automation: SnapshotAuthorityAutomationService,
         applications: ScriptedApplicationInventoryService,
-        windows: ScriptedWindowInventoryService) async -> MCPToolContext
+        windows: ScriptedWindowInventoryService) async throws -> MCPToolContext
     {
         let owner = MCPToolSnapshotOwner()
         let snapshot = await MCPToolUISnapshotStore(owner: owner).createSnapshot(id: fixture.snapshotID)
@@ -266,11 +268,12 @@ struct MCPBackgroundSnapshotAuthorityTests {
                 mode: .window,
                 applicationInfo: fixture.desktopTarget.application,
                 windowInfo: fixture.desktopTarget.window))
+        let snapshots = try await InMemorySnapshotManager.containing(fixture.detectionResult)
         return await MCPToolTestHelpers.makeContext(
             automation: automation,
             applications: applications,
             windows: windows,
-            snapshots: InMemorySnapshotManager(detectionResult: fixture.detectionResult),
+            snapshots: snapshots,
             snapshotOwner: owner)
     }
 

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPComposedInputParityTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPComposedInputParityTests.swift
@@ -3,6 +3,7 @@ import Foundation
 import MCP
 import PeekabooAutomationKitTestSupport
 import PeekabooFoundation
+import PeekabooFoundationTestSupport
 import TachikomaMCP
 import Testing
 @testable import PeekabooAgentRuntime
@@ -15,7 +16,7 @@ struct MCPComposedInputParityTests {
 
     @Test
     func `pixel focus type maps capture coordinates and routes one exact composite request`() async throws {
-        let fixture = await Self.makeFixture()
+        let fixture = try await Self.makeFixture()
         let response = try await TypeTool(context: fixture.context).execute(arguments: ToolArguments(raw: [
             "coords": "500,250",
             "coordinate_space": "image_pixels",
@@ -41,7 +42,7 @@ struct MCPComposedInputParityTests {
         let focusedElement = AutomationTestFixtures.focusedElement(
             processIdentity: .init(processIdentifier: 111, processStartIdentity: 7),
             windowID: 42)
-        let fixture = await Self.makeFixture(focusedElement: focusedElement)
+        let fixture = try await Self.makeFixture(focusedElement: focusedElement)
 
         let response = try await TypeTool(context: fixture.context).execute(arguments: ToolArguments(raw: [
             "coords": "500,250",
@@ -58,7 +59,7 @@ struct MCPComposedInputParityTests {
 
     @Test(arguments: [",10,20", "10,,20", "10,20,", "nan,20", "10,inf"])
     func `pixel focus type rejects malformed coordinate tuples before dispatch`(_ coords: String) async throws {
-        let fixture = await Self.makeFixture()
+        let fixture = try await Self.makeFixture()
         let response = try await TypeTool(context: fixture.context).execute(arguments: ToolArguments(raw: [
             "coords": coords,
             "snapshot": fixture.snapshotID,
@@ -72,7 +73,7 @@ struct MCPComposedInputParityTests {
 
     @Test
     func `pixel focus receipt planning preserves cancellation before dispatch or lease consumption`() async throws {
-        let fixture = await Self.makeFixture()
+        let fixture = try await Self.makeFixture()
         let operation = Task {
             withUnsafeCurrentTask { $0?.cancel() }
             return try await TypeTool.planPixelFocusReceipt(
@@ -90,7 +91,7 @@ struct MCPComposedInputParityTests {
 
     @Test
     func `pixel focus execution propagates receipt cancellation before dispatch`() async throws {
-        let fixture = await Self.makeFixture()
+        let fixture = try await Self.makeFixture()
         let operation = Task {
             withUnsafeCurrentTask { $0?.cancel() }
             return try await TypeTool(context: fixture.context).execute(arguments: ToolArguments(raw: [
@@ -111,7 +112,7 @@ struct MCPComposedInputParityTests {
 
     @Test
     func `modifier click refuses background then projects truthful foreground restoration`() async throws {
-        let fixture = await Self.makeFixture()
+        let fixture = try await Self.makeFixture()
         let refused = try await ClickTool(context: fixture.context).execute(arguments: ToolArguments(raw: [
             "coords": "600,300",
             "snapshot": fixture.snapshotID,
@@ -162,7 +163,7 @@ struct MCPComposedInputParityTests {
 
     @Test
     func `modifier click adapter forwards typed refusal without owning the host lease`() async throws {
-        let fixture = await Self.makeFixture()
+        let fixture = try await Self.makeFixture()
         await MainActor.run {
             fixture.automation.foregroundModifierClickRefusalReason = .targetUnavailable
         }
@@ -188,7 +189,7 @@ struct MCPComposedInputParityTests {
 
     @Test
     func `modifier click adapter refuses a service without host leaf leasing`() async throws {
-        let fixture = await Self.makeFixture()
+        let fixture = try await Self.makeFixture()
         await MainActor.run {
             fixture.automation.supportsForegroundModifierClickSnapshotLease = false
         }
@@ -212,7 +213,7 @@ struct MCPComposedInputParityTests {
 
     @Test
     func `modifier click adapter preserves prelane cancellation without a client lease`() async throws {
-        let fixture = await Self.makeFixture()
+        let fixture = try await Self.makeFixture()
         await MainActor.run {
             fixture.automation.foregroundModifierClickError = DesktopActionFailure.preDispatchRefusal(
                 reason: .requestCancelled,
@@ -240,7 +241,7 @@ struct MCPComposedInputParityTests {
     @Test
     func `already focused pre click cancellation refuses without consuming snapshot`() async throws {
         let automation = await MainActor.run { AlreadyFocusedCancellingModifierClickService() }
-        let fixture = await Self.makeFixture(automation: automation)
+        let fixture = try await Self.makeFixture(automation: automation)
         let operation = Task {
             try await ClickTool(context: fixture.context).execute(arguments: ToolArguments(raw: [
                 "coords": "600,300",
@@ -262,7 +263,7 @@ struct MCPComposedInputParityTests {
     @Test
     func `input drift before first focus write refuses without consuming snapshot`() async throws {
         let automation = await MainActor.run { PreFocusInputDriftModifierClickService() }
-        let fixture = await Self.makeFixture(automation: automation)
+        let fixture = try await Self.makeFixture(automation: automation)
         let response = try await ClickTool(context: fixture.context).execute(arguments: ToolArguments(raw: [
             "coords": "600,300",
             "snapshot": fixture.snapshotID,
@@ -280,7 +281,7 @@ struct MCPComposedInputParityTests {
 
     @Test
     func `modifier click adapter preserves postdispatch failure without owning the host lease`() async throws {
-        let fixture = await Self.makeFixture()
+        let fixture = try await Self.makeFixture()
         await MainActor.run {
             fixture.automation.foregroundModifierClickError = DesktopActionFailure.indeterminate(
                 delivery: .init(mechanism: .composite, mode: .foreground),
@@ -309,7 +310,7 @@ struct MCPComposedInputParityTests {
 
     @Test
     func `modifier click adapter preserves typed receipt refusal without a client lease`() async throws {
-        let fixture = await Self.makeFixture()
+        let fixture = try await Self.makeFixture()
         await MainActor.run {
             fixture.automation.foregroundModifierClickError = SnapshotTargetReceiptPreDispatchError(
                 .incompleteExactWindow)
@@ -336,7 +337,7 @@ struct MCPComposedInputParityTests {
 
     @Test
     func `unknown modifier click failure is retry unsafe without a client lease`() async throws {
-        let fixture = await Self.makeFixture()
+        let fixture = try await Self.makeFixture()
         await MainActor.run {
             fixture.automation.foregroundModifierClickError = MCPComposedInputTestError.unknownServiceFailure
         }
@@ -365,7 +366,7 @@ struct MCPComposedInputParityTests {
 
     @Test
     func `raw prelease modifier click cancellation remains canonical cancellation`() async throws {
-        let fixture = await Self.makeFixture()
+        let fixture = try await Self.makeFixture()
         await MainActor.run {
             fixture.automation.foregroundModifierClickError = CancellationError()
         }
@@ -391,7 +392,7 @@ struct MCPComposedInputParityTests {
 
     @Test
     func `pixel focus type rejects ambiguous authority before dispatch`() async throws {
-        let fixture = await Self.makeFixture()
+        let fixture = try await Self.makeFixture()
         let invalidArguments: [[String: Any]] = [
             ["coords": "600,300", "text": "hi"],
             ["coords": "600,300", "text": "hi", "snapshot": fixture.snapshotID, "foreground": true],
@@ -410,7 +411,7 @@ struct MCPComposedInputParityTests {
 
     @Test
     func `composed input schemas expose closed coordinate and modifier vocabularies`() async throws {
-        let fixture = await Self.makeFixture()
+        let fixture = try await Self.makeFixture()
         let typeProperties = try #require(TypeTool(context: fixture.context).inputSchema
             .objectValue?["properties"]?.objectValue)
         let clickProperties = try #require(ClickTool(context: fixture.context).inputSchema
@@ -435,7 +436,7 @@ struct MCPComposedInputParityTests {
 
     private static func makeFixture(
         automation providedAutomation: MockAutomationService? = nil,
-        focusedElement: FocusedElementIdentity? = nil) async
+        focusedElement: FocusedElementIdentity? = nil) async throws
         -> (
             context: MCPToolContext,
             automation: MockAutomationService,
@@ -445,7 +446,7 @@ struct MCPComposedInputParityTests {
     {
         await self.uiSnapshots.removeAllSnapshots()
         let fixture = AutomationTestFixtures.linkedSnapshotTarget(
-            snapshotID: "composed-input-\(UUID().uuidString)",
+            snapshotID: SnapshotReferenceFixtures.id(301),
             processIdentity: .init(processIdentifier: 111, processStartIdentity: 7),
             bundleIdentifier: "com.example.composed-input",
             applicationName: "ComposedInput",
@@ -468,9 +469,9 @@ struct MCPComposedInputParityTests {
         let automation = await MainActor.run {
             providedAutomation ?? MockAutomationService(accessibilityGranted: true)
         }
+        let storedSnapshots = try await InMemorySnapshotManager.containing(fixture.detectionResult)
         let snapshots = await MainActor.run {
-            SnapshotMutationRecordingManager(wrapping: InMemorySnapshotManager(
-                detectionResult: fixture.detectionResult))
+            SnapshotMutationRecordingManager(wrapping: storedSnapshots)
         }
         let context = await MCPToolTestHelpers.makeContext(
             automation: automation,

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPExactWindowKeyboardToolTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPExactWindowKeyboardToolTests.swift
@@ -88,10 +88,11 @@ struct MCPExactWindowKeyboardToolTests {
     @Test
     func `Background-only exact snapshot press reaches the exact leaf`() async throws {
         let snapshot = await Self.makeSnapshot(window: Self.keyboardWindow(id: 42, index: 0))
+        let snapshots = try await InMemorySnapshotManager.containing(snapshot.detectionResult)
         let fixture = await Self.makeFixture(
             focusedWindowID: 42,
             backgroundOnly: true,
-            snapshots: InMemorySnapshotManager(detectionResult: snapshot.detectionResult))
+            snapshots: snapshots)
 
         let response = try await fixture.context.execute(
             tool: PressTool(context: fixture.context),

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeOperationReceiptTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeOperationReceiptTests.swift
@@ -27,6 +27,10 @@ struct PeekabooBridgeOperationReceiptTests {
             peer: legacy.peer,
             negotiatedCapabilities: .current)
         #expect(current.attestation.sessionID != legacy.attestation.sessionID)
+        #expect(!legacyCapabilities.producerBoundSnapshotReferences)
+        #expect(!legacyCapabilities.targetedClickAccessibilityValueDelivery)
+        #expect(PeekabooBridgeNegotiatedSessionCapabilities.current.producerBoundSnapshotReferences)
+        #expect(PeekabooBridgeNegotiatedSessionCapabilities.current.targetedClickAccessibilityValueDelivery)
 
         let legacyClaim = try await legacy.acceptedClaim(
             authority: authority,

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeOperationSemanticPlanTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeOperationSemanticPlanTests.swift
@@ -27,7 +27,7 @@ struct PeekabooBridgeOperationSemanticPlanTests {
 
         // This count is intentionally reviewed whenever the wire enum grows. The exhaustive
         // policy switches also make a missing classification a compile error.
-        #expect(operations.count == 113)
+        #expect(operations.count == 114)
 
         func partition<Value: Equatable>(_ values: [Value], by keyPath: KeyPath<Semantics.OperationPolicy, Value>) {
             let groups = values.map { expected in

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeRequestPlanTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeRequestPlanTests.swift
@@ -9,7 +9,7 @@ struct PeekabooBridgeRequestPlanTests {
     @Test
     func `Every wire operation has one complete static descriptor`() {
         let operations = PeekabooBridgeOperation.allCases
-        #expect(operations.count == 113)
+        #expect(operations.count == 114)
 
         let descriptors = operations.map(Semantics.operationDescriptor(for:))
         #expect(descriptors.map(\.operation) == operations)

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeTargetedClickValueReceiptTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeTargetedClickValueReceiptTests.swift
@@ -1,0 +1,74 @@
+import Darwin
+import Foundation
+import PeekabooAutomationKit
+import PeekabooBridgeTestSupport
+import PeekabooFoundation
+import Testing
+@testable import PeekabooBridge
+@testable import PeekabooCore
+
+@Suite(.serialized)
+struct PeekabooBridgeTargetedClickValueReceiptTests {
+    @Test
+    func `exact text field focus click returns an attested value-delivery receipt`() async throws {
+        let root = URL(fileURLWithPath: "/tmp/pbor-\(UUID().uuidString)", isDirectory: true)
+        let socketPath = root.appendingPathComponent("bridge.sock").path
+        defer { try? FileManager.default.removeItem(at: root) }
+        let generation = try #require(SystemIdentityResolver.processStartIdentity(getpid()))
+        let bounds = CGRect(x: 10, y: 20, width: 600, height: 400)
+        let identity = WindowMutationIdentity(
+            windowID: 74,
+            ownerProcessIdentifier: getpid(),
+            ownerProcessStartIdentity: generation,
+            capturedBounds: bounds)
+        let exactWindow = try UIAutomationTarget.ExactWindow(identity: identity, bounds: bounds)
+        let services = await MainActor.run {
+            let services = StubServices()
+            services.automationStub.actionOutcome = .confirmedChange(
+                delivery: .init(mechanism: .accessibilityValue, mode: .background),
+                unitCount: .one)
+            services.automationStub.uiAutomationOutcomeTargetIdentity = DesktopTargetIdentity(
+                exactWindow: exactWindow)
+            return services
+        }
+        let server = await MainActor.run {
+            PeekabooBridgeServer(
+                services: services,
+                allowlistedTeams: [],
+                allowlistedBundles: [],
+                permissionStatusEvaluator: { _ in
+                    PermissionsStatus(screenRecording: true, accessibility: true, postEvent: true)
+                })
+        }
+        let host = PeekabooBridgeHost(socketPath: socketPath, server: server, allowedTeamIDs: [])
+        try await host.startChecked()
+
+        do {
+            let client = TrustedBridgeClientFixture.make(socketPath: socketPath)
+            _ = try await client.handshake(client: Self.clientIdentity)
+            let result = try await client.clickWithOutcome(
+                target: .elementId("field"),
+                clickType: .single,
+                snapshotId: "snapshot",
+                expectedWindowIdentity: identity,
+                expectedWindowBounds: bounds)
+            #expect(result.outcome?.delivery?.mechanism == .accessibilityValue)
+            #expect(result.targetIdentity?.exactWindow == exactWindow)
+            let receipt = try #require(await client.lastOperationReceipt())
+            #expect(receipt.payload.operation == .exactWindowTargetedClick)
+            #expect(receipt.payload.target == .window(identity))
+        } catch {
+            await host.stop()
+            throw error
+        }
+        await host.stop()
+    }
+
+    private static var clientIdentity: PeekabooBridgeClientIdentity {
+        PeekabooBridgeClientIdentity(
+            bundleIdentifier: "dev.peekaboo.focus-receipt-tests",
+            teamIdentifier: nil,
+            processIdentifier: getpid(),
+            hostname: nil)
+    }
+}

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeTargetedClickValueReceiptTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeTargetedClickValueReceiptTests.swift
@@ -3,6 +3,7 @@ import Foundation
 import PeekabooAutomationKit
 import PeekabooBridgeTestSupport
 import PeekabooFoundation
+import PeekabooFoundationTestSupport
 import Testing
 @testable import PeekabooBridge
 @testable import PeekabooCore
@@ -27,6 +28,7 @@ struct PeekabooBridgeTargetedClickValueReceiptTests {
             services.automationStub.actionOutcome = .confirmedChange(
                 delivery: .init(mechanism: .accessibilityValue, mode: .background),
                 unitCount: .one)
+            services.automationStub.supportsTargetedClickAccessibilityValueDelivery = true
             services.automationStub.uiAutomationOutcomeTargetIdentity = DesktopTargetIdentity(
                 exactWindow: exactWindow)
             return services
@@ -49,14 +51,42 @@ struct PeekabooBridgeTargetedClickValueReceiptTests {
             let result = try await client.clickWithOutcome(
                 target: .elementId("field"),
                 clickType: .single,
-                snapshotId: "snapshot",
+                snapshotId: SnapshotReferenceFixtures.first.rawValue,
                 expectedWindowIdentity: identity,
                 expectedWindowBounds: bounds)
             #expect(result.outcome?.delivery?.mechanism == .accessibilityValue)
             #expect(result.targetIdentity?.exactWindow == exactWindow)
+            #expect(await MainActor.run {
+                services.automationStub.lastAllowsAccessibilityValueDelivery == true
+            })
             let receipt = try #require(await client.lastOperationReceipt())
             #expect(receipt.payload.operation == .exactWindowTargetedClick)
             #expect(receipt.payload.target == .window(identity))
+
+            await MainActor.run {
+                services.automationStub.actionOutcome = .confirmedChange(
+                    delivery: .init(mechanism: .accessibilityAction, mode: .background),
+                    unitCount: .one)
+            }
+            let remote = await MainActor.run {
+                RemoteUIAutomationService(
+                    client: client,
+                    supportsTargetedClicks: true,
+                    supportsProcessGenerationPinnedClicks: true,
+                    supportsTargetedClickAccessibilityValueDelivery: true,
+                    supportsExactWindowTargetedClicks: true)
+            }
+            let actionResult = try await remote.clickWithOutcome(
+                target: .elementId("field"),
+                clickType: .single,
+                snapshotId: SnapshotReferenceFixtures.first.rawValue,
+                expectedWindowIdentity: identity,
+                expectedWindowBounds: bounds,
+                allowsAccessibilityValueDelivery: false)
+            #expect(actionResult.outcome?.delivery?.mechanism == .accessibilityAction)
+            #expect(await MainActor.run {
+                services.automationStub.lastAllowsAccessibilityValueDelivery == false
+            })
         } catch {
             await host.stop()
             throw error

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeTargetedClickValueSemanticsTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeTargetedClickValueSemanticsTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import PeekabooFoundation
+import PeekabooFoundationTestSupport
 import Testing
 @testable import PeekabooAutomationKit
 @testable import PeekabooBridge
@@ -23,13 +24,29 @@ struct PeekabooBridgeTargetedClickValueSemanticsTests {
             PeekabooBridgeRequest.targetedClick(.init(
                 target: .elementId("field"),
                 clickType: .single,
-                snapshotId: "snapshot",
+                snapshotId: SnapshotReferenceFixtures.first.rawValue,
+                targetProcessIdentifier: identity.ownerProcessIdentifier,
+                expectedProcessIdentity: identity.processIdentity,
+                allowsAccessibilityValueDelivery: true)),
+            PeekabooBridgeRequest.targetedClick(.init(
+                target: .elementId("field"),
+                clickType: .single,
+                snapshotId: SnapshotReferenceFixtures.first.rawValue,
+                targetProcessIdentifier: identity.ownerProcessIdentifier,
+                targetWindowID: identity.windowID,
+                expectedWindowIdentity: identity,
+                expectedWindowBounds: bounds,
+                allowsAccessibilityValueDelivery: true)),
+            PeekabooBridgeRequest.targetedClick(.init(
+                target: .elementId("field"),
+                clickType: .single,
+                snapshotId: SnapshotReferenceFixtures.first.rawValue,
                 targetProcessIdentifier: identity.ownerProcessIdentifier,
                 expectedProcessIdentity: identity.processIdentity)),
             PeekabooBridgeRequest.targetedClick(.init(
                 target: .elementId("field"),
                 clickType: .single,
-                snapshotId: "snapshot",
+                snapshotId: SnapshotReferenceFixtures.first.rawValue,
                 targetProcessIdentifier: identity.ownerProcessIdentifier,
                 targetWindowID: identity.windowID,
                 expectedWindowIdentity: identity,
@@ -40,5 +57,17 @@ struct PeekabooBridgeTargetedClickValueSemanticsTests {
                 response: .ok,
                 request: request))
         }
+
+        let optedOut = PeekabooBridgeRequest.targetedClick(.init(
+            target: .elementId("field"),
+            clickType: .single,
+            snapshotId: SnapshotReferenceFixtures.first.rawValue,
+            targetProcessIdentifier: identity.ownerProcessIdentifier,
+            expectedProcessIdentity: identity.processIdentity,
+            allowsAccessibilityValueDelivery: false))
+        #expect(!PeekabooBridgeOperationResultSemantics.successfulOutcomeMatchesContract(
+            focus,
+            response: .ok,
+            request: optedOut))
     }
 }

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeTargetedClickValueSemanticsTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeTargetedClickValueSemanticsTests.swift
@@ -1,0 +1,44 @@
+import Foundation
+import PeekabooFoundation
+import Testing
+@testable import PeekabooAutomationKit
+@testable import PeekabooBridge
+
+@Suite("Bridge targeted-click value semantics")
+struct PeekabooBridgeTargetedClickValueSemanticsTests {
+    @Test
+    func `single targeted click accepts one verified background focus value write`() throws {
+        let identity = WindowMutationIdentity(
+            windowID: 42,
+            ownerProcessIdentifier: 9001,
+            ownerProcessStartIdentity: 7,
+            capturedBounds: CGRect(x: 0, y: 0, width: 100, height: 100))
+        let bounds = try #require(identity.capturedBounds)
+        let focus = DesktopActionOutcome.confirmedChange(
+            route: .bridge,
+            delivery: .init(mechanism: .accessibilityValue, mode: .background),
+            unitCount: .one)
+
+        for request in [
+            PeekabooBridgeRequest.targetedClick(.init(
+                target: .elementId("field"),
+                clickType: .single,
+                snapshotId: "snapshot",
+                targetProcessIdentifier: identity.ownerProcessIdentifier,
+                expectedProcessIdentity: identity.processIdentity)),
+            PeekabooBridgeRequest.targetedClick(.init(
+                target: .elementId("field"),
+                clickType: .single,
+                snapshotId: "snapshot",
+                targetProcessIdentifier: identity.ownerProcessIdentifier,
+                targetWindowID: identity.windowID,
+                expectedWindowIdentity: identity,
+                expectedWindowBounds: bounds)),
+        ] {
+            #expect(PeekabooBridgeOperationResultSemantics.successfulOutcomeMatchesContract(
+                focus,
+                response: .ok,
+                request: request))
+        }
+    }
+}

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeTests.swift
@@ -6,6 +6,7 @@ import PeekabooAutomationKitTestSupport
 import PeekabooBridgeTestSupport
 import PeekabooCore
 import PeekabooFoundation
+import PeekabooFoundationTestSupport
 import Testing
 @testable import PeekabooBridge
 
@@ -1803,7 +1804,10 @@ extension PeekabooBridgeTests {
             RemoteElementActionUIAutomationService(
                 client: client)
         }
-        let result = try await remote.setValue(target: "T1", value: .string("hello"), snapshotId: "S1")
+        let result = try await remote.setValue(
+            target: "T1",
+            value: .string("hello"),
+            snapshotId: SnapshotReferenceFixtures.first.rawValue)
 
         #expect(result.target == "T1")
         let call = await MainActor.run { services.automationStub.lastSetValue }
@@ -1848,7 +1852,10 @@ extension PeekabooBridgeTests {
             RemoteElementActionUIAutomationService(
                 client: client)
         }
-        let result = try await remote.performAction(target: "B1", actionName: "AXPress", snapshotId: "S1")
+        let result = try await remote.performAction(
+            target: "B1",
+            actionName: "AXPress",
+            snapshotId: SnapshotReferenceFixtures.first.rawValue)
 
         #expect(result.actionName == "AXPress")
         let call = await MainActor.run { services.automationStub.lastPerformAction }
@@ -1892,7 +1899,10 @@ extension PeekabooBridgeTests {
             services.automationStub.clickError = PeekabooError.snapshotStale("window moved")
         }
         do {
-            try await remote.click(target: .elementId("B1"), clickType: .single, snapshotId: "S1")
+            try await remote.click(
+                target: .elementId("B1"),
+                clickType: .single,
+                snapshotId: SnapshotReferenceFixtures.first.rawValue)
             Issue.record("Expected stale snapshot error")
         } catch let failure as DesktopActionFailure {
             #expect(failure.outcome.state == .indeterminate)
@@ -1906,20 +1916,28 @@ extension PeekabooBridgeTests {
             services.automationStub.elementActionError = PeekabooError.snapshotNotFound("expired")
         }
         do {
-            _ = try await elementActions.setValue(target: "T1", value: .string("hello"), snapshotId: "S1")
+            _ = try await elementActions.setValue(
+                target: "T1",
+                value: .string("hello"),
+                snapshotId: SnapshotReferenceFixtures.first.rawValue)
             Issue.record("Expected missing snapshot error")
         } catch let failure as DesktopActionFailure {
-            #expect(failure.outcome.state == .indeterminate)
-            #expect(failure.outcome.retrySafety == .unsafe)
-            #expect(failure.message.contains("expired"))
-            #expect(failure.causeDescription?.contains("snapshotNotFound") == true)
+            #expect(failure.outcome.state == .refused)
+            #expect(failure.outcome.dispatchState == .none)
+            #expect(failure.outcome.retrySafety == .safe)
+            #expect(failure.outcome.refusalReason == .runtimeIncompatible)
+            #expect(failure.message.contains("verifiable set-value result"))
+            #expect(failure.causeDescription == nil)
         }
 
         await MainActor.run {
             services.automationStub.elementActionError = PeekabooError.elementNotFound("B404")
         }
         do {
-            _ = try await elementActions.performAction(target: "B404", actionName: "AXPress", snapshotId: "S1")
+            _ = try await elementActions.performAction(
+                target: "B404",
+                actionName: "AXPress",
+                snapshotId: SnapshotReferenceFixtures.first.rawValue)
             Issue.record("Expected missing element error")
         } catch let failure as DesktopActionFailure {
             #expect(failure.outcome.state == .indeterminate)
@@ -2291,6 +2309,7 @@ final class StubAutomationService: TargetedHotkeyServiceProtocol, TargetedTypeSe
     private(set) var lastClick: Click?
     private(set) var lastProcessTargetedHotkey: TargetedHotkey?
     private(set) var lastProcessTargetedClick: TargetedClick?
+    private(set) var lastAllowsAccessibilityValueDelivery: Bool?
     private(set) var lastProcessTargetedTypeIdentity: ApplicationProcessIdentity?
     private(set) var lastTypeActions: [TypeAction]?
     private(set) var lastSetValue: SetValue?
@@ -2302,6 +2321,7 @@ final class StubAutomationService: TargetedHotkeyServiceProtocol, TargetedTypeSe
     var exactTypeError: (any Error)?
     var exactHotkeyError: (any Error)?
     var targetedClickError: (any Error)?
+    var supportsTargetedClickAccessibilityValueDelivery = false
     private static let defaultActionOutcome = DesktopActionOutcome.dispatchedUnverified(
         delivery: .init(mechanism: .accessibilityAction, mode: .background),
         evidence: .deliveryAccepted)
@@ -2379,6 +2399,21 @@ final class StubAutomationService: TargetedHotkeyServiceProtocol, TargetedTypeSe
     func click(
         target: ClickTarget,
         clickType: ClickType,
+        snapshotId: String?,
+        expectedProcessIdentity: ApplicationProcessIdentity,
+        allowsAccessibilityValueDelivery: Bool) async throws
+    {
+        self.lastAllowsAccessibilityValueDelivery = allowsAccessibilityValueDelivery
+        try await self.click(
+            target: target,
+            clickType: clickType,
+            snapshotId: snapshotId,
+            expectedProcessIdentity: expectedProcessIdentity)
+    }
+
+    func click(
+        target: ClickTarget,
+        clickType: ClickType,
         snapshotId _: String?,
         expectedWindowIdentity: WindowMutationIdentity,
         expectedWindowBounds _: CGRect) async throws
@@ -2397,6 +2432,23 @@ final class StubAutomationService: TargetedHotkeyServiceProtocol, TargetedTypeSe
         if self.recordsExactKeyboardEvents {
             self.exactKeyboardEvents.append("retarget")
         }
+    }
+
+    func click(
+        target: ClickTarget,
+        clickType: ClickType,
+        snapshotId: String?,
+        expectedWindowIdentity: WindowMutationIdentity,
+        expectedWindowBounds: CGRect,
+        allowsAccessibilityValueDelivery: Bool) async throws
+    {
+        self.lastAllowsAccessibilityValueDelivery = allowsAccessibilityValueDelivery
+        try await self.click(
+            target: target,
+            clickType: clickType,
+            snapshotId: snapshotId,
+            expectedWindowIdentity: expectedWindowIdentity,
+            expectedWindowBounds: expectedWindowBounds)
     }
 
     func type(text _: String, target _: String?, clearExisting _: Bool, typingDelay _: Int, snapshotId _: String?) async

--- a/Core/PeekabooCore/Tests/PeekabooTests/ProducerBoundSnapshotBridgeTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/ProducerBoundSnapshotBridgeTests.swift
@@ -1,0 +1,657 @@
+import Darwin
+import Foundation
+import PeekabooAutomationKit
+import PeekabooAutomationKitTestSupport
+import PeekabooBridgeTestSupport
+import PeekabooFoundation
+import PeekabooFoundationTestSupport
+import Testing
+@testable import PeekabooBridge
+@testable import PeekabooCore
+
+@Suite(.serialized)
+struct ProducerBoundSnapshotBridgeTests {
+    @Test
+    @MainActor
+    func `current 1 34 offer exposes signed producer ownership independently`() async throws {
+        let snapshots = InMemorySnapshotManager()
+        let ordinary = try await snapshots.createSnapshot()
+        let pending = try await snapshots.createSnapshot(pendingAt: Date())
+        let explicit = try await snapshots.createExplicitSnapshot()
+        let socketPath = "/tmp/peekaboo-producer-snapshot-\(UUID().uuidString).sock"
+        let server = PeekabooBridgeServer(
+            services: PeekabooServices(snapshotManager: snapshots),
+            hostKind: .onDemand,
+            allowlistedTeams: [],
+            allowlistedBundles: [])
+        let host = PeekabooBridgeHost(socketPath: socketPath, server: server, allowedTeamIDs: [])
+        try await host.startChecked()
+        defer { Task { await host.stop() } }
+
+        let client = TrustedBridgeClientFixture.make(socketPath: socketPath)
+        let handshake = try await client.handshake(client: Self.identity)
+        #expect(handshake.negotiatedVersion == .init(major: 1, minor: 34))
+        #expect(handshake.supportedOperations.contains(.ownsSnapshot))
+        #expect(handshake.hostCapabilities?.contains(
+            PeekabooBridgeHostCapability.producerBoundSnapshotReferences) == true)
+        #expect(handshake.hostCapabilities?.contains(
+            PeekabooBridgeHostCapability.targetedClickAccessibilityValueDelivery) == true)
+
+        for snapshotID in [ordinary, pending, explicit] {
+            #expect(try await client.ownsSnapshot(snapshotId: snapshotID))
+            let receipt = try #require(await client.lastOperationReceipt())
+            #expect(receipt.payload.operation == .ownsSnapshot)
+            #expect(receipt.payload.outcome == nil)
+        }
+        #expect(try await !client.ownsSnapshot(snapshotId: SnapshotReferenceFixtures.id(99)))
+        try await snapshots.cleanSnapshot(snapshotId: ordinary)
+        #expect(try await !client.ownsSnapshot(snapshotId: ordinary))
+        await host.stop()
+    }
+
+    @Test
+    @MainActor
+    func `legacy 1 34 client offer omits only new same-minor operations and capabilities`() async throws {
+        let socketPath = "/tmp/peekaboo-legacy-134-snapshot-\(UUID().uuidString).sock"
+        let server = PeekabooBridgeServer(
+            services: PeekabooServices(snapshotManager: InMemorySnapshotManager()),
+            hostKind: .onDemand,
+            allowlistedTeams: [],
+            allowlistedBundles: [])
+        let host = PeekabooBridgeHost(socketPath: socketPath, server: server, allowedTeamIDs: [])
+        try await host.startChecked()
+        defer { Task { await host.stop() } }
+        let client = TrustedBridgeClientFixture.make(socketPath: socketPath)
+        let response = try await client.send(.handshake(.init(
+            protocolVersion: .init(major: 1, minor: 34),
+            client: Self.identity,
+            operationClientInstanceID: client.operationClientInstanceID,
+            clientCapabilities: nil)))
+        let handshake: PeekabooBridgeHandshakeResponse
+        guard case let .handshake(value) = response else {
+            Issue.record("Expected handshake response")
+            return
+        }
+        handshake = value
+        #expect(!handshake.supportedOperations.contains(.ownsSnapshot))
+        #expect(handshake.enabledOperations?.contains(.ownsSnapshot) != true)
+        #expect(handshake.hostCapabilities?.contains(
+            PeekabooBridgeHostCapability.producerBoundSnapshotReferences) != true)
+        #expect(handshake.hostCapabilities?.contains(
+            PeekabooBridgeHostCapability.targetedClickAccessibilityValueDelivery) != true)
+        // #622 remains independent at the already-shipped 1.34 floor.
+        #expect(handshake.hostCapabilities?.contains(
+            PeekabooBridgeHostCapability.nativeBrowserConnectionBinding) == true)
+        await host.stop()
+    }
+
+    @Test
+    @MainActor
+    func `same minor browser snapshot and value capabilities negotiate independently`() async throws {
+        let browserOnlyServer = PeekabooBridgeServer(
+            services: PeekabooServices(snapshotManager: InMemorySnapshotManager()),
+            hostKind: .onDemand,
+            allowlistedTeams: [],
+            allowlistedBundles: [])
+        let browserOnly = try await Self.rawLiveHandshake(
+            server: browserOnlyServer,
+            clientCapabilities: [])
+        #expect(browserOnly.hostCapabilities?.contains(
+            PeekabooBridgeHostCapability.nativeBrowserConnectionBinding) == true)
+        #expect(browserOnly.hostCapabilities?.contains(
+            PeekabooBridgeHostCapability.producerBoundSnapshotReferences) != true)
+        #expect(browserOnly.hostCapabilities?.contains(
+            PeekabooBridgeHostCapability.targetedClickAccessibilityValueDelivery) != true)
+
+        let snapshotOnlyServer = PeekabooBridgeServer(
+            services: NonBrowserCapabilityServices(
+                base: StubServices(snapshots: InMemorySnapshotManager())),
+            hostKind: .onDemand,
+            allowlistedTeams: [],
+            allowlistedBundles: [])
+        let snapshotOnly = try await Self.rawLiveHandshake(
+            server: snapshotOnlyServer,
+            clientCapabilities: [PeekabooBridgeClientCapability.producerBoundSnapshotReferences])
+        #expect(snapshotOnly.hostCapabilities?.contains(
+            PeekabooBridgeHostCapability.nativeBrowserConnectionBinding) != true)
+        #expect(snapshotOnly.hostCapabilities?.contains(
+            PeekabooBridgeHostCapability.producerBoundSnapshotReferences) == true)
+        #expect(snapshotOnly.hostCapabilities?.contains(
+            PeekabooBridgeHostCapability.targetedClickAccessibilityValueDelivery) != true)
+
+        let valueOnlySnapshots = SnapshotMutationRecordingManager(
+            wrapping: InMemorySnapshotManager(),
+            supportsProducerBoundSnapshotReferences: false)
+        let valueOnlyBase = StubServices(snapshots: valueOnlySnapshots)
+        valueOnlyBase.automationStub.supportsTargetedClickAccessibilityValueDelivery = true
+        let valueOnlyServices = NonBrowserCapabilityServices(base: valueOnlyBase)
+        let valueOnlyServer = PeekabooBridgeServer(
+            services: valueOnlyServices,
+            hostKind: .onDemand,
+            allowlistedTeams: [],
+            allowlistedBundles: [])
+        let valueOnly = try await Self.rawLiveHandshake(
+            server: valueOnlyServer,
+            clientCapabilities: [PeekabooBridgeClientCapability.targetedClickAccessibilityValueDelivery])
+        #expect(valueOnly.hostCapabilities?.contains(
+            PeekabooBridgeHostCapability.nativeBrowserConnectionBinding) != true)
+        #expect(valueOnly.hostCapabilities?.contains(
+            PeekabooBridgeHostCapability.producerBoundSnapshotReferences) != true)
+        #expect(valueOnly.hostCapabilities?.contains(
+            PeekabooBridgeHostCapability.targetedClickAccessibilityValueDelivery) == true)
+    }
+
+    @Test
+    @MainActor
+    func `new client refuses old same minor snapshot creation before a second wire request`() async throws {
+        let snapshots = SnapshotMutationRecordingManager(
+            wrapping: InMemorySnapshotManager(),
+            supportsProducerBoundSnapshotReferences: false)
+        let server = PeekabooBridgeServer(
+            services: StubServices(snapshots: snapshots),
+            hostKind: .onDemand,
+            allowlistedTeams: [],
+            allowlistedBundles: [])
+        let socketPath = "/tmp/peekaboo-old-134-create-\(UUID().uuidString).sock"
+        let host = PeekabooBridgeHost(socketPath: socketPath, server: server, allowedTeamIDs: [])
+        try await host.startChecked()
+        defer { Task { await host.stop() } }
+        let client = TrustedBridgeClientFixture.make(socketPath: socketPath)
+        let handshake = try await client.handshake(client: Self.identity)
+        #expect(handshake.negotiatedVersion == .init(major: 1, minor: 34))
+        #expect(handshake.hostCapabilities?.contains(
+            PeekabooBridgeHostCapability.producerBoundSnapshotReferences) != true)
+
+        await #expect(throws: PeekabooBridgeErrorEnvelope.self) {
+            _ = try await client.createSnapshot()
+        }
+        #expect(snapshots.createCalls.isEmpty)
+        await host.stop()
+    }
+
+    @Test
+    @MainActor
+    func `current client refuses snapshot publication without breaking legacy server carriage`() async throws {
+        let snapshots = SnapshotMutationRecordingManager(
+            wrapping: InMemorySnapshotManager(),
+            supportsProducerBoundSnapshotReferences: false)
+        let server = PeekabooBridgeServer(
+            services: StubServices(snapshots: snapshots),
+            hostKind: .onDemand,
+            allowlistedTeams: [],
+            allowlistedBundles: [])
+        let socketPath = "/tmp/peekaboo-old-134-publication-\(UUID().uuidString).sock"
+        let host = PeekabooBridgeHost(socketPath: socketPath, server: server, allowedTeamIDs: [])
+        try await host.startChecked()
+        defer { Task { await host.stop() } }
+        let client = TrustedBridgeClientFixture.make(socketPath: socketPath)
+        let handshake = try await client.handshake(client: Self.identity)
+        #expect(handshake.hostCapabilities?.contains(
+            PeekabooBridgeHostCapability.producerBoundSnapshotReferences) != true)
+
+        let snapshotID = SnapshotReferenceFixtures.first.rawValue
+        let detection = ElementDetectionResult(
+            snapshotId: snapshotID,
+            screenshotPath: "",
+            elements: DetectedElements(),
+            metadata: DetectionMetadata(detectionTime: 0, elementCount: 0, method: "fixture"))
+        let screenshot = SnapshotScreenshotRequest(
+            snapshotId: snapshotID,
+            screenshotPath: "/tmp/unused.png",
+            applicationBundleId: nil,
+            applicationProcessId: nil,
+            applicationName: nil,
+            windowTitle: nil,
+            windowBounds: nil)
+        let publication = SnapshotObservationPublicationRequest(
+            screenshot: screenshot,
+            detectionResult: detection,
+            annotatedScreenshotPath: nil)
+
+        let requests: [PeekabooBridgeRequest] = [
+            .createSnapshot(.init()),
+            .storeDetectionResult(.init(snapshotId: snapshotID, result: detection)),
+            .storeScreenshot(.init(screenshot)),
+            .storeObservationSnapshot(.init(publication)),
+            .storeAnnotatedScreenshot(.init(
+                snapshotId: snapshotID,
+                annotatedScreenshotPath: "/tmp/unused-annotated.png")),
+        ]
+        let allCreateOrPublish = requests.allSatisfy(\.createsOrPublishesSnapshotState)
+        let allRemainLegacyServerCompatible = requests.allSatisfy {
+            !$0.requiresProducerBoundSnapshotReferences
+        }
+        #expect(allCreateOrPublish)
+        #expect(allRemainLegacyServerCompatible)
+
+        for request in requests {
+            do {
+                _ = try await client.send(request)
+                Issue.record("Expected snapshot publication capability refusal for \(request.operation.rawValue)")
+            } catch let envelope as PeekabooBridgeErrorEnvelope {
+                #expect(envelope.code == .operationNotSupported)
+            }
+        }
+
+        #expect(snapshots.createCalls.isEmpty)
+        #expect(try await snapshots.listSnapshots().isEmpty)
+        await host.stop()
+    }
+
+    @Test
+    @MainActor
+    func `new client refuses explicit value delivery policy on old same minor host before click`() async throws {
+        let services = StubServices(snapshots: InMemorySnapshotManager())
+        let server = PeekabooBridgeServer(
+            services: services,
+            hostKind: .onDemand,
+            allowlistedTeams: [],
+            allowlistedBundles: [])
+        let socketPath = "/tmp/peekaboo-old-134-click-policy-\(UUID().uuidString).sock"
+        let host = PeekabooBridgeHost(socketPath: socketPath, server: server, allowedTeamIDs: [])
+        try await host.startChecked()
+        defer { Task { await host.stop() } }
+        let client = TrustedBridgeClientFixture.make(socketPath: socketPath)
+        let handshake = try await client.handshake(client: Self.identity)
+        #expect(handshake.negotiatedVersion == .init(major: 1, minor: 34))
+        #expect(handshake.hostCapabilities?.contains(
+            PeekabooBridgeHostCapability.targetedClickAccessibilityValueDelivery) != true)
+
+        let identity = ApplicationProcessIdentity(processIdentifier: 42, processStartIdentity: 7)
+        do {
+            _ = try await client.clickWithOutcome(
+                target: .elementId("field"),
+                clickType: .single,
+                snapshotId: SnapshotReferenceFixtures.first.rawValue,
+                expectedProcessIdentity: identity,
+                allowsAccessibilityValueDelivery: false)
+            Issue.record("Expected an old-host policy refusal")
+        } catch let failure as DesktopActionFailure {
+            #expect(failure.outcome.state == .refused)
+            #expect(failure.outcome.dispatchState == .none)
+            #expect(failure.outcome.retrySafety == .safe)
+            #expect(failure.outcome.refusalReason == .runtimeIncompatible)
+            #expect(failure.message.contains("accessibility-value click policy"))
+        }
+        #expect(services.automationStub.lastClick == nil)
+        await host.stop()
+    }
+
+    @Test
+    @MainActor
+    func `client rejects noncanonical references from a capability claiming host`() async throws {
+        let snapshots = SnapshotMutationRecordingManager(
+            wrapping: InMemorySnapshotManager(),
+            createdSnapshotReferenceOverride: "1787675983803-1514")
+        let server = PeekabooBridgeServer(
+            services: StubServices(snapshots: snapshots),
+            hostKind: .onDemand,
+            allowlistedTeams: [],
+            allowlistedBundles: [])
+        let socketPath = "/tmp/peekaboo-hostile-snapshot-reference-\(UUID().uuidString).sock"
+        let host = PeekabooBridgeHost(socketPath: socketPath, server: server, allowedTeamIDs: [])
+        try await host.startChecked()
+        defer { Task { await host.stop() } }
+        let client = TrustedBridgeClientFixture.make(socketPath: socketPath)
+        _ = try await client.handshake(client: Self.identity)
+
+        do {
+            _ = try await client.createSnapshot()
+            Issue.record("Expected the client to reject a noncanonical snapshot reference")
+        } catch let envelope as PeekabooBridgeErrorEnvelope {
+            #expect(envelope.code == .invalidRequest)
+            #expect(envelope.message.contains("non-canonical"))
+        }
+        #expect(snapshots.createCalls.count == 1)
+        await host.stop()
+    }
+
+    @Test
+    @MainActor
+    func `provider claims and protocol floor gate the two additions independently`() async throws {
+        let wrappedSnapshots = SnapshotMutationRecordingManager(
+            wrapping: InMemorySnapshotManager(),
+            supportsProducerBoundSnapshotReferences: false)
+        let legacyServer = PeekabooBridgeServer(
+            services: StubServices(snapshots: wrappedSnapshots),
+            hostKind: .onDemand,
+            allowlistedTeams: [],
+            allowlistedBundles: [])
+        let legacy = try await Self.liveHandshake(server: legacyServer, version: .init(major: 1, minor: 34))
+        #expect(!legacy.supportedOperations.contains(.ownsSnapshot))
+        #expect(legacy.hostCapabilities?.contains(
+            PeekabooBridgeHostCapability.producerBoundSnapshotReferences) != true)
+        #expect(legacy.hostCapabilities?.contains(
+            PeekabooBridgeHostCapability.targetedClickAccessibilityValueDelivery) != true)
+
+        let currentServer = PeekabooBridgeServer(
+            services: PeekabooServices(snapshotManager: InMemorySnapshotManager()),
+            hostKind: .onDemand,
+            allowlistedTeams: [],
+            allowlistedBundles: [])
+        let downgraded = try await Self.liveHandshake(server: currentServer, version: .init(major: 1, minor: 33))
+        #expect(!downgraded.supportedOperations.contains(.ownsSnapshot))
+        #expect(downgraded.hostCapabilities?.contains(
+            PeekabooBridgeHostCapability.producerBoundSnapshotReferences) != true)
+        #expect(downgraded.hostCapabilities?.contains(
+            PeekabooBridgeHostCapability.targetedClickAccessibilityValueDelivery) != true)
+        #expect(downgraded.hostCapabilities?.contains(
+            PeekabooBridgeHostCapability.nativeBrowserConnectionBinding) != true)
+    }
+
+    @Test
+    func `new optional client offer decodes in a legacy handshake payload`() throws {
+        let payload = PeekabooBridgeHandshake(
+            protocolVersion: .init(major: 1, minor: 34),
+            client: Self.identity,
+            operationClientInstanceID: UUID(),
+            clientCapabilities: [
+                PeekabooBridgeClientCapability.producerBoundSnapshotReferences,
+                PeekabooBridgeClientCapability.targetedClickAccessibilityValueDelivery,
+            ])
+        let legacy = try JSONDecoder.peekabooBridgeDecoder().decode(
+            LegacyHandshakePayload.self,
+            from: JSONEncoder.peekabooBridgeEncoder().encode(payload))
+        #expect(legacy.protocolVersion == payload.protocolVersion)
+        #expect(legacy.client.processIdentifier == payload.client.processIdentifier)
+    }
+
+    @Test
+    func `direct client refuses receiptless capability claims before a second request`() async throws {
+        let handshake = BridgeTestFixtures.handshake(
+            negotiatedVersion: .init(major: 1, minor: 34),
+            supportedOperations: [.ownsSnapshot, .targetedClick],
+            hostCapabilities: [
+                PeekabooBridgeHostCapability.producerBoundSnapshotReferences,
+                PeekabooBridgeHostCapability.targetedClickAccessibilityValueDelivery,
+            ])
+        let peer = try ScriptedBridgePeer(responses: [.handshake(handshake)])
+        let client = PeekabooBridgeClient(socketPath: peer.socketPath, requestTimeoutSec: 1)
+
+        await #expect(throws: PeekabooBridgeErrorEnvelope.self) {
+            _ = try await client.handshake(client: Self.identity, protocolVersion: .init(major: 1, minor: 34))
+        }
+        #expect(await peer.requests.count == 1)
+        await peer.waitUntilFinished()
+    }
+
+    @Test
+    @MainActor
+    func `hostile missing and contradictory sessions refuse before snapshot or click providers`() throws {
+        let snapshots = SnapshotMutationRecordingManager(wrapping: InMemorySnapshotManager())
+        let services = StubServices(snapshots: snapshots)
+        let server = PeekabooBridgeServer(
+            services: services,
+            hostKind: .onDemand,
+            allowlistedTeams: [],
+            allowlistedBundles: [])
+        let snapshotID = SnapshotReferenceFixtures.first.rawValue
+        let identity = ApplicationProcessIdentity(processIdentifier: 42, processStartIdentity: 7)
+        let owns = PeekabooBridgeRequest.ownsSnapshot(.init(snapshotId: snapshotID))
+        let click = PeekabooBridgeRequest.targetedClick(.init(
+            target: .elementId("field"),
+            clickType: .single,
+            snapshotId: snapshotID,
+            targetProcessIdentifier: identity.processIdentifier,
+            expectedProcessIdentity: identity,
+            allowsAccessibilityValueDelivery: true))
+        let permissions = PermissionsStatus(screenRecording: true, accessibility: true, postEvent: true)
+        let enabled = server.effectiveAllowedOperations(permissions: permissions)
+        let hostileSessions = [
+            PeekabooBridgeNegotiatedSessionCapabilities(
+                protocolVersion: .init(major: 1, minor: 34),
+                statelessClickVariants: true,
+                exactWindowHeldPointerLifecycle: true,
+                producerBoundSnapshotReferences: false,
+                targetedClickAccessibilityValueDelivery: false),
+            PeekabooBridgeNegotiatedSessionCapabilities(
+                protocolVersion: .init(major: 1, minor: 33),
+                statelessClickVariants: true,
+                exactWindowHeldPointerLifecycle: true,
+                producerBoundSnapshotReferences: true,
+                targetedClickAccessibilityValueDelivery: true),
+        ]
+
+        for session in hostileSessions {
+            for request in [owns, click] {
+                #expect(throws: PeekabooBridgeErrorEnvelope.self) {
+                    try PeekabooBridgeRequestContext.$negotiatedSessionCapabilities.withValue(session) {
+                        try server.validateOperationAccess(
+                            for: request,
+                            permissions: permissions,
+                            effectiveOps: enabled)
+                    }
+                }
+            }
+        }
+        #expect(snapshots.ownsCalls.isEmpty)
+        #expect(services.automationStub.lastClick == nil)
+    }
+
+    @Test
+    @MainActor
+    func `omitted legacy click policy preserves value delivery on a current host`() async throws {
+        let services = StubServices(snapshots: InMemorySnapshotManager())
+        services.automationStub.supportsTargetedClickAccessibilityValueDelivery = true
+        services.automationStub.actionOutcome = .confirmedChange(
+            delivery: .init(mechanism: .accessibilityValue, mode: .background),
+            unitCount: .one)
+        let server = PeekabooBridgeServer(
+            services: services,
+            hostKind: .onDemand,
+            allowlistedTeams: [],
+            allowlistedBundles: [])
+        let identity = ApplicationProcessIdentity(processIdentifier: 42, processStartIdentity: 7)
+        let request = PeekabooBridgeRequest.targetedClick(.init(
+            target: .elementId("field"),
+            clickType: .single,
+            snapshotId: SnapshotReferenceFixtures.first.rawValue,
+            targetProcessIdentifier: identity.processIdentifier,
+            expectedProcessIdentity: identity))
+        let legacySession = PeekabooBridgeNegotiatedSessionCapabilities(
+            protocolVersion: .init(major: 1, minor: 34),
+            statelessClickVariants: true,
+            exactWindowHeldPointerLifecycle: true)
+        let permissions = PermissionsStatus(screenRecording: true, accessibility: true, postEvent: true)
+
+        let handled = try await PeekabooBridgeRequestContext.$usesAttestedOperationResultSemantics.withValue(true) {
+            try await PeekabooBridgeRequestContext.$negotiatedSessionCapabilities.withValue(legacySession) {
+                try await server.handleAuthorized(request, peer: nil, permissions: permissions)
+            }
+        }
+
+        guard case .ok = handled.response else {
+            Issue.record("Expected legacy targeted click success")
+            return
+        }
+        #expect(handled.outcome?.delivery?.mechanism == .accessibilityValue)
+        #expect(services.automationStub.lastAllowsAccessibilityValueDelivery == true)
+    }
+
+    @Test
+    @MainActor
+    func `explicit value policy without pinned identity refuses before click provider`() async throws {
+        let services = StubServices(snapshots: InMemorySnapshotManager())
+        services.automationStub.supportsTargetedClickAccessibilityValueDelivery = true
+        let server = PeekabooBridgeServer(
+            services: services,
+            hostKind: .onDemand,
+            allowlistedTeams: [],
+            allowlistedBundles: [])
+        let permissions = PermissionsStatus(screenRecording: true, accessibility: true, postEvent: true)
+
+        for policy in [false, true] {
+            do {
+                _ = try await PeekabooBridgeRequestContext.$negotiatedSessionCapabilities.withValue(.current) {
+                    try await server.handleAuthorized(
+                        .targetedClick(.init(
+                            target: .elementId("field"),
+                            clickType: .single,
+                            snapshotId: SnapshotReferenceFixtures.first.rawValue,
+                            targetProcessIdentifier: 42,
+                            allowsAccessibilityValueDelivery: policy)),
+                        peer: nil,
+                        permissions: permissions)
+                }
+                Issue.record("Expected explicit policy \(policy) without a pinned identity to be refused")
+            } catch let error as PeekabooBridgeErrorEnvelope {
+                #expect(error.code == .invalidRequest)
+            }
+        }
+
+        #expect(services.automationStub.lastClick == nil)
+        #expect(services.automationStub.lastProcessTargetedClick == nil)
+        #expect(services.automationStub.lastAllowsAccessibilityValueDelivery == nil)
+    }
+
+    @Test
+    @MainActor
+    func `malformed owns and policy blind value provider refuse before service entry`() async throws {
+        let snapshots = SnapshotMutationRecordingManager(wrapping: InMemorySnapshotManager())
+        let services = StubServices(snapshots: snapshots)
+        let server = PeekabooBridgeServer(
+            services: services,
+            hostKind: .onDemand,
+            allowlistedTeams: [],
+            allowlistedBundles: [])
+        let permissions = PermissionsStatus(screenRecording: true, accessibility: true, postEvent: true)
+
+        await #expect(throws: PeekabooBridgeErrorEnvelope.self) {
+            _ = try await PeekabooBridgeRequestContext.$negotiatedSessionCapabilities.withValue(.current) {
+                try await server.handleAuthorized(
+                    .ownsSnapshot(.init(snapshotId: "snapshot-1")),
+                    peer: nil,
+                    permissions: permissions)
+            }
+        }
+        #expect(snapshots.ownsCalls.isEmpty)
+
+        let identity = ApplicationProcessIdentity(processIdentifier: 42, processStartIdentity: 7)
+        await #expect(throws: (any Error).self) {
+            _ = try await PeekabooBridgeRequestContext.$negotiatedSessionCapabilities.withValue(.current) {
+                try await server.handleAuthorized(
+                    .targetedClick(.init(
+                        target: .elementId("field"),
+                        clickType: .single,
+                        snapshotId: SnapshotReferenceFixtures.first.rawValue,
+                        targetProcessIdentifier: identity.processIdentifier,
+                        expectedProcessIdentity: identity,
+                        allowsAccessibilityValueDelivery: false)),
+                    peer: nil,
+                    permissions: permissions)
+            }
+        }
+        #expect(services.automationStub.lastClick == nil)
+    }
+
+    @MainActor
+    private static func liveHandshake(
+        server: PeekabooBridgeServer,
+        version: PeekabooBridgeProtocolVersion) async throws -> PeekabooBridgeHandshakeResponse
+    {
+        let socketPath = "/tmp/peekaboo-capability-matrix-\(UUID().uuidString).sock"
+        let host = PeekabooBridgeHost(socketPath: socketPath, server: server, allowedTeamIDs: [])
+        try await host.startChecked()
+        let client = TrustedBridgeClientFixture.make(socketPath: socketPath)
+        do {
+            let handshake = try await client.handshake(client: Self.identity, protocolVersion: version)
+            await host.stop()
+            return handshake
+        } catch {
+            await host.stop()
+            throw error
+        }
+    }
+
+    @MainActor
+    private static func rawLiveHandshake(
+        server: PeekabooBridgeServer,
+        clientCapabilities: [String]) async throws -> PeekabooBridgeHandshakeResponse
+    {
+        let socketPath = "/tmp/peekaboo-raw-capability-matrix-\(UUID().uuidString).sock"
+        let host = PeekabooBridgeHost(socketPath: socketPath, server: server, allowedTeamIDs: [])
+        try await host.startChecked()
+        let client = TrustedBridgeClientFixture.make(socketPath: socketPath)
+        do {
+            let response = try await client.send(.handshake(.init(
+                protocolVersion: .init(major: 1, minor: 34),
+                client: Self.identity,
+                operationClientInstanceID: client.operationClientInstanceID,
+                clientCapabilities: clientCapabilities)))
+            await host.stop()
+            guard case let .handshake(handshake) = response else {
+                throw PeekabooBridgeErrorEnvelope(
+                    code: .invalidRequest,
+                    message: "Expected capability-matrix handshake response")
+            }
+            return handshake
+        } catch {
+            await host.stop()
+            throw error
+        }
+    }
+
+    private static var identity: PeekabooBridgeClientIdentity {
+        PeekabooBridgeClientIdentity(
+            bundleIdentifier: "dev.peekaboo.snapshot-capability-tests",
+            teamIdentifier: nil,
+            processIdentifier: getpid())
+    }
+}
+
+private struct LegacyHandshakePayload: Codable {
+    let protocolVersion: PeekabooBridgeProtocolVersion
+    let client: PeekabooBridgeClientIdentity
+    let requestedHostKind: PeekabooBridgeHostKind?
+    let operationClientInstanceID: UUID?
+    let replacingOperationSessionID: UUID?
+}
+
+@MainActor
+private final class NonBrowserCapabilityServices: PeekabooBridgeServiceProviding {
+    private let base: StubServices
+
+    init(base: StubServices) {
+        self.base = base
+    }
+
+    var permissions: PermissionsService {
+        self.base.permissions
+    }
+
+    var screenCapture: any ScreenCaptureServiceProtocol {
+        self.base.screenCapture
+    }
+
+    var automation: any UIAutomationServiceProtocol {
+        self.base.automation
+    }
+
+    var windows: any WindowManagementServiceProtocol {
+        self.base.windows
+    }
+
+    var applications: any ApplicationServiceProtocol {
+        self.base.applications
+    }
+
+    var menu: any MenuServiceProtocol {
+        self.base.menu
+    }
+
+    var dock: any DockServiceProtocol {
+        self.base.dock
+    }
+
+    var dialogs: any DialogServiceProtocol {
+        self.base.dialogs
+    }
+
+    var snapshots: any SnapshotManagerProtocol {
+        self.base.snapshots
+    }
+
+    var desktopObservation: any DesktopObservationServiceProtocol {
+        self.base.desktopObservation
+    }
+}

--- a/Core/PeekabooCore/Tests/PeekabooTests/RemoteSnapshotManagerTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/RemoteSnapshotManagerTests.swift
@@ -3,6 +3,7 @@ import PeekabooAutomationKit
 import PeekabooBridge
 import PeekabooCore
 import PeekabooFoundation
+import PeekabooFoundationTestSupport
 import Testing
 
 struct RemoteSnapshotManagerTests {
@@ -13,11 +14,13 @@ struct RemoteSnapshotManagerTests {
             client: PeekabooBridgeClient(socketPath: "/tmp/unused.sock", requestTimeoutSec: 1))
         let current = RemoteSnapshotManager(
             client: PeekabooBridgeClient(socketPath: "/tmp/unused.sock", requestTimeoutSec: 1),
-            supportsSnapshotMutationLeases: true)
+            supportsSnapshotMutationLeases: true,
+            supportsProducerBoundSnapshotReferences: true)
 
         #expect(legacy.copiesScreenshotArtifactsIntoStorage)
         #expect(!legacy.supportsSnapshotMutationLeases)
         #expect(current.supportsSnapshotMutationLeases)
+        #expect(current.supportsProducerBoundSnapshotReferences)
     }
 
     @Test
@@ -33,12 +36,24 @@ struct RemoteSnapshotManagerTests {
     }
 
     @Test
+    @MainActor
+    func `new client refuses ordinary publication on an old host before transport`() async {
+        let oldHost = RemoteSnapshotManager(
+            client: PeekabooBridgeClient(socketPath: "/tmp/unused.sock", requestTimeoutSec: 1),
+            supportsProducerBoundSnapshotReferences: false)
+
+        await #expect(throws: PeekabooBridgeErrorEnvelope.self) {
+            _ = try await oldHost.createSnapshot()
+        }
+    }
+
+    @Test
     func `bridge invalidation payload preserves subsecond cutoff`() throws {
         let cutoff = Date(timeIntervalSinceReferenceDate: 123_456_789.123_456)
         let preservedAt = Date(timeIntervalSinceReferenceDate: 123_456_790.654_321)
         let payload = PeekabooBridgeInvalidateImplicitLatestSnapshotRequest(
             cutoff: cutoff,
-            preservingSnapshotId: "snapshot-1",
+            preservingSnapshotId: SnapshotReferenceFixtures.first.rawValue,
             preservedAt: preservedAt)
 
         let data = try JSONEncoder.peekabooBridgeEncoder().encode(payload)
@@ -47,7 +62,7 @@ struct RemoteSnapshotManagerTests {
             from: data)
 
         #expect(decoded.cutoff == cutoff)
-        #expect(decoded.preservingSnapshotId == "snapshot-1")
+        #expect(decoded.preservingSnapshotId == SnapshotReferenceFixtures.first.rawValue)
         #expect(decoded.preservedAt == preservedAt)
     }
 
@@ -103,6 +118,36 @@ struct RemoteSnapshotManagerTests {
 
     @Test
     @MainActor
+    func `remote manager forwards canonical ownership and creation`() async throws {
+        let snapshots = InMemorySnapshotManager()
+        let owned = try await snapshots.createSnapshot()
+        let server = PeekabooBridgeServer(
+            services: PeekabooServices(snapshotManager: snapshots),
+            hostKind: .gui,
+            allowlistedTeams: [],
+            allowlistedBundles: [])
+        let socketPath = "/tmp/peekaboo-remote-snapshot-owner-\(UUID().uuidString).sock"
+        let host = PeekabooBridgeHost(
+            socketPath: socketPath,
+            server: server,
+            allowedTeamIDs: [],
+            requestTimeoutSec: 2)
+        try await host.startChecked()
+        defer { Task { await host.stop() } }
+        let remote = try await RemoteSnapshotManager(
+            client: Self.currentClient(socketPath: socketPath),
+            supportsProducerBoundSnapshotReferences: true)
+
+        #expect(try await remote.ownsSnapshot(snapshotId: owned))
+        #expect(try await !remote.ownsSnapshot(snapshotId: SnapshotReferenceFixtures.id(99)))
+        let created = try await remote.createSnapshot()
+        #expect(SnapshotReference(rawValue: created) != nil)
+        #expect(try await snapshots.ownsSnapshot(snapshotId: created))
+        await host.stop()
+    }
+
+    @Test
+    @MainActor
     func `bridge mutation lease blocks reuse without deleting snapshot evidence`() async throws {
         let snapshots = InMemorySnapshotManager()
         let snapshotId = try await snapshots.createSnapshot()
@@ -127,7 +172,8 @@ struct RemoteSnapshotManagerTests {
         try await host.startChecked()
         defer { Task { await host.stop() } }
         let remote = try await RemoteSnapshotManager(
-            client: Self.currentClient(socketPath: socketPath))
+            client: Self.currentClient(socketPath: socketPath),
+            supportsProducerBoundSnapshotReferences: true)
 
         let lease = try await remote.beginSnapshotMutation(snapshotId: snapshotId)
         try await remote.finishSnapshotMutation(lease, requiresFreshObservation: true)
@@ -236,10 +282,12 @@ struct RemoteSnapshotManagerTests {
         try await host.startChecked()
         defer { Task { await host.stop() } }
         let remote = try await RemoteSnapshotManager(
-            client: Self.currentClient(socketPath: socketPath))
+            client: Self.currentClient(socketPath: socketPath),
+            supportsProducerBoundSnapshotReferences: true)
         let observationStart = Date()
 
         let snapshotId = try await remote.createSnapshot(pendingAt: observationStart)
+        #expect(SnapshotReference(rawValue: snapshotId) != nil)
         #expect(try await remote.listSnapshots().isEmpty)
         #expect(await remote.getMostRecentSnapshot() == nil)
 
@@ -256,6 +304,7 @@ struct RemoteSnapshotManagerTests {
     @MainActor
     func `bridge explicit-only snapshot remains listed but never implicit latest`() async throws {
         let snapshots = InMemorySnapshotManager()
+        let priorSnapshotID = try await snapshots.createSnapshot()
         let server = PeekabooBridgeServer(
             services: PeekabooServices(snapshotManager: snapshots),
             hostKind: .gui,
@@ -273,19 +322,13 @@ struct RemoteSnapshotManagerTests {
             bundleIdentifier: "boo.peekaboo.tests",
             teamIdentifier: nil,
             processIdentifier: getpid())
-        let oldClient = PeekabooBridgeClient(socketPath: socketPath, requestTimeoutSec: 2)
-        let oldHandshake = try await oldClient.handshake(
-            client: clientIdentity,
-            protocolVersion: .init(major: 1, minor: 25))
-        #expect(oldHandshake.negotiatedVersion == .init(major: 1, minor: 25))
-        let priorSnapshotID = try await oldClient.createSnapshot()
-
         let currentClient = TrustedBridgeClientFixture.make(socketPath: socketPath, requestTimeoutSec: 2)
         let remote = RemoteSnapshotManager(
             client: currentClient,
             supportsImplicitLatestSnapshotInvalidation: true,
             supportsSnapshotMutationLeases: true,
-            supportsExplicitSnapshotPublication: true)
+            supportsExplicitSnapshotPublication: true,
+            supportsProducerBoundSnapshotReferences: true)
 
         let handshake = try await currentClient.handshake(client: clientIdentity)
         #expect(handshake.negotiatedVersion == PeekabooBridgeConstants.protocolVersion)

--- a/Core/PeekabooCore/Tests/PeekabooTests/RemoteUIAutomationServiceActionResultTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/RemoteUIAutomationServiceActionResultTests.swift
@@ -11,6 +11,29 @@ import Testing
 @MainActor
 struct RemoteUIAutomationServiceActionResultTests {
     @Test
+    func `remote explicit value policy requires negotiated support for allow and deny`() async throws {
+        let client = PeekabooBridgeClient(
+            socketPath: "/tmp/peekaboo-unused-value-policy-\(UUID().uuidString).sock",
+            requestTimeoutSec: 1)
+        let remote = RemoteUIAutomationService(
+            client: client,
+            supportsTargetedClicks: true,
+            supportsProcessGenerationPinnedClicks: true)
+        let identity = ApplicationProcessIdentity(processIdentifier: 42, processStartIdentity: 7)
+
+        for allowsValueDelivery in [true, false] {
+            await #expect(throws: PeekabooError.self) {
+                try await remote.clickWithOutcome(
+                    target: .elementId("field"),
+                    clickType: .single,
+                    snapshotId: nil,
+                    expectedProcessIdentity: identity,
+                    allowsAccessibilityValueDelivery: allowsValueDelivery)
+            }
+        }
+    }
+
+    @Test
     func `remote held pointer capability defaults closed and accepts negotiated support`() {
         let client = PeekabooBridgeClient(
             socketPath: "/tmp/peekaboo-unused-held-capability-\(UUID().uuidString).sock",

--- a/Core/PeekabooCore/Tests/PeekabooTests/UIAutomationServiceWaitTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/UIAutomationServiceWaitTests.swift
@@ -1,5 +1,6 @@
 import CoreGraphics
 import Foundation
+import PeekabooFoundationTestSupport
 import Testing
 @testable import PeekabooAutomation
 @testable import PeekabooCore
@@ -32,7 +33,8 @@ struct UIAutomationServiceWaitTests {
                 bounds: CGRect(x: 100, y: 200, width: 50, height: 20))])
         let detection = Self.makeDetectionResult(elements: elements)
 
-        let service = UIAutomationService(snapshotManager: InMemorySnapshotManager(detectionResult: detection))
+        let snapshots = try await InMemorySnapshotManager.containing(detection)
+        let service = UIAutomationService(snapshotManager: snapshots)
 
         let result = try await service.waitForElement(
             target: .elementId("B42"),
@@ -56,7 +58,8 @@ struct UIAutomationServiceWaitTests {
                 bounds: CGRect(x: 10, y: 10, width: 80, height: 30))])
         let detection = Self.makeDetectionResult(elements: elements)
 
-        let service = UIAutomationService(snapshotManager: InMemorySnapshotManager(detectionResult: detection))
+        let snapshots = try await InMemorySnapshotManager.containing(detection)
+        let service = UIAutomationService(snapshotManager: snapshots)
 
         let result = try await service.waitForElement(
             target: .query("submit"),
@@ -80,7 +83,8 @@ struct UIAutomationServiceWaitTests {
                 attributes: ["identifier": "continuous-slider"])])
         let detection = Self.makeDetectionResult(elements: elements)
 
-        let service = UIAutomationService(snapshotManager: InMemorySnapshotManager(detectionResult: detection))
+        let snapshots = try await InMemorySnapshotManager.containing(detection)
+        let service = UIAutomationService(snapshotManager: snapshots)
 
         let result = try await service.waitForElement(
             target: .query("continuous-slider"),
@@ -94,7 +98,7 @@ struct UIAutomationServiceWaitTests {
     // MARK: - Helpers
 
     private static func makeDetectionResult(
-        snapshotId: String = "snapshot-test",
+        snapshotId: String = SnapshotReferenceFixtures.id(100),
         elements: DetectedElements) -> ElementDetectionResult
     {
         let metadata = DetectionMetadata(

--- a/Core/PeekabooFoundation/Sources/PeekabooFoundation/SnapshotReference.swift
+++ b/Core/PeekabooFoundation/Sources/PeekabooFoundation/SnapshotReference.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+/// Producer-bound opaque reference for one UI snapshot.
+///
+/// The `ps1_` prefix versions the reference format. The 128-bit random suffix makes references
+/// globally unique across independent local and Bridge hosts, so ownership is established by the
+/// producer that created the reference instead of by probing collision-prone timestamp names.
+public struct SnapshotReference: RawRepresentable, Codable, Hashable, Sendable, CustomStringConvertible {
+    public static let prefix = "ps1_"
+    public static let randomByteCount = 16
+    public static let encodedLength = prefix.count + randomByteCount * 2
+
+    public let rawValue: String
+
+    public var description: String {
+        self.rawValue
+    }
+
+    public init?(rawValue: String) {
+        guard rawValue.count == Self.encodedLength,
+              rawValue.hasPrefix(Self.prefix)
+        else { return nil }
+
+        let suffix = rawValue.utf8.dropFirst(Self.prefix.utf8.count)
+        guard suffix.allSatisfy({ byte in
+            (UInt8(ascii: "0")...UInt8(ascii: "9")).contains(byte) ||
+                (UInt8(ascii: "a")...UInt8(ascii: "f")).contains(byte)
+        })
+        else { return nil }
+        self.rawValue = rawValue
+    }
+
+    public init?(_ description: String) {
+        self.init(rawValue: description)
+    }
+
+    public static func generate() -> Self {
+        var generator = SystemRandomNumberGenerator()
+        let bytes = (0..<Self.randomByteCount).map { _ in
+            UInt8.random(in: .min ... .max, using: &generator)
+        }
+        let suffix = bytes.map { String(format: "%02x", $0) }.joined()
+        return Self(rawValue: Self.prefix + suffix)!
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let rawValue = try container.decode(String.self)
+        guard let reference = Self(rawValue: rawValue) else {
+            throw DecodingError.dataCorruptedError(
+                in: container,
+                debugDescription: "Snapshot reference must use ps1_ followed by 32 lowercase hexadecimal digits")
+        }
+        self = reference
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(self.rawValue)
+    }
+}

--- a/Core/PeekabooFoundation/Sources/PeekabooFoundationTestSupport/SnapshotReferenceFixtures.swift
+++ b/Core/PeekabooFoundation/Sources/PeekabooFoundationTestSupport/SnapshotReferenceFixtures.swift
@@ -1,0 +1,17 @@
+import Foundation
+import PeekabooFoundation
+
+public enum SnapshotReferenceFixtures {
+    public static let first = Self.reference(1)
+    public static let second = Self.reference(2)
+    public static let third = Self.reference(3)
+
+    public static func reference(_ value: UInt64) -> SnapshotReference {
+        let suffix = String(format: "%016llx%016llx", 0, value)
+        return SnapshotReference(rawValue: SnapshotReference.prefix + suffix)!
+    }
+
+    public static func id(_ value: UInt64 = 1) -> String {
+        self.reference(value).rawValue
+    }
+}

--- a/Core/PeekabooFoundation/Tests/PeekabooFoundationTests/SnapshotReferenceTests.swift
+++ b/Core/PeekabooFoundation/Tests/PeekabooFoundationTests/SnapshotReferenceTests.swift
@@ -1,0 +1,59 @@
+import Foundation
+import PeekabooFoundationTestSupport
+import Testing
+@testable import PeekabooFoundation
+
+struct SnapshotReferenceTests {
+    @Test
+    func `generated references are canonical unique 128 bit authorities`() {
+        let references = Set((0..<64).map { _ in SnapshotReference.generate() })
+        #expect(references.count == 64)
+        #expect(references.allSatisfy { reference in
+            reference.rawValue.count == SnapshotReference.encodedLength &&
+                SnapshotReference(rawValue: reference.rawValue) == reference
+        })
+    }
+
+    @Test(
+        arguments: [
+            "",
+            "ps1_",
+            "ps1_0000000000000000000000000000000",
+            "ps1_000000000000000000000000000000000",
+            "ps1_0000000000000000000000000000000g",
+            "ps1_0000000000000000000000000000000A",
+            "PS1_00000000000000000000000000000000",
+            "../ps1_00000000000000000000000000000000",
+            "1787675983803-1514",
+        ])
+    func `parser rejects malformed and legacy references`(_ rawValue: String) {
+        #expect(SnapshotReference(rawValue: rawValue) == nil)
+    }
+
+    @Test
+    func `parser never trims case folds or accepts non ASCII numerals`() {
+        let canonical = SnapshotReferenceFixtures.first.rawValue
+        let hostile = [
+            " \(canonical)",
+            "\(canonical) ",
+            "\(canonical)\n",
+            "PS1_" + String(canonical.dropFirst(SnapshotReference.prefix.count)),
+            SnapshotReference.prefix + String(repeating: "A", count: 32),
+            SnapshotReference.prefix + String(repeating: "٠", count: 32),
+            SnapshotReference.prefix + String(repeating: "０", count: 32),
+            SnapshotReference.prefix + String(repeating: "é", count: 32),
+        ]
+
+        #expect(hostile.allSatisfy { SnapshotReference(rawValue: $0) == nil })
+    }
+
+    @Test
+    func `codable roundtrip retains only the canonical representation`() throws {
+        let reference = SnapshotReferenceFixtures.first
+        let data = try JSONEncoder().encode(reference)
+        #expect(try JSONDecoder().decode(SnapshotReference.self, from: data) == reference)
+        #expect(throws: DecodingError.self) {
+            try JSONDecoder().decode(SnapshotReference.self, from: Data(#""snapshot-1""#.utf8))
+        }
+    }
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -54,9 +54,18 @@ Permission-bound automation can execute in three runtime shapes:
 | Peekaboo.app | GUI-held TCC grants and app lifecycle | `bridge.sock` Bridge protocol |
 | MCP server | Process-local services owned by the MCP client | stdio; no Bridge listener |
 
-CLI automation resolves a healthy daemon first, then a capable Peekaboo.app host, then auto-starts the reusable daemon.
-Operations that permit local fallback can run in the CLI process when no host is usable. Explicit socket and
-`--no-remote` flags override this selection.
+CLI automation without a snapshot reference resolves a healthy daemon first, then a capable Peekaboo.app host, then
+auto-starts the reusable daemon. Operations that permit local fallback can run in the CLI process when no host is
+usable. Explicit socket and `--no-remote` flags override this selection.
+
+A concrete snapshot reference changes the authority rule from preference to producer affinity. Actionable references
+have the exact grammar `ps1_` followed by 32 lowercase hexadecimal digits (128 random bits). The resolver asks the
+caller-local store and every authenticated live daemon, Peekaboo.app, Claude.app, and Clawdbot.app Bridge candidate
+whether it owns that reference, then proceeds only when exactly one host claims it. Missing, incompatible, unreachable,
+or multiple owners are pre-dispatch refusals; Peekaboo does not replay the action against another host or reinterpret
+the reference as local state. An explicit socket restricts the ownership check to that listener, while `--no-remote`
+restricts it to caller-local services. See [bridge-host.md](bridge-host.md#snapshot-authority) for the handshake and
+compatibility contract.
 
 The daemon and GUI app never share a socket. Each Bridge listener holds an exclusive lease, publishes its socket
 atomically, and removes only the filesystem object it owns. See [daemon.md](daemon.md) and

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -23,6 +23,12 @@ ScreenCaptureKit lease at every real SCK leaf by rescanning all same-user potent
 owner-unaware processes that started after acquisition. Caller-local MCP retains the broader legacy-socket scan because
 no external Bridge generation owns its capture path.
 
+Snapshots returned by current `see` calls use producer-bound references with the exact form `ps1_` plus 32 lowercase
+hexadecimal digits. Follow-up tools carrying that reference stay with its unique authenticated producer; a missing,
+ambiguous, incompatible, or unreachable owner is a pre-dispatch refusal, never a reason to recreate the snapshot or
+replay the action elsewhere. An explicit MCP `--bridge-socket` remains strict for the server lifetime. See
+[Bridge snapshot authority](bridge-host.md#snapshot-authority) for routing and protocol 1.34 capability negotiation.
+
 Action-oriented UI tools include:
 
 - `click`, `scroll`, `type`, and `press` for the background-safe interaction surface.
@@ -226,7 +232,9 @@ ROI requires Bridge protocol 1.21. CLI host selection and MCP remote dispatch re
 request, so a pre-1.21 host cannot ignore the crop or acknowledge only part of the snapshot. After dispatch, the
 client also decodes the quarantined raster and checks its real pixel dimensions against the crop receipt before
 publishing files or the snapshot. A compatible host must enable desktop observation plus the snapshot-publication
-operations used to finalize the validated result.
+operations used to finalize the validated result. Current clients additionally require the independently negotiated
+protocol 1.34 `producerBoundSnapshotReferences` capability before creating or publishing the reference; an old 1.34
+host cannot cause the result to be rebound locally.
 
 The `click` tool accepts exactly one target shape: `on`, `query`, or `coords`. Its published schema requires every
 background `coords` call to include either `snapshot` or `coordinate_reference`; a PID alone is only a consistency

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -23,6 +23,17 @@ Prefer IDs when you can capture them, labels when you can't, and coordinates onl
 
 Process and window selectors are fail-closed. Choose either `--app` or `--pid`, never both. Choose at most one of `--window-id`, `--window-title`, or `--window-index`; title and index require an app or PID owner. The same rules apply to MCP's `app`, `pid`, `window_id`, `window_title`, and `window_index` fields.
 
+Reusable snapshots have producer-bound references: exactly `ps1_` plus 32 lowercase ASCII hexadecimal digits. The
+producer generates the 128-bit random suffix and reserves the reference before it can store detection results,
+screenshots, or other snapshot state. A store cannot claim an ID that was not created first. Treat the reference as an
+opaque receipt and copy it exactly; legacy timestamp IDs are non-actionable and exist only for strict cache cleanup.
+
+A command with a concrete snapshot reference resolves its unique live authenticated producer before the ordinary
+daemon/app preference order. This keeps a snapshot and its in-memory state together even when several Peekaboo hosts
+are available. Explicit routing is still authoritative: `--bridge-socket` checks only that Bridge host, while
+`--no-remote` checks only the local process, and either refuses rather than rerouting when the selected boundary does
+not own the reference.
+
 ## Delivery modes
 
 Peekaboo has two input delivery modes:
@@ -43,6 +54,12 @@ Multi-unit background input is prefix-aware. Once any scroll unit or semantic cl
 Application menu list/click, dialog list, dialog button click, normal dialog dismissal, window close, and exact minimized-window restore also default to background Accessibility actions. Restore changes only the retained window's `AXMinimized` state. Dialog list never focuses. Dialog keyboard/file flows, forced Escape dismissal, coordinate fallback, and window-close Cmd-W fallback require an explicit `--foreground` (or `foreground: true` in MCP) so these global actions cannot interrupt an unrelated foreground app by accident.
 
 Observation follows the same background-first rule. `see` and `capture` do not focus targeted apps by default. Web-content focus recovery is opt-in with `see --web-focus` or MCP `web_focus: true`; live-capture foreground focus remains explicit.
+
+At Bridge protocol 1.34, producer-bound snapshot ownership and targeted Accessibility-value delivery are independent
+client/host capabilities. A current client requires the ownership capability before a remote producer can publish a
+reusable snapshot; an older 1.34 host is not treated as capable from its version alone. The targeted-value capability
+separately gates the verified `AXFocused` write used when a background click focuses a text field. Ordinary `AXPress`
+does not depend on that value-delivery capability.
 
 Examples:
 

--- a/docs/bridge-host.md
+++ b/docs/bridge-host.md
@@ -23,6 +23,9 @@ and host capabilities on the same executable generation. An explicit Bridge sock
 Operations that permit process-local fallback can use it when no compatible host is available. Application inventory
 and launch prefer the GUI host, while relaunch and quit require a reusable daemon that survives the caller.
 
+Commands carrying a concrete snapshot reference do not use this preference order. They resolve the unique producer as
+described in [Snapshot authority](#snapshot-authority) before selecting an execution host.
+
 Bridge diagnostics inspect sockets in this order:
 
 1. **Peekaboo daemon** (normal automation runtime)
@@ -36,7 +39,9 @@ Bridge diagnostics inspect sockets in this order:
 5. **Local in-process** (operation-dependent fallback or explicit `--no-remote`; requires caller-process TCC grants)
 
 This selection preserves existing app-held TCC grants while keeping socket ownership separate. Claude.app and
-Clawdbot.app sockets remain diagnostic-only unless selected with `--bridge-socket` or `PEEKABOO_BRIDGE_SOCKET`.
+Clawdbot.app sockets participate automatically only in authenticated snapshot-owner resolution; for commands without
+a concrete snapshot they remain diagnostic-only unless selected with `--bridge-socket` or
+`PEEKABOO_BRIDGE_SOCKET`.
 
 There is **no auto-launch** of Peekaboo.app.
 
@@ -130,6 +135,7 @@ those app-only services are injected separately; moving them into the embedded r
 - Payloads are `Codable` JSON with a small handshake for:
   - protocol version negotiation
   - capability/operation advertisement
+  - optional raw-string client capability offers for same-version feature negotiation
   - optional host PID/process-start identity, bundle version, code-signature hash, and launch-mode
     capabilities for exact-generation deployment readiness checks
 - Each listener holds an exclusive lease beside its socket for its full lifetime.
@@ -307,6 +313,22 @@ retry-unsafe result rather than a speculative retry.
 Window and frontmost capture receipts bind the exact process/window identity returned by capture metadata; a missing
 target or a window ID that contradicts the request is rejected. Screen and area captures remain targetless global reads.
 
+Protocol `1.34` remains the wire version for three independent capabilities:
+
+- `nativeBrowserConnectionBinding` authenticates native Chrome channel ownership.
+- `producerBoundSnapshotReferences` enables canonical snapshot creation plus the read-only `ownsSnapshot` ownership
+  probe.
+- `targetedClickAccessibilityValueDelivery` attests that the host understands and enforces the targeted-click
+  Accessibility value-delivery policy. An omitted policy retains legacy value fallback; explicit `true` and `false`
+  both require this negotiated capability.
+
+Clients must test the capability needed by an operation; none implies either of the others. The latter two additions
+also require their exact raw strings in the optional handshake `clientCapabilities` offer. A current host suppresses
+`ownsSnapshot` and the corresponding host capability when an already-shipped 1.34 client omits that offer, so the old
+client never sees an unknown operation. Conversely, a current client refuses snapshot creation/publication through an
+old or restricted 1.34 host that does not return `producerBoundSnapshotReferences`. It does not silently downgrade to
+timestamp references, publish locally after remote observation, or replay an action through another host.
+
 Browser execution is bound atomically to the connection receipt observed before dispatch. Protocol 1.29 carries the
 complete normalized browser URL, WebSocket debugger URL, DevTools browser ID, browser version, protocol version, and
 channel. Protocol 1.34 plus `nativeBrowserConnectionBinding` is required for native channel resolution, which carries
@@ -359,12 +381,31 @@ Debug-only escape hatch:
 
 - Set `PEEKABOO_ALLOW_UNSIGNED_SOCKET_CLIENTS=1` to allow same-UID unsigned clients (local dev only).
 
-## Snapshot state
+## Snapshot authority
 
-Bridge hosts are intended to be long-lived and keep automation state **in memory**:
+Actionable snapshot references are producer-bound opaque values with the exact grammar `ps1_` plus 32 lowercase ASCII
+hexadecimal digits. The 128-bit random suffix makes cross-process collisions impractical; a reference becomes owned
+only when its producer creates it, before storing detection or screenshot state. Malformed and legacy timestamp-style
+IDs are never accepted as action authority.
 
-- Hosts typically use `InMemorySnapshotManager` so follow-up actions can reuse the “most recent snapshot” per app/bundle without passing IDs around.
-- Screenshot artifacts are referenced by **file path** (e.g. in `/tmp`). Protocol 1.5 desktop observation avoids returning raw image bytes for daemon-backed screenshot calls.
+The disk owner marker is durable routing and collision evidence inside the user's cooperative cache. It does not
+authenticate snapshot state against a hostile same-user process that can already rewrite that cache.
+
+When an action supplies a concrete reference, the CLI checks caller-local services and all authenticated live Bridge
+candidates: reusable and build-scoped daemons, Peekaboo.app, Claude.app, and Clawdbot.app. It routes only when exactly
+one reports ownership through `ownsSnapshot`. Zero claims, multiple claims, an unreachable producer, or a host that
+cannot negotiate producer-bound references fails before dispatch. There is no “latest” substitution, local fallback,
+cross-host recreation, or speculative replay.
+
+`--bridge-socket` and `PEEKABOO_BRIDGE_SOCKET` are strict: only that authenticated listener may claim the reference,
+and failure is terminal. `--no-remote` and `PEEKABOO_NO_REMOTE` check only the caller-local manager. Without either
+override, the ownership probe can select Claude.app or Clawdbot.app even though those sockets are not general implicit
+routing fallbacks.
+
+Long-lived hosts normally keep automation state in memory; disk-backed managers persist an owner marker with the
+snapshot directory so ownership survives restart. Screenshot artifacts remain path references rather than raw Bridge
+response bytes. Protocol 1.5 desktop observation provides the raster metadata, while protocol 1.34 plus the negotiated
+`producerBoundSnapshotReferences` capability governs current creation and affinity checks.
 
 ## CLI behavior
 

--- a/docs/commands/bridge.md
+++ b/docs/commands/bridge.md
@@ -24,6 +24,9 @@ read_when:
 - Implicit screen-capture observation, AX-tree inspection, browser, and snapshot-state commands first prefer the exact
   CLI build's build-scoped daemon and may auto-start it before considering the GUI host. Use the command's actual
   requirements—not the generic status ordering—to interpret which reported host it will select.
+- A command carrying a canonical `ps1_` snapshot reference uses unique authenticated producer affinity instead of the
+  generic ordering, including local, daemon, Peekaboo.app, Claude.app, and Clawdbot.app candidates. Zero or multiple
+  owners fail before dispatch with no fallback or replay. See [`bridge-host.md`](../bridge-host.md#snapshot-authority).
 - `--no-remote` (or `PEEKABOO_NO_REMOTE`) skips remote probing and forces local execution.
 - `--bridge-socket <path>` (or `PEEKABOO_BRIDGE_SOCKET`) overrides host discovery and probes only that socket.
   The override is strict: an unavailable or incompatible host fails non-zero instead of silently using the local
@@ -36,6 +39,11 @@ read_when:
 - Structured status includes optional `hostIdentity` and `hostCapabilities` from current hosts.
   `hostIdentity` carries the serving PID/process-start identity plus bundle versions and the exact
   executable code-signature hash; older hosts omit these fields and continue to decode normally.
+- Protocol 1.34 negotiates `nativeBrowserConnectionBinding`, `producerBoundSnapshotReferences`, and
+  `targetedClickAccessibilityValueDelivery` independently. The snapshot and targeted-click additions require matching
+  optional raw client offers, so old 1.34 clients are not shown the unknown `ownsSnapshot` operation, an omitted click
+  policy retains legacy value fallback, and either explicit allow or deny requires a host that understands the field.
+  New clients refuse hosts that cannot publish producer-bound references.
 - Protocol 1.29 binds every post-handshake call to one ephemeral listener identity and one listener-signed logical
   operation session, then returns a signed terminal receipt. The listener remains stable for the socket lifetime;
   bounded peer sessions roll over without restarting the host or invalidating older in-flight receipts. Each session

--- a/docs/commands/clean.md
+++ b/docs/commands/clean.md
@@ -12,17 +12,27 @@ read_when:
 ## Modes
 | Flag | Effect |
 | --- | --- |
-| `--all-snapshots` | Delete every cached snapshot directory. |
-| `--older-than <hours>` | Delete snapshots older than the given hour threshold (defaults to 24 if omitted). |
-| `--snapshot <id>` | Remove a single on-disk snapshot by its validated folder name (the `snapshotId` from `see`). |
+| `--all-snapshots` | Delete every producer-owned or cleanup-eligible legacy snapshot directory. |
+| `--older-than <hours>` | Delete eligible snapshots older than the given hour threshold (defaults to 24 if omitted). |
+| `--snapshot <id>` | Remove one eligible on-disk snapshot: a producer-owned `ps1_` reference or a strict legacy timestamp directory. |
 | `--dry-run` | Print what would be removed without touching disk. |
 
 Only one of the three selection flags may be supplied at a time; the command validates this before doing any IO.
 
-`--snapshot` accepts exactly one folder name directly beneath the snapshot cache. Empty values, `.`/`..` traversal, nested or absolute paths, control characters, and symlinks are rejected; ordinary IDs such as `12345`, `abc`, and `a..b` remain valid.
+Current snapshot references use exactly `ps1_` followed by 32 lowercase ASCII hexadecimal digits. Cleanup removes one
+only when its on-disk producer marker binds the directory to that same reference. The 128-bit random reference is
+reserved by its producer before snapshot data is stored; an unowned lookalike directory is ignored.
+
+For migration cleanup only, `clean` also recognizes the old timestamp shape: exactly 13 decimal digits, a hyphen, and
+4 decimal digits, such as `1787675983803-1514`. That directory must contain a regular, non-symlink `snapshot.json`.
+Legacy timestamp IDs are not listed as usable snapshots and cannot be passed to interaction commands. Arbitrary names,
+empty values, `.`/`..` traversal, nested or absolute paths, control characters, symlinks, and malformed legacy
+directories are rejected or ignored without deleting them.
 
 ## Implementation notes
-- Cleanup work is delegated to `services.files` (`cleanAllSnapshots`, `cleanOldSnapshots`, `cleanSpecificSnapshot`); specific-snapshot cleanup validates and resolves the folder before either previewing or deleting it.
+- Cleanup work is delegated to `services.files` (`cleanAllSnapshots`, `cleanOldSnapshots`, `cleanSpecificSnapshot`); specific-snapshot cleanup validates ownership or the strict legacy shape before either previewing or deleting it.
+- `--all-snapshots` and age cleanup remove only producer-owned current directories or cleanup-eligible legacy
+  directories. They leave unowned `ps1_` lookalikes and unrelated cache entries untouched.
 - Text output summarizes number of snapshots removed and bytes freed (using `ByteCountFormatter`), while JSON output wraps the raw `CleanResult` with an `executionTime` so you can log metrics.
 - A valid `--snapshot <id>` that is not found on disk succeeds with zero removals: text output says the ID missed the disk cache and JSON includes `data.not_found: true`. This command does not delete daemon-memory snapshots; that is tracked separately from disk pruning.
 
@@ -34,6 +44,9 @@ peekaboo clean --older-than 12 --dry-run
 # Remove the snapshot returned from the last `see` run
 SNAPSHOT=$(peekaboo see --json | jq -r '.data.snapshot_id')
 peekaboo clean --snapshot "$SNAPSHOT"
+
+# Preview removal of one strict legacy timestamp directory
+peekaboo clean --snapshot 1787675983803-1514 --dry-run
 ```
 
 ## Troubleshooting

--- a/docs/commands/click.md
+++ b/docs/commands/click.md
@@ -16,7 +16,7 @@ read_when:
 | `--on <id>` | Target an opaque Peekaboo element ID copied exactly from current `see` or MCP `inspect_ui` output. |
 | `--at x,y` | Click coordinates. With target flags, coordinates are relative to the resolved target window; without target flags, they are global screen coordinates. |
 | `--global` | Treat `--at` as global screen coordinates even when target flags are supplied. |
-| `--snapshot <id>` | Reuse a prior snapshot; defaults to the latest snapshot for element/query clicks. Background coordinate clicks require an explicit nonempty snapshot from a fresh exact-window `see`. |
+| `--snapshot <id>` | Reuse a prior snapshot. A concrete ID must be `ps1_` plus 32 lowercase ASCII hexadecimal digits; element/query clicks otherwise default to the latest snapshot. Background coordinate clicks require an explicit reference from a fresh exact-window `see`. |
 | Target flags | `--app <name>`, `--pid <pid>`, `--window-id <id>`, `--window-title <title>`, `--window-index <n>` — resolve the app/window that should receive the click. In background mode this does not focus the app; with `--foreground` it focuses before clicking. (`--window-title`/`--window-index` require `--app` or `--pid`; `--window-id` does not.) |
 | `--wait-for <duration>` | Timeout while waiting for the element (default `5s`; bare values are milliseconds). |
 | `--double` / `--triple` / `--right` / `--middle` | Select one alternate click kind. Background middle/triple delivery requires a fresh exact-window snapshot and uses native window-routed events; `--foreground` remains available for shared-pointer behavior. Click-kind flags are mutually exclusive. |
@@ -25,6 +25,24 @@ read_when:
 | `--foreground` | Focus target and send a foreground mouse click. Focus flags require this explicit mode. |
 | Focus flags | `--no-auto-focus`, `--focus-timeout`, `--focus-retry-count`, `--space-switch`, `--bring-to-current-space` (foreground mode only; see `FocusCommandOptions`). |
 | `--focus-background` | Legacy alias for the default background delivery. Use `--app`, `--pid`, `--window-id`, or a snapshot with process metadata. |
+
+## Snapshot affinity
+
+The process that performs `see` generates a 128-bit random `ps1_` reference and reserves it before storing the
+snapshot contents. Stores cannot mint an unreserved reference. When `click --snapshot` receives a concrete reference,
+Peekaboo asks the local process and authenticated live Bridge candidates who owns it, requires exactly one owner, and
+routes there before considering the usual daemon/app preferences. A stopped producer, no owner, or multiple claimants
+is a pre-dispatch refusal rather than permission to guess.
+
+`--bridge-socket` and `--no-remote` stay authoritative. The former checks only the named authenticated Bridge host;
+the latter checks only the current local process. If that selected execution boundary does not own the snapshot, the
+click fails without rerouting. Old timestamp IDs are non-actionable and fail validation even when a legacy cache
+directory still exists.
+
+Bridge 1.34 negotiates producer ownership separately from targeted Accessibility-value click delivery. A current
+client refuses an older 1.34 host that lacks producer-bound reference support before publishing a reusable snapshot.
+The independent targeted-value capability permits the verified `AXFocused` write used for a focusable text field;
+without it, the client does not request that fallback, while ordinary `AXPress` delivery remains available.
 
 ## Delivery modes
 - **Background** is the default when Peekaboo can resolve a target process from target flags or snapshot metadata. Single clicks prefer accessibility actions and never activate or focus the app: element/query clicks invoke the matching AX action on the cached element; coordinate clicks hit-test the AX element at the point (`AXUIElementCopyElementAtPosition`), then press the actionable hit, descendant, or ancestor. Pressability is checked with the Accessibility actions API, so SwiftUI buttons that expose no action attribute are still pressed.
@@ -101,6 +119,9 @@ peekaboo click --window-id "$WINDOW_ID" --snapshot "$SNAPSHOT_ID" --at 420,180 \
 - Verify Screen Recording + Accessibility permissions (`peekaboo permissions status`).
 - Confirm your process with `peekaboo app list`, its exact window with `peekaboo window list`, and current UI with `peekaboo see` before rerunning.
 - If you see `SNAPSHOT_NOT_FOUND`, regenerate the snapshot with `peekaboo see` (or omit `--snapshot` to use the most recent one). Cleaned/expired snapshots cannot be reused.
+- If an explicit socket or local-only run reports that it does not own the snapshot, repeat `see` on that same host or
+  remove the routing override and let Peekaboo find the unique live producer. It will not silently cross an explicit
+  host boundary.
 - If you see `SNAPSHOT_STALE` after an unverified or indeterminate action, do not replay the old snapshot. Observe again and use the new snapshot ID.
 - Re-run with `--json` or `--verbose` to surface detailed errors.
 - Chromium browsers can expose menus plus generic web-area/layout containers while omitting actionable web-content descendants from `see --annotate`. This is a browser accessibility limitation, not proof that the page is empty. Use `screen list` and `window list` to map the intended display/window, then use `--foreground --input-strategy synthOnly` with window-relative coordinates. For already-focused browser automation, targetless `--global` is also valid.

--- a/docs/commands/daemon.md
+++ b/docs/commands/daemon.md
@@ -31,6 +31,11 @@ If an incompatible daemon already owns `daemon.sock`, automation uses a build-sc
 the compatible fallback and warns about the additional daemon; `start` promotes an idle, safely stoppable fallback from
 auto to persistent manual mode on the same socket.
 
+Concrete `ps1_` snapshot references are not routed by these daemon preferences. Peekaboo selects the one authenticated
+local, daemon, or GUI Bridge producer that claims the reference and refuses before dispatch if ownership is missing or
+ambiguous. Explicit socket and local-only options remain strict; see
+[Bridge snapshot authority](../bridge-host.md#snapshot-authority).
+
 ## Commands
 
 ### Start

--- a/docs/commands/see.md
+++ b/docs/commands/see.md
@@ -15,6 +15,17 @@ build-scoped daemon and may auto-start it before considering a healthy Peekaboo.
 AX-tree-only forms because their snapshots and capability decisions are host-memory state. An explicit
 `--bridge-socket`, a custom daemon socket, or `--no-remote` remains authoritative.
 
+Every reusable snapshot is identified by a producer-generated reference with the exact form `ps1_` followed by 32
+lowercase ASCII hexadecimal digits, for example `ps1_0123456789abcdef0123456789abcdef`. The 32-digit suffix contains
+128 random bits. The selected local or Bridge producer reserves that reference before storing detection results or
+screenshots; later store operations can update only a reference that producer already owns and cannot create one.
+
+A later command that supplies a concrete reference finds its unique live authenticated producer before applying the
+normal daemon/app host preferences. Explicit routing remains a hard boundary: `--bridge-socket` probes only that host,
+and `--no-remote` checks only the local process. Either form refuses before action when its selected host does not own
+the reference. Legacy timestamp IDs are never accepted as action references; [clean](clean.md) recognizes only their
+strict on-disk shape for cache removal.
+
 ```bash
 # Capture frontmost window, print JSON, and save an annotated PNG
 peekaboo see --json --annotate --path /tmp/see.png
@@ -86,6 +97,11 @@ Pixel-only `see --no-elements` captures without `--path` write a generated file 
 
 Remote ROI requires Bridge protocol 1.21 with enabled observation and atomic snapshot publication and is rejected before dispatch against an older or restricted host. Returned files and snapshots remain quarantined or unpublished until the client verifies both the exact-window/viewport receipt and every raster's real cropped pixel dimensions. The host commits the snapshot raster, element map, and optional annotation as one transaction. If a validated snapshot is saved but a caller-visible file cannot be installed afterward, the observation remains successful with a warning and omits the unavailable file paths; the independently managed snapshot stays usable. Ordinary full-window `see` remains compatible with older desktop-observation hosts.
 
+Producer-bound references use an independently negotiated Bridge 1.34 client/host capability. A current client does
+not infer support from the `1.34` version number alone: an older 1.34 host that cannot advertise producer ownership is
+refused before a snapshot is published. The separate Bridge 1.34 targeted Accessibility-value delivery capability
+controls click behavior and does not grant snapshot ownership.
+
 ROI coordinates are `x,y,width,height` in top-left-origin, window-local logical points. `--retina` changes the delivered pixel density, not that coordinate system. Pixel alignment can expand a fractional logical rectangle by less than one source pixel; JSON reports both the requested and delivered rectangles.
 
 ROI JSON adds `coordinate_context.viewport`:
@@ -112,7 +128,7 @@ This fallback only runs inside the resolved window (it won’t hop between windo
 
 When `--json` is supplied, the CLI prints:
 
-- `snapshot_id` – reference for subsequent `click --snapshot …` and `type --snapshot …`.
+- `snapshot_id` – producer-bound `ps1_` reference for subsequent `click --snapshot …` and `type --snapshot …`.
 - `semantic_scope`, `snapshot_reusable`, and `mutation_targeting_available` – authority for the returned semantics. `application_partial` always carries `snapshot_id: null`, an empty `ui_map`, both authority booleans `false`, `interactable_count: 0`, and no actionable/value-settable element claims; its elements are read-only context from the exact window's attested process, not evidence for the requested exact window.
 - `ui_map` – path to the persisted snapshot file (`~/.peekaboo/snapshots/<id>/snapshot.json`).
 - `ui_elements` – flattened AX nodes with honest `is_actionable` and optional `is_value_settable` capability metadata.
@@ -135,6 +151,9 @@ peekaboo see --app "Google Chrome" --json --path /tmp/chrome-see.png \
 ## Troubleshooting tips
 
 - If the CLI reports **blind typing**, pass an explicit `--app`, `--pid`, `--window-id`, or fresh `--snapshot` so `type` can resolve a background target process, or add `--foreground` when the target app requires focused keyboard input.
+- If a concrete snapshot reports no unique live host affinity, keep the producing host running or capture again. Do
+  not rewrite the reference, switch to a legacy timestamp ID, or force a different Bridge socket: explicit sockets
+  and `--no-remote` intentionally refuse references they do not own.
 - If JSON/text output reports an AX time deadline, rerun with a longer `--timeout` or a narrower exact-window target. Increase `--depth`, `--max-elements`, or `--max-children` only when the corresponding structural cap is reported. A tree-only inspection that reaches a cap before finding any element exits nonzero instead of publishing an unusable empty snapshot; useful partial evidence remains successful and explicitly truncated.
 - `ACCESSIBILITY_INCOMPLETE` means the exact target exists but an AX-only or combined screenshot+AX observation returned no usable Accessibility elements. This includes legacy Bridge responses that omit the incomplete-read marker: an empty exact-window map is not clean success. Combined failure preserves a valid raster at an explicitly requested `--path` but does not publish the unusable element snapshot. A read-only `--tree --no-screenshot` request can instead return nonempty `application_partial` semantics when the exact WindowServer window still belongs to the requested process but has no AX-window counterpart. That result is explicitly incomplete, has no reusable snapshot or mutation authority, and never claims its elements came from the requested window. Retry the same exact observation once for fresh evidence; if it persists, use `--no-elements` for explicit screenshot-only evidence or add OCR. This code never means the element is absent and never substitutes for `TIMEOUT`; useful nonempty partial evidence remains successful with its warning.
 - Missing text fields after an explicit `--web-focus` retry usually means the page is shielding its inputs from AX entirely. For Chrome targets, use the `browser` tool (`status` → `connect` → `snapshot`/`fill`/`click`) after enabling Chrome remote debugging; otherwise rely on image-based hit tests.

--- a/docs/daemon.md
+++ b/docs/daemon.md
@@ -30,6 +30,11 @@ Commands outside the exact-build preference below prefer the reusable daemon whe
 they use a healthy Peekaboo.app host with the required capability before auto-starting a daemon. If no remote host is
 usable, the command falls back to process-local services when that operation permits it.
 
+A command carrying a concrete `ps1_` snapshot reference bypasses that preference order. It uses the unique
+authenticated producer across caller-local state and live daemon/GUI Bridge candidates, and refuses before dispatch
+when no single host can prove ownership. Explicit `--bridge-socket` checks only that listener; `--no-remote` checks
+only caller-local state. See [Bridge snapshot authority](bridge-host.md#snapshot-authority).
+
 Implicit commands that require screen capture, inspect the AX tree, use browser MCP, or consume/invalidate snapshot
 state first prefer the current CLI build's deterministic `daemon-<build>.sock`. They may auto-start that exact-build
 daemon before considering an otherwise healthy Peekaboo.app host, because protocol compatibility alone does not make


### PR DESCRIPTION
## Summary

- replace collision-prone timestamp snapshot IDs with strict producer-owned `ps1_` references carrying 128 random bits
- reserve references before publication, require ownership for every store/read/mutation, and keep historical IDs cleanup-only
- route concrete references to one unique authenticated local or Bridge producer before ordinary host preference
- negotiate producer ownership and Accessibility-value click delivery as independent raw Bridge 1.34 capabilities
- preserve omitted-policy legacy behavior while refusing explicit opt-outs, incompatible publication hosts, duplicate owners, and stale or malformed references before dispatch

## Compatibility and safety

- Bridge remains protocol 1.34; native browser binding and the two snapshot/click capabilities are independently negotiated
- current clients preflight create/publication operations while current servers retain opaque-reference carriage for already-shipped 1.34 clients
- aliases for one attested producer are deduplicated without discarding later capable endpoints
- disk publication rolls back failed initialization; legacy timestamp and exact pending-crash directories remain cleanup-only and never actionable
- background remains the immutable default; no foreground authority is added

## Proof

- post-rebase focused Foundation snapshot tests: 4 passed
- focused AutomationKit observation/cleanup/manager tests: 86 passed
- focused Core/Bridge producer and click-policy tests: 38 passed
- focused CLI runtime/affinity tests: 63 passed; safe command regressions: 42 passed
- full AutomationKit serial suite: passed (1,569 discovered tests)
- full `pnpm run test:safe`: helper/native-only/consumer gates, background certification, Foundation 81, CLI Core 1,091, controller 50, CLI automation 530, runtime target
- SwiftFormat stable; SwiftLint zero serious findings; docs lint, release preflight 10/10, diff checks, and all submodules clean/current
- exact two-pass branch P0-P2 review: clean

Post-rebase tree: `a889a1e2743cda54025e4630b37343368ec6b5bf`; binary diff SHA-256: `b3a113a7d832a3c30181554615c9183bf3ad79d6f19a8fc27d057a05b148f87c`.

## Compatibility decision

Legacy timestamp references intentionally become cleanup-only. They were collision-prone cache names with no authenticated producer authority; accepting them for new actions would reintroduce cross-host replay. Existing legacy directories can still be removed by exact ID or cleanup commands, but callers must run a fresh observation and use its `ps1_` reference before automation. No action alias or silent migration is provided because ownership cannot be reconstructed safely.

## Source-blind physical proof

A signed exact-head CLI and signed controlled Playground were exercised from an isolated contract without source access. The selected producer was the exact on-demand Bridge at `daemon-3d31f5658241ebb2.sock`, source `fd6d416e6`. A fresh `ps1_` reference performed one background Accessibility-value action and independently changed the controlled field while Finder stayed foreground. A one-digit mutation, the same syntactically valid reference after stopping its producer and starting a fresh generation, and `1234567890123-1234` all refused before dispatch with `retry_safe=true`, `mutation_dispatched=false`, and unchanged state. The controlled field, app, daemons, and task snapshots were restored/removed. Duplicate aliases and multiple authenticated owners are covered by the exact current-head affinity suite; manufacturing a second public producer for the same opaque 128-bit reference is not exposed by the CLI.
