### PR TITLE
test(cli): isolate runtime and Bridge fixtures

### DIFF
--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -283,6 +283,16 @@ jobs:
           swift test --no-parallel -Xswiftc -DPEEKABOO_SKIP_AUTOMATION \
             --filter 'AgentCommandBasicTests|AgentCommandValidationIntegrationTests'
 
+      - name: Run See configuration environment regressions
+        working-directory: Apps/CLI
+        env:
+          PEEKABOO_INCLUDE_AUTOMATION_TESTS: "true"
+          PEEKABOO_INCLUDE_AMBIENT_STATE_TESTS: "false"
+          PEEKABOO_CONFIG_DISABLE_MIGRATION: "1"
+        run: |
+          swift test --no-parallel -Xswiftc -DPEEKABOO_SKIP_AUTOMATION \
+            --filter 'SeeCommandRuntimeTests/config environment restores (inherited values|nested throwing bodies)'
+
   tachikoma:
     name: Tachikoma build & tests
     runs-on: macos-26

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -290,8 +290,7 @@ jobs:
           PEEKABOO_INCLUDE_AMBIENT_STATE_TESTS: "false"
           PEEKABOO_CONFIG_DISABLE_MIGRATION: "1"
         run: |
-          swift test --no-parallel -Xswiftc -DPEEKABOO_SKIP_AUTOMATION \
-            --filter 'SeeCommandRuntimeTests/config environment restores (inherited values|nested throwing bodies)'
+          python3 ../../scripts/test-see-config-environment.py
 
   tachikoma:
     name: Tachikoma build & tests

--- a/Apps/CLI/Tests/CLIAutomationTests/SeeCommandTests.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/SeeCommandTests.swift
@@ -272,6 +272,76 @@ struct SeeCommandTests {
 
 @Suite(.serialized, .tags(.fast))
 struct SeeCommandRuntimeTests {
+    @Test(arguments: [false, true])
+    @MainActor
+    func `config environment restores inherited values`(werePresent: Bool) async throws {
+        let inherited = SeeConfigEnvironment()
+        defer { inherited.restore() }
+        let seeded = SeeConfigEnvironment(values: werePresent ? ["/fixture/inherited", "interactive", "false"] : [
+            nil, nil, nil,
+        ])
+        seeded.restore()
+        let directory = URL(fileURLWithPath: "/fixture/temporary")
+        var resets: [SeeConfigEnvironment] = []
+
+        let result = try await withSeeConfigEnvironment(
+            directory: directory,
+            resetConfiguration: { resets.append(SeeConfigEnvironment()) },
+            body: { receivedDirectory in
+                #expect(receivedDirectory == directory)
+                #expect(SeeConfigEnvironment().values == [directory.path, "1", "1"])
+                return 42
+            }
+        )
+
+        #expect(result == 42)
+        #expect(SeeConfigEnvironment() == seeded)
+        #expect(resets == [SeeConfigEnvironment(values: [directory.path, "1", "1"]), seeded])
+    }
+
+    @Test
+    @MainActor
+    func `config environment restores nested throwing bodies`() async throws {
+        let inherited = SeeConfigEnvironment()
+        defer { inherited.restore() }
+        let seeded = SeeConfigEnvironment(values: ["/fixture/inherited", "", "false"])
+        seeded.restore()
+        let outer = URL(fileURLWithPath: "/fixture/outer")
+        let inner = URL(fileURLWithPath: "/fixture/inner")
+        var resets: [SeeConfigEnvironment] = []
+
+        do {
+            try await withSeeConfigEnvironment(
+                directory: outer,
+                resetConfiguration: { resets.append(SeeConfigEnvironment()) },
+                body: { _ in
+                    do {
+                        try await withSeeConfigEnvironment(
+                            directory: inner,
+                            resetConfiguration: { resets.append(SeeConfigEnvironment()) },
+                            body: { _ in
+                                #expect(SeeConfigEnvironment().values == [inner.path, "1", "1"])
+                                throw SeeConfigEnvironmentTestError.failed
+                            }
+                        )
+                        Issue.record("Expected the inner configuration body to throw")
+                    } catch SeeConfigEnvironmentTestError.failed {}
+                    #expect(SeeConfigEnvironment().values == [outer.path, "1", "1"])
+                    throw SeeConfigEnvironmentTestError.failed
+                }
+            )
+            Issue.record("Expected the outer configuration body to throw")
+        } catch SeeConfigEnvironmentTestError.failed {}
+
+        #expect(SeeConfigEnvironment() == seeded)
+        #expect(resets == [
+            SeeConfigEnvironment(values: [outer.path, "1", "1"]),
+            SeeConfigEnvironment(values: [inner.path, "1", "1"]),
+            SeeConfigEnvironment(values: [outer.path, "1", "1"]),
+            seeded,
+        ])
+    }
+
     @Test
     @MainActor
     func `tree only See propagates its remaining timeout to accessibility inspection`() async throws {
@@ -1040,8 +1110,9 @@ struct SeeCommandRuntimeTests {
         }
     }
 
+    @MainActor
     func withTempConfigEnv<T>(
-        _ body: @escaping (URL) async throws -> T
+        _ body: @escaping @MainActor (URL) async throws -> T
     ) async throws -> T {
         let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
             UUID().uuidString,
@@ -1049,25 +1120,66 @@ struct SeeCommandRuntimeTests {
         )
         try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
 
-        setenv("PEEKABOO_CONFIG_DIR", tempDir.path, 1)
-        setenv("PEEKABOO_CONFIG_NONINTERACTIVE", "1", 1)
-        setenv("PEEKABOO_CONFIG_DISABLE_MIGRATION", "1", 1)
-        #if DEBUG
-        ConfigurationManager.shared.resetForTesting()
-        #endif
-
-        defer {
-            unsetenv("PEEKABOO_CONFIG_DIR")
-            unsetenv("PEEKABOO_CONFIG_NONINTERACTIVE")
-            unsetenv("PEEKABOO_CONFIG_DISABLE_MIGRATION")
-            #if DEBUG
-            ConfigurationManager.shared.resetForTesting()
-            #endif
-            try? FileManager.default.removeItem(at: tempDir)
-        }
-
-        return try await body(tempDir)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+        return try await withSeeConfigEnvironment(
+            directory: tempDir,
+            resetConfiguration: {
+                #if DEBUG
+                ConfigurationManager.shared.resetForTesting()
+                #endif
+            },
+            body: body
+        )
     }
