### PR TITLE
test(cli): prevent stdout capture deadlocks

### DIFF
--- a/Apps/CLI/Tests/CoreCLITests/AgentOutputDelegateBoundaryRegressionTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/AgentOutputDelegateBoundaryRegressionTests.swift
@@ -13,7 +13,7 @@ struct AgentOutputDelegateBoundaryRegressionTests {
     func `Failed communication completion is never rendered as success`(_ result: String) async throws {
         let delegate = AgentOutputDelegate(outputMode: .verbose, jsonOutput: false, task: "test")
 
-        let output = try await self.captureStandardOutput {
+        let output = try await captureStandardOutputText {
             delegate.agentDidEmitEvent(.toolCallCompleted(name: "need_info", result: result))
         }
 
@@ -25,40 +25,11 @@ struct AgentOutputDelegateBoundaryRegressionTests {
     func `Null error communication completion remains successful`() async throws {
         let delegate = AgentOutputDelegate(outputMode: .verbose, jsonOutput: false, task: "test")
 
-        let output = try await self.captureStandardOutput {
+        let output = try await captureStandardOutputText {
             delegate.agentDidEmitEvent(.toolCallCompleted(name: "need_info", result: #"{"error":null}"#))
         }
 
         #expect(output.contains("Need Info completed"))
         #expect(!output.contains("Error:"))
-    }
-
-    private func captureStandardOutput(_ body: () async throws -> Void) async throws -> String {
-        let pipe = Pipe()
-        let originalStandardOutput = dup(STDOUT_FILENO)
-        guard originalStandardOutput >= 0 else {
-            throw CocoaError(.fileWriteUnknown)
-        }
-        guard dup2(pipe.fileHandleForWriting.fileDescriptor, STDOUT_FILENO) >= 0 else {
-            close(originalStandardOutput)
-            throw CocoaError(.fileWriteUnknown)
-        }
-        pipe.fileHandleForWriting.closeFile()
-
-        do {
-            try await body()
-            fflush(nil)
-            _ = dup2(originalStandardOutput, STDOUT_FILENO)
-            close(originalStandardOutput)
-            let data = pipe.fileHandleForReading.readDataToEndOfFile()
-            pipe.fileHandleForReading.closeFile()
-            return String(data: data, encoding: .utf8) ?? ""
-        } catch {
-            fflush(nil)
-            _ = dup2(originalStandardOutput, STDOUT_FILENO)
-            close(originalStandardOutput)
-            pipe.fileHandleForReading.closeFile()
-            throw error
-        }
     }
 }

--- a/Apps/CLI/Tests/CoreCLITests/CaptureActionCommandEndToEndTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/CaptureActionCommandEndToEndTests.swift
@@ -564,7 +564,7 @@ struct CaptureActionCommandEndToEndTests {
         #expect(!FileManager.default.fileExists(atPath: marker.path))
 
         var cliCommand = command
-        let output = try await Self.captureStandardOutput {
+        let output = try await captureStandardOutputBytes {
             _ = try? await cliCommand.run(using: self.makeRuntime())
         }
         let envelope = try JSONDecoder().decode(ResultEnvelope<Empty?>.self, from: output)
@@ -833,24 +833,6 @@ struct CaptureActionCommandEndToEndTests {
             bundleShortVersion: "4.2.3",
             bundleVersion: "1"
         )
-    }
-
-    private static func captureStandardOutput(
-        operation: () async -> Void
-    ) async throws -> Data {
-        let pipe = Pipe()
-        let originalStandardOutput = dup(STDOUT_FILENO)
-        guard originalStandardOutput >= 0,
-              dup2(pipe.fileHandleForWriting.fileDescriptor, STDOUT_FILENO) >= 0
-        else {
-            throw POSIXError(.EIO)
-        }
-        await operation()
-        fflush(stdout)
-        _ = dup2(originalStandardOutput, STDOUT_FILENO)
-        close(originalStandardOutput)
-        try pipe.fileHandleForWriting.close()
-        return try pipe.fileHandleForReading.readToEnd() ?? Data()
     }
 }
 

--- a/Apps/CLI/Tests/CoreCLITests/CaptureOwnershipErrorOutputTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/CaptureOwnershipErrorOutputTests.swift
@@ -12,7 +12,7 @@ struct CaptureOwnershipErrorOutputTests {
     func `nonaction see preflight JSON retains selected host and every blocker`(
         engine: String,
         emitter: String
-    ) throws {
+    ) async throws {
         var see = SeeCommand()
         see.runtimeOptions = try CommanderCLIBinder.makeRuntimeOptions(
             from: .init(
@@ -32,7 +32,7 @@ struct CaptureOwnershipErrorOutputTests {
             screenCaptureKitOwnershipDiagnostic: Self.diagnostic
         )
         // Use the command's classification without constructing a runtime or accessing its services/logger.
-        let output = try Self.captureJSON {
+        let output = try await Self.captureJSON {
             if emitter == "command" {
                 OutputCommand(defaultEffect: see.defaultEffect).handleError(error)
             } else {
@@ -49,14 +49,14 @@ struct CaptureOwnershipErrorOutputTests {
     }
 
     @Test(arguments: ["command", "generic", "render", "entrypoint"])
-    func `remote leaf failure retains capture code and typed evidence`(emitter: String) throws {
+    func `remote leaf failure retains capture code and typed evidence`(emitter: String) async throws {
         let failure = DesktopActionFailure.refused(
             route: .bridge,
             reason: .runtimeIncompatible,
             message: Self.diagnostic.userMessage
         ).preservingScreenCaptureKitDiagnostic(Self.diagnostic)
         #expect(failure.standardErrorCode == .captureFailed)
-        let output = try Self.emit(failure, using: emitter)
+        let output = try await Self.emit(failure, using: emitter)
         try Self.expectDiagnostic(output)
         #expect(output.response.outcome == failure.outcome.projection)
         #expect(output.response.error?.retry_safe == true)
@@ -64,7 +64,7 @@ struct CaptureOwnershipErrorOutputTests {
     }
 
     @Test(arguments: ["command", "generic", "render", "entrypoint"])
-    func `ownership blocker never overwrites earlier dispatched failure`(emitter: String) throws {
+    func `ownership blocker never overwrites earlier dispatched failure`(emitter: String) async throws {
         let failure = DesktopActionFailure.dispatchedUnverified(
             route: .bridge,
             delivery: .init(mechanism: .globalEvents, mode: .foreground),
@@ -72,7 +72,7 @@ struct CaptureOwnershipErrorOutputTests {
             unitCount: .one,
             message: "A mutation was dispatched before capture failed"
         ).preservingScreenCaptureKitDiagnostic(Self.diagnostic)
-        let output = try Self.emit(failure, using: emitter)
+        let output = try await Self.emit(failure, using: emitter)
         try Self.expectDiagnostic(output)
         #expect(output.response.outcome == failure.outcome.projection)
         #expect(output.response.error?.retry_safe == false)
@@ -80,8 +80,8 @@ struct CaptureOwnershipErrorOutputTests {
     }
 
     @Test(arguments: ["command", "generic", "entrypoint"])
-    func `direct diagnostic emits capture code without action claims`(emitter: String) throws {
-        let output = try Self.captureJSON {
+    func `direct diagnostic emits capture code without action claims`(emitter: String) async throws {
+        let output = try await Self.captureJSON {
             if emitter == "command" {
                 OutputCommand(defaultEffect: nil).handleError(Self.diagnostic)
             } else if emitter == "generic" {
@@ -98,7 +98,7 @@ struct CaptureOwnershipErrorOutputTests {
     }
 
     @Test
-    func `Bridge error envelope retains independent diagnostic`() throws {
+    func `Bridge error envelope retains independent diagnostic`() async throws {
         let error = PeekabooBridgeErrorEnvelope(
             code: .internalError,
             message: Self.diagnostic.userMessage,
@@ -106,15 +106,15 @@ struct CaptureOwnershipErrorOutputTests {
                 StandardErrorCode.captureFailed.rawValue,
             screenCaptureKitOwnershipDiagnostic: Self.diagnostic
         )
-        let output = try Self.captureJSON { OutputCommand(defaultEffect: nil).handleError(error) }
+        let output = try await Self.captureJSON { OutputCommand(defaultEffect: nil).handleError(error) }
         try Self.expectDiagnostic(output)
         #expect(output.response.outcome == nil)
         #expect(output.response.error?.mutation_dispatched == nil)
     }
 
     @Test
-    func `unrelated errors omit diagnostic and old JSON still decodes`() throws {
-        let output = try Self.captureJSON {
+    func `unrelated errors omit diagnostic and old JSON still decodes`() async throws {
+        let output = try await Self.captureJSON {
             OutputCommand(defaultEffect: nil).handleError(Commander.ValidationError("Invalid input"))
         }
         #expect(output.response.error?.code == "VALIDATION_ERROR")
@@ -131,7 +131,7 @@ struct CaptureOwnershipErrorOutputTests {
     }
 
     @Test(arguments: ["command", "generic", "entrypoint"])
-    func `wrapped failure retains typed capture evidence and prior mutation`(emitter: String) throws {
+    func `wrapped failure retains typed capture evidence and prior mutation`(emitter: String) async throws {
         let failure = DesktopActionFailure.dispatchedUnverified(
             route: .bridge,
             delivery: .init(mechanism: .globalEvents, mode: .foreground),
@@ -146,7 +146,7 @@ struct CaptureOwnershipErrorOutputTests {
         #expect(screenCaptureKitOwnershipDiagnostic(for: error) == Self.diagnostic)
         #expect(OutputCommand(defaultEffect: .unverifiable).mapErrorToCode(error) == .CAPTURE_FAILED)
         #expect(genericErrorCode(for: error) == .CAPTURE_FAILED)
-        let output = try Self.captureJSON {
+        let output = try await Self.captureJSON {
             switch emitter {
             case "command":
                 OutputCommand(defaultEffect: .unverifiable).handleError(error)
@@ -174,8 +174,8 @@ struct CaptureOwnershipErrorOutputTests {
     }
 
     @Test
-    func `standalone output diagnostic does not invent action metadata`() throws {
-        let output = try Self.captureJSON {
+    func `standalone output diagnostic does not invent action metadata`() async throws {
+        let output = try await Self.captureJSON {
             outputError(
                 message: Self.diagnostic.userMessage,
                 code: .CAPTURE_FAILED,
@@ -191,14 +191,14 @@ struct CaptureOwnershipErrorOutputTests {
     }
 
     @Test(arguments: ["command", "generic", "render", "entrypoint"])
-    func `known capture failure code survives without new diagnostic`(emitter: String) throws {
+    func `known capture failure code survives without new diagnostic`(emitter: String) async throws {
         let failure = DesktopActionFailure.preDispatchRefusal(
             route: .bridge,
             reason: .runtimeIncompatible,
             message: "Legacy capture refusal",
             standardErrorCode: .captureFailed
         )
-        let output = try Self.emit(failure, using: emitter)
+        let output = try await Self.emit(failure, using: emitter)
         #expect(output.response.error?.code == "CAPTURE_FAILED")
         #expect(output.diagnostic == nil)
         #expect(String(data: output.data, encoding: .utf8)?
@@ -229,8 +229,8 @@ struct CaptureOwnershipErrorOutputTests {
         }
     }
 
-    private static func emit(_ failure: DesktopActionFailure, using emitter: String) throws -> CapturedOutput {
-        try self.captureJSON {
+    private static func emit(_ failure: DesktopActionFailure, using emitter: String) async throws -> CapturedOutput {
+        try await self.captureJSON {
             switch emitter {
             case "command":
                 OutputCommand(defaultEffect: .unverifiable).handleError(failure)
@@ -284,22 +284,11 @@ struct CaptureOwnershipErrorOutputTests {
         let error: Failure
     }
 
-    private static func captureJSON(_ body: () -> Void) throws -> CapturedOutput {
-        let pipe = Pipe()
-        defer { Logger.shared.setJsonOutputMode(false) }
-        fflush(stdout)
-        let savedOutput = dup(STDOUT_FILENO)
-        guard savedOutput >= 0 else { throw CocoaError(.fileWriteUnknown) }
-        defer { close(savedOutput) }
-        guard dup2(pipe.fileHandleForWriting.fileDescriptor, STDOUT_FILENO) >= 0 else {
-            throw CocoaError(.fileWriteUnknown)
+    private static func captureJSON(_ body: () -> Void) async throws -> CapturedOutput {
+        let data = try await captureStandardOutputBytes {
+            defer { Logger.shared.setJsonOutputMode(false) }
+            body()
         }
-        pipe.fileHandleForWriting.closeFile()
-        body()
-        fflush(stdout)
-        guard dup2(savedOutput, STDOUT_FILENO) >= 0 else { throw CocoaError(.fileWriteUnknown) }
-        let data = pipe.fileHandleForReading.readDataToEndOfFile()
-        pipe.fileHandleForReading.closeFile()
         return try CapturedOutput(
             data: data,
             response: JSONDecoder().decode(JSONResponse.self, from: data),

--- a/Apps/CLI/Tests/CoreCLITests/ConfigModelsProviderTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/ConfigModelsProviderTests.swift
@@ -68,7 +68,7 @@ struct ConfigModelsProviderTests {
             var command = ConfigCommand.ModelsProviderCommand()
             command.providerId = "openai-proxy"
             command.save = true
-            let output = try await captureStandardOutput {
+            let output = try await captureStandardOutputText {
                 try await command.run(using: self.makeRuntime(jsonOutput: true))
             }
 
@@ -119,7 +119,7 @@ struct ConfigModelsProviderTests {
             command.providerId = "openai-proxy"
             command.discover = true
             command.save = true
-            let output = try await captureStandardOutput {
+            let output = try await captureStandardOutputText {
                 try await command.run(using: self.makeRuntime(jsonOutput: true))
             }
 
@@ -178,7 +178,7 @@ struct ConfigModelsProviderTests {
             command.providerId = "openai-proxy"
             command.discover = true
             command.save = true
-            let output = try await captureStandardOutput {
+            let output = try await captureStandardOutputText {
                 let exitCode = await #expect(throws: ExitCode.self) {
                     try await command.run(using: self.makeRuntime(jsonOutput: true))
                 }
@@ -211,7 +211,7 @@ struct ConfigModelsProviderTests {
 
             var command = ConfigCommand.TestProviderCommand()
             command.providerId = "broken-openai"
-            let output = try await self.captureStandardOutput {
+            let output = try await captureStandardOutputText {
                 let exitCode = await #expect(throws: ExitCode.self) {
                     try await command.run(using: self.makeRuntime(jsonOutput: true))
                 }
@@ -236,7 +236,7 @@ struct ConfigModelsProviderTests {
 
             var command = ConfigCommand.TestProviderCommand()
             command.providerId = "broken-anthropic"
-            let output = try await self.captureStandardOutput {
+            let output = try await captureStandardOutputText {
                 let exitCode = await #expect(throws: ExitCode.self) {
                     try await command.run(using: self.makeRuntime(jsonOutput: true))
                 }
@@ -262,7 +262,7 @@ struct ConfigModelsProviderTests {
             var command = ConfigCommand.ModelsProviderCommand()
             command.providerId = "broken-discover"
             command.discover = true
-            let output = try await self.captureStandardOutput {
+            let output = try await captureStandardOutputText {
                 let exitCode = await #expect(throws: ExitCode.self) {
                     try await command.run(using: self.makeRuntime())
                 }
@@ -294,35 +294,6 @@ struct ConfigModelsProviderTests {
             configuration: .init(verbose: false, jsonOutput: jsonOutput, logLevel: nil),
             services: PeekabooServices()
         )
-    }
-
-    private func captureStandardOutput(_ body: () async throws -> Void) async throws -> String {
-        let pipe = Pipe()
-        let originalStandardOutput = dup(STDOUT_FILENO)
-        guard originalStandardOutput >= 0 else {
-            throw CocoaError(.fileWriteUnknown)
-        }
-        guard dup2(pipe.fileHandleForWriting.fileDescriptor, STDOUT_FILENO) >= 0 else {
-            close(originalStandardOutput)
-            throw CocoaError(.fileWriteUnknown)
-        }
-        pipe.fileHandleForWriting.closeFile()
-
-        do {
-            try await body()
-            fflush(nil)
-            _ = dup2(originalStandardOutput, STDOUT_FILENO)
-            close(originalStandardOutput)
-            let data = pipe.fileHandleForReading.readDataToEndOfFile()
-            pipe.fileHandleForReading.closeFile()
-            return String(data: data, encoding: .utf8) ?? ""
-        } catch {
-            fflush(nil)
-            _ = dup2(originalStandardOutput, STDOUT_FILENO)
-            close(originalStandardOutput)
-            pipe.fileHandleForReading.closeFile()
-            throw error
-        }
     }
 
     private func withTempConfigDir(_ body: () async throws -> Void) async throws {

--- a/Apps/CLI/Tests/CoreCLITests/DaemonControlTransportTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/DaemonControlTransportTests.swift
@@ -28,7 +28,11 @@ struct DaemonControlTransportTests {
         await peer.stop()
         let failure = try #require(error)
         #expect(failure.code == code)
-        let output = Self.captureOutput { handleGenericError(failure, jsonOutput: true, logger: Logger.shared) }
+        let output = try await captureStandardOutputText { handleGenericError(
+            failure,
+            jsonOutput: true,
+            logger: Logger.shared
+        ) }
         let envelope = try #require(JSONSerialization.jsonObject(with: Data(output.utf8)) as? [String: Any])
         #expect(envelope["success"] as? Bool == false)
         #expect(envelope["data"] is NSNull)
@@ -151,18 +155,5 @@ struct DaemonControlTransportTests {
             hostKind: .gui,
             supportedOperations: [.daemonStatus, .daemonStop]
         )
-    }
-
-    private static func captureOutput(_ body: () -> Void) -> String {
-        let pipe = Pipe()
-        fflush(stdout)
-        let saved = dup(STDOUT_FILENO)
-        dup2(pipe.fileHandleForWriting.fileDescriptor, STDOUT_FILENO)
-        body()
-        fflush(stdout)
-        dup2(saved, STDOUT_FILENO)
-        close(saved)
-        try? pipe.fileHandleForWriting.close()
-        return String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
     }
 }

--- a/Apps/CLI/Tests/CoreCLITests/StandardOutputCapture.swift
+++ b/Apps/CLI/Tests/CoreCLITests/StandardOutputCapture.swift
@@ -6,6 +6,22 @@ func captureStandardOutputBytes(
     isolation: isolated (any Actor)? = #isolation,
     operation: () async throws -> Void
 ) async throws -> Data {
+    await StandardOutputCaptureGate.shared.acquire()
+    do {
+        try Task.checkCancellation()
+        let data = try await captureStandardOutputUnlocked(isolation: isolation, operation: operation)
+        await StandardOutputCaptureGate.shared.release()
+        return data
+    } catch {
+        await StandardOutputCaptureGate.shared.release()
+        throw error
+    }
+}
+
+private func captureStandardOutputUnlocked(
+    isolation: isolated (any Actor)? = #isolation,
+    operation: () async throws -> Void
+) async throws -> Data {
     let url = FileManager.default.temporaryDirectory
         .appendingPathComponent("peekaboo-test-stdout-\(UUID().uuidString)")
     let descriptor = Darwin.open(url.path, O_RDWR | O_CREAT | O_EXCL | O_CLOEXEC, 0o600)
@@ -30,6 +46,28 @@ func captureStandardOutputBytes(
 
     try file.seek(toOffset: 0)
     return try file.readToEnd() ?? Data()
+}
+
+private actor StandardOutputCaptureGate {
+    static let shared = StandardOutputCaptureGate()
+    private var held = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func acquire() async {
+        if self.held {
+            await withCheckedContinuation { self.waiters.append($0) }
+        } else {
+            self.held = true
+        }
+    }
+
+    func release() {
+        if self.waiters.isEmpty {
+            self.held = false
+        } else {
+            self.waiters.removeFirst().resume()
+        }
+    }
 }
 
 func captureStandardOutputText(

--- a/Apps/CLI/Tests/CoreCLITests/StandardOutputCapture.swift
+++ b/Apps/CLI/Tests/CoreCLITests/StandardOutputCapture.swift
@@ -75,5 +75,5 @@ func captureStandardOutputText(
     _ operation: () async throws -> Void
 ) async throws -> String {
     let data = try await captureStandardOutputBytes(isolation: isolation, operation: operation)
-    return String(decoding: data, as: UTF8.self)
+    return String(data: data, encoding: .utf8) ?? ""
 }

--- a/Apps/CLI/Tests/CoreCLITests/StandardOutputCapture.swift
+++ b/Apps/CLI/Tests/CoreCLITests/StandardOutputCapture.swift
@@ -1,0 +1,41 @@
+import Darwin
+import Foundation
+
+/// Process-wide redirection for serial tests. A file avoids blocking a producer on pipe capacity.
+func captureStandardOutputBytes(
+    isolation: isolated (any Actor)? = #isolation,
+    operation: () async throws -> Void
+) async throws -> Data {
+    let url = FileManager.default.temporaryDirectory
+        .appendingPathComponent("peekaboo-test-stdout-\(UUID().uuidString)")
+    let descriptor = Darwin.open(url.path, O_RDWR | O_CREAT | O_EXCL | O_CLOEXEC, 0o600)
+    guard descriptor >= 0 else { throw POSIXError(.EIO) }
+    let file = FileHandle(fileDescriptor: descriptor, closeOnDealloc: true)
+    defer {
+        try? file.close()
+        try? FileManager.default.removeItem(at: url)
+    }
+
+    do {
+        let original = dup(STDOUT_FILENO)
+        guard original >= 0 else { throw POSIXError(.EIO) }
+        defer { close(original) }
+        guard fflush(stdout) == 0, dup2(descriptor, STDOUT_FILENO) >= 0 else { throw POSIXError(.EIO) }
+        defer {
+            fflush(stdout)
+            _ = dup2(original, STDOUT_FILENO)
+        }
+        try await operation()
+    }
+
+    try file.seek(toOffset: 0)
+    return try file.readToEnd() ?? Data()
+}
+
+func captureStandardOutputText(
+    isolation: isolated (any Actor)? = #isolation,
+    _ operation: () async throws -> Void
+) async throws -> String {
+    let data = try await captureStandardOutputBytes(isolation: isolation, operation: operation)
+    return String(decoding: data, as: UTF8.self)
+}

--- a/Apps/CLI/Tests/CoreCLITests/StandardOutputCaptureTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/StandardOutputCaptureTests.swift
@@ -4,6 +4,31 @@ import Testing
 @Suite(.serialized)
 struct StandardOutputCaptureTests {
     @Test
+    func `Overlapping captures keep their output separate`() async throws {
+        let results = try await withThrowingTaskGroup(of: (Int, String).self) { group in
+            for index in 0..<10 {
+                group.addTask {
+                    let output = try await captureStandardOutputText {
+                        print("start-\(index)")
+                        await Task.yield()
+                        print("end-\(index)")
+                    }
+                    return (index, output)
+                }
+            }
+            var results: [(Int, String)] = []
+            for try await result in group {
+                results.append(result)
+            }
+            return results
+        }
+        #expect(results.count == 10)
+        for (index, output) in results {
+            #expect(output == "start-\(index)\nend-\(index)\n")
+        }
+    }
+
+    @Test
     func `Output larger than pipe capacity is captured completely`() async throws {
         let payload = String(repeating: "x", count: 1024 * 1024)
         let output = try await captureStandardOutputText {

--- a/Apps/CLI/Tests/CoreCLITests/StandardOutputCaptureTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/StandardOutputCaptureTests.swift
@@ -1,0 +1,30 @@
+import Foundation
+import Testing
+
+@Suite(.serialized)
+struct StandardOutputCaptureTests {
+    @Test
+    func `Output larger than pipe capacity is captured completely`() async throws {
+        let payload = String(repeating: "x", count: 1024 * 1024)
+        let output = try await captureStandardOutputText {
+            print(payload, terminator: "")
+        }
+        #expect(output == payload)
+    }
+
+    @Test
+    func `Throwing producers restore stdout for later captures`() async throws {
+        enum ExpectedFailure: Error { case failed }
+        do {
+            _ = try await captureStandardOutputText {
+                print("discarded")
+                throw ExpectedFailure.failed
+            }
+            Issue.record("Expected the producer failure")
+        } catch ExpectedFailure.failed {}
+        let output = try await captureStandardOutputText {
+            print("next capture")
+        }
+        #expect(output == "next capture\n")
+    }
+}


### PR DESCRIPTION
The full safe CLI suite can deadlock while rendering an error in `CaptureActionCommandEndToEndTests` and `CaptureOwnershipErrorOutputTests`. Its stdout helper redirects into a pipe and waits until the producer returns before draining it. Once buffered test output plus the command response fills the pipe, the producer cannot return.

Use a shared temporary-file capture helper for all five Core CLI stdout fixtures. Flush pending output before redirection, restore stdout on both success and thrown errors, then rewind and read the complete bytes. An async gate serializes participating captures across callers; the surrounding test suites continue running serially because stdout is process-wide. Runtime CLI behavior is unchanged.

Validation:
- Sampled the real stalled test process: `Capture action refuses incomplete host provenance before child dispatch` was blocked in `print` → `fwrite` → `write` inside the old pipe helper. A second full run reached the capture-ownership fixture and exposed the same defect; the remaining Core CLI pipe helpers are now removed.
- The capture-action, capture-ownership, daemon-control, model-provider, output-delegate, and stdout suites pass: 50 tests in 6 suites.
- New regression coverage captures an exact 1 MiB payload and verifies restoration after a throwing producer, and checks ten deliberately overlapping captures.
- A native executable compiled with the shared helper captured **84,128 bytes from 32 real built CLI `--help` invocations**, then verified exact capture after an intentional producer error.
- P0–P2 autoreview is clean. Full safe-suite and exact-head hosted CI results will be posted before landing.

This is independent of #703. Land it before the final notes PR #704. No user-visible release note is needed for this test-harness repair.
