### PR TITLE
fix(cli): clarify browser handoff metadata refusals

### DIFF
--- a/Apps/CLI/Sources/PeekabooCLI/Commands/MCP/BrowserHandoffReceiptStore.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/MCP/BrowserHandoffReceiptStore.swift
@@ -254,8 +254,10 @@ final class BrowserHandoffReceiptStore: @unchecked Sendable {
 
     fileprivate static func validatedFileMetadata(_ descriptor: Int32, expectedSize: off_t? = nil) throws -> stat {
         var info = stat()
-        guard fstat(descriptor, &info) == 0,
-              info.st_mode & S_IFMT == S_IFREG,
+        guard fstat(descriptor, &info) == 0 else {
+            throw BrowserHandoffReceiptStoreError.inspectionFailed(.receipt, .fileStatus)
+        }
+        guard info.st_mode & S_IFMT == S_IFREG,
               info.st_uid == geteuid(),
               info.st_mode & 0o777 == 0o600,
               info.st_nlink == 1,
@@ -267,28 +269,31 @@ final class BrowserHandoffReceiptStore: @unchecked Sendable {
                 "file must be one owner-only regular file with mode 0600 and a bounded size"
             )
         }
-        try self.requireNoExtendedACL(descriptor)
-        try self.requireNoExtendedAttributes(descriptor)
+        try self.requireNoExtendedACL(descriptor, subject: .receipt)
+        try self.requireNoExtendedAttributes(descriptor, subject: .receipt)
         var after = stat()
-        guard fstat(descriptor, &after) == 0, self.sameFile(info, after) else {
+        guard fstat(descriptor, &after) == 0 else {
+            throw BrowserHandoffReceiptStoreError.inspectionFailed(.receipt, .fileStatus)
+        }
+        guard self.sameFile(info, after) else {
             throw BrowserHandoffReceiptStoreError.unsafePath("file metadata changed during validation")
         }
         return after
     }
 
-    fileprivate static func requireNoExtendedACL(_ descriptor: Int32) throws {
+    static func requireNoExtendedACL(_ descriptor: Int32, subject: BrowserHandoffPathSubject) throws {
         errno = 0
         guard let acl = acl_get_fd_np(descriptor, ACL_TYPE_EXTENDED) else {
             if errno == ENOENT {
                 return
             }
-            throw BrowserHandoffReceiptStoreError.unsafePath("access controls could not be inspected")
+            throw BrowserHandoffReceiptStoreError.inspectionFailed(subject, .extendedACL)
         }
         acl_free(UnsafeMutableRawPointer(acl))
-        throw BrowserHandoffReceiptStoreError.unsafePath("extended access-control entries are not accepted")
+        throw BrowserHandoffReceiptStoreError.extendedACL(subject)
     }
 
-    fileprivate static func requireNoExtendedAttributes(_ descriptor: Int32) throws {
+    static func requireNoExtendedAttributes(_ descriptor: Int32, subject: BrowserHandoffPathSubject) throws {
         while true {
             errno = 0
             let count = flistxattr(descriptor, nil, 0, XATTR_SHOWCOMPRESSION)
@@ -299,9 +304,9 @@ final class BrowserHandoffReceiptStore: @unchecked Sendable {
                 continue
             }
             if count > 0 {
-                throw BrowserHandoffReceiptStoreError.unsafePath("extended attributes are not accepted")
+                throw BrowserHandoffReceiptStoreError.extendedAttributes(subject)
             }
-            throw BrowserHandoffReceiptStoreError.unsafePath("extended attributes could not be inspected")
+            throw BrowserHandoffReceiptStoreError.inspectionFailed(subject, .extendedAttributes)
         }
     }
 
@@ -476,8 +481,10 @@ private final class BrowserHandoffReceiptDirectoryBinding: @unchecked Sendable {
 
     private func validatePrivateDirectory(_ descriptor: Int32) throws {
         var before = stat()
-        guard fstat(descriptor, &before) == 0,
-              before.st_mode & S_IFMT == S_IFDIR,
+        guard fstat(descriptor, &before) == 0 else {
+            throw BrowserHandoffReceiptStoreError.inspectionFailed(.parent, .fileStatus)
+        }
+        guard before.st_mode & S_IFMT == S_IFDIR,
               before.st_uid == geteuid(),
               before.st_mode & 0o777 == 0o700,
               before.st_nlink >= 1
@@ -486,12 +493,13 @@ private final class BrowserHandoffReceiptDirectoryBinding: @unchecked Sendable {
                 "parent directory must be owned by the current user with mode 0700"
             )
         }
-        try BrowserHandoffReceiptStore.requireNoExtendedACL(descriptor)
-        try BrowserHandoffReceiptStore.requireNoExtendedAttributes(descriptor)
+        try BrowserHandoffReceiptStore.requireNoExtendedACL(descriptor, subject: .parent)
+        try BrowserHandoffReceiptStore.requireNoExtendedAttributes(descriptor, subject: .parent)
         var after = stat()
-        guard fstat(descriptor, &after) == 0,
-              Self.sameDirectoryMetadata(before, after)
-        else {
+        guard fstat(descriptor, &after) == 0 else {
+            throw BrowserHandoffReceiptStoreError.inspectionFailed(.parent, .fileStatus)
+        }
+        guard Self.sameDirectoryMetadata(before, after) else {
             throw BrowserHandoffReceiptStoreError.unsafePath(
                 "parent directory metadata changed during validation"
             )
@@ -582,9 +590,23 @@ final class BrowserHandoffReceiptStoreCache: @unchecked Sendable {
     }
 }
 
+enum BrowserHandoffPathSubject: String, CaseIterable {
+    case parent = "parent directory"
+    case receipt = "receipt file"
+}
+
+enum BrowserHandoffPathInspection: String, CaseIterable {
+    case fileStatus = "file status"
+    case extendedACL = "extended access controls"
+    case extendedAttributes = "extended attributes"
+}
+
 enum BrowserHandoffReceiptStoreError: LocalizedError, ResultEnvelopeError, Equatable {
     case alreadyExists
     case unsafePath(String)
+    case extendedACL(BrowserHandoffPathSubject)
+    case extendedAttributes(BrowserHandoffPathSubject)
+    case inspectionFailed(BrowserHandoffPathSubject, BrowserHandoffPathInspection)
     case invalidReceipt(String)
     case writeFailed(String)
 
@@ -594,6 +616,12 @@ enum BrowserHandoffReceiptStoreError: LocalizedError, ResultEnvelopeError, Equat
             "A browser handoff receipt already exists at that path."
         case let .unsafePath(reason):
             "Browser handoff receipt path is unsafe: \(reason)."
+        case let .extendedACL(subject):
+            "Browser handoff \(subject.rawValue) is unsafe: extended access controls are not accepted."
+        case let .extendedAttributes(subject):
+            "Browser handoff \(subject.rawValue) is unsafe: extended attributes are not accepted."
+        case let .inspectionFailed(subject, inspection):
+            "Browser handoff \(subject.rawValue) could not be verified: \(inspection.rawValue) could not be inspected."
         case let .invalidReceipt(reason):
             "Browser handoff receipt is invalid: \(reason)."
         case let .writeFailed(reason):
@@ -604,7 +632,7 @@ enum BrowserHandoffReceiptStoreError: LocalizedError, ResultEnvelopeError, Equat
     nonisolated var envelopeCode: ErrorCode? {
         switch self {
         case .alreadyExists, .invalidReceipt: .VALIDATION_ERROR
-        case .unsafePath, .writeFailed: .FILE_IO_ERROR
+        case .unsafePath, .extendedACL, .extendedAttributes, .inspectionFailed, .writeFailed: .FILE_IO_ERROR
         }
     }
 
@@ -626,6 +654,17 @@ enum BrowserHandoffReceiptStoreError: LocalizedError, ResultEnvelopeError, Equat
             "Use a new path; Peekaboo never overwrites capability material."
         case .unsafePath:
             "Use a standardized absolute path in an existing owner-only directory with mode 0700."
+        case .extendedACL:
+            "Both the parent directory and receipt must have zero extended ACLs; " +
+                "owner-only modes alone are insufficient. " +
+                "Handoff remains refused without fallback."
+        case .extendedAttributes:
+            "Both the parent directory and receipt must have zero extended attributes, including OS provenance. " +
+                "Modes 0700/0600 alone are insufficient; environments that attach metadata are not compatible. " +
+                "Handoff remains refused without fallback."
+        case .inspectionFailed:
+            "Inspection failure does not establish whether extended ACLs or attributes are present. " +
+                "Handoff remains refused without fallback because path safety could not be verified."
         case .invalidReceipt:
             "Create a fresh handoff with an authenticated current Bridge host."
         case .writeFailed:

--- a/Apps/CLI/Tests/CoreCLITests/BrowserHandoffCLITests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/BrowserHandoffCLITests.swift
@@ -240,7 +240,9 @@ struct BrowserHandoffCLITests {
                 fileURL: linkedParent.appendingPathComponent("handoff.json")
             )
 
-            #expect(throws: BrowserHandoffReceiptStoreError.self) { try store.validateCanSave() }
+            #expect(throws: BrowserHandoffReceiptStoreError.unsafePath(
+                "parent path components must be existing non-symbolic-link directories"
+            )) { try store.validateCanSave() }
         }
 
         do {
@@ -255,7 +257,9 @@ struct BrowserHandoffCLITests {
             try FileManager.default.moveItem(at: parent, to: displaced)
             try Self.createPrivateDirectory(at: parent)
 
-            #expect(throws: BrowserHandoffReceiptStoreError.self) { try store.save(fixture) }
+            #expect(throws: BrowserHandoffReceiptStoreError.unsafePath(
+                "parent directory or one of its ancestors changed after validation"
+            )) { try store.save(fixture) }
             #expect(!FileManager.default.fileExists(atPath: parent.appendingPathComponent("handoff.json").path))
             #expect(!FileManager.default.fileExists(atPath: displaced.appendingPathComponent("handoff.json").path))
         }
@@ -275,7 +279,9 @@ struct BrowserHandoffCLITests {
             try Self.createPrivateDirectory(at: ancestor)
             try Self.createPrivateDirectory(at: parent)
 
-            #expect(throws: BrowserHandoffReceiptStoreError.self) { try store.save(fixture) }
+            #expect(throws: BrowserHandoffReceiptStoreError.unsafePath(
+                "parent directory or one of its ancestors changed after validation"
+            )) { try store.save(fixture) }
             #expect(!FileManager.default.fileExists(atPath: parent.appendingPathComponent("handoff.json").path))
             let oldReceipt = displaced.appendingPathComponent("parent/handoff.json")
             #expect(!FileManager.default.fileExists(atPath: oldReceipt.path))
@@ -302,7 +308,9 @@ struct BrowserHandoffCLITests {
         try FileManager.default.moveItem(at: parent, to: displaced)
         try Self.createPrivateDirectory(at: parent)
 
-        #expect(throws: BrowserHandoffReceiptStoreError.self) {
+        #expect(throws: BrowserHandoffReceiptStoreError.unsafePath(
+            "parent directory or one of its ancestors changed after validation"
+        )) {
             try command.validateBeforeRuntime()
         }
     }
