### PR TITLE
fix(bridge): preserve exact-window focus proof

### DIFF
--- a/Apps/CLI/Tests/CoreCLITests/PressFocusProofTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/PressFocusProofTests.swift
@@ -1,0 +1,170 @@
+import Commander
+import Foundation
+import PeekabooAgentRuntime
+import PeekabooAutomation
+import PeekabooAutomationKitTestSupport
+import PeekabooCore
+import PeekabooFoundation
+import Testing
+@testable import PeekabooCLI
+
+@Suite(.serialized)
+@MainActor
+struct PressFocusProofTests {
+    @Test
+    func `foreground press stops after retry-unsafe focus proof failure without sending a chord`() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent("press-focus-proof-\(UUID())")
+        defer { try? FileManager.default.removeItem(at: root) }
+        let windows = FailedFocusProofWindows()
+        let automation = FocusProofHotkeyRecorder()
+        let services = FocusProofPressServices(windows: windows, automation: automation)
+        let runtime = CommandRuntime(
+            configuration: .init(verbose: false, jsonOutput: true, logLevel: nil),
+            services: services,
+            interactionMutationTracker: InteractionMutationTracker(
+                desktopMutationWatermarkStore: DesktopMutationWatermarkStore(directoryURL: root)
+            )
+        )
+        var command = PressCommand()
+        command.chords = ["return", "cmd+s"]
+        command.count = 3
+        command.target.windowId = 77
+        command.focusOptions.foreground = true
+        command.focusOptions.focusRetryCount = 5
+
+        await #expect(throws: ExitCode.self) { try await command.run(using: runtime) }
+
+        #expect(windows.focusCalls == 1)
+        #expect(automation.hotkeyCount == 0)
+        #expect(automation.uiAutomationOutcomeScript.callCount(for: .hotkey) == 0)
+        #expect(windows.failure.outcome.projection.retrySafe == false)
+        #expect(windows.failure.outcome.projection.mutationDispatched)
+    }
+}
+
+@MainActor
+private final class FailedFocusProofWindows: ScriptedWindowInventoryService,
+WindowManagementPinnedFocusActionResultProviding {
+    let identity = WindowMutationIdentity(
+        windowID: 77,
+        ownerProcessIdentifier: 420,
+        ownerProcessStartIdentity: 9001,
+        capturedBounds: CGRect(x: 0, y: 0, width: 100, height: 100)
+    )
+    var focusCalls = 0
+
+    var failure: DesktopActionFailure {
+        DesktopActionFailure.indeterminate(
+            route: .bridge,
+            delivery: .init(mechanism: .accessibilityAction, mode: .foreground),
+            evidence: .completionUnknown,
+            unitCount: .one,
+            message: "The accepted focus could not prove its exact window postcondition.",
+            hint: "Observe before retrying."
+        )
+        .attributed(to: self.identity.actionTargetReceipt)
+    }
+
+    override func listWindows(target: WindowTarget) async throws -> [ServiceWindowInfo] {
+        [ServiceWindowInfo(
+            windowID: 77, title: "Fixture", bounds: self.identity.capturedBounds!, mutationIdentity: self.identity
+        )]
+    }
+
+    @MainActor
+    func focusWindowActionResult(target: WindowTarget) async throws -> UIAutomationActionResult<Void> {
+        try await self.focusWindowActionResult(target: target, expectedIdentity: self.identity)
+    }
+
+    @MainActor
+    func focusWindowActionResult(
+        target: WindowTarget, expectedIdentity: WindowMutationIdentity
+    ) async throws -> UIAutomationActionResult<Void> {
+        #expect(target == .windowId(77))
+        #expect(expectedIdentity == self.identity)
+        self.focusCalls += 1
+        throw self.failure
+    }
+}
+
+@MainActor
+private final class FocusProofHotkeyRecorder: MockAutomationService, ScriptedUIAutomationActionOutcomeProviding {
+    let uiAutomationOutcomeScript = UIAutomationOutcomeScript(outcomes: [:], defaultOutcome: .dispatchedUnverified(
+        delivery: .init(mechanism: .globalEvents, mode: .foreground), evidence: .deliveryAccepted
+    ))
+    var hotkeyCount = 0
+
+    override func hotkey(keys: String, holdDuration: Int) async throws {
+        self.hotkeyCount += 1
+    }
+}
+
+/// No native service graph: any unexpected service access stops the deterministic test.
+@MainActor
+private final class FocusProofPressServices: PeekabooServiceProviding {
+    let executionHost: PeekabooServiceExecutionHost = .remote
+    let windows: any WindowManagementServiceProtocol
+    let automation: any UIAutomationServiceProtocol
+    let snapshots: any SnapshotManagerProtocol = InMemorySnapshotManager()
+    var agent: (any AgentServiceProtocol)? {
+        nil
+    }
+
+    init(windows: any WindowManagementServiceProtocol, automation: any UIAutomationServiceProtocol) {
+        self.windows = windows
+        self.automation = automation
+    }
+
+    func ensureVisualizerConnection() {}
+    var logging: any LoggingServiceProtocol {
+        fatalError("Unexpected logging service")
+    }
+
+    var screenCapture: any ScreenCaptureServiceProtocol {
+        fatalError("Unexpected capture")
+    }
+
+    var applications: any ApplicationServiceProtocol {
+        fatalError("Unexpected application operation")
+    }
+
+    var menu: any MenuServiceProtocol {
+        fatalError("Unexpected menu")
+    }
+
+    var dock: any DockServiceProtocol {
+        fatalError("Unexpected Dock")
+    }
+
+    var dialogs: any DialogServiceProtocol {
+        fatalError("Unexpected dialog")
+    }
+
+    var files: any FileServiceProtocol {
+        fatalError("Unexpected files")
+    }
+
+    var clipboard: any ClipboardServiceProtocol {
+        fatalError("Unexpected clipboard")
+    }
+
+    var configuration: PeekabooCore.ConfigurationManager {
+        fatalError("Unexpected configuration")
+    }
+
+    var permissions: PermissionsService {
+        fatalError("Unexpected permissions")
+    }
+
+    var audioInput: AudioInputService {
+        fatalError("Unexpected audio")
+    }
+
+    var screens: any ScreenServiceProtocol {
+        fatalError("Unexpected screens")
+    }
+
+    var browser: any BrowserMCPClientProviding {
+        fatalError("Unexpected browser")
+    }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Reuse validated classic PNG bytes when capture performs no transform instead of encoding the same image twice.
 
 ### Fixed
+- Preserve exact-window foreground focus evidence under the native mutation lane for signed Bridge receipts, and refuse blind retries after accepted focus loses proof.
 - Keep `peekaboo learn` on its injected main-actor service provider instead of crashing when no process-wide tool registry default exists.
 - Keep `capture action` sampling active across pre-roll, child execution, and post-roll, release only generation-attributed children after terminal-event admission, refuse pre-existing video outputs before child release, reserve startup and descendant-drain time inside the capture deadline, derive post-roll from the recorded child-completion boundary, clear inherited termination-signal masks, keep timeout escalation and cancellable validation off the cooperative/main executors, terminate surviving process-group descendants before validation, reject replaced artifacts, compose focus and child receipts without inventing partial effects, and require Apple-anchored source-stamped host provenance.
 - Warm ScreenCaptureKit ownership validation off the main actor before Bridge socket/capability publication, with explicit publication and daemon-readiness reserves beyond the bounded scan.

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Core/Protocols/WindowManagementServiceProtocol.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Core/Protocols/WindowManagementServiceProtocol.swift
@@ -274,6 +274,14 @@ public protocol WindowManagementPinnedFocusActionResultProviding: WindowManageme
         expectedIdentity: WindowMutationIdentity) async throws -> UIAutomationActionResult<Void>
 }
 
