### PR TITLE
fix(mcp): flatten click and paste tool schemas

### DIFF
--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/ClickTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/ClickTool.swift
@@ -17,6 +17,7 @@ public struct ClickTool: MCPTool {
         """
         Clicks on UI elements or coordinates.
         Supports element queries, specific IDs from `see` or `inspect_ui`, or raw coordinates.
+        Choose exactly one of on, query, or coords, and at most one of double, triple, right, or middle.
         Background delivery is the default. Background coordinates require a nonempty snapshot or coordinate_reference
         from a fresh exact-window `see`; pid alone is never a safe coordinate target. Set `foreground` to true only for
         intentional shared-pointer input, which may omit the capture reference.

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/ClickTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/ClickTool.swift
@@ -25,7 +25,7 @@ public struct ClickTool: MCPTool {
     }
 
     public var inputSchema: Value {
-        let baseSchema = SchemaBuilder.object(
+        SchemaBuilder.object(
             properties: [
                 "query": SchemaBuilder.string(
                     description: """
@@ -98,67 +98,6 @@ public struct ClickTool: MCPTool {
                     description: "Foreground-only modifier keys. Requires foreground=true and a fresh exact snapshot."),
             ],
             required: [])
-
-        guard case let .object(fields) = baseSchema else { return baseSchema }
-        var schema = fields
-        schema["oneOf"] = .array(Self.targetRouteSchemas)
-        schema["allOf"] = .array([Self.exclusiveClickVariantSchema])
-        return .object(schema)
-    }
-
-    private static var targetRouteSchemas: [Value] {
-        [
-            self.exclusiveTargetRoute("on"),
-            self.exclusiveTargetRoute("query"),
-            self.exclusiveTargetRoute("coords", additionalFields: [
-                "anyOf": .array([
-                    self.requiredConstant("foreground", value: true),
-                    self.requiredConstant("background", value: false),
-                    .object(["required": .array([.string("snapshot")])]),
-                    .object(["required": .array([.string("coordinate_reference")])]),
-                ]),
-            ]),
-        ]
-    }
-
-    private static func exclusiveTargetRoute(
-        _ name: String,
-        additionalFields: [String: Value] = [:]) -> Value
-    {
-        let otherTargets = ["on", "query", "coords"].filter { $0 != name }
-        var fields = additionalFields
-        fields["required"] = .array([.string(name)])
-        fields["not"] = .object([
-            "anyOf": .array(otherTargets.map { target in
-                .object(["required": .array([.string(target)])])
-            }),
-        ])
-        return .object(fields)
-    }
-
-    private static func requiredConstant(_ name: String, value: Bool) -> Value {
-        .object([
-            "properties": .object([name: .object(["const": .bool(value)])]),
-            "required": .array([.string(name)]),
-        ])
-    }
-
-    private static var exclusiveClickVariantSchema: Value {
-        let variants = ["double", "right", "middle", "triple"]
-        let noVariant = Value.object([
-            "properties": .object(Dictionary(uniqueKeysWithValues: variants.map {
-                ($0, Value.object(["enum": .array([.bool(false)])]))
-            })),
-        ])
-        let selectedVariants = variants.map { selected in
-            Value.object([
-                "properties": .object(Dictionary(uniqueKeysWithValues: variants.map { variant in
-                    (variant, Value.object(["enum": .array([.bool(variant == selected)])]))
-                })),
-                "required": .array([.string(selected)]),
-            ])
-        }
-        return .object(["oneOf": .array([noVariant] + selectedVariants)])
     }
 
     public init(context: MCPToolContext = .shared) {

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/PasteTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/PasteTool.swift
@@ -94,39 +94,9 @@ public struct PasteTool: MCPTool {
                 description: "Optional. Focus a target or intentionally send foreground/global Cmd+V.",
                 default: false)
         }
