### PR TITLE
fix(config): honor print-path without launching an editor

### DIFF
--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Core/ConfigCommand+Bindings.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Core/ConfigCommand+Bindings.swift
@@ -44,7 +44,7 @@ extension ConfigCommand.EditCommand: CommanderBindableCommand {
         if let timeout: CLIDuration = try values.decodeOption("timeout", as: CLIDuration.self) {
             self.timeout = timeout
         }
-        self.printPath = values.flag("print-path")
+        self.printPath = values.flag("printPath")
     }
 }
 

--- a/Apps/CLI/Tests/CoreCLITests/ConfigEditorLaunchTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/ConfigEditorLaunchTests.swift
@@ -52,12 +52,15 @@ struct ConfigEditorLaunchTests {
             command.editor = editor.path
             command.timeout = .seconds(1)
 
-            let startedAt = Date()
+            let runtime = self.makeRuntime()
+            let startedAt = ContinuousClock.now
             let exitCode = await #expect(throws: ExitCode.self) {
-                try await command.run(using: self.makeRuntime())
+                try await command.run(using: runtime)
             }
             #expect(exitCode == ExitCode.failure)
-            #expect(Date().timeIntervalSince(startedAt) < 3)
+            // The one-second timeout permits two more seconds of termination cleanup.
+            // Leave scheduling headroom while staying below the editor's eight-second natural exit.
+            #expect(startedAt.duration(to: .now) < .seconds(5))
 
             let pidText = try String(contentsOf: pidFile, encoding: .utf8)
                 .trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Apps/CLI/Tests/CoreCLITests/ConfigEditorLaunchTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/ConfigEditorLaunchTests.swift
@@ -34,6 +34,24 @@ struct ConfigEditorLaunchTests {
     }
 
     @Test
+    func `CLI print-path does not create configuration or launch an editor`() async throws {
+        try await self.withTempConfigDir { dir in
+            let resolved = try CommanderRuntimeRouter.resolve(argv: [
+                "peekaboo", "config", "edit", "--print-path",
+                "--editor", dir.appendingPathComponent("missing-editor").path,
+            ])
+            var command = try CommanderCLIBinder.instantiateCommand(
+                ofType: ConfigCommand.EditCommand.self,
+                parsedValues: resolved.parsedValues
+            )
+
+            #expect(command.printPath)
+            try await command.run(using: self.makeRuntime())
+            #expect(!FileManager.default.fileExists(atPath: PeekabooCore.ConfigurationManager.configPath))
+        }
+    }
+
+    @Test
     func `EditCommand bounds a non-exiting editor`() async throws {
         try await self.withTempConfigDir { dir in
             let fileManager = FileManager.default

--- a/docs/commands/config.md
+++ b/docs/commands/config.md
@@ -14,7 +14,7 @@ read_when:
 | --- | --- | --- |
 | `init` | Create a default `config.json` (respects `--force`) and print provider readiness (env / credentials / OAuth) in human mode. | `--force` overwrites an existing file; `--timeout` bounds live checks (default `30s`; bare values are milliseconds). |
 | `show` | Print either the raw file or the fully merged “effective” view (config + env + credentials); human `--effective` also live-validates providers. | `--effective` switches to the merged view; `--timeout` bounds validation with the shared duration grammar; JSON mode emits a standard `{ success, data }` object with no appended text. |
-| `edit` | Opens the config in `$EDITOR` (or the `--editor` you pass) and validates the result after you quit. | `--editor` overrides the detected editor; `--timeout` is an optional bound (bare values are milliseconds). Omit it to wait until the editor exits. |
+| `edit` | Opens the config in `$EDITOR` (or the `--editor` you pass) and validates the result after you quit. | `--editor` overrides the detected editor; `--timeout` is an optional bound (bare values are milliseconds). Omit it to wait until the editor exits. `--print-path` prints the config path without creating the file or launching an editor. |
 | `validate` | Parses the config without writing anything and surfaces syntax/errors. | None. |
 | `status` | Display provider credential readiness. | `--timeout` (default `30s`; bare values are milliseconds). |
 | `login` | Run an OAuth flow (no API key stored) for supported providers. | `login openai` (ChatGPT/Codex), `login anthropic` (Claude Pro/Max). |
@@ -40,6 +40,9 @@ read_when:
 # Create a clean config + show the merged view
 peekaboo config init --force
 peekaboo config show --effective
+
+# Locate the config without opening an editor or creating a file
+peekaboo config edit --print-path
 
 # Add and validate an OpenRouter key with the no-echo prompt
 peekaboo config credential set openrouter


### PR DESCRIPTION
`config edit --print-path` appeared in help but was ignored: Commander stores the flag under the Swift property label `printPath`, while the binder queried `print-path`. The real CLI therefore created a configuration file and launched the editor instead of returning its path.

Bind the normalized property key, and exercise the public command spelling through the actual router and binder. The regression supplies a missing editor and checks that no configuration file is created. Document the existing path-only behavior. Release notes are consolidated in #704.

The same validation pass exposed a nearby timing-test defect: a one-second editor timeout allows up to two additional seconds of TERM/KILL cleanup, but the test demanded less than three seconds including runtime construction. Construct that runtime before timing, use ContinuousClock, and leave scheduling headroom while still requiring return before the editor's eight-second natural exit.

Validation:

- Five focused config-editor tests passed, including the router/binder regression and child-reaping timeout case.
- Actual built CLI, using a synthetic isolated configuration directory: print-path returned the scoped path without creating a config or launching a supplied invalid editor; the TERM-ignoring editor returned EDITOR_TIMEOUT after 2.081 seconds and was reaped; a normal editor without a timeout returned 0.
- Formatting, documentation lint, and branch-mode P0–P2 autoreview passed. The complete combined safe suite passed: 81 Foundation tests, 1,978 CLI tests, and all shell/Node/artifact/certification checks. Full lint found zero violations in 1,804 files; the format check found no changes needed in 1,823 files. [macOS CI](https://github.com/openclaw/Peekaboo/actions/runs/34191784511) and [CodeQL](https://github.com/openclaw/Peekaboo/actions/runs/34191784590) are green on the exact final head.

The native CLI was built from the combined validation candidate; the changed config source and regression file were verified byte-for-byte against this PR's final commit.
