### PR TITLE
fix(see): preserve frontmost observation identity

### DIFF
--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Observation/DesktopObservationService+Capture.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Observation/DesktopObservationService+Capture.swift
@@ -87,7 +87,11 @@ extension DesktopObservationService {
         }
     }
 
-    static func normalize(capture: CaptureResult, for target: ResolvedObservationTarget) -> CaptureResult {
+    static func normalize(
+        capture: CaptureResult,
+        for target: ResolvedObservationTarget,
+        requestedTarget: DesktopObservationTargetRequest) -> CaptureResult
+    {
         guard
             let resolvedWindow = target.window,
             let capturedWindow = capture.metadata.windowInfo,
@@ -119,9 +123,17 @@ extension DesktopObservationService {
             isExcludedFromWindowsMenu: capturedWindow.isExcludedFromWindowsMenu,
             observationCapability: capturedWindow.observationCapability,
             mutationIdentity: capturedWindow.mutationIdentity)
+        let mode: CaptureMode = if case .frontmost = requestedTarget,
+                                   target.detectionContext?.windowMutationIdentity != nil,
+                                   capture.metadata.mode == .window
+        {
+            .frontmost
+        } else {
+            capture.metadata.mode
+        }
         let metadata = CaptureMetadata(
             size: capture.metadata.size,
-            mode: capture.metadata.mode,
+            mode: mode,
             videoTimestampMs: capture.metadata.videoTimestampMs,
             applicationInfo: capture.metadata.applicationInfo,
             windowInfo: normalizedWindow,
@@ -179,13 +191,23 @@ extension DesktopObservationService {
 
     static func bindingCaptureReceipt(
         to target: ResolvedObservationTarget,
-        capture: CaptureResult) -> ResolvedObservationTarget
+        capture: CaptureResult,
+        requestedTarget: DesktopObservationTargetRequest) -> ResolvedObservationTarget
     {
         let capturedApplication = capture.metadata.applicationInfo.map(ApplicationIdentity.init)
         let capturedWindow = capture.metadata.windowInfo.map(WindowIdentity.init)
+        // Capture receipt validation already proved this exact owner/window. Native capture metadata
+        // omits discovery-only fields that the signed frontmost snapshot must retain.
+        let application: ApplicationIdentity? = if case .frontmost = requestedTarget,
+                                                   target.detectionContext?.windowMutationIdentity != nil
+        {
+            target.app
+        } else {
+            capturedApplication ?? target.app
+        }
         return ResolvedObservationTarget(
             kind: target.kind,
-            app: capturedApplication ?? target.app,
+            app: application,
             window: capturedWindow ?? target.window,
             bounds: capturedWindow?.bounds ?? target.bounds,
             detectionContext: self.windowContext(for: target, capture: capture),

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Observation/DesktopObservationService.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Observation/DesktopObservationService.swift
@@ -653,8 +653,11 @@ public final class DesktopObservationService: DesktopObservationActionResultProv
                     error,
                     resolution: foregroundCaptureFailureResolution)
             }
-            let capture = Self.normalize(capture: rawCapture, for: target)
-            let captureBoundTarget = Self.bindingCaptureReceipt(to: target, capture: capture)
+            let capture = Self.normalize(capture: rawCapture, for: target, requestedTarget: request.target)
+            let captureBoundTarget = Self.bindingCaptureReceipt(
+                to: target,
+                capture: capture,
+                requestedTarget: request.target)
             let captureBoundResolution = UIAutomationActionResult(
                 payload: captureBoundTarget,
                 outcome: resolution.outcome,

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/DesktopObservationServiceTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/DesktopObservationServiceTests.swift
@@ -163,6 +163,49 @@ extension DesktopObservationServiceTests {
         XCTAssertEqual(automation.detectCalls, 0)
     }
 
+    func testFrontmostObservationRetainsDiscoveryIdentityAfterExactWindowCapture() async throws {
+        let application = ServiceApplicationInfo(
+            processIdentifier: 123,
+            processStartIdentity: 700,
+            bundleIdentifier: "com.example.fixture",
+            name: "Fixture",
+            executablePath: "/Applications/Fixture.app/Contents/MacOS/Fixture",
+            activationPolicy: .regular)
+        let capturedApplication = ServiceApplicationInfo(
+            processIdentifier: 123,
+            processStartIdentity: 700,
+            bundleIdentifier: "com.example.fixture",
+            name: "Fixture")
+        let bounds = CGRect(x: 100, y: 100, width: 400, height: 300)
+        let window = Self.window(
+            id: 42,
+            title: "Captured",
+            bounds: bounds,
+            mutationIdentity: WindowMutationIdentity(
+                windowID: 42,
+                ownerProcessIdentifier: 123,
+                ownerProcessStartIdentity: 700,
+                capturedBounds: bounds))
+        let capture = RecordingScreenCaptureService(
+            result: Self.captureResult(app: capturedApplication, window: window))
+        let service = DesktopObservationService(
+            screenCapture: capture,
+            automation: RecordingUIAutomationService(),
+            applications: RecordingApplicationService(applications: [application], windows: [window]),
+            exactWindowMetadataProvider: StableExactWindowMetadataProvider())
+
+        let result = try await service.observe(DesktopObservationRequest(
+            target: .frontmost,
+            detection: .init(mode: .none)))
+
+        XCTAssertEqual(capture.operations, [.windowID(42, .logical1x, .auto)])
+        XCTAssertEqual(result.target.app, ApplicationIdentity(application))
+        XCTAssertEqual(result.target.app, result.diagnostics.stateSnapshot?.frontmostApplication)
+        XCTAssertEqual(result.capture.metadata.mode, .frontmost)
+        XCTAssertNil(result.capture.metadata.applicationInfo?.executablePath)
+        XCTAssertEqual(result.capture.metadata.windowInfo?.mutationIdentity, window.mutationIdentity)
+    }
+
     func testReusedPIDAndWindowIDFailWhenCaptureReceiptDisagrees() async throws {
         let oldApplication = ServiceApplicationInfo(
             processIdentifier: 123,

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeDesktopObservationBindingTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeDesktopObservationBindingTests.swift
@@ -1,8 +1,8 @@
 import CoreGraphics
 import Foundation
-import PeekabooAutomationKit
 import PeekabooFoundation
 import Testing
+@testable import PeekabooAutomationKit
 @testable import PeekabooBridge
 
 @Suite(.serialized)
@@ -563,6 +563,56 @@ struct PeekabooBridgeDesktopObservationBindingTests: DesktopObservationBindingFi
         #expect(PeekabooBridgeDesktopObservationBinding.mismatch(
             request: request,
             result: forged) == "frontmost application snapshot identity")
+    }
+
+    @Test
+    @MainActor
+    func `sparse exact window capture retains frontmost identity through signed validation`() async throws {
+        let fixture = Self.windowResult(.init(
+            processIdentifier: 42,
+            generation: 1001,
+            bundleIdentifier: "dev.peekaboo.fixture",
+            applicationName: "Fixture",
+            windowID: 73,
+            title: "Document",
+            index: 0,
+            captureMode: .window))
+        let original = fixture.result.target
+        let richApp = ApplicationIdentity(
+            processIdentifier: 42,
+            processStartIdentity: 1001,
+            bundleIdentifier: "dev.peekaboo.fixture",
+            name: "Fixture",
+            executablePath: "/Applications/Fixture.app/Contents/MacOS/Fixture",
+            activationPolicy: .regular)
+        let resolved = ResolvedObservationTarget(
+            kind: original.kind,
+            app: richApp,
+            window: original.window,
+            bounds: original.bounds,
+            detectionContext: original.detectionContext)
+        let request = DesktopObservationRequest(target: .frontmost, detection: .init(mode: .none))
+        try DesktopObservationService.validateCaptureReceipt(fixture.result.capture, for: resolved)
+        let capture = DesktopObservationService.normalize(
+            capture: fixture.result.capture,
+            for: resolved,
+            requestedTarget: request.target)
+        let bound = DesktopObservationService.bindingCaptureReceipt(
+            to: resolved,
+            capture: capture,
+            requestedTarget: request.target)
+        let result = Self.replacingDiagnostics(
+            DesktopObservationResult(target: bound, capture: capture, elements: nil)
+                .withCaptureContentDigest(rawScreenshotData: nil, annotatedScreenshotData: nil),
+            stateSnapshot: DesktopStateSnapshot(frontmostApplication: richApp))
+
+        #expect(result.capture.metadata.applicationInfo?.executablePath == nil)
+        #expect(PeekabooBridgeDesktopObservationBinding.mismatch(request: request, result: result) == nil)
+        let signed = try await Self.makeBundle(
+            request: .desktopObservation(request),
+            response: .desktopObservation(result),
+            target: .window(fixture.identity))
+        try signed.validateIntegrity()
     }
 
     @Test

--- a/docs/commands/see.md
+++ b/docs/commands/see.md
@@ -15,6 +15,10 @@ build-scoped daemon and may auto-start it before considering a healthy Peekaboo.
 AX-tree-only forms because their snapshots and capability decisions are host-memory state. An explicit
 `--bridge-socket`, a custom daemon socket, or `--no-remote` remains authoritative.
 
+Frontmost screenshots retain the application identity observed at the start of the request and report the logical
+`frontmost` capture mode, even when the capture engine uses that application's exact window. The captured process
+generation, window ID, and bounds must still match before the result can be accepted by the Bridge.
+
 Every reusable snapshot is identified by a producer-generated reference with the exact form `ps1_` followed by 32
 lowercase ASCII hexadecimal digits, for example `ps1_0123456789abcdef0123456789abcdef`. The 32-digit suffix contains
 128 random bits. The selected local or Bridge producer reserves that reference before storing detection results or


### PR DESCRIPTION
Frontmost daemon captures were rejected even when they captured the correct process and window. Exact-window capture emits sparse application metadata and a `window` mode; replacing the resolved application with that metadata made it disagree with the signed frontmost snapshot.

Retain the discovery identity and logical `frontmost` mode after the existing owner-generation, exact-window, and bounds checks succeed. Keep strict Bridge validation and direct window-ID capture behavior unchanged. Add producer and signed-result regressions and document the behavior.

Partially addresses #710. Screen-plus-AX attribution and publication before Bridge validation remain separate work, so this PR must not close the issue.

Verification at `7b3c016ba8d33c8a7a61b1f9242e24e61745d90c`:

- A signed native CLI through its own daemon captured a signed synthetic Cocoa window successfully with and without AX detection. The baseline had reproduced the identity refusal on the same fixture.
- The result retained its exact native window, reusable screenshot reference, `frontmost` mode, eight UI elements, and a visually verified 420×272 raster.
- All 48 local observation and exact-window tests passed, including the new producer regression. Hosted core CI also passed the signed-Bridge regression.
- [macOS CI](https://github.com/openclaw/Peekaboo/actions/runs/34654037648), [CodeQL](https://github.com/openclaw/Peekaboo/actions/runs/34654037762), and final P0–P2 autoreview passed.

[Native proof](https://github.com/openclaw/Peekaboo/pull/712#issuecomment-5641737311) uses the explicit classic engine; existing host ownership guards prevented a modern-engine run. Land the independent test repair #714 first and the consolidated notes/dependency PR #713 last.
