### PR TITLE
fix(cli): keep agent task content out of public logs

### DIFF
--- a/Apps/CLI/Sources/PeekabooCLI/Commands/AI/AgentCommand+Execution.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/AI/AgentCommand+Execution.swift
@@ -279,16 +279,7 @@ extension AgentCommand {
                 toolExecutionPolicy: self.newSessionToolExecutionPolicy
             )
             self.displayResult(result, delegate: outputDelegate)
-            let duration = String(format: "%.2f", result.metadata.executionTime)
-            let sessionId = result.sessionId ?? "none"
-            let finalTokens = result.usage?.totalTokens ?? 0
-            let status = result.metadata.context["status"] ?? "completed"
-            AutomationEventLogger.log(
-                .agent,
-                "result status=\(status) task='\(task)' model=\(result.metadata.modelName) duration=\(duration)s "
-                    + "tools=\(result.metadata.toolCallCount) dry_run=\(self.dryRun) "
-                    + "session=\(sessionId) tokens=\(finalTokens)"
-            )
+            Self.logAgentAutomationResult(result, task: task, dryRun: self.dryRun)
             return result
         } catch let error as PeekabooAgentService.AgentStepLimitExceededError where preserveStepLimitError {
             if outputDelegate?.hasReceivedError != true {
@@ -306,6 +297,35 @@ extension AgentCommand {
                 self.printAgentExecutionError("Agent execution failed: \(error.localizedDescription)")
             }
             throw ExitCode.failure
+        }
+    }
+
+    static func logAgentAutomationResult(_ result: AgentExecutionResult, task: String, dryRun: Bool) {
+        let model = Self.agentAutomationModelFamily(result.metadata.modelName)
+        let sessionId = result.sessionId
+            .flatMap(UUID.init(uuidString:))
+            .map(\.uuidString) ?? (result.sessionId == nil ? "none" : "invalid")
+        let duration = String(format: "%.2f", result.metadata.executionTime)
+        let finalTokens = result.usage?.totalTokens ?? 0
+        AutomationEventLogger.log(
+            .agent,
+            "result status=completed task_chars=\(task.count) model=\(model) duration=\(duration)s "
+                + "tools=\(result.metadata.toolCallCount) dry_run=\(dryRun) "
+                + "session=\(sessionId) tokens=\(finalTokens)"
+        )
+    }
+
+    private static func agentAutomationModelFamily(_ modelName: String) -> String {
+        guard let family = modelName.split(separator: "/", maxSplits: 1).first?.lowercased() else {
+            return "other"
+        }
+        return switch family {
+        case "anthropic", "anthropic-compatible", "google", "groq", "grok", "kimi", "lmstudio",
+             "minimax", "minimax-cn", "mistral", "ollama", "openai", "openai-compatible",
+             "openrouter", "replicate", "together":
+            family
+        case "azureopenai": "azure-openai"
+        default: "other"
         }
     }
 

--- a/Apps/CLI/Tests/CoreCLITests/AgentCommandAutomationEventTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/AgentCommandAutomationEventTests.swift
@@ -1,0 +1,112 @@
+import Foundation
+import OSLog
+import PeekabooAgentRuntime
+import Tachikoma
+import Testing
+@testable import PeekabooCLI
+
+@Suite(.tags(.safe))
+struct AgentCommandAutomationEventTests {
+    @Test
+    @MainActor
+    func `Agent completion event omits task result and model content`() async throws {
+        let taskText = """
+        PEEKABOO_ALERT17_SENTINEL
+        prompt=TEST_PROMPT_MARKER
+        credential=TEST_CREDENTIAL_MARKER
+        path=/Users/example/private
+        host=private-host.invalid
+        """
+        let now = Date()
+        let result = AgentExecutionResult(
+            content: "TEST_MODEL_OUTPUT_MARKER",
+            sessionId: "TEST_SESSION_PRIVATE_MARKER",
+            usage: Usage(inputTokens: 11, outputTokens: 7),
+            metadata: AgentMetadata(
+                executionTime: 1.25,
+                toolCallCount: 2,
+                modelName: "TEST_MODEL_MARKER/result",
+                startTime: now,
+                endTime: now,
+                context: [
+                    "apiKey": "TEST_PASSWORD_MARKER",
+                    "prompt": "TEST_RESULT_PROMPT_MARKER",
+                    "status": "TEST_STATUS_PRIVATE_MARKER",
+                ]
+            )
+        )
+        let startedAt = Date()
+
+        AgentCommand.logAgentAutomationResult(result, task: taskText, dryRun: false)
+
+        let events = try await Self.agentEvents(since: startedAt, taskLength: taskText.count)
+        for fragment in [
+            "PEEKABOO_ALERT17_SENTINEL",
+            "TEST_PROMPT_MARKER",
+            "TEST_RESULT_PROMPT_MARKER",
+            "TEST_CREDENTIAL_MARKER",
+            "TEST_PASSWORD_MARKER",
+            "TEST_MODEL_MARKER",
+            "TEST_MODEL_OUTPUT_MARKER",
+            "TEST_SESSION_PRIVATE_MARKER",
+            "TEST_STATUS_PRIVATE_MARKER",
+            "/Users/example/private",
+            "private-host.invalid",
+        ] {
+            #expect(events.allSatisfy { !$0.contains(fragment) })
+        }
+
+        let projectedEvents = events.filter {
+            $0.hasPrefix("result status=completed ") && $0.contains("task_chars=\(taskText.count)")
+        }
+        #expect(projectedEvents.count == 1)
+        let event = try #require(projectedEvents.first)
+        let parts = event.split(separator: " ")
+        #expect(parts.first == "result")
+        let fields = try Dictionary(uniqueKeysWithValues: parts.dropFirst().map { part in
+            let pair = part.split(separator: "=", maxSplits: 1)
+            guard pair.count == 2 else {
+                throw AgentEventTestError.malformedEvent
+            }
+            return try (String(#require(pair.first)), String(#require(pair.last)))
+        })
+        #expect(Set(fields.keys) == [
+            "status", "task_chars", "model", "duration", "tools", "dry_run", "session", "tokens",
+        ])
+        #expect(fields["status"] == "completed")
+        #expect(fields["task_chars"] == String(taskText.count))
+        #expect(fields["model"] == "other")
+        let duration = try #require(fields["duration"])
+        #expect(duration.hasSuffix("s"))
+        #expect(Double(String(duration.dropLast())) != nil)
+        #expect(fields["tools"] == "2")
+        #expect(fields["dry_run"] == "false")
+        #expect(fields["session"] == "invalid")
+        #expect(fields["tokens"] == "18")
+    }
+
+    private static func agentEvents(since date: Date, taskLength: Int) async throws -> [String] {
+        let predicate = NSPredicate(
+            format: "subsystem == %@ AND category == %@",
+            "boo.peekaboo.playground",
+            AutomationLogCategory.agent.rawValue
+        )
+        for _ in 0..<20 {
+            try await Task.sleep(for: .milliseconds(100))
+            let store = try OSLogStore(scope: .currentProcessIdentifier)
+            let position = store.position(date: date)
+            let events = try store.getEntries(at: position, matching: predicate).map(\.composedMessage)
+            if events.contains(where: {
+                $0.hasPrefix("result status=completed ") && $0.contains("task_chars=\(taskLength)")
+            }) {
+                return events
+            }
+        }
+        throw AgentEventTestError.missingEvent
+    }
+
+    private enum AgentEventTestError: Error {
+        case malformedEvent
+        case missingEvent
+    }
+}


