### PR TITLE
fix(test): accept canonical prebuilt Playground fixtures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Reuse validated classic PNG bytes when capture performs no transform instead of encoding the same image twice.
 
 ### Fixed
+- Accept canonical v2 prebuilt Playground fixtures in native validation with strict source, lock, toolchain, bundle, and Foundation signature checks, retaining v1 only for the current invocation's local build.
 - Distinguish browser handoff parent and receipt metadata refusals from inspection failures, and document the unchanged zero-ACL/xattr requirements, including OS provenance, without fallback.
 - Bound debug CLI build-staleness config discovery to the starting directory's ancestors so missing or inaccessible Git metadata cannot cause an endless startup traversal.
 - Share the owner-only credential file between app and CLI, trim surrounding whitespace in app edits and legacy imports, ignore unchanged Settings bindings, recover legacy app keys only on explicit import, and keep failed edits visibly unsaved without Keychain prompts. Thanks @vincentkoc for #651.

--- a/docs/testing/background-computer-use.md
+++ b/docs/testing/background-computer-use.md
@@ -361,11 +361,37 @@ artifact finalizer for signing and notarization. Manifest schema v2 binds the fi
 `Apps/Playground` source tree, marketing version, configuration, bundle identifier, root workspace/scheme, and the path
 plus SHA-256 of the tracked canonical `Apps/Peekaboo.xcworkspace/xcshareddata/swiftpm/Package.resolved`. It also records
 the canonical Developer directory and exact Xcode, macOS SDK, and Swift compiler versions. Standalone Playground
-lockfiles are not accepted.
+lockfiles are not accepted. The native preflight and terminal finalizer share the strict v2 receipt validator in
+`scripts/source-provenance.sh`: exactly one JSON object with the 14 documented fields, numeric schema version 2,
+and an immutable regular receipt. Native preflight independently checks the clean current checkout, exact Playground
+tree, tracked unchanged canonical lock, selected toolchain, and actual bundle identifier/version/executable metadata.
+It verifies the app with `codesign --verify --deep --strict` and an Apple-anchored requirement for the OpenClaw Foundation
+Developer ID, team `FWJYW4S8P8`, and Debug identifier `boo.peekaboo.playground.debug`. Supplied artifacts are never
+restamped, normalized, or re-signed.
+
+The default local build still uses the standalone Playground project and creates a v1 receipt. That narrow exception
+belongs only to the fresh app built and signed by the current harness invocation; it retains exact current commit/tree,
+bundle metadata, and Foundation signature checks. A supplied v1 app is refused, even if it was built by an earlier
+harness invocation. There is no environment variable or flag that grants local-build ownership.
+
+To validate a supplied fixture without running the live harness:
+
+```bash
+scripts/test-background-computer-use.sh --validate-playground-only \
+  --playground-app /absolute/path/Playground.app --skip-playground-build
+```
+
+This uses the same production preflight and exits before probe compilation/execution, CLI or Bridge calls, permissions,
+keychain lookup, artifact setup, launches, or cleanup traps. Toolchain queries use the selected `DEVELOPER_DIR` (or
+`xcode-select -p`), canonicalized before comparison. External-tool doubles are accepted only in explicit headless test
+mode and are rejected on live paths. The live report's closed source evidence includes `source_provenance_sha256`;
+the helper is privately snapshotted, checked for drift, and verified against retained helper bytes by the reporter.
 
 Final terminal qualification also requires `--terminal-artifact-manifest` beside the prebuilt Playground. Portable schema 7
 binds the zipped app, its exact post-staple tree receipt, Foundation identity/notary receipt, and the pinned universal
-Node 24.15.0 qualification app. The harness extracts and verifies that Node app before any candidate action and runs
+Node 24.15.0 qualification app. **That terminal-manifest/pinned-Node integration is not yet implemented by this native
+harness; fixture validation alone does not establish terminal qualification.** The qualification consumer must extract
+and verify that Node app before any candidate action and run
 qualification JavaScript only with `PeekabooQualificationNode.app/Contents/MacOS/node`; ambient `node`, PATH, and an
 OpenClaw installation are not fallbacks. Terminal app payloads permit no extended attributes, `__MACOSX`, or `._*`
 AppleDouble entries, and every ZIP must reproduce the retained canonical tree byte-for-byte.

