### PR TITLE
chore: prepare 4.3.2 notes and refresh pnpm setup

### DIFF
--- a/.github/workflows/crabbox-hydrate.yml
+++ b/.github/workflows/crabbox-hydrate.yml
@@ -42,7 +42,7 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.ref }}
 
-      - uses: pnpm/action-setup@v6.0.9
+      - uses: pnpm/action-setup@v6.1.0
 
       - uses: actions/setup-node@v7
         with:

--- a/.github/workflows/release-validation.yml
+++ b/.github/workflows/release-validation.yml
@@ -178,7 +178,7 @@ jobs:
       - name: Set up repository-pinned pnpm
         if: matrix.group == 'full-safe'
         timeout-minutes: 5
-        uses: pnpm/action-setup@v6.0.9
+        uses: pnpm/action-setup@v6.1.0
         with:
           run_install: false
           cache: false

--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+**Highlights:** Explicit typing dispatch acceptance for scripts and more reliable release recovery.
+
+- Let standalone scripts opt into `type --accept-dispatched` while preserving strict defaults, unverified outcomes, retry warnings, and confirmed-only character counts; thanks @jandubois for #686.
+- Recover authenticated draft releases and accept npm's singleton-array publication metadata without weakening validation.
+- Treat release-preparation binary paths literally during permission, architecture, and help checks to prevent shell interpretation.
+- Update pnpm setup in release validation and hosted build preparation to 6.1.0.
+
 ## 4.3.1 - 2026-09-05
 
 **Highlights:** Exact popup and sheet screenshots, bounded image reads, and more reliable scripted commands.

--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Let standalone scripts opt into `type --accept-dispatched` while preserving strict defaults, unverified outcomes, retry warnings, and confirmed-only character counts; thanks @jandubois for #686.
 - Recover authenticated draft releases and accept npm's singleton-array publication metadata without weakening validation.
 - Treat release-preparation binary paths literally during permission, architecture, and help checks to prevent shell interpretation.
+- Fix the screenshot command documentation's link to the exact-window capture testing guide.
 - Update pnpm setup in release validation and hosted build preparation to 6.1.0.
 
 ## 4.3.1 - 2026-09-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Recover transactional app installs using authenticated GUI Bridge identity when atomic socket publication leaves `lsof` reporting the temporary bind path.
 - Recover authenticated draft releases and accept npm's singleton-array publication metadata without weakening validation.
 - Treat release-preparation binary paths literally during permission, architecture, and help checks to prevent shell interpretation.
+- Fix the screenshot command documentation's link to the exact-window capture testing guide.
 - Update pnpm setup in release validation and hosted build preparation to 6.1.0.
 
 ## 4.3.1 - 2026-09-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,13 @@
 
 ## Unreleased
 
-- Treat release-preparation binary paths literally during permission, architecture, and help checks to prevent shell interpretation.
+**Highlights:** Explicit typing dispatch acceptance for scripts, plus more reliable app installation and release recovery.
+
+- Let standalone scripts opt into `type --accept-dispatched` while preserving strict defaults, unverified outcomes, retry warnings, and confirmed-only character counts; thanks @jandubois for #686.
 - Recover transactional app installs using authenticated GUI Bridge identity when atomic socket publication leaves `lsof` reporting the temporary bind path.
+- Recover authenticated draft releases and accept npm's singleton-array publication metadata without weakening validation.
+- Treat release-preparation binary paths literally during permission, architecture, and help checks to prevent shell interpretation.
+- Update pnpm setup in release validation and hosted build preparation to 6.1.0.
 
 ## 4.3.1 - 2026-09-05
 

--- a/docs/commands/see.md
+++ b/docs/commands/see.md
@@ -94,7 +94,7 @@ WindowServer bounds at the capture scale, both before and after conversion to lo
 or composited surface with different dimensions, the command fails before publishing an image or snapshot. A PNG
 does not provide a trustworthy global origin, so Peekaboo does not guess a crop or stretch that surface into the
 requested window. Missing, invalid, or non-pixel-representable bounds also fail closed. Native synthetic popup/sheet