-        let base = SchemaBuilder.object(
+        return SchemaBuilder.object(
             properties: properties,
             required: foregroundCapable ? [] : ["text"])
-        guard !foregroundCapable, case let .object(fields) = base else { return base }
-        var backgroundSchema = fields
-        backgroundSchema["anyOf"] = .array(Self.backgroundTargetRouteSchemas)
-        return .object(backgroundSchema)
-    }
-
-    private static var backgroundTargetRouteSchemas: [Value] {
-        ["app", "pid"].flatMap { owner in
-            [self.backgroundTargetRoute(owner: owner)] +
-                ["window_id", "window_title", "window_index"].map { window in
-                    self.backgroundTargetRoute(owner: owner, window: window)
-                }
-        }
-    }
-
-    private static func backgroundTargetRoute(owner: String, window: String? = nil) -> Value {
-        let owners: [String] = ["app", "pid"]
-        let windows: [String] = ["window_id", "window_title", "window_index"]
-        let otherOwners = owners.filter { $0 != owner }
-        let otherWindows = windows.filter { $0 != window }
-        let excludedTargets = otherOwners + otherWindows
-        let requiredTargets = [owner] + (window.map { [$0] } ?? [])
-        return .object([
-            "required": .array(requiredTargets.map(Value.string)),
-            "not": .object([
-                "anyOf": .array(excludedTargets.map { target in
-                    .object(["required": .array([.string(target)])])
-                }),
-            ]),
-        ])
     }
 
     public init(context: MCPToolContext = .shared) {

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/PasteTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/PasteTool.swift
@@ -20,6 +20,7 @@ public struct PasteTool: MCPTool {
             return """
             Deliver one direct text payload to an explicit app or PID UI target, optionally pinned to one exact
             window, under immutable background-only authority. This route does not touch the shared clipboard.
+            Provide exactly one of app or pid and at most one of window_id, window_title, or window_index.
             Current-clipboard, binary/file/image payloads, targetless input, and foreground delivery are unavailable.
             If delivery fails after it begins, a prefix may already be present; observe the exact target before
             retrying.

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPPolicyAwareCatalogTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPPolicyAwareCatalogTests.swift
@@ -10,33 +10,14 @@ struct MCPPolicyAwareCatalogTests {
         let tool = PasteTool(context: backgroundContext)
         guard case let .object(schema) = tool.inputSchema,
               case let .object(properties)? = schema["properties"],
-              case let .array(required)? = schema["required"],
-              case let .array(targetAlternatives)? = schema["anyOf"]
+              case let .array(required)? = schema["required"]
         else {
             Issue.record("Expected background-only Paste schema")
             return
         }
         #expect(required == [Value.string("text")])
-        let requiredTargets = targetAlternatives.compactMap { alternative -> Set<String>? in
-            guard case let .object(fields) = alternative,
-                  case let .array(required)? = fields["required"]
-            else { return nil }
-            return Set(required.compactMap(\.stringValue))
-        }
-        #expect(Set(requiredTargets) == Set([
-            Set(["app"]),
-            Set(["pid"]),
-            Set(["app", "window_id"]),
-            Set(["pid", "window_id"]),
-            Set(["app", "window_title"]),
-            Set(["pid", "window_title"]),
-            Set(["app", "window_index"]),
-            Set(["pid", "window_index"]),
-        ]))
-        for alternative in targetAlternatives {
-            let required = try #require(Self.requiredFields(alternative))
-            #expect(Self.excludedTargetFields(alternative) ==
-                Set(["app", "pid", "window_id", "window_title", "window_index"]).subtracting(required))
+        for keyword in ["oneOf", "allOf", "anyOf"] {
+            #expect(schema[keyword] == nil)
         }
         #expect(properties["text"] != nil)
         #expect(properties["app"] != nil)
@@ -99,26 +80,6 @@ struct MCPPolicyAwareCatalogTests {
         #expect(foregroundProperties["window_id"]?.objectValue?["description"]?.stringValue?
             .contains("foreground focus") == true)
         #expect(foregroundTool.description.contains("Paste the current clipboard"))
-    }
-
-    private static func requiredFields(_ schema: Value) -> Set<String>? {
-        guard case let .object(fields) = schema,
-              case let .array(required)? = fields["required"]
-        else { return nil }
-        return Set(required.compactMap(\.stringValue))
-    }
-
-    private static func excludedTargetFields(_ schema: Value) -> Set<String> {
-        guard case let .object(fields) = schema,
-              case let .object(notSchema)? = fields["not"],
-              case let .array(alternatives)? = notSchema["anyOf"]
-        else { return [] }
-        return Set(alternatives.compactMap { alternative in
-            guard case let .object(fields) = alternative,
-                  case let .array(required)? = fields["required"]
-            else { return nil }
-            return required.compactMap(\.stringValue).first
-        })
     }
 
     @Test

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/PeekabooMCPServerTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/PeekabooMCPServerTests.swift
@@ -143,7 +143,7 @@ struct PeekabooMCPServerTests {
 
     @Test
     @MainActor
-    func `click wire schema requires an exclusive target and a background coordinate receipt`() async throws {
+    func `click wire schema is flat and documents runtime target constraints`() async throws {
         let context = await MCPToolTestHelpers.makeContext()
         let session = try await MCPWireSession.connect(context: context)
 
@@ -151,40 +151,16 @@ struct PeekabooMCPServerTests {
             let (tools, _) = try await session.client.listTools()
             let click = try #require(tools.first { $0.name == "click" })
             guard case let .object(schema) = click.inputSchema,
-                  case let .object(properties)? = schema["properties"],
-                  case let .array(routes)? = schema["oneOf"]
+                  case let .object(properties)? = schema["properties"]
             else {
-                Issue.record("click wire schema is missing its target routes")
+                Issue.record("click wire schema is missing its properties")
                 await session.stop()
                 return
             }
 
-            #expect(Set(routes.compactMap(Self.requiredFields)) == Set([["on"], ["query"], ["coords"]]))
-            for route in routes {
-                let required = try #require(Self.requiredFields(route)?.first)
-                #expect(Self.excludedTargetFields(route) == Set(["on", "query", "coords"]).subtracting([required]))
+            for keyword in ["oneOf", "allOf", "anyOf"] {
+                #expect(schema[keyword] == nil)
             }
-
-            let coordinateRoute = try #require(routes.first { Self.requiredFields($0) == ["coords"] })
-            guard case let .object(coordinateFields) = coordinateRoute,
-                  case let .array(coordinateAlternatives)? = coordinateFields["anyOf"]
-            else {
-                Issue.record("coordinate route is missing receipt and foreground alternatives")
-                await session.stop()
-                return
-            }
-
-            #expect(coordinateAlternatives.count == 4)
-            #expect(coordinateAlternatives.contains { Self.requiredFields($0) == ["snapshot"] })
-            #expect(coordinateAlternatives.contains { Self.requiredFields($0) == ["coordinate_reference"] })
-            #expect(Self.hasRequiredBooleanConstant(
-                name: "foreground",
-                value: true,
-                in: coordinateAlternatives))
-            #expect(Self.hasRequiredBooleanConstant(
-                name: "background",
-                value: false,
-                in: coordinateAlternatives))
 
             guard case let .object(snapshotSchema)? = properties["snapshot"],
                   case let .object(referenceSchema)? = properties["coordinate_reference"],
@@ -206,12 +182,6 @@ struct PeekabooMCPServerTests {
                 #expect(variantSchema["type"] == .string("boolean"))
                 #expect(variantSchema["default"] == .bool(false))
             }
-            guard case let .array(variantConstraints)? = schema["allOf"] else {
-                Issue.record("click wire schema is missing variant conflicts")
-                await session.stop()
-                return
-            }
-            #expect(!variantConstraints.isEmpty)
             for field in ["on", "query", "coords"] {
                 guard case let .object(targetSchema)? = properties[field] else {
                     Issue.record("click target property \(field) is missing")
@@ -718,36 +688,6 @@ struct PeekabooMCPServerTests {
 
         #expect(!names.contains("set_value"))
         #expect(!names.contains("action"))
-    }
-
-    private static func requiredFields(_ schema: Value) -> Set<String>? {
-        guard case let .object(fields) = schema,
-              case let .array(required)? = fields["required"]
-        else { return nil }
-        return Set(required.compactMap(\.stringValue))
-    }
-
-    private static func excludedTargetFields(_ schema: Value) -> Set<String>? {
-        guard case let .object(fields) = schema,
-              case let .object(notSchema)? = fields["not"],
-              case let .array(alternatives)? = notSchema["anyOf"]
-        else { return nil }
-        return Set(alternatives.flatMap { Self.requiredFields($0) ?? [] })
-    }
-
-    private static func hasRequiredBooleanConstant(
-        name: String,
-        value: Bool,
-        in schemas: [Value]) -> Bool
-    {
-        schemas.contains { schema in
-            guard Self.requiredFields(schema) == [name],
-                  case let .object(fields) = schema,
-                  case let .object(properties)? = fields["properties"],
-                  case let .object(property)? = properties[name]
-            else { return false }
-            return property["const"] == .bool(value)
-        }
     }
 
     private static func invalidParamsDetail(session: MCPWireSession, params: Value) async -> String? {

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -252,7 +252,11 @@ operations used to finalize the validated result. Current clients additionally r
 protocol 1.34 `producerBoundSnapshotReferences` capability before creating or publishing the reference; an old 1.34
 host cannot cause the result to be rebound locally.
 
-The `click` tool accepts exactly one target shape: `on`, `query`, or `coords`. Its published schema requires every
+The `click` and `paste` tools publish flat object schemas without root-level `oneOf`, `allOf`, or `anyOf`, so MCP clients
+can forward them to providers such as Anthropic without schema rewriting. Peekaboo enforces cross-field constraints
+at runtime before dispatch; the flat catalog does not relax target, receipt, or foreground-consent requirements.
+
+The `click` tool accepts exactly one target shape: `on`, `query`, or `coords`. Runtime validation requires every
 background `coords` call to include either `snapshot` or `coordinate_reference`; a PID alone is only a consistency
 check and never replaces the receipt. Both fields must be nonempty and identify a fresh exact-window `see` capture.
 Pass `coordinate_space: "image_pixels"` for delivered-raster pixels or `coordinate_space: "normalized"` for values


### PR DESCRIPTION
MCP clients that forward Peekaboo's `click` and `paste` schemas to Anthropic can have the entire request rejected because the schemas contain root-level combinators. Publish flat object schemas while retaining the existing runtime checks for exclusive targets, coordinate receipts, click variants, paste payloads, and foreground consent.

Keep policy-specific properties and the background-only `text` requirement unchanged. Document the cross-field requirements in the tool descriptions and MCP guide. Thanks @goutamadwant for the schema repair and @muellah for the report.

Fixes #708.

Validation at `bb6bf302c0d11054d30ac0c311814a265af50da8`:

- Built and Developer ID signed the native CLI, then exercised its real stdio `initialize`, `tools/list`, and `tools/call` transport.
- Installed 4.3.3 reproduced the root combinators; the branch build advertised flat schemas for both tools.
- Mixed click targets, missing coordinate receipts, conflicting click variants, and targetless paste were refused.
- All 87 selected MCP wire, catalog, interaction, and background-policy tests passed.
- SwiftFormat, docs lint, and SwiftLint passed; SwiftLint reported zero violations across 1,804 files.
- Final P0–P2 autoreview is clean.

CI: [macOS](https://github.com/openclaw/Peekaboo/actions/runs/34653688380), [CodeQL](https://github.com/openclaw/Peekaboo/actions/runs/34653688237). The first CLI CI attempt exposed a pre-existing cancellation-test scheduling race; #714 repairs that and a separate TTY fixture timeout found by the local safe suite. Land #714 first. The consolidated changelog entry is in #713, which lands last.

The live proof covers the published MCP schema and runtime refusal behavior; it does not claim a live Anthropic API request.
