### PR TITLE
fix(release): preserve literal binary verification paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Treat release-preparation binary paths literally during permission, architecture, and help checks to prevent shell interpretation.
 - Recover transactional app installs using authenticated GUI Bridge identity when atomic socket publication leaves `lsof` reporting the temporary bind path.
 
 ## 4.3.1 - 2026-09-05

--- a/scripts/prepare-release.js
+++ b/scripts/prepare-release.js
@@ -10,8 +10,8 @@
  * 4. Build, CLI contract, and package verification
  */
 
-import { execSync, spawnSync } from 'child_process';
-import { readFileSync, existsSync } from 'fs';
+import { execFileSync, execSync, spawnSync } from 'child_process';
+import { readFileSync, existsSync, statSync } from 'fs';
 import { dirname, isAbsolute, join, resolve } from 'path';
 import { fileURLToPath } from 'url';
 import {
@@ -678,8 +678,7 @@ function buildAndVerifyPackage() {
   
   // Check if binary is executable
   try {
-    const stats = exec(`stat -f "%Lp" "${binaryPath}" 2>/dev/null || stat -c "%a" "${binaryPath}"`);
-    const perms = parseInt(stats, 8);
+    const perms = statSync(binaryPath).mode;
     if ((perms & 0o111) === 0) {
       logError('peekaboo binary is not executable');
       return false;
@@ -691,7 +690,11 @@ function buildAndVerifyPackage() {
   
   // Check binary architectures (arm64 required; x86_64 optional unless explicitly enforced)
   try {
-    const lipoOutput = exec(`lipo -info "${binaryPath}"`);
+    const lipoOutput = execFileSync('lipo', ['-info', binaryPath], {
+      cwd: projectRoot,
+      stdio: 'pipe',
+      encoding: 'utf8'
+    }).trim();
     const hasArm64 = lipoOutput.includes('arm64');
     const hasX86 = lipoOutput.includes('x86_64');
     if (!hasArm64) {
@@ -716,7 +719,11 @@ function buildAndVerifyPackage() {
   
   // Check if binary responds to --help
   try {
-    const helpOutput = exec(`"${binaryPath}" --help`);
+    const helpOutput = execFileSync(binaryPath, ['--help'], {
+      cwd: projectRoot,
+      stdio: 'pipe',
+      encoding: 'utf8'
+    }).trim();
     if (!helpOutput || helpOutput.length === 0) {
       logError('peekaboo binary does not respond to --help command');
       return false;

--- a/tests/release-preflight-contract.test.mjs
+++ b/tests/release-preflight-contract.test.mjs
@@ -1,6 +1,9 @@
 import assert from 'node:assert/strict';
-import { spawnSync } from 'node:child_process';
-import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { execFileSync, execSync, spawnSync } from 'node:child_process';
+import {
+  chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync,
+  rmSync, statSync, symlinkSync, writeFileSync
+} from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import test from 'node:test';
@@ -224,6 +227,162 @@ const prepareSource = readFileSync(new URL('../scripts/prepare-release.js', impo
 const driverSource = readFileSync(new URL('../scripts/release-binaries.sh', import.meta.url), 'utf8');
 const sanitizerPath = join(projectRoot, 'scripts/terminal-artifact-env.sh');
 const safeTestsFunction = prepareSource.match(/^function runSafeTests\(\) \{[\s\S]*?^\}/m)?.[0];
+
+function verifyBinaryFixture(t, {
+  name = 'peekaboo',
+  mode = 0o755,
+  missing = false,
+  symlink = false,
+  statFailure = false,
+  universal = false,
+  architectures = 'arm64',
+  lipoExit = 0,
+  help = '  fixture help \u00e9\n',
+  helpExit = 0
+} = {}) {
+  const root = realpathSync(mkdtempSync(join(tmpdir(), 'peekaboo-binary-contract-')));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  const tools = join(root, 'tools');
+  const binaryPath = join(root, name);
+  const callLog = join(root, 'calls.jsonl');
+  const messages = [];
+  const shellCalls = [];
+  mkdirSync(tools);
+  writeFileSync(join(root, 'package.json'), '{"version":"1.2.3"}\n');
+  const toolSource = (tool) => `#!${process.execPath}
+const fs = require('node:fs');
+fs.appendFileSync(process.env.FIXTURE_CALL_LOG, JSON.stringify({
+  tool: ${JSON.stringify(tool)}, args: process.argv.slice(2), cwd: process.cwd()
+}) + '\\n');
+process.stdout.write(process.env.${tool.toUpperCase()}_OUTPUT);
+process.exit(Number(process.env.${tool.toUpperCase()}_EXIT));
+`;
+  writeFileSync(join(tools, 'lipo'), toolSource('lipo'), { mode: 0o755 });
+  if (!missing) {
+    const target = symlink ? join(root, 'target-binary') : binaryPath;
+    writeFileSync(target, toolSource('binary'));
+    chmodSync(target, mode);
+    if (symlink) symlinkSync(target, binaryPath);
+  }
+  const env = {
+    PATH: `${tools}:/usr/bin:/bin`,
+    HOME: root,
+    TMPDIR: root,
+    LANG: 'C',
+    FIXTURE_CALL_LOG: callLog,
+    LIPO_OUTPUT: architectures,
+    LIPO_EXIT: String(lipoExit),
+    BINARY_OUTPUT: help,
+    BINARY_EXIT: String(helpExit),
+    PEEKABOO_REQUIRE_UNIVERSAL: universal ? '1' : '0'
+  };
+  const execFunction = prepareSource.match(/^function exec\(command, options = \{\}\) \{[\s\S]*?^\}/m)?.[0];
+  const verifyFunction = prepareSource.match(/^function buildAndVerifyPackage\(\) \{[\s\S]*?^\}/m)?.[0];
+  assert.ok(execFunction && verifyFunction, 'inspect the actual checks without invoking main');
+  const legacyCommands = new Set([
+    `stat -f "%Lp" "${binaryPath}" 2>/dev/null || stat -c "%a" "${binaryPath}"`,
+    `lipo -info "${binaryPath}"`,
+    `"${binaryPath}" --help`
+  ]);
+  const verify = runInNewContext(`${execFunction}\n${verifyFunction}\nbuildAndVerifyPackage`, {
+    projectRoot: root, binaryOverride: binaryPath, noBuild: true, colors: {},
+    process: { env }, join, existsSync, readFileSync,
+    statSync(path) {
+      if (statFailure) throw new Error('fixture stat failure');
+      return statSync(path);
+    },
+    execSync(command, options) {
+      shellCalls.push(command);
+      // Refuse hostile red-phase commands before any shell or marker can run.
+      if (!legacyCommands.has(command) || /["$`]/.test(binaryPath)) {
+        throw new Error('fixture refused shell interpretation of the binary path');
+      }
+      return execSync(command, { ...options, env, timeout: 5000 });
+    },
+    execFileSync(file, args, options) {
+      assert.ok(file === 'lipo' || file === binaryPath, 'only fixture tools may execute');
+      return execFileSync(file, Array.from(args), { ...options, env, timeout: 5000 });
+    },
+    execNpm() { return 'peekaboo\npeekaboo-mcp.js\nREADME.md\nLICENSE\n'; },
+    execWithOutput() { assert.fail('binary verification must not build a release'); },
+    logStep() {},
+    log(message) { messages.push(message); },
+    logSuccess(message) { messages.push(message); },
+    logWarning(message) { messages.push(message); },
+    logError(message) { messages.push(message); }
+  });
+  const passed = verify();
+  const calls = existsSync(callLog)
+    ? readFileSync(callLog, 'utf8').trim().split('\n').map((line) => JSON.parse(line))
+    : [];
+  for (const marker of ['dollar-marker', 'backtick-marker']) {
+    assert.equal(existsSync(join(root, marker)), false, 'path text must never run a marker command');
+  }
+  return { passed, calls, messages, shellCalls, root, binaryPath };
+}
+
+for (const name of [
+  'peekaboo with spaces',
+  "peekaboo 'single quotes'",
+  'peekaboo "double quotes"',
+  'peekaboo $(touch dollar-marker)',
+  'peekaboo `touch backtick-marker`'
+]) {
+  test(`binary verification passes a literal filename: ${name}`, (t) => {
+    const result = verifyBinaryFixture(t, { name });
+    assert.equal(result.passed, true, `${name}: ${result.messages.join('\n')}`);
+    assert.deepEqual(result.shellCalls, [], 'binary verification must not invoke a shell');
+    assert.deepEqual(result.calls, [
+      { tool: 'lipo', args: ['-info', result.binaryPath], cwd: result.root },
+      { tool: 'binary', args: ['--help'], cwd: result.root }
+    ]);
+  });
+}
+
+test('binary verification follows symlinks and accepts owner-only executable permission', (t) => {
+  for (const symlink of [false, true]) {
+    const result = verifyBinaryFixture(t, { symlink, mode: 0o744 });
+    assert.equal(result.passed, true, result.messages.join('\n'));
+    assert.deepEqual(result.calls.map((call) => call.tool), ['lipo', 'binary']);
+    assert.deepEqual(result.calls[0].args, ['-info', result.binaryPath]);
+  }
+});
+
+test('binary verification preserves permission, architecture, and command failures', (t) => {
+  const cases = [
+    [{ missing: true }, 'peekaboo binary not found', []],
+    [{ mode: 0o644 }, 'peekaboo binary is not executable', []],
+    [{ statFailure: true }, 'Failed to check binary permissions', []],
+    [{ architectures: ' \nx86_64 \n' }, 'peekaboo binary is missing arm64', ['lipo']],
+    [{ universal: true }, 'peekaboo binary does not contain x86_64', ['lipo']],
+    [{ lipoExit: 31 }, 'Failed to check binary architectures (lipo command failed)', ['lipo']],
+    [{ help: '' }, 'peekaboo binary does not respond to --help command', ['lipo', 'binary']],
+    [{ help: ' \t\n' }, 'peekaboo binary does not respond to --help command', ['lipo', 'binary']],
+    [{ helpExit: 29 }, 'peekaboo binary failed to execute with --help', ['lipo', 'binary']],
+    // Any executable bit passes the mode gate, even when this owner cannot execute.
+    [{ mode: 0o654 }, 'peekaboo binary failed to execute with --help', ['lipo']]
+  ];
+  for (const [options, diagnostic, tools] of cases) {
+    const result = verifyBinaryFixture(t, options);
+    assert.equal(result.passed, false, JSON.stringify(options));
+    assert.ok(result.messages.some((message) => message.includes(diagnostic)),
+      `${JSON.stringify(options)}: ${result.messages.join('\n')}`);
+    assert.deepEqual(result.calls.map((call) => call.tool), tools);
+    if (options.architectures) assert.ok(result.messages.includes('Found: x86_64'));
+    if (options.helpExit) assert.ok(result.messages.some((message) => message.startsWith('Error: ')));
+  }
+});
+
+test('binary verification requires x86_64 only in universal mode', (t) => {
+  for (const universal of [false, true]) {
+    const result = verifyBinaryFixture(t, { universal, architectures: ' \narm64 x86_64 \n' });
+    assert.equal(result.passed, true, result.messages.join('\n'));
+    assert.ok(result.messages.includes('Binary contains both arm64 and x86_64 architectures'));
+  }
+  const arm = verifyBinaryFixture(t);
+  assert.equal(arm.passed, true, arm.messages.join('\n'));
+  assert.ok(arm.messages.includes('Binary is arm64-only (set PEEKABOO_REQUIRE_UNIVERSAL=1 to enforce universal)'));
+});
 
 function githubDraftLookup(t, { mode = 'draft', apiUrl, command = 'verify' } = {}) {
   const root = mkdtempSync(join(tmpdir(), 'peekaboo-draft-lookup-'));


### PR DESCRIPTION
## Summary

Release preparation interpolated the selected binary path into shell commands for permission, architecture, and help checks. Paths containing shell syntax could be interpreted instead of being passed literally.

Use `statSync().mode` for permissions and argument-vector execution for `lipo -info` and the binary's `--help`. Preserve executable-bit checks, symlink following, architecture requirements, cwd, UTF-8 output trimming, and failure behavior. Include the Unreleased note in the same commit.

## Alert Scope

The previously reported [CodeQL alert 19](https://github.com/openclaw/Peekaboo/security/code-scanning/19) was dismissed separately. Its safe-test launcher is unchanged. This PR repairs three real neighboring binary-path interpolation sites; it does not suppress the rule or claim to repair the dismissed expression.

## Validation

- `node --test tests/release-preflight-contract.test.mjs`: 24 passed, zero failures or skips, rerun after the changelog addition.
- Eight added tests cover 20 scenarios using the actual verification function, synthetic executables, and controlled tools. They exercise spaces, quotes, dollar substitutions, backticks, exact argv/cwd, permissions, symlinks, architecture requirements, empty output, and nonzero exits.
- Before the repair, all five literal-filename cases failed. The harness refused hostile shell commands before dispatch; no injected marker command executed during red or green proof.
- `node --check` passed for both changed JavaScript files; `git diff --check` passed.
- The scoped source/test diff received independent review with no reported actionable findings, then maintainer inspection. Only the requested changelog line was added afterward.

The repository's broad Swift lint/format/build and full `test:safe` gates were not run locally for this JavaScript-only boundary repair. SwiftFormat does not format these files; unrelated Swift sources were not reformatted. Exact-head hosted CI, CodeQL, and automated review remain pending.

No real release, signing, publishing, or release dry-run was performed. The synthetic behavioral harness is validation of these checks, not release-readiness proof.

<!-- Punchcard-Session: brisk-river-lantern-39 -->
