### PR TITLE
feat(browser): add foreground-only receipt-bound DOM click

### DIFF
--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -146,6 +146,12 @@ jobs:
           swift test --no-parallel --filter 'MCPToolExecutionTests|MCPToolErrorHandlingTests|MCPElementActionToolExecutionTests'
           swift test --no-parallel --filter 'MCPDesktopActionOutcomeProjectionTests|MCPCompositeActionOutcomeTests'
 
+      - name: Run browser capability and guidance contracts
+        working-directory: Core/PeekabooCore
+        run: |
+          swift test --no-parallel \
+            --filter 'BrowserToolTests|BrowserToolCapabilityIntegrationTests|RemoteBrowserMCPSessionTests|AgentSystemPromptTests'
+
       - name: Run focused Swift tests
         working-directory: Core/PeekabooCore
         run: |

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/MCP/BrowserCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/MCP/BrowserCommand.swift
@@ -92,7 +92,7 @@ InjectedRuntimeBackedCommand {
         abstract: "Control Chrome page content through the browser MCP tool",
         discussion: """
         Dedicated CLI wrapper around Peekaboo's browser MCP tool. Use it for DOM/page
-        operations such as status, connect, navigate, snapshot, click, fill, type,
+        operations such as status, connect, navigate, snapshot, click, dom-click, fill, type,
         screenshots, console/network inspection, and performance traces.
 
         Examples:
@@ -108,6 +108,9 @@ InjectedRuntimeBackedCommand {
         and report foreground browser-protocol delivery.
         Default calls still require an existing exact connection and never ambiently auto-connect. With explicit
         --foreground, only standalone CLI page actions may auto-connect when no receipt exists.
+        dom-click invokes synthetic element.click() without trusted pointer input. Its provider evaluation still
+        grants browser user activation and requires --foreground. Success does not prove the intended page effect;
+        observe the page before retrying. This is not a guarantee that Chrome stays behind other apps.
         """
     )
 

--- a/Apps/CLI/Tests/CoreCLITests/MCPWrapperCommandBindingTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/MCPWrapperCommandBindingTests.swift
@@ -180,6 +180,31 @@ struct MCPWrapperCommandBindingTests {
     }
 
     @Test
