### PR TITLE
fix(release): handle draft and npm publication metadata

### DIFF
--- a/scripts/release-binaries.sh
+++ b/scripts/release-binaries.sh
@@ -776,7 +776,7 @@ ensure_github_release_tag() {
 verify_github_release_assets() {
     local npm_metadata_path="${1:-}" allow_body_mismatch="${2:-false}"
     local allow_asset_repair="${3:-false}"
-    local expected_assets_json expected_body_json release_json tag_commit
+    local expected_assets_json expected_body_json release_json release_api_path tag_commit
 
     echo -e "\n${BLUE}Verifying GitHub release assets...${NC}"
     assert_publication_receipt "$npm_metadata_path"
@@ -793,8 +793,8 @@ process.stdout.write(JSON.stringify(receipt.assets));
           "$RELEASE_DIR/github-release-body.md")
     fi
 
-    release_json=$(gh api --hostname "$GITHUB_HOST" \
-      "repos/${GITHUB_API_REPOSITORY}/releases/tags/v${VERSION}")
+    release_api_path=$(github_release_api_path) || fail "Could not locate the GitHub release draft"
+    release_json=$(gh api --hostname "$GITHUB_HOST" "$release_api_path")
     printf '{"release":%s,"version":"%s","sourceCommit":"%s","tagCommit":"%s","expectedAssets":%s,"expectedBody":%s,"expectDraft":true,"allowAssetRepair":%s}\n' \
         "$release_json" "$VERSION" "$RELEASE_SOURCE_COMMIT" "$tag_commit" "$expected_assets_json" \
         "$expected_body_json" "$allow_asset_repair" |
@@ -936,22 +936,31 @@ prepare_release_assets() {
     RELEASE_ASSETS+=("$RELEASE_DIR/checksums.txt")
 }
 
-github_release_exists() {
-    local error_path result
+github_release_api_path() {
+    local error_path result api_url release_id
     error_path=$(mktemp "${TMPDIR:-/tmp}/peekaboo-gh-release-view.XXXXXX")
-    if gh api --hostname "$GITHUB_HOST" \
-      "repos/${GITHUB_API_REPOSITORY}/releases/tags/v${VERSION}" >/dev/null 2> "$error_path"; then
+    # The REST tag endpoint omits drafts, including drafts whose Git tag already exists.
+    if api_url=$(gh release view "v${VERSION}" --repo "$GITHUB_REPOSITORY" \
+      --json apiUrl --jq .apiUrl 2> "$error_path"); then
         rm -f "$error_path"
-        return 0
     else
         result=$?
-        if /usr/bin/grep -Eq 'HTTP 404|Not Found.*404' "$error_path"; then
+        if /usr/bin/grep -Eq '^release not found$' "$error_path"; then
             rm -f "$error_path"
             return 2
         fi
         rm -f "$error_path"
         fail "Could not determine whether the GitHub release draft exists (gh exit $result)"
     fi
+    release_id=${api_url##*/}
+    [[ "$release_id" =~ ^[1-9][0-9]*$ &&
+       "$api_url" == "https://api.github.com/repos/${GITHUB_API_REPOSITORY}/releases/${release_id}" ]] ||
+        fail "GitHub returned an invalid release API locator"
+    printf 'repos/%s/releases/%s\n' "$GITHUB_API_REPOSITORY" "$release_id"
+}
+
+github_release_exists() {
+    github_release_api_path >/dev/null
 }
 
 create_github_release_draft() {

--- a/scripts/release-binaries.sh
+++ b/scripts/release-binaries.sh
@@ -802,13 +802,35 @@ process.stdout.write(JSON.stringify(receipt.assets));
     echo -e "${GREEN}✅ GitHub release assets verified${NC}"
 }
 
+npm_view_single_json() {
+    local output result
+    if output=$(npm view "$@" --registry "$NPM_REGISTRY" --json); then
+        printf '%s' "$output" | node -e '
+try {
+  let value = JSON.parse(require("fs").readFileSync(0, "utf8"));
+  if (Array.isArray(value)) {
+    if (value.length !== 1) throw new Error("ambiguous npm result");
+    value = value[0];
+  }
+  process.stdout.write(JSON.stringify(value));
+} catch {
+  console.error("npm view did not return one JSON value");
+  process.exitCode = 1;
+}'
+    else
+        result=$?
+        printf '%s' "$output"
+        return "$result"
+    fi
+}
+
 verify_npm_publication() {
     local metadata package_name publish_times metadata_tmp
     package_name=$(node -p "require('$PROJECT_ROOT/package.json').name")
     [[ "$(npm_package_integrity "$NPM_PACKAGE_PATH")" == "$NPM_PACKAGE_INTEGRITY" ]] ||
         fail "Local npm package changed after it was frozen"
-    metadata=$(npm view "$package_name@$VERSION" --registry "$NPM_REGISTRY" --json)
-    publish_times=$(npm view "$package_name" time --registry "$NPM_REGISTRY" --json)
+    metadata=$(npm_view_single_json "$package_name@$VERSION")
+    publish_times=$(npm_view_single_json "$package_name" time)
     metadata=$(NPM_METADATA="$metadata" NPM_TIMES="$publish_times" node -e '
 const metadata = JSON.parse(process.env.NPM_METADATA);
 metadata.time = JSON.parse(process.env.NPM_TIMES);
@@ -897,8 +919,7 @@ npm_publication_exists() {
     local package_name observed error_path error_output result state
     package_name=$(node -p "require('$PROJECT_ROOT/package.json').name")
     error_path=$(mktemp "${TMPDIR:-/tmp}/peekaboo-npm-view.XXXXXX")
-    if observed=$(npm view "$package_name@$VERSION" version --registry "$NPM_REGISTRY" \
-      --json 2> "$error_path"); then
+    if observed=$(npm_view_single_json "$package_name@$VERSION" version 2> "$error_path"); then
         result=0
     else
         result=$?

--- a/scripts/test-release-signing-policy.sh
+++ b/scripts/test-release-signing-policy.sh
@@ -71,7 +71,9 @@ rg -Fq 'release-driver-contract.mjs' "$ROOT_DIR/scripts/release-binaries.sh"
 rg -Fq 'release-plan.json' "$ROOT_DIR/scripts/release-binaries.sh"
 rg -Fq 'github-release' "$ROOT_DIR/scripts/release-binaries.sh"
 rg -Fq 'npm-publication' "$ROOT_DIR/scripts/release-binaries.sh"
-rg -Fq '"repos/${GITHUB_API_REPOSITORY}/releases/tags/v${VERSION}"' \
+rg -Fq 'github_release_api_path' "$ROOT_DIR/scripts/release-binaries.sh"
+rg -Fq -- '--json apiUrl' "$ROOT_DIR/scripts/release-binaries.sh"
+rg -Fq 'release_json=$(gh api --hostname "$GITHUB_HOST" "$release_api_path")' \
   "$ROOT_DIR/scripts/release-binaries.sh"
 rg -Fq 'ensure_github_release_tag' "$ROOT_DIR/scripts/release-binaries.sh"
 rg -Fq -- '--verify-tag' "$ROOT_DIR/scripts/release-binaries.sh"

--- a/tests/release-preflight-contract.test.mjs
+++ b/tests/release-preflight-contract.test.mjs
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
 import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { tmpdir } from 'node:os';
 import test from 'node:test';
 import { fileURLToPath } from 'node:url';
 import { runInNewContext } from 'node:vm';
@@ -223,6 +224,92 @@ const prepareSource = readFileSync(new URL('../scripts/prepare-release.js', impo
 const driverSource = readFileSync(new URL('../scripts/release-binaries.sh', import.meta.url), 'utf8');
 const sanitizerPath = join(projectRoot, 'scripts/terminal-artifact-env.sh');
 const safeTestsFunction = prepareSource.match(/^function runSafeTests\(\) \{[\s\S]*?^\}/m)?.[0];
+
+function githubDraftLookup(t, { mode = 'draft', apiUrl, command = 'verify' } = {}) {
+  const root = mkdtempSync(join(tmpdir(), 'peekaboo-draft-lookup-'));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  writeFileSync(join(root, 'receipt.json'), JSON.stringify({ assets: {} }));
+  writeFileSync(join(root, 'github-release-body.md'), 'fixture release notes\n');
+  const names = ['github_release_api_path', 'github_release_exists', 'verify_github_release_assets'];
+  const functions = names.map((name) => driverSource.match(
+    new RegExp(`^${name}\\(\\) \\{[\\s\\S]*?^\\}`, 'm'))?.[0] ?? '').join('\n');
+  const sourceCommit = 'a'.repeat(40);
+  const script = `set -euo pipefail
+VERSION=9.8.7
+GITHUB_HOST=github.com
+GITHUB_REPOSITORY=github.com/openclaw/Peekaboo
+GITHUB_API_REPOSITORY=openclaw/Peekaboo
+BLUE= GREEN= NC=
+fail() { printf '%s\\n' "$*" >&2; exit 1; }
+assert_publication_receipt() { :; }
+github_tag_commit() { printf '%s\\n' "$RELEASE_SOURCE_COMMIT"; }
+node() { "$NODE_BIN" "$@"; }
+gh() {
+  printf '%s\\n' "$*" >> "$CALL_LOG"
+  if [[ "$1 $2" == 'release view' ]]; then
+    case "$FIXTURE_MODE" in
+      missing) printf 'release not found\\n' >&2; return 1 ;;
+      auth) printf 'HTTP 401: unauthorized\\n' >&2; return 1 ;;
+      api-error) printf 'HTTP 404: Not Found\\n' >&2; return 1 ;;
+    esac
+    printf '%s\\n' "$FIXTURE_API_URL"
+  elif [[ "$*" == 'api --hostname github.com repos/openclaw/Peekaboo/releases/123' ]]; then
+    printf '%s\\n' "$FIXTURE_RELEASE_JSON"
+  else
+    printf 'HTTP 404: Not Found\\n' >&2
+    return 1
+  fi
+}
+${functions}
+if [[ "$FIXTURE_COMMAND" == verify ]]; then
+  verify_github_release_assets
+else
+  github_release_exists
+fi
+`;
+  const result = spawnSync('/bin/bash', ['--noprofile', '--norc', '-c', script], {
+    encoding: 'utf8',
+    env: {
+      PATH: process.env.PATH, HOME: root, TMPDIR: root, NODE_BIN: process.execPath,
+      RELEASE_DIR: root, RELEASE_SOURCE_COMMIT: sourceCommit,
+      PUBLICATION_RECEIPT_PATH: join(root, 'receipt.json'),
+      RELEASE_CONTRACT: join(projectRoot, 'scripts/release-driver-contract.mjs'),
+      CALL_LOG: join(root, 'calls'), FIXTURE_MODE: mode, FIXTURE_COMMAND: command,
+      FIXTURE_API_URL: apiUrl ?? 'https://api.github.com/repos/openclaw/Peekaboo/releases/123',
+      FIXTURE_RELEASE_JSON: JSON.stringify({ tag_name: 'v9.8.7', draft: true, body: 'fixture release notes\n', assets: [] })
+    }
+  });
+  return { ...result, calls: readFileSync(join(root, 'calls'), 'utf8') };
+}
+
+test('draft verification uses the authenticated release ID when the tag endpoint returns 404', (t) => {
+  const result = githubDraftLookup(t);
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.calls, /release view v9\.8\.7 --repo github\.com\/openclaw\/Peekaboo --json apiUrl/);
+  assert.match(result.calls, /api --hostname github\.com repos\/openclaw\/Peekaboo\/releases\/123/);
+  assert.doesNotMatch(result.calls, /releases\/tags\//);
+  assert.equal(githubDraftLookup(t, { command: 'exists' }).status, 0);
+});
+
+test('draft lookup distinguishes absence from provider failures and rejects redirected locators', (t) => {
+  assert.equal(githubDraftLookup(t, { mode: 'missing', command: 'exists' }).status, 2);
+  for (const mode of ['auth', 'api-error']) {
+    const result = githubDraftLookup(t, { mode, command: 'exists' });
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /Could not determine/);
+  }
+  for (const apiUrl of [
+    'https://example.com/repos/openclaw/Peekaboo/releases/123',
+    'https://api.github.com/repos/other/repo/releases/123',
+    'https://api.github.com/repos/openclaw/Peekaboo/releases/123?redirect=1',
+    'https://api.github.com/repos/openclaw/Peekaboo/releases/0'
+  ]) {
+    const result = githubDraftLookup(t, { apiUrl });
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /invalid release API locator/);
+    assert.doesNotMatch(result.calls, /^api /m);
+  }
+});
 
 function safeTestsLaunch() {
   assert.ok(safeTestsFunction, 'test launcher must be inspectable without executing preparation');

--- a/tests/release-preflight-contract.test.mjs
+++ b/tests/release-preflight-contract.test.mjs
@@ -311,6 +311,37 @@ test('draft lookup distinguishes absence from provider failures and rejects redi
   }
 });
 
+test('npm publication reads normalize singleton JSON wrappers without hiding ambiguous or failed results', () => {
+  const functionSource = driverSource.match(/^npm_view_single_json\(\) \{[\s\S]*?^\}$/m)?.[0];
+  assert.ok(functionSource);
+  const run = (stdout, exit = 0) => spawnSync('/bin/bash', ['--noprofile', '--norc', '-c', `
+set -euo pipefail
+NPM_REGISTRY=https://registry.npmjs.org/
+node() { "$NODE_BIN" "$@"; }
+npm() { printf '%s' "$FIXTURE_STDOUT"; return "$FIXTURE_EXIT"; }
+${functionSource}
+npm_view_single_json @steipete/peekaboo@4.3.1 version
+`], { encoding: 'utf8', env: {
+    PATH: process.env.PATH, NODE_BIN: process.execPath, FIXTURE_STDOUT: stdout, FIXTURE_EXIT: String(exit)
+  } });
+  for (const value of ['4.3.1', { version: '4.3.1', dist: { integrity: 'fixture' } }, { '4.3.1': '2026-09-06T13:15:51Z' }]) {
+    for (const wrapped of [value, [value]]) {
+      const result = run(JSON.stringify(wrapped));
+      assert.equal(result.status, 0, result.stderr);
+      assert.deepEqual(JSON.parse(result.stdout), value);
+    }
+  }
+  for (const invalid of ['[]', '["4.3.0","4.3.1"]', 'not JSON']) {
+    const result = run(invalid);
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /did not return one JSON value/);
+  }
+  const failure = '{"error":{"code":"E404"}}';
+  const result = run(failure, 37);
+  assert.equal(result.status, 37);
+  assert.equal(result.stdout, failure);
+});
+
 function safeTestsLaunch() {
   assert.ok(safeTestsFunction, 'test launcher must be inspectable without executing preparation');
   let launch;


### PR DESCRIPTION
Authenticated draft releases can be absent from GitHub’s REST tag endpoint, and npm 12 can wrap one metadata result in a singleton array. Both cases blocked otherwise valid release publication and recovery.

Resolve the draft through `gh release view --json apiUrl`, validate the fixed GitHub.com repository and numeric release ID, and retrieve that exact release. Normalize exactly one npm result before the existing strict validators; malformed or ambiguous metadata and provider failures remain errors. Update the signing-policy assertion for the authenticated ID lookup.

Validation: the release-signing policy script and all 17 release preflight/driver contract tests pass, including eight driver-gate scenarios. Final branch autoreview is clean through P2. The readers were live-proven during the retained 4.3.1 publication: the original source, all nine asset digests, and the exact npm tarball integrity were verified. GitHub, npm, Sparkle, Homebrew CLI, and the installed app were independently verified. Hosted CI is pending on the latest head.
