### PR TITLE
fix: separate screen capture and accessibility ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix host-routed screen observations with Accessibility elements by validating their semantic owner separately from the screen raster target. #715, #710.
+
 ## 4.3.4 - 2026-09-11
 
 **Highlights:** Restore provider-compatible MCP tools and frontmost daemon captures.

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeDesktopObservationBinding.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeDesktopObservationBinding.swift
@@ -484,9 +484,14 @@ enum PeekabooBridgeDesktopObservationBinding {
     private static func validateApplicationEvidence(_ result: DesktopObservationResult) -> String? {
         guard let targetApp = result.target.app else {
             if result.capture.metadata.applicationInfo != nil ||
-                result.target.detectionContext?.applicationProcessId != nil ||
-                result.elements?.metadata.windowContext?.applicationProcessId != nil
+                result.target.detectionContext?.applicationProcessId != nil
             {
+                return "unexpected application evidence"
+            }
+            if case .screen = result.target.kind {
+                return self.validateScreenSemanticOwner(result.elements?.metadata.windowContext)
+            }
+            if result.elements?.metadata.windowContext?.applicationProcessId != nil {
                 return "unexpected application evidence"
             }
             return nil
@@ -541,12 +546,57 @@ enum PeekabooBridgeDesktopObservationBinding {
         return nil
     }
 
+    private static func validateScreenSemanticOwner(_ context: WindowContext?) -> String? {
+        guard let context,
+              context.applicationProcessId != nil || context.applicationProcessStartIdentity != nil ||
+              context.windowID != nil || context.windowMutationIdentity != nil || context.focusedElement != nil
+        else { return nil }
+        let mismatch = "screen accessibility owner"
+        guard context.applicationProcessId != nil else { return mismatch }
+        if let windowID = context.windowID, windowID <= 0 || UInt32(exactly: windowID) == nil {
+            return mismatch
+        }
+        if let bounds = context.windowBounds, !self.isValidBounds(bounds) {
+            return mismatch
+        }
+        if let focused = context.focusedElement {
+            guard focused.processIdentifier == context.applicationProcessId,
+                  focused.windowID > 0, UInt32(exactly: focused.windowID) != nil,
+                  !focused.role.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+                  self.isValidBounds(focused.frame)
+            else { return mismatch }
+            if let windowID = context.windowID, focused.windowID != windowID {
+                return mismatch
+            }
+            if let bounds = context.windowBounds,
+               !bounds.contains(CGPoint(x: focused.frame.midX, y: focused.frame.midY))
+            {
+                return mismatch
+            }
+        }
+        do {
+            // Screen pixels have no app target. AX carries its own generation-bound semantic owner;
+            // unreceipted window hints must never promote those pixels to exact-window authority.
+            guard try DesktopTargetPlanning.DesktopTargetIdentityCoalescer.resolve([
+                DesktopTargetEvidenceAdapter.evidence(context: context),
+            ]) != nil else { return mismatch }
+        } catch {
+            return mismatch
+        }
+        return nil
+    }
+
     private static func validateWindowEvidence(_ result: DesktopObservationResult) -> String? {
         guard let targetWindow = result.target.window else {
             if result.capture.metadata.windowInfo != nil ||
-                result.target.detectionContext?.windowID != nil ||
-                result.elements?.metadata.windowContext?.windowID != nil
+                result.target.detectionContext?.windowID != nil
             {
+                return "unexpected window evidence"
+            }
+            if case .screen = result.target.kind {
+                return nil
+            }
+            if result.elements?.metadata.windowContext?.windowID != nil {
                 return "unexpected window evidence"
             }
             return nil

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeScreenObservationBindingTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeScreenObservationBindingTests.swift
@@ -1,0 +1,135 @@
+import CoreGraphics
+import Foundation
+import PeekabooAutomationKit
+import PeekabooFoundation
+import Testing
+@testable import PeekabooBridge
+
+@Suite(.serialized)
+struct PeekabooBridgeScreenObservationBindingTests: DesktopObservationBindingFixtureProviding {
+    @Test(arguments: [false, true])
+    @MainActor
+    func `screen raster and generation bound AX owner remain distinct signed evidence`(
+        includesFocusedElement: Bool) async throws
+    {
+        let request = Self.request
+        let result = Self.result(context: Self.context(focusedElement: includesFocusedElement ? Self.focus() : nil))
+        #expect(PeekabooBridgeDesktopObservationBinding.mismatch(request: request, result: result) == nil)
+        #expect(result.target.app == nil)
+        #expect(result.target.window == nil)
+        #expect(result.capture.metadata.applicationInfo == nil)
+        #expect(result.elements?.metadata.windowContext?.applicationProcessId == 42)
+
+        let provider = ObservationProvider(result: result)
+        let server = Self.server(provider: provider)
+        _ = try await PeekabooBridgeRequestContext.$usesAttestedOperationResultSemantics.withValue(true) {
+            try await server.handleAuthorized(.desktopObservation(request), peer: nil, permissions: Self.permissions)
+        }
+        #expect(provider.observationCount == 1)
+
+        let bundle = try await Self.makeBundle(
+            request: .desktopObservation(request), response: .desktopObservation(result), target: .global)
+        try bundle.validateIntegrity()
+    }
+
+    @Test
+    @MainActor
+    func `screen AX owner rejects missing generation and contradictory window receipts`() async throws {
+        let wrongOwner = WindowMutationIdentity(
+            windowID: 73,
+            ownerProcessIdentifier: 99,
+            ownerProcessStartIdentity: 1001,
+            capturedBounds: Self.windowBounds)
+        let wrongGeneration = WindowMutationIdentity(
+            windowID: 73,
+            ownerProcessIdentifier: 42,
+            ownerProcessStartIdentity: 1002,
+            capturedBounds: Self.windowBounds)
+        let wrongBounds = WindowMutationIdentity(
+            windowID: 73,
+            ownerProcessIdentifier: 42,
+            ownerProcessStartIdentity: 1001,
+            capturedBounds: CGRect(x: 10, y: 10, width: 400, height: 300))
+        let contexts = [
+            Self.context(generation: nil),
+            Self.context(generation: 0),
+            Self.context(processIdentifier: 0),
+            Self.context(receipt: wrongOwner),
+            Self.context(receipt: wrongGeneration),
+            Self.context(receipt: wrongBounds),
+            Self.context(focusedElement: Self.focus(processIdentifier: 99)),
+            Self.context(focusedElement: Self.focus(windowID: 74)),
+            Self.context(focusedElement: Self.focus(role: "")),
+            Self.context(focusedElement: Self.focus(frame: CGRect(x: 1000, y: 1000, width: 10, height: 10))),
+        ]
+        for context in contexts {
+            let result = Self.result(context: context)
+            #expect(PeekabooBridgeDesktopObservationBinding.mismatch(
+                request: Self.request, result: result) != nil)
+            let bundle = try await Self.makeBundle(
+                request: .desktopObservation(Self.request), response: .desktopObservation(result), target: .global)
+            #expect(throws: PeekabooBridgeOperationReceiptError.self) {
+                try bundle.validateIntegrity()
+            }
+        }
+    }
+
+    @Test
+    func `screen semantics accept a consistent exact window receipt without changing raster scope`() {
+        let receipt = WindowMutationIdentity(
+            windowID: 73,
+            ownerProcessIdentifier: 42,
+            ownerProcessStartIdentity: 1001,
+            capturedBounds: Self.windowBounds)
+        let result = Self.result(context: Self.context(receipt: receipt))
+        #expect(PeekabooBridgeDesktopObservationBinding.mismatch(request: Self.request, result: result) == nil)
+        #expect(result.capture.metadata.windowInfo == nil)
+    }
+
+    private static var request: DesktopObservationRequest {
+        DesktopObservationRequest(target: .screen(index: 0), detection: .init(traversalBudget: AXTraversalBudget()))
+    }
+
+    private static let windowBounds = CGRect(x: 20, y: 30, width: 400, height: 300)
+
+    private static func context(
+        processIdentifier: Int32 = 42,
+        generation: UInt64? = 1001,
+        receipt: WindowMutationIdentity? = nil,
+        focusedElement: FocusedElementIdentity? = nil) -> WindowContext
+    {
+        WindowContext(
+            applicationName: "Fixture",
+            applicationBundleId: "example.fixture",
+            applicationProcessId: processIdentifier,
+            applicationProcessStartIdentity: generation,
+            windowTitle: "Fixture window",
+            windowID: 73,
+            windowBounds: self.windowBounds,
+            windowMutationIdentity: receipt,
+            focusedElement: focusedElement,
+            shouldFocusWebContent: false,
+            includeMenuBarElements: false,
+            traversalBudget: AXTraversalBudget())
+    }
+
+    private static func focus(
+        processIdentifier: Int32 = 42,
+        windowID: Int = 73,
+        role: String = "AXButton",
+        frame: CGRect = CGRect(x: 30, y: 40, width: 10, height: 10)) -> FocusedElementIdentity
+    {
+        FocusedElementIdentity(processIdentifier: processIdentifier, windowID: windowID, role: role, frame: frame)
+    }
+
+    private static func result(context: WindowContext) -> DesktopObservationResult {
+        replacingElements(
+            screenResult(index: 0),
+            with: ElementDetectionResult(
+                snapshotId: "screen-semantic-fixture",
+                screenshotPath: "",
+                elements: .init(buttons: [.init(id: "B1", type: .button, bounds: self.windowBounds)]),
+                metadata: .init(
+                    detectionTime: 0, elementCount: 1, method: "fixture", windowContext: context, isDialog: false)))
+    }
+}

--- a/docs/commands/see.md
+++ b/docs/commands/see.md
@@ -137,6 +137,10 @@ This fallback only runs inside the resolved window (it won’t hop between windo
 
 ## JSON output primer
 
+Screen captures keep a display-scoped raster and separate application-scoped Accessibility evidence. The AX map
+carries its own process generation; it does not make the screenshot an exact-window capture. Use an explicit
+`--window-id` observation when a follow-up coordinate action needs a window-bound capture receipt.
+
 When `--json` is supplied, the CLI prints:
 
 - `snapshot_id` – producer-bound `ps1_` reference for subsequent `click --snapshot …` and `type --snapshot …`.


### PR DESCRIPTION
Host-routed screen captures with Accessibility detection were rejected because the Bridge validator treated the AX application's identity as if it were the screen raster's target. Pixels-only capture worked; adding AX metadata produced the reported “unexpected application evidence” refusal.

Keep screen pixels globally scoped and validate the AX context as separate semantic evidence. Reuse the canonical process-generation/window-receipt validator, and independently check focused-element PID, window, role, and frame when no exact-window receipt is present. The capture target still rejects application/window claims, and unreceipted AX window hints never become exact-window pixel authority.

Addresses the attribution portions of #715 and #710. Premature artifact publication on rejected observations is separate work; this PR does not claim to fix it. ScreenCaptureKit coordination and fallback policies are unchanged.

Validation:
- Signed native Bridge 1.38 before/after proof through a task-owned daemon and a separate public-API client with an explicit trusted signing team. Explicit classic capture used the same host throughout.
- Before: pixels-only succeeded; screen+AX was refused with “response evidence ... requested unexpected application evidence.”
- After: both succeeded; screen+AX returned 12 elements, a semantic PID and generation, and no application target on the screen raster. Captured PNGs remained local and were removed after structural verification.
- `swift test --package-path Core/PeekabooCore --scratch-path Apps/CLI/.build --filter 'PeekabooBridge.*Observation|RemoteDesktopObservation'`: 51 + 7 tests passed. New signed-bundle cases accept valid independent semantic ownership and reject missing generations, wrong receipt owners/bounds, and contradictory focused-element metadata.
- Isolated Codex autoreview: complete candidate clean at P0–P2 after addressing its focused-element ownership finding.
- CLI build, SwiftFormat, SwiftLint (zero violations), docs lint, and diff checks passed. Updated capture documentation and `Unreleased`.
- Exact-head hosted checks passed: [macOS CI](https://github.com/openclaw/Peekaboo/actions/runs/34725022843), [CodeQL](https://github.com/openclaw/Peekaboo/actions/runs/34725022820), and Bugbot.