-proof instructions are in [Exact-window capture testing](../testing/exact-window-capture.md).
+proof instructions are in [Exact-window capture testing](https://github.com/openclaw/Peekaboo/blob/main/docs/testing/exact-window-capture.md).
 
 Pixel-only `see --no-elements` captures without `--path` write a generated file beneath `PEEKABOO_DEFAULT_SAVE_PATH`, `defaults.savePath`, or the built-in `~/Desktop` default, in that order. Generated names retain a readable timestamp and include a unique token so concurrent callers do not share a path. This also applies with `--json`; `data.files[].path` reports the saved file. Ordinary element-producing `--json` observations without `--path` instead retain the raw image only in managed snapshot storage and return empty `screenshot_raw` and `screenshot_annotated` fields.
 

--- a/tests/release-validation-workflow.test.mjs
+++ b/tests/release-validation-workflow.test.mjs
@@ -295,7 +295,7 @@ test('full safe lane shares source gates and runs only the complete pinned comma
   assert.deepEqual(steps.filter((entry) => /\bbrew install\b|\brg --version\b|\buv --version\b/.test(entry)), [tools]);
   assert.match(safe, /if: matrix.group == 'full-safe'\n        id: safe\n        timeout-minutes: \$\{\{ matrix.test_minutes }}/);
   assert.match(install, /if: matrix.group == 'full-safe'\n        id: safe-install\n        timeout-minutes: 10/);
-  assert.match(pnpm, /if: matrix.group == 'full-safe'\n        timeout-minutes: 5\n        uses: pnpm\/action-setup@v6\.0\.9/);
+  assert.match(pnpm, /if: matrix.group == 'full-safe'\n        timeout-minutes: 5\n        uses: pnpm\/action-setup@v6\.1\.0/);
   assert.match(pnpm, /run_install: false\n          cache: false/);
   assert.doesNotMatch(pnpm, /\n\s+version:/, 'pnpm version must come from package.json');
   assert.match(workflow, /uses: actions\/setup-node@v7\n        with:\n          node-version: '24'\n          package-manager-cache: false/);


### PR DESCRIPTION
Prepare the consolidated root and CLI Unreleased notes for 4.3.2, update pnpm/action-setup from 6.0.9 to 6.1.0 with its matching workflow assertion, and repair the published screenshot guide's link to its exact-window testing instructions. Those developer testing pages are intentionally excluded from the site, so the link now targets the existing GitHub source.

Land this PR **after #699**. It owns all changelog edits in this set, including credit for @jandubois. It also records the existing main changes since v4.3.1: authenticated GUI Bridge install recovery, draft/npm publication recovery, and literal binary verification paths. Released sections, runtime pins, lockfiles, and publication metadata remain unchanged.

Validation:
- Release workflow contracts: 16/16 passed.
- Binary-verification contracts: 8/8 passed on the focused run, including the two cases that encountered a five-second fake-tool timeout under initial host load.
- Documentation lint and site build passed with zero broken-link warnings. Chrome followed the rendered capture-testing link to the correct GitHub guide.
- Deterministic release-preparation dry run passed against the signed built CLI, including help, command, and inventory contracts. This is preparation proof, not publication qualification.
- Independent autoreview through P2 passed. Exact-head hosted CI and full safe-suite results are tracked in proof comments.

Recommend patch 4.3.2. #699 supplies a bounded scripting compatibility remedy while preserving defaults. This PR does not bump the version, tag, or publish a release.

Dependency sweep: external Swift resolutions are current. pnpm 11.26.0 is held by the 48-hour age policy; pnpm 12 changes the toolchain major. Chrome DevTools MCP 1.6.0 remains the audited authority/routing pin. The newer Tachikoma gitlink includes substantial schema API and provider-wire changes and needs dedicated integration qualification; other newer submodule commits only change their own development tooling or resolutions already selected by Peekaboo.