+    func `Browser DOM click requires explicit foreground authority`() throws {
+        let background = try CommanderCLIBinder.instantiateCommand(
+            ofType: BrowserCommand.self,
+            parsedValues: ParsedValues(
+                positional: ["dom-click"],
+                options: ["pageId": ["7"], "uid": ["7_1"]],
+                flags: []
+            )
+        )
+        let foreground = try CommanderCLIBinder.instantiateCommand(
+            ofType: BrowserCommand.self,
+            parsedValues: ParsedValues(
+                positional: ["dom-click"],
+                options: ["pageId": ["7"], "uid": ["7_1"]],
+                flags: ["foreground"]
+            )
+        )
+
+        #expect(background.toolExecutionPolicy == .backgroundOnly)
+        #expect(foreground.toolExecutionPolicy == .foregroundAllowed)
+        #expect(background.runtimeOptions.usesPerToolSnapshotInvalidation)
+        #expect(foreground.runtimeOptions.usesPerToolSnapshotInvalidation)
+    }
+
+    @Test
     func `See tree command binding`() throws {
         let parsed = ParsedValues(
             positional: [],

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/Agent/Tools/AgentSystemPrompt.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/Agent/Tools/AgentSystemPrompt.swift
@@ -336,14 +336,40 @@ public struct AgentSystemPrompt {
             """
             - Open a URL with explicit foreground consent using
               `{ "action": "open", "name": "Safari", "openTargets": ["https://example.com"], "foreground": true }`.
-              In Chrome DevTools flows, `new_page` and `select_page` stay in the background by default.
+              Chrome DevTools page discovery, navigation, and snapshots grant browser user activation in the pinned
+              provider and are available only in this foreground-authorized session.
             """
         } else {
             """
-            - Navigate only through an existing exact browser connection. Create background DevTools pages when the
-              connection supports it; do not call Safari open, browser connect, page fronting, or activation actions.
+            - Page discovery, navigation, snapshots, and DOM element actions are unavailable because the pinned provider
+              grants browser user activation during their internal page evaluation. Do not attempt them in this session.
             """
         }
+        let interactionGuidance = if allowsForeground {
+            """
+            - Trusted browser pointer, form-fill, focused-keyboard, and upload actions can activate standalone Chrome;
+              use them only when foreground browser interaction is intentional.
+            - `dom_click` avoids Puppeteer pointer input, but its `evaluate_script` route still grants browser user
+              activation and must remain foreground-authorized.
+              It is synthetic, not trusted pointer input, and does not guarantee Chrome stays behind other apps.
+              Observe the intended page effect afterward; a successful return is not proof it happened.
+            """
+        } else {
+            """
+            - `dom_click`, raw `evaluate_script`, trusted pointer, form-fill, focused-keyboard, and upload routes are
+              unavailable. Request foreground authority rather than trying to bypass the source-audited catalog.
+            """
+        }
+        let pageScopeGuidance = allowsForeground
+            ? """
+            - Start each Chrome flow with `list_pages` or `new_page`, keep its opaque page reference, and include it as
+              `page_id` in every later page-scoped browser action. Use element references only from that page's newest
+              snapshot. Never copy page or element references across Agent sessions.
+            """
+            : """
+            - Use only actions and arguments advertised by the background browser schema. Do not guess hidden page or
+              element routes, and never copy page or element references across Agent sessions.
+            """
         return """
         **Browser Automation**
         - When the target is Google Chrome and the task concerns page content, forms, DOM/a11y snapshots,
@@ -352,12 +378,12 @@ public struct AgentSystemPrompt {
         - Use native Peekaboo tools (`inspect_ui`, `see`, `click`, `type`, `menu`, `dialog`, `window`) for macOS UI,
           browser chrome, permissions, menus, dialogs, and non-browser apps.
         \(navigationGuidance)
-        - Start each Chrome flow with `list_pages` or `new_page`, retain its opaque page reference, and include it as
-          `page_id` in every later page-scoped browser action. Use element references only from that page's newest
-          snapshot. Never copy page or element references across Agent sessions.
+        \(interactionGuidance)
+        \(pageScopeGuidance)
         - Foreground-capable sessions may use `bring_to_front: true` or `background: false` only when the task
           explicitly requires foreground Chrome; background-only sessions must never emit either form.
-        - If `browser` fails or is unavailable, fall back to native Peekaboo screen/AX tools.
+        - If `browser` fails or is unavailable, native Peekaboo screen/AX tools remain subject to their own authority
+          and exact-target requirements. Never use a fallback to bypass a foreground-consent refusal.
         """
     }
 
@@ -377,6 +403,10 @@ public struct AgentSystemPrompt {
             "Do not emit CLI strings. For example, list applications with `{ \"action\": \"list\" }`; " +
                 "never emit focus or switch payloads in this session."
         }
+        let webNavigationGuidance = allowsForeground
+            ? "When starting a separate Chrome web task, open a new page only through the foreground-authorized " +
+            "browser route."
+            : "Do not open or navigate browser pages; request foreground authority when the task requires either."
         return """
         **Error Recovery**
         - Refresh the view with the appropriate observation tool if an element is missing.
@@ -391,8 +421,7 @@ public struct AgentSystemPrompt {
         - Double-check that each tool call has the necessary data before executing. If you are unsure what payload a
           tool expects, re-read its description for the JSON example.
         - \(pointerGuidance)
-        - When navigating to a new website or starting a separate web task, prefer opening a background page. Reuse
-          the current page only when the user asks to continue there or it is clearly the right place.
+        - \(webNavigationGuidance)
         """
     }
 

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/Browser/BrowserToolCapabilitySession.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/Browser/BrowserToolCapabilitySession.swift
@@ -677,8 +677,8 @@ actor BrowserToolCapabilitySession {
 
     private static func actionUsesPage(_ action: BrowserAction, arguments: ToolArguments) -> Bool {
         switch action {
-        case .selectPage, .closePage, .navigate, .waitFor, .snapshot, .click, .fill, .fillForm, .drag, .hover,
-             .type, .pressKey, .uploadFile, .handleDialog, .console, .network, .screenshot, .performanceTrace:
+        case .selectPage, .closePage, .navigate, .waitFor, .snapshot, .click, .domClick, .fill, .fillForm, .drag,
+             .hover, .type, .pressKey, .uploadFile, .handleDialog, .console, .network, .screenshot, .performanceTrace:
             true
         case .call:
             arguments.getValue(for: "page_id") != nil

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/BrowserTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/BrowserTool.swift
@@ -698,7 +698,9 @@ public struct BrowserTool: MCPTool {
         }
         return outcome
     }
+}
 
+extension BrowserTool {
     private func formatStatus(
         _ status: BrowserMCPStatus,
         headline: String,
@@ -715,7 +717,9 @@ public struct BrowserTool: MCPTool {
         }
         lines.append("Tools: \(status.observation == .confirmed ? String(status.toolCount) : "unknown")")
 
-        if status.detectedBrowsers.isEmpty {
+        if status.observation == .indeterminate {
+            lines.append("Detected Chrome: unknown")
+        } else if status.detectedBrowsers.isEmpty {
             lines.append("Detected Chrome: none")
         } else {
             lines.append("Detected Chrome:")
@@ -761,8 +765,9 @@ public struct BrowserTool: MCPTool {
             "connected": status.observation == .confirmed ? .bool(status.isConnected) : .null,
             "status_observation": .string(status.observation.rawValue),
             "tool_count": status.observation == .confirmed ? .int(status.toolCount) : .null,
-            "browser_count": .int(status.detectedBrowsers.count),
-            "channels": .array(status.detectedBrowsers.map { .string($0.channel.rawValue) }),
+            "browser_count": status.observation == .confirmed ? .int(status.detectedBrowsers.count) : .null,
+            "channels": status.observation == .confirmed
+                ? .array(status.detectedBrowsers.map { .string($0.channel.rawValue) }) : .null,
         ]
         if let providerSessionEpoch = status.providerSessionEpoch {
             meta["provider_session_epoch"] = .string(

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/BrowserTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/BrowserTool.swift
@@ -32,14 +32,15 @@ public struct BrowserTool: MCPTool {
         return """
         Controls and inspects Chrome web pages through Chrome DevTools MCP.
 
-        Use this for browser page content: DOM/accessibility snapshots, web forms, navigation,
-        console messages, network requests, screenshots, and performance traces. Use Peekaboo's
-        native tools for macOS chrome, menus, dialogs, permissions, and non-browser applications.
+        Use this for page content: DOM/accessibility, forms, navigation, console/network, screenshots, and traces.
+        Use Peekaboo native tools for macOS UI, browser chrome, menus, dialogs, permissions, and other apps.
 
         Chrome DevTools MCP requires Chrome 144+ with remote debugging enabled at
         chrome://inspect/#remote-debugging. The user must accept Chrome's remote debugging prompt.
         Routes that can enter Puppeteer page evaluation are foreground-only because the pinned provider grants browser
         user activation even for headless or background pages.
+        dom_click invokes synthetic element.click(), not trusted pointer input. It still requires foreground authority.
+        It may activate Chrome; verify page effects afterward. double and include_snapshot do not apply.
         Peekaboo starts chrome-devtools-mcp with usage statistics and CrUX lookups disabled.
         """
     }
@@ -937,6 +938,7 @@ public enum BrowserAction: String, CaseIterable, Sendable {
     case waitFor = "wait_for"
     case snapshot
     case click
+    case domClick = "dom_click"
     case fill
     case fillForm = "fill_form"
     case drag
@@ -1049,7 +1051,7 @@ public enum BrowserMCPCallMapper {
         case .call:
             // Invalid/unknown raw calls are rejected later; classify them conservatively until then.
             .mutating
-        case .closePage, .newPage, .navigate, .click, .fill, .fillForm, .drag, .hover, .type, .pressKey,
+        case .closePage, .newPage, .navigate, .click, .domClick, .fill, .fillForm, .drag, .hover, .type, .pressKey,
              .uploadFile, .handleDialog:
             .mutating
         }
@@ -1128,7 +1130,8 @@ public enum BrowserMCPCallMapper {
             throw BrowserToolError.invalidAction(action.rawValue)
         case .listPages, .selectPage, .closePage, .newPage, .navigate, .waitFor:
             try self.pageCall(action: action, arguments: arguments)
-        case .snapshot, .click, .fill, .fillForm, .drag, .hover, .type, .pressKey, .uploadFile, .handleDialog,
+        case .snapshot, .click, .domClick, .fill, .fillForm, .drag, .hover, .type, .pressKey, .uploadFile,
+             .handleDialog,
              .screenshot:
             try self.interactionCall(action: action, arguments: arguments)
         case .console, .network, .performanceTrace:
@@ -1143,7 +1146,7 @@ public enum BrowserMCPCallMapper {
 
     private static func requiresPageID(_ action: BrowserAction) -> Bool {
         switch action {
-        case .navigate, .waitFor, .snapshot, .click, .fill, .fillForm, .drag, .hover, .type, .pressKey,
+        case .navigate, .waitFor, .snapshot, .click, .domClick, .fill, .fillForm, .drag, .hover, .type, .pressKey,
              .uploadFile, .handleDialog, .console, .network, .screenshot, .performanceTrace:
             true
         case .status, .connect, .disconnect, .listPages, .selectPage, .closePage, .newPage, .call:
@@ -1204,6 +1207,19 @@ public enum BrowserMCPCallMapper {
                 "dblClick": arguments.getBool("double") ?? false,
                 "includeSnapshot": arguments.getBool("include_snapshot") ?? false,
             ]))
+        case .domClick:
+            return try BrowserMCPMappedCall(toolName: "evaluate_script", arguments: [
+                "function": """
+                (element) => {
+                  if (typeof element?.click !== 'function') {
+                    throw new Error('The selected element does not support a synthetic DOM click.');
+                  }
+                  element.click();
+                  return true;
+                }
+                """,
+                "args": [self.requiredString("uid", arguments)],
+            ])
         case .fill:
             return try BrowserMCPMappedCall(toolName: "fill", arguments: self.compact([
                 "uid": self.requiredString("uid", arguments),

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeOperationResultSemantics.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeOperationResultSemantics.swift
@@ -1311,7 +1311,7 @@ extension PeekabooBridgeOperationResultSemantics {
             target: target)
     }
 
-    private static func actionFailure(in response: PeekabooBridgeResponse) -> DesktopActionFailure? {
+    static func actionFailure(in response: PeekabooBridgeResponse) -> DesktopActionFailure? {
         switch response {
         case let .error(envelope):
             envelope.desktopActionFailure

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer+OperationReceipts.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer+OperationReceipts.swift
@@ -175,6 +175,7 @@ extension PeekabooBridgeServer {
                 failure: failure,
                 originalOutcome: handled.outcome?.projection ??
                     PeekabooBridgeOperationReceiptSemantics.outcome(in: handled.response),
+                originalFailure: PeekabooBridgeOperationResultSemantics.actionFailure(in: handled.response),
                 afterExecution: true)
             target = nil
             focusedElement = nil
@@ -591,6 +592,7 @@ extension PeekabooBridgeServer {
         plan: PeekabooBridgeOperationResultSemantics.PeekabooBridgeRequestPlan,
         failure: PeekabooBridgeTargetAttributionFailure,
         originalOutcome: DesktopActionOutcome.Projection?,
+        originalFailure: DesktopActionFailure? = nil,
         afterExecution: Bool) -> PeekabooBridgeResponse
     {
         let context = "bridge_target_attribution:\(failure.code.rawValue)"
@@ -604,6 +606,15 @@ extension PeekabooBridgeServer {
 
         let original = originalOutcome?.outcome
         let mayHaveDispatched = afterExecution && (original?.dispatchState.mutationDispatched ?? true)
+        var diagnostics = [failure.message]
+        if let originalFailure {
+            // Preserve only caller-facing typed diagnostics, never raw envelope details or target evidence.
+            diagnostics.append("Original operation failure: \(originalFailure.message.prefix(512))")
+            if let cause = originalFailure.causeDescription, !cause.isEmpty {
+                diagnostics.append("Original cause: \(cause.prefix(1536))")
+            }
+        }
+        let causeDescription = diagnostics.joined(separator: "\n")
         let actionFailure: DesktopActionFailure = if mayHaveDispatched {
             .indeterminate(
                 route: .bridge,
@@ -612,14 +623,14 @@ extension PeekabooBridgeServer {
                 unitCount: original?.dispatchState.unitCount,
                 message: "Bridge operation completed without a trustworthy exact target receipt.",
                 hint: "Observe the intended target before any retry.",
-                causeDescription: failure.message)
+                causeDescription: causeDescription)
         } else {
             .preDispatchRefusal(
                 route: .bridge,
                 reason: .invalidRequest,
                 message: "Bridge operation was refused because its target receipt is invalid.",
                 hint: "Capture fresh target evidence and retry with one exact process or window receipt.",
-                causeDescription: failure.message)
+                causeDescription: causeDescription)
         }
         let envelope = PeekabooBridgeErrorEnvelope(
             code: mayHaveDispatched ? .internalError : .invalidRequest,

--- a/Core/PeekabooCore/Sources/PeekabooCore/Support/RemoteBrowserMCPClient.swift
+++ b/Core/PeekabooCore/Sources/PeekabooCore/Support/RemoteBrowserMCPClient.swift
@@ -172,11 +172,7 @@ public final class RemoteBrowserMCPClient: BrowserMCPClientProviding, BrowserMCP
         do {
             return try await Self.status(from: self.client.browserStatus(channel: channel?.rawValue))
         } catch {
-            return BrowserMCPStatus(
-                isConnected: false,
-                toolCount: 0,
-                detectedBrowsers: [],
-                error: error.localizedDescription)
+            return self.indeterminateStatus(error: error)
         }
     }
 

--- a/Core/PeekabooCore/Tests/PeekabooAgentRuntimeTests/AgentSystemPromptTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooAgentRuntimeTests/AgentSystemPromptTests.swift
@@ -172,11 +172,31 @@ struct AgentSystemPromptTests {
         #expect(prompt.contains("focus, and switch are unavailable in this session"))
         #expect(!prompt.contains(#""action": "open", "name": "Safari""#))
         #expect(prompt.contains("Reuse only an existing exact connection"))
-        #expect(prompt.contains("Create background DevTools pages"))
+        #expect(prompt.contains("Page discovery, navigation, snapshots, and DOM element actions are unavailable"))
+        #expect(prompt.contains("`dom_click`, raw `evaluate_script`"))
+        #expect(prompt.contains("Do not guess hidden page"))
+        #expect(prompt.contains("Do not open or navigate browser pages"))
+        #expect(!prompt.contains("prefer opening a background page"))
         #expect(prompt.contains("Observation never focuses the target by default"))
         #expect(prompt.contains("Only set `web_focus: true`"))
         #expect(!prompt.contains("capture and focus background apps"))
         #expect(!prompt.contains("`launch_app` tool"))
+    }
+
+    @Test
+    func `foreground prompt scopes browser navigation to Chrome and preserves Safari`() {
+        guard #available(macOS 14.0, *) else { return }
+        let prompt = AgentSystemPrompt.generate(executionPolicy: .foregroundAllowed)
+
+        #expect(prompt.contains("Trusted browser pointer, form-fill, focused-keyboard, and upload actions"))
+        #expect(prompt.contains("only when foreground browser interaction is intentional"))
+        #expect(prompt.contains("`dom_click` avoids Puppeteer pointer input"))
+        #expect(prompt.contains("must remain foreground-authorized"))
+        #expect(prompt.contains("synthetic, not trusted pointer input"))
+        #expect(prompt.contains("a successful return is not proof"))
+        #expect(prompt.contains("Never use a fallback to bypass a foreground-consent refusal"))
+        #expect(prompt.contains("When starting a separate Chrome web task, open a new page only through"))
+        #expect(prompt.contains(#""action": "open", "name": "Safari""#))
     }
 
     @Test

--- a/Core/PeekabooCore/Tests/PeekabooAgentRuntimeTests/BrowserToolCapabilityIntegrationTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooAgentRuntimeTests/BrowserToolCapabilityIntegrationTests.swift
@@ -9,6 +9,166 @@ import Testing
 @MainActor
 struct BrowserToolCapabilityIntegrationTests {
     @Test
+    func `foreground DOM click retains exact binding preflight and mutation accounting`() async throws {
+        let client = CapabilityBrowserMCPClient()
+        let coordinator = CapabilityMutationCoordinator()
+        let context = Self.context(
+            client: client,
+            coordinator: coordinator,
+            executionPolicy: .foregroundAllowed)
+        let tool = BrowserTool(context: context)
+        let arguments = try await Self.domClickArguments(context: context, tool: tool)
+        #expect(coordinator.sharedPrepareCount == 2)
+        #expect(coordinator.completionCount == 2)
+        let status = await client.status(channel: nil)
+
+        let response = try await context.execute(tool: tool, arguments: arguments)
+
+        #expect(!response.isError)
+        let calls = try #require(client.sequences.last)
+        #expect(calls.count == 1)
+        let call = try #require(calls.first)
+        #expect(call.toolName == "evaluate_script")
+        #expect(call.arguments["pageId"] as? Int == 7)
+        #expect(call.arguments["args"] as? [String] == ["1_0"])
+        #expect(client.sessionBindings.last?.connectionReceipt == status.connectionReceipt)
+        #expect(client.sessionBindings.last?.providerSessionEpoch == status.providerSessionEpoch)
+        #expect(client.elementPreflights.last == BrowserMCPElementPreflight(
+            providerPageID: 7,
+            providerUIDs: ["1_0"]))
+        let meta = try #require(response.meta?.objectValue)
+        #expect(meta["state"] == .string("dispatched_unverified"))
+        #expect(meta["delivery_mode"] == .string("foreground"))
+        #expect(meta["dispatched_unit_count"] == .int(1))
+        #expect(meta["retry_safe"] == .bool(false))
+        #expect(coordinator.sharedPrepareCount == 3)
+        #expect(coordinator.concurrentPrepareCount == 0)
+        #expect(coordinator.completionCount == 3)
+
+        let replay = try await context.execute(tool: tool, arguments: arguments)
+        #expect(replay.isError)
+        #expect(client.sequences.count == 3)
+    }
+
+    @Test(arguments: [
+        "raw-page",
+        "raw-element",
+        "other-caller",
+        "other-page",
+        "wrong-page",
+        "new-snapshot",
+        "navigation",
+    ])
+    func `DOM click refuses invalid capabilities before atomic provider dispatch`(variant: String) async throws {
+        let client = CapabilityBrowserMCPClient()
+        let context = Self.context(client: client, executionPolicy: .foregroundAllowed)
+        let tool = BrowserTool(context: context)
+        let arguments = try await Self.domClickArguments(context: context, tool: tool)
+        var raw = arguments.rawDictionary
+        switch variant {
+        case "raw-page":
+            raw["page_id"] = 7
+        case "raw-element":
+            raw["uid"] = "1_0"
+        case "other-caller", "other-page":
+            let other = Self.context(client: client, executionPolicy: .foregroundAllowed)
+            let otherArguments = try await Self.domClickArguments(context: other, tool: BrowserTool(context: other))
+            let key = variant == "other-page" ? "page_id" : "uid"
+            raw[key] = otherArguments.getString(key)
+        case "wrong-page":
+            client.executeHandler = { _ in
+                ToolResponse(content: [], structuredContent: .object([
+                    "pages": .array([8, 7].map { id in .object([
+                        "id": .int(id),
+                        "url": .string("https://example.test/"),
+                    ]) }),
+                ]))
+            }
+            raw["page_id"] = try await Self.pageReference(from: context.execute(
+                tool: tool,
+                arguments: ToolArguments(raw: ["action": "list_pages"])))
+            client.executeHandler = nil
+        case "new-snapshot", "navigation":
+            let prepared = try await context.execute(tool: tool, arguments: ToolArguments(raw: [
+                "action": variant == "new-snapshot" ? "snapshot" : "navigate",
+                "page_id": #require(arguments.getString("page_id")),
+                "url": "https://example.test/after",
+            ]))
+            #expect(!prepared.isError)
+        default:
+            Issue.record("Unhandled fixture")
+        }
+        let dispatchCount = client.sequences.count
+        let preflightCount = client.elementPreflights.count
+
+        let response = try await context.execute(tool: tool, arguments: ToolArguments(raw: raw))
+
+        #expect(response.isError)
+        #expect(client.sequences.count == dispatchCount)
+        #expect(client.elementPreflights.count == preflightCount)
+    }
+
+    @Test(arguments: [false, true])
+    func `DOM click refuses receipt or epoch drift at atomic dispatch`(changeEpoch: Bool) async throws {
+        let client = CapabilityBrowserMCPClient()
+        let context = Self.context(client: client, executionPolicy: .foregroundAllowed)
+        let tool = BrowserTool(context: context)
+        let arguments = try await Self.domClickArguments(context: context, tool: tool)
+        let original = await client.status(channel: nil)
+        let changed = BrowserMCPStatus(
+            isConnected: true,
+            toolCount: 52,
+            detectedBrowsers: [],
+            connectionReceipt: changeEpoch ? original.connectionReceipt : BrowserMCPConnectionReceipt(
+                browserURL: "http://127.0.0.1:9223/",
+                webSocketDebuggerURL: "ws://127.0.0.1:9223/devtools/browser/browser-b",
+                devToolsBrowserID: "browser-b"),
+            providerSessionEpoch: changeEpoch ? BrowserMCPProviderSessionEpoch() : original.providerSessionEpoch)
+        // The first status resolves refs; the second runs inside the atomic provider boundary.
+        client.statusResponses = [original, changed]
+        let dispatchCount = client.sequences.count
+        let preflightCount = client.elementPreflights.count
+
+        let response = try await context.execute(tool: tool, arguments: arguments)
+
+        #expect(response.isError)
+        #expect(client.statusResponses.isEmpty)
+        #expect(client.sequences.count == dispatchCount)
+        #expect(client.elementPreflights.count == preflightCount)
+        #expect(client.sessionBindings.last?.connectionReceipt == original.connectionReceipt)
+        #expect(client.sessionBindings.last?.providerSessionEpoch == original.providerSessionEpoch)
+    }
+
+    @Test
+    func `DOM click preserves foreground cancellation uncertainty and invalidates its element`() async throws {
+        let client = CapabilityBrowserMCPClient()
+        let context = Self.context(client: client, executionPolicy: .foregroundAllowed)
+        let tool = BrowserTool(context: context)
+        let arguments = try await Self.domClickArguments(context: context, tool: tool)
+        client.executeHandler = { _ in
+            throw DesktopActionFailure.indeterminate(
+                delivery: .init(mechanism: .browserProtocol, mode: .background),
+                evidence: .completionUnknown,
+                unitCount: .one,
+                message: "Provider cancelled after accepting the script.")
+        }
+
+        let response = try await context.execute(tool: tool, arguments: arguments)
+
+        #expect(response.isError)
+        let meta = try #require(response.meta?.objectValue)
+        #expect(meta["state"] == .string("indeterminate"))
+        #expect(meta["delivery_mode"] == .string("foreground"))
+        #expect(meta["dispatch_state"] == .string("may_have_dispatched"))
+        #expect(meta["dispatched_unit_count"] == .int(1))
+        #expect(meta["retry_safe"] == .bool(false))
+        #expect(meta["requires_fresh_observation"] == .bool(true))
+        let replay = try await context.execute(tool: tool, arguments: arguments)
+        #expect(replay.isError)
+        #expect(client.sequences.count == 3)
+    }
+
+    @Test
     func `command line and MCP uid schemas distinguish raw provider IDs from opaque capabilities`() throws {
         let context = Self.context(client: CapabilityBrowserMCPClient())
         let commandLineTool = BrowserTool(context: context, instructionAudience: .commandLine)
@@ -241,8 +401,8 @@ struct BrowserToolCapabilityIntegrationTests {
         #expect(Self.text(from: response) == domainResult)
     }
 
-    @Test
-    func `background capability evaluation refuses before status or provider execution`() async throws {
+    @Test(arguments: ["call", "dom_click"])
+    func `background capability evaluation refuses before status or provider execution`(action: String) async throws {
         let client = CapabilityBrowserMCPClient()
         let context = Self.context(client: client, executionPolicy: .backgroundOnly)
         let tool = BrowserTool(context: context)
@@ -251,7 +411,8 @@ struct BrowserToolCapabilityIntegrationTests {
         let response = try await context.execute(
             tool: tool,
             arguments: ToolArguments(raw: [
-                "action": "call",
+                "action": action,
+                "uid": "be1_" + String(repeating: "b", count: 32),
                 "mcp_tool": "evaluate_script",
                 "page_id": pageReference,
                 "mcp_args_json": #"{"function":"() => navigator.userActivation.isActive"}"#,
@@ -260,6 +421,8 @@ struct BrowserToolCapabilityIntegrationTests {
         #expect(response.isError)
         #expect(response.meta?.objectValue?["refusal_reason"] == .string("foreground_consent_required"))
         #expect(response.meta?.objectValue?["mutation_dispatched"] == .bool(false))
+        #expect(response.meta?.objectValue?["dispatch_state"] == .string("none"))
+        #expect(response.meta?.objectValue?["retry_safe"] == .bool(true))
         #expect(client.statusCount == 0)
         #expect(client.sequences.isEmpty)
     }
@@ -962,6 +1125,21 @@ extension BrowserToolCapabilityIntegrationTests {
             mappings: ["2_1": "be1_fixture"]))
     }
 
+    private static func domClickArguments(context: MCPToolContext, tool: BrowserTool) async throws -> ToolArguments {
+        let pageReference = try await Self.pageReference(from: context.execute(
+            tool: tool,
+            arguments: ToolArguments(raw: ["action": "list_pages"])))
+        let snapshot = try await context.execute(tool: tool, arguments: ToolArguments(raw: [
+            "action": "snapshot",
+            "page_id": pageReference,
+        ]))
+        return try ToolArguments(raw: [
+            "action": "dom_click",
+            "page_id": pageReference,
+            "uid": Self.elementReference(from: snapshot),
+        ])
+    }
+
     private static func context(
         client: any BrowserMCPClientProviding,
         coordinator: (any MCPToolSnapshotMutationCoordinating)? = nil,
@@ -984,6 +1162,7 @@ extension BrowserToolCapabilityIntegrationTests {
             clipboard: services.clipboard,
             browser: client,
             snapshotMutationCoordinator: coordinator,
+            snapshotOwner: MCPToolSnapshotOwner(),
             executionPolicy: executionPolicy)
     }
 
@@ -1089,9 +1268,10 @@ private final class CapabilityBrowserMCPClient: BrowserMCPClientProviding, Brows
     let providerSessionEpoch = BrowserMCPProviderSessionEpoch()
     private(set) var sequences: [[BrowserMCPMappedCall]] = []
     private(set) var elementPreflights: [BrowserMCPElementPreflight?] = []
+    private(set) var sessionBindings: [BrowserMCPExecutionSessionBinding] = []
     private(set) var statusCount = 0
     var statusResponses: [BrowserMCPStatus] = []
-    var executeHandler: (@MainActor (String) async -> ToolResponse)?
+    var executeHandler: (@MainActor (String) async throws -> ToolResponse)?
 
     init(structuredResponses: Bool = true, providesEpoch: Bool = true) {
         self.structuredResponses = structuredResponses
@@ -1142,7 +1322,7 @@ private final class CapabilityBrowserMCPClient: BrowserMCPClientProviding, Brows
     {
         self.sequences.append(calls)
         if let executeHandler {
-            let response = await executeHandler(calls.last?.toolName ?? "")
+            let response = try await executeHandler(calls.last?.toolName ?? "")
             return DesktopActionResult(payload: response, outcome: self.outcome(for: calls, response: response))
         }
         let response = self.response(for: calls.last?.toolName)
@@ -1155,6 +1335,7 @@ private final class CapabilityBrowserMCPClient: BrowserMCPClientProviding, Brows
         expectedSessionBinding: BrowserMCPExecutionSessionBinding,
         elementPreflight: BrowserMCPElementPreflight?) async throws -> DesktopActionResult<ToolResponse>
     {
+        self.sessionBindings.append(expectedSessionBinding)
         let current = await self.status(channel: channel)
         guard current.connectionReceipt == expectedSessionBinding.connectionReceipt,
               current.providerSessionEpoch == expectedSessionBinding.providerSessionEpoch

--- a/Core/PeekabooCore/Tests/PeekabooAgentRuntimeTests/BrowserToolCapabilityIntegrationTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooAgentRuntimeTests/BrowserToolCapabilityIntegrationTests.swift
@@ -405,18 +405,50 @@ struct BrowserToolCapabilityIntegrationTests {
     func `background capability evaluation refuses before status or provider execution`(action: String) async throws {
         let client = CapabilityBrowserMCPClient()
         let context = Self.context(client: client, executionPolicy: .backgroundOnly)
-        let tool = BrowserTool(context: context)
-        let pageReference = "bp1_" + String(repeating: "a", count: 32)
+        // Exercise the caller's authority ceiling, not the background catalog's closed-property refusal.
+        let toolContext = Self.context(client: client, executionPolicy: .foregroundAllowed)
+        let tool = BrowserTool(context: toolContext)
+        let status = client.connectedStatus()
+        let binding = try BrowserMCPExecutionSessionBinding(
+            connectionReceipt: #require(status.connectionReceipt),
+            providerSessionEpoch: #require(status.providerSessionEpoch))
+        let capabilities = toolContext.browserCapabilities
+        // Mint genuine refs in memory without calling status or entering the provider.
+        let listed = try await capabilities.project(
+            client.response(for: "list_pages"),
+            calls: [BrowserMCPMappedCall(toolName: "list_pages", arguments: [:])],
+            resolved: nil,
+            sessionBinding: binding)
+        let pageReference = try Self.pageReference(from: listed)
+        let snapshotArguments = try await capabilities.resolve(
+            action: .snapshot,
+            arguments: ToolArguments(raw: ["page_id": pageReference]),
+            sessionBinding: binding)
+        let snapshot = try await capabilities.project(
+            client.response(for: "take_snapshot"),
+            calls: [BrowserMCPMappedCall(toolName: "take_snapshot", arguments: ["pageId": 7])],
+            resolved: snapshotArguments,
+            sessionBinding: binding)
+        let elementReference = try Self.elementReference(from: snapshot)
+        let arguments = ToolArguments(raw: action == "call" ? [
+            "action": action,
+            "mcp_tool": "evaluate_script",
+            "page_id": pageReference,
+            "mcp_args_json": #"{"function":"(element) => element.tagName","args":["\#(elementReference)"]}"#,
+        ] : [
+            "action": action,
+            "page_id": pageReference,
+            "uid": elementReference,
+        ])
+        try MCPToolArgumentValidator.validateClosedProperties(tool: tool, arguments: arguments)
+        let resolved = try await capabilities.resolve(
+            action: #require(BrowserAction(rawValue: action)),
+            arguments: arguments,
+            sessionBinding: binding)
+        #expect(resolved.providerPageID == 7)
+        #expect(resolved.providerUIDs == ["1_0"])
 
-        let response = try await context.execute(
-            tool: tool,
-            arguments: ToolArguments(raw: [
-                "action": action,
-                "uid": "be1_" + String(repeating: "b", count: 32),
-                "mcp_tool": "evaluate_script",
-                "page_id": pageReference,
-                "mcp_args_json": #"{"function":"() => navigator.userActivation.isActive"}"#,
-            ]))
+        let response = try await context.execute(tool: tool, arguments: arguments)
 
         #expect(response.isError)
         #expect(response.meta?.objectValue?["refusal_reason"] == .string("foreground_consent_required"))
@@ -1286,7 +1318,7 @@ private final class CapabilityBrowserMCPClient: BrowserMCPClientProviding, Brows
         return self.connectedStatus()
     }
 
-    private func connectedStatus() -> BrowserMCPStatus {
+    fileprivate func connectedStatus() -> BrowserMCPStatus {
         BrowserMCPStatus(
             isConnected: true,
             toolCount: 52,
@@ -1346,7 +1378,7 @@ private final class CapabilityBrowserMCPClient: BrowserMCPClientProviding, Brows
         return try await self.executeSequenceWithOutcome(calls, channel: channel)
     }
 
-    private func response(for toolName: String?) -> ToolResponse {
+    fileprivate func response(for toolName: String?) -> ToolResponse {
         switch toolName {
         case "list_pages": self.pageResponse()
         case "take_snapshot": self.snapshotResponse()

--- a/Core/PeekabooCore/Tests/PeekabooAgentRuntimeTests/BrowserToolStatusObservationTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooAgentRuntimeTests/BrowserToolStatusObservationTests.swift
@@ -5,12 +5,47 @@ import Testing
 
 @MainActor
 struct BrowserToolStatusObservationTests {
-    @Test
-    func `indeterminate status does not claim disconnection or a zero tool count`() async throws {
+    @Test(arguments: [false, true])
+    func `confirmed status preserves connection and discovery reporting`(isConnected: Bool) async throws {
+        let client = MockBrowserMCPClient(status: BrowserMCPStatus(
+            isConnected: isConnected,
+            toolCount: isConnected ? 29 : 0,
+            detectedBrowsers: [DetectedBrowser(
+                name: "Google Chrome",
+                bundleIdentifier: "com.google.Chrome",
+                processIdentifier: 4242,
+                version: "151.0",
+                channel: .stable)]))
+        let response = try await BrowserTool(client: client, executionPolicy: .unrestricted).execute(
+            arguments: ToolArguments(raw: ["action": "status"]))
+        let text = response.content.compactMap { item -> String? in
+            guard case let .text(value, _, _) = item else { return nil }
+            return value
+        }.joined(separator: "\n")
+        #expect(text.contains(isConnected ? "Connected: yes" : "Connected: no"))
+        #expect(text.contains(isConnected ? "Tools: 29" : "Tools: 0"))
+        #expect(text.contains("Google Chrome 151.0 [stable] pid=4242"))
+        #expect(text.contains("To enable browser control:") == !isConnected)
+        #expect(response.meta?.objectValue?["status_observation"] == .string("confirmed"))
+        #expect(response.meta?.objectValue?["connected"] == .bool(isConnected))
+        #expect(response.meta?.objectValue?["tool_count"] == .int(isConnected ? 29 : 0))
+        #expect(response.meta?.objectValue?["browser_count"] == .int(1))
+        #expect(response.meta?.objectValue?["channels"] == .array([.string("stable")]))
+    }
+
+    @Test(arguments: [false, true])
+    func `indeterminate status does not claim disconnection or fresh browser discovery`(
+        hasCachedBrowser: Bool) async throws
+    {
         let client = MockBrowserMCPClient(status: BrowserMCPStatus(
             isConnected: false,
             toolCount: 0,
-            detectedBrowsers: [],
+            detectedBrowsers: hasCachedBrowser ? [DetectedBrowser(
+                name: "Google Chrome",
+                bundleIdentifier: "com.google.Chrome",
+                processIdentifier: 4242,
+                version: "151.0",
+                channel: .stable)] : [],
             connectionReceipt: BrowserMCPConnectionReceipt(
                 browserURL: "http://127.0.0.1:9222/",
                 webSocketDebuggerURL: "ws://127.0.0.1:9222/devtools/browser/browser-a",
@@ -30,9 +65,14 @@ struct BrowserToolStatusObservationTests {
         #expect(text.contains("Connected: unknown"))
         #expect(text.contains("Tools: unknown"))
         #expect(text.contains("Observation: indeterminate"))
+        #expect(text.contains("Detected Chrome: unknown"))
+        #expect(!text.contains("Detected Chrome: none"))
+        #expect(!text.contains("pid=4242"))
         #expect(!text.contains("To enable browser control:"))
         #expect(response.meta?.objectValue?["connected"] == .null)
         #expect(response.meta?.objectValue?["tool_count"] == .null)
+        #expect(response.meta?.objectValue?["browser_count"] == .null)
+        #expect(response.meta?.objectValue?["channels"] == .null)
         #expect(response.meta?.objectValue?["status_observation"] == .string("indeterminate"))
     }
 }

--- a/Core/PeekabooCore/Tests/PeekabooAgentRuntimeTests/BrowserToolTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooAgentRuntimeTests/BrowserToolTests.swift
@@ -9,6 +9,37 @@ import Testing
 @MainActor
 struct BrowserToolTests {
     @Test
+    func `DOM click maps one exact element without pointer input`() throws {
+        let calls = try BrowserMCPCallMapper.mapSequence(
+            action: .domClick,
+            arguments: ToolArguments(raw: ["page_id": 12, "uid": "12_4"]))
+        #expect(calls.count == 1)
+        let call = try #require(calls.first)
+        #expect(call.toolName == "evaluate_script")
+        #expect(call.arguments["pageId"] as? Int == 12)
+        #expect(call.arguments["args"] as? [String] == ["12_4"])
+        let function = try #require(call.arguments["function"] as? String)
+        #expect(function.contains("element.click()"))
+        #expect(!function.contains("12_4"))
+        #expect(!function.contains("Input."))
+        #expect(!function.contains("mouse."))
+        #expect(BrowserMCPUserActivationPolicy.decision(for: call).requiresForegroundAuthority)
+    }
+
+    @Test(arguments: ["page_id", "uid"])
+    func `DOM click rejects missing target before provider entry`(missing: String) async throws {
+        let client = UserActivationCountingBrowserMCPClient()
+        var raw: [String: Any] = ["action": "dom_click", "page_id": 12, "uid": "12_4"]
+        raw.removeValue(forKey: missing)
+        let response = try await BrowserTool(client: client, executionPolicy: .foregroundAllowed)
+            .execute(arguments: ToolArguments(raw: raw))
+
+        #expect(response.isError)
+        #expect(client.statusCount == 0)
+        #expect(client.executedSequences.isEmpty)
+    }
+
+    @Test
     func `Browser call mapper maps common actions`() throws {
         let click = try BrowserMCPCallMapper.map(
             action: .click,
@@ -307,8 +338,8 @@ struct BrowserToolTests {
         #expect(meta["mutation_dispatched"] == .bool(true))
     }
 
-    @Test
-    func `Browser tool rejects mutation result without canonical outcome`() async throws {
+    @Test(arguments: ["click", "dom_click"])
+    func `Browser tool rejects mutation result without canonical outcome`(action: String) async throws {
         let legacyMeta: Value = .object([
             "provider_field": .string("legacy"),
             "state": .string("provider-defined"),
@@ -318,7 +349,7 @@ struct BrowserToolTests {
             outcome: nil))
         let response = try await BrowserTool(client: client, executionPolicy: .unrestricted)
             .execute(arguments: ToolArguments(raw: [
-                "action": "click",
+                "action": action,
                 "page_id": 7,
                 "uid": "7_9",
             ]))
@@ -328,6 +359,7 @@ struct BrowserToolTests {
         let meta = try #require(response.meta?.objectValue)
         #expect(meta["state"] == .string("indeterminate"))
         #expect(meta["dispatch_state"] == .string("may_have_dispatched"))
+        #expect(meta["delivery_mode"] == .string("foreground"))
         #expect(meta["retry_safe"] == .bool(false))
         #expect(meta["requires_fresh_observation"] == .bool(true))
         #expect(meta["provider_meta"] == nil)
@@ -354,8 +386,8 @@ struct BrowserToolTests {
         ]))
     }
 
-    @Test
-    func `Browser tool rejects successful payload paired with non-success outcome`() async throws {
+    @Test(arguments: ["click", "dom_click"])
+    func `Browser tool rejects successful payload paired with non-success outcome`(action: String) async throws {
         let delivery = DesktopActionOutcome.Delivery(mechanism: .browserProtocol, mode: .background)
         let cases: [DesktopActionOutcome] = [
             .partial(delivery: delivery, unitCount: .one),
@@ -370,7 +402,7 @@ struct BrowserToolTests {
                 outcome: outcome))
             let response = try await BrowserTool(client: client, executionPolicy: .unrestricted)
                 .execute(arguments: ToolArguments(raw: [
-                    "action": "click",
+                    "action": action,
                     "page_id": 7,
                     "uid": "7_9",
                 ]))
@@ -380,6 +412,11 @@ struct BrowserToolTests {
                 "Browser mutation did not return a successful canonical outcome."))
             let meta = try #require(response.meta?.objectValue)
             #expect(meta["state"] == .string(outcome.state.rawValue))
+            if outcome.dispatchState.unitCount != nil {
+                #expect(meta["dispatched_unit_count"] == .int(1))
+                #expect(meta["delivery_mode"] == .string("foreground"))
+                #expect(meta["retry_safe"] == .bool(outcome.retrySafety == .safe))
+            }
         }
     }
 
@@ -412,15 +449,15 @@ struct BrowserToolTests {
         }
     }
 
-    @Test
-    func `Browser tool projects retry safe zero progress refusal`() async throws {
+    @Test(arguments: ["click", "dom_click"])
+    func `Browser tool projects retry safe zero progress refusal`(action: String) async throws {
         let outcome = DesktopActionOutcome.refused(route: .bridge, reason: .targetUnavailable)
         let client = OutcomeBrowserMCPClient(result: .init(
             payload: .error("browser target changed"),
             outcome: outcome))
         let response = try await BrowserTool(client: client, executionPolicy: .unrestricted)
             .execute(arguments: ToolArguments(raw: [
-                "action": "click",
+                "action": action,
                 "page_id": 7,
                 "uid": "7_9",
             ]))
@@ -462,8 +499,8 @@ struct BrowserToolTests {
         #expect(meta["requires_fresh_observation"] == .bool(true))
     }
 
-    @Test
-    func `Browser tool projects unknown progress without inventing a unit count`() async throws {
+    @Test(arguments: ["click", "dom_click"])
+    func `Browser tool projects unknown progress without inventing a unit count`(action: String) async throws {
         let outcome = DesktopActionOutcome.indeterminate(
             route: .bridge,
             delivery: .init(mechanism: .browserProtocol, mode: .background),
@@ -473,7 +510,7 @@ struct BrowserToolTests {
             outcome: outcome))
         let response = try await BrowserTool(client: client, executionPolicy: .unrestricted)
             .execute(arguments: ToolArguments(raw: [
-                "action": "click",
+                "action": action,
                 "page_id": 7,
                 "uid": "7_9",
             ]))
@@ -483,6 +520,7 @@ struct BrowserToolTests {
         #expect(meta["state"] == .string("indeterminate"))
         #expect(meta["dispatch_state"] == .string("may_have_dispatched"))
         #expect(meta["dispatched_unit_count"] == nil)
+        #expect(meta["delivery_mode"] == .string("foreground"))
         #expect(meta["retry_safety"] == .string("unsafe"))
         #expect(meta["requires_fresh_observation"] == .bool(true))
     }
@@ -1025,6 +1063,7 @@ extension BrowserToolTests {
             executionPolicy: .backgroundOnly,
             instructionAudience: .commandLine)
         let cases: [[String: Any]] = [
+            ["action": "dom_click", "page_id": 1, "uid": "1_0"],
             ["action": "list_pages"],
             ["action": "snapshot", "page_id": 1],
             ["action": "console", "page_id": 1, "message_id": 1],

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPPolicyAwareCatalogTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPPolicyAwareCatalogTests.swift
@@ -139,7 +139,7 @@ struct MCPPolicyAwareCatalogTests {
             BrowserMCPUserActivationPolicy.backgroundCatalogActions.map(\.rawValue)))
         for hidden in [
             BrowserAction.connect, .listPages, .selectPage, .closePage, .newPage, .navigate, .waitFor, .snapshot,
-            .click, .fill, .fillForm, .drag, .hover, .type, .pressKey, .uploadFile, .handleDialog,
+            .click, .domClick, .fill, .fillForm, .drag, .hover, .type, .pressKey, .uploadFile, .handleDialog,
         ] {
             #expect(!actions.contains(.string(hidden.rawValue)))
         }
@@ -169,6 +169,7 @@ struct MCPPolicyAwareCatalogTests {
         #expect(foregroundActions.contains(.string(BrowserAction.connect.rawValue)))
         #expect(foregroundActions.contains(.string(BrowserAction.listPages.rawValue)))
         #expect(foregroundActions.contains(.string(BrowserAction.snapshot.rawValue)))
+        #expect(foregroundActions.contains(.string(BrowserAction.domClick.rawValue)))
         #expect(foregroundProperties["browser_url"] != nil)
         #expect(foregroundProperties["uid"] != nil)
         #expect(foregroundProperties["message_id"] != nil)

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeBrowserClientTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeBrowserClientTests.swift
@@ -2,13 +2,161 @@ import Darwin
 import Foundation
 import MCP
 import PeekabooAgentRuntime
-import PeekabooAutomationKit
 import PeekabooBridgeTestSupport
 import PeekabooFoundation
 import TachikomaMCP
 import Testing
+@testable import PeekabooAutomationKit
 @testable import PeekabooBridge
 @testable import PeekabooCore
+
+extension PeekabooBridgeBrowserClientTests {
+    @Test(arguments: [false, true])
+    @MainActor
+    func `unscoped status distinguishes confirmed absence from transport timeout`(timesOut: Bool) async throws {
+        let version = Self.legacyBrowserConnectVersion
+        let peer = try ScriptedBridgePeer(scripts: [
+            [.respond(.handshake(BridgeTestFixtures.handshake(
+                negotiatedVersion: version,
+                supportedOperations: [.browserStatus])))],
+            timesOut ? [.idle(seconds: 0.3)] : [.respond(.browserStatus(.init(
+                isConnected: false,
+                toolCount: 0,
+                detectedBrowsers: [])))],
+        ], socketPathPrefix: "pr660-status")
+        let bridge = PeekabooBridgeClient(socketPath: peer.socketPath, requestTimeoutSec: 0.1)
+        _ = try await bridge.handshake(client: .init(
+            bundleIdentifier: "dev.peekaboo.status-tests",
+            teamIdentifier: nil,
+            processIdentifier: getpid()), protocolVersion: version)
+        let client = RemoteBrowserMCPClient(client: bridge)
+        let response = try await BrowserTool(client: client, executionPolicy: .unrestricted).execute(
+            arguments: ToolArguments(raw: ["action": "status"]))
+        let text = response.content.compactMap { item -> String? in
+            guard case let .text(value, _, _) = item else { return nil }
+            return value
+        }.joined(separator: "\n")
+        let meta = try #require(response.meta?.objectValue)
+        #expect(!response.isError)
+        #expect(meta["status_observation"] == .string(timesOut ? "indeterminate" : "confirmed"))
+        #expect(meta["connected"] == (timesOut ? .null : .bool(false)))
+        #expect(meta["tool_count"] == (timesOut ? .null : .int(0)))
+        #expect(meta["browser_count"] == (timesOut ? .null : .int(0)))
+        #expect(meta["channels"] == (timesOut ? .null : .array([])))
+        #expect(text.contains(timesOut ? "Connected: unknown" : "Connected: no"))
+        #expect(text.contains(timesOut ? "Tools: unknown" : "Tools: 0"))
+        #expect(text.contains(timesOut ? "Detected Chrome: unknown" : "Detected Chrome: none"))
+        #expect(text.contains("To enable browser control:") == !timesOut)
+        #expect(text.contains("Error:") == timesOut)
+        if timesOut {
+            #expect(text.contains(POSIXError(.ETIMEDOUT).localizedDescription))
+        }
+        #expect(meta["mutation_dispatched"] == nil)
+        await peer.waitUntilFinished()
+        let requests = await peer.requests
+        #expect(requests.count == 2)
+        for data in requests.dropFirst() {
+            let request = try JSONDecoder.peekabooBridgeDecoder().decode(PeekabooBridgeRequest.self, from: data)
+            #expect(request.operation == .browserStatus)
+        }
+    }
+
+    @Test(arguments: [false, true])
+    @MainActor
+    func `unattributed connect preserves bounded typed diagnostics and unsafe outcome`(longCause: Bool) async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("pr660-connect-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let store = DesktopMutationWatermarkStore(directoryURL: root.appendingPathComponent("watermarks"))
+        let services = StubServices(snapshots: InMemorySnapshotManager(desktopMutationWatermarkStore: store))
+        let original = DesktopActionFailure.indeterminate(
+            delivery: .init(mechanism: .browserProtocol, mode: .foreground),
+            evidence: .completionUnknown,
+            unitCount: .one,
+            message: "Browser connection completion is unknown after the provider accepted the request.",
+            hint: "Check browser status before deciding whether to reconnect.",
+            causeDescription: "Fixture approval deadline elapsed." +
+                (longCause ? String(repeating: "x", count: 5000) : ""))
+        services.browserConnectError = PeekabooBridgeErrorEnvelope(
+            code: .internalError,
+            actionFailure: original,
+            details: "RAW-DIAGNOSTIC-NOT-FOR-PROJECTION")
+        let server = PeekabooBridgeServer(
+            services: services,
+            allowlistedTeams: [],
+            allowlistedBundles: [],
+            desktopMutationWatermarkStore: store,
+            desktopOperationLaneCoordinator: DesktopOperationLaneCoordinator(
+                coordinationRootURL: root.appendingPathComponent("coordination")),
+            permissionStatusEvaluator: { _ in
+                PermissionsStatus(screenRecording: true, accessibility: true, postEvent: true)
+            })
+        // Keep the Unix-socket pathname below the platform limit; all persistent fixture state is owned above.
+        let socketPath = "/tmp/pr660-connect-\(UUID().uuidString).sock"
+        let host = PeekabooBridgeHost(socketPath: socketPath, server: server, allowedTeamIDs: [])
+        try await host.startChecked()
+        do {
+            let bridge = TrustedBridgeClientFixture.make(
+                socketPath: socketPath,
+                operationReceiptExportDirectory: root.appendingPathComponent("receipts"))
+            _ = try await bridge.handshake(client: .init(
+                bundleIdentifier: "dev.peekaboo.connect-diagnostic-tests",
+                teamIdentifier: nil,
+                processIdentifier: getpid()))
+            let client = RemoteBrowserMCPClient(client: bridge)
+            let response = try await BrowserTool(client: client, executionPolicy: .unrestricted).execute(
+                arguments: ToolArguments(raw: ["action": "connect", "channel": "stable"]))
+            #expect(response.isError)
+            let text = response.content.compactMap { item -> String? in
+                guard case let .text(value, _, _) = item else { return nil }
+                return value
+            }.joined(separator: "\n")
+            let meta = try #require(response.meta?.objectValue)
+            #expect(meta["state"] == .string("indeterminate"))
+            #expect(meta["dispatch_state"] == .string("may_have_dispatched"))
+            #expect(meta["dispatched_unit_count"] == .int(1))
+            #expect(meta["retry_safe"] == .bool(false))
+            let bundle = try #require(await bridge.lastOperationReceiptBundle())
+            let canonicalResponse = try JSONDecoder.peekabooBridgeDecoder().decode(
+                PeekabooBridgeResponse.self, from: bundle.canonicalResponse)
+            guard case let .projectedAction(projected) = canonicalResponse,
+                  case let .error(envelope) = projected.response
+            else {
+                Issue.record("Expected a projected attribution failure in the verified receipt bundle")
+                await host.stop()
+                return
+            }
+            let failure = try #require(envelope.desktopActionFailure)
+            #expect(failure.message == "Bridge operation completed without a trustworthy exact target receipt.")
+            let cause = try #require(failure.causeDescription)
+            #expect(cause.contains(original.message))
+            #expect(cause.contains("Fixture approval deadline elapsed."))
+            #expect(cause.contains(DesktopTargetIdentityError.incompleteExactWindow.localizedDescription))
+            #expect(!cause.contains("RAW-DIAGNOSTIC-NOT-FOR-PROJECTION"))
+            #expect(text.contains(cause))
+            #expect(envelope.details == nil)
+            #expect(envelope.operationMayHaveCompleted)
+            #expect(cause.count < 2500)
+            #expect(failure.outcome == original.outcome.routed(to: .bridge))
+            #expect(failure.outcome.dispatchState.unitCount == .one)
+            #expect(failure.outcome.retrySafety == .unsafe)
+            #expect(failure.targetReceipt == nil)
+            #expect(failure.selectedLeafEvidence == nil)
+            let receipt = bundle.receipt
+            #expect(receipt.payload.target == nil)
+            #expect(receipt.payload.targetAttributionFailure?.code == .incompleteExactWindow)
+            #expect(receipt.payload.targetAttributionFailure?.stage == .postExecution)
+            #expect(receipt.payload.outcome == failure.outcome.projection)
+            #expect(services.browserConnectResultCallCount == 1)
+            #expect(services.lastBrowserStatusChannel == nil)
+            #expect(services.lastBrowserExecute == nil)
+        } catch {
+            await host.stop()
+            throw error
+        }
+        await host.stop()
+    }
+}
 
 struct PeekabooBridgeBrowserClientTests {
     @Test
@@ -825,6 +973,7 @@ extension StubServices: PeekabooBridgeBrowserConnectionResultProviding {
         channel: String?,
         browserURL: String?) async throws -> DesktopActionResult<PeekabooBridgeBrowserStatus>
     {
+        self.browserConnectResultCallCount += 1
         if let browserConnectError {
             throw browserConnectError
         }

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeTests.swift
@@ -2208,6 +2208,7 @@ final class StubServices: PeekabooBridgeServiceProviding {
     var browserStatusError: (any Error)?
     var browserConnectFailure: DesktopActionFailure?
     var browserConnectError: (any Error)?
+    var browserConnectResultCallCount = 0
     var browserConnectOutcome = DesktopActionOutcome.dispatchedUnverified(
         delivery: .init(mechanism: .browserProtocol, mode: .foreground),
         evidence: .deliveryAccepted,

--- a/Core/PeekabooCore/Tests/PeekabooTests/RemoteBrowserMCPSessionTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/RemoteBrowserMCPSessionTests.swift
@@ -444,8 +444,8 @@ struct RemoteBrowserMCPSessionTests {
         #expect(transport.openedHandoffs == [firstHandoff.payload, secondHandoff.payload])
     }
 
-    @Test
-    func `remote MCP mints opaque refs and refuses raw or copied refs before transport`() async throws {
+    @Test(arguments: ["click", "dom_click"])
+    func `remote MCP mints opaque refs and refuses raw or copied refs before transport`(action: String) async throws {
         let transport = RecordingRemoteBrowserSessionTransport()
         let root = Self.rootClient(transport: transport)
         let base = Self.context(browser: root, executionPolicy: .foregroundAllowed)
@@ -494,7 +494,7 @@ struct RemoteBrowserMCPSessionTests {
         let rawElement = try await first.execute(
             tool: firstTool,
             arguments: ToolArguments(raw: [
-                "action": "click",
+                "action": action,
                 "page_id": pageReference,
                 "uid": "1_0",
             ]))
@@ -504,7 +504,7 @@ struct RemoteBrowserMCPSessionTests {
         let clicked = try await first.execute(
             tool: firstTool,
             arguments: ToolArguments(raw: [
-                "action": "click",
+                "action": action,
                 "page_id": pageReference,
                 "uid": elementReference,
             ]))
@@ -512,6 +512,12 @@ struct RemoteBrowserMCPSessionTests {
         #expect(transport.executeCallCount == dispatchCount + 1)
         #expect(transport.elementPreflights.last??.providerPageID == 7)
         #expect(transport.elementPreflights.last??.providerUIDs == ["1_0"])
+        #expect(clicked.meta?.objectValue?["delivery_mode"] == .string("foreground"))
+        let evidence = try #require(clicked.meta?.objectValue?[BrowserMCPExecutionEvidence.metadataKey]?.objectValue)
+        #expect(evidence["completed_call_count"] == .int(1))
+        #expect(evidence["dispatched_call_count"] == .int(1))
+        #expect(evidence["connection_receipt"] != nil)
+        #expect(evidence["provider_session_epoch"] != nil)
     }
 
     @Test

--- a/docs/browser-mcp.md
+++ b/docs/browser-mcp.md
@@ -187,6 +187,7 @@ Common actions:
 - `wait_for`
 - `snapshot`
 - `click`
+- `dom_click`
 - `fill`
 - `type`
 - `press_key`
@@ -226,6 +227,20 @@ compatibility boundary rather than a persistent caller capability namespace. `se
 page visually behind other apps, but remain foreground-authority operations because their provider response formatting
 grants browser user activation. Use `bring_to_front: true` or `background: false` only when visible foreground
 interaction is intentional.
+
+`dom_click` invokes one synthetic `element.click()` via `evaluate_script`, without CDP/Puppeteer pointer input.
+It uses the existing exact connection receipt, caller-owned page and element references, provider child epoch, and
+fresh element preflight under the same execution gate. Newer snapshots, navigation, session end, or connection/epoch
+replacement invalidate the relevant references; copied references from another caller never authorize dispatch.
+The pinned evaluation route still grants browser user activation. Background sessions hide and refuse `dom_click`
+before provider I/O; explicit foreground sessions report foreground browser-protocol delivery. This is not a
+background-safe route or a guarantee that Chrome cannot activate.
+
+Synthetic click is not trusted pointer input: it does not move or hit-test the pointer or emit a pointer-down/up
+sequence, disabled controls may do nothing, and handlers requiring trusted input may not react. `double` and
+`include_snapshot` do not apply. A successful script return is not final-effect proof: inspect the intended page
+afterward to confirm the handler or navigation actually took effect. Accepted or uncertain dispatch remains
+retry-unsafe; do not blindly replay a click after failure or cancellation.
 
 `type` and `press_key` also require an opaque element reference from the newest snapshot as `uid`. Peekaboo holds one browser execution gate while it
 focuses that exact uid and sends the keyboard operation; concurrent page work cannot interleave between those leaves.

--- a/docs/commands/browser.md
+++ b/docs/commands/browser.md
@@ -41,6 +41,13 @@ In `--json` output, canonical action outcome, effect, retry safety, mutation-dis
 metadata are projected into the standard root CLI envelope. The original MCP metadata remains under `data.meta` for
 tool-specific consumers.
 
+If a status request times out or its transport fails, connection state, tool count, and Chrome discovery are unknown,
+not a confirmed disconnection or absence. Output marks `status_observation=indeterminate` and uses JSON `null` for
+`connected`, `tool_count`, `browser_count`, and `channels`. Any retained exact connection fields identify only the
+last confirmed connection. A failed status observation does not explain or resolve an earlier uncertain action.
+If connect may have dispatched but cannot supply trustworthy target attribution, it remains indeterminate and unsafe
+to retry; its bounded original failure diagnostic accompanies the attribution error without creating a target receipt.
+
 `dom-click --page-id <id> --uid <uid> --foreground` invokes one synthetic `element.click()` through the pinned
 provider's `evaluate_script` route. It avoids CDP/Puppeteer pointer input, but evaluation still grants browser user
 activation: background mode refuses before provider I/O and authorized calls report foreground delivery. It is not

--- a/docs/commands/browser.md
+++ b/docs/commands/browser.md
@@ -41,6 +41,18 @@ In `--json` output, canonical action outcome, effect, retry safety, mutation-dis
 metadata are projected into the standard root CLI envelope. The original MCP metadata remains under `data.meta` for
 tool-specific consumers.
 
+`dom-click --page-id <id> --uid <uid> --foreground` invokes one synthetic `element.click()` through the pinned
+provider's `evaluate_script` route. It avoids CDP/Puppeteer pointer input, but evaluation still grants browser user
+activation: background mode refuses before provider I/O and authorized calls report foreground delivery. It is not
+background-safe and does not guarantee Chrome will remain behind another app.
+
+This is not a trusted pointer click: it does not move the pointer, hit-test, or send a pointer-down/up sequence.
+Disabled controls can do nothing, and handlers requiring trusted input may not react. `double` and `include_snapshot`
+do not apply. A successful script return means only that the invocation returned, not that a handler ran, navigation
+completed, or the intended effect occurred. Observe the intended page before deciding whether to retry.
+The CLI retains its existing numeric page ID and snapshot-local UID compatibility boundary; this action does not add
+durable cross-invocation capabilities. Persistent MCP/Agent callers use the caller-owned references described below.
+
 Browser state is owned by one current-build reusable daemon across CLI invocations. Channel connection requires exactly
 one running official Google-signed Chrome process (Team ID `EQHXZ8M8AV`). Peekaboo pins the signed channel identifier,
 Team ID, and CDHash to its PID generation, safely reads that channel's standard `DevToolsActivePort`, proves its unique

--- a/scripts/test-chrome-devtools-mcp-contract.mjs
+++ b/scripts/test-chrome-devtools-mcp-contract.mjs
@@ -311,6 +311,16 @@ assert.match(
   "evaluate_script no longer enters Puppeteer evaluation",
 );
 assert.match(
+  scriptToolSource,
+  /await evaluatable\.evaluate\(/,
+  "re-audit the synthetic DOM click evaluation route",
+);
+assert.doesNotMatch(
+  scriptToolSource,
+  /\bInput\.|\.mouse\./,
+  "evaluate_script unexpectedly reaches trusted pointer input",
+);
+assert.match(
   waitForHelperSource,
   /this\.#page\.evaluateHandle\(timeout =>/,
   "provider wait-for-action stabilization no longer enters Puppeteer evaluation",


### PR DESCRIPTION
## Summary

Add explicit foreground-only `dom_click` / `dom-click` through the existing browser capability and receipt boundary. It dispatches one synthetic `HTMLElement.click()` via the pinned provider’s `evaluate_script`; it is not trusted pointer input, not background-safe, and dispatch alone does not establish the page’s final effect. Preserve caller authority, provider epoch, page/snapshot/document validation and target receipts. Update CLI/MCP/Agent guidance and exercise consent refusal with action-valid arguments.

Correct two inherited reporting defects found while validating this path: an unscoped remote status timeout reports indeterminate/unknown state rather than confirmed absence, and a failed target-attribution projection retains the bounded original typed diagnostic alongside its attribution error. Neither correction synthesizes target authority, weakens receipt checks, changes dispatch counts, or makes an indeterminate action safe to retry. Raw envelope details are not copied.

PR648’s durable native-window capability namespaces remain explicitly deferred and are not included or closed by this PR.

## Validation

All exact-head checks passed at `fbbb1b38a894a77aeffc945a1c0410660fa9a594`: [macOS CI](https://github.com/openclaw/Peekaboo/actions/runs/33627883934), [full supplemental validation](https://github.com/openclaw/Peekaboo/actions/runs/33627883936), and [CodeQL](https://github.com/openclaw/Peekaboo/actions/runs/33627883881). All four supplemental groups passed. The actual hosted Core log independently confirms that all four reporting functions and eight parameterized cases executed and passed.

The original focused DOM/browser selection passed 128 tests in four suites. The inert pinned-provider contract passed against `chrome-devtools-mcp` 1.6.0 without connecting Chrome: 32 page-scoped, 35 page-targeted, 16 global and one blocked-selected-page case.

The local reporting regression selection executed four functions and eight cases. Reversing only the four reporting production edits produced five failing cases and 21 intended reporting assertions; exact restoration passed all eight. Two repeats also passed, and ten adjacent connect-outcome tests passed. Outcome, dispatch count, unsafe retry, receipt integrity and absent target/selected-leaf assertions remained sensitive.

The test sandbox caught an initial shared-coordinator fixture’s attempted operator-home access. The fixture now injects the existing coordinator under its owned directory alongside owned watermark and receipt stores; no production coordinator behavior or assertion changed. Earlier unsigned-bundle loading, relocated-cache and original-fixture failures remain preserved and are not counted as intended red/green proof. Final credentialless test execution retained operator-home, Keychain, external-network and codesign-process restrictions, using only the linker’s normal unit-test signature.

Scoped formatting/lint, whitespace checks and the complete integrated Codex P0 review passed. The rebased branch tree matches the reviewed integration exactly. PR680’s separately reviewed ambient-test gates touch disjoint files; composition with current main was verified in both merge orders without rewriting this tested head.

## Native limitation

An Xcode 27-built, Foundation-signed earlier candidate ran on the authorized macOS 27 worker. The extension relay was unavailable. One explicitly foreground, direct real-profile connection attempt returned an indeterminate, unsafe-to-retry outcome. Its subsequent status attempt also timed out; the old fallback’s “Connected: no” was not a confirmed observation and did not establish the original connection failure’s cause.

No connection retry, page creation/navigation, DOM click or final page-effect proof occurred. Native DOM-click behavior therefore remains unverified. Reporting fixes were proved with owned local transport/receipt fixtures and hosted tests, not misrepresented as a successful real-browser retry. Owned test daemons were stopped afterward; Chrome and other unowned processes were left untouched.

No changelog or release publication is included.
