### PR TITLE
fix(install): authenticate restored GUI Bridge identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Recover transactional app installs using authenticated GUI Bridge identity when atomic socket publication leaves `lsof` reporting the temporary bind path.
+
 ## 4.3.1 - 2026-09-05
 
 **Highlights:** Exact popup and sheet screenshots, bounded image reads, and updater security fixes.

--- a/scripts/restart-peekaboo.sh
+++ b/scripts/restart-peekaboo.sh
@@ -981,9 +981,10 @@ validate_healthcheck_configuration() {
     "Healthcheck CLI predates exact host-generation readiness; build and sign this checkout's CLI or pass --healthcheck-cli <absolute-current-path>"
 }
 
-verify_replacement_bridge_health() {
+verify_exact_bridge_health() {
   local attempt code_hash current_pids current_start_identity_after current_start_identity_before
   local output short_version bundle_version
+  local require_background_host="$1"
 
   [[ "${LAUNCHED_PID}" =~ ^[0-9]+$ && "${LAUNCHED_PROCESS_START_IDENTITY}" =~ ^[0-9]+$ ]] || return 1
   code_hash="$(bundle_code_signature_hash "${APP_BUNDLE}")" || return 1
@@ -1010,6 +1011,7 @@ verify_replacement_bridge_health() {
       --arg bundle_id "${EXPECTED_BUNDLE_ID}" \
       --arg short_version "${short_version}" \
       --arg bundle_version "${bundle_version}" \
+      --argjson require_background_host "${require_background_host}" \
       --arg code_hash "${code_hash}" '
         .success == true and
         .data.selected.source == "remote" and
@@ -1021,7 +1023,8 @@ verify_replacement_bridge_health() {
         .data.selected.handshake.hostIdentity.bundleShortVersion == $short_version and
         .data.selected.handshake.hostIdentity.bundleVersion == $bundle_version and
         .data.selected.handshake.hostIdentity.codeSignatureHash == $code_hash and
-        (.data.selected.handshake.hostCapabilities | index("backgroundBridgeHost")) != null and
+        ($require_background_host == false or
+          (.data.selected.handshake.hostCapabilities | index("backgroundBridgeHost")) != null) and
         (.data.selected.handshake.hostCapabilities | index("hostGenerationIdentity")) != null and
         (.data.selected.handshake.hostCapabilities | index("codeSignatureBuildIdentity")) != null
       ' <<<"${output}" >/dev/null
@@ -1038,7 +1041,7 @@ verify_replacement_bridge_health() {
     fi
     "${SLEEP_BIN}" "${HEALTH_VERIFY_INTERVAL}"
   done
-  printf 'Replacement process %s did not expose matching background GUI Bridge readiness at %s\n' \
+  printf 'Process %s did not expose matching GUI Bridge readiness at %s\n' \
     "${LAUNCHED_PID}" "${BRIDGE_SOCKET}" >&2
   return 1
 }
@@ -1070,8 +1073,15 @@ verify_restored_bridge_health() {
         .data.selected.source == "remote" and
         .data.selected.socketPath == $socket and
         .data.selected.handshake.hostKind == "gui"
-      ' <<<"${output}" >/dev/null &&
-       current_start_identity_after="$(query_process_start_identity "${LAUNCHED_PID}")" &&
+      ' <<<"${output}" >/dev/null
+    then
+      # Atomic socket publication leaves lsof reporting the temporary bind path. Modern hosts
+      # provide an authenticated process/build receipt; never downgrade a mismatched receipt.
+      if "${JQ_BIN}" -e '.data.selected.handshake | has("hostIdentity")' <<<"${output}" >/dev/null; then
+        verify_exact_bridge_health false
+        return $?
+      fi
+      if current_start_identity_after="$(query_process_start_identity "${LAUNCHED_PID}")" &&
        current_pids_after="$(bundle_pids "${APP_BUNDLE}" 2>/dev/null || true)" &&
        socket_pids_after="$("${LSOF_BIN}" -t -a -U -- "${BRIDGE_SOCKET}" 2>/dev/null | awk '!seen[$0]++')" &&
        [[ "${current_start_identity_before}" == "${LAUNCHED_PROCESS_START_IDENTITY}" &&
@@ -1080,8 +1090,9 @@ verify_restored_bridge_health() {
           "${current_pids_after}" == "${LAUNCHED_PID}" &&
           "${socket_pids_before}" == "${LAUNCHED_PID}" &&
           "${socket_pids_after}" == "${LAUNCHED_PID}" ]]
-    then
-      return 0
+      then
+        return 0
+      fi
     fi
     "${SLEEP_BIN}" "${HEALTH_VERIFY_INTERVAL}"
   done
@@ -1118,7 +1129,7 @@ ensure_restored_bundle_ready() {
 
 launch_and_verify() {
   launch_and_verify_bundle "${APP_BUNDLE}" || return 1
-  verify_replacement_bridge_health
+  verify_exact_bridge_health true
 }
 
 rollback_install() {

--- a/scripts/test-restart-peekaboo.sh
+++ b/scripts/test-restart-peekaboo.sh
@@ -796,7 +796,14 @@ build_id="$(<"${bundle}/build-id")"
 if [[ -f "${state_dir}/fail-health" && "${build_id}" == "new" ]]; then
   exit 71
 fi
+if [[ -f "${state_dir}/restored-bridge-never-ready" && "${build_id}" == "old" ]]; then
+  exit 71
+fi
 bundle_id="$(<"${bundle}/.bundle-id")"
+if [[ "${build_id}" == "old" && ! -f "${state_dir}/modern-restored-host" ]]; then
+  printf '{"success":true,"data":{"selected":{"source":"remote","socketPath":"%s","handshake":{"hostKind":"gui"}}}}\n' "${state_dir}/bridge.sock"
+  exit 0
+fi
 code_hash="$(<"${bundle}/.cdhash")"
 host_pid=4242
 host_process_start_identity=123456
@@ -813,6 +820,9 @@ if [[ -f "${state_dir}/health-adjacent-large-start" ]]; then
 fi
 [[ ! -f "${state_dir}/health-wrong-hash" ]] || code_hash=0000000000000000000000000000000000000000
 [[ ! -f "${state_dir}/health-missing-capability" ]] || capabilities='["hostGenerationIdentity","codeSignatureBuildIdentity"]'
+if [[ "${build_id}" == "old" && -f "${state_dir}/restored-interactive-host" ]]; then
+  capabilities='["hostGenerationIdentity","codeSignatureBuildIdentity"]'
+fi
 short_version="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' \
   "${bundle}/Contents/Info.plist")"
 bundle_version="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' \
@@ -874,6 +884,7 @@ state_dir="$(cd "$(dirname "$0")/.." && pwd)"
   "${4:-}" == "--" && "${5:-}" == "${state_dir}/bridge.sock" && "$#" -eq 5 ]] || exit 72
 [[ -f "${state_dir}/running-path" ]] || exit 1
 bundle="$(<"${state_dir}/running-path")"
+[[ ! -f "${state_dir}/renamed-socket" ]] || exit 1
 if [[ -f "${state_dir}/restored-bridge-never-ready" && "$(<"${bundle}/build-id")" == "old" ]]; then
   exit 1
 fi
@@ -1363,6 +1374,31 @@ assert_text "${restored_health_target}/build-id" old
 find "$(dirname "${restored_health_target}")" -maxdepth 1 -type d \
   -name '.Peekaboo.install.*' | grep -q . || \
   fail 'restored Bridge readiness failure discarded its recovery bundle'
+
+# Modern restored hosts prove exact ownership despite lsof retaining the temporary bind name.
+for restored_case in modern-restored-success modern-restored-interactive modern-restored-wrong-pid modern-restored-wrong-hash; do
+  modern_dir="$(new_case "${restored_case}")"
+  modern_target="${modern_dir}/Applications/Peekaboo.app"
+  mkdir -p "$(dirname "${modern_target}")"
+  make_bundle "${modern_target}" old
+  printf '%s\n' "${modern_target}" >"${modern_dir}/running-path"
+  touch "${modern_dir}/fail-health" "${modern_dir}/modern-restored-host" "${modern_dir}/renamed-socket"
+  case "${restored_case}" in
+    *interactive) touch "${modern_dir}/restored-interactive-host" ;;
+    *wrong-pid) touch "${modern_dir}/health-wrong-pid" ;;
+    *wrong-hash) touch "${modern_dir}/health-wrong-hash" ;;
+  esac
+  if run_restart "${modern_dir}"; then
+    fail 'expected replacement health failure before modern rollback'
+  fi
+  assert_text "${modern_target}/build-id" old
+  modern_journal="$(dirname "${modern_target}")/.Peekaboo.install.journal"
+  if [[ "${restored_case}" == modern-restored-success || "${restored_case}" == modern-restored-interactive ]]; then
+    [[ ! -e "${modern_journal}" ]] || fail 'authenticated restored host left an incomplete journal'
+  else
+    [[ -f "${modern_journal}" ]] || fail 'mismatched restored identity discarded the journal'
+  fi
+done
 
 # If the replacement cannot be stopped, rollback preserves both bundles and never restores over it.
 stop_refusal_dir="$(new_case rollback-stop-refusal)"


### PR DESCRIPTION
A failed transactional install can restore a healthy Peekaboo app yet leave recovery stuck: the Bridge binds a temporary Unix socket and publishes it atomically, while macOS lsof continues reporting the temporary name. Looking up bridge.sock therefore finds no listener.

Modern restored hosts now use the authenticated GUI Bridge process-generation, bundle/version, and code-signature receipt. Replacement launches still require background-host capability; a restored interactive host does not. Legacy hosts retain the existing socket-owner checks, and a mismatched modern identity never falls back to them.

Validation: the exact published, signed and notarized 4.3.1 app was recovered and installed successfully at /Applications/Peekaboo.app using Apple Bash. The installed Homebrew CLI authenticated its GUI Bridge as 4.3.1 (4030199), source f047bd97a260814bfebf4c81e7a4fdfe64581ff4. Added fixtures cover renamed sockets, restored interactive hosts, and rejected PID/hash mismatches; the complete final fixture run passed with `test-restart-peekaboo: ok`. Local and final branch reviews through P2 are clean; hosted CI is pending.

The 4.3.1 artifacts and tag are unchanged. The fix is recorded under Unreleased.
