### PR TITLE
fix(mac): honor menu-bar-only mode when opening windows

### DIFF
--- a/Apps/Mac/Peekaboo/Core/DockIconManager.swift
+++ b/Apps/Mac/Peekaboo/Core/DockIconManager.swift
@@ -1,41 +1,43 @@
 import AppKit
 import os.log
 
-/// Centralized manager for dock icon visibility.
-///
-/// This manager ensures the dock icon is shown whenever any window is visible,
-/// regardless of user preference. It uses KVO to monitor NSApplication.windows
-/// and only hides the dock icon when no windows are open AND the user preference
-/// is set to hide the dock icon.
-///
-/// Based on VibeTunnel's implementation, adapted for Peekaboo.
 @MainActor
-final class DockIconManager: NSObject {
-    /// Shared instance
-    static let shared = DockIconManager()
+protocol DockIconPreferences: AnyObject {
+    var showInDock: Bool { get }
+}
 
-    private var windowsObservation: NSKeyValueObservation?
+extension PeekabooSettings: DockIconPreferences {}
+
+/// Owns activation policy from the Dock preference and unattended-host presentation state.
+/// Window visibility and keyboard focus do not determine Dock or Command-Tab presence.
+@MainActor
+final class DockIconManager {
+    /// Shared instance
+    static let shared = DockIconManager(
+        isBackgroundBridgeHost: PeekabooAppLaunchPolicy.current.isBackgroundBridgeHost,
+        applyActivationPolicy: { policy in
+            NSApp?.setActivationPolicy(policy)
+        })
+
     private let logger = Logger(subsystem: "boo.peekaboo", category: "DockIconManager")
-    private var settings: PeekabooSettings?
-    private var isBackgroundBridgeHost = false
+    private let applyActivationPolicy: (NSApplication.ActivationPolicy) -> Void
+    private var settings: (any DockIconPreferences)?
+    private var isBackgroundBridgeHost: Bool
     private var didAcceptExplicitPresentation = false
 
-    override private init() {
-        self.isBackgroundBridgeHost = PeekabooAppLaunchPolicy.current.isBackgroundBridgeHost
-        super.init()
-        self.setupObservers()
+    init(
+        isBackgroundBridgeHost: Bool,
+        applyActivationPolicy: @escaping (NSApplication.ActivationPolicy) -> Void)
+    {
+        self.isBackgroundBridgeHost = isBackgroundBridgeHost
+        self.applyActivationPolicy = applyActivationPolicy
         self.updateDockVisibility()
-    }
-
-    deinit {
-        self.windowsObservation?.invalidate()
-        NotificationCenter.default.removeObserver(self)
     }
 
     // MARK: - Public Methods
 
     /// Connect to settings instance for preference changes
-    func connectToSettings(_ settings: PeekabooSettings) {
+    func connectToSettings(_ settings: any DockIconPreferences) {
         self.settings = settings
         self.updateDockVisibility()
     }
@@ -52,104 +54,21 @@ final class DockIconManager: NSObject {
     /// Update dock visibility based on current state.
     /// Call this when user preferences change or when you need to ensure proper state.
     func updateDockVisibility() {
-        // Ensure NSApp is available before proceeding
-        guard NSApp != nil else {
-            self.logger.warning("NSApp not available yet, skipping dock visibility update")
-            return
-        }
-
         if self.isBackgroundBridgeHost, !self.didAcceptExplicitPresentation {
             self.logger.debug("Keeping background Bridge host out of the Dock")
-            NSApp.setActivationPolicy(.accessory)
+            self.applyActivationPolicy(.accessory)
             return
         }
 
         let userWantsDockShown = self.settings?.showInDock ?? true // Default to showing
-
-        // Count visible windows (excluding panels and hidden windows)
-        let visibleWindows = NSApp.windows.filter { window in
-            window.isVisible &&
-                window.frame.width > 1 && window.frame.height > 1 && // settings window hack
-                !window.isKind(of: NSPanel.self) &&
-                window.contentViewController != nil &&
-                // Exclude the hidden window
-                !(window.identifier?.rawValue.contains("HiddenWindow") ?? false)
-        }
-
-        let hasVisibleWindows = !visibleWindows.isEmpty
-
-        let message =
-            "Updating dock visibility - User wants shown: \(userWantsDockShown), " +
-            "Visible windows: \(visibleWindows.count)"
-        self.logger.debug("\(message, privacy: .public)")
-
-        // Show dock if user wants it shown OR if any windows are open
-        if userWantsDockShown || hasVisibleWindows {
-            self.logger.debug("Showing dock icon")
-            NSApp.setActivationPolicy(.regular)
-        } else {
-            self.logger.debug("Hiding dock icon")
-            NSApp.setActivationPolicy(.accessory)
-        }
+        self.logger.debug("Updating Dock visibility - User wants shown: \(userWantsDockShown)")
+        self.applyActivationPolicy(userWantsDockShown ? .regular : .accessory)
     }
 
-    /// Force show the dock icon temporarily (e.g., when opening a window).
-    /// The dock visibility will be properly managed automatically via KVO.
-    func temporarilyShowDock() {
-        guard NSApp != nil else {
-            self.logger.warning("NSApp not available, cannot temporarily show dock")
-            return
-        }
+    /// Accept an explicit window request without overriding the user's Dock preference.
+    /// Callers still own opening and focusing the requested window, including in accessory mode.
+    func prepareForPresentation() {
         self.didAcceptExplicitPresentation = true
-        NSApp.setActivationPolicy(.regular)
-    }
-
-    // MARK: - Private Methods
-
-    private func setupObservers() {
-        // Ensure NSApp is available before setting up observers
-        guard NSApp != nil else {
-            self.logger.warning("NSApp not available, delaying observer setup")
-            Task { @MainActor in
-                try? await Task.sleep(for: .milliseconds(200))
-                self.setupObservers()
-            }
-            return
-        }
-
-        // Observe changes to NSApp.windows using KVO
-        if let app = NSApp {
-            self.windowsObservation = app.observe(\.windows, options: [.new]) { [weak self] _, _ in
-                Task { @MainActor in
-                    // Add a small delay to let window state settle
-                    try? await Task.sleep(for: .milliseconds(50))
-                    self?.updateDockVisibility()
-                }
-            }
-        }
-
-        // Also observe individual window visibility changes
-        NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(self.windowVisibilityChanged),
-            name: NSWindow.didBecomeKeyNotification,
-            object: nil)
-
-        NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(self.windowVisibilityChanged),
-            name: NSWindow.didResignKeyNotification,
-            object: nil)
-
-        NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(self.windowVisibilityChanged),
-            name: NSWindow.willCloseNotification,
-            object: nil)
-    }
-
-    @objc
-    private func windowVisibilityChanged(_: Notification) {
         self.updateDockVisibility()
     }
 }

--- a/Apps/Mac/Peekaboo/Features/StatusBar/MenuBarStatusView.swift
+++ b/Apps/Mac/Peekaboo/Features/StatusBar/MenuBarStatusView.swift
@@ -119,13 +119,13 @@ struct MenuBarStatusView: View {
     private func openMainWindow() {
         guard AgentSessionUI.isAvailable(agentModeEnabled: self.settings.agentModeEnabled) else { return }
 
-        DockIconManager.shared.temporarilyShowDock()
+        DockIconManager.shared.prepareForPresentation()
         NSApp.activate(ignoringOtherApps: true)
         self.openWindow(id: "main")
     }
 
     private func openInspector() {
-        DockIconManager.shared.temporarilyShowDock()
+        DockIconManager.shared.prepareForPresentation()
         NSApp.activate(ignoringOtherApps: true)
         NotificationCenter.default.post(name: .showInspector, object: nil)
     }

--- a/Apps/Mac/Peekaboo/Features/StatusBar/StatusBarController.swift
+++ b/Apps/Mac/Peekaboo/Features/StatusBar/StatusBarController.swift
@@ -504,7 +504,7 @@ final class StatusBarController: NSObject, NSMenuDelegate {
               let session = sessionStore.sessions.first(where: { $0.id == sessionId }) else { return }
 
         // Open session detail window
-        DockIconManager.shared.temporarilyShowDock()
+        DockIconManager.shared.prepareForPresentation()
         NSApp.activate(ignoringOtherApps: true)
 
         let window = NSWindow(
@@ -531,7 +531,7 @@ final class StatusBarController: NSObject, NSMenuDelegate {
         self.logger.info("openMainWindow action triggered from menu")
 
         // First ensure the app is active
-        DockIconManager.shared.temporarilyShowDock()
+        DockIconManager.shared.prepareForPresentation()
         NSApp.activate(ignoringOtherApps: true)
 
         // Post notification to open main window

--- a/Apps/Mac/Peekaboo/PeekabooApp.swift
+++ b/Apps/Mac/Peekaboo/PeekabooApp.swift
@@ -436,8 +436,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         self.logger.info("showMainWindow called")
 
-        // Ensure dock icon is visible
-        DockIconManager.shared.temporarilyShowDock()
+        DockIconManager.shared.prepareForPresentation()
 
         // Activate the app first
         NSApp.activate(ignoringOtherApps: true)
@@ -510,8 +509,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         self.logger.info("openWindow called with id: \(id)")
 
-        // Ensure dock icon is visible
-        DockIconManager.shared.temporarilyShowDock()
+        DockIconManager.shared.prepareForPresentation()
 
         // Use the window opener if available
         if let opener = self.windowOpener {

--- a/Apps/Mac/Peekaboo/Utilities/SettingsOpener.swift
+++ b/Apps/Mac/Peekaboo/Utilities/SettingsOpener.swift
@@ -22,11 +22,10 @@ enum SettingsOpener {
             SettingsTabRouter.request(tab)
         }
 
-        // Let DockIconManager handle dock visibility
-        DockIconManager.shared.temporarilyShowDock()
+        DockIconManager.shared.prepareForPresentation()
 
         Task { @MainActor in
-            // Small delay to ensure dock icon is visible
+            // Let activation policy settle before requesting the SwiftUI Settings scene.
             try? await Task.sleep(for: .milliseconds(50))
 
             // Activate the app
@@ -60,8 +59,6 @@ enum SettingsOpener {
                 Task { @MainActor in
                     try? await Task.sleep(for: .milliseconds(100))
                     settingsWindow.level = .normal
-
-                    // DockIconManager will handle dock visibility automatically
                 }
             }
 

--- a/Apps/Mac/PeekabooTests/Core/DockIconManagerTests.swift
+++ b/Apps/Mac/PeekabooTests/Core/DockIconManagerTests.swift
@@ -2,64 +2,116 @@ import AppKit
 import Testing
 @testable import Peekaboo
 
-@Suite(.tags(.ui, .unit), .disabled("Requires AppKit/NSApplication which may hang in tests"))
+@Suite(.tags(.unit, .fast))
 @MainActor
 struct DockIconManagerTests {
-    var manager: DockIconManager!
-    var settings: PeekabooSettings!
+    @Test(arguments: [false, true])
+    func `startup applies policy before settings connect`(backgroundHost: Bool) {
+        let recorder = ActivationPolicyRecorder()
+        _ = DockIconManager(
+            isBackgroundBridgeHost: backgroundHost,
+            applyActivationPolicy: recorder.apply)
 
-    @Test(.disabled("Requires NSApplication"))
-    mutating func `Dock icon is shown by default when setting is true`() async {
-        await self.setup()
-        self.settings.showInDock = true
-        self.manager.updateDockVisibility()
-        #expect(NSApp.activationPolicy() == .regular)
+        #expect(recorder.policies == [backgroundHost ? .accessory : .regular])
     }
 
-    @Test(.disabled("Requires NSApplication"))
-    mutating func `Dock icon is hidden by default when setting is false`() async {
-        await self.setup()
-        self.settings.showInDock = false
-        self.manager.updateDockVisibility()
-        #expect(NSApp.activationPolicy() == .accessory)
+    @Test(arguments: [false, true])
+    func `connecting and changing the preference reconciles ordinary launch`(showInDock: Bool) {
+        let recorder = ActivationPolicyRecorder()
+        let manager = DockIconManager(isBackgroundBridgeHost: false, applyActivationPolicy: recorder.apply)
+        let settings = DockPreferences(showInDock: showInDock)
+
+        manager.connectToSettings(settings)
+        settings.showInDock.toggle()
+        manager.updateDockVisibility()
+        settings.showInDock.toggle()
+        manager.updateDockVisibility()
+
+        let preferred: NSApplication.ActivationPolicy = showInDock ? .regular : .accessory
+        let toggled: NSApplication.ActivationPolicy = showInDock ? .accessory : .regular
+        #expect(recorder.policies == [.regular, preferred, toggled, preferred])
     }
 
-    @Test(.disabled("Requires NSApplication"))
-    mutating func `Dock icon is shown when a window is visible, regardless of setting`() async {
-        await self.setup()
-        self.settings.showInDock = false
-        self.manager.updateDockVisibility()
-        #expect(NSApp.activationPolicy() == .accessory, "Precondition: Dock icon should be hidden")
+    @Test(arguments: [false, true], [false, true])
+    func `presentation and later reconciliation honor the preference`(showInDock: Bool, backgroundHost: Bool) {
+        let recorder = ActivationPolicyRecorder()
+        let manager = DockIconManager(
+            isBackgroundBridgeHost: backgroundHost,
+            applyActivationPolicy: recorder.apply)
+        manager.connectToSettings(DockPreferences(showInDock: showInDock))
+        recorder.policies.removeAll()
 
-        // Simulate opening a window
-        let window = NSWindow(contentRect: .zero, styleMask: .titled, backing: .buffered, defer: false)
-        window.makeKeyAndOrderFront(nil)
+        manager.prepareForPresentation()
+        manager.updateDockVisibility()
+        manager.prepareForPresentation()
 
-        self.manager.updateDockVisibility()
-
-        #expect(NSApp.activationPolicy() == .regular, "Dock icon should be visible when a window is open")
-
-        window.close()
-        self.manager.updateDockVisibility()
-        #expect(NSApp.activationPolicy() == .accessory, "Dock icon should hide again after window is closed")
+        let preferred: NSApplication.ActivationPolicy = showInDock ? .regular : .accessory
+        #expect(recorder.policies == [preferred, preferred, preferred])
     }
 
-    @Test(.disabled("Requires NSApplication"))
-    mutating func `Temporarily showing dock works`() async {
-        await self.setup()
-        self.settings.showInDock = false
-        self.manager.updateDockVisibility()
-        #expect(NSApp.activationPolicy() == .accessory, "Precondition: Dock icon should be hidden")
+    @Test
+    func `settings and mode reconciliation cannot present an unattended host`() {
+        let recorder = ActivationPolicyRecorder()
+        let manager = DockIconManager(isBackgroundBridgeHost: true, applyActivationPolicy: recorder.apply)
+        let settings = DockPreferences(showInDock: true)
 
-        self.manager.temporarilyShowDock()
-        #expect(NSApp.activationPolicy() == .regular, "Dock icon should be temporarily visible")
+        manager.connectToSettings(settings)
+        settings.showInDock = false
+        manager.updateDockVisibility()
+        settings.showInDock = true
+        manager.updateDockVisibility()
+        manager.setBackgroundBridgeHostMode(true)
+
+        #expect(recorder.policies == [.accessory, .accessory, .accessory, .accessory, .accessory])
     }
 
-    private mutating func setup() async {
-        _ = NSApplication.shared
-        self.manager = DockIconManager.shared
-        // Use a temporary, non-shared settings instance for testing
-        self.settings = makeTestSettings()
-        self.manager.connectToSettings(self.settings)
+    @Test
+    func `explicit presentation survives late settings and repeated background setup`() {
+        let recorder = ActivationPolicyRecorder()
+        let manager = DockIconManager(isBackgroundBridgeHost: true, applyActivationPolicy: recorder.apply)
+
+        manager.prepareForPresentation()
+        manager.setBackgroundBridgeHostMode(true)
+        let settings = DockPreferences(showInDock: false)
+        manager.connectToSettings(settings)
+        manager.updateDockVisibility()
+        settings.showInDock = true
+        manager.updateDockVisibility()
+
+        #expect(recorder.policies == [.accessory, .regular, .regular, .accessory, .accessory, .regular])
+    }
+
+    @Test
+    func `leaving background mode clears the explicit presentation latch`() {
+        let recorder = ActivationPolicyRecorder()
+        let manager = DockIconManager(isBackgroundBridgeHost: true, applyActivationPolicy: recorder.apply)
+        manager.connectToSettings(DockPreferences(showInDock: true))
+        manager.prepareForPresentation()
+        recorder.policies.removeAll()
+
+        manager.setBackgroundBridgeHostMode(false)
+        manager.setBackgroundBridgeHostMode(true)
+        manager.updateDockVisibility()
+        manager.prepareForPresentation()
+
+        #expect(recorder.policies == [.regular, .accessory, .accessory, .regular])
+    }
+}
+
+@MainActor
+private final class DockPreferences: DockIconPreferences {
+    var showInDock: Bool
+
+    init(showInDock: Bool) {
+        self.showInDock = showInDock
+    }
+}
+
+@MainActor
+private final class ActivationPolicyRecorder {
+    var policies: [NSApplication.ActivationPolicy] = []
+
+    func apply(_ policy: NSApplication.ActivationPolicy) {
+        self.policies.append(policy)
     }
 }

--- a/docs/install.md
+++ b/docs/install.md
@@ -36,6 +36,16 @@ This is the form you point Codex, Claude Code, and Cursor at. See [MCP.md](MCP.m
 
 The full menu-bar app (visualizer, permission flows, status item) ships as a drag-to-Applications DMG on the [Releases](https://github.com/openclaw/Peekaboo/releases/latest) page. The app and CLI are separate installs; use Homebrew or npm above when you also need the `peekaboo` command on your `PATH`.
 
+In Settings, **Show Peekaboo in → Menu bar only** keeps Peekaboo out of the Dock and Command-Tab,
+even while Settings, Inspector, or an enabled Sessions window is open. Use the menu-bar item or
+configured keyboard shortcuts to return to those windows. **Menu bar and Dock** keeps the Dock
+and Command-Tab entry available even after all windows are closed.
+
+An unattended background Bridge host stays out of the Dock and suppresses automatic window
+presentation regardless of the saved Dock preference. Explicitly opening a window from the menu
+bar or a shortcut resumes that preference for the running host; it does not force a Dock entry
+when **Menu bar only** is selected.
+
 ## Build from source
 
 Requires macOS 15.0+ and a Swift 6.2+ toolchain. See [platform-support.md](platform-support.md)


### PR DESCRIPTION
## Summary

Honor menu-bar-only mode while Settings, Inspector or session windows are open. Dock policy follows the stored preference instead of treating any visible window as a reason to become a regular Dock application.

Replace seven unconditional temporary-Dock calls with one preference-aware presentation method. Remove window enumeration, KVO/notification observers and delayed visibility bookkeeping. Preserve the existing Settings-opening workaround, activation/order/delays, launch guards and background-host explicit-presentation latch. Documentation explains the behavior.

## Validation

All exact-head [macOS CI](https://github.com/openclaw/Peekaboo/actions/runs/33616246623) and [CodeQL](https://github.com/openclaw/Peekaboo/actions/runs/33616246696) checks passed at `e4913619f0705dae09d2c33874380a5f6fb326d6`. The saved successful hosted log proves **141 Mac package tests in 28 suites**, including all **six Dock policy declarations and eleven cases**. Full Peekaboo and Inspector Xcode builds passed. Scoped formatting/lint and the complete integration’s Codex P0 review are clean.

Signed synthetic fixtures compile the exact baseline and candidate Dock manager/Settings opener with the same real SwiftUI Settings bridge. On macOS 27, a private fixture request invoked that production opener while a different owned synthetic app was foreground. Independent process, window, Accessibility and actual Dock observations showed:

| Observation | Baseline | Candidate |
| --- | --- | --- |
| Settings picker value | Menu bar only | Menu bar only |
| Activation policy after opening | regular | accessory |
| Exact fixture title in Dock AX inventory | present once | absent |
| Intended app becomes foreground; Settings is key | yes | yes |
| Physical cursor moved | no | no |

The candidate also accepted a background clear-and-replace in its exact Settings text field, with independent AX readback of the synthetic text. Delivery was `accessibility_value`, not hardware keyboard events; process generation, accessory policy, foreground app and cursor remained unchanged. The retained signed driver was automation infrastructure, not claimed as a current-source CLI qualification.

This is focused owner/Settings proof, not a complete production-app, persistence, close/reopen, all-window-caller or continuous Cmd-Tab matrix. The window inventory separately reported one omitted helper row and unverified raster capture; neither was presented as a complete screenshot-capability result.

## Before/after export diagnostics — incomplete, not accepted as full visual proof

These inspected images contain only synthetic fixture content. They are real app-exported content views, **not WindowServer/desktop screenshots**, and do not picture the Dock. Material/picker rendering is incomplete and some edge text is clipped, so they are retained as failed-render diagnostics rather than evidence of a complete visual pass. The Dock/focus conclusions above come from independent native observations, not these images.

Baseline partial export:

![Baseline partial Settings content export; incomplete rendering, no Dock pictured](https://github.com/user-attachments/assets/0fa24e81-e3c9-48f7-be4a-636829d726cb)

Candidate partial export:

![Candidate partial Settings content export; incomplete rendering, no Dock pictured](https://github.com/user-attachments/assets/4b864201-37f2-42ef-b84d-46c45e5b1acd)

Full desktop capture remained unavailable: the existing GUI host could not accept the requested classic backend, automatic capture refused an existing owner’s incomplete routing receipt, and caller-local/Apple capture lacked a working Screen Recording path. No unowned process was stopped, identity borrowed, permission changed or replacement image fabricated. An earlier fixture controller rejected an actually absent extended ACL; its test-only guard was corrected after read-only native observation and an extended-ACL negative control, with production owner bytes unchanged.

No changelog or publication change is included. Thanks to @anildigital for the report.

Fixes #676.
