### PR TITLE
fix: set analyze image MIME from the file extension

### DIFF
--- a/Core/PeekabooCore/Sources/PeekabooAutomation/Services/AI/PeekabooAIService.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAutomation/Services/AI/PeekabooAIService.swift
@@ -2,6 +2,7 @@ import CoreGraphics
 import Foundation
 import ImageIO
 import Tachikoma
+import UniformTypeIdentifiers
 
 public struct InferredAnthropicModelCapabilities: Sendable {
     public let contextLength: Int
@@ -213,13 +214,13 @@ public final class PeekabooAIService {
     public func analyzeImageDetailed(
         imageData: Data,
         question: String,
-        model: LanguageModel? = nil) async throws -> AnalysisResult
+        model: LanguageModel? = nil,
+        path: String? = nil) async throws -> AnalysisResult
     {
         let selectedModel = try self.resolveVisionModel(model)
 
         // Create a message with the image using Tachikoma's API
-        let base64String = imageData.base64EncodedString()
-        let imageContent = ModelMessage.ContentPart.ImageContent(data: base64String, mimeType: "image/png")
+        let imageContent = Self.analyzeImageContent(imageData: imageData, path: path)
         let messages = [ModelMessage.user(text: question, images: [imageContent])]
 
         let response = try await Tachikoma.generateText(
@@ -247,7 +248,11 @@ public final class PeekabooAIService {
         let url = Self.imageFileURL(for: path)
         let imageData = try Data(contentsOf: url)
 
-        return try await self.analyzeImage(imageData: imageData, question: question, model: model)
+        return try await self.analyzeImageDetailed(
+            imageData: imageData,
+            question: question,
+            model: model,
+            path: path).text
     }
 
     /// Analyze an image file returning structured metadata
@@ -259,11 +264,69 @@ public final class PeekabooAIService {
         // Analyze an image file returning structured metadata
         let url = Self.imageFileURL(for: path)
         let imageData = try Data(contentsOf: url)
-        return try await self.analyzeImageDetailed(imageData: imageData, question: question, model: model)
+        return try await self.analyzeImageDetailed(
+            imageData: imageData,
+            question: question,
+            model: model,
+            path: path)
     }
 
     static func imageFileURL(for path: String) -> URL {
         URL(fileURLWithPath: (path as NSString).expandingTildeInPath)
+    }
+
+    nonisolated static func imageMIMEType(forPath path: String, imageData: Data? = nil) -> String {
+        if let imageData, let fromImageIO = imageMIMETypeFromImageIO(imageData) {
+            return fromImageIO
+        }
+        return Self.imageMIMETypeFromPathExtension(path) ?? "image/png"
+    }
+
+    nonisolated static func imageMIMEType(forImageData data: Data) -> String {
+        self.imageMIMETypeFromImageIO(data) ?? "image/png"
+    }
+
+    nonisolated static func analyzeImageContent(
+        imageData: Data,
+        path: String? = nil) -> ModelMessage.ContentPart.ImageContent
+    {
+        let mimeType = path.map { Self.imageMIMEType(forPath: $0, imageData: imageData) }
+            ?? Self.imageMIMEType(forImageData: imageData)
+        return ModelMessage.ContentPart.ImageContent(
+            data: imageData.base64EncodedString(),
+            mimeType: mimeType)
+    }
+
+    private nonisolated static func imageMIMETypeFromPathExtension(_ path: String) -> String? {
+        switch URL(fileURLWithPath: path).pathExtension.lowercased() {
+        case "png":
+            "image/png"
+        case "jpg", "jpeg":
+            "image/jpeg"
+        case "gif":
+            "image/gif"
+        case "webp":
+            "image/webp"
+        default:
+            nil
+        }
+    }
+
+    private nonisolated static func imageMIMETypeFromImageIO(_ data: Data) -> String? {
+        guard !data.isEmpty else { return nil }
+        let options = [kCGImageSourceShouldCache: false] as CFDictionary
+        guard let source = CGImageSourceCreateWithData(data as CFData, options),
+              let type = CGImageSourceGetType(source) as String?,
+              let mime = UTType(type)?.preferredMIMEType?.lowercased()
+        else {
+            return nil
+        }
+        switch mime {
+        case "image/png", "image/jpeg", "image/gif", "image/webp":
+            return mime
+        default:
+            return nil
+        }
     }
 
     /// Generate text from a prompt

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooAIServiceImageMIMETests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooAIServiceImageMIMETests.swift
@@ -1,0 +1,79 @@
+import CoreGraphics
+import Foundation
+import ImageIO
+import Testing
+import UniformTypeIdentifiers
+@testable import PeekabooAutomation
+
+struct PeekabooAIServiceImageMIMETests {
+    @Test
+    func `Analyze image MIME uses jpeg for jpg and jpeg paths`() {
+        #expect(PeekabooAIService.imageMIMEType(forPath: "/tmp/shot.jpg") == "image/jpeg")
+        #expect(PeekabooAIService.imageMIMEType(forPath: "/tmp/shot.jpeg") == "image/jpeg")
+        #expect(PeekabooAIService.imageMIMEType(forPath: "/tmp/shot.JPG") == "image/jpeg")
+    }
+
+    @Test
+    func `Analyze image MIME uses webp and png from the path extension`() {
+        #expect(PeekabooAIService.imageMIMEType(forPath: "/tmp/shot.webp") == "image/webp")
+        #expect(PeekabooAIService.imageMIMEType(forPath: "/tmp/shot.png") == "image/png")
+    }
+
+    @Test
+    func `Analyze image MIME uses ImageIO for jpeg bytes without a path`() throws {
+        let jpegData = try Self.makePixelImage(uti: .jpeg)
+        #expect(PeekabooAIService.imageMIMEType(forImageData: jpegData) == "image/jpeg")
+    }
+
+    @Test
+    func `Analyze image content labels jpeg files as image/jpeg`() throws {
+        let jpegData = try Self.makePixelImage(uti: .jpeg)
+        let content = PeekabooAIService.analyzeImageContent(imageData: jpegData, path: "/tmp/photo.jpg")
+        #expect(content.mimeType == "image/jpeg")
+        #expect(content.data == jpegData.base64EncodedString())
+    }
+
+    @Test
+    func `Analyze image content labels webp paths as image/webp`() {
+        let content = PeekabooAIService.analyzeImageContent(imageData: Data([0x00]), path: "/tmp/photo.webp")
+        #expect(content.mimeType == "image/webp")
+    }
+
+    private static func makePixelImage(uti: UTType) throws -> Data {
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        var pixels: [UInt8] = [255, 0, 0, 255]
+        guard let context = CGContext(
+            data: &pixels,
+            width: 1,
+            height: 1,
+            bitsPerComponent: 8,
+            bytesPerRow: 4,
+            space: colorSpace,
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue),
+            let image = context.makeImage()
+        else {
+            throw MIMETestError.couldNotCreatePixel
+        }
+
+        let output = NSMutableData()
+        guard let destination = CGImageDestinationCreateWithData(
+            output,
+            uti.identifier as CFString,
+            1,
+            nil)
+        else {
+            throw MIMETestError.couldNotCreateDestination
+        }
+        CGImageDestinationAddImage(destination, image, nil)
+        guard CGImageDestinationFinalize(destination) else {
+            throw MIMETestError.couldNotFinalize
+        }
+        return output as Data
+    }
+}
+
+private enum MIMETestError: Error {
+    case couldNotCreatePixel
+    case couldNotCreateDestination
+    case couldNotFinalize
+}


### PR DESCRIPTION
## What Problem This Solves

MCP `analyze` and `PeekabooAIService.analyzeImageFile` / `analyzeImageFileDetailed` accept `.jpg`, `.jpeg`, and `.webp` files, then forward the raw bytes. `analyzeImageDetailed` always built `ImageContent(..., mimeType: "image/png")`.

Providers that honor `media_type` (Anthropic copies `imageContent.mimeType` into the image source) can refuse or misread a JPEG or WebP labeled as PNG.

The same file-path mapping already exists in Tachikoma `generateText` for `.filePath` images (`png` / `jpg` / `jpeg` / `gif` / `webp`). Analyze did not use it.

This has been present since [`43ff1eddc`](https://github.com/openclaw/Peekaboo/commit/43ff1eddc) (2025-11-14), 288 days.

Sibling size-cap work is [#666](https://github.com/openclaw/Peekaboo/pull/666). This PR only sets the analyze MIME type.

## Evidence

Unfixed analyze always reports `image/png`, including for a real JPEG (`ffd8ff` magic, `file` says JPEG image data).

After the patch, the same JPEG path and JPEG bytes become `image/jpeg`. A `.webp` path becomes `image/webp`. PNG stays `image/png`.

terminal output from `swift /tmp/prove-f041-analyze-mime.swift`:

```console
$ file /tmp/peekaboo-f041-photo.jpg
/tmp/peekaboo-f041-photo.jpg: JPEG image data, JFIF standard 1.01, aspect ratio, density 72x72, segment length 16, Exif Standard: [TIFF image data, big-endian, direntries=1], baseline, precision 8, 1x1, components 3

$ swift /tmp/prove-f041-analyze-mime.swift
jpeg_path=/tmp/peekaboo-f041-photo.jpg
jpeg_bytes=707
jpeg_magic=ffd8ff
case=photo.jpg unfixed=image/png fixed=image/jpeg
case=photo.jpeg unfixed=image/png fixed=image/jpeg
case=photo.webp unfixed=image/png fixed=image/webp
case=photo.png unfixed=image/png fixed=image/png
case=jpeg-bytes-no-path unfixed=image/png fixed=image/jpeg
```

Production `analyzeImageFile` / `analyzeImageFileDetailed` now pass the path into `analyzeImageContent`, so MCP `analyze` and the agent analyze tool send the same MIME.

## Real behavior proof

- **Behavior or issue addressed:** Vision analyze labeled every file as `image/png`, including JPEG and WebP paths that MCP `analyze` already accepts.
- **Real environment tested:** macOS 26.6.2 arm64, Apple Swift 6.3.3, Peekaboo `upstream/main` [`36413615`](https://github.com/openclaw/Peekaboo/commit/36413615) plus this patch.
- **Exact steps or command run after this patch:** wrote a 1x1 JPEG to `/tmp/peekaboo-f041-photo.jpg`, ran `file /tmp/peekaboo-f041-photo.jpg`, then `swift /tmp/prove-f041-analyze-mime.swift` using the same extension and ImageIO mapping as `PeekabooAIService`.
- **Evidence after fix:** terminal output from the patched mapping:

  ```console
  jpeg_path=/tmp/peekaboo-f041-photo.jpg
  jpeg_bytes=707
  jpeg_magic=ffd8ff
  case=photo.jpg unfixed=image/png fixed=image/jpeg
  case=photo.jpeg unfixed=image/png fixed=image/jpeg
  case=photo.webp unfixed=image/png fixed=image/webp
  case=photo.png unfixed=image/png fixed=image/png
  case=jpeg-bytes-no-path unfixed=image/png fixed=image/jpeg
  ```

- **Observed result after fix:** JPEG files and JPEG bytes are labeled `image/jpeg`. WebP paths are labeled `image/webp`. PNG stays `image/png`.
- **What was not tested:** a live Anthropic or OpenAI vision call with provider credentials on a JPEG file.

## Change

- `analyzeImageContent` sets MIME from ImageIO when the bytes are a known image type.
- File analyze APIs also pass the path so `.jpg` / `.jpeg` / `.webp` still get a type when ImageIO cannot read the bytes.
- Extension map matches Tachikoma file-path analyze: png, jpg/jpeg, gif, webp.

## Validation

Red: unfixed helper labeled `photo.jpg`, `photo.webp`, and JPEG bytes as `image/png`.
Green: the same inputs are `image/jpeg`, `image/webp`, and `image/jpeg`.
