### PR TITLE
fix(capture): preserve exact popup and sheet extents

### DIFF
--- a/Apps/CLI/TestFixtures/ExactWindowCapture/main.swift
+++ b/Apps/CLI/TestFixtures/ExactWindowCapture/main.swift
@@ -1,0 +1,169 @@
+import AppKit
+import Foundation
+
+@MainActor
+final class SyntheticSurface: NSView {
+    let isPopup: Bool
+
+    init(frame: NSRect, isPopup: Bool) {
+        self.isPopup = isPopup
+        super.init(frame: frame)
+    }
+
+    required init?(coder: NSCoder) {
+        nil
+    }
+
+    override var isOpaque: Bool {
+        true
+    }
+
+    override var isFlipped: Bool {
+        true
+    }
+
+    override func draw(_ dirtyRect: NSRect) {
+        if self.isPopup {
+            let splitX = self.bounds.width / 4
+            let splitY = self.bounds.height / 3
+            let tiles: [(NSRect, NSColor)] = [
+                (NSRect(x: 0, y: 0, width: splitX, height: splitY), .red),
+                (NSRect(x: splitX, y: 0, width: self.bounds.width - splitX, height: splitY), .green),
+                (NSRect(x: 0, y: splitY, width: splitX, height: self.bounds.height - splitY), .blue),
+                (NSRect(
+                    x: splitX,
+                    y: splitY,
+                    width: self.bounds.width - splitX,
+                    height: self.bounds.height - splitY
+                ), .yellow),
+            ]
+            for (rect, color) in tiles {
+                color.setFill()
+                rect.fill()
+            }
+            self.label("POPUP 448 x 240", at: NSPoint(x: 140, y: 140))
+        } else {
+            NSColor.magenta.setFill()
+            self.bounds.fill()
+            NSColor.black.setFill()
+            for x in stride(from: 0, to: Int(self.bounds.width), by: 100) {
+                NSRect(x: x, y: 0, width: 12, height: Int(self.bounds.height)).fill()
+            }
+            self.label("SYNTHETIC PARENT — MUST NOT FILL POPUP CAPTURE", at: NSPoint(x: 30, y: 40))
+        }
+    }
+
+    private func label(_ text: String, at point: NSPoint) {
+        (text as NSString).draw(at: point, withAttributes: [
+            .font: NSFont.monospacedSystemFont(ofSize: 18, weight: .bold),
+            .foregroundColor: NSColor.black,
+            .backgroundColor: NSColor.white,
+        ])
+    }
+}
+
+@MainActor
+final class FixtureDelegate: NSObject, NSApplicationDelegate {
+    let readyURL: URL
+    let mode: String
+    private var parent: NSWindow?
+    private var popup: NSWindow?
+
+    init(readyURL: URL, mode: String) {
+        self.readyURL = readyURL
+        self.mode = mode
+    }
+
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        guard let screen = NSScreen.screens.first,
+              screen.visibleFrame.width >= 1000, screen.visibleFrame.height >= 800
+        else {
+            fputs("Fixture requires a display with at least 1000 x 800 logical points.\n", stderr)
+            NSApp.terminate(nil)
+            return
+        }
+        let frame = NSRect(
+            x: screen.visibleFrame.minX + 40,
+            y: screen.visibleFrame.maxY - 740,
+            width: 900,
+            height: 700
+        )
+        let parent = self.window(frame: frame, isPopup: false)
+        let popup = self.window(
+            frame: NSRect(x: frame.minX + 173, y: frame.maxY - 113 - 240, width: 448, height: 240),
+            isPopup: true
+        )
+        self.parent = parent
+        self.popup = popup
+        parent.makeKeyAndOrderFront(nil)
+        if self.mode == "sheet" {
+            parent.beginSheet(popup)
+        } else {
+            parent.addChildWindow(popup, ordered: .above)
+            popup.orderFront(nil)
+        }
+        NSApp.activate()
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+            self.publishReady(primaryScreen: screen.frame)
+        }
+    }
+
+    private func window(frame: NSRect, isPopup: Bool) -> NSWindow {
+        let window = NSWindow(contentRect: frame, styleMask: .borderless, backing: .buffered, defer: false)
+        window.title = isPopup ? "Synthetic Exact Popup" : "Synthetic Parent"
+        window.isReleasedWhenClosed = false
+        window.isOpaque = true
+        window.backgroundColor = isPopup ? .yellow : .magenta
+        window.hasShadow = false
+        window.contentView = SyntheticSurface(frame: NSRect(origin: .zero, size: frame.size), isPopup: isPopup)
+        return window
+    }
+
+    private func publishReady(primaryScreen: NSRect) {
+        guard let parent, let popup else { return }
+        func entry(_ window: NSWindow) -> [String: Any] {
+            [
+                "window_id": window.windowNumber,
+                "bounds": [
+                    "x": window.frame.minX,
+                    "y": primaryScreen.maxY - window.frame.maxY,
+                    "width": window.frame.width,
+                    "height": window.frame.height,
+                ],
+                "backing_scale": window.backingScaleFactor,
+            ]
+        }
+        do {
+            let data = try JSONSerialization.data(withJSONObject: [
+                "pid": ProcessInfo.processInfo.processIdentifier,
+                "mode": self.mode,
+                "parent": entry(parent),
+                "popup": entry(popup),
+            ], options: [.prettyPrinted, .sortedKeys])
+            try data.write(to: self.readyURL, options: .withoutOverwriting)
+            print("Ready: \(self.readyURL.path)")
+            fflush(stdout)
+        } catch {
+            fputs("Could not create fixture receipt: \(error)\n", stderr)
+            NSApp.terminate(nil)
+        }
+    }
+}
+
+@main
+enum ExactWindowCaptureFixture {
+    static func main() {
+        let arguments = CommandLine.arguments
+        guard arguments.count == 3, ["popup", "sheet"].contains(arguments[1]),
+              arguments[2].hasPrefix("/"), !FileManager.default.fileExists(atPath: arguments[2])
+        else {
+            fputs("Usage: ExactWindowCapture popup|sheet /absolute/new-ready.json\n", stderr)
+            exit(2)
+        }
+        let delegate = FixtureDelegate(readyURL: URL(fileURLWithPath: arguments[2]), mode: arguments[1])
+        let application = NSApplication.shared
+        application.setActivationPolicy(.regular)
+        application.delegate = delegate
+        withExtendedLifetime(delegate) { application.run() }
+    }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ### Fixed
+- Exclude attached windows from classic window captures and reject mismatched raster extents before publishing window coordinates or snapshots; preserve exact 1×/Retina mapping without double-scaling private captures.
 - Preserve current GUI capture support and typed ScreenCaptureKit blockers when preparation fails, allowing explicit classic capture on the same proven host without changing auto or modern engines, with negotiated typed errors that preserve older clients' signed receipts.
 - Verify ScreenCaptureKit owner and capability-marker close-on-fork protection through child descriptor behavior instead of SDK query bits, preserving atomic open flags and isolating marker tests.
 

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/LegacyScreenCaptureOperator+Support.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/LegacyScreenCaptureOperator+Support.swift
@@ -115,13 +115,11 @@ extension LegacyScreenCaptureOperator {
 
     func scaleFactor(for bounds: CGRect) -> CGFloat {
         let screens = NSScreen.screens
-        let appKitBounds = GlobalScreenCoordinateGeometry.appKitRect(
-            fromGlobalDisplay: bounds,
-            primaryScreenFrame: screens.first?.frame)
-        if let screen = screens.first(where: { $0.frame.contains(appKitBounds) }) {
-            return screen.backingScaleFactor
+        guard let index = LegacyWindowCaptureGeometry.screenIndex(for: bounds, screenFrames: screens.map(\.frame))
+        else {
+            return 1.0
         }
-        return screens.first?.backingScaleFactor ?? 1.0
+        return screens[index].backingScaleFactor
     }
 
     func scalePlan(

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/LegacyScreenCaptureOperator+Support.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/LegacyScreenCaptureOperator+Support.swift
@@ -9,7 +9,7 @@ extension LegacyScreenCaptureOperator {
     func captureWindowWithCGWindowList(
         windowID: CGWindowID,
         correlationId: String,
-        scale: CaptureScalePreference) async throws -> LegacyCapturedRaster
+        geometry: LegacyWindowCaptureGeometry) async throws -> LegacyCapturedRaster
     {
         let allowsPrivateSCKLookup = ScreenCaptureService.captureEnginePreference != .legacy
         if Self.privateScreenCaptureKitWindowLookupEnabled(), allowsPrivateSCKLookup {
@@ -17,8 +17,10 @@ extension LegacyScreenCaptureOperator {
                 let image = try await self.captureWindowWithPrivateScreenCaptureKit(
                     windowID: windowID,
                     correlationId: correlationId,
-                    scale: scale)
-                return LegacyCapturedRaster(image: image)
+                    scale: geometry.scalePlan.preference)
+                return try geometry.deliver(
+                    LegacyCapturedRaster(image: image),
+                    sourceScale: geometry.scalePlan.outputScale)
             } catch {
                 guard PrivateScreenCaptureKitWindowLookupPolicy.allowsSystemFallback(
                     after: error,
@@ -42,9 +44,10 @@ extension LegacyScreenCaptureOperator {
         }
 
         do {
-            return try await self.captureWindowWithSystemScreencapture(
+            let raster = try await self.captureWindowWithSystemScreencapture(
                 windowID: windowID,
                 correlationId: correlationId)
+            return try geometry.deliver(raster, sourceScale: geometry.scalePlan.nativeScale)
         } catch {
             self.logger.error(
                 "Isolated system screencapture window capture failed",
@@ -129,7 +132,7 @@ extension LegacyScreenCaptureOperator {
         return ScreenCaptureScaleResolver.plan(
             preference: preference,
             screenBackingScaleFactor: scaleFactor,
-            fallbackPixelWidth: Int(bounds.width * scaleFactor),
+            fallbackPixelWidth: Int(exactly: bounds.width * scaleFactor) ?? 0,
             frameWidth: bounds.width)
     }
 

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/LegacyScreenCaptureOperator+SystemScreencapture.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/LegacyScreenCaptureOperator+SystemScreencapture.swift
@@ -101,11 +101,13 @@ extension LegacyScreenCaptureOperator {
     {
         // Match Apple's native window capture path; Hopper shows `screencapture -l` using
         // private window-id lookup before building its SCScreenshotManager content filter.
+        // Exclude attached windows; the caller still validates the returned extent before publication.
         try await self.captureImageWithSystemScreencapture(
             arguments: [
                 "-l",
                 String(windowID),
                 "-o",
+                "-a",
                 "-x",
             ],
             outputPrefix: "peekaboo-window-\(windowID)",

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/LegacyScreenCaptureOperator+Window.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/LegacyScreenCaptureOperator+Window.swift
@@ -73,17 +73,19 @@ extension LegacyScreenCaptureOperator {
             ],
             correlationId: correlationId)
 
+        let bounds = try Self.windowBounds(from: targetWindow)
+        let scalePlan = self.scalePlan(for: bounds, preference: scale)
+        let geometry = try LegacyWindowCaptureGeometry(bounds: bounds, scalePlan: scalePlan)
         let raster = try await self.captureWindowImage(
             windowID: windowID,
             correlationId: correlationId,
-            scale: scale)
+            geometry: geometry)
         let image = raster.image
         let mutationIdentity: WindowMutationIdentity? = mutationSnapshot.flatMap { snapshot in
             guard snapshot.ownerProcessStartIdentity == app.processStartIdentity else { return nil }
             return Self.validatedMutationIdentity(snapshot)
         }
 
-        let bounds = Self.windowBounds(from: targetWindow, fallbackImage: image)
         let selectorResolutionProofs = try self.selectorResolutionProofs(
             app: app,
             windows: appWindows,
@@ -92,14 +94,9 @@ extension LegacyScreenCaptureOperator {
                 index: resolvedIndex,
                 bounds: bounds,
                 identity: mutationIdentity))
-        let scalePlan = self.scalePlan(for: bounds, preference: scale)
         let imageData: Data
-        let scaledImage = ScreenCaptureImageScaler.maybeDownscale(
-            image,
-            scale: scale,
-            fallbackScale: scalePlan.nativeScale)
         do {
-            imageData = try raster.pngData(for: scaledImage)
+            imageData = try raster.pngData(for: image)
         } catch {
             throw OperationError.captureFailed(reason: "Failed to convert image to PNG format")
         }
@@ -113,7 +110,7 @@ extension LegacyScreenCaptureOperator {
             correlationId: correlationId)
 
         let metadata = CaptureMetadata(
-            size: CGSize(width: scaledImage.width, height: scaledImage.height),
+            size: CGSize(width: image.width, height: image.height),
             mode: .window,
             applicationInfo: app,
             windowInfo: ServiceWindowInfo(
@@ -139,7 +136,7 @@ extension LegacyScreenCaptureOperator {
                 scaleFactor: scalePlan.outputScale),
             diagnostics: ScreenCaptureScaleResolver.diagnostics(
                 plan: scalePlan,
-                finalPixelSize: CGSize(width: scaledImage.width, height: scaledImage.height)),
+                finalPixelSize: CGSize(width: image.width, height: image.height)),
             selectorResolutionProofs: selectorResolutionProofs)
 
         return CaptureResult(
@@ -186,22 +183,19 @@ extension LegacyScreenCaptureOperator {
             ],
             correlationId: correlationId)
 
+        let bounds = try Self.windowBounds(from: targetWindow)
+        let scalePlan = self.scalePlan(for: bounds, preference: scale)
+        let geometry = try LegacyWindowCaptureGeometry(bounds: bounds, scalePlan: scalePlan)
         let raster = try await self.captureWindowImage(
             windowID: windowID,
             correlationId: correlationId,
-            scale: scale)
+            geometry: geometry)
         let image = raster.image
         let mutationIdentity = mutationSnapshot.flatMap(Self.validatedMutationIdentity)
 
-        let bounds = Self.windowBounds(from: targetWindow, fallbackImage: image)
-        let scalePlan = self.scalePlan(for: bounds, preference: scale)
         let imageData: Data
-        let scaledImage = ScreenCaptureImageScaler.maybeDownscale(
-            image,
-            scale: scale,
-            fallbackScale: scalePlan.nativeScale)
         do {
-            imageData = try raster.pngData(for: scaledImage)
+            imageData = try raster.pngData(for: image)
         } catch {
             throw OperationError.captureFailed(reason: "Failed to convert image to PNG format")
         }
@@ -223,7 +217,7 @@ extension LegacyScreenCaptureOperator {
         }
 
         let metadata = CaptureMetadata(
-            size: CGSize(width: scaledImage.width, height: scaledImage.height),
+            size: CGSize(width: image.width, height: image.height),
             mode: .window,
             applicationInfo: applicationInfo,
             windowInfo: ServiceWindowInfo(
@@ -248,7 +242,7 @@ extension LegacyScreenCaptureOperator {
                 scaleFactor: scalePlan.outputScale),
             diagnostics: ScreenCaptureScaleResolver.diagnostics(
                 plan: scalePlan,
-                finalPixelSize: CGSize(width: scaledImage.width, height: scaledImage.height)))
+                finalPixelSize: CGSize(width: image.width, height: image.height)))
 
         return CaptureResult(
             imageData: imageData,
@@ -289,12 +283,12 @@ extension LegacyScreenCaptureOperator {
     private func captureWindowImage(
         windowID: CGWindowID,
         correlationId: String,
-        scale: CaptureScalePreference) async throws -> LegacyCapturedRaster
+        geometry: LegacyWindowCaptureGeometry) async throws -> LegacyCapturedRaster
     {
         let raster = try await self.captureWindowWithCGWindowList(
             windowID: windowID,
             correlationId: correlationId,
-            scale: scale)
+            geometry: geometry)
         self.logger.debug(
             "Captured window via isolated legacy path",
             metadata: ["windowID": String(windowID)],
@@ -303,19 +297,15 @@ extension LegacyScreenCaptureOperator {
     }
 
     private static func windowBounds(
-        from window: [String: Any],
-        fallbackImage image: CGImage) -> CGRect
+        from window: [String: Any]) throws -> CGRect
     {
-        if let boundsDict = window[kCGWindowBounds as String] as? [String: Any],
-           let x = boundsDict["X"] as? CGFloat,
-           let y = boundsDict["Y"] as? CGFloat,
-           let width = boundsDict["Width"] as? CGFloat,
-           let height = boundsDict["Height"] as? CGFloat
-        {
-            return CGRect(x: x, y: y, width: width, height: height)
+        guard let boundsDict = window[kCGWindowBounds as String] as? [String: Any],
+              let bounds = CGRect(dictionaryRepresentation: boundsDict as CFDictionary)
+        else {
+            throw OperationError.captureFailed(reason: "Exact window capture requires WindowServer bounds")
         }
-
-        return CGRect(x: 0, y: 0, width: image.width, height: image.height)
+        try LegacyWindowCaptureGeometry.validateBounds(bounds)
+        return bounds
     }
 
     private struct SelectedWindowProofContext {

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/LegacyWindowCaptureGeometry.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/LegacyWindowCaptureGeometry.swift
@@ -1,0 +1,57 @@
+import CoreGraphics
+import PeekabooFoundation
+
+/// A window raster has no origin receipt. Never infer its extent or density from its dimensions.
+struct LegacyWindowCaptureGeometry {
+    let bounds: CGRect
+    let scalePlan: ScreenCaptureScaleResolver.Plan
+
+    init(bounds: CGRect, scalePlan: ScreenCaptureScaleResolver.Plan) throws {
+        try Self.validateBounds(bounds)
+        self.bounds = bounds
+        self.scalePlan = scalePlan
+        _ = try self.pixelSize(scale: scalePlan.nativeScale)
+        _ = try self.pixelSize(scale: scalePlan.outputScale)
+    }
+
+    static func validateBounds(_ bounds: CGRect) throws {
+        guard bounds.origin.x.isFinite, bounds.origin.y.isFinite,
+              bounds.size.width.isFinite, bounds.size.height.isFinite,
+              bounds.size.width > 0, bounds.size.height > 0,
+              bounds.maxX.isFinite, bounds.maxY.isFinite
+        else {
+            throw OperationError.captureFailed(reason: "Exact window capture requires finite, positive window bounds")
+        }
+    }
+
+    func deliver(_ raster: LegacyCapturedRaster, sourceScale: CGFloat) throws -> LegacyCapturedRaster {
+        try self.validate(raster.image, scale: sourceScale)
+        let image = ScreenCaptureImageScaler.maybeDownscale(
+            raster.image,
+            scale: self.scalePlan.preference,
+            fallbackScale: sourceScale)
+        try self.validate(image, scale: self.scalePlan.outputScale)
+        return image === raster.image ? raster : LegacyCapturedRaster(image: image)
+    }
+
+    private func validate(_ image: CGImage, scale: CGFloat) throws {
+        let expected = try self.pixelSize(scale: scale)
+        guard image.width == expected.width, image.height == expected.height else {
+            throw OperationError.captureFailed(
+                reason: "Exact window capture returned \(image.width)x\(image.height) pixels; " +
+                    "expected \(expected.width)x\(expected.height) for the selected window. " +
+                    "Refusing a raster whose extent cannot be mapped to that window.")
+        }
+    }
+
+    private func pixelSize(scale: CGFloat) throws -> (width: Int, height: Int) {
+        guard scale.isFinite, scale > 0,
+              let width = Int(exactly: self.bounds.width * scale), width > 0,
+              let height = Int(exactly: self.bounds.height * scale), height > 0
+        else {
+            throw OperationError.captureFailed(
+                reason: "Exact window bounds must map to whole pixels at the capture scale")
+        }
+        return (width, height)
+    }
+}

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/LegacyWindowCaptureGeometry.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/LegacyWindowCaptureGeometry.swift
@@ -14,6 +14,18 @@ struct LegacyWindowCaptureGeometry {
         _ = try self.pixelSize(scale: scalePlan.outputScale)
     }
 
+    static func screenIndex(for bounds: CGRect, screenFrames: [CGRect]) -> Int? {
+        let appKitBounds = GlobalScreenCoordinateGeometry.appKitRect(
+            fromGlobalDisplay: bounds,
+            primaryScreenFrame: screenFrames.first)
+        switch ScreenCapturePlanner.matchDisplay(windowFrame: appKitBounds, displayFrames: screenFrames) {
+        case let .mapped(index), let .unmapped(index):
+            return index
+        case .noDisplays:
+            return nil
+        }
+    }
+
     static func validateBounds(_ bounds: CGRect) throws {
         guard bounds.origin.x.isFinite, bounds.origin.y.isFinite,
               bounds.size.width.isFinite, bounds.size.height.isFinite,

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/LegacyWindowCaptureGeometryTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/LegacyWindowCaptureGeometryTests.swift
@@ -1,0 +1,194 @@
+import CoreGraphics
+import Foundation
+import PeekabooFoundation
+import Testing
+@_spi(Testing) @testable import PeekabooAutomationKit
+
+struct LegacyWindowCaptureGeometryTests {
+    @Test(arguments: [1, 2])
+    func `parent and attached union cannot be published as an offset popup`(density: Int) throws {
+        let geometry = try Self.geometry(density: density, preference: .logical1x)
+        let parent = try Self.image(width: 900 * density, height: 700 * density)
+        let union = try Self.image(width: 980 * density, height: 745 * density)
+        for image in [parent, union] {
+            #expect(throws: PeekabooError.self) {
+                try geometry.deliver(LegacyCapturedRaster(image: image), sourceScale: CGFloat(density))
+            }
+        }
+    }
+
+    @Test
+    func `observed 1891 by 1490 raster is refused for 448 by 240 popup`() throws {
+        let raster = try LegacyCapturedRaster(image: Self.image(width: 1891, height: 1490))
+        for density in [1, 2] {
+            let geometry = try Self.geometry(density: density, preference: .logical1x)
+            #expect(throws: PeekabooError.self) {
+                try geometry.deliver(raster, sourceScale: CGFloat(density))
+            }
+        }
+    }
+
+    @Test(arguments: [1, 2], [CaptureScalePreference.logical1x, .native])
+    func `exact popup preserves asymmetric pixels and global mapping`(
+        density: Int,
+        preference: CaptureScalePreference) throws
+    {
+        let geometry = try Self.geometry(density: density, preference: preference)
+        let original = try Self.image(width: 448 * density, height: 240 * density)
+        let raster = try LegacyCapturedRaster(systemScreencapturePNG: original.pngData())
+        let delivered = try geometry.deliver(raster, sourceScale: CGFloat(density))
+        let outputDensity = preference == .native ? density : 1
+        #expect(delivered.image.width == 448 * outputDensity)
+        #expect(delivered.image.height == 240 * outputDensity)
+        #expect(try Self.pixel(delivered.image, x: 20 * outputDensity, y: 20 * outputDensity) == [255, 0, 0, 255])
+        #expect(try Self.pixel(delivered.image, x: 300 * outputDensity, y: 20 * outputDensity) == [0, 255, 0, 255])
+        #expect(try Self.pixel(delivered.image, x: 20 * outputDensity, y: 200 * outputDensity) == [0, 0, 255, 255])
+        #expect(try Self.pixel(delivered.image, x: 300 * outputDensity, y: 200 * outputDensity) == [255, 255, 0, 255])
+
+        let context = CaptureCoordinateContext(metadata: CaptureMetadata(
+            size: CGSize(width: delivered.image.width, height: delivered.image.height),
+            mode: .window,
+            displayInfo: DisplayInfo(
+                index: 0,
+                name: nil,
+                bounds: geometry.bounds,
+                scaleFactor: CGFloat(outputDensity))))
+        let global = try CaptureCoordinateMapper.globalPoint(
+            for: CGPoint(x: 71 * outputDensity, y: 113 * outputDensity),
+            in: .imagePixels,
+            context: context)
+        #expect(global == CGPoint(x: -229, y: 313))
+        #expect(context.outputScale == CGFloat(outputDensity))
+        if density == outputDensity {
+            #expect(delivered.image === raster.image)
+            #expect(delivered.sourcePNG == raster.sourcePNG)
+        } else {
+            #expect(delivered.sourcePNG == nil)
+        }
+    }
+
+    @Test
+    func `already logical private capture is not downscaled twice`() throws {
+        let geometry = try Self.geometry(density: 2, preference: .logical1x)
+        let raster = try LegacyCapturedRaster(image: Self.image(width: 448, height: 240))
+        let delivered = try geometry.deliver(raster, sourceScale: 1)
+        #expect(delivered.image === raster.image)
+    }
+
+    @Test
+    func `failed downscale cannot publish native pixels as logical 1x`() throws {
+        let palette: [UInt8] = [0, 0, 0, 255, 255, 255]
+        let colorSpace = try #require(palette.withUnsafeBufferPointer {
+            CGColorSpace(indexedBaseSpace: CGColorSpaceCreateDeviceRGB(), last: 1, colorTable: $0.baseAddress!)
+        })
+        let provider = try #require(CGDataProvider(data: Data(repeating: 0, count: 896 * 480) as CFData))
+        let image = try #require(CGImage(
+            width: 896,
+            height: 480,
+            bitsPerComponent: 8,
+            bitsPerPixel: 8,
+            bytesPerRow: 896,
+            space: colorSpace,
+            bitmapInfo: CGBitmapInfo(rawValue: CGImageAlphaInfo.none.rawValue),
+            provider: provider,
+            decode: nil,
+            shouldInterpolate: false,
+            intent: .defaultIntent))
+        let geometry = try Self.geometry(density: 2, preference: .logical1x)
+        #expect(throws: PeekabooError.self) {
+            try geometry.deliver(LegacyCapturedRaster(image: image), sourceScale: 2)
+        }
+    }
+
+    @Test
+    func `uniform oversized and anisotropic rasters are not reinterpreted as Retina`() throws {
+        let geometry = try Self.geometry(density: 1, preference: .logical1x)
+        for size in [CGSize(width: 896, height: 480), CGSize(width: 448, height: 480)] {
+            let raster = try LegacyCapturedRaster(image: Self.image(width: Int(size.width), height: Int(size.height)))
+            #expect(throws: PeekabooError.self) {
+                try geometry.deliver(raster, sourceScale: 1)
+            }
+        }
+    }
+
+    @Test
+    func `invalid and unrepresentable geometry fails closed`() throws {
+        let invalidBounds = [
+            CGRect.zero,
+            CGRect(x: 0, y: 0, width: -448, height: 240),
+            CGRect(x: CGFloat.nan, y: 0, width: 448, height: 240),
+            CGRect(x: 0, y: CGFloat.infinity, width: 448, height: 240),
+            CGRect(x: 0, y: 0, width: CGFloat.infinity, height: 240),
+            CGRect(x: 0, y: 0, width: CGFloat.greatestFiniteMagnitude, height: 240),
+            CGRect(x: 0, y: 0, width: 448.25, height: 240),
+        ]
+        for bounds in invalidBounds {
+            #expect(throws: PeekabooError.self) {
+                try Self.geometry(bounds: bounds, density: 2, preference: .logical1x)
+            }
+        }
+        for scale in [CGFloat.zero, -1, .nan, .infinity] {
+            #expect(throws: PeekabooError.self) {
+                try LegacyWindowCaptureGeometry(
+                    bounds: CGRect(x: 0, y: 0, width: 448, height: 240),
+                    scalePlan: ScreenCaptureScaleResolver.Plan(
+                        preference: .native, nativeScale: scale, outputScale: scale, source: .fallback1x))
+            }
+        }
+    }
+
+    private static func geometry(
+        bounds: CGRect = CGRect(x: -300, y: 200, width: 448, height: 240),
+        density: Int,
+        preference: CaptureScalePreference) throws -> LegacyWindowCaptureGeometry
+    {
+        try LegacyWindowCaptureGeometry(
+            bounds: bounds,
+            scalePlan: ScreenCaptureScaleResolver.Plan(
+                preference: preference,
+                nativeScale: CGFloat(density),
+                outputScale: preference == .native ? CGFloat(density) : 1,
+                source: .screenBackingScaleFactor))
+    }
+
+    private static func image(width: Int, height: Int) throws -> CGImage {
+        var bytes = [UInt8](repeating: 0, count: width * height * 4)
+        let colors: [[UInt8]] = [[255, 0, 0, 255], [0, 255, 0, 255], [0, 0, 255, 255], [255, 255, 0, 255]]
+        for y in 0..<height {
+            for x in 0..<width {
+                let color = colors[(y < height / 3 ? 0 : 2) + (x < width / 4 ? 0 : 1)]
+                let offset = (y * width + x) * 4
+                bytes.replaceSubrange(offset..<(offset + 4), with: color)
+            }
+        }
+        let provider = try #require(CGDataProvider(data: Data(bytes) as CFData))
+        return try #require(CGImage(
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bitsPerPixel: 32,
+            bytesPerRow: width * 4,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGBitmapInfo(rawValue: CGImageAlphaInfo.premultipliedLast.rawValue)
+                .union(.byteOrder32Big),
+            provider: provider,
+            decode: nil,
+            shouldInterpolate: false,
+            intent: .defaultIntent))
+    }
+
+    private static func pixel(_ image: CGImage, x: Int, y: Int) throws -> [UInt8] {
+        let context = try #require(CGContext(
+            data: nil,
+            width: image.width,
+            height: image.height,
+            bitsPerComponent: 8,
+            bytesPerRow: image.width * 4,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue | CGBitmapInfo.byteOrder32Big.rawValue))
+        context.draw(image, in: CGRect(x: 0, y: 0, width: image.width, height: image.height))
+        let data = try #require(context.data).assumingMemoryBound(to: UInt8.self)
+        let offset = y * context.bytesPerRow + x * 4
+        return Array(UnsafeBufferPointer(start: data + offset, count: 4))
+    }
+}

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/LegacyWindowCaptureGeometryTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/LegacyWindowCaptureGeometryTests.swift
@@ -137,6 +137,42 @@ struct LegacyWindowCaptureGeometryTests {
         }
     }
 
