### PR TITLE
fix(cli): bound peekaboo config edit editor wait

### DIFF
--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Core/ConfigCommand+Bindings.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Core/ConfigCommand+Bindings.swift
@@ -41,6 +41,9 @@ extension ConfigCommand.EditCommand: AsyncRuntimeCommand {}
 extension ConfigCommand.EditCommand: CommanderBindableCommand {
     mutating func applyCommanderValues(_ values: CommanderBindableValues) throws {
         self.editor = values.singleOption("editor")
+        if let timeout: CLIDuration = try values.decodeOption("timeout", as: CLIDuration.self) {
+            self.timeout = timeout
+        }
         self.printPath = values.flag("print-path")
     }
 }

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Core/ConfigCommand+InitShowEdit.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Core/ConfigCommand+InitShowEdit.swift
@@ -263,9 +263,9 @@ extension ConfigCommand {
         var editor: String?
         @Option(
             name: .customLong("timeout"),
-            help: "Editor wait timeout (bare values are milliseconds; default 1h)"
+            help: "Optional editor wait timeout (bare values are milliseconds). Omit to wait until the editor exits."
         )
-        var timeout: CLIDuration = .seconds(3600)
+        var timeout: CLIDuration?
         @Flag(name: .customLong("print-path"), help: "Print the configuration path and exit without opening an editor")
         var printPath: Bool = false
         @RuntimeStorage var runtime: CommandRuntime?
@@ -306,7 +306,11 @@ extension ConfigCommand {
 
             do {
                 try process.run()
-                try waitForProcessExit(process, timeoutSeconds: self.timeout.seconds)
+                if let timeout = self.timeout {
+                    try waitForProcessExit(process, timeoutSeconds: timeout.seconds)
+                } else {
+                    process.waitUntilExit()
+                }
 
                 guard process.terminationStatus == 0 else {
                     if self.jsonOutput {
@@ -342,7 +346,7 @@ extension ConfigCommand {
                     }
                 }
             } catch ProcessWaitError.timedOut {
-                let seconds = Int(self.timeout.seconds.rounded(.up))
+                let seconds = Int((self.timeout?.seconds ?? 0).rounded(.up))
                 if self.jsonOutput {
                     let errorOutput = ErrorOutput(
                         error: true,

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Core/ConfigCommand+InitShowEdit.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Core/ConfigCommand+InitShowEdit.swift
@@ -261,6 +261,11 @@ extension ConfigCommand {
 
         @Option(name: .long, help: "Editor to use (defaults to $EDITOR or nano)")
         var editor: String?
+        @Option(
+            name: .customLong("timeout"),
+            help: "Editor wait timeout (bare values are milliseconds; default 1h)"
+        )
+        var timeout: CLIDuration = .seconds(3600)
         @Flag(name: .customLong("print-path"), help: "Print the configuration path and exit without opening an editor")
         var printPath: Bool = false
         @RuntimeStorage var runtime: CommandRuntime?
@@ -301,7 +306,7 @@ extension ConfigCommand {
 
             do {
                 try process.run()
-                process.waitUntilExit()
+                try waitForProcessExit(process, timeoutSeconds: self.timeout.seconds)
 
                 guard process.terminationStatus == 0 else {
                     if self.jsonOutput {
@@ -336,6 +341,22 @@ extension ConfigCommand {
                         print("[warn] Configuration may be invalid. Please check your changes.")
                     }
                 }
+            } catch ProcessWaitError.timedOut {
+                let seconds = Int(self.timeout.seconds.rounded(.up))
+                if self.jsonOutput {
+                    let errorOutput = ErrorOutput(
+                        error: true,
+                        code: "EDITOR_TIMEOUT",
+                        message: "Editor timed out after \(seconds)s",
+                        details: editorCommand
+                    )
+                    outputJSON(errorOutput, logger: self.logger)
+                } else {
+                    print("[error] Editor timed out after \(seconds)s")
+                }
+                throw ExitCode.failure
+            } catch let error as ExitCode {
+                throw error
             } catch {
                 if self.jsonOutput {
                     let errorOutput = ErrorOutput(

--- a/Apps/CLI/Sources/PeekabooCLI/Helpers/ProcessWait.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Helpers/ProcessWait.swift
@@ -1,0 +1,66 @@
+import Darwin
+import Foundation
+
+enum ProcessWaitError: Error {
+    case timedOut
+}
+
+/// Wait for a launched `Process` with a hard deadline.
+///
+/// Foundation's `waitUntilExit()` can block forever if the child wedges.
+nonisolated func waitForProcessExit(
+    _ process: Process,
+    timeoutSeconds: TimeInterval
+) throws {
+    final class LeaveOnce: @unchecked Sendable {
+        private let lock = NSLock()
+        private let group = DispatchGroup()
+        private var left = false
+
+        init() {
+            self.group.enter()
+        }
+
+        func leave() {
+            self.lock.lock()
+            defer { self.lock.unlock() }
+            guard !self.left else { return }
+            self.left = true
+            self.group.leave()
+        }
+
+        func wait(timeoutSeconds: TimeInterval) -> DispatchTimeoutResult {
+            self.group.wait(timeout: .now() + timeoutSeconds)
+        }
+    }
+
+    let once = LeaveOnce()
+    process.terminationHandler = { _ in
+        once.leave()
+    }
+    // Cover the race where the child exits before the handler is installed.
+    if !process.isRunning {
+        once.leave()
+    }
+
+    let waitResult = once.wait(timeoutSeconds: timeoutSeconds)
+    guard waitResult == .timedOut else {
+        return
+    }
+
+    // Child can exit after the group wait times out and before cleanup.
+    // Process.terminate() on an already-exited task can raise; match daemon cleanup.
+    if process.isRunning {
+        process.terminate()
+        let grace = once.wait(timeoutSeconds: 1.0)
+        if grace == .timedOut, process.isRunning {
+            let pid = process.processIdentifier
+            if pid > 0 {
+                kill(pid, SIGKILL)
+            }
+            _ = once.wait(timeoutSeconds: 1.0)
+        }
+    }
+
+    throw ProcessWaitError.timedOut
+}

--- a/Apps/CLI/Sources/PeekabooCLI/Helpers/TerminalColors.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Helpers/TerminalColors.swift
@@ -3,7 +3,6 @@
 //  PeekabooCLI
 //
 
-import Darwin
 import Foundation
 
 // MARK: - Terminal Color Codes
@@ -60,55 +59,9 @@ nonisolated func waitForTerminalTitleProcessExit(
     _ process: Process,
     timeoutSeconds: TimeInterval = 2
 ) throws {
-    final class LeaveOnce: @unchecked Sendable {
-        private let lock = NSLock()
-        private let group = DispatchGroup()
-        private var left = false
-
-        init() {
-            self.group.enter()
-        }
-
-        func leave() {
-            self.lock.lock()
-            defer { self.lock.unlock() }
-            guard !self.left else { return }
-            self.left = true
-            self.group.leave()
-        }
-
-        func wait(timeoutSeconds: TimeInterval) -> DispatchTimeoutResult {
-            self.group.wait(timeout: .now() + timeoutSeconds)
-        }
+    do {
+        try waitForProcessExit(process, timeoutSeconds: timeoutSeconds)
+    } catch ProcessWaitError.timedOut {
+        throw TerminalTitleProcessWaitError.timedOut
     }
-
-    let once = LeaveOnce()
-    process.terminationHandler = { _ in
-        once.leave()
-    }
-    // Cover the race where the child exits before the handler is installed.
-    if !process.isRunning {
-        once.leave()
-    }
-
-    let waitResult = once.wait(timeoutSeconds: timeoutSeconds)
-    guard waitResult == .timedOut else {
-        return
-    }
-
-    // Child can exit after the group wait times out and before cleanup.
-    // Process.terminate() on an already-exited task can raise; match daemon cleanup.
-    if process.isRunning {
-        process.terminate()
-        let grace = once.wait(timeoutSeconds: 1.0)
-        if grace == .timedOut, process.isRunning {
-            let pid = process.processIdentifier
-            if pid > 0 {
-                kill(pid, SIGKILL)
-            }
-            _ = once.wait(timeoutSeconds: 1.0)
-        }
-    }
-
-    throw TerminalTitleProcessWaitError.timedOut
 }

--- a/Apps/CLI/Tests/CoreCLITests/ConfigEditorLaunchTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/ConfigEditorLaunchTests.swift
@@ -1,6 +1,11 @@
+import Commander
+import Darwin
+import Foundation
+import PeekabooCore
 import Testing
 @testable import PeekabooCLI
 
+@Suite(.tags(.safe), .serialized)
 struct ConfigEditorLaunchTests {
     @Test
     func `EditCommand terminates env options before an option-like editor`() {
@@ -20,5 +25,81 @@ struct ConfigEditorLaunchTests {
         )
 
         #expect(arguments == ["--", "/usr/bin/nano", "/tmp/config.json"])
+    }
+
+    @Test
+    func `EditCommand bounds a non-exiting editor`() async throws {
+        try await self.withTempConfigDir { dir in
+            let fileManager = FileManager.default
+            let editor = dir.appendingPathComponent("hanging-editor")
+            let pidFile = dir.appendingPathComponent("editor.pid")
+            let script = """
+            #!/bin/sh
+            printf '%s\\n' "$$" > "\(pidFile.path)"
+            trap '' TERM
+            exec /bin/sleep 8
+            """
+            try script.write(to: editor, atomically: true, encoding: .utf8)
+            try fileManager.setAttributes([.posixPermissions: 0o755], ofItemAtPath: editor.path)
+
+            var command = ConfigCommand.EditCommand()
+            command.editor = editor.path
+            command.timeout = .seconds(1)
+
+            let startedAt = Date()
+            let exitCode = await #expect(throws: ExitCode.self) {
+                try await command.run(using: self.makeRuntime())
+            }
+            #expect(exitCode == ExitCode.failure)
+            #expect(Date().timeIntervalSince(startedAt) < 3)
+
+            let pidText = try String(contentsOf: pidFile, encoding: .utf8)
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            let pid = try #require(Int32(pidText))
+            errno = 0
+            #expect(kill(pid, 0) == -1)
+            #expect(errno == ESRCH)
+        }
+    }
+
+    private func makeRuntime() -> CommandRuntime {
+        CommandRuntime(
+            configuration: .init(verbose: false, jsonOutput: false, logLevel: nil),
+            services: PeekabooServices()
+        )
+    }
+
+    private func withTempConfigDir(_ body: (URL) async throws -> Void) async throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("peekaboo-cli-config-edit-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+
+        let environmentKeys = [
+            "PEEKABOO_CONFIG_DIR",
+            "PEEKABOO_CONFIG_NONINTERACTIVE",
+            "PEEKABOO_CONFIG_DISABLE_MIGRATION",
+        ]
+        let previous = Dictionary(uniqueKeysWithValues: environmentKeys.map { key in
+            (key, getenv(key).map { String(cString: $0) })
+        })
+
+        setenv("PEEKABOO_CONFIG_DIR", tempDir.path, 1)
+        setenv("PEEKABOO_CONFIG_NONINTERACTIVE", "1", 1)
+        setenv("PEEKABOO_CONFIG_DISABLE_MIGRATION", "1", 1)
+        PeekabooCore.ConfigurationManager.shared.resetForTesting()
+
+        defer {
+            for key in environmentKeys {
+                if case let value?? = previous[key] {
+                    setenv(key, value, 1)
+                } else {
+                    unsetenv(key)
+                }
+            }
+            PeekabooCore.ConfigurationManager.shared.resetForTesting()
+            try? FileManager.default.removeItem(at: tempDir)
+        }
+
+        try await body(tempDir)
     }
 }

--- a/Apps/CLI/Tests/CoreCLITests/ConfigEditorLaunchTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/ConfigEditorLaunchTests.swift
@@ -28,6 +28,12 @@ struct ConfigEditorLaunchTests {
     }
 
     @Test
+    func `EditCommand leaves the editor wait unbounded unless timeout is set`() {
+        let command = ConfigCommand.EditCommand()
+        #expect(command.timeout == nil)
+    }
+
+    @Test
     func `EditCommand bounds a non-exiting editor`() async throws {
         try await self.withTempConfigDir { dir in
             let fileManager = FileManager.default

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+- Add an optional `config edit --timeout` for scripted editor waits while preserving unlimited interactive editing. Thanks @SebTardif for #681.
+
 ## [4.3.0] - 2026-09-02
 
 ### Highlights

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,5 @@
 # Changelog
 
-## Unreleased
-
-### Fixed
-- Add an optional `config edit --timeout` for scripted editor waits while preserving unlimited interactive editing. Thanks @SebTardif for #681.
-
 ## [4.3.0] - 2026-09-02
 
 ### Highlights

--- a/docs/commands/config.md
+++ b/docs/commands/config.md
@@ -14,7 +14,7 @@ read_when:
 | --- | --- | --- |
 | `init` | Create a default `config.json` (respects `--force`) and print provider readiness (env / credentials / OAuth) in human mode. | `--force` overwrites an existing file; `--timeout` bounds live checks (default `30s`; bare values are milliseconds). |
 | `show` | Print either the raw file or the fully merged “effective” view (config + env + credentials); human `--effective` also live-validates providers. | `--effective` switches to the merged view; `--timeout` bounds validation with the shared duration grammar; JSON mode emits a standard `{ success, data }` object with no appended text. |
-| `edit` | Opens the config in `$EDITOR` (or the `--editor` you pass) and validates the result after you quit. | `--editor` overrides the detected editor. |
+| `edit` | Opens the config in `$EDITOR` (or the `--editor` you pass) and validates the result after you quit. | `--editor` overrides the detected editor; `--timeout` bounds the editor wait (default `1h`; bare values are milliseconds). |
 | `validate` | Parses the config without writing anything and surfaces syntax/errors. | None. |
 | `status` | Display provider credential readiness. | `--timeout` (default `30s`; bare values are milliseconds). |
 | `login` | Run an OAuth flow (no API key stored) for supported providers. | `login openai` (ChatGPT/Codex), `login anthropic` (Claude Pro/Max). |

--- a/docs/commands/config.md
+++ b/docs/commands/config.md
@@ -14,7 +14,7 @@ read_when:
 | --- | --- | --- |
 | `init` | Create a default `config.json` (respects `--force`) and print provider readiness (env / credentials / OAuth) in human mode. | `--force` overwrites an existing file; `--timeout` bounds live checks (default `30s`; bare values are milliseconds). |
 | `show` | Print either the raw file or the fully merged “effective” view (config + env + credentials); human `--effective` also live-validates providers. | `--effective` switches to the merged view; `--timeout` bounds validation with the shared duration grammar; JSON mode emits a standard `{ success, data }` object with no appended text. |
-| `edit` | Opens the config in `$EDITOR` (or the `--editor` you pass) and validates the result after you quit. | `--editor` overrides the detected editor; `--timeout` bounds the editor wait (default `1h`; bare values are milliseconds). |
+| `edit` | Opens the config in `$EDITOR` (or the `--editor` you pass) and validates the result after you quit. | `--editor` overrides the detected editor; `--timeout` is an optional bound (bare values are milliseconds). Omit it to wait until the editor exits. |
 | `validate` | Parses the config without writing anything and surfaces syntax/errors. | None. |
 | `status` | Display provider credential readiness. | `--timeout` (default `30s`; bare values are milliseconds). |
 | `login` | Run an OAuth flow (no API key stored) for supported providers. | `login openai` (ChatGPT/Codex), `login anthropic` (Claude Pro/Max). |


### PR DESCRIPTION
## What Problem This Solves

`peekaboo config edit` spawned `$EDITOR` (or `--editor`) through `/usr/bin/env` and then called Foundation `Process.waitUntilExit()` with no deadline. A wedged editor, or an `EDITOR` that never exits, blocked the CLI until someone killed the process from outside.

This is the same hang class already fixed for dock helpers (#303), the menubar helper (#475), VibeTunnel title updates (#489), and capture action children (#215). Interactive edits stay unbounded when `--timeout` is omitted, so a user can keep vim or TextEdit open. Scripts and automation pass `--timeout`. After that deadline the child gets SIGTERM, then SIGKILL.

## Evidence

Call chain: `peekaboo config edit` -> `ConfigCommand.EditCommand.run` -> `/usr/bin/env -- <editor> <config>` -> unbounded `waitUntilExit()`.

Trigger: any editor that stays running (hung GUI editor, `EDITOR=sleep`, a script that ignores SIGTERM).

On the unfixed tree, the same hanging editor (`trap '' TERM; exec /bin/sleep 8`) returned success after the full 8.2s sleep. The new `--timeout` flag was ignored because nothing waited on it.

After this patch, an explicit `--timeout` stops the wait, prints `EDITOR_TIMEOUT`, and reaps the child:

```console
$ peekaboo config edit --editor /tmp/hanging-editor --timeout 1s
No configuration file found. Creating default configuration...
[error] Editor timed out after 1s
exit=1
elapsed_s=2.925
editor_pid=51512 reaped=True
```

`elapsed_s` is the 1s wait plus the 1s SIGTERM grace used when the child ignores TERM, then SIGKILL. The editor was `sleep 30` and would have held the CLI for the remaining 27s (or forever, if it never exited).

A normal editor still finishes immediately:

```console
$ peekaboo config edit --editor /usr/bin/true --timeout 5s
No configuration file found. Creating default configuration...
[ok] Configuration saved.
[ok] Configuration is valid.
exit=0 elapsed_s=0.055
```

`--timeout` is visible on the public command and is optional:

```console
$ peekaboo config edit --help
--timeout <timeout>   Optional editor wait timeout (bare values are milliseconds). Omit to wait until the editor exits.
```

Same-repo siblings: [#303](https://github.com/openclaw/Peekaboo/pull/303), [#475](https://github.com/openclaw/Peekaboo/pull/475), [#489](https://github.com/openclaw/Peekaboo/pull/489), [#215](https://github.com/openclaw/Peekaboo/pull/215). Related `config edit` argv hardening: [#562](https://github.com/openclaw/Peekaboo/pull/562).

The unbounded wait landed in [`d359d139a9`](https://github.com/openclaw/Peekaboo/commit/d359d139a9) (Peter Steinberger, 2025-11-17, `refactor(config): split config command`) and has been present for 289 days.

## Real behavior proof

- **Behavior or issue addressed:** `peekaboo config edit --timeout` no longer blocks forever when the editor never exits. After that deadline the CLI sends SIGTERM, then SIGKILL, and exits with `EDITOR_TIMEOUT`. Omitting `--timeout` keeps the previous interactive wait.
- **Real environment tested:** macOS 26 arm64, Swift 6.3.3, Peekaboo CLI built from this branch at `/tmp/peekaboo-f042`, isolated `PEEKABOO_CONFIG_DIR`.
- **Exact steps or command run after this patch:**

  ```bash
  swift build --package-path Apps/CLI
  BIN=$(swift build --package-path Apps/CLI --show-bin-path)/peekaboo
  export PEEKABOO_CONFIG_DIR=/tmp/peekaboo-f042-live-cfg
  export PEEKABOO_CONFIG_NONINTERACTIVE=1
  export PEEKABOO_CONFIG_DISABLE_MIGRATION=1
  printf '%s\n' '#!/bin/sh' "printf '%s\\n' \"\$\$\" > /tmp/peekaboo-f042-editor.pid" "trap '' TERM" 'exec /bin/sleep 30' > /tmp/hanging-editor
  chmod 755 /tmp/hanging-editor
  $BIN config edit --editor /tmp/hanging-editor --timeout 1s
  $BIN config edit --editor /usr/bin/true --timeout 5s
  $BIN config edit --help
  ```

- **Evidence after fix:** terminal output from the patched `peekaboo` binary (not a mock). The hanging editor path printed `[error] Editor timed out after 1s`, exited 1 in 2.925s, and the recorded pid 51512 was gone (`kill -0` failed). `/usr/bin/true` printed `[ok] Configuration saved.` and `[ok] Configuration is valid.` in 0.055s with exit 0.
- **Observed result after fix:** A wedged editor no longer holds the CLI when `--timeout` is set. Interactive `config edit` without `--timeout` still waits until the editor exits.
- **What was not tested:** GUI editors that detach from the spawned process.
