### PR TITLE
test(capture): decouple completion proof from frame cadence

### DIFF
--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Core/CaptureCommand+Action.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Core/CaptureCommand+Action.swift
@@ -349,10 +349,10 @@ RuntimeOptionsConfigurable, InjectedRuntimeBackedCommand {
         actionCompletedNs: UInt64,
         captureDeadlineNs: UInt64
     ) async throws -> CaptureActionCaptureCompletion {
-        let postRollDeadlineNs = try timing.postRollDeadline(startingAtNs: actionCompletedNs)
-        guard postRollDeadlineNs <= captureDeadlineNs else {
-            throw ValidationError("Action completion left insufficient time for the requested post-roll")
-        }
+        let postRollDeadlineNs = try timing.postRollDeadline(
+            startingAtNs: actionCompletedNs,
+            captureDeadlineNs: captureDeadlineNs
+        )
         try await Self.sleep(untilMonotonicNanoseconds: postRollDeadlineNs)
         if timing.postRollMs > 0 {
             session.requestStop(afterSampleStartedAtOrAfter: actionCompletedNs)
@@ -1037,16 +1037,14 @@ struct CaptureActionTiming {
         return captureDeadlineNs - postRollNs
     }
 
-    func postRollFits(startingAtNs: UInt64, captureDeadlineNs: UInt64) -> Bool {
-        guard let deadlineNs = try? self.postRollDeadline(startingAtNs: startingAtNs) else { return false }
-        return deadlineNs <= captureDeadlineNs
-    }
-
-    func postRollDeadline(startingAtNs: UInt64) throws -> UInt64 {
+    func postRollDeadline(startingAtNs: UInt64, captureDeadlineNs: UInt64) throws -> UInt64 {
         let postRollNs = try Self.nanoseconds(milliseconds: self.postRollMs)
         let (deadlineNs, overflowed) = startingAtNs.addingReportingOverflow(postRollNs)
         guard !overflowed else {
             throw ValidationError("--post-roll overflowed the capture deadline")
+        }
+        guard deadlineNs <= captureDeadlineNs else {
+            throw ValidationError("Action completion left insufficient time for the requested post-roll")
         }
         return deadlineNs
     }

--- a/Apps/CLI/Tests/CoreCLITests/CaptureActionCommandEndToEndTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/CaptureActionCommandEndToEndTests.swift
@@ -943,6 +943,7 @@ extension CaptureActionCommandEndToEndTests {
             )
         defer { try? FileManager.default.removeItem(at: outputDirectory) }
         let processStartIdentity = try #require(SystemIdentityResolver.processStartIdentity(getpid()))
+        var runnerReturnedAfterDeadline = false
         var command = CaptureActionCommand()
         command.mode = "frontmost"
         command.durationLimit = CLIDuration(argument: "2500ms")
@@ -955,12 +956,14 @@ extension CaptureActionCommandEndToEndTests {
             deadlineProcessRunner: { childCommand, timeoutSeconds, completionDeadlineNs, onLaunch in
                 let actionStartedNs = DispatchTime.now().uptimeNanoseconds
                 onLaunch(actionStartedNs)
-                let completedAtNs = completionDeadlineNs - 50_000_000
+                // Keep sampling headroom independent of the delayed delivery being tested.
+                let completedAtNs = actionStartedNs
                 let delayedReturnNs = completionDeadlineNs + 20_000_000
                 let nowNs = DispatchTime.now().uptimeNanoseconds
                 if delayedReturnNs > nowNs {
                     try await Task.sleep(nanoseconds: delayedReturnNs - nowNs)
                 }
+                runnerReturnedAfterDeadline = DispatchTime.now().uptimeNanoseconds > completionDeadlineNs
                 return CaptureActionProcessResult(
                     command: childCommand,
                     processIdentifier: getpid(),
@@ -988,7 +991,10 @@ extension CaptureActionCommandEndToEndTests {
             from: Data(contentsOf: URL(fileURLWithPath: receipt.path))
         )
 
+        #expect(runnerReturnedAfterDeadline)
         #expect(result.success)
+        #expect(manifest.timeline.actionCompletedMs == manifest.timeline.actionStartedMs)
+        #expect(manifest.provesPostActionSample)
         #expect(manifest.timeline.samplingCompletedMs >= manifest.timeline.actionCompletedMs + 100)
     }
 
@@ -1138,14 +1144,17 @@ extension CaptureActionCommandEndToEndTests {
             captureDeadlineNs: captureDeadlineNs
         )
         #expect(actionCompletionDeadlineNs == captureStartedNs + 2_300_000_000)
-        #expect(timing.postRollFits(
-            startingAtNs: actionCompletionDeadlineNs,
-            captureDeadlineNs: captureDeadlineNs
-        ))
-        #expect(!timing.postRollFits(
-            startingAtNs: actionCompletionDeadlineNs + 1,
-            captureDeadlineNs: captureDeadlineNs
-        ))
+        for start in [actionCompletionDeadlineNs - 50_000_000, actionCompletionDeadlineNs] {
+            #expect(try timing.postRollDeadline(
+                startingAtNs: start,
+                captureDeadlineNs: captureDeadlineNs
+            ) == start + 200_000_000)
+        }
+        for start in [actionCompletionDeadlineNs + 1, actionCompletionDeadlineNs + 20_000_000, UInt64.max] {
+            #expect(throws: (any Error).self) {
+                try timing.postRollDeadline(startingAtNs: start, captureDeadlineNs: captureDeadlineNs)
+            }
+        }
         #expect(throws: (any Error).self) {
             _ = try CaptureActionTiming.resolve(
                 durationLimit: 1.7,


### PR DESCRIPTION
Main CI's delayed-runner test assumed that a valid frame would begin in the final 150 ms of capture. Under load, the last frame began earlier and finished after the cap, so the new post-action evidence check correctly refused success. That coupled the runner-delivery regression to frame cadence.

Keep the 2.5-second cap and deliberately deliver the runner result after its completion deadline, but record completion early enough to leave sampling headroom. Preserve the success and elapsed-coverage assertions, and add explicit checks for late delivery, the recorded completion boundary, and retained post-action sample proof.

Deadline-edge coverage now calls the same throwing admission helper as production for 50 ms before, exactly at, one nanosecond after, 20 ms after, and overflowing boundaries. Remove the unused Boolean helper that only tests called. Production behavior and error messages are unchanged.

Validation: 22 focused capture tests passed, lint/format/diff checks passed, and isolated Codex review found no actionable P0–P2 findings. The signed, source-stamped CLI at `859b64176b79a437a874f2382d176ecc0da2b8e9` ran a real `/usr/bin/true` child during local classic screen capture: exit 0, two retained frames, child completion `275988000` ns, last sample start `2032758291` ns, and valid retained post-action proof. Captured images were removed after structural verification.

Failure evidence: https://github.com/openclaw/Peekaboo/actions/runs/34733287499 (CLI job; `Capture action admits post roll from the runner completion boundary`). No assertion, timeout, capture cap, or CI gate was removed or weakened.
