### PR TITLE
test(release): isolate fixture custody and temporary files

### DIFF
--- a/scripts/test-terminal-artifact-env.sh
+++ b/scripts/test-terminal-artifact-env.sh
@@ -2,11 +2,15 @@
 
 set -euo pipefail
 
+# Fixtures supply their own custody values; never inherit the operator's credentials.
+unset OP_SERVICE_ACCOUNT_TOKEN MOLTY_OP_SERVICE_ACCOUNT_TOKEN \
+  PEEKABOO_OP_SERVICE_TOKEN_FILE PEEKABOO_MOLTY_OP_SERVICE_TOKEN_FILE
+
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 # shellcheck source=scripts/terminal-artifact-env.sh
 source "$ROOT_DIR/scripts/terminal-artifact-env.sh"
 
-TEST_DIR="$(mktemp -d /tmp/peekaboo-terminal-env-test.XXXXXX)"
+TEST_DIR="$(mktemp -d "${TMPDIR:-/tmp}/peekaboo-terminal-env-test.XXXXXX")"
 trap 'rm -rf -- "$TEST_DIR"' EXIT
 
 fail() {


### PR DESCRIPTION
The safe suite failed its release-entrypoint custody fixture on developer machines with an exported 1Password service-account token: the fixture also supplied a fake custody file, so the production wrapper correctly refused conflicting custody before reaching the expected missing-helper check.

Clear only the fixture process's inherited service-account/custody variables and keep all explicit synthetic credential cases. The test now also honors `TMPDIR` instead of creating its top-level directory in shared `/tmp`. Production release behavior is unchanged.

Validation: shell syntax passed; the real fixture and production entrypoint checks passed with both synthetic parent tokens and both synthetic parent custody-file variables set. This reproduces the previously failing environment without using credentials. Isolated Codex review through P2 is clean. Full safe-suite and hosted CI results will be recorded before landing.
