### PR TITLE
fix(see): bound publication artifact re-reads

### DIFF
--- a/Apps/CLI/Sources/PeekabooCLI/Commands/AI/SeeCommand+Output.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/AI/SeeCommand+Output.swift
@@ -34,17 +34,16 @@ extension SeeCommand {
         }
     }
 
-    private static func requireCurrentArtifact(path: String, verifiedData: Data?, label: String) throws {
+    static func requireCurrentArtifact(path: String, verifiedData: Data?, label: String) throws {
         guard !path.isEmpty else { return }
         guard let verifiedData else {
             throw CaptureError.captureFailure("\(label.capitalized) has no verified content before publication")
         }
-        let current: Data
-        do {
-            current = try Data(contentsOf: URL(fileURLWithPath: path))
-        } catch {
-            throw CaptureError.captureFailure("Verified \(label) could not be read before publication")
-        }
+        let current = try SeePublicationArtifact.readMatchingVerifiedBytes(
+            at: path,
+            expectedByteCount: verifiedData.count,
+            label: label
+        )
         try DesktopObservationContentDigest.verify(
             current,
             expectedSHA256: DesktopObservationContentDigest.sha256(verifiedData)

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/AI/SeeCommand+PixelOutput.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/AI/SeeCommand+PixelOutput.swift
@@ -286,12 +286,11 @@ extension SeeCommand {
 
     static func requireCurrentCaptureArtifacts(_ captures: [ImageCapturedFile]) throws {
         for capture in captures {
-            let current: Data
-            do {
-                current = try Data(contentsOf: URL(fileURLWithPath: capture.file.path))
-            } catch {
-                throw CaptureError.captureFailure("Verified screenshot could not be read before publication")
-            }
+            let current = try SeePublicationArtifact.readMatchingVerifiedBytes(
+                at: capture.file.path,
+                expectedByteCount: capture.imageData.count,
+                label: "screenshot"
+            )
             try DesktopObservationContentDigest.verify(
                 current,
                 expectedSHA256: DesktopObservationContentDigest.sha256(capture.imageData)

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/AI/SeeCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/AI/SeeCommand.swift
@@ -619,7 +619,14 @@ RuntimeBackedCommand {
                         annotatedScreenshotPath: annotatedPath
                     )
                     try Task.checkCancellation()
-                    annotatedData = try Data(contentsOf: URL(fileURLWithPath: annotatedPath))
+                    annotatedData = try SeePublicationArtifact.readBounded(
+                        at: annotatedPath,
+                        maxBytes: max(
+                            ClipboardPayloadBuilder.defaultSizeLimit,
+                            captureResult.screenshotData?.count ?? 0
+                        ),
+                        label: "annotated screenshot"
+                    )
                 }
                 logger.operationComplete(
                     "generate_annotations",

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/AI/SeeCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/AI/SeeCommand.swift
@@ -621,10 +621,6 @@ RuntimeBackedCommand {
                     try Task.checkCancellation()
                     annotatedData = try SeePublicationArtifact.readBounded(
                         at: annotatedPath,
-                        maxBytes: max(
-                            ClipboardPayloadBuilder.defaultSizeLimit,
-                            captureResult.screenshotData?.count ?? 0
-                        ),
                         label: "annotated screenshot"
                     )
                 }

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/AI/SeePublicationArtifact.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/AI/SeePublicationArtifact.swift
@@ -1,0 +1,58 @@
+import Foundation
+import PeekabooCore
+import PeekabooFoundation
+
+enum SeePublicationArtifact {
+    static func readMatchingVerifiedBytes(
+        at path: String,
+        expectedByteCount: Int,
+        label: String
+    ) throws -> Data {
+        let size = try self.regularFileSize(at: path, label: label)
+        guard size == expectedByteCount else {
+            throw CaptureError.captureFailure(
+                "Verified \(label) size \(size) does not match verified content " +
+                    "(\(expectedByteCount) bytes) before publication"
+            )
+        }
+        return try self.contents(at: path, label: label)
+    }
+
+    static func readBounded(
+        at path: String,
+        maxBytes: Int = ClipboardPayloadBuilder.defaultSizeLimit,
+        label: String
+    ) throws -> Data {
+        let size = try self.regularFileSize(at: path, label: label)
+        guard size <= maxBytes else {
+            throw CaptureError.captureFailure(
+                "Verified \(label) exceeds the capture size limit " +
+                    "(\(size) bytes, limit \(maxBytes)) before publication"
+            )
+        }
+        return try self.contents(at: path, label: label)
+    }
+
+    private static func regularFileSize(at path: String, label: String) throws -> Int {
+        let url = URL(fileURLWithPath: path)
+        do {
+            let values = try url.resourceValues(forKeys: [.fileSizeKey, .isRegularFileKey])
+            guard values.isRegularFile == true, let size = values.fileSize, size >= 0 else {
+                throw CaptureError.captureFailure("Verified \(label) could not be read before publication")
+            }
+            return size
+        } catch let error as CaptureError {
+            throw error
+        } catch {
+            throw CaptureError.captureFailure("Verified \(label) could not be read before publication")
+        }
+    }
+
+    private static func contents(at path: String, label: String) throws -> Data {
+        do {
+            return try Data(contentsOf: URL(fileURLWithPath: path))
+        } catch {
+            throw CaptureError.captureFailure("Verified \(label) could not be read before publication")
+        }
+    }
+}

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/AI/SeePublicationArtifact.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/AI/SeePublicationArtifact.swift
@@ -8,49 +8,39 @@ enum SeePublicationArtifact {
         expectedByteCount: Int,
         label: String
     ) throws -> Data {
-        let size = try self.regularFileSize(at: path, label: label)
-        guard size == expectedByteCount else {
+        let file = try self.open(at: path, maxBytes: expectedByteCount, label: label)
+        guard file.byteCount == expectedByteCount else {
             throw CaptureError.captureFailure(
-                "Verified \(label) size \(size) does not match verified content " +
+                "Verified \(label) size \(file.byteCount) does not match verified content " +
                     "(\(expectedByteCount) bytes) before publication"
             )
         }
-        return try self.contents(at: path, label: label)
+        return try self.contents(of: file, label: label)
     }
 
     static func readBounded(
         at path: String,
-        maxBytes: Int = ClipboardPayloadBuilder.defaultSizeLimit,
+        maxBytes: Int = CaptureArtifactIntegrityValidator.maximumPNGBytes,
         label: String
     ) throws -> Data {
-        let size = try self.regularFileSize(at: path, label: label)
-        guard size <= maxBytes else {
-            throw CaptureError.captureFailure(
-                "Verified \(label) exceeds the capture size limit " +
-                    "(\(size) bytes, limit \(maxBytes)) before publication"
-            )
-        }
-        return try self.contents(at: path, label: label)
+        try self.contents(of: self.open(at: path, maxBytes: maxBytes, label: label), label: label)
     }
 
-    private static func regularFileSize(at path: String, label: String) throws -> Int {
-        let url = URL(fileURLWithPath: path)
+    private static func open(at path: String, maxBytes: Int, label: String) throws -> BoundedArtifactFile {
         do {
-            let values = try url.resourceValues(forKeys: [.fileSizeKey, .isRegularFileKey])
-            guard values.isRegularFile == true, let size = values.fileSize, size >= 0 else {
-                throw CaptureError.captureFailure("Verified \(label) could not be read before publication")
-            }
-            return size
-        } catch let error as CaptureError {
-            throw error
+            return try BoundedArtifactFile(path: path, maximumBytes: maxBytes)
+        } catch BoundedArtifactFileError.tooLarge {
+            throw CaptureError.captureFailure("Verified \(label) exceeds the capture size limit before publication")
         } catch {
             throw CaptureError.captureFailure("Verified \(label) could not be read before publication")
         }
     }
 
-    private static func contents(at path: String, label: String) throws -> Data {
+    private static func contents(of file: BoundedArtifactFile, label: String) throws -> Data {
         do {
-            return try Data(contentsOf: URL(fileURLWithPath: path))
+            return try file.read()
+        } catch is CancellationError {
+            throw CancellationError()
         } catch {
             throw CaptureError.captureFailure("Verified \(label) could not be read before publication")
         }

--- a/Apps/CLI/Tests/CoreCLITests/SeePublicationArtifactSizeTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/SeePublicationArtifactSizeTests.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 import PeekabooAutomation
 import PeekabooCore
@@ -24,9 +25,7 @@ struct SeePublicationArtifactSizeTests {
             Issue.record("Expected size-mismatch refusal before load")
             return
         }
-        #expect(message.contains("does not match verified content"))
-        #expect(message.contains("64"))
-        #expect(message.contains("\(verifiedData.count)"))
+        #expect(message.contains("exceeds the capture size limit"))
     }
 
     @Test
@@ -45,8 +44,7 @@ struct SeePublicationArtifactSizeTests {
             Issue.record("Expected sparse-file size refusal before load")
             return
         }
-        #expect(message.contains("does not match verified content"))
-        #expect(message.contains("\(ClipboardPayloadBuilder.defaultSizeLimit + 1)"))
+        #expect(message.contains("exceeds the capture size limit"))
     }
 
     @Test
@@ -68,8 +66,7 @@ struct SeePublicationArtifactSizeTests {
             Issue.record("Expected observation size-mismatch refusal")
             return
         }
-        #expect(message.contains("does not match verified content"))
-        #expect(message.contains("32"))
+        #expect(message.contains("exceeds the capture size limit"))
     }
 
     @Test
@@ -89,7 +86,6 @@ struct SeePublicationArtifactSizeTests {
             return
         }
         #expect(message.contains("exceeds the capture size limit"))
-        #expect(message.contains("\(ClipboardPayloadBuilder.defaultSizeLimit + 1)"))
     }
 
     @Test
@@ -104,6 +100,45 @@ struct SeePublicationArtifactSizeTests {
             label: "annotated screenshot"
         )
         #expect(data == payload)
+    }
+
+    @Test
+    func `valid annotation larger than both raw capture and ten MiB remains readable`() throws {
+        func makeBitmap() throws -> NSBitmapImageRep {
+            try #require(NSBitmapImageRep(
+                bitmapDataPlanes: nil,
+                pixelsWide: 2048,
+                pixelsHigh: 2048,
+                bitsPerSample: 8,
+                samplesPerPixel: 3,
+                hasAlpha: false,
+                isPlanar: false,
+                colorSpaceName: .deviceRGB,
+                bytesPerRow: 0,
+                bitsPerPixel: 24
+            ))
+        }
+        let source = try makeBitmap()
+        let sourceBytes = try #require(source.bitmapData)
+        sourceBytes.initialize(repeating: 0, count: source.bytesPerRow * source.pixelsHigh)
+        let raw = try #require(source.representation(using: .png, properties: [:]))
+        let bitmap = try makeBitmap()
+        let bytes = try #require(bitmap.bitmapData)
+        let count = bitmap.bytesPerRow * bitmap.pixelsHigh
+        var random: UInt32 = 0x1234_5678
+        for index in 0..<count {
+            random ^= random << 13
+            random ^= random >> 17
+            random ^= random << 5
+            bytes[index] = UInt8(truncatingIfNeeded: random)
+        }
+        let annotated = try #require(bitmap.representation(using: .png, properties: [:]))
+        #expect(annotated.count > max(ClipboardPayloadBuilder.defaultSizeLimit, raw.count))
+        let fixture = try Fixture(data: annotated)
+        defer { fixture.cleanup() }
+        #expect(try SeePublicationArtifact.readBounded(
+            at: fixture.url.path, label: "annotated screenshot"
+        ) == annotated)
     }
 
     @Test

--- a/Apps/CLI/Tests/CoreCLITests/SeePublicationArtifactSizeTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/SeePublicationArtifactSizeTests.swift
@@ -1,0 +1,172 @@
+import Foundation
+import PeekabooAutomation
+import PeekabooCore
+import PeekabooFoundation
+import Testing
+@testable import PeekabooCLI
+
+@Suite(.serialized, .tags(.safe))
+struct SeePublicationArtifactSizeTests {
+    @Test
+    @MainActor
+    func `pixel publication rejects an oversized replacement before loading`() throws {
+        let fixture = try Fixture(byteCount: 64)
+        defer { fixture.cleanup() }
+        let verifiedData = Data("verified-pixels".utf8)
+        #expect(verifiedData.count < 64)
+
+        let capture = Self.capture(path: fixture.url.path, imageData: verifiedData)
+
+        let error = #expect(throws: CaptureError.self) {
+            try SeeCommand.requireCurrentCaptureArtifacts([capture])
+        }
+        guard case let .captureFailure(message) = error else {
+            Issue.record("Expected size-mismatch refusal before load")
+            return
+        }
+        #expect(message.contains("does not match verified content"))
+        #expect(message.contains("64"))
+        #expect(message.contains("\(verifiedData.count)"))
+    }
+
+    @Test
+    @MainActor
+    func `pixel publication rejects a sparse file larger than verified bytes`() throws {
+        let verifiedData = Data("verified-pixels".utf8)
+        let fixture = try Fixture(sparseByteCount: ClipboardPayloadBuilder.defaultSizeLimit + 1)
+        defer { fixture.cleanup() }
+
+        let capture = Self.capture(path: fixture.url.path, imageData: verifiedData)
+
+        let error = #expect(throws: CaptureError.self) {
+            try SeeCommand.requireCurrentCaptureArtifacts([capture])
+        }
+        guard case let .captureFailure(message) = error else {
+            Issue.record("Expected sparse-file size refusal before load")
+            return
+        }
+        #expect(message.contains("does not match verified content"))
+        #expect(message.contains("\(ClipboardPayloadBuilder.defaultSizeLimit + 1)"))
+    }
+
+    @Test
+    @MainActor
+    func `observation publication rejects an oversized screenshot before loading`() throws {
+        let fixture = try Fixture(byteCount: 32)
+        defer { fixture.cleanup() }
+        let verifiedData = Data("see-shot".utf8)
+        #expect(verifiedData.count < 32)
+
+        let error = #expect(throws: CaptureError.self) {
+            try SeeCommand.requireCurrentArtifact(
+                path: fixture.url.path,
+                verifiedData: verifiedData,
+                label: "screenshot"
+            )
+        }
+        guard case let .captureFailure(message) = error else {
+            Issue.record("Expected observation size-mismatch refusal")
+            return
+        }
+        #expect(message.contains("does not match verified content"))
+        #expect(message.contains("32"))
+    }
+
+    @Test
+    func `bounded annotated reload refuses a file over the capture cap`() throws {
+        let fixture = try Fixture(sparseByteCount: ClipboardPayloadBuilder.defaultSizeLimit + 1)
+        defer { fixture.cleanup() }
+
+        let error = #expect(throws: CaptureError.self) {
+            _ = try SeePublicationArtifact.readBounded(
+                at: fixture.url.path,
+                maxBytes: ClipboardPayloadBuilder.defaultSizeLimit,
+                label: "annotated screenshot"
+            )
+        }
+        guard case let .captureFailure(message) = error else {
+            Issue.record("Expected annotated size-limit refusal")
+            return
+        }
+        #expect(message.contains("exceeds the capture size limit"))
+        #expect(message.contains("\(ClipboardPayloadBuilder.defaultSizeLimit + 1)"))
+    }
+
+    @Test
+    func `bounded annotated reload loads a file at the inclusive max`() throws {
+        let payload = Data(repeating: 0x41, count: 16)
+        let fixture = try Fixture(data: payload)
+        defer { fixture.cleanup() }
+
+        let data = try SeePublicationArtifact.readBounded(
+            at: fixture.url.path,
+            maxBytes: 16,
+            label: "annotated screenshot"
+        )
+        #expect(data == payload)
+    }
+
+    @Test
+    @MainActor
+    func `pixel publication still reports digest mismatch for same-size replacement`() throws {
+        let verifiedData = Data("verified-pixels".utf8)
+        let replacement = Data("replaced-pixels".utf8)
+        #expect(verifiedData.count == replacement.count)
+        let fixture = try Fixture(data: replacement)
+        defer { fixture.cleanup() }
+
+        #expect(throws: DesktopObservationContentVerificationError.digestMismatch) {
+            try SeeCommand.requireCurrentCaptureArtifacts([
+                Self.capture(path: fixture.url.path, imageData: verifiedData),
+            ])
+        }
+    }
+}
+
+extension SeePublicationArtifactSizeTests {
+    @MainActor
+    private static func capture(path: String, imageData: Data) -> ImageCapturedFile {
+        ImageCapturedFile(
+            file: SavedFile(path: path, mime_type: "image/png"),
+            imageData: imageData,
+            observation: ImageObservationDiagnostics(
+                timings: ObservationTimings(),
+                diagnostics: DesktopObservationDiagnostics()
+            ),
+            snapshotID: nil,
+            receipt: .none
+        )
+    }
+}
+
+private struct Fixture {
+    let root: URL
+    let url: URL
+
+    init(byteCount: Int) throws {
+        try self.init(data: Data(repeating: 0x41, count: byteCount))
+    }
+
+    init(data: Data) throws {
+        self.root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("peekaboo-see-publication-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: self.root, withIntermediateDirectories: false)
+        self.url = self.root.appendingPathComponent("artifact.png")
+        try data.write(to: self.url, options: .atomic)
+    }
+
+    init(sparseByteCount: Int) throws {
+        self.root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("peekaboo-see-publication-sparse-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: self.root, withIntermediateDirectories: false)
+        self.url = self.root.appendingPathComponent("sparse.png")
+        FileManager.default.createFile(atPath: self.url.path, contents: Data())
+        let handle = try FileHandle(forWritingTo: self.url)
+        try handle.truncate(atOffset: UInt64(sparseByteCount))
+        try handle.close()
+    }
+
+    func cleanup() {
+        try? FileManager.default.removeItem(at: self.root)
+    }
+}

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/CaptureArtifactIntegrityValidator.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/CaptureArtifactIntegrityValidator.swift
@@ -29,7 +29,7 @@ public enum CaptureArtifactIntegrityValidator {
         let sha256: String
     }
 
-    static let maximumPNGBytes = 256 * 1024 * 1024
+    public static let maximumPNGBytes = 256 * 1024 * 1024
     public static let maximumVideoBytes = 4 * 1024 * 1024 * 1024
     private static let maximumMetadataBytes = 16 * 1024 * 1024
 

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/System/BoundedArtifactFile.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/System/BoundedArtifactFile.swift
@@ -1,0 +1,88 @@
+import Darwin
+import Foundation
+
+public enum BoundedArtifactFileError: Error, Equatable {
+    case invalidLimit
+    case unreadable
+    case tooLarge
+    case changedDuringRead
+}
+
+/// Retains one regular-file descriptor and caps every read, including growth after opening.
+public final class BoundedArtifactFile {
+    public let byteCount: Int
+    private let descriptor: Int32
+    private let path: String
+    private let maximumBytes: Int
+    private let initialInfo: stat
+
+    public init(path: String, maximumBytes: Int) throws {
+        guard maximumBytes >= 0 else { throw BoundedArtifactFileError.invalidLimit }
+        // Preserve ordinary symlink paths without waiting for a special-file writer.
+        let descriptor = Darwin.open(path, O_RDONLY | O_CLOEXEC | O_NONBLOCK)
+        guard descriptor >= 0 else { throw BoundedArtifactFileError.unreadable }
+        var retained = false
+        defer {
+            if !retained {
+                Darwin.close(descriptor)
+            }
+        }
+        var info = stat()
+        guard Darwin.fstat(descriptor, &info) == 0,
+              info.st_mode & S_IFMT == S_IFREG,
+              info.st_size >= 0,
+              let byteCount = Int(exactly: info.st_size)
+        else { throw BoundedArtifactFileError.unreadable }
+        guard byteCount <= maximumBytes else { throw BoundedArtifactFileError.tooLarge }
+        self.descriptor = descriptor
+        self.path = path
+        self.maximumBytes = maximumBytes
+        self.initialInfo = info
+        self.byteCount = byteCount
+        retained = true
+    }
+
+    deinit { Darwin.close(self.descriptor) }
+
+    /// Read once; refuse replacement or mutation rather than publishing bytes under a stale path.
+    public func read() throws -> Data {
+        var data = Data()
+        data.reserveCapacity(self.byteCount)
+        var buffer = [UInt8](repeating: 0, count: 64 * 1024)
+        while true {
+            try Task.checkCancellation()
+            let remaining = self.maximumBytes - data.count
+            let requested = remaining < buffer.count ? remaining + 1 : buffer.count
+            let count = Darwin.read(self.descriptor, &buffer, requested)
+            if count == 0 {
+                break
+            }
+            if count < 0 {
+                if errno == EINTR {
+                    continue
+                }
+                throw BoundedArtifactFileError.unreadable
+            }
+            guard count <= remaining else { throw BoundedArtifactFileError.tooLarge }
+            data.append(contentsOf: buffer.prefix(count))
+        }
+        var descriptorInfo = stat()
+        var pathInfo = stat()
+        guard Darwin.fstat(self.descriptor, &descriptorInfo) == 0,
+              Darwin.fstatat(AT_FDCWD, self.path, &pathInfo, 0) == 0,
+              Self.unchanged(self.initialInfo, descriptorInfo),
+              Self.unchanged(self.initialInfo, pathInfo),
+              data.count == self.byteCount
+        else { throw BoundedArtifactFileError.changedDuringRead }
+        return data
+    }
+
+    private static func unchanged(_ first: stat, _ second: stat) -> Bool {
+        first.st_dev == second.st_dev && first.st_ino == second.st_ino &&
+            first.st_mode == second.st_mode && first.st_size == second.st_size &&
+            first.st_mtimespec.tv_sec == second.st_mtimespec.tv_sec &&
+            first.st_mtimespec.tv_nsec == second.st_mtimespec.tv_nsec &&
+            first.st_ctimespec.tv_sec == second.st_ctimespec.tv_sec &&
+            first.st_ctimespec.tv_nsec == second.st_ctimespec.tv_nsec
+    }
+}

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/BoundedArtifactFileTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/BoundedArtifactFileTests.swift
@@ -1,0 +1,86 @@
+import Darwin
+import Foundation
+import Testing
+@testable import PeekabooAutomationKit
+
+struct BoundedArtifactFileTests {
+    @Test
+    func `inclusive limits and ordinary symlinks remain readable`() throws {
+        let fixture = try Fixture()
+        defer { fixture.cleanup() }
+        let link = fixture.root.appendingPathComponent("link")
+        try FileManager.default.createSymbolicLink(at: link, withDestinationURL: fixture.url)
+        let file = try BoundedArtifactFile(path: link.path, maximumBytes: fixture.data.count)
+        #expect(file.byteCount == fixture.data.count)
+        #expect(try file.read() == fixture.data)
+    }
+
+    @Test
+    func `empty file works with a zero byte limit`() throws {
+        let fixture = try Fixture(data: Data())
+        defer { fixture.cleanup() }
+        #expect(try BoundedArtifactFile(path: fixture.url.path, maximumBytes: 0).read().isEmpty)
+    }
+
+    @Test
+    func `growth after open cannot bypass the read budget`() throws {
+        let fixture = try Fixture()
+        defer { fixture.cleanup() }
+        let file = try BoundedArtifactFile(path: fixture.url.path, maximumBytes: 16)
+        let writer = try FileHandle(forWritingTo: fixture.url)
+        try writer.truncate(atOffset: 1_000_000)
+        try writer.close()
+        #expect(throws: BoundedArtifactFileError.tooLarge) { try file.read() }
+    }
+
+    @Test
+    func `replacement after open cannot publish the old inode under the new path`() throws {
+        let fixture = try Fixture()
+        defer { fixture.cleanup() }
+        let file = try BoundedArtifactFile(path: fixture.url.path, maximumBytes: 16)
+        try Data(repeating: 0x42, count: fixture.data.count).write(to: fixture.url, options: .atomic)
+        #expect(throws: BoundedArtifactFileError.changedDuringRead) { try file.read() }
+    }
+
+    @Test
+    func `truncation and in-budget growth after open are refused`() throws {
+        for size in [0, 12] {
+            let fixture = try Fixture()
+            defer { fixture.cleanup() }
+            let file = try BoundedArtifactFile(path: fixture.url.path, maximumBytes: 16)
+            let writer = try FileHandle(forWritingTo: fixture.url)
+            try writer.truncate(atOffset: UInt64(size))
+            try writer.close()
+            #expect(throws: BoundedArtifactFileError.changedDuringRead) { try file.read() }
+        }
+    }
+
+    @Test
+    func `special files never wait for a writer`() throws {
+        let fixture = try Fixture()
+        defer { fixture.cleanup() }
+        let fifo = fixture.root.appendingPathComponent("fifo")
+        #expect(mkfifo(fifo.path, 0o600) == 0)
+        #expect(throws: BoundedArtifactFileError.unreadable) {
+            try BoundedArtifactFile(path: fifo.path, maximumBytes: 16)
+        }
+    }
+
+    private struct Fixture {
+        let root: URL
+        let url: URL
+        let data: Data
+
+        init(data: Data = Data("original".utf8)) throws {
+            self.root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+            self.url = self.root.appendingPathComponent("artifact")
+            self.data = data
+            try FileManager.default.createDirectory(at: self.root, withIntermediateDirectories: false)
+            try data.write(to: self.url)
+        }
+
+        func cleanup() {
+            try? FileManager.default.removeItem(at: self.root)
+        }
+    }
+}

--- a/docs/commands/see.md
+++ b/docs/commands/see.md
@@ -89,6 +89,10 @@ For agent and automation runs, pass `--path` to a known temporary file when usin
 
 Passive background observations retry one resolve-and-capture transaction when the target's exact receipt changes during capture, then fail closed if it changes again. Foreground capture, explicit web-focus fallback, and menu-opening observations never retry because they can mutate visible desktop state.
 
+Before publication, saved images are read through one retained descriptor with a byte limit and checked against
+their verified content. Changed or oversized artifacts fail closed. Independently encoded annotations use the
+256 MiB capture-image limit; their size is not restricted to that of the raw screenshot.
+
 Pixel-only `see --no-elements` captures without `--path` write a generated file beneath `PEEKABOO_DEFAULT_SAVE_PATH`, `defaults.savePath`, or the built-in `~/Desktop` default, in that order. Generated names retain a readable timestamp and include a unique token so concurrent callers do not share a path. This also applies with `--json`; `data.files[].path` reports the saved file. Ordinary element-producing `--json` observations without `--path` instead retain the raw image only in managed snapshot storage and return empty `screenshot_raw` and `screenshot_annotated` fields.
 
 ## Exact-window ROI capture

--- a/docs/commands/see.md
+++ b/docs/commands/see.md
@@ -89,10 +89,6 @@ For agent and automation runs, pass `--path` to a known temporary file when usin
 
 Passive background observations retry one resolve-and-capture transaction when the target's exact receipt changes during capture, then fail closed if it changes again. Foreground capture, explicit web-focus fallback, and menu-opening observations never retry because they can mutate visible desktop state.
 
-Before publication, saved images are read through one retained descriptor with a byte limit and checked against
-their verified content. Changed or oversized artifacts fail closed. Independently encoded annotations use the
-256 MiB capture-image limit; their size is not restricted to that of the raw screenshot.
-
 Pixel-only `see --no-elements` captures without `--path` write a generated file beneath `PEEKABOO_DEFAULT_SAVE_PATH`, `defaults.savePath`, or the built-in `~/Desktop` default, in that order. Generated names retain a readable timestamp and include a unique token so concurrent callers do not share a path. This also applies with `--json`; `data.files[].path` reports the saved file. Ordinary element-producing `--json` observations without `--path` instead retain the raw image only in managed snapshot storage and return empty `screenshot_raw` and `screenshot_annotated` fields.
 
 ## Exact-window ROI capture
@@ -165,6 +161,10 @@ peekaboo see --app "Google Chrome" --json --path /tmp/chrome-see.png \
 - Rapid repeated `see` calls for the same window reuse a short-lived AX cache (~1.5s); wait a beat if you need a fully fresh traversal.
 
 ## Smart label placement (`--annotate`)
+
+Before publication, saved images are read through one retained descriptor with a byte limit and checked against
+their verified content. Changed or oversized artifacts fail closed. Independently encoded annotations use the
+256 MiB capture-image limit; their size is not restricted to that of the raw screenshot.
 - The `SmartLabelPlacer` generates external label candidates (above/below/sides/corners) for each element, filters out overlaps/out-of-bounds positions, then scores remaining spots via `AcceleratedTextDetector.scoreRegionForLabelPlacement` to prefer calm regions. Internal placements are a last-resort fallback.
 - Edge-aware scoring samples a padded rectangle (6 px halo, clamped to the image) so the chosen region stays clean once text is drawn; above/below placements get slight bonuses to reduce sideways clutter.
 - Preferred orientations nudge horizontally tight elements toward vertical labels when scores tie.


### PR DESCRIPTION
`peekaboo see` previously reloaded saved screenshots and annotations without bounding the read before publication checks. This change retains one regular-file descriptor, enforces the byte budget during reading, and rejects detected replacement or mutation before the existing digest check. Ordinary symlink paths remain supported.

Annotations use the existing 256 MiB PNG limit independently of the raw screenshot's encoded size, so a valid annotation larger than both its source and 10 MiB still loads. The shared reader and its regressions are identical to the reader prepared in #683; these PRs repair different callers. Thanks @SebTardif for the original contribution.

Validation:
- Built the CLI and signed it with the OpenClaw Foundation Developer ID.
- All 7 `SeePublicationArtifactSizeTests` pass, including a valid PNG larger than its raw capture and 10 MiB, oversized/sparse rejection, and same-size digest mismatch.
- Shared-reader regressions cover growth/replacement after opening, truncation, symlinks, zero-byte limits, and special files. A standalone executable compiled from that production source exercises real sparse-file, growth, and replacement refusals.
- The signed CLI successfully published a pixel-only capture and completed full `see --annotate` against a signed synthetic native window. This fixture did not produce a separate annotated artifact; annotation-size compatibility is covered by the real PNG regression above.
- Changed-file strict SwiftLint using the repository root configuration, SwiftFormat, docs lint, and isolated Codex review through P2 passed.

The broader safe suite encountered an existing release-environment fixture failure caused by inherited service-account custody variables. A test-only isolation fix is being prepared separately. Hosted CI on the exact final head remains a landing gate. Release notes and contributor credit are being consolidated in a separate main-based notes PR to avoid conflicting changelog insertions across the queue.
