### PR TITLE
chore(deps): refresh Swift libraries and build tooling

### DIFF
--- a/.github/workflows/crabbox-hydrate.yml
+++ b/.github/workflows/crabbox-hydrate.yml
@@ -44,7 +44,7 @@ jobs:
 
       - uses: pnpm/action-setup@v6.0.9
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: pnpm

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -143,14 +143,19 @@ jobs:
       - name: Run MCP action fixtures and outcome contract tests
         working-directory: Core/PeekabooCore
         run: |
-          swift test --no-parallel --filter 'MCPToolExecutionTests|MCPToolErrorHandlingTests|MCPElementActionToolExecutionTests'
+          swift test --no-parallel --filter 'MCPToolExecutionTests|MCPToolErrorHandlingTests|MCPElementActionToolExecutionTests|MCPSeeExactWindowTests'
           swift test --no-parallel --filter 'MCPDesktopActionOutcomeProjectionTests|MCPCompositeActionOutcomeTests'
+
+      - name: Run Bridge negotiation and cancellation contracts
+        working-directory: Core/PeekabooCore
+        run: |
+          swift test --no-parallel --filter 'PeekabooBridgeClientHostTrustTests|CaptureDiagnosticWireCompatibilityTests|PeekabooBridgeCancellationTests'
 
       - name: Run browser capability and guidance contracts
         working-directory: Core/PeekabooCore
         run: |
           swift test --no-parallel \
-            --filter 'BrowserToolTests|BrowserToolCapabilityIntegrationTests|RemoteBrowserMCPSessionTests|AgentSystemPromptTests'
+            --filter 'BrowserToolTests|BrowserToolCapabilityIntegrationTests|RemoteBrowserMCPSessionTests|PeekabooServicesBrowserSessionProviderTests|AgentSystemPromptTests'
 
       - name: Run focused Swift tests
         working-directory: Core/PeekabooCore

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Set up Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: "24"
 

--- a/.github/workflows/release-validation.yml
+++ b/.github/workflows/release-validation.yml
@@ -154,7 +154,7 @@ jobs:
           grep -Eq '^Xcode 26\.[0-9]+(\.[0-9]+)?$' "$VALIDATION_RESULTS/toolchain.txt"
           printf 'DEVELOPER_DIR=%s\n' "$DEVELOPER_DIR" >> "$GITHUB_ENV"
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: '24'
           package-manager-cache: false

--- a/Apps/Mac/Package.resolved
+++ b/Apps/Mac/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mattt/eventsource.git",
       "state" : {
-        "revision" : "a3a85a85214caf642abaa96ae664e4c772a59f6e",
-        "version" : "1.4.1"
+        "revision" : "86b5096ac59ab46e66bd1f6377c604bc1dab0bc2",
+        "version" : "1.5.1"
       }
     },
     {
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/sparkle-project/Sparkle",
       "state" : {
-        "revision" : "79bc9e872948e47877e76f194cb0c8e0412b0b90",
-        "version" : "2.9.5"
+        "revision" : "ac2def288cbff5cfc7df3ffef6abdf45b72bcb0a",
+        "version" : "2.9.6"
       }
     },
     {
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-asn1.git",
       "state" : {
-        "revision" : "a9a5efd40eaf558a2bcd48d64b1d1646be686008",
-        "version" : "1.7.1"
+        "revision" : "d9a5b37470adc940d22c3bcd5ca6953a516b727f",
+        "version" : "1.7.2"
       }
     },
     {
@@ -87,8 +87,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-crypto.git",
       "state" : {
-        "revision" : "47d3869a7291f085c1fb9fb1e6d3b97a793f45c6",
-        "version" : "4.5.1"
+        "revision" : "da9d28d69ebe3894b18376c8f2395c2f37b8448f",
+        "version" : "4.5.2"
       }
     },
     {
@@ -105,8 +105,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "0b18836bd8b0162e7e17a995a3fbee20ed8f3b2b",
-        "version" : "2.101.3"
+        "revision" : "a931f2c1de8dd49381ce3bf2e279d033f68d8865",
+        "version" : "2.102.0"
       }
     },
     {
@@ -132,8 +132,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swift-server/swift-service-lifecycle",
       "state" : {
-        "revision" : "9829955b385e5bb88128b73f1b8389e9b9c3191a",
-        "version" : "2.11.0"
+        "revision" : "7f9326b0326ff86e3646295ea6e891f68c471c5e",
+        "version" : "2.12.0"
       }
     },
     {
@@ -141,8 +141,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-system",
       "state" : {
-        "revision" : "704705c5c51156ede21172a38654d522ce487074",
-        "version" : "1.8.0"
+        "revision" : "869129b7bf4ecc57b97d0193ad29690ca2134750",
+        "version" : "1.8.1"
       }
     }
   ],