@@ -342,7 +350,9 @@ struct BrowserHandoffCLITests {
             let store = try BrowserHandoffReceiptStore(fileURL: destination)
             try store.validateCanSave()
 
-            #expect(throws: BrowserHandoffReceiptStoreError.self) {
+            #expect(throws: BrowserHandoffReceiptStoreError.unsafePath(
+                "parent directory or one of its ancestors changed after validation"
+            )) {
                 try store.save(fixture, afterPublication: {
                     try FileManager.default.moveItem(at: ancestor, to: displaced)
                     try Self.createPrivateDirectory(at: ancestor)
@@ -358,7 +368,7 @@ struct BrowserHandoffCLITests {
 
     @Test
     @MainActor
-    func `store rejects symlinks hardlinks widened modes ACLs and nonprivate parents`() async throws {
+    func `handoff path diagnostics reject unsafe paths`() async throws {
         let fixture = try await Self.canonicalHandoffData()
 
         do {
@@ -366,12 +376,13 @@ struct BrowserHandoffCLITests {
             defer { try? FileManager.default.removeItem(at: directory) }
             let target = directory.appendingPathComponent("target.json")
             let link = directory.appendingPathComponent("handoff.json")
-            try fixture.write(to: target)
-            try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: target.path)
+            _ = try Self.cleanReceiptStore(fixture, at: target)
             try FileManager.default.createSymbolicLink(at: link, withDestinationURL: target)
             let store = try BrowserHandoffReceiptStore(fileURL: link)
-            #expect(throws: BrowserHandoffReceiptStoreError.self) { try store.load() }
-            #expect(throws: BrowserHandoffReceiptStoreError.self) { try store.validateCanSave() }
+            #expect(throws: BrowserHandoffReceiptStoreError.unsafePath("symbolic links are not accepted")) {
+                try store.load()
+            }
+            #expect(throws: BrowserHandoffReceiptStoreError.alreadyExists) { try store.validateCanSave() }
         }
 
         do {
@@ -379,11 +390,12 @@ struct BrowserHandoffCLITests {
             defer { try? FileManager.default.removeItem(at: directory) }
             let file = directory.appendingPathComponent("handoff.json")
             let alias = directory.appendingPathComponent("alias.json")
-            try fixture.write(to: file)
-            try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: file.path)
-            #expect(link(file.path, alias.path) == 0)
-            #expect(throws: BrowserHandoffReceiptStoreError.self) {
-                try BrowserHandoffReceiptStore(fileURL: file).load()
+            let store = try Self.cleanReceiptStore(fixture, at: file)
+            try #require(link(file.path, alias.path) == 0)
+            #expect(throws: BrowserHandoffReceiptStoreError.unsafePath(
+                "file must be one owner-only regular file with mode 0600 and a bounded size"
+            )) {
+                try store.load()
             }
         }
 
@@ -391,51 +403,142 @@ struct BrowserHandoffCLITests {
             let directory = try Self.privateDirectory()
             defer { try? FileManager.default.removeItem(at: directory) }
             let file = directory.appendingPathComponent("handoff.json")
-            try fixture.write(to: file)
+            let store = try Self.cleanReceiptStore(fixture, at: file)
             try FileManager.default.setAttributes([.posixPermissions: 0o644], ofItemAtPath: file.path)
-            #expect(throws: BrowserHandoffReceiptStoreError.self) {
-                try BrowserHandoffReceiptStore(fileURL: file).load()
+            #expect(throws: BrowserHandoffReceiptStoreError.unsafePath(
+                "file must be one owner-only regular file with mode 0600 and a bounded size"
+            )) {
+                try store.load()
             }
         }
 
         do {
             let directory = try Self.privateDirectory()
-            defer { try? FileManager.default.removeItem(at: directory) }
-            let file = directory.appendingPathComponent("handoff.json")
-            try fixture.write(to: file)
-            try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: file.path)
-            try Self.addReadableACL(to: file)
-            #expect(throws: BrowserHandoffReceiptStoreError.self) {
-                try BrowserHandoffReceiptStore(fileURL: file).load()
-            }
-        }
-
-        do {
-            let directory = try Self.privateDirectory(mode: 0o755)
             defer { try? FileManager.default.removeItem(at: directory) }
             let store = try BrowserHandoffReceiptStore(fileURL: directory.appendingPathComponent("handoff.json"))
-            #expect(throws: BrowserHandoffReceiptStoreError.self) { try store.validateCanSave() }
-        }
-
-        do {
-            let directory = try Self.privateDirectory()
-            defer { try? FileManager.default.removeItem(at: directory) }
-            try Self.addExtendedAttribute(to: directory)
-            let store = try BrowserHandoffReceiptStore(fileURL: directory.appendingPathComponent("handoff.json"))
-            #expect(throws: BrowserHandoffReceiptStoreError.self) { try store.validateCanSave() }
-        }
-
-        do {
-            let directory = try Self.privateDirectory()
-            defer { try? FileManager.default.removeItem(at: directory) }
-            let file = directory.appendingPathComponent("handoff.json")
-            try fixture.write(to: file)
-            try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: file.path)
-            try Self.addExtendedAttribute(to: file)
-            #expect(throws: BrowserHandoffReceiptStoreError.self) {
-                try BrowserHandoffReceiptStore(fileURL: file).load()
+            try store.validateCanSave()
+            try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: directory.path)
+            #expect(throws: BrowserHandoffReceiptStoreError.unsafePath(
+                "parent directory must be owned by the current user with mode 0700"
+            )) {
+                try store.validateCanSave()
             }
         }