+}
+
+private struct SeeConfigEnvironment: Equatable {
+    private static let names = [
+        "PEEKABOO_CONFIG_DIR", "PEEKABOO_CONFIG_NONINTERACTIVE", "PEEKABOO_CONFIG_DISABLE_MIGRATION",
+    ]
+
+    let values: [String?]
+
+    init(values: [String?]) {
+        precondition(values.count == Self.names.count)
+        self.values = values
+    }
+
+    init() {
+        self.values = Self.names.map { name in getenv(name).map { String(cString: $0) } }
+    }
+
+    func restore() {
+        for (name, value) in zip(Self.names, self.values) {
+            if let value {
+                setenv(name, value, 1)
+            } else {
+                unsetenv(name)
+            }
+        }
+    }
+}
+
+private enum SeeConfigEnvironmentTestError: Error {
+    case failed
+}
+
+/// Callers belong to the serialized See runtime suite; regression tests inject an inert reset callback.
+/// Run focused proof with --no-parallel: environment changes also affect sibling suites.
+@MainActor
+private func withSeeConfigEnvironment<T>(
+    directory: URL,
+    resetConfiguration: () -> Void,
+    body: @MainActor (URL) async throws -> T
+) async throws -> T {
+    let inherited = SeeConfigEnvironment()
+    SeeConfigEnvironment(values: [directory.path, "1", "1"]).restore()
+    resetConfiguration()
+    defer {
+        inherited.restore()
+        resetConfiguration()
+    }
+    return try await body(directory)
 }
 
 extension SeeCommandRuntimeTests {

--- a/Apps/CLI/Tests/CoreCLITests/BridgeReceiptCommandTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/BridgeReceiptCommandTests.swift
@@ -80,29 +80,30 @@ struct BridgeReceiptCommandTests {
     #if DEBUG
     @Test
     func `validator authenticates a live listener independently from the exported bundle`() async throws {
-        let root = URL(
-            fileURLWithPath: "/tmp/pb-receipt-\(UUID().uuidString)",
-            isDirectory: true
-        )
-        let socketPath = root.appendingPathComponent("bridge.sock").path
-        let exportDirectory = root.appendingPathComponent("exports", isDirectory: true)
-        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
-        defer { try? FileManager.default.removeItem(at: root) }
+        try await CLIBridgeHostFixture.withHosts { fixture in
+            let root = fixture.desktop.root
+            let socketPath = root.appendingPathComponent("bridge.sock").path
+            let exportDirectory = root.appendingPathComponent("exports", isDirectory: true)
 
-        let server = PeekabooBridgeServer(
-            services: PeekabooServices(),
-            allowlistedTeams: [],
-            allowlistedBundles: []
-        )
-        let host = PeekabooBridgeHost(
-            socketPath: socketPath,
-            server: server,
-            allowedTeamIDs: [],
-            requestTimeoutSec: 2
-        )
-        try await host.startChecked()
+            let server = PeekabooBridgeServer(
+                services: CLISnapshotBridgeServices(snapshots: InMemorySnapshotManager(), directory: root),
+                allowlistedTeams: [],
+                allowlistedBundles: [],
+                allowedOperations: [.permissionsStatus],
+                desktopOperationLaneCoordinator: fixture.desktop.laneCoordinator,
+                screenCaptureKitProcessCapabilityRegistrar: {},
+                screenCaptureKitOwnershipPreparer: {},
+                screenCaptureKitOwnerClaimProvider: CLISnapshotBridgeServices.unexpectedScreenCaptureKitClaim,
+                permissionStatusEvaluator: { _ in CLISnapshotBridgeServices.grantedPermissions() }
+            )
+            let host = PeekabooBridgeHost(
+                socketPath: socketPath,
+                server: server,
+                allowedTeamIDs: [],
+                requestTimeoutSec: 2
+            )
+            try await fixture.start(host)
 
-        do {
             let exportingClient = BridgeTestFixtures.authenticatedClient(
                 socketPath: socketPath,
                 requestTimeoutSec: 2,
@@ -134,6 +135,7 @@ struct BridgeReceiptCommandTests {
             )
 
             await host.stop()
+            await host.waitUntilFullyStopped()
             try await host.startChecked()
             await #expect(throws: BridgeReceiptValidationError.invalidBundle) {
                 _ = try await BridgeReceiptVerifier.validate(
@@ -143,11 +145,7 @@ struct BridgeReceiptCommandTests {
                     makeClient: Self.authenticatedClient
                 )
             }
-        } catch {
-            await host.stop()
-            throw error
         }
-        await host.stop()
     }
     #endif
 

--- a/Apps/CLI/Tests/CoreCLITests/CLIDesktopFixtureTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/CLIDesktopFixtureTests.swift
@@ -1,0 +1,112 @@
+import Foundation
+import PeekabooCore
+import Testing
+@testable import PeekabooAutomationKit
+@testable import PeekabooBridge
+
+@Suite(.tags(.safe))
+struct CLIDesktopFixtureTests {
+    @Test
+    func `separate fixtures do not share watermarks`() throws {
+        let first = try CLIDesktopFixture()
+        defer { first.removeDirectory() }
+        let second = try CLIDesktopFixture()
+        defer { second.removeDirectory() }
+        let cutoff = Date()
+        let mutation = try first.watermarkStore.beginMutation(at: cutoff)
+        try first.watermarkStore.completeMutation(mutation, through: cutoff)
+
+        #expect(first.root != second.root)
+        #expect(first.watermarkStore.effectiveWatermark() == cutoff)
+        #expect(second.watermarkStore.effectiveWatermark() == nil)
+    }
+
+    @Test
+    func `separate fixtures allow independent lanes`() async throws {
+        let first = try CLIDesktopFixture()
+        defer { first.removeDirectory() }
+        let second = try CLIDesktopFixture()
+        defer { second.removeDirectory() }
+
+        let result = try await first.laneCoordinator.run(scope: .global, access: .write) {
+            try await second.laneCoordinator.run(scope: .global, access: .write) { 42 }
+        }
+        #expect(result == 42)
+    }
+
+    @Test
+    func `borrowed coordinator retains same root exclusion`() async throws {
+        let fixture = try CLIDesktopFixture()
+        defer { fixture.removeDirectory() }
+        let borrowed = DesktopOperationLaneCoordinator(coordinationRootURL: fixture.root)
+
+        try await fixture.laneCoordinator.run(scope: .global, access: .write) {
+            do {
+                try await borrowed.run(scope: .global, access: .write) {
+                    Issue.record("A second coordinator must not bypass the same-root lane")
+                }
+                Issue.record("Expected nested same-root acquisition to fail")
+            } catch DesktopOperationLaneError.nestedAcquisition {
+                // The real lane retains ownership until the outer operation returns.
+            }
+        }
+        let result = try await borrowed.run(scope: .global, access: .write) { 42 }
+        #expect(result == 42)
+    }
+
+    #if DEBUG
+    @Test(arguments: [false, true])
+    @MainActor
+    func `Bridge fixture stops hosts on success and failure`(bodyThrows: Bool) async throws {
+        var root: URL?
+        var retainedHost: PeekabooBridgeHost?
+
+        do {
+            let result = try await CLIBridgeHostFixture.withHosts { fixture in
+                root = fixture.desktop.root
+                let server = PeekabooBridgeServer(
+                    services: CLISnapshotBridgeServices(
+                        snapshots: InMemorySnapshotManager(),
+                        directory: fixture.desktop.root
+                    ),
+                    allowlistedTeams: [],
+                    allowlistedBundles: [],
+                    allowedOperations: CLISnapshotBridgeServices.snapshotOperations,
+                    desktopOperationLaneCoordinator: fixture.desktop.laneCoordinator,
+                    screenCaptureKitProcessCapabilityRegistrar: {},
+                    screenCaptureKitOwnershipPreparer: {},
+                    screenCaptureKitOwnerClaimProvider: CLISnapshotBridgeServices.unexpectedScreenCaptureKitClaim,
+                    permissionStatusEvaluator: { _ in CLISnapshotBridgeServices.grantedPermissions() }
+                )
+                let host = PeekabooBridgeHost(
+                    socketPath: fixture.desktop.root.appendingPathComponent("cleanup.sock").path,
+                    server: server,
+                    allowedTeamIDs: [],
+                    requestTimeoutSec: 2
+                )
+                retainedHost = host
+                try await fixture.start(host)
+                #expect(await host.listenerReadinessNotificationCountForTesting() != nil)
+                if bodyThrows {
+                    throw FixtureBodyError.expected
+                }
+                return 42
+            }
+            #expect(!bodyThrows)
+            #expect(result == 42)
+        } catch FixtureBodyError.expected {
+            #expect(bodyThrows)
+        }
+
+        let host = try #require(retainedHost)
+        let directory = try #require(root)
+        #expect(await host.listenerReadinessNotificationCountForTesting() == nil)
+        #expect(await host.isRetainingOwnershipForRequestsForTesting == false)
+        #expect(!FileManager.default.fileExists(atPath: directory.path))
+    }
+    #endif
+}
+
+private enum FixtureBodyError: Error {
+    case expected
+}

--- a/Apps/CLI/Tests/CoreCLITests/InteractionMutationInvalidatorTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/InteractionMutationInvalidatorTests.swift
@@ -128,6 +128,8 @@ struct InteractionMutationInvalidatorTests {
 
     @Test
     func `Command wrapper uses completion cutoff unless success preserves a fresh observation`() async throws {
+        let desktop = try CLIDesktopFixture()
+        defer { desktop.removeDirectory() }
         let snapshots = InMemorySnapshotManager()
         let original = try await snapshots.createSnapshot()
         let runtime = CommandRuntime(
@@ -138,7 +140,10 @@ struct InteractionMutationInvalidatorTests {
                 captureEnginePreference: nil,
                 inputStrategy: nil
             ),
-            services: PeekabooServices(snapshotManager: snapshots)
+            services: PeekabooServices(snapshotManager: snapshots),
+            interactionMutationTracker: InteractionMutationTracker(
+                desktopMutationWatermarkStore: desktop.watermarkStore
+            )
         )
 
         await #expect(throws: TestCommandError.self) {
@@ -272,6 +277,7 @@ struct InteractionMutationInvalidatorTests {
 
     @Test
     func `Remote-selected local mutation installs a caller barrier`() async throws {
+        // Excluded from protected proof: runtime invalidation still constructs a caller-local SnapshotManager.
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("peekaboo-cli-remote-caller-barrier-\(UUID().uuidString)", isDirectory: true)
         defer { try? FileManager.default.removeItem(at: root) }
@@ -466,6 +472,9 @@ struct InteractionMutationInvalidatorTests {
 
     @Test
     func `Remote coordinator rejects a host observation certificate that forbids preservation`() async throws {
+        // Excluded from protected proof: the owned tracker does not isolate caller-local snapshot invalidation.
+        let desktop = try CLIDesktopFixture()
+        defer { desktop.removeDirectory() }
         let snapshots = InMemorySnapshotManager()
         let runtime = CommandRuntime(
             configuration: .init(
@@ -476,7 +485,10 @@ struct InteractionMutationInvalidatorTests {
                 inputStrategy: nil
             ),
             services: PeekabooServices(snapshotManager: snapshots),
-            selectedRemoteSocketPath: "/tmp/selected.sock"
+            selectedRemoteSocketPath: "/tmp/selected.sock",
+            interactionMutationTracker: InteractionMutationTracker(
+                desktopMutationWatermarkStore: desktop.watermarkStore
+            )
         )
         let snapshotID = try await snapshots.createSnapshot()
         let scope = MCPToolSnapshotMutationScope(
@@ -501,6 +513,8 @@ struct InteractionMutationInvalidatorTests {
 extension InteractionMutationInvalidatorTests {
     @Test
     func `Command wrapper retries failed invalidation with the original cutoff`() async throws {
+        let desktop = try CLIDesktopFixture()
+        defer { desktop.removeDirectory() }
         let snapshots = RetrySnapshotManager()
         let runtime = CommandRuntime(
             configuration: .init(
@@ -510,7 +524,10 @@ extension InteractionMutationInvalidatorTests {
                 captureEnginePreference: nil,
                 inputStrategy: nil
             ),
-            services: PeekabooServices(snapshotManager: snapshots)
+            services: PeekabooServices(snapshotManager: snapshots),
+            interactionMutationTracker: InteractionMutationTracker(
+                desktopMutationWatermarkStore: desktop.watermarkStore
+            )
         )
 
         let result = try await CommanderRuntimeExecutor.runWithImplicitSnapshotInvalidation(
@@ -532,6 +549,8 @@ extension InteractionMutationInvalidatorTests {
 
     @Test
     func `Successful command remains successful when snapshot invalidation fails twice`() async throws {
+        let desktop = try CLIDesktopFixture()
+        defer { desktop.removeDirectory() }
         let snapshots = RetrySnapshotManager(firstInvalidationAction: .alwaysFail)
         let runtime = CommandRuntime(
             configuration: .init(
@@ -541,7 +560,10 @@ extension InteractionMutationInvalidatorTests {
                 captureEnginePreference: nil,
                 inputStrategy: nil
             ),
-            services: PeekabooServices(snapshotManager: snapshots)
+            services: PeekabooServices(snapshotManager: snapshots),
+            interactionMutationTracker: InteractionMutationTracker(
+                desktopMutationWatermarkStore: desktop.watermarkStore
+            )
         )
 
         try await CommanderRuntimeExecutor.runWithImplicitSnapshotInvalidation(
@@ -590,6 +612,8 @@ extension InteractionMutationInvalidatorTests {
 
     @Test
     func `Command wrapper makes one retry after direct invalidation failure`() async throws {
+        let desktop = try CLIDesktopFixture()
+        defer { desktop.removeDirectory() }
         let snapshots = RetrySnapshotManager(firstInvalidationAction: .alwaysFail)
         let runtime = CommandRuntime(
             configuration: .init(
@@ -599,7 +623,10 @@ extension InteractionMutationInvalidatorTests {
                 captureEnginePreference: nil,
                 inputStrategy: nil
             ),
-            services: PeekabooServices(snapshotManager: snapshots)
+            services: PeekabooServices(snapshotManager: snapshots),
+            interactionMutationTracker: InteractionMutationTracker(
+                desktopMutationWatermarkStore: desktop.watermarkStore
+            )
         )
         runtime.beginInteractionMutation()
         let cutoff = Date()
@@ -627,6 +654,8 @@ extension InteractionMutationInvalidatorTests {
 
     @Test
     func `Operation failure remains primary when snapshot cleanup fails twice`() async throws {
+        let desktop = try CLIDesktopFixture()
+        defer { desktop.removeDirectory() }
         let snapshots = RetrySnapshotManager(firstInvalidationAction: .alwaysFail)
         let runtime = CommandRuntime(
             configuration: .init(
@@ -636,7 +665,10 @@ extension InteractionMutationInvalidatorTests {
                 captureEnginePreference: nil,
                 inputStrategy: nil
             ),
-            services: PeekabooServices(snapshotManager: snapshots)
+            services: PeekabooServices(snapshotManager: snapshots),
+            interactionMutationTracker: InteractionMutationTracker(
+                desktopMutationWatermarkStore: desktop.watermarkStore
+            )
         )
 
         await #expect(throws: TestCommandError.self) {
@@ -655,6 +687,8 @@ extension InteractionMutationInvalidatorTests {
 
     @Test
     func `Successful capture focus preserves snapshots created after focus completion`() async throws {
+        let desktop = try CLIDesktopFixture()
+        defer { desktop.removeDirectory() }
         let snapshots = InMemorySnapshotManager()
         let runtime = CommandRuntime(
             configuration: .init(
@@ -664,7 +698,10 @@ extension InteractionMutationInvalidatorTests {
                 captureEnginePreference: nil,
                 inputStrategy: nil
             ),
-            services: PeekabooServices(snapshotManager: snapshots)
+            services: PeekabooServices(snapshotManager: snapshots),
+            interactionMutationTracker: InteractionMutationTracker(
+                desktopMutationWatermarkStore: desktop.watermarkStore
+            )
         )
         var freshSnapshot: String?
 
@@ -682,6 +719,8 @@ extension InteractionMutationInvalidatorTests {
 
     @Test
     func `Failed capture focus invalidates snapshots through command completion`() async throws {
+        let desktop = try CLIDesktopFixture()
+        defer { desktop.removeDirectory() }
         let snapshots = InMemorySnapshotManager()
         let runtime = CommandRuntime(
             configuration: .init(
@@ -691,7 +730,10 @@ extension InteractionMutationInvalidatorTests {
                 captureEnginePreference: nil,
                 inputStrategy: nil
             ),
-            services: PeekabooServices(snapshotManager: snapshots)
+            services: PeekabooServices(snapshotManager: snapshots),
+            interactionMutationTracker: InteractionMutationTracker(
+                desktopMutationWatermarkStore: desktop.watermarkStore
+            )
         )
         var focusSnapshot: String?
 
@@ -713,6 +755,8 @@ extension InteractionMutationInvalidatorTests {
 
     @Test
     func `Action mutation reopens a completed capture focus boundary`() async throws {
+        let desktop = try CLIDesktopFixture()
+        defer { desktop.removeDirectory() }
         let snapshots = InMemorySnapshotManager()
         let runtime = CommandRuntime(
             configuration: .init(
@@ -722,7 +766,10 @@ extension InteractionMutationInvalidatorTests {
                 captureEnginePreference: nil,
                 inputStrategy: nil
             ),
-            services: PeekabooServices(snapshotManager: snapshots)
+            services: PeekabooServices(snapshotManager: snapshots),
+            interactionMutationTracker: InteractionMutationTracker(
+                desktopMutationWatermarkStore: desktop.watermarkStore
+            )
         )
 
         try await CommanderRuntimeExecutor.runWithImplicitSnapshotInvalidation(
@@ -739,6 +786,8 @@ extension InteractionMutationInvalidatorTests {
 
     @Test
     func `Command cancellation invalidates snapshots after a completed focus boundary`() async throws {
+        let desktop = try CLIDesktopFixture()
+        defer { desktop.removeDirectory() }
         let snapshots = InMemorySnapshotManager()
         let runtime = CommandRuntime(
             configuration: .init(
@@ -748,7 +797,10 @@ extension InteractionMutationInvalidatorTests {
                 captureEnginePreference: nil,
                 inputStrategy: nil
             ),
-            services: PeekabooServices(snapshotManager: snapshots)
+            services: PeekabooServices(snapshotManager: snapshots),
+            interactionMutationTracker: InteractionMutationTracker(
+                desktopMutationWatermarkStore: desktop.watermarkStore
+            )
         )
 
         let task = Task { @MainActor in
@@ -771,6 +823,8 @@ extension InteractionMutationInvalidatorTests {
 
     @Test
     func `Cancellation during success cleanup forces completion invalidation`() async throws {
+        let desktop = try CLIDesktopFixture()
+        defer { desktop.removeDirectory() }
         let snapshots = RetrySnapshotManager(firstInvalidationAction: .cancelAfterSuccess)
         let runtime = CommandRuntime(
             configuration: .init(
@@ -780,7 +834,10 @@ extension InteractionMutationInvalidatorTests {
                 captureEnginePreference: nil,
                 inputStrategy: nil
             ),
-            services: PeekabooServices(snapshotManager: snapshots)
+            services: PeekabooServices(snapshotManager: snapshots),
+            interactionMutationTracker: InteractionMutationTracker(
+                desktopMutationWatermarkStore: desktop.watermarkStore
+            )
         )
 
         let task = Task { @MainActor in

--- a/Apps/CLI/Tests/CoreCLITests/OpenCommandFlowTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/OpenCommandFlowTests.swift
@@ -106,27 +106,28 @@ struct AppCommandLaunchFlowTests {
 
     @Test
     func `Background no-op launch preserves selected and discovered snapshots`() async throws {
-        let service = self.makeLaunchService(name: "Notes", bundleIdentifier: "com.apple.Notes")
-        let snapshots = try await SnapshotInvalidationFixture.start()
-        defer { Task { await snapshots.host.stop() } }
+        try await CLIBridgeHostFixture.withHosts { hosts in
+            let service = self.makeLaunchService(name: "Notes", bundleIdentifier: "com.apple.Notes")
+            let snapshots = try await SnapshotInvalidationFixture.start(hosts: hosts)
 
-        var command = AppCommand.LaunchSubcommand()
-        command.app = "Notes"
-        command.noFocus = true
-        let runtime = CommandRuntime(
-            configuration: .init(verbose: false, jsonOutput: true, logLevel: nil),
-            services: ServicesWithApplicationStub(
-                applications: service,
-                snapshots: snapshots.selected
-            ),
-            snapshotInvalidationRemoteSocketPaths: [snapshots.discoveredSocketPath]
-        )
-        try await command.run(using: runtime)
+            var command = AppCommand.LaunchSubcommand()
+            command.app = "Notes"
+            command.noFocus = true
+            let runtime = CommandRuntime(
+                configuration: .init(verbose: false, jsonOutput: true, logLevel: nil),
+                services: ServicesWithApplicationStub(
+                    applications: service,
+                    snapshots: snapshots.selected
+                ),
+                snapshotInvalidationRemoteSocketPaths: [snapshots.discoveredSocketPath]
+            )
+            try await command.run(using: runtime)
 
-        let request = try #require(service.launchRequests.first)
-        #expect(!request.activates)
-        #expect(await snapshots.selected.getMostRecentSnapshot() != nil)
-        #expect(await snapshots.discovered.getMostRecentSnapshot() != nil)
+            let request = try #require(service.launchRequests.first)
+            #expect(!request.activates)
+            #expect(await snapshots.selected.getMostRecentSnapshot() != nil)
+            #expect(await snapshots.discovered.getMostRecentSnapshot() != nil)
+        }
     }
 
     @Test
@@ -853,20 +854,24 @@ private struct SnapshotInvalidationFixture {
     let selected: InMemorySnapshotManager
     let discovered: InMemorySnapshotManager
     let discoveredSocketPath: String
-    let host: PeekabooBridgeHost
 
-    static func start() async throws -> Self {
+    static func start(hosts: CLIBridgeHostFixture) async throws -> Self {
         let selected = InMemorySnapshotManager()
         let discovered = InMemorySnapshotManager()
         _ = try await selected.createSnapshot()
         _ = try await discovered.createSnapshot()
 
-        let discoveredSocketPath = "/tmp/peekaboo-open-snapshots-\(UUID().uuidString).sock"
+        let discoveredSocketPath = hosts.desktop.root.appendingPathComponent("discovered.sock").path
         let server = PeekabooBridgeServer(
-            services: PeekabooServices(snapshotManager: discovered),
+            services: CLISnapshotBridgeServices(snapshots: discovered, directory: hosts.desktop.root),
             hostKind: .gui,
             allowlistedTeams: [],
             allowlistedBundles: [],
+            allowedOperations: CLISnapshotBridgeServices.snapshotOperations,
+            desktopOperationLaneCoordinator: hosts.desktop.laneCoordinator,
+            screenCaptureKitProcessCapabilityRegistrar: {},
+            screenCaptureKitOwnershipPreparer: {},
+            screenCaptureKitOwnerClaimProvider: CLISnapshotBridgeServices.unexpectedScreenCaptureKitClaim,
             permissionStatusEvaluator: { _ in
                 PermissionsStatus(
                     screenRecording: true,
@@ -882,13 +887,12 @@ private struct SnapshotInvalidationFixture {
             allowedTeamIDs: [],
             requestTimeoutSec: 2
         )
-        try await host.startChecked()
+        try await hosts.start(host)
 
         return Self(
             selected: selected,
             discovered: discovered,
-            discoveredSocketPath: discoveredSocketPath,
-            host: host
+            discoveredSocketPath: discoveredSocketPath
         )
     }
 }

--- a/Apps/CLI/Tests/CoreCLITests/PeekabooBridgeHostUnauthorizedResponseTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/PeekabooBridgeHostUnauthorizedResponseTests.swift
@@ -6,41 +6,56 @@ import Testing
 
 struct PeekabooBridgeHostUnauthorizedResponseTests {
     @Test
+    @MainActor
     func `unauthorized clients receive an error response (not EOF)`() async throws {
-        let socketPath = "/tmp/peekaboo-bridge-host-\(UUID().uuidString).sock"
-
-        let server = await MainActor.run {
-            PeekabooBridgeServer(
-                services: PeekabooServices(),
+        try await CLIBridgeHostFixture.withHosts { fixture in
+            let socketPath = fixture.desktop.root.appendingPathComponent("bridge.sock").path
+            let server = PeekabooBridgeServer(
+                services: CLISnapshotBridgeServices(
+                    snapshots: InMemorySnapshotManager(),
+                    directory: fixture.desktop.root
+                ),
                 hostKind: .gui,
                 allowlistedTeams: ["NOT_A_REAL_TEAM"],
-                allowlistedBundles: []
+                allowlistedBundles: [],
+                allowedOperations: [.permissionsStatus],
+                desktopOperationLaneCoordinator: fixture.desktop.laneCoordinator,
+                screenCaptureKitProcessCapabilityRegistrar: {},
+                screenCaptureKitOwnershipPreparer: {},
+                screenCaptureKitOwnerClaimProvider: CLISnapshotBridgeServices.unexpectedScreenCaptureKitClaim,
+                permissionStatusEvaluator: { _ in
+                    Issue.record("Unauthorized requests must be rejected before permission evaluation")
+                    return PermissionsStatus(screenRecording: false, accessibility: false, postEvent: false)
+                }
             )
+
+            let host = PeekabooBridgeHost(
+                socketPath: socketPath,
+                server: server,
+                allowedTeamIDs: ["NOT_A_REAL_TEAM"],
+                requestTimeoutSec: 2
+            )
+
+            try await fixture.start(host)
+
+            let requestData = try JSONEncoder.peekabooBridgeEncoder().encode(PeekabooBridgeRequest.permissionsStatus)
+            let responseData = try await Self.sendUnixRequest(path: socketPath, request: requestData)
+            let response = try JSONDecoder.peekabooBridgeDecoder().decode(
+                PeekabooBridgeResponse.self,
+                from: responseData
+            )
+
+            guard case let .error(envelope) = response else {
+                Issue.record("Expected error response, got \(response)")
+                return
+            }
+
+            #expect(envelope.code == .unauthorizedClient)
         }
-
-        let host = PeekabooBridgeHost(
-            socketPath: socketPath,
-            server: server,
-            allowedTeamIDs: ["NOT_A_REAL_TEAM"],
-            requestTimeoutSec: 2
-        )
-
-        try await host.startChecked()
-        defer { Task { await host.stop() } }
-
-        let requestData = try JSONEncoder.peekabooBridgeEncoder().encode(PeekabooBridgeRequest.permissionsStatus)
-        let responseData = try Self.sendUnixRequest(path: socketPath, request: requestData)
-        let response = try JSONDecoder.peekabooBridgeDecoder().decode(PeekabooBridgeResponse.self, from: responseData)
-
-        guard case let .error(envelope) = response else {
-            Issue.record("Expected error response, got \(response)")
-            return
-        }
-
-        #expect(envelope.code == .unauthorizedClient)
     }
 
-    private static func sendUnixRequest(path: String, request: Data) throws -> Data {
+    @concurrent
+    private static func sendUnixRequest(path: String, request: Data) async throws -> Data {
         let fd = socket(AF_UNIX, SOCK_STREAM, 0)
         guard fd >= 0 else { throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO) }
         defer { close(fd) }
@@ -69,7 +84,7 @@ struct PeekabooBridgeHostUnauthorizedResponseTests {
         return try Self.readAll(fd: fd, maxBytes: 1024 * 1024)
     }
 
-    private static func writeAll(fd: Int32, data: Data) throws {
+    private nonisolated static func writeAll(fd: Int32, data: Data) throws {
         try data.withUnsafeBytes { buf in
             guard let base = buf.baseAddress else { return }
             var written = 0
@@ -87,7 +102,7 @@ struct PeekabooBridgeHostUnauthorizedResponseTests {
         }
     }
 
-    private static func readAll(fd: Int32, maxBytes: Int) throws -> Data {
+    private nonisolated static func readAll(fd: Int32, maxBytes: Int) throws -> Data {
         var data = Data()
         var buffer = [UInt8](repeating: 0, count: 16 * 1024)
 

--- a/Apps/CLI/Tests/CoreCLITests/SnapshotHostAffinityRuntimeTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/SnapshotHostAffinityRuntimeTests.swift
@@ -14,94 +14,94 @@ import Testing
 struct SnapshotHostAffinityRuntimeTests {
     @Test
     func `live authenticated probes retain the sole snapshot producer`() async throws {
-        let missingSnapshots = InMemorySnapshotManager()
-        let ownerSnapshots = InMemorySnapshotManager()
-        let snapshotID = try await ownerSnapshots.createSnapshot()
-        let bounds = CGRect(x: 10, y: 20, width: 600, height: 400)
-        let identity = WindowMutationIdentity(
-            windowID: 74,
-            ownerProcessIdentifier: getpid(),
-            ownerProcessStartIdentity: 7,
-            capturedBounds: bounds
-        )
-        let window = ServiceWindowInfo(
-            windowID: identity.windowID,
-            title: "No Elements",
-            bounds: bounds,
-            mutationIdentity: identity
-        )
-        try await ownerSnapshots.storeObservationSnapshot(SnapshotObservationPublicationRequest(
-            screenshot: SnapshotScreenshotRequest(
-                snapshotId: snapshotID,
-                screenshotPath: "/tmp/no-elements.png",
-                applicationBundleId: "boo.peekaboo.fixture",
-                applicationProcessId: identity.ownerProcessIdentifier,
-                applicationName: "Fixture",
-                windowTitle: window.title,
-                windowBounds: bounds,
+        try await CLIBridgeHostFixture.withHosts { hosts in
+            let missingSnapshots = InMemorySnapshotManager()
+            let ownerSnapshots = InMemorySnapshotManager()
+            let snapshotID = try await ownerSnapshots.createSnapshot()
+            let bounds = CGRect(x: 10, y: 20, width: 600, height: 400)
+            let identity = WindowMutationIdentity(
+                windowID: 74,
+                ownerProcessIdentifier: getpid(),
+                ownerProcessStartIdentity: 7,
+                capturedBounds: bounds
+            )
+            let window = ServiceWindowInfo(
                 windowID: identity.windowID,
-                windowMutationIdentity: identity,
-                captureCoordinateContext: CaptureCoordinateContext(
-                    metadata: CaptureMetadata(
-                        size: bounds.size,
-                        mode: .window,
-                        windowInfo: window
-                    ),
-                    referenceID: snapshotID
-                )
-            ),
-            detectionResult: nil,
-            annotatedScreenshotPath: nil
-        ))
-        let synthesized = try #require(try await ownerSnapshots.getDetectionResult(snapshotId: snapshotID))
-        #expect(synthesized.elements.all.isEmpty)
-        _ = try SnapshotTargetReceiptPlanner.assemble(
-            snapshotID: snapshotID,
-            detectionResult: synthesized
-        ).receipt.requireCoordinateAuthority()
+                title: "No Elements",
+                bounds: bounds,
+                mutationIdentity: identity
+            )
+            try await ownerSnapshots.storeObservationSnapshot(SnapshotObservationPublicationRequest(
+                screenshot: SnapshotScreenshotRequest(
+                    snapshotId: snapshotID,
+                    screenshotPath: "/tmp/no-elements.png",
+                    applicationBundleId: "boo.peekaboo.fixture",
+                    applicationProcessId: identity.ownerProcessIdentifier,
+                    applicationName: "Fixture",
+                    windowTitle: window.title,
+                    windowBounds: bounds,
+                    windowID: identity.windowID,
+                    windowMutationIdentity: identity,
+                    captureCoordinateContext: CaptureCoordinateContext(
+                        metadata: CaptureMetadata(
+                            size: bounds.size,
+                            mode: .window,
+                            windowInfo: window
+                        ),
+                        referenceID: snapshotID
+                    )
+                ),
+                detectionResult: nil,
+                annotatedScreenshotPath: nil
+            ))
+            let synthesized = try #require(try await ownerSnapshots.getDetectionResult(snapshotId: snapshotID))
+            #expect(synthesized.elements.all.isEmpty)
+            _ = try SnapshotTargetReceiptPlanner.assemble(
+                snapshotID: snapshotID,
+                detectionResult: synthesized
+            ).receipt.requireCoordinateAuthority()
 
-        let missingSocket = "/tmp/peekaboo-affinity-missing-\(UUID().uuidString).sock"
-        let ownerSocket = "/tmp/peekaboo-affinity-owner-\(UUID().uuidString).sock"
-        let missingHost = try await self.startHost(
-            socketPath: missingSocket,
-            hostKind: .gui,
-            snapshots: missingSnapshots
-        )
-        let ownerHost = try await self.startHost(
-            socketPath: ownerSocket,
-            hostKind: .onDemand,
-            snapshots: ownerSnapshots
-        )
-        defer {
-            Task {
-                await missingHost.stop()
-                await ownerHost.stop()
+            let missingSocket = hosts.desktop.root.appendingPathComponent("missing.sock").path
+            let ownerSocket = hosts.desktop.root.appendingPathComponent("owner.sock").path
+            try await self.startHost(
+                hosts: hosts,
+                socketPath: missingSocket,
+                hostKind: .gui,
+                snapshots: missingSnapshots
+            )
+            try await self.startHost(
+                hosts: hosts,
+                socketPath: ownerSocket,
+                hostKind: .onDemand,
+                snapshots: ownerSnapshots
+            )
+            let candidates = [self.candidate(missingSocket), self.candidate(ownerSocket)]
+            let cache = RuntimeHostResolver.RemoteHandshakeCache(
+                identity: self.identity,
+                clientFactory: { BridgeTestFixtures.authenticatedClient(socketPath: $0) }
+            )
+            for candidate in candidates {
+                let handshake = try await cache.handshake(candidate, identity: self.identity).response
+                #expect(handshake.supportedOperations.contains(.ownsSnapshot))
+                #expect(BridgeCapabilityPolicy.supportsProducerBoundSnapshotReferences(for: handshake))
+                #expect(Set(handshake.supportedOperations).isSubset(of: CLISnapshotBridgeServices.snapshotOperations))
+                #expect(handshake.hostCapabilities?.contains(
+                    PeekabooBridgeHostCapability.screenCaptureKitProcessOwnership
+                ) != true)
+            }
+
+            let selected = try await RuntimeHostResolver.resolveSnapshotAffinity(
+                snapshotID: snapshotID,
+                candidates: candidates,
+                identity: self.identity,
+                handshakeCache: cache
+            )
+
+            #expect(selected.socketPath == ownerSocket)
+            for candidate in candidates {
+                #expect(cache.entry(for: candidate, identity: self.identity) != nil)
             }
         }
-        let candidates = [self.candidate(missingSocket), self.candidate(ownerSocket)]
-        let cache = RuntimeHostResolver.RemoteHandshakeCache(
-            identity: self.identity,
-            clientFactory: { BridgeTestFixtures.authenticatedClient(socketPath: $0) }
-        )
-        for candidate in candidates {
-            let handshake = try await cache.handshake(candidate, identity: self.identity).response
-            #expect(handshake.supportedOperations.contains(.ownsSnapshot))
-            #expect(BridgeCapabilityPolicy.supportsProducerBoundSnapshotReferences(for: handshake))
-        }
-
-        let selected = try await RuntimeHostResolver.resolveSnapshotAffinity(
-            snapshotID: snapshotID,
-            candidates: candidates,
-            identity: self.identity,
-            handshakeCache: cache
-        )
-
-        #expect(selected.socketPath == ownerSocket)
-        for candidate in candidates {
-            #expect(cache.entry(for: candidate, identity: self.identity) != nil)
-        }
-        await missingHost.stop()
-        await ownerHost.stop()
     }
 
     @Test
@@ -144,91 +144,83 @@ struct SnapshotHostAffinityRuntimeTests {
 
     @Test
     func `two authenticated endpoints from one process count as one snapshot owner`() async throws {
-        let snapshots = InMemorySnapshotManager()
-        let snapshotID = try await snapshots.createSnapshot()
-        let firstSocket = "/tmp/peekaboo-affinity-first-\(UUID().uuidString).sock"
-        let secondSocket = "/tmp/peekaboo-affinity-second-\(UUID().uuidString).sock"
-        let firstHost = try await self.startHost(
-            socketPath: firstSocket,
-            hostKind: .onDemand,
-            snapshots: snapshots
-        )
-        let secondHost = try await self.startHost(
-            socketPath: secondSocket,
-            hostKind: .onDemand,
-            snapshots: snapshots
-        )
-        defer {
-            Task {
-                await firstHost.stop()
-                await secondHost.stop()
-            }
+        try await CLIBridgeHostFixture.withHosts { hosts in
+            let snapshots = InMemorySnapshotManager()
+            let snapshotID = try await snapshots.createSnapshot()
+            let firstSocket = hosts.desktop.root.appendingPathComponent("first.sock").path
+            let secondSocket = hosts.desktop.root.appendingPathComponent("second.sock").path
+            try await self.startHost(
+                hosts: hosts,
+                socketPath: firstSocket,
+                hostKind: .onDemand,
+                snapshots: snapshots
+            )
+            try await self.startHost(
+                hosts: hosts,
+                socketPath: secondSocket,
+                hostKind: .onDemand,
+                snapshots: snapshots
+            )
+            let cache = RuntimeHostResolver.RemoteHandshakeCache(
+                identity: self.identity,
+                clientFactory: { BridgeTestFixtures.authenticatedClient(socketPath: $0) }
+            )
+
+            let selected = try await RuntimeHostResolver.resolveSnapshotAffinity(
+                snapshotID: snapshotID,
+                candidates: [self.candidate(firstSocket), self.candidate(secondSocket)],
+                identity: self.identity,
+                handshakeCache: cache
+            )
+
+            #expect(selected.socketPath == firstSocket)
         }
-        let cache = RuntimeHostResolver.RemoteHandshakeCache(
-            identity: self.identity,
-            clientFactory: { BridgeTestFixtures.authenticatedClient(socketPath: $0) }
-        )
-
-        let selected = try await RuntimeHostResolver.resolveSnapshotAffinity(
-            snapshotID: snapshotID,
-            candidates: [self.candidate(firstSocket), self.candidate(secondSocket)],
-            identity: self.identity,
-            handshakeCache: cache
-        )
-
-        #expect(selected.socketPath == firstSocket)
-        await firstHost.stop()
-        await secondHost.stop()
     }
 
     @Test
     func `same-producer affinity tries every alias for command capability`() async throws {
-        let snapshots = InMemorySnapshotManager()
-        let snapshotID = try await snapshots.createSnapshot()
-        let firstSocket = "/tmp/peekaboo-affinity-limited-\(UUID().uuidString).sock"
-        let secondSocket = "/tmp/peekaboo-affinity-capable-\(UUID().uuidString).sock"
-        let firstHost = try await self.startHost(
-            socketPath: firstSocket,
-            hostKind: .onDemand,
-            snapshots: snapshots,
-            allowedOperations: [.ownsSnapshot]
-        )
-        let secondHost = try await self.startHost(
-            socketPath: secondSocket,
-            hostKind: .onDemand,
-            snapshots: snapshots,
-            allowedOperations: [.ownsSnapshot, .targetedClick]
-        )
-        defer {
-            Task {
-                await firstHost.stop()
-                await secondHost.stop()
-            }
+        try await CLIBridgeHostFixture.withHosts { hosts in
+            let snapshots = InMemorySnapshotManager()
+            let snapshotID = try await snapshots.createSnapshot()
+            let firstSocket = hosts.desktop.root.appendingPathComponent("limited.sock").path
+            let secondSocket = hosts.desktop.root.appendingPathComponent("capable.sock").path
+            try await self.startHost(
+                hosts: hosts,
+                socketPath: firstSocket,
+                hostKind: .onDemand,
+                snapshots: snapshots,
+                allowedOperations: [.ownsSnapshot]
+            )
+            try await self.startHost(
+                hosts: hosts,
+                socketPath: secondSocket,
+                hostKind: .onDemand,
+                snapshots: snapshots,
+                allowedOperations: [.ownsSnapshot, .targetedClick]
+            )
+            var options = CommandRuntimeOptions()
+            options.explicitSnapshotID = snapshotID
+            options.requiresProducerBoundSnapshotReferences = true
+            options.requiresProcessGenerationPinnedClicks = true
+            let dependencies = RuntimeHostResolver.Dependencies(
+                makeLocalServices: { _ in PeekabooServices(snapshotManager: InMemorySnapshotManager()) },
+                claimScreenCaptureKitOwner: { throw POSIXError(.EPERM) },
+                inspectScreenCaptureKitOwner: { nil },
+                remoteCandidatePlan: { _, _ in
+                    self.plan(candidates: [self.candidate(firstSocket), self.candidate(secondSocket)])
+                },
+                makeRemoteHandshakeCache: { self.authenticatedHandshakeCache() }
+            )
+
+            let resolution = try await RuntimeHostResolver.resolveServices(
+                options: options,
+                environment: [:],
+                configurationInput: nil,
+                dependencies: dependencies
+            )
+
+            #expect(resolution.selectedRemoteSocketPath == secondSocket)
         }
-        var options = CommandRuntimeOptions()
-        options.explicitSnapshotID = snapshotID
-        options.requiresProducerBoundSnapshotReferences = true
-        options.requiresProcessGenerationPinnedClicks = true
-        let dependencies = RuntimeHostResolver.Dependencies(
-            makeLocalServices: { _ in PeekabooServices(snapshotManager: InMemorySnapshotManager()) },
-            claimScreenCaptureKitOwner: { throw POSIXError(.EPERM) },
-            inspectScreenCaptureKitOwner: { nil },
-            remoteCandidatePlan: { _, _ in
-                self.plan(candidates: [self.candidate(firstSocket), self.candidate(secondSocket)])
-            },
-            makeRemoteHandshakeCache: { self.authenticatedHandshakeCache() }
-        )
-
-        let resolution = try await RuntimeHostResolver.resolveServices(
-            options: options,
-            environment: [:],
-            configurationInput: nil,
-            dependencies: dependencies
-        )
-
-        #expect(resolution.selectedRemoteSocketPath == secondSocket)
-        await firstHost.stop()
-        await secondHost.stop()
     }
 
     @Test
@@ -321,71 +313,73 @@ struct SnapshotHostAffinityRuntimeTests {
 
     @Test
     func `full runtime accepts an explicit socket only when that host owns the snapshot`() async throws {
-        let snapshots = InMemorySnapshotManager()
-        let snapshotID = try await snapshots.createSnapshot()
-        let socketPath = "/tmp/peekaboo-explicit-owner-\(UUID().uuidString).sock"
-        let host = try await self.startHost(
-            socketPath: socketPath,
-            hostKind: .onDemand,
-            snapshots: snapshots
-        )
-        defer { Task { await host.stop() } }
-        var options = CommandRuntimeOptions()
-        options.bridgeSocketPath = socketPath
-        options.explicitSnapshotID = snapshotID
-        let dependencies = RuntimeHostResolver.Dependencies(
-            makeLocalServices: { _ in PeekabooServices(snapshotManager: InMemorySnapshotManager()) },
-            claimScreenCaptureKitOwner: { throw POSIXError(.EPERM) },
-            inspectScreenCaptureKitOwner: { nil },
-            remoteCandidatePlan: { _, _ in self.explicitPlan(socketPath: socketPath) },
-            makeRemoteHandshakeCache: { self.authenticatedHandshakeCache() }
-        )
+        try await CLIBridgeHostFixture.withHosts { hosts in
+            let snapshots = InMemorySnapshotManager()
+            let snapshotID = try await snapshots.createSnapshot()
+            let socketPath = hosts.desktop.root.appendingPathComponent("owner.sock").path
+            try await self.startHost(
+                hosts: hosts,
+                socketPath: socketPath,
+                hostKind: .onDemand,
+                snapshots: snapshots
+            )
+            var options = CommandRuntimeOptions()
+            options.bridgeSocketPath = socketPath
+            options.explicitSnapshotID = snapshotID
+            let dependencies = RuntimeHostResolver.Dependencies(
+                makeLocalServices: { _ in PeekabooServices(snapshotManager: InMemorySnapshotManager()) },
+                claimScreenCaptureKitOwner: { throw POSIXError(.EPERM) },
+                inspectScreenCaptureKitOwner: { nil },
+                remoteCandidatePlan: { _, _ in self.explicitPlan(socketPath: socketPath) },
+                makeRemoteHandshakeCache: { self.authenticatedHandshakeCache() }
+            )
 
-        let resolution = try await RuntimeHostResolver.resolveServices(
-            options: options,
-            environment: [:],
-            configurationInput: nil,
-            dependencies: dependencies
-        )
-
-        #expect(resolution.selectedRemoteSocketPath == socketPath)
-        #expect(try await resolution.services.snapshots.ownsSnapshot(snapshotId: snapshotID))
-        await host.stop()
-    }
-
-    @Test
-    func `full runtime refuses an explicit socket that does not own the snapshot`() async throws {
-        let socketPath = "/tmp/peekaboo-explicit-nonowner-\(UUID().uuidString).sock"
-        let host = try await self.startHost(
-            socketPath: socketPath,
-            hostKind: .onDemand,
-            snapshots: InMemorySnapshotManager()
-        )
-        defer { Task { await host.stop() } }
-        var options = CommandRuntimeOptions()
-        options.bridgeSocketPath = socketPath
-        options.explicitSnapshotID = SnapshotReferenceFixtures.first.rawValue
-        let dependencies = RuntimeHostResolver.Dependencies(
-            makeLocalServices: { _ in PeekabooServices(snapshotManager: InMemorySnapshotManager()) },
-            claimScreenCaptureKitOwner: { throw POSIXError(.EPERM) },
-            inspectScreenCaptureKitOwner: { nil },
-            remoteCandidatePlan: { _, _ in self.explicitPlan(socketPath: socketPath) },
-            makeRemoteHandshakeCache: { self.authenticatedHandshakeCache() }
-        )
-
-        do {
-            _ = try await RuntimeHostResolver.resolveServices(
+            let resolution = try await RuntimeHostResolver.resolveServices(
                 options: options,
                 environment: [:],
                 configurationInput: nil,
                 dependencies: dependencies
             )
-            Issue.record("Expected explicit non-owner refusal")
-        } catch let error as PreDispatchActionError {
-            #expect(error.code == .SNAPSHOT_NOT_FOUND)
-            #expect(error.localizedDescription.contains("no unique live host affinity"))
+
+            #expect(resolution.selectedRemoteSocketPath == socketPath)
+            #expect(try await resolution.services.snapshots.ownsSnapshot(snapshotId: snapshotID))
         }
-        await host.stop()
+    }
+
+    @Test
+    func `full runtime refuses an explicit socket that does not own the snapshot`() async throws {
+        try await CLIBridgeHostFixture.withHosts { hosts in
+            let socketPath = hosts.desktop.root.appendingPathComponent("nonowner.sock").path
+            try await self.startHost(
+                hosts: hosts,
+                socketPath: socketPath,
+                hostKind: .onDemand,
+                snapshots: InMemorySnapshotManager()
+            )
+            var options = CommandRuntimeOptions()
+            options.bridgeSocketPath = socketPath
+            options.explicitSnapshotID = SnapshotReferenceFixtures.first.rawValue
+            let dependencies = RuntimeHostResolver.Dependencies(
+                makeLocalServices: { _ in PeekabooServices(snapshotManager: InMemorySnapshotManager()) },
+                claimScreenCaptureKitOwner: { throw POSIXError(.EPERM) },
+                inspectScreenCaptureKitOwner: { nil },
+                remoteCandidatePlan: { _, _ in self.explicitPlan(socketPath: socketPath) },
+                makeRemoteHandshakeCache: { self.authenticatedHandshakeCache() }
+            )
+
+            do {
+                _ = try await RuntimeHostResolver.resolveServices(
+                    options: options,
+                    environment: [:],
+                    configurationInput: nil,
+                    dependencies: dependencies
+                )
+                Issue.record("Expected explicit non-owner refusal")
+            } catch let error as PreDispatchActionError {
+                #expect(error.code == .SNAPSHOT_NOT_FOUND)
+                #expect(error.localizedDescription.contains("no unique live host affinity"))
+            }
+        }
     }
 
     @Test
@@ -410,31 +404,32 @@ struct SnapshotHostAffinityRuntimeTests {
 
     @Test
     func `dishonest ownership capability is classified as incompatible`() async throws {
-        let snapshots = SnapshotMutationRecordingManager(wrapping: InMemorySnapshotManager())
-        snapshots.ownsSnapshotError = PeekabooBridgeErrorEnvelope(
-            code: .operationNotSupported,
-            message: "Injected dishonest capability"
-        )
-        let socketPath = "/tmp/peekaboo-dishonest-owner-\(UUID().uuidString).sock"
-        let host = try await self.startHost(
-            socketPath: socketPath,
-            hostKind: .onDemand,
-            snapshots: snapshots
-        )
-        defer { Task { await host.stop() } }
-        let candidate = self.candidate(socketPath)
-        let cache = self.authenticatedHandshakeCache()
+        try await CLIBridgeHostFixture.withHosts { hosts in
+            let snapshots = SnapshotMutationRecordingManager(wrapping: InMemorySnapshotManager())
+            snapshots.ownsSnapshotError = PeekabooBridgeErrorEnvelope(
+                code: .operationNotSupported,
+                message: "Injected dishonest capability"
+            )
+            let socketPath = hosts.desktop.root.appendingPathComponent("dishonest.sock").path
+            try await self.startHost(
+                hosts: hosts,
+                socketPath: socketPath,
+                hostKind: .onDemand,
+                snapshots: snapshots
+            )
+            let candidate = self.candidate(socketPath)
+            let cache = self.authenticatedHandshakeCache()
 
-        let result = try await RuntimeHostResolver.liveSnapshotAffinityProbe(
-            candidate,
-            SnapshotReferenceFixtures.first.rawValue,
-            self.identity,
-            cache
-        )
+            let result = try await RuntimeHostResolver.liveSnapshotAffinityProbe(
+                candidate,
+                SnapshotReferenceFixtures.first.rawValue,
+                self.identity,
+                cache
+            )
 
-        #expect(result == .incompatible)
-        #expect(snapshots.ownsCalls == [SnapshotReferenceFixtures.first.rawValue])
-        await host.stop()
+            #expect(result == .incompatible)
+            #expect(snapshots.ownsCalls == [SnapshotReferenceFixtures.first.rawValue])
+        }
     }
 
     @Test
@@ -612,35 +607,31 @@ struct SnapshotHostAffinityRuntimeTests {
     }
 
     private func startHost(
+        hosts: CLIBridgeHostFixture,
         socketPath: String,
         hostKind: PeekabooBridgeHostKind,
         snapshots: any SnapshotManagerProtocol,
         allowedOperations: Set<PeekabooBridgeOperation>? = nil
-    ) async throws -> PeekabooBridgeHost {
-        let services = PeekabooServices(snapshotManager: snapshots)
-        let server = if let allowedOperations {
-            PeekabooBridgeServer(
-                services: services,
-                hostKind: hostKind,
-                allowlistedTeams: [],
-                allowlistedBundles: [],
-                allowedOperations: allowedOperations
-            )
-        } else {
-            PeekabooBridgeServer(
-                services: services,
-                hostKind: hostKind,
-                allowlistedTeams: [],
-                allowlistedBundles: []
-            )
-        }
+    ) async throws {
+        let services = CLISnapshotBridgeServices(snapshots: snapshots, directory: hosts.desktop.root)
+        let server = PeekabooBridgeServer(
+            services: services,
+            hostKind: hostKind,
+            allowlistedTeams: [],
+            allowlistedBundles: [],
+            allowedOperations: allowedOperations ?? CLISnapshotBridgeServices.snapshotOperations,
+            desktopOperationLaneCoordinator: hosts.desktop.laneCoordinator,
+            screenCaptureKitProcessCapabilityRegistrar: {},
+            screenCaptureKitOwnershipPreparer: {},
+            screenCaptureKitOwnerClaimProvider: CLISnapshotBridgeServices.unexpectedScreenCaptureKitClaim,
+            permissionStatusEvaluator: { _ in CLISnapshotBridgeServices.grantedPermissions() }
+        )
         let host = PeekabooBridgeHost(
             socketPath: socketPath,
             server: server,
             allowedTeamIDs: [],
             requestTimeoutSec: 2
         )
-        try await host.startChecked()
-        return host
+        try await hosts.start(host)
     }
 }

--- a/Apps/CLI/Tests/CoreCLITests/Support/CLIDesktopFixture.swift
+++ b/Apps/CLI/Tests/CoreCLITests/Support/CLIDesktopFixture.swift
@@ -1,0 +1,71 @@
+import Darwin
+import Foundation
+import PeekabooBridge
+import PeekabooCore
+import Testing
+@testable import PeekabooAutomationKit
+
+/// Owns only a newly created directory, never a borrowed store or an ambient runtime root.
+struct CLIDesktopFixture {
+    let root: URL
+    let watermarkStore: DesktopMutationWatermarkStore
+    let laneCoordinator: DesktopOperationLaneCoordinator
+
+    init() throws {
+        // Keep UNIX socket paths below sockaddr_un's limit, including on Darwin's long temporary paths.
+        var template = Array("/tmp/pb-cli-XXXXXX".utf8CString)
+        guard mkdtemp(&template) != nil else {
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
+        let root = URL(fileURLWithPath: String(cString: template), isDirectory: true)
+        self.root = root
+        self.watermarkStore = DesktopMutationWatermarkStore(directoryURL: root)
+        self.laneCoordinator = DesktopOperationLaneCoordinator(coordinationRootURL: root)
+    }
+
+    /// Call only after all operations borrowing the store/coordinator have completed.
+    func removeDirectory() {
+        do {
+            try FileManager.default.removeItem(at: self.root)
+        } catch {
+            Issue.record("Could not remove CLI fixture directory: \(error)")
+        }
+    }
+}
+
+@MainActor
+final class CLIBridgeHostFixture {
+    let desktop: CLIDesktopFixture
+    private var hosts: [PeekabooBridgeHost] = []
+
+    private init() throws {
+        self.desktop = try CLIDesktopFixture()
+    }
+
+    static func withHosts<T>(_ body: @MainActor (CLIBridgeHostFixture) async throws -> T) async throws -> T {
+        let fixture = try CLIBridgeHostFixture()
+        do {
+            let result = try await body(fixture)
+            await fixture.stopAndRemoveDirectory()
+            return result
+        } catch {
+            await fixture.stopAndRemoveDirectory()
+            throw error
+        }
+    }
+
+    func start(_ host: PeekabooBridgeHost) async throws {
+        // Retain before startup so partial startup and later sibling failures also drain the host.
+        self.hosts.append(host)
+        try await host.startChecked()
+    }
+
+    private func stopAndRemoveDirectory() async {
+        for host in self.hosts.reversed() {
+            await host.stop()
+            await host.waitUntilFullyStopped()
+        }
+        self.hosts.removeAll()
+        self.desktop.removeDirectory()
+    }
+}

--- a/Apps/CLI/Tests/CoreCLITests/Support/CLISnapshotBridgeServices.swift
+++ b/Apps/CLI/Tests/CoreCLITests/Support/CLISnapshotBridgeServices.swift
@@ -1,0 +1,61 @@
+import Foundation
+import PeekabooAutomationKit
+import PeekabooBridge
+import PeekabooCore
+import Testing
+
+/// Snapshot/authentication fixtures must not initialize native capture, configuration, or AI services.
+@MainActor
+final class CLISnapshotBridgeServices: PeekabooBridgeServiceProviding {
+    static let snapshotOperations: Set<PeekabooBridgeOperation> = [
+        .ownsSnapshot, .invalidateImplicitLatestSnapshot, .permissionsStatus,
+    ]
+
+    let snapshots: any SnapshotManagerProtocol
+    let automation: any UIAutomationServiceProtocol = MockTargetedAutomationService()
+    let applications: any ApplicationServiceProtocol
+    let dialogs: any DialogServiceProtocol
+    let supportsDesktopObservationCaptureEngine = false
+    let supportsScreenCaptureKitProcessOwnership = false
+
+    init(snapshots: any SnapshotManagerProtocol, directory: URL) {
+        self.snapshots = snapshots
+        // Handshake inspects these adapters' false capability flags, without connecting or a local fallback.
+        let client = PeekabooBridgeClient(socketPath: directory.appendingPathComponent("absent.sock").path)
+        self.applications = RemoteApplicationService(client: client)
+        self.dialogs = RemoteDialogService(client: client)
+    }
+
+    static func grantedPermissions() -> PermissionsStatus {
+        PermissionsStatus(screenRecording: true, accessibility: true, appleScript: true, postEvent: true)
+    }
+
+    nonisolated static func unexpectedScreenCaptureKitClaim() throws -> ScreenCaptureKitOwnerLease.OwnerReceipt {
+        Issue.record("Snapshot Bridge fixture must not claim ScreenCaptureKit ownership")
+        throw POSIXError(.ENOTSUP)
+    }
+
+    var permissions: PermissionsService {
+        fatalError("Inject the fixture permission evaluator")
+    }
+
+    var screenCapture: any ScreenCaptureServiceProtocol {
+        fatalError("Capture is not advertised by this fixture")
+    }
+
+    var desktopObservation: any DesktopObservationServiceProtocol {
+        fatalError("Observation is not advertised by this fixture")
+    }
+
+    var windows: any WindowManagementServiceProtocol {
+        fatalError("Windows are not advertised by this fixture")
+    }
+
+    var menu: any MenuServiceProtocol {
+        fatalError("Menus are not advertised by this fixture")
+    }
+
+    var dock: any DockServiceProtocol {
+        fatalError("Dock operations are not advertised by this fixture")
+    }
+}

--- a/scripts/test-see-config-environment.py
+++ b/scripts/test-see-config-environment.py
@@ -18,6 +18,9 @@ DISPLAY_NAMES = (
 )
 # Test.ID can append a source location; do not match another declaration sharing a prefix.
 SELECTION = "^(?:" + "|".join(re.escape(name) for name in EXPECTED_IDS) + ")(?:/|$)"
+TEST_BUILD_ARGUMENTS = (
+    "--disable-xctest", "--enable-swift-testing", "-Xswiftc", "-DPEEKABOO_SKIP_AUTOMATION",
+)
 
 
 def require(condition, message):
@@ -27,8 +30,7 @@ def require(condition, message):
 
 def run_swift(arguments):
     result = subprocess.run(
-        ["swift", "test", "--no-parallel", "--disable-xctest", "--enable-swift-testing",
-         "-Xswiftc", "-DPEEKABOO_SKIP_AUTOMATION", "--filter", SELECTION, *arguments],
+        ["swift", *arguments],
         cwd=Path(__file__).resolve().parent.parent / "Apps/CLI",
         stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, check=False,
     )
@@ -38,12 +40,13 @@ def run_swift(arguments):
 
 
 def verify_discovery(output):
-    # Ignore compiler chatter, but reject missing, duplicate, or additional test IDs.
+    # `swift test list` has no documented filter: select from its global listing locally.
     discovered = [line.strip() for line in output.splitlines()
                   if re.match(r"^[A-Za-z_]\w*\.[^/]+/", line.strip())]
-    require(sorted(discovered) == sorted(EXPECTED_IDS),
-            f"Expected exactly the two See environment declaration IDs, got {discovered!r}")
-    print("Verified discovery: 2 See environment test declarations.", flush=True)
+    selected = [test_id for test_id in discovered if re.search(SELECTION, test_id)]
+    require(sorted(selected) == sorted(EXPECTED_IDS),
+            f"Expected exactly the two selected See environment declaration IDs, got {selected!r}")
+    print("Verified discovery: 2 selected See environment test declarations from the global listing.", flush=True)
 
 
 def verify_execution(output):
@@ -73,9 +76,12 @@ def main():
         ("PEEKABOO_CONFIG_DISABLE_MIGRATION", "1"),
     ):
         require(os.environ.get(name) == expected, f"Set {name}={expected} for this hosted proof")
-    verify_discovery(run_swift(["--list-tests"]))
-    # A separate nonparallel process, reusing precisely the discovered build and selector.
-    verify_execution(run_swift(["--skip-build"]))
+    # The deprecated --list-tests alias reparses execution flags as list options and fails.
+    verify_discovery(run_swift(["test", "list", *TEST_BUILD_ARGUMENTS]))
+    # Only execution is filtered and nonparallel, reusing precisely the discovered build.
+    verify_execution(run_swift([
+        "test", *TEST_BUILD_ARGUMENTS, "--skip-build", "--no-parallel", "--filter", SELECTION,
+    ]))
 
 
 if __name__ == "__main__":

--- a/scripts/test-see-config-environment.py
+++ b/scripts/test-see-config-environment.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Hosted-only focused proof; a zero-test Swift Testing exit is not success."""
+
+import os
+from pathlib import Path
+import re
+import subprocess
+import sys
+
+
+EXPECTED_IDS = (
+    "CLIAutomationTests.SeeCommandRuntimeTests/`config environment restores inherited values`(werePresent:)",
+    "CLIAutomationTests.SeeCommandRuntimeTests/`config environment restores nested throwing bodies`()",
+)
+DISPLAY_NAMES = (
+    "config environment restores inherited values",
+    "config environment restores nested throwing bodies",
+)
+# Test.ID can append a source location; do not match another declaration sharing a prefix.
+SELECTION = "^(?:" + "|".join(re.escape(name) for name in EXPECTED_IDS) + ")(?:/|$)"
+
+
+def require(condition, message):
+    if not condition:
+        raise RuntimeError(message)
+
+
+def run_swift(arguments):
+    result = subprocess.run(
+        ["swift", "test", "--no-parallel", "--disable-xctest", "--enable-swift-testing",
+         "-Xswiftc", "-DPEEKABOO_SKIP_AUTOMATION", "--filter", SELECTION, *arguments],
+        cwd=Path(__file__).resolve().parent.parent / "Apps/CLI",
+        stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, check=False,
+    )
+    print(result.stdout, end="", flush=True)
+    require(result.returncode == 0, f"Swift command failed with exit {result.returncode}")
+    return re.sub(r"\x1b\[[0-9;]*m", "", result.stdout)
+
+
+def verify_discovery(output):
+    # Ignore compiler chatter, but reject missing, duplicate, or additional test IDs.
+    discovered = [line.strip() for line in output.splitlines()
+                  if re.match(r"^[A-Za-z_]\w*\.[^/]+/", line.strip())]
+    require(sorted(discovered) == sorted(EXPECTED_IDS),
+            f"Expected exactly the two See environment declaration IDs, got {discovered!r}")
+    print("Verified discovery: 2 See environment test declarations.", flush=True)
+
+
+def verify_execution(output):
+    summaries = re.findall(r"Test run with .*", output)
+    require(len(summaries) == 1 and re.fullmatch(
+        r"Test run with 2 tests in 1 suite passed after .+ seconds\.", summaries[0]),
+        f"Expected one passing 2-test/1-suite summary, got {summaries!r}")
+    passed = re.findall(r'Test "([^"]+)" passed after .+ seconds\.', output)
+    require(sorted(passed) == sorted(DISPLAY_NAMES),
+            f"Expected both See environment tests to pass exactly once, got {passed!r}")
+    arguments = re.findall(
+        r'Test case passing 1 argument werePresent → (false|true) '
+        r'to "config environment restores inherited values" started\.', output)
+    require(sorted(arguments) == ["false", "true"],
+            f"Expected both inherited-value argument cases, got {arguments!r}")
+    print("Verified execution: 2 tests in 1 suite, including both inherited-value cases.", flush=True)
+
+
+def main():
+    # This is not an operator-state sandbox or a replacement for protected local proof.
+    require(os.environ.get("GITHUB_ACTIONS") == "true"
+            and os.environ.get("RUNNER_ENVIRONMENT") == "github-hosted",
+            "See environment proof is restricted to the secretless GitHub-hosted CI runner")
+    for name, expected in (
+        ("PEEKABOO_INCLUDE_AUTOMATION_TESTS", "true"),
+        ("PEEKABOO_INCLUDE_AMBIENT_STATE_TESTS", "false"),
+        ("PEEKABOO_CONFIG_DISABLE_MIGRATION", "1"),
+    ):
+        require(os.environ.get(name) == expected, f"Set {name}={expected} for this hosted proof")
+    verify_discovery(run_swift(["--list-tests"]))
+    # A separate nonparallel process, reusing precisely the discovered build and selector.
+    verify_execution(run_swift(["--skip-build"]))
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except RuntimeError as error:
+        sys.exit(str(error))

--- a/scripts/test-see-config-environment.py
+++ b/scripts/test-see-config-environment.py
@@ -54,7 +54,7 @@ def verify_execution(output):
     require(len(summaries) == 1 and re.fullmatch(
         r"Test run with 2 tests in 1 suite passed after .+ seconds\.", summaries[0]),
         f"Expected one passing 2-test/1-suite summary, got {summaries!r}")
-    passed = re.findall(r'Test "([^"]+)" passed after .+ seconds\.', output)
+    passed = re.findall(r'Test "([^"]+)"(?: with 2 test cases)? passed after .+ seconds\.', output)
     require(sorted(passed) == sorted(DISPLAY_NAMES),
             f"Expected both See environment tests to pass exactly once, got {passed!r}")
     arguments = re.findall(

--- a/tests/ambient-state-test-policy.test.mjs
+++ b/tests/ambient-state-test-policy.test.mjs
@@ -95,10 +95,12 @@ if sys.argv[1:3] == ["test", "list"]:
 lines = [
     '◇ Test case passing 1 argument werePresent → false to "config environment restores inherited values" started.',
     '◇ Test case passing 1 argument werePresent → true to "config environment restores inherited values" started.',
-    '✔ Test "config environment restores inherited values" passed after 0.001 seconds.',
+    '✔ Test "config environment restores inherited values" with 2 test cases passed after 0.001 seconds.',
     '✔ Test "config environment restores nested throwing bodies" passed after 0.001 seconds.',
     '✔ Test run with 2 tests in 1 suite passed after 0.003 seconds.',
 ]
+if mode == "plain-pass-format": lines[2] = lines[2].replace(" with 2 test cases", "")
+if mode == "wrong-parameter-count": lines[2] = lines[2].replace("with 2 test cases", "with 3 test cases")
 if mode == "zero-execution": lines = ['✔ Test run with 0 tests in 0 suites passed after 0.001 seconds.']
 if mode == "missing-summary": lines.pop()
 if mode == "duplicate-summary": lines.append(lines[-1])
@@ -152,12 +154,14 @@ test("hosted See proof selects two declarations from global discovery and execut
   // A package containing only the selected IDs is also valid; it is not required.
   const selectedOnly = runSeeProofFixture("selected-only");
   assert.equal(selectedOnly.status, 0, selectedOnly.stderr);
+  const plain = runSeeProofFixture("plain-pass-format");
+  assert.equal(plain.status, 0, plain.stderr);
 });
 
 test("hosted See proof fails closed on absent or incomplete evidence", () => {
   for (const mode of ["zero-discovery", "no-selected-id", "missing-id", "duplicate-id", "extra-selected-id", "display-id", "discovery-failed",
     "zero-execution", "missing-summary", "duplicate-summary", "wrong-count", "missing-pass", "extra-pass",
-    "missing-argument", "duplicate-argument", "execution-failed"]) {
+    "missing-argument", "duplicate-argument", "wrong-parameter-count", "execution-failed"]) {
     const result = runSeeProofFixture(mode);
     assert.notEqual(result.status, 0, mode);
     assert.equal(result.invocations.length, ["zero-discovery", "no-selected-id", "missing-id", "duplicate-id", "extra-selected-id", "display-id", "discovery-failed"].includes(mode) ? 1 : 2, mode);

--- a/tests/ambient-state-test-policy.test.mjs
+++ b/tests/ambient-state-test-policy.test.mjs
@@ -11,6 +11,13 @@ const seeEnvironmentIDs = [
   "CLIAutomationTests.SeeCommandRuntimeTests/`config environment restores inherited values`(werePresent:)",
   "CLIAutomationTests.SeeCommandRuntimeTests/`config environment restores nested throwing bodies`()",
 ];
+const unrelatedSeeIDs = [
+  "CLIAutomationTests.SeeCommandRuntimeTests/unsafeRuntime()",
+  "CoreCLITests.AppCommandLaunchFlowTests/launch()",
+  "CoreCLITests.InteractionMutationInvalidatorTests/`Remote-selected local mutation installs a caller barrier`()",
+  "CoreCLITests.InteractionMutationInvalidatorTests/`Remote coordinator rejects a host observation certificate that forbids preservation`()",
+  `${seeEnvironmentIDs[0]}Extra`,
+];
 const packageJSON = JSON.parse(readFileSync(`${repositoryRoot}/package.json`, "utf8"));
 const runtimeTests = readFileSync(
   `${repositoryRoot}/Apps/CLI/Tests/CLIRuntimeTests/CLIRuntimeSmokeTests.swift`,
@@ -75,12 +82,14 @@ with open(os.environ["SEE_PROOF_CALLS"], "a") as output:
     output.write(json.dumps(sys.argv[1:]) + "\\n")
 mode = os.environ["SEE_PROOF_SCENARIO"]
 ids = ${JSON.stringify(seeEnvironmentIDs)}
-if "--list-tests" in sys.argv:
-    if mode == "zero-discovery": ids = []
+if sys.argv[1:3] == ["test", "list"]:
+    if mode in ["zero-discovery", "no-selected-id"]: ids = []
     if mode == "missing-id": ids.pop()
     if mode == "duplicate-id": ids.append(ids[0])
-    if mode == "extra-id": ids.append("CLIAutomationTests.SeeCommandRuntimeTests/unsafeRuntime()")
+    if mode == "extra-selected-id": ids.append(ids[0] + "/SeeCommandTests.swift:1:1")
     if mode == "display-id": ids[0] = "CLIAutomationTests.SeeCommandRuntimeTests/config environment restores inherited values"
+    if mode not in ["selected-only", "zero-discovery"]: ids += ${JSON.stringify(unrelatedSeeIDs)}
+    print("Building for debugging...")
     print("\\n".join(ids))
     sys.exit(1 if mode == "discovery-failed" else 0)
 lines = [
@@ -95,7 +104,9 @@ if mode == "missing-summary": lines.pop()
 if mode == "duplicate-summary": lines.append(lines[-1])
 if mode == "wrong-count": lines[-1] = '✔ Test run with 3 tests in 1 suite passed after 0.003 seconds.'
 if mode == "missing-pass": lines.pop(3)
+if mode == "extra-pass": lines.insert(4, '✔ Test "unsafeRuntime" passed after 0.001 seconds.')
 if mode == "missing-argument": lines.pop(1)
+if mode == "duplicate-argument": lines.insert(1, lines[0])
 print("\\n".join(lines))
 sys.exit(1 if mode == "execution-failed" else 0)
 `, { mode: 0o755 });
@@ -120,32 +131,73 @@ sys.exit(1 if mode == "execution-failed" else 0)
   }
 }
 
-test("hosted See proof counts discovery and execution in separate nonparallel processes", () => {
+test("hosted See proof selects two declarations from global discovery and executes only those nonparallel", () => {
   const result = runSeeProofFixture("passed");
   assert.equal(result.status, 0, result.stderr);
   assert.equal(result.invocations.length, 2);
-  for (const args of result.invocations) {
-    for (const flag of ["--no-parallel", "--disable-xctest", "--enable-swift-testing", "-DPEEKABOO_SKIP_AUTOMATION"]) {
-      assert.ok(args.includes(flag), flag);
-    }
-    const selection = new RegExp(args[args.indexOf("--filter") + 1]);
-    for (const id of seeEnvironmentIDs) assert.ok(selection.test(id), id);
-    assert.ok(!selection.test("CLIAutomationTests.SeeCommandRuntimeTests/unsafeRuntime()"));
-    assert.ok(!selection.test("CoreCLITests.AppCommandLaunchFlowTests/launch()"));
-  }
-  assert.ok(result.invocations[0].includes("--list-tests"));
-  assert.ok(result.invocations[1].includes("--skip-build"));
+  assert.deepEqual(result.invocations[0], [
+    "test", "list", "--disable-xctest", "--enable-swift-testing", "-Xswiftc", "-DPEEKABOO_SKIP_AUTOMATION",
+  ]);
+  const execution = result.invocations[1];
+  const filter = execution[execution.indexOf("--filter") + 1];
+  assert.deepEqual(execution, [
+    "test", "--disable-xctest", "--enable-swift-testing", "-Xswiftc", "-DPEEKABOO_SKIP_AUTOMATION",
+    "--skip-build", "--no-parallel", "--filter", filter,
+  ]);
+  const selection = new RegExp(filter);
+  for (const id of seeEnvironmentIDs) assert.ok(selection.test(id), id);
+  for (const id of unrelatedSeeIDs) assert.ok(!selection.test(id), id);
+  assert.match(result.stdout, /Verified discovery: 2 selected See environment test declarations from the global listing/);
   assert.match(result.stdout, /Verified execution: 2 tests in 1 suite/);
+  // A package containing only the selected IDs is also valid; it is not required.
+  const selectedOnly = runSeeProofFixture("selected-only");
+  assert.equal(selectedOnly.status, 0, selectedOnly.stderr);
 });
 
 test("hosted See proof fails closed on absent or incomplete evidence", () => {
-  for (const mode of ["zero-discovery", "missing-id", "duplicate-id", "extra-id", "display-id", "discovery-failed",
-    "zero-execution", "missing-summary", "duplicate-summary", "wrong-count", "missing-pass", "missing-argument", "execution-failed"]) {
+  for (const mode of ["zero-discovery", "no-selected-id", "missing-id", "duplicate-id", "extra-selected-id", "display-id", "discovery-failed",
+    "zero-execution", "missing-summary", "duplicate-summary", "wrong-count", "missing-pass", "extra-pass",
+    "missing-argument", "duplicate-argument", "execution-failed"]) {
     const result = runSeeProofFixture(mode);
     assert.notEqual(result.status, 0, mode);
-    assert.equal(result.invocations.length, ["zero-discovery", "missing-id", "duplicate-id", "extra-id", "display-id", "discovery-failed"].includes(mode) ? 1 : 2, mode);
+    assert.equal(result.invocations.length, ["zero-discovery", "no-selected-id", "missing-id", "duplicate-id", "extra-selected-id", "display-id", "discovery-failed"].includes(mode) ? 1 : 2, mode);
   }
   const local = runSeeProofFixture("passed", false);
   assert.notEqual(local.status, 0);
   assert.match(local.stderr, /restricted to the secretless GitHub-hosted CI runner/);
+});
+
+test("See proof arguments agree with installed Swift help and parse without running discovery", {
+  skip: process.platform !== "darwin",
+}, () => {
+  const directory = mkdtempSync(join(tmpdir(), "peekaboo-see-parser-"));
+  const swift = (args) => spawnSync("swift", args, {
+    cwd: directory, encoding: "utf8", timeout: 20_000,
+  });
+  try {
+    const listHelp = swift(["test", "list", "--help-hidden"]);
+    assert.equal(listHelp.status, 0, listHelp.stderr);
+    // Parent test options can parse without being documented list options.
+    assert.doesNotMatch(listHelp.stdout, /^\s+--(?:filter|parallel|no-parallel)\b/m);
+    for (const option of ["--disable-xctest", "--enable-swift-testing", "-Xswiftc"]) {
+      assert.ok(listHelp.stdout.includes(option), option);
+    }
+    const fixture = runSeeProofFixture("passed");
+    assert.equal(fixture.status, 0, fixture.stderr);
+    for (const args of fixture.invocations) {
+      const help = swift([...args, "--help"]);
+      assert.equal(help.status, 0, help.stderr);
+      // --help alone masks bad flags. Force a parser error before command dispatch;
+      // a preceding unknown option must win over this last, deliberate stop token.
+      const stop = "--see-proof-parser-stop";
+      const parsed = swift([...args, stop]);
+      assert.equal(parsed.status, 64, parsed.stderr);
+      assert.match(parsed.stderr, /^error: Unknown option '--see-proof-parser-stop'/m);
+      const invalid = swift([...args, "--invalid-see-option", stop]);
+      assert.equal(invalid.status, 64, invalid.stderr);
+      assert.match(invalid.stderr, /^error: Unknown option '--invalid-see-option'/m);
+    }
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
 });

--- a/tests/ambient-state-test-policy.test.mjs
+++ b/tests/ambient-state-test-policy.test.mjs
@@ -1,9 +1,16 @@
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
 
 const repositoryRoot = fileURLToPath(new URL("..", import.meta.url));
+const seeEnvironmentIDs = [
+  "CLIAutomationTests.SeeCommandRuntimeTests/`config environment restores inherited values`(werePresent:)",
+  "CLIAutomationTests.SeeCommandRuntimeTests/`config environment restores nested throwing bodies`()",
+];
 const packageJSON = JSON.parse(readFileSync(`${repositoryRoot}/package.json`, "utf8"));
 const runtimeTests = readFileSync(
   `${repositoryRoot}/Apps/CLI/Tests/CLIRuntimeTests/CLIRuntimeSmokeTests.swift`,
@@ -26,4 +33,119 @@ test("ambient-state tests require the exact shared opt-in", () => {
     runtimeTests,
     /@Test\(\.enabled\(if: CLIRuntimeEnvironment\.runAmbientStateTests\)\)/,
   );
+});
+
+test("hosted See proof retains target inclusion without opting into ambient tests", () => {
+  const manifest = readFileSync(`${repositoryRoot}/Apps/CLI/Package.swift`, "utf8");
+  const workflow = readFileSync(`${repositoryRoot}/.github/workflows/macos-ci.yml`, "utf8");
+  const step = workflow.split("      - name: Run See configuration environment regressions\n")[1]
+    .split("\n  tachikoma:")[0];
+  assert.match(step, /PEEKABOO_INCLUDE_AUTOMATION_TESTS: "true"/);
+  assert.match(step, /PEEKABOO_INCLUDE_AMBIENT_STATE_TESTS: "false"/);
+  assert.match(step, /PEEKABOO_CONFIG_DISABLE_MIGRATION: "1"/);
+  assert.match(step, /python3 ..\/..\/scripts\/test-see-config-environment.py/);
+  assert.match(manifest, /if includeAutomationTests \{[\s\S]*name: "CLIAutomationTests"/);
+  const target = manifest.split('name: "CLIAutomationTests"')[1].split("let package = Package(")[0];
+  assert.doesNotMatch(target, /\b(?:exclude|sources):/);
+  assert.doesNotMatch(manifest, /PEEKABOO_INCLUDE_AMBIENT_STATE_TESTS/);
+});
+
+test("See environment proof uses declaration IDs, including backticks and argument labels", () => {
+  const oldSelection = /SeeCommandRuntimeTests\/config environment restores (inherited values|nested throwing bodies)/;
+  assert.ok(seeEnvironmentIDs.every((id) => !oldSelection.test(id)), "The old display-name filter discovers neither ID");
+  const source = readFileSync(`${repositoryRoot}/Apps/CLI/Tests/CLIAutomationTests/SeeCommandTests.swift`, "utf8");
+  assert.match(source, /@Test\(arguments: \[false, true\]\)\s+@MainActor\s+func `config environment restores inherited values`\(werePresent: Bool\)/);
+  assert.match(source, /@Test\s+@MainActor\s+func `config environment restores nested throwing bodies`\(\)/);
+  const regressions = source.split("struct SeeCommandRuntimeTests {")[1]
+    .split("func `tree only See propagates")[0];
+  assert.match(regressions, /resetConfiguration: \{ resets.append\(SeeConfigEnvironment\(\)\) \}/);
+  assert.doesNotMatch(regressions, /ConfigurationManager|InProcessCommandRunner|executePeekabooCLI/);
+});
+
+function runSeeProofFixture(mode, hosted = true) {
+  const directory = mkdtempSync(join(tmpdir(), "peekaboo-see-proof-"));
+  try {
+    const bin = join(directory, "bin");
+    mkdirSync(bin);
+    const calls = join(directory, "calls.jsonl");
+    // Never discover or execute the real Swift tests on the operator's machine.
+    writeFileSync(join(bin, "swift"), `#!/usr/bin/env python3
+import json, os, sys
+with open(os.environ["SEE_PROOF_CALLS"], "a") as output:
+    output.write(json.dumps(sys.argv[1:]) + "\\n")
+mode = os.environ["SEE_PROOF_SCENARIO"]
+ids = ${JSON.stringify(seeEnvironmentIDs)}
+if "--list-tests" in sys.argv:
+    if mode == "zero-discovery": ids = []
+    if mode == "missing-id": ids.pop()
+    if mode == "duplicate-id": ids.append(ids[0])
+    if mode == "extra-id": ids.append("CLIAutomationTests.SeeCommandRuntimeTests/unsafeRuntime()")
+    if mode == "display-id": ids[0] = "CLIAutomationTests.SeeCommandRuntimeTests/config environment restores inherited values"
+    print("\\n".join(ids))
+    sys.exit(1 if mode == "discovery-failed" else 0)
+lines = [
+    '◇ Test case passing 1 argument werePresent → false to "config environment restores inherited values" started.',
+    '◇ Test case passing 1 argument werePresent → true to "config environment restores inherited values" started.',
+    '✔ Test "config environment restores inherited values" passed after 0.001 seconds.',
+    '✔ Test "config environment restores nested throwing bodies" passed after 0.001 seconds.',
+    '✔ Test run with 2 tests in 1 suite passed after 0.003 seconds.',
+]
+if mode == "zero-execution": lines = ['✔ Test run with 0 tests in 0 suites passed after 0.001 seconds.']
+if mode == "missing-summary": lines.pop()
+if mode == "duplicate-summary": lines.append(lines[-1])
+if mode == "wrong-count": lines[-1] = '✔ Test run with 3 tests in 1 suite passed after 0.003 seconds.'
+if mode == "missing-pass": lines.pop(3)
+if mode == "missing-argument": lines.pop(1)
+print("\\n".join(lines))
+sys.exit(1 if mode == "execution-failed" else 0)
+`, { mode: 0o755 });
+    const result = spawnSync("python3", [join(repositoryRoot, "scripts/test-see-config-environment.py")], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PATH: `${bin}:${process.env.PATH}`,
+        GITHUB_ACTIONS: hosted ? "true" : "false",
+        RUNNER_ENVIRONMENT: hosted ? "github-hosted" : "self-hosted",
+        PEEKABOO_INCLUDE_AUTOMATION_TESTS: "true",
+        PEEKABOO_INCLUDE_AMBIENT_STATE_TESTS: "false",
+        PEEKABOO_CONFIG_DISABLE_MIGRATION: "1",
+        SEE_PROOF_CALLS: calls,
+        SEE_PROOF_SCENARIO: mode,
+      },
+    });
+    const invocations = hosted ? readFileSync(calls, "utf8").trim().split("\n").map(JSON.parse) : [];
+    return { ...result, invocations };
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+}
+
+test("hosted See proof counts discovery and execution in separate nonparallel processes", () => {
+  const result = runSeeProofFixture("passed");
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.invocations.length, 2);
+  for (const args of result.invocations) {
+    for (const flag of ["--no-parallel", "--disable-xctest", "--enable-swift-testing", "-DPEEKABOO_SKIP_AUTOMATION"]) {
+      assert.ok(args.includes(flag), flag);
+    }
+    const selection = new RegExp(args[args.indexOf("--filter") + 1]);
+    for (const id of seeEnvironmentIDs) assert.ok(selection.test(id), id);
+    assert.ok(!selection.test("CLIAutomationTests.SeeCommandRuntimeTests/unsafeRuntime()"));
+    assert.ok(!selection.test("CoreCLITests.AppCommandLaunchFlowTests/launch()"));
+  }
+  assert.ok(result.invocations[0].includes("--list-tests"));
+  assert.ok(result.invocations[1].includes("--skip-build"));
+  assert.match(result.stdout, /Verified execution: 2 tests in 1 suite/);
+});
+
+test("hosted See proof fails closed on absent or incomplete evidence", () => {
+  for (const mode of ["zero-discovery", "missing-id", "duplicate-id", "extra-id", "display-id", "discovery-failed",
+    "zero-execution", "missing-summary", "duplicate-summary", "wrong-count", "missing-pass", "missing-argument", "execution-failed"]) {
+    const result = runSeeProofFixture(mode);
+    assert.notEqual(result.status, 0, mode);
+    assert.equal(result.invocations.length, ["zero-discovery", "missing-id", "duplicate-id", "extra-id", "display-id", "discovery-failed"].includes(mode) ? 1 : 2, mode);
+  }
+  const local = runSeeProofFixture("passed", false);
+  assert.notEqual(local.status, 0);
+  assert.match(local.stderr, /restricted to the secretless GitHub-hosted CI runner/);
 });


### PR DESCRIPTION
## Summary

Refresh the existing runtime/Bridge fixture work on current `main`, preserving the CLI naming fixes and independently landed mutation-test split. Fixtures own their watermark stores, lane coordinators, narrow Bridge providers and live listeners; cleanup is awaited on successful and throwing bodies. The See fixture restores inherited configuration exactly, including empty and absent values, before its inert reset callback.

The hosted See gate uses canonical `swift test list`, validates the two exact declaration IDs, then executes only those tests nonparallel. It requires two passing tests in one suite, including both inherited-value arguments; zero, missing or extra selected execution fails.

## Isolation boundary

This is partial fixture isolation, not proof that ambient CLI execution is safe. These Remote cases remain present but excluded from the protected local selection because they can still reach caller-local `SnapshotManager` defaults:

- `Remote-selected local mutation installs a caller barrier`
- `Remote coordinator rejects a host observation certificate that forbids preservation`

Other runtime construction still needs isolation. Secretless hosted CI is a separate boundary, not protected local proof. The helper refuses ordinary local execution and does not expand the executed selection. No native capture, input, TCC or complete runtime hermeticity is claimed.

## Validation

All final-head checks passed at `0f03594ef7ca5cd8a6bbdf46caaea6bc737050a9`: [macOS CI](https://github.com/openclaw/Peekaboo/actions/runs/33617982437), [full supplemental suites](https://github.com/openclaw/Peekaboo/actions/runs/33617982548), and [CodeQL](https://github.com/openclaw/Peekaboo/actions/runs/33617982443).

The final successful CLI job explicitly discovered both See declarations and executed two tests in one suite: both inherited-value arguments and the nested throwing case passed, for three test-body executions. The verifier also accepted that execution. Seven policy/verifier/parser checks pass locally without running runtime discovery or the ambient Swift tests.

Earlier failures remain recorded rather than counted as proof: the initial filter omitted literal backticks and ran zero tests; the first discovery helper used a deprecated alias that rejected execution flags; the subsequent real tests passed but the verifier omitted Swift’s normal `with 2 test cases` completion suffix. The final parser accepts that suffix while retaining count and argument checks. The observed output shape failed before the correction and passed afterward; an incorrect parameter count is still rejected. Canonical argument parsing was checked on Swift 6.3.3 and 6.4 without unsafe local discovery.

The complete uncommitted integration onto `main` at `d35e7006f48629714d086e402540e30407992111` received a clean scoped Codex P0 review, and all seven verifier checks passed in that tree. Source inventories of 64 CoreCLI declarations are not asserted as an executed test count.

No production behavior, changelog or release publication changes are included. Original Peter Steinberger attribution is retained.