+/// Additive focus capability that captures exact foreground evidence before releasing the mutation lane.
+/// Existing 4.x focus APIs retain their void payload; providers without this capability still require readback.
+public protocol WindowManagementFocusProofProviding: WindowManagementPinnedFocusActionResultProviding {
+    func focusWindowProofActionResult(
+        target: WindowTarget,
+        expectedIdentity: WindowMutationIdentity) async throws -> UIAutomationActionResult<ServiceWindowInfo>
+}
+
 extension WindowManagementServiceProtocol {
     /// Validates a result-aware exact-window mutation and retains its caller-held target receipt.
     ///

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/WindowFocusReadback.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/WindowFocusReadback.swift
@@ -1,0 +1,82 @@
+import AppKit
+import Foundation
+import PeekabooFoundation
+
+/// Focus alone needs AX/foreground evidence; ordinary exact-ID listings remain geometry-only.
+@MainActor
+struct WindowFocusReadback {
+    let catalog: WindowCGInfoLookup
+    var processStartIdentity: (pid_t) -> UInt64? = SystemIdentityResolver.processStartIdentity
+    var windowIdentity: (CGWindowID) -> SystemWindowIdentity? = SystemIdentityResolver.windowIdentity
+    var focusedWindowID: (pid_t, TimeInterval) async throws -> CGWindowID? = { pid, timeout in
+        guard let app = NSRunningApplication(processIdentifier: pid) else { return nil }
+        return WindowIdentityService().focusedWindowID(for: app, timeout: timeout)
+    }
+
+    var frontmostPID: () -> pid_t? = { NSWorkspace.shared.frontmostApplication?.processIdentifier }
+    var now: () -> ContinuousClock.Instant = { ContinuousClock.now }
+
+    func validateIdentity(_ expected: WindowMutationIdentity) throws {
+        guard let bounds = expected.capturedBounds,
+              SystemIdentityResolver.validateWindowMutationIdentity(
+                  expected,
+                  expectedBounds: bounds,
+                  processStartIdentityProvider: self.processStartIdentity,
+                  windowIdentityProvider: { windowID in
+                      guard let current = self.windowIdentity(windowID),
+                            current.windowID == windowID else { return nil }
+                      return current
+                  })
+        else {
+            throw PeekabooError.commandFailed("Window \(expected.windowID) changed identity during focus")
+        }
+    }
+
+    func capture(expectedIdentity: WindowMutationIdentity) async throws -> ServiceWindowInfo {
+        try Task.checkCancellation()
+        let deadline = self.now().advanced(by: .seconds(1))
+        try self.validateIdentity(expectedIdentity)
+        guard let window = self.catalog.serviceWindowInfo(windowID: expectedIdentity.windowID),
+              let identity = window.mutationIdentity,
+              identity.hasSameStableReceipt(as: expectedIdentity),
+              window.bounds == expectedIdentity.capturedBounds,
+              identity.capturedBounds == window.bounds,
+              !window.isMinimized
+        else {
+            throw FocusError.focusVerificationFailed(CGWindowID(expectedIdentity.windowID))
+        }
+        // Fresh app and child AX wrappers each carry a bounded native messaging timeout.
+        let focusedID = try await self.focusedWindowID(expectedIdentity.ownerProcessIdentifier, 0.1)
+        let foregroundPID = self.frontmostPID()
+        try self.validateIdentity(expectedIdentity)
+        try Task.checkCancellation()
+        guard self.now() < deadline else {
+            throw FocusError.focusVerificationTimeout(CGWindowID(expectedIdentity.windowID))
+        }
+        guard FocusManagementService.isVerifiedFocus(
+            targetWindowID: CGWindowID(expectedIdentity.windowID),
+            ownerPID: expectedIdentity.ownerProcessIdentifier,
+            focusedWindowID: focusedID,
+            frontmostPID: foregroundPID)
+        else {
+            throw FocusError.focusVerificationFailed(CGWindowID(expectedIdentity.windowID))
+        }
+
+        return ServiceWindowInfo(
+            windowID: window.windowID,
+            title: window.title,
+            bounds: window.bounds,
+            isMinimized: window.isMinimized,
+            isMainWindow: window.isMainWindow,
+            isKeyWindow: focusedID.map(Int.init) == window.windowID,
+            isFrontmost: foregroundPID == identity.ownerProcessIdentifier,
+            windowLevel: window.windowLevel,
+            alpha: window.alpha,
+            index: window.index,
+            isOffScreen: window.isOffScreen,
+            layer: window.layer,
+            isOnScreen: window.isOnScreen,
+            sharingState: window.sharingState,
+            mutationIdentity: identity)
+    }
+}

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/WindowManagementService+Focus.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/WindowManagementService+Focus.swift
@@ -19,6 +19,46 @@ extension WindowManagementService {
         target: WindowTarget,
         expectedIdentity: WindowMutationIdentity) async throws -> UIAutomationActionResult<Void>
     {
+        let result = try await self.focusWindowProofActionResult(target: target, expectedIdentity: expectedIdentity)
+        return UIAutomationActionResult(
+            payload: (),
+            outcome: result.outcome,
+            targetIdentity: result.targetIdentity,
+            selectedLeafEvidence: result.selectedLeafEvidence)
+    }
+
+    public func focusWindowProofActionResult(
+        target: WindowTarget,
+        expectedIdentity: WindowMutationIdentity) async throws -> UIAutomationActionResult<ServiceWindowInfo>
+    {
+        try await self.focusWindowProofActionResult(
+            target: target,
+            expectedIdentity: expectedIdentity,
+            validateBeforeDispatch: {
+                try self.validatePinnedWindowMutation(target: target, expectedIdentity: expectedIdentity)
+            },
+            dispatch: { options, onDispatch in
+                let focusService = FocusManagementService(
+                    applications: self.applicationService,
+                    operationLaneCoordinator: self.operationLaneCoordinator)
+                try await focusService.focusWindowWithOwnedLane(
+                    windowID: CGWindowID(expectedIdentity.windowID),
+                    options: options,
+                    expectedIdentity: expectedIdentity,
+                    onDispatch: onDispatch)
+            },
+            readback: WindowFocusReadback(catalog: self.cgInfoLookup))
+    }
+
+    func focusWindowProofActionResult(
+        target: WindowTarget,
+        expectedIdentity: WindowMutationIdentity,
+        validateBeforeDispatch: () throws -> Void,
+        dispatch: (
+            _ options: FocusManagementService.FocusOptions,
+            _ onDispatch: @escaping (FocusDispatchRecord) -> Void) async throws -> Void,
+        readback: WindowFocusReadback) async throws -> UIAutomationActionResult<ServiceWindowInfo>
+    {
         guard case let .windowId(windowID) = target,
               windowID == expectedIdentity.windowID,
               let bounds = expectedIdentity.capturedBounds
@@ -32,28 +72,20 @@ extension WindowManagementService {
         var sequence = DesktopActionSequenceAccumulator()
 
         do {
-            try await self.operationLaneCoordinator.run(scope: .global, access: .write) {
+            return try await self.operationLaneCoordinator.run(scope: .global, access: .write) {
                 self.logger.info("Attempting to focus window with target: \(target)")
                 self.logger.debug("WindowManagementService.focusWindow called with target: \(target)")
-                try self.validatePinnedWindowMutation(
-                    target: target,
-                    expectedIdentity: expectedIdentity)
-                let focusService = FocusManagementService(
-                    applications: self.applicationService,
-                    operationLaneCoordinator: self.operationLaneCoordinator)
-                try await focusService.focusWindowWithOwnedLane(
-                    windowID: CGWindowID(expectedIdentity.windowID),
-                    expectedIdentity: expectedIdentity,
-                    onDispatch: { record in
-                        sequence.record(record.sequenceStep)
-                    })
-                guard SystemIdentityResolver.validateWindowMutationIdentity(
-                    expectedIdentity,
-                    expectedBounds: bounds)
-                else {
-                    throw PeekabooError.commandFailed(
-                        "Window \(expectedIdentity.windowID) changed identity during focus")
+                try validateBeforeDispatch()
+                // Settlement may wait, but an ambiguous mutation must never trigger another raise.
+                try await dispatch(.init(retryCount: 1)) { record in
+                    sequence.record(record.sequenceStep)
                 }
+                let window = try await readback.capture(expectedIdentity: expectedIdentity)
+                let outcome = FocusDispatchAccounting.verifiedFocusOutcome(sequence.successResolution())
+                return UIAutomationActionResult(
+                    payload: window,
+                    outcome: outcome,
+                    targetIdentity: targetIdentity)
             }
         } catch let failure as DesktopActionFailure {
             throw self.focusFailure(
@@ -77,12 +109,6 @@ extension WindowManagementService {
                 sequence: sequence,
                 targetReceipt: targetReceipt)
         }
-
-        let outcome = FocusDispatchAccounting.verifiedFocusOutcome(sequence.successResolution())
-        return UIAutomationActionResult(
-            payload: (),
-            outcome: outcome,
-            targetIdentity: targetIdentity)
     }
 
     private func focusFailure(

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/WindowManagementService.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/WindowManagementService.swift
@@ -41,7 +41,7 @@ public final class WindowManagementService: WindowManagementServiceProtocol,
     WindowMutationInventoryProviding,
     WindowManagementActionOutcomeProviding,
     WindowManagementActionResultProviding,
-    WindowManagementPinnedFocusActionResultProviding
+    WindowManagementFocusProofProviding
 {
     let applicationService: any ApplicationServiceProtocol
     let windowIdentityService = WindowIdentityService()

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/WindowFocusReadbackTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/WindowFocusReadbackTests.swift
@@ -1,0 +1,268 @@
+import CoreGraphics
+import Darwin
+import Foundation
+import PeekabooFoundation
+import Testing
+@testable import PeekabooAutomationKit
+
+@MainActor
+struct WindowFocusReadbackTests {
+    @Test
+    func `geometry-only catalog lacks focus but native readback retains exact evidence`() async throws {
+        let fixture = FocusReadbackFixture()
+        let geometry = try #require(fixture.catalog.serviceWindowInfo(windowID: 712))
+        #expect(geometry.isMainWindow)
+        #expect(geometry.isKeyWindow == nil)
+        #expect(geometry.isFrontmost == nil)
+
+        let result = try await fixture.focus()
+        #expect(result.payload.isKeyWindow == true)
+        #expect(result.payload.isFrontmost == true)
+        #expect(result.payload.mutationIdentity?.hasSameStableReceipt(as: fixture.expected) == true)
+        #expect(result.targetIdentity?.exactWindow?.identity == fixture.expected)
+        #expect(result.outcome?.isConfirmed == true)
+        #expect(result.outcome?.projection.retrySafe == false)
+        #expect(result.outcome?.dispatchState.mutationDispatched == true)
+        #expect(result.outcome?.dispatchState.unitCount == .one)
+        #expect(fixture.dispatchCount == 1)
+        #expect(fixture.focusReadCount == 1)
+    }
+
+    @Test(arguments: [
+        "missing",
+        "other-window",
+        "foreground",
+        "owner",
+        "generation",
+        "bounds",
+        "catalog",
+        "native-window",
+        "cancel",
+        "timeout",
+        "ax-timeout",
+    ])
+    func `failed proof never retries an accepted mutation`(fault: String) async throws {
+        let fixture = FocusReadbackFixture()
+        fixture.afterDispatch = {
+            if fault == "catalog" {
+                fixture.catalogWindowID = 713
+            }
+        }
+        fixture.onFocusRead = {
+            switch fault {
+            case "missing": fixture.focusedID = nil
+            case "other-window": fixture.focusedID = 713
+            case "foreground": fixture.foregroundPID = 52
+            case "owner": fixture.ownerPID = 52
+            case "native-window": fixture.nativeWindowID = 713
+            case "generation": fixture.generation = 9002
+            case "bounds": fixture.currentBounds.origin.x += 1
+            case "cancel": throw CancellationError()
+            case "timeout": fixture.clock = fixture.clock.advanced(by: .seconds(2))
+            case "ax-timeout": throw FocusError.focusVerificationTimeout(712)
+            default: break
+            }
+        }
+        do {
+            _ = try await fixture.focus()
+            Issue.record("Expected exact focus proof to fail: \(fault)")
+        } catch let failure as DesktopActionFailure {
+            #expect(failure.outcome.state == .indeterminate)
+            #expect(failure.outcome.projection.retrySafe == false)
+            #expect(failure.outcome.dispatchState.mutationDispatched)
+            #expect(failure.outcome.dispatchState.unitCount == .one)
+            #expect(failure.targetReceipt == fixture.expected.actionTargetReceipt)
+        }
+        #expect(fixture.dispatchCount == 1)
+        #expect(fixture.focusReadCount <= 1)
+    }
+
+    @Test(arguments: ["owner", "generation", "bounds", "missing-bounds", "selector"])
+    func `invalid original receipt refuses before dispatch`(fault: String) async throws {
+        let fixture = FocusReadbackFixture()
+        switch fault {
+        case "owner": fixture.ownerPID = 52
+        case "generation": fixture.generation = 9002
+        case "bounds": fixture.currentBounds.origin.x += 1
+        case "missing-bounds":
+            fixture.expected = WindowMutationIdentity(
+                windowID: 712, ownerProcessIdentifier: 41, ownerProcessStartIdentity: 9001)
+        default: break
+        }
+        await #expect(throws: (any Error).self) {
+            _ = try await fixture.focus(target: fault == "selector" ? .windowId(713) : .windowId(712))
+        }
+        #expect(fixture.dispatchCount == 0)
+        #expect(fixture.focusReadCount == 0)
+    }
+
+    @Test
+    func `native settlement failure stops after the first accepted raise`() async throws {
+        let fixture = FocusReadbackFixture()
+        fixture.settlementFails = true
+        do {
+            _ = try await fixture.focus()
+            Issue.record("Expected settlement failure")
+        } catch let failure as DesktopActionFailure {
+            #expect(failure.outcome.state == .indeterminate)
+            #expect(failure.outcome.projection.retrySafe == false)
+            #expect(failure.outcome.dispatchState.unitCount == .one)
+        }
+        #expect(fixture.dispatchCount == 1)
+        #expect(fixture.focusReadCount == 0)
+    }
+
+    @Test
+    func `pre-cancelled native focus does not dispatch`() async throws {
+        let fixture = FocusReadbackFixture()
+        let task = Task { @MainActor in
+            withUnsafeCurrentTask { $0?.cancel() }
+            return try await fixture.focus()
+        }
+        await #expect(throws: CancellationError.self) { _ = try await task.value }
+        #expect(fixture.dispatchCount == 0)
+    }
+
+    @Test
+    func `focus readback completes before the existing global lane is released`() async throws {
+        let fixture = FocusReadbackFixture()
+        let entered = FocusReadbackGate()
+        let release = FocusReadbackGate()
+        fixture.onFocusRead = {
+            await entered.open()
+            await release.wait()
+        }
+        let task = Task { try await fixture.focus() }
+        await entered.wait()
+        let descriptor = open(fixture.root.appendingPathComponent("global.lock").path, O_RDWR | O_CLOEXEC)
+        #expect(descriptor >= 0)
+        defer { close(descriptor) }
+        #expect(flock(descriptor, LOCK_EX | LOCK_NB) == -1)
+        #expect(errno == EWOULDBLOCK)
+        await release.open()
+        _ = try await task.value
+        #expect(flock(descriptor, LOCK_EX | LOCK_NB) == 0)
+        _ = flock(descriptor, LOCK_UN)
+        #expect(fixture.focusReadCount == 1)
+    }
+}
+
+@MainActor
+private final class FocusReadbackFixture {
+    let root = FileManager.default.temporaryDirectory.appendingPathComponent("focus-proof-\(UUID())")
+    var expected = WindowMutationIdentity(
+        windowID: 712,
+        ownerProcessIdentifier: 41,
+        ownerProcessStartIdentity: 9001,
+        capturedBounds: CGRect(x: 10, y: 20, width: 800, height: 600))
+    var ownerPID: pid_t = 41
+    var generation: UInt64 = 9001
+    var currentBounds = CGRect(x: 10, y: 20, width: 800, height: 600)
+    var catalogWindowID = 712
+    var nativeWindowID: CGWindowID?
+    var focusedID: CGWindowID? = 712
+    var foregroundPID: pid_t? = 41
+    var clock = ContinuousClock.now
+    var dispatchCount = 0
+    var settlementFails = false
+    var focusReadCount = 0
+    var onFocusRead: () async throws -> Void = {}
+    var afterDispatch: () -> Void = {}
+
+    deinit { try? FileManager.default.removeItem(at: self.root) }
+
+    var catalog: WindowCGInfoLookup {
+        WindowCGInfoLookup(
+            windowListProvider: { _, _ in
+                [[
+                    kCGWindowNumber as String: self.catalogWindowID,
+                    kCGWindowOwnerPID as String: self.ownerPID,
+                    kCGWindowBounds as String: [
+                        "X": self.currentBounds.minX,
+                        "Y": self.currentBounds.minY,
+                        "Width": self.currentBounds.width,
+                        "Height": self.currentBounds.height,
+                    ],
+                    kCGWindowIsOnscreen as String: true,
+                ]]
+            },
+            processStartIdentityProvider: { _ in self.generation },
+            currentWindowIdentityProvider: { self.systemWindow($0) },
+            isMainWindowProvider: { _ in true })
+    }
+
+    func systemWindow(_ id: CGWindowID) -> SystemWindowIdentity {
+        SystemWindowIdentity(
+            windowID: self.nativeWindowID ?? id,
+            ownerProcessIdentifier: self.ownerPID,
+            title: "Fixture",
+            bounds: self.currentBounds,
+            layer: 0,
+            alpha: 1,
+            isOnScreen: true,
+            sharingState: .readOnly)
+    }
+
+    func focus(target: WindowTarget = .windowId(712)) async throws -> UIAutomationActionResult<ServiceWindowInfo> {
+        let readback = WindowFocusReadback(
+            catalog: self.catalog,
+            processStartIdentity: { _ in self.generation },
+            windowIdentity: { self.systemWindow($0) },
+            focusedWindowID: { pid, timeout in
+                #expect(pid == 41)
+                #expect(timeout > 0 && timeout <= 0.1)
+                self.focusReadCount += 1
+                try await self.onFocusRead()
+                return self.focusedID
+            },
+            frontmostPID: { self.foregroundPID },
+            now: { self.clock })
+        let service = WindowManagementService(
+            operationLaneCoordinator: DesktopOperationLaneCoordinator(coordinationRootURL: self.root))
+        return try await service.focusWindowProofActionResult(
+            target: target,
+            expectedIdentity: self.expected,
+            validateBeforeDispatch: { try readback.validateIdentity(self.expected) },
+            dispatch: { options, record in
+                try await FocusRaiseSettlement.run(
+                    attemptCount: options.retryCount,
+                    requiresStrictDispatchOwnership: false,
+                    prepareAttempt: {},
+                    dispatchRaise: {
+                        self.dispatchCount += 1
+                        _ = try FocusDispatchAccounting.acceptingBool(
+                            delivery: .init(mechanism: .accessibilityAction, mode: .foreground),
+                            onDispatch: record,
+                            operation: { true })
+                        self.afterDispatch()
+                    },
+                    verifyFocus: {
+                        if self.settlementFails {
+                            throw FocusError.focusVerificationTimeout(712)
+                        }
+                    },
+                    completeRaise: {},
+                    sleepBeforeRetry: { Issue.record("Unexpected mutation retry") },
+                    fallbackError: FocusError.focusVerificationFailed(712))
+            },
+            readback: readback)
+    }
+}
+
+private actor FocusReadbackGate {
+    private var opened = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func wait() async {
+        if self.opened {
+            return
+        }
+        await withCheckedContinuation { self.waiters.append($0) }
+    }
+
+    func open() {
+        self.opened = true
+        self.waiters.forEach { $0.resume() }
+        self.waiters.removeAll()
+    }
+}

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer+Handlers.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer+Handlers.swift
@@ -1517,9 +1517,25 @@ extension PeekabooBridgeServer {
                 message: "Window focus target changed before dispatch.",
                 hint: "List windows again and retry with the fresh exact target receipt.")
         }
-        let result = try await self.services.windows.focusWindowResult(
-            target: payload.target,
-            expectedIdentity: identity)
+        let result: UIAutomationActionResult<Void>
+        let focusReadback: ServiceWindowInfo?
+        if let provider = self.services.windows as? any WindowManagementFocusProofProviding {
+            let proof = try await provider.focusWindowProofActionResult(
+                target: payload.target,
+                expectedIdentity: identity)
+            focusReadback = proof.payload
+            result = UIAutomationActionResult(
+                payload: (),
+                outcome: proof.outcome,
+                targetIdentity: proof.targetIdentity,
+                selectedLeafEvidence: proof.selectedLeafEvidence)
+        } else {
+            // Preserve the public 4.x provider contract and its existing fail-closed readback.
+            focusReadback = nil
+            result = try await self.services.windows.focusWindowResult(
+                target: payload.target,
+                expectedIdentity: identity)
+        }
         let outcome = try Self.requireCurrentWindowOutcome(result.outcome, operation: "focus window")
         if outcome.state == .refused, outcome.dispatchState == .none {
             return try Self.handledActionResponse(
@@ -1541,7 +1557,8 @@ extension PeekabooBridgeServer {
         }
         let response = try await self.windowMutationResponse(
             request: .focusWindow(payload),
-            outcome: result.outcome)
+            outcome: result.outcome,
+            focusReadback: focusReadback)
         return try Self.handledActionResponse(
             response: response,
             result: result,

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer+MutationProof.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer+MutationProof.swift
@@ -83,7 +83,8 @@ extension PeekabooBridgeServer {
 
     func windowMutationResponse(
         request: PeekabooBridgeRequest,
-        outcome: DesktopActionOutcome?) async throws -> PeekabooBridgeResponse
+        outcome: DesktopActionOutcome?,
+        focusReadback: ServiceWindowInfo? = nil) async throws -> PeekabooBridgeResponse
     {
         guard PeekabooBridgeRequestContext.usesAttestedOperationResultSemantics,
               let outcome,
@@ -96,8 +97,12 @@ extension PeekabooBridgeServer {
             }
             let rawReadback: ServiceWindowInfo?
             do {
-                rawReadback = try await self.services.windows
-                    .listWindows(target: .windowId(identity.windowID)).first
+                if request.operation == .focusWindow, let focusReadback {
+                    rawReadback = focusReadback
+                } else {
+                    rawReadback = try await self.services.windows
+                        .listWindows(target: .windowId(identity.windowID)).first
+                }
             } catch let error as PeekabooError {
                 if [.closeWindow, .backgroundCloseWindow].contains(request.operation),
                    case .windowNotFound = error

--- a/Core/PeekabooCore/Tests/PeekabooTests/NativeWindowFocusProofTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/NativeWindowFocusProofTests.swift
@@ -1,0 +1,191 @@
+import CoreGraphics
+import Foundation
+import PeekabooAutomationKitTestSupport
+import PeekabooFoundation
+import Testing
+@testable import PeekabooAutomationKit
+@testable import PeekabooBridge
+
+@Suite(.serialized)
+@MainActor
+struct NativeWindowFocusProofTests {
+    @Test
+    func `production focus passes unchanged validation while geometry alone fails`() async throws {
+        let windows = NativeFocusProofWindows()
+        let geometry = try #require(windows.readback.catalog.serviceWindowInfo(windowID: 77))
+        let result = try await windows.focusWindowProofActionResult(
+            target: .windowId(77), expectedIdentity: windows.identity)
+        let request = PeekabooBridgeRequest.focusWindow(.init(
+            target: .windowId(77),
+            expectedIdentity: windows.identity))
+        #expect(geometry.isKeyWindow == nil)
+        #expect(geometry.isFrontmost == nil)
+        #expect(throws: (any Error).self) {
+            try PeekabooBridgeOperationReceiptSemantics.validatePostMutationWindow(
+                geometry, request: request, outcome: result.outcome)
+        }
+        try PeekabooBridgeOperationReceiptSemantics.validatePostMutationWindow(
+            result.payload, request: request, outcome: result.outcome)
+    }
+
+    @Test(arguments: [false, true])
+    func `signed remote focus uses production evidence and never geometry-only reread`(loseFocus: Bool) async throws {
+        let windows = NativeFocusProofWindows()
+        windows.focusedID = loseFocus ? 78 : 77
+        let socketPath = "/tmp/peekaboo-native-focus-proof-\(UUID()).sock"
+        let server = PeekabooBridgeServer(
+            services: StubServices(windows: windows, ownedDesktopOperationLanes: [.focusWindow]),
+            allowlistedTeams: [],
+            allowlistedBundles: [],
+            allowedOperations: [.focusWindow],
+            windowOwnerProcessIdentifierProvider: { _ in 420 },
+            windowBoundsProvider: { _ in NativeFocusProofWindows.bounds },
+            processStartIdentityProvider: { _ in 9001 })
+        let host = PeekabooBridgeHost(socketPath: socketPath, server: server, allowedTeamIDs: [], requestTimeoutSec: 2)
+        try await host.startChecked()
+        defer { Task { await host.stop() } }
+        let client = TrustedBridgeClientFixture.make(socketPath: socketPath, requestTimeoutSec: 2)
+        _ = try await client.handshake(client: .init(
+            bundleIdentifier: "boo.peekaboo.tests", teamIdentifier: nil, processIdentifier: getpid(), hostname: nil))
+        do {
+            let result = try await client.focusWindowResult(target: .windowId(77), expectedIdentity: windows.identity)
+            #expect(!loseFocus)
+            #expect(result.outcome?.isConfirmed == true)
+            #expect(result.targetIdentity?.exactWindow?.identity.hasSameStableReceipt(as: windows.identity) == true)
+        } catch let failure as DesktopActionFailure {
+            #expect(loseFocus)
+            #expect(failure.outcome.state == .indeterminate)
+        }
+        let bundle = try #require(await client.lastOperationReceiptBundle())
+        try bundle.validate()
+        #expect(bundle.receipt.payload.outcome?.retrySafe == false)
+        #expect(bundle.receipt.payload.outcome?.dispatchState.mutationDispatched == true)
+        #expect(bundle.receipt.payload.outcome?.dispatchState.unitCount == .one)
+        #expect(bundle.receipt.payload.target == .window(windows.identity))
+        if !loseFocus {
+            let response = try JSONDecoder.peekabooBridgeDecoder().decode(
+                PeekabooBridgeResponse.self, from: bundle.canonicalResponse)
+            guard case let .projectedAction(projected) = response, case let .window(window) = projected.response else {
+                Issue.record("Missing signed focus readback")
+                return
+            }
+            #expect(window?.isKeyWindow == true)
+            #expect(window?.isFrontmost == true)
+        }
+        #expect(windows.dispatchCount == 1)
+        #expect(windows.listCount == 0)
+        await host.stop()
+    }
+
+    @Test
+    func `older geometry-only provider still fails closed after accepted focus`() async throws {
+        let windows = LegacyGeometryFocusWindows()
+        let server = PeekabooBridgeServer(
+            services: StubServices(windows: windows), allowlistedTeams: [], allowlistedBundles: [])
+        let result = try await windows.focusWindowActionResult(
+            target: .windowId(77),
+            expectedIdentity: windows.identity)
+        await #expect(throws: DesktopActionFailure.self) {
+            try await PeekabooBridgeRequestContext.$usesAttestedOperationResultSemantics.withValue(true) {
+                _ = try await server.windowMutationResponse(
+                    request: .focusWindow(.init(target: .windowId(77), expectedIdentity: windows.identity)),
+                    outcome: result.outcome)
+            }
+        }
+        #expect(windows.dispatchCount == 1)
+        #expect(windows.listCount == 1)
+    }
+}
+
+@MainActor
+private class LegacyGeometryFocusWindows: ScriptedWindowInventoryService,
+WindowManagementPinnedFocusActionResultProviding {
+    nonisolated static let bounds = CGRect(x: 0, y: 0, width: 100, height: 100)
+    let identity = WindowMutationIdentity(
+        windowID: 77, ownerProcessIdentifier: 420, ownerProcessStartIdentity: 9001, capturedBounds: bounds)
+    var focusedID: CGWindowID? = 77
+    var dispatchCount = 0
+    var listCount = 0
+    let root = FileManager.default.temporaryDirectory.appendingPathComponent("native-focus-lane-\(UUID())")
+
+    deinit { try? FileManager.default.removeItem(at: self.root) }
+
+    var readback: WindowFocusReadback {
+        let nativeIdentity: (CGWindowID) -> SystemWindowIdentity? = { id in
+            SystemWindowIdentity(
+                windowID: id,
+                ownerProcessIdentifier: 420,
+                title: "Fixture",
+                bounds: Self.bounds,
+                layer: 0,
+                alpha: 1,
+                isOnScreen: true,
+                sharingState: .readOnly)
+        }
+        return WindowFocusReadback(
+            catalog: WindowCGInfoLookup(
+                windowListProvider: { _, _ in
+                    [[
+                        kCGWindowNumber as String: 77,
+                        kCGWindowOwnerPID as String: 420,
+                        kCGWindowBounds as String: ["X": 0, "Y": 0, "Width": 100, "Height": 100],
+                        kCGWindowIsOnscreen as String: true,
+                    ]]
+                },
+                processStartIdentityProvider: { _ in 9001 },
+                currentWindowIdentityProvider: nativeIdentity,
+                isMainWindowProvider: { _ in true }),
+            processStartIdentity: { _ in 9001 },
+            windowIdentity: nativeIdentity,
+            focusedWindowID: { _, _ in self.focusedID },
+            frontmostPID: { 420 })
+    }
+
+    override func listWindows(target: WindowTarget) async throws -> [ServiceWindowInfo] {
+        self.listCount += 1
+        return try [#require(self.readback.catalog.serviceWindowInfo(windowID: 77))]
+    }
+
+    func focusWindowActionResult(target: WindowTarget) async throws -> UIAutomationActionResult<Void> {
+        try await self.focusWindowActionResult(target: target, expectedIdentity: self.identity)
+    }
+
+    func focusWindowActionResult(
+        target: WindowTarget, expectedIdentity: WindowMutationIdentity) async throws -> UIAutomationActionResult<Void>
+    {
+        let result = try await self.nativeFocus(target: target, expectedIdentity: expectedIdentity)
+        return UIAutomationActionResult(payload: (), outcome: result.outcome, targetIdentity: result.targetIdentity)
+    }
+
+    func nativeFocus(
+        target: WindowTarget,
+        expectedIdentity: WindowMutationIdentity) async throws -> UIAutomationActionResult<ServiceWindowInfo>
+    {
+        let readback = self.readback
+        let service = WindowManagementService(
+            operationLaneCoordinator: DesktopOperationLaneCoordinator(coordinationRootURL: self.root))
+        return try await service.focusWindowProofActionResult(
+            target: target,
+            expectedIdentity: expectedIdentity,
+            validateBeforeDispatch: { try readback.validateIdentity(expectedIdentity) },
+            dispatch: { options, record in
+                #expect(options.retryCount == 1)
+                self.dispatchCount += 1
+                _ = try FocusDispatchAccounting.acceptingBool(
+                    delivery: .init(mechanism: .accessibilityAction, mode: .foreground),
+                    onDispatch: record,
+                    operation: { true })
+            },
+            readback: readback)
+    }
+}
+
+@MainActor
+private final class NativeFocusProofWindows: LegacyGeometryFocusWindows, WindowManagementFocusProofProviding {
+    func focusWindowProofActionResult(
+        target: WindowTarget,
+        expectedIdentity: WindowMutationIdentity) async throws -> UIAutomationActionResult<ServiceWindowInfo>
+    {
+        try await self.nativeFocus(target: target, expectedIdentity: expectedIdentity)
+    }
+}

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeDesktopObservationResultTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeDesktopObservationResultTests.swift
@@ -235,15 +235,16 @@ struct PeekabooBridgeDesktopObservationResultTests {
         await host.stop()
     }
 
-    @Test
-    func `signed read-only handler error keeps targetless refusal metadata`() async throws {
+    @Test(arguments: [false, true])
+    func `signed read-only handler error keeps targetless refusal metadata`(exactWindowROI: Bool) async throws {
         let provider = FailingObservationProvider()
         let root = URL(fileURLWithPath: "/tmp/pb-ob-targetless-error-\(UUID().uuidString)", isDirectory: true)
         defer { try? FileManager.default.removeItem(at: root) }
         let socketPath = root.appendingPathComponent("bridge.sock").path
+        // Mirror GUI lane ownership: exercise provider failure, not ambient exact-window lookup.
         let host = PeekabooBridgeHost(
             socketPath: socketPath,
-            server: Self.server(provider: provider),
+            server: Self.server(provider: provider, ownsObservationLane: true),
             allowedTeamIDs: [],
             requestTimeoutSec: 2)
         try await host.startChecked()
@@ -252,8 +253,12 @@ struct PeekabooBridgeDesktopObservationResultTests {
         let client = TrustedBridgeClientFixture.make(socketPath: socketPath, requestTimeoutSec: 2)
         _ = try await client.handshake(client: Self.clientIdentity)
         let request = DesktopObservationRequest(
-            target: .app(identifier: "Fixture", window: .automatic),
-            capture: .init(engine: .modern, focus: .background),
+            target: exactWindowROI ? .pid(42, window: .id(73)) : .app(identifier: "Fixture", window: .automatic),
+            capture: .init(
+                engine: exactWindowROI ? .auto : .modern,
+                scale: exactWindowROI ? .native : .logical1x,
+                focus: .background,
+                roi: exactWindowROI ? .init(bounds: CGRect(x: 20, y: 30, width: 320, height: 180)) : nil),
             detection: .init(mode: .accessibility))
 
         do {
@@ -368,9 +373,14 @@ struct PeekabooBridgeDesktopObservationResultTests {
         processStartIdentity: 9001,
         windowID: 73)
 
-    private static func server(provider: any DesktopObservationServiceProtocol) -> PeekabooBridgeServer {
+    private static func server(
+        provider: any DesktopObservationServiceProtocol,
+        ownsObservationLane: Bool = false) -> PeekabooBridgeServer
+    {
         PeekabooBridgeServer(
-            services: StubServices(desktopObservation: provider),
+            services: StubServices(
+                desktopObservation: provider,
+                ownedDesktopOperationLanes: ownsObservationLane ? [.desktopObservation] : []),
             allowlistedTeams: [],
             allowlistedBundles: [],
             allowedOperations: [.desktopObservation],

--- a/docs/focus.md
+++ b/docs/focus.md
@@ -55,8 +55,19 @@ When you execute a foreground interaction command (`type`, `click --foreground`,
 3. **Detects which Space** contains the window
 4. **Switches or moves Spaces** only when `--space-switch` or `--bring-to-current-space` is explicit
 5. **Brings app to front** and focuses the specific window
-6. **Verifies focus succeeded** before proceeding
+6. **Verifies exact focus succeeded** before proceeding
 7. **Executes your command** on the correctly focused window
+
+For receipt-bound native window focus, the focus owner captures fresh, bounded `AXFocusedWindow` identity and
+foreground application ownership before releasing its global mutation lane. It checks the original PID, process
+generation, exact window ID, and captured bounds around that readback. Bridge validates and signs this evidence;
+ordinary exact-ID window listings remain inexpensive geometry-only reads and do not imply focus. Existing/custom
+4.x providers without the additive focus-proof capability still undergo the existing fail-closed readback validation.
+
+Receipt-bound focus makes one mutation attempt. If an accepted or possibly dispatched action loses exact focus proof,
+is cancelled, or times out, the result remains retry-unsafe with its actual dispatch count. Observe the window before
+trying again; the retry option does not authorize replay after an indeterminate result. Foreground `press` sends no
+chords when setup focus fails, and verified focus does not prove a later chord's semantic effect.
 
 ## Automatic Focus Management
 
@@ -79,7 +90,7 @@ By default, Peekaboo will:
 - ✅ Focus the target window only after explicit foreground consent
 - ✅ Refuse an unintended Space switch unless `--space-switch` or `--bring-to-current-space` is explicit
 - ✅ Wait up to 5 seconds for focus to complete
-- ✅ Retry up to 3 times if focus fails
+- ✅ Retry only where safe; receipt-bound native focus never repeats an indeterminate mutation
 - ✅ Verify focus before proceeding
 
 ## Focus Options
@@ -141,7 +152,8 @@ Use cases:
 - Network-based apps that may be sluggish
 
 ### `--focus-retry-count <number>`
-Sets how many times to retry focus operations (default: 3).
+Sets the retry limit for focus paths that support safe retries (default: 3). Receipt-bound native window focus makes
+one mutation attempt and never retries after dispatch becomes indeterminate.
 
 ```bash
 peekaboo click "Save" --foreground --focus-retry-count 5


### PR DESCRIPTION
## Summary

Fix the native-to-Bridge ownership mismatch behind exact-window foreground focus receipt failures. Native focus verified the target, but Bridge discarded that evidence and reread geometry-only window metadata without `isKeyWindow` or `isFrontmost`; the signed postcondition guard correctly rejected the incomplete record.

The native focus owner now captures fresh AX focused-window and foreground-owner evidence while holding its existing mutation lane, with the original process generation, exact window ID, and bounds checked around readback. Bridge validates and signs that evidence instead of replacing it with a geometry-only reread. The additive focus-proof capability preserves public 4.x APIs and the fail-closed path for existing/custom providers.

Accepted or indeterminate focus is never blindly retried. A foreground `press` whose setup focus fails sends no hotkeys, even when multiple chords, repetitions, or a larger retry count were requested. Receipt, signature, attribution, and bounds guards are unchanged. The changelog and focus documentation describe the behavior.

## Validation

- 50 deterministic native focus/geometry/dispatch/ROI tests passed.
- 77 signed Bridge, remote window, semantic receipt, observation-result, and observation-binding tests passed.
- The ungated CLI focus-failure regression passed and recorded zero hotkey calls.
- Red/green proof: temporarily restoring the old geometry-only Bridge reread reproduced the signed-focus failure; restoring the native proof path passed.
- Scoped SwiftFormat and `git diff --check` passed. Repository SwiftLint passed with the unchanged baseline of 132 warnings and zero serious violations.
- Isolated Codex autoreview reported no accepted/actionable findings at its default blocking threshold.
- The repository-wide local `test:safe` run passed its initial policy, guidance, docs, and provenance checks, then stopped in unchanged release-tooling setup because the installed `mac-release` helper did not match the repository pin. Full safe-suite completion is not claimed; no shared release tooling was changed.

## Capture scope and live-proof limits

The v4.2.2 capture-attribution message can mask an underlying capture error; error preservation is already corrected on the base. This PR adds exact-PID/window Retina ROI regression coverage proving that the original provider failure survives signed transport with one provider invocation. It does not speculate about missing capture metadata or claim the underlying live screenshot failure is solved.

Tests inject native OS leaves and use isolated fixture Bridge sockets. No live desktop capture, browser changes, permission changes, GUI-host replacement, or deployment was performed. Real-application confirmation still requires a signed updated GUI host and a controlled non-private window.