### PR TITLE
fix(runtime): preserve legacy handshakes and TERM grace

### DIFF
--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -143,14 +143,19 @@ jobs:
       - name: Run MCP action fixtures and outcome contract tests
         working-directory: Core/PeekabooCore
         run: |
-          swift test --no-parallel --filter 'MCPToolExecutionTests|MCPToolErrorHandlingTests|MCPElementActionToolExecutionTests'
+          swift test --no-parallel --filter 'MCPToolExecutionTests|MCPToolErrorHandlingTests|MCPElementActionToolExecutionTests|MCPSeeExactWindowTests'
           swift test --no-parallel --filter 'MCPDesktopActionOutcomeProjectionTests|MCPCompositeActionOutcomeTests'
+
+      - name: Run Bridge negotiation and cancellation contracts
+        working-directory: Core/PeekabooCore
+        run: |
+          swift test --no-parallel --filter 'PeekabooBridgeClientHostTrustTests|CaptureDiagnosticWireCompatibilityTests|PeekabooBridgeCancellationTests'
 
       - name: Run browser capability and guidance contracts
         working-directory: Core/PeekabooCore
         run: |
           swift test --no-parallel \
-            --filter 'BrowserToolTests|BrowserToolCapabilityIntegrationTests|RemoteBrowserMCPSessionTests|AgentSystemPromptTests'
+            --filter 'BrowserToolTests|BrowserToolCapabilityIntegrationTests|RemoteBrowserMCPSessionTests|PeekabooServicesBrowserSessionProviderTests|AgentSystemPromptTests'
 
       - name: Run focused Swift tests
         working-directory: Core/PeekabooCore

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Core/CaptureActionProcessRunner.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Core/CaptureActionProcessRunner.swift
@@ -329,7 +329,7 @@ private final class CaptureActionProcessBox: @unchecked Sendable {
             let nowNs = DispatchTime.now().uptimeNanoseconds
             let effectiveDeadlineNs = self.effectiveWaitAbandonDeadline(originalNs: abandonDeadlineNs)
             if nowNs >= timeoutDeadlineNs {
-                self.requestTimeoutTermination(observedAtNs: nowNs)
+                self.requestTimeoutTermination()
             }
             self.sendTerminationKillIfDue(
                 observedAtNs: nowNs,
@@ -475,8 +475,8 @@ private final class CaptureActionProcessBox: @unchecked Sendable {
             return
         }
         if self.terminationRequestedAtNs == nil {
-            self.terminationRequestedAtNs = requestedAtNs
             self.killProcessGroup(pid: pid, signal: SIGTERM)
+            self.terminationRequestedAtNs = DispatchTime.now().uptimeNanoseconds
         }
         self.lock.unlock()
     }
@@ -633,7 +633,7 @@ private final class CaptureActionProcessBox: @unchecked Sendable {
         }
     }
 