--- a/scripts/build-terminal-artifacts.sh
+++ b/scripts/build-terminal-artifacts.sh
@@ -306,29 +306,10 @@ tree_digest() {
 verify_playground_manifest() {
   local app="$1"
   local manifest="$app/Contents/Resources/PeekabooPlaygroundSource.json"
-  [[ -f "$manifest" && ! -L "$manifest" ]] || return 1
-  jq -e \
-    --arg sourceCommit "$SOURCE_COMMIT" \
-    --arg sourceTree "$(git -C "$ROOT_DIR" rev-parse HEAD:Apps/Playground)" \
-    --arg lockPath "$CANONICAL_LOCK_RELATIVE" \
-    --arg lockSHA "$DEPENDENCY_LOCK_SHA256" \
-    --arg marketingVersion "$VERSION" \
-    --arg developerDir "$EFFECTIVE_DEVELOPER_DIR" \
-    --arg xcodebuildVersion "$XCODEBUILD_VERSION" \
-    --arg sdkVersion "$SDK_VERSION" \
-    --arg swiftcVersion "$SWIFTC_VERSION" '
-      type == "object" and keys == [
-        "bundle_identifier", "configuration", "dependency_lock_path", "dependency_lock_sha256",
-        "developer_dir", "marketing_version", "scheme", "sdk_version", "source_commit",
-        "source_tree", "swiftc_version", "version", "workspace", "xcodebuild_version"
-      ] and .version == 2 and .source_commit == $sourceCommit and .source_tree == $sourceTree and
-      .dependency_lock_path == $lockPath and .dependency_lock_sha256 == $lockSHA and
-      .workspace == "Apps/Peekaboo.xcworkspace" and .scheme == "Playground" and
-      .configuration == "Debug" and .bundle_identifier == "boo.peekaboo.playground.debug" and
-      .marketing_version == $marketingVersion and .developer_dir == $developerDir and
-      .xcodebuild_version == $xcodebuildVersion and .sdk_version == $sdkVersion and
-      .swiftc_version == $swiftcVersion
-    ' "$manifest" >/dev/null
+  peekaboo_verify_playground_v2_receipt "$manifest" \
+    "$SOURCE_COMMIT" "$(git -C "$ROOT_DIR" rev-parse HEAD:Apps/Playground)" \
+    "$CANONICAL_LOCK_RELATIVE" "$DEPENDENCY_LOCK_SHA256" "$VERSION" \
+    "$EFFECTIVE_DEVELOPER_DIR" "$XCODEBUILD_VERSION" "$SDK_VERSION" "$SWIFTC_VERSION"
 }
 
 verify_node_source_manifest() {

--- a/scripts/source-provenance.sh
+++ b/scripts/source-provenance.sh
@@ -102,3 +102,70 @@ peekaboo_short_source_commit() {
     printf '%s\n' unknown
   fi
 }
+
+# Read-only receipts must be regular files, including when the caller owns them.
+peekaboo_is_immutable_receipt() {
+  local receipt="${1:?receipt required}" mode
+  [[ -f "$receipt" && ! -L "$receipt" ]] || return 1
+  mode="$(/usr/bin/stat -f '%Lp' "$receipt")" || return 1
+  [[ "$mode" =~ ^[0-7]{3,4}$ ]] && (( (8#$mode & 0222) == 0 ))
+}
+
+# Expected values come from the caller's trusted checkout/build context, never
+# from the candidate receipt. Signing and notarization remain caller-owned.
+peekaboo_verify_playground_v2_receipt() {
+  local receipt="${1:?receipt required}"
+  peekaboo_is_immutable_receipt "$receipt" || return 1
+  jq -se \
+    --arg sourceCommit "${2:?source commit required}" \
+    --arg sourceTree "${3:?source tree required}" \
+    --arg lockPath "${4:?canonical lock path required}" \
+    --arg lockSHA "${5:?canonical lock hash required}" \
+    --arg marketingVersion "${6:?marketing version required}" \
+    --arg developerDir "${7:?developer directory required}" \
+    --arg xcodebuildVersion "${8:?Xcode version required}" \
+    --arg sdkVersion "${9:?SDK version required}" \
+    --arg swiftcVersion "${10:?Swift version required}" '
+      length == 1 and (.[0] |
+      type == "object" and keys == [
+        "bundle_identifier", "configuration", "dependency_lock_path", "dependency_lock_sha256",
+        "developer_dir", "marketing_version", "scheme", "sdk_version", "source_commit",
+        "source_tree", "swiftc_version", "version", "workspace", "xcodebuild_version"
+      ] and .version == 2 and .source_commit == $sourceCommit and .source_tree == $sourceTree and
+      .dependency_lock_path == $lockPath and .dependency_lock_sha256 == $lockSHA and
+      .workspace == "Apps/Peekaboo.xcworkspace" and .scheme == "Playground" and
+      .configuration == "Debug" and .bundle_identifier == "boo.peekaboo.playground.debug" and
+      .marketing_version == $marketingVersion and .developer_dir == $developerDir and
+      .xcodebuild_version == $xcodebuildVersion and .sdk_version == $sdkVersion and
+      .swiftc_version == $swiftcVersion)
+    ' "$receipt" >/dev/null
+}
+
+# Check this boundary before general checkout cleanliness so lock failures are
+# actionable, including an ignored/untracked or assume-unchanged resolver file.
+peekaboo_playground_lock_sha256() {
+  local root="${1:?repository root required}"
+  local relative=Apps/Peekaboo.xcworkspace/xcshareddata/swiftpm/Package.resolved
+  local lock="$root/$relative" competing digest committed_digest
+  [[ -f "$lock" && ! -L "$lock" ]] || {
+    echo 'Canonical Playground dependency lock missing or symlinked.' >&2; return 1;
+  }
+  git -C "$root" ls-files --error-unmatch "$relative" >/dev/null 2>&1 || {
+    echo 'Canonical Playground dependency lock is not tracked.' >&2; return 1;
+  }
+  for competing in \
+    Apps/Playground/Package.resolved \
+    Apps/Playground/Playground.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved; do
+    [[ ! -e "$root/$competing" && ! -L "$root/$competing" ]] || {
+      echo "Noncanonical Playground dependency lock: $competing" >&2; return 1;
+    }
+  done
+  digest="$(shasum -a 256 "$lock" | awk '{print $1}')" || return 1
+  committed_digest="$(git -C "$root" show "HEAD:$relative" | shasum -a 256 | awk '{print $1}')" || return 1
+  [[ "$digest" == "$committed_digest" ]] &&
+    git -C "$root" diff --quiet --cached HEAD -- "$relative" &&
+    git -C "$root" diff --quiet -- "$relative" || {
+      echo 'Canonical Playground dependency lock differs from HEAD.' >&2; return 1;
+    }
+  printf '%s\n' "$digest"
+}

--- a/scripts/support/test-playground-fixture-compatibility.sh
+++ b/scripts/support/test-playground-fixture-compatibility.sh
@@ -1,0 +1,296 @@
+#!/usr/bin/env bash
+# Sourced by test-build-playground-artifact.sh after the real producer runs.
+# All candidate changes below are deliberate corruptions of disposable fixtures.
+
+COMPATIBILITY_SOURCE_ROOT="$ROOT_DIR"
+export FIXTURE_FORBIDDEN_LOG="$TEST_DIR/forbidden-operations.log"
+export FIXTURE_SIGNATURE_LOG="$TEST_DIR/signature-checks.log"
+export FIXTURE_VERIFY_ONLY=1
+mkdir -p "$TEST_DIR/forbidden-tools"
+for tool in swiftc open security peekaboo codesign xcodebuild; do
+  cat > "$TEST_DIR/forbidden-tools/$tool" <<'EOF'
+#!/bin/bash
+echo "unexpected operation: $0 $*" >> "${FIXTURE_FORBIDDEN_LOG:?}"
+exit 90
+EOF
+  chmod 755 "$TEST_DIR/forbidden-tools/$tool"
+done
+export PATH="$TEST_DIR/forbidden-tools:$PATH"
+cat > "$TEST_DIR/codesign-verifier" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+printf '%s\n' "$*" >> "${FIXTURE_SIGNATURE_LOG:?}"
+requirement='-R=anchor apple generic and certificate leaf[subject.OU] = "FWJYW4S8P8" and certificate leaf[subject.CN] = "Developer ID Application: OpenClaw Foundation (FWJYW4S8P8)" and identifier "boo.peekaboo.playground.debug"'
+if [[ $# == 5 && "$1" == --verify && "$2" == --deep && "$3" == --strict && "$4" == "$requirement" ]]; then
+  [[ "${FIXTURE_SIGNATURE_FAILURE:-}" != invalid && "${FIXTURE_SIGNATURE_FAILURE:-}" != adhoc ]] || exit 1
+  [[ "$(cat "$5/Contents/_CodeSignature/CodeResources")" == 'synthetic signature resource seal' ]] || exit 1
+  [[ "$(cat "$5/Contents/Resources/fixture.txt")" == 'fixture resource' ]] || exit 1
+elif [[ $# == 3 && "$1" == -dv && "$2" == --verbose=2 ]]; then
+  team=FWJYW4S8P8
+  identifier=boo.peekaboo.playground.debug
+  authority='Developer ID Application: OpenClaw Foundation (FWJYW4S8P8)'
+  case "${FIXTURE_SIGNATURE_FAILURE:-}" in
+    team) team=WRONGTEAM1 ;;
+    identifier) identifier=wrong.identifier ;;
+    authority) authority='Developer ID Application: Someone Else (FWJYW4S8P8)' ;;
+    adhoc-details) team='not set'; authority='' ;;
+  esac
+  printf 'Identifier=%s\nAuthority=%s\nAuthority=Apple Root CA\nTeamIdentifier=%s\n' "$identifier" "$authority" "$team"
+else
+  echo "unexpected codesign operation/omitted verification: $*" >> "${FIXTURE_FORBIDDEN_LOG:?}"
+  exit 90
+fi
+EOF
+chmod 755 "$TEST_DIR/codesign-verifier"
+
+native_validate() {
+  env PEEKABOO_PLAYGROUND_TEST_MODE=1 \
+    PEEKABOO_PLAYGROUND_CODESIGN_BIN="$TEST_DIR/codesign-verifier" \
+    PEEKABOO_PLAYGROUND_XCODEBUILD_BIN="$TEST_DIR/xcodebuild" \
+    PEEKABOO_PLAYGROUND_XCRUN_BIN="$TEST_DIR/xcrun" \
+    PEEKABOO_PLAYGROUND_XCODE_SELECT_BIN="$TEST_DIR/xcode-select" \
+    "$FIXTURE_ROOT/scripts/test-background-computer-use.sh" \
+    --validate-playground-only --playground-app "$1" --skip-playground-build
+}
+
+shared_validate() {
+  peekaboo_verify_playground_v2_receipt "$1/Contents/Resources/PeekabooPlaygroundSource.json" \
+    "$SOURCE_COMMIT" "$(git -C "$FIXTURE_ROOT" rev-parse HEAD:Apps/Playground)" \
+    "$CANONICAL_LOCK_RELATIVE" "$DEPENDENCY_LOCK_SHA256" "$VERSION" \
+    "$EFFECTIVE_DEVELOPER_DIR" "$XCODEBUILD_VERSION" "$SDK_VERSION" "$SWIFTC_VERSION"
+}
+
+terminal_validate() {
+  (ROOT_DIR="$FIXTURE_ROOT"; verify_playground_manifest "$1")
+}
+
+inventory() {
+  /usr/bin/ruby "$COMPATIBILITY_SOURCE_ROOT/scripts/artifact-tree-manifest.rb" "$1" > "$2.tree"
+  /usr/bin/xattr -lr -x -s "$1" > "$2.xattrs"
+}
+
+assert_native() {
+  local app="$1" expected="$2" diagnostic="${3:-}" result=0
+  inventory "$app" "$TEST_DIR/before"
+  native_validate "$app" > "$TEST_DIR/native-result.log" 2>&1 || result=$?
+  inventory "$app" "$TEST_DIR/after"
+  cmp "$TEST_DIR/before.tree" "$TEST_DIR/after.tree" || fail 'native validation mutated artifact bytes/modes/symlinks'
+  cmp "$TEST_DIR/before.xattrs" "$TEST_DIR/after.xattrs" || fail 'native validation mutated xattrs'
+  [[ ! -e "$FIXTURE_FORBIDDEN_LOG" ]] || fail "forbidden operation: $(cat "$FIXTURE_FORBIDDEN_LOG")"
+  if [[ "$expected" == accept && "$result" != 0 ]] || [[ "$expected" == refuse && "$result" == 0 ]]; then
+    cat "$TEST_DIR/native-result.log" >&2
+    fail "native $expected failed for $app (exit $result)"
+  fi
+  [[ -z "$diagnostic" ]] || grep -Fq "$diagnostic" "$TEST_DIR/native-result.log" || {
+    cat "$TEST_DIR/native-result.log" >&2
+    fail "missing refusal diagnostic: $diagnostic"
+  }
+}
+
+inventory "$OUTPUT_APP" "$TEST_DIR/producer"
+shared_validate "$OUTPUT_APP" || fail 'shared validator rejected producer v2'
+terminal_validate "$OUTPUT_APP" || fail 'terminal wrapper rejected producer v2'
+assert_native "$OUTPUT_APP" accept
+inventory "$OUTPUT_APP" "$TEST_DIR/consumed"
+cmp "$TEST_DIR/producer.tree" "$TEST_DIR/consumed.tree"
+cmp "$TEST_DIR/producer.xattrs" "$TEST_DIR/consumed.xattrs"
+[[ "$(wc -l < "$FIXTURE_SIGNATURE_LOG" | tr -d ' ')" == 2 ]] || fail 'native omitted signature verification or display'
+printf 'producer -> shared validator -> terminal wrapper -> native preflight: unchanged v2 accepted\n'
+
+new_candidate() {
+  candidate="$TEST_DIR/candidate-$1.app"
+  /usr/bin/ditto "$OUTPUT_APP" "$candidate"
+  candidate_receipt="$candidate/Contents/Resources/PeekabooPlaygroundSource.json"
+}
+
+assert_receipt_refused() {
+  local label="$1"
+  inventory "$candidate" "$TEST_DIR/receipt-before"
+  if shared_validate "$candidate" >/dev/null 2>&1; then fail "shared validator accepted $label"; fi
+  if terminal_validate "$candidate" >/dev/null 2>&1; then fail "terminal wrapper accepted $label"; fi
+  assert_native "$candidate" refuse
+  inventory "$candidate" "$TEST_DIR/receipt-after"
+  cmp "$TEST_DIR/receipt-before.tree" "$TEST_DIR/receipt-after.tree"
+  cmp "$TEST_DIR/receipt-before.xattrs" "$TEST_DIR/receipt-after.xattrs"
+}
+
+# Mutate the real producer receipt; no separately authored happy-path v2 schema.
+receipt_cases=0
+for field in $(jq -r 'keys[]' "$manifest"); do
+  for mutation in wrong removed type; do
+    new_candidate "$field-$mutation"
+    jq --arg field "$field" --arg mutation "$mutation" '
+      if $mutation == "removed" then del(.[$field])
+      elif $mutation == "type" then .[$field] = (if $field == "version" then "2" else 2 end)
+      elif $field == "version" then .[$field] = 3
+      elif $field == "source_commit" or $field == "source_tree" then .[$field] = ("a" * 40)
+      elif $field == "dependency_lock_sha256" then .[$field] = ("a" * 64)
+      else .[$field] += "-wrong" end
+    ' "$manifest" > "$TEST_DIR/receipt.json"
+    chmod u+w "$candidate_receipt"
+    cp "$TEST_DIR/receipt.json" "$candidate_receipt"
+    chmod 444 "$candidate_receipt"
+    assert_receipt_refused "$field/$mutation"
+    receipt_cases=$((receipt_cases + 1))
+  done
+done
+for mutation in extra malformed multiple array writable symlink missing; do
+  new_candidate "$mutation"
+  case "$mutation" in
+    extra) jq '.extra = true' "$manifest" > "$TEST_DIR/receipt.json" ;;
+    malformed) printf '{bad json\n' > "$TEST_DIR/receipt.json" ;;
+    multiple) cat "$manifest" "$manifest" > "$TEST_DIR/receipt.json" ;;
+    array) jq -s '.' "$manifest" > "$TEST_DIR/receipt.json" ;;
+  esac
+  case "$mutation" in
+    writable) chmod 644 "$candidate_receipt" ;;
+    symlink) mv "$candidate_receipt" "$candidate/Contents/Resources/receipt-target.json"
+      ln -s receipt-target.json "$candidate_receipt" ;;
+    missing) rm "$candidate_receipt" ;;
+    *) chmod u+w "$candidate_receipt"; cp "$TEST_DIR/receipt.json" "$candidate_receipt"; chmod 444 "$candidate_receipt" ;;
+  esac
+  assert_receipt_refused "$mutation"
+  receipt_cases=$((receipt_cases + 1))
+done
+printf 'strict v2 refusals: %s field/schema/file corruptions, all three consumers\n' "$receipt_cases"
+
+# Each source-lock mutation must reach its own boundary, before generic dirtiness.
+lock="$FIXTURE_ROOT/$CANONICAL_LOCK_RELATIVE"
+cp "$lock" "$TEST_DIR/original-lock"
+mv "$lock" "$TEST_DIR/absent-lock"
+assert_native "$OUTPUT_APP" refuse 'lock missing or symlinked'
+mv "$TEST_DIR/absent-lock" "$lock"
+mv "$lock" "$TEST_DIR/symlink-lock"
+ln -s "$TEST_DIR/symlink-lock" "$lock"
+assert_native "$OUTPUT_APP" refuse 'lock missing or symlinked'
+rm "$lock"
+mv "$TEST_DIR/symlink-lock" "$lock"
+git -C "$FIXTURE_ROOT" rm --cached -q "$CANONICAL_LOCK_RELATIVE"
+assert_native "$OUTPUT_APP" refuse 'lock is not tracked'
+git -C "$FIXTURE_ROOT" add "$CANONICAL_LOCK_RELATIVE"
+printf '\n' >> "$lock"
+assert_native "$OUTPUT_APP" refuse 'lock differs from HEAD'
+git -C "$FIXTURE_ROOT" update-index --assume-unchanged "$CANONICAL_LOCK_RELATIVE"
+assert_native "$OUTPUT_APP" refuse 'lock differs from HEAD'
+git -C "$FIXTURE_ROOT" update-index --no-assume-unchanged "$CANONICAL_LOCK_RELATIVE"
+cp "$TEST_DIR/original-lock" "$lock"
+for relative in Apps/Playground/Package.resolved \
+  Apps/Playground/Playground.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved; do
+  mkdir -p "$(dirname "$FIXTURE_ROOT/$relative")"
+  printf '{}\n' > "$FIXTURE_ROOT/$relative"
+  assert_native "$OUTPUT_APP" refuse 'Noncanonical Playground dependency lock'
+  rm "$FIXTURE_ROOT/$relative"
+  ln -s missing "$FIXTURE_ROOT/$relative"
+  assert_native "$OUTPUT_APP" refuse 'Noncanonical Playground dependency lock'
+  rm "$FIXTURE_ROOT/$relative"
+done
+printf 'source lock refusals: absent, symlinked, untracked, dirty, assume-unchanged, competing\n'
+
+for field in CFBundleIdentifier CFBundleShortVersionString CFBundleExecutable; do
+  for mutation in wrong missing; do
+    new_candidate "plist-$field-$mutation"
+    if [[ "$mutation" == wrong ]]; then
+      /usr/libexec/PlistBuddy -c "Set :$field wrong" "$candidate/Contents/Info.plist"
+    else
+      /usr/libexec/PlistBuddy -c "Delete :$field" "$candidate/Contents/Info.plist"
+    fi
+    assert_native "$candidate" refuse 'bundle metadata differs'
+  done
+done
+for mutation in missing nonexecutable symlink; do
+  new_candidate "executable-$mutation"
+  case "$mutation" in
+    missing) rm "$candidate/Contents/MacOS/Playground" ;;
+    nonexecutable) chmod 644 "$candidate/Contents/MacOS/Playground" ;;
+    symlink) mv "$candidate/Contents/MacOS/Playground" "$candidate/Contents/MacOS/target"
+      ln -s target "$candidate/Contents/MacOS/Playground" ;;
+  esac
+  assert_native "$candidate" refuse 'Playground executable'
+done
+for failure in invalid adhoc adhoc-details team identifier authority; do
+  FIXTURE_SIGNATURE_FAILURE="$failure" assert_native "$OUTPUT_APP" refuse
+done
+for resource in Resources/fixture.txt _CodeSignature/CodeResources; do
+  new_candidate "tamper-${resource##*/}"
+  printf 'tampered\n' >> "$candidate/Contents/$resource"
+  assert_native "$candidate" refuse
+done
+printf 'bundle metadata/executable and signature enforcement refusals passed\n'
+
+# Actual selected toolchain changes must invalidate the unchanged receipt.
+for tool in xcodebuild xcrun; do
+  cp "$TEST_DIR/$tool" "$TEST_DIR/$tool.saved"
+  # Replace only this disposable external tool double, never a candidate receipt.
+  cat > "$TEST_DIR/$tool" <<'EOF'
+#!/bin/bash
+printf 'different toolchain\n'
+EOF
+  assert_native "$OUTPUT_APP" refuse 'current-source/toolchain v2 receipt'
+  cp "$TEST_DIR/$tool.saved" "$TEST_DIR/$tool"
+done
+mkdir "$TEST_DIR/OtherDeveloper"
+DEVELOPER_DIR="$TEST_DIR/OtherDeveloper" assert_native "$OUTPUT_APP" refuse 'current-source/toolchain v2 receipt'
+# Resolve the selector's alias to the same canonical directory.
+ln -s "$FIXTURE_DEVELOPER_DIR" "$TEST_DIR/DeveloperAlias"
+DEVELOPER_DIR="$TEST_DIR/DeveloperAlias" assert_native "$OUTPUT_APP" accept
+(unset DEVELOPER_DIR; assert_native "$OUTPUT_APP" accept)
+
+# Execute the production local builder and preflight in a shell with explicit
+# build/sign doubles. There is no production CLI option granting v1 ownership.
+(
+  eval "$(sed -n '/^build_playground() {/,/^}/p' "$ROOT_DIR/scripts/test-background-computer-use.sh")"
+  eval "$(sed -n '/^validate_playground_fixture() {/,/^}/p' "$ROOT_DIR/scripts/test-background-computer-use.sh")"
+  ROOT_DIR="$FIXTURE_ROOT"
+  ARTIFACT_ROOT="$TEST_DIR/local-build"
+  mkdir "$ARTIFACT_ROOT"
+  PLAYGROUND_APP=""
+  PLAYGROUND_BUILT_APP=""
+  PLAYGROUND_BUNDLE_ID=boo.peekaboo.playground.debug
+  PLAYGROUND_SOURCE_COMMIT="$SOURCE_COMMIT"
+  PLAYGROUND_SOURCE_TREE="$(git -C "$ROOT_DIR" rev-parse HEAD:Apps/Playground)"
+  PLAYGROUND_CODESIGN_BIN="$TEST_DIR/codesign-verifier"
+  PEEKABOO_PLAYGROUND_SIGN_IDENTITY='Synthetic test identity'
+  xcodebuild() {
+    FIXTURE_VERIFY_ONLY=0 "$TEST_DIR/xcodebuild" "$@"
+  }
+  sign_playground_app() {
+    [[ "$2" == 'Synthetic test identity' ]] || return 1
+    printf '%s\n' "$1" > "$TEST_DIR/local-sign-call"
+  }
+  build_playground
+  [[ "$(cat "$TEST_DIR/local-sign-call")" == "$PLAYGROUND_APP" ]] || fail 'local builder did not sign'
+  validate_playground_fixture || fail 'fresh internally built v1 rejected'
+  jq -e '.version == 1' "$PLAYGROUND_SOURCE_MANIFEST" >/dev/null
+  assert_native "$PLAYGROUND_APP" refuse 'supplied v1 is refused'
+  export PLAYGROUND_BUILT_APP="$PLAYGROUND_APP"
+  assert_native "$PLAYGROUND_APP" refuse 'supplied v1 is refused'
+  PLAYGROUND_BUILT_APP="$PLAYGROUND_APP" validate_playground_fixture || fail 'internal ownership lost'
+  PLAYGROUND_BUILT_APP=""
+  if validate_playground_fixture >/dev/null 2>&1; then fail 'unowned v1 accepted'; fi
+)
+
+if env PEEKABOO_PLAYGROUND_TEST_MODE=1 \
+  "$FIXTURE_ROOT/scripts/test-background-computer-use.sh" --playground-app "$OUTPUT_APP" \
+  --skip-playground-build > "$TEST_DIR/live-mode.log" 2>&1; then
+  fail 'test mode accepted on live path'
+fi
+grep -Fq 'restricted to --validate-playground-only' "$TEST_DIR/live-mode.log"
+for override in PEEKABOO_PLAYGROUND_CODESIGN_BIN PEEKABOO_PLAYGROUND_XCODEBUILD_BIN \
+  PEEKABOO_PLAYGROUND_XCRUN_BIN PEEKABOO_PLAYGROUND_XCODE_SELECT_BIN; do
+  if env "$override=/not/a/tool" "$FIXTURE_ROOT/scripts/test-background-computer-use.sh" \
+    --playground-app "$OUTPUT_APP" --skip-playground-build > "$TEST_DIR/override.log" 2>&1; then
+    fail 'test override accepted on live path'
+  fi
+  grep -Fq 'is test-only' "$TEST_DIR/override.log"
+done
+for args in '--validate-playground-only' '--validate-playground-only --skip-playground-build'; do
+  # Intentional splitting of these fixed test arguments.
+  if "$FIXTURE_ROOT/scripts/test-background-computer-use.sh" $args > "$TEST_DIR/arguments.log" 2>&1; then
+    fail 'validation-only accepted missing explicit fixture options'
+  fi
+  grep -Fq 'requires --playground-app and --skip-playground-build' "$TEST_DIR/arguments.log"
+done
+[[ ! -e "$FIXTURE_FORBIDDEN_LOG" ]] || fail 'test performed a forbidden live operation'
+[[ ! -e "$FIXTURE_ROOT/.artifacts" ]] || fail 'validation-only entered artifact/probe setup'
+printf 'local v1 ownership, supplied-v1 refusal, headless-only overrides, and early exit passed\n'
+unset FIXTURE_VERIFY_ONLY

