### PR TITLE
fix(codeql): isolate internal CLI target identities

### DIFF
--- a/Apps/CLI/Package.swift
+++ b/Apps/CLI/Package.swift
@@ -41,7 +41,7 @@ var targets: [Target] = [
         path: "Sources/PeekabooCLI",
         swiftSettings: cliConcurrencySettings),
     .executableTarget(
-        name: "peekaboo",
+        name: "PeekabooExec",
         dependencies: [
             "PeekabooCLI",
         ],
@@ -149,7 +149,7 @@ let package = Package(
     products: [
         .executable(
             name: "peekaboo",
-            targets: ["peekaboo"]),
+            targets: ["PeekabooExec"]),
         .executable(
             name: "peekaboo-certification-controller",
             targets: ["PeekabooCertificationController"]),

--- a/Apps/Peekaboo.xcworkspace/xcshareddata/xcschemes/CodeQL.xcscheme
+++ b/Apps/Peekaboo.xcworkspace/xcshareddata/xcschemes/CodeQL.xcscheme
@@ -7,6 +7,8 @@
       buildImplicitDependencies = "YES"
       buildArchitectures = "Automatic">
       <BuildActionEntries>
+         <!-- Compile SwiftPM's internal modules here. The public executable products are linked and tested by macOS CI;
+              their case-folded wrapper names collide with the Peekaboo app target on hosted case-insensitive runners. -->
          <BuildActionEntry
             buildForTesting = "YES"
             buildForRunning = "YES"
@@ -15,9 +17,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "peekaboo"
-               BuildableName = "peekaboo"
-               BlueprintName = "peekaboo"
+               BlueprintIdentifier = "PeekabooExec"
+               BuildableName = "PeekabooExec"
+               BlueprintName = "PeekabooExec"
                ReferencedContainer = "container:CLI">
             </BuildableReference>
          </BuildActionEntry>
@@ -29,9 +31,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "peekaboo-certification-controller"
-               BuildableName = "peekaboo-certification-controller"
-               BlueprintName = "peekaboo-certification-controller"
+               BlueprintIdentifier = "PeekabooCertificationController"
+               BuildableName = "PeekabooCertificationController"
+               BlueprintName = "PeekabooCertificationController"
                ReferencedContainer = "container:CLI">
             </BuildableReference>
          </BuildActionEntry>

--- a/tests/codeql-build-graph.test.mjs
+++ b/tests/codeql-build-graph.test.mjs
@@ -3,10 +3,12 @@ import { readdirSync, readFileSync } from 'node:fs';
 import test from 'node:test';
 
 const workflow = readFileSync(new URL('../.github/workflows/codeql.yml', import.meta.url), 'utf8');
+const macOSCI = readFileSync(new URL('../.github/workflows/macos-ci.yml', import.meta.url), 'utf8');
 const workspace = readFileSync(new URL('../Apps/Peekaboo.xcworkspace/contents.xcworkspacedata', import.meta.url), 'utf8');
 const codeQLScheme = readFileSync(
   new URL('../Apps/Peekaboo.xcworkspace/xcshareddata/xcschemes/CodeQL.xcscheme', import.meta.url),
   'utf8');
+const cliPackage = readFileSync(new URL('../Apps/CLI/Package.swift', import.meta.url), 'utf8');
 
 test('Swift CodeQL uses one complete shared Xcode build graph', () => {
   const swiftJob = workflow.slice(workflow.indexOf('  analyze-swift:'));
@@ -21,7 +23,7 @@ test('Swift CodeQL uses one complete shared Xcode build graph', () => {
   assert.match(workspace, /location = "group:CLI"/);
 });
 
-test('CodeQL workspace scheme covers every analyzed product exactly once', () => {
+test('CodeQL workspace scheme covers every analyzed buildable exactly once', () => {
   const entries = [...codeQLScheme.matchAll(/<BuildActionEntry(?<entry>[\s\S]*?)<\/BuildActionEntry>/g)]
     .map(({ groups }) => groups.entry)
     .map((entry) => {
@@ -35,11 +37,11 @@ test('CodeQL workspace scheme covers every analyzed product exactly once', () =>
     });
 
   assert.deepEqual(entries, [
-    { id: 'peekaboo', name: 'peekaboo', product: 'peekaboo', container: 'CLI' },
+    { id: 'PeekabooExec', name: 'PeekabooExec', product: 'PeekabooExec', container: 'CLI' },
     {
-      id: 'peekaboo-certification-controller',
-      name: 'peekaboo-certification-controller',
-      product: 'peekaboo-certification-controller',
+      id: 'PeekabooCertificationController',
+      name: 'PeekabooCertificationController',
+      product: 'PeekabooCertificationController',
       container: 'CLI',
     },
     {
@@ -61,7 +63,29 @@ test('CodeQL workspace scheme covers every analyzed product exactly once', () =>
       container: 'PeekabooInspector/Inspector.xcodeproj',
     },
   ]);
+  const foldedNames = entries.map((entry) => entry.name.toLowerCase());
+  assert.equal(new Set(foldedNames).size, foldedNames.length,
+    'Aggregate target names must remain unique on case-insensitive filesystems');
   assert.match(codeQLScheme, /<AnalyzeAction\s+buildConfiguration = "Debug">/);
+});
+
+test('public CLI product remains named peekaboo', () => {
+  assert.match(
+    cliPackage,
+    /\.executable\(\s*name: "peekaboo",\s*targets: \["PeekabooExec"\]\)/);
+});
+
+test('macOS CI links and runs the public CLI product', () => {
+  const start = macOSCI.indexOf('  peekaboo-cli:');
+  const end = macOSCI.indexOf('\n  tachikoma:', start);
+  const cliJob = macOSCI.slice(start, end);
+
+  assert.ok(start >= 0 && end > start, 'macOS CI must retain its dedicated CLI job');
+  assert.match(cliJob, /name: Peekaboo CLI build & tests/);
+  assert.match(cliJob, /working-directory: Apps\/CLI/);
+  assert.match(cliJob, /swift build --configuration debug/);
+  assert.match(cliJob, /PEEKABOO_CLI_BINARY=.*\/peekaboo/);
+  assert.match(cliJob, /swift test --no-parallel/);
 });
 
 test('workspace CLI entry point avoids main.swift special-file semantics', () => {


### PR DESCRIPTION
## Summary

- rename the internal SwiftPM executable target from `peekaboo` to `PeekabooExec` while preserving the public `peekaboo` product and binary
- make the CodeQL workspace scheme compile the internal `PeekabooExec` and `PeekabooCertificationController` modules instead of their public product wrappers
- keep the five aggregate buildable names unique on case-insensitive filesystems and retain macOS CI as the public CLI link/test owner

## Root cause

PR #661 unified Swift analysis into one Xcode build graph, but its CLI product wrapper `peekaboo` and app target `Peekaboo` collapse onto the same intermediate directory on case-insensitive hosted runners. The CLI SwiftDriver then consumes the app target's generated asset input list and fails because `GeneratedAssetSymbols.swift` does not exist in the colliding path.

This happened in [run 33213279659](https://github.com/openclaw/Peekaboo/actions/runs/33213279659) and again in [run 33219112945](https://github.com/openclaw/Peekaboo/actions/runs/33219112945). The second run proved that renaming only the SwiftPM target is insufficient while the aggregate still references the public product wrapper.

The correction keeps public executable linking in the existing macOS CI job and gives CodeQL the complete compile/module graph through collision-free internal targets.

## Proof

- one cold Xcode 27 aggregate invocation completed in 71 seconds and produced both internal CLI modules plus Peekaboo, Playground, and Inspector
- SwiftPM built the public `peekaboo` Mach-O and 1,367 CLI tests passed
- CodeQL contract tests, actionlint, scheme XML validation, SwiftFormat, and SwiftLint passed; SwiftLint reported only the existing non-serious warning baseline
- P0-P2 autoreview completed; its concern that internal buildable references would not resolve was rejected against the successful cold aggregate build and emitted module artifacts

No changelog entry: this repairs CI build ownership without changing user-visible behavior.
