### PR TITLE
test(cli): gate ambient snapshot invalidation cases

### DIFF
--- a/Apps/CLI/Tests/CoreCLITests/InteractionMutationInvalidatorTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/InteractionMutationInvalidatorTests.swift
@@ -275,9 +275,10 @@ struct InteractionMutationInvalidatorTests {
         #expect(await snapshots.getMostRecentSnapshot() == nil)
     }
 
-    @Test
+    @Test(.enabled(if: ProcessInfo.processInfo.environment["PEEKABOO_INCLUDE_AMBIENT_STATE_TESTS"] == "true"))
     func `Remote-selected local mutation installs a caller barrier`() async throws {
-        // Excluded from protected proof: runtime invalidation still constructs a caller-local SnapshotManager.
+        // Ambient opt-in: the caller-local SnapshotManager advances the effective-UID desktop watermark and
+        // target ledger despite this test's injected tracker and in-memory snapshots.
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("peekaboo-cli-remote-caller-barrier-\(UUID().uuidString)", isDirectory: true)
         defer { try? FileManager.default.removeItem(at: root) }
@@ -470,9 +471,10 @@ struct InteractionMutationInvalidatorTests {
         try remoteTracker.cancelDurableMutation()
     }
 
-    @Test
+    @Test(.enabled(if: ProcessInfo.processInfo.environment["PEEKABOO_INCLUDE_AMBIENT_STATE_TESTS"] == "true"))
     func `Remote coordinator rejects a host observation certificate that forbids preservation`() async throws {
-        // Excluded from protected proof: the owned tracker does not isolate caller-local snapshot invalidation.
+        // Ambient opt-in: the owned tracker does not isolate caller-local invalidation of the effective-UID
+        // desktop watermark and target ledger.
         let desktop = try CLIDesktopFixture()
         defer { desktop.removeDirectory() }
         let snapshots = InMemorySnapshotManager()

--- a/Apps/CLI/Tests/LOCAL_TESTS.md
+++ b/Apps/CLI/Tests/LOCAL_TESTS.md
@@ -45,6 +45,8 @@ If LaunchServices cannot resolve `Playground` by name, also set `PEEKABOO_PLAYGR
 
 Tests that read or mutate uncontrolled host state use the shared `PEEKABOO_INCLUDE_AMBIENT_STATE_TESTS=true` selector. Ordinary local and automation-action selectors never imply this consent, and `test:safe` explicitly overrides inherited ambient-state opt-ins. The live clipboard smoke test uses this selector and must only be enabled with fresh authorization to read, replace, and restore the ambient clipboard.
 
+The caller-barrier and rejected-host-certificate tests in `InteractionMutationInvalidatorTests` also require this opt-in: their caller-local `SnapshotManager` advances the effective-UID desktop watermark and target ledger despite injected trackers and in-memory snapshots. These two bodies are intentionally skipped by safe preflight, not counted as passed, and may run only with explicit authorization for those ambient mutations.
+
 ## Test Categories
 
 ### Screenshot Validation Tests (`ScreenshotValidationTests.swift`)

--- a/tests/ambient-state-test-policy.test.mjs
+++ b/tests/ambient-state-test-policy.test.mjs
@@ -42,6 +42,25 @@ test("ambient-state tests require the exact shared opt-in", () => {
   );
 });
 
+for (const name of [
+  "Remote-selected local mutation installs a caller barrier",
+  "Remote coordinator rejects a host observation certificate that forbids preservation",
+]) {
+  test(`ambient mutation declaration requires the exact shared opt-in: ${name}`, () => {
+    const lines = readFileSync(
+      `${repositoryRoot}/Apps/CLI/Tests/CoreCLITests/InteractionMutationInvalidatorTests.swift`,
+      "utf8",
+    ).split("\n");
+    const declaration = lines.indexOf(`    func \`${name}\`() async throws {`);
+    assert.notEqual(declaration, -1, `Missing test declaration: ${name}`);
+    assert.equal(
+      lines[declaration - 1].trim(),
+      '@Test(.enabled(if: ProcessInfo.processInfo.environment["PEEKABOO_INCLUDE_AMBIENT_STATE_TESTS"] == "true"))',
+      `The declaration must be immediately governed by the ambient-state gate: ${name}`,
+    );
+  });
+}
+
 test("hosted See proof retains target inclusion without opting into ambient tests", () => {
   const manifest = readFileSync(`${repositoryRoot}/Apps/CLI/Package.swift`, "utf8");
   const workflow = readFileSync(`${repositoryRoot}/.github/workflows/macos-ci.yml`, "utf8");


### PR DESCRIPTION
## Summary

Require the existing exact ambient-state opt-in for two runtime mutation tests that still construct a caller-local `SnapshotManager`. Their temporary trackers and in-memory snapshots do not prevent completion invalidation from advancing the effective UID’s real desktop watermark and target ledger. A temporary `HOME` is not isolation for that coordination root.

Gate only the caller-barrier and rejected-host-certificate declarations. Preserve all 28 bodies and leave the other 26 declarations ungated. The two ambient bodies remain available for explicitly authorized execution and are intentionally skipped—not counted as passed—by ordinary safe preflight. Production behavior and the `test:safe` command are unchanged.

## Validation

All exact-head [macOS CI](https://github.com/openclaw/Peekaboo/actions/runs/33626698186) and [CodeQL](https://github.com/openclaw/Peekaboo/actions/runs/33626698258) checks passed at `03d586546ca9d9c362d759540c8fc33a0b8dc199`. The successful hosted CLI job explicitly reports both named ambient tests as skipped. They were not executed and are not counted as passing mutation tests.

The Node policy suite independently protects each declaration’s gate. Against the prior Swift source, the original seven checks passed and both new checks failed. With the gates installed, all nine pass. Removing either gate in a temporary copy fails its own check while the other passes.

Xcode 27 syntax parsing, scoped SwiftFormat, strict SwiftLint, whitespace validation and Codex P0 review passed. No Swift discovery or ambient bodies were executed locally.

Update local-test guidance to document the real ambient mutation boundary. This corrects a gap left after PR662’s narrower protected proof excluded these names. It does not claim that every CLI fixture is hermetic or provide whole-process filesystem isolation for the release driver. No changelog or release publication is included.
