### PR TITLE
test(dock): wait for timeout fixture readiness

### DIFF
--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/DockProcessWaitTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/DockProcessWaitTests.swift
@@ -20,14 +20,29 @@ struct DockProcessWaitTests {
         #expect(process.terminationStatus == 7)
     }
 
-    @Test
-    func `timed out child is killed and reaped`() throws {
+    @Test(arguments: [0.0, 0.1])
+    func `timed out child is killed and reaped`(startupDelay: Double) throws {
         let process = Process()
+        let readiness = Pipe()
+        defer { try? readiness.fileHandleForReading.close() }
         process.executableURL = URL(fileURLWithPath: "/bin/sh")
-        process.arguments = ["-c", "trap '' TERM; exec /bin/sleep 30"]
+        process.arguments = ["-c", "sleep \(startupDelay); trap '' TERM; printf r; exec /bin/sleep 30"]
+        process.standardOutput = readiness
 
         try process.run()
         let pid = process.processIdentifier
+        defer {
+            if process.isRunning {
+                _ = kill(pid, SIGKILL)
+                process.waitUntilExit()
+            }
+        }
+        try readiness.fileHandleForWriting.close()
+
+        // Process.run() does not guarantee that the child has installed its TERM handler.
+        var descriptor = pollfd(fd: readiness.fileHandleForReading.fileDescriptor, events: Int16(POLLIN), revents: 0)
+        try #require(poll(&descriptor, 1, 10000) == 1)
+        try #require(readiness.fileHandleForReading.read(upToCount: 1) == Data("r".utf8))
         let startedAt = Date()
 
         #expect(throws: PeekabooError.self) {


### PR DESCRIPTION
The Dock timeout test could send TERM before its shell installed `trap '' TERM`, then falsely fail because the child exited with SIGTERM instead of SIGKILL. This occurred in the supplemental library job for #700 at `9601a61fde508d5797b448a89d219ec88aa7fca0`.

Wait for one readiness byte emitted after the trap is installed before starting the 50 ms Dock timeout. Bound readiness to 10 seconds and kill/reap the owned fixture on setup failure. A 100 ms startup-delay case deliberately exceeds the action timeout so the synchronization matters. Production code, the action timeout, the two-second completion assertion, and the SIGKILL/ESRCH assertions are unchanged.

Proof:
- `swift test --package-path Core/PeekabooAutomationKit --filter DockProcessWaitTests` passed: normal exit plus immediate and delayed-start timeout cases, using the real Dock wait implementation and native children.
- A separate native-process probe reproduced signal 15 without readiness and signal 9 with readiness; both children were confirmed reaped.
- SwiftFormat, SwiftLint, diff checks, and independent autoreview through P2 passed.

Failure evidence: https://github.com/openclaw/Peekaboo/actions/runs/34101637259/job/101677178085. The log was fetched once and retained for diagnosis. This branch is independent of #699 and #700, and contains no changelog edit because behavior outside the test fixture is unchanged.
