### PR TITLE
fix(homebrew): match the v4 help header in the formula smoke test

### DIFF
--- a/homebrew/peekaboo.rb
+++ b/homebrew/peekaboo.rb
@@ -34,6 +34,6 @@ class Peekaboo < Formula
     assert_match "Peekaboo", shell_output("#{bin}/peekaboo --version")
 
     # Test help command
-    assert_match "USAGE:", shell_output("#{bin}/peekaboo --help")
+    assert_match(/\AUsage\n\s+peekaboo\b/, shell_output("#{bin}/peekaboo --help"))
   end
 end


### PR DESCRIPTION
The tap smoke test generated from `homebrew/peekaboo.rb` still expects the pre-v4 `USAGE:` header, so `brew test openclaw/tap/peekaboo` fails on 4.3.2 even though the install is fine. Anchor the assertion on the real `Usage` header plus the indented command name.

The matching one-line fix is applied directly in openclaw/homebrew-tap so the current formula passes; this change keeps the next release handoff from regressing it. Test-only; no runtime change.
