### PR TITLE
fix(cli): allow explicit acceptance of dispatched typing

### DIFF
--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/TypeCommand+CommanderMetadata.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/TypeCommand+CommanderMetadata.swift
@@ -49,6 +49,11 @@ extension TypeCommand: CommanderSignatureProviding {
             ],
             flags: [
                 .commandFlag(
+                    "acceptDispatched",
+                    help: "Accept dispatched but unverified typing as success; observe before retrying",
+                    long: "accept-dispatched"
+                ),
+                .commandFlag(
                     "clear",
                     help: "Clear the field before typing (Cmd+A, Delete)",
                     long: "clear"

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/TypeCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/TypeCommand.swift
@@ -37,6 +37,9 @@ struct TypeCommand: ActionOutputFormattable, ErrorHandlingCommand, OutputFormatt
     @Flag(help: "Clear the field before typing (Cmd+A, Delete)")
     var clear = false
 
+    @Flag(help: "Accept dispatched but unverified typing as success; observe before retrying")
+    var acceptDispatched = false
+
     @OptionGroup var target: InteractionTargetOptions
 
     @OptionGroup var focusOptions: FocusCommandOptions
@@ -134,7 +137,7 @@ struct TypeCommand: ActionOutputFormattable, ErrorHandlingCommand, OutputFormatt
                     snapshotId: observation.snapshotId,
                     target: deliveryTarget
                 )
-                _ = try UIAutomationActionResultSemantics.requireConfirmedChange(
+                try self.requireAcceptedTyping(
                     actionResult,
                     deliveryMode: Self.delivery(for: deliveryTarget).mode,
                     operation: "Typing"
@@ -358,7 +361,7 @@ struct TypeCommand: ActionOutputFormattable, ErrorHandlingCommand, OutputFormatt
                     windowBounds: authority.target.bounds
                 )
             )
-            _ = try UIAutomationActionResultSemantics.requireConfirmedChange(
+            try self.requireAcceptedTyping(
                 result,
                 deliveryMode: .background,
                 targetRequirement: .exact(expectedTarget),
@@ -403,6 +406,29 @@ struct TypeCommand: ActionOutputFormattable, ErrorHandlingCommand, OutputFormatt
             throw CancellationError()
         } catch {
             throw ValidationError("Snapshot '\(snapshotID)' is stale or has inconsistent target metadata")
+        }
+    }
+
+    private func requireAcceptedTyping(
+        _ result: UIAutomationActionResult<TypeResult>,
+        deliveryMode: DesktopActionOutcome.Delivery.Mode,
+        targetRequirement: UIAutomationActionResultSemantics.TargetRequirement = .optional,
+        operation: String
+    ) throws {
+        if self.acceptDispatched, result.outcome?.state == .dispatchedUnverified {
+            _ = try UIAutomationActionResultSemantics.requireAcceptedOutcome(
+                result,
+                policy: .confirmedOrDispatched(requiring: deliveryMode),
+                targetRequirement: targetRequirement,
+                operation: operation
+            )
+        } else {
+            _ = try UIAutomationActionResultSemantics.requireConfirmedChange(
+                result,
+                deliveryMode: deliveryMode,
+                targetRequirement: targetRequirement,
+                operation: operation
+            )
         }
     }
 
@@ -601,6 +627,7 @@ extension TypeCommand: CommanderBindableCommand {
             self.profileOption = profile
         }
         self.clear = values.flag("clear")
+        self.acceptDispatched = values.flag("acceptDispatched")
         self.target = try values.makeInteractionTargetOptions()
         self.focusOptions = try values.makeFocusOptions(includeBackgroundDelivery: true)
     }
