### PR TITLE
fix(release): accept plain version changelog headings

### DIFF
--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -206,7 +206,9 @@ path must leave every byte and manifest hash unchanged and validate without a Pe
 
 ## 3. Date, commit, push, and run publication preflight
 
-Replace `Unreleased` with the actual release date, then use standard Git commands with Conventional Commits. Push
+Use `## X.Y.Z - YYYY-MM-DD` in both changelogs; square brackets around the version are also accepted. Each target
+version must have exactly one heading with a valid calendar date. Replace `Unreleased` with the actual release date,
+then use standard Git commands with Conventional Commits. Push
 `main`, pull with `--ff-only`, and confirm the publication commit is current and the tree is clean. Only then run the
 full publication preflight:
 

--- a/scripts/release-preflight-contract.mjs
+++ b/scripts/release-preflight-contract.mjs
@@ -262,17 +262,20 @@ function isValidCalendarDate(value) {
 
 export function validateChangelogContract({ changelogSource, version, requireDatedHeading }) {
   const escapedVersion = escapeRegExp(version);
-  const headingPattern = new RegExp(`^## \\[${escapedVersion}\\] - (Unreleased|\\d{4}-\\d{2}-\\d{2})$`, 'gm');
+  const headingPattern = new RegExp(
+    `^## (?:\\[${escapedVersion}\\]|${escapedVersion}) - (Unreleased|\\d{4}-\\d{2}-\\d{2})$`, 'gm');
   const matches = [...changelogSource.matchAll(headingPattern)];
   if (matches.length !== 1) {
     return [
-      `CHANGELOG.md must contain exactly one '## [${version}] - Unreleased' or dated ISO heading; ` +
+      `CHANGELOG.md must contain exactly one '## ${version} - Unreleased' or dated ISO heading ` +
+      `(version brackets optional); ` +
       `found ${matches.length}`
     ];
   }
   const match = matches[0];
   if (requireDatedHeading && match[1] === 'Unreleased') {
-    return [`full publication preflight requires '## [${version}] - YYYY-MM-DD'; found Unreleased`];
+    return [`full publication preflight requires '## ${version} - YYYY-MM-DD' ` +
+      `(version brackets optional); found Unreleased`];
   }
   if (match[1] !== 'Unreleased' && !isValidCalendarDate(match[1])) {
     return [`CHANGELOG.md has an invalid release date for ${version}: ${match[1]}`];

--- a/tests/release-preflight-contract.test.mjs
+++ b/tests/release-preflight-contract.test.mjs
@@ -47,7 +47,7 @@ test('preparation accepts Unreleased while publication requires a dated heading'
     changelogSource,
     version: '4.0.0',
     requireDatedHeading: true
-  }), ["full publication preflight requires '## [4.0.0] - YYYY-MM-DD'; found Unreleased"]);
+  }), ["full publication preflight requires '## 4.0.0 - YYYY-MM-DD' (version brackets optional); found Unreleased"]);
 });
 
 test('publication accepts only an exact heading with a valid ISO calendar date', () => {
@@ -71,8 +71,36 @@ test('publication accepts only an exact heading with a valid ISO calendar date',
     version: '4.0.0',
     requireDatedHeading: false
   }), [
-    "CHANGELOG.md must contain exactly one '## [4.0.0] - Unreleased' or dated ISO heading; found 2"
+    "CHANGELOG.md must contain exactly one '## 4.0.0 - Unreleased' or dated ISO heading " +
+      "(version brackets optional); found 2"
   ]);
+});
+
+test('publication accepts plain version headings while preserving date and uniqueness checks', () => {
+  const validate = (changelogSource, requireDatedHeading = true) => validateChangelogContract({
+    changelogSource,
+    version: '4.3.1',
+    requireDatedHeading
+  });
+  assert.deepEqual(validate('## 4.3.1 - 2026-09-05\n'), []);
+  assert.deepEqual(validate('## 4.3.1 - Unreleased\n', false), []);
+  assert.match(validate('## 4.3.1 - Unreleased\n')[0], /requires.*YYYY-MM-DD.*Unreleased/);
+  assert.match(validate('## 4.3.1 - 2026-02-30\n')[0], /invalid release date/);
+  assert.match(validate('## 4.3.1 - 2026-09-05\n\n## [4.3.1] - 2026-09-05\n')[0], /found 2/);
+  for (const heading of ['## [4.3.1 - 2026-09-05', '## 4.3.1] - 2026-09-05', '## 4.3.10 - 2026-09-05']) {
+    assert.match(validate(`${heading}\n`)[0], /found 0/);
+  }
+});
+
+test('current root and CLI release headings pass the preparation gate', () => {
+  const { version } = JSON.parse(readFileSync(join(projectRoot, 'package.json'), 'utf8'));
+  for (const path of ['CHANGELOG.md', 'Apps/CLI/CHANGELOG.md']) {
+    assert.deepEqual(validateChangelogContract({
+      changelogSource: readFileSync(join(projectRoot, path), 'utf8'),
+      version,
+      requireDatedHeading: false
+    }), [], path);
+  }
 });
 
 test('command registry roots must have exact page, index, and reference parity', () => {


### PR DESCRIPTION
The 4.3.1 publication preflight rejects `## 4.3.1 - 2026-09-05`, although the release-note extractor accepts that heading and the prepared release uses it. Accept either plain or fully bracketed versions in the changelog gate, retaining exact version matching, a single heading across both forms, valid calendar dates, and the requirement to date a publication entry.

Add regression coverage for plain headings, mixed-form duplicates, malformed brackets, invalid dates, and the actual root/CLI changelogs. Document both accepted forms. Release notes, Highlights, and their ordering are unchanged.

Validation:
- The added regressions failed before the fix; all 13 release-preflight tests pass afterward.
- Release-driver contract tests pass.
- Both real changelogs pass the full-publication heading validator.
- `node scripts/prepare-release.js --dry-run --bin /opt/homebrew/bin/peekaboo` passes, including documentation and live help/inventory contracts against the installed 4.3.0 CLI. This is preparation proof, not 4.3.1 artifact proof.
- Autoreview is clean through P2.

This unblocks a real full-preflight failure on release commit `957ebb8d9b413ab2da2ce809c1ca193fcb90bb97`. Signing and notarization authentication passed, but the driver stopped before building or publishing any release artifact. The corrected release source must receive fresh green CI before tagging or publication.