--- a/Apps/Peekaboo.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Apps/Peekaboo.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "1bb1fb075c8a26c20577db3dd3b3fc4bd78f183d2880c9bffd2586bebeee2b31",
+  "originHash" : "5ecc385c9a27a056508410f80a101d8a10dce31db733465ff014a61bdd808c0d",
   "pins" : [
     {
       "identity" : "bluesignals",

--- a/Apps/Peekaboo.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Apps/Peekaboo.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mattt/eventsource.git",
       "state" : {
-        "revision" : "a3a85a85214caf642abaa96ae664e4c772a59f6e",
-        "version" : "1.4.1"
+        "revision" : "86b5096ac59ab46e66bd1f6377c604bc1dab0bc2",
+        "version" : "1.5.1"
       }
     },
     {
@@ -51,8 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/sparkle-project/Sparkle",
       "state" : {
-        "revision" : "79bc9e872948e47877e76f194cb0c8e0412b0b90",
-        "version" : "2.9.5"
+        "revision" : "ac2def288cbff5cfc7df3ffef6abdf45b72bcb0a",
+        "version" : "2.9.6"
       }
     },
     {
@@ -87,8 +87,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-asn1.git",
       "state" : {
-        "revision" : "a9a5efd40eaf558a2bcd48d64b1d1646be686008",
-        "version" : "1.7.1"
+        "revision" : "d9a5b37470adc940d22c3bcd5ca6953a516b727f",
+        "version" : "1.7.2"
       }
     },
     {
@@ -141,8 +141,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-crypto.git",
       "state" : {
-        "revision" : "47d3869a7291f085c1fb9fb1e6d3b97a793f45c6",
-        "version" : "4.5.1"
+        "revision" : "da9d28d69ebe3894b18376c8f2395c2f37b8448f",
+        "version" : "4.5.2"
       }
     },
     {
@@ -177,8 +177,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "0b18836bd8b0162e7e17a995a3fbee20ed8f3b2b",
-        "version" : "2.101.3"
+        "revision" : "a931f2c1de8dd49381ce3bf2e279d033f68d8865",
+        "version" : "2.102.0"
       }
     },
     {
@@ -204,8 +204,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swift-server/swift-service-lifecycle",
       "state" : {
-        "revision" : "9829955b385e5bb88128b73f1b8389e9b9c3191a",
-        "version" : "2.11.0"
+        "revision" : "7f9326b0326ff86e3646295ea6e891f68c471c5e",
+        "version" : "2.12.0"
       }
     },
     {
@@ -222,8 +222,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-system",
       "state" : {
-        "revision" : "704705c5c51156ede21172a38654d522ce487074",
-        "version" : "1.8.0"
+        "revision" : "869129b7bf4ecc57b97d0193ad29690ca2134750",
+        "version" : "1.8.1"
       }
     }
   ],

