### PR TITLE
fix(app): refuse CLI-style bundle invocation

### DIFF
--- a/Apps/Mac/Peekaboo/Core/PeekabooAppLaunchPolicy.swift
+++ b/Apps/Mac/Peekaboo/Core/PeekabooAppLaunchPolicy.swift
@@ -62,12 +62,7 @@ struct PeekabooAppLaunchPolicy: Equatable, Sendable {
         let explicitlyRequestedInteractive = launchArguments.contains(Self.interactiveArgument)
         self.explicitlyRequestedBackgroundHost = explicitlyRequestedBackgroundHost
         self.currentBuildReceipt = currentBuildReceipt
-        let offendingArgument = launchArguments.enumerated().first { index, argument in
-            (index == 0 && !argument.hasPrefix("-")) ||
-                (argument.hasPrefix("--") && argument != Self.backgroundBridgeHostArgument &&
-                    argument != Self.interactiveArgument) ||
-                argument == "-V" || argument == "-v" || argument == "-h" || argument == "-j"
-        }?.element
+        let offendingArgument = Self.firstCommandLineArgument(in: launchArguments)
         self.mode = if let offendingArgument {
             .refusedCommandLineInvocation(argument: offendingArgument)
         } else if explicitlyRequestedBackgroundHost {
@@ -79,6 +74,27 @@ struct PeekabooAppLaunchPolicy: Equatable, Sendable {
         } else {
             .interactive
         }
+    }
+
+    private static func firstCommandLineArgument(in arguments: ArraySlice<String>) -> String? {
+        var acceptsCocoaValue = false
+        for argument in arguments {
+            if argument == Self.backgroundBridgeHostArgument || argument == Self.interactiveArgument ||
+                argument.hasPrefix("-psn_")
+            {
+                acceptsCocoaValue = false
+            } else if argument.hasPrefix("--") || ["-V", "-v", "-h", "-j"].contains(argument) {
+                return argument
+            } else if argument.hasPrefix("-") {
+                // Cocoa defaults may carry one value, unlike the app's valueless launch flags.
+                acceptsCocoaValue = true
+            } else if acceptsCocoaValue {
+                acceptsCocoaValue = false
+            } else {
+                return argument
+            }
+        }
+        return nil
     }
 
     @MainActor

--- a/Apps/Mac/Peekaboo/Core/PeekabooAppLaunchPolicy.swift
+++ b/Apps/Mac/Peekaboo/Core/PeekabooAppLaunchPolicy.swift
@@ -39,6 +39,7 @@ struct PeekabooAppLaunchPolicy: Equatable, Sendable {
     enum Mode: Equatable, Sendable {
         case interactive
         case backgroundBridgeHost
+        case refusedCommandLineInvocation(argument: String)
     }
 
     enum PresentationIntent: Equatable, Sendable {
@@ -61,7 +62,15 @@ struct PeekabooAppLaunchPolicy: Equatable, Sendable {
         let explicitlyRequestedInteractive = launchArguments.contains(Self.interactiveArgument)
         self.explicitlyRequestedBackgroundHost = explicitlyRequestedBackgroundHost
         self.currentBuildReceipt = currentBuildReceipt
-        self.mode = if explicitlyRequestedBackgroundHost {
+        let offendingArgument = launchArguments.enumerated().first { index, argument in
+            (index == 0 && !argument.hasPrefix("-")) ||
+                (argument.hasPrefix("--") && argument != Self.backgroundBridgeHostArgument &&
+                    argument != Self.interactiveArgument) ||
+                argument == "-v" || argument == "-h"
+        }?.element
+        self.mode = if let offendingArgument {
+            .refusedCommandLineInvocation(argument: offendingArgument)
+        } else if explicitlyRequestedBackgroundHost {
             .backgroundBridgeHost
         } else if explicitlyRequestedInteractive {
             .interactive

--- a/Apps/Mac/Peekaboo/Core/PeekabooAppLaunchPolicy.swift
+++ b/Apps/Mac/Peekaboo/Core/PeekabooAppLaunchPolicy.swift
@@ -66,7 +66,7 @@ struct PeekabooAppLaunchPolicy: Equatable, Sendable {
             (index == 0 && !argument.hasPrefix("-")) ||
                 (argument.hasPrefix("--") && argument != Self.backgroundBridgeHostArgument &&
                     argument != Self.interactiveArgument) ||
-                argument == "-v" || argument == "-h"
+                argument == "-V" || argument == "-v" || argument == "-h" || argument == "-j"
         }?.element
         self.mode = if let offendingArgument {
             .refusedCommandLineInvocation(argument: offendingArgument)

--- a/Apps/Mac/Peekaboo/PeekabooApp.swift
+++ b/Apps/Mac/Peekaboo/PeekabooApp.swift
@@ -215,6 +215,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var didObserveAgentMode = false
 
     override init() {
+        if case let .refusedCommandLineInvocation(argument) = PeekabooAppLaunchPolicy(
+            arguments: CommandLine.arguments).mode
+        {
+            let message =
+                "Peekaboo.app is the GUI/Bridge host and cannot handle CLI argument \(argument.debugDescription). " +
+                "Use the separate peekaboo CLI binary from Homebrew or the release tarball " +
+                "peekaboo-macos-universal.tar.gz; the app bundle executable must not be used as the CLI.\n"
+            FileHandle.standardError.write(Data(message.utf8))
+            exit(EX_USAGE)
+        }
         try? ScreenCaptureKitOwnerLease.registerCurrentProcessCapability()
         ScreenCaptureKitOwnerLease.beginCurrentProcessCapabilityPreparation()
         let launchPolicy = PeekabooAppLaunchPolicy.current

--- a/Apps/Mac/PeekabooTests/Core/PeekabooAppLaunchPolicyTests.swift
+++ b/Apps/Mac/PeekabooTests/Core/PeekabooAppLaunchPolicyTests.swift
@@ -59,6 +59,8 @@ struct PeekabooAppLaunchPolicyTests {
         ["-psn_0_123"],
         ["-NSDocumentRevisionsDebugMode", "YES"],
         ["--interactive", "-NSDocumentRevisionsDebugMode", "YES"],
+        ["-NSDocumentRevisionsDebugMode", "YES", "--interactive"],
+        ["-psn_0_123", "-NSDocumentRevisionsDebugMode", "YES"],
     ])
     func `app and Cocoa launch arguments remain accepted`(arguments: [String]) {
         let policy = PeekabooAppLaunchPolicy(arguments: ["Peekaboo"] + arguments)
@@ -84,15 +86,26 @@ struct PeekabooAppLaunchPolicyTests {
         #expect(policy.mode == .refusedCommandLineInvocation(argument: arguments[0]))
     }
 
-    @Test(arguments: ["--background-bridge-host", "--interactive", "-psn_0_123"], ["--no-elements", "-V", "-j"])
-    func `CLI options are refused even after accepted flags`(argument: String, cliOption: String) throws {
+    @Test(
+        arguments: ["--background-bridge-host", "--interactive", "-psn_0_123"],
+        ["--no-elements", "-V", "-j", "version", "permissions", "see"])
+    func `CLI arguments are refused even after accepted flags`(argument: String, cliArgument: String) throws {
         let receipt = try #require(self.receipt(bundleVersion: "42", codeSignatureHash: "abc123"))
         let policy = PeekabooAppLaunchPolicy(
-            arguments: ["Peekaboo", argument, cliOption],
+            arguments: ["Peekaboo", argument, cliArgument],
             managedReceipt: receipt,
             currentBuildReceipt: receipt)
 
-        #expect(policy.mode == .refusedCommandLineInvocation(argument: cliOption))
+        #expect(policy.mode == .refusedCommandLineInvocation(argument: cliArgument))
+    }
+
+    @Test
+    func `Cocoa option value does not hide a subsequent CLI command`() {
+        let policy = PeekabooAppLaunchPolicy(arguments: [
+            "Peekaboo", "-NSDocumentRevisionsDebugMode", "YES", "permissions", "status",
+        ])
+
+        #expect(policy.mode == .refusedCommandLineInvocation(argument: "permissions"))
     }
 
     @Test

--- a/Apps/Mac/PeekabooTests/Core/PeekabooAppLaunchPolicyTests.swift
+++ b/Apps/Mac/PeekabooTests/Core/PeekabooAppLaunchPolicyTests.swift
@@ -51,7 +51,45 @@ struct PeekabooAppLaunchPolicyTests {
             "--background-bridge-host=true",
         ])
 
+        #expect(policy.mode == .refusedCommandLineInvocation(argument: "--background-bridge-host=true"))
+    }
+
+    @Test(arguments: [
+        ["--interactive"],
+        ["-psn_0_123"],
+        ["-NSDocumentRevisionsDebugMode", "YES"],
+        ["--interactive", "-NSDocumentRevisionsDebugMode", "YES"],
+    ])
+    func `app and Cocoa launch arguments remain accepted`(arguments: [String]) {
+        let policy = PeekabooAppLaunchPolicy(arguments: ["Peekaboo"] + arguments)
+
         #expect(policy.mode == .interactive)
+    }
+
+    @Test(arguments: [
+        ["--version"],
+        ["--help"],
+        ["-v"],
+        ["-h"],
+        ["see", "--no-elements"],
+        ["permissions", "status"],
+        ["version"],
+    ])
+    func `CLI invocation is refused with the first offending argument`(arguments: [String]) {
+        let policy = PeekabooAppLaunchPolicy(arguments: ["Peekaboo"] + arguments)
+
+        #expect(policy.mode == .refusedCommandLineInvocation(argument: arguments[0]))
+    }
+
+    @Test(arguments: ["--background-bridge-host", "--interactive", "-psn_0_123"])
+    func `unknown long options are refused even after accepted flags`(argument: String) throws {
+        let receipt = try #require(self.receipt(bundleVersion: "42", codeSignatureHash: "abc123"))
+        let policy = PeekabooAppLaunchPolicy(
+            arguments: ["Peekaboo", argument, "--no-elements"],
+            managedReceipt: receipt,
+            currentBuildReceipt: receipt)
+
+        #expect(policy.mode == .refusedCommandLineInvocation(argument: "--no-elements"))
     }
 
     @Test

--- a/Apps/Mac/PeekabooTests/Core/PeekabooAppLaunchPolicyTests.swift
+++ b/Apps/Mac/PeekabooTests/Core/PeekabooAppLaunchPolicyTests.swift
@@ -69,8 +69,11 @@ struct PeekabooAppLaunchPolicyTests {
     @Test(arguments: [
         ["--version"],
         ["--help"],
+        ["-V"],
         ["-v"],
         ["-h"],
+        ["-j"],
+        ["-j", "see"],
         ["see", "--no-elements"],
         ["permissions", "status"],
         ["version"],
@@ -81,15 +84,26 @@ struct PeekabooAppLaunchPolicyTests {
         #expect(policy.mode == .refusedCommandLineInvocation(argument: arguments[0]))
     }
 
-    @Test(arguments: ["--background-bridge-host", "--interactive", "-psn_0_123"])
-    func `unknown long options are refused even after accepted flags`(argument: String) throws {
+    @Test(arguments: ["--background-bridge-host", "--interactive", "-psn_0_123"], ["--no-elements", "-V", "-j"])
+    func `CLI options are refused even after accepted flags`(argument: String, cliOption: String) throws {
         let receipt = try #require(self.receipt(bundleVersion: "42", codeSignatureHash: "abc123"))
         let policy = PeekabooAppLaunchPolicy(
-            arguments: ["Peekaboo", argument, "--no-elements"],
+            arguments: ["Peekaboo", argument, cliOption],
             managedReceipt: receipt,
             currentBuildReceipt: receipt)
 
-        #expect(policy.mode == .refusedCommandLineInvocation(argument: "--no-elements"))
+        #expect(policy.mode == .refusedCommandLineInvocation(argument: cliOption))
+    }
+
+    @Test
+    func `short version option overrides matching managed receipt`() throws {
+        let receipt = try #require(self.receipt(bundleVersion: "42", codeSignatureHash: "abc123"))
+        let policy = PeekabooAppLaunchPolicy(
+            arguments: ["Peekaboo", "-V"],
+            managedReceipt: receipt,
+            currentBuildReceipt: receipt)
+
+        #expect(policy.mode == .refusedCommandLineInvocation(argument: "-V"))
     }
 
     @Test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## Unreleased
 
-- Refuse CLI-style invocations of Peekaboo.app before capture or Bridge startup, with guidance to use the separate `peekaboo` CLI binary.
-
 ## 4.3.2 - 2026-09-07
 
 **Highlights:** Explicit typing dispatch acceptance for scripts, plus more reliable app installation and release recovery.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Refuse CLI-style invocations of Peekaboo.app before capture or Bridge startup, with guidance to use the separate `peekaboo` CLI binary.
+
 ## 4.3.2 - 2026-09-07
 
 **Highlights:** Explicit typing dispatch acceptance for scripts, plus more reliable app installation and release recovery.

--- a/docs/bridge-host.md
+++ b/docs/bridge-host.md
@@ -45,6 +45,13 @@ a concrete snapshot they remain diagnostic-only unless selected with `--bridge-s
 
 There is **no auto-launch** of Peekaboo.app.
 
+Peekaboo.app is the GUI/Bridge host; its bundle executable is not the CLI, even when a
+case-insensitive filesystem accepts the lowercase name `peekaboo`. CLI-style invocations such as
+`Peekaboo.app/Contents/MacOS/peekaboo --version` or `Peekaboo see --no-elements` print installation
+guidance to stderr and exit with status 64 before registering capture capability or starting a Bridge
+listener. Use the separate `peekaboo` binary from Homebrew or `peekaboo-macos-universal.tar.gz`.
+The app's `--background-bridge-host`, `--interactive`, and Cocoa/LaunchServices launch arguments remain supported.
+
 `pnpm app:restart` remains the contributor workflow: it builds Debug with the repository's ordinary
 local Xcode signing configuration. It does not require or inject an OpenClaw Foundation identity.
 Managed replacement of the stable TCC app is deliberately


### PR DESCRIPTION
CLI-style calls to the app bundle executable could silently start a GUI process, claim `bridge.sock`, and prevent the intended Bridge host from launching. On case-insensitive filesystems, `Peekaboo.app/Contents/MacOS/peekaboo` resolves to the GUI executable.

The app now refuses identifiable CLI invocations before capture registration or Bridge startup, prints guidance to use the separate Homebrew/release-tarball CLI, and exits with `EX_USAGE` (64). The guard covers commands, long options, and the CLI short options `-V`, `-v`, `-h`, and `-j`. Ordinary app flags and Cocoa/LaunchServices forms retain their behavior. Refusal takes precedence over managed background receipts.

Maintainer repair adds the missing `-V` and `-j` cases, detects positional commands after app/Cocoa arguments, and adds regression coverage. All changelog entries are consolidated in #704, which should land last; this PR contains only code, tests, and Bridge documentation. No release or publication is part of this change.

Validation:

- Launch-policy suite: 14 tests passed, including parameterized accepted and refused invocations and managed-receipt precedence. On Xcode 27.0, the SwiftPM runner needed an explicit linker rpath to its built Sparkle framework; the unadjusted runner failed to locate Sparkle before executing tests.
- SwiftFormat on changed Swift files, documentation lint, and full SwiftLint (0 violations in 1,802 files) passed.
- `scripts/test-build-playground-artifact.sh` passed in the maintainer worktree, including all 49 corruption cases; the earlier author-environment fixture failure did not reproduce.
- The complete combined `pnpm run test:safe` passed with all five final candidate source changes: 81 Foundation tests, 1,978 CLI tests, and all shell/Node/artifact/certification checks. Every changed file was verified against its final PR blob. The Mac launch-policy suite is tested separately.
- [Signed app runtime proof](https://github.com/openclaw/Peekaboo/pull/706#issuecomment-5579817059): 17 invocations passed at the final head, with the installed host and socket unchanged. Branch-mode P0–P2 autoreview is clean; [macOS CI](https://github.com/openclaw/Peekaboo/actions/runs/34190925624) and [CodeQL](https://github.com/openclaw/Peekaboo/actions/runs/34190925647) are green on the exact final head.