--- a/scripts/test-background-computer-use.sh
+++ b/scripts/test-background-computer-use.sh
@@ -15,6 +15,10 @@ PEEKABOO_BIN="${PEEKABOO_BIN:-}"
 ARTIFACT_ROOT=""
 PLAYGROUND_APP=""
 SKIP_PLAYGROUND_BUILD=false
+VALIDATE_PLAYGROUND_ONLY=false
+# Never inherit receipt ownership from the caller; only build_playground sets it.
+PLAYGROUND_BUILT_APP=""
+SOURCE_PROVENANCE="$ROOT_DIR/scripts/source-provenance.sh"
 RUN_FOREGROUND_PHASE=false
 SELF_TEST_ONLY=false
 NO_REMOTE=false
@@ -35,6 +39,7 @@ Options:
   --artifacts PATH           Artifact directory (default: .artifacts/background-computer-use/<UTC>)
   --playground-app PATH      Use an existing signed Playground.app
   --skip-playground-build    Require --playground-app and skip xcodebuild
+  --validate-playground-only Validate the supplied fixture and exit without live setup
   --foreground-phase        Also run explicit physical-pointer tests
   --no-remote               Force the exact CLI process to use its local TCC grants
   --bridge-socket PATH      Pin every remote command to one exact Bridge host