--- a/Core/PeekabooCore/Package.resolved
+++ b/Core/PeekabooCore/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "71ec3de13a9edb15c606f3eea68f8164ee515dc3667bfd91f8800b3ee0a8505e",
+  "originHash" : "226469a26ce75830b7bfc9124e761415c7b62c0a9873fb0c47b73e5528798b4e",
   "pins" : [
     {
       "identity" : "eventsource",

--- a/Core/PeekabooCore/Package.resolved
+++ b/Core/PeekabooCore/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mattt/eventsource.git",
       "state" : {
-        "revision" : "a3a85a85214caf642abaa96ae664e4c772a59f6e",
-        "version" : "1.4.1"
+        "revision" : "86b5096ac59ab46e66bd1f6377c604bc1dab0bc2",
+        "version" : "1.5.1"
       }
     },
     {
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-asn1.git",
       "state" : {
-        "revision" : "a9a5efd40eaf558a2bcd48d64b1d1646be686008",
-        "version" : "1.7.1"
+        "revision" : "d9a5b37470adc940d22c3bcd5ca6953a516b727f",
+        "version" : "1.7.2"
       }
     },
     {
@@ -69,8 +69,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-crypto.git",
       "state" : {
-        "revision" : "47d3869a7291f085c1fb9fb1e6d3b97a793f45c6",
-        "version" : "4.5.1"
+        "revision" : "da9d28d69ebe3894b18376c8f2395c2f37b8448f",
+        "version" : "4.5.2"
       }
     },
     {
@@ -87,8 +87,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "0b18836bd8b0162e7e17a995a3fbee20ed8f3b2b",
-        "version" : "2.101.3"
+        "revision" : "a931f2c1de8dd49381ce3bf2e279d033f68d8865",
+        "version" : "2.102.0"
       }
     },
     {
@@ -114,8 +114,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swift-server/swift-service-lifecycle",
       "state" : {
-        "revision" : "9829955b385e5bb88128b73f1b8389e9b9c3191a",
-        "version" : "2.11.0"
+        "revision" : "7f9326b0326ff86e3646295ea6e891f68c471c5e",
+        "version" : "2.12.0"
       }
     },
     {
@@ -123,8 +123,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-system",
       "state" : {
-        "revision" : "704705c5c51156ede21172a38654d522ce487074",
-        "version" : "1.8.0"
+        "revision" : "869129b7bf4ecc57b97d0193ad29690ca2134750",
+        "version" : "1.8.1"
       }
     }
   ],

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeClient.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeClient.swift
@@ -736,7 +736,9 @@ public actor PeekabooBridgeClient {
             requestedHostKind: inputs.requestedHost,
             operationClientInstanceID: self.operationClientInstanceID,
             replacingOperationSessionID: replacingOperationSessionID,
-            clientCapabilities: Self.offeredCapabilities(for: protocolVersion))
+            clientCapabilities: protocolVersion >= PeekabooBridgeConstants.attestedOperationReceiptVersion
+                ? Self.offeredCapabilities(for: protocolVersion)
+                : nil)
         let reply = try await self.sendCarryingActionOutcome(.handshake(payload), timeoutSec: timeoutSec)
         try self.validateTrustedConnectedHost(reply.connectedHost)
         let response = reply.response

--- a/Core/PeekabooCore/Tests/PeekabooBridgeTests/PeekabooBridgeClientHostTrustTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooBridgeTests/PeekabooBridgeClientHostTrustTests.swift
@@ -81,6 +81,21 @@ struct PeekabooBridgeClientHostTrustTests {
             .appendingPathComponent(relativePath).path
     }
 
+    @Test(arguments: [28, 29])
+    func `wire capability field begins with receipt capable negotiation`(minor: Int) async throws {
+        let probe = HandshakeOfferProbe()
+        let client = PeekabooBridgeClient(socketPath: Self.socketPath("Peekaboo/bridge.sock"), encoder: probe)
+        let offer = try await Self.offer(from: client, probe: probe, protocolVersion: .init(major: 1, minor: minor))
+        let data = try JSONEncoder.peekabooBridgeEncoder().encode(offer)
+        let object = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        if minor == 28 {
+            #expect(object["clientCapabilities"] == nil)
+        } else {
+            let capabilities = try #require(object["clientCapabilities"] as? [String])
+            #expect(capabilities.contains(PeekabooBridgeClientCapability.screenCaptureKitOwnershipDiagnostics))
+        }
+    }
+
     private static func offer(
         from client: PeekabooBridgeClient,
         probe: HandshakeOfferProbe,

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPSeeExactWindowTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPSeeExactWindowTests.swift
@@ -1,4 +1,5 @@
-import AppKit
+import CoreGraphics
+import Foundation
 import MCP
 import PeekabooAutomationKit
 import TachikomaMCP
@@ -48,11 +49,10 @@ struct MCPSeeExactWindowTests {
                         windowInfo: window))
                 }))
         }