@@ -631,8 +658,9 @@ extension TypeCommand: ParsableCommand {
                 discussion: """
                     The 'type' command sends keyboard input to a targeted app or snapshot
                     process. Background delivery is the default and requires a process target.
-                    Use --foreground for intentional global input. Success requires a confirmed
-                    receiver change; event dispatch alone remains a retry-unsafe non-success.
+                    Use --foreground for intentional global input. By default, success requires a
+                    confirmed receiver change. --accept-dispatched also accepts unverified dispatch;
+                    it remains retry-unsafe and requires a fresh observation.
 
                     EXAMPLES:
                       peekaboo type "Hello World" --snapshot "$SNAPSHOT_ID" --clear

--- a/Apps/CLI/Tests/CLIAutomationTests/Support/InProcessCommandRunner.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/Support/InProcessCommandRunner.swift
@@ -217,15 +217,26 @@ enum InProcessCommandRunner {
         standardInput: String? = nil,
         _ body: () async throws -> Int32
     ) async throws -> (Int32, Data, Data) {
-        // Prevent writes to closed pipes from crashing the test runner.
-        let previousSigpipeHandler = signal(SIGPIPE, SIG_IGN)
-        defer { _ = signal(SIGPIPE, previousSigpipeHandler) }
-
-        let stdoutPipe = Pipe()
-        let stderrPipe = Pipe()
+        // Commands can replay more than a pipe buffer before returning to this runner.
+        let stdoutFile = try self.makeOutputFile()
+        defer { try? stdoutFile.close() }
+        let stderrFile = try self.makeOutputFile()
+        defer { try? stderrFile.close() }
 
         let originalStdout = dup(STDOUT_FILENO)
+        guard originalStdout >= 0 else { throw self.currentPOSIXError() }
+        defer {
+            fflush(stdout)
+            _ = dup2(originalStdout, STDOUT_FILENO)
+            close(originalStdout)
+        }
         let originalStderr = dup(STDERR_FILENO)
+        guard originalStderr >= 0 else { throw self.currentPOSIXError() }
+        defer {
+            fflush(stderr)
+            _ = dup2(originalStderr, STDERR_FILENO)
+            close(originalStderr)
+        }
         let originalStdin: Int32
         if standardInput == nil {
             originalStdin = -1
@@ -295,64 +306,32 @@ enum InProcessCommandRunner {
             clearerr(stdin)
         }
 
-        dup2(stdoutPipe.fileHandleForWriting.fileDescriptor, STDOUT_FILENO)
-        dup2(stderrPipe.fileHandleForWriting.fileDescriptor, STDERR_FILENO)
+        fflush(stdout)
+        fflush(stderr)
+        guard dup2(stdoutFile.fileDescriptor, STDOUT_FILENO) >= 0,
+              dup2(stderrFile.fileDescriptor, STDERR_FILENO) >= 0
+        else { throw self.currentPOSIXError() }
 
-        stdoutPipe.fileHandleForWriting.closeFile()
-        stderrPipe.fileHandleForWriting.closeFile()
-
-        do {
-            let status = try await body()
-            dup2(originalStdout, STDOUT_FILENO)
-            dup2(originalStderr, STDERR_FILENO)
-            close(originalStdout)
-            close(originalStderr)
-
-            let stdoutData = self.drainNonBlocking(stdoutPipe.fileHandleForReading)
-            let stderrData = self.drainNonBlocking(stderrPipe.fileHandleForReading)
-            stdoutPipe.fileHandleForReading.closeFile()
-            stderrPipe.fileHandleForReading.closeFile()
-            return (status, stdoutData, stderrData)
-        } catch {
-            dup2(originalStdout, STDOUT_FILENO)
-            dup2(originalStderr, STDERR_FILENO)
-            close(originalStdout)
-            close(originalStderr)
-
-            _ = self.drainNonBlocking(stdoutPipe.fileHandleForReading)
-            _ = self.drainNonBlocking(stderrPipe.fileHandleForReading)
-            stdoutPipe.fileHandleForReading.closeFile()
-            stderrPipe.fileHandleForReading.closeFile()
-            throw error
-        }
+        let exitStatus = try await body()
+        fflush(stdout)
+        fflush(stderr)
+        try stdoutFile.seek(toOffset: 0)
+        try stderrFile.seek(toOffset: 0)
+        return try (exitStatus, stdoutFile.readToEnd() ?? Data(), stderrFile.readToEnd() ?? Data())
     }
 
-    private static func drainNonBlocking(_ handle: FileHandle) -> Data {
-        let fd = handle.fileDescriptor
-        let flags = fcntl(fd, F_GETFL)
-        if flags != -1 {
-            _ = fcntl(fd, F_SETFL, flags | O_NONBLOCK)
+    private static func makeOutputFile() throws -> FileHandle {
+        var template = FileManager.default.temporaryDirectory
+            .appendingPathComponent("peekaboo-cli-output.XXXXXX").path.utf8CString
+        let descriptor = template.withUnsafeMutableBufferPointer { mkstemp($0.baseAddress!) }
+        guard descriptor >= 0 else { throw self.currentPOSIXError() }
+        let path = template.withUnsafeBufferPointer { String(cString: $0.baseAddress!) }
+        guard unlink(path) == 0 else {
+            let error = self.currentPOSIXError()
+            close(descriptor)
+            throw error
         }
-
-        var buffer = [UInt8](repeating: 0, count: 4096)
-        var data = Data()
-
-        while true {
-            let bytesRead = read(fd, &buffer, buffer.count)
-            if bytesRead > 0 {
-                data.append(buffer, count: bytesRead)
-                continue
-            }
-            if bytesRead == 0 {
-                break // EOF
-            }
-            if errno == EAGAIN || errno == EWOULDBLOCK {
-                break // no more data right now
-            }
-            break // other error; bail out
-        }
-
-        return data
+        return FileHandle(fileDescriptor: descriptor, closeOnDealloc: true)
     }
 
     private static func currentPOSIXError() -> NSError {

--- a/Apps/CLI/Tests/CLIAutomationTests/TypeCommandTruthTests.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/TypeCommandTruthTests.swift
@@ -54,6 +54,72 @@ struct TypeCommandTruthTests {
     }
 
     @Test
+    func `Dispatch acceptance preserves uncertainty and confirmed counters`() async throws {
+        for foreground in [false, true] {
+            let automation = self.automation(focused: self.textFocus())
+            automation.actionOutcome = .dispatchedUnverified(
+                delivery: .init(
+                    mechanism: foreground ? .globalEvents : .windowTargetedEvents,
+                    mode: foreground ? .foreground : .background
+                ),
+                evidence: .deliveryAccepted,
+                unitCount: .one
+            )
+            let context = self.context(automation: automation)
+            let target = foreground ? ["--foreground"] : ["--app", "TextEdit"]
+            let result = try await self.runType(
+                ["Hello", "--accept-dispatched", "--json"] + target,
+                context: context
+            )
+            let payload = try ExternalCommandRunner.decodeJSONResponse(
+                from: result,
+                as: CodableJSONResponse<TypeCommandResult>.self
+            )
+            let envelope = try ExternalCommandRunner.decodeJSONResponse(from: result, as: JSONResponse.self)
+
+            #expect(result.exitStatus == 0)
+            #expect(envelope.success == true)
+            #expect(envelope.outcome?.state == .dispatchedUnverified)
+            #expect(envelope.outcome?.dispatchState.unitCount == .one)
+            #expect(envelope.outcome?.mutationDispatched == true)
+            #expect(result.stdout.contains("\"retry_safe\" : false"))
+            #expect(result.stdout.contains("\"requires_fresh_observation\" : true"))
+            #expect(payload.data.typedText == nil)
+            #expect(payload.data.totalCharacters == 0)
+            #expect(payload.data.keyPresses == 0)
+            #expect(payload.data.specialKeyPresses == 0)
+            #expect(payload.data.requestedText == "Hello")
+        }
+    }
+
+    @Test
+    func `Dispatch acceptance never accepts other failures or wrong delivery`() async throws {
+        let delivery = DesktopActionOutcome.Delivery(mechanism: .globalEvents, mode: .foreground)
+        let outcomes: [DesktopActionOutcome?] = [
+            nil,
+            .confirmedNoChange(),
+            .suspectedNoop(delivery: delivery),
+            .partial(delivery: delivery),
+            .refused(reason: .targetUnavailable),
+            .indeterminate(delivery: delivery, evidence: .completionUnknown),
+            .dispatchedUnverified(
+                delivery: .init(mechanism: .windowTargetedEvents, mode: .background),
+                evidence: .deliveryAccepted
+            ),
+        ]
+        for outcome in outcomes {
+            let automation = OutcomeStubAutomationService()
+            automation.actionOutcome = outcome
+            let result = try await InProcessCommandRunner.run(
+                ["type", "Hello", "--foreground", "--accept-dispatched", "--json"],
+                services: TestServicesFactory.makePeekabooServices(automation: automation)
+            )
+            #expect(result.exitStatus != 0)
+            #expect(!result.combinedOutput.contains("typedText"))
+        }
+    }
+
+    @Test
     func `Every non-confirmed typing state is CLI non-success without typed fields`() async throws {
         let delivery = DesktopActionOutcome.Delivery(mechanism: .globalEvents, mode: .foreground)
         let outcomes: [DesktopActionOutcome?] = [
@@ -241,6 +307,38 @@ struct TypeCommandTruthTests {
         #expect(payload.success == false)
         #expect(payload.outcome?.state == .indeterminate)
         #expect(payload.outcome?.mutationDispatched == true)
+    }
+
+    @Test
+    func `Accepted unverified typing after confirmed focus still invalidates observations`() async throws {
+        let windows = InputFocusWindowService(focusOutcome: InputFocusFixtures.focusOutcome)
+        let automation = OutcomeStubAutomationService()
+        automation.actionOutcome = .dispatchedUnverified(
+            route: .bridge,
+            delivery: .init(mechanism: .globalEvents, mode: .foreground),
+            evidence: .deliveryAccepted
+        )
+        let base = TestServicesFactory.makeAutomationTestContext(automation: automation, windows: windows)
+        let services = InputExecutionHostServices(host: .remote, base: base.services)
+        _ = try await base.snapshots.createSnapshot()
+
+        let result = try await InProcessCommandRunner.run(
+            [
+                "type", "Hello", "--window-id", String(InputFocusFixtures.windowID),
+                "--foreground", "--accept-dispatched", "--json",
+            ],
+            services: services
+        )
+        let payload = try ExternalCommandRunner.decodeJSONResponse(
+            from: result,
+            as: CodableJSONResponse<TypeCommandResult>.self
+        )
+        #expect(result.exitStatus == 0)
+        #expect(base.snapshots.invalidationCutoffs.count == 1)
+        #expect(await base.snapshots.getMostRecentSnapshot() == nil)
+        #expect(payload.data.typedText == nil)
+        #expect(payload.data.totalCharacters == 0)
+        #expect(payload.data.keyPresses == 0)
     }
 
     @Test

--- a/Apps/CLI/Tests/CLIAutomationTests/TypeCommandTruthTests.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/TypeCommandTruthTests.swift
@@ -171,6 +171,27 @@ struct TypeCommandTruthTests {
     }
 
     @Test
+    func `Large typing output is captured completely without pipe backpressure`() async throws {
+        let text = String(repeating: "x", count: 128 * 1024)
+        let automation = OutcomeStubAutomationService()
+        automation.actionOutcome = .confirmedChange(delivery: .init(
+            mechanism: .globalEvents,
+            mode: .foreground
+        ))
+        let result = try await InProcessCommandRunner.run(
+            ["type", text, "--foreground", "--json"],
+            services: TestServicesFactory.makePeekabooServices(automation: automation)
+        )
+        let payload = try ExternalCommandRunner.decodeJSONResponse(
+            from: result,
+            as: CodableJSONResponse<TypeCommandResult>.self
+        )
+        #expect(result.exitStatus == 0)
+        #expect(payload.data.requestedText == text)
+        #expect(payload.data.typedText == text)
+    }
+
+    @Test
     func `CLI prefers authoritative special key event count over legacy arithmetic`() async throws {
         let cases: [(arguments: [String], result: TypeResult, expectedSpecialKeys: Int)] = [
             (

--- a/docs/commands/type.md
+++ b/docs/commands/type.md
@@ -23,6 +23,7 @@ that snapshot. Use `press` for standalone keys or chords.
 | `--wpm <80-220>` | Enable human-typing cadence at the chosen words per minute. |
 | `--profile <linear|human>` | Switch between linear (default, honors `--delay`) and human (honors `--wpm`). |
 | `--clear` | Clear before typing. Background targets prefer one AXValue replacement; keyboard fallback uses Cmd+A, Delete. |
+| `--accept-dispatched` | CLI only: also return exit 0 for accepted but unverified dispatch. Keeps the unverified outcome, zero confirmed counts, and observe-before-retry warning. Default remains confirmed change only. |
 | Target flags | `--app <name>`, `--pid <pid>`, or an exact window selector for background input. |
 | `--foreground` | Focus a supplied target or intentionally send foreground/global keyboard input. |
 | Focus flags | Foreground focus controls (`--no-auto-focus`, `--space-switch`, etc.). |
@@ -51,8 +52,13 @@ that snapshot. Use `press` for standalone keys or chords.
 - Background delivery prefers Accessibility value and selection edits for writable focused text controls. Unsupported or rejected AX routes fall back to process-targeted CoreGraphics keyboard events, which require Event Synthesizing access. Apps that accept neither background route may still need `--foreground`.
 - Printable event fallback carries Unicode instead of physical US key positions, so the requested characters remain stable across active keyboard layouts.
 - Background app/PID delivery is pinned to the process generation resolved before dispatch. Peekaboo revalidates the receipt before every character or special action, stops on target exit/relaunch, and reports partial delivery as retry-unsafe. Requests containing non-empty text, clear, or an editable focused-text key require Bridge protocol 1.36 plus `compositeTypeDelivery`, because those actions may use AXValue delivery; event-only special keys retain their earlier compatibility floor.
-- Event injection is not evidence that the receiver changed. A native `dispatched_unverified` result is returned as
-  non-success and requires a fresh observation; `typedText`, `totalCharacters`, and `keyPresses` claim completed work
+- Event injection is not evidence that the receiver changed. By default, a native `dispatched_unverified` result is
+  non-success and requires a fresh observation. Standalone CLI callers can opt into `--accept-dispatched` to return
+  exit 0 and `success: true` for this state, like `press` and `click`, without claiming the text arrived. The outcome
+  still reports `effect: unverifiable`, `retry_safe: false`, and `requires_fresh_observation: true`; confirmed counters
+  remain zero and `typedText` is omitted. This flag does not change foreground consent or Agent/MCP acceptance.
+  Missing, refused, partial, indeterminate, suspected-no-op, and confirmed-no-change results remain non-success.
+  `typedText`, `totalCharacters`, and `keyPresses` claim completed work
   only when the typing effect is a confirmed change. `confirmed_no_change` and missing outcomes are also non-success.
   Exact-window `--clear` followed only by printable literal text can confirm when a generation-bound, readable,
   non-secure AX value changes from its private pre-dispatch value to the exact requested value during a short bounded
@@ -74,6 +80,9 @@ peekaboo type "status report ready" --snapshot "$SNAPSHOT_ID" --clear
 
 # Intentionally dispatch foreground typing, then observe; this remains non-success without readback
 peekaboo type "status report ready" --app TextEdit --foreground
+
+# Accept dispatch for a script that performs its own follow-up observation
+peekaboo type "status report ready" --app TextEdit --foreground --accept-dispatched --json
 
 # Cadence options also require follow-up observation unless the exact replacement shape above applies
 peekaboo type "status report ready" --app TextEdit --wpm 140


### PR DESCRIPTION
`type --accept-dispatched` lets standalone CLI scripts accept a dispatched-but-unverified typing result with exit 0. The default still requires a confirmed destination change, so the option provides a compatibility path for #686 while preserving Agent/MCP acceptance, foreground consent, target validation, and confirmed character counts.

Unverified results retain their canonical outcome, unsafe-to-retry warning, and fresh-observation requirement. They omit `typedText` and report zero confirmed characters/keys. Refused, missing, partial, indeterminate, suspected-no-op, confirmed-no-change, and wrong-delivery results still fail. Normal and pixel-focus typing share the same CLI-local gate.

Running the regression suite also exposed an existing test-harness deadlock: it drained output pipes only after a command returned, so deferred CLI output could fill the pipe and block that command. The test-only capture now uses private, immediately unlinked files and restores descriptors through deferred cleanup. A 128 KiB output regression exercises the failure mode.

Validation:
- Native CLI build, OpenClaw Developer ID signing, and signature verification passed.
- Calculator live proof: default typing delivered `5` and exited 1; opt-in local typing delivered `7` and exited 0; opt-in authenticated GUI Bridge typing delivered `8` and exited 0. Both successful dispatches retained unverifiable/unsafe-retry metadata, zero confirmed counters, and no `typedText`.
- All 14 typing truth tests passed, including the large-output regression, rejection cases, target validation, and snapshot invalidation.
- Docs lint, changed-file SwiftFormat, browser contract/guidance checks, and independent autoreview through P2 passed. Full safe-suite and exact-head hosted results are tracked in proof comments.

#700 owns the consolidated changelog and reporter credit for @jandubois; land it after this PR. No released notes are edited here.

Refs #686. The option addresses dispatch acceptance; it does not automatically restore the old default or resolve the report's separate targeted-focus observations.