+    }
+
+    @Test(arguments: BrowserHandoffPathSubject.allCases, [
+        BrowserHandoffPathInspection.extendedACL, .extendedAttributes,
+    ])
+    @MainActor
+    func `handoff path diagnostics reject metadata before runtime`(
+        subject: BrowserHandoffPathSubject,
+        inspection: BrowserHandoffPathInspection
+    ) async throws {
+        let fixture = try await Self.canonicalHandoffData()
+        let directory = try Self.privateDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = try Self.cleanReceiptStore(fixture, at: directory.appendingPathComponent("handoff.json"))
+        let url = subject == .parent ? directory : store.fileURL
+        let expected: BrowserHandoffReceiptStoreError
+        var privateValue: String?
+        if inspection == .extendedACL {
+            try Self.addReadableACL(to: url)
+            expected = .extendedACL(subject)
+        } else {
+            privateValue = try Self.addExtendedAttribute(to: url)
+            expected = .extendedAttributes(subject)
+        }
+
+        do {
+            _ = try store.load()
+            Issue.record("Expected the deliberately added metadata to be refused")
+        } catch let error as BrowserHandoffReceiptStoreError {
+            #expect(error == expected)
+            let diagnostic = error.localizedDescription + (error.envelopeHint ?? "") + String(describing: error)
+            // Assert only a Boolean so a failing test never prints the private fixture value.
+            let disclosedValue = privateValue.map { diagnostic.contains($0) } ?? false
+            #expect(!disclosedValue)
+        }
+
+        let inputError = BrowserHandoffCLIInputError.invalidReceipt(expected.localizedDescription)
+        #expect(inputError.envelopeCode == .VALIDATION_ERROR)
+        #expect(inputError.envelopeRetrySafe == true)
+        #expect(inputError.envelopeMutationDispatched == false)
+        #expect(inputError.envelopeHint?.contains("do not fall back") == true)
+        var runtimeConstructed = false
+        let factory = CommanderRuntimeExecutor.RuntimeFactory { _ in
+            runtimeConstructed = true
+            throw StopBeforeRuntimeConstruction()
+        }
+        await #expect(throws: inputError) {
+            try await CommanderRuntimeExecutor.resolveAndRun(
+                arguments: [
+                    "peekaboo", "mcp", "serve",
+                    "--browser-handoff", store.fileURL.path,
+                    "--bridge-socket", "/private/tmp/peekaboo-handoff.sock",
+                ],
+                runtimeFactory: factory
+            )
+        }
+        if subject == .parent {
+            #expect(throws: expected) { try store.validateCanSave() }
+            await #expect(throws: expected) {
+                try await CommanderRuntimeExecutor.resolveAndRun(
+                    arguments: [
+                        "peekaboo", "browser", "connect", "--foreground",
+                        "--handoff-file", directory.appendingPathComponent("unused.json").path,
+                        "--bridge-socket", "/private/tmp/peekaboo-handoff.sock",
+                    ],
+                    runtimeFactory: factory
+                )
+            }
+        }
+        #expect(!runtimeConstructed)
+    }
+
+    @Test(arguments: BrowserHandoffPathSubject.allCases)
+    func `handoff path diagnostics distinguish inspection failures`(subject: BrowserHandoffPathSubject) {
+        #expect(throws: BrowserHandoffReceiptStoreError.inspectionFailed(subject, .extendedACL)) {
+            try BrowserHandoffReceiptStore.requireNoExtendedACL(-1, subject: subject)
+        }
+        #expect(throws: BrowserHandoffReceiptStoreError.inspectionFailed(subject, .extendedAttributes)) {
+            try BrowserHandoffReceiptStore.requireNoExtendedAttributes(-1, subject: subject)
+        }
+    }
+
+    @Test(arguments: BrowserHandoffPathSubject.allCases)
+    func `handoff path diagnostics keep distinct hints and envelope`(subject: BrowserHandoffPathSubject) {
+        let attributes = BrowserHandoffReceiptStoreError.extendedAttributes(subject)
+        let acl = BrowserHandoffReceiptStoreError.extendedACL(subject)
+        #expect(attributes.errorDescription ==
+            "Browser handoff \(subject.rawValue) is unsafe: extended attributes are not accepted.")
+        #expect(acl.errorDescription ==
+            "Browser handoff \(subject.rawValue) is unsafe: extended access controls are not accepted.")
+        #expect(attributes.envelopeHint?.contains("zero extended attributes, including OS provenance") == true)
+        #expect(attributes.envelopeHint?.contains("not compatible") == true)
+        #expect(acl.envelopeHint?.contains("zero extended ACLs") == true)
+        #expect(acl.envelopeHint?.contains("OS provenance") == false)
+
+        let inspections = BrowserHandoffPathInspection.allCases.map {
+            BrowserHandoffReceiptStoreError.inspectionFailed(subject, $0)
+        }
+        for error in inspections {
+            #expect(error.errorDescription?.contains(subject.rawValue) == true)
+            #expect(error.errorDescription?.contains("could not be inspected") == true)
+            #expect(error.errorDescription?.contains("are not accepted") == false)
+            #expect(error.envelopeHint?.contains("does not establish whether") == true)
+            #expect(error.envelopeHint?.contains("OS provenance") == false)
+        }
+        for error in [attributes, acl] + inspections {
+            #expect(error.envelopeCode == .FILE_IO_ERROR)
+            #expect(error.envelopeEffect == nil)
+            #expect(error.envelopeRetrySafe == true)
+            #expect(error.envelopeMutationDispatched == false)
+            #expect(error.envelopeHint?.contains("without fallback") == true)
+            #expect(error.envelopeHint?.contains("Use a standardized absolute path") == false)
+        }
+        let unrelated = BrowserHandoffReceiptStoreError.unsafePath("extended attributes are not accepted")
+        #expect(unrelated.envelopeHint?.contains("OS provenance") == false)
     }
 
     @Test
