### PR TITLE
test(cli): isolate ScreenCaptureKit owner fixtures

### DIFF
--- a/Apps/CLI/Tests/CoreCLITests/ScreenCaptureKitOwnerFixtureTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/ScreenCaptureKitOwnerFixtureTests.swift
@@ -1,0 +1,70 @@
+import Darwin
+import Foundation
+import PeekabooBridge
+import PeekabooFoundation
+import Testing
+@testable import PeekabooCLI
+
+extension ScreenCaptureKitOwnerRuntimeTests {
+    @Test(arguments: [true, false])
+    func `fixture ownership capability follows service support`(ownerAware: Bool) async throws {
+        let socketPath = "/tmp/peekaboo-owner-fixture-\(UUID().uuidString).sock"
+        let host = try await Self.startHost(
+            socketPath: socketPath,
+            processIdentifier: 4242,
+            processStartIdentity: 9001,
+            codeSignatureHash: "owner-build",
+            ownerAware: ownerAware
+        )
+        defer { Task { await host.stop() } }
+
+        let handshake = try await PeekabooBridgeClient(socketPath: socketPath).handshake(
+            client: BridgeDiagnostics.currentClientIdentity()
+        )
+
+        #expect(handshake.hostCapabilities?.contains(
+            PeekabooBridgeHostCapability.screenCaptureKitProcessOwnership
+        ) == ownerAware)
+        #expect(handshake.hostIdentity?.processIdentifier == 4242)
+        #expect(handshake.hostIdentity?.processStartIdentity == 9001)
+        #expect(handshake.hostIdentity?.codeSignatureHash == "owner-build")
+        await host.stop()
+    }
+
+    @Test(arguments: [true, false])
+    func `fixture ownership failures remain owner unaware`(registrationFails: Bool) async throws {
+        let socketPath = "/tmp/peekaboo-owner-fixture-failure-\(UUID().uuidString).sock"
+        let host = try await Self.startHost(
+            socketPath: socketPath,
+            processIdentifier: 4242,
+            processStartIdentity: 9001,
+            codeSignatureHash: "owner-build",
+            screenCaptureKitProcessCapabilityRegistrar: {
+                if registrationFails {
+                    throw OperationError.captureFailed(reason: "Fixture registration failure")
+                }
+            },
+            screenCaptureKitOwnershipPreparer: {
+                #expect(!registrationFails)
+                throw OperationError.captureFailed(reason: "Fixture preparation failure")
+            }
+        )
+        defer { Task { await host.stop() } }
+
+        let unawareHost = try await RuntimeHostResolver.firstScreenCaptureKitOwnerUnawareHost(
+            candidates: [.init(
+                socketPath: socketPath,
+                requireReusableDaemon: false,
+                requiredHostKind: nil,
+                requiresValidatedHistoricalDaemon: false
+            )],
+            identity: BridgeDiagnostics.currentClientIdentity(),
+            externalHostPresence: { _ in .absent }
+        )
+
+        #expect(unawareHost?.socketPath == socketPath)
+        #expect(unawareHost?.processIdentifier == 4242)
+        #expect(unawareHost?.processStartIdentity == 9001)
+        await host.stop()
+    }
+}

--- a/Apps/CLI/Tests/CoreCLITests/ScreenCaptureKitOwnerRuntimeTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/ScreenCaptureKitOwnerRuntimeTests.swift
@@ -2,12 +2,12 @@ import Commander
 import Darwin
 import Foundation
 import PeekabooAutomation
-import PeekabooAutomationKit
 import PeekabooBridge
 import PeekabooBridgeTestSupport
 import PeekabooCore
 import PeekabooFoundation
 import Testing
+@testable import PeekabooAutomationKit
 @testable import PeekabooCLI
 
 @Suite(.serialized, .tags(.safe))
