### PR TITLE
fix(test): wait for terminal-title fixture readiness

### DIFF
--- a/Apps/CLI/Tests/CoreCLITests/TerminalTitleProcessTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/TerminalTitleProcessTests.swift
@@ -37,12 +37,36 @@ struct TerminalTitleProcessTests {
 
     @Test
     func `timed out child is killed and reaped`() throws {
+        let fileManager = FileManager.default
+        let scratch = fileManager.temporaryDirectory
+            .appendingPathComponent("peekaboo-terminal-title-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fileManager.removeItem(at: scratch) }
+        try fileManager.createDirectory(at: scratch, withIntermediateDirectories: false)
+        let readyFile = scratch.appendingPathComponent("ready")
+
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/bin/sh")
-        process.arguments = ["-c", "trap '' TERM; exec /bin/sleep 30"]
+        process.arguments = [
+            "-c", "trap '' TERM && : > \"$1\" && exec /bin/sleep 30",
+            "terminal-title-fixture", readyFile.path,
+        ]
 
         try process.run()
         let pid = process.processIdentifier
+        defer {
+            if process.isRunning {
+                kill(pid, SIGKILL)
+            }
+            process.waitUntilExit()
+        }
+
+        // The timeout must start after the child ignores TERM, even when shell startup is slow.
+        let clock = ContinuousClock()
+        let deadline = clock.now + .seconds(5)
+        while !fileManager.fileExists(atPath: readyFile.path), process.isRunning, clock.now < deadline {
+            Thread.sleep(forTimeInterval: 0.005)
+        }
+        try #require(fileManager.fileExists(atPath: readyFile.path), "Child did not become ready to ignore TERM")
 
         #expect(throws: TerminalTitleProcessWaitError.self) {
             try waitForTerminalTitleProcessExit(process, timeoutSeconds: 0.05)


### PR DESCRIPTION
The terminal-title timeout fixture can receive SIGTERM before its shell has installed the TERM-ignore trap when startup exceeds the 50ms helper timeout. The test then observes signal 15 instead of the expected SIGKILL (9). This matches the failure observed in [PR #669](https://github.com/openclaw/Peekaboo/pull/669) and [CI run 33338033398](https://github.com/openclaw/Peekaboo/actions/runs/33338033398).

Have the shell create a unique readiness marker after ignoring TERM, and wait for that marker under a five-second monotonic deadline before starting the unchanged 50ms helper timeout. Deferred cleanup kills/reaps the child and removes the temporary directory on failure. The original SIGKILL and reaping assertions still run before deferred cleanup. Only `TerminalTitleProcessTests.swift` changes; the production helper in `TerminalColors.swift` is unchanged.

Validation completed for this exact patch:

- Real `Apps/CLI` package: all four focused tests passed; the timeout test passed 25/25 repetitions. An independent rerun of all four tests five times passed all 20 executions.
- Supplemental isolated harness using the actual test suite and unchanged helper: 25 repetitions passed all 100 executions.
- A controlled 250ms delay before trap installation passed 20/20 repetitions with readiness waiting. Removing only the readiness wait reproduced signal 15 versus expected signal 9.
- Missing-marker readiness failed after 5.030s, with the child confirmed reaped (`ESRCH`) and its temporary directory removed. Early-exit and launch-failure cleanup probes also passed.
- Targeted SwiftFormat, strict SwiftLint, and `git diff --check` passed. Independent review found no P0 findings, and the full diff and production helper were manually reviewed.

Focused package commands, with temporary scratch/cache location options omitted:

```sh
swift test --package-path Apps/CLI --no-parallel -Xswiftc -DPEEKABOO_SKIP_AUTOMATION --filter TerminalTitleProcessTests --disable-keychain --disable-netrc --jobs 4
swift test --package-path Apps/CLI --no-parallel -Xswiftc -DPEEKABOO_SKIP_AUTOMATION --filter 'timed out child is killed and reaped' --disable-keychain --disable-netrc --jobs 4 --skip-build --maximum-repetitions 25 --repeat-until fail
```

Local validation was limited to these focused tests and supplemental probes; the full 1,370-test suite was not run locally.
