### PR TITLE
fix(observation): reject oversized artifacts before Data load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+- Bound observation and MCP image artifact reads on one descriptor, rejecting oversized, growing, or replaced files before publication. Thanks @SebTardif for #683.
+
 ## [4.3.0] - 2026-09-02
 
 ### Highlights

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,5 @@
 # Changelog
 
-## Unreleased
-
-### Fixed
-- Bound observation and MCP image artifact reads on one descriptor, rejecting oversized, growing, or replaced files before publication. Thanks @SebTardif for #683.
-
 ## [4.3.0] - 2026-09-02
 
 ### Highlights

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Observation/DesktopObservationResultModels.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Observation/DesktopObservationResultModels.swift
@@ -365,24 +365,12 @@ extension DesktopObservationResult {
         label: String,
         maxBytes: Int = DesktopObservationResult.maximumArtifactBytes) throws -> Data
     {
-        let url = URL(fileURLWithPath: path)
-        let fileSize: Int
         do {
-            let values = try url.resourceValues(forKeys: [.fileSizeKey, .isRegularFileKey])
-            guard values.isRegularFile == true, let size = values.fileSize, size >= 0 else {
-                throw DesktopObservationContentVerificationError.unreadableArtifact(label)
-            }
-            fileSize = size
-        } catch let error as DesktopObservationContentVerificationError {
-            throw error
-        } catch {
-            throw DesktopObservationContentVerificationError.unreadableArtifact(label)
-        }
-        guard fileSize <= maxBytes else {
+            return try BoundedArtifactFile(path: path, maximumBytes: maxBytes).read()
+        } catch BoundedArtifactFileError.tooLarge {
             throw DesktopObservationContentVerificationError.artifactTooLarge(label)
-        }
-        do {
-            return try Data(contentsOf: url)
+        } catch is CancellationError {
+            throw CancellationError()
         } catch {
             throw DesktopObservationContentVerificationError.unreadableArtifact(label)
         }

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Observation/DesktopObservationResultModels.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Observation/DesktopObservationResultModels.swift
@@ -99,6 +99,7 @@ public enum DesktopObservationContentVerificationError: Error, LocalizedError, S
     case missingArtifactDigest(String)
     case missingArtifactPath(String)
     case unreadableArtifact(String)
+    case artifactTooLarge(String)
     case digestMismatch
 
     public var errorDescription: String? {
@@ -111,6 +112,8 @@ public enum DesktopObservationContentVerificationError: Error, LocalizedError, S
             "Desktop observation omitted its \(label) path."
         case let .unreadableArtifact(label):
             "Desktop observation \(label) could not be read."
+        case let .artifactTooLarge(label):
+            "Desktop observation \(label) exceeds the capture size limit."
         case .digestMismatch:
             "Desktop observation content no longer matches its signed digest."
         }
@@ -348,24 +351,50 @@ extension DesktopObservationResult {
         guard let path else {
             throw DesktopObservationContentVerificationError.missingArtifactPath(label)
         }
-        let data: Data
-        do {
-            data = try Data(contentsOf: URL(fileURLWithPath: path))
-        } catch {
-            throw DesktopObservationContentVerificationError.unreadableArtifact(label)
-        }
+        let data = try Self.readArtifact(at: path, label: label)
         guard let expectedSHA256 else { return data }
         try DesktopObservationContentDigest.verify(data, expectedSHA256: expectedSHA256)
         return data
     }
 
-    private static func readArtifactIfPresent(at path: String?, label: String) throws -> Data? {
-        guard let path else { return nil }
+    /// Capture PNG bound reused for observation verify/rebinding file loads.
+    public static let maximumArtifactBytes = CaptureArtifactIntegrityValidator.maximumPNGBytes
+
+    public static func readArtifact(
+        at path: String,
+        label: String,
+        maxBytes: Int = DesktopObservationResult.maximumArtifactBytes) throws -> Data
+    {
+        let url = URL(fileURLWithPath: path)
+        let fileSize: Int
         do {
-            return try Data(contentsOf: URL(fileURLWithPath: path))
+            let values = try url.resourceValues(forKeys: [.fileSizeKey, .isRegularFileKey])
+            guard values.isRegularFile == true, let size = values.fileSize, size >= 0 else {
+                throw DesktopObservationContentVerificationError.unreadableArtifact(label)
+            }
+            fileSize = size
+        } catch let error as DesktopObservationContentVerificationError {
+            throw error
         } catch {
             throw DesktopObservationContentVerificationError.unreadableArtifact(label)
         }
+        guard fileSize <= maxBytes else {
+            throw DesktopObservationContentVerificationError.artifactTooLarge(label)
+        }
+        do {
+            return try Data(contentsOf: url)
+        } catch {
+            throw DesktopObservationContentVerificationError.unreadableArtifact(label)
+        }
+    }
+
+    static func readArtifactIfPresent(
+        at path: String?,
+        label: String,
+        maxBytes: Int = DesktopObservationResult.maximumArtifactBytes) throws -> Data?
+    {
+        guard let path else { return nil }
+        return try self.readArtifact(at: path, label: label, maxBytes: maxBytes)
     }
 
     private static func requireDigestIfNeeded(

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/System/BoundedArtifactFile.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/System/BoundedArtifactFile.swift
@@ -1,0 +1,88 @@
+import Darwin
+import Foundation
+
+public enum BoundedArtifactFileError: Error, Equatable {
+    case invalidLimit
+    case unreadable
+    case tooLarge
+    case changedDuringRead
+}
+
+/// Retains one regular-file descriptor and caps every read, including growth after opening.
+public final class BoundedArtifactFile {
+    public let byteCount: Int
+    private let descriptor: Int32
+    private let path: String
+    private let maximumBytes: Int
+    private let initialInfo: stat
+
+    public init(path: String, maximumBytes: Int) throws {
+        guard maximumBytes >= 0 else { throw BoundedArtifactFileError.invalidLimit }
+        // Preserve ordinary symlink paths without waiting for a special-file writer.
+        let descriptor = Darwin.open(path, O_RDONLY | O_CLOEXEC | O_NONBLOCK)
+        guard descriptor >= 0 else { throw BoundedArtifactFileError.unreadable }
+        var retained = false
+        defer {
+            if !retained {
+                Darwin.close(descriptor)
+            }
+        }
+        var info = stat()
+        guard Darwin.fstat(descriptor, &info) == 0,
+              info.st_mode & S_IFMT == S_IFREG,
+              info.st_size >= 0,
+              let byteCount = Int(exactly: info.st_size)
+        else { throw BoundedArtifactFileError.unreadable }
+        guard byteCount <= maximumBytes else { throw BoundedArtifactFileError.tooLarge }
+        self.descriptor = descriptor
+        self.path = path
+        self.maximumBytes = maximumBytes
+        self.initialInfo = info
+        self.byteCount = byteCount
+        retained = true
+    }
+
+    deinit { Darwin.close(self.descriptor) }
+
+    /// Read once; refuse replacement or mutation rather than publishing bytes under a stale path.
+    public func read() throws -> Data {
+        var data = Data()
+        data.reserveCapacity(self.byteCount)
+        var buffer = [UInt8](repeating: 0, count: 64 * 1024)
+        while true {
+            try Task.checkCancellation()
+            let remaining = self.maximumBytes - data.count
+            let requested = remaining < buffer.count ? remaining + 1 : buffer.count
+            let count = Darwin.read(self.descriptor, &buffer, requested)
+            if count == 0 {
+                break
+            }
+            if count < 0 {
+                if errno == EINTR {
+                    continue
+                }
+                throw BoundedArtifactFileError.unreadable
+            }
+            guard count <= remaining else { throw BoundedArtifactFileError.tooLarge }
+            data.append(contentsOf: buffer.prefix(count))
+        }
+        var descriptorInfo = stat()
+        var pathInfo = stat()
+        guard Darwin.fstat(self.descriptor, &descriptorInfo) == 0,
+              Darwin.fstatat(AT_FDCWD, self.path, &pathInfo, 0) == 0,
+              Self.unchanged(self.initialInfo, descriptorInfo),
+              Self.unchanged(self.initialInfo, pathInfo),
+              data.count == self.byteCount
+        else { throw BoundedArtifactFileError.changedDuringRead }
+        return data
+    }
+
+    private static func unchanged(_ first: stat, _ second: stat) -> Bool {
+        first.st_dev == second.st_dev && first.st_ino == second.st_ino &&
+            first.st_mode == second.st_mode && first.st_size == second.st_size &&
+            first.st_mtimespec.tv_sec == second.st_mtimespec.tv_sec &&
+            first.st_mtimespec.tv_nsec == second.st_mtimespec.tv_nsec &&
+            first.st_ctimespec.tv_sec == second.st_ctimespec.tv_sec &&
+            first.st_ctimespec.tv_nsec == second.st_ctimespec.tv_nsec
+    }
+}

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/BoundedArtifactFileTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/BoundedArtifactFileTests.swift
@@ -1,0 +1,86 @@
+import Darwin
+import Foundation
+import Testing
+@testable import PeekabooAutomationKit
+
+struct BoundedArtifactFileTests {
+    @Test
+    func `inclusive limits and ordinary symlinks remain readable`() throws {
+        let fixture = try Fixture()
+        defer { fixture.cleanup() }
+        let link = fixture.root.appendingPathComponent("link")
+        try FileManager.default.createSymbolicLink(at: link, withDestinationURL: fixture.url)
+        let file = try BoundedArtifactFile(path: link.path, maximumBytes: fixture.data.count)
+        #expect(file.byteCount == fixture.data.count)
+        #expect(try file.read() == fixture.data)
+    }
+
+    @Test
+    func `empty file works with a zero byte limit`() throws {
+        let fixture = try Fixture(data: Data())
+        defer { fixture.cleanup() }
+        #expect(try BoundedArtifactFile(path: fixture.url.path, maximumBytes: 0).read().isEmpty)
+    }
+
+    @Test
+    func `growth after open cannot bypass the read budget`() throws {
+        let fixture = try Fixture()
+        defer { fixture.cleanup() }
+        let file = try BoundedArtifactFile(path: fixture.url.path, maximumBytes: 16)
+        let writer = try FileHandle(forWritingTo: fixture.url)
+        try writer.truncate(atOffset: 1_000_000)
+        try writer.close()
+        #expect(throws: BoundedArtifactFileError.tooLarge) { try file.read() }
+    }
+
+    @Test
+    func `replacement after open cannot publish the old inode under the new path`() throws {
+        let fixture = try Fixture()
+        defer { fixture.cleanup() }
+        let file = try BoundedArtifactFile(path: fixture.url.path, maximumBytes: 16)
+        try Data(repeating: 0x42, count: fixture.data.count).write(to: fixture.url, options: .atomic)
+        #expect(throws: BoundedArtifactFileError.changedDuringRead) { try file.read() }
+    }
+
+    @Test
+    func `truncation and in-budget growth after open are refused`() throws {
+        for size in [0, 12] {
+            let fixture = try Fixture()
+            defer { fixture.cleanup() }
+            let file = try BoundedArtifactFile(path: fixture.url.path, maximumBytes: 16)
+            let writer = try FileHandle(forWritingTo: fixture.url)
+            try writer.truncate(atOffset: UInt64(size))
+            try writer.close()
+            #expect(throws: BoundedArtifactFileError.changedDuringRead) { try file.read() }
+        }
+    }
+
+    @Test
+    func `special files never wait for a writer`() throws {
+        let fixture = try Fixture()
+        defer { fixture.cleanup() }
+        let fifo = fixture.root.appendingPathComponent("fifo")
+        #expect(mkfifo(fifo.path, 0o600) == 0)
+        #expect(throws: BoundedArtifactFileError.unreadable) {
+            try BoundedArtifactFile(path: fifo.path, maximumBytes: 16)
+        }
+    }
+
+    private struct Fixture {
+        let root: URL
+        let url: URL
+        let data: Data
+
+        init(data: Data = Data("original".utf8)) throws {
+            self.root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+            self.url = self.root.appendingPathComponent("artifact")
+            self.data = data
+            try FileManager.default.createDirectory(at: self.root, withIntermediateDirectories: false)
+            try data.write(to: self.url)
+        }
+
+        func cleanup() {
+            try? FileManager.default.removeItem(at: self.root)
+        }
+    }
+}

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/DesktopObservationArtifactSizeTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/DesktopObservationArtifactSizeTests.swift
@@ -1,0 +1,128 @@
+import Foundation
+import Testing
+@testable import PeekabooAutomationKit
+
+struct DesktopObservationArtifactSizeTests {
+    @Test
+    func `readArtifact rejects a file larger than the supplied max before loading`() throws {
+        let fixture = try Fixture(byteCount: 64)
+        defer { fixture.cleanup() }
+
+        #expect(throws: DesktopObservationContentVerificationError.artifactTooLarge("raw screenshot")) {
+            _ = try DesktopObservationResult.readArtifact(
+                at: fixture.url.path,
+                label: "raw screenshot",
+                maxBytes: 16)
+        }
+    }
+
+    @Test
+    func `readArtifact loads a file at the inclusive max`() throws {
+        let payload = Data(repeating: 0x41, count: 16)
+        let fixture = try Fixture(data: payload)
+        defer { fixture.cleanup() }
+
+        let data = try DesktopObservationResult.readArtifact(
+            at: fixture.url.path,
+            label: "raw screenshot",
+            maxBytes: 16)
+        #expect(data == payload)
+    }
+
+    @Test
+    func `readArtifactIfPresent skips a missing path and rejects an oversized present file`() throws {
+        #expect(try DesktopObservationResult.readArtifactIfPresent(
+            at: nil,
+            label: "raw screenshot",
+            maxBytes: 16) == nil)
+
+        let fixture = try Fixture(byteCount: 32)
+        defer { fixture.cleanup() }
+        #expect(throws: DesktopObservationContentVerificationError.artifactTooLarge("annotated screenshot")) {
+            _ = try DesktopObservationResult.readArtifactIfPresent(
+                at: fixture.url.path,
+                label: "annotated screenshot",
+                maxBytes: 16)
+        }
+    }
+
+    @Test
+    func `verified raw screenshot rejects a sparse file over the capture limit`() throws {
+        let fixture = try Fixture(sparseByteCount: DesktopObservationResult.maximumArtifactBytes + 1)
+        defer { fixture.cleanup() }
+
+        let pixels = Data("pixels".utf8)
+        let result = DesktopObservationResult(
+            target: ResolvedObservationTarget(kind: .screen(index: 0)),
+            capture: CaptureResult(
+                imageData: pixels,
+                savedPath: fixture.url.path,
+                metadata: CaptureMetadata(size: .init(width: 1, height: 1), mode: .screen)),
+            elements: nil,
+            files: DesktopObservationFiles(rawScreenshotPath: fixture.url.path))
+
+        #expect(throws: DesktopObservationContentVerificationError.artifactTooLarge("raw screenshot")) {
+            _ = try result.verifiedRawScreenshotData()
+        }
+    }
+
+    @Test
+    func `attesting capture content rejects an oversized annotated artifact`() throws {
+        let fixture = try Fixture(sparseByteCount: DesktopObservationResult.maximumArtifactBytes + 1)
+        defer { fixture.cleanup() }
+
+        let pixels = Data("pixels".utf8)
+        let result = DesktopObservationResult(
+            target: ResolvedObservationTarget(kind: .screen(index: 0)),
+            capture: CaptureResult(
+                imageData: pixels,
+                metadata: CaptureMetadata(size: .init(width: 1, height: 1), mode: .screen)),
+            elements: nil,
+            files: DesktopObservationFiles(annotatedScreenshotPath: fixture.url.path))
+
+        #expect(throws: DesktopObservationContentVerificationError.artifactTooLarge("annotated screenshot")) {
+            _ = try result.attestingCaptureContent()
+        }
+    }
+
+    @Test
+    func `readArtifact still reports an unreadable missing file`() {
+        let missing = FileManager.default.temporaryDirectory
+            .appendingPathComponent("peekaboo-missing-observation-\(UUID().uuidString).png")
+        #expect(throws: DesktopObservationContentVerificationError.unreadableArtifact("raw screenshot")) {
+            _ = try DesktopObservationResult.readArtifact(at: missing.path, label: "raw screenshot")
+        }
+    }
+}
+
+private struct Fixture {
+    let root: URL
+    let url: URL
+
+    init(byteCount: Int) throws {
+        try self.init(data: Data(repeating: 0x41, count: byteCount))
+    }
+
+    init(data: Data) throws {
+        self.root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("peekaboo-observation-artifact-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: self.root, withIntermediateDirectories: false)
+        self.url = self.root.appendingPathComponent("artifact.png")
+        try data.write(to: self.url, options: .atomic)
+    }
+
+    init(sparseByteCount: Int) throws {
+        self.root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("peekaboo-observation-sparse-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: self.root, withIntermediateDirectories: false)
+        self.url = self.root.appendingPathComponent("sparse.png")
+        FileManager.default.createFile(atPath: self.url.path, contents: Data())
+        let handle = try FileHandle(forWritingTo: self.url)
+        try handle.truncate(atOffset: UInt64(sparseByteCount))
+        try handle.close()
+    }
+
+    func cleanup() {
+        try? FileManager.default.removeItem(at: self.root)
+    }
+}

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/ImageTool+Capture.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/ImageTool+Capture.swift
@@ -279,7 +279,7 @@ extension ImageTool {
             throw OperationError.captureFailed(reason: "Image processing requires exactly one capture")
         }
         let data: Data = if readFromRawPath, let rawPath {
-            try Data(contentsOf: URL(fileURLWithPath: rawPath))
+            try DesktopObservationResult.readArtifact(at: rawPath, label: "raw screenshot")
         } else if !capture.imageData.isEmpty {
             capture.imageData
         } else {
@@ -349,7 +349,8 @@ extension ImageTool {
         for capture in captureSet.captures {
             let savedPath = capture.savedPath ?? captureSet.observation.files.rawScreenshotPath
             let imageData = if capture.imageData.isEmpty, let savedPath {
-                (try? Data(contentsOf: URL(fileURLWithPath: savedPath))) ?? capture.imageData
+                (try? DesktopObservationResult.readArtifact(at: savedPath, label: "raw screenshot"))
+                    ?? capture.imageData
             } else {
                 capture.imageData
             }
@@ -415,7 +416,8 @@ extension ImageTool {
 
         if format == .data, let capture = captureResults.first, captureResults.count == 1 {
             let data = if capture.imageData.isEmpty, let path = savedFiles.first?.path {
-                (try? Data(contentsOf: URL(fileURLWithPath: path))) ?? capture.imageData
+                (try? DesktopObservationResult.readArtifact(at: path, label: "raw screenshot"))
+                    ?? capture.imageData
             } else {
                 capture.imageData
             }

--- a/docs/commands/see.md
+++ b/docs/commands/see.md
@@ -89,6 +89,10 @@ For agent and automation runs, pass `--path` to a known temporary file when usin
 
 Passive background observations retry one resolve-and-capture transaction when the target's exact receipt changes during capture, then fail closed if it changes again. Foreground capture, explicit web-focus fallback, and menu-opening observations never retry because they can mutate visible desktop state.
 
+Observation verification and MCP image reloads limit each artifact to 256 MiB. Reads retain one regular-file
+descriptor and reject files that grow or change during the read. Ordinary symlink paths remain supported;
+oversized or replaced artifacts fail before their content is published.
+
 Pixel-only `see --no-elements` captures without `--path` write a generated file beneath `PEEKABOO_DEFAULT_SAVE_PATH`, `defaults.savePath`, or the built-in `~/Desktop` default, in that order. Generated names retain a readable timestamp and include a unique token so concurrent callers do not share a path. This also applies with `--json`; `data.files[].path` reports the saved file. Ordinary element-producing `--json` observations without `--path` instead retain the raw image only in managed snapshot storage and return empty `screenshot_raw` and `screenshot_annotated` fields.
 
 ## Exact-window ROI capture

--- a/docs/commands/see.md
+++ b/docs/commands/see.md
@@ -89,10 +89,6 @@ For agent and automation runs, pass `--path` to a known temporary file when usin
 
 Passive background observations retry one resolve-and-capture transaction when the target's exact receipt changes during capture, then fail closed if it changes again. Foreground capture, explicit web-focus fallback, and menu-opening observations never retry because they can mutate visible desktop state.
 
-Observation verification and MCP image reloads limit each artifact to 256 MiB. Reads retain one regular-file
-descriptor and reject files that grow or change during the read. Ordinary symlink paths remain supported;
-oversized or replaced artifacts fail before their content is published.
-
 Pixel-only `see --no-elements` captures without `--path` write a generated file beneath `PEEKABOO_DEFAULT_SAVE_PATH`, `defaults.savePath`, or the built-in `~/Desktop` default, in that order. Generated names retain a readable timestamp and include a unique token so concurrent callers do not share a path. This also applies with `--json`; `data.files[].path` reports the saved file. Ordinary element-producing `--json` observations without `--path` instead retain the raw image only in managed snapshot storage and return empty `screenshot_raw` and `screenshot_annotated` fields.
 
 ## Exact-window ROI capture
@@ -153,6 +149,10 @@ peekaboo see --app "Google Chrome" --json --path /tmp/chrome-see.png \
 ```
 
 ## Troubleshooting tips
+
+Observation verification and MCP image reloads limit each artifact to 256 MiB. Reads retain one regular-file
+descriptor and reject files that grow or change during the read. Ordinary symlink paths remain supported;
+oversized or replaced artifacts fail before their content is published.
 
 - If the CLI reports **blind typing**, pass an explicit `--app`, `--pid`, `--window-id`, or fresh `--snapshot` so `type` can resolve a background target process, or add `--foreground` when the target app requires focused keyboard input.
 - If a concrete snapshot reports no unique live host affinity, keep the producing host running or capture again. Do


### PR DESCRIPTION
Desktop-observation verification and MCP image reloads previously loaded screenshot paths without bounding memory use. The shared reader now opens one regular-file descriptor, enforces the 256 MiB capture budget while reading, and rejects detected growth, replacement, or metadata changes before returning bytes. Ordinary symlinks remain supported; digest checks are unchanged. Thanks @SebTardif for the original contribution.

The same shared reader is prepared in #688 for the separate CLI publication paths. Its source and regression tests are identical across both PRs.

Validation:
- `pnpm run build:cli` passed.
- All 12 focused `BoundedArtifactFileTests|DesktopObservationArtifactSizeTests` passed.
- A standalone executable compiled from the production reader retained valid bytes and rejected a 256 MiB + 1 sparse file, growth after opening under a 16-byte budget, and path replacement after opening.
- The actual CLI, signed with the OpenClaw Foundation Developer ID, completed full `see` against a signed synthetic native window and produced the expected 900×700 PNG and an observation snapshot. One initial classic-capture timeout cleared on a retry with a fresh private temporary directory.
- Changed-file strict lint, formatting, docs lint, and isolated Codex review through P2 passed.

Full safe-suite validation exposed an existing test fixture that inherits service-account custody variables. Clearing those variables for the test makes that fixture pass; its isolation repair is being prepared separately. Unreleased notes and credit are being consolidated in a separate main-based PR so this code branch stays mergeable without merging main into it. Exact-head hosted CI remains a landing gate.