@@ -449,7 +552,7 @@ struct BrowserHandoffCLITests {
         let store = try BrowserHandoffReceiptStore(fileURL: file)
         try store.save(fixture)
 
-        #expect(throws: BrowserHandoffReceiptStoreError.self) {
+        #expect(throws: BrowserHandoffReceiptStoreError.unsafePath("file changed while it was being read")) {
             try store.load {
                 try FileManager.default.moveItem(at: file, to: displaced)
                 try fixture.write(to: file)
@@ -459,17 +562,21 @@ struct BrowserHandoffCLITests {
 
         var noncanonical = fixture
         noncanonical.append(UInt8(ascii: "\n"))
-        #expect(throws: BrowserHandoffReceiptStoreError.self) {
+        #expect(throws: BrowserHandoffReceiptStoreError.invalidReceipt("receipt bundle bytes are not canonical")) {
             try BrowserHandoffReceiptStore.validateCanonicalReceipt(noncanonical)
         }
         let oversized = Data(
             repeating: UInt8(ascii: "x"),
             count: Int(BrowserHandoffReceiptStore.maximumReceiptBytes) + 1
         )
-        #expect(throws: BrowserHandoffReceiptStoreError.self) {
+        #expect(throws: BrowserHandoffReceiptStoreError.invalidReceipt(
+            "receipt must be nonempty and at most \(BrowserHandoffReceiptStore.maximumReceiptBytes) bytes"
+        )) {
             try BrowserHandoffReceiptStore.validateCanonicalReceipt(oversized)
         }