-    private nonisolated func requestTimeoutTermination(observedAtNs: UInt64) {
+    private nonisolated func requestTimeoutTermination() {
         self.lock.lock()
         defer { self.lock.unlock() }
         guard !self.forceStop,
@@ -643,8 +643,8 @@ private final class CaptureActionProcessBox: @unchecked Sendable {
               !self.didFinishWaiting
         else { return }
         self.timedOut = true
-        self.terminationRequestedAtNs = observedAtNs
         self.killProcessGroup(pid: pid, signal: SIGTERM)
+        self.terminationRequestedAtNs = DispatchTime.now().uptimeNanoseconds
     }
 
     private nonisolated func sendTerminationKillIfDue(

--- a/Apps/CLI/Tests/CLIRuntimeTests/ConfigCredentialInputCLITests.swift
+++ b/Apps/CLI/Tests/CLIRuntimeTests/ConfigCredentialInputCLITests.swift
@@ -666,16 +666,15 @@ extension ConfigCredentialInputCLITests {
                 }
             case let .stopAndContinue(signalNumber, input):
                 _ = kill(processIdentifier, signalNumber)
-                let didStop = self.waitForStopped(
+                stoppedSignal = self.waitForStopped(
                     processIdentifier: processIdentifier,
                     fileDescriptor: primaryDescriptor,
                     output: &output,
                     timeout: 2
                 )
-                stoppedSignal = didStop ? signalNumber : nil
-                echoEnabledWhileStopped = didStop &&
+                echoEnabledWhileStopped = stoppedSignal != nil &&
                     self.waitForEcho(fileDescriptor: primaryDescriptor, enabled: true, timeout: 1)
-                if didStop {
+                if stoppedSignal != nil {
                     _ = kill(processIdentifier, SIGCONT)
                     echoDisabledAfterContinue = self.waitForEcho(
                         fileDescriptor: primaryDescriptor,
@@ -821,19 +820,21 @@ extension ConfigCredentialInputCLITests {
         fileDescriptor: Int32,
         output: inout Data,
         timeout: TimeInterval
-    ) -> Bool {
+    ) -> Int32? {
+        let marker = "PEEKABOO_CHILD_STOPPED=\(processIdentifier):"
         let deadline = Date().addingTimeInterval(timeout)
         while Date() < deadline {
             self.drainTTY(fileDescriptor: fileDescriptor, into: &output)
-            var processInfo = proc_bsdinfo()
-            let expectedSize = Int32(MemoryLayout<proc_bsdinfo>.size)
-            if proc_pidinfo(processIdentifier, PROC_PIDTBSDINFO, 0, &processInfo, expectedSize) == expectedSize,
-               processInfo.pbi_status == UInt32(SSTOP) {
-                return true
+            if let text = String(data: output, encoding: .utf8),
+               let markerRange = text.range(of: marker),
+               let lineEnd = text[markerRange.upperBound...].firstIndex(where: \.isNewline),
+               let signalNumber = Int32(text[markerRange.upperBound..<lineEnd]
+                   .trimmingCharacters(in: .whitespacesAndNewlines)) {
+                return signalNumber
             }
             usleep(10000)
         }
-        return false
+        return nil
     }
 
     private nonisolated func waitForEcho(fileDescriptor: Int32, enabled: Bool, timeout: TimeInterval) -> Bool {

--- a/Apps/CLI/Tests/CoreCLITests/CaptureActionProcessRunnerTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/CaptureActionProcessRunnerTests.swift
@@ -223,6 +223,37 @@ struct CaptureActionProcessRunnerTests {
         }
     }
 
+    @Test(arguments: [false, true])
+    func `TERM grace starts after dispatch`(cancel: Bool) async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("peekaboo-action-delayed-term-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let marker = root.appendingPathComponent("graceful-exit")
+        let ready = root.appendingPathComponent("ready")
+        let task = Task {
+            try await CaptureActionProcessRunner.run(
+                command: ["/usr/bin/perl", "-e", Self.gracefulTermHandlerScript, marker.path, ready.path, "0.1"],
+                timeoutSeconds: cancel ? 5 : 1,
+                signalProcessGroup: { pid, signal in
+                    if signal == SIGTERM {
+                        usleep(750_000)
+                    }
+                    _ = Darwin.kill(-pid, signal)
+                }
+            )
+        }
+
+        if cancel {
+            try await Self.waitUntilFileExists(ready)
+            task.cancel()
+        }
+        let result = try await task.value
+        #expect(FileManager.default.fileExists(atPath: marker.path))
+        #expect(result.exitCode == 0)
+        #expect(result.timedOut == !cancel)
+    }
+
     @Test
     func `cancellation returns quickly for TERM ignoring child with long timeout`() async throws {
         let root = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
@@ -616,8 +647,9 @@ struct CaptureActionProcessRunnerTests {
     }
 
     private static let gracefulTermHandlerScript = """
-    my ($marker, $ready) = @ARGV;
+    my ($marker, $ready, $handler_delay) = @ARGV;
     $SIG{TERM} = sub {
+        select(undef, undef, undef, $handler_delay) if defined($handler_delay);
         open(my $fh, '>', $marker) or die "marker: $!";
         print $fh "ok\\n";
         close($fh);

--- a/Apps/CLI/Tests/Support/TTYCredentialSupervisor.c
+++ b/Apps/CLI/Tests/Support/TTYCredentialSupervisor.c
@@ -87,9 +87,22 @@ int main(int argument_count, char *arguments[]) {
 
     int child_status = 0;
     pid_t wait_result;
-    do {
-        wait_result = waitpid(process_identifier, &child_status, 0);
-    } while (wait_result < 0 && errno == EINTR);
+    for (;;) {
+        wait_result = waitpid(process_identifier, &child_status, WUNTRACED);
+        if (wait_result < 0 && errno == EINTR) {
+            continue;
+        }
+        if (wait_result == process_identifier && WIFSTOPPED(child_status)) {
+            // Resume only after the parent has consumed the completed stop event.
+            if (dprintf(STDOUT_FILENO, "PEEKABOO_CHILD_STOPPED=%d:%d\n",
+                        process_identifier, WSTOPSIG(child_status)) < 0) {
+                terminate_child(process_identifier);
+                return 132;
+            }
+            continue;
+        }
+        break;
+    }
     (void)tcsetpgrp(STDIN_FILENO, getpgrp());
     if (wait_result != process_identifier) {
         return 130;

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeClient.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeClient.swift
@@ -736,7 +736,9 @@ public actor PeekabooBridgeClient {
             requestedHostKind: inputs.requestedHost,
             operationClientInstanceID: self.operationClientInstanceID,
             replacingOperationSessionID: replacingOperationSessionID,
-            clientCapabilities: Self.offeredCapabilities(for: protocolVersion))
+            clientCapabilities: protocolVersion >= PeekabooBridgeConstants.attestedOperationReceiptVersion
+                ? Self.offeredCapabilities(for: protocolVersion)
+                : nil)
         let reply = try await self.sendCarryingActionOutcome(.handshake(payload), timeoutSec: timeoutSec)
         try self.validateTrustedConnectedHost(reply.connectedHost)
         let response = reply.response

--- a/Core/PeekabooCore/Tests/PeekabooBridgeTests/PeekabooBridgeClientHostTrustTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooBridgeTests/PeekabooBridgeClientHostTrustTests.swift
@@ -81,6 +81,21 @@ struct PeekabooBridgeClientHostTrustTests {
             .appendingPathComponent(relativePath).path
     }
 
+    @Test(arguments: [28, 29])
+    func `wire capability field begins with receipt capable negotiation`(minor: Int) async throws {
+        let probe = HandshakeOfferProbe()
+        let client = PeekabooBridgeClient(socketPath: Self.socketPath("Peekaboo/bridge.sock"), encoder: probe)
+        let offer = try await Self.offer(from: client, probe: probe, protocolVersion: .init(major: 1, minor: minor))
+        let data = try JSONEncoder.peekabooBridgeEncoder().encode(offer)
+        let object = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        if minor == 28 {
+            #expect(object["clientCapabilities"] == nil)
+        } else {
+            let capabilities = try #require(object["clientCapabilities"] as? [String])
+            #expect(capabilities.contains(PeekabooBridgeClientCapability.screenCaptureKitOwnershipDiagnostics))
+        }
+    }
+
     private static func offer(
         from client: PeekabooBridgeClient,
         probe: HandshakeOfferProbe,

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPSeeExactWindowTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPSeeExactWindowTests.swift
@@ -1,4 +1,5 @@
-import AppKit
+import CoreGraphics
+import Foundation
 import MCP
 import PeekabooAutomationKit
 import TachikomaMCP
@@ -48,11 +49,10 @@ struct MCPSeeExactWindowTests {
                         windowInfo: window))
                 }))
         }
-        let context = await MCPToolTestHelpers.makeContext(
-            automation: automation,
-            screenCapture: screenCapture,
-            applications: applications,
-            exactWindowMetadataProvider: ExactWindowTestMetadataProvider(values: [
+        let (screens, snapshots, observation) = await MainActor.run {
+            let screens = MockScreenService(screens: [])
+            let snapshots = InMemorySnapshotManager()
+            let metadataProvider = ExactWindowTestMetadataProvider(values: [
                 42: ExactWindowObservationMetadata(
                     ownerProcessIdentifier: app.processIdentifier,
                     ownerProcessStartIdentity: 700,
@@ -63,7 +63,27 @@ struct MCPSeeExactWindowTests {
                     ownerProcessStartIdentity: 700,
                     title: foreignWindow.title,
                     bounds: foreignWindow.bounds),
-            ]))
+            ])
+            let observation = DesktopObservationService(
+                screenCapture: screenCapture,
+                automation: automation,
+                applications: applications,
+                screens: screens,
+                snapshotManager: snapshots,
+                exactWindowMetadataProvider: metadataProvider,
+                processStartIdentityProvider: { _ in 700 },
+                windowMutationIdentityProvider: { windowID in
+                    windows.first { $0.windowID == Int(windowID) }?.mutationIdentity
+                })
+            return (screens, snapshots, observation)
+        }
+        let context = await MCPToolTestHelpers.makeContext(
+            automation: automation,
+            screenCapture: screenCapture,
+            applications: applications,
+            screens: screens,
+            snapshots: snapshots,
+            desktopObservation: observation)
         let tool = SeeTool(context: context)
 
         let legacyIndex = try await context.execute(
@@ -80,7 +100,13 @@ struct MCPSeeExactWindowTests {
                 "app_target": app.name,
                 "window_id": 42,
             ]))
-        #expect(exact.isError == false)
+        #expect(exact.isError == false, "Exact response: \(String(describing: exact.content))")
+        #expect(await MainActor.run { screenCapture.lastWindowID } == 42)
+
+        let ownerless = try await context.execute(
+            tool: tool,
+            arguments: ToolArguments(raw: ["window_id": 42]))
+        #expect(ownerless.isError == false, "Owner resolution: \(String(describing: ownerless.content))")
         #expect(await MainActor.run { screenCapture.lastWindowID } == 42)
 
         let mixedSelectors = try await context.execute(
@@ -98,13 +124,25 @@ struct MCPSeeExactWindowTests {
                 "window_id": 99999,
             ]))
         #expect(wrongOwner.isError)
-        #expect(await MainActor.run { screenCapture.captureAttemptCount } == 2)
+        #expect(await MainActor.run { screenCapture.captureAttemptCount } == 3)
     }
 
     @Test
-    func `See tool exact window id requires an owner target`() async throws {
-        let screenCapture = await MainActor.run { MockScreenCaptureService(screenRecordingGranted: true) }
-        let context = await MCPToolTestHelpers.makeContext(screenCapture: screenCapture)
+    func `See tool unresolved exact window metadata refuses before capture`() async throws {
+        let (screenCapture, observation) = await MainActor.run {
+            let screenCapture = MockScreenCaptureService(screenRecordingGranted: true)
+            let observation = DesktopObservationService(
+                screenCapture: screenCapture,
+                automation: MockAutomationService(accessibilityGranted: true),
+                applications: MockApplicationService(applications: []),
+                screens: MockScreenService(screens: []),
+                exactWindowMetadataProvider: ExactWindowTestMetadataProvider(values: [:]),
+                processStartIdentityProvider: { _ in nil },
+                windowMutationIdentityProvider: { _ in nil })
+            return (screenCapture, observation)
+        }
+        let context = await MCPToolTestHelpers.makeContext(
+            screenCapture: screenCapture, desktopObservation: observation)
 
         let response = try await context.execute(
             tool: SeeTool(context: context),
@@ -176,7 +214,7 @@ struct MCPSeeExactWindowTests {
             name: "Zephyr Agency",
             isActive: true,
             windowCount: 3)
-        let screenFrame = NSScreen.main?.frame ?? CGRect(x: 0, y: 0, width: 2000, height: 1200)
+        let screenFrame = CGRect(x: 0, y: 0, width: 2000, height: 1200)
         let visibleOrigin = CGPoint(x: screenFrame.minX + 20, y: screenFrame.minY + 20)
         let offscreenOrigin = CGPoint(x: screenFrame.maxX + 10000, y: screenFrame.maxY + 10000)
 

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeCancellationTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeCancellationTests.swift
@@ -375,16 +375,16 @@ struct PeekabooBridgeCancellationTests {
             socketPath: socketPath,
             server: server,
             allowedTeamIDs: [],
-            requestTimeoutSec: 1,
+            requestTimeoutSec: 5,
             requestDrainTimeoutSec: 0.05)
         try await host.startChecked()
 
-        let timedOutClient = PeekabooBridgeClient(socketPath: socketPath, requestTimeoutSec: 0.25)
-        try await Self.negotiateLegacyTransport(timedOutClient)
+        let disconnectedClient = PeekabooBridgeClient(socketPath: socketPath, requestTimeoutSec: 5)
+        try await Self.negotiateLegacyTransport(disconnectedClient)
         let firstRequest = PeekabooBridgeRequest.desktopObservation(
             Self.mutatingObservationRequest(snapshotID: "blocked"))
-        let firstTask = Task { try await timedOutClient.send(firstRequest) }
-        let observationStarted = try await Self.waitForObservationStart(observations)
+        let firstTask = Task { try await disconnectedClient.send(firstRequest) }
+        let observationStarted = try await Self.waitForObservationStart(observations, timeout: .seconds(4))
         guard observationStarted else {
             Issue.record("Expected the bridge observation to start")
             firstTask.cancel()
@@ -392,9 +392,11 @@ struct PeekabooBridgeCancellationTests {
             return
         }
 
+        // The host has consumed the half-close; disconnect only after work starts.
+        firstTask.cancel()
         do {
             _ = try await firstTask.value
-            Issue.record("Expected the first client to time out")
+            Issue.record("Expected the disconnected client to fail")
         } catch let failure as DesktopActionFailure {
             Self.expectResponseLostFailure(failure)
         } catch {
@@ -635,9 +637,10 @@ struct PeekabooBridgeCancellationTests {
 
     @MainActor
     private static func waitForObservationStart(
-        _ observations: CancellationTestObservationService) async throws -> Bool
+        _ observations: CancellationTestObservationService,
+        timeout: Duration = .seconds(1)) async throws -> Bool
     {
-        let deadline = ContinuousClock.now.advanced(by: .seconds(1))
+        let deadline = ContinuousClock.now.advanced(by: timeout)
         while !observations.hasStarted {
             guard ContinuousClock.now < deadline else { return false }
             try await Task.sleep(for: .milliseconds(5))

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooServicesBrowserSessionProviderTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooServicesBrowserSessionProviderTests.swift
@@ -406,7 +406,16 @@ struct PeekabooServicesBrowserSessionProviderTests {
         #expect(await Self.waitUntil {
             child.removeCount == 1 && fixture.root.existingAuthenticatedSession(named: sessionName) == nil
         })
-        _ = try await fixture.root.connectWithOutcome(channel: nil, browserURL: Self.browserURL)
+        let releaseDeadline = ContinuousClock.now + .seconds(1)
+        while true {
+            do {
+                _ = try await fixture.root.connectWithOutcome(channel: nil, browserURL: Self.browserURL)
+                break
+            } catch BrowserMCPConnectionError.targetLocked where ContinuousClock.now < releaseDeadline {
+                // Provider removal precedes the reaper's final target-lease release.
+                try await Task.sleep(for: .milliseconds(1))
+            }
+        }
         await fixture.root.disconnect()
         #expect(await host.stop() == .stopped)
     }

--- a/docs/bridge-host.md
+++ b/docs/bridge-host.md
@@ -154,6 +154,9 @@ those app-only services are injected separately; moving them into the embedded r
 - Listener acceptance is kernel-readiness-driven: one coalesced notification drains the queued connection backlog to
   `EAGAIN`, while source cancellation owns descriptor closure and bounded shutdown waits for queued handlers to drain.
 
+Receiptless offers through protocol `1.28` omit `clientCapabilities` rather than sending an empty array.
+Receipt-capable `1.29` and newer offers retain version-gated capabilities, including ownership diagnostics.
+
 Protocol `1.3` adds element action operations:
 
 - `setValue` for direct accessibility value mutation.

--- a/docs/commands/capture.md
+++ b/docs/commands/capture.md
@@ -84,7 +84,8 @@ Peekaboo starts the process-group leader suspended, captures and revalidates its
 forwarding, clears inherited termination-signal masks, restores default SIGINT/SIGTERM dispositions, and only then
 releases command code. If generation evidence is unavailable, no child code runs. Blocking
 leader observation runs outside Swift's cooperative executor so concurrent actions cannot starve cancellation or timeout
-work. After the direct child exits Peekaboo gives remaining members a bounded TERM grace,
+work. Timeout and cancellation give the child a 500 ms TERM grace measured after signal dispatch, still capped by the
+capture's absolute completion deadline. After the direct child exits Peekaboo gives remaining members a bounded TERM grace,
 escalates to KILL, and verifies that the group is gone before post-roll completion, artifact validation, or manifest
 publication. Startup, child timeout, TERM/KILL escalation, and descendant drain share the capture's one absolute
 deadline; one blocking waiter owns escalation, and post-roll uses its recorded completion boundary so actor scheduling


### PR DESCRIPTION
Restore legacy Bridge 1.28 handshake encoding and capture-action termination grace. Receiptless offers omit `clientCapabilities`, while modern version-gated negotiation remains intact. Timeout and cancellation start the child’s TERM grace after signal dispatch, bounded by the original absolute completion deadline.

Delayed dispatch previously consumed the grace window before the child received TERM, allowing immediate SIGKILL. New timeout/cancellation regressions and a standalone production-runner executable cover a 750 ms dispatch delay: the old code exited 137 without its marker; the repaired code exited 0 with its marker. Docs describe the unchanged hard deadline. The Bridge regression covers encoded 1.28/1.29 offers, with separate real SDK UNIX-socket wire proof.

Related fixtures now synchronize with the state they assert: the PTY supervisor reports the actual stopped-child event before SIGCONT; exact-window MCP fixtures inject coherent identities; browser cleanup waits for lease release; cancellation waits for observation admission. Existing refusal, echo/no-disclosure, exit-status, and deadline assertions remain intact.

Qualified head `a32c2ef57c56f76662d294083672a06d1abfef7a` passes [macOS CI](https://github.com/openclaw/Peekaboo/actions/runs/34008905746), [CodeQL](https://github.com/openclaw/Peekaboo/actions/runs/34008905671), and [all complete supplemental suites](https://github.com/openclaw/Peekaboo/actions/runs/34008905704). The app job passed on its one infrastructure rerun after missing SwiftPM cache directories blocked initial package resolution. Local validation passed 1,965 CLI tests, including both new delayed-dispatch cases, plus 20 extra job-control repetitions; final branch autoreview is clean through P2. Source and documentation are based on main after #682, #683, #688, and #690. #693 carries the ordered release notes and lands last.
