### PR TITLE
fix(cli): advertise runnable MCP transport

### DIFF
--- a/Apps/CLI/Sources/PeekabooCLI/Commands/MCP/MCPCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/MCP/MCPCommand.swift
@@ -20,7 +20,7 @@ struct MCPCommand: ParsableCommand {
         EXAMPLES:
           peekaboo mcp                          # Start MCP server on stdio
           peekaboo mcp serve                     # Explicitly start MCP server
-          peekaboo mcp serve --transport http    # HTTP transport (future)
+          peekaboo mcp serve --transport stdio   # Explicitly select stdio transport
         """,
         subcommands: [
             Serve.self,

--- a/Apps/CLI/Tests/CLIRuntimeTests/CLIRuntimeSmokeTests.swift
+++ b/Apps/CLI/Tests/CLIRuntimeTests/CLIRuntimeSmokeTests.swift
@@ -459,11 +459,13 @@ struct CLIRuntimeSmokeTests {
     }
 
     @Test
-    func `peekaboo mcp help renders without starting server`() async throws {
+    func `peekaboo mcp help renders only runnable transport examples without starting server`() async throws {
         guard Self.ensureLocalRuntimeAvailable() else { return }
         let result = try await TestChildProcess.runPeekaboo(["mcp", "--help"])
         #expect(result.status == .exited(0))
         #expect(result.standardOutput.contains("Start Peekaboo as an MCP server"))
+        #expect(result.standardOutput.contains("peekaboo mcp serve --transport stdio"))
+        #expect(!result.standardOutput.contains("peekaboo mcp serve --transport http"))
     }
 
     @Test


### PR DESCRIPTION
## Summary

- replace the non-runnable future HTTP transport example in top-level `peekaboo mcp --help`
- advertise the supported explicit stdio invocation instead
- lock the rendered help contract so unavailable transport examples cannot drift back in

This PR is intentionally stacked on #643 to preserve dependency order and an MCP-help-only review diff. Its single two-file commit replays 1:1 over #643's exact head. GitHub does not run the full macOS CI and CodeQL workflows for a non-`main` base; exact-head hosted proof will begin only after the ancestor PRs land and this PR is retargeted or rebased to `main`.

## Tests

- rendered MCP help: 1/1
- focused MCP tests: 12/12
- SwiftFormat, SwiftLint, and diff hygiene
- exact-commit P0-P2 review clean (0.99)
- post-replay `git range-diff`: 1:1 unchanged patch

No local build was repeated after the byte-identical replay. The prior focused proof is retained but is not a substitute for hosted proof; full exact-head CI remains required after retargeting to `main`.

## Changelog

No separate entry: this corrects an example for an already-unsupported transport and is included with the release's broader CLI truth updates; it does not add or remove runtime functionality.