-        #expect(throws: BrowserHandoffReceiptStoreError.self) {
+        #expect(throws: BrowserHandoffReceiptStoreError.unsafePath(
+            "path must be absolute, nonempty, and already in standardized component form"
+        )) {
             _ = try BrowserHandoffReceiptStore(resolvingAbsolutePath: "relative.json")
         }
 
@@ -577,9 +684,10 @@ struct BrowserHandoffCLITests {
         let receipt = directory.appendingPathComponent("handoff.json")
         try Data("{}".utf8).write(to: receipt)
         try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: receipt.path)
+        let expected = BrowserHandoffReceiptStoreError.invalidReceipt("receipt bundle is not internally valid")
         var runtimeConstructed = false
 
-        await #expect(throws: BrowserHandoffCLIInputError.self) {
+        await #expect(throws: BrowserHandoffCLIInputError.invalidReceipt(expected.localizedDescription)) {
             try await CommanderRuntimeExecutor.resolveAndRun(
                 arguments: [
                     "peekaboo", "mcp", "serve",
@@ -588,7 +696,7 @@ struct BrowserHandoffCLITests {
                 ],
                 runtimeFactory: .init { _ in
                     runtimeConstructed = true
-                    return CommandRuntime(options: CommandRuntimeOptions(), services: PeekabooServices())
+                    throw StopBeforeRuntimeConstruction()
                 }
             )
         }
