### PR TITLE
test(cli): stabilize cancellation and process-cleanup checks

### DIFF
--- a/Apps/CLI/Tests/CoreCLITests/ScreenCaptureKitOwnerRuntimeTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/ScreenCaptureKitOwnerRuntimeTests.swift
@@ -1134,15 +1134,12 @@ extension ScreenCaptureKitOwnerRuntimeTests {
             )
         }
 
-        var resumeHandshake: CheckedContinuation<Void, Never>?
         let uncooperativeHandshake = Task { @MainActor in
             try await RuntimeHostResolver.firstScreenCaptureKitOwnerUnawareHost(
                 candidates: [candidate],
                 identity: identity,
                 handshake: { _, _ in
-                    await withCheckedContinuation { continuation in
-                        resumeHandshake = continuation
-                    }
+                    withUnsafeCurrentTask { $0?.cancel() }
                     return Self.handshake(
                         processIdentifier: 3131,
                         processStartIdentity: 4141,
@@ -1154,11 +1151,6 @@ extension ScreenCaptureKitOwnerRuntimeTests {
                 }
             )
         }
-        while resumeHandshake == nil {
-            await Task.yield()
-        }
-        uncooperativeHandshake.cancel()
-        resumeHandshake?.resume()
         await #expect(throws: CancellationError.self) {
             _ = try await uncooperativeHandshake.value
         }
@@ -1292,7 +1284,6 @@ extension ScreenCaptureKitOwnerRuntimeTests {
             teamIdentifier: nil,
             processIdentifier: getpid()
         )
-        var resumeHandshake: CheckedContinuation<Void, Never>?
         let task = Task { @MainActor in
             var permissionRejections: [String] = []
             return try await RuntimeHostResolver.resolveRemoteServices(
@@ -1303,9 +1294,7 @@ extension ScreenCaptureKitOwnerRuntimeTests {
                 permissionRejections: &permissionRejections,
                 makeRemoteServices: Self.makeInertRemoteServices,
                 handshake: { _, _ in
-                    await withCheckedContinuation { continuation in
-                        resumeHandshake = continuation
-                    }
+                    withUnsafeCurrentTask { $0?.cancel() }
                     return Self.handshake(
                         processIdentifier: 4242,
                         processStartIdentity: 9001
@@ -1314,11 +1303,6 @@ extension ScreenCaptureKitOwnerRuntimeTests {
             )
         }
 
-        while resumeHandshake == nil {
-            await Task.yield()
-        }
-        task.cancel()
-        resumeHandshake?.resume()
         await #expect(throws: CancellationError.self) {
             _ = try await task.value
         }

--- a/Apps/CLI/Tests/CoreCLITests/ScreenCaptureKitOwnerRuntimeTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/ScreenCaptureKitOwnerRuntimeTests.swift
@@ -1134,12 +1134,15 @@ extension ScreenCaptureKitOwnerRuntimeTests {
             )
         }
 
+        var resumeHandshake: CheckedContinuation<Void, Never>?
         let uncooperativeHandshake = Task { @MainActor in
             try await RuntimeHostResolver.firstScreenCaptureKitOwnerUnawareHost(
                 candidates: [candidate],
                 identity: identity,
                 handshake: { _, _ in
-                    try? await Task.sleep(for: .milliseconds(20))
+                    await withCheckedContinuation { continuation in
+                        resumeHandshake = continuation
+                    }
                     return Self.handshake(
                         processIdentifier: 3131,
                         processStartIdentity: 4141,
@@ -1151,8 +1154,11 @@ extension ScreenCaptureKitOwnerRuntimeTests {
                 }
             )
         }
-        try await Task.sleep(for: .milliseconds(1))
+        while resumeHandshake == nil {
+            await Task.yield()
+        }
         uncooperativeHandshake.cancel()
+        resumeHandshake?.resume()
         await #expect(throws: CancellationError.self) {
             _ = try await uncooperativeHandshake.value
         }
@@ -1286,6 +1292,7 @@ extension ScreenCaptureKitOwnerRuntimeTests {
             teamIdentifier: nil,
             processIdentifier: getpid()
         )
+        var resumeHandshake: CheckedContinuation<Void, Never>?
         let task = Task { @MainActor in
             var permissionRejections: [String] = []
             return try await RuntimeHostResolver.resolveRemoteServices(
@@ -1296,7 +1303,9 @@ extension ScreenCaptureKitOwnerRuntimeTests {
                 permissionRejections: &permissionRejections,
                 makeRemoteServices: Self.makeInertRemoteServices,
                 handshake: { _, _ in
-                    try? await Task.sleep(for: .milliseconds(20))
+                    await withCheckedContinuation { continuation in
+                        resumeHandshake = continuation
+                    }
                     return Self.handshake(
                         processIdentifier: 4242,
                         processStartIdentity: 9001
@@ -1305,8 +1314,11 @@ extension ScreenCaptureKitOwnerRuntimeTests {
             )
         }
 
-        try await Task.sleep(for: .milliseconds(1))
+        while resumeHandshake == nil {
+            await Task.yield()
+        }
         task.cancel()
+        resumeHandshake?.resume()
         await #expect(throws: CancellationError.self) {
             _ = try await task.value
         }

--- a/Apps/CLI/Tests/CoreCLITests/TTYCommandRunnerTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/TTYCommandRunnerTests.swift
@@ -9,6 +9,7 @@ struct TTYCommandRunnerTests {
         let tmp = FileManager.default.temporaryDirectory
             .appendingPathComponent("tty-runner-tests-\(UUID().uuidString)")
         try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmp) }
 
         let scriptURL = tmp.appendingPathComponent("spawn_child.sh")
         let script = """
@@ -26,7 +27,7 @@ struct TTYCommandRunnerTests {
         let result = try runner.run(
             binary: scriptURL.path,
             send: "",
-            options: .init(rows: 5, cols: 40, timeout: 0.8, extraArgs: [])
+            options: .init(rows: 5, cols: 40, extraArgs: [])
         )
 
         guard let childPID = Self.extractChildPID(result.text) else {
@@ -34,10 +35,17 @@ struct TTYCommandRunnerTests {
             return
         }
 
-        usleep(150_000) // allow teardown signals to land
-
-        let stillAlive = kill(childPID, 0) == 0
-        #expect(stillAlive == false, "Child process (pid: \(childPID)) is still alive; process-group kill failed")
+        let deadline = ContinuousClock.now.advanced(by: .seconds(2))
+        while kill(childPID, 0) == 0, ContinuousClock.now < deadline {
+            usleep(10000)
+        }
+        errno = 0
+        let probe = kill(childPID, 0)
+        let probeError = errno
+        #expect(
+            probe == -1 && probeError == ESRCH,
+            "Child process (pid: \(childPID)) was not proven absent after cleanup"
+        )
     }
 
     private static func extractChildPID(_ text: String) -> pid_t? {


### PR DESCRIPTION
Two CLI test fixtures could fail on a loaded host. The cancellation checks raced a 1 ms parent sleep against a 20 ms mocked handshake. The process-group cleanup test allowed only 800 ms for a shell to print its child PID and assumed teardown completed after a fixed 150 ms sleep.

Cancel the current task inside each mocked handshake before it returns, exercising the existing post-handshake cancellation checks without scheduling races or wait loops. Use the PTY runner's normal five-second readiness budget, poll for definite ESRCH after cleanup, and remove the test's temporary files. Production code is unchanged, and the child-absence assertion is stricter.

Observed CI failure: https://github.com/openclaw/Peekaboo/actions/runs/34653688380. The separate TTY timeout occurred during the full local safe suite; the original focused test passed in a fresh private temp directory, consistent with the short readiness deadline being sensitive to host load.

Verification at `48ba8b168b3e0c8df0f1fda5be8b67167de68a34`:

- The full CLI command from `test:safe` passed all 1,978 tests across four targets, including the real Bash/PTY process-group fixture.
- The built and Developer ID signed CLI ran `--version` and a successful local permissions query.
- SwiftFormat and final P0–P2 branch autoreview passed.
- [Native/test proof](https://github.com/openclaw/Peekaboo/pull/714#issuecomment-5641810849), [macOS CI](https://github.com/openclaw/Peekaboo/actions/runs/34657052698), [CodeQL](https://github.com/openclaw/Peekaboo/actions/runs/34657052742).

Land this CI repair before #711 and #712, then land the consolidated notes/dependency PR #713 last.