### PR DESCRIPTION
## Summary

- remove raw Agent task content from the public unified completion log
- replace free-form status, model, and session values with a bounded projection
- retain useful operational metadata: task length, model family, duration, tool count, dry-run state, canonical session state, and token count
- add a real `OSLogStore` regression test that rejects sensitive task, prompt, credential, path, host, result, model, status, and session markers across every Agent-category event

## Root Cause

Commit `3bb53a2fff2efa4a8fb2221a00449db2eeb8bda7` moved Agent completion logging into `executeAgentTask` and interpolated the complete task into an `AutomationEventLogger` message. That logger intentionally publishes its payload, so operator prompts and embedded sensitive content reached the unified log.

The CLI Agent completion producer owns the fix. `AutomationEventLogger` remains unchanged for other categories and callers.

## Fix

`executeAgentTask` now delegates completion logging to one producer that emits only:

- constant completion status
- task character count
- closed, allowlisted provider family or `other`
- numeric duration, tool count, and token count
- boolean dry-run state
- canonical UUID, `none`, or `invalid` session state

The producer never interpolates task text, result content, arbitrary context, model IDs, or raw session values.

CodeQL alert: https://github.com/openclaw/Peekaboo/security/code-scanning/17

PR #651 is disjoint and was not modified: https://github.com/openclaw/Peekaboo/pull/651

## Proof

- Pre-fix sentinel exposure reproduced in the real unified log. Evidence SHA-256: `dbdccd486c99f0ed60c4c4ff3b95ba56d81ac7b53d07f376f40eff5611f0f951`.
- Test target compile: `swift build --package-path Apps/CLI --build-tests` passed without executing tests.
- SwiftFormat 0.62.1: clean.
- SwiftLint CI configuration: 0 violations.
- TruffleHog outgoing-diff scan: 0 findings.
- High-reasoning security autoreview: clean.
- High-reasoning test-audit: clean.
- Final public diff SHA-256: `efe974c3b6fd240e829a8567c620806494777b2663d5191e42b759b46cf8709d`.

The focused regression test invokes the exact production producer used by `executeAgentTask`, reads the real unified-log sink, inspects all matching Agent events, and requires exactly one event with the closed eight-field schema.

## State Isolation

An initial local suite attempt exposed an existing runtime-root bug: part of the CLI test graph bypassed the temporary `HOME`/config overrides and created six task-owned runtime entries under `~/.peekaboo`. Execution stopped immediately. Only those exact task-created entries were removed.

Existing config, credentials, sessions, preferences, and checked keychain-service presence were restored and reverified without reading credential values. File hashes and non-root metadata match the pre-test snapshot. The root directory's ctime necessarily advanced during creation/removal; no content remains. No executable local test was run after that incident.

All later compile-only gates used an empty environment with isolated `HOME`, `CFFIXED_USER_HOME`, `TMPDIR`, `XDG_CONFIG_HOME`, and `PEEKABOO_CONFIG_DIR`. The before/after real-state manifests are byte-identical with SHA-256 `0b92f859182cbb879b71577e35a72e8409956fae145f8e77db682a3570e8c704`.

## LOC

- production: `+30/-10` raw, net `+20` (includes extracting the existing log block into the directly testable producer)
- tests: `+112/-0`
- generic logger: unchanged

## Remaining Gates

- secretless GitHub-hosted macOS 26 focused proof
- exact-head CI and CodeQL
- ClawSweeper exact-head review
- security/logging owner review
- post-merge default-branch verification that alert 17 closes without dismissal
