### PR TITLE
fix(capture): verify close-on-fork ownership by behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+- Verify ScreenCaptureKit owner and capability-marker close-on-fork protection through child descriptor behavior instead of SDK query bits, preserving atomic open flags and isolating marker tests.
+
 ## [4.3.0] - 2026-09-02
 
 ### Highlights

--- a/Core/PeekabooAutomationKit/Package.swift
+++ b/Core/PeekabooAutomationKit/Package.swift
@@ -52,11 +52,16 @@ let package = Package(
                 .product(name: "PeekabooFoundationTestSupport", package: "PeekabooFoundation"),
             ],
             swiftSettings: approachableConcurrencySettings),
+        .target(
+            name: "DescriptorForkTestSupport",
+            path: "Tests/Support/DescriptorForkTestSupport",
+            publicHeadersPath: "include"),
         .testTarget(
             name: "PeekabooAutomationKitTests",
             dependencies: [
                 "PeekabooAutomationKit",
                 "PeekabooAutomationKitTestSupport",
+                "DescriptorForkTestSupport",
                 .product(name: "PeekabooFoundationTestSupport", package: "PeekabooFoundation"),
             ],
             path: "Tests/PeekabooAutomationKitTests",

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/ScreenCaptureKitOwnerLease.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/ScreenCaptureKitOwnerLease.swift
@@ -199,6 +199,8 @@ public final class ScreenCaptureKitOwnerLease: Sendable {
     public static let processCapabilityDirectoryURL = ScreenCaptureKitProcessCapabilityRegistry.directoryURL
 
     private static let maximumReceiptBytes = 4096
+    /// The compiler gate exposes the SDK flag, not an F_GETFD guarantee: macOS 26.6.2
+    /// honors atomic O_CLOFORK opens even though F_GETFD omits FD_CLOFORK.
     static let closeOnForkOpenFlag: Int32 = {
         #if compiler(>=6.4)
         O_CLOFORK

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/ScreenCaptureKitProcessCapabilityRegistry.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/ScreenCaptureKitProcessCapabilityRegistry.swift
@@ -62,7 +62,17 @@ enum ScreenCaptureKitProcessCapabilityRegistry {
     }
 
     static func register(ownerIdentity: Lease.OwnerIdentity) throws {
-        let signatureIdentity = self.currentCodeSignatureIdentity()
+        try self.register(
+            ownerIdentity: ownerIdentity,
+            directory: self.directoryURL,
+            signatureIdentity: self.currentCodeSignatureIdentity())
+    }
+
+    static func register(
+        ownerIdentity: Lease.OwnerIdentity,
+        directory: URL,
+        signatureIdentity: CodeSignatureIdentity?) throws
+    {
         let receipt = ProcessCapabilityReceipt(
             processIdentifier: ownerIdentity.processIdentifier,
             processStartIdentity: ownerIdentity.processStartIdentity,
@@ -72,7 +82,8 @@ enum ScreenCaptureKitProcessCapabilityRegistry {
             teamIdentifier: signatureIdentity?.teamIdentifier)
         let markerURL = self.markerURL(
             processIdentifier: receipt.processIdentifier,
-            processStartIdentity: receipt.processStartIdentity)
+            processStartIdentity: receipt.processStartIdentity,
+            directory: directory)
         let markerPath = markerURL.path
 
         try self.registryLock.withLock {

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ScreenCaptureKitOwnerLeaseTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ScreenCaptureKitOwnerLeaseTests.swift
@@ -1,4 +1,5 @@
 import Darwin
+import DescriptorForkTestSupport
 import Foundation
 import Testing
 @testable import PeekabooAutomationKit
@@ -29,30 +30,69 @@ struct ScreenCaptureKitOwnerLeaseTests {
 
     @Test
     func `Process capability marker is build bound and held for process lifetime`() throws {
-        let processStartIdentity = try #require(SystemIdentityResolver.processStartIdentity(getpid()))
+        let fixture = try LeaseFixture(name: "capability-marker")
+        defer { fixture.removeLockPath() }
+        let ownerIdentity = ScreenCaptureKitOwnerLease.OwnerIdentity(
+            processIdentifier: 42420,
+            processStartIdentity: 9001,
+            buildIdentity: "synthetic-marker-build",
+            codeSignatureHash: "synthetic-marker-cdhash")
+        let signatureIdentity = ScreenCaptureKitOwnerLease.CodeSignatureIdentity(
+            signingIdentifier: "test.peekaboo.marker",
+            teamIdentifier: "TESTTEAM",
+            codeSignatureHash: ownerIdentity.codeSignatureHash)
 
-        try ScreenCaptureKitOwnerLease.registerCurrentProcessCapability()
+        try ScreenCaptureKitProcessCapabilityRegistry.register(
+            ownerIdentity: ownerIdentity,
+            directory: fixture.directoryURL,
+            signatureIdentity: signatureIdentity)
 
         let markerURL = ScreenCaptureKitOwnerLease.processCapabilityMarkerURL(
-            processIdentifier: getpid(),
-            processStartIdentity: processStartIdentity)
+            processIdentifier: ownerIdentity.processIdentifier,
+            processStartIdentity: ownerIdentity.processStartIdentity,
+            directory: fixture.directoryURL)
+        let receiptData = try Data(contentsOf: markerURL)
         let receipt = try JSONDecoder().decode(
             ScreenCaptureKitOwnerLease.ProcessCapabilityReceipt.self,
-            from: Data(contentsOf: markerURL))
-        #expect(receipt.processIdentifier == getpid())
-        #expect(receipt.processStartIdentity == processStartIdentity)
-        #expect(receipt.buildIdentity?.isEmpty == false || receipt.codeSignatureHash?.isEmpty == false)
+            from: receiptData)
+        #expect(receipt.processIdentifier == ownerIdentity.processIdentifier)
+        #expect(receipt.processStartIdentity == ownerIdentity.processStartIdentity)
+        #expect(receipt.buildIdentity == ownerIdentity.buildIdentity)
+        #expect(receipt.codeSignatureHash == ownerIdentity.codeSignatureHash)
+        #expect(receipt.signingIdentifier == signatureIdentity.signingIdentifier)
+        #expect(receipt.teamIdentifier == signatureIdentity.teamIdentifier)
 
         var fileInfo = stat()
         #expect(lstat(markerURL.path, &fileInfo) == 0)
+        #expect(fileInfo.st_mode & mode_t(S_IFMT) == mode_t(S_IFREG))
         #expect(fileInfo.st_uid == geteuid())
         #expect(fileInfo.st_nlink == 1)
         #expect(fileInfo.st_mode & mode_t(S_IRWXU | S_IRWXG | S_IRWXO) == mode_t(S_IRUSR | S_IWUSR))
         let heldDescriptor = try #require(self.descriptor(for: fileInfo))
-        #expect(fcntl(heldDescriptor, F_GETFD) & FD_CLOEXEC == FD_CLOEXEC)
+        self.expectLiveCloseOnExecDescriptor(heldDescriptor, matching: fileInfo)
+
+        try ScreenCaptureKitProcessCapabilityRegistry.register(
+            ownerIdentity: .init(
+                processIdentifier: ownerIdentity.processIdentifier,
+                processStartIdentity: ownerIdentity.processStartIdentity,
+                buildIdentity: "replacement-build",
+                codeSignatureHash: "replacement-cdhash"),
+            directory: fixture.directoryURL,
+            signatureIdentity: .init(
+                signingIdentifier: "test.peekaboo.replacement",
+                teamIdentifier: "REPLACEMENT",
+                codeSignatureHash: "replacement-cdhash"))
+        #expect(try Data(contentsOf: markerURL) == receiptData)
+
+        var reentryInfo = stat()
+        #expect(lstat(markerURL.path, &reentryInfo) == 0)
+        #expect(reentryInfo.st_dev == fileInfo.st_dev)
+        #expect(reentryInfo.st_ino == fileInfo.st_ino)
         #if compiler(>=6.4)
-        #expect(fcntl(heldDescriptor, F_GETFD) & FD_CLOFORK == FD_CLOFORK)
+        #expect(peekaboo_probe_descriptor_after_fork(heldDescriptor) == DescriptorForkProbeClosed)
         #endif
+        self.expectLiveCloseOnExecDescriptor(heldDescriptor, matching: fileInfo)
+        #expect(try Data(contentsOf: markerURL) == receiptData)
 
         let contender = open(markerURL.path, O_RDONLY | O_CLOEXEC | O_NOFOLLOW)
         #expect(contender >= 0)
@@ -62,6 +102,52 @@ struct ScreenCaptureKitOwnerLeaseTests {
             #expect(errno == EWOULDBLOCK || errno == EAGAIN)
         }
     }
+
+    @Test
+    func `Fork probe inherits a close-on-exec-only descriptor`() throws {
+        let fixture = try LeaseFixture(name: "fork-cloexec-control")
+        defer { fixture.removeLockPath() }
+        let descriptor = open(fixture.lockURL.path, O_CREAT | O_EXCL | O_RDWR | O_CLOEXEC, S_IRUSR | S_IWUSR)
+        try #require(descriptor >= 0)
+        defer { close(descriptor) }
+        var fileInfo = stat()
+        try #require(fstat(descriptor, &fileInfo) == 0)
+        self.expectLiveCloseOnExecDescriptor(descriptor, matching: fileInfo)
+
+        #expect(peekaboo_probe_descriptor_after_fork(descriptor) == DescriptorForkProbeInherited)
+
+        self.expectLiveCloseOnExecDescriptor(descriptor, matching: fileInfo)
+    }
+
+    @Test(arguments: [Int32(-1), Int32.max])
+    func `Fork probe rejects invalid input as an error`(descriptor: Int32) {
+        #expect(peekaboo_probe_descriptor_after_fork(descriptor) == DescriptorForkProbeInputError)
+    }
+
+    #if compiler(>=6.4)
+    @Test(arguments: [false, true])
+    func `Atomic owner open flags close descriptors across fork`(useOpenAt: Bool) throws {
+        let fixture = try LeaseFixture(name: "fork-atomic-open")
+        defer { fixture.removeLockPath() }
+        let directory = open(fixture.directoryURL.path, O_RDONLY | O_DIRECTORY | O_CLOEXEC)
+        try #require(directory >= 0)
+        defer { close(directory) }
+        let flags = O_CREAT | O_EXCL | O_RDWR | O_CLOEXEC | ScreenCaptureKitOwnerLease.closeOnForkOpenFlag | O_NOFOLLOW
+        let descriptor = useOpenAt
+            ? openat(directory, fixture.lockURL.lastPathComponent, flags, S_IRUSR | S_IWUSR)
+            : open(fixture.lockURL.path, flags, S_IRUSR | S_IWUSR)
+        try #require(descriptor >= 0)
+        defer { close(descriptor) }
+        var fileInfo = stat()
+        try #require(fstat(descriptor, &fileInfo) == 0)
+        self.expectLiveCloseOnExecDescriptor(descriptor, matching: fileInfo)
+
+        #expect(ScreenCaptureKitOwnerLease.closeOnForkOpenFlag == O_CLOFORK)
+        #expect(peekaboo_probe_descriptor_after_fork(descriptor) == DescriptorForkProbeClosed)
+
+        self.expectLiveCloseOnExecDescriptor(descriptor, matching: fileInfo)
+    }
+    #endif
 
     @Test
     func `Pre-lease process blocks claim before owner file creation`() throws {
@@ -299,10 +385,14 @@ struct ScreenCaptureKitOwnerLeaseTests {
         #expect(fileInfo.st_mode & mode_t(S_IRWXU | S_IRWXG | S_IRWXO) == mode_t(S_IRUSR | S_IWUSR))
 
         let heldDescriptor = try #require(self.descriptor(for: fileInfo))
-        #expect(fcntl(heldDescriptor, F_GETFD) & FD_CLOEXEC == FD_CLOEXEC)
+        self.expectLiveCloseOnExecDescriptor(heldDescriptor, matching: fileInfo)
         #if compiler(>=6.4)
-        #expect(fcntl(heldDescriptor, F_GETFD) & FD_CLOFORK == FD_CLOFORK)
+        #expect(peekaboo_probe_descriptor_after_fork(heldDescriptor) == DescriptorForkProbeClosed)
         #endif
+        self.expectLiveCloseOnExecDescriptor(heldDescriptor, matching: fileInfo)
+        #expect(try fixture.persistedReceipt() == firstReceipt)
+        #expect(try fixture.makeLease(buildIdentity: "after-fork")
+            .claim() == .alreadyOwnedByCurrentProcess(firstReceipt))
 
         let descriptor = open(fixture.lockURL.path, O_RDONLY | O_NOFOLLOW)
         #expect(descriptor >= 0)
@@ -599,6 +689,16 @@ struct ScreenCaptureKitOwnerLeaseTests {
         throw TestError("Could not resolve child process generation")
     }
 
+    private func expectLiveCloseOnExecDescriptor(_ descriptor: Int32, matching expectedInfo: stat) {
+        let flags = fcntl(descriptor, F_GETFD)
+        #expect(flags >= 0)
+        #expect(flags & FD_CLOEXEC == FD_CLOEXEC)
+        var fileInfo = stat()
+        #expect(fstat(descriptor, &fileInfo) == 0)
+        #expect(fileInfo.st_dev == expectedInfo.st_dev)
+        #expect(fileInfo.st_ino == expectedInfo.st_ino)
+    }
+
     private func descriptor(for expectedInfo: stat) -> Int32? {
         for descriptor in 0..<getdtablesize() {
             var candidateInfo = stat()
@@ -637,7 +737,10 @@ private struct LeaseFixture {
                 processIdentifier: getpid(),
                 processStartIdentity: self.processStartIdentity,
                 buildIdentity: buildIdentity),
-            processStartIdentity: SystemIdentityResolver.processStartIdentity)
+            processStartIdentity: SystemIdentityResolver.processStartIdentity,
+            registerProcessCapability: {},
+            uncoordinatedProcesses: { [] },
+            uncoordinatedHosts: { [] })
     }
 
     func write(receipt: ScreenCaptureKitOwnerLease.OwnerReceipt) throws {

--- a/Core/PeekabooAutomationKit/Tests/Support/DescriptorForkTestSupport/DescriptorForkTestSupport.c
+++ b/Core/PeekabooAutomationKit/Tests/Support/DescriptorForkTestSupport/DescriptorForkTestSupport.c
@@ -1,0 +1,59 @@
+#include "DescriptorForkTestSupport.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+DescriptorForkProbeResult peekaboo_probe_descriptor_after_fork(int descriptor) {
+    struct stat original;
+    if (fcntl(descriptor, F_GETFD) < 0 || fstat(descriptor, &original) < 0) {
+        return DescriptorForkProbeInputError;
+    }
+
+    pid_t child = fork();
+    if (child < 0) {
+        return DescriptorForkProbeForkError;
+    }
+    if (child == 0) {
+        // Never return to Swift or unlock the shared flock: only async-signal-safe child operations.
+        if (fcntl(descriptor, F_GETFD) < 0) {
+            _exit(errno == EBADF ? DescriptorForkProbeClosed : DescriptorForkProbeChildError);
+        }
+        struct stat inherited;
+        if (fstat(descriptor, &inherited) < 0 ||
+            inherited.st_dev != original.st_dev || inherited.st_ino != original.st_ino) {
+            _exit(DescriptorForkProbeChildError);
+        }
+        _exit(DescriptorForkProbeInherited);
+    }
+
+    int child_status;
+    pid_t waited;
+    do {
+        waited = waitpid(child, &child_status, 0);
+    } while (waited < 0 && errno == EINTR);
+    if (waited != child) {
+        return DescriptorForkProbeWaitError;
+    }
+
+    struct stat parent;
+    if (fcntl(descriptor, F_GETFD) < 0 || fstat(descriptor, &parent) < 0 ||
+        parent.st_dev != original.st_dev || parent.st_ino != original.st_ino) {
+        return DescriptorForkProbeParentChanged;
+    }
+    if (!WIFEXITED(child_status)) {
+        return DescriptorForkProbeUnexpectedExit;
+    }
+    switch (WEXITSTATUS(child_status)) {
+        case DescriptorForkProbeClosed:
+            return DescriptorForkProbeClosed;
+        case DescriptorForkProbeInherited:
+            return DescriptorForkProbeInherited;
+        case DescriptorForkProbeChildError:
+            return DescriptorForkProbeChildError;
+        default:
+            return DescriptorForkProbeUnexpectedExit;
+    }
+}

--- a/Core/PeekabooAutomationKit/Tests/Support/DescriptorForkTestSupport/include/DescriptorForkTestSupport.h
+++ b/Core/PeekabooAutomationKit/Tests/Support/DescriptorForkTestSupport/include/DescriptorForkTestSupport.h
@@ -1,0 +1,18 @@
+#ifndef DESCRIPTOR_FORK_TEST_SUPPORT_H
+#define DESCRIPTOR_FORK_TEST_SUPPORT_H
+
+typedef enum DescriptorForkProbeResult {
+    DescriptorForkProbeClosed,
+    DescriptorForkProbeInherited,
+    DescriptorForkProbeInputError,
+    DescriptorForkProbeForkError,
+    DescriptorForkProbeWaitError,
+    DescriptorForkProbeChildError,
+    DescriptorForkProbeUnexpectedExit,
+    DescriptorForkProbeParentChanged
+} DescriptorForkProbeResult;
+
+// Validates a live descriptor, forks/reaps entirely in C, and checks the parent still owns the same inode.
+DescriptorForkProbeResult peekaboo_probe_descriptor_after_fork(int descriptor);
+
+#endif

--- a/docs/engine.md
+++ b/docs/engine.md
@@ -75,6 +75,19 @@ policy therefore has an explicit restart boundary: stop or relaunch every report
 are safely removed from a dedicated private marker directory; repeated scans reuse PID, process-generation, executable,
 and signature inspection results while revalidating the executable path.
 
+The owner lease and capability marker retain `flock` descriptors for process lifetime. Their opens atomically include
+`O_CLOEXEC` and, under the existing Swift 6.4 compiler/SDK gate, `O_CLOFORK`. An inherited descriptor could keep the
+parent's lease locked after the parent exits; unlocking the shared `flock` in a child would also unlock the parent's
+lease. Atomic close-on-fork protects even the interval between opening a descriptor and storing it in the registry.
+
+SDK flag availability does not establish runtime support for querying or setting descriptor flags. On the checked
+macOS 26.6.2 (25G83) runtime, built with Xcode 27 / Swift 6.4, both `open` and `openat` with `O_CLOFORK` close the
+descriptor in the fork child, while `F_GETFD` omits `FD_CLOFORK` and `F_SETFD` cannot set or clear its semantics despite
+returning success. Tests therefore check actual child `EBADF`, parent inode/lock retention, and strict `FD_CLOEXEC`
+reporting; a missing query bit never excuses inheritance. The runtime introduction of `FD_CLOFORK` query/set support
+has not been established, and no macOS 27 runtime was tested. Builds using older compiler/SDK combinations that omit
+`O_CLOFORK` retain close-on-exec only: there is no implemented atfork cleanup or pre-exec fork-safety guarantee.
+
 Long-running Agent and MCP modes remain available for non-capture tools when they discover a pre-lease Bridge. Peekaboo
 keeps that runtime local and records a process-lifetime SCK blocker instead of failing startup or routing capture to the
 old host. A later SCK leaf refuses before framework dispatch. The blocker is intentionally irreversible for that Agent


### PR DESCRIPTION
## Summary

Fix the ScreenCaptureKit ownership tests that treated an absent `FD_CLOFORK` query bit as proof that close-on-fork protection was missing. Preserve production atomic open flags and verify the ownership behavior directly instead.

On macOS 26.6.2 (25G83) with Xcode 27 / Swift 6.4, `open` and `openat` honor `O_CLOFORK`: the fork child gets `EBADF`, even though `F_GETFD` reports only `FD_CLOEXEC`. `F_SETFD` also cannot establish equivalent close-on-fork protection on that runtime despite returning success. Adding a macOS-27-only gate or substituting a later `fcntl` would therefore remove working protection or introduce a race.

## Changes

- Replace the two `FD_CLOFORK` query assertions with actual fork-child descriptor checks through a test-only C helper. The child performs only async-signal-safe operations and exits without returning to Swift or unlocking the shared `flock`.
- Keep strict close-on-exec, parent descriptor/inode, receipt, reentry, and exclusive-lock checks. Add inherited-CLOEXEC-only and invalid-descriptor controls, plus `open`/`openat` coverage.
- Reuse the private-directory/signature seam that landed concurrently in [the GUI-readiness fix](https://github.com/openclaw/Peekaboo/pull/684), rather than adding a duplicate wrapper. Tests use private files and synthetic identities; the capability registry now matches `main` exactly.
- Document the runtime distinction and maintain the changelog. Older builds that omit `O_CLOFORK` still have no implemented pre-exec fork cleanup guarantee; this change does not claim otherwise.

## Validation

The isolated baseline reproduced exactly the two original query-assertion failures. The revised suite and an independent rerun each passed **21 tests / 23 cases**. The local test bundle was signed with the matching Developer ID and strictly verified before execution. Source tests used private marker/lock paths and inert registrars/scanners; installed applications, user-wide ownership markers, and TCC settings were untouched.

Scoped SwiftFormat and SwiftLint checks passed, the C helper compiled with `-std=c11 -Wall -Wextra -Werror`, and `git diff --check` passed. Independent diff review and isolated Codex autoreview found no actionable P0 findings. After integrating the concurrent `main` update, the signed isolated suite and an independent rerun again passed all 21 tests / 23 cases.

Both existing Python subprocess tests and broader GUI/ambient-state suites were intentionally excluded from local proof. No macOS 27 runtime was tested, and the runtime introduction of public `FD_CLOFORK` query/set support remains unestablished.