+    @Test(arguments: [1, 2], [CaptureScalePreference.logical1x, .native])
+    func `partially visible secondary windows use their own display density`(
+        density: Int,
+        preference: CaptureScalePreference) throws
+    {
+        let screens = [
+            CGRect(x: 0, y: 0, width: 1200, height: 900),
+            CGRect(x: -1000, y: 100, width: 1000, height: 800),
+        ]
+        let scaleFactors = [density == 1 ? 2 : 1, density]
+        // Straddling displays, mostly off the left edge, and partly above the secondary display.
+        for bounds in [
+            CGRect(x: -300, y: 200, width: 448, height: 240),
+            CGRect(x: -1300, y: 200, width: 448, height: 240),
+            CGRect(x: -600, y: -100, width: 448, height: 240),
+        ] {
+            let index = try #require(LegacyWindowCaptureGeometry.screenIndex(for: bounds, screenFrames: screens))
+            #expect(index == 1)
+            let sourceScale = scaleFactors[index]
+            let geometry = try Self.geometry(bounds: bounds, density: sourceScale, preference: preference)
+            let raster = try LegacyCapturedRaster(image: Self.image(width: 448 * density, height: 240 * density))
+            let delivered = try geometry.deliver(raster, sourceScale: CGFloat(sourceScale))
+            let outputScale = preference == .native ? density : 1
+            #expect(delivered.image.width == 448 * outputScale)
+            #expect(delivered.image.height == 240 * outputScale)
+        }
+    }
+
+    @Test
+    func `fully offscreen and absent displays retain bounded fallback`() {
+        let screens = [CGRect(x: 0, y: 0, width: 1200, height: 900)]
+        let bounds = CGRect(x: 2000, y: 2000, width: 448, height: 240)
+        #expect(LegacyWindowCaptureGeometry.screenIndex(for: bounds, screenFrames: screens) == 0)
+        #expect(LegacyWindowCaptureGeometry.screenIndex(for: bounds, screenFrames: []) == nil)
+    }
+
     private static func geometry(
         bounds: CGRect = CGRect(x: -300, y: 200, width: 448, height: 240),
         density: Int,

--- a/docs/commands/see.md
+++ b/docs/commands/see.md
@@ -89,6 +89,13 @@ For agent and automation runs, pass `--path` to a known temporary file when usin
 
 Passive background observations retry one resolve-and-capture transaction when the target's exact receipt changes during capture, then fail closed if it changes again. Foreground capture, explicit web-focus fallback, and menu-opening observations never retry because they can mutate visible desktop state.
 
+Classic (`cg`) window capture excludes attached windows and checks the returned raster against the selected
+WindowServer bounds at the capture scale, both before and after conversion to logical 1×. If macOS returns a parent
+or composited surface with different dimensions, the command fails before publishing an image or snapshot. A PNG
+does not provide a trustworthy global origin, so Peekaboo does not guess a crop or stretch that surface into the
+requested window. Missing, invalid, or non-pixel-representable bounds also fail closed. Native synthetic popup/sheet
+proof instructions are in [Exact-window capture testing](../testing/exact-window-capture.md).
+
 Pixel-only `see --no-elements` captures without `--path` write a generated file beneath `PEEKABOO_DEFAULT_SAVE_PATH`, `defaults.savePath`, or the built-in `~/Desktop` default, in that order. Generated names retain a readable timestamp and include a unique token so concurrent callers do not share a path. This also applies with `--json`; `data.files[].path` reports the saved file. Ordinary element-producing `--json` observations without `--path` instead retain the raw image only in managed snapshot storage and return empty `screenshot_raw` and `screenshot_annotated` fields.
 
 ## Exact-window ROI capture

--- a/docs/testing/exact-window-capture.md
+++ b/docs/testing/exact-window-capture.md
@@ -9,8 +9,10 @@ read_when:
 The classic path uses `/usr/sbin/screencapture -l <id> -o -a -x`. The `-a` option excludes attached windows. The
 returned PNG must match the selected WindowServer bounds at the independently resolved source scale. A larger
 surface is refused, because its PNG dimensions do not establish its origin or identify a safe crop. Successful
-output must also match the requested delivery scale. This check supplements the existing owner-generation,
-window-identity, and bounds receipts; it does not replace them.
+output must also match the requested delivery scale. Display density uses the existing center/overlap display
+planner, so partly visible or straddling windows do not inherit the primary display's density merely because no
+display contains their entire bounds. This check supplements the existing owner-generation, window-identity,
+and bounds receipts; it does not replace them.
 
 ## Verified local reproduction (2026-09-05)
 

--- a/docs/testing/exact-window-capture.md
+++ b/docs/testing/exact-window-capture.md
@@ -1,0 +1,146 @@
+---
+summary: 'Local synthetic proof for exact-window classic capture extent and coordinate mapping'
+read_when:
+  - 'Validating popup or sheet capture geometry'
+---
+
+# Exact-window capture proof
+
+The classic path uses `/usr/sbin/screencapture -l <id> -o -a -x`. The `-a` option excludes attached windows. The
+returned PNG must match the selected WindowServer bounds at the independently resolved source scale. A larger
+surface is refused, because its PNG dimensions do not establish its origin or identify a safe crop. Successful
+output must also match the requested delivery scale. This check supplements the existing owner-generation,
+window-identity, and bounds receipts; it does not replace them.
+
+## Verified local reproduction (2026-09-05)
+
+On macOS 27.0 (26A5425a), with a 2× display and OpenClaw Foundation Developer ID signatures, the installed
+4.3.0 (`main/44eff916c`) CLI reproduced the mismatch for both fixture modes: selecting the 448×240 popup or sheet
+returned the complete 900×700 parent image while JSON still named the child and reported its bounds with scale 1.
+The patched CLI returned only the asymmetric child: 448×240 at logical 1× and 896×480 with `--retina`, with matching
+JSON dimensions, child ID, and origin. Popup origin was `(213,183)`; sheet origin was `(266,300)`. The four color
+regions and upright label were preserved. All capture commands exited successfully. Existing local grants were
+used without permission requests; neither Chrome nor private images were involved. Artifacts remain local.
+
+## Offline checks
+
+From the task checkout, with its pinned submodules initialized:
+
+```bash
+pnpm run setup:swift
+pnpm exec swift test --package-path Core/PeekabooAutomationKit \
+  --filter 'LegacyWindowCaptureGeometryTests|LegacyCapturedRasterTests|ScreenCaptureImageScalerTests|ObservationCaptureReceiptBindingTests'
+pnpm run build:cli
+```
+
+The geometry tests use generated RGBA images only. They cover a parent/union substituted for a popup, the reported
+1891×1490 versus 448×240 mismatch, asymmetric pixels, negative global offsets, 1×/2× source and output, already
+logical private output, failed scaling, and invalid geometry. No screen capture or GUI fixture runs in these tests.
+
+## Parent-owned live proof
+
+Run this section only in the already-authorized GUI session. The caller and signed CLI must already have the
+necessary Screen Recording and Accessibility grants. A matching approved Developer ID identity must already sign
+without prompting. Stop on any permission/signing prompt or missing grant; do not grant permissions, change
+Keychain access, attach Chrome, change a Gateway, or change global configuration to make the proof run.
+
+The fixture has a distinct bundle ID, no Keychain/authentication code, no network access, and no saved application
+state. It draws a fully opaque 900×700 striped magenta parent and a fully opaque 448×240 asymmetric red/green/blue/
+yellow child. It requires a display with at least 1000×800 available logical points. Keep the complete fixture
+visible and stationary throughout each comparison. All artifacts stay local. Do not use original/private images.
+
+Build in a fresh local proof directory. This script only compiles an app; it never signs or launches it:
+
+```bash
+TASK_ROOT="$(pwd)"
+mkdir -p "$TASK_ROOT/build"
+PROOF_DIR="$(mktemp -d "$TASK_ROOT/build/exact-window-proof.XXXXXX")"
+bash scripts/build-exact-window-fixture.sh "$PROOF_DIR/ExactWindowCapture.app"
+pnpm run build:cli
+CLI_BIN_DIR="$(pnpm exec swift build --package-path Apps/CLI --show-bin-path)"
+mkdir "$PROOF_DIR/after"
+cp "$CLI_BIN_DIR/peekaboo" "$PROOF_DIR/after/peekaboo"
+git diff --binary > "$PROOF_DIR/source.patch"
+git ls-files --others --exclude-standard > "$PROOF_DIR/new-source-files.txt"
+```
+
+The patch does not include untracked source files: retain those listed files with the task checkout when handing
+off the proof. Set `SIGN_IDENTITY` to the already-approved Developer ID name matching the permitted CLI identity,
+and `BEFORE_CLI` to the existing signed 4.3.0 binary from the observed build. Do not overwrite that binary. Reuse the
+repository's signing wrapper, but not its debug helper that auto-selects an identity and copies a root binary:
+
+```bash
+: "${SIGN_IDENTITY:?Set the pre-approved Developer ID identity}"
+: "${BEFORE_CLI:?Set the existing signed baseline binary path}"
+bash scripts/codesign-with-retry.sh --force --sign "$SIGN_IDENTITY" --options runtime --timestamp=none \
+  "$PROOF_DIR/ExactWindowCapture.app"
+bash scripts/codesign-with-retry.sh --force --sign "$SIGN_IDENTITY" --options runtime --timestamp=none \
+  --identifier boo.peekaboo.peekaboo --entitlements Apps/CLI/Sources/Resources/peekaboo.entitlements \
+  "$PROOF_DIR/after/peekaboo"
+codesign --verify --strict "$PROOF_DIR/ExactWindowCapture.app"
+codesign --verify --strict "$PROOF_DIR/after/peekaboo"
+codesign --verify --strict "$BEFORE_CLI"
+codesign -dv --verbose=4 "$PROOF_DIR/ExactWindowCapture.app" 2> "$PROOF_DIR/fixture-signature.txt"
+codesign -dv --verbose=4 "$PROOF_DIR/after/peekaboo" 2> "$PROOF_DIR/after-signature.txt"
+codesign -dv --verbose=4 "$BEFORE_CLI" 2> "$PROOF_DIR/before-signature.txt"
+shasum -a 256 "$BEFORE_CLI" "$PROOF_DIR/after/peekaboo" > "$PROOF_DIR/binary-sha256.txt"
+```
+
+Inspect those signature records for the expected identity before launch. In a separate tracked foreground terminal
+or parent-owned execution session, launch the fixture and leave it running:
+
+```bash
+"$PROOF_DIR/ExactWindowCapture.app/Contents/MacOS/ExactWindowCapture" popup "$PROOF_DIR/ready.json"
+```
+
+The fixture writes `ready.json` after showing both windows. Use that exact file in the capture terminal; no global
+application/window inventory is needed. These commands capture only the fixture's explicit popup ID. `--no-remote`
+keeps the request caller-local, and `--capture-engine cg` avoids claiming caller-local ScreenCaptureKit ownership:
+
+```bash
+FIXTURE_PID="$(jq -er '.pid' "$PROOF_DIR/ready.json")"
+POPUP_ID="$(jq -er '.popup.window_id' "$PROOF_DIR/ready.json")"
+mkdir "$PROOF_DIR/config"
+
+capture_proof() {
+  local label="$1" binary="$2"
+  shift 2
+  local capture_rc=0
+  env PEEKABOO_CONFIG_DIR="$PROOF_DIR/config" PEEKABOO_CONFIG_DISABLE_MIGRATION=1 \
+    "$binary" see --pid "$FIXTURE_PID" --window-id "$POPUP_ID" \
+    --no-remote --capture-engine cg --no-elements --path "$PROOF_DIR/$label.png" --json "$@" \
+    > "$PROOF_DIR/$label.json" 2> "$PROOF_DIR/$label.stderr" || capture_rc=$?
+  printf '%s\n' "$capture_rc" > "$PROOF_DIR/$label.exit"
+}
+capture_proof before "$BEFORE_CLI"
+capture_proof after "$PROOF_DIR/after/peekaboo"
+capture_proof after-retina "$PROOF_DIR/after/peekaboo" --retina
+```
+
+`PEEKABOO_CONFIG_DIR` isolates configuration; normal exact-window snapshot receipts still use local
+`~/.peekaboo/snapshots`. Keep those receipts intact for inspection. A geometry failure must return nonzero and must
+not create the requested PNG or a new reusable snapshot. Preserve the error JSON and exit status. If the baseline
+does not reproduce on this OS/fixture, record that; do not claim a live before/after reproduction.
+
+For successful results, compare the real PNG dimensions with JSON:
+
+```bash
+cat "$PROOF_DIR/ready.json"
+jq '{success, error, data: {files: .data.files, observations: .data.observations, snapshot_id: .data.snapshot_id}}' \
+  "$PROOF_DIR/after.json"
+sips -g pixelWidth -g pixelHeight "$PROOF_DIR/after.png"
+sips -g pixelWidth -g pixelHeight "$PROOF_DIR/after-retina.png"
+```
+
+The ordinary PNG must be 448×240; the Retina PNG must be 448×240 multiplied by the fixture's `popup.backing_scale`.
+`data.files[0].window_id` must equal `popup.window_id`. The observation coordinates must report that same popup's
+global bounds, the actual pixel size, and scale 1 or the recorded backing scale. Inspect each entire local image:
+the upper-left red tile occupies one quarter of the width and one third of the height; green is above/right, blue
+below/left, yellow below/right. The popup label remains upright. Parent stripes/magenta must never fill the popup
+image. A pixel `(71*s,113*s)` maps to `(popup.x+71,popup.y+113)` global logical points at output scale `s`.
+
+Stop the fixture through its owned foreground session (Ctrl-C), then repeat in a fresh proof directory with `sheet`
+instead of `popup`; record the actual sheet bounds from its new ready file. If display availability permits, repeat
+on an already-configured 1× and 2× display without changing global display settings. Do not reuse stale PIDs/window
+IDs. Parent capture can be checked separately using the fixture's explicit parent ID. No live proof is complete
+until the parent has checked signed launch, pixels, metadata, and refusal behavior on the relevant OS.

--- a/scripts/build-exact-window-fixture.sh
+++ b/scripts/build-exact-window-fixture.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+umask 077
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+OUTPUT_APP="${1:?Usage: build-exact-window-fixture.sh /absolute/new/ExactWindowCapture.app}"
+[[ "$OUTPUT_APP" == /* && ! -e "$OUTPUT_APP" && ! -L "$OUTPUT_APP" ]] || {
+  echo 'Output must be a new absolute app path.' >&2
+  exit 2
+}
+mkdir -p "$OUTPUT_APP/Contents/MacOS"
+cat > "$OUTPUT_APP/Contents/Info.plist" <<'EOF'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+  <key>CFBundleIdentifier</key><string>boo.peekaboo.fixture.exact-window</string>
+  <key>CFBundleName</key><string>ExactWindowCapture</string>
+  <key>CFBundleExecutable</key><string>ExactWindowCapture</string>
+  <key>CFBundlePackageType</key><string>APPL</string>
+  <key>CFBundleVersion</key><string>1</string>
+  <key>LSMinimumSystemVersion</key><string>15.0</string>
+  <key>NSHighResolutionCapable</key><true/>
+</dict></plist>
+EOF
+xcrun swiftc -parse-as-library -swift-version 6 -target "$(uname -m)-apple-macos15.0" \
+  "$ROOT_DIR/Apps/CLI/TestFixtures/ExactWindowCapture/main.swift" \
+  -o "$OUTPUT_APP/Contents/MacOS/ExactWindowCapture"
+printf 'Built only; sign with the approved Developer ID before launch: %s\n' "$OUTPUT_APP"


### PR DESCRIPTION
## Summary

Fix classic exact-window capture returning a parent/window-family image while still reporting the requested popup's ID, logical bounds, and scale. Besides exposing content outside the requested target, the old result did not provide a valid image-to-target coordinate transform.

macOS `screencapture -l` includes attached windows by default. The classic backend now adds `-a` and validates the incoming raster against independently resolved WindowServer geometry and density, then validates the delivered extent after scaling. If that extent cannot be mapped to the target, capture fails before publishing the requested image or reusable snapshot; no crop or origin is guessed. Process-generation, exact-window, and bounds receipt checks remain intact. Already-logical private captures are no longer downscaled a second time.

Display density now uses the existing center/overlap planner instead of requiring full-rectangle containment. This fixes the review-discovered mixed-density case where a partly visible secondary-display window incorrectly inherited the primary display's density. New synthetic cases were verified failing before this correction and passing afterward; extent checks remain strict.

Adds synthetic geometry regressions, a native popup/sheet fixture, reproducible signed-proof instructions, command documentation, and an Unreleased changelog entry. No new dependencies or submodule changes.

## Signed synthetic proof

On macOS 27.0 (26A5425a), Xcode 27.0, and an existing 2× display, the fixture bundle and patched CLI were signed with the same OpenClaw Foundation Developer ID as the installed 4.3.0 baseline (`main/44eff916c`). Exact fixture PID/window selectors were used with `--no-remote --capture-engine cg --no-elements`.

| Target | Baseline PNG | Patched logical PNG | Patched Retina PNG |
| --- | --- | --- | --- |
| 448×240 native popup | 900×700 parent, mislabeled with popup bounds | 448×240, scale 1 | 896×480, scale 2 |
| 448×240 native sheet | 900×700 parent, mislabeled with sheet bounds | 448×240, scale 1 | 896×480, scale 2 |

PNG dimensions, JSON pixel size, global origin, scale, and window ID were checked against fixture receipts. Whole-image inspection verified asymmetric colors and upright labels with no parent overcapture. Existing permissions were used without requests; no real browser, private screenshots, or unrelated desktop content were used. Attached before/after images contain only synthetic fixture content and were inspected before upload.

## Validation

- Final CLI build and signed popup/sheet rechecks passed after the display-selection follow-up.
- All 31 focused geometry, raster/scaler, owner-generation, window/bounds receipt, and receipt-recovery tests passed. Parameterized cases cover 1×/2× source density, logical/native output, negative coordinates, and partly visible/straddling mixed-density displays.
- Foundation: 81 tests passed. All four CLI targets passed on the initial broad run (1,953 tests reported; built-in skips retained). The final-head rerun had one intermittent local app-inventory smoke failure; the unchanged 26-test smoke suite then passed on retry. Hosted final-head CLI checks passed.
- Repository lint exited 0 (one existing warning in unchanged `BrowserHandoffCLITests.swift`); changed Swift files pass strict lint and formatting checks. Docs lint, fixture build/plist/shell checks, and `git diff --check` passed.
- Final staged independent Codex autoreview: scoped-clean through P2, no accepted/actionable findings. Bugbot also passes after the mixed-display fix.
- Full local `test:safe` was attempted but did not complete: after resolving the inherited service-token fixture inputs through test-process-only scrubbing, an unrelated Playground packaging fixture hit a dangling Homebrew Python link and Apple's fallback Python could not run under its fake SDK. Foundation and CLI suites were therefore run separately; no global tooling, permissions, or production guards were changed. The monolithic local safe suite is not claimed green.
- Final-head hosted [macOS CI](https://github.com/openclaw/Peekaboo/actions/runs/33988371673) passed, including Core, CLI, Tachikoma, both macOS apps, and lint. [CodeQL](https://github.com/openclaw/Peekaboo/actions/runs/33988371669) also passed for Swift, JavaScript/TypeScript, and Actions.

Live proof is macOS 27 evidence, not a claim of live macOS 26 or physical 1×-display coverage. Fixture and proof instructions: `docs/testing/exact-window-capture.md`.

![Before: 448x240 synthetic popup incorrectly returns its 900x700 parent](https://github.com/user-attachments/assets/67df146b-3d61-490b-a260-481cb5298443)

![After: exact 448x240 synthetic popup with correct origin and scale](https://github.com/user-attachments/assets/da2aab1e-00e2-4f98-a506-80f4cf5b5602)