-        let context = await MCPToolTestHelpers.makeContext(
-            automation: automation,
-            screenCapture: screenCapture,
-            applications: applications,
-            exactWindowMetadataProvider: ExactWindowTestMetadataProvider(values: [
+        let (screens, snapshots, observation) = await MainActor.run {
+            let screens = MockScreenService(screens: [])
+            let snapshots = InMemorySnapshotManager()
+            let metadataProvider = ExactWindowTestMetadataProvider(values: [
                 42: ExactWindowObservationMetadata(
                     ownerProcessIdentifier: app.processIdentifier,
                     ownerProcessStartIdentity: 700,
@@ -63,7 +63,27 @@ struct MCPSeeExactWindowTests {
                     ownerProcessStartIdentity: 700,
                     title: foreignWindow.title,
                     bounds: foreignWindow.bounds),
-            ]))
+            ])
+            let observation = DesktopObservationService(
+                screenCapture: screenCapture,
+                automation: automation,
+                applications: applications,
+                screens: screens,
+                snapshotManager: snapshots,
+                exactWindowMetadataProvider: metadataProvider,
+                processStartIdentityProvider: { _ in 700 },
+                windowMutationIdentityProvider: { windowID in
+                    windows.first { $0.windowID == Int(windowID) }?.mutationIdentity
+                })
+            return (screens, snapshots, observation)
+        }
+        let context = await MCPToolTestHelpers.makeContext(
+            automation: automation,
+            screenCapture: screenCapture,
+            applications: applications,
+            screens: screens,
+            snapshots: snapshots,
+            desktopObservation: observation)
         let tool = SeeTool(context: context)
 
         let legacyIndex = try await context.execute(
@@ -80,7 +100,13 @@ struct MCPSeeExactWindowTests {
                 "app_target": app.name,
                 "window_id": 42,
             ]))
-        #expect(exact.isError == false)
+        #expect(exact.isError == false, "Exact response: \(String(describing: exact.content))")
+        #expect(await MainActor.run { screenCapture.lastWindowID } == 42)
+
+        let ownerless = try await context.execute(
+            tool: tool,
+            arguments: ToolArguments(raw: ["window_id": 42]))
+        #expect(ownerless.isError == false, "Owner resolution: \(String(describing: ownerless.content))")
         #expect(await MainActor.run { screenCapture.lastWindowID } == 42)
 
         let mixedSelectors = try await context.execute(
@@ -98,13 +124,25 @@ struct MCPSeeExactWindowTests {
                 "window_id": 99999,
             ]))
         #expect(wrongOwner.isError)
-        #expect(await MainActor.run { screenCapture.captureAttemptCount } == 2)
+        #expect(await MainActor.run { screenCapture.captureAttemptCount } == 3)
     }
 
     @Test
