### PR TITLE
fix: keep SwiftPM consumers versioned in custom scratch builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Reuse validated classic PNG bytes when capture performs no transform instead of encoding the same image twice.
 
 ### Fixed
+- Keep public SwiftPM consumers on versioned Commander dependencies with custom scratch directories by pinning AXorcist 0.1.8.
 - Include nested dialog static text and nonblank AX text metadata fallbacks in `dialog list`, preserving dialog scope and control order.
 - Accept canonical v2 prebuilt Playground fixtures in native validation with strict source, lock, toolchain, bundle, and Foundation signature checks, retaining v1 only for the current invocation's local build.
 - Distinguish browser handoff parent and receipt metadata refusals from inspection failures, and document the unchanged zero-ACL/xattr requirements, including OS provenance, without fallback.

--- a/Package.swift
+++ b/Package.swift
@@ -36,7 +36,7 @@ let package = Package(
             targets: ["PeekabooBridge"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/openclaw/AXorcist.git", exact: "0.1.6"),
+        .package(url: "https://github.com/openclaw/AXorcist.git", exact: "0.1.8"),
         .package(url: "https://github.com/apple/swift-algorithms", from: "1.2.1"),
     ],
     targets: [

--- a/scripts/test-swiftpm-consumer.sh
+++ b/scripts/test-swiftpm-consumer.sh
@@ -33,7 +33,7 @@ if (JSON.stringify(actual) !== JSON.stringify([...expected].sort())) {
   process.exit(1);
 }
 
-const expectedAXVersion = "0.1.6";
+const expectedAXVersion = "0.1.8";
 const sourceDependencies = manifest.dependencies.flatMap(dependency => dependency.sourceControl ?? []);
 const axorcist = sourceDependencies.find(dependency => dependency.identity === "axorcist");
 const actualAXVersion = axorcist?.requirement?.exact?.[0];


### PR DESCRIPTION
## What Problem This Solves

Fixes public SwiftPM consumer builds that fail when using a custom scratch directory. AXorcist 0.1.6 can mistake SwiftPM's sibling Commander checkout for an intentional local developer override, changing Commander from exact version 0.2.4 to an unversioned filesystem dependency during resolution.

The original OpenClaw macOS cold build reproduced the exact frozen-resolution error: Commander was resolved to 0.2.4 but now has an unversioned requirement. The conflicting paths are Peekaboo → AXorcist → local Commander and Swabble → versioned Commander.

## Why This Change Was Made

Pin the public package to the published [AXorcist 0.1.8 release](https://github.com/openclaw/AXorcist/releases/tag/v0.1.8), which includes the canonical [upstream repair](https://github.com/openclaw/AXorcist/pull/53). Update the existing public-consumer contract's matching version assertion. Commander remains exact 0.2.4; no cache patches, global mirrors, or weaker dependency requirements are introduced.

This PR changes the public root package only. The separate CLI/app submodule and checkout-workspace adoption remain with [Peekaboo 4.3.0 release preparation](https://github.com/openclaw/Peekaboo/pull/664); its worktree is untouched. The public root manifest does not consume that gitlink.

## User Impact

SwiftPM consumers can use isolated custom scratch paths without AXorcist silently selecting an unversioned Commander sibling. Intentional developer overrides remain explicit workspace operations documented by AXorcist.

## Evidence

- `bash scripts/test-swiftpm-consumer.sh` passed on Swift 6.4, compiling all four public products and the embedded Bridge API in release mode.
- AXorcist release validation passed formatting, SwiftLint, native-only policy, all eight Commander dependency regression suites, and the Swift test suites (221 tests reported; opt-in desktop automation disabled).
- AXorcist 0.1.8's public archive checksum, both architectures, Foundation Developer ID signature, online notarization requirement, version/help, and ping were verified. Its signed tag peels to `bab3f2228bac0ce3a34786b8395b65bb36242221`.
- Fresh Codex autoreview: no accepted/actionable findings.
- Production manifest LOC: +1/-1 (net 0). Test-support LOC: +1/-1 (net 0). Changelog: +1.

A separate cold public-root `PeekabooBridge` release build passed with a custom scratch path containing spaces, resolving AXorcist 0.1.8 and Commander 0.2.4. This PR's exact-head CI is checked before landing. OpenClaw's downstream revision/lock update follows the resulting merge commit; no AnyCodable repair files were changed.