@@ -671,7 +779,9 @@ struct BrowserHandoffCLITests {
             )
         }
     }
+}
 
+extension BrowserHandoffCLITests {
     @MainActor
     private static func browserCommand(
         action: String,
@@ -692,18 +802,18 @@ struct BrowserHandoffCLITests {
         )
     }
 
-    private static func privateDirectory(mode: Int = 0o700) throws -> URL {
+    private static func privateDirectory() throws -> URL {
         let baseDirectory = try Self.canonicalExistingDirectory(FileManager.default.temporaryDirectory)
         let directory = baseDirectory.appendingPathComponent(
             "peekaboo-browser-handoff-\(UUID().uuidString)",
             isDirectory: true
         )
-        try FileManager.default.createDirectory(
-            at: directory,
-            withIntermediateDirectories: false,
-            attributes: [.posixPermissions: mode]
-        )
-        try FileManager.default.setAttributes([.posixPermissions: mode], ofItemAtPath: directory.path)
+        do {
+            try Self.createPrivateDirectory(at: directory)
+        } catch {
+            try? FileManager.default.removeItem(at: directory)
+            throw error
+        }
         return directory
     }
 
@@ -726,10 +836,21 @@ struct BrowserHandoffCLITests {
             attributes: [.posixPermissions: 0o700]
         )
         try FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: directory.path)
+        // Ambient ACLs or attributes are a failing fixture precondition, never the intended negative case.
+        try BrowserHandoffReceiptStore(fileURL: directory.appendingPathComponent("baseline.json")).validateCanSave()
     }
 
