### PR TITLE
fix(capture): preserve GUI readiness and classic recovery

### DIFF
--- a/Apps/CLI/Sources/PeekabooCLI/CLI/Output/JSONOutput.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/CLI/Output/JSONOutput.swift
@@ -198,9 +198,11 @@ struct PreDispatchActionError: LocalizedError, ResultEnvelopeError {
         message: String,
         code: ErrorCode,
         hint: String?,
-        reason: DesktopActionOutcome.RefusalReason
+        reason: DesktopActionOutcome.RefusalReason,
+        screenCaptureKitOwnershipDiagnostic: ScreenCaptureKitOwnershipDiagnostic? = nil
     ) {
-        self.failure = .preDispatchRefusal(reason: reason, message: message, hint: hint)
+        self.failure = DesktopActionFailure.preDispatchRefusal(reason: reason, message: message, hint: hint)
+            .preservingScreenCaptureKitDiagnostic(screenCaptureKitOwnershipDiagnostic)
         self.code = code
         self.hint = hint
     }
@@ -268,6 +270,7 @@ struct ErrorInfo: Codable {
     let details: String?
     let retry_safe: Bool?
     let mutation_dispatched: Bool?
+    let screen_capture_kit_ownership_diagnostic: ScreenCaptureKitOwnershipDiagnostic?
 
     init(
         message: String,
@@ -275,7 +278,8 @@ struct ErrorInfo: Codable {
         hint: String? = nil,
         details: String? = nil,
         retrySafe: Bool? = nil,
-        mutationDispatched: Bool? = nil
+        mutationDispatched: Bool? = nil,
+        screenCaptureKitOwnershipDiagnostic: ScreenCaptureKitOwnershipDiagnostic? = nil
     ) {
         self.init(
             message: message,
@@ -283,7 +287,8 @@ struct ErrorInfo: Codable {
             hint: hint,
             details: details,
             retrySafe: retrySafe,
-            mutationDispatched: mutationDispatched
+            mutationDispatched: mutationDispatched,
+            screenCaptureKitOwnershipDiagnostic: screenCaptureKitOwnershipDiagnostic
         )
     }
 
@@ -293,7 +298,8 @@ struct ErrorInfo: Codable {
         hint: String? = nil,
         details: String? = nil,
         retrySafe: Bool? = nil,
-        mutationDispatched: Bool? = nil
+        mutationDispatched: Bool? = nil,
+        screenCaptureKitOwnershipDiagnostic: ScreenCaptureKitOwnershipDiagnostic? = nil
     ) {
         let presentation = splitErrorHint(from: message)
         self.code = code
@@ -302,6 +308,7 @@ struct ErrorInfo: Codable {
         self.details = details
         self.retry_safe = retrySafe
         self.mutation_dispatched = mutationDispatched
+        self.screen_capture_kit_ownership_diagnostic = screenCaptureKitOwnershipDiagnostic
     }
 }
 
@@ -561,6 +568,7 @@ func outputError(
     actionFailure: DesktopActionFailure? = nil,
     targetReceipt: DesktopActionTargetReceipt? = nil,
     targetIdentity: DesktopTargetIdentity? = nil,
+    screenCaptureKitOwnershipDiagnostic: ScreenCaptureKitOwnershipDiagnostic? = nil,
     logger: Logger
 ) {
     let response = makeErrorEnvelope(
@@ -575,6 +583,7 @@ func outputError(
         actionFailure: actionFailure,
         targetReceipt: targetReceipt,
         targetIdentity: targetIdentity,
+        screenCaptureKitOwnershipDiagnostic: screenCaptureKitOwnershipDiagnostic,
         debugLogs: logger.getDebugLogs()
     )
     outputJSONCodable(response, logger: logger)
@@ -592,6 +601,7 @@ func makeErrorEnvelope(
     actionFailure: DesktopActionFailure? = nil,
     targetReceipt: DesktopActionTargetReceipt? = nil,
     targetIdentity: DesktopTargetIdentity? = nil,
+    screenCaptureKitOwnershipDiagnostic: ScreenCaptureKitOwnershipDiagnostic? = nil,
     debugLogs: [String] = []
 ) -> ResultEnvelope<Empty?> {
     let suppliedOutcome = actionOutcome?.projection ?? actionFailure?.outcome.projection
@@ -624,7 +634,9 @@ func makeErrorEnvelope(
             hint: hint,
             details: details,
             retrySafe: resolvedRetrySafe,
-            mutationDispatched: resolvedMutationDispatched
+            mutationDispatched: resolvedMutationDispatched,
+            screenCaptureKitOwnershipDiagnostic: screenCaptureKitOwnershipDiagnostic ??
+                actionFailure?.screenCaptureKitOwnershipDiagnostic
         )
     )
 }

--- a/Apps/CLI/Sources/PeekabooCLI/CLI/PeekabooEntryPoint.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/CLI/PeekabooEntryPoint.swift
@@ -88,7 +88,7 @@ private func printCommanderError(_ error: CommanderProgramError, jsonOutput: Boo
     }
 }
 
-private func printGenericError(_ error: any Error, jsonOutput: Bool) {
+func printGenericError(_ error: any Error, jsonOutput: Bool) {
     let envelopeError = error as? any ResultEnvelopeError
     let fallbackCode: ErrorCode = if error is CommanderBindingError || error is CommanderUsageError {
         .INVALID_ARGUMENT
@@ -97,7 +97,7 @@ private func printGenericError(_ error: any Error, jsonOutput: Bool) {
     } else {
         .UNKNOWN_ERROR
     }
-    let code = envelopeError?.envelopeCode ?? fallbackCode
+    let code = captureOwnershipErrorCode(for: error) ?? envelopeError?.envelopeCode ?? fallbackCode
     let actionMetadata = actionErrorEnvelopeMetadata(
         for: error,
         isActionCommand: ResultEnvelopeContext.isActionCommand
@@ -125,6 +125,7 @@ private func printGenericError(_ error: any Error, jsonOutput: Bool) {
             actionFailure: actionFailure,
             targetReceipt: actionMetadata.targetReceipt,
             targetIdentity: actionMetadata.targetIdentity,
+            screenCaptureKitOwnershipDiagnostic: screenCaptureKitOwnershipDiagnostic(for: error),
             logger: logger
         )
     }

--- a/Apps/CLI/Sources/PeekabooCLI/CLI/Utilities/ErrorHandling.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/CLI/Utilities/ErrorHandling.swift
@@ -10,10 +10,16 @@ private func emitError(
     code: ErrorCode,
     jsonOutput: Bool,
     logger: Logger,
+    screenCaptureKitOwnershipDiagnostic: ScreenCaptureKitOwnershipDiagnostic? = nil,
     prefix: String = "❌"
 ) {
     if jsonOutput {
-        outputError(message: message, code: code, logger: logger)
+        outputError(
+            message: message,
+            code: code,
+            screenCaptureKitOwnershipDiagnostic: screenCaptureKitOwnershipDiagnostic,
+            logger: logger
+        )
     } else {
         print("\(prefix) \(message)")
     }
@@ -47,6 +53,7 @@ func handleGenericError(_ error: any Error, jsonOutput: Bool, logger: Logger) {
                 actionOutcome: metadata.outcome,
                 targetReceipt: metadata.targetReceipt,
                 targetIdentity: metadata.targetIdentity,
+                screenCaptureKitOwnershipDiagnostic: screenCaptureKitOwnershipDiagnostic(for: error),
                 logger: logger
             )
         } else {
@@ -62,7 +69,8 @@ func handleGenericError(_ error: any Error, jsonOutput: Bool, logger: Logger) {
         message: error.localizedDescription,
         code: genericErrorCode(for: error),
         jsonOutput: jsonOutput,
-        logger: logger
+        logger: logger,
+        screenCaptureKitOwnershipDiagnostic: screenCaptureKitOwnershipDiagnostic(for: error)
     )
 }
 
@@ -76,7 +84,7 @@ func renderDesktopActionFailure(
     if jsonOutput {
         outputError(
             message: failure.message,
-            code: .INTERACTION_FAILED,
+            code: captureOwnershipErrorCode(for: failure) ?? .INTERACTION_FAILED,
             hint: failure.hint,
             details: failure.causeDescription,
             actionFailure: failure,
@@ -94,6 +102,9 @@ func renderDesktopActionFailure(
 }
 
 func genericErrorCode(for error: any Error) -> ErrorCode {
+    if let captureCode = captureOwnershipErrorCode(for: error) {
+        return captureCode
+    }
     if error is DesktopActionFailure {
         return .INTERACTION_FAILED
     }
@@ -104,4 +115,28 @@ func genericErrorCode(for error: any Error) -> ErrorCode {
         return .UNKNOWN_ERROR
     }
     return errorCode(for: bridgeError)
+}
+
+nonisolated func screenCaptureKitOwnershipDiagnostic(
+    for error: any Error
+) -> ScreenCaptureKitOwnershipDiagnostic? {
+    switch error {
+    case let diagnostic as ScreenCaptureKitOwnershipDiagnostic:
+        diagnostic
+    case let failure as DesktopActionFailure:
+        failure.screenCaptureKitOwnershipDiagnostic
+    case let envelope as any ResultEnvelopeError:
+        envelope.envelopeActionFailure?.screenCaptureKitOwnershipDiagnostic
+    case let envelope as PeekabooBridgeErrorEnvelope:
+        envelope.screenCaptureKitOwnershipDiagnostic
+    default:
+        nil
+    }
+}
+
+nonisolated func captureOwnershipErrorCode(for error: any Error) -> ErrorCode? {
+    let failure = (error as? DesktopActionFailure) ??
+        (error as? any ResultEnvelopeError)?.envelopeActionFailure
+    return screenCaptureKitOwnershipDiagnostic(for: error) != nil || failure?.standardErrorCode == .captureFailed
+        ? .CAPTURE_FAILED : nil
 }

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommandErrorHandling.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommandErrorHandling.swift
@@ -26,7 +26,8 @@ extension ErrorHandlingCommand {
             message: presentation.message,
             code: code,
             hint: (error as? any ResultEnvelopeError)?.envelopeHint ?? presentation.hint,
-            reason: explicitReason ?? defaultActionRefusalReason(code) ?? .targetUnavailable
+            reason: explicitReason ?? defaultActionRefusalReason(code) ?? .targetUnavailable,
+            screenCaptureKitOwnershipDiagnostic: screenCaptureKitOwnershipDiagnostic(for: error)
         )
     }
 
@@ -39,7 +40,8 @@ extension ErrorHandlingCommand {
             let actionFailure = actionMetadata.failure
             let lifecycleRefusal = applicationLifecycleRefusalProjection(for: error)
             let lifecycleFailure = applicationLifecycleFailureProjection(for: error)
-            let errorCode = customCode ?? envelopeError?.envelopeCode ?? self.mapErrorToCode(error)
+            let errorCode = customCode ?? captureOwnershipErrorCode(for: error)
+                ?? envelopeError?.envelopeCode ?? self.mapErrorToCode(error)
             let failureReceipt = lifecycleFailure.map { failure in
                 CaptureFailureReceipt(
                     retrySafe: failure.metadata.retrySafe,
@@ -70,6 +72,7 @@ extension ErrorHandlingCommand {
                     actionFailure: actionFailure,
                     targetReceipt: actionMetadata.targetReceipt,
                     targetIdentity: actionMetadata.targetIdentity,
+                    screenCaptureKitOwnershipDiagnostic: screenCaptureKitOwnershipDiagnostic(for: error),
                     logger: logger
                 )
             }
@@ -103,6 +106,10 @@ extension ErrorHandlingCommand {
 
     /// Map various error types to error codes
     func mapErrorToCode(_ error: any Error) -> ErrorCode {
+        captureOwnershipErrorCode(for: error) ?? self.mapOtherErrorToCode(error)
+    }
+
+    private func mapOtherErrorToCode(_ error: any Error) -> ErrorCode {
         switch error {
         case let cleanupError as CaptureArtifactCleanupError:
             self.mapErrorToCode(cleanupError.primaryError)

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/BridgeCapabilityPolicy+Capture.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/BridgeCapabilityPolicy+Capture.swift
@@ -1,0 +1,40 @@
+import PeekabooBridge
+import PeekabooFoundation
+
+extension BridgeCapabilityPolicy {
+    static func supportsScreenCaptureKitProcessOwnership(
+        for handshake: PeekabooBridgeHandshakeResponse
+    ) -> Bool {
+        handshake.supportedOperations.contains(.desktopObservation) &&
+            (handshake.hostCapabilities?.contains(
+                PeekabooBridgeHostCapability.screenCaptureKitProcessOwnership
+            ) == true || handshake.hostCapabilities?.contains(
+                PeekabooBridgeHostCapability.screenCaptureKitOwnershipEnforcement
+            ) == true)
+    }
+
+    static func supportsClassicCaptureWithoutScreenCaptureKit(
+        for handshake: PeekabooBridgeHandshakeResponse
+    ) -> Bool {
+        handshake.supportedOperations.contains(.desktopObservation) &&
+            (handshake.hostCapabilities?.contains(
+                PeekabooBridgeHostCapability.classicCaptureWithoutScreenCaptureKit
+            ) == true || handshake.hostCapabilities?.contains(
+                PeekabooBridgeHostCapability.screenCaptureKitProcessOwnership
+            ) == true)
+    }
+
+    static func screenCaptureKitReadinessRefusal(
+        for handshake: PeekabooBridgeHandshakeResponse
+    ) -> ScreenCaptureKitOwnershipDiagnostic? {
+        guard self.supportsScreenCaptureKitProcessOwnership(for: handshake) else { return nil }
+        // The old capability is the named compatibility contract for hosts without readiness data.
+        if handshake.screenCaptureKitReadiness == nil,
+           handshake.hostCapabilities?.contains(PeekabooBridgeHostCapability.screenCaptureKitOwnershipEnforcement)
+           != true {
+            return nil
+        }
+        guard handshake.screenCaptureKitReadiness?.permitsAttempt != true else { return nil }
+        return handshake.screenCaptureKitReadiness?.refusal ?? ScreenCaptureKitReadiness(state: .unknown).refusal
+    }
+}

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/BridgeCapabilityPolicy.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/BridgeCapabilityPolicy.swift
@@ -17,7 +17,7 @@ enum BridgeCapabilityPolicy {
     ) -> Bool {
         let defersScreenRecording = self.defersRemoteScreenRecordingPermission(options: options)
         let supportsCapture = defersScreenRecording
-            ? handshake.supportedOperations.contains(.captureScreen)
+            ? self.supportsPermissionDeferredOperation(.captureScreen, for: handshake, options: options)
             : self.supportsOperation(.captureScreen, for: handshake)
         if options.requiresScreenCapturePermission || options.requiresSilentCapture,
            !supportsCapture {
@@ -156,10 +156,18 @@ enum BridgeCapabilityPolicy {
             return false
         }
         if options.requiresScreenCaptureKitOwnerCapability,
-           !self.supportsScreenCaptureKitProcessOwnership(for: handshake) {
+           !(self.defersClassicScreenRecordingPermission(options: options)
+               ? self.supportsClassicCaptureWithoutScreenCaptureKit(for: handshake)
+               : self.supportsScreenCaptureKitProcessOwnership(for: handshake)) {
             return false
         }
         if options.requiresExactWindowROIObservation, !capabilities.exactWindowROIObservation {
+            return false
+        }
+        if !options.usesPerToolSnapshotInvalidation,
+           options.requiresScreenCaptureKitOwnerCapability,
+           !self.defersClassicScreenRecordingPermission(options: options),
+           self.screenCaptureKitReadinessRefusal(for: handshake) != nil {
             return false
         }
         if options.requiresExplicitSnapshotPublication,
@@ -185,7 +193,7 @@ enum BridgeCapabilityPolicy {
 
         let supportsObservation = handshake.negotiatedVersion >=
             PeekabooBridgeProtocolVersion(major: 1, minor: 5) &&
-            handshake.supportedOperations.contains(.desktopObservation)
+            self.supportsPermissionDeferredOperation(.desktopObservation, for: handshake, options: options)
         return ObservationCapabilities(
             desktopObservation: supportsObservation,
             desktopObservationOCR: supportsObservation &&
@@ -560,15 +568,6 @@ enum BridgeCapabilityPolicy {
             ) == true
     }
 
-    static func supportsScreenCaptureKitProcessOwnership(
-        for handshake: PeekabooBridgeHandshakeResponse
-    ) -> Bool {
-        handshake.supportedOperations.contains(.desktopObservation) &&
-            handshake.hostCapabilities?.contains(
-                PeekabooBridgeHostCapability.screenCaptureKitProcessOwnership
-            ) == true
-    }
-
     private static func defersClassicScreenRecordingPermission(options: CommandRuntimeOptions) -> Bool {
         options.requiresScreenCaptureKitOwnerCapability &&
             ObservationCommandSupport.captureEnginePreference(
@@ -579,6 +578,20 @@ enum BridgeCapabilityPolicy {
 
     private static func defersRemoteScreenRecordingPermission(options: CommandRuntimeOptions) -> Bool {
         self.defersClassicScreenRecordingPermission(options: options) || options.usesPerToolSnapshotInvalidation
+    }
+
+    private static func supportsPermissionDeferredOperation(
+        _ operation: PeekabooBridgeOperation,
+        for handshake: PeekabooBridgeHandshakeResponse,
+        options: CommandRuntimeOptions
+    ) -> Bool {
+        guard handshake.supportedOperations.contains(operation) else { return false }
+        if options.usesPerToolSnapshotInvalidation || self.supportsOperation(operation, for: handshake) {
+            return true
+        }
+        return handshake.permissions?.screenRecording == false &&
+            self.supportsClassicCaptureWithoutScreenCaptureKit(for: handshake) &&
+            self.missingPermissions(for: operation, handshake: handshake).subtracting([.screenRecording]).isEmpty
     }
 
     static func supportsExactWindowROIObservation(for handshake: PeekabooBridgeHandshakeResponse) -> Bool {

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/RuntimeHostResolver+Resolution.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/RuntimeHostResolver+Resolution.swift
@@ -18,6 +18,7 @@ extension RuntimeHostResolver {
         let identity: PeekabooBridgeClientIdentity
         let trustedHostTeamIDs: Set<String>?
         let clientFactory: (@MainActor (String) -> PeekabooBridgeClient)?
+        let handshakeProvider: ScreenCaptureKitHandshake?
         private var entriesBySocketPath: [String: Entry] = [:]
 
         convenience init() {
@@ -32,11 +33,13 @@ extension RuntimeHostResolver {
         init(
             identity: PeekabooBridgeClientIdentity,
             trustedHostTeamIDs: Set<String>? = nil,
-            clientFactory: (@MainActor (String) -> PeekabooBridgeClient)? = nil
+            clientFactory: (@MainActor (String) -> PeekabooBridgeClient)? = nil,
+            handshakeProvider: ScreenCaptureKitHandshake? = nil
         ) {
             self.identity = identity
             self.trustedHostTeamIDs = trustedHostTeamIDs
             self.clientFactory = clientFactory
+            self.handshakeProvider = handshakeProvider
         }
 
         func handshake(
@@ -55,7 +58,11 @@ extension RuntimeHostResolver {
                 socketPath: candidate.socketPath,
                 trustedHostTeamIDs: self.trustedHostTeamIDs
             )
-            let response = try await client.handshake(client: self.identity, requestedHost: nil)
+            let response = if let handshakeProvider {
+                try await handshakeProvider(candidate, self.identity)
+            } else {
+                try await client.handshake(client: self.identity, requestedHost: nil)
+            }
             let entry = Entry(client: client, response: response)
             self.entriesBySocketPath[socketPath] = entry
             return entry

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/RuntimeHostResolver+ScreenCaptureKitOwner.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/RuntimeHostResolver+ScreenCaptureKitOwner.swift
@@ -4,10 +4,83 @@ import Foundation
 import PeekabooAutomationKit
 import PeekabooBridge
 import PeekabooCore
+import PeekabooFoundation
 
 @MainActor
 extension RuntimeHostResolver {
+    static func explicitCaptureHandshakeCache(
+        options: CommandRuntimeOptions,
+        environment: [String: String],
+        dependencies: Dependencies
+    ) async throws -> RemoteHandshakeCache? {
+        guard options.requiresScreenCaptureKitOwnerCapability,
+              !options.usesPerToolSnapshotInvalidation,
+              options.requiresScreenCapturePermission || options.requiresSilentCapture,
+              !self.remoteIsolationRequested(options: options, environment: environment),
+              let socket = BridgeSocketResolver.explicitBridgeSocket(options: options, environment: environment)
+        else { return nil }
+        let cache = dependencies.makeRemoteHandshakeCache()
+        try await self.validateExplicitCaptureReadiness(
+            socketPath: socket, options: options, environment: environment, cache: cache
+        )
+        return cache
+    }
+
+    static func validateExplicitCaptureReadiness(
+        socketPath: String,
+        options: CommandRuntimeOptions,
+        environment: [String: String],
+        cache: RemoteHandshakeCache
+    ) async throws {
+        let candidate = ImplicitRemoteCandidate(
+            socketPath: socketPath,
+            requireReusableDaemon: false,
+            requiredHostKind: nil,
+            requiresValidatedHistoricalDaemon: false
+        )
+        let response: PeekabooBridgeHandshakeResponse
+        do {
+            response = try await cache.handshake(candidate, identity: cache.identity).response
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch {
+            try Task.checkCancellation()
+            return
+        }
+        guard self.captureEnginePreferenceForOwnership(options: options, environment: environment) != .legacy,
+              let diagnostic = BridgeCapabilityPolicy.screenCaptureKitReadinessRefusal(for: response)
+        else { return }
+        throw self.readinessRefusal(diagnostic, handshake: response, socketPath: socketPath)
+    }
+
+    static func readinessRefusal(
+        _ diagnostic: ScreenCaptureKitOwnershipDiagnostic,
+        handshake: PeekabooBridgeHandshakeResponse,
+        socketPath: String
+    ) -> PreDispatchActionError {
+        let identified = diagnostic.selectingHost(.init(
+            processIdentifier: handshake.hostIdentity?.processIdentifier,
+            processStartIdentity: handshake.hostIdentity?.processStartIdentity,
+            socketPath: socketPath,
+            buildIdentity: self.safeDiagnosticBuildIdentity(handshake.build),
+            codeSignatureHash: handshake.hostIdentity?.codeSignatureHash
+        ))
+        let hint = BridgeCapabilityPolicy.supportsClassicCaptureWithoutScreenCaptureKit(for: handshake)
+            ? "Explicit --capture-engine classic can use this same socket without in-process ScreenCaptureKit."
+            : "This host has not proven a classic capture path without in-process ScreenCaptureKit."
+        return PreDispatchActionError(
+            message: identified.userMessage,
+            code: .CAPTURE_FAILED,
+            hint: hint,
+            reason: .runtimeIncompatible,
+            screenCaptureKitOwnershipDiagnostic: identified
+        )
+    }
+
     typealias LocalServiceFactory = @MainActor (CommandRuntimeOptions) -> any PeekabooServiceProviding
+    typealias RemoteServiceFactory = @MainActor (
+        PeekabooBridgeClient, PeekabooBridgeHandshakeResponse, CommandRuntimeOptions
+    ) -> any PeekabooServiceProviding
     typealias ScreenCaptureKitOwnerClaim = () throws -> ScreenCaptureKitOwnerLease.OwnerReceipt
     typealias ScreenCaptureKitOwnerInspector = () throws -> ScreenCaptureKitOwnerLease.OwnerReceipt?
     typealias RemoteCandidatePlanner = @MainActor (
@@ -38,6 +111,7 @@ extension RuntimeHostResolver {
         let remoteCandidatePlan: RemoteCandidatePlanner
         let snapshotAffinityProbe: SnapshotAffinityProbe
         let makeRemoteHandshakeCache: RemoteHandshakeCacheFactory
+        let makeRemoteServices: RemoteServiceFactory
 
         init(
             makeLocalServices: @escaping LocalServiceFactory,
@@ -47,7 +121,10 @@ extension RuntimeHostResolver {
             recordScreenCaptureKitSafetyBlocker: @escaping ScreenCaptureKitSafetyRecorder = { _ in },
             remoteCandidatePlan: @escaping RemoteCandidatePlanner = RuntimeHostResolver.remoteCandidatePlan,
             snapshotAffinityProbe: @escaping SnapshotAffinityProbe = RuntimeHostResolver.liveSnapshotAffinityProbe,
-            makeRemoteHandshakeCache: @escaping RemoteHandshakeCacheFactory = { RemoteHandshakeCache() }
+            makeRemoteHandshakeCache: @escaping RemoteHandshakeCacheFactory = { RemoteHandshakeCache() },
+            makeRemoteServices: @escaping RemoteServiceFactory = {
+                RuntimeHostResolver.remoteServices(client: $0, handshake: $1, options: $2)
+            }
         ) {
             self.makeLocalServices = makeLocalServices
             self.claimScreenCaptureKitOwner = claimScreenCaptureKitOwner
@@ -57,6 +134,7 @@ extension RuntimeHostResolver {
             self.remoteCandidatePlan = remoteCandidatePlan
             self.snapshotAffinityProbe = snapshotAffinityProbe
             self.makeRemoteHandshakeCache = makeRemoteHandshakeCache
+            self.makeRemoteServices = makeRemoteServices
         }
 
         static let live = Dependencies(
@@ -105,6 +183,9 @@ extension RuntimeHostResolver {
         let makeLocalServices: LocalServiceFactory
         let inspectScreenCaptureKitSafety: ScreenCaptureKitSafetyInspector
         let recordScreenCaptureKitSafetyBlocker: ScreenCaptureKitSafetyRecorder
+        var makeRemoteServices: RemoteServiceFactory = {
+            RuntimeHostResolver.remoteServices(client: $0, handshake: $1, options: $2)
+        }
 
         func resolveRemoteServices(
             candidates: [ImplicitRemoteCandidate],
@@ -120,6 +201,7 @@ extension RuntimeHostResolver {
                 requiredOwner: requiredOwner,
                 snapshotInvalidationRemoteSocketPaths: self.snapshotInvalidationRemoteSocketPaths,
                 permissionRejections: &permissionRejections,
+                makeRemoteServices: self.makeRemoteServices,
                 handshakeCache: self.handshakeCache
             )
         }
@@ -265,7 +347,7 @@ extension RuntimeHostResolver {
         owner: ScreenCaptureKitOwnerLease.OwnerReceipt
     ) -> Bool {
         let capabilities = handshake.hostCapabilities ?? []
-        guard capabilities.contains(PeekabooBridgeHostCapability.screenCaptureKitProcessOwnership),
+        guard BridgeCapabilityPolicy.supportsScreenCaptureKitProcessOwnership(for: handshake),
               capabilities.contains(PeekabooBridgeHostCapability.hostGenerationIdentity),
               let hostIdentity = handshake.hostIdentity,
               hostIdentity.processIdentifier == owner.processIdentifier,
@@ -357,31 +439,18 @@ extension RuntimeHostResolver {
         callerLocal: Bool,
         selectedSocket: String? = nil
     ) -> PreDispatchActionError {
-        if let leaseError = error as? ScreenCaptureKitOwnerLease.LeaseError {
-            switch leaseError {
-            case let .ownedByAnotherProcess(_, receipt):
-                return self.ownerRefusal(owner: receipt, callerLocal: callerLocal)
-            case let .uncoordinatedHosts(hosts):
-                if let host = hosts.first {
-                    return self.ownerCapabilityRefusal(
-                        host: ScreenCaptureKitOwnerUnawareHost(
-                            socketPath: host.socketPath,
-                            processIdentifier: host.processIdentifier,
-                            processStartIdentity: host.processStartIdentity,
-                            buildIdentity: host.buildIdentity
-                        ),
-                        selectedSocket: selectedSocket
-                    )
-                }
-            default:
-                break
-            }
+        var diagnostic = ScreenCaptureKitOwnershipDiagnostic.capturing(error, stage: .admission)
+        if let selectedSocket {
+            diagnostic = diagnostic.selectingHost(.init(socketPath: selectedSocket))
         }
+        let route = selectedSocket.map { "Selected socket: \($0). " }
+            ?? (callerLocal ? "Selected route: caller-local. " : "Selected socket: automatic resolution. ")
         return PreDispatchActionError(
-            message: "Peekaboo could not establish safe ScreenCaptureKit process ownership. No capture was dispatched.",
+            message: route + diagnostic.userMessage,
             code: .CAPTURE_FAILED,
-            hint: error.localizedDescription,
-            reason: .runtimeIncompatible
+            hint: "Use a host that proves the required capture contract and satisfies process ownership.",
+            reason: .runtimeIncompatible,
+            screenCaptureKitOwnershipDiagnostic: diagnostic
         )
     }
 
@@ -390,44 +459,27 @@ extension RuntimeHostResolver {
         selectedSocket: String?
     ) -> PreDispatchActionError {
         let ownerSocket = NSString(string: host.socketPath).standardizingPath
-        let selectedSocket = selectedSocket.map { NSString(string: $0).standardizingPath }
         let selectedSocketText = selectedSocket ?? "automatic resolution"
-        let buildText = self.safeDiagnosticBuildIdentity(host.buildIdentity).map { ", build \($0)" } ?? ""
-        let hasExactProcessIdentity = host.processIdentifier != nil && host.processStartIdentity != nil
-        let identityText: String
-        let message: String
-        if let processIdentifier = host.processIdentifier,
-           let processStartIdentity = host.processStartIdentity {
-            identityText = "PID \(processIdentifier), generation \(processStartIdentity)\(buildText)"
-            message = "Bridge host \(identityText) at owner socket \(ownerSocket) predates safe " +
-                "process-lifetime ScreenCaptureKit ownership. Selected socket: \(selectedSocketText). " +
-                "No capture was dispatched."
-        } else if let processIdentifier = host.processIdentifier {
-            identityText = "PID \(processIdentifier)\(buildText)"
-            message = "Bridge host \(identityText) at owner socket \(ownerSocket) may predate safe " +
-                "process-lifetime ScreenCaptureKit ownership, but its exact process-start identity is unavailable. " +
-                "Selected socket: \(selectedSocketText). No capture was dispatched."
-        } else {
-            identityText = "unknown process identity\(buildText)"
-            message = "A live Bridge host at owner socket \(ownerSocket) may predate safe process-lifetime " +
-                "ScreenCaptureKit ownership, but its exact PID and process-start identity are unavailable" +
-                "\(buildText). Selected socket: \(selectedSocketText). No capture was dispatched."
-        }
-        let classicRecovery = self.classicCaptureRecoveryGuidance
-        let hint = if hasExactProcessIdentity {
-            "Update or relaunch the host at owner socket \(ownerSocket). If stopping it is necessary, first " +
-                "revalidate and stop exactly \(identityText); never use the socket path alone. Alternatively, " +
-                classicRecovery
-        } else {
-            "Update or relaunch the app configured for owner socket \(ownerSocket), or " +
-                classicRecovery + " Do not stop any process based on this refusal: the exact PID and " +
-                "process-start identity are unavailable."
-        }
+        let evidence = ScreenCaptureKitOwnershipDiagnostic.ProcessEvidence(
+            processIdentifier: host.processIdentifier,
+            processStartIdentity: host.processStartIdentity,
+            socketPath: ownerSocket,
+            buildIdentity: self.safeDiagnosticBuildIdentity(host.buildIdentity)
+        )
+        let diagnostic = ScreenCaptureKitOwnershipDiagnostic(
+            kind: .uncoordinatedHosts,
+            stage: .admission,
+            message: "Safe ScreenCaptureKit ownership support cannot be proven for the Bridge host at " +
+                "owner socket \(ownerSocket). Selected socket: \(selectedSocketText). No capture was dispatched.",
+            blockers: [evidence]
+        )
         return PreDispatchActionError(
-            message: message,
+            message: diagnostic.userMessage,
             code: .CAPTURE_FAILED,
-            hint: hint,
-            reason: .runtimeIncompatible
+            hint: "Use a host that proves the required capture contract. Classic capture on this unproven " +
+                "socket cannot be assumed safe.",
+            reason: .runtimeIncompatible,
+            screenCaptureKitOwnershipDiagnostic: diagnostic
         )
     }
 
@@ -436,9 +488,8 @@ extension RuntimeHostResolver {
         selectedSocket: String?
     ) -> MCPToolCapturePreflightRefusal {
         let refusal = self.ownerCapabilityRefusal(host: host, selectedSocket: selectedSocket)
-        let sessionGuidance = "This capture refusal is fixed for the lifetime of this MCP or Agent session; " +
-            "after the owner is updated or stopped, start a fresh session before retrying auto or modern capture. " +
-            "The see tool can instead use capture_engine 'classic' in this session without entering ScreenCaptureKit."
+        let sessionGuidance = "This capture refusal is fixed for the lifetime of this MCP or Agent session. " +
+            "Noncapture tools remain available; classic capture still requires proof from the selected host."
         return MCPToolCapturePreflightRefusal(
             message: refusal.localizedDescription,
             hint: [refusal.hint, sessionGuidance].compactMap(\.self).joined(separator: " ")
@@ -636,19 +687,13 @@ extension RuntimeHostResolver {
                 "Bridge host for that exact process generation is available. Selected socket: automatic " +
                 "resolution; owner socket: unavailable in the process ownership receipt. No capture was dispatched."
         }
-        let classicRecovery = self.classicCaptureRecoveryGuidance
-        let hint = if callerLocal {
-            "Retry without --no-remote to use the selected owner host; otherwise verify and stop exactly " +
-                "\(ownerText), or " + classicRecovery
-        } else {
-            "Use a Bridge socket served by exactly \(ownerText); otherwise verify and stop that exact owner, " +
-                "or " + classicRecovery
-        }
+        let hint = "Use a Bridge socket served by exactly \(ownerText) with the required capture contract."
         return PreDispatchActionError(
             message: message,
             code: .CAPTURE_FAILED,
             hint: hint,
-            reason: .runtimeIncompatible
+            reason: .runtimeIncompatible,
+            screenCaptureKitOwnershipDiagnostic: self.ownerDiagnostic(owner)
         )
     }
 
@@ -662,15 +707,11 @@ extension RuntimeHostResolver {
             message: "Selected socket: \(selectedSocket). The ScreenCaptureKit owner is \(ownerText), but its " +
                 "owner socket is unavailable in the process ownership receipt. No capture was dispatched.",
             code: .CAPTURE_FAILED,
-            hint: "Change or remove --bridge-socket to select the exact owner host; otherwise verify and stop " +
-                "\(ownerText), or " + self.classicCaptureRecoveryGuidance,
-            reason: .runtimeIncompatible
+            hint: "Change or remove --bridge-socket to select the exact owner host with the required capture contract.",
+            reason: .runtimeIncompatible,
+            screenCaptureKitOwnershipDiagnostic: self.ownerDiagnostic(owner)
         )
     }
-
-    private static let classicCaptureRecoveryGuidance =
-        "use classic capture through a command that exposes it. For an interaction, first run " +
-        "'peekaboo see --capture-engine classic' for the exact target and retry with its --snapshot."
 
     static func ownerExactBuildConflict(
         owner: ScreenCaptureKitOwnerLease.OwnerReceipt,
@@ -682,9 +723,25 @@ extension RuntimeHostResolver {
             message: "ScreenCaptureKit owner \(ownerText) does not serve selected socket \(selectedSocket); " +
                 "the owner socket is unavailable in the process ownership receipt. No capture was dispatched.",
             code: .CAPTURE_FAILED,
-            hint: "Stop or upgrade the exact owner before retrying. Peekaboo will not violate process ownership " +
-                "or route stateful snapshot work to a different build.",
-            reason: .runtimeIncompatible
+            hint: "The selected socket must match the owner generation and required build for this stateful request.",
+            reason: .runtimeIncompatible,
+            screenCaptureKitOwnershipDiagnostic: self.ownerDiagnostic(owner)
+        )
+    }
+
+    private static func ownerDiagnostic(
+        _ owner: ScreenCaptureKitOwnerLease.OwnerReceipt
+    ) -> ScreenCaptureKitOwnershipDiagnostic {
+        .init(
+            kind: .ownedByAnotherProcess,
+            stage: .admission,
+            message: "The required ScreenCaptureKit owner host is unavailable for this route.",
+            blockers: [.init(
+                processIdentifier: owner.processIdentifier,
+                processStartIdentity: owner.processStartIdentity,
+                buildIdentity: self.safeDiagnosticBuildIdentity(owner.buildIdentity),
+                codeSignatureHash: self.safeDiagnosticBuildIdentity(owner.codeSignatureHash)
+            )]
         )
     }
 

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/RuntimeHostResolver.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/RuntimeHostResolver.swift
@@ -26,13 +26,15 @@ enum RuntimeHostResolver {
         dependencies: Dependencies
     ) async throws -> Resolution {
         var captureSafety = CaptureSafetyResolution()
-        var handshakeCache: RemoteHandshakeCache?
         try self.inspectCallerLocalOwner(options: options, environment: environment, dependencies: dependencies)
+        var handshakeCache = try await self.explicitCaptureHandshakeCache(
+            options: options, environment: environment, dependencies: dependencies
+        )
         let safetyPlan: RemoteCandidatePlan?
         if self.requiresCallerLocalScreenCaptureKitSafetyCheck(options: options, environment: environment) {
             let plan = try await dependencies.remoteCandidatePlan(options, environment)
             safetyPlan = plan
-            let resolvedHandshakeCache = dependencies.makeRemoteHandshakeCache()
+            let resolvedHandshakeCache = handshakeCache ?? dependencies.makeRemoteHandshakeCache()
             handshakeCache = resolvedHandshakeCache
             if let oldHost = try await dependencies.inspectScreenCaptureKitSafety(
                 options,
@@ -119,7 +121,8 @@ enum RuntimeHostResolver {
                 preferredScreenCaptureKitOwner: nil,
                 makeLocalServices: dependencies.makeLocalServices,
                 inspectScreenCaptureKitSafety: dependencies.inspectScreenCaptureKitSafety,
-                recordScreenCaptureKitSafetyBlocker: dependencies.recordScreenCaptureKitSafetyBlocker
+                recordScreenCaptureKitSafetyBlocker: dependencies.recordScreenCaptureKitSafetyBlocker,
+                makeRemoteServices: dependencies.makeRemoteServices
             )
             var permissionRejections: [String] = []
             var resolution = try await self.resolveSnapshotAffinityServices(
@@ -176,7 +179,8 @@ enum RuntimeHostResolver {
             preferredScreenCaptureKitOwner: preferredScreenCaptureKitOwner,
             makeLocalServices: dependencies.makeLocalServices,
             inspectScreenCaptureKitSafety: dependencies.inspectScreenCaptureKitSafety,
-            recordScreenCaptureKitSafetyBlocker: dependencies.recordScreenCaptureKitSafetyBlocker
+            recordScreenCaptureKitSafetyBlocker: dependencies.recordScreenCaptureKitSafetyBlocker,
+            makeRemoteServices: dependencies.makeRemoteServices
         ))
         resolution.captureEngineSafetyOverride = captureSafety.engineOverride
         resolution.toolCapturePreflightRefusal = captureSafety.toolPreflightRefusal
@@ -301,6 +305,10 @@ enum RuntimeHostResolver {
         if explicitSocket != nil,
            self.captureEnginePreferenceForOwnership(options: options, environment: context.environment) == .legacy,
            options.requiresScreenCaptureKitOwnerCapability,
+           !candidatePlan.candidates.contains(where: {
+               guard let entry = context.handshakeCache.entry(for: $0, identity: context.identity) else { return false }
+               return BridgeCapabilityPolicy.supportsClassicCaptureWithoutScreenCaptureKit(for: entry.response)
+           }),
            let oldHost = try await context.inspectScreenCaptureKitSafety(
                options,
                context.environment,
@@ -755,10 +763,13 @@ extension RuntimeHostResolver {
         requiredOwner: ScreenCaptureKitOwnerLease.OwnerReceipt? = nil,
         snapshotInvalidationRemoteSocketPaths: [String],
         permissionRejections: inout [String],
+        makeRemoteServices: RemoteServiceFactory = {
+            RuntimeHostResolver.remoteServices(client: $0, handshake: $1, options: $2)
+        },
         handshake: ScreenCaptureKitHandshake? = nil,
         handshakeCache: RemoteHandshakeCache? = nil
     )
-    async throws -> Resolution? {
+        async throws -> Resolution? {
         for candidate in candidates {
             try Task.checkCancellation()
             let socketPath = candidate.socketPath
@@ -768,7 +779,8 @@ extension RuntimeHostResolver {
                 if let handshake {
                     client = PeekabooBridgeClient(socketPath: socketPath)
                     handshakeResponse = try await handshake(candidate, identity)
-                } else if let cached = handshakeCache?.entry(for: candidate, identity: identity) {
+                } else if let handshakeCache {
+                    let cached = try await handshakeCache.handshake(candidate, identity: identity)
                     client = cached.client
                     handshakeResponse = cached.response
                 } else {
@@ -776,6 +788,18 @@ extension RuntimeHostResolver {
                     handshakeResponse = try await client.handshake(client: identity, requestedHost: nil)
                 }
                 try Task.checkCancellation()
+                if let requiredOwner,
+                   !self.screenCaptureKitHostMatchesOwner(handshake: handshakeResponse, owner: requiredOwner) {
+                    continue
+                }
+                if options.requiresScreenCaptureKitOwnerCapability,
+                   !options.usesPerToolSnapshotInvalidation,
+                   ObservationCommandSupport.captureEnginePreference(
+                       cliValue: options.captureEnginePreference, configuredValue: nil
+                   ) != .legacy,
+                   let diagnostic = BridgeCapabilityPolicy.screenCaptureKitReadinessRefusal(for: handshakeResponse) {
+                    throw self.readinessRefusal(diagnostic, handshake: handshakeResponse, socketPath: socketPath)
+                }
                 let validation = await self.validateRemoteCandidate(
                     candidate,
                     handshake: handshakeResponse,
@@ -798,15 +822,11 @@ extension RuntimeHostResolver {
                     }
                     continue
                 }
-                if let requiredOwner,
-                   !self.screenCaptureKitHostMatchesOwner(handshake: handshakeResponse, owner: requiredOwner) {
-                    continue
-                }
                 try Task.checkCancellation()
                 let authenticatedHostIdentity = await client.authenticatedHostIdentity()
                 let hostDescription = Self.remoteHostDescription(handshake: handshakeResponse, socketPath: socketPath)
                 return Resolution(
-                    services: Self.remoteServices(client: client, handshake: handshakeResponse, options: options),
+                    services: makeRemoteServices(client, handshakeResponse, options),
                     hostDescription: hostDescription,
                     selectedRemoteSocketPath: NSString(string: socketPath).standardizingPath,
                     selectedRemoteHostProcessIdentifier: validation.reusableDaemonStatus?.pid ??
@@ -822,6 +842,8 @@ extension RuntimeHostResolver {
                     ),
                     requiredHostFailure: nil
                 )
+            } catch let error as PreDispatchActionError {
+                throw error
             } catch let error as CancellationError {
                 throw error
             } catch {

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Core/BridgeCommand+Models.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Core/BridgeCommand+Models.swift
@@ -1,6 +1,7 @@
 import Foundation
 import PeekabooBridge
 import PeekabooCore
+import PeekabooFoundation
 
 struct BridgeStatusReport: Codable {
     let remoteSkipped: Bool
@@ -168,6 +169,7 @@ struct BridgeHandshakeReport: Codable {
     let permissionTags: [String: [PeekabooBridgePermissionKind]]
     let hostIdentity: PeekabooBridgeHostIdentity?
     let hostCapabilities: [String]?
+    let screenCaptureKitReadiness: ScreenCaptureKitReadiness?
 
     init(from handshake: PeekabooBridgeHandshakeResponse) {
         self.negotiatedVersion = handshake.negotiatedVersion
@@ -179,6 +181,7 @@ struct BridgeHandshakeReport: Codable {
         self.permissionTags = handshake.permissionTags
         self.hostIdentity = handshake.hostIdentity
         self.hostCapabilities = handshake.hostCapabilities
+        self.screenCaptureKitReadiness = handshake.screenCaptureKitReadiness
     }
 }
 

--- a/Apps/CLI/Tests/CoreCLITests/BridgeStatusReportHintTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/BridgeStatusReportHintTests.swift
@@ -346,6 +346,30 @@ struct BridgeStatusReportHintTests {
     }
 
     @Test
+    func `Bridge report preserves typed capture readiness`() throws {
+        let handshake = PeekabooBridgeHandshakeResponse(
+            negotiatedVersion: PeekabooBridgeConstants.protocolVersion,
+            hostKind: .gui,
+            build: "fixture",
+            supportedOperations: [.desktopObservation],
+            screenCaptureKitReadiness: .init(state: .blocked, failure: .init(
+                kind: .uncoordinatedProcesses,
+                stage: .preparation,
+                message: "Synthetic coordination blocker",
+                blockers: [.init(processIdentifier: 4242, processStartIdentity: 9001)]
+            ))
+        )
+        let data = try JSONEncoder().encode(BridgeHandshakeReport(from: handshake))
+        let object = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let readiness = try #require(object["screenCaptureKitReadiness"] as? [String: Any])
+        #expect(readiness["state"] as? String == "blocked")
+        let failure = try #require(readiness["failure"] as? [String: Any])
+        let blockers = try #require(failure["blockers"] as? [[String: Any]])
+        #expect(blockers.first?["processIdentifier"] as? Int == 4242)
+        #expect(blockers.first?["processStartIdentity"] as? Int == 9001)
+    }
+
+    @Test
     func `Bridge report preserves host generation build and launch capabilities`() throws {
         let identity = PeekabooBridgeHostIdentity(
             processIdentifier: 4242,

--- a/Apps/CLI/Tests/CoreCLITests/CaptureOwnershipErrorOutputTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/CaptureOwnershipErrorOutputTests.swift
@@ -1,0 +1,335 @@
+import Commander
+import Foundation
+import PeekabooBridge
+import PeekabooFoundation
+import Testing
+@testable import PeekabooCLI
+
+@Suite(.serialized, .tags(.safe))
+@MainActor
+struct CaptureOwnershipErrorOutputTests {
+    @Test(arguments: ["default", "modern"], ["command", "entrypoint"])
+    func `nonaction see preflight JSON retains selected host and every blocker`(
+        engine: String,
+        emitter: String
+    ) throws {
+        var see = SeeCommand()
+        see.runtimeOptions = try CommanderCLIBinder.makeRuntimeOptions(
+            from: .init(
+                positional: [],
+                options: engine == "modern" ? ["captureEngine": [engine]] : [:],
+                flags: ["json"]
+            ),
+            commandType: SeeCommand.self,
+            environment: [:]
+        )
+        #expect(see.defaultEffect == nil)
+        let error = PreDispatchActionError(
+            message: Self.diagnostic.userMessage,
+            code: .CAPTURE_FAILED,
+            hint: nil,
+            reason: .runtimeIncompatible,
+            screenCaptureKitOwnershipDiagnostic: Self.diagnostic
+        )
+        // Use the command's classification without constructing a runtime or accessing its services/logger.
+        let output = try Self.captureJSON {
+            if emitter == "command" {
+                OutputCommand(defaultEffect: see.defaultEffect).handleError(error)
+            } else {
+                ResultEnvelopeContext.$isActionCommand.withValue(false) {
+                    printGenericError(error, jsonOutput: true)
+                }
+            }
+        }
+        try Self.expectDiagnostic(output)
+        #expect(output.response.outcome == nil)
+        #expect(output.response.effect == nil)
+        #expect(output.response.error?.retry_safe == nil)
+        #expect(output.response.error?.mutation_dispatched == nil)
+    }
+
+    @Test(arguments: ["command", "generic", "render", "entrypoint"])
+    func `remote leaf failure retains capture code and typed evidence`(emitter: String) throws {
+        let failure = DesktopActionFailure.refused(
+            route: .bridge,
+            reason: .runtimeIncompatible,
+            message: Self.diagnostic.userMessage
+        ).preservingScreenCaptureKitDiagnostic(Self.diagnostic)
+        #expect(failure.standardErrorCode == .captureFailed)
+        let output = try Self.emit(failure, using: emitter)
+        try Self.expectDiagnostic(output)
+        #expect(output.response.outcome == failure.outcome.projection)
+        #expect(output.response.error?.retry_safe == true)
+        #expect(output.response.error?.mutation_dispatched == false)
+    }
+
+    @Test(arguments: ["command", "generic", "render", "entrypoint"])
+    func `ownership blocker never overwrites earlier dispatched failure`(emitter: String) throws {
+        let failure = DesktopActionFailure.dispatchedUnverified(
+            route: .bridge,
+            delivery: .init(mechanism: .globalEvents, mode: .foreground),
+            evidence: .deliveryAccepted,
+            unitCount: .one,
+            message: "A mutation was dispatched before capture failed"
+        ).preservingScreenCaptureKitDiagnostic(Self.diagnostic)
+        let output = try Self.emit(failure, using: emitter)
+        try Self.expectDiagnostic(output)
+        #expect(output.response.outcome == failure.outcome.projection)
+        #expect(output.response.error?.retry_safe == false)
+        #expect(output.response.error?.mutation_dispatched == true)
+    }
+
+    @Test(arguments: ["command", "generic", "entrypoint"])
+    func `direct diagnostic emits capture code without action claims`(emitter: String) throws {
+        let output = try Self.captureJSON {
+            if emitter == "command" {
+                OutputCommand(defaultEffect: nil).handleError(Self.diagnostic)
+            } else if emitter == "generic" {
+                handleGenericError(Self.diagnostic, jsonOutput: true, logger: .shared)
+            } else {
+                printGenericError(Self.diagnostic, jsonOutput: true)
+            }
+        }
+        try Self.expectDiagnostic(output)
+        #expect(output.response.outcome == nil)
+        #expect(output.response.error?.mutation_dispatched == nil)
+        #expect(OutputCommand(defaultEffect: nil).mapErrorToCode(Self.diagnostic) == .CAPTURE_FAILED)
+        #expect(genericErrorCode(for: Self.diagnostic) == .CAPTURE_FAILED)
+    }
+
+    @Test
+    func `Bridge error envelope retains independent diagnostic`() throws {
+        let error = PeekabooBridgeErrorEnvelope(
+            code: .internalError,
+            message: Self.diagnostic.userMessage,
+            context: PeekabooBridgeErrorEnvelope.standardizedErrorContextPrefix +
+                StandardErrorCode.captureFailed.rawValue,
+            screenCaptureKitOwnershipDiagnostic: Self.diagnostic
+        )
+        let output = try Self.captureJSON { OutputCommand(defaultEffect: nil).handleError(error) }
+        try Self.expectDiagnostic(output)
+        #expect(output.response.outcome == nil)
+        #expect(output.response.error?.mutation_dispatched == nil)
+    }
+
+    @Test
+    func `unrelated errors omit diagnostic and old JSON still decodes`() throws {
+        let output = try Self.captureJSON {
+            OutputCommand(defaultEffect: nil).handleError(Commander.ValidationError("Invalid input"))
+        }
+        #expect(output.response.error?.code == "VALIDATION_ERROR")
+        #expect(output.diagnostic == nil)
+        #expect(String(data: output.data, encoding: .utf8)?
+            .contains("screen_capture_kit_ownership_diagnostic") == false)
+        let old = Data(
+            #"{"success":false,"data":null,"debug_logs":[],"error":{"code":"CAPTURE_FAILED","message":"Old error"}}"#
+                .utf8
+        )
+        let decoded = try JSONDecoder().decode(JSONResponse.self, from: old)
+        #expect(decoded.error?.message == "Old error")
+        #expect(decoded.error?.screen_capture_kit_ownership_diagnostic == nil)
+    }
+
+    @Test(arguments: ["command", "generic", "entrypoint"])
+    func `wrapped failure retains typed capture evidence and prior mutation`(emitter: String) throws {
+        let failure = DesktopActionFailure.dispatchedUnverified(
+            route: .bridge,
+            delivery: .init(mechanism: .globalEvents, mode: .foreground),
+            evidence: .deliveryAccepted,
+            unitCount: .one,
+            message: "Capture failed after input",
+            hint: "Observe the target before retrying.",
+            causeDescription: "Synthetic ownership refusal"
+        ).attributed(to: .init(processIdentifier: 3131, processStartIdentity: 4141, windowID: 73))
+            .preservingScreenCaptureKitDiagnostic(Self.diagnostic)
+        let error = WrappedFailure(failure: failure)
+        #expect(screenCaptureKitOwnershipDiagnostic(for: error) == Self.diagnostic)
+        #expect(OutputCommand(defaultEffect: .unverifiable).mapErrorToCode(error) == .CAPTURE_FAILED)
+        #expect(genericErrorCode(for: error) == .CAPTURE_FAILED)
+        let output = try Self.captureJSON {
+            switch emitter {
+            case "command":
+                OutputCommand(defaultEffect: .unverifiable).handleError(error)
+            case "generic":
+                handleGenericError(error, jsonOutput: true, logger: .shared)
+            default:
+                ResultEnvelopeContext.$isActionCommand.withValue(true) {
+                    printGenericError(error, jsonOutput: true)
+                }
+            }
+        }
+        try Self.expectDiagnostic(output)
+        #expect(output.response.outcome == failure.outcome.projection)
+        #expect(output.response.target_receipt == failure.targetReceipt)
+        #expect(output.response.error?.retry_safe == false)
+        #expect(output.response.error?.mutation_dispatched == true)
+        #expect(output.response.error?.hint == failure.hint)
+    }
+
+    @Test
+    func `pre-dispatch wrapping preserves the direct ownership diagnostic`() {
+        let error = OutputCommand(defaultEffect: nil).preDispatchActionError(for: Self.diagnostic)
+        #expect(error.code == .CAPTURE_FAILED)
+        #expect(screenCaptureKitOwnershipDiagnostic(for: error) == Self.diagnostic)
+    }
+
+    @Test
+    func `standalone output diagnostic does not invent action metadata`() throws {
+        let output = try Self.captureJSON {
+            outputError(
+                message: Self.diagnostic.userMessage,
+                code: .CAPTURE_FAILED,
+                screenCaptureKitOwnershipDiagnostic: Self.diagnostic,
+                logger: .shared
+            )
+        }
+        try Self.expectDiagnostic(output)
+        #expect(output.response.outcome == nil)
+        #expect(output.response.effect == nil)
+        #expect(output.response.error?.retry_safe == nil)
+        #expect(output.response.error?.mutation_dispatched == nil)
+    }
+
+    @Test(arguments: ["command", "generic", "render", "entrypoint"])
+    func `known capture failure code survives without new diagnostic`(emitter: String) throws {
+        let failure = DesktopActionFailure.preDispatchRefusal(
+            route: .bridge,
+            reason: .runtimeIncompatible,
+            message: "Legacy capture refusal",
+            standardErrorCode: .captureFailed
+        )
+        let output = try Self.emit(failure, using: emitter)
+        #expect(output.response.error?.code == "CAPTURE_FAILED")
+        #expect(output.diagnostic == nil)
+        #expect(String(data: output.data, encoding: .utf8)?
+            .contains("screen_capture_kit_ownership_diagnostic") == false)
+        #expect(output.response.outcome == failure.outcome.projection)
+    }
+
+    private struct WrappedFailure: LocalizedError, ResultEnvelopeError {
+        let failure: DesktopActionFailure
+        nonisolated var errorDescription: String? {
+            self.failure.message
+        }
+
+        nonisolated var envelopeCode: ErrorCode? {
+            .INTERACTION_FAILED
+        }
+
+        nonisolated var envelopeEffect: ActionEffect? {
+            self.failure.outcome.effect
+        }
+
+        nonisolated var envelopeHint: String? {
+            self.failure.hint
+        }
+
+        nonisolated var envelopeActionFailure: DesktopActionFailure? {
+            self.failure
+        }
+    }
+
+    private static func emit(_ failure: DesktopActionFailure, using emitter: String) throws -> CapturedOutput {
+        try self.captureJSON {
+            switch emitter {
+            case "command":
+                OutputCommand(defaultEffect: .unverifiable).handleError(failure)
+            case "generic":
+                handleGenericError(failure, jsonOutput: true, logger: .shared)
+            case "entrypoint":
+                ResultEnvelopeContext.$isActionCommand.withValue(true) {
+                    printGenericError(failure, jsonOutput: true)
+                }
+            default:
+                renderDesktopActionFailure(failure, jsonOutput: true, logger: .shared)
+            }
+        }
+    }
+
+    private static func expectDiagnostic(_ output: CapturedOutput) throws {
+        #expect(output.response.success == false)
+        #expect(output.response.error?.code == "CAPTURE_FAILED")
+        #expect(output.diagnostic == self.diagnostic)
+        #expect(output.response.error?.screen_capture_kit_ownership_diagnostic == self.diagnostic)
+        let legacy = try JSONDecoder().decode(LegacyEnvelope.self, from: output.data)
+        #expect(legacy.error.code == "CAPTURE_FAILED")
+        #expect(!legacy.error.message.isEmpty)
+    }
+
+    private struct OutputCommand: ErrorHandlingCommand, ActionOutputFormattable {
+        let jsonOutput = true
+        let defaultEffect: ActionEffect?
+    }
+
+    private struct CapturedOutput {
+        let data: Data
+        let response: JSONResponse
+        let diagnostic: ScreenCaptureKitOwnershipDiagnostic?
+    }
+
+    private struct DiagnosticEnvelope: Decodable {
+        struct Failure: Decodable {
+            let screen_capture_kit_ownership_diagnostic: ScreenCaptureKitOwnershipDiagnostic?
+        }
+
+        let error: Failure
+    }
+
+    private struct LegacyEnvelope: Decodable {
+        struct Failure: Decodable {
+            let code: String
+            let message: String
+        }
+
+        let error: Failure
+    }
+
+    private static func captureJSON(_ body: () -> Void) throws -> CapturedOutput {
+        let pipe = Pipe()
+        defer { Logger.shared.setJsonOutputMode(false) }
+        fflush(stdout)
+        let savedOutput = dup(STDOUT_FILENO)
+        guard savedOutput >= 0 else { throw CocoaError(.fileWriteUnknown) }
+        defer { close(savedOutput) }
+        guard dup2(pipe.fileHandleForWriting.fileDescriptor, STDOUT_FILENO) >= 0 else {
+            throw CocoaError(.fileWriteUnknown)
+        }
+        pipe.fileHandleForWriting.closeFile()
+        body()
+        fflush(stdout)
+        guard dup2(savedOutput, STDOUT_FILENO) >= 0 else { throw CocoaError(.fileWriteUnknown) }
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        pipe.fileHandleForReading.closeFile()
+        return try CapturedOutput(
+            data: data,
+            response: JSONDecoder().decode(JSONResponse.self, from: data),
+            diagnostic: JSONDecoder().decode(DiagnosticEnvelope.self, from: data)
+                .error.screen_capture_kit_ownership_diagnostic
+        )
+    }
+
+    private static let diagnostic = ScreenCaptureKitOwnershipDiagnostic(
+        kind: .uncoordinatedProcesses,
+        stage: .entry,
+        message: "Potential capture processes do not publish ownership support.",
+        operation: "syntheticCapture",
+        blockers: [
+            .init(processIdentifier: 4242, processStartIdentity: 9001, executablePath: "/synthetic/PotentialHost"),
+            .init(
+                processIdentifier: 4343,
+                processStartIdentity: 9002,
+                executablePath: "/synthetic/OtherPotentialHost",
+                socketPath: "/synthetic/other.sock",
+                buildIdentity: "other-fixture"
+            ),
+        ],
+        selectedHost: .init(
+            processIdentifier: 3131,
+            processStartIdentity: 4141,
+            executablePath: "/synthetic/CurrentGUI",
+            socketPath: "/synthetic/selected.sock",
+            buildIdentity: "current-fixture",
+            codeSignatureHash: "fixture-hash"
+        )
+    )
+}

--- a/Apps/CLI/Tests/CoreCLITests/CaptureReadinessRuntimeTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/CaptureReadinessRuntimeTests.swift
@@ -1,0 +1,256 @@
+import Commander
+import Foundation
+import PeekabooAutomationKit
+import PeekabooBridge
+import PeekabooBridgeTestSupport
+import PeekabooCore
+import PeekabooFoundation
+import Testing
+@testable import PeekabooCLI
+
+@Suite(.serialized, .tags(.safe))
+@MainActor
+struct CaptureReadinessRuntimeTests {
+    @Test(
+        arguments: ["classic", "cg", "auto", "modern", "sckit", "omitted"],
+        ["blockedFlag", "blockedEnvironment", "missingEnvironment", "silentRefresh"]
+    )
+    func `current GUI keeps explicit socket and typed readiness`(engine: String, scenario: String) async throws {
+        try await Self.checkRoute(engine: engine, scenario: scenario)
+    }
+
+    @Test(
+        arguments: ["classic", "cg", "modern"],
+        ["flag-normal", "flag-noElements", "environment-normal", "environment-noElements"]
+    )
+    func `effective environment engine keeps the selected socket`(engine: String, scenario: String) async throws {
+        try await Self.checkRoute(
+            engine: engine,
+            scenario: scenario.hasPrefix("environment") ? "blockedEnvironment" : "blockedFlag",
+            noElements: scenario.hasSuffix("noElements"),
+            engineFromEnvironment: true
+        )
+    }
+
+    private static func checkRoute(
+        engine: String,
+        scenario: String,
+        noElements: Bool = true,
+        engineFromEnvironment: Bool = false
+    ) async throws {
+        let socket = "/synthetic/selected-gui.sock"
+        let response = Self.handshake(readiness: scenario == "missingEnvironment" ? nil : Self.blockedReadiness)
+        var environment = scenario == "blockedFlag" ? [:] : ["PEEKABOO_BRIDGE_SOCKET": socket]
+        var arguments: [String: [String]] = scenario == "blockedFlag" ? ["bridge-socket": [socket]] : [:]
+        if engineFromEnvironment {
+            environment["PEEKABOO_CAPTURE_ENGINE"] = engine
+        } else if engine != "omitted" {
+            arguments["captureEngine"] = [engine]
+        }
+        let parsed = ParsedValues(positional: [], options: arguments, flags: noElements ? ["noElements"] : [])
+        var options = try CommanderCLIBinder.makeRuntimeOptions(
+            from: parsed,
+            commandType: SeeCommand.self,
+            environment: environment
+        ).applyingEnvironmentOverrides(environment: environment)
+        if engineFromEnvironment {
+            #expect(options.captureEnginePreference == engine)
+            #expect(options.requiresCaptureEnginePreferenceCapability)
+        }
+        options.autoStartDaemon = false
+        if scenario == "silentRefresh" {
+            options.requiresScreenCapturePermission = false
+        }
+        var localFactories = 0
+        var ownerClaims = 0
+        var safetyRecords = 0
+        var remoteFactories = 0
+        var handshakes: [String] = []
+        let cache = RuntimeHostResolver.RemoteHandshakeCache(
+            identity: .init(bundleIdentifier: "synthetic.client", teamIdentifier: nil, processIdentifier: 123),
+            handshakeProvider: { candidate, _ in
+                handshakes.append(candidate.socketPath)
+                #expect(candidate.socketPath == socket)
+                return response
+            }
+        )
+        let dependencies = RuntimeHostResolver.Dependencies(
+            makeLocalServices: { _ in
+                localFactories += 1
+                return OwnerPolicyFixtureServices(ownerAware: true)
+            },
+            claimScreenCaptureKitOwner: {
+                ownerClaims += 1
+                throw POSIXError(.ENOTSUP)
+            },
+            inspectScreenCaptureKitOwner: { nil },
+            inspectScreenCaptureKitSafety: { _, _, candidates, cache in
+                try await RuntimeHostResolver.firstScreenCaptureKitOwnerUnawareHost(
+                    candidates: (candidates ?? []).filter { $0.socketPath == socket },
+                    identity: cache.identity,
+                    handshakeCache: cache,
+                    externalHostPresence: { _ in .absent }
+                )
+            },
+            recordScreenCaptureKitSafetyBlocker: { _ in safetyRecords += 1 },
+            remoteCandidatePlan: { _, _ in
+                .init(
+                    explicitSocket: socket,
+                    daemonSocketPath: "/synthetic/unused.sock",
+                    runtimeBuildIdentity: "fixture",
+                    buildScopedDaemonSocketPath: nil,
+                    historicalBuildScopedDaemonSocketPaths: [],
+                    candidates: [.init(
+                        socketPath: socket,
+                        requireReusableDaemon: false,
+                        requiredHostKind: .gui,
+                        requiresValidatedHistoricalDaemon: false
+                    )]
+                )
+            },
+            makeRemoteHandshakeCache: { cache },
+            makeRemoteServices: { _, _, _ in
+                remoteFactories += 1
+                return OwnerPolicyFixtureServices(ownerAware: true)
+            }
+        )
+
+        if engine == "classic" || engine == "cg" {
+            let result = try await RuntimeHostResolver.resolveServices(
+                options: options, environment: environment, configurationInput: nil, dependencies: dependencies
+            )
+            #expect(result.selectedRemoteSocketPath == socket)
+            #expect(result.selectedRemoteHostProcessIdentifier == 3131)
+            #expect(result.captureEngineSafetyOverride == nil)
+            #expect(remoteFactories == 1)
+        } else {
+            let error = await #expect(throws: PreDispatchActionError.self) {
+                _ = try await RuntimeHostResolver.resolveServices(
+                    options: options, environment: environment, configurationInput: nil, dependencies: dependencies
+                )
+            }
+            #expect(error?.code == .CAPTURE_FAILED)
+            let diagnostic = try #require(error?.failure.screenCaptureKitOwnershipDiagnostic)
+            if scenario == "missingEnvironment" {
+                #expect(diagnostic.kind == .unavailable)
+                #expect(diagnostic.blockers.isEmpty)
+            } else {
+                #expect(diagnostic.blockers == Self.blockedReadiness.failure?.blockers)
+            }
+            #expect(diagnostic.selectedHost?.processIdentifier == 3131)
+            #expect(diagnostic.selectedHost?.socketPath == socket)
+            #expect(error?.localizedDescription.contains("predates") == false)
+            #expect(remoteFactories == 0)
+        }
+        #expect(localFactories == 0)
+        #expect(ownerClaims == 0)
+        #expect(safetyRecords == 0)
+        #expect(handshakes == [socket])
+    }
+
+    @Test(arguments: ["classic", "cg"])
+    func `classic missing readiness still requires positive proof`(engine: String) throws {
+        let options = try Self.options(engine: engine)
+        #expect(BridgeCapabilityPolicy.supportsRemoteRequirements(
+            for: Self.handshake(readiness: nil),
+            options: options
+        ))
+        let engineOnly = Self.handshake(capabilities: [PeekabooBridgeHostCapability.desktopObservationCaptureEngine])
+        #expect(!BridgeCapabilityPolicy.supportsRemoteRequirements(for: engineOnly, options: options))
+        let ownershipOnly = Self
+            .handshake(capabilities: [PeekabooBridgeHostCapability.screenCaptureKitOwnershipEnforcement])
+        #expect(!BridgeCapabilityPolicy.supportsRemoteRequirements(for: ownershipOnly, options: options))
+        let disabled = Self.handshake(enabledOperations: [.captureScreen])
+        #expect(!BridgeCapabilityPolicy.supportsRemoteRequirements(for: disabled, options: options))
+    }
+
+    @Test
+    func `local owner conversion retains every blocker`() throws {
+        let original = try #require(Self.blockedReadiness.failure)
+        let refusal = RuntimeHostResolver.ownerRefusal(
+            error: original, callerLocal: false, selectedSocket: "/synthetic/current.sock"
+        )
+        #expect(refusal.failure.screenCaptureKitOwnershipDiagnostic?.blockers == original.blockers)
+        #expect(refusal.failure.screenCaptureKitOwnershipDiagnostic?.selectedHost?
+            .socketPath == "/synthetic/current.sock")
+    }
+
+    @Test
+    func `missing and contradictory readiness cannot authorize modern`() throws {
+        let options = try Self.options(engine: "modern")
+        for readiness in [
+            nil,
+            ScreenCaptureKitReadiness(state: .unknown),
+            .init(state: .ready, failure: Self.blockedReadiness.failure)
+        ] {
+            #expect(!BridgeCapabilityPolicy.supportsRemoteRequirements(
+                for: Self.handshake(readiness: readiness),
+                options: options
+            ))
+        }
+        let oldOwner = Self.handshake(readiness: nil, capabilities: [
+            PeekabooBridgeHostCapability.screenCaptureKitProcessOwnership,
+            PeekabooBridgeHostCapability.desktopObservationCaptureEngine,
+        ])
+        #expect(BridgeCapabilityPolicy.supportsRemoteRequirements(for: oldOwner, options: options))
+    }
+
+    @Test
+    func `ax only ignores capture readiness and ambient engine`() throws {
+        let options = try CommanderCLIBinder.makeRuntimeOptions(
+            from: .init(positional: [], options: [:], flags: ["tree", "noScreenshot"]),
+            commandType: SeeCommand.self,
+            environment: ["PEEKABOO_CAPTURE_ENGINE": "modern"]
+        ).applyingEnvironmentOverrides(environment: ["PEEKABOO_CAPTURE_ENGINE": "modern"])
+        #expect(options.captureEnginePreference == nil)
+        #expect(!options.requiresScreenCaptureKitOwnerCapability)
+        #expect(BridgeCapabilityPolicy.supportsRemoteRequirements(for: Self.handshake(), options: options))
+    }
+
+    private static func options(engine: String) throws -> CommandRuntimeOptions {
+        try CommanderCLIBinder.makeRuntimeOptions(
+            from: .init(positional: [], options: ["captureEngine": [engine]], flags: []),
+            commandType: SeeCommand.self,
+            environment: [:]
+        )
+    }
+
+    private static let blockedReadiness = ScreenCaptureKitReadiness.failed(
+        ScreenCaptureKitOwnerLease.LeaseError.uncoordinatedProcesses([
+            .init(processIdentifier: 4242, processStartIdentity: 9001, executablePath: "/synthetic/PotentialHost"),
+            .init(processIdentifier: 4343, processStartIdentity: 9002, executablePath: "/synthetic/OtherPotentialHost"),
+        ]), stage: .preparation
+    )
+
+    private static func handshake(
+        readiness: ScreenCaptureKitReadiness? = Self.blockedReadiness,
+        capabilities: [String] = [
+            PeekabooBridgeHostCapability.screenCaptureKitOwnershipEnforcement,
+            PeekabooBridgeHostCapability.classicCaptureWithoutScreenCaptureKit,
+            PeekabooBridgeHostCapability.desktopObservationCaptureEngine,
+        ],
+        enabledOperations: [PeekabooBridgeOperation]? = nil
+    ) -> PeekabooBridgeHandshakeResponse {
+        .init(
+            negotiatedVersion: PeekabooBridgeConstants.protocolVersion,
+            hostKind: .gui,
+            build: "current-fixture",
+            supportedOperations: [.captureScreen, .desktopObservation, .inspectAccessibilityTree, .ownsSnapshot],
+            permissions: .init(screenRecording: true, accessibility: true, appleScript: false, postEvent: false),
+            enabledOperations: enabledOperations,
+            hostIdentity: .init(
+                processIdentifier: 3131,
+                processStartIdentity: 4141,
+                bundleIdentifier: "synthetic.gui",
+                bundleShortVersion: nil,
+                bundleVersion: nil,
+                codeSignatureHash: "fixture-hash"
+            ),
+            hostCapabilities: capabilities + [
+                PeekabooBridgeHostCapability.producerBoundSnapshotReferences,
+                PeekabooBridgeHostCapability.attestedOperationReceipts
+            ],
+            screenCaptureKitReadiness: readiness
+        )
+    }
+}

--- a/Apps/CLI/Tests/CoreCLITests/ScreenCaptureKitDynamicToolRuntimeTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/ScreenCaptureKitDynamicToolRuntimeTests.swift
@@ -11,7 +11,7 @@ import Testing
 extension ScreenCaptureKitOwnerRuntimeTests {
     @Test
     func `browser-only MCP runtime never consults an unrelated ScreenCaptureKit owner`() async throws {
-        let buildScopedSocket = "/tmp/peekaboo-browser-only-build-\(UUID().uuidString).sock"
+        let buildScopedSocket = Self.fixtureSocketPath()
         var options = try CommanderCLIBinder.makeRuntimeOptions(
             from: ParsedValues(positional: [], options: [:], flags: []),
             commandType: MCPCommand.Serve.self,
@@ -27,10 +27,10 @@ extension ScreenCaptureKitOwnerRuntimeTests {
             options: options,
             environment: ["PEEKABOO_ALLOW_TOOLS": "browser"],
             configurationInput: nil,
-            dependencies: .init(
+            dependencies: Self.inertDependencies(
                 makeLocalServices: { _ in
                     localFactoryCalls += 1
-                    return PeekabooServices()
+                    return OwnerPolicyFixtureServices(ownerAware: true)
                 },
                 claimScreenCaptureKitOwner: {
                     claimCalls += 1
@@ -77,7 +77,7 @@ extension ScreenCaptureKitOwnerRuntimeTests {
 
     @Test
     func `capture-capable MCP runtime remains bound to the exact ScreenCaptureKit owner`() async throws {
-        let buildScopedSocket = "/tmp/peekaboo-browser-capture-build-\(UUID().uuidString).sock"
+        let buildScopedSocket = Self.fixtureSocketPath()
         var options = try CommanderCLIBinder.makeRuntimeOptions(
             from: ParsedValues(positional: [], options: [:], flags: []),
             commandType: MCPCommand.Serve.self,
@@ -94,10 +94,10 @@ extension ScreenCaptureKitOwnerRuntimeTests {
                 options: options,
                 environment: ["PEEKABOO_ALLOW_TOOLS": "browser,see"],
                 configurationInput: nil,
-                dependencies: .init(
+                dependencies: Self.inertDependencies(
                     makeLocalServices: { _ in
                         localFactoryCalls += 1
-                        return PeekabooServices()
+                        return OwnerPolicyFixtureServices(ownerAware: true)
                     },
                     claimScreenCaptureKitOwner: {
                         claimCalls += 1
@@ -203,8 +203,8 @@ extension ScreenCaptureKitOwnerRuntimeTests {
 
     @Test
     func `explicit dynamic host ignores unrelated legacy owner and reuses selected generation`() async throws {
-        let selectedSocket = "/tmp/peekaboo-dynamic-selected-\(UUID().uuidString).sock"
-        let unrelatedSocket = "/tmp/peekaboo-dynamic-unrelated-\(UUID().uuidString).sock"
+        let selectedSocket = Self.fixtureSocketPath()
+        let unrelatedSocket = Self.fixtureSocketPath()
         var selectedHandshakeCount = 0
         var unrelatedHandshakeCount = 0
         let selectedHost = try await Self.startHost(
@@ -251,10 +251,10 @@ extension ScreenCaptureKitOwnerRuntimeTests {
             options: options,
             environment: [:],
             configurationInput: nil,
-            dependencies: .init(
+            dependencies: Self.inertDependencies(
                 makeLocalServices: { _ in
                     localFactoryCalls += 1
-                    return PeekabooServices()
+                    return OwnerPolicyFixtureServices(ownerAware: true)
                 },
                 claimScreenCaptureKitOwner: { Self.ownerReceipt() },
                 inspectScreenCaptureKitOwner: {
@@ -308,7 +308,7 @@ extension ScreenCaptureKitOwnerRuntimeTests {
 
     @Test
     func `explicit dynamic host remains fail closed when the selected socket is unavailable`() async throws {
-        let selectedSocket = "/tmp/peekaboo-dynamic-missing-\(UUID().uuidString).sock"
+        let selectedSocket = Self.fixtureSocketPath()
         var options = try CommanderCLIBinder.makeRuntimeOptions(
             from: ParsedValues(
                 positional: [],
@@ -325,10 +325,10 @@ extension ScreenCaptureKitOwnerRuntimeTests {
                 options: options,
                 environment: [:],
                 configurationInput: nil,
-                dependencies: .init(
+                dependencies: Self.inertDependencies(
                     makeLocalServices: { _ in
                         localFactoryCalls += 1
-                        return PeekabooServices()
+                        return OwnerPolicyFixtureServices(ownerAware: true)
                     },
                     claimScreenCaptureKitOwner: { Self.ownerReceipt() },
                     inspectScreenCaptureKitOwner: { nil },
@@ -364,7 +364,7 @@ extension ScreenCaptureKitOwnerRuntimeTests {
 
     @Test
     func `explicit verify screenshot inherits deferred capture refusal`() async throws {
-        let selectedSocket = "/tmp/peekaboo-verify-selected-\(UUID().uuidString).sock"
+        let selectedSocket = Self.fixtureSocketPath()
         let selectedHost = try await Self.startHost(
             socketPath: selectedSocket,
             processIdentifier: 4242,
@@ -407,8 +407,8 @@ extension ScreenCaptureKitOwnerRuntimeTests {
             options: options,
             environment: [:],
             configurationInput: nil,
-            dependencies: .init(
-                makeLocalServices: { _ in PeekabooServices() },
+            dependencies: Self.inertDependencies(
+                makeLocalServices: { _ in OwnerPolicyFixtureServices(ownerAware: true) },
                 claimScreenCaptureKitOwner: { Self.ownerReceipt() },
                 inspectScreenCaptureKitOwner: { nil },
                 inspectScreenCaptureKitSafety: { _, _, _, cache in
@@ -429,19 +429,12 @@ extension ScreenCaptureKitOwnerRuntimeTests {
             )
         )
         let refusal = try #require(resolution.toolCapturePreflightRefusal)
-        let runtime = CommandRuntime(
-            configuration: options.makeConfiguration(),
+        // The Verify adapter passes these same values; construct its context directly to avoid
+        // process-wide profile, visualizer, and mutation-tracker initialization in this routing test.
+        let context = MCPToolContext(
             services: resolution.services,
-            hostDescription: resolution.hostDescription,
-            selectedRemoteSocketPath: resolution.selectedRemoteSocketPath,
-            selectedRemoteHostProcessIdentifier: resolution.selectedRemoteHostProcessIdentifier,
-            captureEngineSafetyOverride: resolution.captureEngineSafetyOverride,
-            toolCapturePreflightRefusal: refusal,
-            snapshotInvalidationRemoteSocketPaths: resolution.snapshotInvalidationRemoteSocketPaths,
-            applicationRelaunchAllowed: resolution.applicationRelaunchAllowed,
-            requiredHostFailure: resolution.requiredHostFailure
+            capturePreflightRefusal: refusal
         )
-        let context = VerifyCommand.makeToolContext(using: runtime)
         let counter = VerifyCaptureInvocationCounter()
         let response = try await context.execute(
             tool: VerifyCaptureInvocationProbe(counter: counter),

--- a/Apps/CLI/Tests/CoreCLITests/ScreenCaptureKitOwnerFixtureTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/ScreenCaptureKitOwnerFixtureTests.swift
@@ -8,7 +8,7 @@ import Testing
 extension ScreenCaptureKitOwnerRuntimeTests {
     @Test(arguments: [true, false])
     func `fixture ownership capability follows service support`(ownerAware: Bool) async throws {
-        let socketPath = "/tmp/peekaboo-owner-fixture-\(UUID().uuidString).sock"
+        let socketPath = Self.fixtureSocketPath()
         let host = try await Self.startHost(
             socketPath: socketPath,
             processIdentifier: 4242,
@@ -32,8 +32,8 @@ extension ScreenCaptureKitOwnerRuntimeTests {
     }
 
     @Test(arguments: [true, false])
-    func `fixture ownership failures remain owner unaware`(registrationFails: Bool) async throws {
-        let socketPath = "/tmp/peekaboo-owner-fixture-failure-\(UUID().uuidString).sock"
+    func `fixture preparation failures retain ownership implementation proof`(registrationFails: Bool) async throws {
+        let socketPath = Self.fixtureSocketPath()
         let host = try await Self.startHost(
             socketPath: socketPath,
             processIdentifier: 4242,
@@ -62,9 +62,13 @@ extension ScreenCaptureKitOwnerRuntimeTests {
             externalHostPresence: { _ in .absent }
         )
 
-        #expect(unawareHost?.socketPath == socketPath)
-        #expect(unawareHost?.processIdentifier == 4242)
-        #expect(unawareHost?.processStartIdentity == 9001)
+        #expect(unawareHost == nil)
+        let handshake = try await PeekabooBridgeClient(socketPath: socketPath).handshake(
+            client: .init(bundleIdentifier: "synthetic.client", teamIdentifier: nil, processIdentifier: getpid())
+        )
+        #expect(handshake.screenCaptureKitReadiness?.state == .unavailable)
+        #expect(handshake.screenCaptureKitReadiness?.failure?
+            .stage == (registrationFails ? .registration : .preparation))
         await host.stop()
     }
 }

--- a/Apps/CLI/Tests/CoreCLITests/ScreenCaptureKitOwnerRuntimeTests+Fixtures.swift
+++ b/Apps/CLI/Tests/CoreCLITests/ScreenCaptureKitOwnerRuntimeTests+Fixtures.swift
@@ -1,0 +1,337 @@
+import Darwin
+import Foundation
+import PeekabooAgentRuntime
+import PeekabooAutomation
+import PeekabooBridge
+import PeekabooCore
+import PeekabooFoundation
+import Testing
+import UniformTypeIdentifiers
+@testable import PeekabooAutomationKit
+@testable import PeekabooCLI
+
+@MainActor
+extension ScreenCaptureKitOwnerRuntimeTests {
+    static var fixtureSockets: Set<String> = []
+
+    static func fixtureSocketPath() -> String {
+        FileManager.default.temporaryDirectory.appendingPathComponent("s-\(UUID().uuidString).sock").path
+    }
+
+    static func makeInertRemoteServices(
+        client: PeekabooBridgeClient,
+        handshake: PeekabooBridgeHandshakeResponse,
+        options: CommandRuntimeOptions
+    ) -> any PeekabooServiceProviding {
+        OwnerPolicyFixtureServices(ownerAware: true, remoteClient: client)
+    }
+
+    static func inertHandshakeCache() -> RuntimeHostResolver.RemoteHandshakeCache {
+        RuntimeHostResolver.RemoteHandshakeCache(
+            identity: .init(
+                bundleIdentifier: "boo.peekaboo.test.client",
+                teamIdentifier: nil,
+                processIdentifier: getpid()
+            ),
+            clientFactory: { path in
+                // Only task-owned listeners can be reached, including by legacy candidate scans.
+                let isolatedPath = self.fixtureSockets.contains(path) ? path : self.fixtureSocketPath()
+                return PeekabooBridgeClient(socketPath: isolatedPath)
+            }
+        )
+    }
+
+    static func inertDependencies(
+        makeLocalServices: @escaping RuntimeHostResolver.LocalServiceFactory,
+        claimScreenCaptureKitOwner: @escaping RuntimeHostResolver.ScreenCaptureKitOwnerClaim,
+        inspectScreenCaptureKitOwner: @escaping RuntimeHostResolver.ScreenCaptureKitOwnerInspector,
+        inspectScreenCaptureKitSafety: @escaping RuntimeHostResolver
+            .ScreenCaptureKitSafetyInspector = { _, _, _, _ in nil },
+        recordScreenCaptureKitSafetyBlocker: @escaping RuntimeHostResolver.ScreenCaptureKitSafetyRecorder = { _ in },
+        remoteCandidatePlan: RuntimeHostResolver.RemoteCandidatePlanner? = nil,
+        makeRemoteHandshakeCache: RuntimeHostResolver.RemoteHandshakeCacheFactory? = nil
+    ) -> RuntimeHostResolver.Dependencies {
+        .init(
+            makeLocalServices: makeLocalServices,
+            claimScreenCaptureKitOwner: claimScreenCaptureKitOwner,
+            inspectScreenCaptureKitOwner: inspectScreenCaptureKitOwner,
+            inspectScreenCaptureKitSafety: inspectScreenCaptureKitSafety,
+            recordScreenCaptureKitSafetyBlocker: recordScreenCaptureKitSafetyBlocker,
+            remoteCandidatePlan: remoteCandidatePlan ?? { options, environment in
+                let socket = options.bridgeSocketPath ?? environment["PEEKABOO_BRIDGE_SOCKET"]
+                let daemon = environment["PEEKABOO_DAEMON_SOCKET"] ?? "/synthetic/daemon.sock"
+                return .init(
+                    explicitSocket: socket,
+                    daemonSocketPath: daemon,
+                    runtimeBuildIdentity: "fixture",
+                    buildScopedDaemonSocketPath: nil,
+                    historicalBuildScopedDaemonSocketPaths: [],
+                    candidates: socket.map { [.init(
+                        socketPath: $0,
+                        requireReusableDaemon: false,
+                        requiredHostKind: nil,
+                        requiresValidatedHistoricalDaemon: false
+                    )] } ??
+                        []
+                )
+            },
+            makeRemoteHandshakeCache: makeRemoteHandshakeCache ?? { self.inertHandshakeCache() },
+            makeRemoteServices: self.makeInertRemoteServices
+        )
+    }
+
+    static func startHost(
+        socketPath: String,
+        processIdentifier: pid_t,
+        processStartIdentity: UInt64,
+        codeSignatureHash: String,
+        ownerAware: Bool = true,
+        screenRecording: Bool = true,
+        maximumProtocolVersion: PeekabooBridgeProtocolVersion =
+            PeekabooBridgeConstants.exactForcedDialogDismissExecutionVersion,
+        usesCurrentHostIdentity: Bool = false,
+        serviceOverride: (any PeekabooBridgeServiceProviding)? = nil,
+        coordinationRootURL: URL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("peekaboo-owner-lane-\(UUID().uuidString)", isDirectory: true),
+        windowIdentity: WindowMutationIdentity? = nil,
+        screenCaptureKitProcessCapabilityRegistrar: @MainActor @Sendable () throws -> Void = {},
+        screenCaptureKitOwnershipPreparer: @escaping @Sendable () async throws -> Void = {},
+        permissionEvaluationObserver: @escaping @MainActor @Sendable () -> Void = {}
+    ) async throws -> PeekabooBridgeHost {
+        let services: any PeekabooBridgeServiceProviding = if let serviceOverride {
+            serviceOverride
+        } else if ownerAware {
+            OwnerPolicyFixtureServices(ownerAware: true)
+        } else {
+            OwnerPolicyFixtureServices(ownerAware: false)
+        }
+        let server = PeekabooBridgeServer(
+            services: services,
+            hostKind: .onDemand,
+            allowlistedTeams: [],
+            allowlistedBundles: [],
+            supportedVersions: ClosedRange(uncheckedBounds: (
+                lower: PeekabooBridgeConstants.supportedProtocolRange.lowerBound,
+                upper: maximumProtocolVersion
+            )),
+            allowedOperations: [
+                .permissionsStatus,
+                .captureScreen,
+                .desktopObservation,
+                .invalidateImplicitLatestSnapshot,
+                .launchApplicationWithOptions,
+                .findApplication,
+                .activateApplication,
+                .targetedHotkey,
+                .targetedTypeActions,
+                .targetedClick,
+                .ownsSnapshot,
+                .targetedDialogListElements,
+                .prepareDialogAction,
+                .exactDialogClickButton,
+                .exactDialogDismiss,
+            ],
+            hostIdentity: usesCurrentHostIdentity
+                ? .current()
+                : PeekabooBridgeHostIdentity(
+                    processIdentifier: processIdentifier,
+                    processStartIdentity: processStartIdentity,
+                    bundleIdentifier: "boo.peekaboo.test.host",
+                    bundleShortVersion: nil,
+                    bundleVersion: nil,
+                    codeSignatureHash: codeSignatureHash
+                ),
+            // Synthetic startup and dispatch must not use user-wide ownership or desktop coordination state.
+            desktopOperationLaneCoordinator: DesktopOperationLaneCoordinator(coordinationRootURL: coordinationRootURL),
+            screenCaptureKitProcessCapabilityRegistrar: screenCaptureKitProcessCapabilityRegistrar,
+            screenCaptureKitOwnershipPreparer: screenCaptureKitOwnershipPreparer,
+            screenCaptureKitOwnerClaimProvider: {
+                Issue.record("Routing fixture must not claim ScreenCaptureKit")
+                throw ScreenCaptureKitOwnerLease.LeaseError.invalidOwnerIdentity("unexpected fixture claim")
+            },
+            postEventAccessEvaluator: { true },
+            postEventAccessRequester: { false },
+            permissionStatusEvaluator: { _ in
+                permissionEvaluationObserver()
+                return PermissionsStatus(
+                    screenRecording: screenRecording,
+                    accessibility: true,
+                    appleScript: false,
+                    postEvent: true
+                )
+            },
+            windowOwnerProcessIdentifierProvider: { windowID in
+                windowIdentity?.windowID == Int(windowID) ? windowIdentity?.ownerProcessIdentifier : nil
+            },
+            windowBoundsProvider: { windowID in
+                windowIdentity?.windowID == Int(windowID) ? windowIdentity?.capturedBounds : nil
+            },
+            maximizedVisibleWorkAreaProvider: { _ in nil },
+            processStartIdentityProvider: { pid in
+                windowIdentity?.ownerProcessIdentifier == pid ? windowIdentity?.ownerProcessStartIdentity : nil
+            },
+            processPresenceProvider: { pid in windowIdentity?.ownerProcessIdentifier == pid }
+        )
+        let host = PeekabooBridgeHost(
+            socketPath: socketPath,
+            server: server,
+            allowedTeamIDs: [],
+            requestTimeoutSec: 2
+        )
+        try await host.startChecked()
+        self.fixtureSockets.insert(socketPath)
+        return host
+    }
+}
+
+@MainActor
+final class OwnerPolicyFixtureServices: PeekabooBridgeServiceProviding, PeekabooServiceProviding {
+    let automation: any UIAutomationServiceProtocol = MockTargetedAutomationService()
+    let applications: any ApplicationServiceProtocol
+    let dialogs: any DialogServiceProtocol
+    let snapshots: any SnapshotManagerProtocol
+    let desktopObservation: any DesktopObservationServiceProtocol
+    let supportsDesktopObservationCaptureEngine = true
+    let supportsScreenCaptureKitProcessOwnership: Bool
+    let supportsClassicCaptureWithoutScreenCaptureKit: Bool
+    private let remoteClient: PeekabooBridgeClient?
+
+    init(
+        ownerAware: Bool,
+        observation: (any DesktopObservationServiceProtocol)? = nil,
+        snapshots: any SnapshotManagerProtocol = InMemorySnapshotManager(),
+        remoteClient: PeekabooBridgeClient? = nil
+    ) {
+        self.supportsScreenCaptureKitProcessOwnership = ownerAware
+        self.supportsClassicCaptureWithoutScreenCaptureKit = ownerAware
+        self.remoteClient = remoteClient
+        self.snapshots = snapshots
+        if let remoteClient {
+            self.desktopObservation = RemoteDesktopObservationService(
+                client: remoteClient, supportsDesktopObservationCaptureEngine: true
+            )
+        } else {
+            self.desktopObservation = observation ?? ClassicDispatchSentinelObservationService()
+        }
+        // Capability reads are inert; an unexpected operation has no ambient endpoint.
+        let client = PeekabooBridgeClient(socketPath: FileManager.default.temporaryDirectory
+            .appendingPathComponent("absent-\(UUID().uuidString).sock").path)
+        self.screenCapture = RemoteScreenCaptureService(client: client)
+        self.browser = RemoteBrowserMCPClient(client: client)
+        self.applications = RemoteApplicationService(
+            client: client,
+            supportsLaunchOptions: true,
+            supportsSafeBackgroundLaunchNoOp: true,
+            supportsPinnedActivation: true
+        )
+        self.dialogs = RemoteDialogService(client: client)
+    }
+
+    let permissions = PermissionsService(
+        dependencies: .init(
+            screenRecordingPreflight: { fatalError("No permission probe") },
+            screenRecordingRequest: { fatalError("No permission request") },
+            screenRecordingEvaluator: ScreenRecordingPermissionChecker(
+                preflight: { fatalError("No permission probe") },
+                coreGraphicsEvidence: { fatalError("No metadata probe") },
+                shareableContentProbe: { fatalError("No ScreenCaptureKit probe") }
+            ),
+            postEventPreflight: { fatalError("No permission probe") },
+            postEventRequest: { fatalError("No permission request") }
+        ),
+        loggingService: MockLoggingService()
+    )
+    let screenCapture: any ScreenCaptureServiceProtocol
+    let windows: any WindowManagementServiceProtocol = MockWindowService(result: [])
+    let menu: any MenuServiceProtocol = MockMenuService(barItems: [])
+    let dock: any DockServiceProtocol = MockDockService(items: [])
+
+    var configuration: PeekabooCore.ConfigurationManager {
+        fatalError("No ambient configuration")
+    }
+
+    var audioInput: AudioInputService {
+        fatalError("No provider initialization")
+    }
+
+    var logging: any LoggingServiceProtocol {
+        fatalError("No shared logging service")
+    }
+
+    var files: any FileServiceProtocol {
+        fatalError("No file service")
+    }
+
+    let clipboard: any ClipboardServiceProtocol = UnusedRoutingClipboard()
+    let screens: any ScreenServiceProtocol = EmptyRoutingScreens()
+    let browser: any BrowserMCPClientProviding
+
+    var agent: (any AgentServiceProtocol)? {
+        nil
+    }
+
+    func permissionsStatus() async throws -> PermissionsStatus {
+        guard let remoteClient else { fatalError("Inject fixture permission status") }
+        return try await remoteClient.permissionsStatus()
+    }
+
+    func ensureVisualizerConnection() {}
+}
+
+@MainActor
+final class ClassicDispatchSentinelObservationService: DesktopObservationServiceProtocol {
+    private let expectedTarget: DesktopObservationTargetRequest?
+
+    init(expectedTarget: DesktopObservationTargetRequest? = nil) {
+        self.expectedTarget = expectedTarget
+    }
+
+    func observe(_ request: DesktopObservationRequest) async throws -> DesktopObservationResult {
+        if let expectedTarget {
+            #expect(request.target == expectedTarget)
+            #expect(request.capture.engine == .legacy)
+        }
+        throw OperationError.captureFailed(reason: "classic request reached the remote observation service")
+    }
+}
+
+@MainActor
+private struct EmptyRoutingScreens: ScreenServiceProtocol {
+    func listScreens() -> [ScreenInfo] {
+        []
+    }
+
+    func screenContainingWindow(bounds: CGRect) -> ScreenInfo? {
+        nil
+    }
+
+    func screen(at index: Int) -> ScreenInfo? {
+        nil
+    }
+
+    var primaryScreen: ScreenInfo? {
+        nil
+    }
+}
+
+private struct UnusedRoutingClipboard: ClipboardServiceProtocol {
+    func get(prefer uti: UTType?) throws -> ClipboardReadResult? {
+        throw POSIXError(.ENOTSUP)
+    }
+
+    func set(_ request: ClipboardWriteRequest) throws -> ClipboardReadResult {
+        throw POSIXError(.ENOTSUP)
+    }
+
+    func clear() {
+        fatalError("No clipboard writes")
+    }
+
+    func save(slot: String) throws {
+        throw POSIXError(.ENOTSUP)
+    }
+
+    func restore(slot: String) throws -> ClipboardReadResult {
+        throw POSIXError(.ENOTSUP)
+    }
+}

--- a/Apps/CLI/Tests/CoreCLITests/ScreenCaptureKitOwnerRuntimeTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/ScreenCaptureKitOwnerRuntimeTests.swift
@@ -1,6 +1,7 @@
 import Commander
 import Darwin
 import Foundation
+import PeekabooAgentRuntime
 import PeekabooAutomation
 import PeekabooBridge
 import PeekabooBridgeTestSupport
@@ -29,10 +30,10 @@ struct ScreenCaptureKitOwnerRuntimeTests {
                 options: options,
                 environment: [:],
                 configurationInput: nil,
-                dependencies: .init(
+                dependencies: Self.inertDependencies(
                     makeLocalServices: { _ in
                         localFactoryCalls += 1
-                        return PeekabooServices()
+                        return OwnerPolicyFixtureServices(ownerAware: true)
                     },
                     claimScreenCaptureKitOwner: {
                         claimCalls += 1
@@ -74,10 +75,10 @@ struct ScreenCaptureKitOwnerRuntimeTests {
             options: options,
             environment: [:],
             configurationInput: nil,
-            dependencies: .init(
+            dependencies: Self.inertDependencies(
                 makeLocalServices: { _ in
                     localFactoryCalls += 1
-                    return PeekabooServices()
+                    return OwnerPolicyFixtureServices(ownerAware: true)
                 },
                 claimScreenCaptureKitOwner: {
                     claimCalls += 1
@@ -117,10 +118,10 @@ struct ScreenCaptureKitOwnerRuntimeTests {
             options: options,
             environment: [:],
             configurationInput: nil,
-            dependencies: .init(
+            dependencies: Self.inertDependencies(
                 makeLocalServices: { _ in
                     localFactoryCalls += 1
-                    return PeekabooServices()
+                    return OwnerPolicyFixtureServices(ownerAware: true)
                 },
                 claimScreenCaptureKitOwner: {
                     claimCalls += 1
@@ -155,7 +156,7 @@ struct ScreenCaptureKitOwnerRuntimeTests {
     func `caller-local explicit snapshot scroll skips capture ownership and old-host discovery`() async throws {
         let snapshots = InMemorySnapshotManager()
         let snapshotID = try await snapshots.createSnapshot()
-        let localServices = PeekabooServices(snapshotManager: snapshots)
+        let localServices = OwnerPolicyFixtureServices(ownerAware: true, snapshots: snapshots)
         var options = try CommanderCLIBinder.makeRuntimeOptions(
             from: ParsedValues(
                 positional: [],
@@ -175,7 +176,7 @@ struct ScreenCaptureKitOwnerRuntimeTests {
             options: options,
             environment: [:],
             configurationInput: nil,
-            dependencies: .init(
+            dependencies: Self.inertDependencies(
                 makeLocalServices: { _ in
                     localFactoryCalls += 1
                     return localServices
@@ -212,7 +213,7 @@ struct ScreenCaptureKitOwnerRuntimeTests {
         engine: String
     ) async {
         let owner = Self.ownerReceipt()
-        let missingSocket = "/tmp/peekaboo-unmatched-owner-\(UUID().uuidString).sock"
+        let missingSocket = Self.fixtureSocketPath()
         let options = Self.captureOptions(engine: engine)
         var claimCalls = 0
         var inspectCalls = 0
@@ -223,10 +224,10 @@ struct ScreenCaptureKitOwnerRuntimeTests {
                 options: options,
                 environment: ["PEEKABOO_DAEMON_SOCKET": missingSocket],
                 configurationInput: nil,
-                dependencies: .init(
+                dependencies: Self.inertDependencies(
                     makeLocalServices: { _ in
                         localFactoryCalls += 1
-                        return PeekabooServices()
+                        return OwnerPolicyFixtureServices(ownerAware: true)
                     },
                     claimScreenCaptureKitOwner: {
                         claimCalls += 1
@@ -253,7 +254,7 @@ struct ScreenCaptureKitOwnerRuntimeTests {
     func `explicit transported capture refuses an owner-unaware host before capture or local fallback`(
         engine: String
     ) async throws {
-        let explicitSocket = "/tmp/peekaboo-owner-unaware-\(UUID().uuidString).sock"
+        let explicitSocket = Self.fixtureSocketPath()
         let oldHost = try await Self.startHost(
             socketPath: explicitSocket,
             processIdentifier: 3131,
@@ -274,10 +275,10 @@ struct ScreenCaptureKitOwnerRuntimeTests {
                 options: options,
                 environment: [:],
                 configurationInput: nil,
-                dependencies: .init(
+                dependencies: Self.inertDependencies(
                     makeLocalServices: { _ in
                         localFactoryCalls += 1
-                        return PeekabooServices()
+                        return OwnerPolicyFixtureServices(ownerAware: true)
                     },
                     claimScreenCaptureKitOwner: { Self.ownerReceipt() },
                     inspectScreenCaptureKitOwner: {
@@ -307,8 +308,8 @@ struct ScreenCaptureKitOwnerRuntimeTests {
         #expect(error?.localizedDescription.contains("build 4.0.0 (4000099)") == true)
         #expect(error?.localizedDescription.contains(explicitSocket) == true)
         #expect(error?.localizedDescription.contains("Selected socket: \(explicitSocket)") == true)
-        #expect(error?.hint?.contains("revalidate and stop exactly PID 3131, generation 4141") == true)
-        #expect(error?.hint?.contains("never use the socket path alone") == true)
+        #expect(error?.hint?.contains("Classic capture on this unproven") == true)
+        #expect(error?.localizedDescription.contains("support cannot be proven") == true)
         #expect(inspectCalls == 0)
         #expect(recordedBlockers == [RuntimeHostResolver.ScreenCaptureKitOwnerUnawareHost(
             socketPath: explicitSocket,
@@ -322,7 +323,7 @@ struct ScreenCaptureKitOwnerRuntimeTests {
 
     @Test
     func `automatic capture routes to an owner-aware host around an auxiliary legacy SCK blocker`() async throws {
-        let selectedSocket = "/tmp/peekaboo-auto-classic-first-\(UUID().uuidString).sock"
+        let selectedSocket = Self.fixtureSocketPath()
         let ownerAwareHost = try await Self.startHost(
             socketPath: selectedSocket,
             processIdentifier: 3131,
@@ -347,10 +348,10 @@ struct ScreenCaptureKitOwnerRuntimeTests {
             options: options,
             environment: [:],
             configurationInput: nil,
-            dependencies: .init(
+            dependencies: Self.inertDependencies(
                 makeLocalServices: { _ in
                     localFactoryCalls += 1
-                    return PeekabooServices()
+                    return OwnerPolicyFixtureServices(ownerAware: true)
                 },
                 claimScreenCaptureKitOwner: { Self.ownerReceipt() },
                 inspectScreenCaptureKitOwner: { nil },
@@ -368,7 +369,7 @@ struct ScreenCaptureKitOwnerRuntimeTests {
 
     @Test
     func `explicit modern capture still refuses an auxiliary legacy SCK blocker`() async throws {
-        let selectedSocket = "/tmp/peekaboo-modern-auxiliary-blocker-\(UUID().uuidString).sock"
+        let selectedSocket = Self.fixtureSocketPath()
         let ownerAwareHost = try await Self.startHost(
             socketPath: selectedSocket,
             processIdentifier: 3131,
@@ -394,10 +395,10 @@ struct ScreenCaptureKitOwnerRuntimeTests {
                 options: options,
                 environment: [:],
                 configurationInput: nil,
-                dependencies: .init(
+                dependencies: Self.inertDependencies(
                     makeLocalServices: { _ in
                         localFactoryCalls += 1
-                        return PeekabooServices()
+                        return OwnerPolicyFixtureServices(ownerAware: true)
                     },
                     claimScreenCaptureKitOwner: { Self.ownerReceipt() },
                     inspectScreenCaptureKitOwner: { nil },
@@ -434,10 +435,10 @@ struct ScreenCaptureKitOwnerRuntimeTests {
         #expect(error.localizedDescription.contains("build 4.0.0 (4000099)") == true)
         #expect(error.localizedDescription.contains("owner socket \(ownerSocket)") == true)
         #expect(error.localizedDescription.contains("Selected socket: \(selectedSocket)") == true)
-        #expect(error.hint?.contains("stop exactly PID 3131, generation 4141") == true)
-        #expect(error.hint?.contains("never use the socket path alone") == true)
-        #expect(error.hint?.contains("peekaboo see --capture-engine classic") == true)
-        #expect(error.hint?.contains("retry with its --snapshot") == true)
+        #expect(error.hint?.contains("Classic capture on this unproven") == true)
+        #expect(error.localizedDescription.contains("support cannot be proven") == true)
+        #expect(error.hint?.contains("peekaboo see --capture-engine classic") == false)
+        #expect(error.hint?.contains("retry with its --snapshot") == false)
         #expect(error.hint?.contains("explicitly choose --capture-engine classic") == false)
     }
 
@@ -456,12 +457,12 @@ struct ScreenCaptureKitOwnerRuntimeTests {
             selectedSocket: selectedSocket
         )
 
-        #expect(error.localizedDescription.contains("exact PID and process-start identity are unavailable") == true)
+        #expect(error.failure.screenCaptureKitOwnershipDiagnostic?.blockers.first?.processIdentifier == nil)
         #expect(error.localizedDescription.contains("owner socket \(ownerSocket)") == true)
         #expect(error.localizedDescription.contains("Selected socket: \(selectedSocket)") == true)
         #expect(!error.localizedDescription.contains(hostileBuild))
         #expect(!error.localizedDescription.contains("/private/user"))
-        #expect(error.hint?.contains("Do not stop any process") == true)
+        #expect(error.hint?.contains("Use a host that proves") == true)
         #expect(error.hint?.contains("stop exactly") == false)
     }
 
@@ -477,10 +478,10 @@ struct ScreenCaptureKitOwnerRuntimeTests {
             selectedSocket: nil
         )
 
-        #expect(error.localizedDescription.contains("PID 3131, build 4.0.0") == true)
-        #expect(error.localizedDescription.contains("exact process-start identity is unavailable") == true)
+        #expect(error.localizedDescription.contains("PID 3131") == true)
+        #expect(error.failure.screenCaptureKitOwnershipDiagnostic?.blockers.first?.processStartIdentity == nil)
         #expect(error.localizedDescription.contains("Selected socket: automatic resolution") == true)
-        #expect(error.hint?.contains("Do not stop any process") == true)
+        #expect(error.hint?.contains("Use a host that proves") == true)
     }
 
     @Test
@@ -499,13 +500,13 @@ struct ScreenCaptureKitOwnerRuntimeTests {
 
         #expect(error.localizedDescription.contains("PID 3131, generation 4141") == true)
         #expect(error.localizedDescription.contains("build 4.0.0 (4000099)") == true)
-        #expect(error.localizedDescription.contains("owner socket /tmp/deferred-owner.sock") == true)
+        #expect(error.localizedDescription.contains("/tmp/deferred-owner.sock") == true)
         #expect(error.localizedDescription.contains("Selected socket: /tmp/selected-current.sock") == true)
     }
 
     @Test
-    func `classic false-permission host remains executable after request-aware selection`() async throws {
-        let socketPath = "/tmp/peekaboo-classic-deferral-\(UUID().uuidString).sock"
+    func `blocked current host admits classic exact-window dispatch despite false permission preflight`() async throws {
+        let socketPath = Self.fixtureSocketPath()
         let coordinationRoot = URL(fileURLWithPath: socketPath).appendingPathExtension("coordination")
         defer { try? FileManager.default.removeItem(at: coordinationRoot) }
         let host = try await Self.startHost(
@@ -516,9 +517,20 @@ struct ScreenCaptureKitOwnerRuntimeTests {
             screenRecording: false,
             serviceOverride: OwnerPolicyFixtureServices(
                 ownerAware: true,
-                observation: ClassicDispatchSentinelObservationService()
+                observation: ClassicDispatchSentinelObservationService(expectedTarget: .windowID(77))
             ),
-            coordinationRootURL: coordinationRoot
+            coordinationRootURL: coordinationRoot,
+            windowIdentity: WindowMutationIdentity(
+                windowID: 77,
+                ownerProcessIdentifier: 3030,
+                ownerProcessStartIdentity: 4040,
+                capturedBounds: CGRect(x: 10, y: 20, width: 100, height: 80)
+            ),
+            screenCaptureKitOwnershipPreparer: {
+                throw ScreenCaptureKitOwnerLease.LeaseError.uncoordinatedProcesses([
+                    .init(processIdentifier: 4242, processStartIdentity: 9001, executablePath: "/synthetic/Blocker")
+                ])
+            }
         )
         defer { Task { await host.stop() } }
         var permissionRejections: [String] = []
@@ -538,19 +550,22 @@ struct ScreenCaptureKitOwnerRuntimeTests {
             ),
             options: Self.captureOptions(engine: "classic"),
             snapshotInvalidationRemoteSocketPaths: [],
-            permissionRejections: &permissionRejections
+            permissionRejections: &permissionRejections,
+            makeRemoteServices: Self.makeInertRemoteServices,
+            handshakeCache: Self.inertHandshakeCache()
         )
         let resolution = try #require(resolved)
+        #expect(resolution.selectedRemoteSocketPath == socketPath)
 
         let error = await #expect(throws: PeekabooBridgeErrorEnvelope.self) {
             _ = try await resolution.services.desktopObservation.observe(DesktopObservationRequest(
-                target: .screen(index: 0),
+                target: .windowID(77),
                 capture: DesktopCaptureOptions(engine: .legacy),
                 detection: DesktopDetectionOptions(mode: .none)
             ))
         }
 
-        #expect(error?.standardizedErrorCode == .captureFailed)
+        #expect(error?.standardizedErrorCode == .captureFailed, "\(String(describing: error))")
         #expect(error?.message.contains("classic request reached the remote observation service") == true)
         #expect(permissionRejections.isEmpty)
         await host.stop()
@@ -558,7 +573,7 @@ struct ScreenCaptureKitOwnerRuntimeTests {
 
     @Test
     func `dynamic remote projection evaluates each request engine from raw host capabilities`() async throws {
-        let socketPath = "/tmp/peekaboo-dynamic-classic-deferral-\(UUID().uuidString).sock"
+        let socketPath = Self.fixtureSocketPath()
         let coordinationRoot = URL(fileURLWithPath: socketPath).appendingPathExtension("coordination")
         defer { try? FileManager.default.removeItem(at: coordinationRoot) }
         let host = try await Self.startHost(
@@ -595,7 +610,9 @@ struct ScreenCaptureKitOwnerRuntimeTests {
             identity: identity,
             options: options,
             snapshotInvalidationRemoteSocketPaths: [],
-            permissionRejections: &permissionRejections
+            permissionRejections: &permissionRejections,
+            makeRemoteServices: Self.makeInertRemoteServices,
+            handshakeCache: Self.inertHandshakeCache()
         )
         let resolution = try #require(resolved)
 
@@ -615,7 +632,7 @@ struct ScreenCaptureKitOwnerRuntimeTests {
 
     @Test
     func `explicit remote modern refuses a nonowner socket without rerouting or local fallback`() async throws {
-        let explicitSocket = "/tmp/peekaboo-explicit-nonowner-\(UUID().uuidString).sock"
+        let explicitSocket = Self.fixtureSocketPath()
         let nonownerHost = try await Self.startHost(
             socketPath: explicitSocket,
             processIdentifier: 1111,
@@ -635,10 +652,10 @@ struct ScreenCaptureKitOwnerRuntimeTests {
                 options: options,
                 environment: [:],
                 configurationInput: nil,
-                dependencies: .init(
+                dependencies: Self.inertDependencies(
                     makeLocalServices: { _ in
                         localFactoryCalls += 1
-                        return PeekabooServices()
+                        return OwnerPolicyFixtureServices(ownerAware: true)
                     },
                     claimScreenCaptureKitOwner: {
                         claimCalls += 1
@@ -666,7 +683,7 @@ struct ScreenCaptureKitOwnerRuntimeTests {
 
     @Test
     func `explicit remote modern accepts the exact owner socket without rerouting`() async throws {
-        let explicitSocket = "/tmp/peekaboo-explicit-owner-\(UUID().uuidString).sock"
+        let explicitSocket = Self.fixtureSocketPath()
         let ownerHost = try await Self.startHost(
             socketPath: explicitSocket,
             processIdentifier: 4242,
@@ -684,10 +701,10 @@ struct ScreenCaptureKitOwnerRuntimeTests {
             options: options,
             environment: [:],
             configurationInput: nil,
-            dependencies: .init(
+            dependencies: Self.inertDependencies(
                 makeLocalServices: { _ in
                     localFactoryCalls += 1
-                    return PeekabooServices()
+                    return OwnerPolicyFixtureServices(ownerAware: true)
                 },
                 claimScreenCaptureKitOwner: { Self.ownerReceipt() },
                 inspectScreenCaptureKitOwner: {
@@ -705,7 +722,7 @@ struct ScreenCaptureKitOwnerRuntimeTests {
 
     @Test(arguments: ["auto", "classic"])
     func `local-default dynamic tools follow an explicit owner Bridge`(startupEngine: String) async throws {
-        let ownerSocket = "/tmp/peekaboo-dynamic-owner-\(UUID().uuidString).sock"
+        let ownerSocket = Self.fixtureSocketPath()
         let ownerHost = try await Self.startHost(
             socketPath: ownerSocket,
             processIdentifier: 4242,
@@ -725,10 +742,10 @@ struct ScreenCaptureKitOwnerRuntimeTests {
             options: options,
             environment: [:],
             configurationInput: nil,
-            dependencies: .init(
+            dependencies: Self.inertDependencies(
                 makeLocalServices: { _ in
                     localFactoryCalls += 1
-                    return PeekabooServices()
+                    return OwnerPolicyFixtureServices(ownerAware: true)
                 },
                 claimScreenCaptureKitOwner: { Self.ownerReceipt() },
                 inspectScreenCaptureKitOwner: { Self.ownerReceipt() }
@@ -742,7 +759,7 @@ struct ScreenCaptureKitOwnerRuntimeTests {
 
     @Test
     func `stateful dynamic tools follow an implicit owner outside the build-scoped daemon`() async throws {
-        let ownerSocket = "/tmp/peekaboo-dynamic-implicit-owner-\(UUID().uuidString).sock"
+        let ownerSocket = Self.fixtureSocketPath()
         let ownerHost = try await Self.startHost(
             socketPath: ownerSocket,
             processIdentifier: 4242,
@@ -760,10 +777,10 @@ struct ScreenCaptureKitOwnerRuntimeTests {
             options: options,
             environment: [:],
             configurationInput: nil,
-            dependencies: .init(
+            dependencies: Self.inertDependencies(
                 makeLocalServices: { _ in
                     localFactoryCalls += 1
-                    return PeekabooServices()
+                    return OwnerPolicyFixtureServices(ownerAware: true)
                 },
                 claimScreenCaptureKitOwner: { Self.ownerReceipt() },
                 inspectScreenCaptureKitOwner: { Self.ownerReceipt() },
@@ -815,10 +832,10 @@ extension ScreenCaptureKitOwnerRuntimeTests {
             options: options,
             environment: [:],
             configurationInput: nil,
-            dependencies: .init(
+            dependencies: Self.inertDependencies(
                 makeLocalServices: { _ in
                     localFactoryCalls += 1
-                    return PeekabooServices()
+                    return OwnerPolicyFixtureServices(ownerAware: true)
                 },
                 claimScreenCaptureKitOwner: {
                     claimCalls += 1
@@ -858,7 +875,7 @@ extension ScreenCaptureKitOwnerRuntimeTests {
 
     @Test(arguments: ["modern", "classic", "auto"])
     func `remote capture engines never preclaim in the caller`(engine: String) async throws {
-        let missingSocket = "/tmp/peekaboo-owner-runtime-\(UUID().uuidString).sock"
+        let missingSocket = Self.fixtureSocketPath()
         var options = Self.captureOptions(engine: engine)
         options.bridgeSocketPath = missingSocket
         options.autoStartDaemon = false
@@ -870,10 +887,10 @@ extension ScreenCaptureKitOwnerRuntimeTests {
             options: options,
             environment: [:],
             configurationInput: nil,
-            dependencies: .init(
+            dependencies: Self.inertDependencies(
                 makeLocalServices: { _ in
                     localFactoryCalls += 1
-                    return PeekabooServices()
+                    return OwnerPolicyFixtureServices(ownerAware: true)
                 },
                 claimScreenCaptureKitOwner: {
                     claimCalls += 1
@@ -1277,6 +1294,7 @@ extension ScreenCaptureKitOwnerRuntimeTests {
                 options: Self.captureOptions(engine: "auto"),
                 snapshotInvalidationRemoteSocketPaths: [],
                 permissionRejections: &permissionRejections,
+                makeRemoteServices: Self.makeInertRemoteServices,
                 handshake: { _, _ in
                     try? await Task.sleep(for: .milliseconds(20))
                     return Self.handshake(
@@ -1312,7 +1330,9 @@ extension ScreenCaptureKitOwnerRuntimeTests {
                 identity: identity,
                 options: Self.captureOptions(engine: "auto"),
                 snapshotInvalidationRemoteSocketPaths: [],
-                permissionRejections: &permissionRejections
+                permissionRejections: &permissionRejections,
+                makeRemoteServices: Self.makeInertRemoteServices,
+                handshakeCache: Self.inertHandshakeCache()
             )
         }
         while resumeResolution == nil {
@@ -1328,8 +1348,8 @@ extension ScreenCaptureKitOwnerRuntimeTests {
 
     @Test
     func `remote resolution prefers the exact live owner over an earlier capable host`() async throws {
-        let firstSocket = "/tmp/peekaboo-nonowner-\(UUID().uuidString).sock"
-        let ownerSocket = "/tmp/peekaboo-owner-\(UUID().uuidString).sock"
+        let firstSocket = Self.fixtureSocketPath()
+        let ownerSocket = Self.fixtureSocketPath()
         let firstHost = try await Self.startHost(
             socketPath: firstSocket,
             processIdentifier: 1111,
@@ -1373,7 +1393,9 @@ extension ScreenCaptureKitOwnerRuntimeTests {
             options: Self.captureOptions(engine: "modern"),
             requiredOwner: Self.ownerReceipt(),
             snapshotInvalidationRemoteSocketPaths: [],
-            permissionRejections: &permissionRejections
+            permissionRejections: &permissionRejections,
+            makeRemoteServices: Self.makeInertRemoteServices,
+            handshakeCache: Self.inertHandshakeCache()
         )
 
         #expect(resolution?.selectedRemoteSocketPath == ownerSocket)
@@ -1435,176 +1457,5 @@ extension ScreenCaptureKitOwnerRuntimeTests {
             ),
             hostCapabilities: hostCapabilities
         )
-    }
-
-    static func startHost(
-        socketPath: String,
-        processIdentifier: pid_t,
-        processStartIdentity: UInt64,
-        codeSignatureHash: String,
-        ownerAware: Bool = true,
-        screenRecording: Bool = true,
-        maximumProtocolVersion: PeekabooBridgeProtocolVersion =
-            PeekabooBridgeConstants.exactForcedDialogDismissExecutionVersion,
-        usesCurrentHostIdentity: Bool = false,
-        serviceOverride: (any PeekabooBridgeServiceProviding)? = nil,
-        coordinationRootURL: URL = FileManager.default.temporaryDirectory
-            .appendingPathComponent("peekaboo-owner-lane-\(UUID().uuidString)", isDirectory: true),
-        screenCaptureKitProcessCapabilityRegistrar: @MainActor @Sendable () throws -> Void = {},
-        screenCaptureKitOwnershipPreparer: @escaping @Sendable () async throws -> Void = {},
-        permissionEvaluationObserver: @escaping @MainActor @Sendable () -> Void = {}
-    ) async throws -> PeekabooBridgeHost {
-        let services: any PeekabooBridgeServiceProviding = if let serviceOverride {
-            serviceOverride
-        } else if ownerAware {
-            PeekabooServices()
-        } else {
-            OwnerPolicyFixtureServices(ownerAware: false)
-        }
-        let server = PeekabooBridgeServer(
-            services: services,
-            hostKind: .onDemand,
-            allowlistedTeams: [],
-            allowlistedBundles: [],
-            supportedVersions: ClosedRange(uncheckedBounds: (
-                lower: PeekabooBridgeConstants.supportedProtocolRange.lowerBound,
-                upper: maximumProtocolVersion
-            )),
-            allowedOperations: [
-                .permissionsStatus,
-                .captureScreen,
-                .desktopObservation,
-                .invalidateImplicitLatestSnapshot,
-                .launchApplicationWithOptions,
-                .findApplication,
-                .activateApplication,
-                .targetedHotkey,
-                .targetedTypeActions,
-                .targetedClick,
-                .ownsSnapshot,
-                .targetedDialogListElements,
-                .prepareDialogAction,
-                .exactDialogClickButton,
-                .exactDialogDismiss,
-            ],
-            hostIdentity: usesCurrentHostIdentity
-                ? .current()
-                : PeekabooBridgeHostIdentity(
-                    processIdentifier: processIdentifier,
-                    processStartIdentity: processStartIdentity,
-                    bundleIdentifier: "boo.peekaboo.test.host",
-                    bundleShortVersion: nil,
-                    bundleVersion: nil,
-                    codeSignatureHash: codeSignatureHash
-                ),
-            // Synthetic startup and dispatch must not use user-wide ownership or desktop coordination state.
-            desktopOperationLaneCoordinator: DesktopOperationLaneCoordinator(coordinationRootURL: coordinationRootURL),
-            screenCaptureKitProcessCapabilityRegistrar: screenCaptureKitProcessCapabilityRegistrar,
-            screenCaptureKitOwnershipPreparer: screenCaptureKitOwnershipPreparer,
-            permissionStatusEvaluator: { _ in
-                permissionEvaluationObserver()
-                return PermissionsStatus(
-                    screenRecording: screenRecording,
-                    accessibility: true,
-                    appleScript: false,
-                    postEvent: true
-                )
-            }
-        )
-        let host = PeekabooBridgeHost(
-            socketPath: socketPath,
-            server: server,
-            allowedTeamIDs: [],
-            requestTimeoutSec: 2
-        )
-        try await host.startChecked()
-        return host
-    }
-}
-
-@MainActor
-private final class OwnerPolicyFixtureServices: PeekabooBridgeServiceProviding {
-    private let base = PeekabooServices()
-    private let ownerAware: Bool
-    private let observation: (any DesktopObservationServiceProtocol)?
-
-    init(
-        ownerAware: Bool,
-        observation: (any DesktopObservationServiceProtocol)? = nil
-    ) {
-        self.ownerAware = ownerAware
-        self.observation = observation
-    }
-
-    var permissions: PermissionsService {
-        self.base.permissions
-    }
-
-    var screenCapture: any ScreenCaptureServiceProtocol {
-        self.base.screenCapture
-    }
-
-    var automation: any UIAutomationServiceProtocol {
-        self.base.automation
-    }
-
-    var windows: any WindowManagementServiceProtocol {
-        self.base.windows
-    }
-
-    var applications: any ApplicationServiceProtocol {
-        self.base.applications
-    }
-
-    var menu: any MenuServiceProtocol {
-        self.base.menu
-    }
-
-    var dock: any DockServiceProtocol {
-        self.base.dock
-    }
-
-    var dialogs: any DialogServiceProtocol {
-        self.base.dialogs
-    }
-
-    var snapshots: any SnapshotManagerProtocol {
-        self.base.snapshots
-    }
-
-    var desktopObservation: any DesktopObservationServiceProtocol {
-        self.observation ?? self.base.desktopObservation
-    }
-
-    var supportsDesktopObservationCaptureEngine: Bool {
-        true
-    }
-
-    var supportsScreenCaptureKitProcessOwnership: Bool {
-        self.ownerAware
-    }
-
-    func browserStatus(channel: String?) async throws -> PeekabooBridgeBrowserStatus {
-        try await self.base.browserStatus(channel: channel)
-    }
-
-    func browserConnect(channel: String?) async throws -> PeekabooBridgeBrowserStatus {
-        try await self.base.browserConnect(channel: channel)
-    }
-
-    func browserDisconnect() async throws {
-        try await self.base.browserDisconnect()
-    }
-
-    func browserExecute(_ request: PeekabooBridgeBrowserExecuteRequest) async throws
-    -> PeekabooBridgeBrowserToolResponse {
-        try await self.base.browserExecute(request)
-    }
-}
-
-@MainActor
-private final class ClassicDispatchSentinelObservationService: DesktopObservationServiceProtocol {
-    func observe(_ request: DesktopObservationRequest) async throws -> DesktopObservationResult {
-        throw OperationError.captureFailed(reason: "classic request reached the remote observation service")
     }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+- Preserve current GUI capture support and typed ScreenCaptureKit blockers when preparation fails, allowing explicit classic capture on the same proven host without changing auto or modern engines, with negotiated typed errors that preserve older clients' signed receipts.
+
 ## [4.3.0] - 2026-09-02
 
 ### Highlights

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/ScreenCaptureKitCaptureGate.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/ScreenCaptureKitCaptureGate.swift
@@ -12,10 +12,20 @@ enum ScreenCaptureKitCaptureGate {
     @TaskLocal static var processOwnerClaimOverride:
         (@MainActor @Sendable () throws -> ScreenCaptureKitOwnerLease.OwnerReceipt)?
     @TaskLocal static var postCaptureSettleOverride: (@MainActor @Sendable () async -> Void)?
+    @TaskLocal static var coordinationOverride: Coordination?
     private static let processOwnerLease = Result { try ScreenCaptureKitOwnerLease() }
-    @MainActor private static let captureCoordinator = ScreenCaptureKitOperationCoordinator(
+    @MainActor private static let liveCaptureCoordinator = ScreenCaptureKitOperationCoordinator(
         lockFilePath: (NSTemporaryDirectory() as NSString)
             .appendingPathComponent("boo.peekaboo.sckit-capture.lock"))
+
+    struct Coordination: Sendable {
+        let operationLockPath: String
+        let coordinator: ScreenCaptureKitOperationCoordinator
+    }
+
+    @MainActor private static var captureCoordinator: ScreenCaptureKitOperationCoordinator {
+        self.coordinationOverride?.coordinator ?? self.liveCaptureCoordinator
+    }
 
     @discardableResult
     @MainActor
@@ -27,12 +37,8 @@ enum ScreenCaptureKitCaptureGate {
                 return try processOwnerClaimOverride()
             }
             return try self.processOwnerLease.get().claim().receipt
-        } catch let error as ScreenCaptureKitOwnerLease.LeaseError {
-            throw self.captureError(for: error, operationName: operationName)
         } catch {
-            throw OperationError.captureFailed(
-                reason: "ScreenCaptureKit owner setup failed before \(operationName): " +
-                    "\(error.localizedDescription). No ScreenCaptureKit operation was dispatched.")
+            throw ScreenCaptureKitOwnershipDiagnostic.capturing(error, stage: .entry, operation: operationName)
         }
     }
 
@@ -115,7 +121,7 @@ enum ScreenCaptureKitCaptureGate {
     }
 
     static func openExclusiveOperationLockDescriptor() -> Int32 {
-        let path = (NSTemporaryDirectory() as NSString)
+        let path = self.coordinationOverride?.operationLockPath ?? (NSTemporaryDirectory() as NSString)
             .appendingPathComponent("boo.peekaboo.sckit-operation.lock")
         // Agent actions can spawn long-lived children while this lock is held. Set close-on-exec atomically so an
         // abrupt owner exit cannot leave its capture transaction pinned by an inherited child descriptor.
@@ -176,22 +182,6 @@ enum ScreenCaptureKitCaptureGate {
                 excludingDesktopWindows,
                 onScreenWindowsOnly: onScreenWindowsOnly)
         }
-    }
-
-    private static func captureError(
-        for error: ScreenCaptureKitOwnerLease.LeaseError,
-        operationName: String) -> PeekabooError
-    {
-        if case let .ownedByAnotherProcess(_, receipt) = error {
-            return OperationError.captureFailed(
-                reason: "ScreenCaptureKit is already owned by another Peekaboo process " +
-                    "(PID \(receipt.processIdentifier), generation \(receipt.processStartIdentity)). " +
-                    "Use the active Bridge host, verify and stop that exact owner before retrying, " +
-                    "or explicitly choose the classic capture engine. No ScreenCaptureKit operation was dispatched.")
-        }
-        return OperationError.captureFailed(
-            reason: "ScreenCaptureKit owner validation failed before \(operationName): " +
-                "\(error.localizedDescription). No ScreenCaptureKit operation was dispatched.")
     }
 }
 

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/ScreenCaptureKitOwnerLease.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/ScreenCaptureKitOwnerLease.swift
@@ -163,11 +163,11 @@ public final class ScreenCaptureKitOwnerLease: Sendable {
                 "ScreenCaptureKit is already owned by PID \(receipt.processIdentifier) " +
                     "(generation \(receipt.processStartIdentity)) via \(path)"
             case let .uncoordinatedProcesses(processes):
-                "Live pre-lease Peekaboo processes may already own ScreenCaptureKit: " + processes.map {
+                "ScreenCaptureKit coordination cannot be proven for potential host processes: " + processes.map {
                     "PID \($0.processIdentifier) (generation \($0.processStartIdentity))"
                 }.joined(separator: ", ")
             case let .uncoordinatedHosts(hosts):
-                "Live pre-lease Bridge hosts may already own ScreenCaptureKit: " + hosts.map {
+                "ScreenCaptureKit coordination cannot be proven for Bridge hosts: " + hosts.map {
                     if let processIdentifier = $0.processIdentifier,
                        let processStartIdentity = $0.processStartIdentity
                     {
@@ -177,9 +177,7 @@ public final class ScreenCaptureKitOwnerLease: Sendable {
                         return "\($0.socketPath) (PID \(processIdentifier))"
                     }
                     return $0.socketPath
-                }.joined(separator: ", ") +
-                    ". Update or relaunch those hosts, then restart this process before retrying SCK. " +
-                    "Do not stop a process unless its exact PID and process generation are known and revalidated"
+                }.joined(separator: ", ")
             case let .preparationTimedOut(seconds):
                 "ScreenCaptureKit owner preparation timed out after \(seconds) seconds"
             }

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/ScreenCaptureKitOwnershipDiagnostic+Lease.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/ScreenCaptureKitOwnershipDiagnostic+Lease.swift
@@ -1,0 +1,94 @@
+import Foundation
+import PeekabooFoundation
+
+extension ScreenCaptureKitOwnershipDiagnostic {
+    public static func capturing(
+        _ error: any Error,
+        stage: Stage,
+        operation: String? = nil) -> Self
+    {
+        if let diagnostic = error as? Self {
+            return diagnostic
+        }
+        guard let lease = error as? ScreenCaptureKitOwnerLease.LeaseError else {
+            return Self(
+                kind: error is CancellationError ? .cancelled : .unknown,
+                stage: stage,
+                message: error.localizedDescription,
+                operation: operation)
+        }
+        var kind: Kind
+        var path: String?
+        var systemCode: Int32?
+        var timeout: TimeInterval?
+        var blockers: [ProcessEvidence] = []
+        var failedOperation = operation
+        switch lease {
+        case let .fileSystem(leaseOperation, leasePath, _):
+            kind = .fileSystem
+            failedOperation = leaseOperation
+            path = leasePath
+        case let .systemCall(leaseOperation, leasePath, code):
+            kind = .systemCall
+            failedOperation = leaseOperation
+            path = leasePath
+            systemCode = code
+        case let .unsafeDirectory(leasePath):
+            kind = .unsafeDirectory
+            path = leasePath
+        case let .unsafeLockFile(leasePath):
+            kind = .unsafeLockFile
+            path = leasePath
+        case .invalidOwnerIdentity:
+            kind = .invalidOwnerIdentity
+        case let .invalidOwnerReceipt(leasePath, _):
+            kind = .invalidOwnerReceipt
+            path = leasePath
+        case let .ownedByAnotherProcess(leasePath, receipt):
+            kind = .ownedByAnotherProcess
+            path = leasePath
+            blockers = [.init(
+                processIdentifier: receipt.processIdentifier,
+                processStartIdentity: receipt.processStartIdentity,
+                buildIdentity: receipt.buildIdentity,
+                codeSignatureHash: receipt.codeSignatureHash)]
+        case let .uncoordinatedProcesses(processes):
+            kind = .uncoordinatedProcesses
+            blockers = processes.map {
+                .init(
+                    processIdentifier: $0.processIdentifier,
+                    processStartIdentity: $0.processStartIdentity,
+                    executablePath: $0.executablePath)
+            }
+        case let .uncoordinatedHosts(hosts):
+            kind = .uncoordinatedHosts
+            blockers = hosts.map {
+                .init(
+                    processIdentifier: $0.processIdentifier,
+                    processStartIdentity: $0.processStartIdentity,
+                    socketPath: $0.socketPath,
+                    buildIdentity: $0.buildIdentity)
+            }
+        case let .preparationTimedOut(seconds):
+            kind = .timedOut
+            timeout = seconds
+        }
+        return Self(
+            kind: kind,
+            stage: stage,
+            message: lease.localizedDescription,
+            operation: failedOperation,
+            path: path,
+            systemCode: systemCode,
+            timeoutSeconds: timeout,
+            blockers: blockers)
+    }
+}
+
+extension ScreenCaptureKitReadiness {
+    public static func failed(_ error: any Error, stage: ScreenCaptureKitOwnershipDiagnostic.Stage) -> Self {
+        let failure = ScreenCaptureKitOwnershipDiagnostic.capturing(error, stage: stage)
+        let blocked = [.ownedByAnotherProcess, .uncoordinatedProcesses, .uncoordinatedHosts].contains(failure.kind)
+        return Self(state: blocked ? .blocked : .unavailable, failure: failure)
+    }
+}

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/ScreenCaptureKitProcessCapabilityRegistry.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/ScreenCaptureKitProcessCapabilityRegistry.swift
@@ -61,8 +61,11 @@ enum ScreenCaptureKitProcessCapabilityRegistry {
         let codeSignatureHash: String?
     }
 
-    static func register(ownerIdentity: Lease.OwnerIdentity) throws {
-        let signatureIdentity = self.currentCodeSignatureIdentity()
+    static func register(
+        ownerIdentity: Lease.OwnerIdentity,
+        directory: URL = directoryURL,
+        signatureIdentity: CodeSignatureIdentity? = currentCodeSignatureIdentity()) throws
+    {
         let receipt = ProcessCapabilityReceipt(
             processIdentifier: ownerIdentity.processIdentifier,
             processStartIdentity: ownerIdentity.processStartIdentity,
@@ -72,7 +75,8 @@ enum ScreenCaptureKitProcessCapabilityRegistry {
             teamIdentifier: signatureIdentity?.teamIdentifier)
         let markerURL = self.markerURL(
             processIdentifier: receipt.processIdentifier,
-            processStartIdentity: receipt.processStartIdentity)
+            processStartIdentity: receipt.processStartIdentity,
+            directory: directory)
         let markerPath = markerURL.path
 
         try self.registryLock.withLock {

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/ScreenCapturePermissionGate.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/ScreenCapturePermissionGate.swift
@@ -1,6 +1,7 @@
 import CoreGraphics
 import Darwin
 import Foundation
+import PeekabooFoundation
 
 @_spi(Testing) public enum ScreenRecordingPermissionProbePolicy: Sendable, Equatable {
     case allowScreenCaptureKit
@@ -12,9 +13,19 @@ import Foundation
     func hasPermission(
         logger: CategoryLogger,
         policy: ScreenRecordingPermissionProbePolicy) async -> Bool
+    func evaluatePermission(
+        logger: CategoryLogger,
+        policy: ScreenRecordingPermissionProbePolicy) async throws -> Bool
 }
 
 extension ScreenRecordingPermissionEvaluating {
+    public func evaluatePermission(
+        logger: CategoryLogger,
+        policy: ScreenRecordingPermissionProbePolicy) async throws -> Bool
+    {
+        await self.hasPermission(logger: logger, policy: policy)
+    }
+
     func hasPermission(logger: CategoryLogger) async -> Bool {
         await self.hasPermission(logger: logger, policy: .allowScreenCaptureKit)
     }
@@ -48,6 +59,13 @@ struct ScreenRecordingPermissionChecker: ScreenRecordingPermissionEvaluating {
         logger: CategoryLogger,
         policy: ScreenRecordingPermissionProbePolicy = .allowScreenCaptureKit) async -> Bool
     {
+        await (try? self.evaluatePermission(logger: logger, policy: policy)) ?? false
+    }
+
+    func evaluatePermission(
+        logger: CategoryLogger,
+        policy: ScreenRecordingPermissionProbePolicy) async throws -> Bool
+    {
         let preflightResult = self.preflight()
         if preflightResult {
             return true
@@ -73,6 +91,8 @@ struct ScreenRecordingPermissionChecker: ScreenRecordingPermissionEvaluating {
             try await self.shareableContentProbe()
             logger.info("Screen recording permission granted (SCShareableContent probe)")
             return true
+        } catch let diagnostic as ScreenCaptureKitOwnershipDiagnostic {
+            throw diagnostic
         } catch {
             if let delay = ScreenCaptureKitTransientError.retryDelayNanoseconds(after: error) {
                 logger.warning(
@@ -87,6 +107,8 @@ struct ScreenRecordingPermissionChecker: ScreenRecordingPermissionEvaluating {
                     try await self.shareableContentProbe()
                     logger.info("Screen recording permission granted (SCShareableContent retry)")
                     return true
+                } catch let diagnostic as ScreenCaptureKitOwnershipDiagnostic {
+                    throw diagnostic
                 } catch {
                     logger.warning("Screen recording permission retry failed: \(error)")
                 }
@@ -145,7 +167,7 @@ struct ScreenCapturePermissionGate {
         policy: ScreenRecordingPermissionProbePolicy = .allowScreenCaptureKit) async throws
     {
         logger.debug("Checking screen recording permission", correlationId: correlationId)
-        guard await self.hasPermission(logger: logger, policy: policy) else {
+        guard try await self.evaluator.evaluatePermission(logger: logger, policy: policy) else {
             logger.error("Screen recording permission denied", correlationId: correlationId)
             throw PermissionError.screenRecording()
         }

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/ScreenCaptureService+Testing.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/ScreenCaptureService+Testing.swift
@@ -9,6 +9,23 @@ import Foundation
 import PeekabooFoundation
 
 extension ScreenCaptureService {
+    @MainActor
+    @_spi(Testing) public static func withIsolatedCaptureCoordination<T: Sendable>(
+        directory: URL,
+        operation: @MainActor () async throws -> T) async rethrows -> T
+    {
+        let coordination = ScreenCaptureKitCaptureGate.Coordination(
+            operationLockPath: directory.appendingPathComponent("operation.lock").path,
+            coordinator: ScreenCaptureKitOperationCoordinator(
+                lockFilePath: directory.appendingPathComponent("capture.lock").path))
+        return try await ScreenCaptureKitCaptureGate.$coordinationOverride.withValue(coordination) {
+            try await ScreenCaptureKitCaptureGate.$processOwnerClaimOverride.withValue({
+                throw ScreenCaptureKitOwnerLease.LeaseError.invalidOwnerIdentity(
+                    "Synthetic capture must inject its owner claim")
+            }, operation: operation)
+        }
+    }
+
     @_spi(Testing) public struct TestFixtures: Sendable {
         @_spi(Testing) public struct Display: Sendable {
             public let name: String
@@ -150,7 +167,8 @@ extension ScreenCaptureService {
             },
             makeLegacyOperator: { _ in
                 MockModernCaptureOperator(fixtures: fixtures)
-            })
+            },
+            screenLockProbe: { false })
         return ScreenCaptureService(loggingService: loggingService, dependencies: dependencies)
     }
 }

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Observation/DesktopObservationService.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Observation/DesktopObservationService.swift
@@ -41,6 +41,7 @@ extension DesktopObservationServiceProtocol {
                 "Desktop observation failed after a conditional mutation may have been dispatched.",
                 hint: "Observe the target before retrying this observation.",
                 causeDescription: error.localizedDescription)
+                .preservingScreenCaptureKitDiagnostic(error as? ScreenCaptureKitOwnershipDiagnostic)
         }
     }
 
@@ -183,6 +184,7 @@ public enum ObservationActionResultSemantics {
                 message: failure.message,
                 hint: failure.hint ?? "Observe the target before retrying \(operation).",
                 causeDescription: failure.causeDescription)
+                .preservingScreenCaptureKitDiagnostic(failure.screenCaptureKitOwnershipDiagnostic)
         }
 
         var validation = UIAutomationActionResultSequenceAccumulator()
@@ -197,6 +199,7 @@ public enum ObservationActionResultSemantics {
             : validationResolution.selectedLeafEvidence
 
         let message = error.localizedDescription
+        let diagnostic = error as? ScreenCaptureKitOwnershipDiagnostic
         let hint = "Observe the target before retrying \(operation)."
         let causeDescription = String(describing: error)
         if let failure = DesktopActionFailure(
@@ -207,6 +210,7 @@ public enum ObservationActionResultSemantics {
             targetReceipt: targetReceipt)
         {
             return failure.selectingLeaves(validatedSelectedLeafEvidence)
+                .preservingScreenCaptureKitDiagnostic(diagnostic)
         }
         switch outcome.state {
         case .confirmedChange:
@@ -220,6 +224,7 @@ public enum ObservationActionResultSemantics {
                 causeDescription: causeDescription)
                 .attributed(to: targetReceipt)
                 .selectingLeaves(validatedSelectedLeafEvidence)
+                .preservingScreenCaptureKitDiagnostic(diagnostic)
         case .confirmedNoChange:
             return DesktopActionFailure.preDispatchRefusal(
                 route: outcome.route,
@@ -228,6 +233,7 @@ public enum ObservationActionResultSemantics {
                 hint: hint,
                 causeDescription: causeDescription)
                 .attributed(to: targetReceipt)
+                .preservingScreenCaptureKitDiagnostic(diagnostic)
         case .partial, .dispatchedUnverified, .suspectedNoop, .refused, .indeterminate:
             preconditionFailure("A non-confirmed outcome must construct a desktop action failure")
         }

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Strategy/UIAutomationActionResultSequenceAccumulator.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Strategy/UIAutomationActionResultSequenceAccumulator.swift
@@ -495,7 +495,8 @@ public struct UIAutomationActionResultSequenceAccumulator: Sendable {
             causeDescription: composed.causeDescription,
             standardErrorCode: leafFailure.standardErrorCode,
             targetReceipt: targetReceipt,
-            selectedLeafEvidence: evidence)
+            selectedLeafEvidence: evidence,
+            screenCaptureKitOwnershipDiagnostic: leafFailure.screenCaptureKitOwnershipDiagnostic)
         else {
             preconditionFailure("Composed action failures must retain a non-confirmed canonical outcome")
         }
@@ -512,7 +513,8 @@ public struct UIAutomationActionResultSequenceAccumulator: Sendable {
                 message: failure.message,
                 hint: failure.hint,
                 causeDescription: failure.causeDescription,
-                standardErrorCode: failure.standardErrorCode)
+                standardErrorCode: failure.standardErrorCode,
+                screenCaptureKitOwnershipDiagnostic: failure.screenCaptureKitOwnershipDiagnostic)
             else {
                 preconditionFailure("A reconciled desktop action failure must remain non-confirmed")
             }

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKitTestSupport/CaptureTestIsolation.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKitTestSupport/CaptureTestIsolation.swift
@@ -4,11 +4,7 @@ import Testing
 
 /// Synthetic capture tests use private locks and refuse any uninjected ownership claim.
 public struct CaptureTestIsolation: TestTrait, SuiteTrait, TestScoping {
-    #if compiler(>=6.4)
     public typealias TestBody = @concurrent @Sendable () async throws -> Void
-    #else
-    public typealias TestBody = @Sendable () async throws -> Void
-    #endif
 
     public init() {}
 

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKitTestSupport/CaptureTestIsolation.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKitTestSupport/CaptureTestIsolation.swift
@@ -1,0 +1,28 @@
+import Foundation
+@_spi(Testing) import PeekabooAutomationKit
+import Testing
+
+/// Synthetic capture tests use private locks and refuse any uninjected ownership claim.
+public struct CaptureTestIsolation: TestTrait, SuiteTrait, TestScoping {
+    #if compiler(>=6.4)
+    public typealias TestBody = @concurrent @Sendable () async throws -> Void
+    #else
+    public typealias TestBody = @Sendable () async throws -> Void
+    #endif
+
+    public init() {}
+
+    public func provideScope(
+        for test: Test,
+        testCase: Test.Case?,
+        performing function: TestBody) async throws
+    {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("capture-test-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        try await ScreenCaptureService.withIsolatedCaptureCoordination(directory: directory) {
+            try await function()
+        }
+    }
+}

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ScreenCaptureKitOwnerLeafTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ScreenCaptureKitOwnerLeafTests.swift
@@ -1,8 +1,10 @@
 import Darwin
+import PeekabooAutomationKitTestSupport
 import PeekabooFoundation
 import Testing
 @testable import PeekabooAutomationKit
 
+@Suite(.serialized, CaptureTestIsolation())
 @MainActor
 struct ScreenCaptureKitOwnerLeafTests {
     @Test
@@ -111,14 +113,14 @@ struct ScreenCaptureKitOwnerLeafTests {
             }
         }
 
-        let error: PeekabooError
+        let error: ScreenCaptureKitOwnershipDiagnostic
         do {
             _ = try await ScreenCaptureKitCaptureGate.$processOwnerClaimOverride.withValue(
                 claim,
                 operation: operation)
             Issue.record("Foreign ownership should refuse before the leaf")
             return
-        } catch let caught as PeekabooError {
+        } catch let caught as ScreenCaptureKitOwnershipDiagnostic {
             error = caught
         } catch {
             Issue.record("Unexpected error: \(error)")
@@ -127,7 +129,8 @@ struct ScreenCaptureKitOwnerLeafTests {
 
         #expect(error.code == StandardErrorCode.captureFailed)
         #expect(error.localizedDescription.contains("PID 4242, generation 9001"))
-        #expect(error.localizedDescription.contains("No ScreenCaptureKit operation was dispatched"))
+        #expect(error.blockers.first?.processIdentifier == 4242)
+        #expect(error.blockers.first?.processStartIdentity == 9001)
         #expect(leafCalls == 0)
     }
 
@@ -159,9 +162,11 @@ struct ScreenCaptureKitOwnerLeafTests {
                 claim,
                 operation: operation)
             Issue.record("The second owner check should refuse before the delayed leaf")
-        } catch let error as PeekabooError {
+        } catch let error as ScreenCaptureKitOwnershipDiagnostic {
             #expect(error.code == StandardErrorCode.captureFailed)
             #expect(error.localizedDescription.contains("old-bridge.sock"))
+            #expect(error.kind == .uncoordinatedHosts)
+            #expect(error.blockers.first?.socketPath == blocker.socketPath)
         } catch {
             Issue.record("Unexpected error: \(error)")
         }

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ScreenCaptureKitOwnerLeaseTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ScreenCaptureKitOwnerLeaseTests.swift
@@ -29,13 +29,21 @@ struct ScreenCaptureKitOwnerLeaseTests {
 
     @Test
     func `Process capability marker is build bound and held for process lifetime`() throws {
-        let processStartIdentity = try #require(SystemIdentityResolver.processStartIdentity(getpid()))
-
-        try ScreenCaptureKitOwnerLease.registerCurrentProcessCapability()
+        let fixture = try LeaseFixture(name: "private-capability")
+        defer { fixture.removeLockPath() }
+        let processStartIdentity = fixture.processStartIdentity
+        try ScreenCaptureKitProcessCapabilityRegistry.register(
+            ownerIdentity: .init(
+                processIdentifier: getpid(),
+                processStartIdentity: processStartIdentity,
+                buildIdentity: "synthetic-build"),
+            directory: fixture.directoryURL,
+            signatureIdentity: nil)
 
         let markerURL = ScreenCaptureKitOwnerLease.processCapabilityMarkerURL(
             processIdentifier: getpid(),
-            processStartIdentity: processStartIdentity)
+            processStartIdentity: processStartIdentity,
+            directory: fixture.directoryURL)
         let receipt = try JSONDecoder().decode(
             ScreenCaptureKitOwnerLease.ProcessCapabilityReceipt.self,
             from: Data(contentsOf: markerURL))

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ScreenRecordingPermissionCancellationTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ScreenRecordingPermissionCancellationTests.swift
@@ -1,9 +1,34 @@
 import Foundation
+import PeekabooFoundation
 import Testing
 @_spi(Testing) @testable import PeekabooAutomationKit
 
 @MainActor
 struct ScreenRecordingPermissionCancellationTests {
+    @Test
+    func `ownership refusal survives required permission evaluation`() async throws {
+        let blocker = ScreenCaptureKitOwnerLease.UncoordinatedProcess(
+            processIdentifier: 4242, processStartIdentity: 9001, executablePath: "/synthetic/Host")
+        let diagnostic = ScreenCaptureKitOwnershipDiagnostic.capturing(
+            ScreenCaptureKitOwnerLease.LeaseError.uncoordinatedProcesses([blocker]), stage: .entry)
+        var probes = 0
+        let checker = ScreenRecordingPermissionChecker(
+            preflight: { false },
+            coreGraphicsEvidence: { false },
+            shareableContentProbe: {
+                probes += 1
+                throw diagnostic
+            })
+        let gate = ScreenCapturePermissionGate(evaluator: checker)
+        let error = await #expect(throws: ScreenCaptureKitOwnershipDiagnostic.self) {
+            try await gate.requirePermission(
+                logger: MockLoggingService().logger(category: "test"),
+                correlationId: "test")
+        }
+        #expect(error == diagnostic)
+        #expect(probes == 1)
+    }
+
     @Test
     func `cancel during transient permission retry skips second probe`() async {
         let logger = MockLoggingService().logger(category: "test")

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeClient+Transport.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeClient+Transport.swift
@@ -1204,6 +1204,7 @@ extension PeekabooBridgeClient {
             message: envelope.message,
             hint: "Observe the target before retrying this operation.",
             causeDescription: envelope.details)
+            .preservingScreenCaptureKitDiagnostic(envelope.screenCaptureKitOwnershipDiagnostic)
     }
 }
 

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeClient.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeClient.swift
@@ -709,6 +709,21 @@ public actor PeekabooBridgeClient {
         }
     }
 
+    nonisolated static func offeredCapabilities(for protocolVersion: PeekabooBridgeProtocolVersion) -> [String] {
+        var capabilities: [String] = []
+        if protocolVersion >= PeekabooBridgeConstants.attestedOperationReceiptVersion {
+            capabilities.append(PeekabooBridgeClientCapability.screenCaptureKitOwnershipDiagnostics)
+        }
+        if protocolVersion >= PeekabooBridgeConstants.producerBoundSnapshotReferencesVersion {
+            capabilities.append(PeekabooBridgeClientCapability.producerBoundSnapshotReferences)
+            capabilities.append(PeekabooBridgeClientCapability.targetedClickAccessibilityValueDelivery)
+        }
+        if protocolVersion >= PeekabooBridgeConstants.browserConnectionHandoffVersion {
+            capabilities.append(PeekabooBridgeClientCapability.browserConnectionHandoff)
+        }
+        return capabilities
+    }
+
     private func performHandshake(
         inputs: PeekabooBridgeClientHandshakeInputs,
         protocolVersion: PeekabooBridgeProtocolVersion,
@@ -721,14 +736,7 @@ public actor PeekabooBridgeClient {
             requestedHostKind: inputs.requestedHost,
             operationClientInstanceID: self.operationClientInstanceID,
             replacingOperationSessionID: replacingOperationSessionID,
-            clientCapabilities: protocolVersion >= PeekabooBridgeConstants.producerBoundSnapshotReferencesVersion
-                ? ([
-                    PeekabooBridgeClientCapability.producerBoundSnapshotReferences,
-                    PeekabooBridgeClientCapability.targetedClickAccessibilityValueDelivery,
-                ] + (protocolVersion >= PeekabooBridgeConstants.browserConnectionHandoffVersion
-                    ? [PeekabooBridgeClientCapability.browserConnectionHandoff]
-                    : []))
-                : nil)
+            clientCapabilities: Self.offeredCapabilities(for: protocolVersion))
         let reply = try await self.sendCarryingActionOutcome(.handshake(payload), timeoutSec: timeoutSec)
         try self.validateTrustedConnectedHost(reply.connectedHost)
         let response = reply.response

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeModels.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeModels.swift
@@ -377,7 +377,10 @@ public enum PeekabooBridgeHostCapability {
     public static let backgroundBridgeHost = "backgroundBridgeHost"
     public static let desktopObservationOCR = "desktopObservationOCR"
     public static let desktopObservationCaptureEngine = "desktopObservationCaptureEngine"
+    // Old clients require successful preparation as well as implemented ownership support.
     public static let screenCaptureKitProcessOwnership = "screenCaptureKitProcessOwnership"
+    public static let screenCaptureKitOwnershipEnforcement = "screenCaptureKitOwnershipEnforcement"
+    public static let classicCaptureWithoutScreenCaptureKit = "classicCaptureWithoutScreenCaptureKit"
     public static let safeBackgroundApplicationLaunchNoOp = "safeBackgroundApplicationLaunchNoOp"
     public static let processGenerationPinnedApplicationActivation =
         "processGenerationPinnedApplicationActivation"
@@ -411,6 +414,7 @@ public enum PeekabooBridgeHostCapability {
 /// decodable by already-shipped hosts while the offer prevents new 1.34 operations or semantics
 /// from being advertised to already-shipped 1.34 clients.
 public enum PeekabooBridgeClientCapability {
+    public static let screenCaptureKitOwnershipDiagnostics = "screenCaptureKitOwnershipDiagnostics"
     public static let producerBoundSnapshotReferences = "producerBoundSnapshotReferences"
     public static let targetedClickAccessibilityValueDelivery = "targetedClickAccessibilityValueDelivery"
     public static let browserConnectionHandoff = "browserConnectionHandoff"
@@ -431,6 +435,7 @@ public struct PeekabooBridgeHandshakeResponse: Codable, Sendable {
     public let hostIdentity: PeekabooBridgeHostIdentity?
     /// Optional raw capabilities of this host process and its launch mode.
     public let hostCapabilities: [String]?
+    public let screenCaptureKitReadiness: ScreenCaptureKitReadiness?
     /// Ephemeral identity of the exact listener that served this handshake.
     public let operationAttestation: PeekabooBridgeListenerAttestation?
     /// Listener-signed, peer-bound replay session for protocol 1.29 requests.
@@ -446,6 +451,7 @@ public struct PeekabooBridgeHandshakeResponse: Codable, Sendable {
         permissionTags: [String: [PeekabooBridgePermissionKind]] = [:],
         hostIdentity: PeekabooBridgeHostIdentity? = nil,
         hostCapabilities: [String]? = nil,
+        screenCaptureKitReadiness: ScreenCaptureKitReadiness? = nil,
         operationAttestation: PeekabooBridgeListenerAttestation? = nil,
         operationSessionAttestation: PeekabooBridgeOperationSessionAttestation? = nil)
     {
@@ -458,6 +464,7 @@ public struct PeekabooBridgeHandshakeResponse: Codable, Sendable {
         self.permissionTags = permissionTags
         self.hostIdentity = hostIdentity
         self.hostCapabilities = hostCapabilities
+        self.screenCaptureKitReadiness = screenCaptureKitReadiness
         self.operationAttestation = operationAttestation
         self.operationSessionAttestation = operationSessionAttestation
     }
@@ -472,6 +479,7 @@ public struct PeekabooBridgeHandshakeResponse: Codable, Sendable {
         case permissionTags
         case hostIdentity
         case hostCapabilities
+        case screenCaptureKitReadiness
         case operationAttestation
         case operationSessionAttestation
     }
@@ -491,6 +499,8 @@ public struct PeekabooBridgeHandshakeResponse: Codable, Sendable {
             forKey: .permissionTags) ?? [:]
         self.hostIdentity = try container.decodeIfPresent(PeekabooBridgeHostIdentity.self, forKey: .hostIdentity)
         self.hostCapabilities = try container.decodeIfPresent([String].self, forKey: .hostCapabilities)
+        self.screenCaptureKitReadiness = try container.decodeIfPresent(
+            ScreenCaptureKitReadiness.self, forKey: .screenCaptureKitReadiness)
         self.operationAttestation = try container.decodeIfPresent(
             PeekabooBridgeListenerAttestation.self,
             forKey: .operationAttestation)
@@ -514,6 +524,7 @@ public struct PeekabooBridgeHandshakeResponse: Codable, Sendable {
         if let hostCapabilities, !hostCapabilities.isEmpty {
             try container.encode(hostCapabilities, forKey: .hostCapabilities)
         }
+        try container.encodeIfPresent(self.screenCaptureKitReadiness, forKey: .screenCaptureKitReadiness)
         try container.encodeIfPresent(self.operationAttestation, forKey: .operationAttestation)
         try container.encodeIfPresent(
             self.operationSessionAttestation,
@@ -562,6 +573,13 @@ public struct PeekabooBridgeErrorEnvelope: Codable, Sendable, LocalizedError {
     public let actionFailureCauseDescription: String?
     public let actionTargetReceipt: DesktopActionTargetReceipt?
     public let actionSelectedLeafEvidence: [DesktopSelectedLeafEvidence]?
+    public private(set) var screenCaptureKitOwnershipDiagnostic: ScreenCaptureKitOwnershipDiagnostic?
+
+    func removingScreenCaptureKitDiagnostic() -> Self {
+        var compatible = self
+        compatible.screenCaptureKitOwnershipDiagnostic = nil
+        return compatible
+    }
 
     private enum CodingKeys: String, CodingKey {
         case code
@@ -576,6 +594,7 @@ public struct PeekabooBridgeErrorEnvelope: Codable, Sendable, LocalizedError {
         case actionFailureCauseDescription
         case actionTargetReceipt
         case actionSelectedLeafEvidence
+        case screenCaptureKitOwnershipDiagnostic
     }
 
     public init(
@@ -585,7 +604,8 @@ public struct PeekabooBridgeErrorEnvelope: Codable, Sendable, LocalizedError {
         permission: PeekabooBridgePermissionKind? = nil,
         kind: PeekabooBridgeErrorKind? = nil,
         context: String? = nil,
-        operationMayHaveCompleted: Bool = false)
+        operationMayHaveCompleted: Bool = false,
+        screenCaptureKitOwnershipDiagnostic: ScreenCaptureKitOwnershipDiagnostic? = nil)
     {
         self.code = code
         self.message = message
@@ -599,6 +619,7 @@ public struct PeekabooBridgeErrorEnvelope: Codable, Sendable, LocalizedError {
         self.actionFailureCauseDescription = nil
         self.actionTargetReceipt = nil
         self.actionSelectedLeafEvidence = nil
+        self.screenCaptureKitOwnershipDiagnostic = screenCaptureKitOwnershipDiagnostic
     }
 
     public init(
@@ -623,6 +644,7 @@ public struct PeekabooBridgeErrorEnvelope: Codable, Sendable, LocalizedError {
         self.actionFailureCauseDescription = actionFailure.causeDescription
         self.actionTargetReceipt = actionFailure.targetReceipt
         self.actionSelectedLeafEvidence = actionFailure.selectedLeafEvidence
+        self.screenCaptureKitOwnershipDiagnostic = actionFailure.screenCaptureKitOwnershipDiagnostic
     }
 
     public init(from decoder: any Decoder) throws {
@@ -637,6 +659,8 @@ public struct PeekabooBridgeErrorEnvelope: Codable, Sendable, LocalizedError {
         let encodedOperationMayHaveCompleted = try container.decodeIfPresent(
             Bool.self,
             forKey: .operationMayHaveCompleted)
+        self.screenCaptureKitOwnershipDiagnostic = try container.decodeIfPresent(
+            ScreenCaptureKitOwnershipDiagnostic.self, forKey: .screenCaptureKitOwnershipDiagnostic)
         self.actionOutcome = try container.decodeIfPresent(
             DesktopActionOutcome.Projection.self,
             forKey: .actionOutcome)
@@ -697,6 +721,9 @@ public struct PeekabooBridgeErrorEnvelope: Codable, Sendable, LocalizedError {
         if self.operationMayHaveCompleted {
             try container.encode(true, forKey: .operationMayHaveCompleted)
         }
+        try container.encodeIfPresent(
+            self.screenCaptureKitOwnershipDiagnostic,
+            forKey: .screenCaptureKitOwnershipDiagnostic)
         try container.encodeIfPresent(self.actionOutcome, forKey: .actionOutcome)
         try container.encodeIfPresent(self.actionFailureHint, forKey: .actionFailureHint)
         try container.encodeIfPresent(
@@ -728,7 +755,8 @@ public struct PeekabooBridgeErrorEnvelope: Codable, Sendable, LocalizedError {
             causeDescription: self.actionFailureCauseDescription,
             standardErrorCode: self.standardizedErrorCode,
             targetReceipt: self.actionTargetReceipt,
-            selectedLeafEvidence: self.actionSelectedLeafEvidence)
+            selectedLeafEvidence: self.actionSelectedLeafEvidence,
+            screenCaptureKitOwnershipDiagnostic: self.screenCaptureKitOwnershipDiagnostic)
     }
 }
 

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeOperationResultSemantics.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeOperationResultSemantics.swift
@@ -1397,7 +1397,8 @@ extension PeekabooBridgeOperationResultSemantics {
         }
         return .init(
             code: compatibleEnvelope.code,
-            actionFailure: failure,
+            actionFailure: failure.preservingScreenCaptureKitDiagnostic(
+                compatibleEnvelope.screenCaptureKitOwnershipDiagnostic),
             details: compatibleEnvelope.details,
             permission: compatibleEnvelope.permission,
             kind: compatibleEnvelope.kind,

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeOperationSessionClaim.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeOperationSessionClaim.swift
@@ -2,6 +2,7 @@ import Foundation
 
 struct PeekabooBridgeNegotiatedSessionCapabilities: Hashable, Sendable {
     let protocolVersion: PeekabooBridgeProtocolVersion
+    let screenCaptureKitOwnershipDiagnostics: Bool
     let statelessClickVariants: Bool
     let exactWindowHeldPointerLifecycle: Bool
     let nativeBrowserConnectionBinding: Bool
@@ -22,7 +23,8 @@ struct PeekabooBridgeNegotiatedSessionCapabilities: Hashable, Sendable {
         targetedClickAccessibilityValueDelivery: true,
         requestPinnedExactWindowScrollReceipt: true,
         compositeTypeDelivery: true,
-        processGenerationBoundElementMutations: true)
+        processGenerationBoundElementMutations: true,
+        screenCaptureKitOwnershipDiagnostics: true)
 
     init(
         protocolVersion: PeekabooBridgeProtocolVersion,
@@ -34,9 +36,11 @@ struct PeekabooBridgeNegotiatedSessionCapabilities: Hashable, Sendable {
         targetedClickAccessibilityValueDelivery: Bool = false,
         requestPinnedExactWindowScrollReceipt: Bool = false,
         compositeTypeDelivery: Bool = false,
-        processGenerationBoundElementMutations: Bool = false)
+        processGenerationBoundElementMutations: Bool = false,
+        screenCaptureKitOwnershipDiagnostics: Bool = false)
     {
         self.protocolVersion = protocolVersion
+        self.screenCaptureKitOwnershipDiagnostics = screenCaptureKitOwnershipDiagnostics
         self.statelessClickVariants = statelessClickVariants
         self.exactWindowHeldPointerLifecycle = exactWindowHeldPointerLifecycle
         self.nativeBrowserConnectionBinding = nativeBrowserConnectionBinding

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeResponse+CaptureDiagnostics.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeResponse+CaptureDiagnostics.swift
@@ -1,0 +1,29 @@
+import PeekabooFoundation
+
+extension PeekabooBridgeResponse {
+    /// Only an authenticated operation session can opt into fields that affect the signed response digest.
+    func projectingScreenCaptureKitDiagnostics(offered: Bool) -> Self {
+        guard !offered else { return self }
+        switch self {
+        case let .error(envelope):
+            return .error(envelope.removingScreenCaptureKitDiagnostic())
+        case let .projectedAction(projected):
+            return .projectedAction(.init(
+                response: projected.response.projectingScreenCaptureKitDiagnostics(offered: false),
+                outcome: projected.outcome))
+        case let .browserToolResponse(response):
+            return .browserToolResponse(.init(
+                content: response.content,
+                isError: response.isError,
+                meta: response.meta,
+                structuredContent: response.structuredContent,
+                connectionReceipt: response.connectionReceipt,
+                completedCallCount: response.completedCallCount,
+                dispatchedCallCount: response.dispatchedCallCount,
+                actionFailure: response.actionFailure?.removingScreenCaptureKitDiagnostic(),
+                providerSessionEpoch: response.providerSessionEpoch))
+        default:
+            return self
+        }
+    }
+}

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer+Handshake.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer+Handshake.swift
@@ -318,7 +318,9 @@ extension PeekabooBridgeServer {
                         compositeTypeDelivery: advertisedCapabilities.contains(
                             PeekabooBridgeHostCapability.compositeTypeDelivery),
                         processGenerationBoundElementMutations: advertisedCapabilities.contains(
-                            PeekabooBridgeHostCapability.processGenerationBoundElementMutations)),
+                            PeekabooBridgeHostCapability.processGenerationBoundElementMutations),
+                        screenCaptureKitOwnershipDiagnostics: clientCapabilities.contains(
+                            PeekabooBridgeClientCapability.screenCaptureKitOwnershipDiagnostics)),
                     replacing: payload.replacingOperationSessionID)
                 self.clearReceiptlessNegotiation(peer: peer)
             } catch let error as PeekabooBridgeOperationReceiptError {
@@ -353,6 +355,7 @@ extension PeekabooBridgeServer {
             permissionTags: permissionTags,
             hostIdentity: self.hostIdentity,
             hostCapabilities: advertisedCapabilities.sorted(),
+            screenCaptureKitReadiness: self.screenCaptureKitReadiness,
             operationAttestation: supportsAttestedOperationReceipts
                 ? operationReceiptAuthority?.attestation
                 : nil,

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer+OperationReceipts.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer+OperationReceipts.swift
@@ -277,6 +277,9 @@ extension PeekabooBridgeServer {
         selectedLeafEvidence: [DesktopSelectedLeafEvidence]? = nil,
         context: OperationReceiptEncodingContext) async throws -> Data
     {
+        // Shipped clients reconstruct the digest after decoding. Project unknown fields before hashing or signing.
+        let response = response.projectingScreenCaptureKitDiagnostics(
+            offered: context.claim.negotiatedCapabilities.screenCaptureKitOwnershipDiagnostics)
         let receiptPayload = try PeekabooBridgeOperationReceiptPayload(
             requestID: context.requestPayload.requestID,
             sessionID: context.requestPayload.sessionID,
@@ -518,7 +521,7 @@ extension PeekabooBridgeServer {
             causeDescription: envelope.details)
         return PeekabooBridgeErrorEnvelope(
             code: envelope.code,
-            actionFailure: failure,
+            actionFailure: failure.preservingScreenCaptureKitDiagnostic(envelope.screenCaptureKitOwnershipDiagnostic),
             details: envelope.details,
             permission: envelope.permission,
             kind: envelope.kind,
@@ -581,7 +584,7 @@ extension PeekabooBridgeServer {
             causeDescription: envelope.details)
         return PeekabooBridgeErrorEnvelope(
             code: envelope.code,
-            actionFailure: failure,
+            actionFailure: failure.preservingScreenCaptureKitDiagnostic(envelope.screenCaptureKitOwnershipDiagnostic),
             details: envelope.details,
             permission: envelope.permission,
             kind: envelope.kind,

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer+RequestDecoding.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer+RequestDecoding.swift
@@ -33,7 +33,7 @@ extension PeekabooBridgeServer {
                 return await self.handleProjectedAction(payload, peer: peer)
             }
             let handled = try await self.route(request, peer: peer)
-            return try self.encoder.encode(handled.response)
+            return try self.encoder.encode(handled.response.projectingScreenCaptureKitDiagnostics(offered: false))
         } catch let envelope as PeekabooBridgeErrorEnvelope {
             self.logger.error("bridge request failed code=\(envelope.code.rawValue, privacy: .public)")
             return PeekabooBridgeResponse.encodeError(envelope.legacyCompatible, using: self.encoder)

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer+Routing.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer+Routing.swift
@@ -63,6 +63,12 @@ extension PeekabooBridgeServer {
                 peer: peer,
                 permissions: permissions,
                 effectiveOps: effectiveOps)
+        } catch let diagnostic as ScreenCaptureKitOwnershipDiagnostic {
+            failed = true
+            throw PeekabooBridgeOperationResultSemantics.canonicalFailure(
+                Self.bridgeErrorEnvelope(for: diagnostic, operation: op),
+                plan: plan,
+                stage: .preDispatch(.runtimeIncompatible))
         } catch let envelope as PeekabooBridgeErrorEnvelope {
             failed = true
             let duration = Date().timeIntervalSince(start)

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer.swift
@@ -70,10 +70,7 @@ public final class PeekabooBridgeServer {
     public static let defaultScreenCaptureKitOwnershipPreparationTimeoutSeconds =
         ScreenCaptureKitOwnerLease.defaultProcessCapabilityPreparationTimeoutSeconds + 1
 
-    private enum ScreenCaptureKitOwnershipPreparationOutcome: Sendable {
-        case available
-        case unavailable(String)
-    }
+    private typealias ScreenCaptureKitOwnershipPreparationOutcome = ScreenCaptureKitReadiness
 
     private final class ScreenCaptureKitOwnershipPreparationWaiter: @unchecked Sendable {
         typealias PreparationResult = Result<ScreenCaptureKitOwnershipPreparationOutcome, any Error>
@@ -118,6 +115,7 @@ public final class PeekabooBridgeServer {
     let allowedOperations: Set<PeekabooBridgeOperation>
     let hostIdentity: PeekabooBridgeHostIdentity?
     private(set) var hostCapabilities: Set<String>
+    private(set) var screenCaptureKitReadiness: ScreenCaptureKitReadiness?
     nonisolated let supportsBrowserHandoffMaintenance: Bool
     let servingSocketPath: String?
     var agentExecutionRunner: (any PeekabooBridgeAgentExecutionRunning)?
@@ -234,24 +232,22 @@ public final class PeekabooBridgeServer {
             services: services,
             supportedVersions: supportedVersions,
             allowedOperations: self.allowedOperations)
+        self.screenCaptureKitReadiness = Self.registerScreenCaptureKitCapability(
+            supported: services.supportsScreenCaptureKitProcessOwnership,
+            register: screenCaptureKitProcessCapabilityRegistrar)
         let registeredScreenCaptureKitOwnership = services.supportsScreenCaptureKitProcessOwnership &&
-            (try? screenCaptureKitProcessCapabilityRegistrar()) != nil
-        resolvedHostCapabilities.remove(PeekabooBridgeHostCapability.screenCaptureKitProcessOwnership)
+            self.screenCaptureKitReadiness?.failure == nil
         if hostIdentity?.processStartIdentity != nil {
             resolvedHostCapabilities.insert(PeekabooBridgeHostCapability.hostGenerationIdentity)
         }
         if hostIdentity?.codeSignatureHash != nil {
             resolvedHostCapabilities.insert(PeekabooBridgeHostCapability.codeSignatureBuildIdentity)
         }
-        if self.allowedOperations.contains(.desktopObservation) {
-            resolvedHostCapabilities.insert(PeekabooBridgeHostCapability.desktopObservationOCR)
-            if services.supportsDesktopObservationCaptureEngine {
-                resolvedHostCapabilities.insert(PeekabooBridgeHostCapability.desktopObservationCaptureEngine)
-            }
-            if registeredScreenCaptureKitOwnership {
-                resolvedHostCapabilities.insert(PeekabooBridgeHostCapability.screenCaptureKitProcessOwnership)
-            }
-        }
+        Self.updateCaptureCapabilities(
+            to: &resolvedHostCapabilities,
+            services: services,
+            allowedOperations: self.allowedOperations,
+            registeredOwnership: registeredScreenCaptureKitOwnership)
         if supportedVersions.upperBound >= PeekabooBridgeConstants.agentExecutionTraceVersion,
            self.allowedOperations.contains(.agentExecutionTrace),
            servingSocketPath != nil,
@@ -352,9 +348,9 @@ public final class PeekabooBridgeServer {
             let created = Task<ScreenCaptureKitOwnershipPreparationOutcome, Never> {
                 do {
                     try await prepare()
-                    return .available
+                    return .init(state: .ready)
                 } catch {
-                    return .unavailable(error.localizedDescription)
+                    return .failed(error, stage: .preparation)
                 }
             }
             self.screenCaptureKitOwnershipPreparationTask = created
@@ -368,16 +364,60 @@ public final class PeekabooBridgeServer {
         } catch is CancellationError {
             throw CancellationError()
         } catch {
-            outcome = .unavailable(error.localizedDescription)
+            outcome = .failed(error, stage: .preparation)
         }
         try Task.checkCancellation()
-        if case let .unavailable(reason) = outcome {
+        self.screenCaptureKitReadiness = outcome
+        if !outcome.permitsAttempt {
             self.hostCapabilities.remove(PeekabooBridgeHostCapability.screenCaptureKitProcessOwnership)
             self.logger.warning(
                 """
-                ScreenCaptureKit ownership preparation failed; serving without ownership capability: \
-                \(reason, privacy: .public)
+                ScreenCaptureKit ownership preparation failed; preserving implementation support: \
+                \(outcome.refusal.userMessage, privacy: .public)
                 """)
+        }
+    }
+
+    private static func updateCaptureCapabilities(
+        to capabilities: inout Set<String>,
+        services: any PeekabooBridgeServiceProviding,
+        allowedOperations: Set<PeekabooBridgeOperation>,
+        registeredOwnership: Bool)
+    {
+        capabilities.subtract([
+            PeekabooBridgeHostCapability.screenCaptureKitProcessOwnership,
+            PeekabooBridgeHostCapability.screenCaptureKitOwnershipEnforcement,
+            PeekabooBridgeHostCapability.classicCaptureWithoutScreenCaptureKit,
+        ])
+        if allowedOperations.contains(.desktopObservation) {
+            if services.supportsScreenCaptureKitProcessOwnership {
+                capabilities.insert(PeekabooBridgeHostCapability.screenCaptureKitOwnershipEnforcement)
+            }
+            if services.supportsClassicCaptureWithoutScreenCaptureKit,
+               services.supportsDesktopObservationCaptureEngine
+            {
+                capabilities.insert(PeekabooBridgeHostCapability.classicCaptureWithoutScreenCaptureKit)
+            }
+            capabilities.insert(PeekabooBridgeHostCapability.desktopObservationOCR)
+            if services.supportsDesktopObservationCaptureEngine {
+                capabilities.insert(PeekabooBridgeHostCapability.desktopObservationCaptureEngine)
+            }
+            if registeredOwnership {
+                capabilities.insert(PeekabooBridgeHostCapability.screenCaptureKitProcessOwnership)
+            }
+        }
+    }
+
+    private static func registerScreenCaptureKitCapability(
+        supported: Bool,
+        register: @MainActor () throws -> Void) -> ScreenCaptureKitReadiness?
+    {
+        guard supported else { return nil }
+        do {
+            try register()
+            return .init(state: .unavailable)
+        } catch {
+            return .failed(error, stage: .registration)
         }
     }
 
@@ -447,7 +487,8 @@ public final class PeekabooBridgeServer {
             let handled = try await self.route(request, peer: peer)
             return try self.encoder.encode(PeekabooBridgeResponse.projectedActionForCurrentRequestVocabulary(
                 response: handled.response,
-                outcome: handled.outcome?.routed(to: .bridge).projection))
+                outcome: handled.outcome?.routed(to: .bridge).projection)
+                .projectingScreenCaptureKitDiagnostics(offered: false))
         } catch let envelope as PeekabooBridgeErrorEnvelope {
             self.logger.error(
                 "projected bridge request failed code=\(envelope.code.rawValue, privacy: .public)")
@@ -470,8 +511,10 @@ public final class PeekabooBridgeServer {
         let response = PeekabooBridgeResponse.projectedActionForCurrentRequestVocabulary(
             response: .error(envelope),
             outcome: envelope.actionOutcome)
+            .projectingScreenCaptureKitDiagnostics(offered: false)
         guard let data = try? self.encoder.encode(response), !data.isEmpty else {
-            return PeekabooBridgeResponse.encodeError(envelope, using: self.encoder)
+            return PeekabooBridgeResponse.encodeError(
+                envelope.removingScreenCaptureKitDiagnostic(), using: self.encoder)
         }
         return data
     }
@@ -480,7 +523,7 @@ public final class PeekabooBridgeServer {
         for error: any Error,
         operation: PeekabooBridgeOperation) -> PeekabooBridgeErrorEnvelope
     {
-        if let envelope = self.actionFailureEnvelope(for: error) {
+        if let envelope = self.captureOrActionFailureEnvelope(for: error) {
             return envelope
         }
         if let error = error as? ApplicationLifecycleRefusalError {
@@ -587,7 +630,15 @@ public final class PeekabooBridgeServer {
             details: "\(error)")
     }
 
-    private static func actionFailureEnvelope(for error: any Error) -> PeekabooBridgeErrorEnvelope? {
+    private static func captureOrActionFailureEnvelope(for error: any Error) -> PeekabooBridgeErrorEnvelope? {
+        if let diagnostic = error as? ScreenCaptureKitOwnershipDiagnostic {
+            return .init(
+                code: .internalError,
+                message: diagnostic.userMessage,
+                context: PeekabooBridgeErrorEnvelope.standardizedErrorContextPrefix +
+                    StandardErrorCode.captureFailed.rawValue,
+                screenCaptureKitOwnershipDiagnostic: diagnostic)
+        }
         if let failure = error as? DesktopActionFailure {
             return .init(
                 code: .internalError,
@@ -1042,6 +1093,7 @@ public final class PeekabooBridgeServer {
                 code: .operationNotSupported,
                 message: "Operation \(op.rawValue) is not supported by this host")
         }
+        try self.validateScreenCaptureKitReadiness(for: request)
         if case let .browserExecute(payload) = request {
             _ = try Self.validatedBrowserExecutionReceipt(payload)
         }
@@ -1179,8 +1231,25 @@ public final class PeekabooBridgeServer {
     {
         guard case let .desktopObservation(payload) = request else { return false }
         return payload.capture.engine == .legacy &&
-            hostCapabilities.contains(PeekabooBridgeHostCapability.screenCaptureKitProcessOwnership) &&
+            (hostCapabilities.contains(PeekabooBridgeHostCapability.screenCaptureKitProcessOwnership) ||
+                hostCapabilities.contains(PeekabooBridgeHostCapability.classicCaptureWithoutScreenCaptureKit)) &&
             allowedOperations.contains(.desktopObservation)
+    }
+
+    private func validateScreenCaptureKitReadiness(for request: PeekabooBridgeRequest) throws {
+        let requiresScreenCaptureKit: Bool = switch request {
+        case let .desktopObservation(payload):
+            payload.capture.engine != .legacy
+        case .captureScreen, .captureWindow, .captureFrontmost, .captureArea:
+            true
+        default:
+            false
+        }
+        guard requiresScreenCaptureKit,
+              self.services.supportsScreenCaptureKitProcessOwnership,
+              self.screenCaptureKitReadiness?.permitsAttempt != true
+        else { return }
+        throw self.screenCaptureKitReadiness?.refusal ?? ScreenCaptureKitReadiness(state: .unknown).refusal
     }
 
     private static func validateTargetedClickAccess(

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServiceProviding.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServiceProviding.swift
@@ -19,6 +19,7 @@ public protocol PeekabooBridgeServiceProviding: AnyObject, Sendable {
     var desktopObservation: any DesktopObservationServiceProtocol { get }
     var supportsDesktopObservationCaptureEngine: Bool { get }
     var supportsScreenCaptureKitProcessOwnership: Bool { get }
+    var supportsClassicCaptureWithoutScreenCaptureKit: Bool { get }
     var browserSessionBootstrapProvider: (any PeekabooBridgeBrowserSessionBootstrapProviding)? { get }
 
     /// Whether the concrete native service owns the lane for this exact operation.
@@ -59,6 +60,10 @@ extension PeekabooBridgeServiceProviding {
     }
 
     public var supportsScreenCaptureKitProcessOwnership: Bool {
+        false
+    }
+
+    public var supportsClassicCaptureWithoutScreenCaptureKit: Bool {
         false
     }
 

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooEmbeddedBridgeRuntime.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooEmbeddedBridgeRuntime.swift
@@ -30,6 +30,10 @@ public final class PeekabooEmbeddedBridgeServices: PeekabooBridgeServiceProvidin
         true
     }
 
+    public var supportsClassicCaptureWithoutScreenCaptureKit: Bool {
+        true
+    }
+
     public init(
         desktopMutationWatermarkStore: DesktopMutationWatermarkStore = DesktopMutationWatermarkStore(),
         snapshotOptions: InMemorySnapshotManager.Options = .init(copyArtifactsOnStore: true),

--- a/Core/PeekabooCore/Sources/PeekabooCore/Support/PeekabooServices.swift
+++ b/Core/PeekabooCore/Sources/PeekabooCore/Support/PeekabooServices.swift
@@ -424,6 +424,10 @@ public final class PeekabooServices {
 
 extension PeekabooServices: PeekabooServiceProviding {}
 extension PeekabooServices: PeekabooBridgeServiceProviding {
+    public var supportsClassicCaptureWithoutScreenCaptureKit: Bool {
+        self.screenCapture is ScreenCaptureService
+    }
+
     public var supportsScreenCaptureKitProcessOwnership: Bool {
         self.screenCapture is ScreenCaptureService
     }

--- a/Core/PeekabooCore/Tests/PeekabooTests/AutoScreenCaptureConcurrencyTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/AutoScreenCaptureConcurrencyTests.swift
@@ -1,9 +1,9 @@
 import CoreGraphics
 import Foundation
-@_spi(Testing) import PeekabooAutomationKit
-import PeekabooBridge
 import PeekabooFoundation
 import Testing
+@_spi(Testing) @testable import PeekabooAutomationKit
+@testable import PeekabooBridge
 @testable import PeekabooCore
 
 @Suite(.serialized)
@@ -25,12 +25,13 @@ struct AutoScreenCaptureConcurrencyTests {
     }
 
     @Test
-    func `Bridge without registered ScreenCaptureKit capability preserves automatic capture`() async throws {
-        let socketPath = "/tmp/peekaboo-auto-screen-registration-failure-\(UUID().uuidString).sock"
+    func `Bridge registration failure refuses automatic capture with its diagnostic`() async throws {
+        let socketPath = Self.fixtureSocketPath()
         let ownerReceipt = try #require(Self.currentProcessOwnerReceipt())
         let claimCounter = BridgeOwnerClaimCounter()
         let observation = BridgeAutoScreenObservationService(failSlowAutomaticCapture: false)
         let services = StubServices(
+            snapshots: InMemorySnapshotManager(),
             desktopObservation: observation,
             supportsScreenCaptureKitProcessOwnership: true)
         let server = PeekabooBridgeServer(
@@ -40,14 +41,24 @@ struct AutoScreenCaptureConcurrencyTests {
             allowlistedBundles: [],
             allowedOperations: [.desktopObservation],
             hostCapabilities: [PeekabooBridgeHostCapability.screenCaptureKitProcessOwnership],
+            desktopOperationLaneCoordinator: DesktopOperationLaneCoordinator(
+                coordinationRootURL: URL(fileURLWithPath: socketPath + ".coordination")),
             screenCaptureKitProcessCapabilityRegistrar: {
                 throw OperationError.captureFailed(reason: "Fixture registration failure")
             },
+            screenCaptureKitOwnershipPreparer: {},
             screenCaptureKitOwnerClaimProvider: {
                 claimCounter.record()
                 return ownerReceipt
             },
-            permissionStatusEvaluator: Self.grantedPermissions)
+            postEventAccessEvaluator: { true },
+            postEventAccessRequester: { false },
+            permissionStatusEvaluator: Self.grantedPermissions,
+            windowOwnerProcessIdentifierProvider: { _ in nil },
+            windowBoundsProvider: { _ in nil },
+            maximizedVisibleWorkAreaProvider: { _ in nil },
+            processStartIdentityProvider: { _ in nil },
+            processPresenceProvider: { _ in false })
         let host = PeekabooBridgeHost(
             socketPath: socketPath,
             server: server,
@@ -59,19 +70,19 @@ struct AutoScreenCaptureConcurrencyTests {
             socketPath: socketPath,
             requestTimeoutSec: 2)
 
-        _ = try await client.desktopObservation(Self.backgroundAutoScreenRequest)
-
-        #expect(observation.requests.count == 1)
-        #expect(observation.requests.first?.capture.engine == .auto)
-        #expect(observation.legacyAttemptCount == 1)
-        #expect(observation.modernAttemptCount == 0)
+        let error = await #expect(throws: DesktopActionFailure.self) {
+            _ = try await client.desktopObservation(Self.backgroundAutoScreenRequest)
+        }
+        #expect(error?.screenCaptureKitOwnershipDiagnostic?.stage == .registration)
+        #expect(error?.standardErrorCode == .captureFailed)
+        #expect(observation.requests.isEmpty)
         #expect(!claimCounter.didRecord)
         await host.stop()
     }
 
     @Test
     func `Bridge prepares screen ownership before serving concurrent captures inside its envelope`() async throws {
-        let socketPath = "/tmp/peekaboo-auto-screen-prepared-\(UUID().uuidString).sock"
+        let socketPath = Self.fixtureSocketPath()
         let ownerReceipt = try #require(Self.currentProcessOwnerReceipt())
         let claimCounter = BridgeOwnerClaimCounter()
         let preparation = BridgeOwnerPreparationGate()
@@ -80,6 +91,7 @@ struct AutoScreenCaptureConcurrencyTests {
             settlementDelay: .milliseconds(5))
         let observation = BridgeAutoScreenObservationService(captureLane: captureLane)
         let services = StubServices(
+            snapshots: InMemorySnapshotManager(),
             desktopObservation: observation,
             supportsScreenCaptureKitProcessOwnership: true)
         let server = PeekabooBridgeServer(
@@ -88,6 +100,8 @@ struct AutoScreenCaptureConcurrencyTests {
             allowlistedTeams: [],
             allowlistedBundles: [],
             allowedOperations: [.desktopObservation],
+            desktopOperationLaneCoordinator: DesktopOperationLaneCoordinator(
+                coordinationRootURL: URL(fileURLWithPath: socketPath + ".coordination")),
             screenCaptureKitProcessCapabilityRegistrar: {},
             screenCaptureKitOwnershipPreparer: {
                 await preparation.prepare()
@@ -96,7 +110,14 @@ struct AutoScreenCaptureConcurrencyTests {
                 claimCounter.record()
                 return ownerReceipt
             },
-            permissionStatusEvaluator: Self.grantedPermissions)
+            postEventAccessEvaluator: { true },
+            postEventAccessRequester: { false },
+            permissionStatusEvaluator: Self.grantedPermissions,
+            windowOwnerProcessIdentifierProvider: { _ in nil },
+            windowBoundsProvider: { _ in nil },
+            maximizedVisibleWorkAreaProvider: { _ in nil },
+            processStartIdentityProvider: { _ in nil },
+            processPresenceProvider: { _ in false })
         let host = PeekabooBridgeHost(
             socketPath: socketPath,
             server: server,
@@ -132,10 +153,11 @@ struct AutoScreenCaptureConcurrencyTests {
 
     @Test
     func `Bridge preparation failure suppresses screen ownership capability`() async throws {
-        let socketPath = "/tmp/peekaboo-auto-screen-preparation-failure-\(UUID().uuidString).sock"
+        let socketPath = Self.fixtureSocketPath()
         let preparation = BridgeOwnerPreparationGate()
         let observation = BridgeAutoScreenObservationService(failSlowAutomaticCapture: false)
         let services = StubServices(
+            snapshots: InMemorySnapshotManager(),
             desktopObservation: observation,
             supportsScreenCaptureKitProcessOwnership: true)
         let server = PeekabooBridgeServer(
@@ -144,12 +166,25 @@ struct AutoScreenCaptureConcurrencyTests {
             allowlistedTeams: [],
             allowlistedBundles: [],
             allowedOperations: [.desktopObservation],
+            desktopOperationLaneCoordinator: DesktopOperationLaneCoordinator(
+                coordinationRootURL: URL(fileURLWithPath: socketPath + ".coordination")),
             screenCaptureKitProcessCapabilityRegistrar: {},
             screenCaptureKitOwnershipPreparer: {
                 await preparation.prepare()
             },
+            screenCaptureKitOwnerClaimProvider: {
+                Issue.record("Preparation must not claim an owner")
+                throw ScreenCaptureKitOwnerLease.LeaseError.invalidOwnerIdentity("unexpected fixture claim")
+            },
             screenCaptureKitOwnershipPreparationTimeoutSeconds: 0.02,
-            permissionStatusEvaluator: Self.grantedPermissions)
+            postEventAccessEvaluator: { true },
+            postEventAccessRequester: { false },
+            permissionStatusEvaluator: Self.grantedPermissions,
+            windowOwnerProcessIdentifierProvider: { _ in nil },
+            windowBoundsProvider: { _ in nil },
+            maximizedVisibleWorkAreaProvider: { _ in nil },
+            processStartIdentityProvider: { _ in nil },
+            processPresenceProvider: { _ in false })
         let host = PeekabooBridgeHost(
             socketPath: socketPath,
             server: server,
@@ -162,18 +197,21 @@ struct AutoScreenCaptureConcurrencyTests {
             socketPath: socketPath,
             requestTimeoutSec: 2)
 
-        _ = try await client.desktopObservation(Self.backgroundAutoScreenRequest)
-
-        #expect(observation.requests.count == 1)
-        #expect(observation.requests.first?.capture.engine == .auto)
+        let error = await #expect(throws: DesktopActionFailure.self) {
+            _ = try await client.desktopObservation(Self.backgroundAutoScreenRequest)
+        }
+        #expect(error?.screenCaptureKitOwnershipDiagnostic?.kind == .timedOut)
+        #expect(error?.screenCaptureKitOwnershipDiagnostic?.timeoutSeconds == 0.02)
+        #expect(observation.requests.isEmpty)
         await host.stop()
     }
 
     @Test
     func `Bridge stop during ownership preparation prevents later socket publication`() async throws {
-        let socketPath = "/tmp/peekaboo-auto-screen-preparation-stop-\(UUID().uuidString).sock"
+        let socketPath = Self.fixtureSocketPath()
         let preparation = BridgeOwnerPreparationGate()
         let services = StubServices(
+            snapshots: InMemorySnapshotManager(),
             desktopObservation: BridgeAutoScreenObservationService(),
             supportsScreenCaptureKitProcessOwnership: true)
         let server = PeekabooBridgeServer(
@@ -182,11 +220,24 @@ struct AutoScreenCaptureConcurrencyTests {
             allowlistedTeams: [],
             allowlistedBundles: [],
             allowedOperations: [.desktopObservation],
+            desktopOperationLaneCoordinator: DesktopOperationLaneCoordinator(
+                coordinationRootURL: URL(fileURLWithPath: socketPath + ".coordination")),
             screenCaptureKitProcessCapabilityRegistrar: {},
             screenCaptureKitOwnershipPreparer: {
                 await preparation.prepare()
             },
-            permissionStatusEvaluator: Self.grantedPermissions)
+            screenCaptureKitOwnerClaimProvider: {
+                Issue.record("Preparation must not claim an owner")
+                throw ScreenCaptureKitOwnerLease.LeaseError.invalidOwnerIdentity("unexpected fixture claim")
+            },
+            postEventAccessEvaluator: { true },
+            postEventAccessRequester: { false },
+            permissionStatusEvaluator: Self.grantedPermissions,
+            windowOwnerProcessIdentifierProvider: { _ in nil },
+            windowBoundsProvider: { _ in nil },
+            maximizedVisibleWorkAreaProvider: { _ in nil },
+            processStartIdentityProvider: { _ in nil },
+            processPresenceProvider: { _ in false })
         let host = PeekabooBridgeHost(
             socketPath: socketPath,
             server: server,
@@ -204,10 +255,11 @@ struct AutoScreenCaptureConcurrencyTests {
 
     @Test
     func `Bridge start cancellation does not cancel or wait for shared ownership preparation`() async throws {
-        let socketPath = "/tmp/peekaboo-auto-screen-preparation-cancel-\(UUID().uuidString).sock"
+        let socketPath = Self.fixtureSocketPath()
         let preparation = BridgeOwnerPreparationGate()
         let completion = BridgeStartCompletionFlag()
         let services = StubServices(
+            snapshots: InMemorySnapshotManager(),
             desktopObservation: BridgeAutoScreenObservationService(),
             supportsScreenCaptureKitProcessOwnership: true)
         let server = PeekabooBridgeServer(
@@ -216,11 +268,24 @@ struct AutoScreenCaptureConcurrencyTests {
             allowlistedTeams: [],
             allowlistedBundles: [],
             allowedOperations: [.desktopObservation],
+            desktopOperationLaneCoordinator: DesktopOperationLaneCoordinator(
+                coordinationRootURL: URL(fileURLWithPath: socketPath + ".coordination")),
             screenCaptureKitProcessCapabilityRegistrar: {},
             screenCaptureKitOwnershipPreparer: {
                 await preparation.prepare()
             },
-            permissionStatusEvaluator: Self.grantedPermissions)
+            screenCaptureKitOwnerClaimProvider: {
+                Issue.record("Preparation must not claim an owner")
+                throw ScreenCaptureKitOwnerLease.LeaseError.invalidOwnerIdentity("unexpected fixture claim")
+            },
+            postEventAccessEvaluator: { true },
+            postEventAccessRequester: { false },
+            permissionStatusEvaluator: Self.grantedPermissions,
+            windowOwnerProcessIdentifierProvider: { _ in nil },
+            windowBoundsProvider: { _ in nil },
+            maximizedVisibleWorkAreaProvider: { _ in nil },
+            processStartIdentityProvider: { _ in nil },
+            processPresenceProvider: { _ in false })
         let host = PeekabooBridgeHost(
             socketPath: socketPath,
             server: server,
@@ -253,11 +318,12 @@ struct AutoScreenCaptureConcurrencyTests {
 
     @Test
     func `Fresh Bridge owner claims before concurrent background auto screen observations`() async throws {
-        let socketPath = "/tmp/peekaboo-auto-screen-concurrency-\(UUID().uuidString).sock"
+        let socketPath = Self.fixtureSocketPath()
         let ownerReceipt = try #require(Self.currentProcessOwnerReceipt())
         let claimCounter = BridgeOwnerClaimCounter()
         let observation = BridgeAutoScreenObservationService()
         let services = StubServices(
+            snapshots: InMemorySnapshotManager(),
             desktopObservation: observation,
             supportsScreenCaptureKitProcessOwnership: true)
         let server = PeekabooBridgeServer(
@@ -266,12 +332,22 @@ struct AutoScreenCaptureConcurrencyTests {
             allowlistedTeams: [],
             allowlistedBundles: [],
             allowedOperations: [.desktopObservation],
+            desktopOperationLaneCoordinator: DesktopOperationLaneCoordinator(
+                coordinationRootURL: URL(fileURLWithPath: socketPath + ".coordination")),
+            screenCaptureKitProcessCapabilityRegistrar: {},
             screenCaptureKitOwnershipPreparer: {},
             screenCaptureKitOwnerClaimProvider: {
                 claimCounter.record()
                 return ownerReceipt
             },
-            permissionStatusEvaluator: Self.grantedPermissions)
+            postEventAccessEvaluator: { true },
+            postEventAccessRequester: { false },
+            permissionStatusEvaluator: Self.grantedPermissions,
+            windowOwnerProcessIdentifierProvider: { _ in nil },
+            windowBoundsProvider: { _ in nil },
+            maximizedVisibleWorkAreaProvider: { _ in nil },
+            processStartIdentityProvider: { _ in nil },
+            processPresenceProvider: { _ in false })
         let host = PeekabooBridgeHost(
             socketPath: socketPath,
             server: server,
@@ -302,7 +378,7 @@ struct AutoScreenCaptureConcurrencyTests {
 
     @Test
     func `Claimed screen owner generation drift preserves automatic capture`() async throws {
-        let socketPath = "/tmp/peekaboo-auto-screen-different-owner-\(UUID().uuidString).sock"
+        let socketPath = Self.fixtureSocketPath()
         let ownerReceipt = try #require(Self.currentProcessOwnerReceipt())
         let claimCounter = BridgeOwnerClaimCounter()
         let differentOwnerReceipt = ScreenCaptureKitOwnerLease.OwnerReceipt(
@@ -310,6 +386,7 @@ struct AutoScreenCaptureConcurrencyTests {
             processStartIdentity: ownerReceipt.processStartIdentity + 1)
         let observation = BridgeAutoScreenObservationService(failSlowAutomaticCapture: false)
         let services = StubServices(
+            snapshots: InMemorySnapshotManager(),
             desktopObservation: observation,
             supportsScreenCaptureKitProcessOwnership: true)
         let server = PeekabooBridgeServer(
@@ -318,13 +395,22 @@ struct AutoScreenCaptureConcurrencyTests {
             allowlistedTeams: [],
             allowlistedBundles: [],
             allowedOperations: [.desktopObservation],
+            desktopOperationLaneCoordinator: DesktopOperationLaneCoordinator(
+                coordinationRootURL: URL(fileURLWithPath: socketPath + ".coordination")),
             screenCaptureKitProcessCapabilityRegistrar: {},
             screenCaptureKitOwnershipPreparer: {},
             screenCaptureKitOwnerClaimProvider: {
                 claimCounter.record()
                 return differentOwnerReceipt
             },
-            permissionStatusEvaluator: Self.grantedPermissions)
+            postEventAccessEvaluator: { true },
+            postEventAccessRequester: { false },
+            permissionStatusEvaluator: Self.grantedPermissions,
+            windowOwnerProcessIdentifierProvider: { _ in nil },
+            windowBoundsProvider: { _ in nil },
+            maximizedVisibleWorkAreaProvider: { _ in nil },
+            processStartIdentityProvider: { _ in nil },
+            processPresenceProvider: { _ in false })
         let host = PeekabooBridgeHost(
             socketPath: socketPath,
             server: server,
@@ -348,7 +434,7 @@ struct AutoScreenCaptureConcurrencyTests {
 
     @Test
     func `Competing screen owner claim preserves automatic capture`() async throws {
-        let socketPath = "/tmp/peekaboo-auto-screen-competing-owner-\(UUID().uuidString).sock"
+        let socketPath = Self.fixtureSocketPath()
         let ownerReceipt = try #require(Self.currentProcessOwnerReceipt())
         let competingReceipt = ScreenCaptureKitOwnerLease.OwnerReceipt(
             processIdentifier: ownerReceipt.processIdentifier + 1,
@@ -356,6 +442,7 @@ struct AutoScreenCaptureConcurrencyTests {
         let claimCounter = BridgeOwnerClaimCounter()
         let observation = BridgeAutoScreenObservationService(failSlowAutomaticCapture: false)
         let services = StubServices(
+            snapshots: InMemorySnapshotManager(),
             desktopObservation: observation,
             supportsScreenCaptureKitProcessOwnership: true)
         let server = PeekabooBridgeServer(
@@ -364,6 +451,9 @@ struct AutoScreenCaptureConcurrencyTests {
             allowlistedTeams: [],
             allowlistedBundles: [],
             allowedOperations: [.desktopObservation],
+            desktopOperationLaneCoordinator: DesktopOperationLaneCoordinator(
+                coordinationRootURL: URL(fileURLWithPath: socketPath + ".coordination")),
+            screenCaptureKitProcessCapabilityRegistrar: {},
             screenCaptureKitOwnershipPreparer: {},
             screenCaptureKitOwnerClaimProvider: {
                 claimCounter.record()
@@ -371,7 +461,14 @@ struct AutoScreenCaptureConcurrencyTests {
                     path: "/tmp/peekaboo-competing-owner.lock",
                     receipt: competingReceipt)
             },
-            permissionStatusEvaluator: Self.grantedPermissions)
+            postEventAccessEvaluator: { true },
+            postEventAccessRequester: { false },
+            permissionStatusEvaluator: Self.grantedPermissions,
+            windowOwnerProcessIdentifierProvider: { _ in nil },
+            windowBoundsProvider: { _ in nil },
+            maximizedVisibleWorkAreaProvider: { _ in nil },
+            processStartIdentityProvider: { _ in nil },
+            processPresenceProvider: { _ in false })
         let host = PeekabooBridgeHost(
             socketPath: socketPath,
             server: server,
@@ -395,10 +492,11 @@ struct AutoScreenCaptureConcurrencyTests {
 
     @Test
     func `Unexpected screen owner claim failure preserves automatic capture`() async throws {
-        let socketPath = "/tmp/peekaboo-auto-screen-claim-failure-\(UUID().uuidString).sock"
+        let socketPath = Self.fixtureSocketPath()
         let claimCounter = BridgeOwnerClaimCounter()
         let observation = BridgeAutoScreenObservationService(failSlowAutomaticCapture: false)
         let services = StubServices(
+            snapshots: InMemorySnapshotManager(),
             desktopObservation: observation,
             supportsScreenCaptureKitProcessOwnership: true)
         let server = PeekabooBridgeServer(
@@ -407,12 +505,22 @@ struct AutoScreenCaptureConcurrencyTests {
             allowlistedTeams: [],
             allowlistedBundles: [],
             allowedOperations: [.desktopObservation],
+            desktopOperationLaneCoordinator: DesktopOperationLaneCoordinator(
+                coordinationRootURL: URL(fileURLWithPath: socketPath + ".coordination")),
+            screenCaptureKitProcessCapabilityRegistrar: {},
             screenCaptureKitOwnershipPreparer: {},
             screenCaptureKitOwnerClaimProvider: {
                 claimCounter.record()
                 throw ScreenCaptureKitOwnerLease.LeaseError.invalidOwnerIdentity("fixture drift")
             },
-            permissionStatusEvaluator: Self.grantedPermissions)
+            postEventAccessEvaluator: { true },
+            postEventAccessRequester: { false },
+            permissionStatusEvaluator: Self.grantedPermissions,
+            windowOwnerProcessIdentifierProvider: { _ in nil },
+            windowBoundsProvider: { _ in nil },
+            maximizedVisibleWorkAreaProvider: { _ in nil },
+            processStartIdentityProvider: { _ in nil },
+            processPresenceProvider: { _ in false })
         let host = PeekabooBridgeHost(
             socketPath: socketPath,
             server: server,
@@ -436,13 +544,14 @@ struct AutoScreenCaptureConcurrencyTests {
 
     @Test
     func `Claimed automatic screen capture falls back to legacy after modern failure`() async throws {
-        let socketPath = "/tmp/peekaboo-auto-screen-modern-fallback-\(UUID().uuidString).sock"
+        let socketPath = Self.fixtureSocketPath()
         let ownerReceipt = try #require(Self.currentProcessOwnerReceipt())
         let claimCounter = BridgeOwnerClaimCounter()
         let observation = BridgeAutoScreenObservationService(
             failSlowAutomaticCapture: false,
             failModernAutomaticCapture: true)
         let services = StubServices(
+            snapshots: InMemorySnapshotManager(),
             desktopObservation: observation,
             supportsScreenCaptureKitProcessOwnership: true)
         let server = PeekabooBridgeServer(
@@ -451,12 +560,22 @@ struct AutoScreenCaptureConcurrencyTests {
             allowlistedTeams: [],
             allowlistedBundles: [],
             allowedOperations: [.desktopObservation],
+            desktopOperationLaneCoordinator: DesktopOperationLaneCoordinator(
+                coordinationRootURL: URL(fileURLWithPath: socketPath + ".coordination")),
+            screenCaptureKitProcessCapabilityRegistrar: {},
             screenCaptureKitOwnershipPreparer: {},
             screenCaptureKitOwnerClaimProvider: {
                 claimCounter.record()
                 return ownerReceipt
             },
-            permissionStatusEvaluator: Self.grantedPermissions)
+            postEventAccessEvaluator: { true },
+            postEventAccessRequester: { false },
+            permissionStatusEvaluator: Self.grantedPermissions,
+            windowOwnerProcessIdentifierProvider: { _ in nil },
+            windowBoundsProvider: { _ in nil },
+            maximizedVisibleWorkAreaProvider: { _ in nil },
+            processStartIdentityProvider: { _ in nil },
+            processPresenceProvider: { _ in false })
         let host = PeekabooBridgeHost(
             socketPath: socketPath,
             server: server,
@@ -476,6 +595,10 @@ struct AutoScreenCaptureConcurrencyTests {
         #expect(observation.legacyAttemptCount == 1)
         #expect(claimCounter.count == 1)
         await host.stop()
+    }
+
+    private static func fixtureSocketPath() -> String {
+        FileManager.default.temporaryDirectory.appendingPathComponent("s-\(UUID().uuidString).sock").path
     }
 
     private static let backgroundAutoScreenRequest = DesktopObservationRequest(

--- a/Core/PeekabooCore/Tests/PeekabooTests/CaptureDiagnosticWireCompatibilityTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/CaptureDiagnosticWireCompatibilityTests.swift
@@ -1,0 +1,288 @@
+import Foundation
+import PeekabooFoundation
+import Testing
+@testable import PeekabooAutomationKit
+@testable import PeekabooBridge
+
+@Suite(.serialized)
+@MainActor
+struct CaptureDiagnosticWireCompatibilityTests {
+    @Test
+    func `unoffered signed late blocker survives an old decoder`() async throws {
+        let fixture = try await Self.fixture(offers: nil)
+        let response = try await Self.signedResponse(fixture)
+        let old = try JSONDecoder.peekabooBridgeDecoder().decode(
+            OldResponse.self,
+            from: PeekabooBridgeOperationReceiptCoding.canonicalData(response.response))
+        #expect(try PeekabooBridgeOperationReceiptCoding.sha256(old) == response.receipt.payload.responseSHA256)
+        #expect(Self.error(in: response.response)?.screenCaptureKitOwnershipDiagnostic == nil)
+        #expect(Self.error(in: response.response)?.message.contains("4242") == true)
+    }
+
+    @Test(arguments: ["absent", "unknown", "typed"], [29, PeekabooBridgeConstants.protocolVersion.minor])
+    func `signed diagnostics require an exact offer at each supported version`(offer: String, minor: Int) async throws {
+        let fixture = try await Self.fixture(offers: Self.offers(offer), version: .init(major: 1, minor: minor))
+        let response = try await Self.signedResponse(fixture)
+        let envelope = try #require(Self.error(in: response.response))
+        #expect(envelope.screenCaptureKitOwnershipDiagnostic == (offer == "typed" ? Self.diagnostic : nil))
+        #expect(envelope.standardizedErrorCode == .captureFailed)
+        #expect(envelope.message == Self.diagnostic.userMessage)
+        #expect(envelope.actionOutcome?.mutationDispatched == false)
+        if offer != "typed" {
+            let old = try JSONDecoder.peekabooBridgeDecoder().decode(
+                OldResponse.self, from: PeekabooBridgeOperationReceiptCoding.canonicalData(response.response))
+            #expect(try PeekabooBridgeOperationReceiptCoding.sha256(old) == response.receipt.payload.responseSHA256)
+        }
+    }
+
+    @Test(arguments: [false, true], [false, true])
+    func `signed projection preserves earlier mutation outcomes`(offered: Bool, projected: Bool) async throws {
+        let fixture = try await Self.fixture(offers: Self.offers(offered ? "typed" : "absent"), priorMutation: true)
+        if !projected {
+            let error = await #expect(throws: PeekabooBridgeErrorEnvelope.self) {
+                _ = try await Self.signedResponse(fixture, priorMutation: true, projected: false)
+            }
+            #expect(error?.code == .invalidRequest)
+            #expect(error?.message == "Mutating attested Bridge operations require action outcome carriage")
+            return
+        }
+        let response = try await Self.signedResponse(fixture, priorMutation: true, projected: projected)
+        let envelope = try #require(Self.error(in: response.response))
+        #expect(envelope.operationMayHaveCompleted)
+        #expect(envelope.actionOutcome?.mutationDispatched == true)
+        #expect(envelope.desktopActionFailure?.outcome.retrySafety == .unsafe)
+        #expect(envelope.standardizedErrorCode == .captureFailed)
+        #expect(envelope.screenCaptureKitOwnershipDiagnostic == (offered ? Self.diagnostic : nil))
+        if !offered {
+            let old = try JSONDecoder.peekabooBridgeDecoder().decode(
+                OldResponse.self, from: PeekabooBridgeOperationReceiptCoding.canonicalData(response.response))
+            #expect(try PeekabooBridgeOperationReceiptCoding.sha256(old) == response.receipt.payload.responseSHA256)
+        }
+    }
+
+    @Test
+    func `a later offered handshake cannot upgrade an earlier session`() async throws {
+        let old = try await Self.fixture(offers: nil)
+        let currentSession = try await Self.session(
+            server: old.server,
+            authority: old.authority,
+            peer: old.session.peer,
+            offers: Self.offers("typed"),
+            version: PeekabooBridgeConstants.protocolVersion)
+        let current = Fixture(server: old.server, authority: old.authority, session: currentSession)
+        #expect(try await Self.error(in: Self.signedResponse(old).response)?.screenCaptureKitOwnershipDiagnostic == nil)
+        #expect(try await Self.error(in: Self.signedResponse(current).response)?
+            .screenCaptureKitOwnershipDiagnostic == Self.diagnostic)
+        let rawData = await PeekabooBridgeRequestContext.$operationReceiptAuthority.withValue(old.authority) {
+            await old.server.handleDecoded(Self.request(priorMutation: false, projected: false), peer: old.session.peer)
+        }
+        let rawResponse = try JSONDecoder.peekabooBridgeDecoder().decode(PeekabooBridgeResponse.self, from: rawData)
+        #expect(Self.error(in: rawResponse)?.screenCaptureKitOwnershipDiagnostic == nil)
+        #expect(Self.error(in: rawResponse)?.standardizedErrorCode == .captureFailed)
+    }
+
+    @Test(arguments: ["absent", "unknown", "typed"], [false, true])
+    func `receiptless old protocol offers cannot authorize diagnostic fields`(
+        offer: String,
+        projected: Bool) async throws
+    {
+        let server = CaptureReadinessPublicationTests.server(
+            observation: LateBlockerObservation(diagnostic: Self.diagnostic, priorMutation: projected))
+        try await server.prepareScreenCaptureKitOwnershipForServing()
+        let peer = try OperationReceiptSessionFixture.currentPeer(codeSignatureHash: "synthetic-client")
+        let handshakeResponse = try await server.handleHandshake(
+            .init(
+                protocolVersion: .init(major: 1, minor: 28),
+                client: .init(bundleIdentifier: nil, teamIdentifier: nil, processIdentifier: getpid()),
+                operationClientInstanceID: UUID(),
+                clientCapabilities: Self.offers(offer)),
+            peer: peer,
+            permissions: Self.permissions)
+        guard case let .handshake(handshake) = handshakeResponse else { throw POSIXError(.EINVAL) }
+        #expect(handshake.operationSessionAttestation == nil)
+        #expect(handshake.screenCaptureKitReadiness?.permitsAttempt == true)
+        let request = Self.request(priorMutation: projected, projected: projected)
+        let data = await server.handleDecoded(request, peer: peer)
+        let response = try JSONDecoder.peekabooBridgeDecoder().decode(PeekabooBridgeResponse.self, from: data)
+        let envelope = try #require(Self.error(in: response))
+        #expect(envelope.screenCaptureKitOwnershipDiagnostic == nil)
+        #expect(envelope.standardizedErrorCode == .captureFailed)
+        #expect(envelope.operationMayHaveCompleted == projected)
+        let old = try JSONDecoder.peekabooBridgeDecoder().decode(OldResponse.self, from: data)
+        #expect(try PeekabooBridgeOperationReceiptCoding.canonicalData(old) ==
+            PeekabooBridgeOperationReceiptCoding.canonicalData(response))
+    }
+
+    @Test
+    func `current client offers diagnostic response semantics only with signed sessions`() {
+        #expect(PeekabooBridgeClient.offeredCapabilities(for: PeekabooBridgeConstants.protocolVersion)
+            .contains(PeekabooBridgeClientCapability.screenCaptureKitOwnershipDiagnostics))
+        #expect(PeekabooBridgeClient.offeredCapabilities(for: .init(major: 1, minor: 29))
+            .contains(PeekabooBridgeClientCapability.screenCaptureKitOwnershipDiagnostics))
+        #expect(!PeekabooBridgeClient.offeredCapabilities(for: .init(major: 1, minor: 28))
+            .contains(PeekabooBridgeClientCapability.screenCaptureKitOwnershipDiagnostics))
+    }
+
+    @Test
+    func `blocked capture readiness does not gate inspectAccessibilityTree`() async throws {
+        let diagnostic = Self.diagnostic
+        let server = CaptureReadinessPublicationTests.server(
+            allowedOperations: [.desktopObservation, .inspectAccessibilityTree],
+            preparation: { throw diagnostic })
+        try await server.prepareScreenCaptureKitOwnershipForServing()
+        try server.validateOperationAccess(
+            for: .inspectAccessibilityTree(.init(windowContext: nil)),
+            permissions: .init(screenRecording: false, accessibility: true, appleScript: false, postEvent: false),
+            effectiveOps: [.inspectAccessibilityTree])
+    }
+
+    private static func offers(_ offer: String) -> [String]? {
+        switch offer {
+        case "typed": [PeekabooBridgeClientCapability.screenCaptureKitOwnershipDiagnostics]
+        case "unknown": ["futureUnknownDiagnosticFormat"]
+        default: nil
+        }
+    }
+
+    private static let permissions = PermissionsStatus(
+        screenRecording: true, accessibility: true, appleScript: false, postEvent: false)
+
+    private static let diagnostic = ScreenCaptureKitOwnershipDiagnostic.capturing(
+        ScreenCaptureKitOwnerLease.LeaseError.uncoordinatedProcesses([
+            .init(processIdentifier: 4242, processStartIdentity: 9001, executablePath: "/synthetic/first"),
+            .init(processIdentifier: 4343, processStartIdentity: 9002, executablePath: "/synthetic/second"),
+        ]), stage: .entry)
+
+    private struct Fixture {
+        let server: PeekabooBridgeServer
+        let authority: PeekabooBridgeOperationReceiptAuthority
+        let session: OperationReceiptSessionFixture
+    }
+
+    private static func fixture(
+        offers: [String]?,
+        version: PeekabooBridgeProtocolVersion = PeekabooBridgeConstants.protocolVersion,
+        priorMutation: Bool = false) async throws -> Fixture
+    {
+        let socket = FileManager.default.temporaryDirectory.appendingPathComponent("wire-\(UUID().uuidString).sock")
+        let authority = try PeekabooBridgeOperationReceiptAuthority(socketPath: socket.path)
+        let peer = try OperationReceiptSessionFixture.currentPeer(
+            codeSignatureHash: "synthetic-client")
+        let server = CaptureReadinessPublicationTests.server(
+            observation: LateBlockerObservation(diagnostic: Self.diagnostic, priorMutation: priorMutation))
+        try await server.prepareScreenCaptureKitOwnershipForServing()
+        #expect(server.hostCapabilities.contains(PeekabooBridgeHostCapability.screenCaptureKitProcessOwnership))
+        let session = try await Self.session(
+            server: server,
+            authority: authority,
+            peer: peer,
+            offers: offers,
+            version: version)
+        return Fixture(server: server, authority: authority, session: session)
+    }
+
+    private static func session(
+        server: PeekabooBridgeServer,
+        authority: PeekabooBridgeOperationReceiptAuthority,
+        peer: PeekabooBridgePeer,
+        offers: [String]?,
+        version: PeekabooBridgeProtocolVersion) async throws -> OperationReceiptSessionFixture
+    {
+        let clientID = UUID()
+        let response = try await PeekabooBridgeRequestContext.$operationReceiptAuthority.withValue(authority) {
+            try await server.handleHandshake(
+                .init(
+                    protocolVersion: version,
+                    client: .init(
+                        bundleIdentifier: "synthetic.client",
+                        teamIdentifier: nil,
+                        processIdentifier: getpid()),
+                    operationClientInstanceID: clientID,
+                    clientCapabilities: offers),
+                peer: peer,
+                permissions: Self.permissions)
+        }
+        guard case let .handshake(handshake) = response else { throw POSIXError(.EINVAL) }
+        return try OperationReceiptSessionFixture(
+            clientInstanceID: clientID,
+            peer: peer,
+            attestation: #require(handshake.operationSessionAttestation))
+    }
+
+    private static func request(priorMutation: Bool, projected: Bool) -> PeekabooBridgeRequest {
+        let request = PeekabooBridgeRequest.desktopObservation(.init(
+            target: .screen(index: 0),
+            capture: .init(engine: .modern, focus: priorMutation ? .foreground : .background),
+            detection: .init(mode: .none)))
+        return projected ? .projectedAction(.init(request: request)) : request
+    }
+
+    private static func signedResponse(
+        _ fixture: Fixture,
+        priorMutation: Bool = false,
+        projected: Bool = false) async throws -> PeekabooBridgeAttestedOperationResponse
+    {
+        let request = Self.request(priorMutation: priorMutation, projected: projected)
+        let payload = fixture.session.request(authority: fixture.authority, sequence: 0, request: request)
+        let data = try await PeekabooBridgeRequestContext.$operationReceiptAuthority.withValue(fixture.authority) {
+            try await fixture.server.handleAttestedOperation(payload, peer: fixture.session.peer)
+        }
+        guard case let .attestedOperation(response) = try JSONDecoder.peekabooBridgeDecoder()
+            .decode(PeekabooBridgeResponse.self, from: data) else { throw POSIXError(.EINVAL) }
+        try response.receipt.validateSignature(publicKey: fixture.authority.attestation.publicKey)
+        #expect(try PeekabooBridgeOperationReceiptCoding.sha256(response.response) == response.receipt.payload
+            .responseSHA256)
+        return response
+    }
+
+    private static func error(in response: PeekabooBridgeResponse) -> PeekabooBridgeErrorEnvelope? {
+        switch response {
+        case let .error(envelope): envelope
+        case let .projectedAction(projected): self.error(in: projected.response)
+        default: nil
+        }
+    }
+}
+
+@MainActor
+private struct LateBlockerObservation: DesktopObservationServiceProtocol {
+    let diagnostic: ScreenCaptureKitOwnershipDiagnostic
+    let priorMutation: Bool
+
+    func observe(_ request: DesktopObservationRequest) async throws -> DesktopObservationResult {
+        if self.priorMutation {
+            throw DesktopActionFailure.indeterminate(
+                delivery: .init(mechanism: .capturePipeline, mode: .foreground),
+                evidence: .completionUnknown,
+                message: self.diagnostic.userMessage)
+                .preservingScreenCaptureKitDiagnostic(self.diagnostic)
+        }
+        throw self.diagnostic
+    }
+}
+
+/// Shipped response vocabulary, deliberately without the new diagnostic field.
+private enum OldResponse: Codable {
+    case error(OldErrorEnvelope)
+    indirect case projectedAction(OldProjectedResponse)
+}
+
+private struct OldProjectedResponse: Codable {
+    let response: OldResponse
+    let outcome: DesktopActionOutcome.Projection?
+}
+
+private struct OldErrorEnvelope: Codable {
+    let code: PeekabooBridgeErrorCode
+    let message: String
+    let details: String?
+    let permission: PeekabooBridgePermissionKind?
+    let kind: PeekabooBridgeErrorKind?
+    let context: String?
+    let operationMayHaveCompleted: Bool?
+    let actionOutcome: DesktopActionOutcome.Projection?
+    let actionFailureHint: String?
+    let actionFailureCauseDescription: String?
+    let actionTargetReceipt: DesktopActionTargetReceipt?
+    let actionSelectedLeafEvidence: [DesktopSelectedLeafEvidence]?
+}

--- a/Core/PeekabooCore/Tests/PeekabooTests/CaptureReadinessPublicationTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/CaptureReadinessPublicationTests.swift
@@ -1,0 +1,238 @@
+import Foundation
+import PeekabooFoundation
+import Testing
+@testable import PeekabooAutomationKit
+@testable import PeekabooBridge
+
+@Suite(.serialized)
+@MainActor
+struct CaptureReadinessPublicationTests {
+    @Test
+    func `authenticated transport retains every preparation blocker`() async throws {
+        let blockers: [ScreenCaptureKitOwnerLease.UncoordinatedProcess] = [
+            .init(processIdentifier: 4242, processStartIdentity: 9001, executablePath: "/synthetic/first"),
+            .init(processIdentifier: 4343, processStartIdentity: 9002, executablePath: "/synthetic/second"),
+        ]
+        let server = Self.server(hostIdentity: .current(), preparation: {
+            throw ScreenCaptureKitOwnerLease.LeaseError.uncoordinatedProcesses(blockers)
+        })
+        let socket = FileManager.default.temporaryDirectory
+            .appendingPathComponent("s-\(UUID().uuidString).sock").path
+        let host = PeekabooBridgeHost(socketPath: socket, server: server, allowedTeamIDs: [])
+        try await host.startChecked()
+        defer { Task { await host.stop() } }
+        let client = TrustedBridgeClientFixture.make(socketPath: socket, requestTimeoutSec: 2)
+        let handshake = try await client.handshake(
+            client: .init(bundleIdentifier: "synthetic.readiness", teamIdentifier: nil, processIdentifier: getpid()))
+        #expect(handshake.operationAttestation != nil)
+        let error = await #expect(throws: DesktopActionFailure.self) {
+            _ = try await client.desktopObservation(.init(
+                target: .screen(index: 0), capture: .init(engine: .modern), detection: .init(mode: .none)))
+        }
+        #expect(error?.standardErrorCode == .captureFailed)
+        #expect(error?.screenCaptureKitOwnershipDiagnostic?.blockers.map(\.processIdentifier) == [4242, 4343])
+        #expect(error?.screenCaptureKitOwnershipDiagnostic?.blockers.map(\.processStartIdentity) == [9001, 9002])
+        await host.stop()
+    }
+
+    @Test
+    func `blocked preparation preserves implementation proof`() async throws {
+        let blocker = ScreenCaptureKitOwnerLease.UncoordinatedProcess(
+            processIdentifier: 4242,
+            processStartIdentity: 9001,
+            executablePath: "/synthetic/PotentialHost.app/Contents/MacOS/PotentialHost")
+        let server = Self.server(preparation: {
+            throw ScreenCaptureKitOwnerLease.LeaseError.uncoordinatedProcesses([blocker])
+        })
+        try await server.prepareScreenCaptureKitOwnershipForServing()
+
+        // This assertion also ran, and failed, against unchanged production code.
+        #expect(server.hostCapabilities.contains("screenCaptureKitOwnershipEnforcement"))
+        #expect(!server.hostCapabilities.contains(PeekabooBridgeHostCapability.screenCaptureKitProcessOwnership))
+        #expect(server.hostCapabilities.contains(PeekabooBridgeHostCapability.classicCaptureWithoutScreenCaptureKit))
+        #expect(server.screenCaptureKitReadiness?.state == .blocked)
+        #expect(server.screenCaptureKitReadiness?.failure?.blockers == [.init(
+            processIdentifier: 4242,
+            processStartIdentity: 9001,
+            executablePath: "/synthetic/PotentialHost.app/Contents/MacOS/PotentialHost")])
+    }
+
+    @Test(arguments: [CaptureEnginePreference.auto, .modern, .legacy])
+    func `blocked readiness only admits explicit classic`(engine: CaptureEnginePreference) async throws {
+        let server = Self.server(preparation: {
+            throw ScreenCaptureKitOwnerLease.LeaseError.preparationTimedOut(seconds: 1)
+        })
+        try await server.prepareScreenCaptureKitOwnershipForServing()
+        let request = PeekabooBridgeRequest.desktopObservation(.init(
+            target: .screen(index: 0), capture: .init(engine: engine), detection: .init(mode: .none)))
+        if engine == .legacy {
+            try server.validateOperationAccess(
+                for: request,
+                permissions: Self.permissions,
+                effectiveOps: [.desktopObservation])
+        } else {
+            let error = #expect(throws: ScreenCaptureKitOwnershipDiagnostic.self) {
+                try server.validateOperationAccess(
+                    for: request, permissions: Self.permissions, effectiveOps: [.desktopObservation])
+            }
+            #expect(error?.kind == .timedOut)
+        }
+    }
+
+    @Test
+    func `caller capabilities cannot invent implementation or classic proof`() async throws {
+        let claimed: Set<String> = [
+            PeekabooBridgeHostCapability.screenCaptureKitProcessOwnership,
+            PeekabooBridgeHostCapability.screenCaptureKitOwnershipEnforcement,
+            PeekabooBridgeHostCapability.classicCaptureWithoutScreenCaptureKit,
+        ]
+        for allowed in [Set<PeekabooBridgeOperation>(), [.desktopObservation]] {
+            let server = Self.server(supportsCaptureContract: false, allowedOperations: allowed, capabilities: claimed)
+            try await server.prepareScreenCaptureKitOwnershipForServing()
+            #expect(server.hostCapabilities.isDisjoint(with: claimed))
+        }
+        let disabled = Self.server(allowedOperations: [], capabilities: claimed)
+        #expect(disabled.hostCapabilities.isDisjoint(with: claimed))
+    }
+
+    @Test
+    func `registration failure remains typed and classic capable`() async throws {
+        let server = Self.server(registrar: {
+            throw ScreenCaptureKitOwnerLease.LeaseError.systemCall(
+                operation: "register",
+                path: "/synthetic/marker",
+                code: 13)
+        })
+        try await server.prepareScreenCaptureKitOwnershipForServing()
+        #expect(server.screenCaptureKitReadiness?.failure?.stage == .registration)
+        #expect(server.screenCaptureKitReadiness?.failure?.systemCode == 13)
+        #expect(server.screenCaptureKitReadiness?.failure?.path == "/synthetic/marker")
+        #expect(server.hostCapabilities.contains(PeekabooBridgeHostCapability.classicCaptureWithoutScreenCaptureKit))
+    }
+
+    @Test
+    func `cancelled preparation publishes unavailable readiness while retaining classic proof`() async throws {
+        let server = Self.server(preparation: { throw CancellationError() })
+        try await server.prepareScreenCaptureKitOwnershipForServing()
+        #expect(server.screenCaptureKitReadiness?.state == .unavailable)
+        #expect(server.screenCaptureKitReadiness?.failure?.kind == .cancelled)
+        #expect(server.screenCaptureKitReadiness?.failure?.stage == .preparation)
+        #expect(server.hostCapabilities.contains(PeekabooBridgeHostCapability.classicCaptureWithoutScreenCaptureKit))
+        #expect(!server.hostCapabilities.contains(PeekabooBridgeHostCapability.screenCaptureKitProcessOwnership))
+    }
+
+    @Test
+    func `handshake absent and future readiness decode without authority`() throws {
+        let old = Self.handshake(readiness: nil)
+        let encoded = try JSONEncoder().encode(old)
+        #expect(try JSONDecoder().decode(PeekabooBridgeHandshakeResponse.self, from: encoded)
+            .screenCaptureKitReadiness == nil)
+        var object = try #require(JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+        object["screenCaptureKitReadiness"] = ["state": "futureState"]
+        let future = try JSONDecoder().decode(
+            PeekabooBridgeHandshakeResponse.self, from: JSONSerialization.data(withJSONObject: object))
+        #expect(future.screenCaptureKitReadiness?.state == .unknown)
+        #expect(future.screenCaptureKitReadiness?.permitsAttempt == false)
+        object["screenCaptureKitReadiness"] = ["state": "ready"]
+        let unobserved = try JSONDecoder().decode(
+            PeekabooBridgeHandshakeResponse.self, from: JSONSerialization.data(withJSONObject: object))
+        #expect(unobserved.screenCaptureKitReadiness?.permitsAttempt == false)
+        let oldPeer = try JSONDecoder().decode(OldHandshake.self, from: JSONEncoder().encode(Self.handshake(
+            readiness: .init(state: .ready))))
+        #expect(oldPeer.negotiatedVersion == PeekabooBridgeConstants.protocolVersion)
+    }
+
+    @Test
+    func `multi blocker diagnostics survive wire and earlier mutation`() throws {
+        let error = ScreenCaptureKitOwnerLease.LeaseError.uncoordinatedHosts([
+            .init(
+                socketPath: "/synthetic/a.sock",
+                processIdentifier: 41,
+                processStartIdentity: 51,
+                buildIdentity: "build-a"),
+            .init(
+                socketPath: "/synthetic/b.sock",
+                processIdentifier: 42,
+                processStartIdentity: 52,
+                buildIdentity: "build-b"),
+        ])
+        let diagnostic = ScreenCaptureKitOwnershipDiagnostic.capturing(error, stage: .entry)
+        let readiness = ScreenCaptureKitReadiness.failed(error, stage: .preparation)
+        let handshake = try JSONDecoder().decode(
+            PeekabooBridgeHandshakeResponse.self, from: JSONEncoder().encode(Self.handshake(readiness: readiness)))
+        #expect(handshake.screenCaptureKitReadiness == readiness)
+        let outcome = DesktopActionOutcome.dispatchedUnverified(
+            delivery: .init(mechanism: .nativeFramework, mode: .foreground),
+            evidence: .deliveryAccepted,
+            unitCount: .one)
+        let failure = try #require(ObservationActionResultSemantics.preservingFailure(
+            diagnostic, after: outcome, targetReceipt: nil, operation: "capture") as? DesktopActionFailure)
+        #expect(failure.outcome.dispatchState.mutationDispatched)
+        #expect(failure.screenCaptureKitOwnershipDiagnostic == diagnostic)
+        let envelope = PeekabooBridgeServer.bridgeErrorEnvelope(for: failure, operation: .desktopObservation)
+        let decoded = try JSONDecoder().decode(PeekabooBridgeErrorEnvelope.self, from: JSONEncoder().encode(envelope))
+        #expect(decoded.desktopActionFailure?.screenCaptureKitOwnershipDiagnostic == diagnostic)
+        #expect(decoded.operationMayHaveCompleted)
+        #expect(decoded.legacyCompatible.screenCaptureKitOwnershipDiagnostic == nil)
+        #expect(decoded.legacyCompatible.operationMayHaveCompleted)
+    }
+
+    private struct OldHandshake: Decodable {
+        let negotiatedVersion: PeekabooBridgeProtocolVersion
+        let supportedOperations: [PeekabooBridgeOperation]
+    }
+
+    private static let permissions = PermissionsStatus(
+        screenRecording: true, accessibility: true, appleScript: false, postEvent: false)
+
+    private static func handshake(readiness: ScreenCaptureKitReadiness?) -> PeekabooBridgeHandshakeResponse {
+        .init(
+            negotiatedVersion: PeekabooBridgeConstants.protocolVersion,
+            hostKind: .gui,
+            build: "fixture",
+            supportedOperations: [.desktopObservation],
+            screenCaptureKitReadiness: readiness)
+    }
+
+    static func server(
+        supportsCaptureContract: Bool = true,
+        allowedOperations: Set<PeekabooBridgeOperation> = [.desktopObservation],
+        capabilities: Set<String> = [],
+        hostIdentity: PeekabooBridgeHostIdentity? = nil,
+        observation: (any DesktopObservationServiceProtocol)? = nil,
+        registrar: @MainActor @Sendable () throws -> Void = {},
+        preparation: @escaping @Sendable () async throws -> Void = {}) -> PeekabooBridgeServer
+    {
+        PeekabooBridgeServer(
+            services: StubServices(
+                snapshots: InMemorySnapshotManager(),
+                desktopObservation: observation,
+                supportsScreenCaptureKitProcessOwnership: supportsCaptureContract,
+                supportsClassicCaptureWithoutScreenCaptureKit: supportsCaptureContract,
+                supportsDesktopObservationCaptureEngine: supportsCaptureContract),
+            allowlistedTeams: [],
+            allowlistedBundles: [],
+            allowedOperations: allowedOperations,
+            hostIdentity: hostIdentity,
+            hostCapabilities: capabilities,
+            desktopOperationLaneCoordinator: DesktopOperationLaneCoordinator(
+                coordinationRootURL: FileManager.default.temporaryDirectory
+                    .appendingPathComponent("readiness-\(UUID().uuidString)")),
+            screenCaptureKitProcessCapabilityRegistrar: registrar,
+            screenCaptureKitOwnershipPreparer: preparation,
+            screenCaptureKitOwnerClaimProvider: {
+                Issue.record("Preparation must not claim ownership")
+                throw ScreenCaptureKitOwnerLease.LeaseError.invalidOwnerIdentity("unexpected claim")
+            },
+            postEventAccessEvaluator: { false },
+            postEventAccessRequester: { false },
+            permissionStatusEvaluator: { _ in
+                PermissionsStatus(screenRecording: true, accessibility: true, appleScript: false, postEvent: false)
+            },
+            windowOwnerProcessIdentifierProvider: { _ in nil },
+            windowBoundsProvider: { _ in nil },
+            maximizedVisibleWorkAreaProvider: { _ in nil },
+            processStartIdentityProvider: { _ in nil },
+            processPresenceProvider: { _ in false })
+    }
+}

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeTests.swift
@@ -2198,6 +2198,8 @@ final class StubServices: PeekabooBridgeServiceProviding {
     let desktopObservation: any DesktopObservationServiceProtocol
     let permissions: PermissionsService = .init()
     let supportsScreenCaptureKitProcessOwnership: Bool
+    let supportsClassicCaptureWithoutScreenCaptureKit: Bool
+    let supportsDesktopObservationCaptureEngine: Bool
     var lastBrowserStatusChannel: String?
     var lastBrowserConnectTarget: (channel: String?, browserURL: String?)?
     var lastBrowserExecute: PeekabooBridgeBrowserExecuteRequest?
@@ -2244,7 +2246,9 @@ final class StubServices: PeekabooBridgeServiceProviding {
         snapshots: any SnapshotManagerProtocol = SnapshotManager(),
         desktopObservation: (any DesktopObservationServiceProtocol)? = nil,
         ownedDesktopOperationLanes: Set<PeekabooBridgeOperation> = [],
-        supportsScreenCaptureKitProcessOwnership: Bool = false)
+        supportsScreenCaptureKitProcessOwnership: Bool = false,
+        supportsClassicCaptureWithoutScreenCaptureKit: Bool = false,
+        supportsDesktopObservationCaptureEngine: Bool = false)
     {
         let desktopObservationStub = StubDesktopObservationService()
         self.screenCapture = self.screenCaptureStub
@@ -2256,6 +2260,8 @@ final class StubServices: PeekabooBridgeServiceProviding {
         self.desktopObservation = desktopObservation ?? desktopObservationStub
         self.ownedDesktopOperationLanes = ownedDesktopOperationLanes
         self.supportsScreenCaptureKitProcessOwnership = supportsScreenCaptureKitProcessOwnership
+        self.supportsClassicCaptureWithoutScreenCaptureKit = supportsClassicCaptureWithoutScreenCaptureKit
+        self.supportsDesktopObservationCaptureEngine = supportsDesktopObservationCaptureEngine
     }
 
     func ownsDesktopOperationLane(for operation: PeekabooBridgeOperation) -> Bool {

--- a/Core/PeekabooCore/Tests/PeekabooTests/ScreenCaptureServiceFlowTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/ScreenCaptureServiceFlowTests.swift
@@ -1,5 +1,6 @@
 import AppKit
 import Foundation
+import PeekabooAutomationKitTestSupport
 import PeekabooFoundation
 import Testing
 @testable import PeekabooAgentRuntime
@@ -8,7 +9,7 @@ import Testing
 @testable import PeekabooCore
 @testable import PeekabooVisualizer
 
-@Suite(.tags(.ui))
+@Suite(.serialized, .tags(.ui), CaptureTestIsolation())
 @MainActor
 struct ScreenCaptureServiceFlowTests {
     private func makeFixtures() -> ScreenCaptureService.TestFixtures {
@@ -308,7 +309,8 @@ struct ScreenCaptureServiceFlowTests {
             applicationResolver: FixtureResolver(fixtures: fixtures),
             makeFrameSource: { _ in NoOpCaptureFrameSource() },
             makeModernOperator: { _, _ in captureOperator },
-            makeLegacyOperator: { _ in captureOperator })
+            makeLegacyOperator: { _ in captureOperator },
+            screenLockProbe: { false })
         let service = ScreenCaptureService(
             loggingService: MockLoggingService(),
             dependencies: dependencies)
@@ -335,7 +337,8 @@ struct ScreenCaptureServiceFlowTests {
             applicationResolver: FixtureResolver(fixtures: fixtures),
             makeFrameSource: { _ in NoOpCaptureFrameSource() },
             makeModernOperator: { _, _ in failingOperator },
-            makeLegacyOperator: { _ in legacyOperator })
+            makeLegacyOperator: { _ in legacyOperator },
+            screenLockProbe: { false })
 
         let service = ScreenCaptureService(loggingService: MockLoggingService(), dependencies: dependencies)
 
@@ -359,7 +362,8 @@ struct ScreenCaptureServiceFlowTests {
             applicationResolver: FixtureResolver(fixtures: fixtures),
             makeFrameSource: { _ in NoOpCaptureFrameSource() },
             makeModernOperator: { _, _ in modernOperator },
-            makeLegacyOperator: { _ in legacyOperator })
+            makeLegacyOperator: { _ in legacyOperator },
+            screenLockProbe: { false })
         let service = ScreenCaptureService(loggingService: MockLoggingService(), dependencies: dependencies)
         let windowID = CGWindowID(truncatingIfNeeded: "Dashboard".hashValue)
 
@@ -384,7 +388,8 @@ struct ScreenCaptureServiceFlowTests {
             applicationResolver: FixtureResolver(fixtures: fixtures),
             makeFrameSource: { _ in NoOpCaptureFrameSource() },
             makeModernOperator: { _, _ in FixtureCaptureOperator(fixtures: fixtures) },
-            makeLegacyOperator: { _ in FixtureCaptureOperator(fixtures: fixtures) })
+            makeLegacyOperator: { _ in FixtureCaptureOperator(fixtures: fixtures) },
+            screenLockProbe: { false })
 
         let service = ScreenCaptureService(loggingService: MockLoggingService(), dependencies: dependencies)
 
@@ -406,7 +411,8 @@ struct ScreenCaptureServiceFlowTests {
             applicationResolver: FixtureResolver(fixtures: fixtures),
             makeFrameSource: { _ in NoOpCaptureFrameSource() },
             makeModernOperator: { _, _ in FixtureCaptureOperator(fixtures: fixtures) },
-            makeLegacyOperator: { _ in FixtureCaptureOperator(fixtures: fixtures) })
+            makeLegacyOperator: { _ in FixtureCaptureOperator(fixtures: fixtures) },
+            screenLockProbe: { false })
 
         let service = ScreenCaptureService(loggingService: MockLoggingService(), dependencies: dependencies)
 
@@ -427,7 +433,8 @@ struct ScreenCaptureServiceFlowTests {
             applicationResolver: FixtureResolver(fixtures: fixtures),
             makeFrameSource: { _ in NoOpCaptureFrameSource() },
             makeModernOperator: { _, _ in FixtureCaptureOperator(fixtures: fixtures) },
-            makeLegacyOperator: { _ in FixtureCaptureOperator(fixtures: fixtures) })
+            makeLegacyOperator: { _ in FixtureCaptureOperator(fixtures: fixtures) },
+            screenLockProbe: { false })
         let service = ScreenCaptureService(loggingService: MockLoggingService(), dependencies: dependencies)
 
         _ = try await service.withCaptureEngine(.legacy) {

--- a/Core/PeekabooFoundation/Sources/PeekabooFoundation/DesktopActionOutcome.swift
+++ b/Core/PeekabooFoundation/Sources/PeekabooFoundation/DesktopActionOutcome.swift
@@ -763,6 +763,13 @@ public struct DesktopActionFailure: Codable, Equatable, LocalizedError, Sendable
     public let standardErrorCode: StandardErrorCode?
     public let targetReceipt: DesktopActionTargetReceipt?
     public let selectedLeafEvidence: [DesktopSelectedLeafEvidence]?
+    public private(set) var screenCaptureKitOwnershipDiagnostic: ScreenCaptureKitOwnershipDiagnostic?
+
+    public func removingScreenCaptureKitDiagnostic() -> Self {
+        var compatible = self
+        compatible.screenCaptureKitOwnershipDiagnostic = nil
+        return compatible
+    }
 
     public init?(
         outcome: DesktopActionOutcome,
@@ -771,7 +778,8 @@ public struct DesktopActionFailure: Codable, Equatable, LocalizedError, Sendable
         causeDescription: String? = nil,
         standardErrorCode: StandardErrorCode? = nil,
         targetReceipt: DesktopActionTargetReceipt? = nil,
-        selectedLeafEvidence: [DesktopSelectedLeafEvidence]? = nil)
+        selectedLeafEvidence: [DesktopSelectedLeafEvidence]? = nil,
+        screenCaptureKitOwnershipDiagnostic: ScreenCaptureKitOwnershipDiagnostic? = nil)
     {
         guard !outcome.isConfirmed,
               selectedLeafEvidence == nil || outcome.dispatchState.mutationDispatched,
@@ -783,6 +791,7 @@ public struct DesktopActionFailure: Codable, Equatable, LocalizedError, Sendable
         self.hint = hint
         self.causeDescription = causeDescription
         self.standardErrorCode = standardErrorCode
+        self.screenCaptureKitOwnershipDiagnostic = screenCaptureKitOwnershipDiagnostic
         self.targetReceipt = targetReceipt
         self.selectedLeafEvidence = selectedLeafEvidence
     }
@@ -911,13 +920,15 @@ public struct DesktopActionFailure: Codable, Equatable, LocalizedError, Sendable
         causeDescription: String?,
         standardErrorCode: StandardErrorCode? = nil,
         targetReceipt: DesktopActionTargetReceipt? = nil,
-        selectedLeafEvidence: [DesktopSelectedLeafEvidence]? = nil)
+        selectedLeafEvidence: [DesktopSelectedLeafEvidence]? = nil,
+        screenCaptureKitOwnershipDiagnostic: ScreenCaptureKitOwnershipDiagnostic? = nil)
     {
         self.outcome = outcome
         self.message = message
         self.hint = hint
         self.causeDescription = causeDescription
         self.standardErrorCode = standardErrorCode
+        self.screenCaptureKitOwnershipDiagnostic = screenCaptureKitOwnershipDiagnostic
         self.targetReceipt = targetReceipt
         self.selectedLeafEvidence = outcome.dispatchState.mutationDispatched ? selectedLeafEvidence : nil
     }
@@ -943,7 +954,8 @@ public struct DesktopActionFailure: Codable, Equatable, LocalizedError, Sendable
             causeDescription: self.causeDescription,
             standardErrorCode: self.standardErrorCode,
             targetReceipt: self.targetReceipt,
-            selectedLeafEvidence: self.selectedLeafEvidence)
+            selectedLeafEvidence: self.selectedLeafEvidence,
+            screenCaptureKitOwnershipDiagnostic: self.screenCaptureKitOwnershipDiagnostic)
     }
 
     /// Attaches a resolved target only after the execution owner has established it.
@@ -956,7 +968,8 @@ public struct DesktopActionFailure: Codable, Equatable, LocalizedError, Sendable
             causeDescription: self.causeDescription,
             standardErrorCode: self.standardErrorCode,
             targetReceipt: targetReceipt,
-            selectedLeafEvidence: self.selectedLeafEvidence)
+            selectedLeafEvidence: self.selectedLeafEvidence,
+            screenCaptureKitOwnershipDiagnostic: self.screenCaptureKitOwnershipDiagnostic)
     }
 
     /// Attaches the exact selected leaves only after at least one mutation crossed dispatch.
@@ -973,10 +986,25 @@ public struct DesktopActionFailure: Codable, Equatable, LocalizedError, Sendable
             causeDescription: self.causeDescription,
             standardErrorCode: self.standardErrorCode,
             targetReceipt: self.targetReceipt,
-            selectedLeafEvidence: evidence)
+            selectedLeafEvidence: evidence,
+            screenCaptureKitOwnershipDiagnostic: self.screenCaptureKitOwnershipDiagnostic)
+    }
+
+    public func preservingScreenCaptureKitDiagnostic(_ diagnostic: ScreenCaptureKitOwnershipDiagnostic?) -> Self {
+        guard let diagnostic else { return self }
+        return Self(
+            validatedOutcome: self.outcome,
+            message: self.message,
+            hint: self.hint,
+            causeDescription: self.causeDescription,
+            standardErrorCode: self.standardErrorCode ?? .captureFailed,
+            targetReceipt: self.targetReceipt,
+            selectedLeafEvidence: self.selectedLeafEvidence,
+            screenCaptureKitOwnershipDiagnostic: diagnostic)
     }
 
     private enum CodingKeys: String, CodingKey {
+        case screenCaptureKitOwnershipDiagnostic = "screen_capture_kit_ownership_diagnostic"
         case outcome
         case message
         case hint
@@ -1000,6 +1028,8 @@ public struct DesktopActionFailure: Codable, Equatable, LocalizedError, Sendable
         self.hint = try container.decodeIfPresent(String.self, forKey: .hint)
         self.causeDescription = try container.decodeIfPresent(String.self, forKey: .causeDescription)
         self.standardErrorCode = try container.decodeIfPresent(StandardErrorCode.self, forKey: .standardErrorCode)
+        self.screenCaptureKitOwnershipDiagnostic = try container.decodeIfPresent(
+            ScreenCaptureKitOwnershipDiagnostic.self, forKey: .screenCaptureKitOwnershipDiagnostic)
         self.targetReceipt = try container.decodeIfPresent(DesktopActionTargetReceipt.self, forKey: .targetReceipt)
         self.selectedLeafEvidence = try container.decodeIfPresent(
             [DesktopSelectedLeafEvidence].self,

--- a/Core/PeekabooFoundation/Sources/PeekabooFoundation/ScreenCaptureKitOwnershipDiagnostic.swift
+++ b/Core/PeekabooFoundation/Sources/PeekabooFoundation/ScreenCaptureKitOwnershipDiagnostic.swift
@@ -1,0 +1,171 @@
+import Foundation
+
+/// Evidence from an ownership check, not a claim that an uncoordinated process used ScreenCaptureKit.
+public struct ScreenCaptureKitOwnershipDiagnostic: Codable, Equatable, StandardizedError {
+    public enum Kind: String, Codable, Sendable {
+        case fileSystem, systemCall, unsafeDirectory, unsafeLockFile, invalidOwnerIdentity, invalidOwnerReceipt
+        case ownedByAnotherProcess, uncoordinatedProcesses, uncoordinatedHosts, timedOut, cancelled, unavailable,
+             unknown
+
+        public init(from decoder: any Decoder) throws {
+            self = try Self(rawValue: decoder.singleValueContainer().decode(String.self)) ?? .unknown
+        }
+    }
+
+    public enum Stage: String, Codable, Sendable {
+        case registration, preparation, entry, admission, unknown
+
+        public init(from decoder: any Decoder) throws {
+            self = try Self(rawValue: decoder.singleValueContainer().decode(String.self)) ?? .unknown
+        }
+    }
+
+    public struct ProcessEvidence: Codable, Equatable, Sendable {
+        public let processIdentifier: Int32?
+        public let processStartIdentity: UInt64?
+        public let executablePath: String?
+        public let socketPath: String?
+        public let buildIdentity: String?
+        public let codeSignatureHash: String?
+
+        public init(
+            processIdentifier: Int32? = nil,
+            processStartIdentity: UInt64? = nil,
+            executablePath: String? = nil,
+            socketPath: String? = nil,
+            buildIdentity: String? = nil,
+            codeSignatureHash: String? = nil)
+        {
+            self.processIdentifier = processIdentifier
+            self.processStartIdentity = processStartIdentity
+            self.executablePath = executablePath
+            self.socketPath = socketPath
+            self.buildIdentity = buildIdentity
+            self.codeSignatureHash = codeSignatureHash
+        }
+
+        public var description: String {
+            var parts: [String] = []
+            if let processIdentifier {
+                parts.append("PID \(processIdentifier)")
+            }
+            if let processStartIdentity {
+                parts.append("generation \(processStartIdentity)")
+            }
+            if let executablePath {
+                parts.append(executablePath)
+            }
+            if let socketPath {
+                parts.append("socket \(socketPath)")
+            }
+            if let buildIdentity {
+                parts.append("build \(buildIdentity)")
+            }
+            if let codeSignatureHash {
+                parts.append("CDHash \(codeSignatureHash)")
+            }
+            return parts.isEmpty ? "unknown process identity" : parts.joined(separator: ", ")
+        }
+    }
+
+    public let kind: Kind
+    public let stage: Stage
+    public let message: String
+    public let operation: String?
+    public let path: String?
+    public let systemCode: Int32?
+    public let timeoutSeconds: TimeInterval?
+    public let blockers: [ProcessEvidence]
+    public let selectedHost: ProcessEvidence?
+
+    public init(
+        kind: Kind,
+        stage: Stage,
+        message: String,
+        operation: String? = nil,
+        path: String? = nil,
+        systemCode: Int32? = nil,
+        timeoutSeconds: TimeInterval? = nil,
+        blockers: [ProcessEvidence] = [],
+        selectedHost: ProcessEvidence? = nil)
+    {
+        self.kind = kind
+        self.stage = stage
+        self.message = message
+        self.operation = operation
+        self.path = path
+        self.systemCode = systemCode
+        self.timeoutSeconds = timeoutSeconds
+        self.blockers = blockers
+        self.selectedHost = selectedHost
+    }
+
+    public var code: StandardErrorCode {
+        .captureFailed
+    }
+
+    public var context: [String: String] {
+        [:]
+    }
+
+    public var userMessage: String {
+        let host = self.selectedHost.map { "Selected host: \($0.description). " } ?? ""
+        let blockers = self.blockers.isEmpty ? "" :
+            " Blockers: " + self.blockers.map(\.description).joined(separator: "; ") + "."
+        return host + self.message + blockers + " The ownership check did not dispatch ScreenCaptureKit."
+    }
+
+    public func selectingHost(_ host: ProcessEvidence) -> Self {
+        Self(
+            kind: self.kind,
+            stage: self.stage,
+            message: self.message,
+            operation: self.operation,
+            path: self.path,
+            systemCode: self.systemCode,
+            timeoutSeconds: self.timeoutSeconds,
+            blockers: self.blockers,
+            selectedHost: host)
+    }
+}
+
+/// A preparation observation permits an attempt; actual ownership is checked again at every SCK entry.
+public struct ScreenCaptureKitReadiness: Codable, Equatable, Sendable {
+    public enum State: String, Codable, Sendable {
+        case ready, blocked, unavailable, unknown
+
+        public init(from decoder: any Decoder) throws {
+            self = try Self(rawValue: decoder.singleValueContainer().decode(String.self)) ?? .unknown
+        }
+    }
+
+    public let state: State
+    public let observedAt: Date?
+    public let failure: ScreenCaptureKitOwnershipDiagnostic?
+
+    public init(state: State, observedAt: Date = Date(), failure: ScreenCaptureKitOwnershipDiagnostic? = nil) {
+        self.state = state
+        self.observedAt = observedAt
+        self.failure = failure
+    }
+
+    public var permitsAttempt: Bool {
+        self.state == .ready && self.observedAt != nil && self.failure == nil
+    }
+
+    private enum CodingKeys: String, CodingKey { case state, observedAt, failure }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.state = try container.decodeIfPresent(State.self, forKey: .state) ?? .unknown
+        self.observedAt = try container.decodeIfPresent(Date.self, forKey: .observedAt)
+        self.failure = try container.decodeIfPresent(ScreenCaptureKitOwnershipDiagnostic.self, forKey: .failure)
+    }
+
+    public var refusal: ScreenCaptureKitOwnershipDiagnostic {
+        self.failure ?? .init(
+            kind: .unavailable,
+            stage: .admission,
+            message: "ScreenCaptureKit preparation readiness is unavailable.")
+    }
+}

--- a/docs/bridge-host.md
+++ b/docs/bridge-host.md
@@ -224,6 +224,27 @@ enabled `desktopObservation` operation is absent; an older host cannot silently 
 and run its default backend. `auto` remains compatible, and request-scoped selection does not alter
 the long-lived daemon's fallback policy.
 
+Capture support and startup preparation are separate, additive handshake contracts at the existing protocol version.
+`screenCaptureKitOwnershipEnforcement` and `classicCaptureWithoutScreenCaptureKit` are derived from the host's concrete
+service contracts and allowed observation operation. Caller-supplied capability strings cannot manufacture either
+proof. The older `screenCaptureKitProcessOwnership` capability remains conservative and is removed if registration or
+preparation fails, preserving old-client wire safety.
+
+Optional `screenCaptureKitReadiness` records the preparation observation and typed failure, including all original
+blocker identities that were available. A ready observation is permission to attempt SCK, not actual ownership.
+Unknown or missing readiness supplies no new SCK authority. A current blocked host can still accept explicit classic
+on that same socket when it proves no in-process SCK, while auto and modern return the typed refusal before capture.
+AX-only operations remain independent. Typed ownership errors also survive capture, permission, and Bridge error
+conversion; a refused SCK entry does not erase an earlier desktop mutation outcome.
+
+Typed terminal error fields additionally require the raw client offer `screenCaptureKitOwnershipDiagnostics`, bound to
+an authenticated operation session. Before computing the terminal response digest and signing its receipt, the host
+removes only the new diagnostic fields for sessions without that offer. This preserves shipped clients that decode
+unknown fields away before reconstructing the signed response digest. Offered sessions retain all typed blockers and
+any earlier mutation outcome. The offer works at existing signed-session protocol versions; receiptless requests
+(including older protocols and unknown offers) retain their legacy error shape. Handshake readiness is not part of a
+terminal operation response digest and remains additive.
+
 Protocol `1.22` adds process-generation receipts to process-targeted typing and clicks. Current CLI, Agent, and MCP background input retain the application discovery receipt through Bridge admission and native dispatch. Typing revalidates it before every emitted unit; clicks validate before dispatch and report a retry-unsafe indeterminate outcome if the generation changes after dispatch. Process-targeted Cmd+V uses the generation-pinned hotkey contract introduced in 1.19. New clients refuse older hosts before sending these inputs because an older decoder could otherwise ignore the optional receipt and route input using only a reusable PID. Legacy raw-PID payloads remain decodable for old clients, but current user-facing paths never select them.
 
 Protocol `1.29` adds listener-signed operation receipts without imposing a lifetime request limit on a long-running

--- a/docs/engine.md
+++ b/docs/engine.md
@@ -42,15 +42,29 @@ compatible Bridge host whose PID, process generation, and signed build match tha
 Every claim scans and refuses owner-unaware live processes, including processes discovered after the current generation
 acquired the canonical lease.
 
-Every transported engine requires the additive `screenCaptureKitProcessOwnership` host capability. For `auto` and
-`modern`, it proves the host enforces the owner lease; for `classic`, it proves a false CoreGraphics permission preflight
-will not fall into an in-process SCK probe. During an upgrade, Peekaboo refuses live older capture hosts before starting
-another owner; update/relaunch or stop those exact hosts first.
+Current hosts advertise implemented ownership enforcement separately from their observed preparation readiness.
+`screenCaptureKitOwnershipEnforcement` proves the service contract; optional `screenCaptureKitReadiness` reports
+preparation success, a blocker, or an unavailable check. Preparation never claims ownership, and every actual SCK entry
+still scans and claims independently. Blocked preparation retains the original typed failure and known blocker
+PID, generation, executable, socket, and build evidence. A potential uncoordinated host is not proof of actual SCK use.
+
+Explicit `classic`/`cg` uses `classicCaptureWithoutScreenCaptureKit` plus capture-engine transport to stay on the selected
+socket even when SCK preparation failed or its readiness report is missing. It retains permission evidence, enabled
+operation, target freshness, and receipt checks. Default/`auto` and explicit `modern` refuse a current host's blocked or
+unavailable readiness with that host and blocker context; they do not substitute classic. Unblocked auto behavior is
+unchanged. Older hosts carrying `screenCaptureKitProcessOwnership` retain their established compatibility contract.
+Hosts with neither applicable proof fail closed; engine transport or a version label alone is insufficient.
+
+CLI JSON errors expose available typed ownership evidence as `error.screen_capture_kit_ownership_diagnostic`, with
+`CAPTURE_FAILED` as the error code. This optional field includes the selected host and original blockers independently
+of action metadata, including for ordinary `see --json` preflight failures. Its absence supplies no ownership evidence.
+A blocked SCK entry does not imply that an earlier desktop mutation was absent or safe to repeat; any existing action
+outcome and retry-safety receipt remain authoritative.
 
 `--no-remote --capture-engine modern` explicitly requests caller-local ownership. If another Peekaboo process owns
 SCK, the command refuses before constructing local capture services or calling the framework. Retry without
-`--no-remote` to use the owner host, verify and stop that exact PID/process generation, or explicitly request
-`--capture-engine classic`. Peekaboo never silently changes an explicit `modern` request to classic. Explicit classic
+`--no-remote` to use a compatible host for that exact owner generation, or explicitly request
+`--capture-engine classic` on a host that proves the classic contract. Peekaboo never silently changes an explicit `modern` request to classic. Explicit classic
 does not probe or claim in-process ScreenCaptureKit. Because the CoreGraphics permission preflight is not authoritative
 for rebuilt CLI binaries, a false preflight must be corroborated by readable protected metadata from a foreign visible
 WindowServer window before classic dispatches; otherwise it refuses before a wallpaper-only capture can be accepted.
@@ -69,9 +83,9 @@ or remove the explicit socket. Classic remains a process-isolated, in-process-SC
 New CLI and app processes publish a private PID/process-generation/build receipt and retain its file lock for their
 lifetime. Before every SCK leaf, Peekaboo scans exact same-user Peekaboo and companion host entry points plus the known
 Peekaboo, Claude, and Clawdbot Bridge sockets. Ordinary Claude Code, renderer, crash-reporting, audio, and model helpers
-are not hosts. A matching live host without a valid current receipt is treated as a pre-lease process that may already
-own SCK, including a renamed official binary or long-running `agent`/`capture live` process. The first upgrade to this
-policy therefore has an explicit restart boundary: stop or relaunch every reported old process. Unlocked stale receipts
+are not hosts. A matching live host without a valid current receipt blocks SCK because its coordination cannot be
+proven, including a renamed official binary or long-running `agent`/`capture live` process. This observation does not
+establish whether that process has used SCK or which build first implemented ownership. Unlocked stale receipts
 are safely removed from a dedicated private marker directory; repeated scans reuse PID, process-generation, executable,
 and signature inspection results while revalidating the executable path.
 


### PR DESCRIPTION
## Summary

Fix the GUI capture readiness/diagnostic defect reproduced with the public Peekaboo 4.3.0 app and CLI. A current GUI implemented process-lifetime ScreenCaptureKit ownership, but a blocked startup preparation scan removed its capability. The CLI then incorrectly said the GUI predated safe ownership and rejected explicit classic capture with the same error, despite recommending classic as recovery.

Separate implemented support, observed preparation readiness, and ownership at the actual ScreenCaptureKit leaf. Preserve the original typed blocker instead of substituting the selected GUI's identity. A current host's positively proven no-in-process-SCK classic path can now run over that same explicit socket while preparation is blocked.

## Safety and compatibility

- Keep the external-app classifier, actual SCK leaf scans, process-lifetime lease, late-arrival checks, and quarantine behavior. Missing coordination proof is not evidence that another application actually used SCK.
- Keep default/auto and explicit modern fail-closed when readiness is blocked; do not silently convert either engine to classic or move capture into the caller/another host.
- Preserve independent permission, enabled-operation, engine-transport, exact-target, and receipt checks. AX-only observation remains independent of capture readiness.
- Carry typed ownership diagnostics through capture/permission errors, canonical action outcomes, Bridge, CLI error JSON, and `bridge status`.
- Negotiate new signed diagnostic fields per authenticated operation session. Older clients reconstruct response hashes after decoding, so unoffered fields are projected away before signing. Protocol remains 1.38.
- Isolate affected tests with inert service/permission/ownership providers and private coordination rather than touching user-wide ownership state.

Docs and the Unreleased changelog are updated. No version, appcast, release tag, dependency pin, or submodule pointer changes.

## Verification

Behavioral failures were recorded before each relevant repair and passed afterward: lost implementation capability, old-decoder signed-response hash mismatch, lost CLI diagnostic/error code, and the status report's missing readiness field.

| Focused run | Result |
| --- | --- |
| Core readiness, concurrency, capture flow, signed compatibility | 51 tests passed |
| CLI readiness, ownership, and engine routing | 58 tests passed |
| CLI error output, envelopes, and mapping | 63 tests passed |
| SCK leaf, permission, timeout, and quarantine guards | 19 tests passed |
| Final status/runtime regression run | 16 tests passed |

Counts are per run, not a sum of unique tests. Final changed-source SwiftFormat, full SwiftLint, documentation lint, and diff checks pass. The ordinary CLI and full GUI build; the full GUI bundle passed signature verification without being installed or launched. The complete final patch also passed the configured independent pre-commit review.

### Bounded live proof

A separate Developer-ID-signed GUI Bridge fixture exercised the production native host/capture path while the installed Peekaboo and the current Claude process remained running. All requests selected the exact fixture socket and a fresh synthetic window:

- Classic, the `cg` alias, and normal `see` with environment-selected classic all succeeded on that same GUI host.
- AX-only observation succeeded with blocked SCK readiness and read back the synthetic challenge.
- Default/modern refused before SCK dispatch with the actual blocker PID/generation, rather than calling the GUI old.
- The unchanged installed host remained fail-closed because its required support could not be proven; there was no reroute or caller-local fallback.
- The three successful 720×340 captures were byte-identical and inspected. The fixture completed checked shutdown and removed its socket afterward.

Before this fix, the public GUI produced no screenshot for either default or explicit classic capture. The following is the inspected, synthetic-only after image; it contains no personal desktop data:

![Synthetic exact-window classic capture through the GUI Bridge](https://github.com/user-attachments/assets/7154ae60-1717-456c-b1f9-8f24b48e59a6)

### Verification limits

This is shared production GUI Bridge/capture proof, not a restart of the full installed app or a complete release/automation qualification. The installed app was deliberately untouched; no TCC/security settings or ownership markers were manually changed.

Two pre-existing owner-lease assertions still fail at `FD_CLOFORK` on macOS 26.6.2 with Xcode 27 headers. An independent inert probe accepts `O_CLOFORK` but reports only `FD_CLOEXEC`. Those assertions and the ownership guarantee were not weakened; runtime/SDK qualification is a separate follow-up. The broader owner run passed 37 of 39 tests. The full local `test:safe`/automation matrix was not run against the operator's desktop; CI is the clean-host landing gate.

## CI follow-up

The first macOS CI run exposed a test-support conformance error: the capture-isolation helper selected the `@concurrent @Sendable` test-body signature only for Swift 6.4+, although CI’s Testing library requires it under the existing concurrency settings. A focused follow-up removes that incorrect compiler conditional. The private coordination and ownership guards, production behavior, and all assertions remain unchanged.

All six inert owner-leaf tests passed after the repair, along with scoped formatting and lint checks. The four-line delta passed the configured independent review. CI subsequently passed the previously failing mutation inventory/selector step on its own toolchain.

Final CI for `80df0163e9c2842ab37ec25721cc02ec30b00622`: [macOS CI](https://github.com/openclaw/Peekaboo/actions/runs/33717506038) passed all five jobs (Core, CLI, Tachikoma, app builds, SwiftLint); [CodeQL](https://github.com/openclaw/Peekaboo/actions/runs/33717505958) passed Swift, Actions, and JavaScript/TypeScript analysis. The initial compile failure was corrected in the focused follow-up above; no checks or assertions were disabled.
