### PR TITLE
docs(changelog): prepare 4.3.1 maintenance notes

### DIFF
--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to Peekaboo CLI will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+**Highlights:** Exact popup and sheet screenshots, bounded image reads, and more reliable scripted commands.
+
+### Fixed
+- Capture exact popup and sheet extents without attached windows, reject mismatched images before publishing coordinates, and preserve 1×/Retina mapping without double-scaling. #689.
+- Cap observation and MCP screenshot reads and reject files that grow or are replaced during reading; thanks @SebTardif for #683.
+- Bound `see` publication reads while preserving annotations larger than their raw screenshots; thanks @SebTardif for #688.
+- Add an optional `config edit --timeout` for scripted editor waits while preserving unlimited interactive editing; thanks @SebTardif for #681.
+- Bound debug build-staleness Git probes and drain their output so large dirty worktrees still report stale builds; thanks @SebTardif for #682.
+- Preserve GUI capture readiness after ScreenCaptureKit preparation fails, allowing explicit classic recovery on the same proven host while retaining typed blockers, automatic-engine behavior, and older clients' signed receipts. #684.
+- Preserve omitted capability metadata in legacy Bridge 1.28 handshakes while retaining modern diagnostic negotiation. #692.
+- Verify ScreenCaptureKit owner and capability-marker close-on-fork protection through child descriptor behavior instead of SDK query bits, preserving atomic open flags.
+- Refresh Swift networking and crypto dependencies, pnpm, and Node setup tooling. #691.
+- Keep validation fixtures independent of operator credentials and live window IDs, and synchronize cleanup/disconnect checks with completed state transitions. #690, #692.
+
 ## [4.3.0] - 2026-09-02
 
 ### Highlights

--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Capture exact popup and sheet extents without attached windows, reject mismatched images before publishing coordinates, and preserve 1×/Retina mapping without double-scaling. #689.
 - Cap observation and MCP screenshot reads and reject files that grow or are replaced during reading; thanks @SebTardif for #683.
 - Bound `see` publication reads while preserving annotations larger than their raw screenshots; thanks @SebTardif for #688.
+- Start the `capture action` TERM grace after signal dispatch so delayed cancellation or timeout handling does not prematurely kill graceful children; retain the absolute completion deadline. #692.
 - Add an optional `config edit --timeout` for scripted editor waits while preserving unlimited interactive editing; thanks @SebTardif for #681.
 - Bound debug build-staleness Git probes and drain their output so large dirty worktrees still report stale builds; thanks @SebTardif for #682.
 - Preserve GUI capture readiness after ScreenCaptureKit preparation fails, allowing explicit classic recovery on the same proven host while retaining typed blockers, automatic-engine behavior, and older clients' signed receipts. #684.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,20 @@
 
 ## Unreleased
 
+**Highlights:** Exact popup and sheet screenshots, bounded image reads, and updater security fixes.
+
 ### Fixed
-- Exclude attached windows from classic window captures and reject mismatched raster extents before publishing window coordinates or snapshots; preserve exact 1×/Retina mapping without double-scaling private captures.
-- Preserve current GUI capture support and typed ScreenCaptureKit blockers when preparation fails, allowing explicit classic capture on the same proven host without changing auto or modern engines, with negotiated typed errors that preserve older clients' signed receipts.
-- Verify ScreenCaptureKit owner and capability-marker close-on-fork protection through child descriptor behavior instead of SDK query bits, preserving atomic open flags and isolating marker tests.
+- Capture exact popup and sheet extents without attached windows, reject mismatched images before publishing coordinates, and preserve 1×/Retina mapping without double-scaling. #689.
+- Update Sparkle to 2.9.6 for installer archive handling and signature validation security fixes. #691.
+- Cap observation and MCP screenshot reads and reject files that grow or are replaced during reading; thanks @SebTardif for #683.
+- Bound `see` publication reads while preserving annotations larger than their raw screenshots; thanks @SebTardif for #688.
+- Add an optional `config edit --timeout` for scripted editor waits while preserving unlimited interactive editing; thanks @SebTardif for #681.
+- Bound debug build-staleness Git probes and drain their output so large dirty worktrees still report stale builds; thanks @SebTardif for #682.
+- Preserve GUI capture readiness after ScreenCaptureKit preparation fails, allowing explicit classic recovery on the same proven host while retaining typed blockers, automatic-engine behavior, and older clients' signed receipts. #684.
+- Preserve omitted capability metadata in legacy Bridge 1.28 handshakes while retaining modern diagnostic negotiation. #692.
+- Verify ScreenCaptureKit owner and capability-marker close-on-fork protection through child descriptor behavior instead of SDK query bits, preserving atomic open flags.
+- Refresh Swift networking and crypto dependencies, pnpm, and Node setup tooling. #691.
+- Keep validation fixtures independent of operator credentials and live window IDs, and synchronize cleanup/disconnect checks with completed state transitions. #690, #692.
 
 ## [4.3.0] - 2026-09-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Update Sparkle to 2.9.6 for installer archive handling and signature validation security fixes. #691.
 - Cap observation and MCP screenshot reads and reject files that grow or are replaced during reading; thanks @SebTardif for #683.
 - Bound `see` publication reads while preserving annotations larger than their raw screenshots; thanks @SebTardif for #688.
+- Start the `capture action` TERM grace after signal dispatch so delayed cancellation or timeout handling does not prematurely kill graceful children; retain the absolute completion deadline. #692.
 - Add an optional `config edit --timeout` for scripted editor waits while preserving unlimited interactive editing; thanks @SebTardif for #681.
 - Bound debug build-staleness Git probes and drain their output so large dirty worktrees still report stale builds; thanks @SebTardif for #682.
 - Preserve GUI capture readiness after ScreenCaptureKit preparation fails, allowing explicit classic recovery on the same proven host while retaining typed blockers, automatic-engine behavior, and older clients' signed receipts. #684.


### PR DESCRIPTION
Consolidate all user-visible changes since v4.3.0 into the root and CLI Unreleased sections for the planned 4.3.1 patch. Highlights stays first, fixes remain ordered by user interest, and contributor credit is preserved. Include exact popup/sheet capture, bounded artifact reads, Sparkle security updates, reliable scripted commands, legacy Bridge metadata, and capture-action TERM grace.

The branch is rebased onto current main after #682, #683, #688, and #690 landed. Land it last, after #692, #681, and #691, so every advertised fix is present on main.

Head `4d724e2b18c8e8b0c758eab3d58bbb99c1e77166` passes [macOS CI](https://github.com/openclaw/Peekaboo/actions/runs/34009045260), [CodeQL](https://github.com/openclaw/Peekaboo/actions/runs/34009045257), docs lint, and final branch autoreview through P2. Only two changelogs change; both released sections were compared byte-for-byte with main and remain identical. No version bump, tag, or publication is included.