@@ -62,6 +67,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --skip-playground-build)
             SKIP_PLAYGROUND_BUILD=true
+            shift
+            ;;
+        --validate-playground-only)
+            VALIDATE_PLAYGROUND_ONLY=true
             shift
             ;;
         --foreground-phase)
@@ -115,7 +124,42 @@ if [[ "$(uname -s)" != "Darwin" ]]; then
     exit 2
 fi
 
-for command_name in file git jq node plutil realpath rg swiftc xcodebuild codesign security open uuidgen shasum; do
+if $VALIDATE_PLAYGROUND_ONLY; then
+    if ! $SKIP_PLAYGROUND_BUILD || [[ -z "$PLAYGROUND_APP" ]] || $SELF_TEST_ONLY || $RUN_FOREGROUND_PHASE; then
+        echo "--validate-playground-only requires --playground-app and --skip-playground-build, without live/self-test phases." >&2
+        exit 2
+    fi
+fi
+
+PLAYGROUND_CODESIGN_BIN=/usr/bin/codesign
+PLAYGROUND_XCODEBUILD_BIN=/usr/bin/xcodebuild
+PLAYGROUND_XCRUN_BIN=/usr/bin/xcrun
+PLAYGROUND_XCODE_SELECT_BIN=/usr/bin/xcode-select
+case "${PEEKABOO_PLAYGROUND_TEST_MODE:-0}" in
+    1)
+        $VALIDATE_PLAYGROUND_ONLY || {
+            echo "Playground test mode is restricted to --validate-playground-only." >&2
+            exit 2
+        }
+        PLAYGROUND_CODESIGN_BIN="${PEEKABOO_PLAYGROUND_CODESIGN_BIN:?test codesign required}"
+        PLAYGROUND_XCODEBUILD_BIN="${PEEKABOO_PLAYGROUND_XCODEBUILD_BIN:?test xcodebuild required}"
+        PLAYGROUND_XCRUN_BIN="${PEEKABOO_PLAYGROUND_XCRUN_BIN:?test xcrun required}"
+        PLAYGROUND_XCODE_SELECT_BIN="${PEEKABOO_PLAYGROUND_XCODE_SELECT_BIN:?test xcode-select required}"
+        ;;
+    0|'')
+        for override in PEEKABOO_PLAYGROUND_CODESIGN_BIN PEEKABOO_PLAYGROUND_XCODEBUILD_BIN \
+            PEEKABOO_PLAYGROUND_XCRUN_BIN PEEKABOO_PLAYGROUND_XCODE_SELECT_BIN; do
+            [[ -z "${!override+x}" ]] || { echo "$override is test-only." >&2; exit 2; }
+        done
+        ;;
+    *) echo "PEEKABOO_PLAYGROUND_TEST_MODE must be 0 or 1." >&2; exit 2 ;;
+esac
+
+required_commands=(git jq realpath shasum)
+if ! $VALIDATE_PLAYGROUND_ONLY; then
+    required_commands+=(file node plutil rg swiftc xcodebuild codesign security open uuidgen)
+fi
+for command_name in "${required_commands[@]}"; do
     if ! command -v "$command_name" >/dev/null 2>&1; then
         echo "Missing required command: $command_name" >&2
         exit 2
