### PR TITLE
fix(cli): bound debug staleness config discovery

### DIFF
--- a/Apps/CLI/Sources/PeekabooCLI/CLI/Utilities/BuildStalenessChecker.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/CLI/Utilities/BuildStalenessChecker.swift
@@ -78,18 +78,20 @@ private func defaultGitConfigPaths(environment: [String: String], currentDirecto
         paths.append(URL(fileURLWithPath: home).appendingPathComponent(".gitconfig").path)
     }
 
-    if let localConfigPath = findGitConfigPath(startingAt: currentDirectory) {
+    if let localConfigPath = findGitConfigPath(startingAt: URL(fileURLWithPath: currentDirectory, isDirectory: true)) {
         paths.append(localConfigPath)
     }
 
     return paths
 }
 
-private func findGitConfigPath(startingAt path: String) -> String? {
-    let fileManager = FileManager.default
-    var directory = URL(fileURLWithPath: path, isDirectory: true).standardizedFileURL
+func findGitConfigPath(startingAt directory: URL, fileManager: FileManager = .default) -> String? {
+    var components = directory.standardizedFileURL.pathComponents
 
-    while true {
+    // Consume one component per ancestor, including root, without asking for root's parent.
+    while !components.isEmpty {
+        let directory = URL(fileURLWithPath: NSString.path(withComponents: components), isDirectory: true)
+        components.removeLast()
         let dotGit = directory.appendingPathComponent(".git").path
         var isDirectory: ObjCBool = false
         if fileManager.fileExists(atPath: dotGit, isDirectory: &isDirectory) {
@@ -108,13 +110,9 @@ private func findGitConfigPath(startingAt path: String) -> String? {
                 return gitDirURL.appendingPathComponent("config").path
             }
         }
-
-        let parent = directory.deletingLastPathComponent()
-        if parent.path == directory.path {
-            return nil
-        }
-        directory = parent
     }
+
+    return nil
 }
 
 /// Check if the embedded git commit differs from the current git commit

--- a/Apps/CLI/Tests/CoreCLITests/BuildStalenessTraversalTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/BuildStalenessTraversalTests.swift
@@ -1,0 +1,236 @@
+import Darwin
+import Foundation
+import Testing
+@testable import PeekabooCLI
+
+extension UtilityTests.BuildStalenessCheckerTests {
+    @Test(arguments: ["/", "//", "/./", "/../", "/missing/../"])
+    func `Root is checked exactly once`(path: String) {
+        let fileManager = MissingGitFileManager(maximumChecks: 1)
+
+        #expect(findGitConfigPath(
+            startingAt: URL(fileURLWithPath: path, isDirectory: true),
+            fileManager: fileManager
+        ) == nil)
+        #expect(fileManager.checkedPaths == ["/.git"])
+    }
+
+    @Test(arguments: ["/", "/peekaboo-missing/./child/.."])
+    func `Bridged URLs cannot traverse above root`(path: String) {
+        let directory = NSURL(fileURLWithPath: path, isDirectory: true) as URL
+        let fileManager = MissingGitFileManager(maximumChecks: directory.standardizedFileURL.pathComponents.count)
+
+        #expect(findGitConfigPath(startingAt: directory, fileManager: fileManager) == nil)
+        #expect(fileManager.checkedPaths.last == "/.git")
+        #expect(fileManager.checkedPaths.count == directory.standardizedFileURL.pathComponents.count)
+    }
+
+    @Test
+    func `Missing metadata visits only canonical ancestors`() {
+        let fileManager = MissingGitFileManager(maximumChecks: 4)
+
+        #expect(findGitConfigPath(
+            startingAt: URL(fileURLWithPath: "/peekaboo-missing/one/./unused/../two/", isDirectory: true),
+            fileManager: fileManager
+        ) == nil)
+        #expect(fileManager.checkedPaths == [
+            "/peekaboo-missing/one/two/.git",
+            "/peekaboo-missing/one/.git",
+            "/peekaboo-missing/.git",
+            "/.git"
+        ])
+    }
+
+    @Test(arguments: ["", ".", "..", "missing/child", "missing/../child"])
+    func `Empty and relative starting paths have finite ancestor searches`(path: String) {
+        let directory = URL(fileURLWithPath: path, isDirectory: true)
+        let fileManager = MissingGitFileManager(maximumChecks: directory.standardizedFileURL.pathComponents.count)
+
+        #expect(findGitConfigPath(startingAt: directory, fileManager: fileManager) == nil)
+        #expect(fileManager.checkedPaths.count == directory.standardizedFileURL.pathComponents.count)
+        #expect(fileManager.checkedPaths.last == "/.git")
+        #expect(Set(fileManager.checkedPaths).count == fileManager.checkedPaths.count)
+    }
+
+    @Test
+    func `Nearest git directory wins even from nonexistent descendants`() throws {
+        let directory = try self.makeStalenessDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        try FileManager.default.createDirectory(
+            at: directory.appendingPathComponent(".git"),
+            withIntermediateDirectories: true
+        )
+        let nested = directory.appendingPathComponent("nested", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: nested.appendingPathComponent(".git"),
+            withIntermediateDirectories: true
+        )
+
+        #expect(findGitConfigPath(startingAt: directory) == directory.appendingPathComponent(".git/config").path)
+        #expect(findGitConfigPath(startingAt: nested.appendingPathComponent("missing/child"))
+            == nested.appendingPathComponent(".git/config").path)
+    }
+
+    @Test(arguments: [false, true])
+    func `Gitdir files resolve relative and absolute directories`(absolute: Bool) throws {
+        let directory = try self.makeStalenessDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let checkout = directory.appendingPathComponent("checkout", isDirectory: true)
+        let metadata = directory.appendingPathComponent("metadata", isDirectory: true)
+        try FileManager.default.createDirectory(at: checkout, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: metadata, withIntermediateDirectories: true)
+        let gitdir = absolute ? metadata.path : "../metadata"
+        try "gitdir: \(gitdir)\n".write(to: checkout.appendingPathComponent(".git"), atomically: true, encoding: .utf8)
+        try "[peekaboo]\ncheck-build-staleness = true\n".write(
+            to: metadata.appendingPathComponent("config"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        #expect(findGitConfigPath(startingAt: checkout.appendingPathComponent("missing"))
+            == metadata.appendingPathComponent("config").path)
+        #expect(isBuildStalenessCheckEnabled(environment: [:], currentDirectory: checkout.path))
+    }
+
+    @Test
+    func `Malformed gitdir files allow ancestor lookup`() throws {
+        let directory = try self.makeStalenessDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let checkout = directory.appendingPathComponent("checkout", isDirectory: true)
+        try FileManager.default.createDirectory(at: checkout, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(
+            at: directory.appendingPathComponent(".git"),
+            withIntermediateDirectories: true
+        )
+        try "not a gitdir file\n".write(to: checkout.appendingPathComponent(".git"), atomically: true, encoding: .utf8)
+
+        #expect(findGitConfigPath(startingAt: checkout) == directory.appendingPathComponent(".git/config").path)
+    }
+
+    @Test(.enabled(if: geteuid() != 0, "POSIX permissions do not deny root access"))
+    func `Inaccessible metadata allows ancestor lookup`() throws {
+        let directory = try self.makeStalenessDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let blocked = directory.appendingPathComponent("blocked", isDirectory: true)
+        let child = blocked.appendingPathComponent("child", isDirectory: true)
+        try FileManager.default.createDirectory(at: child, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(
+            at: blocked.appendingPathComponent(".git"),
+            withIntermediateDirectories: true
+        )
+        try FileManager.default.createDirectory(
+            at: directory.appendingPathComponent(".git"),
+            withIntermediateDirectories: true
+        )
+        try FileManager.default.setAttributes([.posixPermissions: 0o000], ofItemAtPath: blocked.path)
+        defer { try? FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: blocked.path) }
+
+        #expect(!FileManager.default.fileExists(atPath: blocked.appendingPathComponent(".git").path))
+        #expect(findGitConfigPath(startingAt: child) == directory.appendingPathComponent(".git/config").path)
+    }
+
+    @Test(.enabled(if: geteuid() != 0, "POSIX permissions do not deny root access"))
+    func `Unreadable gitdir files allow ancestor lookup`() throws {
+        let directory = try self.makeStalenessDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let checkout = directory.appendingPathComponent("checkout", isDirectory: true)
+        try FileManager.default.createDirectory(at: checkout, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(
+            at: directory.appendingPathComponent(".git"),
+            withIntermediateDirectories: true
+        )
+        let dotGit = checkout.appendingPathComponent(".git")
+        try "gitdir: ../metadata\n".write(to: dotGit, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o000], ofItemAtPath: dotGit.path)
+        defer { try? FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: dotGit.path) }
+
+        #expect(throws: (any Error).self) { try String(contentsOf: dotGit, encoding: .utf8) }
+        #expect(findGitConfigPath(startingAt: checkout) == directory.appendingPathComponent(".git/config").path)
+    }
+
+    @Test(arguments: ["1", " TRUE ", "yes", "0", "false", "no", "other"])
+    func `Nonempty environment override takes precedence over config`(override: String) throws {
+        let directory = try self.makeStalenessDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let enabled = ["1", " TRUE ", "yes"].contains(override)
+        let config = directory.appendingPathComponent("config")
+        try "[peekaboo]\ncheck-build-staleness = \(!enabled)\n".write(to: config, atomically: true, encoding: .utf8)
+
+        #expect(isBuildStalenessCheckEnabled(
+            environment: ["PEEKABOO_CHECK_BUILD_STALENESS": override],
+            currentDirectory: "/",
+            gitConfigPaths: [config.path]
+        ) == enabled)
+    }
+
+    @Test(arguments: ["", " \n "])
+    func `Blank environment override preserves config opt in`(override: String) throws {
+        let directory = try self.makeStalenessDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let config = directory.appendingPathComponent("config")
+        try "[peekaboo]\ncheck-build-staleness = true\n".write(to: config, atomically: true, encoding: .utf8)
+
+        #expect(isBuildStalenessCheckEnabled(
+            environment: ["PEEKABOO_CHECK_BUILD_STALENESS": override],
+            gitConfigPaths: [config.path]
+        ))
+        #expect(!isBuildStalenessCheckEnabled(
+            environment: ["PEEKABOO_CHECK_BUILD_STALENESS": override],
+            gitConfigPaths: []
+        ))
+        #expect(!isBuildStalenessCheckEnabled(environment: [:], gitConfigPaths: []))
+    }
+
+    @Test
+    func `Discovered repository config overrides home and XDG settings`() throws {
+        let directory = try self.makeStalenessDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let home = directory.appendingPathComponent("home", isDirectory: true)
+        let xdg = directory.appendingPathComponent("xdg", isDirectory: true)
+        let checkout = directory.appendingPathComponent("checkout", isDirectory: true)
+        for path in [home, xdg.appendingPathComponent("git"), checkout] {
+            try FileManager.default.createDirectory(at: path, withIntermediateDirectories: true)
+        }
+        try "[peekaboo]\ncheck-build-staleness = false\n".write(
+            to: xdg.appendingPathComponent("git/config"), atomically: true, encoding: .utf8
+        )
+        try "[peekaboo]\ncheck-build-staleness = true\n".write(
+            to: home.appendingPathComponent(".gitconfig"), atomically: true, encoding: .utf8
+        )
+        let environment = ["HOME": home.path, "XDG_CONFIG_HOME": xdg.path]
+        #expect(isBuildStalenessCheckEnabled(environment: environment, currentDirectory: checkout.path))
+
+        try FileManager.default.createDirectory(
+            at: checkout.appendingPathComponent(".git"), withIntermediateDirectories: true
+        )
+        try "[peekaboo]\ncheck-build-staleness = false\n".write(
+            to: checkout.appendingPathComponent(".git/config"), atomically: true, encoding: .utf8
+        )
+        #expect(!isBuildStalenessCheckEnabled(environment: environment, currentDirectory: checkout.path))
+    }
+
+    private func makeStalenessDirectory() throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true).resolvingSymlinksInPath()
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        return directory
+    }
+}
+
+/// Each instance belongs to one synchronous test; no real filesystem metadata is consulted.
+private final nonisolated class MissingGitFileManager: FileManager, @unchecked Sendable {
+    private(set) var checkedPaths: [String] = []
+    private let maximumChecks: Int
+
+    init(maximumChecks: Int) {
+        self.maximumChecks = maximumChecks
+        super.init()
+    }
+
+    override func fileExists(atPath path: String, isDirectory: UnsafeMutablePointer<ObjCBool>?) -> Bool {
+        self.checkedPaths.append(path)
+        // Return a sentinel repository on overrun so a regression fails instead of hanging the test runner.
+        isDirectory?.pointee = true
+        return self.checkedPaths.count > self.maximumChecks
+    }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Reuse validated classic PNG bytes when capture performs no transform instead of encoding the same image twice.
 
 ### Fixed
+- Bound debug CLI build-staleness config discovery to the starting directory's ancestors so missing or inaccessible Git metadata cannot cause an endless startup traversal.
 - Share the owner-only credential file between app and CLI, trim surrounding whitespace in app edits and legacy imports, ignore unchanged Settings bindings, recover legacy app keys only on explicit import, and keep failed edits visibly unsaved without Keychain prompts. Thanks @vincentkoc for #651.
 - Preserve exact-window foreground focus evidence under the native mutation lane for signed Bridge receipts, and refuse blind retries after accepted focus loses proof.
 - Keep `peekaboo learn` on its injected main-actor service provider instead of crashing when no process-wide tool registry default exists.

--- a/docs/building.md
+++ b/docs/building.md
@@ -41,6 +41,20 @@ pnpm run build:swift:all
 ./scripts/build-cli-standalone.sh [--install]
 ```
 
+## Debug build-staleness checks
+
+Debug CLI builds leave staleness checks disabled unless Git config contains
+`check-build-staleness = true` in a `[peekaboo]` section or `PEEKABOO_CHECK_BUILD_STALENESS` enables them.
+Set `PEEKABOO_CHECK_BUILD_STALENESS=0` to skip both config discovery and staleness checks;
+`1`, `true`, and `yes` enable them (case-insensitive, with surrounding whitespace ignored).
+Any other nonempty override disables them; an unset or blank override falls back to config.
+Config settings are read in system, XDG, home, then nearest repository order, with later settings taking precedence.
+
+Repository discovery visits each ancestor once, stopping after the filesystem root even when Git metadata is
+missing or inaccessible. It accepts `.git` directories and `.git` files with absolute or relative `gitdir:` paths.
+It reads `config` directly in the referenced Git directory; it does not follow a linked worktree's `commondir`.
+Release builds do not run this startup check.
+
 ## Releases
 
 For full release automation (tarballs, npm package, checksums), follow [RELEASING.md](RELEASING.md). Quick recap:


### PR DESCRIPTION
## Summary

Fix a debug-only startup hang in build-staleness Git config discovery. Foundation URLs backed by `NSURL` can traverse `/` → `/..` → `/../..`, so comparing a directory with its uncanonicalized parent does not guarantee termination when no `.git` is visible.

Consume one standardized path component per iteration instead. The search has a finite bound, checks root once, and preserves the existing staleness opt-in, environment override, config precedence, and `.git` directory/file behavior. Add focused regressions and update the building guide and changelog. No credential code is changed.

## Proof

- Debug CLI build passed on macOS 26.6.2 with Swift 6.4 / Xcode beta SDK 27.
- All 18 focused staleness tests passed, including root, bridged URLs, empty/relative/canonical paths, inaccessible metadata, absolute/relative gitdir files, and opt-in/config precedence. Overrun sentinels let the regression tests fail rather than hang.
- All 81 Foundation tests passed.
- Repository SwiftLint, SwiftFormat check, docs lint, and Codex autoreview passed.
- Independent source-blind runtime validation passed 22 CLI invocations with no timeouts: version/help, completions, invalid-command handling, root/neutral directories, and sandbox-denied Git metadata. The critical sandbox runs left `PEEKABOO_CHECK_BUILD_STALENESS` unset; separate runs verified `0` and `1`. Metadata denial was independently demonstrated, and the tested executable hash matched the built binary.

## Validation notes

The broad local `test:safe` command stopped on a release-helper pin mismatch. Running its CLI suite directly exposed 12 issues in unchanged ScreenCaptureKit owner/Bridge fixtures, before the staleness suite ran; those failures are being tracked separately rather than mixed into this patch. The initial base commit's [macOS CI](https://github.com/openclaw/Peekaboo/actions/runs/33156646204) and [CodeQL](https://github.com/openclaw/Peekaboo/actions/runs/33156646040) runs passed. This PR must pass its own exact-head CI before merge.

The existing linked-worktree `commondir` limitation is unchanged and documented. Runtime proof used only synthetic fixtures, without operator credentials. Raw process samples are not included.
