### PR TITLE
docs: prepare consolidated 4.3.3 release notes

### DIFF
--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Refuse CLI-style invocations of Peekaboo.app before capture or Bridge startup, with guidance to use the separate `peekaboo` CLI binary. #706.
 - Read immutable Firestaff frames across atomic updates, reject detectable in-place rewrites, and add opt-in byte limits while preserving the unlimited default; thanks @SebTardif for #703.
+- Honor `config edit --print-path` without creating a configuration file or launching an editor. #707.
 - Fix generated Homebrew formula smoke tests to recognize the v4 `Usage` header. #702.
 
 ## 4.3.2 - 2026-09-07

--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -7,8 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-**Highlights:** Safer Firestaff manifest reads with optional memory limits.
+**Highlights:** Prevent accidental GUI host launches and read Firestaff manifests more safely.
 
+- Refuse CLI-style invocations of Peekaboo.app before capture or Bridge startup, with guidance to use the separate `peekaboo` CLI binary. #706.
 - Read immutable Firestaff frames across atomic updates, reject detectable in-place rewrites, and add opt-in byte limits while preserving the unlimited default; thanks @SebTardif for #703.
 - Fix generated Homebrew formula smoke tests to recognize the v4 `Usage` header. #702.
 

--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+**Highlights:** Safer Firestaff manifest reads with optional memory limits.
+
+- Read immutable Firestaff frames across atomic updates, reject detectable in-place rewrites, and add opt-in byte limits while preserving the unlimited default; thanks @SebTardif for #703.
+- Fix generated Homebrew formula smoke tests to recognize the v4 `Usage` header. #702.
+
 ## 4.3.2 - 2026-09-07
 
 **Highlights:** Explicit typing dispatch acceptance for scripts and more reliable release recovery.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Refuse CLI-style invocations of Peekaboo.app before capture or Bridge startup, with guidance to use the separate `peekaboo` CLI binary. #706.
 - Read immutable Firestaff frames across atomic updates, reject detectable in-place rewrites, and add opt-in byte limits while preserving the unlimited default; thanks @SebTardif for #703.
+- Honor `config edit --print-path` without creating a configuration file or launching an editor. #707.
 - Fix generated Homebrew formula smoke tests to recognize the v4 `Usage` header. #702.
 
 ## 4.3.2 - 2026-09-07

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## Unreleased
 
-**Highlights:** Safer Firestaff manifest reads with optional memory limits.
+**Highlights:** Prevent accidental GUI host launches and read Firestaff manifests more safely.
 
+- Refuse CLI-style invocations of Peekaboo.app before capture or Bridge startup, with guidance to use the separate `peekaboo` CLI binary. #706.
 - Read immutable Firestaff frames across atomic updates, reject detectable in-place rewrites, and add opt-in byte limits while preserving the unlimited default; thanks @SebTardif for #703.
 - Fix generated Homebrew formula smoke tests to recognize the v4 `Usage` header. #702.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+**Highlights:** Safer Firestaff manifest reads with optional memory limits.
+
+- Read immutable Firestaff frames across atomic updates, reject detectable in-place rewrites, and add opt-in byte limits while preserving the unlimited default; thanks @SebTardif for #703.
+- Fix generated Homebrew formula smoke tests to recognize the v4 `Usage` header. #702.
+
 ## 4.3.2 - 2026-09-07
 
 **Highlights:** Explicit typing dispatch acceptance for scripts, plus more reliable app installation and release recovery.


### PR DESCRIPTION
Prepare the consolidated Unreleased notes for the next patch release after #703, #705, #706, and #707, including the Homebrew v4 help-header fix already on main. This PR is independent of the code/test PRs and should land last so the code branches do not conflict over changelog edits.

Recommend 4.3.3: the changes prevent accidental GUI host startup from CLI invocations, harden existing Firestaff manifest loading with a compatible opt-in budget, restore config path queries, and repair the generated Homebrew smoke test. Version stamping, signing, notarization, publication, and Sparkle/Homebrew updates remain release gates.

Validation: documentation lint and 18 documentation/release-workflow contracts pass. The unchanged dependency graph passes frozen installation and the real pinned Chrome DevTools MCP contract check. Branch-mode P0–P2 autoreview is clean. [macOS CI](https://github.com/openclaw/Peekaboo/actions/runs/34191753629) and [CodeQL](https://github.com/openclaw/Peekaboo/actions/runs/34191753630) are green on the exact final head. The complete combined candidate also passed the safe suite, full lint, and formatting checks.

Dependency review: retain pnpm 11.25.0. A locally tested pnpm 12.3.4 update generated an environment-first, multi-document lockfile; current upstream dependency-inventory support remains incomplete (pnpm/pnpm#13805 and dependabot/dependabot-core#14794). The newer 11.26.0 maintenance release is still within the 48-hour minimum release age. Chrome DevTools MCP 1.6.0 remains the audited browser-routing pin, shipping Swift pins are current, and BlueSignals 2.x is outside the transitive 1.x constraint. No dependency or security-check policy changes are included.
