### PR TITLE
chore(deps): update SwiftLog and prepare 4.3.4 notes

### DIFF
--- a/Apps/Mac/Package.resolved
+++ b/Apps/Mac/Package.resolved
@@ -96,8 +96,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",
       "state" : {
-        "revision" : "3ffafb9722d5d918c614feb496c8789a3b59d222",
-        "version" : "1.15.0"
+        "revision" : "9c6fb14227f55d8f711ce3847dc2f419fb0ecacb",
+        "version" : "1.15.1"
       }
     },
     {

--- a/Apps/Peekaboo.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Apps/Peekaboo.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -159,8 +159,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log",
       "state" : {
-        "revision" : "3ffafb9722d5d918c614feb496c8789a3b59d222",
-        "version" : "1.15.0"
+        "revision" : "9c6fb14227f55d8f711ce3847dc2f419fb0ecacb",
+        "version" : "1.15.1"
       }
     },
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+**Highlights:** Restore provider-compatible MCP tools and frontmost daemon captures.
+
+- Publish flat `click` and `paste` MCP schemas for clients that forward tools to Anthropic, while preserving runtime target, receipt, and foreground-consent validation; thanks @goutamadwant for #711 and @muellah for #708.
+- Preserve the observed application identity and frontmost capture mode across exact-window capture so the daemon can validate frontmost screenshots without relaxing owner-generation or window checks. #710.
+- Update SwiftLog to 1.15.1 for default logging dispatch and Swift toolchain compatibility fixes.
+
 ## 4.3.3 - 2026-09-08
 
 **Highlights:** Prevent accidental GUI host launches and read Firestaff manifests more safely.

--- a/Core/PeekabooCore/Package.resolved
+++ b/Core/PeekabooCore/Package.resolved
@@ -78,8 +78,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",
       "state" : {
-        "revision" : "3ffafb9722d5d918c614feb496c8789a3b59d222",
-        "version" : "1.15.0"
+        "revision" : "9c6fb14227f55d8f711ce3847dc2f419fb0ecacb",
+        "version" : "1.15.1"
       }
     },
     {


### PR DESCRIPTION
Update the three tracked SwiftLog resolutions from 1.15.0 to 1.15.1, which repairs default logging dispatch and Swift toolchain compatibility. Keep the Mac and Xcode workspace locks aligned with the core lock.

Collect the complete 4.3.4 Unreleased notes here: #711's MCP schema compatibility repair, #712's frontmost observation repair, and the dependency patch. Land #714, #711, and #712 before this final notes PR. No tag or publication is included.

SwiftLog 1.15.1 was published September 8 and clears the repository's 48-hour age policy. Sparkle remains at stable 2.9.6. Chrome DevTools MCP keeps its audited 1.6.0 contract; the newer provider changes filesystem defaults, script execution controls, target filtering, and background behavior. Tachikoma retains the deliberately selected maintenance line from #675.

Verification at `1ac0e1b6a6e1330c4885ad139f8e70c5609ac985`:

- [macOS CI](https://github.com/openclaw/Peekaboo/actions/runs/34654052578), [CodeQL](https://github.com/openclaw/Peekaboo/actions/runs/34654052630), and [all four supplemental full suites](https://github.com/openclaw/Peekaboo/actions/runs/34654111450) passed.
- Release package-resolution contracts and final P0–P2 autoreview passed.
- The native CLI was built and Developer ID signed with SwiftLog 1.15.1 at `9c6fb14227f55d8f711ce3847dc2f419fb0ecacb`, then executed successfully.
- A separate compiled Swift consumer implemented the event-only LogHandler API and verified both the repaired legacy flat-argument entrypoint and ordinary Logger.info delivery.

The notes cover only the frontmost portion of #710. Screen-plus-AX attribution and artifact-publication ordering remain open.