@@ -506,6 +506,8 @@ struct ScreenCaptureKitOwnerRuntimeTests {
     @Test
     func `classic false-permission host remains executable after request-aware selection`() async throws {
         let socketPath = "/tmp/peekaboo-classic-deferral-\(UUID().uuidString).sock"
+        let coordinationRoot = URL(fileURLWithPath: socketPath).appendingPathExtension("coordination")
+        defer { try? FileManager.default.removeItem(at: coordinationRoot) }
         let host = try await Self.startHost(
             socketPath: socketPath,
             processIdentifier: 3131,
@@ -515,7 +517,8 @@ struct ScreenCaptureKitOwnerRuntimeTests {
             serviceOverride: OwnerPolicyFixtureServices(
                 ownerAware: true,
                 observation: ClassicDispatchSentinelObservationService()
-            )
+            ),
+            coordinationRootURL: coordinationRoot
         )
         defer { Task { await host.stop() } }
         var permissionRejections: [String] = []
@@ -556,6 +559,8 @@ struct ScreenCaptureKitOwnerRuntimeTests {
     @Test
     func `dynamic remote projection evaluates each request engine from raw host capabilities`() async throws {
         let socketPath = "/tmp/peekaboo-dynamic-classic-deferral-\(UUID().uuidString).sock"
+        let coordinationRoot = URL(fileURLWithPath: socketPath).appendingPathExtension("coordination")
+        defer { try? FileManager.default.removeItem(at: coordinationRoot) }
         let host = try await Self.startHost(
             socketPath: socketPath,
             processIdentifier: 3131,
@@ -565,7 +570,8 @@ struct ScreenCaptureKitOwnerRuntimeTests {
             serviceOverride: OwnerPolicyFixtureServices(
                 ownerAware: true,
                 observation: ClassicDispatchSentinelObservationService()
-            )
+            ),
+            coordinationRootURL: coordinationRoot
         )
         defer { Task { await host.stop() } }
         let identity = PeekabooBridgeClientIdentity(
@@ -1442,6 +1448,10 @@ extension ScreenCaptureKitOwnerRuntimeTests {
             PeekabooBridgeConstants.exactForcedDialogDismissExecutionVersion,
         usesCurrentHostIdentity: Bool = false,
         serviceOverride: (any PeekabooBridgeServiceProviding)? = nil,
+        coordinationRootURL: URL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("peekaboo-owner-lane-\(UUID().uuidString)", isDirectory: true),
+        screenCaptureKitProcessCapabilityRegistrar: @MainActor @Sendable () throws -> Void = {},
+        screenCaptureKitOwnershipPreparer: @escaping @Sendable () async throws -> Void = {},
         permissionEvaluationObserver: @escaping @MainActor @Sendable () -> Void = {}
     ) async throws -> PeekabooBridgeHost {
         let services: any PeekabooBridgeServiceProviding = if let serviceOverride {
@@ -1487,6 +1497,10 @@ extension ScreenCaptureKitOwnerRuntimeTests {
                     bundleVersion: nil,
                     codeSignatureHash: codeSignatureHash
                 ),
+            // Synthetic startup and dispatch must not use user-wide ownership or desktop coordination state.
+            desktopOperationLaneCoordinator: DesktopOperationLaneCoordinator(coordinationRootURL: coordinationRootURL),
+            screenCaptureKitProcessCapabilityRegistrar: screenCaptureKitProcessCapabilityRegistrar,
+            screenCaptureKitOwnershipPreparer: screenCaptureKitOwnershipPreparer,
             permissionStatusEvaluator: { _ in
                 permissionEvaluationObserver()
                 return PermissionsStatus(


### PR DESCRIPTION
## Summary

The CLI owner-runtime fixture constructed synthetic Bridge hosts but left production ScreenCaptureKit capability registration and preparation enabled. Those callbacks use user-wide ownership state, so a fixture could lose its advertised ownership capability before selection. The shared fixture now injects deterministic callbacks through the existing server parameters, without changing production ownership validation.

Protected testing also exposed two mock capture-dispatch tests using the production desktop-operation coordinator. The fixture now uses a test-local coordinator; those dispatch tests own and clean their temporary coordination roots. Regression cases cover owner-aware versus owner-unaware services and fail-closed registration/preparation failures.

This is a two-file, test-only change. It does not modify the debug-staleness fix, credential handling, production capture behavior, or dependency revisions. No changelog entry is needed for this fixture-only repair.

## Validation

- The combined `ScreenCaptureKitOwnerRuntimeTests` suite, including handshake-reuse and dynamic-tool extensions, passed all 38 tests in three fresh test processes.
- Runtime proof used an empty home/configuration, disabled configuration migration, and OS sandbox denials on operator credentials and shared ownership/coordination state. The protections were verified using disposable sentinels, not operator records.
- Scoped SwiftFormat and SwiftLint passed. Repository SwiftLint passed with existing warnings. Independent Codex autoreview reported no actionable blockers.
- A broader local CLI run under those stricter protections encountered unrelated fixtures using the canonical mutation-barrier root and timed out after five minutes. This is recorded as a separate fixture-isolation follow-up; the broad local gate is not claimed green. Hosted macOS CI is required before merge.

The original ambient trigger remains unproven. No ordinary pre-change runtime baseline is claimed, and raw runtime logs or private host identifiers are not included.