-    func `See tool exact window id requires an owner target`() async throws {
-        let screenCapture = await MainActor.run { MockScreenCaptureService(screenRecordingGranted: true) }
-        let context = await MCPToolTestHelpers.makeContext(screenCapture: screenCapture)
+    func `See tool unresolved exact window metadata refuses before capture`() async throws {
+        let (screenCapture, observation) = await MainActor.run {
+            let screenCapture = MockScreenCaptureService(screenRecordingGranted: true)
+            let observation = DesktopObservationService(
+                screenCapture: screenCapture,
+                automation: MockAutomationService(accessibilityGranted: true),
+                applications: MockApplicationService(applications: []),
+                screens: MockScreenService(screens: []),
+                exactWindowMetadataProvider: ExactWindowTestMetadataProvider(values: [:]),
+                processStartIdentityProvider: { _ in nil },
+                windowMutationIdentityProvider: { _ in nil })
+            return (screenCapture, observation)
+        }
+        let context = await MCPToolTestHelpers.makeContext(
+            screenCapture: screenCapture, desktopObservation: observation)
 
         let response = try await context.execute(
             tool: SeeTool(context: context),
@@ -176,7 +214,7 @@ struct MCPSeeExactWindowTests {
             name: "Zephyr Agency",
             isActive: true,
             windowCount: 3)
-        let screenFrame = NSScreen.main?.frame ?? CGRect(x: 0, y: 0, width: 2000, height: 1200)
+        let screenFrame = CGRect(x: 0, y: 0, width: 2000, height: 1200)
         let visibleOrigin = CGPoint(x: screenFrame.minX + 20, y: screenFrame.minY + 20)
         let offscreenOrigin = CGPoint(x: screenFrame.maxX + 10000, y: screenFrame.maxY + 10000)
 

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeCancellationTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeCancellationTests.swift
@@ -375,16 +375,16 @@ struct PeekabooBridgeCancellationTests {
             socketPath: socketPath,
             server: server,
             allowedTeamIDs: [],
-            requestTimeoutSec: 1,
+            requestTimeoutSec: 5,
             requestDrainTimeoutSec: 0.05)
         try await host.startChecked()
 
-        let timedOutClient = PeekabooBridgeClient(socketPath: socketPath, requestTimeoutSec: 0.25)
-        try await Self.negotiateLegacyTransport(timedOutClient)
+        let disconnectedClient = PeekabooBridgeClient(socketPath: socketPath, requestTimeoutSec: 5)
+        try await Self.negotiateLegacyTransport(disconnectedClient)
         let firstRequest = PeekabooBridgeRequest.desktopObservation(
             Self.mutatingObservationRequest(snapshotID: "blocked"))
-        let firstTask = Task { try await timedOutClient.send(firstRequest) }
-        let observationStarted = try await Self.waitForObservationStart(observations)
+        let firstTask = Task { try await disconnectedClient.send(firstRequest) }
+        let observationStarted = try await Self.waitForObservationStart(observations, timeout: .seconds(4))
         guard observationStarted else {
             Issue.record("Expected the bridge observation to start")
             firstTask.cancel()
@@ -392,9 +392,11 @@ struct PeekabooBridgeCancellationTests {
             return
         }
 
+        // The host has consumed the half-close; disconnect only after work starts.
+        firstTask.cancel()
         do {
             _ = try await firstTask.value
-            Issue.record("Expected the first client to time out")
+            Issue.record("Expected the disconnected client to fail")
         } catch let failure as DesktopActionFailure {
             Self.expectResponseLostFailure(failure)
         } catch {
@@ -635,9 +637,10 @@ struct PeekabooBridgeCancellationTests {
 
     @MainActor
     private static func waitForObservationStart(
-        _ observations: CancellationTestObservationService) async throws -> Bool
+        _ observations: CancellationTestObservationService,
+        timeout: Duration = .seconds(1)) async throws -> Bool
     {
-        let deadline = ContinuousClock.now.advanced(by: .seconds(1))
+        let deadline = ContinuousClock.now.advanced(by: timeout)
         while !observations.hasStarted {
             guard ContinuousClock.now < deadline else { return false }
             try await Task.sleep(for: .milliseconds(5))

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooServicesBrowserSessionProviderTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooServicesBrowserSessionProviderTests.swift
@@ -406,7 +406,16 @@ struct PeekabooServicesBrowserSessionProviderTests {
         #expect(await Self.waitUntil {
             child.removeCount == 1 && fixture.root.existingAuthenticatedSession(named: sessionName) == nil
         })
-        _ = try await fixture.root.connectWithOutcome(channel: nil, browserURL: Self.browserURL)
+        let releaseDeadline = ContinuousClock.now + .seconds(1)
+        while true {
+            do {
+                _ = try await fixture.root.connectWithOutcome(channel: nil, browserURL: Self.browserURL)
+                break
+            } catch BrowserMCPConnectionError.targetLocked where ContinuousClock.now < releaseDeadline {
+                // Provider removal precedes the reaper's final target-lease release.
+                try await Task.sleep(for: .milliseconds(1))
+            }
+        }
         await fixture.root.disconnect()
         #expect(await host.stop() == .stopped)
     }

--- a/docs/bridge-host.md
+++ b/docs/bridge-host.md
@@ -154,6 +154,9 @@ those app-only services are injected separately; moving them into the embedded r
 - Listener acceptance is kernel-readiness-driven: one coalesced notification drains the queued connection backlog to
   `EAGAIN`, while source cancellation owns descriptor closure and bounded shutdown waits for queued handlers to drain.
 
+Receiptless offers through protocol `1.28` omit `clientCapabilities` rather than sending an empty array.
+Receipt-capable `1.29` and newer offers retain version-gated capabilities, including ownership diagnostics.
+
 Protocol `1.3` adds element action operations:
 
 - `setValue` for direct accessibility value mutation.

--- a/package.json
+++ b/package.json
@@ -92,5 +92,5 @@
   "devDependencies": {
     "chrome-devtools-mcp": "1.6.0"
   },
-  "packageManager": "pnpm@11.21.0+sha512.521705bce689924eac72f5a3587122f362689ef6571e55ba80076fd637c11132ecffada26fad4ea79c485bfddbfd3d5a2a5b05805a77e893de71ec8a6cca3bb1"
+  "packageManager": "pnpm@11.25.0+sha512.5cde925b4f075f725eb71fbae18a42ffe784524789f19b61c731cb8721ec28aaee160e01a8d5af4fedb2a42cdbf300efe23db356b0d4a17b4d63e11f8ab7c956"
 }

--- a/scripts/test-release-package-resolution.sh
+++ b/scripts/test-release-package-resolution.sh
@@ -5,8 +5,8 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 WORKSPACE_LOCK="$ROOT_DIR/Apps/Peekaboo.xcworkspace/xcshareddata/swiftpm/Package.resolved"
 MAC_LOCK="$ROOT_DIR/Apps/Mac/Package.resolved"
-EXPECTED_SPARKLE_VERSION=2.9.5
-EXPECTED_SPARKLE_REVISION=79bc9e872948e47877e76f194cb0c8e0412b0b90
+EXPECTED_SPARKLE_VERSION=2.9.6
+EXPECTED_SPARKLE_REVISION=ac2def288cbff5cfc7df3ffef6abdf45b72bcb0a
 TEST_DIR="$(mktemp -d "${TMPDIR:-/tmp}/peekaboo-release-resolution-test.XXXXXX")"
 trap 'rm -rf "$TEST_DIR"' EXIT
 
@@ -143,7 +143,7 @@ export PACKAGE_RESOLUTION_TEST_REVISION="$EXPECTED_SPARKLE_REVISION"
 write_sparkle_info "$EXPECTED_SPARKLE_VERSION"
 verify_fixture >/dev/null
 
-write_sparkle_info 2.9.6
+write_sparkle_info 2.9.5
 assert_fixture_refused embedded-version 'does not match locked version'
 write_sparkle_info "$EXPECTED_SPARKLE_VERSION"
 

--- a/scripts/test-terminal-artifact-env.sh
+++ b/scripts/test-terminal-artifact-env.sh
@@ -2,11 +2,15 @@
 
 set -euo pipefail
 
+# Fixtures supply their own custody values; never inherit the operator's credentials.
+unset OP_SERVICE_ACCOUNT_TOKEN MOLTY_OP_SERVICE_ACCOUNT_TOKEN \
+  PEEKABOO_OP_SERVICE_TOKEN_FILE PEEKABOO_MOLTY_OP_SERVICE_TOKEN_FILE
+
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 # shellcheck source=scripts/terminal-artifact-env.sh
 source "$ROOT_DIR/scripts/terminal-artifact-env.sh"
 
-TEST_DIR="$(mktemp -d /tmp/peekaboo-terminal-env-test.XXXXXX)"
+TEST_DIR="$(mktemp -d "${TMPDIR:-/tmp}/peekaboo-terminal-env-test.XXXXXX")"
 trap 'rm -rf -- "$TEST_DIR"' EXIT
 
 fail() {

--- a/tests/release-validation-workflow.test.mjs
+++ b/tests/release-validation-workflow.test.mjs
@@ -298,7 +298,7 @@ test('full safe lane shares source gates and runs only the complete pinned comma
   assert.match(pnpm, /if: matrix.group == 'full-safe'\n        timeout-minutes: 5\n        uses: pnpm\/action-setup@v6\.0\.9/);
   assert.match(pnpm, /run_install: false\n          cache: false/);
   assert.doesNotMatch(pnpm, /\n\s+version:/, 'pnpm version must come from package.json');
-  assert.match(workflow, /uses: actions\/setup-node@v6\n        with:\n          node-version: '24'\n          package-manager-cache: false/);
+  assert.match(workflow, /uses: actions\/setup-node@v7\n        with:\n          node-version: '24'\n          package-manager-cache: false/);
   assert.match(script('Record safe-suite runtime and frozen dependency install'), /^pnpm install --frozen-lockfile 2>&1 \| tee /m);
   assert.match(script('Run full repository safe suite'), /^pnpm run test:safe 2>&1 \| tee /m);
   assert.equal(script('Run full repository safe suite').match(/^pnpm /gm)?.length, 1);


### PR DESCRIPTION
Refresh the canonical Swift package locks, including Sparkle 2.9.6’s installer security fixes, and keep the Mac/workspace/Core graphs consistent. Update release pin checks, pnpm within major 11, and Node setup while retaining Node 24 and disabled package-manager caching in qualification.

Updated versions: EventSource 1.5.1, Sparkle 2.9.6, Swift ASN.1 1.7.2, Swift Crypto 4.5.2, Swift NIO 2.102.0, ServiceLifecycle 2.12.0, Swift System 1.8.1, pnpm 11.25.0, and actions/setup-node v7. Upstream tags and commit pins were checked; selected releases satisfied the 48-hour release-age policy when selected.

This branch includes the independent #690 fixture-isolation and #692 legacy-handshake/Core-fixture repairs. #690 has landed; land #692 before this PR. The subsequent PTY synchronization and TERM-grace fixes in #692 are inherited from main when these changes are merged. Consolidated release notes are in #693, which lands last.

Keep chrome-devtools-mcp at audited 1.6.0: 1.8.0 adds six provider tools, including PWA installation/launch/removal, and needs authority-routing qualification and contract-fixture updates. The checked pnpm/action-setup 6.1.0 and newest pnpm 12 releases were outside the age window. Submodule-owned dependency majors remain in their owning repositories.

Qualified head: `babf587b7bf492caec2f8df2224679e0ef8fbb09`. [macOS CI](https://github.com/openclaw/Peekaboo/actions/runs/33996812853), [CodeQL](https://github.com/openclaw/Peekaboo/actions/runs/33996812854), and [all complete supplemental suites](https://github.com/openclaw/Peekaboo/actions/runs/33996812898) passed on this head. Frozen install, release-package-resolution checks, workflow/docs tests, and final branch autoreview through P2 passed.

All 3,222 local Core tests passed in a fresh private temp directory. The first combined run had three remote-application timing failures; the isolated 24-test retry and full Core retry passed without assertion changes. The complete local safe suite also passed on the preceding dependency head.

The final-head Mac app built with Developer ID signing, passed deep/strict signature verification, launched, and was driven through its About dialog with the candidate Sparkle 2.9.6 framework loaded. The rebuilt, signed CLI ran its version and isolated config-init commands successfully. The proof app exited cleanly; existing app processes and tracked preferences were preserved. No merge, tag, or publication was performed.
