### PR TITLE
refactor(formatting): reuse duration and truncation helpers

### DIFF
--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/ToolFormatting/Formatters/SystemToolFormatter.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/ToolFormatting/Formatters/SystemToolFormatter.swift
@@ -463,7 +463,7 @@ public class SystemToolFormatter: BaseToolFormatter {
         if toolType == .shell {
             let exitCode = ToolResultExtractor.int("exitCode", from: result) ?? 0
             if duration > 5.0 {
-                let durationText = formatDuration(duration)
+                let durationText = FormattingUtilities.formatDetailedDuration(duration)
                 if exitCode == 0 {
                     return "\(AgentDisplayTokens.Status.success) Command completed successfully after \(durationText)"
                 }

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/ToolFormatting/Formatters/UIAutomationToolFormatter+PointerResults.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/ToolFormatting/Formatters/UIAutomationToolFormatter+PointerResults.swift
@@ -165,10 +165,10 @@ extension UIAutomationToolFormatter {
 
     func elementDescription(from result: [String: Any]) -> String? {
         if let element = ToolResultExtractor.string("element", from: result) {
-            return "on \"\(self.truncate(element, limit: 40))\""
+            return "on \"\(self.truncate(element, maxLength: 40))\""
         }
         if let description = ToolResultExtractor.string("description", from: result) {
-            return "on \(self.truncate(description, limit: 40))"
+            return "on \(self.truncate(description, maxLength: 40))"
         }
         return nil
     }
@@ -238,14 +238,14 @@ extension UIAutomationToolFormatter {
     func locationDescription(_ key: String, fallback: String?, from result: [String: Any]) -> String? {
         if let location = ToolResultExtractor.dictionary(key, from: result) {
             if let description = location["description"] as? String {
-                return self.truncate(description, limit: 50)
+                return self.truncate(description, maxLength: 50)
             }
             if let point = self.pointSummary(from: location) {
                 return point
             }
         }
         if let fallback, let value = ToolResultExtractor.string(fallback, from: result) {
-            return self.truncate(value, limit: 50)
+            return self.truncate(value, maxLength: 50)
         }
         return nil
     }
@@ -274,12 +274,5 @@ extension UIAutomationToolFormatter {
             return Int(value)
         }
         return nil
-    }
-
-    func truncate(_ text: String, limit: Int) -> String {
-        if text.count > limit {
-            return String(text.prefix(limit)) + "..."
-        }
-        return text
     }
 }

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/ToolFormatting/FormattingUtilities.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/ToolFormatting/FormattingUtilities.swift
@@ -9,7 +9,6 @@ import Foundation
 public enum FormattingUtilities {
     /// Format keyboard shortcut with proper symbols
     public static func formatKeyboardShortcut(_ keys: String) -> String {
-        // Format keyboard shortcut with proper symbols
         keys.replacingOccurrences(of: "cmd", with: "⌘")
             .replacingOccurrences(of: "command", with: "⌘")
             .replacingOccurrences(of: "shift", with: "⇧")
@@ -32,7 +31,6 @@ public enum FormattingUtilities {
 
     /// Format duration for display
     public static func formatDetailedDuration(_ seconds: TimeInterval) -> String {
-        // Format duration for display
         if seconds < 0.001 {
             return String(format: "%.0fµs", seconds * 1_000_000)
         } else if seconds < 1.0 {

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/ToolFormatting/ToolFormatter.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/ToolFormatting/ToolFormatter.swift
@@ -34,7 +34,7 @@ public protocol ToolFormatter {
 
 /// Base implementation of ToolFormatter with common functionality
 open class BaseToolFormatter: ToolFormatter {
-    /// Format the tool execution start message
+    /// The tool type this formatter handles.
     public let toolType: ToolType
 
     public init(toolType: ToolType) {
@@ -74,7 +74,6 @@ open class BaseToolFormatter: ToolFormatter {
     }
 
     open func formatCompactSummary(arguments: [String: Any]) -> String {
-        // Default: no summary
         ""
     }
 
@@ -92,25 +91,8 @@ open class BaseToolFormatter: ToolFormatter {
 
     // MARK: - Helper Methods
 
-    /// Format duration in a human-readable way
-    func formatDuration(_ seconds: TimeInterval) -> String {
-        // Format duration in a human-readable way
-        if seconds < 0.001 {
-            return String(format: "%.0fµs", seconds * 1_000_000)
-        } else if seconds < 1.0 {
-            return String(format: "%.0fms", seconds * 1000)
-        } else if seconds < 60.0 {
-            return String(format: "%.1fs", seconds)
-        } else {
-            let minutes = Int(seconds / 60)
-            let remainingSeconds = Int(seconds.truncatingRemainder(dividingBy: 60))
-            return String(format: "%dmin %ds", minutes, remainingSeconds)
-        }
-    }
-
     /// Truncate text if too long
     func truncate(_ text: String, maxLength: Int = 30) -> String {
-        // Truncate text if too long
         if text.count > maxLength {
             return String(text.prefix(maxLength)) + "..."
         }

--- a/Core/PeekabooCore/Tests/PeekabooTests/ToolFormatterEnrichmentTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/ToolFormatterEnrichmentTests.swift
@@ -6,7 +6,7 @@ struct ToolFormatterEnrichmentTests {
     private let registry = ToolFormatterRegistry()
 
     @Test(arguments: [
-        (5.0, "→ completed"),
+        (5.0, "→ Success"),
         (5.1, "[ok] Command completed successfully after 5.1s"),
         (60.0, "[ok] Command completed successfully after 1min 0s"),
         (90.0, "[ok] Command completed successfully after 1min 30s"),

--- a/Core/PeekabooCore/Tests/PeekabooTests/ToolFormatterEnrichmentTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/ToolFormatterEnrichmentTests.swift
@@ -5,6 +5,34 @@ import Testing
 struct ToolFormatterEnrichmentTests {
     private let registry = ToolFormatterRegistry()
 
+    @Test(arguments: [
+        (5.0, "→ completed"),
+        (5.1, "[ok] Command completed successfully after 5.1s"),
+        (60.0, "[ok] Command completed successfully after 1min 0s"),
+        (90.0, "[ok] Command completed successfully after 1min 30s"),
+    ])
+    func `shell completion preserves duration wording`(duration: Double, expected: String) {
+        let formatter = self.registry.formatter(for: .shell)
+        #expect(formatter.formatCompleted(result: ["exitCode": 0], duration: duration) == expected)
+    }
+
+    @Test
+    func `pointer descriptions preserve truncation boundaries and unicode characters`() {
+        let formatter = UIAutomationToolFormatter(toolType: .click)
+        let text = String(repeating: "👩🏽‍💻", count: 40)
+        #expect(formatter.elementDescription(from: ["element": text]) == "on \"\(text)\"")
+        #expect(formatter.elementDescription(from: ["element": text + "x"]) == "on \"\(text)...\"")
+        #expect(formatter.elementDescription(from: ["description": text + "x"]) == "on \(text)...")
+
+        let location = String(repeating: "é", count: 50)
+        #expect(formatter.locationDescription("from", fallback: nil, from: [
+            "from": ["description": location],
+        ]) == location)
+        #expect(formatter.locationDescription("from", fallback: "source", from: [
+            "source": location + "x",
+        ]) == location + "...")
+    }
+
     @Test
     func `list menus supports item and menu structure results`() {
         let formatter = self.registry.formatter(for: .listMenus)

--- a/docs/tool-formatter-architecture.md
+++ b/docs/tool-formatter-architecture.md
@@ -27,6 +27,8 @@ Core/PeekabooCore/Sources/PeekabooAgentRuntime/ToolFormatting/
 - `ToolResultExtractor` and `FormattingUtilities` normalize wrapped values and shared display operations.
 - `Formatters/` contains the application, communication, dock, element, menu/dialog, system, UI automation, vision, and window formatter families.
 
+Duration displays use `FormattingUtilities.formatDetailedDuration`; formatter subclasses share the base truncation helper.
+
 The registry is available as `ToolFormatterRegistry.shared` or as a separately initialized registry in tests.
 
 ### Mac App Consumption


### PR DESCRIPTION
Shell-completion duration formatting duplicated `FormattingUtilities`, and pointer result descriptions duplicated their inherited truncation helper under a different argument label. Use the existing shared implementations and remove the two internal duplicates, preserving duration wording, thresholds, ellipses, and Swift Character boundaries.

Add output tests for the five-second shell threshold, minute formatting, exact truncation boundaries, and composed Unicode characters. Update the formatter ownership guide and remove repeated implementation comments.

Validation:
- Isolated Codex autoreview at P0–P2: scoped-clean, no actionable findings.
- SwiftLint, SwiftFormat, docs lint, and `git diff --check` passed.
- `swift test --package-path Core/PeekabooCore --scratch-path Apps/CLI/.build --no-parallel --filter ToolFormatterEnrichmentTests`: 15 tests passed. The first run exposed an incorrect new five-second expected string; it now asserts the existing `→ Success` summary. Production behavior was unchanged.
- `pnpm run build:cli`: passed.
- Live proof: signed the rebuilt CLI with the matching Developer ID and verified its signature. `--version`, `tools --no-remote --json`, and `tools describe click --no-remote --json` passed with an isolated configuration; the catalog and schema commands both returned `success: true` with their expected structured fields.
- Complete-candidate isolated review repeated after staging the corrected test: scoped-clean at P0–P2.
- `pnpm run test:safe` passed (exit 0) on `9fc4dbefe0583145e5db7df999005d9952a2b39b`, including script/certification contracts, the standalone SwiftPM consumer, Foundation, and CLI suites. Existing opt-in, ambient-state, and unavailable historical-fixture skips were retained. Hosted macOS CI and CodeQL must finish green on the exact head before merge.
