### PR TITLE
fix(cli): keep learn on injected runtime

### DIFF
--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reuse validated classic PNG bytes when capture performs no transform instead of encoding the same image twice.
 
 ### Fixed
+- Keep `peekaboo learn` on its injected main-actor service provider instead of crashing when no process-wide tool registry default exists.
 - Keep `capture action` sampling active across pre-roll, child execution, and post-roll, release only generation-attributed children after terminal-event admission, refuse pre-existing video outputs before child release, reserve startup and descendant-drain time inside the capture deadline, derive post-roll from the recorded child-completion boundary, clear inherited termination-signal masks, keep timeout escalation and cancellable validation off the cooperative/main executors, terminate surviving process-group descendants before validation, reject replaced artifacts, compose focus and child receipts without inventing partial effects, and require Apple-anchored source-stamped host provenance.
 - Warm ScreenCaptureKit ownership validation off the main actor before Bridge socket/capability publication, with explicit publication and daemon-readiness reserves beyond the bounded scan.
 - Claim and generation-check the host's ScreenCaptureKit lease before trying the concurrent engine first for background Bridge full-screen automatic capture, preserving legacy fallback after modern failure and automatic fallback on every claim failure or competing owner.

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Core/LearnCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Core/LearnCommand.swift
@@ -29,8 +29,12 @@ struct LearnCommand {
     mutating func run(using runtime: CommandRuntime) async throws {
         self.runtime = runtime
         let systemPrompt = AgentSystemPrompt.generate()
-        let tools = ToolRegistry.allTools()
+        let tools = Self.toolDefinitions(using: runtime.services)
         self.outputComprehensiveGuide(systemPrompt: systemPrompt, tools: tools)
+    }
+
+    static func toolDefinitions(using services: any PeekabooServiceProviding) -> [PeekabooToolDefinition] {
+        ToolRegistry.allTools(using: services)
     }
 
     private func outputComprehensiveGuide(systemPrompt: String, tools: [PeekabooToolDefinition]) {

--- a/Apps/CLI/Tests/CLIRuntimeTests/CommandRuntimeInjectionTests.swift
+++ b/Apps/CLI/Tests/CLIRuntimeTests/CommandRuntimeInjectionTests.swift
@@ -41,6 +41,23 @@ struct CommandRuntimeInjectionTests {
 
     @Test
     @MainActor
+    func `learn resolves tools from its injected service provider`() {
+        let injectedServices = RecordingPeekabooServices()
+        let fallbackServices = RecordingPeekabooServices()
+        var fallbackRequests = 0
+        ToolRegistry.configureDefaultServices {
+            fallbackRequests += 1
+            return fallbackServices
+        }
+
+        let tools = LearnCommand.toolDefinitions(using: injectedServices)
+
+        #expect(!tools.isEmpty)
+        #expect(fallbackRequests == 0)
+    }
+
+    @Test
+    @MainActor
     func `aligns Tachikoma profile directory with Peekaboo`() {
         let previousProfile = TachikomaConfiguration.profileDirectoryName
         defer { TachikomaConfiguration.profileDirectoryName = previousProfile }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Reuse validated classic PNG bytes when capture performs no transform instead of encoding the same image twice.
 
 ### Fixed
+- Keep `peekaboo learn` on its injected main-actor service provider instead of crashing when no process-wide tool registry default exists.
 - Keep `capture action` sampling active across pre-roll, child execution, and post-roll, release only generation-attributed children after terminal-event admission, refuse pre-existing video outputs before child release, reserve startup and descendant-drain time inside the capture deadline, derive post-roll from the recorded child-completion boundary, clear inherited termination-signal masks, keep timeout escalation and cancellable validation off the cooperative/main executors, terminate surviving process-group descendants before validation, reject replaced artifacts, compose focus and child receipts without inventing partial effects, and require Apple-anchored source-stamped host provenance.
 - Warm ScreenCaptureKit ownership validation off the main actor before Bridge socket/capability publication, with explicit publication and daemon-readiness reserves beyond the bounded scan.
 - Claim and generation-check the host's ScreenCaptureKit lease before trying the concurrent engine first for background Bridge full-screen automatic capture, preserving legacy fallback after modern failure and automatic fallback on every claim failure or competing owner.


### PR DESCRIPTION
## Summary

- keep `peekaboo learn` on the command runtime's injected service provider
- avoid the process-global tool-registry fallback that can terminate embedded or isolated CLI runs
- cover the dependency boundary with a regression test

## Proof

- `CommandRuntimeInjectionTests`: 41/41
- optimized `peekaboo learn --no-remote`: 50/50
- optimized default `peekaboo learn`: 10/10
- SwiftFormat and SwiftLint clean
- exact P0-P2 Autoreview clean

### Exact-head macOS behavior witness

Verified on macOS at source head `e55039f22f1594dba3ee9a4e48d3ed8c5a24742f` using the optimized release binary:

- binary SHA-256: `e07036734ae967b754b45c75367fbb93716ad51b5b06e5f85bcaeaa4df01476b`
- `learn --no-remote`: exit 0 in 20/20 fresh invocations; 87,722 bytes / 1,465 lines; begins `# Peekaboo Comprehensive Guide`; output SHA-256 `a15ba2a33b992c3e19880750be2e17d7976ecfa50cfba2700046c98be8e32488`
- default `learn`: exit 0 in 10/10 fresh invocations; 87,722 bytes / 1,465 lines; output SHA-256 `d5aae16c5bdcae39548b2b1f5a49fb504dcaaab149e2f203f3d28002bca2b4cd`

ClawSweeper's first live attempt ran the macOS-only Swift build on Linux, where pnpm correctly reported an unsupported platform; it did not reach the changed command. The macOS exact-head witness above covers the runnable platform.