-    private static func addExtendedAttribute(to url: URL) throws {
-        let value = Data("test".utf8)
+    private static func cleanReceiptStore(_ data: Data, at file: URL) throws -> BrowserHandoffReceiptStore {
+        try data.write(to: file)
+        try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: file.path)
+        let store = try BrowserHandoffReceiptStore(fileURL: file)
+        _ = try store.load()
+        return store
+    }
+
+    private static func addExtendedAttribute(to url: URL) throws -> String {
+        let privateValue = UUID().uuidString
+        let value = Data(privateValue.utf8)
         let result = value.withUnsafeBytes { bytes in
             url.path.withCString { path in
                 "dev.peekaboo.browser-handoff-test".withCString { name in
@@ -738,12 +859,15 @@ struct BrowserHandoffCLITests {
             }
         }
         guard result == 0 else { throw CocoaError(.fileWriteUnknown) }
+        return privateValue
     }
 
     private static func addReadableACL(to url: URL) throws {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/bin/chmod")
         process.arguments = ["+a", "everyone allow read", url.path]
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
         try process.run()
         process.waitUntilExit()
         guard process.terminationStatus == 0 else { throw CocoaError(.fileWriteUnknown) }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Reuse validated classic PNG bytes when capture performs no transform instead of encoding the same image twice.
 
 ### Fixed
+- Distinguish browser handoff parent and receipt metadata refusals from inspection failures, and document the unchanged zero-ACL/xattr requirements, including OS provenance, without fallback.
 - Bound debug CLI build-staleness config discovery to the starting directory's ancestors so missing or inaccessible Git metadata cannot cause an endless startup traversal.
 - Share the owner-only credential file between app and CLI, trim surrounding whitespace in app edits and legacy imports, ignore unchanged Settings bindings, recover legacy app keys only on explicit import, and keep failed edits visibly unsaved without Keychain prompts. Thanks @vincentkoc for #651.
 - Hide and pre-dispatch refuse every pinned browser-provider route that can grant browser user activation under default background authority, while explicit foreground calls report truthful foreground browser-protocol outcomes.

--- a/docs/commands/browser.md
+++ b/docs/commands/browser.md
@@ -67,6 +67,15 @@ generation, exact target receipt, claim, and provider epoch before creating a se
 disconnect, and end stay bound to that namespace, and no request can fall back to the Bridge's root browser connection.
 Older or incompatible hosts refuse the handoff before MCP serving begins.
 
+The handoff path requires a current-user-owned parent directory with mode `0700` and a current-user-owned regular,
+single-link receipt with mode `0600`. Both must have zero extended ACLs and zero extended attributes, including OS
+provenance; symlink paths are refused. `mkdir -m 700` establishes the necessary parent mode but is not sufficient:
+newly created directories and files can carry OS metadata, and mode changes do not remove it. Diagnostics distinguish
+detected attributes, detected ACLs, and inspection failures, naming the parent or receipt without reading or printing
+attribute values. This is diagnostic guidance, not compatibility with metadata-producing environments. An unsafe
+parent is refused before connect runtime construction; an unsafe newly created receipt fails publication and triggers
+the existing reserved-target disconnect. MCP receipt loading fails before runtime construction, with no fallback.
+
 `browser upload-file` requires `--page-id`, a fresh file-input `--uid`, and an absolute `--path` to a current-user
 regular file no larger than 100 MiB. Peekaboo never grants Chrome DevTools MCP unrestricted filesystem access. The daemon
 copies the already-open source into its private browser-session temporary root, preserves only the source basename, and

--- a/docs/commands/mcp.md
+++ b/docs/commands/mcp.md
@@ -77,6 +77,7 @@ peekaboo mcp serve --allow-foreground
 peekaboo mcp serve --bridge-socket "$HOME/Library/Application Support/Peekaboo/bridge.sock"
 
 # Transfer one exact foreground-approved browser connection into a background Bridge-scoped MCP server
+# Mode 0700 is necessary but not sufficient: the parent and receipt must also have zero extended ACLs/xattrs.
 mkdir -m 700 /private/tmp/peekaboo-browser-handoff
 peekaboo browser connect --channel stable --foreground \
   --bridge-socket "$HOME/Library/Application Support/Peekaboo/bridge.sock" \
@@ -85,6 +86,14 @@ peekaboo mcp serve \
   --bridge-socket "$HOME/Library/Application Support/Peekaboo/bridge.sock" \
   --browser-handoff /private/tmp/peekaboo-browser-handoff/receipt.json
 ```
+
+Handoff storage requires a current-user-owned parent directory with mode `0700` and a current-user-owned regular,
+single-link receipt with mode `0600`. Both must have zero extended ACLs and zero extended attributes, including OS
+provenance; symlink paths are refused. `mkdir -m 700` establishes the parent mode only and is not sufficient proof of
+admission. Newly created directories and files can carry OS metadata, and mode changes do not remove it. Detected
+attributes, detected ACLs, and inspection failures have distinct diagnostics naming the parent or receipt, without
+reading or printing attribute values. These diagnostics do not make metadata-producing environments compatible:
+handoff remains fail-closed with no fallback, and receipt loading fails before runtime construction.
 
 The `see` tool publishes a closed `capture_engine` choice: `auto` (default), `modern`, or `classic`. `classic` is the
 request-local no-ScreenCaptureKit recovery path and remains bound to the same selected Bridge host.


### PR DESCRIPTION
## Summary

Browser handoff storage already requires zero extended ACLs and zero extended attributes on both the current-user-owned mode-0700 parent and the mode-0600 receipt. The previous diagnostics grouped metadata refusals under an unsafe-path hint that recommended owner-only permissions, while the public example only prescribed `mkdir -m 700`.

- Distinguish detected xattrs, detected ACLs, and inspection failures, identifying the parent directory or receipt file without reading or disclosing metadata values.
- Keep mode/ownership, symlink/hardlink, canonical-byte, authentication, one-shot ownership, pre-runtime refusal, rollback, and fallback behavior unchanged. No metadata is exempted, including OS provenance.
- Require clean test baselines and exact refusal causes so ambient metadata cannot make a negative test pass for the wrong reason; cover parent/receipt metadata, inspection failures, envelope hints, and pre-runtime sentinels.
- Qualify the handoff examples in both command guides and add an Unreleased changelog entry: owner-only modes are necessary but insufficient, and metadata-producing environments remain unsupported by this strict policy.

Example diagnostic: `Browser handoff parent directory is unsafe: extended attributes are not accepted.` Its hint explains the zero-xattr requirement rather than suggesting permissions alone will fix it.

## Validation

- Scoped SwiftFormat and strict SwiftLint checks passed for both changed Swift files.
- Swift syntax parsing and `git diff --check` passed.
- An isolated harness using exact production diagnostics and two exact regression methods, with minimal envelope dependency stubs, passed 4 tests / 8 parameter cases. This is not full CLI integration proof.
- Source comparisons verified that path binding, save/load, canonical validation, publication/rollback, syscall admission rules, and CLI input wrapping remain unchanged.
- Full package tests were not run locally: the worktree lacks initialized Swift submodules/build artifacts, and newly created private fixtures carry xattrs. No OS markers were stripped. Full CLI package execution is left to hosted macOS CI.

This corrects truthfulness, not compatibility in provenance-producing environments. It is separate from release-readiness claims. No browser/provider/UI operation or production restart was used for local validation.