@@ -177,6 +221,116 @@ sign_playground_app() {
     "$ROOT_DIR/scripts/codesign-with-retry.sh" \
         --force --options runtime --timestamp --sign "$identity" "$app"
 }
+
+build_playground() {
+    local derived_data="$ARTIFACT_ROOT/DerivedData"
+    local build_log="$ARTIFACT_ROOT/playground-build.log"
+    if [[ -n "$(git -C "$ROOT_DIR" status --porcelain --untracked-files=all -- Apps/Playground)" ]]; then
+        echo "Playground sources differ from the committed source tree; refusing a false provenance stamp." >&2
+        return 1
+    fi
+    xcodebuild \
+        -project "$ROOT_DIR/Apps/Playground/Playground.xcodeproj" \
+        -scheme Playground \
+        -configuration Debug \
+        -derivedDataPath "$derived_data" \
+        build CODE_SIGNING_ALLOWED=NO > "$build_log" 2>&1
+
+    PLAYGROUND_APP="$derived_data/Build/Products/Debug/Playground.app"
+    local identity="${PEEKABOO_PLAYGROUND_SIGN_IDENTITY:-}"
+    if [[ -z "$identity" ]]; then
+        identity="$(openclaw_codesign_identity)"
+    fi
+    if [[ -z "$identity" ]]; then
+        echo "No OpenClaw Foundation Developer ID Application identity is available." >&2
+        return 1
+    fi
+
+    mkdir -p "$PLAYGROUND_APP/Contents/Resources"
+    jq -n \
+        --arg sourceCommit "$PLAYGROUND_SOURCE_COMMIT" \
+        --arg sourceTree "$PLAYGROUND_SOURCE_TREE" '
+        {version: 1, source_commit: $sourceCommit, source_tree: $sourceTree}
+    ' > "$PLAYGROUND_APP/Contents/Resources/PeekabooPlaygroundSource.json"
+    chmod 444 "$PLAYGROUND_APP/Contents/Resources/PeekabooPlaygroundSource.json"
+
+    sign_playground_app "$PLAYGROUND_APP" "$identity" || return 1
+    PLAYGROUND_BUILT_APP="$PLAYGROUND_APP"
+}
+
+validate_playground_fixture() {
+    local lock_sha marketing_version developer_dir xcode_version sdk_version swift_version
+    local plist requirement
+    [[ "$PLAYGROUND_APP" == /* ]] || PLAYGROUND_APP="$ROOT_DIR/$PLAYGROUND_APP"
+    [[ -d "$PLAYGROUND_APP" && ! -L "$PLAYGROUND_APP" ]] || {
+        echo "Playground app missing or symlinked: $PLAYGROUND_APP" >&2; return 1;
+    }
+    PLAYGROUND_SOURCE_MANIFEST="$PLAYGROUND_APP/Contents/Resources/PeekabooPlaygroundSource.json"
+    peekaboo_is_immutable_receipt "$PLAYGROUND_SOURCE_MANIFEST" || {
+        echo 'Playground requires an immutable regular source receipt.' >&2; return 1;
+    }
+    PLAYGROUND_SOURCE_COMMIT="$(git -C "$ROOT_DIR" rev-parse HEAD)" || return 1
+    PLAYGROUND_SOURCE_TREE="$(git -C "$ROOT_DIR" rev-parse HEAD:Apps/Playground)" || return 1
+    marketing_version="$(/usr/bin/plutil -extract version raw -o - "$ROOT_DIR/package.json")" || return 1
+    if [[ -n "$PLAYGROUND_BUILT_APP" && "$PLAYGROUND_APP" == "$PLAYGROUND_BUILT_APP" ]]; then
+        # The standalone local builder has a v1 contract; supplied apps never own this exception.
+        [[ -z "$(git -C "$ROOT_DIR" status --porcelain --untracked-files=all -- Apps/Playground)" ]] || {
+            echo 'Playground sources changed after the local build.' >&2; return 1;
+        }
+        jq -se --arg sourceCommit "$PLAYGROUND_SOURCE_COMMIT" --arg sourceTree "$PLAYGROUND_SOURCE_TREE" '
+            length == 1 and (.[0] |
+            type == "object" and keys == ["source_commit", "source_tree", "version"] and
+            .version == 1 and .source_commit == $sourceCommit and .source_tree == $sourceTree)
+        ' "$PLAYGROUND_SOURCE_MANIFEST" >/dev/null || {
+            echo 'Locally built Playground lacks its exact current-source v1 receipt.' >&2; return 1;
+        }
+    else
+        lock_sha="$(peekaboo_playground_lock_sha256 "$ROOT_DIR")" || return 1
+        peekaboo_verify_source_commit "$ROOT_DIR" "$PLAYGROUND_SOURCE_COMMIT" || return 1
+        developer_dir="${DEVELOPER_DIR:-$("$PLAYGROUND_XCODE_SELECT_BIN" -p)}"
+        developer_dir="$(realpath "$developer_dir")" || return 1
+        xcode_version="$(DEVELOPER_DIR="$developer_dir" "$PLAYGROUND_XCODEBUILD_BIN" -version)" || return 1
+        sdk_version="$(DEVELOPER_DIR="$developer_dir" "$PLAYGROUND_XCRUN_BIN" --sdk macosx --show-sdk-version)" || return 1
+        swift_version="$(DEVELOPER_DIR="$developer_dir" "$PLAYGROUND_XCRUN_BIN" swiftc --version 2>&1)" || return 1
+        peekaboo_verify_playground_v2_receipt "$PLAYGROUND_SOURCE_MANIFEST" \
+            "$PLAYGROUND_SOURCE_COMMIT" "$PLAYGROUND_SOURCE_TREE" \
+            Apps/Peekaboo.xcworkspace/xcshareddata/swiftpm/Package.resolved "$lock_sha" "$marketing_version" \
+            "$developer_dir" "$xcode_version" "$sdk_version" "$swift_version" || {
+            echo 'Supplied Playground requires an exact current-source/toolchain v2 receipt; supplied v1 is refused.' >&2
+            return 1
+        }
+    fi
+    plist="$PLAYGROUND_APP/Contents/Info.plist"
+    [[ -f "$plist" && ! -L "$plist" ]] &&
+        [[ "$(/usr/bin/plutil -extract CFBundleIdentifier raw -o - "$plist")" == "$PLAYGROUND_BUNDLE_ID" ]] &&
+        [[ "$(/usr/bin/plutil -extract CFBundleShortVersionString raw -o - "$plist")" == "$marketing_version" ]] &&
+        [[ "$(/usr/bin/plutil -extract CFBundleExecutable raw -o - "$plist")" == Playground ]] || {
+        echo 'Playground bundle metadata differs from the fixture contract.' >&2; return 1;
+    }
+    PLAYGROUND_EXECUTABLE_NAME=Playground
+    PLAYGROUND_EXECUTABLE="$PLAYGROUND_APP/Contents/MacOS/$PLAYGROUND_EXECUTABLE_NAME"
+    [[ -f "$PLAYGROUND_EXECUTABLE" && -x "$PLAYGROUND_EXECUTABLE" && ! -L "$PLAYGROUND_EXECUTABLE" ]] || {
+        echo 'Playground executable missing, symlinked, or not executable.' >&2; return 1;
+    }
+    requirement='anchor apple generic and certificate leaf[subject.OU] = "FWJYW4S8P8" and certificate leaf[subject.CN] = "Developer ID Application: OpenClaw Foundation (FWJYW4S8P8)" and identifier "boo.peekaboo.playground.debug"'
+    "$PLAYGROUND_CODESIGN_BIN" --verify --deep --strict "-R=$requirement" "$PLAYGROUND_APP" || return 1
+    PLAYGROUND_SIGNATURE_DETAILS="$("$PLAYGROUND_CODESIGN_BIN" -dv --verbose=2 "$PLAYGROUND_APP" 2>&1)" || return 1
+    [[ "$(sed -n 's/^TeamIdentifier=//p' <<<"$PLAYGROUND_SIGNATURE_DETAILS")" == FWJYW4S8P8 &&
+       "$(sed -n 's/^Identifier=//p' <<<"$PLAYGROUND_SIGNATURE_DETAILS")" == "$PLAYGROUND_BUNDLE_ID" &&
+       "$(awk '/^Authority=/ {sub(/^Authority=/, ""); print; exit}' <<<"$PLAYGROUND_SIGNATURE_DETAILS")" == \
+           'Developer ID Application: OpenClaw Foundation (FWJYW4S8P8)' ]] || {
+        echo 'Playground requires the OpenClaw Foundation Developer ID, team, and identifier.' >&2; return 1;
+    }
+}
+
+if $VALIDATE_PLAYGROUND_ONLY; then
+    # No probe, CLI, permissions, keychain, launch, artifact setup, or cleanup trap.
+    [[ -f "$SOURCE_PROVENANCE" && ! -L "$SOURCE_PROVENANCE" ]] || exit 2
+    source "$SOURCE_PROVENANCE"
+    validate_playground_fixture || exit 2
+    echo 'Playground fixture validation passed.'
+    exit 0
+fi
 
 CERTIFICATION_INVARIANTS_JSON="$(jq -cer '
     .invariants |
@@ -243,11 +397,15 @@ cp -p "$SOURCE_CATALOG" "$SOURCE_INPUT_ROOT/catalog.json"
 cp -p "$SOURCE_REPORTER" "$SOURCE_INPUT_ROOT/reporter.mjs"
 cp -p "$SOURCE_PROBE" "$SOURCE_INPUT_ROOT/probe.swift"
 cp -p "$SOURCE_HARNESS" "$SOURCE_INPUT_ROOT/harness.sh"
+[[ -f "$SOURCE_PROVENANCE" && ! -L "$SOURCE_PROVENANCE" ]] || exit 2
+cp -p "$SOURCE_PROVENANCE" "$SOURCE_INPUT_ROOT/source-provenance.sh"
 chmod 400 "$SOURCE_INPUT_ROOT"/*
 CATALOG_SHA256_INITIAL="$(shasum -a 256 "$SOURCE_INPUT_ROOT/catalog.json" | awk '{print $1}')"
 REPORTER_SHA256_INITIAL="$(shasum -a 256 "$SOURCE_INPUT_ROOT/reporter.mjs" | awk '{print $1}')"
 PROBE_SOURCE_SHA256_INITIAL="$(shasum -a 256 "$SOURCE_INPUT_ROOT/probe.swift" | awk '{print $1}')"
 HARNESS_SHA256_INITIAL="$(shasum -a 256 "$SOURCE_INPUT_ROOT/harness.sh" | awk '{print $1}')"
+SOURCE_PROVENANCE_SHA256_INITIAL="$(shasum -a 256 "$SOURCE_INPUT_ROOT/source-provenance.sh" | awk '{print $1}')"
+source "$SOURCE_INPUT_ROOT/source-provenance.sh"
 CERTIFICATION_CATALOG="$SOURCE_INPUT_ROOT/catalog.json"
 CERTIFICATION_REPORTER="$SOURCE_INPUT_ROOT/reporter.mjs"
 CERTIFICATION_INVARIANTS_JSON="$(jq -cer '
@@ -1394,40 +1552,6 @@ fi
 PLAYGROUND_SOURCE_COMMIT="$(git -C "$ROOT_DIR" rev-parse HEAD)"
 PLAYGROUND_SOURCE_TREE="$(git -C "$ROOT_DIR" rev-parse HEAD:Apps/Playground)"
 
-build_playground() {
-    local derived_data="$ARTIFACT_ROOT/DerivedData"
-    local build_log="$ARTIFACT_ROOT/playground-build.log"
-    if [[ -n "$(git -C "$ROOT_DIR" status --porcelain --untracked-files=all -- Apps/Playground)" ]]; then
-        echo "Playground sources differ from the committed source tree; refusing a false provenance stamp." >&2
-        return 1
-    fi
-    xcodebuild \
-        -project "$ROOT_DIR/Apps/Playground/Playground.xcodeproj" \
-        -scheme Playground \
-        -configuration Debug \
-        -derivedDataPath "$derived_data" \
-        build CODE_SIGNING_ALLOWED=NO > "$build_log" 2>&1
-
-    PLAYGROUND_APP="$derived_data/Build/Products/Debug/Playground.app"
-    local identity="${PEEKABOO_PLAYGROUND_SIGN_IDENTITY:-}"
-    if [[ -z "$identity" ]]; then
-        identity="$(openclaw_codesign_identity)"
-    fi
-    if [[ -z "$identity" ]]; then
-        echo "No OpenClaw Foundation Developer ID Application identity is available." >&2
-        return 1
-    fi
-
-    mkdir -p "$PLAYGROUND_APP/Contents/Resources"
-    jq -n \
-        --arg sourceCommit "$PLAYGROUND_SOURCE_COMMIT" \
-        --arg sourceTree "$PLAYGROUND_SOURCE_TREE" '
-        {version: 1, source_commit: $sourceCommit, source_tree: $sourceTree}
-    ' > "$PLAYGROUND_APP/Contents/Resources/PeekabooPlaygroundSource.json"
-    chmod 444 "$PLAYGROUND_APP/Contents/Resources/PeekabooPlaygroundSource.json"
-
-    sign_playground_app "$PLAYGROUND_APP" "$identity"
-}
 
 if $SKIP_PLAYGROUND_BUILD; then
     if [[ -z "$PLAYGROUND_APP" ]]; then
@@ -1438,33 +1562,8 @@ elif [[ -z "$PLAYGROUND_APP" ]]; then
     build_playground
 fi
 
-if [[ "$PLAYGROUND_APP" != /* ]]; then
-    PLAYGROUND_APP="$ROOT_DIR/$PLAYGROUND_APP"
-fi
-if [[ ! -d "$PLAYGROUND_APP" ]]; then
-    echo "Playground app not found: $PLAYGROUND_APP" >&2
-    exit 2
-fi
-PLAYGROUND_SOURCE_MANIFEST="$PLAYGROUND_APP/Contents/Resources/PeekabooPlaygroundSource.json"
-if ! jq -e \
-    --arg sourceCommit "$PLAYGROUND_SOURCE_COMMIT" \
-    --arg sourceTree "$PLAYGROUND_SOURCE_TREE" '
-    type == "object" and keys == ["source_commit", "source_tree", "version"] and
-    .version == 1 and .source_commit == $sourceCommit and .source_tree == $sourceTree
-' "$PLAYGROUND_SOURCE_MANIFEST" >/dev/null; then
-    echo "Playground app lacks an exact current-source manifest; rebuild it from this checkout." >&2
-    exit 2
-fi
-codesign --verify --deep --strict "$PLAYGROUND_APP"
-codesign -dv --verbose=2 "$PLAYGROUND_APP" > "$ARTIFACT_ROOT/playground-signature.txt" 2>&1
-if ! rg -q '^TeamIdentifier=' "$ARTIFACT_ROOT/playground-signature.txt" || \
-   rg -q '^TeamIdentifier=not set$' "$ARTIFACT_ROOT/playground-signature.txt"; then
-    echo "Playground must have a team-signed identity, not an ad-hoc signature." >&2
-    exit 2
-fi
-PLAYGROUND_EXECUTABLE_NAME="$(plutil -extract CFBundleExecutable raw \
-    "$PLAYGROUND_APP/Contents/Info.plist")"
-PLAYGROUND_EXECUTABLE="$PLAYGROUND_APP/Contents/MacOS/$PLAYGROUND_EXECUTABLE_NAME"
+validate_playground_fixture || exit 2
+printf '%s\n' "$PLAYGROUND_SIGNATURE_DETAILS" > "$ARTIFACT_ROOT/playground-signature.txt"
 
 MONITOR_PID=""
 PLAYGROUND_PID=""
@@ -3454,10 +3553,13 @@ for source_and_digest in \
     "$SOURCE_CATALOG:$CATALOG_SHA256_INITIAL" \
     "$SOURCE_REPORTER:$REPORTER_SHA256_INITIAL" \
     "$SOURCE_PROBE:$PROBE_SOURCE_SHA256_INITIAL" \
-    "$SOURCE_HARNESS:$HARNESS_SHA256_INITIAL"; do
+    "$SOURCE_HARNESS:$HARNESS_SHA256_INITIAL" \
+    "$SOURCE_PROVENANCE:$SOURCE_PROVENANCE_SHA256_INITIAL" \
+    "$SOURCE_INPUT_ROOT/source-provenance.sh:$SOURCE_PROVENANCE_SHA256_INITIAL"; do
     source_path="${source_and_digest%:*}"
     expected_digest="${source_and_digest##*:}"
-    if [[ "$(shasum -a 256 "$source_path" | awk '{print $1}')" != "$expected_digest" ]]; then
+    if [[ ! -f "$source_path" || -L "$source_path" ]] ||
+       [[ "$(shasum -a 256 "$source_path" | awk '{print $1}')" != "$expected_digest" ]]; then
         record_failure "certification source input changed after its private snapshot: $source_path"
         PROVENANCE_STABLE=false
     fi
@@ -3504,6 +3606,7 @@ SOURCE_ARTIFACTS_JSON="$(jq -cn \
     --arg probeSourceSHA256 "$PROBE_SOURCE_SHA256_INITIAL" \
     --arg probeExecutableSHA256 "$PROBE_EXECUTABLE_SHA256_INITIAL" \
     --arg harnessSHA256 "$HARNESS_SHA256_INITIAL" \
+    --arg sourceProvenanceSHA256 "$SOURCE_PROVENANCE_SHA256_INITIAL" \
     --arg cliExecutableSHA256 "$PEEKABOO_EXECUTABLE_SHA256" \
     --arg cliCodeSignatureHash "$PEEKABOO_CODE_SIGNATURE_HASH" \
     --arg cliExecutableDevice "$PEEKABOO_EXECUTABLE_DEVICE" \
@@ -3521,6 +3624,7 @@ SOURCE_ARTIFACTS_JSON="$(jq -cn \
         probe_source_sha256: $probeSourceSHA256,
         probe_executable_sha256: $probeExecutableSHA256,
         harness_sha256: $harnessSHA256,
+        source_provenance_sha256: $sourceProvenanceSHA256,
         cli_executable_sha256: $cliExecutableSHA256,
         cli_code_signature_hash: $cliCodeSignatureHash,
         cli_executable_device: $cliExecutableDevice,

--- a/scripts/test-build-playground-artifact.sh
+++ b/scripts/test-build-playground-artifact.sh
@@ -23,6 +23,7 @@ mkdir -p \
   "$FIXTURE_ROOT/Apps/Peekaboo.xcworkspace/xcshareddata/swiftpm"
 cp "$ROOT_DIR/scripts/build-playground-artifact.sh" "$FIXTURE_ROOT/scripts/"
 cp "$ROOT_DIR/scripts/source-provenance.sh" "$FIXTURE_ROOT/scripts/"
+cp "$ROOT_DIR/scripts/test-background-computer-use.sh" "$FIXTURE_ROOT/scripts/"
 cp "$ROOT_DIR/scripts/terminal-artifact-env.sh" "$FIXTURE_ROOT/scripts/"
 cp "$ROOT_DIR/package.json" "$FIXTURE_ROOT/"
 printf '<Workspace version="1.0"/>\n' > "$FIXTURE_ROOT/Apps/Peekaboo.xcworkspace/contents.xcworkspacedata"
@@ -46,6 +47,10 @@ if [[ "${1:-}" == -version ]]; then
   printf 'Xcode Fixture\nBuild version Fixture\n'
   exit 0
 fi
+if [[ "${FIXTURE_VERIFY_ONLY:-0}" == 1 ]]; then
+  echo 'unexpected build' >> "${FIXTURE_FORBIDDEN_LOG:?}"
+  exit 90
+fi
 printf '%s\n' "$@" > "${ARG_LOG:?}"
 derived_data=
 configuration=Debug
@@ -57,7 +62,11 @@ while (($# > 0)); do
   esac
 done
 app="$derived_data/Build/Products/$configuration/Playground.app"
-mkdir -p "$app/Contents/MacOS"
+mkdir -p "$app/Contents/MacOS" "$app/Contents/Resources" "$app/Contents/_CodeSignature"
+printf 'synthetic signature resource seal\n' > "$app/Contents/_CodeSignature/CodeResources"
+printf 'fixture resource\n' > "$app/Contents/Resources/fixture.txt"
+ln -s fixture.txt "$app/Contents/Resources/fixture-link"
+/usr/bin/xattr -w boo.peekaboo.fixture synthetic "$app/Contents/Resources/fixture.txt"
 cp /usr/bin/true "$app/Contents/MacOS/Playground"
 cat > "$app/Contents/Info.plist" <<PLIST
 <?xml version="1.0" encoding="UTF-8"?>
@@ -65,10 +74,31 @@ cat > "$app/Contents/Info.plist" <<PLIST
 <plist version="1.0"><dict>
 <key>CFBundleExecutable</key><string>Playground</string>
 <key>CFBundleIdentifier</key><string>boo.peekaboo.playground.debug</string>
+<key>CFBundleShortVersionString</key><string>$(/usr/bin/plutil -extract version raw -o - "$FIXTURE_ROOT/package.json")</string>
 </dict></plist>
 PLIST
 EOF
 chmod 755 "$TEST_DIR/xcodebuild"
+
+mkdir -p "$TEST_DIR/Developer"
+cat > "$TEST_DIR/xcode-select" <<'EOF'
+#!/bin/bash
+[[ "$*" == -p ]] || exit 90
+printf '%s\n' "$FIXTURE_DEVELOPER_DIR"
+EOF
+cat > "$TEST_DIR/xcrun" <<'EOF'
+#!/bin/bash
+case "$*" in
+  '--sdk macosx --show-sdk-version') printf '99.0\n' ;;
+  'swiftc --version') printf 'Apple Swift Fixture\nTarget: fixture\n' ;;
+  *) exit 90 ;;
+esac
+EOF
+chmod 755 "$TEST_DIR/xcode-select" "$TEST_DIR/xcrun"
+export FIXTURE_DEVELOPER_DIR="$(realpath "$TEST_DIR/Developer")"
+export DEVELOPER_DIR="$FIXTURE_DEVELOPER_DIR"
+export PLAYGROUND_XCRUN_BIN="$TEST_DIR/xcrun"
+export PLAYGROUND_XCODE_SELECT_BIN="$TEST_DIR/xcode-select"
 
 export FIXTURE_ROOT ARG_LOG
 export APP_STORE_CONNECT_API_KEY_P8=secret
@@ -117,11 +147,28 @@ for required_arg in \
   grep -Fxq -- "$required_arg" "$ARG_LOG" || fail "xcodebuild omitted $required_arg"
 done
 
+# Exercise the canonical wrapper without running the terminal orchestrator.
+source "$ROOT_DIR/scripts/source-provenance.sh"
+eval "$(sed -n '/^verify_playground_manifest() {/,/^}/p' "$ROOT_DIR/scripts/build-terminal-artifacts.sh")"
+SOURCE_COMMIT="$(git -C "$FIXTURE_ROOT" rev-parse HEAD)"
+CANONICAL_LOCK_RELATIVE=Apps/Peekaboo.xcworkspace/xcshareddata/swiftpm/Package.resolved
+DEPENDENCY_LOCK_SHA256="$lock_sha"
+VERSION="$(/usr/bin/plutil -extract version raw -o - "$FIXTURE_ROOT/package.json")"
+EFFECTIVE_DEVELOPER_DIR="$FIXTURE_DEVELOPER_DIR"
+XCODEBUILD_VERSION="$($TEST_DIR/xcodebuild -version)"
+SDK_VERSION="$($TEST_DIR/xcrun --sdk macosx --show-sdk-version)"
+SWIFTC_VERSION="$($TEST_DIR/xcrun swiftc --version)"
+(ROOT_DIR="$FIXTURE_ROOT"; verify_playground_manifest "$OUTPUT_APP") || fail 'canonical terminal rejected producer v2'
+printf 'canonical terminal wrapper accepted unchanged producer v2\n'
+
 caller_derived="$TEST_DIR/caller-derived"
 PLAYGROUND_XCODEBUILD_BIN="$TEST_DIR/xcodebuild" PEEKABOO_TERMINAL_TEST_MODE=1 \
   "$FIXTURE_ROOT/scripts/build-playground-artifact.sh" \
   --derived-data "$caller_derived" --output-app "$TEST_DIR/output-two/Playground.app" >/dev/null
 [[ ! -e "$caller_derived" ]] || fail 'caller-provided DerivedData was retained without --keep-derived-data'
+
+# Shared validator, actual terminal wrapper, and the native validation-only CLI.
+source "$ROOT_DIR/scripts/support/test-playground-fixture-compatibility.sh"
 
 mkdir -p "$FIXTURE_ROOT/Apps/Playground/Playground.xcodeproj/project.xcworkspace/xcshareddata/swiftpm"
 printf '{}\n' > \

--- a/scripts/validate-background-computer-use-report.mjs
+++ b/scripts/validate-background-computer-use-report.mjs
@@ -220,6 +220,7 @@ function isExactSourceArtifacts(value) {
     "probe_executable_sha256",
     "probe_source_sha256",
     "reporter_sha256",
+    "source_provenance_sha256",
   ];
   return keys.length === expected.length
     && keys.every((key, index) => key === expected[index])
@@ -231,6 +232,7 @@ function isExactSourceArtifacts(value) {
       value.probe_executable_sha256,
       value.probe_source_sha256,
       value.reporter_sha256,
+      value.source_provenance_sha256,
     ].every((digest) => typeof digest === "string" && exactSHA256.test(digest))
     && typeof value.cli_code_signature_hash === "string"
     && exactSourceCommit.test(value.cli_code_signature_hash)
@@ -396,16 +398,17 @@ function validateProvenance(report, failures, trustedSourceArtifacts) {
     failures.push(failure(
       "certification",
       "source_artifacts",
-      "Catalog, reporter, probe, harness, and Playground provenance must be exact digests",
+      "Catalog, reporter, probe, harness, source helper, and Playground provenance must be exact digests",
     ));
   }
   if (trustedSourceArtifacts
       && (provenance.source_artifacts?.catalog_sha256 !== trustedSourceArtifacts.catalog_sha256
-        || provenance.source_artifacts?.reporter_sha256 !== trustedSourceArtifacts.reporter_sha256)) {
+        || provenance.source_artifacts?.reporter_sha256 !== trustedSourceArtifacts.reporter_sha256
+        || provenance.source_artifacts?.source_provenance_sha256 !== trustedSourceArtifacts.source_provenance_sha256)) {
     failures.push(failure(
       "certification",
       "trusted_source_artifacts",
-      "Reported catalog or reporter digest differs from the trusted files used for validation",
+      "Reported catalog, reporter, or source helper digest differs from the trusted files used for validation",
     ));
   }
   if (!["local", "remote"].includes(provenance.event_producer_source)) {
@@ -799,6 +802,7 @@ export function makePassingReport(catalog) {
         probe_source_sha256: "3".repeat(64),
         probe_executable_sha256: "4".repeat(64),
         harness_sha256: "5".repeat(64),
+        source_provenance_sha256: "a".repeat(64),
         playground_source_tree: sourceCommit,
         playground_executable_sha256: "6".repeat(64),
         playground_code_signature_hash: "7".repeat(40),
@@ -838,9 +842,14 @@ function runCLI() {
   const report = args.selfTest
     ? makePassingReport(catalog)
     : JSON.parse(fs.readFileSync(args.report ?? "", "utf8"));
+  const sourceHelper = new URL("./source-provenance.sh", import.meta.url);
+  if (!args.selfTest && !fs.lstatSync(sourceHelper).isFile()) {
+    throw new Error("Source provenance helper must be a regular, unsymlinked file");
+  }
   const trustedSourceArtifacts = args.selfTest ? null : {
     catalog_sha256: sha256(catalogBytes),
     reporter_sha256: sha256(fs.readFileSync(fileURLToPath(import.meta.url))),
+    source_provenance_sha256: sha256(fs.readFileSync(sourceHelper)),
   };
   const result = validateCertification(catalog, report, trustedSourceArtifacts);
   writeResult(result, args.output);

--- a/tests/background-computer-use-report.test.mjs
+++ b/tests/background-computer-use-report.test.mjs
@@ -1,6 +1,9 @@
 import assert from "node:assert/strict";
 import fs from "node:fs";
 import path from "node:path";
+import os from "node:os";
+import { createHash } from "node:crypto";
+import { spawnSync } from "node:child_process";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
 
@@ -257,6 +260,49 @@ test("post-run provenance drift is part of the canonical verdict", () => {
   const report = makePassingReport(catalog);
   report.provenance_stable = false;
   assert.ok(rules(validateCertification(catalog, report)).has("provenance_stability"));
+});
+
+test("source helper evidence is required and bound to the retained helper bytes", (t) => {
+  const missing = makePassingReport(catalog);
+  delete missing.provenance.source_artifacts.source_provenance_sha256;
+  assert.ok(rules(validateCertification(catalog, missing)).has("source_artifacts"));
+
+  const directory = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "peekaboo-source-helper-")));
+  t.after(() => fs.rmSync(directory, { recursive: true, force: true }));
+  const reporter = path.join(directory, "reporter.mjs");
+  const helper = path.join(directory, "source-provenance.sh");
+  fs.copyFileSync(path.join(root, "scripts/validate-background-computer-use-report.mjs"), reporter);
+  fs.copyFileSync(path.join(root, "scripts/source-provenance.sh"), helper);
+  const catalogPath = path.join(directory, "catalog.json");
+  fs.writeFileSync(catalogPath, JSON.stringify(catalog));
+  const report = makePassingReport(catalog);
+  const digest = (file) => createHash("sha256").update(fs.readFileSync(file)).digest("hex");
+  Object.assign(report.provenance.source_artifacts, {
+    catalog_sha256: digest(catalogPath),
+    reporter_sha256: digest(reporter),
+    source_provenance_sha256: digest(helper),
+  });
+  const reportPath = path.join(directory, "report.json");
+  fs.writeFileSync(reportPath, JSON.stringify(report));
+  const run = () => spawnSync(process.execPath, [reporter, "--catalog", catalogPath, "--report", reportPath], {
+    encoding: "utf8",
+  });
+  const accepted = run();
+  assert.equal(accepted.status, 0, accepted.stderr);
+  assert.equal(JSON.parse(accepted.stdout).success, true);
+  const original = fs.readFileSync(helper);
+  fs.appendFileSync(helper, "\n# changed helper\n");
+  const changed = run();
+  assert.equal(changed.status, 1, changed.stderr);
+  assert.ok(rules(JSON.parse(changed.stdout)).has("trusted_source_artifacts"));
+  fs.copyFileSync(reporter, helper);
+  assert.ok(rules(JSON.parse(run().stdout)).has("trusted_source_artifacts"));
+  fs.unlinkSync(helper);
+  assert.equal(run().status, 2);
+  const target = path.join(directory, "helper-target.sh");
+  fs.writeFileSync(target, original);
+  fs.symlinkSync(target, helper);
+  assert.equal(run().status, 2);
 });
 
 test("case monitor receipts are run-bound, ordered, and instance-distinct", () => {


### PR DESCRIPTION
Canonical prebuilt Playground fixtures carry schema-v2 receipts, but the native background harness previously required schema v1 and rejected the producer's output. Share one strict v2 receipt validator between terminal finalization and native preflight, checking the exact trusted source commit/tree, canonical dependency lock, selected toolchain, bundle metadata, and OpenClaw Foundation signature without changing the candidate.

Retain v1 only for the fresh app built and signed by the current harness invocation; externally supplied v1 fixtures are now refused. Add `--validate-playground-only` to run the production preflight and exit before probe compilation/execution, CLI or Bridge setup, TCC, Keychain lookup, artifact setup, or app launches. Include the shared helper in the reporter's retained source evidence and drift checks. Update the testing documentation and changelog.

Validation uses disposable synthetic fixtures and external-tool doubles:

- `bash scripts/test-build-playground-artifact.sh`: complete producer/shared-validator/terminal-wrapper/native-preflight matrix, including 49 receipt corruptions, lock/toolchain/bundle/signature refusals, candidate immutability, local-v1 ownership, and headless-only boundaries.
- `bash scripts/test-source-provenance.sh`.
- `node --test tests/background-computer-use-report.test.mjs`: 36 passing tests.
- `bash -n` for all five changed shell files; `git diff --check`.

The focused checks do not establish the full safe gate. Portability was not rerun: prior runs failed on unbound DMG extended attributes, and the unmodified baseline also failed during extended-attribute cleanup of read-only fixture source files. No live GUI harness, Swift probe, actual signing, or notarization was run for this PR. Full terminal-manifest/pinned-Node integration remains a separate documented gap; fixture validation does not establish terminal qualification.
